### PR TITLE
feat: real-time agent activity dashboard

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -21,6 +21,7 @@ import {
 } from "../config/config.js";
 import { resolveAgentIdFromSessionKey, type SessionEntry } from "../config/sessions.js";
 import { resolveSessionTranscriptFile } from "../config/sessions/transcript.js";
+import { emitActivityEvent, summarizeForMetadata } from "../infra/activity-events.js";
 import {
   clearAgentRunContext,
   emitAgentEvent,
@@ -162,6 +163,29 @@ async function prepareAgentCommandExecution(
     throw new Error("Message (--message) is required");
   }
   const body = prependInternalEventContext(message, opts.internalEvents);
+
+  // Emit activity events for subagent completion results delivered to parent.
+  if (opts.internalEvents?.length) {
+    for (const evt of opts.internalEvents) {
+      if (evt.type === "task_completion") {
+        emitActivityEvent(
+          opts.runId ?? "",
+          {
+            kind: "subagent.completed",
+            metadata: {
+              outcome: evt.status,
+              task: evt.taskLabel,
+              result: summarizeForMetadata(evt.result),
+              childSessionKey: evt.childSessionKey,
+              source: evt.source,
+            },
+          },
+          opts.sessionKey,
+        );
+      }
+    }
+  }
+
   if (!opts.to && !opts.sessionId && !opts.sessionKey && !opts.agentId) {
     throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
   }

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -1,3 +1,4 @@
+import { emitActivityEvent } from "../infra/activity-events.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
@@ -33,6 +34,14 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
     stream: "lifecycle",
     data: { phase: "start" },
   });
+  emitActivityEvent(
+    ctx.params.runId,
+    {
+      kind: "run.start",
+      agentId: ctx.params.agentId,
+    },
+    ctx.params.sessionKey,
+  );
 }
 
 export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
@@ -85,6 +94,16 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
         error: safeErrorText,
       },
     });
