### PR TITLE
[codex] Stabilize session recovery and Discord delivery guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,10 @@ USER.md
 
 # local tooling
 .serena/
+.codex-artifacts/
+.playwright-cli/
+output/
+apps/macos/build/
 
 # Agent credentials and memory (NEVER COMMIT)
 /memory/

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,16 @@
+# Attribution
+
+This file describes OpenClaw redistribution guidance. It does not amend the
+root [LICENSE](LICENSE).
+
+OpenClaw redistribution should preserve:
+
+- the root [LICENSE](LICENSE)
+- the root [NOTICE](NOTICE)
+- any component-specific license or notice files shipped with the relevant code
+- a clear source reference to the official project or repository when publicly
+  reposting or mirroring OpenClaw where reasonably practicable
+
+For trademark rules, see [TRADEMARKS.md](TRADEMARKS.md).
+For copyright, patent, attribution, or takedown intake, see
+[INFRINGEMENT.md](INFRINGEMENT.md).

--- a/INFRINGEMENT.md
+++ b/INFRINGEMENT.md
@@ -1,0 +1,70 @@
+# Copyright, Trademark, and Takedown Policy
+
+This document provides the project intake path for copyright, attribution,
+trademark, and related intellectual-property complaints.
+
+It is project process guidance only and is not legal advice.
+
+## Intake channel
+
+Until a dedicated legal alias is published, send notices to
+`security@openclaw.ai` with a subject prefix such as:
+
+- `[Legal][Copyright]`
+- `[Legal][Trademark]`
+- `[Legal][Patent]`
+- `[Legal][Takedown]`
+
+If the notice concerns a specific GitHub repository, release asset, package, or
+app build, include the exact URL and version.
+
+## Copyright or DMCA-style notices
+
+Please include:
+
+1. your full name and contact information
+2. the copyrighted work you claim is affected
+3. the exact repository path, URL, release, package, or asset at issue
+4. a short explanation of why the use is unauthorized
+5. the requested action
+6. a statement that you have a good-faith belief the use is unauthorized
+7. a statement that the information is accurate and that you are authorized to
+   act for the rights holder
+
+## Trademark notices
+
+Please include:
+
+1. the trademark or brand identifier at issue
+2. the jurisdiction or registration details, if any
+3. the exact use you are objecting to
+4. why the use is likely to confuse users or imply endorsement
+5. the requested action
+
+## Patent inquiries
+
+Please include:
+
+1. the patent number or application identifier
+2. the exact feature, file path, release, or behavior at issue
+3. a concise explanation of the asserted claims
+4. the requested action or discussion path
+
+## Process expectations
+
+- We may ask for clarification before acting.
+- We may preserve evidence, logs, or release artifacts while reviewing a claim.
+- If a complaint appears complete and credible, we may remove, disable, rename,
+  or limit access to the material while the issue is reviewed.
+- Where appropriate, we may allow a correction, counter-notice, or non-branded
+  re-distribution path instead of permanent removal.
+- We may forward the notice to the affected maintainer, distributor, or host as
+  needed to resolve the issue.
+
+## Related materials
+
+- [LICENSE](LICENSE)
+- [NOTICE](NOTICE)
+- [TRADEMARKS.md](TRADEMARKS.md)
+- [PATENTS.md](PATENTS.md)
+- [SECURITY.md](SECURITY.md)

--- a/LEGAL_ENFORCEMENT.md
+++ b/LEGAL_ENFORCEMENT.md
@@ -1,0 +1,4 @@
+# Legal Enforcement
+
+For copyright, attribution, trademark, patent, and takedown process details, see
+[INFRINGEMENT.md](INFRINGEMENT.md).

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,34 @@
+OpenClaw
+Copyright (c) 2025 Peter Steinberger and contributors
+
+This repository is distributed under the MIT License in the root LICENSE file.
+Redistributions of the Software, in source or substantial copied form, must
+preserve applicable copyright notices and license text.
+
+The source-reference and forwarding expectations below are project
+redistribution guidance and brand-protection rules. They do not amend or
+replace the MIT License text in the root LICENSE file.
+
+Redistribution and forwarding expectations:
+
+- Keep the root LICENSE file and this NOTICE alongside redistributed source
+  archives, mirrors, package snapshots, or other substantial copies.
+- Preserve any component-specific notices or licenses shipped with bundled or
+  vendored material.
+- When redistributing from a public mirror, catalog, listing, or reposted page,
+  include a clear source reference to https://github.com/openclaw/openclaw or
+  https://openclaw.ai where reasonably practicable.
+- Use of OpenClaw names, logos, and other brand identifiers is governed
+  separately by TRADEMARKS.md. The software license does not grant trademark
+  rights.
+
+Known component-specific notices and licenses include:
+
+- apps/macos/Sources/OpenClaw/Resources/DeviceModels/NOTICE.md
+- apps/macos/Sources/OpenClaw/Resources/DeviceModels/LICENSE.apple-device-identifiers.txt
+- Swabble/LICENSE
+- vendor/a2ui/LICENSE
+- extensions/open-prose/skills/prose/LICENSE
+
+For copyright, attribution, trademark, or takedown requests, see
+INFRINGEMENT.md.

--- a/PATENTS.md
+++ b/PATENTS.md
@@ -1,0 +1,30 @@
+# Patent Position
+
+VeriClaw 爪印 is distributed under the repository [LICENSE](LICENSE).
+
+This file is an informational statement of current project posture. It does not
+expand, reduce, or replace the rights granted by the repository license or by
+applicable law.
+
+## Current position
+
+- No separate express patent license, patent promise, non-assert pledge,
+  covenant not to sue, or patent retaliation framework is published in this
+  repository beyond the rights, if any, that arise under the repository
+  [LICENSE](LICENSE) and applicable law.
+- Except to the extent any patent rights are unavoidably granted by the
+  repository [LICENSE](LICENSE) or by law, all patent rights are reserved.
+- Publication of source code, APIs, examples, release artifacts, docs, or
+  interoperability notes should not be read as a separate express patent
+  license or waiver.
+- Any broader patent permission, commercial patent license, partner
+  distribution right, or trademark-linked official distribution approval
+  requires a separate written agreement from the rights holder.
+- The project may use public releases, source publication, changelogs, and
+  documentation as defensive prior-art records.
+
+## Questions
+
+For patent inquiries, defensive-publication coordination, patent-related
+notice, or requests for separate written patent permission, use the intake path
+in [INFRINGEMENT.md](INFRINGEMENT.md).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,46 @@
+# VeriClaw 爪印 Privacy
+
+VeriClaw 爪印 is designed as a local-first verification companion for a user-controlled OpenClaw Gateway.
+
+## What the app processes
+
+- Pairing details needed to connect your device to your chosen gateway
+- Content you explicitly share, capture, or approve for review flows
+- Optional device signals you enable, such as camera, microphone, photo library, notifications, motion, and location
+- Operational state needed to keep the companion connected and deliver review actions
+
+## Where data goes
+
+- By default, VeriClaw 爪印 sends data only to the OpenClaw Gateway you pair it with
+- The app does not require a hosted VeriClaw account to function
+- If your paired gateway routes data to third-party providers or automations, that routing is controlled by your gateway configuration rather than by the App Store client alone
+
+## Sharing
+
+- Device data is shared with your paired OpenClaw Gateway only when a feature is enabled and a workflow requests it
+- Any onward sharing to model providers, third-party services, or external automations is determined by your gateway configuration
+- VeriClaw 爪印 does not promise a separate hosted cloud account layer for routing or storage
+
+## Permissions
+
+VeriClaw 爪印 requests only the permissions needed for features you use, including:
+
+- Camera and photos for evidence capture
+- Microphone and speech recognition for voice-triggered workflows
+- Location and motion for device-aware verification workflows
+- Notifications for review prompts and companion actions
+
+## Data control
+
+- You control the gateway, pairing, and enabled device capabilities
+- You can disconnect the gateway, revoke permissions, or remove local app data through your device settings and paired runtime setup
+
+## Retention and deletion
+
+- Local app state is retained only as long as needed to keep pairing, review, and notification flows working on your device
+- Gateway-side retention is controlled by the OpenClaw runtime you pair with
+- To stop future collection from this device, disconnect the gateway pairing, revoke permissions, or remove the app and its local data
+
+## Support
+
+For current support and release materials, see [SUPPORT.md](SUPPORT.md).

