### PR TITLE
fix(agents): detect empty provider responses as failures, improve Telegram error routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ apps/ios/*.mobileprovision
 # Local untracked files
 .local/
 docs/.local/
+docs/SESSION_LOG.md
 IDENTITY.md
 USER.md
 .tgz
@@ -121,3 +122,4 @@ dist/protocol.schema.json
 
 # Synthing
 **/.stfolder/
+.design

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -8,7 +8,11 @@ import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import { isAnthropicBillingError } from "./live-auth-keys.js";
-import { runWithImageModelFallback, runWithModelFallback } from "./model-fallback.js";
+import {
+  EmptyResponseError,
+  runWithImageModelFallback,
+  runWithModelFallback,
+} from "./model-fallback.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
 const makeCfg = makeModelFallbackCfg;
@@ -1201,6 +1205,53 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5"); // Rate limit allows attempt
       expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile"); // Cross-provider works
     });
+  });
+
+  it("treats empty content array (no meta) as failure and falls back to next candidate", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-4.1-mini", fallbacks: ["fallback/ok-model"] },
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce({ content: [] }) // primary: empty, no meta → EmptyResponseError
+      .mockResolvedValueOnce("ok"); // fallback succeeds
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts a result with meta field even when content is empty", async () => {
+    const cfg = makeCfg({
+      agents: { defaults: { model: { primary: "openai/gpt-4.1-mini" } } },
+    });
+    const payload = { content: [], meta: { usage: { input_tokens: 10, output_tokens: 0 } } };
+    const run = vi.fn().mockResolvedValueOnce(payload);
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      run,
+    });
+    expect(result.result).toEqual(payload);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("EmptyResponseError", () => {
+  it("is an instance of Error with correct name", () => {
+    const err = new EmptyResponseError();
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("EmptyResponseError");
+    expect(err.message).toBe("Empty response content received from provider");
   });
 });
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -1244,6 +1244,17 @@ describe("runWithModelFallback", () => {
     expect(result.result).toEqual(payload);
     expect(run).toHaveBeenCalledTimes(1);
   });