+    emitActivityEvent(
+      ctx.params.runId,
+      {
+        kind: "run.error",
+        agentId: ctx.params.agentId,
+        isError: true,
+        error: safeErrorText,
+      },
+      ctx.params.sessionKey,
+    );
   } else {
     ctx.log.debug(`embedded run agent end: runId=${ctx.params.runId} isError=${isError}`);
     emitAgentEvent({
@@ -99,6 +118,14 @@ export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
       stream: "lifecycle",
       data: { phase: "end" },
     });
+    emitActivityEvent(
+      ctx.params.runId,
+      {
+        kind: "run.end",
+        agentId: ctx.params.agentId,
+      },
+      ctx.params.sessionKey,
+    );
   }
 
   const finalizeAgentEnd = () => {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -2,6 +2,7 @@ import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { emitActivityEvent } from "../infra/activity-events.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
@@ -209,6 +210,13 @@ export function handleMessageUpdate(
 
   if (evtType === "thinking_start" || evtType === "thinking_delta" || evtType === "thinking_end") {
     if (evtType === "thinking_start" || evtType === "thinking_delta") {
+      if (!ctx.state.reasoningStreamOpen) {
+        emitActivityEvent(
+          ctx.params.runId,
+          { kind: "thinking.start", agentId: ctx.params.agentId },
+          ctx.params.sessionKey,
+        );
+      }
       ctx.state.reasoningStreamOpen = true;
     }
     const thinkingDelta = typeof assistantRecord?.delta === "string" ? assistantRecord.delta : "";
@@ -232,6 +240,11 @@ export function handleMessageUpdate(
       if (!ctx.state.reasoningStreamOpen) {
         ctx.state.reasoningStreamOpen = true;
       }
+      emitActivityEvent(
+        ctx.params.runId,
+        { kind: "thinking.end", agentId: ctx.params.agentId },
+        ctx.params.sessionKey,
+      );
       emitReasoningEnd(ctx);
     }
     return;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import { emitActivityEvent } from "../infra/activity-events.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import {
   buildExecApprovalPendingReplyPayload,
@@ -400,6 +401,16 @@ export function handleToolExecutionStart(
       stream: "tool",
       data: { phase: "start", name: toolName, toolCallId },
     });
+    emitActivityEvent(
+      ctx.params.runId,
+      {
+        kind: "tool.start",
+        toolName,
+        toolCallId,
+        agentId: ctx.params.agentId,
+      },
+      ctx.params.sessionKey,
+    );
 
     if (
       ctx.params.onToolResult &&
@@ -597,6 +608,21 @@ export async function handleToolExecutionEnd(
     },
   });
 
+  const toolDurationMs =
+    startData?.startTime != null ? Date.now() - startData.startTime : undefined;
+  emitActivityEvent(
+    ctx.params.runId,
+    {
+      kind: "tool.end",
+      toolName,
+      toolCallId,
+      agentId: ctx.params.agentId,
+      durationMs: toolDurationMs,
+      isError: isToolError,
+      error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
+    },
+    ctx.params.sessionKey,
+  );
   ctx.log.debug(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,5 +1,5 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
-import { emitActivityEvent } from "../infra/activity-events.js";
+import { emitActivityEvent, summarizeForMetadata } from "../infra/activity-events.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import {
   buildExecApprovalPendingReplyPayload,
@@ -408,6 +408,7 @@ export function handleToolExecutionStart(
         toolName,
         toolCallId,
         agentId: ctx.params.agentId,
+        metadata: { args: summarizeForMetadata(args) },
       },
       ctx.params.sessionKey,
     );
@@ -620,6 +621,7 @@ export async function handleToolExecutionEnd(
       durationMs: toolDurationMs,
       isError: isToolError,
       error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
+      metadata: { result: summarizeForMetadata(sanitizedResult) },
     },
     ctx.params.sessionKey,
   );

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -1,5 +1,6 @@
-import { emitActivityEvent } from "../infra/activity-events.js";
+import { emitActivityEvent, summarizeForMetadata } from "../infra/activity-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { captureSubagentCompletionReply } from "./subagent-announce-output.js";
 import type { SubagentRunOutcome } from "./subagent-announce.js";
 import {
   SUBAGENT_ENDED_OUTCOME_ERROR,
@@ -91,6 +92,14 @@ export async function emitSubagentEndedHookOnce(params: {
     }
     params.entry.endedHookEmittedAt = Date.now();
     params.persist();
+    // Best-effort capture of the child agent's output for the activity panel.
+    let resultPreview: string | undefined;
+    try {
+      const reply = await captureSubagentCompletionReply(params.entry.childSessionKey);
+      resultPreview = summarizeForMetadata(reply);
+    } catch {
+      // Non-blocking — activity event still fires without the result.
+    }
     emitActivityEvent(
       runId,
       {
@@ -100,6 +109,7 @@ export async function emitSubagentEndedHookOnce(params: {
           error: params.error,
           reason: params.reason,
           childSessionKey: params.entry.childSessionKey,
+          result: resultPreview,
         },
       },
       params.entry.requesterSessionKey,

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -1,3 +1,4 @@
+import { emitActivityEvent } from "../infra/activity-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { SubagentRunOutcome } from "./subagent-announce.js";
 import {
@@ -90,6 +91,19 @@ export async function emitSubagentEndedHookOnce(params: {
     }
     params.entry.endedHookEmittedAt = Date.now();
     params.persist();
+    emitActivityEvent(
+      runId,
+      {
+        kind: "subagent.completed",
+        metadata: {
+          outcome: params.outcome,
+          error: params.error,
+          reason: params.reason,
+          childSessionKey: params.entry.childSessionKey,
+        },
+      },
+      params.entry.requesterSessionKey,
+    );
     return true;
   } catch {
     return false;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { promises as fs } from "node:fs";
+import { emitActivityEvent } from "../infra/activity-events.js";
 import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
 import {
   isValidAgentId,
@@ -720,6 +721,16 @@ export async function spawnSubagentDirect(
 
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
+  const spawnStartTime = Date.now();
+  emitActivityEvent(
+    childIdem,
+    {
+      kind: "subagent.start",
+      agentId: targetAgentId,
+      depth: callerDepth + 1,
+    },
+    ctx.agentSessionKey,
+  );
   try {
     const {
       spawnedBy: _spawnedBy,
@@ -908,6 +919,16 @@ export async function spawnSubagentDirect(
         ? undefined
         : SUBAGENT_SPAWN_ACCEPTED_NOTE;
 
+  emitActivityEvent(
+    childRunId,
+    {
+      kind: "subagent.end",
+      agentId: targetAgentId,
+      depth: callerDepth + 1,
+      durationMs: Date.now() - spawnStartTime,
+    },
+    ctx.agentSessionKey,
+  );
   return {
     status: "accepted",
     childSessionKey,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -728,6 +728,11 @@ export async function spawnSubagentDirect(
       kind: "subagent.start",
       agentId: targetAgentId,
       depth: callerDepth + 1,
+      metadata: {
+        childSessionKey,
+        parentSessionKey: ctx.agentSessionKey,
+        task: typeof task === "string" && task.length > 200 ? `${task.slice(0, 197)}…` : task,
+      },
     },
     ctx.agentSessionKey,
   );
@@ -926,6 +931,7 @@ export async function spawnSubagentDirect(
       agentId: targetAgentId,
       depth: callerDepth + 1,
       durationMs: Date.now() - spawnStartTime,
+      metadata: { childSessionKey },
     },
     ctx.agentSessionKey,
   );

--- a/src/infra/activity-events.test.ts
+++ b/src/infra/activity-events.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { emitActivityEvent, type ActivityEventData } from "./activity-events.js";
+import { onAgentEvent, resetAgentEventsForTest, type AgentEventPayload } from "./agent-events.js";
+
+describe("emitActivityEvent", () => {
+  let captured: AgentEventPayload[];
+  let unsub: () => void;
+
+  beforeEach(() => {
+    captured = [];
+    unsub = onAgentEvent((evt) => captured.push(evt));
+  });
+
+  afterEach(() => {
+    unsub();
+    resetAgentEventsForTest();
+  });
+
+  it("emits an agent event with stream=activity", () => {
+    emitActivityEvent("run-1", { kind: "run.start", agentId: "main" });
+    expect(captured).toHaveLength(1);
+    expect(captured[0].stream).toBe("activity");
+    expect(captured[0].runId).toBe("run-1");
+    expect(captured[0].data).toMatchObject({ kind: "run.start", agentId: "main" });
+  });
+
+  it("includes sessionKey when provided", () => {
+    emitActivityEvent("run-2", { kind: "tool.start", toolName: "read" }, "agent:main:user");
+    expect(captured[0].sessionKey).toBe("agent:main:user");
+  });
+
+  it("auto-assigns seq and ts", () => {
+    emitActivityEvent("run-3", { kind: "run.end" });
+    expect(captured[0].seq).toBe(1);
+    expect(typeof captured[0].ts).toBe("number");
+    expect(captured[0].ts).toBeGreaterThan(0);
+  });
+
+  it("increments seq per runId", () => {
+    emitActivityEvent("run-4", { kind: "run.start" });
+    emitActivityEvent("run-4", { kind: "tool.start", toolName: "exec" });
+    emitActivityEvent("run-4", { kind: "tool.end", toolName: "exec", durationMs: 150 });
+    expect(captured.map((e) => e.seq)).toEqual([1, 2, 3]);
+  });
+
+  it("emits all activity event kinds without error", () => {
+    const kinds: ActivityEventData["kind"][] = [
+      "run.start",
+      "run.end",
+      "run.error",
+      "tool.start",
+      "tool.end",
+      "thinking.start",
+      "thinking.end",
+      "subagent.start",
+      "subagent.end",
+    ];
+    for (const kind of kinds) {
+      emitActivityEvent("run-kinds", { kind });
+    }
+    expect(captured).toHaveLength(kinds.length);
+    expect(captured.map((e) => (e.data as ActivityEventData).kind)).toEqual(kinds);
+  });
+});

--- a/src/infra/activity-events.test.ts
+++ b/src/infra/activity-events.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { emitActivityEvent, type ActivityEventData } from "./activity-events.js";
+import {
+  emitActivityEvent,
+  summarizeForMetadata,
+  type ActivityEventData,
+} from "./activity-events.js";
 import { onAgentEvent, resetAgentEventsForTest, type AgentEventPayload } from "./agent-events.js";
 
 describe("emitActivityEvent", () => {
@@ -60,5 +64,27 @@ describe("emitActivityEvent", () => {
     }
     expect(captured).toHaveLength(kinds.length);
     expect(captured.map((e) => (e.data as ActivityEventData).kind)).toEqual(kinds);
+  });
+});
+
+describe("summarizeForMetadata", () => {
+  it("returns undefined for null/undefined", () => {
+    expect(summarizeForMetadata(null)).toBeUndefined();
+    expect(summarizeForMetadata(undefined)).toBeUndefined();
+  });
+
+  it("serializes objects to JSON", () => {
+    expect(summarizeForMetadata({ path: "foo.ts" })).toBe('{"path":"foo.ts"}');
+  });
+
+  it("passes through short strings", () => {
+    expect(summarizeForMetadata("hello")).toBe("hello");
+  });
+
+  it("truncates long values", () => {
+    const long = "x".repeat(3000);
+    const result = summarizeForMetadata(long, 100)!;
+    expect(result.length).toBe(101);
+    expect(result.endsWith("…")).toBe(true);
   });
 });

--- a/src/infra/activity-events.ts
+++ b/src/infra/activity-events.ts
@@ -24,6 +24,26 @@ export type ActivityEventData = {
   metadata?: Record<string, unknown>;
 };
 
+const DEFAULT_METADATA_MAX_LEN = 2048;
+
+export function summarizeForMetadata(
+  value: unknown,
+  maxLen = DEFAULT_METADATA_MAX_LEN,
+): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  try {
+    const json = typeof value === "string" ? value : JSON.stringify(value);
+    if (json.length <= maxLen) {
+      return json;
+    }
+    return `${json.slice(0, maxLen)}…`;
+  } catch {
+    return undefined;
+  }
+}
+
 export function emitActivityEvent(
   runId: string,
   data: ActivityEventData,

--- a/src/infra/activity-events.ts
+++ b/src/infra/activity-events.ts
@@ -1,0 +1,38 @@
+import { emitAgentEvent } from "./agent-events.js";
+
+export type ActivityEventKind =
+  | "run.start"
+  | "run.end"
+  | "run.error"
+  | "tool.start"
+  | "tool.end"
+  | "thinking.start"
+  | "thinking.end"
+  | "subagent.start"
+  | "subagent.end";
+
+export type ActivityEventData = {
+  kind: ActivityEventKind;
+  agentId?: string;
+  parentRunId?: string;
+  depth?: number;
+  toolName?: string;
+  toolCallId?: string;
+  durationMs?: number;
+  isError?: boolean;
+  error?: string;
+  metadata?: Record<string, unknown>;
+};
+
+export function emitActivityEvent(
+  runId: string,
+  data: ActivityEventData,
+  sessionKey?: string,
+): void {
+  emitAgentEvent({
+    runId,
+    stream: "activity",
+    data: data as Record<string, unknown>,
+    sessionKey,
+  });
+}

--- a/src/infra/activity-events.ts
+++ b/src/infra/activity-events.ts
@@ -9,7 +9,8 @@ export type ActivityEventKind =
   | "thinking.start"
   | "thinking.end"
   | "subagent.start"
-  | "subagent.end";
+  | "subagent.end"
+  | "subagent.completed";
 
 export type ActivityEventData = {
   kind: ActivityEventKind;

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -26,6 +26,7 @@ export const de: TranslationMap = {
   tabs: {
     agents: "Agenten",
     overview: "Übersicht",
+    activity: "Aktivität",
     channels: "Kanäle",
     instances: "Instanzen",
     sessions: "Sitzungen",
@@ -41,6 +42,7 @@ export const de: TranslationMap = {
   subtitles: {
     agents: "Agent-Arbeitsbereiche, Tools und Identitäten verwalten.",
     overview: "Gateway-Status, Einstiegspunkte und eine schnelle Zustandsprüfung.",
+    activity: "Echtzeit-Agent-Ausführungsbaum und Zeitachse.",
     channels: "Kanäle und Einstellungen verwalten.",
     instances: "Präsenzsignale von verbundenen Clients und Geräten.",
     sessions: "Aktive Sitzungen inspizieren und Standardeinstellungen pro Sitzung anpassen.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -29,6 +29,7 @@ export const en: TranslationMap = {
   tabs: {
     agents: "Agents",
     overview: "Overview",
+    activity: "Activity",
     channels: "Channels",
     instances: "Instances",
     sessions: "Sessions",
@@ -50,6 +51,7 @@ export const en: TranslationMap = {
   subtitles: {
     agents: "Workspaces, tools, identities.",
     overview: "Status, entry points, health.",
+    activity: "Live agent execution tree and timeline.",
     channels: "Channels and settings.",
     instances: "Connected clients and nodes.",
     sessions: "Active sessions and defaults.",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -26,6 +26,7 @@ export const es: TranslationMap = {
   tabs: {
     agents: "Agentes",
     overview: "Resumen",
+    activity: "Actividad",
     channels: "Canales",
     instances: "Instancias",
     sessions: "Sesiones",
@@ -41,6 +42,7 @@ export const es: TranslationMap = {
   subtitles: {
     agents: "Gestionar espacios de trabajo, herramientas e identidades de agentes.",
     overview: "Estado de la puerta de enlace, puntos de entrada y lectura rápida de salud.",
+    activity: "Árbol de ejecución del agente y línea de tiempo en tiempo real.",
     channels: "Gestionar canales y ajustes.",
     instances: "Balizas de presencia de clientes y nodos conectados.",
     sessions: "Inspeccionar sesiones activas y ajustar valores predeterminados por sesión.",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -28,6 +28,7 @@ export const pt_BR: TranslationMap = {
   tabs: {
     agents: "Agentes",
     overview: "Visão Geral",
+    activity: "Atividade",
     channels: "Canais",
     instances: "Instâncias",
     sessions: "Sessões",
@@ -48,6 +49,7 @@ export const pt_BR: TranslationMap = {
   subtitles: {
     agents: "Espaços, ferramentas, identidades.",
     overview: "Status, entrada, saúde.",
+    activity: "Árvore de execução do agente e linha do tempo em tempo real.",
     channels: "Canais e configurações.",
     instances: "Clientes e nós conectados.",
     sessions: "Sessões ativas e padrões.",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -28,6 +28,7 @@ export const zh_CN: TranslationMap = {
   tabs: {
     agents: "代理",
     overview: "概览",
+    activity: "活动",
     channels: "频道",
     instances: "实例",
     sessions: "会话",
@@ -48,6 +49,7 @@ export const zh_CN: TranslationMap = {
   subtitles: {
     agents: "工作区、工具、身份。",
     overview: "状态、入口点、健康。",
+    activity: "实时代理执行树和时间线。",
     channels: "频道和设置。",
     instances: "已连接客户端和节点。",
     sessions: "活动会话和默认设置。",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -28,6 +28,7 @@ export const zh_TW: TranslationMap = {
   tabs: {
     agents: "代理",
     overview: "概覽",
+    activity: "活動",
     channels: "頻道",
     instances: "實例",
     sessions: "會話",
@@ -48,6 +49,7 @@ export const zh_TW: TranslationMap = {
   subtitles: {
     agents: "工作區、工具、身份。",
     overview: "狀態、入口點、健康。",
+    activity: "即時代理執行樹和時間線。",
     channels: "頻道和設置。",
     instances: "已連接客戶端和節點。",
     sessions: "活動會話和默認設置。",

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -6,6 +6,7 @@
 @import "./styles/config.css";
 @import "./styles/usage.css";
 @import "./styles/dreams.css";
+@import "./styles/activity.css";
 @import "@create-markdown/preview/themes/system.css";
 
 .cm-preview {

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -193,8 +193,44 @@
   height: 14px;
 }
 
+.activity-node__kind-tag {
+  font-size: 0.65rem;
+  padding: 1px 5px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  flex-shrink: 0;
+  background: var(--bg-card, rgba(255, 255, 255, 0.06));
+  color: var(--color-muted, #888);
+}
+
+.activity-node__kind-tag--run {
+  color: var(--color-accent, #ff5a36);
+  background: rgba(255, 90, 54, 0.12);
+}
+
+.activity-node__kind-tag--tool {
+  color: var(--color-accent, #5b9bd5);
+  background: rgba(91, 155, 213, 0.12);
+}
+
+.activity-node__kind-tag--thinking {
+  color: #9b59b6;
+  background: rgba(155, 89, 182, 0.12);
+}
+
+.activity-node__kind-tag--subagent {
+  color: var(--color-success, #2ecc71);
+  background: rgba(46, 204, 113, 0.12);
+}
+
 .activity-node__label {
   font-weight: 500;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .activity-node__duration {

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -1,0 +1,436 @@
+/* Activity tab styles */
+
+.activity-view {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+}
+
+/* Metrics bar — card style with sparklines */
+.activity-metrics-bar {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.activity-metric-card {
+  display: flex;
+  flex-direction: column;
+  padding: 0.6rem 1rem;
+  border-radius: var(--radius, 8px);
+  background: var(--bg-card, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  min-width: 100px;
+  flex: 1;
+}
+
+.activity-metric-card--active {
+  border-color: var(--color-accent, #ff5a36);
+}
+
+.activity-metric-card--error .activity-metric-card__value {
+  color: var(--color-error, #e74c3c);
+}
+
+.activity-metric-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.activity-metric-card__value {
+  font-size: 1.4rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.activity-metric-card__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 0.25rem;
+}
+
+/* Sparkline SVG */
+.activity-sparkline {
+  width: 60px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.activity-sparkline polyline {
+  fill: none;
+  stroke: var(--color-accent, #ff5a36);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+/* Filters bar */
+.activity-filters {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.activity-filters__search {
+  padding: 0.35rem 0.6rem;
+  border-radius: var(--radius, 8px);
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card, rgba(255, 255, 255, 0.04));
+  color: inherit;
+  font-size: 0.8rem;
+  min-width: 160px;
+  outline: none;
+}
+
+.activity-filters__search:focus {
+  border-color: var(--color-accent, #ff5a36);
+}
+
+.activity-filters__kinds {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.activity-filters__kind {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.activity-filters__kind input[type="checkbox"] {
+  accent-color: var(--color-accent, #ff5a36);
+}
+
+.activity-filters__time {
+  display: flex;
+  gap: 0.25rem;
+  margin-left: auto;
+}
+
+.btn--xs {
+  padding: 0.15rem 0.5rem;
+  font-size: 0.7rem;
+}
+
+.btn--active {
+  background: var(--color-accent, #ff5a36);
+  color: #fff;
+  border-color: var(--color-accent, #ff5a36);
+}
+
+/* Panels */
+.activity-panels {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.activity-panels--with-detail {
+  grid-template-columns: 1fr 1fr 320px;
+}
+
+.activity-panel {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  border-radius: var(--radius, 8px);
+  overflow: hidden;
+}
+
+.activity-panel__header {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card, rgba(255, 255, 255, 0.02));
+}
+
+.activity-panel__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.5rem;
+}
+
+/* Tree nodes */
+.activity-node {
+  font-size: 0.85rem;
+}
+
+.activity-node__row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.4rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.activity-node__row:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+}
+
+.activity-node__row:focus-visible {
+  outline: 2px solid var(--color-accent, #ff5a36);
+  outline-offset: -1px;
+}
+
+.activity-node__icon {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+}
+
+.activity-node__label {
+  font-weight: 500;
+}
+
+.activity-node__duration {
+  font-size: 0.75rem;
+  margin-left: auto;
+}
+
+.activity-node__error {
+  font-size: 0.75rem;
+  color: var(--color-error, #e74c3c);
+}
+
+/* Status indicators */
+.activity-status {
+  flex-shrink: 0;
+  width: 14px;
+  text-align: center;
+  font-size: 0.75rem;
+}
+
+.activity-status--running {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--color-accent, #ff5a36);
+  animation: activity-pulse 1.2s infinite;
+}
+
+.activity-status--done {
+  color: var(--color-success, #2ecc71);
+}
+
+.activity-status--error {
+  color: var(--color-error, #e74c3c);
+}
+
+.activity-status--pending {
+  color: var(--color-muted, #888);
+}
+
+@keyframes activity-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+
+/* Timeline */
+.activity-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.activity-timeline-empty {
+  padding: 2rem;
+  text-align: center;
+}
+
+.activity-timeline__entry {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.8rem;
+  border-radius: 4px;
+}
+
+.activity-timeline__entry:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.04));
+}
+
+.activity-timeline__entry--error {
+  color: var(--color-error, #e74c3c);
+}
+
+.activity-timeline__ts {
+  font-size: 0.7rem;
+  flex-shrink: 0;
+  width: 70px;
+}
+
+.activity-timeline__dot {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+}
+
+.activity-timeline__label {
+  font-weight: 500;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-timeline__status {
+  font-size: 0.7rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--bg-card, rgba(255, 255, 255, 0.04));
+}
+
+.activity-timeline__status--running {
+  color: var(--color-accent, #ff5a36);
+}
+
+.activity-timeline__status--completed {
+  color: var(--color-success, #2ecc71);
+}
+
+.activity-timeline__status--error {
+  color: var(--color-error, #e74c3c);
+}
+
+.activity-timeline__duration {
+  font-size: 0.7rem;
+  flex-shrink: 0;
+}
+
+/* Detail panel */
+.activity-detail {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.activity-detail__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card, rgba(255, 255, 255, 0.02));
+}
+
+.activity-detail__title {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.activity-detail__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.activity-detail__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.activity-detail__section--error {
+  color: var(--color-error, #e74c3c);
+}
+
+.activity-detail__section-title {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.activity-detail__field {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  padding: 0.15rem 0;
+}
+
+.activity-detail__field-label {
+  flex-shrink: 0;
+}
+
+.activity-detail__field-value {
+  text-align: right;
+  word-break: break-all;
+}
+
+.activity-detail__json {
+  font-size: 0.75rem;
+  background: var(--bg-card, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.08));
+  border-radius: 4px;
+  padding: 0.5rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  margin: 0;
+}
+
+.activity-detail__error {
+  font-size: 0.8rem;
+  background: rgba(231, 76, 60, 0.1);
+  border: 1px solid rgba(231, 76, 60, 0.2);
+  border-radius: 4px;
+  padding: 0.5rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin: 0;
+}
+
+/* Empty state */
+.activity-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.activity-empty__icon {
+  width: 48px;
+  height: 48px;
+  opacity: 0.3;
+}
+
+.activity-empty__text {
+  max-width: 320px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .activity-panels,
+  .activity-panels--with-detail {
+    grid-template-columns: 1fr;
+  }
+}

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -442,6 +442,23 @@
   margin: 0;
 }
 
+/* JSON syntax highlighting */
+.json-key {
+  color: #e06c75;
+}
+
+.json-string {
+  color: #98c379;
+}
+
+.json-number {
+  color: #d19a66;
+}
+
+.json-bool {
+  color: #56b6c2;
+}
+
 /* Empty state */
 .activity-empty {
   display: flex;

--- a/ui/src/ui/activity/activity-controller.ts
+++ b/ui/src/ui/activity/activity-controller.ts
@@ -151,6 +151,13 @@ export class ActivityController implements ReactiveController {
     if (payload.stream !== "activity") {
       return;
     }
+    // eslint-disable-next-line no-console
+    console.log(
+      "[activity]",
+      payload.data?.kind,
+      "metadata:",
+      JSON.stringify(payload.data?.metadata),
+    );
 
     this._tree = applyActivityEvent(this._tree, {
       runId: payload.runId,

--- a/ui/src/ui/activity/activity-controller.ts
+++ b/ui/src/ui/activity/activity-controller.ts
@@ -151,9 +151,6 @@ export class ActivityController implements ReactiveController {
     if (payload.stream !== "activity") {
       return;
     }
-    // eslint-disable-next-line no-console
-    console.log("[activity]", JSON.stringify(payload.data));
-
     this._tree = applyActivityEvent(this._tree, {
       runId: payload.runId,
       ts: payload.ts,

--- a/ui/src/ui/activity/activity-controller.ts
+++ b/ui/src/ui/activity/activity-controller.ts
@@ -1,4 +1,5 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { AgentEventPayload } from "../app-tool-stream.ts";
 import {
   createMetricsHistory,
@@ -12,6 +13,8 @@ import {
   computeMetrics,
   pruneCompletedBranches,
   filterTree,
+  serializeTree,
+  deserializeTree,
   type ActivityFilterCriteria,
 } from "./activity-tree.ts";
 import type {
@@ -24,9 +27,70 @@ import type {
 const THROTTLE_MS = 100;
 const PRUNE_INTERVAL_MS = 30_000;
 const METRICS_SAMPLE_INTERVAL_MS = 2_000;
+const SAVE_DEBOUNCE_MS = 500;
+const STORAGE_KEY = "openclaw.activity.tree.v1";
+const MAX_STORAGE_BYTES = 500_000;
+
+function loadPersistedTree(): ActivityTree {
+  try {
+    const storage = getSafeLocalStorage();
+    if (!storage) {
+      return createActivityTree();
+    }
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return createActivityTree();
+    }
+    const parsed = JSON.parse(raw);
+    const tree = deserializeTree(parsed);
+    if (!tree) {
+      return createActivityTree();
+    }
+    // Mark any previously-running nodes as stale (they didn't finish before refresh).
+    for (const node of tree.nodeById.values()) {
+      if (node.status === "running") {
+        node.status = "completed";
+        node.endedAt = node.endedAt ?? node.startedAt;
+        node.durationMs = node.durationMs ?? 0;
+      }
+    }
+    return tree;
+  } catch {
+    return createActivityTree();
+  }
+}
+
+function saveTree(tree: ActivityTree): void {
+  try {
+    const storage = getSafeLocalStorage();
+    if (!storage) {
+      return;
+    }
+    const serialized = JSON.stringify(serializeTree(tree));
+    if (serialized.length > MAX_STORAGE_BYTES) {
+      pruneCompletedBranches(tree, 0);
+      const pruned = JSON.stringify(serializeTree(tree));
+      if (pruned.length <= MAX_STORAGE_BYTES) {
+        storage.setItem(STORAGE_KEY, pruned);
+      }
+      return;
+    }
+    storage.setItem(STORAGE_KEY, serialized);
+  } catch {
+    // Quota exceeded or other storage error — skip silently.
+  }
+}
+
+function clearPersistedTree(): void {
+  try {
+    getSafeLocalStorage()?.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore.
+  }
+}
 
 export class ActivityController implements ReactiveController {
-  private _tree: ActivityTree = createActivityTree();
+  private _tree: ActivityTree;
   private _metrics: ActivityMetrics = {
     activeRuns: 0,
     activeTools: 0,
@@ -43,12 +107,15 @@ export class ActivityController implements ReactiveController {
   };
   private _host: ReactiveControllerHost;
   private _updateTimer: ReturnType<typeof setTimeout> | null = null;
+  private _saveTimer: ReturnType<typeof setTimeout> | null = null;
   private _pruneTimer: ReturnType<typeof setInterval> | null = null;
   private _sampleTimer: ReturnType<typeof setInterval> | null = null;
   private _dirty = false;
 
   constructor(host: ReactiveControllerHost) {
     this._host = host;
+    this._tree = loadPersistedTree();
+    this._metrics = computeMetrics(this._tree);
     host.addController(this);
   }
 
@@ -145,6 +212,12 @@ export class ActivityController implements ReactiveController {
       clearTimeout(this._updateTimer);
       this._updateTimer = null;
     }
+    if (this._saveTimer !== null) {
+      clearTimeout(this._saveTimer);
+      this._saveTimer = null;
+    }
+    // Final save on disconnect.
+    saveTree(this._tree);
   }
 
   handleEvent(payload: AgentEventPayload): void {
@@ -171,6 +244,7 @@ export class ActivityController implements ReactiveController {
 
     this._dirty = true;
     this._scheduleUpdate();
+    this._scheduleSave();
   }
 
   reset(): void {
@@ -184,6 +258,7 @@ export class ActivityController implements ReactiveController {
     };
     this._metricsHistory = createMetricsHistory();
     this._selectedNodeId = null;
+    clearPersistedTree();
     this._host.requestUpdate();
   }
 
@@ -199,5 +274,15 @@ export class ActivityController implements ReactiveController {
         this._host.requestUpdate();
       }
     }, THROTTLE_MS);
+  }
+
+  private _scheduleSave(): void {
+    if (this._saveTimer !== null) {
+      return;
+    }
+    this._saveTimer = setTimeout(() => {
+      this._saveTimer = null;
+      saveTree(this._tree);
+    }, SAVE_DEBOUNCE_MS);
   }
 }

--- a/ui/src/ui/activity/activity-controller.ts
+++ b/ui/src/ui/activity/activity-controller.ts
@@ -1,0 +1,204 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { AgentEventPayload } from "../app-tool-stream.ts";
+import {
+  createMetricsHistory,
+  pushSample,
+  getSparklineData,
+  type MetricsHistory,
+} from "./activity-metrics-history.ts";
+import {
+  createActivityTree,
+  applyActivityEvent,
+  computeMetrics,
+  pruneCompletedBranches,
+  filterTree,
+  type ActivityFilterCriteria,
+} from "./activity-tree.ts";
+import type {
+  ActivityTree,
+  ActivityMetrics,
+  ActivityNode,
+  ActivityNodeKind,
+} from "./activity-types.ts";
+
+const THROTTLE_MS = 100;
+const PRUNE_INTERVAL_MS = 30_000;
+const METRICS_SAMPLE_INTERVAL_MS = 2_000;
+
+export class ActivityController implements ReactiveController {
+  private _tree: ActivityTree = createActivityTree();
+  private _metrics: ActivityMetrics = {
+    activeRuns: 0,
+    activeTools: 0,
+    totalToolCalls: 0,
+    totalErrors: 0,
+    completedNodes: 0,
+  };
+  private _metricsHistory: MetricsHistory = createMetricsHistory();
+  private _selectedNodeId: string | null = null;
+  private _filters: ActivityFilterCriteria = {
+    kinds: new Set<ActivityNodeKind>(["run", "tool", "thinking", "subagent"]),
+    search: "",
+    timeRangeMs: null,
+  };
+  private _host: ReactiveControllerHost;
+  private _updateTimer: ReturnType<typeof setTimeout> | null = null;
+  private _pruneTimer: ReturnType<typeof setInterval> | null = null;
+  private _sampleTimer: ReturnType<typeof setInterval> | null = null;
+  private _dirty = false;
+
+  constructor(host: ReactiveControllerHost) {
+    this._host = host;
+    host.addController(this);
+  }
+
+  get tree(): ActivityTree {
+    return this._tree;
+  }
+
+  get filteredTree(): ActivityTree {
+    const hasFilters =
+      this._filters.search !== "" ||
+      this._filters.timeRangeMs !== null ||
+      this._filters.kinds.size < 4;
+    if (!hasFilters) {
+      return this._tree;
+    }
+    return filterTree(this._tree, this._filters);
+  }
+
+  get filters(): ActivityFilterCriteria {
+    return this._filters;
+  }
+
+  get metrics(): ActivityMetrics {
+    return this._metrics;
+  }
+
+  get selectedNode(): ActivityNode | null {
+    if (!this._selectedNodeId) {
+      return null;
+    }
+    return this._tree.nodeById.get(this._selectedNodeId) ?? null;
+  }
+
+  get toolCallsHistory(): number[] {
+    return getSparklineData(this._metricsHistory, (m) => m.totalToolCalls);
+  }
+
+  get errorsHistory(): number[] {
+    return getSparklineData(this._metricsHistory, (m) => m.totalErrors);
+  }
+
+  get activeRunsHistory(): number[] {
+    return getSparklineData(this._metricsHistory, (m) => m.activeRuns);
+  }
+
+  selectNode(nodeId: string | null): void {
+    this._selectedNodeId = nodeId;
+    this._host.requestUpdate();
+  }
+
+  setSearch(search: string): void {
+    this._filters = { ...this._filters, search };
+    this._host.requestUpdate();
+  }
+
+  toggleKind(kind: ActivityNodeKind): void {
+    const next = new Set(this._filters.kinds);
+    if (next.has(kind)) {
+      next.delete(kind);
+    } else {
+      next.add(kind);
+    }
+    this._filters = { ...this._filters, kinds: next };
+    this._host.requestUpdate();
+  }
+
+  setTimeRange(ms: number | null): void {
+    this._filters = { ...this._filters, timeRangeMs: ms };
+    this._host.requestUpdate();
+  }
+
+  hostConnected(): void {
+    this._pruneTimer = setInterval(() => {
+      pruneCompletedBranches(this._tree);
+      this._metrics = computeMetrics(this._tree);
+      this._host.requestUpdate();
+    }, PRUNE_INTERVAL_MS);
+
+    this._sampleTimer = setInterval(() => {
+      pushSample(this._metricsHistory, this._metrics);
+    }, METRICS_SAMPLE_INTERVAL_MS);
+  }
+
+  hostDisconnected(): void {
+    if (this._pruneTimer !== null) {
+      clearInterval(this._pruneTimer);
+      this._pruneTimer = null;
+    }
+    if (this._sampleTimer !== null) {
+      clearInterval(this._sampleTimer);
+      this._sampleTimer = null;
+    }
+    if (this._updateTimer !== null) {
+      clearTimeout(this._updateTimer);
+      this._updateTimer = null;
+    }
+  }
+
+  handleEvent(payload: AgentEventPayload): void {
+    if (payload.stream !== "activity") {
+      return;
+    }
+
+    this._tree = applyActivityEvent(this._tree, {
+      runId: payload.runId,
+      ts: payload.ts,
+      sessionKey: payload.sessionKey,
+      data: payload.data as {
+        kind: string;
+        agentId?: string;
+        parentRunId?: string;
+        depth?: number;
+        toolName?: string;
+        toolCallId?: string;
+        durationMs?: number;
+        isError?: boolean;
+        error?: string;
+        metadata?: Record<string, unknown>;
+      },
+    });
+
+    this._dirty = true;
+    this._scheduleUpdate();
+  }
+
+  reset(): void {
+    this._tree = createActivityTree();
+    this._metrics = {
+      activeRuns: 0,
+      activeTools: 0,
+      totalToolCalls: 0,
+      totalErrors: 0,
+      completedNodes: 0,
+    };
+    this._metricsHistory = createMetricsHistory();
+    this._selectedNodeId = null;
+    this._host.requestUpdate();
+  }
+
+  private _scheduleUpdate(): void {
+    if (this._updateTimer !== null) {
+      return;
+    }
+    this._updateTimer = setTimeout(() => {
+      this._updateTimer = null;
+      if (this._dirty) {
+        this._dirty = false;
+        this._metrics = computeMetrics(this._tree);
+        this._host.requestUpdate();
+      }
+    }, THROTTLE_MS);
+  }
+}

--- a/ui/src/ui/activity/activity-controller.ts
+++ b/ui/src/ui/activity/activity-controller.ts
@@ -152,12 +152,7 @@ export class ActivityController implements ReactiveController {
       return;
     }
     // eslint-disable-next-line no-console
-    console.log(
-      "[activity]",
-      payload.data?.kind,
-      "metadata:",
-      JSON.stringify(payload.data?.metadata),
-    );
+    console.log("[activity]", JSON.stringify(payload.data));
 
     this._tree = applyActivityEvent(this._tree, {
       runId: payload.runId,

--- a/ui/src/ui/activity/activity-metrics-history.ts
+++ b/ui/src/ui/activity/activity-metrics-history.ts
@@ -1,0 +1,30 @@
+import type { ActivityMetrics } from "./activity-types.ts";
+
+const MAX_SAMPLES = 60;
+
+export type MetricsSample = {
+  ts: number;
+  metrics: ActivityMetrics;
+};
+
+export type MetricsHistory = {
+  samples: MetricsSample[];
+};
+
+export function createMetricsHistory(): MetricsHistory {
+  return { samples: [] };
+}
+
+export function pushSample(history: MetricsHistory, metrics: ActivityMetrics): void {
+  history.samples.push({ ts: Date.now(), metrics });
+  if (history.samples.length > MAX_SAMPLES) {
+    history.samples.splice(0, history.samples.length - MAX_SAMPLES);
+  }
+}
+
+export function getSparklineData(
+  history: MetricsHistory,
+  accessor: (m: ActivityMetrics) => number,
+): number[] {
+  return history.samples.map((s) => accessor(s.metrics));
+}

--- a/ui/src/ui/activity/activity-tree.test.ts
+++ b/ui/src/ui/activity/activity-tree.test.ts
@@ -6,6 +6,8 @@ import {
   flattenTimeline,
   pruneCompletedBranches,
   filterTree,
+  serializeTree,
+  deserializeTree,
 } from "./activity-tree.ts";
 
 function makeEvent(
@@ -282,5 +284,47 @@ describe("activity-tree", () => {
     const tool = tree.nodeById.get("r1:tool:t1")!;
     expect(tool.metadata.args).toBe('{"path":"foo.ts"}');
     expect(tool.metadata.result).toBe('"file contents"');
+  });
+
+  it("serialize/deserialize round-trips correctly", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }));
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", {
+        toolName: "exec",
+        toolCallId: "t1",
+        metadata: { args: '{"cmd":"ls"}' },
+      }),
+    );
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.end", { toolName: "exec", toolCallId: "t1", durationMs: 50 }),
+    );
+
+    const serialized = serializeTree(tree);
+    const json = JSON.stringify(serialized);
+    const restored = deserializeTree(JSON.parse(json))!;
+
+    expect(restored).not.toBeNull();
+    expect(restored.totalNodes).toBe(tree.totalNodes);
+    expect(restored.rootNodes).toEqual(tree.rootNodes);
+    expect(restored.nodeById.size).toBe(tree.nodeById.size);
+
+    const run = restored.nodeById.get("r1")!;
+    expect(run.kind).toBe("run");
+    expect(run.children).toContain("r1:tool:t1");
+
+    const tool = restored.nodeById.get("r1:tool:t1")!;
+    expect(tool.kind).toBe("tool");
+    expect(tool.status).toBe("completed");
+    expect(tool.durationMs).toBe(50);
+    expect(tool.metadata.args).toBe('{"cmd":"ls"}');
+  });
+
+  it("deserializeTree returns null for invalid data", () => {
+    expect(deserializeTree(null)).toBeNull();
+    expect(deserializeTree("bad")).toBeNull();
+    expect(deserializeTree({})).toBeNull();
   });
 });

--- a/ui/src/ui/activity/activity-tree.test.ts
+++ b/ui/src/ui/activity/activity-tree.test.ts
@@ -223,4 +223,64 @@ describe("activity-tree", () => {
     expect(filtered.nodeById.has("new")).toBe(true);
     expect(filtered.nodeById.has("old")).toBe(false);
   });
+
+  it("nests tools under their parent run node", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }));
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "read", toolCallId: "t1" }),
+    );
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "exec", toolCallId: "t2" }),
+    );
+
+    const run = tree.nodeById.get("r1")!;
+    expect(run.children).toEqual(["r1:tool:t1", "r1:tool:t2"]);
+    expect(tree.rootNodes).toEqual(["r1"]);
+
+    const tool = tree.nodeById.get("r1:tool:t1")!;
+    expect(tool.parentId).toBe("r1");
+    expect(tool.depth).toBe(1);
+  });
+
+  it("nests thinking under parent run", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }));
+    tree = applyActivityEvent(tree, makeEvent("r1", "thinking.start", { agentId: "main" }));
+
+    const run = tree.nodeById.get("r1")!;
+    expect(run.children).toContain("r1:thinking");
+    expect(tree.rootNodes).toEqual(["r1"]);
+
+    const thinking = tree.nodeById.get("r1:thinking")!;
+    expect(thinking.parentId).toBe("r1");
+    expect(thinking.kind).toBe("thinking");
+  });
+
+  it("merges metadata from end events", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }));
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", {
+        toolName: "read",
+        toolCallId: "t1",
+        metadata: { args: '{"path":"foo.ts"}' },
+      }),
+    );
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.end", {
+        toolName: "read",
+        toolCallId: "t1",
+        metadata: { result: '"file contents"' },
+      }),
+    );
+
+    const tool = tree.nodeById.get("r1:tool:t1")!;
+    expect(tool.metadata.args).toBe('{"path":"foo.ts"}');
+    expect(tool.metadata.result).toBe('"file contents"');
+  });
 });

--- a/ui/src/ui/activity/activity-tree.test.ts
+++ b/ui/src/ui/activity/activity-tree.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import {
+  createActivityTree,
+  applyActivityEvent,
+  computeMetrics,
+  flattenTimeline,
+  pruneCompletedBranches,
+  filterTree,
+} from "./activity-tree.ts";
+
+function makeEvent(
+  runId: string,
+  kind: string,
+  extra: Record<string, unknown> = {},
+  ts = Date.now(),
+) {
+  return {
+    runId,
+    ts,
+    data: { kind, ...extra },
+  };
+}
+
+describe("activity-tree", () => {
+  it("creates an empty tree", () => {
+    const tree = createActivityTree();
+    expect(tree.totalNodes).toBe(0);
+    expect(tree.rootNodes).toEqual([]);
+  });
+
+  it("adds a run.start node", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }));
+    expect(tree.totalNodes).toBe(1);
+    expect(tree.rootNodes).toHaveLength(1);
+
+    const node = tree.nodeById.get("r1")!;
+    expect(node.kind).toBe("run");
+    expect(node.status).toBe("running");
+    expect(node.label).toBe("main");
+  });
+
+  it("completes a run on run.end", () => {
+    let tree = createActivityTree();
+    const t0 = Date.now();
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }, t0));
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.end", { agentId: "main" }, t0 + 500));
+
+    const node = tree.nodeById.get("r1")!;
+    expect(node.status).toBe("completed");
+    expect(node.durationMs).toBe(500);
+  });
+
+  it("marks run as error on run.error", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }));
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "run.error", { agentId: "main", isError: true, error: "LLM failed" }),
+    );
+
+    const node = tree.nodeById.get("r1")!;
+    expect(node.status).toBe("error");
+    expect(node.isError).toBe(true);
+    expect(node.error).toBe("LLM failed");
+  });
+
+  it("tracks tool start and end", () => {
+    let tree = createActivityTree();
+    const t0 = Date.now();
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "read", toolCallId: "tc1" }, t0),
+    );
+    expect(tree.totalNodes).toBe(1);
+
+    const toolNode = tree.nodeById.get("r1:tool:tc1")!;
+    expect(toolNode.kind).toBe("tool");
+    expect(toolNode.status).toBe("running");
+    expect(toolNode.label).toBe("read");
+
+    tree = applyActivityEvent(
+      tree,
+      makeEvent(
+        "r1",
+        "tool.end",
+        { toolName: "read", toolCallId: "tc1", durationMs: 120 },
+        t0 + 120,
+      ),
+    );
+
+    expect(toolNode.status).toBe("completed");
+    expect(toolNode.durationMs).toBe(120);
+  });
+
+  it("tracks subagent events", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "subagent.start", { agentId: "ops", depth: 1 }),
+    );
+    const node = tree.nodeById.get("r1:subagent:ops")!;
+    expect(node.kind).toBe("subagent");
+    expect(node.depth).toBe(1);
+
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "subagent.end", { agentId: "ops", depth: 1, durationMs: 2000 }),
+    );
+    expect(node.status).toBe("completed");
+    expect(node.durationMs).toBe(2000);
+  });
+
+  it("computes metrics correctly", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }));
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "exec", toolCallId: "t1" }),
+    );
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "read", toolCallId: "t2" }),
+    );
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.end", { toolName: "exec", toolCallId: "t1" }),
+    );
+
+    const metrics = computeMetrics(tree);
+    expect(metrics.activeRuns).toBe(1);
+    expect(metrics.activeTools).toBe(1);
+    expect(metrics.totalToolCalls).toBe(2);
+    expect(metrics.completedNodes).toBe(1);
+    expect(metrics.totalErrors).toBe(0);
+  });
+
+  it("flattenTimeline returns sorted entries", () => {
+    let tree = createActivityTree();
+    const t0 = 1000;
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }, t0));
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "exec", toolCallId: "t1" }, t0 + 100),
+    );
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "read", toolCallId: "t2" }, t0 + 50),
+    );
+
+    const timeline = flattenTimeline(tree);
+    expect(timeline).toHaveLength(3);
+    expect(timeline[0].ts).toBe(t0);
+    expect(timeline[1].ts).toBe(t0 + 50);
+    expect(timeline[2].ts).toBe(t0 + 100);
+  });
+
+  it("prunes completed branches older than maxAge", () => {
+    let tree = createActivityTree();
+    const oldTs = Date.now() - 10 * 60 * 1000;
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }, oldTs));
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.end", { agentId: "main" }, oldTs + 100));
+    tree = applyActivityEvent(tree, makeEvent("r2", "run.start", { agentId: "ops" }));
+
+    expect(tree.totalNodes).toBe(2);
+
+    pruneCompletedBranches(tree);
+    expect(tree.totalNodes).toBe(1);
+    expect(tree.nodeById.has("r1")).toBe(false);
+    expect(tree.nodeById.has("r2")).toBe(true);
+  });
+
+  it("filterTree filters by kind", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(tree, makeEvent("r1", "run.start", { agentId: "main" }));
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "exec", toolCallId: "t1" }),
+    );
+
+    const filtered = filterTree(tree, {
+      kinds: new Set(["tool"]),
+      search: "",
+      timeRangeMs: null,
+    });
+    expect(filtered.totalNodes).toBe(1);
+    expect(filtered.nodeById.has("r1:tool:t1")).toBe(true);
+    expect(filtered.nodeById.has("r1")).toBe(false);
+  });
+
+  it("filterTree filters by search text", () => {
+    let tree = createActivityTree();
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "read", toolCallId: "t1" }),
+    );
+    tree = applyActivityEvent(
+      tree,
+      makeEvent("r1", "tool.start", { toolName: "exec", toolCallId: "t2" }),
+    );
+
+    const filtered = filterTree(tree, {
+      kinds: new Set(["run", "tool", "thinking", "subagent"]),
+      search: "read",
+      timeRangeMs: null,
+    });
+    expect(filtered.totalNodes).toBe(1);
+    expect(filtered.nodeById.has("r1:tool:t1")).toBe(true);
+  });
+
+  it("filterTree filters by time range", () => {
+    let tree = createActivityTree();
+    const oldTs = Date.now() - 10 * 60 * 1000;
+    tree = applyActivityEvent(tree, makeEvent("old", "run.start", { agentId: "main" }, oldTs));
+    tree = applyActivityEvent(tree, makeEvent("new", "run.start", { agentId: "ops" }));
+
+    const filtered = filterTree(tree, {
+      kinds: new Set(["run", "tool", "thinking", "subagent"]),
+      search: "",
+      timeRangeMs: 5 * 60 * 1000,
+    });
+    expect(filtered.totalNodes).toBe(1);
+    expect(filtered.nodeById.has("new")).toBe(true);
+    expect(filtered.nodeById.has("old")).toBe(false);
+  });
+});