--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ If you want a personal, single-user assistant that feels local, fast, and always
 
 [Website](https://openclaw.ai) · [Docs](https://docs.openclaw.ai) · [Vision](VISION.md) · [DeepWiki](https://deepwiki.com/openclaw/openclaw) · [Getting Started](https://docs.openclaw.ai/start/getting-started) · [Updating](https://docs.openclaw.ai/install/updating) · [Showcase](https://docs.openclaw.ai/start/showcase) · [FAQ](https://docs.openclaw.ai/help/faq) · [Wizard](https://docs.openclaw.ai/start/wizard) · [Nix](https://github.com/openclaw/nix-openclaw) · [Docker](https://docs.openclaw.ai/install/docker) · [Discord](https://discord.gg/clawd)
 
+License and IP: [LICENSE](LICENSE) · [NOTICE](NOTICE) · [TRADEMARKS](TRADEMARKS.md) · [INFRINGEMENT](INFRINGEMENT.md) · [PATENTS](PATENTS.md)
+
+## Launch focus: VeriClaw 爪印
+
+`VeriClaw 爪印` is the Apple-native correction companion for OpenClaw.
+
+OpenClaw remains the runtime and Gateway. VeriClaw adds the native supervision
+layer for evidence-first correction cases, professional-role drift diagnosis,
+prescription and follow-up guidance, verification before closure, and per-bot
+casebook learning.
+
+This launch window is focused on the GitHub-first public story for OpenClaw
+plus VeriClaw. The Apple companion path continues in parallel, but GitHub is
+the current publish surface. Watch remains outside the current release gate.
+
+Launch materials: [GitHub launch kit](docs/launch/github-launch-kit.md) · [GitHub release announcement](docs/launch/github-release-announcement.md) · [Market differentiation](docs/launch/market-differentiation.md)
+
 Preferred setup: run the onboarding wizard (`openclaw onboard`) in your terminal.
 The wizard guides you step by step through setting up the gateway, workspace, channels, and skills. The CLI wizard is the recommended path and works on **macOS, Linux, and Windows (via WSL2; strongly recommended)**.
 Works with npm, pnpm, or bun.
@@ -286,8 +303,11 @@ The Gateway alone delivers a great experience. All apps are optional and add ext
 
 If you plan to build/run companion apps, follow the platform runbooks below.
 
-### macOS (OpenClaw.app) (optional)
+### macOS (VeriClaw 爪印.app) (optional)
 
+- Apple-native correction workspace and hover supervisor for drifting bots.
+- Case-based loop: evidence, diagnosis, prescription, verification, casebook.
+- Professional-role drift review for named seats and agents.
 - Menu bar control for the Gateway and health.
 - Voice Wake + push-to-talk overlay.
 - WebChat + debug tools.
@@ -297,6 +317,7 @@ Note: signed builds required for macOS permissions to stick across rebuilds (see
 
 ### iOS node (optional)
 
+- Secure companion surface for evidence capture and role-aware correction follow-up.
 - Pairs as a node over the Gateway WebSocket (device pairing).
 - Voice trigger forwarding + Canvas surface.
 - Controlled via `openclaw nodes …`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🦞 OpenClaw — Personal AI Assistant
+# 🦞 OpenClaw — Self-Hosted AI Assistant & MCP-Compatible Gateway
 
 <p align="center">
     <picture>
@@ -18,10 +18,10 @@
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge" alt="MIT License"></a>
 </p>
 
-**OpenClaw** is a _personal AI assistant_ you run on your own devices.
-It answers you on the channels you already use (WhatsApp, Telegram, Slack, Discord, Google Chat, Signal, iMessage, BlueBubbles, IRC, Microsoft Teams, Matrix, Feishu, LINE, Mattermost, Nextcloud Talk, Nostr, Synology Chat, Tlon, Twitch, Zalo, Zalo Personal, WebChat). It can speak and listen on macOS/iOS/Android, and can render a live Canvas you control. The Gateway is just the control plane — the product is the assistant.
+**OpenClaw** is a _self-hosted personal AI assistant_ and _MCP-compatible AI gateway_ you run on your own devices.
+It connects Model Context Protocol (MCP) tools, browser automation, and the channels you already use (WhatsApp, Telegram, Slack, Discord, Google Chat, Signal, iMessage, BlueBubbles, IRC, Microsoft Teams, Matrix, Feishu, LINE, Mattermost, Nextcloud Talk, Nostr, Synology Chat, Tlon, Twitch, Zalo, Zalo Personal, WebChat). It can speak and listen on macOS/iOS/Android, route multi-agent workflows, and render a live Canvas you control. The Gateway is just the control plane — the product is the assistant.
 
-If you want a personal, single-user assistant that feels local, fast, and always-on, this is it.
+If you want a local-first AI assistant, messaging bot gateway, and automation control plane that feels fast and always-on, this is it.
 
 [Website](https://openclaw.ai) · [Docs](https://docs.openclaw.ai) · [Vision](VISION.md) · [DeepWiki](https://deepwiki.com/openclaw/openclaw) · [Getting Started](https://docs.openclaw.ai/start/getting-started) · [Updating](https://docs.openclaw.ai/install/updating) · [Showcase](https://docs.openclaw.ai/start/showcase) · [FAQ](https://docs.openclaw.ai/help/faq) · [Wizard](https://docs.openclaw.ai/start/wizard) · [Nix](https://github.com/openclaw/nix-openclaw) · [Docker](https://docs.openclaw.ai/install/docker) · [Discord](https://discord.gg/clawd)
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,20 @@
+# VeriClaw 爪印 Support
+
+VeriClaw 爪印 ships as a verification and correction companion for OpenClaw.
+
+## Product support
+
+- GitHub repository: https://github.com/openclaw/openclaw
+- Issue tracker: https://github.com/openclaw/openclaw/issues
+
+## What to include in a support report
+
+- Device and OS version
+- App version
+- Whether the issue is on iPhone, Apple Watch, or macOS
+- Whether the problem happens during pairing, review intake, evidence capture, or gateway reconnect
+
+## Review and release context
+
+- VeriClaw 爪印 is intended to pair with a user-controlled OpenClaw Gateway
+- The companion app focuses on verification, review intake, evidence capture, and correction follow-up rather than replacing the full OpenClaw runtime

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,45 @@
+# Trademark Policy
+
+`OpenClaw`, the OpenClaw name, project logos, and related brand identifiers are
+trademarks or source identifiers of the OpenClaw project and its maintainers.
+The repository license covers copyright in the code and docs. It does not grant
+permission to use project branding in ways that imply affiliation, sponsorship,
+or endorsement.
+
+## Allowed without separate permission
+
+- Truthful, referential use such as "built with OpenClaw", "compatible with
+  OpenClaw", or "forked from OpenClaw".
+- Linking to the official project, repository, docs, or release pages.
+- Redistributing unmodified official OpenClaw releases while preserving
+  copyright, license, and notice materials.
+
+## Not allowed without separate permission
+
+- Using `OpenClaw` or confusingly similar branding in the name of a modified
+  fork, hosted service, app listing, package, domain, social handle, or product
+  in a way that implies official status.
+- Using project logos, app icons, or brand artwork for modified builds or
+  derivative products in a way that suggests endorsement.
+- Marketing a fork, mirror, or commercial offer as if it were the official
+  OpenClaw project.
+
+## Modified builds and forks
+
+If you ship a modified build, fork, hosted service, or repackaged distribution:
+
+- choose your own product name and branding by default
+- remove or replace official logos and app artwork unless you have permission
+- keep the required copyright and license notices
+- include a clear statement that the build is unofficial and not endorsed by
+  the OpenClaw project
+
+Example disclaimer:
+
+`This is an unofficial build derived from OpenClaw. It is not affiliated with,
+endorsed by, or published by the OpenClaw project.`
+
+## Reporting misuse or asking permission
+
+For trademark permissions, trademark misuse reports, or brand-enforcement
+questions, follow the intake path in [INFRINGEMENT.md](INFRINGEMENT.md).

--- a/apps/ios/APP_STORE_SUBMISSION_KIT.md
+++ b/apps/ios/APP_STORE_SUBMISSION_KIT.md
@@ -1,0 +1,93 @@
+# VeriClaw 爪印 App Store Submission Kit
+
+This file is the operator checklist for the iPhone-side App Store submission.
+
+## Metadata source of truth
+
+- App description:
+  [description.txt](fastlane/metadata/en-US/description.txt)
+- Subtitle:
+  [subtitle.txt](fastlane/metadata/en-US/subtitle.txt)
+- Promotional text:
+  [promotional_text.txt](fastlane/metadata/en-US/promotional_text.txt)
+- Keywords:
+  [keywords.txt](fastlane/metadata/en-US/keywords.txt)
+- Release notes:
+  [release_notes.txt](fastlane/metadata/en-US/release_notes.txt)
+- App Review notes template:
+  [notes.txt](fastlane/metadata/review_information/notes.txt)
+
+## Screenshot plan
+
+Current iPhone screenshot set:
+
+1. [onboarding.png](screenshots/session-2026-03-07/onboarding.png)
+2. [settings.png](screenshots/session-2026-03-07/settings.png)
+3. [talk-mode.png](screenshots/session-2026-03-07/talk-mode.png)
+4. [canvas-cool.png](screenshots/session-2026-03-07/canvas-cool.png)
+
+Suggested product-page caption direction:
+
+1. Connect to your gateway
+2. Review evidence and settings
+3. Send role-aware follow-up
+4. Capture device context fast
+
+## App Review information to fill locally
+
+Before `fastlane ios metadata`, fill these local env vars in
+`.env` under `apps/ios/fastlane/`:
+
+- `IOS_APP_REVIEW_FIRST_NAME`
+- `IOS_APP_REVIEW_LAST_NAME`
+- `IOS_APP_REVIEW_EMAIL`
+- `IOS_APP_REVIEW_PHONE`
+- `IOS_APP_REVIEW_NOTES_APPEND`
+
+`IOS_APP_REVIEW_NOTES_APPEND` should include the concrete pairing, test gateway,
+demo account, or other reviewer-only instructions for this submission.
+
+Local preflight command:
+
+```bash
+pnpm ios:review:local-check
+```
+
+Compact submission-side gate on the release Mac:
+
+```bash
+pnpm release:apple:submit-check
+```
+
+Local metadata preview:
+
+```bash
+pnpm ios:review:preview
+```
+
+This renders the review-contact metadata into
+`apps/ios/build/app-store-metadata-preview` so the operator can read the
+App Review text exactly as it will be staged locally.
+
+## Open gap before submission
+
+- This synchronized launch path excludes the Watch companion. Keep any watchOS
+  screenshots and watch-specific submission media out of the current App Store
+  checklist.
+- Re-verify that the current iPhone screenshots still match the latest
+  `VeriClaw 爪印` branding and onboarding copy.
+- Fill the submission-specific App Review notes locally before metadata upload
+  and confirm the rendered preview reads naturally.
+
+## Why this checklist exists
+
+Apple's current App Store Connect help says:
+
+- screenshots are required platform-version metadata
+- you can upload a minimum of one and a maximum of ten screenshots
+- if the UI is the same across device sizes, provide the highest-resolution
+  required screenshots and App Store Connect will scale them down
+- watchOS screenshots are uploaded in Media Manager only for watchOS apps, which
+  are not part of the current launch scope
+- App Review notes should include any settings, test registration, or account
+  details needed to review the app

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -301,9 +301,12 @@ final class ControlChannel {
         }
     }
 
-    private func establishGatewayConnection(timeoutMs: Int = 5000) async throws {
+    private func establishGatewayConnection(timeoutMs: Int? = nil) async throws {
+        let bootstrapTimeoutMs =
+            timeoutMs ??
+            (CommandResolver.connectionModeIsRemote() ? 8_000 : 12_000)
         try await GatewayConnection.shared.refresh()
-        let ok = try await GatewayConnection.shared.healthOK(timeoutMs: timeoutMs)
+        let ok = try await GatewayConnection.shared.healthOK(timeoutMs: bootstrapTimeoutMs)
         if ok == false {
             throw NSError(
                 domain: "Gateway",

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayChannelConnectTests.swift
@@ -47,6 +47,22 @@ struct GatewayChannelConnectTests {
             })
     }
 
+    private func makeChallengeTimeoutProfile() -> GatewayChannelTimeoutProfile {
+        GatewayChannelTimeoutProfile(
+            connectTimeoutSeconds: 0.2,
+            connectChallengeTimeoutSeconds: 0.05,
+            loopbackConnectTimeoutSeconds: 0.2,
+            loopbackConnectChallengeTimeoutSeconds: 0.15)
+    }
+
+    private func makeConnectTimeoutProfile() -> GatewayChannelTimeoutProfile {
+        GatewayChannelTimeoutProfile(
+            connectTimeoutSeconds: 0.08,
+            connectChallengeTimeoutSeconds: 0.05,
+            loopbackConnectTimeoutSeconds: 0.2,
+            loopbackConnectChallengeTimeoutSeconds: 0.05)
+    }
+
     @Test func `concurrent connect is single flight on success`() async throws {
         let session = self.makeSession(response: .helloOk(delayMs: 200))
         let channel = try GatewayChannelActor(
@@ -107,6 +123,105 @@ struct GatewayChannelConnectTests {
             #expect(error.recommendedNextStepCode == GatewayConnectRecoveryNextStep.updateAuthConfiguration.rawValue)
         } catch {
             Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test func `loopback connect tolerates a slower challenge budget`() async throws {
+        let session = GatewayTestWebSocketSession(
+            taskFactory: {
+                GatewayTestWebSocketTask(
+                    receiveHook: { task, receiveIndex in
+                        if receiveIndex == 0 {
+                            try await Task.sleep(nanoseconds: 100_000_000)
+                            return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                        }
+                        let id = task.snapshotConnectRequestID() ?? "connect"
+                        return .data(GatewayWebSocketTestSupport.connectOkData(id: id))
+                    })
+            })
+        let channel = try GatewayChannelActor(
+            url: #require(URL(string: "ws://127.0.0.1:18789")),
+            token: nil,
+            session: WebSocketSessionBox(session: session),
+            timeoutProfile: self.makeChallengeTimeoutProfile())
+
+        try await channel.connect()
+        #expect(session.snapshotMakeCount() == 1)
+    }
+
+    @Test func `remote connect keeps the tighter challenge budget`() async throws {
+        let session = GatewayTestWebSocketSession(
+            taskFactory: {
+                GatewayTestWebSocketTask(
+                    receiveHook: { _, receiveIndex in
+                        if receiveIndex == 0 {
+                            try await Task.sleep(nanoseconds: 100_000_000)
+                            return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                        }
+                        Issue.record("remote connect should time out before challenge arrives")
+                        return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                    })
+            })
+        let channel = try GatewayChannelActor(
+            url: #require(URL(string: "ws://example.invalid")),
+            token: nil,
+            session: WebSocketSessionBox(session: session),
+            timeoutProfile: self.makeChallengeTimeoutProfile())
+
+        do {
+            try await channel.connect()
+            Issue.record("expected connect to fail before the delayed challenge arrives")
+        } catch {
+            #expect(String(describing: error).contains("ConnectChallengeError"))
+        }
+    }
+
+    @Test func `loopback connect tolerates a slower connect response budget`() async throws {
+        let session = GatewayTestWebSocketSession(
+            taskFactory: {
+                GatewayTestWebSocketTask(
+                    receiveHook: { task, receiveIndex in
+                        if receiveIndex == 0 {
+                            return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                        }
+                        try await Task.sleep(nanoseconds: 100_000_000)
+                        let id = task.snapshotConnectRequestID() ?? "connect"
+                        return .data(GatewayWebSocketTestSupport.connectOkData(id: id))
+                    })
+            })
+        let channel = try GatewayChannelActor(
+            url: #require(URL(string: "ws://127.0.0.1:18789")),
+            token: nil,
+            session: WebSocketSessionBox(session: session),
+            timeoutProfile: self.makeConnectTimeoutProfile())
+
+        try await channel.connect()
+    }
+
+    @Test func `remote connect keeps the tighter overall connect budget`() async throws {
+        let session = GatewayTestWebSocketSession(
+            taskFactory: {
+                GatewayTestWebSocketTask(
+                    receiveHook: { task, receiveIndex in
+                        if receiveIndex == 0 {
+                            return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                        }
+                        try await Task.sleep(nanoseconds: 100_000_000)
+                        let id = task.snapshotConnectRequestID() ?? "connect"
+                        return .data(GatewayWebSocketTestSupport.connectOkData(id: id))
+                    })
+            })
+        let channel = try GatewayChannelActor(
+            url: #require(URL(string: "ws://example.invalid")),
+            token: nil,
+            session: WebSocketSessionBox(session: session),
+            timeoutProfile: self.makeConnectTimeoutProfile())
+
+        do {
+            try await channel.connect()
+            Issue.record("expected connect to fail before the delayed response arrives")
+        } catch {
+            #expect(error.localizedDescription.contains("connect timed out"))
         }
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -109,6 +109,31 @@ public struct GatewayConnectOptions: Sendable {
     }
 }
 
+public struct GatewayChannelTimeoutProfile: Sendable {
+    public static let `default` = GatewayChannelTimeoutProfile(
+        connectTimeoutSeconds: 12,
+        connectChallengeTimeoutSeconds: 6,
+        loopbackConnectTimeoutSeconds: 18,
+        loopbackConnectChallengeTimeoutSeconds: 10)
+
+    public var connectTimeoutSeconds: Double
+    public var connectChallengeTimeoutSeconds: Double
+    public var loopbackConnectTimeoutSeconds: Double
+    public var loopbackConnectChallengeTimeoutSeconds: Double
+
+    public init(
+        connectTimeoutSeconds: Double,
+        connectChallengeTimeoutSeconds: Double,
+        loopbackConnectTimeoutSeconds: Double,
+        loopbackConnectChallengeTimeoutSeconds: Double)
+    {
+        self.connectTimeoutSeconds = connectTimeoutSeconds
+        self.connectChallengeTimeoutSeconds = connectChallengeTimeoutSeconds
+        self.loopbackConnectTimeoutSeconds = loopbackConnectTimeoutSeconds
+        self.loopbackConnectChallengeTimeoutSeconds = loopbackConnectChallengeTimeoutSeconds
+    }
+}
+
 public enum GatewayAuthSource: String, Sendable {
     case deviceToken = "device-token"
     case sharedToken = "shared-token"
@@ -182,10 +207,7 @@ public actor GatewayChannelActor {
     private var lastAuthSource: GatewayAuthSource = .none
     private let decoder = JSONDecoder()
     private let encoder = JSONEncoder()
-    // Remote gateways (tailscale/wan) can take longer to deliver connect.challenge.
-    // Connect now requires this nonce before we send device-auth.
-    private let connectTimeoutSeconds: Double = 12
-    private let connectChallengeTimeoutSeconds: Double = 6.0
+    private let timeoutProfile: GatewayChannelTimeoutProfile
     // Some networks will silently drop idle TCP/TLS flows around ~30s. The gateway tick is server->client,
     // but NATs/proxies often require outbound traffic to keep the connection alive.
     private let keepaliveIntervalSeconds: Double = 15.0
@@ -206,6 +228,7 @@ public actor GatewayChannelActor {
         bootstrapToken: String? = nil,
         password: String? = nil,
         session: WebSocketSessionBox? = nil,
+        timeoutProfile: GatewayChannelTimeoutProfile = .default,
         pushHandler: (@Sendable (GatewayPush) async -> Void)? = nil,
         connectOptions: GatewayConnectOptions? = nil,
         disconnectHandler: (@Sendable (String) async -> Void)? = nil)
@@ -215,12 +238,45 @@ public actor GatewayChannelActor {
         self.bootstrapToken = bootstrapToken
         self.password = password
         self.session = session?.session ?? URLSession(configuration: .default)
+        self.timeoutProfile = timeoutProfile
         self.pushHandler = pushHandler
         self.connectOptions = connectOptions
         self.disconnectHandler = disconnectHandler
         Task { [weak self] in
             await self?.startWatchdog()
         }
+    }
+
+    private var isLoopbackEndpoint: Bool {
+        guard let host = self.url.host?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !host.isEmpty
+        else {
+            return false
+        }
+        if host == "localhost" || host == "::1" || host == "127.0.0.1" {
+            return true
+        }
+        return host.hasPrefix("127.")
+    }
+
+    // Local gateway boot can be briefly noisy while launchd, the gateway, and the app
+    // are all coming up together. Give loopback a wider budget than remote endpoints.
+    private var connectTimeoutSeconds: Double {
+        if self.isLoopbackEndpoint {
+            return max(
+                self.timeoutProfile.connectTimeoutSeconds,
+                self.timeoutProfile.loopbackConnectTimeoutSeconds)
+        }
+        return self.timeoutProfile.connectTimeoutSeconds
+    }
+
+    private var connectChallengeTimeoutSeconds: Double {
+        if self.isLoopbackEndpoint {
+            return max(
+                self.timeoutProfile.connectChallengeTimeoutSeconds,
+                self.timeoutProfile.loopbackConnectChallengeTimeoutSeconds)
+        }
+        return self.timeoutProfile.connectChallengeTimeoutSeconds
     }
 
     public func authSource() -> GatewayAuthSource { self.lastAuthSource }

--- a/docs/design/first-use-ux-iteration.md
+++ b/docs/design/first-use-ux-iteration.md
@@ -1,0 +1,120 @@
+---
+summary: "First-use UX audit for making VeriClaw legible without a manual"
+read_when:
+  - Checking whether a brand-new user can operate the app immediately
+  - Polishing the Apple-native correction workspace before release
+  - Reviewing interaction changes that affect Control, Cases, or the hover widget
+title: "First-Use UX Iteration"
+---
+
+# First-use UX iteration
+
+Goal:
+
+- a new user should understand where to start
+- a new user should understand why a case exists
+- a new user should understand whether the loop is actually closing
+- the app should not require a README to perform the first useful action
+
+## Problem statement
+
+Earlier builds had strong visual polish, but first-use orientation was still too
+dependent on user inference.
+
+Main friction points:
+
+- Control exposed multiple equal-weight actions without a clear `start here`
+  path
+- Cases detail contained rich data, but the correction loop state was still too
+  implicit
+- issue rows did not surface enough scan-friendly context for role drift or live
+  treatment state
+- the hover widget looked premium, but it did not expose enough case load or
+  validation state to feel like a real supervision companion
+
+## Changes landed on 2026-04-04
+
+### Control
+
+- added a state-based primary CTA in the hero:
+  - degraded -> `Open Cases`
+  - linking needed -> `Open Settings`
+  - unknown -> `Refresh Status`
+  - healthy/live -> `Open Chat` or `Continue Chat`
+- restored the existing `Quick Actions` card into the main dashboard flow
+- added a `Closed Loop` orientation card so the product teaches:
+  - Control
+  - Cases
+  - Chat
+  - Verify
+
+### Cases
+
+- added a `Closed Loop` section in the detail view
+- each active case now shows a stage strip for:
+  - Evidence
+  - Diagnosis
+  - Prescription
+  - Verify
+  - Casebook
+- issue rows now expose a stronger scan line so a user can see role drift or
+  live treatment state before opening detail
+- row badges are now clearer about proof count, prior history, and role/casebook
+  context
+
+### Hover widget
+
+- added active case count and pending synthetic validation count
+- the `Cases` scene is now more explicit about whether:
+  - there are active cases
+  - there are pending trials
+  - the workspace is quiet
+- the `Cases` primary action now changes with loop state:
+  - open cases -> `Review Focus Case` / `Review Open Cases`
+  - queued validation only -> `Review Trial Queue`
+  - quiet -> `Open Casebook`
+- scene tabs now surface lightweight attention badges such as `Open`, `Queued`,
+  or `Alert` so a user can see where supervision pressure lives before opening a
+  panel
+- compact mode now surfaces one state-driven primary action so the small widget
+  still teaches the recommended first click
+- expanded scene cards now show an inline interaction hint so swipe-vs-open
+  behavior does not have to be inferred
+- quiet-state chat copy now explicitly says `Start in chat` so a first-time user
+  does not confuse an idle desk with a live-thread return state
+- the currently recommended scene now surfaces a small `Start here` /
+  `Recommended` badge in the scene card header
+- the `Chat` secondary action is now state-driven:
+  - open loops -> review cases
+  - quiet healthy desk -> check pulse
+  - linking needed -> open settings
+
+## UX acceptance bar
+
+The interface is acceptable only if all of these are true:
+
+1. A new user can identify the first click from the Control hero alone.
+2. A selected case explains:
+   - what went wrong
+   - what to do next
+   - what stage of the correction loop is currently gating closure
+3. The hover widget communicates whether supervision pressure is low or high
+   without opening the full workspace.
+4. The interface never asks the user to choose between equally-weighted entry
+   points when the system already knows the better next step.
+
+## Verification
+
+Local verification after this pass:
+
+- `pnpm mac:test`
+- result: `436 tests` across `108 suites` passed on 2026-04-04
+
+## Remaining UX risks
+
+- App Store screenshots still need a fresh pass so the visual story matches the
+  now-clearer first-use routing
+- release media still needs a clean App + GitHub story pass so the widget and
+  correction loop are represented without relying on unsupported surfaces
+- real-world dogfooding should still validate whether the `Start here` CTA is
+  sufficient or whether an even stronger one-task-only first state is needed

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "name": "OpenClaw",
-  "description": "Self-hosted gateway that connects WhatsApp, Telegram, Discord, iMessage, and more to AI coding agents. Run a single Gateway process on your own machine and message your AI assistant from anywhere.",
+  "description": "Self-hosted AI assistant and MCP-compatible gateway for Discord, Telegram, WhatsApp, Slack, iMessage, browser automation, and multi-agent workflows. Run one Gateway on your own machine and control your assistant from anywhere.",
   "theme": "mint",
   "icons": {
     "library": "lucide"

--- a/docs/launch/github-launch-kit.md
+++ b/docs/launch/github-launch-kit.md
@@ -1,0 +1,163 @@
+---
+summary: "Reusable GitHub-facing copy deck for the VeriClaw launch"
+read_when:
+  - Preparing the GitHub release page
+  - Refreshing the repository README hero copy
+  - Writing launch posts, blurbs, or FAQ answers
+title: "GitHub Launch Kit"
+---
+
+# GitHub launch kit
+
+This file is the source-of-truth copy deck for the GitHub-facing launch story
+for `VeriClaw 爪印`.
+
+Use it when writing:
+
+- the GitHub release body
+- the repository README launch section
+- short launch blurbs
+- FAQ replies
+- screenshot captions and launch-safe positioning
+
+Current release posture:
+
+- GitHub is the current public launch surface
+- Apple companion hardening continues in parallel
+- do not imply the App Store path is already publicly live
+
+## Positioning
+
+`VeriClaw 爪印` is the Apple-native correction companion for OpenClaw.
+
+OpenClaw remains the runtime, gateway, and assistant substrate.
+VeriClaw adds the native supervision layer:
+
+- evidence-first correction cases
+- professional-role drift diagnosis
+- prescription and follow-up guidance
+- verification before closure
+- per-bot casebook learning
+- a desktop hover companion that keeps supervision pressure visible
+
+## Short copy
+
+Hero line:
+
+- `Apple-native correction companion for OpenClaw`
+
+Short subtitle:
+
+- `Turn drift evidence into diagnosis, intervention, verification, and casebook learning.`
+
+One-sentence description:
+
+- `VeriClaw 爪印 is the Apple-native correction companion for OpenClaw, designed to supervise drifting bots through evidence, diagnosis, prescription, verification, and casebook learning.`
+
+Medium description:
+
+- `VeriClaw 爪印 strengthens OpenClaw with a native correction workspace. Instead of stopping at alerts, it helps turn evidence of hallucination, fake completion, disobedience, or role drift into a concrete loop: diagnosis, recommended intervention, verification, and a per-bot casebook that improves future corrections.`
+
+Long description:
+
+- `VeriClaw 爪印 is an Apple-native correction workspace and supervision companion for OpenClaw. It is built for the moment when a bot is drifting, overreaching, hallucinating, or failing its professional role contract. Rather than only showing telemetry, it organizes the problem into evidence, diagnosis, prescription, verification, and casebook updates. The result is a companion surface that helps teams understand what went wrong, what to do next, and whether the loop is actually closing.`
+
+## Launch pillars
+
+Keep these four ideas together in most public GitHub-facing copy:
+
+1. `Companion, not clone`
+   - VeriClaw strengthens OpenClaw instead of pretending to replace it.
+2. `Correction, not just monitoring`
+   - the product should answer what to do next, not only what went wrong.
+3. `Professional-role drift`
+   - the app treats many failures as occupational-role contract failures when appropriate.
+4. `Apple-native supervision`
+   - the macOS app, iPhone companion, and hover surfaces should feel like one native workflow.
+
+## GitHub-first framing
+
+When the public message needs to reflect the current rollout order, prefer:
+
+- `GitHub-first launch for the OpenClaw + VeriClaw story`
+- `public repository launch now, Apple submission path continuing in parallel`
+- `GitHub is live first; the Apple companion follows after final hardening`
+
+Avoid:
+
+- saying the App Store launch has already happened
+- implying GitHub and App Store shipped simultaneously when they did not
+
+## Product proof points
+
+Use these when a GitHub release needs concrete detail:
+
+- `evidence -> diagnosis -> prescription -> verification -> casebook`
+- professional-role contract and role-drift labeling for named bots or seats
+- desktop hover companion that exposes supervision pressure before opening the full workspace
+- case-based remediation instead of generic monitoring-only alerts
+- template validation before broader promotion
+
+## Launch-safe wording
+
+Preferred wording:
+
+- `Apple-native correction workspace for supervising drifting bots`
+- `professional-role correction companion for OpenClaw`
+- `evidence-first intervention and casebook learning`
+- `correction-first supervision surface`
+
+Avoid:
+
+- claiming universal market exclusivity as a hard fact
+- implying that VeriClaw replaces all observability tooling
+- implying that the current launch ships watchOS as part of the release window
+- implying fully autonomous correction when user confirmation still matters
+
+## FAQ copy
+
+`What is VeriClaw?`
+
+- `VeriClaw 爪印 is the native correction companion for OpenClaw. It turns evidence of bot drift into diagnosis, recommended intervention, verification, and casebook learning.`
+
+`Is VeriClaw separate from OpenClaw?`
+
+- `It is a companion, not a replacement. OpenClaw remains the runtime and gateway. VeriClaw adds the Apple-native supervision and correction layer.`
+
+`Is this just another AI monitor?`
+
+- `No. Monitoring is part of the workflow, but the product is designed around correction. The core loop is evidence, diagnosis, prescription, verification, and casebook learning.`
+
+`What makes it different from generic agent observability?`
+
+- `The product focuses on professional-role drift, case-based remediation, and native supervision surfaces rather than only dashboards, traces, or remote terminals.`
+
+`Is watchOS part of this launch?`
+
+- `No. The current synchronized launch scope is GitHub plus the App Store path without making Watch a release blocker.`
+
+`Is the App Store live right now?`
+
+- `Not yet. The current public launch surface is GitHub first while the Apple companion continues through final hardening and submission steps.`
+
+`Can people redistribute the repo?`
+
+- `Yes, but redistribution should preserve license, notices, attribution, and source reference expectations. Branding rights are separate and governed by the repository trademark policy.`
+
+## Screenshot caption direction
+
+Suggested GitHub screenshot or media caption style:
+
+1. `See drift pressure before it becomes invisible`
+2. `Open a case, not just a log`
+3. `Diagnose role drift and choose the next intervention`
+4. `Verify the fix before calling the loop closed`
+
+## Handy links
+
+- Market scan and differentiation:
+  [market-differentiation.md](market-differentiation.md)
+- Apple submission copy and screenshot notes:
+  [APP_STORE_SUBMISSION_KIT.md](../../apps/ios/APP_STORE_SUBMISSION_KIT.md)
+- First-use UX acceptance notes:
+  [first-use-ux-iteration.md](../design/first-use-ux-iteration.md)

--- a/docs/launch/github-publish-checklist.md
+++ b/docs/launch/github-publish-checklist.md
@@ -1,0 +1,60 @@
+---
+summary: "Operator checklist for a GitHub-first public launch of OpenClaw + VeriClaw"
+read_when:
+  - Preparing the public GitHub release first
+  - Verifying the repository-facing launch surface
+  - Handing GitHub launch work between product, engineering, and ops
+title: "GitHub Publish Checklist"
+---
+
+# GitHub publish checklist
+
+Use this checklist when GitHub is the first public launch surface.
+
+Current positioning:
+
+- `OpenClaw` remains the runtime and gateway
+- `VeriClaw 爪印` is the Apple-native correction companion
+- GitHub is public first
+- Apple submission continues in parallel and should not be falsely presented as already live
+
+## Repository-facing checklist
+
+- README hero and launch section mention `VeriClaw 爪印` clearly
+- GitHub release body is ready from
+  [github-release-announcement.md](github-release-announcement.md)
+- copy deck is aligned in
+  [github-launch-kit.md](github-launch-kit.md)
+- legal/IP pack is present at repo root:
+  - [LICENSE](../../LICENSE)
+  - [NOTICE](../../NOTICE)
+  - [ATTRIBUTION.md](../../ATTRIBUTION.md)
+  - [TRADEMARKS.md](../../TRADEMARKS.md)
+  - [PATENTS.md](../../PATENTS.md)
+  - [INFRINGEMENT.md](../../INFRINGEMENT.md)
+  - [LEGAL_ENFORCEMENT.md](../../LEGAL_ENFORCEMENT.md)
+  - [PRIVACY.md](../../PRIVACY.md)
+  - [SUPPORT.md](../../SUPPORT.md)
+
+## Message discipline
+
+- say `companion, not clone`
+- say `correction, not just monitoring`
+- keep `professional-role drift` in the story
+- do not claim the App Store path is already public unless it truly is
+- do not claim watchOS is in the current launch scope
+
+## Operator checklist
+
+1. Confirm the branch/commit you want public is actually the intended launch snapshot.
+2. Confirm the version/tag you plan to publish is newer than the latest existing GitHub release.
+3. Publish or draft the GitHub release body from
+   [github-release-announcement.md](github-release-announcement.md).
+4. Recheck the top-level README after push on the live GitHub page.
+5. If Apple is still pending, explicitly state `GitHub-first` in any release note, discussion, or pinned update.
+
+## Current local caution
+
+On this workspace, the worktree is heavily dirty. Do not treat the current
+tree as automatically safe to publish wholesale without selecting the intended
+scope first.

--- a/docs/launch/github-release-announcement.md
+++ b/docs/launch/github-release-announcement.md
@@ -1,0 +1,105 @@
+---
+summary: "Paste-ready GitHub release announcement draft for VeriClaw"
+read_when:
+  - Publishing the GitHub-first public release
+  - Writing the GitHub Releases page body
+  - Preparing a launch post that mirrors the repository story
+title: "GitHub Release Announcement"
+---
+
+# GitHub release announcement
+
+Use this file as the default draft for the GitHub Releases page.
+
+Current release posture:
+
+- GitHub is the first public launch surface
+- Apple companion release work continues in parallel
+- release wording should not imply the App Store path is already public
+
+## Release title options
+
+- `VeriClaw 爪印: Apple-native correction companion for OpenClaw`
+- `Introducing VeriClaw 爪印 for OpenClaw`
+- `VeriClaw 爪印: correction-first supervision for OpenClaw`
+
+## Paste-ready GitHub release body
+
+```md
+# VeriClaw 爪印
+
+VeriClaw 爪印 is the Apple-native correction companion for OpenClaw.
+
+OpenClaw remains the runtime and gateway. VeriClaw adds the native supervision
+layer for the moments when a bot is drifting, hallucinating, overreaching, or
+failing its professional role contract.
+
+Instead of stopping at alerts, the core loop is:
+
+- evidence
+- diagnosis
+- prescription
+- verification
+- casebook learning
+
+## What this release adds
+
+- a correction-first native workspace instead of monitoring-only surfaces
+- professional-role drift framing for named bots or seats
+- a desktop hover companion that keeps supervision pressure visible
+- case-based follow-up so every issue can move toward closure
+- verification and casebook updates before a loop is considered closed
+
+## Why this is different
+
+The goal is not to replace OpenClaw or generic observability tooling.
+
+The goal is to give OpenClaw a native correction companion that answers three
+questions clearly:
+
+1. What went wrong?
+2. What should happen next?
+3. Did the correction actually hold?
+
+## Current launch scope
+
+- GitHub-first public release path
+- OpenClaw runtime plus VeriClaw companion story
+- Apple companion submission path continues in parallel
+- watchOS remains outside the current release gate
+
+## Legal and redistribution
+
+Redistribution should preserve license, notice, attribution, and source
+reference expectations.
+
+See:
+
+- LICENSE
+- NOTICE
+- ATTRIBUTION.md
+- TRADEMARKS.md
+- PATENTS.md
+- INFRINGEMENT.md
+```
+
+## Short announcement version
+
+Use this when a shorter GitHub post or pinned discussion is needed:
+
+```md
+VeriClaw 爪印 is the Apple-native correction companion for OpenClaw.
+
+It is built for the moment when a bot drifts. Instead of stopping at monitoring,
+it pushes the workflow toward evidence, diagnosis, prescription, verification,
+and casebook learning.
+
+OpenClaw remains the runtime. VeriClaw adds the native supervision layer.
+```
+
+## Maintainer notes
+
+- Keep the wording `companion, not clone`.
+- Do not claim watchOS is in the current release scope.
+- Do not overstate market exclusivity.
+- Keep the legal/IP pack linked anywhere the release body is substantially reused.

--- a/docs/launch/market-differentiation.md
+++ b/docs/launch/market-differentiation.md
@@ -1,0 +1,106 @@
+---
+summary: "Current market scan and differentiation thesis for VeriClaw 爪印"
+read_when:
+  - Preparing launch positioning
+  - Explaining why VeriClaw is not just another AI monitor
+  - Checking whether the current product still occupies a distinctive gap
+title: "Market Differentiation"
+---
+
+# Market differentiation
+
+Scan date:
+`2026-04-04`
+
+Important caution:
+
+- this is a current market scan, not mathematical proof that no similar product
+  exists anywhere
+- the strongest defensible claim is:
+  - no exact match was found in the scanned set for an Apple-native
+    correction-first companion app that combines case-based remediation,
+    professional-role drift correction, and a desktop hover supervisor
+
+## Adjacent products found
+
+- [Agent Watch](https://agent-watch.com/)
+  - remote control and monitoring for coding agents
+  - strong on agent visibility and remote operations
+  - does not present itself as a case-based correction workspace with
+    prescription, verification, and casebook learning
+- [AgentWatch local monitor](https://www.agentwatch.tools/)
+  - local tray-style monitoring for coding agents
+  - strong adjacency to desktop supervision
+  - currently framed around process/resource monitoring rather than
+    professional-role correction
+- [Arize Phoenix](https://phoenix.arize.com/)
+  - LLM observability, evaluation, and troubleshooting platform
+  - clearly powerful, but platform/web observability oriented rather than an
+    Apple-native end-user companion surface
+- [LangWatch](https://langwatch.ai/)
+  - agent testing, simulations, evals, and monitoring
+  - strong adjacency in validation and monitoring
+  - positioned as a collaborative evaluation platform, not a native Mac/iPhone
+    correction companion
+- [AgentsRoom on the App Store](https://apps.apple.com/us/app/agentsroom/id6761265182)
+  - an iPhone/iPad companion for monitoring Claude agents in real time
+  - closest App Store adjacency on the monitoring side
+  - product copy emphasizes live terminal monitoring and remote control, not
+    occupational-role drift correction or casebook-driven remediation
+
+## Inference from the scan
+
+- The market already has:
+  - web observability tools
+  - desktop or tray monitoring tools
+  - remote/mobile companions for agent monitoring
+- The market does not appear saturated with:
+  - Apple-native correction-first supervision surfaces
+  - professional-role contract and role-drift assistance for named bots
+  - a closed-loop remediation model of:
+    - evidence
+    - diagnosis
+    - prescription
+    - verification
+    - casebook learning
+  - a native hover or floating desktop companion that shows supervision pressure
+    and routes directly into a correction workspace
+
+## Differentiation thesis to preserve
+
+VeriClaw should keep all four of these together:
+
+1. `Companion, not clone`
+   - it strengthens OpenClaw rather than pretending to replace it
+2. `Correction, not just monitoring`
+   - it should always answer what to do next, not only what went wrong
+3. `Professional-role drift`
+   - it frames hallucination, fake completion, disobedience, and overreach as
+     occupational contract failures when possible
+4. `Apple-native supervision`
+   - Mac, iPhone, and the hover widget should feel like one coherent native
+     tool, not a repackaged dashboard
+
+## Anti-drift guardrails
+
+If the product drifts toward any of these, differentiation weakens fast:
+
+- generic AI chat client
+- generic observability dashboard
+- generic remote terminal monitor
+- generic agent launcher without evidence-backed correction logic
+
+## Launch-safe wording
+
+Preferred wording:
+
+- `Apple-native correction workspace for supervising drifting bots`
+- `professional-role correction companion for OpenClaw`
+- `evidence-first intervention and casebook learning`
+
+Avoid overstating:
+
+- do not claim universal market exclusivity as a hard fact
+- do not claim the app replaces all observability tooling
+- do not claim fully autonomous correction if the user still needs to confirm
+  dispatches and outcomes

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -9,6 +9,7 @@ import type { RuntimeEnv } from "../../../../src/runtime.js";
 
 const DISCORD_GATEWAY_BOT_URL = "https://discord.com/api/v10/gateway/bot";
 const DEFAULT_DISCORD_GATEWAY_URL = "wss://gateway.discord.gg/";
+const PREMATURE_WS_CLOSE_ERROR = "WebSocket was closed before the connection was established";
 
 type DiscordGatewayMetadataResponse = Pick<Response, "ok" | "status" | "text">;
 type DiscordGatewayFetchInit = Record<string, unknown> & {
@@ -144,6 +145,9 @@ function createGatewayPlugin(params: {
   fetchInit?: DiscordGatewayFetchInit;
   wsAgent?: HttpsProxyAgent<string>;
 }): GatewayPlugin {
+  const isPrematureWebSocketCloseError = (error: unknown) =>
+    error instanceof Error && error.message.includes(PREMATURE_WS_CLOSE_ERROR);
+
   class SafeGatewayPlugin extends GatewayPlugin {
     constructor() {
       super(params.options);
@@ -165,6 +169,17 @@ function createGatewayPlugin(params: {
         return super.createWebSocket(url);
       }
       return new WebSocket(url, { agent: params.wsAgent });
+    }
+
+    override disconnect() {
+      try {
+        return super.disconnect();
+      } catch (error) {
+        if (isPrematureWebSocketCloseError(error)) {
+          return;
+        }
+        throw error;
+      }
     }
   }
 

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -364,7 +364,15 @@ describe("runDiscordGatewayLifecycle", () => {
             waitParams.registerForceStop?.((err) => reject(err));
           }),
       );
-      const { lifecycleParams } = createLifecycleHarness({ gateway });
+      const {
+        lifecycleParams,
+        runtimeError,
+        releaseEarlyGatewayErrorGuard,
+        start,
+        statusSink,
+        stop,
+        threadStop,
+      } = createLifecycleHarness({ gateway });
 
       const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
       lifecyclePromise.catch(() => {});
@@ -372,6 +380,41 @@ describe("runDiscordGatewayLifecycle", () => {
 
       await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_000);
       await expect(lifecyclePromise).rejects.toThrow("reconnect watchdog timeout");
+      expect(runtimeError).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "discord: reconnect watchdog timeout: idle 300000ms (limit 300000ms); force-stopping monitor task",
+        ),
+      );
+      const closePatch = statusSink.mock.calls.find((call) => {
+        const patch = (call[0] ?? {}) as {
+          connected?: boolean;
+          lastDisconnect?: { status?: number };
+        };
+        return patch.connected === false && patch.lastDisconnect?.status === 1006;
+      });
+      expect(closePatch).toBeDefined();
+      const watchdogPatch = statusSink.mock.calls.find((call) => {
+        const patch = (call[0] ?? {}) as {
+          connected?: boolean;
+          lastError?: string;
+          lastDisconnect?: { error?: string };
+        };
+        return (
+          patch.connected === false &&
+          patch.lastError ===
+            "discord reconnect watchdog timeout: idle 300000ms (limit 300000ms)" &&
+          patch.lastDisconnect?.error ===
+            "discord reconnect watchdog timeout: idle 300000ms (limit 300000ms)"
+        );
+      });
+      expect(watchdogPatch).toBeDefined();
+      expectLifecycleCleanup({
+        start,
+        stop,
+        threadStop,
+        waitCalls: 1,
+        releaseEarlyGatewayErrorGuard,
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -63,14 +63,13 @@ export async function runDiscordGatewayLifecycle(params: {
     timeoutMs: RECONNECT_STALL_TIMEOUT_MS,
     abortSignal: params.abortSignal,
     runtime: params.runtime,
-    onTimeout: () => {
+    onTimeout: ({ idleMs, timeoutMs }) => {
       if (params.abortSignal?.aborted || lifecycleStopping) {
         return;
       }
       const at = Date.now();
-      const error = new Error(
-        `discord reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms`,
-      );
+      const timeoutSummary = `idle ${idleMs}ms (limit ${timeoutMs}ms)`;
+      const error = new Error(`discord reconnect watchdog timeout: ${timeoutSummary}`);
       pushStatus({
         connected: false,
         lastEventAt: at,
@@ -82,7 +81,7 @@ export async function runDiscordGatewayLifecycle(params: {
       });
       params.runtime.error?.(
         danger(
-          `discord: reconnect watchdog timeout after ${RECONNECT_STALL_TIMEOUT_MS}ms; force-stopping monitor task`,
+          `discord: reconnect watchdog timeout: ${timeoutSummary}; force-stopping monitor task`,
         ),
       );
       triggerForceStop(error);

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   GatewayIntents,
+  baseDisconnectSpy,
   baseRegisterClientSpy,
   GatewayPlugin,
   globalFetchMock,
@@ -20,6 +21,7 @@ const {
   const undiciFetchMock = vi.fn();
   const globalFetchMock = vi.fn();
   const baseRegisterClientSpy = vi.fn();
+  const baseDisconnectSpy = vi.fn();
   const webSocketSpy = vi.fn();
 
   const GatewayIntents = {
@@ -43,6 +45,9 @@ const {
     async registerClient(client: unknown) {
       baseRegisterClientSpy(client);
     }
+    disconnect() {
+      baseDisconnectSpy();
+    }
   }
 
   class HttpsProxyAgent {
@@ -59,6 +64,7 @@ const {
   }
 
   return {
+    baseDisconnectSpy,
     baseRegisterClientSpy,
     GatewayIntents,
     GatewayPlugin,
@@ -162,6 +168,7 @@ describe("createDiscordGatewayPlugin", () => {
   beforeEach(() => {
     vi.stubGlobal("fetch", globalFetchMock);
     baseRegisterClientSpy.mockClear();
+    baseDisconnectSpy.mockClear();
     globalFetchMock.mockClear();
     restProxyAgentSpy.mockClear();
     undiciFetchMock.mockClear();
@@ -262,5 +269,43 @@ describe("createDiscordGatewayPlugin", () => {
         throw new Error("body stream closed");
       },
     } as unknown as Response);
+  });
+
+  it("swallows disconnect errors when the gateway websocket never opened", () => {
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+    baseDisconnectSpy.mockImplementationOnce(() => {
+      throw new Error("WebSocket was closed before the connection was established");
+    });
+
+    expect(() =>
+      (
+        plugin as {
+          disconnect: () => void;
+        }
+      ).disconnect(),
+    ).not.toThrow();
+  });
+
+  it("rethrows unexpected disconnect failures", () => {
+    const runtime = createRuntime();
+    const plugin = createDiscordGatewayPlugin({
+      discordConfig: {},
+      runtime,
+    });
+    baseDisconnectSpy.mockImplementationOnce(() => {
+      throw new Error("disconnect boom");
+    });
+
+    expect(() =>
+      (
+        plugin as {
+          disconnect: () => void;
+        }
+      ).disconnect(),
+    ).toThrow("disconnect boom");
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,8 +1,28 @@
 {
   "name": "openclaw",
   "version": "2026.3.14",
-  "description": "Multi-channel AI gateway with extensible messaging integrations",
-  "keywords": [],
+  "description": "Self-hosted AI assistant and MCP-compatible gateway for Discord, Telegram, WhatsApp, Slack, iMessage, browser automation, and multi-agent workflows",
+  "keywords": [
+    "ai-assistant",
+    "ai-gateway",
+    "automation",
+    "browser-automation",
+    "claude",
+    "codex",
+    "discord-bot",
+    "imessage",
+    "local-first",
+    "mcp",
+    "mcp-client",
+    "model-context-protocol",
+    "multi-agent",
+    "openclaw",
+    "personal-ai-assistant",
+    "self-hosted-ai",
+    "slack-bot",
+    "telegram-bot",
+    "whatsapp-bot"
+  ],
   "homepage": "https://github.com/openclaw/openclaw#readme",
   "bugs": {
     "url": "https://github.com/openclaw/openclaw/issues"

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
+import type { AgentDefaultsLikeConfig } from "../config/types.agents.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   DEFAULT_AGENT_ID,
@@ -25,7 +26,7 @@ export { resolveAgentIdFromSessionKey };
 
 type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
 
-type ResolvedAgentConfig = {
+type ResolvedAgentConfig = AgentDefaultsLikeConfig & {
   name?: string;
   workspace?: string;
   agentDir?: string;
@@ -135,6 +136,13 @@ export function resolveAgentConfig(
     skills: Array.isArray(entry.skills) ? entry.skills : undefined,
     memorySearch: entry.memorySearch,
     humanDelay: entry.humanDelay,
+    thinkingDefault: entry.thinkingDefault,
+    verboseDefault: entry.verboseDefault,
+    elevatedDefault: entry.elevatedDefault,
+    fastModeDefault: entry.fastModeDefault,
+    reasoningDefault: entry.reasoningDefault,
+    blockStreamingDefault: entry.blockStreamingDefault,
+    blockStreamingBreak: entry.blockStreamingBreak,
     heartbeat: entry.heartbeat,
     identity: entry.identity,
     groupChat: entry.groupChat,

--- a/src/agents/fast-mode.test.ts
+++ b/src/agents/fast-mode.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveFastModeState } from "./fast-mode.js";
+
+describe("resolveFastModeState", () => {
+  it("uses agent fastModeDefault when session override is absent", () => {
+    const state = resolveFastModeState({
+      cfg: {},
+      provider: "openai",
+      model: "gpt-4o-mini",
+      agentCfg: { fastModeDefault: true },
+    });
+
+    expect(state).toEqual({ enabled: true, source: "config" });
+  });
+
+  it("prefers session override over agent fastModeDefault", () => {
+    const state = resolveFastModeState({
+      cfg: {},
+      provider: "openai",
+      model: "gpt-4o-mini",
+      sessionEntry: { fastMode: false },
+      agentCfg: { fastModeDefault: true },
+    });
+
+    expect(state).toEqual({ enabled: false, source: "session" });
+  });
+});

--- a/src/agents/fast-mode.ts
+++ b/src/agents/fast-mode.ts
@@ -42,10 +42,20 @@ export function resolveFastModeState(params: {
   provider: string;
   model: string;
   sessionEntry?: Pick<SessionEntry, "fastMode"> | undefined;
+  agentCfg?: {
+    fastModeDefault?: unknown;
+  };
 }): FastModeState {
   const sessionOverride = normalizeFastMode(params.sessionEntry?.fastMode);
   if (sessionOverride !== undefined) {
     return { enabled: sessionOverride, source: "session" };
+  }
+
+  const agentDefault = normalizeFastMode(
+    params.agentCfg?.fastModeDefault as string | boolean | null | undefined,
+  );
+  if (agentDefault !== undefined) {
+    return { enabled: agentDefault, source: "config" };
   }
 
   const configuredRaw = resolveConfiguredFastModeRaw(params);

--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -1,6 +1,6 @@
 import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelId, ChannelPlugin } from "../channels/plugins/types.js";
-import { normalizeAnyChannelId } from "../channels/registry.js";
+import { normalizeAnyChannelId, normalizeChatChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { normalizeStringEntries } from "../shared/string-normalization.js";
 import {
@@ -29,6 +29,10 @@ function resolveProviderFromContext(ctx: MsgContext, cfg: OpenClawConfig): Chann
     return undefined;
   }
   const direct =
+    normalizeChatChannelId(explicitMessageChannel ?? undefined) ??
+    normalizeChatChannelId(ctx.Provider) ??
+    normalizeChatChannelId(ctx.Surface) ??
+    normalizeChatChannelId(ctx.OriginatingChannel) ??
     normalizeAnyChannelId(explicitMessageChannel ?? undefined) ??
     normalizeAnyChannelId(ctx.Provider) ??
     normalizeAnyChannelId(ctx.Surface) ??
@@ -70,6 +74,43 @@ function resolveProviderFromContext(ctx: MsgContext, cfg: OpenClawConfig): Chann
     return configured[0];
   }
   return undefined;
+}
+
+function resolveChannelAllowFromFallback(params: {
+  cfg: OpenClawConfig;
+  providerId?: ChannelId;
+  accountId?: string | null;
+}): Array<string | number> {
+  const providerId = params.providerId?.trim();
+  if (!providerId) {
+    return [];
+  }
+
+  const channels = params.cfg.channels as Record<string, unknown> | undefined;
+  const channelConfig = channels && typeof channels === "object" ? channels[providerId] : undefined;
+  if (!channelConfig || typeof channelConfig !== "object") {
+    return [];
+  }
+
+  const accountId = params.accountId?.trim();
+  if ("accounts" in channelConfig) {
+    const accounts = (channelConfig as { accounts?: Record<string, unknown> }).accounts;
+    if (accounts && typeof accounts === "object") {
+      const scopedAccount =
+        (accountId ? accounts[accountId] : undefined) ??
+        accounts.default ??
+        accounts.DEFAULT_ACCOUNT_ID;
+      if (scopedAccount && typeof scopedAccount === "object") {
+        const scopedAllowFrom = (scopedAccount as { allowFrom?: Array<string | number> }).allowFrom;
+        if (Array.isArray(scopedAllowFrom)) {
+          return scopedAllowFrom;
+        }
+      }
+    }
+  }
+
+  const allowFrom = (channelConfig as { allowFrom?: Array<string | number> }).allowFrom;
+  return Array.isArray(allowFrom) ? allowFrom : [];
 }
 
 function formatAllowFromList(params: {
@@ -275,7 +316,11 @@ export function resolveCommandAuthorization(params: {
 
   const allowFromRaw = plugin?.config?.resolveAllowFrom
     ? plugin.config.resolveAllowFrom({ cfg, accountId: ctx.AccountId })
-    : [];
+    : resolveChannelAllowFromFallback({
+        cfg,
+        providerId,
+        accountId: ctx.AccountId,
+      });
   const allowFromList = formatAllowFromList({
     plugin,
     cfg,
@@ -352,7 +397,10 @@ export function resolveCommandAuthorization(params: {
     ctx.GatewayClientScopes.includes("operator.admin");
   const ownerAllowlistConfigured = ownerAllowAll || explicitOwners.length > 0;
   const senderIsOwner = senderIsOwnerByIdentity || senderIsOwnerByScope || ownerAllowAll;
-  const requireOwner = enforceOwner || ownerAllowlistConfigured;
+  const requireOwner =
+    enforceOwner ||
+    ownerAllowlistConfigured ||
+    (!allowAll && ownerCandidatesForCommands.length > 0);
   const isOwnerForCommands = !requireOwner
     ? true
     : ownerAllowAll

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,8 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
-import { runCliAgent } from "../../agents/cli-runner.js";
-import { getCliSessionId } from "../../agents/cli-session.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
@@ -48,6 +46,19 @@ import type { FollowupRun } from "./queue.js";
 import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
 import { createReplyMediaPathNormalizer } from "./reply-media-paths.js";
 import type { TypingSignaler } from "./typing-mode.js";
+
+let cliRunnerModulePromise: Promise<typeof import("../../agents/cli-runner.js")> | undefined;
+let cliSessionModulePromise: Promise<typeof import("../../agents/cli-session.js")> | undefined;
+
+function loadCliRunnerModule() {
+  cliRunnerModulePromise ??= import("../../agents/cli-runner.js");
+  return cliRunnerModulePromise;
+}
+
+function loadCliSessionModule() {
+  cliSessionModulePromise ??= import("../../agents/cli-session.js");
+  return cliSessionModulePromise;
+}
 
 export type RuntimeFallbackAttempt = {
   provider: string;
@@ -201,7 +212,7 @@ export async function runAgentTurnWithFallback(params: {
       const fallbackResult = await runWithModelFallback({
         ...resolveModelFallbackOptions(params.followupRun.run),
         runId,
-        run: (provider, model, runOptions) => {
+        run: async (provider, model, runOptions) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.
           params.opts?.onModelSelected?.({
@@ -221,6 +232,8 @@ export async function runAgentTurnWithFallback(params: {
                 startedAt,
               },
             });
+            const { getCliSessionId } = await loadCliSessionModule();
+            const { runCliAgent } = await loadCliRunnerModule();
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
             return (async () => {
               let lifecycleTerminalEmitted = false;

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -1,5 +1,6 @@
 import {
   resolveAgentDir,
+  resolveAgentConfig,
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
@@ -163,6 +164,7 @@ export async function buildStatusReply(params: {
       })
     : selectedModelAuth;
   const agentDefaults = cfg.agents?.defaults ?? {};
+  const agentCfg = resolveAgentConfig(cfg, statusAgentId) ?? agentDefaults;
   const effectiveFastMode =
     resolvedFastMode ??
     resolveFastModeState({
@@ -170,11 +172,13 @@ export async function buildStatusReply(params: {
       provider,
       model,
       sessionEntry,
+      agentCfg,
     }).enabled;
   const statusText = buildStatusMessage({
     config: cfg,
     agent: {
       ...agentDefaults,
+      ...agentCfg,
       model: {
         ...toAgentModelListLike(agentDefaults.model),
         primary: `${provider}/${model}`,

--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -138,6 +138,7 @@ export async function handleDirectiveOnly(
     provider: resolvedProvider,
     model: resolvedModel,
     sessionEntry,
+    agentCfg,
   });
   const effectiveFastMode = directives.fastMode ?? currentFastMode ?? fastModeState.enabled;
   const effectiveFastModeSource =

--- a/src/auto-reply/reply/directive-handling.levels.test.ts
+++ b/src/auto-reply/reply/directive-handling.levels.test.ts
@@ -33,4 +33,18 @@ describe("resolveCurrentDirectiveLevels", () => {
     expect(result.currentThinkLevel).toBe("minimal");
     expect(resolveDefaultThinkingLevel).not.toHaveBeenCalled();
   });
+
+  it("surfaces agent fast and reasoning defaults when session is unset", async () => {
+    const result = await resolveCurrentDirectiveLevels({
+      sessionEntry: {},
+      agentCfg: {
+        fastModeDefault: true,
+        reasoningDefault: "on",
+      },
+      resolveDefaultThinkingLevel: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(result.currentFastMode).toBe(true);
+    expect(result.currentReasoningLevel).toBe("on");
+  });
 });

--- a/src/auto-reply/reply/directive-handling.levels.ts
+++ b/src/auto-reply/reply/directive-handling.levels.ts
@@ -10,7 +10,9 @@ export async function resolveCurrentDirectiveLevels(params: {
   };
   agentCfg?: {
     thinkingDefault?: unknown;
+    fastModeDefault?: unknown;
     verboseDefault?: unknown;
+    reasoningDefault?: unknown;
     elevatedDefault?: unknown;
   };
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
@@ -27,12 +29,18 @@ export async function resolveCurrentDirectiveLevels(params: {
     (params.agentCfg?.thinkingDefault as ThinkLevel | undefined);
   const currentThinkLevel = resolvedDefaultThinkLevel;
   const currentFastMode =
-    typeof params.sessionEntry?.fastMode === "boolean" ? params.sessionEntry.fastMode : undefined;
+    typeof params.sessionEntry?.fastMode === "boolean"
+      ? params.sessionEntry.fastMode
+      : typeof params.agentCfg?.fastModeDefault === "boolean"
+        ? params.agentCfg.fastModeDefault
+        : undefined;
   const currentVerboseLevel =
     (params.sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (params.agentCfg?.verboseDefault as VerboseLevel | undefined);
   const currentReasoningLevel =
-    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (params.agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+    "off";
   const currentElevatedLevel =
     (params.sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
     (params.agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/auto-reply/reply/get-reply-directives-apply.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { AgentDefaultsLikeConfig } from "../../config/types.agents.js";
 import type { MsgContext } from "../templating.js";
 import type { ElevatedLevel } from "../thinking.js";
 import type { ReplyPayload } from "../types.js";
@@ -15,8 +16,6 @@ import { resolveCurrentDirectiveLevels } from "./directive-handling.levels.js";
 import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import type { createModelSelectionState } from "./model-selection.js";
 import type { TypingController } from "./typing.js";
-
-type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 
 export type ApplyDirectiveResult =
   | { kind: "reply"; reply: ReplyPayload | ReplyPayload[] | undefined }
@@ -40,7 +39,7 @@ export async function applyInlineDirectiveOverrides(params: {
   cfg: OpenClawConfig;
   agentId: string;
   agentDir: string;
-  agentCfg: AgentDefaults;
+  agentCfg: AgentDefaultsLikeConfig;
   sessionEntry: SessionEntry;
   sessionStore: Record<string, SessionEntry>;
   sessionKey: string;

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -5,6 +5,7 @@ import { resolveSandboxRuntimeStatus } from "../../agents/sandbox.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import type { AgentDefaultsLikeConfig } from "../../config/types.agents.js";
 import { listChatCommands, shouldHandleTextCommands } from "../commands-registry.js";
 import { listSkillCommandsForWorkspace } from "../skill-commands.js";
 import type { MsgContext, TemplateContext } from "../templating.js";
@@ -22,7 +23,6 @@ import { formatElevatedUnavailableMessage, resolveElevatedPermissions } from "./
 import { stripInlineStatus } from "./reply-inline.js";
 import type { TypingController } from "./typing.js";
 
-type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
 
 export type ReplyDirectiveContinuation = {
@@ -92,7 +92,7 @@ export async function resolveReplyDirectives(params: {
   agentId: string;
   agentDir: string;
   workspaceDir: string;
-  agentCfg: AgentDefaults;
+  agentCfg: AgentDefaultsLikeConfig;
   sessionCtx: TemplateContext;
   sessionEntry: SessionEntry;
   sessionStore: Record<string, SessionEntry>;
@@ -351,6 +351,7 @@ export async function resolveReplyDirectives(params: {
       provider,
       model,
       sessionEntry,
+      agentCfg,
     }).enabled;
 
   const resolvedVerboseLevel =
@@ -360,6 +361,7 @@ export async function resolveReplyDirectives(params: {
   let resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
     "off";
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -16,6 +16,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import type { AgentDefaultsLikeConfig } from "../../config/types.agents.js";
 import { logVerbose } from "../../globals.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
@@ -51,7 +52,6 @@ import { resolveRunTypingPolicy } from "./typing-policy.js";
 import type { TypingController } from "./typing.js";
 import { appendUntrustedContext } from "./untrusted-context.js";
 
-type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
 
 function buildResetSessionNoticeText(params: {
@@ -130,7 +130,7 @@ type RunPreparedReplyParams = {
   cfg: OpenClawConfig;
   agentId: string;
   agentDir: string;
-  agentCfg: AgentDefaults;
+  agentCfg: AgentDefaultsLikeConfig;
   sessionCfg: OpenClawConfig["session"];
   commandAuthorized: boolean;
   command: ReturnType<typeof buildCommandContext>;
@@ -515,6 +515,7 @@ export async function runPreparedReply(
         provider,
         model,
         sessionEntry,
+        agentCfg,
       }).enabled,
       verboseLevel: resolvedVerboseLevel,
       reasoningLevel: resolvedReasoningLevel,

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -226,6 +226,9 @@ export function stripMentions(
       agentId,
     });
   }
+  // Slack user mentions are common command prefixes in channels and should be
+  // stripped even when the plugin registry is not initialized.
+  result = result.replace(/<@[A-Z0-9]+(?:\|[^>]+)?>/gi, " ");
   // Generic mention patterns like @123456789 or plain digits
   result = result.replace(/@[0-9+]{5,}/g, " ");
   return result.replace(/\s+/g, " ").trim();

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -263,6 +263,90 @@ describe("createModelSelectionState respects session model override", () => {
     expect(state.provider).toBe(defaultProvider);
     expect(state.model).toBe("deepseek-v3-4bit-mlx");
   });
+
+  it("clears a legacy main-session provider pin when it only mirrors the old runtime model", async () => {
+    const sessionEntry = makeEntry({
+      providerOverride: "openai-codex",
+      modelOverride: "deepseek-v3-4bit-mlx",
+      modelProvider: "openai-codex",
+      model: "deepseek-v3-4bit-mlx",
+    });
+    const sessionStore = { "agent:main:main": sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: { session: { mainKey: "main" } } as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:main",
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(state.resetModelOverride).toBe(true);
+    expect(sessionStore["agent:main:main"]?.providerOverride).toBeUndefined();
+    expect(sessionStore["agent:main:main"]?.modelOverride).toBeUndefined();
+  });
+
+  it("keeps explicit user-tagged main-session overrides", async () => {
+    const { loadModelCatalog } = await import("../../agents/model-catalog.js");
+    vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+      { provider: "inferencer", id: "deepseek-v3-4bit-mlx", name: "DeepSeek V3" },
+      { provider: "openai-codex", id: "deepseek-v3-4bit-mlx", name: "DeepSeek V3 via Codex" },
+    ]);
+    const sessionEntry = makeEntry({
+      providerOverride: "openai-codex",
+      modelOverride: "deepseek-v3-4bit-mlx",
+      modelOverrideSource: "user",
+      modelProvider: "openai-codex",
+      model: "deepseek-v3-4bit-mlx",
+    });
+    const sessionStore = { "agent:main:main": sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: { session: { mainKey: "main" } } as OpenClawConfig,
+      agentCfg: undefined,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:main",
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+    });
+
+    expect(state.provider).toBe("openai-codex");
+    expect(state.model).toBe("deepseek-v3-4bit-mlx");
+    expect(state.resetModelOverride).toBe(false);
+    expect(sessionStore["agent:main:main"]?.providerOverride).toBe("openai-codex");
+    expect(sessionStore["agent:main:main"]?.modelOverrideSource).toBe("user");
+  });
+
+  it("prefers agent reasoningDefault over catalog-derived default", async () => {
+    const sessionEntry = makeEntry();
+    const sessionStore = { "agent:main:main": sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg: {} as OpenClawConfig,
+      agentCfg: { reasoningDefault: "on" },
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:main",
+      defaultProvider: "openai",
+      defaultModel: "gpt-4o-mini",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      hasModelDirective: false,
+    });
+
+    await expect(state.resolveDefaultReasoningLevel()).resolves.toBe("on");
+  });
 });
 
 describe("createModelSelectionState resolveDefaultReasoningLevel", () => {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -13,7 +13,11 @@ import {
 } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { type SessionEntry, updateSessionStore } from "../../config/sessions.js";
-import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import type { AgentDefaultsLikeConfig } from "../../config/types.agents.js";
+import {
+  applyModelOverrideToSessionEntry,
+  resetLegacyMainSessionModelOverride,
+} from "../../sessions/model-overrides.js";
 import { resolveThreadParentSessionKey } from "../../sessions/session-key-utils.js";
 import type { ThinkLevel } from "./directives.js";
 
@@ -264,7 +268,7 @@ function scoreFuzzyMatch(params: {
 export async function createModelSelectionState(params: {
   cfg: OpenClawConfig;
   agentId?: string;
-  agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
+  agentCfg: AgentDefaultsLikeConfig | undefined;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
@@ -322,6 +326,25 @@ export async function createModelSelectionState(params: {
     allowedModelKeys = allowed.allowedKeys;
   }
 
+  if (sessionEntry && sessionStore && sessionKey) {
+    const { updated } = resetLegacyMainSessionModelOverride({
+      entry: sessionEntry,
+      sessionKey,
+      mainKey: cfg.session?.mainKey,
+      defaultProvider,
+      defaultModel,
+    });
+    if (updated) {
+      sessionStore[sessionKey] = sessionEntry;
+      if (storePath) {
+        await updateSessionStore(storePath, (store) => {
+          store[sessionKey] = sessionEntry;
+        });
+      }
+      resetModelOverride = true;
+    }
+  }
+
   if (sessionEntry && sessionStore && sessionKey && hasStoredOverride) {
     const overrideProvider = sessionEntry.providerOverride?.trim() || defaultProvider;
     const overrideModel = sessionEntry.modelOverride?.trim();
@@ -340,7 +363,7 @@ export async function createModelSelectionState(params: {
             });
           }
         }
-        resetModelOverride = updated;
+        resetModelOverride = resetModelOverride || updated;
       }
     }
   }
@@ -403,6 +426,13 @@ export async function createModelSelectionState(params: {
   };
 
   const resolveDefaultReasoningLevel = async (): Promise<"on" | "off"> => {
+    const configured =
+      params.agentCfg?.reasoningDefault === "on" || params.agentCfg?.reasoningDefault === "off"
+        ? params.agentCfg.reasoningDefault
+        : undefined;
+    if (configured) {
+      return configured;
+    }
     let catalogForReasoning = modelCatalog ?? allowedModelCatalog;
     if (!catalogForReasoning || catalogForReasoning.length === 0) {
       modelCatalog = await loadModelCatalog({ config: cfg });
@@ -601,7 +631,7 @@ export function resolveModelDirectiveSelection(params: {
 }
 
 export function resolveContextTokens(params: {
-  agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
+  agentCfg: AgentDefaultsLikeConfig | undefined;
   model: string;
 }): number {
   return (

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1428,6 +1428,47 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
     }
   });
 
+  it("does not carry model overrides into a reset session", async () => {
+    const storePath = await createStorePath("openclaw-reset-model-override-");
+    const sessionKey = "agent:main:telegram:dm:model-override";
+    await seedSessionStoreWithOverrides({
+      storePath,
+      sessionKey,
+      sessionId: "existing-session-model-override",
+      overrides: {
+        providerOverride: "openai-codex",
+        modelOverride: "gpt-5.4",
+        modelOverrideSource: "user",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "/new",
+        RawBody: "/new",
+        CommandBody: "/new",
+        From: "user-model-override",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "telegram",
+        Surface: "telegram",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.resetTriggered).toBe(true);
+    expect(result.sessionEntry.providerOverride).toBeUndefined();
+    expect(result.sessionEntry.modelOverride).toBeUndefined();
+    expect(result.sessionEntry.modelOverrideSource).toBeUndefined();
+  });
+
   it("archives the old session store entry on /new", async () => {
     const storePath = await createStorePath("openclaw-archive-old-");
     const sessionKey = "agent:main:telegram:dm:user-archive";

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -31,6 +31,7 @@ import {
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { archiveSessionTranscripts } from "../../gateway/session-utils.fs.js";
 import { resolveConversationIdFromTargets } from "../../infra/outbound/conversation-id.js";
+import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -147,23 +148,96 @@ function resolveAcpResetBindingContext(ctx: MsgContext): {
   };
 }
 
+function hasConfiguredAcpBindingFallback(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  accountId: string;
+  conversationId: string;
+  parentConversationId?: string;
+}): boolean {
+  const channel = normalizeConversationText(params.channel).toLowerCase();
+  const accountId = normalizeConversationText(params.accountId) || "default";
+  const conversationId = normalizeConversationText(params.conversationId);
+  const parentConversationId = normalizeConversationText(params.parentConversationId);
+  if (!channel || !conversationId) {
+    return false;
+  }
+
+  for (const binding of params.cfg.bindings ?? []) {
+    if (binding.type !== "acp") {
+      continue;
+    }
+    const bindingChannel = normalizeConversationText(binding.match.channel).toLowerCase();
+    if (bindingChannel !== channel) {
+      continue;
+    }
+    const bindingAccountId = normalizeConversationText(binding.match.accountId);
+    if (bindingAccountId && bindingAccountId !== "*" && bindingAccountId !== accountId) {
+      continue;
+    }
+    const bindingConversationId = normalizeConversationText(binding.match.peer?.id);
+    if (!bindingConversationId) {
+      continue;
+    }
+    if (
+      bindingConversationId === conversationId ||
+      bindingConversationId === parentConversationId
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function resolveBoundAcpSessionForReset(params: {
   cfg: OpenClawConfig;
   ctx: MsgContext;
 }): string | undefined {
   const activeSessionKey = normalizeConversationText(params.ctx.SessionKey);
+  const activeAcpSessionKey = activeSessionKey.includes(":acp:binding:") ? activeSessionKey : "";
   const bindingContext = resolveAcpResetBindingContext(params.ctx);
-  return resolveEffectiveResetTargetSessionKey({
+  if (!bindingContext?.channel || !bindingContext.conversationId) {
+    return activeAcpSessionKey || undefined;
+  }
+
+  const resolvedTarget = resolveEffectiveResetTargetSessionKey({
     cfg: params.cfg,
-    channel: bindingContext?.channel,
-    accountId: bindingContext?.accountId,
-    conversationId: bindingContext?.conversationId,
-    parentConversationId: bindingContext?.parentConversationId,
+    channel: bindingContext.channel,
+    accountId: bindingContext.accountId,
+    conversationId: bindingContext.conversationId,
+    parentConversationId: bindingContext.parentConversationId,
     activeSessionKey,
     allowNonAcpBindingSessionKey: false,
     skipConfiguredFallbackWhenActiveSessionNonAcp: true,
     fallbackToActiveAcpWhenUnbound: false,
   });
+  if (resolvedTarget) {
+    return resolvedTarget;
+  }
+  if (!activeAcpSessionKey) {
+    return undefined;
+  }
+
+  const liveBinding = getSessionBindingService().resolveByConversation({
+    channel: bindingContext.channel,
+    accountId: bindingContext.accountId,
+    conversationId: bindingContext.conversationId,
+    parentConversationId: bindingContext.parentConversationId,
+  });
+  if (liveBinding) {
+    return undefined;
+  }
+
+  return hasConfiguredAcpBindingFallback({
+    cfg: params.cfg,
+    channel: bindingContext.channel,
+    accountId: bindingContext.accountId,
+    conversationId: bindingContext.conversationId,
+    parentConversationId: bindingContext.parentConversationId,
+  })
+    ? activeAcpSessionKey
+    : undefined;
 }
 
 export async function initSessionState(params: {
@@ -215,8 +289,6 @@ export async function initSessionState(params: {
   let persistedVerbose: string | undefined;
   let persistedReasoning: string | undefined;
   let persistedTtsAuto: TtsAutoMode | undefined;
-  let persistedModelOverride: string | undefined;
-  let persistedProviderOverride: string | undefined;
   let persistedLabel: string | undefined;
 
   const normalizedChatType = normalizeChatType(ctx.ChatType);
@@ -351,8 +423,6 @@ export async function initSessionState(params: {
     persistedVerbose = entry.verboseLevel;
     persistedReasoning = entry.reasoningLevel;
     persistedTtsAuto = entry.ttsAuto;
-    persistedModelOverride = entry.modelOverride;
-    persistedProviderOverride = entry.providerOverride;
     persistedLabel = entry.label;
   } else {
     sessionId = crypto.randomUUID();
@@ -367,8 +437,6 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
       persistedLabel = entry.label;
     }
   }
@@ -418,8 +486,6 @@ export async function initSessionState(params: {
     reasoningLevel: persistedReasoning ?? baseEntry?.reasoningLevel,
     ttsAuto: persistedTtsAuto ?? baseEntry?.ttsAuto,
     responseUsage: baseEntry?.responseUsage,
-    modelOverride: persistedModelOverride ?? baseEntry?.modelOverride,
-    providerOverride: persistedProviderOverride ?? baseEntry?.providerOverride,
     label: persistedLabel ?? baseEntry?.label,
     sendPolicy: baseEntry?.sendPolicy,
     queueMode: baseEntry?.queueMode,

--- a/src/channels/transport/stall-watchdog.test.ts
+++ b/src/channels/transport/stall-watchdog.test.ts
@@ -23,6 +23,10 @@ describe("createArmableStallWatchdog", () => {
       await vi.advanceTimersByTimeAsync(1_500);
 
       expect(onTimeout).toHaveBeenCalledTimes(1);
+      const [meta] = onTimeout.mock.calls[0] ?? [];
+      expect(meta).toMatchObject({ timeoutMs: 1_000 });
+      expect(meta?.idleMs).toBeGreaterThanOrEqual(1_000);
+      expect(meta?.idleMs).toBeLessThan(1_100);
       expect(watchdog.isArmed()).toBe(false);
       watchdog.stop();
     } finally {

--- a/src/cli/banner-config-lite.test.ts
+++ b/src/cli/banner-config-lite.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { readCliBannerTaglineMode } from "./banner-config-lite.js";
+
+describe("readCliBannerTaglineMode", () => {
+  it("reads the tagline mode from env only", () => {
+    expect(
+      readCliBannerTaglineMode({
+        OPENCLAW_CLI_BANNER_TAGLINE_MODE: "off",
+      } as NodeJS.ProcessEnv),
+    ).toBe("off");
+  });
+
+  it("ignores invalid env values", () => {
+    expect(
+      readCliBannerTaglineMode({
+        OPENCLAW_CLI_BANNER_TAGLINE_MODE: "loud",
+      } as NodeJS.ProcessEnv),
+    ).toBeUndefined();
+  });
+});

--- a/src/cli/banner-config-lite.ts
+++ b/src/cli/banner-config-lite.ts
@@ -1,6 +1,3 @@
-import fs from "node:fs";
-import JSON5 from "json5";
-import { resolveConfigPath } from "../config/paths.js";
 import type { TaglineMode } from "./tagline.js";
 
 function parseTaglineMode(value: unknown): TaglineMode | undefined {
@@ -13,12 +10,5 @@ function parseTaglineMode(value: unknown): TaglineMode | undefined {
 export function readCliBannerTaglineMode(
   env: NodeJS.ProcessEnv = process.env,
 ): TaglineMode | undefined {
-  try {
-    const configPath = resolveConfigPath(env);
-    const raw = fs.readFileSync(configPath, "utf8");
-    const parsed: { cli?: { banner?: { taglineMode?: unknown } } } = JSON5.parse(raw);
-    return parseTaglineMode(parsed.cli?.banner?.taglineMode);
-  } catch {
-    return undefined;
-  }
+  return parseTaglineMode(env.OPENCLAW_CLI_BANNER_TAGLINE_MODE);
 }

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -11,7 +11,7 @@ import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import * as commandSecretGatewayModule from "../cli/command-secret-gateway.js";
 import type { OpenClawConfig } from "../config/config.js";
 import * as configModule from "../config/config.js";
-import * as sessionsModule from "../config/sessions.js";
+import * as sessionPathsModule from "../config/sessions/paths.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -462,19 +462,17 @@ describe("agentCommand", () => {
       const store = path.join(customStoreDir, "sessions.json");
       writeSessionStoreSeed(store, {});
       mockConfig(home, store);
-      const resolveSessionFilePathSpy = vi.spyOn(sessionsModule, "resolveSessionFilePath");
+      const resolveSessionFilePathOptionsSpy = vi.spyOn(
+        sessionPathsModule,
+        "resolveSessionFilePathOptions",
+      );
 
       await agentCommand({ message: "resume me", sessionId: "session-custom-123" }, runtime);
 
-      const matchingCall = resolveSessionFilePathSpy.mock.calls.find(
-        (call) => call[0] === "session-custom-123",
-      );
-      expect(matchingCall?.[2]).toEqual(
-        expect.objectContaining({
-          agentId: "main",
-          sessionsDir: customStoreDir,
-        }),
-      );
+      expect(resolveSessionFilePathOptionsSpy).toHaveBeenCalledWith({
+        agentId: "main",
+        storePath: store,
+      });
     });
   });
 
@@ -624,6 +622,52 @@ describe("agentCommand", () => {
       >;
       expect(saved["agent:main:subagent:allow-any"]?.providerOverride).toBe("openai");
       expect(saved["agent:main:subagent:allow-any"]?.modelOverride).toBe("gpt-custom-foo");
+    });
+  });
+
+  it("clears a legacy main-session provider pin when it only mirrors the stale runtime model", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:main": {
+          sessionId: "session-main-legacy-provider-pin",
+          updatedAt: Date.now(),
+          providerOverride: "openai-codex",
+          modelOverride: "gpt-5.4",
+          modelProvider: "openai-codex",
+          model: "gpt-5.4",
+        },
+      });
+
+      mockConfig(home, store, {
+        model: { primary: "miaomiaocode-codex/gpt-5.4" },
+        models: {
+          "miaomiaocode-codex/gpt-5.4": {},
+          "openai-codex/gpt-5.4": {},
+        },
+      });
+
+      vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+        { id: "gpt-5.4", name: "GPT-5.4", provider: "miaomiaocode-codex" },
+        { id: "gpt-5.4", name: "GPT-5.4", provider: "openai-codex" },
+      ]);
+
+      await runAgentWithSessionKey("agent:main:main");
+
+      expectLastRunProviderModel("miaomiaocode-codex", "gpt-5.4");
+
+      const saved = JSON.parse(fs.readFileSync(store, "utf-8")) as Record<
+        string,
+        {
+          providerOverride?: string;
+          modelOverride?: string;
+          modelOverrideSource?: string;
+        }
+      >;
+      const entry = saved["agent:main:main"];
+      expect(entry?.providerOverride).toBeUndefined();
+      expect(entry?.modelOverride).toBeUndefined();
+      expect(entry?.modelOverrideSource).toBeUndefined();
     });
   });
 

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -18,8 +18,6 @@ import {
 import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
 import { clearSessionAuthProfileOverride } from "../agents/auth-profiles/session-override.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../agents/bootstrap-budget.js";
-import { runCliAgent } from "../agents/cli-runner.js";
-import { getCliSessionId, setCliSessionId } from "../agents/cli-session.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { FailoverError } from "../agents/failover-error.js";
 import { formatAgentInternalEventsForPrompt } from "../agents/internal-events.js";
@@ -84,7 +82,10 @@ import { getRemoteSkillEligibility } from "../infra/skills-remote.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
-import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  resetLegacyMainSessionModelOverride,
+} from "../sessions/model-overrides.js";
 import { resolveSendPolicy } from "../sessions/send-policy.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { resolveMessageChannel } from "../utils/message-channel.js";
@@ -93,6 +94,19 @@ import { resolveAgentRunContext } from "./agent/run-context.js";
 import { updateSessionStoreAfterAgentRun } from "./agent/session-store.js";
 import { resolveSession } from "./agent/session.js";
 import type { AgentCommandIngressOpts, AgentCommandOpts } from "./agent/types.js";
+
+let cliRunnerModulePromise: Promise<typeof import("../agents/cli-runner.js")> | undefined;
+let cliSessionModulePromise: Promise<typeof import("../agents/cli-session.js")> | undefined;
+
+function loadCliRunnerModule() {
+  cliRunnerModulePromise ??= import("../agents/cli-runner.js");
+  return cliRunnerModulePromise;
+}
+
+function loadCliSessionModule() {
+  cliSessionModulePromise ??= import("../agents/cli-session.js");
+  return cliSessionModulePromise;
+}
 
 type PersistSessionEntryParams = {
   sessionStore: Record<string, SessionEntry>;
@@ -104,6 +118,7 @@ type PersistSessionEntryParams = {
 type OverrideFieldClearedByDelete =
   | "providerOverride"
   | "modelOverride"
+  | "modelOverrideSource"
   | "authProfileOverride"
   | "authProfileOverrideSource"
   | "authProfileOverrideCompactionCount"
@@ -115,6 +130,7 @@ type OverrideFieldClearedByDelete =
 const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
   "providerOverride",
   "modelOverride",
+  "modelOverrideSource",
   "authProfileOverride",
   "authProfileOverrideSource",
   "authProfileOverrideCompactionCount",
@@ -317,7 +333,7 @@ async function persistAcpTurnTranscript(params: {
   return sessionEntry;
 }
 
-function runAgentAttempt(params: {
+async function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
   cfg: ReturnType<typeof loadConfig>;
@@ -355,6 +371,8 @@ function runAgentAttempt(params: {
   const bootstrapPromptWarningSignature =
     bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
   if (isCliProvider(params.providerOverride, params.cfg)) {
+    const { getCliSessionId, setCliSessionId } = await loadCliSessionModule();
+    const { runCliAgent } = await loadCliRunnerModule();
     const cliSessionId = getCliSessionId(params.sessionEntry, params.providerOverride);
     const runCliWithSession = (nextCliSessionId: string | undefined) =>
       runCliAgent({
@@ -957,6 +975,24 @@ async function agentCommandInternal(
       allowAnyModel = allowed.allowAny ?? false;
     }
 
+    if (sessionEntry && sessionStore && sessionKey) {
+      const { updated } = resetLegacyMainSessionModelOverride({
+        entry: sessionEntry,
+        sessionKey,
+        mainKey: cfg.session?.mainKey,
+        defaultProvider,
+        defaultModel,
+      });
+      if (updated) {
+        await persistSessionEntry({
+          sessionStore,
+          sessionKey,
+          storePath,
+          entry: sessionEntry,
+        });
+      }
+    }
+
     if (sessionEntry && sessionStore && sessionKey && hasStoredOverride) {
       const entry = sessionEntry;
       const overrideProvider = sessionEntry.providerOverride?.trim() || defaultProvider;
@@ -1069,6 +1105,7 @@ async function agentCommandInternal(
         sessionId,
         sessionKey: sessionKey ?? sessionId,
         sessionEntry,
+        storePath,
         agentId: sessionAgentId,
         threadId: opts.threadId,
       });

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -2,7 +2,7 @@ import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import type { SessionEntry } from "../../config/sessions.js";
+import { resolveAgentIdFromSessionKey, type SessionEntry } from "../../config/sessions.js";
 import {
   resolveAgentDeliveryPlan,
   resolveAgentOutboundTarget,
@@ -82,8 +82,12 @@ export async function deliverAgentCommandResult(params: {
   const turnSourceTo = opts.runContext?.currentChannelId ?? opts.to;
   const turnSourceAccountId = opts.runContext?.accountId ?? opts.accountId;
   const turnSourceThreadId = opts.runContext?.currentThreadTs ?? opts.threadId;
+  const deliveryAgentId =
+    outboundSession?.agentId ?? resolveAgentIdFromSessionKey(effectiveSessionKey ?? opts.sessionId);
   const deliveryPlan = resolveAgentDeliveryPlan({
     sessionEntry,
+    cfg,
+    agentId: deliveryAgentId,
     requestedChannel: opts.replyChannel ?? opts.channel,
     explicitTo: opts.replyTo ?? opts.to,
     explicitThreadId: opts.threadId,

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -138,6 +138,50 @@ describe("config io paths", () => {
     });
   });
 
+  it("accepts agent-level directive defaults from existing configs", async () => {
+    await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      const configPath = path.join(configDir, "openclaw.json");
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            agents: {
+              list: [
+                {
+                  id: "ops",
+                  thinkingDefault: "high",
+                  verboseDefault: "on",
+                  elevatedDefault: "ask",
+                  fastModeDefault: true,
+                  reasoningDefault: "on",
+                  blockStreamingDefault: "on",
+                  blockStreamingBreak: "message_end",
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+        "utf-8",
+      );
+      const io = createIoForHome(home);
+      const cfg = io.loadConfig();
+      expect(cfg.agents?.list?.[0]).toMatchObject({
+        id: "ops",
+        thinkingDefault: "high",
+        verboseDefault: "on",
+        elevatedDefault: "ask",
+        fastModeDefault: true,
+        reasoningDefault: "on",
+        blockStreamingDefault: "on",
+        blockStreamingBreak: "message_end",
+      });
+    });
+  });
+
   it("logs invalid config path details and throws on invalid config", async () => {
     await withTempHome(async (home) => {
       const configDir = path.join(home, ".openclaw");

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1013,6 +1013,20 @@ export const FIELD_HELP: Record<string, string> = {
     "Plugin entry name inside the source marketplace, used for later updates.",
   "agents.list.*.identity.avatar":
     "Agent avatar (workspace-relative path, http(s) URL, or data URI).",
+  "agents.list[].thinkingDefault":
+    "Per-agent default thinking level used when no session override or /think directive is present.",
+  "agents.list[].verboseDefault":
+    "Per-agent default verbose level used when no session override or /verbose directive is present.",
+  "agents.list[].elevatedDefault":
+    "Per-agent default elevated-actions level used when no session override or /elevated directive is present.",
+  "agents.list[].fastModeDefault":
+    "Per-agent default fast-mode toggle used when no session override or /fast directive is present.",
+  "agents.list[].reasoningDefault":
+    "Per-agent default reasoning visibility used when no session override or /reasoning directive is present.",
+  "agents.list[].blockStreamingDefault":
+    "Per-agent default for block-streaming replies when no session override is present.",
+  "agents.list[].blockStreamingBreak":
+    "Per-agent block-streaming boundary: text block end or whole-message end.",
   "agents.defaults.model.primary": "Primary model (provider/model).",
   "agents.defaults.model.fallbacks":
     "Ordered fallback models (provider/model). Used when the primary model fails.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -837,6 +837,13 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.imessage.cliPath": "iMessage CLI Path",
   "agents.list[].skills": "Agent Skill Filter",
   "agents.list[].identity.avatar": "Agent Avatar",
+  "agents.list[].thinkingDefault": "Agent Thinking Default",
+  "agents.list[].verboseDefault": "Agent Verbose Default",
+  "agents.list[].elevatedDefault": "Agent Elevated Default",
+  "agents.list[].fastModeDefault": "Agent Fast Mode Default",
+  "agents.list[].reasoningDefault": "Agent Reasoning Default",
+  "agents.list[].blockStreamingDefault": "Agent Block Streaming Default",
+  "agents.list[].blockStreamingBreak": "Agent Block Streaming Break",
   "agents.list[].heartbeat.suppressToolErrorWarnings":
     "Agent Heartbeat Suppress Tool Error Warnings",
   "agents.list[].sandbox.browser.network": "Agent Sandbox Browser Network",

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -112,6 +112,7 @@ export type SessionEntry = {
   responseUsage?: "on" | "off" | "tokens" | "full";
   providerOverride?: string;
   modelOverride?: string;
+  modelOverrideSource?: "user";
   authProfileOverride?: string;
   authProfileOverrideSource?: "auto" | "user";
   authProfileOverrideCompactionCount?: number;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -5,6 +5,20 @@ import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
+export type AgentDirectiveDefaultsConfig = Pick<
+  AgentDefaultsConfig,
+  | "thinkingDefault"
+  | "verboseDefault"
+  | "elevatedDefault"
+  | "blockStreamingDefault"
+  | "blockStreamingBreak"
+> & {
+  /** Optional per-agent default fast-mode toggle when no session override is present. */
+  fastModeDefault?: boolean;
+  /** Optional per-agent default reasoning visibility when no session override is present. */
+  reasoningDefault?: "on" | "off";
+};
+
 export type AgentRuntimeAcpConfig = {
   /** ACP harness adapter id (for example codex, claude). */
   agent?: string;
@@ -58,7 +72,7 @@ export type AgentAcpBinding = {
 
 export type AgentBinding = AgentRouteBinding | AgentAcpBinding;
 
-export type AgentConfig = {
+export type AgentConfig = AgentDirectiveDefaultsConfig & {
   id: string;
   default?: boolean;
   name?: string;
@@ -88,6 +102,8 @@ export type AgentConfig = {
   /** Optional runtime descriptor for this agent. */
   runtime?: AgentRuntimeConfig;
 };
+
+export type AgentDefaultsLikeConfig = Partial<AgentDefaultsConfig> & Partial<AgentConfig>;
 
 export type AgentsConfig = {
   defaults?: AgentDefaultsConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -775,6 +775,25 @@ export const AgentEntrySchema = z
     skills: z.array(z.string()).optional(),
     memorySearch: MemorySearchSchema,
     humanDelay: HumanDelaySchema.optional(),
+    thinkingDefault: z
+      .union([
+        z.literal("off"),
+        z.literal("minimal"),
+        z.literal("low"),
+        z.literal("medium"),
+        z.literal("high"),
+        z.literal("xhigh"),
+        z.literal("adaptive"),
+      ])
+      .optional(),
+    verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    elevatedDefault: z
+      .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
+      .optional(),
+    fastModeDefault: z.boolean().optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
+    blockStreamingDefault: z.union([z.literal("off"), z.literal("on")]).optional(),
+    blockStreamingBreak: z.union([z.literal("text_end"), z.literal("message_end")]).optional(),
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -7,8 +7,6 @@ import {
 } from "../../agents/agent-scope.js";
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
-import { runCliAgent } from "../../agents/cli-runner.js";
-import { getCliSessionId, setCliSessionId } from "../../agents/cli-session.js";
 import { lookupContextTokens } from "../../agents/context.js";
 import { resolveCronStyleNow } from "../../agents/current-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
@@ -75,6 +73,19 @@ import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";
 import { resolveCronSkillsSnapshot } from "./skills-snapshot.js";
 import { isLikelyInterimCronMessage } from "./subagent-followup.js";
+
+let cliRunnerModulePromise: Promise<typeof import("../../agents/cli-runner.js")> | undefined;
+let cliSessionModulePromise: Promise<typeof import("../../agents/cli-session.js")> | undefined;
+
+function loadCliRunnerModule() {
+  cliRunnerModulePromise ??= import("../../agents/cli-runner.js");
+  return cliRunnerModulePromise;
+}
+
+function loadCliSessionModule() {
+  cliSessionModulePromise ??= import("../../agents/cli-session.js");
+  return cliSessionModulePromise;
+}
 
 export type RunCronAgentTurnResult = {
   /** Last non-empty agent text output (not truncated). */
@@ -587,6 +598,8 @@ export async function runCronIsolatedAgentTurn(params: {
           const bootstrapPromptWarningSignature =
             bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1];
           if (isCliProvider(providerOverride, cfgWithAgentDefaults)) {
+            const { getCliSessionId } = await loadCliSessionModule();
+            const { runCliAgent } = await loadCliRunnerModule();
             // Fresh isolated cron sessions must not reuse a stored CLI session ID.
             // Passing an existing ID activates the resume watchdog profile
             // (noOutputTimeoutRatio 0.3, maxMs 180 s) instead of the fresh profile
@@ -644,6 +657,7 @@ export async function runCronIsolatedAgentTurn(params: {
               provider: providerOverride,
               model: modelOverride,
               sessionEntry: cronSession.sessionEntry,
+              agentCfg,
             }).enabled,
             verboseLevel: resolvedVerboseLevel,
             timeoutMs,
@@ -747,6 +761,7 @@ export async function runCronIsolatedAgentTurn(params: {
     });
     cronSession.sessionEntry.contextTokens = contextTokens;
     if (isCliProvider(providerUsed, cfgWithAgentDefaults)) {
+      const { setCliSessionId } = await loadCliSessionModule();
       const cliSessionId = finalRunResult.meta?.agentMeta?.sessionId?.trim();
       if (cliSessionId) {
         setCliSessionId(cronSession.sessionEntry, providerUsed, cliSessionId);

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -769,9 +769,6 @@ export function createGatewayHttpServer(opts: {
     }
 
     try {
-      const configSnapshot = loadConfig();
-      const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
-      const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
       const scopedCanvas = normalizeCanvasScopedUrl(req.url ?? "/");
       if (scopedCanvas.malformedScopedPath) {
         sendGatewayAuthFailure(res, { ok: false, reason: "unauthorized" });
@@ -781,6 +778,22 @@ export function createGatewayHttpServer(opts: {
         req.url = scopedCanvas.rewrittenUrl;
       }
       const requestPath = new URL(req.url ?? "/", "http://localhost").pathname;
+      if (
+        await handleGatewayProbeRequest(
+          req,
+          res,
+          requestPath,
+          resolvedAuth,
+          [],
+          false,
+          getReadiness,
+        )
+      ) {
+        return;
+      }
+      const configSnapshot = loadConfig();
+      const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
+      const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
       const mattermostSlashCallbackPaths = resolveMattermostSlashCallbackPaths(configSnapshot);
       const pluginPathContext = handlePluginRequest
         ? resolvePluginRoutePathContext(requestPath)
@@ -902,20 +915,6 @@ export function createGatewayHttpServer(opts: {
             }),
         });
       }
-
-      requestStages.push({
-        name: "gateway-probes",
-        run: () =>
-          handleGatewayProbeRequest(
-            req,
-            res,
-            requestPath,
-            resolvedAuth,
-            trustedProxies,
-            allowRealIpFallback,
-            getReadiness,
-          ),
-      });
 
       if (await runGatewayHttpRequestStages(requestStages)) {
         return;

--- a/src/gateway/server-maintenance.test.ts
+++ b/src/gateway/server-maintenance.test.ts
@@ -123,4 +123,24 @@ describe("startGatewayMaintenanceTimers", () => {
 
     stopMaintenanceTimers(timers);
   });
+
+  it("keeps the warm health cache on fast snapshots instead of probe refreshes", async () => {
+    vi.useFakeTimers();
+    const refreshGatewayHealthSnapshot = vi.fn(async () => ({ ok: true }) as HealthSummary);
+    const { startGatewayMaintenanceTimers } = await import("./server-maintenance.js");
+
+    const timers = startGatewayMaintenanceTimers({
+      ...createMaintenanceTimerDeps(),
+      refreshGatewayHealthSnapshot,
+    });
+
+    expect(refreshGatewayHealthSnapshot).toHaveBeenCalledWith({ probe: false });
+
+    refreshGatewayHealthSnapshot.mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(refreshGatewayHealthSnapshot).toHaveBeenCalledWith({ probe: false });
+
+    stopMaintenanceTimers(timers);
+  });
 });

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -62,16 +62,17 @@ export function startGatewayMaintenanceTimers(params: {
     params.nodeSendToAllSubscribed("tick", payload);
   }, TICK_INTERVAL_MS);
 
-  // periodic health refresh to keep cached snapshot warm
+  // Keep the UI snapshot warm with a fast refresh. Deep probes stay on-demand
+  // so connect/health calls do not inherit a slow network-bound probe cycle.
   const healthInterval = setInterval(() => {
     void params
-      .refreshGatewayHealthSnapshot({ probe: true })
+      .refreshGatewayHealthSnapshot({ probe: false })
       .catch((err) => params.logHealth.error(`refresh failed: ${formatError(err)}`));
   }, HEALTH_REFRESH_INTERVAL_MS);
 
-  // Prime cache so first client gets a snapshot without waiting.
+  // Prime cache so first client gets a quick snapshot without waiting.
   void params
-    .refreshGatewayHealthSnapshot({ probe: true })
+    .refreshGatewayHealthSnapshot({ probe: false })
     .catch((err) => params.logHealth.error(`initial refresh failed: ${formatError(err)}`));
 
   // dedupe cache cleanup

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -492,6 +492,8 @@ export const agentHandlers: GatewayRequestHandlers = {
       explicitTo,
       explicitThreadId,
       accountId: request.replyAccountId ?? request.accountId,
+      cfg: cfgForAgent ?? cfg,
+      agentId: agentId ?? resolveAgentIdFromSessionKey(resolvedSessionKey ?? requestedSessionKey),
       wantsDelivery,
       turnSourceChannel,
       turnSourceTo,

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -284,12 +284,18 @@ export function createExecApprovalHandlers(
       }
       const p = params as { id: string; decision: string };
       const decision = p.decision as ExecApprovalDecision;
+      const requestedId = typeof p.id === "string" ? p.id.trim() : "";
       if (decision !== "allow-once" && decision !== "allow-always" && decision !== "deny") {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "invalid decision"));
         return;
       }
       const resolvedId = manager.lookupPendingId(p.id);
       if (resolvedId.kind === "none") {
+        const settled = requestedId ? manager.getSnapshot(requestedId) : null;
+        if (settled?.resolvedAtMs !== undefined && settled.decision === decision) {
+          respond(true, { ok: true, alreadyResolved: true }, undefined);
+          return;
+        }
         respond(
           false,
           undefined,
@@ -315,6 +321,11 @@ export function createExecApprovalHandlers(
       const resolvedBy = client?.connect?.client?.displayName ?? client?.connect?.client?.id;
       const ok = manager.resolve(approvalId, decision, resolvedBy ?? null);
       if (!ok) {
+        const settled = manager.getSnapshot(approvalId);
+        if (settled?.resolvedAtMs !== undefined && settled.decision === decision) {
+          respond(true, { ok: true, alreadyResolved: true }, undefined);
+          return;
+        }
         respond(
           false,
           undefined,

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -824,6 +824,39 @@ describe("exec approval handlers", () => {
     );
   });
 
+  it("treats duplicate late resolve for the same exact approval id as success", async () => {
+    const manager = new ExecApprovalManager();
+    const handlers = createExecApprovalHandlers(manager);
+    const context = {
+      broadcast: (_event: string, _payload: unknown) => {},
+      hasExecApprovalClients: () => true,
+    };
+    const respondFirst = vi.fn();
+    const respondSecond = vi.fn();
+
+    void manager.register(manager.create({ command: "echo one" }, 60_000, "approval-dup"), 60_000);
+
+    await resolveExecApproval({
+      handlers,
+      id: "approval-dup",
+      respond: respondFirst,
+      context,
+    });
+    await resolveExecApproval({
+      handlers,
+      id: "approval-dup",
+      respond: respondSecond,
+      context,
+    });
+
+    expect(respondFirst).toHaveBeenCalledWith(true, { ok: true }, undefined);
+    expect(respondSecond).toHaveBeenCalledWith(
+      true,
+      { ok: true, alreadyResolved: true },
+      undefined,
+    );
+  });
+
   it("resolves only the targeted approval id when multiple requests are pending", async () => {
     const manager = new ExecApprovalManager();
     const handlers = createExecApprovalHandlers(manager);

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -455,6 +455,43 @@ describe("gateway server agent", () => {
     }
   });
 
+  test("agent uses uniquely bound channel when delivery requested and no last channel exists", async () => {
+    setRegistry(defaultRegistry);
+    testState.allowFrom = ["+1555"];
+    testState.bindingsConfig = [
+      {
+        agentId: "main",
+        match: { channel: "discord", accountId: "kaiser_hq" },
+      },
+    ];
+    try {
+      await setTestSessionStore({
+        entries: {
+          main: {
+            sessionId: "sess-main-bound-discord",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const res = await rpcReq(ws, "agent", {
+        message: "hi",
+        sessionKey: "main",
+        deliver: true,
+        idempotencyKey: "idem-agent-bound-discord",
+      });
+      expect(res.ok).toBe(true);
+
+      const call = latestAgentCall();
+      expectChannels(call, "discord");
+      expect(call.accountId).toBe("kaiser_hq");
+      expect(call.deliver).toBe(true);
+      expect(call.bestEffortDeliver).toBe(true);
+    } finally {
+      testState.allowFrom = undefined;
+      testState.bindingsConfig = undefined;
+    }
+  });
+
   test.each([
     {
       name: "whatsapp",

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HealthSummary } from "../../commands/health.js";
+
+const getHealthSnapshotMock = vi.fn();
+
+vi.mock("../../commands/health.js", () => ({
+  getHealthSnapshot: getHealthSnapshotMock,
+}));
+
+const { __resetHealthStateForTest, getHealthCache, refreshGatewayHealthSnapshot } =
+  await import("./health-state.js");
+
+function createHealthSummary(ts: number): HealthSummary {
+  return {
+    ok: true,
+    ts,
+    durationMs: 1,
+    channels: {},
+    channelOrder: [],
+    channelLabels: {},
+    heartbeatSeconds: 0,
+    defaultAgentId: "main",
+    agents: [],
+    sessions: {
+      path: "/tmp/sessions.json",
+      count: 0,
+      recent: [],
+    },
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("refreshGatewayHealthSnapshot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetHealthStateForTest();
+  });
+
+  afterEach(() => {
+    __resetHealthStateForTest();
+  });
+
+  it("does not block a fast snapshot behind an in-flight probe refresh", async () => {
+    const probeDeferred = createDeferred<HealthSummary>();
+    getHealthSnapshotMock.mockImplementation(({ probe }: { probe?: boolean }) =>
+      probe ? probeDeferred.promise : Promise.resolve(createHealthSummary(20)),
+    );
+
+    let probeResolved = false;
+    const probePromise = refreshGatewayHealthSnapshot({ probe: true }).then((result) => {
+      probeResolved = true;
+      return result;
+    });
+
+    const snapshotResult = await refreshGatewayHealthSnapshot({ probe: false });
+
+    expect(snapshotResult.ts).toBe(20);
+    expect(probeResolved).toBe(false);
+    expect(getHealthCache()?.ts).toBe(20);
+    expect(getHealthSnapshotMock).toHaveBeenNthCalledWith(1, { probe: true });
+    expect(getHealthSnapshotMock).toHaveBeenNthCalledWith(2, { probe: false });
+
+    probeDeferred.resolve(createHealthSummary(30));
+    await expect(probePromise).resolves.toMatchObject({ ts: 30 });
+    expect(getHealthCache()?.ts).toBe(30);
+  });
+
+  it("deduplicates concurrent refreshes with the same probe mode", async () => {
+    const snapshotDeferred = createDeferred<HealthSummary>();
+    getHealthSnapshotMock.mockImplementation(({ probe }: { probe?: boolean }) =>
+      probe ? Promise.resolve(createHealthSummary(99)) : snapshotDeferred.promise,
+    );
+
+    const first = refreshGatewayHealthSnapshot({ probe: false });
+    const second = refreshGatewayHealthSnapshot({ probe: false });
+
+    expect(getHealthSnapshotMock).toHaveBeenCalledTimes(1);
+    snapshotDeferred.resolve(createHealthSummary(42));
+
+    await expect(first).resolves.toMatchObject({ ts: 42 });
+    await expect(second).resolves.toMatchObject({ ts: 42 });
+    expect(getHealthCache()?.ts).toBe(42);
+  });
+});

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -11,8 +11,18 @@ import type { Snapshot } from "../protocol/index.js";
 let presenceVersion = 1;
 let healthVersion = 1;
 let healthCache: HealthSummary | null = null;
-let healthRefresh: Promise<HealthSummary> | null = null;
+let healthSnapshotRefresh: Promise<HealthSummary> | null = null;
+let healthProbeRefresh: Promise<HealthSummary> | null = null;
 let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
+
+function commitHealthSnapshot(snap: HealthSummary): HealthSummary {
+  healthCache = snap;
+  healthVersion += 1;
+  if (broadcastHealthUpdate) {
+    broadcastHealthUpdate(snap);
+  }
+  return snap;
+}
 
 export function buildGatewaySnapshot(): Snapshot {
   const cfg = loadConfig();
@@ -68,18 +78,43 @@ export function setBroadcastHealthUpdate(fn: ((snap: HealthSummary) => void) | n
 }
 
 export async function refreshGatewayHealthSnapshot(opts?: { probe?: boolean }) {
-  if (!healthRefresh) {
-    healthRefresh = (async () => {
-      const snap = await getHealthSnapshot({ probe: opts?.probe });
-      healthCache = snap;
-      healthVersion += 1;
-      if (broadcastHealthUpdate) {
-        broadcastHealthUpdate(snap);
-      }
-      return snap;
-    })().finally(() => {
-      healthRefresh = null;
-    });
+  const wantsProbe = opts?.probe === true;
+  const inFlight = wantsProbe ? healthProbeRefresh : healthSnapshotRefresh;
+  if (inFlight) {
+    return inFlight;
   }
-  return healthRefresh;
+
+  const refresh = (async () => {
+    const snap = await getHealthSnapshot({ probe: wantsProbe });
+    return commitHealthSnapshot(snap);
+  })().finally(() => {
+    if (wantsProbe) {
+      if (healthProbeRefresh === refresh) {
+        healthProbeRefresh = null;
+      }
+      return;
+    }
+    if (healthSnapshotRefresh === refresh) {
+      healthSnapshotRefresh = null;
+    }
+  });
+
+  if (wantsProbe) {
+    healthProbeRefresh = refresh;
+  } else {
+    healthSnapshotRefresh = refresh;
+  }
+  return refresh;
+}
+
+export function __resetHealthStateForTest(): void {
+  if (!process.env.VITEST && process.env.NODE_ENV !== "test") {
+    return;
+  }
+  presenceVersion = 1;
+  healthVersion = 1;
+  healthCache = null;
+  healthSnapshotRefresh = null;
+  healthProbeRefresh = null;
+  broadcastHealthUpdate = null;
 }

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -25,6 +25,7 @@ type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 const LOG_HEADER_MAX_LEN = 300;
 const LOG_HEADER_FORMAT_REGEX = /\p{Cf}/gu;
+const LOCAL_HANDSHAKE_TIMEOUT_MS = 8_000;
 
 function replaceControlChars(value: string): string {
   let cleaned = "";
@@ -264,7 +265,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       close();
     });
 
-    const handshakeTimeoutMs = getHandshakeTimeoutMs();
+    const handshakeTimeoutMs = isLoopbackAddress(remoteAddr)
+      ? Math.max(getHandshakeTimeoutMs(), LOCAL_HANDSHAKE_TIMEOUT_MS)
+      : getHandshakeTimeoutMs();
     const handshakeTimer = setTimeout(() => {
       if (!client) {
         handshakeState = "failed";

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -198,62 +198,8 @@ export function attachGatewayWsMessageHandler(params: {
     logWsControl,
   } = params;
 
-  const configSnapshot = loadConfig();
-  const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
-  const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
-  const clientIp = resolveClientIp({
-    remoteAddr,
-    forwardedFor,
-    realIp,
-    trustedProxies,
-    allowRealIpFallback,
-  });
-
-  // If proxy headers are present but the remote address isn't trusted, don't treat
-  // the connection as local. This prevents auth bypass when running behind a reverse
-  // proxy without proper configuration - the proxy's loopback connection would otherwise
-  // cause all external requests to be treated as trusted local clients.
-  const hasProxyHeaders = Boolean(forwardedFor || realIp);
-  const remoteIsTrustedProxy = isTrustedProxyAddress(remoteAddr, trustedProxies);
-  const hasUntrustedProxyHeaders = hasProxyHeaders && !remoteIsTrustedProxy;
-  const hostIsLocalish = isLocalishHost(requestHost);
-  const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback);
-  const reportedClientIp =
-    isLocalClient || hasUntrustedProxyHeaders
-      ? undefined
-      : clientIp && !isLoopbackAddress(clientIp)
-        ? clientIp
-        : undefined;
-
-  if (hasUntrustedProxyHeaders) {
-    logWsControl.warn(
-      "Proxy headers detected from untrusted address. " +
-        "Connection will not be treated as local. " +
-        "Configure gateway.trustedProxies to restore local client detection behind your proxy.",
-    );
-  }
-  if (!hostIsLocalish && isLoopbackAddress(remoteAddr) && !hasProxyHeaders) {
-    logWsControl.warn(
-      "Loopback connection with non-local Host header. " +
-        "Treating it as remote. If you're behind a reverse proxy, " +
-        "set gateway.trustedProxies and forward X-Forwarded-For/X-Real-IP.",
-    );
-  }
-
   const isWebchatConnect = (p: ConnectParams | null | undefined) => isWebchatClient(p?.client);
   const unauthorizedFloodGuard = new UnauthorizedFloodGuard();
-  const browserSecurity = resolveHandshakeBrowserSecurityContext({
-    requestOrigin,
-    clientIp,
-    rateLimiter,
-    browserRateLimiter,
-  });
-  const {
-    hasBrowserOriginHeader,
-    enforceOriginCheckForAnyClient,
-    rateLimitClientIp: browserRateLimitClientIp,
-    authRateLimiter,
-  } = browserSecurity;
 
   socket.on("message", async (data) => {
     if (isClosed()) {
@@ -349,6 +295,55 @@ export function attachGatewayWsMessageHandler(params: {
           mode: connectParams.client.mode,
           version: connectParams.client.version,
         };
+        // Attach the message listener before reading config so early `connect`
+        // frames are not dropped when config validation is slow on startup.
+        const configSnapshot = loadConfig();
+        const trustedProxies = configSnapshot.gateway?.trustedProxies ?? [];
+        const allowRealIpFallback = configSnapshot.gateway?.allowRealIpFallback === true;
+        const clientIp = resolveClientIp({
+          remoteAddr,
+          forwardedFor,
+          realIp,
+          trustedProxies,
+          allowRealIpFallback,
+        });
+        const hasProxyHeaders = Boolean(forwardedFor || realIp);
+        const remoteIsTrustedProxy = isTrustedProxyAddress(remoteAddr, trustedProxies);
+        const hasUntrustedProxyHeaders = hasProxyHeaders && !remoteIsTrustedProxy;
+        const hostIsLocalish = isLocalishHost(requestHost);
+        const isLocalClient = isLocalDirectRequest(upgradeReq, trustedProxies, allowRealIpFallback);
+        const reportedClientIp =
+          isLocalClient || hasUntrustedProxyHeaders
+            ? undefined
+            : clientIp && !isLoopbackAddress(clientIp)
+              ? clientIp
+              : undefined;
+        if (hasUntrustedProxyHeaders) {
+          logWsControl.warn(
+            "Proxy headers detected from untrusted address. " +
+              "Connection will not be treated as local. " +
+              "Configure gateway.trustedProxies to restore local client detection behind your proxy.",
+          );
+        }
+        if (!hostIsLocalish && isLoopbackAddress(remoteAddr) && !hasProxyHeaders) {
+          logWsControl.warn(
+            "Loopback connection with non-local Host header. " +
+              "Treating it as remote. If you're behind a reverse proxy, " +
+              "set gateway.trustedProxies and forward X-Forwarded-For/X-Real-IP.",
+          );
+        }
+        const browserSecurity = resolveHandshakeBrowserSecurityContext({
+          requestOrigin,
+          clientIp,
+          rateLimiter,
+          browserRateLimiter,
+        });
+        const {
+          hasBrowserOriginHeader,
+          enforceOriginCheckForAnyClient,
+          rateLimitClientIp: browserRateLimitClientIp,
+          authRateLimiter,
+        } = browserSecurity;
         const markHandshakeFailure = (cause: string, meta?: Record<string, unknown>) => {
           setHandshakeState("failed");
           setCloseCause(cause, { ...meta, ...clientMeta });
@@ -1053,7 +1048,7 @@ export function attachGatewayWsMessageHandler(params: {
         });
 
         send({ type: "res", id: frame.id, ok: true, payload: helloOk });
-        void refreshGatewayHealthSnapshot({ probe: true }).catch((err) =>
+        void refreshGatewayHealthSnapshot({ probe: false }).catch((err) =>
           logHealth.error(`post-connect health refresh failed: ${formatError(err)}`),
         );
         return;

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -672,6 +672,97 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("falls back to the most recent routed session when the main heartbeat session is missing", async () => {
+    const tmpDir = await createCaseDir("hb-route-fallback");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            heartbeat: { every: "30m" },
+          },
+          list: [
+            { id: "main", default: true },
+            {
+              id: "ops",
+              workspace: tmpDir,
+              heartbeat: {
+                every: "5m",
+                target: "last",
+                isolatedSession: true,
+                accountId: "ops",
+              },
+            },
+          ],
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const latestRouteKey = buildAgentPeerSessionKey({
+        agentId: "ops",
+        channel: "whatsapp",
+        accountId: "ops",
+        peerKind: "channel",
+        peerId: "team-room",
+      });
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [latestRouteKey]: {
+            sessionId: "sid-route",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+            lastAccountId: "ops",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: "Final alert" }]);
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: unknown,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({
+          messageId: "m1",
+          toJid: "jid",
+        });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "ops",
+        deps: createHeartbeatDeps(sendWhatsApp),
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+      expect(sendWhatsApp).toHaveBeenCalledWith(
+        "120363401234567890@g.us",
+        "Final alert",
+        expect.any(Object),
+      );
+      expect(replySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          From: "120363401234567890@g.us",
+          To: "120363401234567890@g.us",
+          OriginatingChannel: "whatsapp",
+          OriginatingTo: "120363401234567890@g.us",
+          SessionKey: "agent:ops:main:heartbeat",
+        }),
+        expect.objectContaining({ isHeartbeat: true, suppressToolErrorWarnings: false }),
+        cfg,
+      );
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
   it("reuses non-default agent sessionFile from templated stores", async () => {
     const tmpDir = await createCaseDir("hb-templated-store");
     const storeTemplate = path.join(tmpDir, "agents", "{agentId}", "sessions", "sessions.json");

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -32,6 +32,7 @@ import {
   saveSessionStore,
   updateSessionStore,
 } from "../config/sessions.js";
+import type { SessionEntry } from "../config/sessions.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import { resolveCronSession } from "../cron/isolated-agent/session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -39,11 +40,14 @@ import { getQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import {
   normalizeAgentId,
+  normalizeAccountId,
   parseAgentSessionKey,
   toAgentStoreSessionKey,
 } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { escapeRegExp } from "../utils.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.js";
+import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import { formatErrorMessage, hasErrnoCode } from "./errors.js";
 import { isWithinActiveHours } from "./heartbeat-active-hours.js";
 import {
@@ -164,6 +168,46 @@ function resolveHeartbeatAckMaxChars(cfg: OpenClawConfig, heartbeat?: HeartbeatC
   );
 }
 
+function resolveRecentHeartbeatDeliveryEntry(params: {
+  store: Record<string, SessionEntry>;
+  preferredEntry?: SessionEntry;
+  preferredSessionKey: string;
+  accountId?: string;
+}): SessionEntry | undefined {
+  const preferredContext = deliveryContextFromSession(params.preferredEntry);
+  if (
+    preferredContext?.channel &&
+    isDeliverableMessageChannel(preferredContext.channel) &&
+    preferredContext.to
+  ) {
+    return params.preferredEntry;
+  }
+
+  const normalizedAccountId = normalizeAccountId(params.accountId);
+  const candidate = Object.entries(params.store)
+    .filter(([key]) => key !== params.preferredSessionKey && key !== "global" && key !== "unknown")
+    .filter(([key]) => !key.endsWith(":heartbeat"))
+    .map(([_, entry]) => ({
+      entry,
+      context: deliveryContextFromSession(entry),
+    }))
+    .filter(({ context }) =>
+      Boolean(
+        context?.channel && isDeliverableMessageChannel(context.channel) && context.to?.trim(),
+      ),
+    )
+    .filter(({ context }) => {
+      if (!normalizedAccountId) {
+        return true;
+      }
+      const contextAccountId = normalizeAccountId(context?.accountId);
+      return !contextAccountId || contextAccountId === normalizedAccountId;
+    })
+    .toSorted((a, b) => (b.entry.updatedAt ?? 0) - (a.entry.updatedAt ?? 0))[0];
+
+  return candidate?.entry ?? params.preferredEntry;
+}
+
 function resolveHeartbeatSession(
   cfg: OpenClawConfig,
   agentId?: string,
@@ -181,9 +225,16 @@ function resolveHeartbeatSession(
   });
   const store = loadSessionStore(storePath);
   const mainEntry = store[mainSessionKey];
+  const heartbeatAccountId = heartbeat?.accountId?.trim();
+  const fallbackEntry = resolveRecentHeartbeatDeliveryEntry({
+    store,
+    preferredEntry: mainEntry,
+    preferredSessionKey: mainSessionKey,
+    accountId: heartbeatAccountId,
+  });
 
   if (scope === "global") {
-    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
+    return { sessionKey: mainSessionKey, storePath, store, entry: fallbackEntry };
   }
 
   const forced = forcedSessionKey?.trim();
@@ -213,12 +264,12 @@ function resolveHeartbeatSession(
 
   const trimmed = heartbeat?.session?.trim() ?? "";
   if (!trimmed) {
-    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
+    return { sessionKey: mainSessionKey, storePath, store, entry: fallbackEntry };
   }
 
   const normalized = trimmed.toLowerCase();
   if (normalized === "main" || normalized === "global") {
-    return { sessionKey: mainSessionKey, storePath, store, entry: mainEntry };
+    return { sessionKey: mainSessionKey, storePath, store, entry: fallbackEntry };
   }
 
   const candidate = toAgentStoreSessionKey({

--- a/src/infra/outbound/agent-delivery.test.ts
+++ b/src/infra/outbound/agent-delivery.test.ts
@@ -72,6 +72,44 @@ describe("agent delivery helpers", () => {
     expect(plan.deliveryTargetMode).toBeUndefined();
   });
 
+  it("uses a uniquely bound delivery channel when session has none", () => {
+    const plan = resolveAgentDeliveryPlan({
+      sessionEntry: undefined,
+      cfg: {
+        bindings: [{ agentId: "main", match: { channel: "discord", accountId: "kaiser_hq" } }],
+      } as OpenClawConfig,
+      agentId: "main",
+      requestedChannel: "last",
+      explicitTo: undefined,
+      accountId: undefined,
+      wantsDelivery: true,
+    });
+
+    expect(plan.resolvedChannel).toBe("discord");
+    expect(plan.resolvedAccountId).toBe("kaiser_hq");
+    expect(plan.deliveryTargetMode).toBe("implicit");
+  });
+
+  it("keeps delivery unresolved when agent is bound to multiple channels", () => {
+    const plan = resolveAgentDeliveryPlan({
+      sessionEntry: undefined,
+      cfg: {
+        bindings: [
+          { agentId: "main", match: { channel: "discord", accountId: "kaiser_hq" } },
+          { agentId: "main", match: { channel: "telegram", accountId: "main" } },
+        ],
+      } as OpenClawConfig,
+      agentId: "main",
+      requestedChannel: "last",
+      explicitTo: undefined,
+      accountId: undefined,
+      wantsDelivery: true,
+    });
+
+    expect(plan.resolvedChannel).toBe("webchat");
+    expect(plan.resolvedAccountId).toBeUndefined();
+  });
+
   it("skips outbound target resolution when explicit target validation is disabled", () => {
     const plan = resolveAgentDeliveryPlan({
       sessionEntry: {

--- a/src/infra/outbound/agent-delivery.ts
+++ b/src/infra/outbound/agent-delivery.ts
@@ -1,6 +1,7 @@
 import type { ChannelOutboundTargetMode } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { resolveUniqueBoundChannelForAgent } from "../../routing/bindings.js";
 import { normalizeAccountId } from "../../utils/account-id.js";
 import {
   INTERNAL_MESSAGE_CHANNEL,
@@ -27,6 +28,8 @@ export type AgentDeliveryPlan = {
 
 export function resolveAgentDeliveryPlan(params: {
   sessionEntry?: SessionEntry;
+  cfg?: OpenClawConfig;
+  agentId?: string;
   requestedChannel?: string;
   explicitTo?: string;
   explicitThreadId?: string | number;
@@ -86,6 +89,11 @@ export function resolveAgentDeliveryPlan(params: {
     turnSourceThreadId,
   });
 
+  const boundDelivery =
+    params.wantsDelivery && params.cfg
+      ? resolveUniqueBoundChannelForAgent(params.cfg, params.agentId ?? "main")
+      : null;
+
   const resolvedChannel = (() => {
     if (requestedChannel === INTERNAL_MESSAGE_CHANNEL) {
       return INTERNAL_MESSAGE_CHANNEL;
@@ -93,6 +101,9 @@ export function resolveAgentDeliveryPlan(params: {
     if (requestedChannel === "last") {
       if (baseDelivery.channel && baseDelivery.channel !== INTERNAL_MESSAGE_CHANNEL) {
         return baseDelivery.channel;
+      }
+      if (boundDelivery && isDeliverableMessageChannel(boundDelivery.channelId)) {
+        return boundDelivery.channelId;
       }
       return INTERNAL_MESSAGE_CHANNEL;
     }
@@ -104,6 +115,9 @@ export function resolveAgentDeliveryPlan(params: {
     if (baseDelivery.channel && baseDelivery.channel !== INTERNAL_MESSAGE_CHANNEL) {
       return baseDelivery.channel;
     }
+    if (boundDelivery && isDeliverableMessageChannel(boundDelivery.channelId)) {
+      return boundDelivery.channelId;
+    }
     return INTERNAL_MESSAGE_CHANNEL;
   })();
 
@@ -113,9 +127,12 @@ export function resolveAgentDeliveryPlan(params: {
       ? "implicit"
       : undefined;
 
+  const boundAccountIds = boundDelivery?.accountIds ?? [];
   const resolvedAccountId =
     normalizeAccountId(params.accountId) ??
-    (deliveryTargetMode === "implicit" ? baseDelivery.accountId : undefined);
+    (deliveryTargetMode === "implicit"
+      ? (baseDelivery.accountId ?? boundAccountIds[0])
+      : undefined);
 
   let resolvedTo = explicitTo;
   if (

--- a/src/routing/bindings.ts
+++ b/src/routing/bindings.ts
@@ -102,6 +102,52 @@ export function buildChannelAccountBindings(cfg: OpenClawConfig) {
   return map;
 }
 
+export function resolveUniqueBoundChannelForAgent(
+  cfg: OpenClawConfig,
+  agentId: string,
+): {
+  channelId: string;
+  accountIds: string[];
+} | null {
+  const normalizedAgentId = normalizeAgentId(agentId);
+  let channelId: string | null = null;
+  const accountIds = new Set<string>();
+
+  for (const binding of listBindings(cfg)) {
+    if (!binding || typeof binding !== "object") {
+      continue;
+    }
+    if (normalizeAgentId(binding.agentId) !== normalizedAgentId) {
+      continue;
+    }
+    const match = binding.match;
+    if (!match || typeof match !== "object") {
+      continue;
+    }
+    const normalizedChannelId = normalizeBindingChannelId(match.channel);
+    if (!normalizedChannelId) {
+      continue;
+    }
+    if (channelId && channelId !== normalizedChannelId) {
+      return null;
+    }
+    channelId = normalizedChannelId;
+
+    const accountId = typeof match.accountId === "string" ? match.accountId.trim() : "";
+    if (accountId && accountId !== "*") {
+      accountIds.add(normalizeAccountId(accountId));
+    }
+  }
+
+  if (!channelId) {
+    return null;
+  }
+  return {
+    channelId,
+    accountIds: Array.from(accountIds).toSorted((a, b) => a.localeCompare(b)),
+  };
+}
+
 export function resolvePreferredAccountId(params: {
   accountIds: string[];
   defaultAccountId: string;

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
-import { applyModelOverrideToSessionEntry } from "./model-overrides.js";
+import {
+  applyModelOverrideToSessionEntry,
+  shouldResetLegacyMainSessionModelOverride,
+} from "./model-overrides.js";
 
 function applyOpenAiSelection(entry: SessionEntry) {
   return applyModelOverrideToSessionEntry({
@@ -15,6 +18,7 @@ function applyOpenAiSelection(entry: SessionEntry) {
 function expectRuntimeModelFieldsCleared(entry: SessionEntry, before: number) {
   expect(entry.providerOverride).toBe("openai");
   expect(entry.modelOverride).toBe("gpt-5.2");
+  expect(entry.modelOverrideSource).toBe("user");
   expect(entry.modelProvider).toBeUndefined();
   expect(entry.model).toBeUndefined();
   expect((entry.updatedAt ?? 0) > before).toBe(true);
@@ -114,7 +118,30 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(result.updated).toBe(true);
     expect(entry.providerOverride).toBeUndefined();
     expect(entry.modelOverride).toBeUndefined();
+    expect(entry.modelOverrideSource).toBeUndefined();
     expect(entry.contextTokens).toBeUndefined();
     expect((entry.updatedAt ?? 0) > before).toBe(true);
+  });
+
+  it("does not treat explicit user-tagged main-session overrides as legacy drift", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-5",
+      updatedAt: Date.now(),
+      providerOverride: "openai-codex",
+      modelOverride: "gpt-5.4",
+      modelOverrideSource: "user",
+      modelProvider: "openai-codex",
+      model: "gpt-5.4",
+    };
+
+    expect(
+      shouldResetLegacyMainSessionModelOverride({
+        entry,
+        sessionKey: "agent:main:main",
+        mainKey: "main",
+        defaultProvider: "miaomiaocode-codex",
+        defaultModel: "gpt-5.4",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -1,4 +1,5 @@
 import type { SessionEntry } from "../config/sessions.js";
+import { normalizeMainKey, parseAgentSessionKey } from "../routing/session-key.js";
 
 export type ModelOverrideSelection = {
   provider: string;
@@ -6,13 +7,17 @@ export type ModelOverrideSelection = {
   isDefault?: boolean;
 };
 
+export type ModelOverrideSource = "user";
+
 export function applyModelOverrideToSessionEntry(params: {
   entry: SessionEntry;
   selection: ModelOverrideSelection;
+  modelOverrideSource?: ModelOverrideSource;
   profileOverride?: string;
   profileOverrideSource?: "auto" | "user";
 }): { updated: boolean } {
   const { entry, selection, profileOverride } = params;
+  const modelOverrideSource = params.modelOverrideSource ?? "user";
   const profileOverrideSource = params.profileOverrideSource ?? "user";
   let updated = false;
   let selectionUpdated = false;
@@ -27,6 +32,10 @@ export function applyModelOverrideToSessionEntry(params: {
       delete entry.modelOverride;
       updated = true;
       selectionUpdated = true;
+    }
+    if (entry.modelOverrideSource) {
+      delete entry.modelOverrideSource;
+      updated = true;
     }
   } else {
     if (entry.providerOverride !== selection.provider) {
@@ -50,6 +59,14 @@ export function applyModelOverrideToSessionEntry(params: {
   const runtimeAligned =
     runtimeModel === selection.model &&
     (runtimeProvider.length === 0 || runtimeProvider === selection.provider);
+  if (
+    !selection.isDefault &&
+    entry.modelOverrideSource !== modelOverrideSource &&
+    (selectionUpdated || (runtimePresent && !runtimeAligned))
+  ) {
+    entry.modelOverrideSource = modelOverrideSource;
+    updated = true;
+  }
   if (runtimePresent && (selectionUpdated || !runtimeAligned)) {
     if (entry.model !== undefined) {
       delete entry.model;
@@ -109,4 +126,74 @@ export function applyModelOverrideToSessionEntry(params: {
   }
 
   return { updated };
+}
+
+function trimToUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function normalizeProviderKey(value: string | undefined): string | undefined {
+  const trimmed = trimToUndefined(value);
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+export function shouldResetLegacyMainSessionModelOverride(params: {
+  entry: SessionEntry;
+  sessionKey?: string;
+  mainKey?: string;
+  defaultProvider: string;
+  defaultModel: string;
+}): boolean {
+  const sessionKey = trimToUndefined(params.sessionKey);
+  if (!sessionKey) {
+    return false;
+  }
+
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed || parsed.rest !== normalizeMainKey(params.mainKey)) {
+    return false;
+  }
+
+  if (trimToUndefined(params.entry.modelOverrideSource)) {
+    return false;
+  }
+
+  const overrideModel = trimToUndefined(params.entry.modelOverride);
+  const defaultModel = trimToUndefined(params.defaultModel);
+  if (!overrideModel || !defaultModel || overrideModel !== defaultModel) {
+    return false;
+  }
+
+  const overrideProvider = normalizeProviderKey(
+    trimToUndefined(params.entry.providerOverride) ?? params.defaultProvider,
+  );
+  const defaultProvider = normalizeProviderKey(params.defaultProvider);
+  if (!overrideProvider || !defaultProvider || overrideProvider === defaultProvider) {
+    return false;
+  }
+
+  const runtimeModel = trimToUndefined(params.entry.model);
+  const runtimeProvider = normalizeProviderKey(params.entry.modelProvider);
+  return runtimeModel === overrideModel && runtimeProvider === overrideProvider;
+}
+
+export function resetLegacyMainSessionModelOverride(params: {
+  entry: SessionEntry;
+  sessionKey?: string;
+  mainKey?: string;
+  defaultProvider: string;
+  defaultModel: string;
+}): { updated: boolean } {
+  if (!shouldResetLegacyMainSessionModelOverride(params)) {
+    return { updated: false };
+  }
+  return applyModelOverrideToSessionEntry({
+    entry: params.entry,
+    selection: {
+      provider: params.defaultProvider,
+      model: params.defaultModel,
+      isDefault: true,
+    },
+  });
 }


### PR DESCRIPTION
This PR hardens the non-Apple GitHub-side runtime work that sits behind VeriClaw/OpenClaw's multi-channel agent flows. It combines two related areas that were causing user-visible instability: stale main-session model/provider recovery after rotator changes, and brittle Discord / outbound delivery lifecycle handling when channels stalled or lost their last routed target.

On the session and model side, the root problem was that older main-session records could keep a provider/model override that only mirrored a stale runtime selection. After defaults changed, the main session could stay pinned to an outdated provider even though the effective default model had already moved. This branch teaches model override persistence to distinguish explicit user overrides from legacy drift, clears legacy main-session pins only when they are clearly stale, and keeps agent/session state aligned with the current default routing rules. It also improves related gateway and agent state plumbing so those resets propagate cleanly through the runtime.

On the delivery and Discord side, the previous lifecycle handling was too fragile in a few places. Discord reconnect watchdog failures did not surface enough structured context, disconnects could throw if the websocket died before the connection fully opened, heartbeat replies could lose a valid delivery target when the canonical heartbeat session entry was missing, and outbound delivery did not reliably fall back to a uniquely bound channel for the agent. This branch adds stronger watchdog metadata, safer Discord disconnect behavior, better heartbeat session fallback logic, and more resilient delivery-plan resolution so responses keep flowing to the right channel even under degraded state.

I validated the branch with a focused vitest run covering the changed surfaces: Discord lifecycle and proxy tests, watchdog behavior, heartbeat fallback delivery, outbound agent delivery, gateway server health/state, server method handling, and config/runtime compatibility. That targeted run completed successfully with 9 test files and 136 passing tests. The local commit hook checks also passed during commit creation.
