### PR TITLE
fix(agents): re-expose toolsAllow core tools in embedded runs

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts
@@ -70,6 +70,45 @@ describe("runEmbeddedAttempt memory flush tool forwarding", () => {
     }
   });
 
+  it("forwards toolsAllow as forceAllowTools before post-filtering the tool list", async () => {
+    vi.resetModules();
+
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-tools-allow-"));
+    const stop = new Error("stop after tool creation");
+    const capturedOptions: Array<Record<string, unknown> | undefined> = [];
+
+    try {
+      vi.doMock("../../pi-tools.js", async () => {
+        const actual =
+          await vi.importActual<typeof import("../../pi-tools.js")>("../../pi-tools.js");
+        return {
+          ...actual,
+          createOpenClawCodingTools: vi.fn((options) => {
+            capturedOptions.push(options as Record<string, unknown> | undefined);
+            throw stop;
+          }),
+        };
+      });
+
+      const { runEmbeddedAttempt } = await import("./attempt.js");
+
+      await expect(
+        runEmbeddedAttempt({
+          ...createAttemptParams(workspaceDir),
+          toolsAllow: ["exec", "read"],
+        }),
+      ).rejects.toBe(stop);
+
+      expect(capturedOptions).toHaveLength(1);
+      expect(capturedOptions[0]).toMatchObject({
+        forceAllowTools: ["exec", "read"],
+      });
+    } finally {
+      vi.doUnmock("../../pi-tools.js");
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("activates the memory flush append-only write wrapper", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-attempt-memory-flush-"));
     const memoryFile = path.join(workspaceDir, MEMORY_RELATIVE_PATH);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -437,6 +437,7 @@ export async function runEmbeddedAttempt(
             senderE164: params.senderE164,
             senderIsOwner: params.senderIsOwner,
             allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+            forceAllowTools: params.toolsAllow,
             sessionKey: sandboxSessionKey,
             sessionId: params.sessionId,
             runId: params.runId,

--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -99,12 +99,13 @@ describe("Agent-specific tool filtering", () => {
     }
   }
 
-  function createMainSessionTools(cfg: OpenClawConfig) {
+  function createMainSessionTools(cfg: OpenClawConfig, options?: { forceAllowTools?: string[] }) {
     return createOpenClawCodingTools({
       config: cfg,
       sessionKey: "agent:main:main",
       workspaceDir: "/tmp/test",
       agentDir: "/tmp/agent",
+      forceAllowTools: options?.forceAllowTools,
     });
   }
 
@@ -211,6 +212,42 @@ describe("Agent-specific tool filtering", () => {
     expect(toolNames).toContain("read");
     expect(toolNames).toContain("exec");
     expect(toolNames).toContain("apply_patch");
+  });
+
+  it("re-exposes explicitly requested core tools through restrictive allowlists", () => {
+    const cfg = createMainAgentConfig({
+      tools: {
+        profile: "full",
+        allow: ["group:openclaw"],
+      },
+    });
+
+    const defaultToolNames = createMainSessionTools(cfg).map((tool) => tool.name);
+    expect(defaultToolNames).not.toContain("exec");
+    expect(defaultToolNames).not.toContain("read");
+    expect(defaultToolNames).not.toContain("write");
+
+    const forcedToolNames = createMainSessionTools(cfg, {
+      forceAllowTools: ["exec", "read", "write"],
+    }).map((tool) => tool.name);
+    expect(forcedToolNames).toContain("exec");
+    expect(forcedToolNames).toContain("read");
+    expect(forcedToolNames).toContain("write");
+  });
+
+  it("keeps deny precedence over force-allowed core tools", () => {
+    const cfg = createMainAgentConfig({
+      tools: {
+        profile: "full",
+        allow: ["group:openclaw"],
+        deny: ["exec"],
+      },
+    });
+
+    const toolNames = createMainSessionTools(cfg, {
+      forceAllowTools: ["exec"],
+    }).map((tool) => tool.name);
+    expect(toolNames).not.toContain("exec");
   });
 
   it("should allow disabling apply_patch explicitly", () => {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -48,6 +48,7 @@ import {
 import { cleanToolSchemaForGemini, normalizeToolParameters } from "./pi-tools.schema.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxContext } from "./sandbox.js";
+import { isKnownCoreToolId } from "./tool-catalog.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
 import {
   applyToolPolicyPipeline,
@@ -57,6 +58,8 @@ import {
   applyOwnerOnlyToolPolicy,
   collectExplicitAllowlist,
   mergeAlsoAllowPolicy,
+  mergeForceAllowPolicy,
+  normalizeToolName,
   resolveToolProfilePolicy,
 } from "./tool-policy.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
@@ -321,6 +324,8 @@ export function createOpenClawCodingTools(options?: {
   senderIsOwner?: boolean;
   /** Callback invoked when sessions_yield tool is called. */
   onYield?: (message: string) => Promise<void> | void;
+  /** Re-expose explicitly requested core tools through restrictive config allowlists. */
+  forceAllowTools?: string[];
 }): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
@@ -366,11 +371,33 @@ export function createOpenClawCodingTools(options?: {
   });
   const profilePolicy = resolveToolProfilePolicy(profile);
   const providerProfilePolicy = resolveToolProfilePolicy(providerProfile);
+  const forceAllowCoreTools = Array.isArray(options?.forceAllowTools)
+    ? Array.from(
+        new Set(
+          options.forceAllowTools
+            .map((toolName) => normalizeToolName(toolName))
+            .filter((toolName) => isKnownCoreToolId(toolName)),
+        ),
+      )
+    : undefined;
 
-  const profilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(profilePolicy, profileAlsoAllow);
-  const providerProfilePolicyWithAlsoAllow = mergeAlsoAllowPolicy(
-    providerProfilePolicy,
-    providerProfileAlsoAllow,
+  const profilePolicyWithAlsoAllow = mergeForceAllowPolicy(
+    mergeAlsoAllowPolicy(profilePolicy, profileAlsoAllow),
+    forceAllowCoreTools,
+  );
+  const providerProfilePolicyWithAlsoAllow = mergeForceAllowPolicy(
+    mergeAlsoAllowPolicy(providerProfilePolicy, providerProfileAlsoAllow),
+    forceAllowCoreTools,
+  );
+  const globalPolicyWithForceAllow = mergeForceAllowPolicy(globalPolicy, forceAllowCoreTools);
+  const globalProviderPolicyWithForceAllow = mergeForceAllowPolicy(
+    globalProviderPolicy,
+    forceAllowCoreTools,
+  );
+  const agentPolicyWithForceAllow = mergeForceAllowPolicy(agentPolicy, forceAllowCoreTools);
+  const agentProviderPolicyWithForceAllow = mergeForceAllowPolicy(
+    agentProviderPolicy,
+    forceAllowCoreTools,
   );
   // Prefer sessionKey for process isolation scope to prevent cross-session process visibility/killing.
   // Fallback to agentId if no sessionKey is available (e.g. legacy or global contexts).
@@ -383,10 +410,10 @@ export function createOpenClawCodingTools(options?: {
   const allowBackground = isToolAllowedByPolicies("process", [
     profilePolicyWithAlsoAllow,
     providerProfilePolicyWithAlsoAllow,
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy,
+    globalPolicyWithForceAllow,
+    globalProviderPolicyWithForceAllow,
+    agentPolicyWithForceAllow,
+    agentProviderPolicyWithForceAllow,
     groupPolicy,
     sandboxToolPolicy,
     subagentPolicy,
@@ -572,10 +599,10 @@ export function createOpenClawCodingTools(options?: {
       pluginToolAllowlist: collectExplicitAllowlist([
         profilePolicy,
         providerProfilePolicy,
-        globalPolicy,
-        globalProviderPolicy,
-        agentPolicy,
-        agentProviderPolicy,
+        globalPolicyWithForceAllow,
+        globalProviderPolicyWithForceAllow,
+        agentPolicyWithForceAllow,
+        agentProviderPolicyWithForceAllow,
         groupPolicy,
         sandboxToolPolicy,
         subagentPolicy,
@@ -645,10 +672,10 @@ export function createOpenClawCodingTools(options?: {
         providerProfilePolicy: providerProfilePolicyWithAlsoAllow,
         providerProfile,
         providerProfileUnavailableCoreWarningAllowlist: providerProfilePolicy?.allow,
-        globalPolicy,
-        globalProviderPolicy,
-        agentPolicy,
-        agentProviderPolicy,
+        globalPolicy: globalPolicyWithForceAllow,
+        globalProviderPolicy: globalProviderPolicyWithForceAllow,
+        agentPolicy: agentPolicyWithForceAllow,
+        agentProviderPolicy: agentProviderPolicyWithForceAllow,
         groupPolicy,
         agentId,
       }),

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -213,3 +213,16 @@ export function mergeAlsoAllowPolicy<TPolicy extends { allow?: string[] }>(
   }
   return { ...policy, allow: Array.from(new Set([...policy.allow, ...alsoAllow])) };
 }
+
+export function mergeForceAllowPolicy<TPolicy extends { allow?: string[] }>(
+  policy: TPolicy | undefined,
+  forceAllow?: string[],
+): TPolicy | undefined {
+  if (!policy?.allow || !Array.isArray(forceAllow) || forceAllow.length === 0) {
+    return policy;
+  }
+  if (policy.allow.length === 0 || policy.allow.some((entry) => normalizeToolName(entry) === "*")) {
+    return policy;
+  }
+  return { ...policy, allow: Array.from(new Set([...policy.allow, ...forceAllow])) };
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: embedded runs only post-filtered `toolsAllow` after `createOpenClawCodingTools`, so restrictive config allowlists could remove `exec`/`read`/`write` before `toolsAllow` had any effect.
- Why it matters: cron/isolated runs with `toolsAllow: ["exec"]` still lost `exec` under configs like `tools.allow: ["group:openclaw"]`, breaking workflows that depended on explicit per-run tool exposure.
- What changed: `runEmbeddedAttempt` now forwards `toolsAllow` into `createOpenClawCodingTools`, and the tool policy merge re-exposes explicitly requested core tools through restrictive config allowlists without overriding `deny`.
- What did NOT change (scope boundary): this does not bypass explicit `deny`, sandbox/group/subagent tool policies, or provider/runtime capability gating.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60841
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `runEmbeddedAttempt` only did a final `.filter()` against `toolsAllow`, but `createOpenClawCodingTools` had already applied config-driven allowlists. Once the policy pipeline filtered a core tool out, the later post-filter could not re-add it.
- Missing detection / guardrail: there was no regression test covering `toolsAllow` under a restrictive config allowlist such as `group:openclaw`.
- Contributing context (if known): `group:openclaw` intentionally excludes `exec`, `process`, `read`, `write`, and `edit`, so the bug is deterministic under configs that rely on that group and then expect `toolsAllow` to re-expose a core tool for a specific run.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-tools-agent-config.test.ts`, `src/agents/pi-embedded-runner/run/attempt.memory-flush-forwarding.test.ts`
- Scenario the test should lock in: restrictive config allowlists still permit explicitly requested core tools for that embedded run, while explicit `deny` continues to win.
- Why this is the smallest reliable guardrail: one test pins the effective tool inventory after policy application, and the other pins the `runEmbeddedAttempt -> createOpenClawCodingTools` forwarding seam.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Embedded runs that set `toolsAllow` can now re-expose the requested core tools (`exec`, `read`, `write`, etc.) even when a restrictive config allowlist would otherwise hide them. Explicit `deny` still wins.

## Diagram (if applicable)

```text
Before:
[embedded run with toolsAllow=[exec]] -> [createOpenClawCodingTools applies config allowlist] -> [exec removed] -> [post-filter keeps missing set] -> [cron run still has no exec]

After:
[embedded run with toolsAllow=[exec]] -> [forceAllowTools merged into restrictive config allowlists] -> [exec survives policy pipeline unless denied] -> [post-filter selects exec] -> [cron run gets exec]
```

## Security Impact (required)

- New permissions/capabilities? Yes
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? Yes
- If any `Yes`, explain risk + mitigation:
  The PR allows an embedded run to re-expose explicitly requested core tools through restrictive config allowlists. Mitigation: the re-exposure is limited to named core tools for that run, explicit `deny` still wins, and sandbox/group/subagent/provider/runtime restrictions still apply.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout
- Model/provider: policy regression is model-agnostic; forwarding seam verified with `openai/gpt-5.4`
- Integration/channel (if any): embedded runner / cron-style tool exposure
- Relevant config (redacted): `tools.profile: "full"`, `tools.allow: ["group:openclaw"]`

### Steps

1. Configure a restrictive core-tool allowlist such as `tools.allow: ["group:openclaw"]`.
2. Run an embedded attempt with `toolsAllow: ["exec"]`.
3. Inspect the effective tool set.

### Expected

- The effective tool set contains `exec` for that run unless a stronger deny/runtime restriction blocks it.

### Actual

- Before this fix, `exec` was missing because it had already been filtered out before `toolsAllow` was applied.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted regression tests for restrictive allowlist re-exposure and explicit-deny precedence; full `attempt.memory-flush-forwarding` test file; `pnpm check`; `pnpm build`.
- Edge cases checked: allow-all semantics are preserved, explicit `deny` still blocks forced tools, and only known core tool ids are re-exposed.
- What you did **not** verify: I did not run a live end-to-end cron job against a local gateway build from this branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a per-run `toolsAllow` request could unintentionally widen a restrictive config allowlist too broadly.
  - Mitigation: the merge only applies to explicitly requested known core tools, and allow-all / `deny` semantics are preserved.