--- a/ui/src/ui/activity/activity-tree.ts
+++ b/ui/src/ui/activity/activity-tree.ts
@@ -97,8 +97,22 @@ export function applyActivityEvent(tree: ActivityTree, event: IncomingEvent): Ac
       metadata: data.metadata ?? {},
     };
 
+    // Link tool, thinking, and subagent nodes to their parent run.
+    // For these kinds, event.runId is the parent run's ID.
+    const nodeKind = resolveKind(kind);
+    if (nodeKind !== "run") {
+      const parentRun = tree.nodeById.get(event.runId);
+      if (parentRun) {
+        node.parentId = event.runId;
+        node.depth = parentRun.depth + 1;
+        if (!parentRun.children.includes(nodeId)) {
+          parentRun.children.push(nodeId);
+        }
+      }
+    }
+
     tree.nodeById.set(nodeId, node);
-    if (!tree.rootNodes.includes(nodeId) && !findParent(tree, nodeId)) {
+    if (!node.parentId && !tree.rootNodes.includes(nodeId)) {
       tree.rootNodes.push(nodeId);
     }
     tree.totalNodes = tree.nodeById.size;
@@ -118,20 +132,14 @@ export function applyActivityEvent(tree: ActivityTree, event: IncomingEvent): Ac
       existing.durationMs = data.durationMs ?? event.ts - existing.startedAt;
       existing.isError = data.isError ?? kind.endsWith(".error");
       existing.error = data.error ?? null;
+      if (data.metadata) {
+        existing.metadata = { ...existing.metadata, ...data.metadata };
+      }
     }
     return tree;
   }
 
   return tree;
