### PR TITLE
fix(plugins): downgrade workspace manifest-not-found diagnostic to warn via typed failure reason

### DIFF
--- a/src/plugins/bundle-manifest.ts
+++ b/src/plugins/bundle-manifest.ts
@@ -3,7 +3,11 @@ import path from "node:path";
 import JSON5 from "json5";
 import { matchBoundaryFileOpenFailure, openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { isRecord } from "../utils.js";
-import { DEFAULT_PLUGIN_ENTRY_CANDIDATES, PLUGIN_MANIFEST_FILENAME } from "./manifest.js";
+import {
+  DEFAULT_PLUGIN_ENTRY_CANDIDATES,
+  type ManifestLoadFailureReason,
+  PLUGIN_MANIFEST_FILENAME,
+} from "./manifest.js";
 import type { PluginBundleFormat } from "./types.js";
 
 export const CODEX_BUNDLE_MANIFEST_RELATIVE_PATH = ".codex-plugin/plugin.json";
@@ -25,11 +29,11 @@ export type BundlePluginManifest = {
 
 export type BundleManifestLoadResult =
   | { ok: true; manifest: BundlePluginManifest; manifestPath: string }
-  | { ok: false; error: string; manifestPath: string };
+  | { ok: false; error: string; reason: ManifestLoadFailureReason; manifestPath: string };
 
 type BundleManifestFileLoadResult =
   | { ok: true; raw: Record<string, unknown>; manifestPath: string }
-  | { ok: false; error: string; manifestPath: string };
+  | { ok: false; error: string; reason: ManifestLoadFailureReason; manifestPath: string };
 
 function normalizeString(value: unknown): string | undefined {
   const trimmed = typeof value === "string" ? value.trim() : "";
@@ -108,11 +112,17 @@ function loadBundleManifestFile(params: {
         if (params.allowMissing) {
           return { ok: true, raw: {}, manifestPath };
         }
-        return { ok: false, error: `plugin manifest not found: ${manifestPath}`, manifestPath };
+        return {
+          ok: false,
+          error: `plugin manifest not found: ${manifestPath}`,
+          reason: "not-found",
+          manifestPath,
+        } satisfies BundleManifestFileLoadResult;
       },
-      fallback: (failure) => ({
+      fallback: (failure): BundleManifestFileLoadResult => ({
         ok: false,
         error: `unsafe plugin manifest path: ${manifestPath} (${failure.reason})`,
+        reason: "unsafe-path",
         manifestPath,
       }),
     });
@@ -120,13 +130,19 @@ function loadBundleManifestFile(params: {
   try {
     const raw = JSON5.parse(fs.readFileSync(opened.fd, "utf-8")) as unknown;
     if (!isRecord(raw)) {
-      return { ok: false, error: "plugin manifest must be an object", manifestPath };
+      return {
+        ok: false,
+        error: "plugin manifest must be an object",
+        reason: "invalid",
+        manifestPath,
+      };
     }
     return { ok: true, raw, manifestPath };
   } catch (err) {
     return {
       ok: false,
       error: `failed to parse plugin manifest: ${String(err)}`,
+      reason: "parse-error",
       manifestPath,
     };
   } finally {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -653,6 +653,33 @@ describe("loadPluginManifestRegistry", () => {
     expect(hasPluginIdMismatchWarning(registry)).toBe(false);
   });
 
+  it("downgrades missing manifest diagnostic to warn for workspace-origin candidates", () => {
+    const dir = makeTempDir();
+    // No manifest written, so loadPluginManifest will fail with "plugin manifest not found".
+    const registry = loadSingleCandidateRegistry({
+      idHint: "not-a-plugin",
+      rootDir: dir,
+      origin: "workspace",
+    });
+
+    expect(registry.plugins).toHaveLength(0);
+    expectRegistryDiagnosticContains(registry, "plugin manifest not found");
+    expect(registry.diagnostics.every((diag) => diag.level !== "error")).toBe(true);
+  });
+
+  it("keeps missing manifest diagnostic as error for non-workspace origins", () => {
+    const dir = makeTempDir();
+    const registry = loadSingleCandidateRegistry({
+      idHint: "missing-global",
+      rootDir: dir,
+      origin: "global",
+    });
+
+    expect(registry.plugins).toHaveLength(0);
+    expectRegistryDiagnosticContains(registry, "plugin manifest not found");
+    expect(registry.diagnostics.some((diag) => diag.level === "error")).toBe(true);
+  });
+
   it.each([
     {
       name: "loads Codex bundle manifests into the registry",

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -414,8 +414,10 @@ export function loadPluginManifestRegistry(
             })
           : loadPluginManifest(candidate.rootDir, rejectHardlinks);
     if (!manifestRes.ok) {
+      const isWorkspaceMissingManifest =
+        candidate.origin === "workspace" && manifestRes.reason === "not-found";
       diagnostics.push({
-        level: "error",
+        level: isWorkspaceMissingManifest ? "warn" : "error",
         message: manifestRes.error,
         source: manifestRes.manifestPath,
       });

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -115,9 +115,11 @@ export type PluginManifestProviderAuthChoice = {
 
 export type PluginManifestOnboardingScope = "text-inference" | "image-generation";
 
+export type ManifestLoadFailureReason = "not-found" | "unsafe-path" | "parse-error" | "invalid";
+
 export type PluginManifestLoadResult =
   | { ok: true; manifest: PluginManifest; manifestPath: string }
-  | { ok: false; error: string; manifestPath: string };
+  | { ok: false; error: string; reason: ManifestLoadFailureReason; manifestPath: string };
 
 function normalizeStringList(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -320,14 +322,16 @@ export function loadPluginManifest(
   });
   if (!opened.ok) {
     return matchBoundaryFileOpenFailure(opened, {
-      path: () => ({
+      path: (): PluginManifestLoadResult => ({
         ok: false,
         error: `plugin manifest not found: ${manifestPath}`,
+        reason: "not-found",
         manifestPath,
       }),
-      fallback: (failure) => ({
+      fallback: (failure): PluginManifestLoadResult => ({
         ok: false,
         error: `unsafe plugin manifest path: ${manifestPath} (${failure.reason})`,
+        reason: "unsafe-path",
         manifestPath,
       }),
     });
@@ -339,21 +343,32 @@ export function loadPluginManifest(
     return {
       ok: false,
       error: `failed to parse plugin manifest: ${String(err)}`,
+      reason: "parse-error",
       manifestPath,
     };
   } finally {
     fs.closeSync(opened.fd);
   }
   if (!isRecord(raw)) {
-    return { ok: false, error: "plugin manifest must be an object", manifestPath };
+    return {
+      ok: false,
+      error: "plugin manifest must be an object",
+      reason: "invalid",
+      manifestPath,
+    };
   }
   const id = typeof raw.id === "string" ? raw.id.trim() : "";
   if (!id) {
-    return { ok: false, error: "plugin manifest requires id", manifestPath };
+    return { ok: false, error: "plugin manifest requires id", reason: "invalid", manifestPath };
   }
   const configSchema = isRecord(raw.configSchema) ? raw.configSchema : null;
   if (!configSchema) {
-    return { ok: false, error: "plugin manifest requires configSchema", manifestPath };
+    return {
+      ok: false,
+      error: "plugin manifest requires configSchema",
+      reason: "invalid",
+      manifestPath,
+    };
   }
 
   const kind = parsePluginKind(raw.kind);


### PR DESCRIPTION
## Summary

Addresses the narrower variant of #60686: loose top-level files or directories with an index.js under .openclaw/extensions are treated as workspace plugin candidates and fail with "plugin manifest not found" at error level, which can block gateway startup.

This PR does **not** add venv directory ignores (the original issue's example paths are not reachable through current workspace discovery, which is scoped to .openclaw/extensions).

### Changes

**src/plugins/manifest.ts**:
- Export ManifestLoadFailureReason union type: "not-found" | "unsafe-path" | "parse-error" | "invalid"
- Add reason field to the failure branch of PluginManifestLoadResult
- Tag each failure return in loadPluginManifest with the appropriate reason

**src/plugins/bundle-manifest.ts**:
- Add reason field to BundleManifestLoadResult and BundleManifestFileLoadResult failure branches
- Tag each failure return in loadBundleManifestFile with the appropriate reason

**src/plugins/manifest-registry.ts**:
- Use manifestRes.reason === "not-found" instead of string matching on manifestRes.error
- Downgrade to warn only for workspace-origin candidates with not-found reason; all other failure reasons remain error for all origins

## Test plan

- [x] pnpm test src/plugins/manifest-registry.test.ts -- 27/27 passing
- [x] pnpm test src/plugins/discovery.test.ts -- 28/28 passing
- [x] pnpm tsgo -- clean (only pre-existing extensions/matrix/src/doctor.ts error on main)
- [x] Test: workspace-origin candidates with missing manifests produce warn not error
- [x] Test: non-workspace origins with missing manifests still produce error

Supersedes #60701, which was closed for review feedback (now addressed).
