### PR TITLE
fix: add additionalProperties:false to tool schemas for OpenAI/Copilot providers

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -143,4 +143,55 @@ describe("normalizeToolParameters", () => {
     expect(parameters.properties?.query.minLength).toBeUndefined();
     expect(parameters.properties?.query.type).toBe("string");
   });
+
+  it("injects additionalProperties:false for openai provider", () => {
+    const tool: AnyAgentTool = {
+      name: "read",
+      label: "read",
+      description: "Read a file",
+      parameters: Type.Object({
+        path: Type.String({ description: "Path to the file" }),
+        offset: Type.Optional(Type.Number()),
+        limit: Type.Optional(Type.Number()),
+      }),
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool, { modelProvider: "openai" });
+    const parameters = normalized.parameters as Record<string, unknown>;
+    expect(parameters.additionalProperties).toBe(false);
+  });
+
+  it("injects additionalProperties:false for github-copilot provider", () => {
+    const tool: AnyAgentTool = {
+      name: "read",
+      label: "read",
+      description: "Read a file",
+      parameters: Type.Object({
+        path: Type.String({ description: "Path to the file" }),
+      }),
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool, { modelProvider: "github-copilot" });
+    const parameters = normalized.parameters as Record<string, unknown>;
+    expect(parameters.additionalProperties).toBe(false);
+  });
+
+  it("does not inject additionalProperties:false for anthropic provider", () => {
+    const tool: AnyAgentTool = {
+      name: "read",
+      label: "read",
+      description: "Read a file",
+      parameters: Type.Object({
+        path: Type.String({ description: "Path to the file" }),
+      }),
+      execute: vi.fn(),
+    };
+
+    const normalized = normalizeToolParameters(tool, { modelProvider: "anthropic" });
+    const parameters = normalized.parameters as Record<string, unknown>;
+    // Anthropic does not require additionalProperties: false
+    expect(parameters.additionalProperties).toBeUndefined();
+  });
 });

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -141,6 +141,8 @@ export function normalizeToolParameterSchema(
   // - Gemini rejects several JSON Schema keywords, so we scrub those.
   // - OpenAI rejects function tool schemas unless the *top-level* is `type: "object"`.
   //   (TypeBox root unions compile to `{ anyOf: [...] }` without `type`).
+  // - OpenAI and GitHub Copilot require `additionalProperties: false` on all tool schemas.
+  //   Without it they return HTTP 400: 'additionalProperties' is required to be false.
   // - Anthropic expects full JSON Schema draft 2020-12 compliance.
   // - xAI rejects validation-constraint keywords (minLength, maxLength, etc.) outright.
   //
@@ -151,6 +153,25 @@ export function normalizeToolParameterSchema(
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);
 
+  // OpenAI and GitHub Copilot require `additionalProperties: false` on every object schema
+  // used as a tool definition. Without this field they return HTTP 400.
+  const normalizedProvider = options?.modelProvider?.trim().toLowerCase() ?? "";
+  const isOpenAIFamilyProvider =
+    normalizedProvider === "openai" ||
+    normalizedProvider === "openai-codex" ||
+    normalizedProvider === "github-copilot";
+
+  function enforceAdditionalPropertiesFalse(s: unknown): unknown {
+    if (!isOpenAIFamilyProvider || !s || typeof s !== "object") {
+      return s;
+    }
+    const record = s as Record<string, unknown>;
+    if (record.additionalProperties === false) {
+      return s;
+    }
+    return { ...record, additionalProperties: false };
+  }
+
   function applyProviderCleaning(s: unknown): unknown {
     if (isGeminiProvider && !isAnthropicProvider) {
       return cleanSchemaForGemini(s);
@@ -158,7 +179,7 @@ export function normalizeToolParameterSchema(
     if (unsupportedToolSchemaKeywords.size > 0) {
       return stripUnsupportedSchemaKeywords(s, unsupportedToolSchemaKeywords);
     }
-    return s;
+    return enforceAdditionalPropertiesFalse(s);
   }
 
   const conditionalKey = getTopLevelConditionalKey(schemaRecord);
@@ -241,7 +262,11 @@ export function normalizeToolParameterSchema(
       Object.keys(mergedProperties).length > 0 ? mergedProperties : (schemaRecord.properties ?? {}),
     ...(mergedRequired && mergedRequired.length > 0 ? { required: mergedRequired } : {}),
     additionalProperties:
-      "additionalProperties" in schemaRecord ? schemaRecord.additionalProperties : true,
+      isOpenAIFamilyProvider
+        ? false
+        : "additionalProperties" in schemaRecord
+          ? schemaRecord.additionalProperties
+          : true,
   };
 
   // Flatten union schemas into a single object schema:


### PR DESCRIPTION
## Summary

Built-in tool schemas (notably `read`) were missing `additionalProperties: false`, which OpenAI and GitHub Copilot providers require. This caused HTTP 400 on every agent turn for users with `tools.profile: "coding"` and OpenAI/Copilot models.

Error: `HTTP 400: Invalid schema for function 'read': In context=(), 'additionalProperties' is required to be supplied and to be false.`

## Root Cause

The upstream `pi-coding-agent` package emits tool schemas (e.g. for `read`) without `additionalProperties: false`. The OpenAI and GitHub Copilot APIs require this field to be explicitly set to `false` on all function/tool object schemas.

## Changes

### `src/agents/pi-tools.schema.ts`
- Added `isOpenAIFamilyProvider` detection (covers `openai`, `openai-codex`, `github-copilot`)
- Added `enforceAdditionalPropertiesFalse()` helper that injects `additionalProperties: false` when targeting OpenAI-family providers
- Hooked into `applyProviderCleaning()` so all schema paths (simple object schemas AND flattened union schemas) get the injection
- For union/anyOf schemas: use `false` directly instead of defaulting to `true` when targeting OpenAI-family providers

### `src/agents/pi-tools.schema.test.ts`
- Added tests for `openai` provider (should inject `additionalProperties: false`)
- Added tests for `github-copilot` provider (should inject `additionalProperties: false`)
- Added tests for `anthropic` provider (should NOT inject — Anthropic is fine without it)

## Approach

**Option B** (blanket fix in the schema normalization pass) — `normalizeToolParameterSchema` is the single point where all tool schemas are normalized before dispatch to providers, making it the right place for this fix. No tool-by-tool changes needed.

Fixes openclaw/openclaw#60821