-}
-
-function findParent(tree: ActivityTree, nodeId: string): string | null {
-  for (const [id, node] of tree.nodeById) {
-    if (id !== nodeId && node.children.includes(nodeId)) {
-      return id;
-    }
-  }
-  return null;
 }
 
 export function pruneCompletedBranches(tree: ActivityTree, maxAgeMs: number = PRUNE_AGE_MS): void {

--- a/ui/src/ui/activity/activity-tree.ts
+++ b/ui/src/ui/activity/activity-tree.ts
@@ -50,9 +50,42 @@ function resolveKind(eventKind: string): ActivityNodeKind {
   return "run";
 }
 
+function summarizeToolArgs(args: unknown): string {
+  if (!args) {
+    return "";
+  }
+  const str = typeof args === "string" ? args : "";
+  if (!str) {
+    return "";
+  }
+  try {
+    const parsed = JSON.parse(str);
+    if (typeof parsed !== "object" || parsed === null) {
+      return "";
+    }
+    // Show the most informative field as a short suffix
+    const path = parsed.path ?? parsed.file_path ?? parsed.filePath;
+    if (typeof path === "string") {
+      return path.length > 60 ? `…${path.slice(-55)}` : path;
+    }
+    const cmd = parsed.command ?? parsed.cmd;
+    if (typeof cmd === "string") {
+      return cmd.length > 60 ? `${cmd.slice(0, 57)}…` : cmd;
+    }
+    const action = parsed.action;
+    if (typeof action === "string") {
+      return action;
+    }
+  } catch {
+    // not JSON
+  }
+  return "";
+}
+
 function resolveLabel(data: ActivityEventData): string {
   if (data.toolName) {
-    return data.toolName;
+    const argsSummary = summarizeToolArgs(data.metadata?.args);
+    return argsSummary ? `${data.toolName}  ${argsSummary}` : data.toolName;
   }
   if (data.agentId) {
     return data.agentId;

--- a/ui/src/ui/activity/activity-tree.ts
+++ b/ui/src/ui/activity/activity-tree.ts
@@ -13,6 +13,7 @@ export function createActivityTree(): ActivityTree {
   return {
     rootNodes: [],
     nodeById: new Map(),
+    sessionKeyToSpawner: new Map(),
     totalNodes: 0,
   };
 }
@@ -87,6 +88,11 @@ function resolveLabel(data: ActivityEventData): string {
     const argsSummary = summarizeToolArgs(data.metadata?.args);
     return argsSummary ? `${data.toolName}  ${argsSummary}` : data.toolName;
   }
+  if (data.kind.startsWith("subagent.") && data.agentId) {
+    const task = typeof data.metadata?.task === "string" ? data.metadata.task : "";
+    const taskPreview = task.length > 60 ? `${task.slice(0, 57)}…` : task;
+    return taskPreview ? `${data.agentId}: ${taskPreview}` : data.agentId;
+  }
   if (data.agentId) {
     return data.agentId;
   }
@@ -130,9 +136,15 @@ export function applyActivityEvent(tree: ActivityTree, event: IncomingEvent): Ac
       metadata: data.metadata ?? {},
     };
 
+    const nodeKind = resolveKind(kind);
+
+    // Register subagent session key → spawner mapping.
+    if (nodeKind === "subagent" && typeof data.metadata?.childSessionKey === "string") {
+      tree.sessionKeyToSpawner.set(data.metadata.childSessionKey, nodeId);
+    }
+
     // Link tool, thinking, and subagent nodes to their parent run.
     // For these kinds, event.runId is the parent run's ID.
-    const nodeKind = resolveKind(kind);
     if (nodeKind !== "run") {
       const parentRun = tree.nodeById.get(event.runId);
       if (parentRun) {
@@ -140,6 +152,21 @@ export function applyActivityEvent(tree: ActivityTree, event: IncomingEvent): Ac
         node.depth = parentRun.depth + 1;
         if (!parentRun.children.includes(nodeId)) {
           parentRun.children.push(nodeId);
+        }
+      }
+    }
+
+    // For run nodes, check if this session was spawned by a subagent.
+    if (nodeKind === "run" && event.sessionKey) {
+      const spawnerNodeId = tree.sessionKeyToSpawner.get(event.sessionKey);
+      if (spawnerNodeId) {
+        const spawner = tree.nodeById.get(spawnerNodeId);
+        if (spawner) {
+          node.parentId = spawnerNodeId;
+          node.depth = spawner.depth + 1;
+          if (!spawner.children.includes(nodeId)) {
+            spawner.children.push(nodeId);
+          }
         }
       }
     }
@@ -239,6 +266,7 @@ export function filterTree(tree: ActivityTree, filters: ActivityFilterCriteria):
   const filtered: ActivityTree = {
     rootNodes: [],
     nodeById: new Map(),
+    sessionKeyToSpawner: new Map(tree.sessionKeyToSpawner),
     totalNodes: 0,
   };
 

--- a/ui/src/ui/activity/activity-tree.ts
+++ b/ui/src/ui/activity/activity-tree.ts
@@ -133,7 +133,10 @@ export function applyActivityEvent(tree: ActivityTree, event: IncomingEvent): Ac
       children: [],
       isError: false,
       error: null,
-      metadata: data.metadata ?? {},
+      metadata: {
+        ...data.metadata,
+        ...(event.sessionKey ? { _sessionKey: event.sessionKey } : {}),
+      },
     };
 
     const nodeKind = resolveKind(kind);
@@ -143,15 +146,35 @@ export function applyActivityEvent(tree: ActivityTree, event: IncomingEvent): Ac
       tree.sessionKeyToSpawner.set(data.metadata.childSessionKey, nodeId);
     }
 
