### PR TITLE
fix(skills): rebuild snapshot when skills config version changes

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -497,8 +497,12 @@ async function agentCommandInternal(
       });
     }
 
-    const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+    const needsSkillsSnapshot =
+      isNewSession ||
+      !sessionEntry?.skillsSnapshot ||
+      (skillsSnapshotVersion !== undefined &&
+        sessionEntry.skillsSnapshot.version !== skillsSnapshotVersion);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const skillsSnapshot = needsSkillsSnapshot
       ? buildWorkspaceSkillSnapshot(workspaceDir, {


### PR DESCRIPTION
## Problem

Skills configured or added via the Control UI appear as **eligible** in the UI (`skills.status` is called fresh each time) but are **missing from `available_skills`** in the session system prompt. The assistant then assumes the skill is unavailable even though it works at runtime.

Reported in #60716.

## Root Cause

In `agent-command.ts`, the condition for rebuilding the skills snapshot was:

```ts
const needsSkillsSnapshot = isNewSession || !sessionEntry?.skillsSnapshot;
```

This misses the case where:
1. A session already exists with a cached `skillsSnapshot`
2. The user adds/configures a skill (bumping `skillsSnapshotVersion` on disk)
3. The next turn in the **same session** still uses the stale snapshot because `isNewSession` is false and `skillsSnapshot` is truthy

The version number was computed but never compared against the persisted snapshot's version.

## Fix

Add a version-mismatch guard to the rebuild condition:

```ts
const needsSkillsSnapshot =
  isNewSession ||
  !sessionEntry?.skillsSnapshot ||
  (skillsSnapshotVersion !== undefined &&
    sessionEntry.skillsSnapshot.version !== skillsSnapshotVersion);
```

When the config version advances (new skill installed, skill enabled/disabled), the cached snapshot is treated as stale and rebuilt on the next agent turn — without requiring the user to start a `/new` session.

Fixes #60716