### PR TITLE
Heartbeat: isolate session runs by default

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1130,7 +1130,7 @@ Periodic heartbeat runs.
         model: "openai/gpt-5.4-mini",
         includeReasoning: false,
         lightContext: false, // default: false; true keeps only HEARTBEAT.md from workspace bootstrap files
-        isolatedSession: false, // default: false; true runs each heartbeat in a fresh session (no conversation history)
+        isolatedSession: true, // default: true; set false to share the main transcript
         session: "main",
         to: "+15555550123",
         directPolicy: "allow", // allow (default) | block
@@ -1148,7 +1148,7 @@ Periodic heartbeat runs.
 - `suppressToolErrorWarnings`: when true, suppresses tool error warning payloads during heartbeat runs.
 - `directPolicy`: direct/DM delivery policy. `allow` (default) permits direct-target delivery. `block` suppresses direct-target delivery and emits `reason=dm-blocked`.
 - `lightContext`: when true, heartbeat runs use lightweight bootstrap context and keep only `HEARTBEAT.md` from workspace bootstrap files.
-- `isolatedSession`: when true, each heartbeat runs in a fresh session with no prior conversation history. Same isolation pattern as cron `sessionTarget: "isolated"`. Reduces per-heartbeat token cost from ~100K to ~2-5K tokens.
+- `isolatedSession`: defaults to `true`, so each heartbeat runs in a fresh session with no prior conversation history. Same isolation pattern as cron `sessionTarget: "isolated"`. Set `false` to opt back into the main transcript.
 - Per-agent: set `agents.list[].heartbeat`. When any agent defines `heartbeat`, **only those agents** run heartbeats.
 - Heartbeats run full agent turns — shorter intervals burn more tokens.
 

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -10,10 +10,11 @@ title: "Heartbeat"
 
 > **Heartbeat vs Cron?** See [Automation & Tasks](/automation) for guidance on when to use each.
 
-Heartbeat runs **periodic agent turns** in the main session so the model can
-surface anything that needs attention without spamming you.
+Heartbeat runs **periodic agent turns** so the model can surface anything that
+needs attention without spamming you. By default, the run uses a fresh
+heartbeat session while delivery routing still reads the main session context.
 