-    // Link tool, thinking, and subagent nodes to their parent run.
+    // Link tool and thinking nodes to their parent run.
     // For these kinds, event.runId is the parent run's ID.
-    if (nodeKind !== "run") {
+    if (nodeKind === "tool" || nodeKind === "thinking") {
       const parentRun = tree.nodeById.get(event.runId);
       if (parentRun) {
         node.parentId = event.runId;
         node.depth = parentRun.depth + 1;
         if (!parentRun.children.includes(nodeId)) {
           parentRun.children.push(nodeId);
+        }
+      }
+    }
+
+    // Link subagent nodes to their parent run by session key.
+    // The subagent event's sessionKey is the parent's session key.
+    if (nodeKind === "subagent" && event.sessionKey) {
+      for (const [candidateId, candidate] of tree.nodeById) {
+        if (candidate.kind === "run" && candidate.status === "running") {
+          // Match by session key: find a running run node whose events
+          // came from the same session as this subagent spawn.
+          const candidateSessionKey = candidate.metadata._sessionKey;
+          if (candidateSessionKey === event.sessionKey) {
+            node.parentId = candidateId;
+            node.depth = candidate.depth + 1;
+            if (!candidate.children.includes(nodeId)) {
+              candidate.children.push(nodeId);
+            }
+            break;
+          }
         }
       }
     }

--- a/ui/src/ui/activity/activity-tree.ts
+++ b/ui/src/ui/activity/activity-tree.ts
@@ -157,15 +157,39 @@ export function applyActivityEvent(tree: ActivityTree, event: IncomingEvent): Ac
     }
 
     // For run nodes, check if this session was spawned by a subagent.