+
+  it("throws EmptyResponseError when the only candidate returns empty content", async () => {
+    const cfg = makeCfg({
+      agents: { defaults: { model: { primary: "openai/gpt-4.1-mini" } } },
+    });
+    const run = vi.fn().mockResolvedValueOnce({ content: [] });
+    await expect(
+      runWithModelFallback({ cfg, provider: "openai", model: "gpt-4.1-mini", run }),
+    ).rejects.toBeInstanceOf(EmptyResponseError);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("EmptyResponseError", () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -28,6 +28,13 @@ import {
 import type { FailoverReason } from "./pi-embedded-helpers.js";
 import { isLikelyContextOverflowError } from "./pi-embedded-helpers.js";
 
+export class EmptyResponseError extends Error {
+  constructor() {
+    super("Empty response content received from provider");
+    this.name = "EmptyResponseError";
+  }
+}
+
 type ModelCandidate = {
   provider: string;
   model: string;
@@ -153,6 +160,23 @@ async function runFallbackAttempt<T>(params: {
     model: params.model,
   });
   if (runResult.ok) {
+    // Check for empty raw provider response content array (treat as failure)
+    // Do NOT check EmbeddedPiRunResult payloads here - that should be handled upstream
+    // to avoid breaking valid use cases like memory flush which intentionally return empty
+    const result = runResult.result;
+    if (
+      result &&
+      typeof result === "object" &&
+      "content" in result &&
+      Array.isArray(result.content) &&
+      result.content.length === 0 &&
+      // Only apply to raw provider responses (not wrapped in EmbeddedPiRunResult)
+      !("meta" in result)
+    ) {
+      return {
+        error: new EmptyResponseError(),
+      };
+    }
     return {
       success: buildFallbackSuccess({
         result: runResult.result,

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -153,6 +153,9 @@ async function runFallbackAttempt<T>(params: {
   provider: string;
   model: string;
   attempts: FallbackAttempt[];
+  /** Predicate to distinguish raw provider responses from wrapper types (e.g. EmbeddedPiRunResult).
+   *  Only raw responses with empty content trigger EmptyResponseError. */
+  isRawProviderResult?: (result: T) => boolean;
 }): Promise<{ success: ModelFallbackRunResult<T> } | { error: unknown }> {
   const runResult = await runFallbackCandidate({
     run: params.run,
@@ -160,18 +163,19 @@ async function runFallbackAttempt<T>(params: {
     model: params.model,
   });
   if (runResult.ok) {
-    // Check for empty raw provider response content array (treat as failure)
+    // Check for empty raw provider response content array (treat as failure).
     // Do NOT check EmbeddedPiRunResult payloads here - that should be handled upstream
-    // to avoid breaking valid use cases like memory flush which intentionally return empty
+    // to avoid breaking valid use cases like memory flush which intentionally return empty.
     const result = runResult.result;
+    const isRaw =
+      params.isRawProviderResult?.(result) ??
+      (typeof result === "object" && result !== null && !("meta" in result));
+    const resultObj = isRaw && typeof result === "object" && result !== null ? result : null;
     if (
-      result &&
-      typeof result === "object" &&
-      "content" in result &&
-      Array.isArray(result.content) &&
-      result.content.length === 0 &&
-      // Only apply to raw provider responses (not wrapped in EmbeddedPiRunResult)
-      !("meta" in result)
+      resultObj &&
+      "content" in resultObj &&
+      Array.isArray((resultObj as { content: unknown }).content) &&
+      (resultObj as { content: unknown[] }).content.length === 0
     ) {
       return {
         error: new EmptyResponseError(),
@@ -465,6 +469,10 @@ export async function runWithModelFallback<T>(params: {
   fallbacksOverride?: string[];
   run: (provider: string, model: string) => Promise<T>;
   onError?: ModelFallbackErrorHandler;
+  /** Predicate to distinguish raw provider responses from wrapper types.
+   *  Only raw responses with empty content trigger EmptyResponseError.
+   *  Defaults to checking absence of `meta` field. */
+  isRawProviderResult?: (result: T) => boolean;
 }): Promise<ModelFallbackRunResult<T>> {
   const candidates = resolveFallbackCandidates({
     cfg: params.cfg,
@@ -524,7 +532,12 @@ export async function runWithModelFallback<T>(params: {
       }
     }
 
-    const attemptRun = await runFallbackAttempt({ run: params.run, ...candidate, attempts });
+    const attemptRun = await runFallbackAttempt({
+      run: params.run,
+      ...candidate,
+      attempts,
+      isRawProviderResult: params.isRawProviderResult,
+    });
     if ("success" in attemptRun) {
       return attemptRun.success;
     }
@@ -547,7 +560,7 @@ export async function runWithModelFallback<T>(params: {
       // Even unrecognized errors should not abort the fallback loop when
       // there are remaining candidates.  Only abort/context-overflow errors
       // (handled above) are truly non-retryable.
-      const isKnownFailover = isFailoverError(normalized);
+      const isKnownFailover = isFailoverError(normalized) || err instanceof EmptyResponseError;
       if (!isKnownFailover && i === candidates.length - 1) {
         throw err;
       }
@@ -589,6 +602,8 @@ export async function runWithImageModelFallback<T>(params: {
   modelOverride?: string;
   run: (provider: string, model: string) => Promise<T>;
   onError?: ModelFallbackErrorHandler;
+  /** @inheritDoc runWithModelFallback */
+  isRawProviderResult?: (result: T) => boolean;
 }): Promise<ModelFallbackRunResult<T>> {
   const candidates = resolveImageFallbackCandidates({
     cfg: params.cfg,
@@ -606,7 +621,12 @@ export async function runWithImageModelFallback<T>(params: {
 
   for (let i = 0; i < candidates.length; i += 1) {
     const candidate = candidates[i];
-    const attemptRun = await runFallbackAttempt({ run: params.run, ...candidate, attempts });
+    const attemptRun = await runFallbackAttempt({
+      run: params.run,
+      ...candidate,
+      attempts,
+      isRawProviderResult: params.isRawProviderResult,
+    });
     if ("success" in attemptRun) {
       return attemptRun.success;
     }

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -1,10 +1,12 @@
 import type { Bot } from "grammy";
 import { resolveAgentDir } from "../agents/agent-scope.js";
+import { isTimeoutError, resolveFailoverReasonFromError } from "../agents/failover-error.js";
 import {
   findModelInCatalog,
   loadModelCatalog,
   modelSupportsVision,
 } from "../agents/model-catalog.js";
+import { EmptyResponseError } from "../agents/model-fallback.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { resolveChunkMode } from "../auto-reply/chunk.js";
 import { clearHistoryEntriesIfEnabled } from "../auto-reply/reply/history.js";
@@ -18,6 +20,7 @@ import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import type { OpenClawConfig, ReplyToMode, TelegramAccountConfig } from "../config/types.js";
 import { danger, logVerbose } from "../globals.js";
+import { isAbortError } from "../infra/unhandled-rejections.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
@@ -41,7 +44,12 @@ import {
 import { editMessageTelegram } from "./send.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 
-const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
+const EMPTY_RESPONSE_FALLBACK =
+  "I wasn't able to generate a response. Please try rephrasing your question.";
+const RATE_LIMIT_FALLBACK =
+  "Sorry, the service is currently rate limited. Please try again in a few minutes.";
+const GENERAL_ERROR_FALLBACK =
+  "Sorry, I encountered an error while processing your request. Please try again later.";
 
 /** Minimum chars before sending first streaming message (improves push notification UX) */
 const DRAFT_MIN_INITIAL_CHARS = 30;
@@ -486,6 +494,8 @@ export const dispatchTelegramMessage = async ({
   });
 
   let queuedFinal = false;
+  let lastError: unknown = null;
+  let caughtDispatchError: unknown = null;
 
   if (statusReactionController) {
     void statusReactionController.setThinking();
@@ -504,178 +514,192 @@ export const dispatchTelegramMessage = async ({
   });
 
   try {
-    ({ queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
-      ctx: ctxPayload,
-      cfg,
-      dispatcherOptions: {
-        ...prefixOptions,
-        typingCallbacks,
-        deliver: async (payload, info) => {
-          if (info.kind === "final") {
-            // Assistant callbacks are fire-and-forget; ensure queued boundary
-            // rotations/partials are applied before final delivery mapping.
-            await enqueueDraftLaneEvent(async () => {});
-          }
-          const previewButtons = (
-            payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
-          )?.buttons;
-          const split = splitTextIntoLaneSegments(payload.text);
-          const segments = split.segments;
-          const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+    try {
+      ({ queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
+        ctx: ctxPayload,
+        cfg,
+        dispatcherOptions: {
+          ...prefixOptions,
+          typingCallbacks,
+          deliver: async (payload, info) => {
+            if (info.kind === "final") {
+              // Assistant callbacks are fire-and-forget; ensure queued boundary
+              // rotations/partials are applied before final delivery mapping.
+              await enqueueDraftLaneEvent(async () => {});
+            }
+            const previewButtons = (
+              payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
+            )?.buttons;
+            const split = splitTextIntoLaneSegments(payload.text);
+            const segments = split.segments;
+            const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
 
-          const flushBufferedFinalAnswer = async () => {
-            const buffered = reasoningStepState.takeBufferedFinalAnswer();
-            if (!buffered) {
+            const flushBufferedFinalAnswer = async () => {
+              const buffered = reasoningStepState.takeBufferedFinalAnswer();
+              if (!buffered) {
+                return;
+              }
+              const bufferedButtons = (
+                buffered.payload.channelData?.telegram as
+                  | { buttons?: TelegramInlineButtons }
+                  | undefined
+              )?.buttons;
+              await deliverLaneText({
+                laneName: "answer",
+                text: buffered.text,
+                payload: buffered.payload,
+                infoKind: "final",
+                previewButtons: bufferedButtons,
+              });
+              reasoningStepState.resetForNextStep();
+            };
+
+            for (const segment of segments) {
+              if (
+                segment.lane === "answer" &&
+                info.kind === "final" &&
+                reasoningStepState.shouldBufferFinalAnswer()
+              ) {
+                reasoningStepState.bufferFinalAnswer({ payload, text: segment.text });
+                continue;
+              }
+              if (segment.lane === "reasoning") {
+                reasoningStepState.noteReasoningHint();
+              }
+              const result = await deliverLaneText({
+                laneName: segment.lane,
+                text: segment.text,
+                payload,
+                infoKind: info.kind,
+                previewButtons,
+                allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
+              });
+              if (segment.lane === "reasoning") {
+                if (result !== "skipped") {
+                  reasoningStepState.noteReasoningDelivered();
+                  await flushBufferedFinalAnswer();
+                }
+                continue;
+              }
+              if (info.kind === "final") {
+                if (reasoningLane.hasStreamedMessage) {
+                  finalizedPreviewByLane.reasoning = true;
+                }
+                reasoningStepState.resetForNextStep();
+              }
+            }
+            if (segments.length > 0) {
               return;
             }
-            const bufferedButtons = (
-              buffered.payload.channelData?.telegram as
-                | { buttons?: TelegramInlineButtons }
-                | undefined
-            )?.buttons;
-            await deliverLaneText({
-              laneName: "answer",
-              text: buffered.text,
-              payload: buffered.payload,
-              infoKind: "final",
-              previewButtons: bufferedButtons,
-            });
-            reasoningStepState.resetForNextStep();
-          };
-
-          for (const segment of segments) {
-            if (
-              segment.lane === "answer" &&
-              info.kind === "final" &&
-              reasoningStepState.shouldBufferFinalAnswer()
-            ) {
-              reasoningStepState.bufferFinalAnswer({ payload, text: segment.text });
-              continue;
-            }
-            if (segment.lane === "reasoning") {
-              reasoningStepState.noteReasoningHint();
-            }
-            const result = await deliverLaneText({
-              laneName: segment.lane,
-              text: segment.text,
-              payload,
-              infoKind: info.kind,
-              previewButtons,
-              allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
-            });
-            if (segment.lane === "reasoning") {
-              if (result !== "skipped") {
-                reasoningStepState.noteReasoningDelivered();
+            if (split.suppressedReasoningOnly) {
+              if (hasMedia) {
+                const payloadWithoutSuppressedReasoning =
+                  typeof payload.text === "string" ? { ...payload, text: "" } : payload;
+                await sendPayload(payloadWithoutSuppressedReasoning);
+              }
+              if (info.kind === "final") {
                 await flushBufferedFinalAnswer();
               }
-              continue;
+              return;
             }
+
             if (info.kind === "final") {
-              if (reasoningLane.hasStreamedMessage) {
-                finalizedPreviewByLane.reasoning = true;
-              }
+              await answerLane.stream?.stop();
+              await reasoningLane.stream?.stop();
               reasoningStepState.resetForNextStep();
             }
-          }
-          if (segments.length > 0) {
-            return;
-          }
-          if (split.suppressedReasoningOnly) {
-            if (hasMedia) {
-              const payloadWithoutSuppressedReasoning =
-                typeof payload.text === "string" ? { ...payload, text: "" } : payload;
-              await sendPayload(payloadWithoutSuppressedReasoning);
+            const canSendAsIs =
+              hasMedia || (typeof payload.text === "string" && payload.text.length > 0);
+            if (!canSendAsIs) {
+              if (info.kind === "final") {
+                await flushBufferedFinalAnswer();
+              }
+              return;
             }
+            await sendPayload(payload);
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();
             }
-            return;
-          }
-
-          if (info.kind === "final") {
-            await answerLane.stream?.stop();
-            await reasoningLane.stream?.stop();
-            reasoningStepState.resetForNextStep();
-          }
-          const canSendAsIs =
-            hasMedia || (typeof payload.text === "string" && payload.text.length > 0);
-          if (!canSendAsIs) {
-            if (info.kind === "final") {
-              await flushBufferedFinalAnswer();
+          },
+          onSkip: (_payload, info) => {
+            if (info.reason !== "silent") {
+              deliveryState.markNonSilentSkip();
             }
-            return;
-          }
-          await sendPayload(payload);
-          if (info.kind === "final") {
-            await flushBufferedFinalAnswer();
-          }
+          },
+          onError: (err, info) => {
+            deliveryState.markNonSilentFailure();
+            lastError = err;
+            runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
+          },
         },
-        onSkip: (_payload, info) => {
-          if (info.reason !== "silent") {
-            deliveryState.markNonSilentSkip();
-          }
-        },
-        onError: (err, info) => {
-          deliveryState.markNonSilentFailure();
-          runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
-        },
-      },
-      replyOptions: {
-        skillFilter,
-        disableBlockStreaming,
-        onPartialReply:
-          answerLane.stream || reasoningLane.stream
+        replyOptions: {
+          skillFilter,
+          disableBlockStreaming,
+          onPartialReply:
+            answerLane.stream || reasoningLane.stream
+              ? (payload) =>
+                  enqueueDraftLaneEvent(async () => {
+                    await ingestDraftLaneSegments(payload.text);
+                  })
+              : undefined,
+          onReasoningStream: reasoningLane.stream
             ? (payload) =>
                 enqueueDraftLaneEvent(async () => {
+                  // Split between reasoning blocks only when the next reasoning
+                  // stream starts. Splitting at reasoning-end can orphan the active
+                  // preview and cause duplicate reasoning sends on reasoning final.
+                  if (splitReasoningOnNextStream) {
+                    reasoningLane.stream?.forceNewMessage();
+                    resetDraftLaneState(reasoningLane);
+                    splitReasoningOnNextStream = false;
+                  }
                   await ingestDraftLaneSegments(payload.text);
                 })
             : undefined,
-        onReasoningStream: reasoningLane.stream
-          ? (payload) =>
-              enqueueDraftLaneEvent(async () => {
-                // Split between reasoning blocks only when the next reasoning
-                // stream starts. Splitting at reasoning-end can orphan the active
-                // preview and cause duplicate reasoning sends on reasoning final.
-                if (splitReasoningOnNextStream) {
-                  reasoningLane.stream?.forceNewMessage();
-                  resetDraftLaneState(reasoningLane);
-                  splitReasoningOnNextStream = false;
-                }
-                await ingestDraftLaneSegments(payload.text);
-              })
-          : undefined,
-        onAssistantMessageStart: answerLane.stream
-          ? () =>
-              enqueueDraftLaneEvent(async () => {
-                reasoningStepState.resetForNextStep();
-                if (skipNextAnswerMessageStartRotation) {
-                  skipNextAnswerMessageStartRotation = false;
+          onAssistantMessageStart: answerLane.stream
+            ? () =>
+                enqueueDraftLaneEvent(async () => {
+                  reasoningStepState.resetForNextStep();
+                  if (skipNextAnswerMessageStartRotation) {
+                    skipNextAnswerMessageStartRotation = false;
+                    finalizedPreviewByLane.answer = false;
+                    return;
+                  }
+                  await rotateAnswerLaneForNewAssistantMessage();
+                  // Message-start is an explicit assistant-message boundary.
+                  // Even when no forceNewMessage happened (e.g. prior answer had no
+                  // streamed partials), the next partial belongs to a fresh lifecycle
+                  // and must not trigger late pre-rotation mid-message.
                   finalizedPreviewByLane.answer = false;
-                  return;
-                }
-                await rotateAnswerLaneForNewAssistantMessage();
-                // Message-start is an explicit assistant-message boundary.
-                // Even when no forceNewMessage happened (e.g. prior answer had no
-                // streamed partials), the next partial belongs to a fresh lifecycle
-                // and must not trigger late pre-rotation mid-message.
-                finalizedPreviewByLane.answer = false;
-              })
-          : undefined,
-        onReasoningEnd: reasoningLane.stream
-          ? () =>
-              enqueueDraftLaneEvent(async () => {
-                // Split when/if a later reasoning block begins.
-                splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
-              })
-          : undefined,
-        onToolStart: statusReactionController
-          ? async (payload) => {
-              await statusReactionController.setTool(payload.name);
-            }
-          : undefined,
-        onModelSelected,
-      },
-    }));
+                })
+            : undefined,
+          onReasoningEnd: reasoningLane.stream
+            ? () =>
+                enqueueDraftLaneEvent(async () => {
+                  // Split when/if a later reasoning block begins.
+                  splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
+                })
+            : undefined,
+          onToolStart: statusReactionController
+            ? async (payload) => {
+                await statusReactionController.setTool(payload.name);
+              }
+            : undefined,
+          onModelSelected,
+        },
+      }));
+    } catch (err) {
+      // Intentional cancellations and timeouts must not produce a fallback reply
+      if (isAbortError(err) || isTimeoutError(err)) {
+        throw err;
+      }
+      // Capture error so the fallback message can run; re-throw after cleanup
+      // so callers still see the failure for logging/alerting
+      lastError = err;
+      caughtDispatchError = err;
+      deliveryState.markNonSilentFailure();
+      runtime.error?.(danger(`telegram dispatch failed: ${String(err)}`));
+    }
   } finally {
     // Upstream assistant callbacks are fire-and-forget; drain queued lane work
     // before stream cleanup so boundary rotations/materialization complete first.
@@ -746,8 +770,19 @@ export const dispatchTelegramMessage = async ({
     !deliverySummary.delivered &&
     (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0)
   ) {
+    let errorMessage = GENERAL_ERROR_FALLBACK;
+
+    if (lastError) {
+      const failoverReason = resolveFailoverReasonFromError(lastError);
+      if (failoverReason === "rate_limit") {
+        errorMessage = RATE_LIMIT_FALLBACK;
+      } else if (lastError instanceof EmptyResponseError) {
+        errorMessage = EMPTY_RESPONSE_FALLBACK;
+      }
+    }
+
     const result = await deliverReplies({
-      replies: [{ text: EMPTY_RESPONSE_FALLBACK }],
+      replies: [{ text: errorMessage }],
       ...deliveryBaseOptions,
     });
     sentFallback = result.delivered;
@@ -790,4 +825,8 @@ export const dispatchTelegramMessage = async ({
     });
   }
   clearGroupHistory();
+  // Re-throw dispatcher crashes after fallback/cleanup so callers can log/alert
+  if (caughtDispatchError) {
+    throw caughtDispatchError;
+  }
 };

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -798,6 +798,11 @@ export const dispatchTelegramMessage = async ({
 
   if (!hasFinalResponse) {
     clearGroupHistory();
+    // Re-throw dispatcher crashes even on the no-response early-return path
+    // so callers still see the failure for logging/alerting.
+    if (caughtDispatchError) {
+      throw caughtDispatchError;
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary

- Adds `EmptyResponseError` typed class in `model-fallback.ts`; replaces the fragile string-matched `new Error("Empty response content received from provider")`
- In `runFallbackAttempt`: treats a raw provider response with `content: []` and no `meta` field as a failure, triggering fallback to the next candidate (benefits all channels)
- In Telegram dispatch: tracks `lastError` via `onError` and an outer try/catch; routes the user-visible fallback message by error type (rate limit / empty response / general); re-throws aborts and timeouts so they don't produce spurious fallback replies; re-throws other dispatcher crashes after cleanup so callers still see the failure for logging/alerting
- Adds tests for the empty-content detection (triggers fallback) and the `meta` field guard (accepted as valid)

## Related

Follow-up work tracked in:
- #60812 — extend user-visible error fallback to Discord, Slack, Signal, WhatsApp
- #60813 — upgrade LINE's hardcoded error fallback to typed error routing

## Test plan

- [ ] `pnpm test src/agents/model-fallback.test.ts` — all tests pass including 3 new ones
- [ ] `bunx oxlint src/agents/model-fallback.ts src/telegram/bot-message-dispatch.ts` — 0 errors
- [ ] Telegram: provider returns empty content → user sees "I wasn't able to generate a response. Please try rephrasing your question."
- [ ] Telegram: rate-limited provider → user sees rate limit message
- [ ] Telegram: `/stop` or timeout → no spurious fallback reply sent