-Heartbeat is a scheduled main-session turn — it does **not** create [background task](/automation/tasks) records.
+Heartbeat is a scheduled agent turn — it does **not** create [background task](/automation/tasks) records.
 Task records are for detached work (ACP runs, subagents, isolated cron jobs).
 
 Troubleshooting: [Scheduled Tasks](/automation/cron-jobs#troubleshooting)
@@ -25,7 +26,7 @@ Troubleshooting: [Scheduled Tasks](/automation/cron-jobs#troubleshooting)
 3. Decide where heartbeat messages should go (`target: "none"` is the default; set `target: "last"` to route to the last contact).
 4. Optional: enable heartbeat reasoning delivery for transparency.
 5. Optional: use lightweight bootstrap context if heartbeat runs only need `HEARTBEAT.md`.
-6. Optional: enable isolated sessions to avoid sending full conversation history each heartbeat.
+6. Optional: set `isolatedSession: false` if you want heartbeat runs to share the main transcript.
 7. Optional: restrict heartbeats to active hours (local time).
 
 Example config:
@@ -39,7 +40,7 @@ Example config:
         target: "last", // explicit delivery to last contact (default is "none")
         directPolicy: "allow", // default: allow direct/DM targets; set "block" to suppress
         lightContext: true, // optional: only inject HEARTBEAT.md from bootstrap files
-        isolatedSession: true, // optional: fresh session each run (no conversation history)
+        // isolatedSession: false, // optional: share the main transcript instead of the default fresh heartbeat session
         // activeHours: { start: "08:00", end: "24:00" },
         // includeReasoning: true, // optional: send separate `Reasoning:` message too
       },
@@ -98,7 +99,7 @@ and logged; a message that is only `HEARTBEAT_OK` is dropped.
         model: "anthropic/claude-opus-4-6",
         includeReasoning: false, // default: false (deliver separate Reasoning: message when available)
         lightContext: false, // default: false; true keeps only HEARTBEAT.md from workspace bootstrap files
-        isolatedSession: false, // default: false; true runs each heartbeat in a fresh session (no conversation history)
+        isolatedSession: true, // default: true; set false to share the main transcript
         target: "last", // default: none | options: last | none | <channel id> (core or plugin, e.g. "bluebubbles")
         to: "+15551234567", // optional channel-specific override
         accountId: "ops-bot", // optional multi-account channel id
@@ -220,7 +221,7 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 - `model`: optional model override for heartbeat runs (`provider/model`).
 - `includeReasoning`: when enabled, also deliver the separate `Reasoning:` message when available (same shape as `/reasoning on`).
 - `lightContext`: when true, heartbeat runs use lightweight bootstrap context and keep only `HEARTBEAT.md` from workspace bootstrap files.
-- `isolatedSession`: when true, each heartbeat runs in a fresh session with no prior conversation history. Uses the same isolation pattern as cron `sessionTarget: "isolated"`. Dramatically reduces per-heartbeat token cost. Combine with `lightContext: true` for maximum savings. Delivery routing still uses the main session context.
+- `isolatedSession`: defaults to `true`, so each heartbeat runs in a fresh session with no prior conversation history. Uses the same isolation pattern as cron `sessionTarget: "isolated"`. Set `false` to opt back into the main transcript. Combine with `lightContext: true` for maximum savings. Delivery routing still uses the main session context.
 - `session`: optional session key for heartbeat runs.
   - `main` (default): agent main session.
   - Explicit session key (copy from `openclaw sessions --json` or the [sessions CLI](/cli/sessions)).
@@ -429,7 +430,7 @@ off in group chats.
 
 Heartbeats run full agent turns. Shorter intervals burn more tokens. To reduce cost:
 
-- Use `isolatedSession: true` to avoid sending full conversation history (~100K tokens down to ~2-5K per run).
+- Keep the default `isolatedSession: true` to avoid sending full conversation history (~100K tokens down to ~2-5K per run).
 - Use `lightContext: true` to limit bootstrap files to just `HEARTBEAT.md`.
 - Set a cheaper `model` (e.g. `ollama/llama3.2:1b`).
 - Keep `HEARTBEAT.md` small.

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -276,10 +276,11 @@ export type AgentDefaultsConfig = {
      */
     lightContext?: boolean;
     /**
-     * If true, run heartbeat turns in an isolated session with no prior
-     * conversation history. The heartbeat only sees its bootstrap context
-     * (HEARTBEAT.md when lightContext is also enabled). Dramatically reduces
-     * per-heartbeat token cost by avoiding the full session transcript.
+     * Defaults to true. Run heartbeat turns in an isolated session with no
+     * prior conversation history. Set false to share the main transcript.
+     * The heartbeat only sees its bootstrap context (HEARTBEAT.md when
+     * lightContext is also enabled). Dramatically reduces per-heartbeat token
+     * cost by avoiding the full session transcript.
      */
     isolatedSession?: boolean;
     /**

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveAgentMainSessionKey, resolveMainSessionKey } from "../config/sessions.js";
+import {
+  loadSessionStore,
+  resolveAgentMainSessionKey,
+  resolveMainSessionKey,
+  updateSessionStore,
+} from "../config/sessions.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import {
   seedSessionStore,
@@ -171,7 +176,7 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
     });
   });
 
-  it("uses main session key when isolatedSession is not set", async () => {
+  it("uses isolated session key by default when isolatedSession is not set", async () => {
     await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
       const cfg: OpenClawConfig = {
         agents: {
@@ -194,7 +199,87 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
         replySpy,
       });
 
+      expect(result.ctx?.SessionKey).toBe(`${sessionKey}:heartbeat`);
+    });
+  });
+
+  it("uses main session key when isolatedSession is explicitly false", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+              isolatedSession: false,
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      const result = await runHeartbeatWithSeed({
+        seedSession,
+        cfg,
+        sessionKey,
+        replySpy,
+      });
+
       expect(result.ctx?.SessionKey).toBe(sessionKey);
+    });
+  });
+
+  it("preserves main-session abort recovery state under the default isolated heartbeat session", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, replySpy, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedSession(sessionKey, {
+        lastChannel: "whatsapp",
+        lastTo: "+1555",
+      });
+
+      let clearedSessionKey: string | undefined;
+      replySpy.mockImplementation(async (ctx) => {
+        clearedSessionKey = ctx.SessionKey;
+        return { text: "HEARTBEAT_OK" };
+      });
+
+      await updateSessionStore(storePath, async (store) => {
+        const seededMainSession = store[sessionKey];
+        if (!seededMainSession) {
+          throw new Error(`Expected seeded main session for ${sessionKey}`);
+        }
+        store[sessionKey] = {
+          ...seededMainSession,
+          abortedLastRun: true,
+        };
+      });
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(clearedSessionKey).toBe(`${sessionKey}:heartbeat`);
+      expect(loadSessionStore(storePath)[sessionKey]?.abortedLastRun).toBe(true);
     });
   });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -600,12 +600,11 @@ export async function runHeartbeatOnce(opts: {
 
   const previousUpdatedAt = entry?.updatedAt;
 
-  // When isolatedSession is enabled, create a fresh session via the same
-  // pattern as cron sessionTarget: "isolated". This gives the heartbeat
-  // a new session ID (empty transcript) each run, avoiding the cost of
-  // sending the full conversation history (~100K tokens) to the LLM.
-  // Delivery routing still uses the main session entry (lastChannel, lastTo).
-  const useIsolatedSession = heartbeat?.isolatedSession === true;
+  // Heartbeats default to an isolated session so background runs do not
+  // contaminate the agent's interactive transcript when a model stream hangs
+  // or when HEARTBEAT.md-driven prompts diverge from the active chat.
+  // Operators can opt back into shared history with isolatedSession: false.
+  const useIsolatedSession = heartbeat?.isolatedSession !== false;
   const delivery = resolveHeartbeatDeliveryTarget({
     cfg,
     entry,


### PR DESCRIPTION
## Summary
- make heartbeat runs default to an isolated `:heartbeat` session instead of reusing the main interactive session
- preserve an explicit `isolatedSession: false` escape hatch for operators who still want shared history
- add regression coverage for default isolation, the explicit shared-session path, and preserving main-session abort recovery state

## Testing
- `pnpm exec vitest run --config vitest.config.ts src/infra/heartbeat-runner.model-override.test.ts`

## Context
The previous PR for this fix had incorrect branch ancestry and pulled in unrelated history, so this PR replaces it with the minimal diff.