-    if (nodeKind === "run" && event.sessionKey) {
-      const spawnerNodeId = tree.sessionKeyToSpawner.get(event.sessionKey);
-      if (spawnerNodeId) {
-        const spawner = tree.nodeById.get(spawnerNodeId);
-        if (spawner) {
-          node.parentId = spawnerNodeId;
-          node.depth = spawner.depth + 1;
-          if (!spawner.children.includes(nodeId)) {
-            spawner.children.push(nodeId);
+    if (nodeKind === "run" && !node.parentId) {
+      let matched = false;
+
+      // Try session key matching first.
+      if (event.sessionKey) {
+        const spawnerNodeId = tree.sessionKeyToSpawner.get(event.sessionKey);
+        if (spawnerNodeId) {
+          const spawner = tree.nodeById.get(spawnerNodeId);
+          if (spawner) {
+            node.parentId = spawnerNodeId;
+            node.depth = spawner.depth + 1;
+            if (!spawner.children.includes(nodeId)) {
+              spawner.children.push(nodeId);
+            }
+            matched = true;
+          }
+        }
+      }
+
+      // Fallback: find a recent unmatched subagent node with the same agentId.
+      if (!matched && data.agentId) {
+        for (const [candidateId, candidate] of tree.nodeById) {
+          if (
+            candidate.kind === "subagent" &&
+            candidate.label.startsWith(data.agentId) &&
+            candidate.children.length === 0
+          ) {
+            node.parentId = candidateId;
+            node.depth = candidate.depth + 1;
+            if (!candidate.children.includes(nodeId)) {
+              candidate.children.push(nodeId);
+            }
+            break;
           }
         }
       }

--- a/ui/src/ui/activity/activity-tree.ts
+++ b/ui/src/ui/activity/activity-tree.ts
@@ -397,3 +397,47 @@ export function flattenTimeline(tree: ActivityTree): TimelineEntry[] {
   entries.sort((a, b) => a.ts - b.ts);
   return entries;
 }
+
+type SerializedTree = {
+  rootNodes: string[];
+  nodes: Record<string, ActivityNode>;
+  sessionKeyToSpawner: Record<string, string>;
+};
+
+export function serializeTree(tree: ActivityTree): SerializedTree {
+  const nodes: Record<string, ActivityNode> = {};
+  for (const [id, node] of tree.nodeById) {
+    nodes[id] = node;
+  }
+  const spawner: Record<string, string> = {};
+  for (const [k, v] of tree.sessionKeyToSpawner) {
+    spawner[k] = v;
+  }
+  return { rootNodes: tree.rootNodes, nodes, sessionKeyToSpawner: spawner };
+}
+
+export function deserializeTree(data: unknown): ActivityTree | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+  const raw = data as SerializedTree;
+  if (!Array.isArray(raw.rootNodes) || typeof raw.nodes !== "object") {
+    return null;
+  }
+  const tree = createActivityTree();
+  tree.rootNodes = raw.rootNodes;
+  for (const [id, node] of Object.entries(raw.nodes)) {
+    if (node && typeof node === "object" && typeof node.id === "string") {
+      tree.nodeById.set(id, node);
+    }
+  }
+  if (raw.sessionKeyToSpawner && typeof raw.sessionKeyToSpawner === "object") {
+    for (const [k, v] of Object.entries(raw.sessionKeyToSpawner)) {
+      if (typeof v === "string") {
+        tree.sessionKeyToSpawner.set(k, v);
+      }
+    }
+  }
+  tree.totalNodes = tree.nodeById.size;
+  return tree;
+}

--- a/ui/src/ui/activity/activity-tree.ts
+++ b/ui/src/ui/activity/activity-tree.ts
@@ -246,6 +246,33 @@ export function applyActivityEvent(tree: ActivityTree, event: IncomingEvent): Ac
     return tree;
   }
 
+  // Handle subagent.completed — merge outcome into the existing subagent node.
+  if (kind === "subagent.completed") {
+    // Find the subagent node by runId match.
+    const subagentNodeId = `${event.runId}:subagent:${data.agentId ?? "unknown"}`;
+    let target = tree.nodeById.get(subagentNodeId);
+    // Fallback: find any subagent node with matching runId.
+    if (!target) {
+      for (const node of tree.nodeById.values()) {
+        if (node.kind === "subagent" && node.runId === event.runId) {
+          target = node;
+          break;
+        }
+      }
+    }
+    if (target) {
+      target.status = data.isError || data.error ? "error" : "completed";
+      target.endedAt = event.ts;
+      target.durationMs = event.ts - target.startedAt;
+      target.isError = Boolean(data.isError || data.error);
+      target.error = typeof data.error === "string" ? data.error : null;
+      if (data.metadata) {
+        target.metadata = { ...target.metadata, ...data.metadata };
+      }
+    }
+    return tree;
+  }
+
   return tree;
 }
 

--- a/ui/src/ui/activity/activity-tree.ts
+++ b/ui/src/ui/activity/activity-tree.ts
@@ -1,0 +1,256 @@
+import type {
+  ActivityTree,
+  ActivityNode,
+  ActivityNodeKind,
+  ActivityNodeStatus,
+  ActivityMetrics,
+} from "./activity-types.ts";
+
+const MAX_TREE_NODES = 500;
+const PRUNE_AGE_MS = 5 * 60 * 1000;
+
+export function createActivityTree(): ActivityTree {
+  return {
+    rootNodes: [],
+    nodeById: new Map(),
+    totalNodes: 0,
+  };
+}
+
+type ActivityEventData = {
+  kind: string;
+  agentId?: string;
+  parentRunId?: string;
+  depth?: number;
+  toolName?: string;
+  toolCallId?: string;
+  durationMs?: number;
+  isError?: boolean;
+  error?: string;
+  metadata?: Record<string, unknown>;
+};
+
+type IncomingEvent = {
+  runId: string;
+  ts: number;
+  sessionKey?: string;
+  data: ActivityEventData;
+};
+
+function resolveKind(eventKind: string): ActivityNodeKind {
+  if (eventKind.startsWith("tool.")) {
+    return "tool";
+  }
+  if (eventKind.startsWith("thinking.")) {
+    return "thinking";
+  }
+  if (eventKind.startsWith("subagent.")) {
+    return "subagent";
+  }
+  return "run";
+}
+
+function resolveLabel(data: ActivityEventData): string {
+  if (data.toolName) {
+    return data.toolName;
+  }
+  if (data.agentId) {
+    return data.agentId;
+  }
+  return data.kind;
+}
+
+function resolveNodeId(event: IncomingEvent): string {
+  const data = event.data;
+  if (data.toolCallId) {
+    return `${event.runId}:tool:${data.toolCallId}`;
+  }
+  if (data.kind.startsWith("subagent.")) {
+    return `${event.runId}:subagent:${data.agentId ?? "unknown"}`;
+  }
+  if (data.kind.startsWith("thinking.")) {
+    return `${event.runId}:thinking`;
+  }
+  return event.runId;
+}
+
+export function applyActivityEvent(tree: ActivityTree, event: IncomingEvent): ActivityTree {
+  const data = event.data;
+  const kind = data.kind;
+  const nodeId = resolveNodeId(event);
+
+  if (kind.endsWith(".start")) {
+    const node: ActivityNode = {
+      id: nodeId,
+      runId: event.runId,
+      parentId: null,
+      kind: resolveKind(kind),
+      status: "running",
+      label: resolveLabel(data),
+      startedAt: event.ts,
+      endedAt: null,
+      durationMs: null,
+      depth: typeof data.depth === "number" ? data.depth : 0,
+      children: [],
+      isError: false,
+      error: null,
+      metadata: data.metadata ?? {},
+    };
+
+    tree.nodeById.set(nodeId, node);
+    if (!tree.rootNodes.includes(nodeId) && !findParent(tree, nodeId)) {
+      tree.rootNodes.push(nodeId);
+    }
+    tree.totalNodes = tree.nodeById.size;
+
+    if (tree.totalNodes > MAX_TREE_NODES) {
+      pruneCompletedBranches(tree, 0);
+    }
+
+    return tree;
+  }
+
+  if (kind.endsWith(".end") || kind.endsWith(".error")) {
+    const existing = tree.nodeById.get(nodeId);
+    if (existing) {
+      existing.status = data.isError || kind.endsWith(".error") ? "error" : "completed";
+      existing.endedAt = event.ts;
+      existing.durationMs = data.durationMs ?? event.ts - existing.startedAt;
+      existing.isError = data.isError ?? kind.endsWith(".error");
+      existing.error = data.error ?? null;
+    }
+    return tree;
+  }
+
+  return tree;
+}
+
+function findParent(tree: ActivityTree, nodeId: string): string | null {
+  for (const [id, node] of tree.nodeById) {
+    if (id !== nodeId && node.children.includes(nodeId)) {
+      return id;
+    }
+  }
+  return null;
+}
+
+export function pruneCompletedBranches(tree: ActivityTree, maxAgeMs: number = PRUNE_AGE_MS): void {
+  const now = Date.now();
+  const toRemove: string[] = [];
+
+  for (const [id, node] of tree.nodeById) {
+    if (
+      (node.status === "completed" || node.status === "error") &&
+      node.endedAt !== null &&
+      now - node.endedAt > maxAgeMs
+    ) {
+      toRemove.push(id);
+    }
+  }
+
+  for (const id of toRemove) {
+    tree.nodeById.delete(id);
+    const rootIdx = tree.rootNodes.indexOf(id);
+    if (rootIdx !== -1) {
+      tree.rootNodes.splice(rootIdx, 1);
+    }
+  }
+
+  tree.totalNodes = tree.nodeById.size;
+}
+
+export function computeMetrics(tree: ActivityTree): ActivityMetrics {
+  let activeRuns = 0;
+  let activeTools = 0;
+  let totalToolCalls = 0;
+  let totalErrors = 0;
+  let completedNodes = 0;
+
+  for (const node of tree.nodeById.values()) {
+    if (node.kind === "run" && node.status === "running") {
+      activeRuns++;
+    }
+    if (node.kind === "tool") {
+      totalToolCalls++;
+      if (node.status === "running") {
+        activeTools++;
+      }
+    }
+    if (node.isError) {
+      totalErrors++;
+    }
+    if (node.status === "completed" || node.status === "error") {
+      completedNodes++;
+    }
+  }
+
+  return { activeRuns, activeTools, totalToolCalls, totalErrors, completedNodes };
+}
+
+export type ActivityFilterCriteria = {
+  kinds: Set<ActivityNodeKind>;
+  search: string;
+  timeRangeMs: number | null;
+};
+
+export function filterTree(tree: ActivityTree, filters: ActivityFilterCriteria): ActivityTree {
+  const now = Date.now();
+  const filtered: ActivityTree = {
+    rootNodes: [],
+    nodeById: new Map(),
+    totalNodes: 0,
+  };
+
+  for (const [id, node] of tree.nodeById) {
+    if (!filters.kinds.has(node.kind)) {
+      continue;
+    }
+    if (filters.timeRangeMs !== null && now - node.startedAt > filters.timeRangeMs) {
+      continue;
+    }
+    if (
+      filters.search &&
+      !node.label.toLowerCase().includes(filters.search.toLowerCase()) &&
+      !node.id.toLowerCase().includes(filters.search.toLowerCase())
+    ) {
+      continue;
+    }
+    filtered.nodeById.set(id, node);
+  }
+
+  for (const rootId of tree.rootNodes) {
+    if (filtered.nodeById.has(rootId)) {
+      filtered.rootNodes.push(rootId);
+    }
+  }
+
+  filtered.totalNodes = filtered.nodeById.size;
+  return filtered;
+}
+
+export type TimelineEntry = {
+  id: string;
+  kind: string;
+  label: string;
+  status: ActivityNodeStatus;
+  ts: number;
+  durationMs: number | null;
+  isError: boolean;
+};
+
+export function flattenTimeline(tree: ActivityTree): TimelineEntry[] {
+  const entries: TimelineEntry[] = [];
+  for (const node of tree.nodeById.values()) {
+    entries.push({
+      id: node.id,
+      kind: node.kind,
+      label: node.label,
+      status: node.status,
+      ts: node.startedAt,
+      durationMs: node.durationMs,
+      isError: node.isError,
+    });
+  }
+  entries.sort((a, b) => a.ts - b.ts);
+  return entries;
+}

--- a/ui/src/ui/activity/activity-types.ts
+++ b/ui/src/ui/activity/activity-types.ts
@@ -22,6 +22,8 @@ export type ActivityNode = {
 export type ActivityTree = {
   rootNodes: string[];
   nodeById: Map<string, ActivityNode>;
+  /** Maps child session keys to the subagent node ID that spawned them. */
+  sessionKeyToSpawner: Map<string, string>;
   totalNodes: number;
 };
 

--- a/ui/src/ui/activity/activity-types.ts
+++ b/ui/src/ui/activity/activity-types.ts
@@ -1,0 +1,34 @@
+export type ActivityNodeStatus = "pending" | "running" | "completed" | "error";
+
+export type ActivityNodeKind = "run" | "tool" | "thinking" | "subagent";
+
+export type ActivityNode = {
+  id: string;
+  runId: string;
+  parentId: string | null;
+  kind: ActivityNodeKind;
+  status: ActivityNodeStatus;
+  label: string;
+  startedAt: number;
+  endedAt: number | null;
+  durationMs: number | null;
+  depth: number;
+  children: string[];
+  isError: boolean;
+  error: string | null;
+  metadata: Record<string, unknown>;
+};
+
+export type ActivityTree = {
+  rootNodes: string[];
+  nodeById: Map<string, ActivityNode>;
+  totalNodes: number;
+};
+
+export type ActivityMetrics = {
+  activeRuns: number;
+  activeTools: number;
+  totalToolCalls: number;
+  totalErrors: number;
+  completedNodes: number;
+};

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -2,6 +2,7 @@ import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
 } from "../../../src/gateway/events.js";
+import type { ActivityController } from "./activity/activity-controller.ts";
 import {
   CHAT_SESSIONS_ACTIVE_MINUTES,
   clearPendingQueueItemsForRun,
@@ -88,6 +89,7 @@ type GatewayHost = {
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalError: string | null;
   updateAvailable: UpdateAvailable | null;
+  activityController?: ActivityController | null;
 };
 
 type SessionDefaultsSnapshot = {
@@ -371,10 +373,11 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     if (host.onboarding) {
       return;
     }
-    handleAgentEvent(
-      host as unknown as Parameters<typeof handleAgentEvent>[0],
-      evt.payload as AgentEventPayload | undefined,
-    );
+    const agentPayload = evt.payload as AgentEventPayload | undefined;
+    handleAgentEvent(host as unknown as Parameters<typeof handleAgentEvent>[0], agentPayload);
+    if (agentPayload?.stream === "activity" && host.activityController) {
+      host.activityController.handleEvent(agentPayload);
+    }
     return;
   }
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -100,6 +100,7 @@ import "./components/dashboard-header.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
+import { renderActivity } from "./views/activity.ts";
 import { agentLogoUrl } from "./views/agents-utils.ts";
 import {
   resolveAgentConfig,
@@ -775,6 +776,12 @@ export function renderApp(state: AppViewState) {
               onRefresh: () => state.loadOverview(),
               onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
               onRefreshLogs: () => state.loadOverview(),
+            })
+          : nothing}
+        ${state.tab === "activity"
+          ? renderActivity({
+              connected: state.connected,
+              controller: state.activityController,
             })
           : nothing}
         ${state.tab === "channels"

--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -465,6 +465,11 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
     return;
   }
 
+  // Activity events are handled by the ActivityController, not here.
+  if (payload.stream === "activity") {
+    return;
+  }
+
   if (payload.stream !== "tool") {
     return;
   }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -74,6 +74,7 @@ export type AppViewState = {
   chatRunId: string | null;
   compactionStatus: CompactionStatus | null;
   fallbackStatus: FallbackStatus | null;
+  activityController: import("./activity/activity-controller.ts").ActivityController;
   chatAvatarUrl: string | null;
   chatThinkingLevel: string | null;
   chatModelOverrides: Record<string, ChatModelOverride | null>;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -2,6 +2,7 @@ import { LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { resolveAgentIdFromSessionKey } from "../../../src/routing/session-key.js";
 import { i18n, I18nController, isSupportedLocale } from "../i18n/index.ts";
+import { ActivityController } from "./activity/activity-controller.ts";
 import {
   handleChannelConfigReload as handleChannelConfigReloadInternal,
   handleChannelConfigSave as handleChannelConfigSaveInternal,
@@ -168,6 +169,8 @@ export class OpenClawApp extends LitElement {
   @state() chatRunId: string | null = null;
   @state() compactionStatus: CompactionStatus | null = null;
   @state() fallbackStatus: FallbackStatus | null = null;
+
+  activityController = new ActivityController(this);
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
   @state() chatModelOverrides: Record<string, ChatModelOverride | null> = {};

--- a/ui/src/ui/icons.ts
+++ b/ui/src/ui/icons.ts
@@ -462,6 +462,11 @@ export const icons = {
       <line x1="3" x2="10" y1="21" y2="14" />
     </svg>
   `,
+  activity: html`
+    <svg viewBox="0 0 24 24">
+      <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+    </svg>
+  `,
 } as const;
 
 export type IconName = keyof typeof icons;

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -5,7 +5,7 @@ export const TAB_GROUPS = [
   { label: "chat", tabs: ["chat"] },
   {
     label: "control",
-    tabs: ["overview", "channels", "instances", "sessions", "usage", "cron"],
+    tabs: ["overview", "activity", "channels", "instances", "sessions", "usage", "cron"],
   },
   { label: "agent", tabs: ["agents", "skills", "nodes", "dreams"] },
   {
@@ -26,6 +26,7 @@ export const TAB_GROUPS = [
 export type Tab =
   | "agents"
   | "overview"
+  | "activity"
   | "channels"
   | "instances"
   | "sessions"
@@ -47,6 +48,7 @@ export type Tab =
 const TAB_PATHS: Record<Tab, string> = {
   agents: "/agents",
   overview: "/overview",
+  activity: "/activity",
   channels: "/channels",
   instances: "/instances",
   sessions: "/sessions",
@@ -155,6 +157,8 @@ export function iconForTab(tab: Tab): IconName {
       return "messageSquare";
     case "overview":
       return "barChart";
+    case "activity":
+      return "activity";
     case "channels":
       return "link";
     case "instances":

--- a/ui/src/ui/views/activity-detail.ts
+++ b/ui/src/ui/views/activity-detail.ts
@@ -1,0 +1,90 @@
+import { html, nothing } from "lit";
+import type { ActivityNode } from "../activity/activity-types.ts";
+import { icons } from "../icons.ts";
+
+function formatTimestamp(ts: number): string {
+  return new Date(ts).toLocaleTimeString();
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) {
+    return "—";
+  }
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  if (ms < 60_000) {
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+  return `${(ms / 60_000).toFixed(1)}m`;
+}
+
+function renderField(label: string, value: string | number | null | undefined) {
+  if (value === null || value === undefined || value === "") {
+    return nothing;
+  }
+  return html`
+    <div class="activity-detail__field">
+      <span class="activity-detail__field-label muted">${label}</span>
+      <span class="activity-detail__field-value">${value}</span>
+    </div>
+  `;
+}
+
+function renderMetadataBlock(metadata: Record<string, unknown>) {
+  const entries = Object.entries(metadata).filter(([, v]) => v !== undefined && v !== null);
+  if (entries.length === 0) {
+    return nothing;
+  }
+
+  return html`
+    <div class="activity-detail__section">
+      <div class="activity-detail__section-title muted">Metadata</div>
+      <pre class="activity-detail__json">
+${JSON.stringify(Object.fromEntries(entries), null, 2)}</pre
+      >
+    </div>
+  `;
+}
+
+export type ActivityDetailProps = {
+  node: ActivityNode | null;
+  onClose: () => void;
+};
+
+export function renderActivityDetail(props: ActivityDetailProps) {
+  const { node, onClose } = props;
+  if (!node) {
+    return nothing;
+  }
+
+  return html`
+    <div class="activity-detail">
+      <div class="activity-detail__header">
+        <span class="activity-detail__title">${node.label}</span>
+        <button class="btn btn--subtle btn--sm" @click=${onClose}>${icons.x}</button>
+      </div>
+
+      <div class="activity-detail__body">
+        <div class="activity-detail__section">
+          <div class="activity-detail__section-title muted">Info</div>
+          ${renderField("Kind", node.kind)} ${renderField("Status", node.status)}
+          ${renderField("Started", formatTimestamp(node.startedAt))}
+          ${renderField("Ended", node.endedAt ? formatTimestamp(node.endedAt) : null)}
+          ${renderField("Duration", formatDuration(node.durationMs))}
+          ${renderField("Depth", node.depth)} ${renderField("Run ID", node.runId)}
+        </div>
+
+        ${node.error
+          ? html`
+              <div class="activity-detail__section activity-detail__section--error">
+                <div class="activity-detail__section-title muted">Error</div>
+                <pre class="activity-detail__error">${node.error}</pre>
+              </div>
+            `
+          : nothing}
+        ${renderMetadataBlock(node.metadata)}
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui/views/activity-detail.ts
+++ b/ui/src/ui/views/activity-detail.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import type { ActivityNode } from "../activity/activity-types.ts";
 import { icons } from "../icons.ts";
 
@@ -31,19 +32,50 @@ function renderField(label: string, value: string | number | null | undefined) {
   `;
 }
 
-function formatJsonPreview(value: unknown): string {
+function parseJsonSafe(value: unknown): unknown {
   if (typeof value === "string") {
     try {
-      return JSON.stringify(JSON.parse(value), null, 2);
+      return JSON.parse(value);
     } catch {
       return value;
     }
   }
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
+  return value;
+}
+
+function renderJsonHighlighted(value: unknown): ReturnType<typeof html> {
+  const parsed = parseJsonSafe(value);
+  if (typeof parsed === "string") {
+    return html`<pre class="activity-detail__json">${parsed}</pre>`;
   }
+  try {
+    const json = JSON.stringify(parsed, null, 2);
+    const highlighted = json.replace(
+      /("(?:[^"\\]|\\.)*")\s*:|("(?:[^"\\]|\\.)*")|(true|false|null)|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g,
+      (match, key, str, bool, num) => {
+        if (key) {
+          return `<span class="json-key">${escapeHtml(key)}</span>:`;
+        }
+        if (str) {
+          return `<span class="json-string">${escapeHtml(str)}</span>`;
+        }
+        if (bool) {
+          return `<span class="json-bool">${bool}</span>`;
+        }
+        if (num) {
+          return `<span class="json-number">${num}</span>`;
+        }
+        return match;
+      },
+    );
+    return html`<pre class="activity-detail__json">${unsafeHTML(highlighted)}</pre>`;
+  } catch {
+    return html`<pre class="activity-detail__json">${String(value)}</pre>`;
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 function renderMetadataBlock(metadata: Record<string, unknown>) {
@@ -109,17 +141,13 @@ export function renderActivityDetail(props: ActivityDetailProps) {
               <div class="activity-detail__section">
                 <div class="activity-detail__section-title muted">Input</div>
                 ${node.metadata.args
-                  ? html`<pre class="activity-detail__json">
-${formatJsonPreview(node.metadata.args)}</pre
-                    >`
+                  ? renderJsonHighlighted(node.metadata.args)
                   : html`<span class="muted">No input data</span>`}
               </div>
               <div class="activity-detail__section">
                 <div class="activity-detail__section-title muted">Output</div>
                 ${node.metadata.result
-                  ? html`<pre class="activity-detail__json">
-${formatJsonPreview(node.metadata.result)}</pre
-                    >`
+                  ? renderJsonHighlighted(node.metadata.result)
                   : html`<span class="muted"
                       >${node.status === "running" ? "Waiting for result…" : "No output data"}</span
                     >`}

--- a/ui/src/ui/views/activity-detail.ts
+++ b/ui/src/ui/views/activity-detail.ts
@@ -183,6 +183,14 @@ ${typeof node.metadata.task === "string"
               </div>
             `
           : nothing}
+        ${node.kind === "subagent" && node.metadata.result
+          ? html`
+              <div class="activity-detail__section">
+                <div class="activity-detail__section-title muted">Result</div>
+                ${renderJsonHighlighted(node.metadata.result)}
+              </div>
+            `
+          : nothing}
         ${node.error
           ? html`
               <div class="activity-detail__section activity-detail__section--error">

--- a/ui/src/ui/views/activity-detail.ts
+++ b/ui/src/ui/views/activity-detail.ts
@@ -104,19 +104,25 @@ export function renderActivityDetail(props: ActivityDetailProps) {
           ${renderField("Depth", node.depth)} ${renderField("Run ID", node.runId)}
         </div>
 
-        ${node.kind === "tool" && node.metadata.args
+        ${node.kind === "tool"
           ? html`
               <div class="activity-detail__section">
                 <div class="activity-detail__section-title muted">Input</div>
-                <pre class="activity-detail__json">${formatJsonPreview(node.metadata.args)}</pre>
+                ${node.metadata.args
+                  ? html`<pre class="activity-detail__json">
+${formatJsonPreview(node.metadata.args)}</pre
+                    >`
+                  : html`<span class="muted">No input data</span>`}
               </div>
-            `
-          : nothing}
-        ${node.kind === "tool" && node.metadata.result
-          ? html`
               <div class="activity-detail__section">
                 <div class="activity-detail__section-title muted">Output</div>
-                <pre class="activity-detail__json">${formatJsonPreview(node.metadata.result)}</pre>
+                ${node.metadata.result
+                  ? html`<pre class="activity-detail__json">
+${formatJsonPreview(node.metadata.result)}</pre
+                    >`
+                  : html`<span class="muted"
+                      >${node.status === "running" ? "Waiting for result…" : "No output data"}</span
+                    >`}
               </div>
             `
           : nothing}

--- a/ui/src/ui/views/activity-detail.ts
+++ b/ui/src/ui/views/activity-detail.ts
@@ -31,8 +31,25 @@ function renderField(label: string, value: string | number | null | undefined) {
   `;
 }
 
+function formatJsonPreview(value: unknown): string {
+  if (typeof value === "string") {
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      return value;
+    }
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
 function renderMetadataBlock(metadata: Record<string, unknown>) {
-  const entries = Object.entries(metadata).filter(([, v]) => v !== undefined && v !== null);
+  const entries = Object.entries(metadata).filter(
+    ([k, v]) => v !== undefined && v !== null && k !== "args" && k !== "result",
+  );
   if (entries.length === 0) {
     return nothing;
   }
@@ -75,6 +92,22 @@ export function renderActivityDetail(props: ActivityDetailProps) {
           ${renderField("Depth", node.depth)} ${renderField("Run ID", node.runId)}
         </div>
 
+        ${node.kind === "tool" && node.metadata.args
+          ? html`
+              <div class="activity-detail__section">
+                <div class="activity-detail__section-title muted">Input</div>
+                <pre class="activity-detail__json">${formatJsonPreview(node.metadata.args)}</pre>
+              </div>
+            `
+          : nothing}
+        ${node.kind === "tool" && node.metadata.result
+          ? html`
+              <div class="activity-detail__section">
+                <div class="activity-detail__section-title muted">Output</div>
+                <pre class="activity-detail__json">${formatJsonPreview(node.metadata.result)}</pre>
+              </div>
+            `
+          : nothing}
         ${node.error
           ? html`
               <div class="activity-detail__section activity-detail__section--error">

--- a/ui/src/ui/views/activity-detail.ts
+++ b/ui/src/ui/views/activity-detail.ts
@@ -48,7 +48,19 @@ function formatJsonPreview(value: unknown): string {
 
 function renderMetadataBlock(metadata: Record<string, unknown>) {
   const entries = Object.entries(metadata).filter(
-    ([k, v]) => v !== undefined && v !== null && k !== "args" && k !== "result",
+    ([k, v]) =>
+      v !== undefined &&
+      v !== null &&
+      ![
+        "args",
+        "result",
+        "outcome",
+        "reason",
+        "task",
+        "_sessionKey",
+        "childSessionKey",
+        "parentSessionKey",
+      ].includes(k),
   );
   if (entries.length === 0) {
     return nothing;
@@ -105,6 +117,35 @@ export function renderActivityDetail(props: ActivityDetailProps) {
               <div class="activity-detail__section">
                 <div class="activity-detail__section-title muted">Output</div>
                 <pre class="activity-detail__json">${formatJsonPreview(node.metadata.result)}</pre>
+              </div>
+            `
+          : nothing}
+        ${node.kind === "subagent" && node.metadata.outcome
+          ? html`
+              <div class="activity-detail__section">
+                <div class="activity-detail__section-title muted">Outcome</div>
+                ${renderField(
+                  "Status",
+                  typeof node.metadata.outcome === "string"
+                    ? node.metadata.outcome
+                    : JSON.stringify(node.metadata.outcome),
+                )}
+                ${renderField(
+                  "Reason",
+                  typeof node.metadata.reason === "string" ? node.metadata.reason : null,
+                )}
+              </div>
+            `
+          : nothing}
+        ${node.kind === "subagent" && node.metadata.task
+          ? html`
+              <div class="activity-detail__section">
+                <div class="activity-detail__section-title muted">Task</div>
+                <pre class="activity-detail__json">
+${typeof node.metadata.task === "string"
+                    ? node.metadata.task
+                    : JSON.stringify(node.metadata.task)}</pre
+                >
               </div>
             `
           : nothing}

--- a/ui/src/ui/views/activity-filters.ts
+++ b/ui/src/ui/views/activity-filters.ts
@@ -1,0 +1,83 @@
+import { html } from "lit";
+import type { ActivityNodeKind } from "../activity/activity-types.ts";
+
+export type ActivityFilters = {
+  kinds: Set<ActivityNodeKind>;
+  search: string;
+  timeRangeMs: number | null;
+};
+
+export function createDefaultFilters(): ActivityFilters {
+  return {
+    kinds: new Set(["run", "tool", "thinking", "subagent"]),
+    search: "",
+    timeRangeMs: null,
+  };
+}
+
+const KIND_OPTIONS: { kind: ActivityNodeKind; label: string }[] = [
+  { kind: "run", label: "Runs" },
+  { kind: "tool", label: "Tools" },
+  { kind: "thinking", label: "Thinking" },
+  { kind: "subagent", label: "Subagents" },
+];
+
+const TIME_RANGE_OPTIONS = [
+  { label: "All", value: null },
+  { label: "1m", value: 60_000 },
+  { label: "5m", value: 5 * 60_000 },
+  { label: "15m", value: 15 * 60_000 },
+];
+
+export type ActivityFiltersBarProps = {
+  filters: ActivityFilters;
+  onSearchChange: (search: string) => void;
+  onKindToggle: (kind: ActivityNodeKind) => void;
+  onTimeRangeChange: (ms: number | null) => void;
+};
+
+export function renderActivityFilters(props: ActivityFiltersBarProps) {
+  const { filters } = props;
+
+  return html`
+    <div class="activity-filters">
+      <input
+        type="text"
+        class="activity-filters__search"
+        placeholder="Search events…"
+        .value=${filters.search}
+        @input=${(e: Event) => props.onSearchChange((e.target as HTMLInputElement).value)}
+      />
+
+      <div class="activity-filters__kinds" role="group" aria-label="Filter by kind">
+        ${KIND_OPTIONS.map(
+          (opt) => html`
+            <label class="activity-filters__kind">
+              <input
+                type="checkbox"
+                .checked=${filters.kinds.has(opt.kind)}
+                @change=${() => props.onKindToggle(opt.kind)}
+              />
+              ${opt.label}
+            </label>
+          `,
+        )}
+      </div>
+
+      <div class="activity-filters__time" role="group" aria-label="Time range">
+        ${TIME_RANGE_OPTIONS.map(
+          (opt) => html`
+            <button
+              class="btn btn--subtle btn--xs ${filters.timeRangeMs === opt.value
+                ? "btn--active"
+                : ""}"
+              @click=${() => props.onTimeRangeChange(opt.value)}
+            >
+              ${opt.label}
+            </button>
+          `,
+        )}
+      </div>
+    </div>
+  `;
+}

--- a/ui/src/ui/views/activity-metrics.ts
+++ b/ui/src/ui/views/activity-metrics.ts
@@ -1,0 +1,83 @@
+import { html, nothing } from "lit";
+import type { ActivityMetrics } from "../activity/activity-types.ts";
+
+function renderSparkline(data: number[]) {
+  if (data.length < 2) {
+    return nothing;
+  }
+
+  const max = Math.max(...data, 1);
+  const width = 60;
+  const height = 20;
+  const points = data
+    .map((v, i) => {
+      const x = (i / (data.length - 1)) * width;
+      const y = height - (v / max) * height;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return html`
+    <svg class="activity-sparkline" viewBox="0 0 ${width} ${height}" preserveAspectRatio="none">
+      <polyline points="${points}" />
+    </svg>
+  `;
+}
+
+export type ActivityMetricsBarProps = {
+  metrics: ActivityMetrics;
+  toolCallsHistory: number[];
+  errorsHistory: number[];
+  activeRunsHistory: number[];
+};
+
+function renderMetricCard(
+  label: string,
+  value: number | string,
+  sparklineData: number[],
+  active = false,
+  isError = false,
+) {
+  return html`
+    <div
+      class="activity-metric-card ${active ? "activity-metric-card--active" : ""} ${isError
+        ? "activity-metric-card--error"
+        : ""}"
+    >
+      <div class="activity-metric-card__top">
+        <span class="activity-metric-card__value">${value}</span>
+        ${renderSparkline(sparklineData)}
+      </div>
+      <span class="activity-metric-card__label muted">${label}</span>
+    </div>
+  `;
+}
+
+export function renderActivityMetrics(props: ActivityMetricsBarProps) {
+  const { metrics } = props;
+
+  return html`
+    <div class="activity-metrics-bar">
+      ${renderMetricCard(
+        "Active Runs",
+        metrics.activeRuns,
+        props.activeRunsHistory,
+        metrics.activeRuns > 0,
+      )}
+      ${renderMetricCard(
+        "Tool Calls",
+        metrics.totalToolCalls,
+        props.toolCallsHistory,
+        metrics.activeTools > 0,
+      )}
+      ${renderMetricCard(
+        "Errors",
+        metrics.totalErrors,
+        props.errorsHistory,
+        false,
+        metrics.totalErrors > 0,
+      )}
+      ${renderMetricCard("Completed", metrics.completedNodes, [], false)}
+    </div>
+  `;
+}

--- a/ui/src/ui/views/activity-timeline.ts
+++ b/ui/src/ui/views/activity-timeline.ts
@@ -1,0 +1,81 @@
+import { html, nothing } from "lit";
+import type { TimelineEntry } from "../activity/activity-tree.ts";
+import { icons } from "../icons.ts";
+
+function kindColor(kind: string): string {
+  switch (kind) {
+    case "tool":
+      return "var(--color-accent, #5b9bd5)";
+    case "thinking":
+      return "var(--color-purple, #9b59b6)";
+    case "subagent":
+      return "var(--color-success, #2ecc71)";
+    default:
+      return "var(--color-muted, #888)";
+  }
+}
+
+function kindIcon(kind: string) {
+  switch (kind) {
+    case "tool":
+      return icons.wrench;
+    case "thinking":
+      return icons.brain;
+    case "subagent":
+      return icons.folder;
+    default:
+      return icons.zap;
+  }
+}
+
+function formatTime(ts: number): string {
+  return new Date(ts).toLocaleTimeString();
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) {
+    return "";
+  }
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export type ActivityTimelineProps = {
+  entries: TimelineEntry[];
+};
+
+export function renderActivityTimeline(props: ActivityTimelineProps) {
+  if (props.entries.length === 0) {
+    return html`<div class="activity-timeline-empty muted">No activity yet.</div>`;
+  }
+
+  return html`
+    <div class="activity-timeline">
+      ${props.entries.map(
+        (entry) => html`
+          <div
+            class="activity-timeline__entry ${entry.isError
+              ? "activity-timeline__entry--error"
+              : ""}"
+          >
+            <span class="activity-timeline__ts muted">${formatTime(entry.ts)}</span>
+            <span class="activity-timeline__dot" style="color: ${kindColor(entry.kind)}">
+              <span class="nav-item__icon">${kindIcon(entry.kind)}</span>
+            </span>
+            <span class="activity-timeline__label">${entry.label}</span>
+            <span class="activity-timeline__status activity-timeline__status--${entry.status}">
+              ${entry.status}
+            </span>
+            ${entry.durationMs !== null
+              ? html`<span class="activity-timeline__duration muted"
+                  >${formatDuration(entry.durationMs)}</span
+                >`
+              : nothing}
+          </div>
+        `,
+      )}
+    </div>
+  `;
+}

--- a/ui/src/ui/views/activity-tree-node.ts
+++ b/ui/src/ui/views/activity-tree-node.ts
@@ -1,0 +1,71 @@
+import { html, nothing } from "lit";
+import type { ActivityNode, ActivityTree } from "../activity/activity-types.ts";
+import { icons } from "../icons.ts";
+
+function statusIndicator(status: string, isError: boolean) {
+  if (isError || status === "error") {
+    return html`<span class="activity-status activity-status--error">✗</span>`;
+  }
+  if (status === "running") {
+    return html`<span class="activity-status activity-status--running"></span>`;
+  }
+  if (status === "completed") {
+    return html`<span class="activity-status activity-status--done">✓</span>`;
+  }
+  return html`<span class="activity-status activity-status--pending">○</span>`;
+}
+
+function kindIcon(kind: string) {
+  switch (kind) {
+    case "tool":
+      return icons.wrench;
+    case "thinking":
+      return icons.brain;
+    case "subagent":
+      return icons.folder;
+    default:
+      return icons.zap;
+  }
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) {
+    return "";
+  }
+  if (ms < 1000) {
+    return `${ms}ms`;
+  }
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function renderActivityTreeNode(
+  node: ActivityNode,
+  tree: ActivityTree,
+  depth = 0,
+  onSelect?: (nodeId: string) => void,
+): ReturnType<typeof html> {
+  const children = node.children
+    .map((id) => tree.nodeById.get(id))
+    .filter((n): n is ActivityNode => n !== undefined);
+
+  const handleClick = () => onSelect?.(node.id);
+
+  return html`
+    <div class="activity-node" style="padding-left: ${depth * 20}px">
+      <div class="activity-node__row" @click=${handleClick} role="button" tabindex="0">
+        ${statusIndicator(node.status, node.isError)}
+        <span class="activity-node__icon nav-item__icon">${kindIcon(node.kind)}</span>
+        <span class="activity-node__label">${node.label}</span>
+        ${node.durationMs !== null
+          ? html`<span class="activity-node__duration muted"
+              >${formatDuration(node.durationMs)}</span
+            >`
+          : nothing}
+        ${node.error
+          ? html`<span class="activity-node__error muted">${node.error.slice(0, 80)}</span>`
+          : nothing}
+      </div>
+      ${children.map((child) => renderActivityTreeNode(child, tree, depth + 1, onSelect))}
+    </div>
+  `;
+}

--- a/ui/src/ui/views/activity-tree-node.ts
+++ b/ui/src/ui/views/activity-tree-node.ts
@@ -28,6 +28,21 @@ function kindIcon(kind: string) {
   }
 }
 
+function kindTag(kind: string) {
+  switch (kind) {
+    case "tool":
+      return "tool";
+    case "thinking":
+      return "think";
+    case "subagent":
+      return "agent";
+    case "run":
+      return "run";
+    default:
+      return kind;
+  }
+}
+
 function formatDuration(ms: number | null): string {
   if (ms === null) {
     return "";
@@ -55,6 +70,9 @@ export function renderActivityTreeNode(
       <div class="activity-node__row" @click=${handleClick} role="button" tabindex="0">
         ${statusIndicator(node.status, node.isError)}
         <span class="activity-node__icon nav-item__icon">${kindIcon(node.kind)}</span>
+        <span class="activity-node__kind-tag activity-node__kind-tag--${node.kind}"
+          >${kindTag(node.kind)}</span
+        >
         <span class="activity-node__label">${node.label}</span>
         ${node.durationMs !== null
           ? html`<span class="activity-node__duration muted"

--- a/ui/src/ui/views/activity.ts
+++ b/ui/src/ui/views/activity.ts
@@ -1,0 +1,99 @@
+import { html, nothing } from "lit";
+import type { ActivityController } from "../activity/activity-controller.ts";
+import { flattenTimeline } from "../activity/activity-tree.ts";
+import type { ActivityNode } from "../activity/activity-types.ts";
+import { icons } from "../icons.ts";
+import { renderActivityDetail } from "./activity-detail.ts";
+import { renderActivityFilters } from "./activity-filters.ts";
+import { renderActivityMetrics } from "./activity-metrics.ts";
+import { renderActivityTimeline } from "./activity-timeline.ts";
+import { renderActivityTreeNode } from "./activity-tree-node.ts";
+
+export type ActivityViewProps = {
+  connected: boolean;
+  controller: ActivityController;
+};
+
+function renderEmptyState() {
+  return html`
+    <div class="activity-empty">
+      <span class="activity-empty__icon">${icons.activity}</span>
+      <p class="activity-empty__text muted">
+        No agent activity. Send a message to see the execution tree here.
+      </p>
+    </div>
+  `;
+}
+
+export function renderActivity(props: ActivityViewProps) {
+  if (!props.connected) {
+    return html`<div class="activity-empty muted">
+      Connect to the gateway to see agent activity.
+    </div>`;
+  }
+
+  const { controller } = props;
+  const metrics = controller.metrics;
+  const displayTree = controller.filteredTree;
+  const timeline = flattenTimeline(displayTree);
+  const selectedNode = controller.selectedNode;
+
+  const rootNodes = displayTree.rootNodes
+    .map((id) => displayTree.nodeById.get(id))
+    .filter((n): n is ActivityNode => n !== undefined);
+
+  return html`
+    <div class="activity-view">
+      ${renderActivityMetrics({
+        metrics,
+        toolCallsHistory: controller.toolCallsHistory,
+        errorsHistory: controller.errorsHistory,
+        activeRunsHistory: controller.activeRunsHistory,
+      })}
+      ${renderActivityFilters({
+        filters: {
+          kinds: controller.filters.kinds,
+          search: controller.filters.search,
+          timeRangeMs: controller.filters.timeRangeMs,
+        },
+        onSearchChange: (s) => controller.setSearch(s),
+        onKindToggle: (k) => controller.toggleKind(k),
+        onTimeRangeChange: (ms) => controller.setTimeRange(ms),
+      })}
+      ${controller.tree.totalNodes === 0
+        ? renderEmptyState()
+        : displayTree.totalNodes === 0
+          ? html`<div class="activity-empty muted">No events match filters.</div>`
+          : html`
+              <div class="activity-panels ${selectedNode ? "activity-panels--with-detail" : ""}">
+                <div class="activity-panel activity-panel--tree">
+                  <div class="activity-panel__header muted">Execution Tree</div>
+                  <div class="activity-panel__body">
+                    ${rootNodes.map((node) =>
+                      renderActivityTreeNode(node, displayTree, 0, (id) =>
+                        controller.selectNode(id),
+                      ),
+                    )}
+                  </div>
+                </div>
+                <div class="activity-panel activity-panel--timeline">
+                  <div class="activity-panel__header muted">Timeline</div>
+                  <div class="activity-panel__body">
+                    ${renderActivityTimeline({ entries: timeline })}
+                  </div>
+                </div>
+                ${selectedNode
+                  ? html`
+                      <div class="activity-panel activity-panel--detail">
+                        ${renderActivityDetail({
+                          node: selectedNode,
+                          onClose: () => controller.selectNode(null),
+                        })}
+                      </div>
+                    `
+                  : nothing}
+              </div>
+            `}
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary

- Adds a real-time agent activity panel to the Control UI
- Execution tree, timeline, and live metrics for full visibility into what the agent is doing
- Eliminates the black-box experience during multi-step agent tasks

Closes #60810

## Approach

**Gateway side:** Instrument the Pi agent loop to emit typed `AgentActivityEvent` messages over the existing WS protocol at each phase (thinking, tool dispatch/return, delegation, completion).

**Control UI side:** New `AgentActivity` panel subscribing to the activity event stream with:
- `ExecutionTree` — live-updating tree with expand/collapse
- `Timeline` — virtual-scrolled event stream with filters
- `MetricsSidebar` — live token/cost/error counters

### Prior art

Adapted from a system I've created agent observability stack:
- `EventBus` (typed pub/sub with correlation IDs)
- `ExecutionTree` (delegation chains with cycle detection and cost rollups)
- `ExecutionVisualizer` (timeline + graph layout)
- `Metrics` (counter/gauge/histogram collectors)

## Test plan

- [ ] Gateway emits `AgentActivityEvent` for thinking, tool calls, delegations
- [ ] Control UI renders execution tree in real time
- [ ] Timeline filters by event type, agent, and session
- [ ] Metrics sidebar shows live token/cost counters
- [ ] No regression on existing WS protocol clients
- [ ] Events are ephemeral by default (no storage overhead)