### PR TITLE
feat: add cover image support to Discord event create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - Agents/context engine: expose prompt-cache runtime context to context engines and keep current-turn prompt-cache usage aligned with the active attempt instead of stale prior-turn assistant state. (#62179) Thanks @jalehman.
 - Tools/media: document per-provider music and video generation capabilities, and add shared live video-to-video sweep coverage for providers that support local reference clips.
 - Compaction: add pluggable compaction provider registry so plugins can replace the built-in summarization pipeline. Configure via `agents.defaults.compaction.provider`; falls back to LLM summarization on provider failure. (#56224) Thanks @DhruvBhatia0.
+- Discord/events: allow `event-create` to accept a cover image URL or local file path, load and validate PNG/JPG/GIF event cover media, and pass the encoded image payload through Discord admin action/runtime paths. (#60883) Thanks @bittoby.
 
 ### Fixes
 

--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -15,7 +15,7 @@ import {
 
 type Ctx = Pick<
   ChannelMessageActionContext,
-  "action" | "params" | "cfg" | "accountId" | "requesterSenderId"
+  "action" | "params" | "cfg" | "accountId" | "requesterSenderId" | "mediaLocalRoots"
 >;
 
 export async function tryHandleDiscordMessageActionGuildAdmin(params: {
@@ -352,6 +352,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         image,
       },
       cfg,
+      { mediaLocalRoots: ctx.mediaLocalRoots },
     );
   }
 

--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -336,6 +336,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const channelId = readStringParam(actionParams, "channelId");
     const location = readStringParam(actionParams, "location");
     const entityType = readStringParam(actionParams, "eventType");
+    const image = readStringParam(actionParams, "image", { trim: false });
     return await handleDiscordAction(
       {
         action: "eventCreate",
@@ -348,6 +349,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         channelId,
         location,
         entityType,
+        image,
       },
       cfg,
     );

--- a/extensions/discord/src/actions/runtime.guild.ts
+++ b/extensions/discord/src/actions/runtime.guild.ts
@@ -30,6 +30,7 @@ import {
   setChannelPermissionDiscord,
   uploadEmojiDiscord,
   uploadStickerDiscord,
+  resolveEventCoverImage,
 } from "../send.js";
 import { readDiscordParentIdParam } from "./runtime.shared.js";
 
@@ -37,6 +38,7 @@ export const discordGuildActionRuntime = {
   addRoleDiscord,
   createChannelDiscord,
   createScheduledEventDiscord,
+  resolveEventCoverImage,
   deleteChannelDiscord,
   editChannelDiscord,
   fetchChannelInfoDiscord,
@@ -299,8 +301,12 @@ export async function handleDiscordGuildAction(
       const description = readStringParam(params, "description");
       const channelId = readStringParam(params, "channelId");
       const location = readStringParam(params, "location");
+      const imageUrl = readStringParam(params, "image", { trim: false });
       const entityTypeRaw = readStringParam(params, "entityType");
       const entityType = entityTypeRaw === "stage" ? 1 : entityTypeRaw === "external" ? 3 : 2;
+      const image = imageUrl
+        ? await discordGuildActionRuntime.resolveEventCoverImage(imageUrl)
+        : undefined;
       const payload = {
         name,
         description,
@@ -309,6 +315,7 @@ export async function handleDiscordGuildAction(
         entity_type: entityType,
         channel_id: channelId,
         entity_metadata: entityType === 3 && location ? { location } : undefined,
+        image,
         privacy_level: 2,
       };
       const event = accountId

--- a/extensions/discord/src/actions/runtime.guild.ts
+++ b/extensions/discord/src/actions/runtime.guild.ts
@@ -97,6 +97,7 @@ export async function handleDiscordGuildAction(
   params: Record<string, unknown>,
   isActionEnabled: ActionGate<DiscordActionConfig>,
   cfg?: OpenClawConfig,
+  options?: { mediaLocalRoots?: readonly string[] },
 ): Promise<AgentToolResult<unknown>> {
   const accountId = readStringParam(params, "accountId");
   switch (action) {
@@ -305,7 +306,9 @@ export async function handleDiscordGuildAction(
       const entityTypeRaw = readStringParam(params, "entityType");
       const entityType = entityTypeRaw === "stage" ? 1 : entityTypeRaw === "external" ? 3 : 2;
       const image = imageUrl
-        ? await discordGuildActionRuntime.resolveEventCoverImage(imageUrl)
+        ? await discordGuildActionRuntime.resolveEventCoverImage(imageUrl, {
+            localRoots: options?.mediaLocalRoots,
+          })
         : undefined;
       const payload = {
         name,

--- a/extensions/discord/src/actions/runtime.ts
+++ b/extensions/discord/src/actions/runtime.ts
@@ -69,7 +69,7 @@ export async function handleDiscordAction(
     return await handleDiscordMessagingAction(action, params, isActionEnabled, options, cfg);
   }
   if (guildActions.has(action)) {
-    return await handleDiscordGuildAction(action, params, isActionEnabled, cfg);
+    return await handleDiscordGuildAction(action, params, isActionEnabled, cfg, options);
   }
   if (moderationActions.has(action)) {
     return await handleDiscordModerationAction(action, params, isActionEnabled);

--- a/extensions/discord/src/send.guild.ts
+++ b/extensions/discord/src/send.guild.ts
@@ -7,6 +7,7 @@ import type {
   RESTPostAPIGuildScheduledEventJSONBody,
 } from "discord-api-types/v10";
 import { Routes } from "discord-api-types/v10";
+import { loadWebMediaRaw } from "openclaw/plugin-sdk/web-media";
 import { resolveDiscordRest } from "./send.shared.js";
 import type {
   DiscordModerationTarget,
@@ -14,6 +15,7 @@ import type {
   DiscordRoleChange,
   DiscordTimeoutTarget,
 } from "./send.types.js";
+import { DISCORD_MAX_EVENT_COVER_BYTES } from "./send.types.js";
 
 export async function fetchMemberInfoDiscord(
   guildId: string,
@@ -75,6 +77,20 @@ export async function listScheduledEventsDiscord(
 ): Promise<APIGuildScheduledEvent[]> {
   const rest = resolveDiscordRest(opts);
   return (await rest.get(Routes.guildScheduledEvents(guildId))) as APIGuildScheduledEvent[];
+}
+
+const ALLOWED_EVENT_COVER_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/gif"];
+
+// Loads an image from a URL or path and returns a data URI suitable for the Discord API.
+export async function resolveEventCoverImage(imageUrl: string): Promise<string> {
+  const media = await loadWebMediaRaw(imageUrl, DISCORD_MAX_EVENT_COVER_BYTES);
+  const contentType = media.contentType?.toLowerCase();
+  if (!contentType || !ALLOWED_EVENT_COVER_TYPES.includes(contentType)) {
+    throw new Error(
+      `Discord event cover images must be PNG, JPG, or GIF (got ${contentType ?? "unknown"})`,
+    );
+  }
+  return `data:${contentType};base64,${media.buffer.toString("base64")}`;
 }
 
 export async function createScheduledEventDiscord(

--- a/extensions/discord/src/send.guild.ts
+++ b/extensions/discord/src/send.guild.ts
@@ -82,8 +82,13 @@ export async function listScheduledEventsDiscord(
 const ALLOWED_EVENT_COVER_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/gif"];
 
 // Loads an image from a URL or path and returns a data URI suitable for the Discord API.
-export async function resolveEventCoverImage(imageUrl: string): Promise<string> {
-  const media = await loadWebMediaRaw(imageUrl, DISCORD_MAX_EVENT_COVER_BYTES);
+export async function resolveEventCoverImage(
+  imageUrl: string,
+  opts?: { localRoots?: readonly string[] },
+): Promise<string> {
+  const media = await loadWebMediaRaw(imageUrl, DISCORD_MAX_EVENT_COVER_BYTES, {
+    localRoots: opts?.localRoots,
+  });
   const contentType = media.contentType?.toLowerCase();
   if (!contentType || !ALLOWED_EVENT_COVER_TYPES.includes(contentType)) {
     throw new Error(

--- a/extensions/discord/src/send.guild.ts
+++ b/extensions/discord/src/send.guild.ts
@@ -79,7 +79,7 @@ export async function listScheduledEventsDiscord(
   return (await rest.get(Routes.guildScheduledEvents(guildId))) as APIGuildScheduledEvent[];
 }
 
-const ALLOWED_EVENT_COVER_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/gif"];
+const ALLOWED_EVENT_COVER_TYPES = new Set(["image/png", "image/jpeg", "image/jpg", "image/gif"]);
 
 // Loads an image from a URL or path and returns a data URI suitable for the Discord API.
 export async function resolveEventCoverImage(
@@ -90,7 +90,7 @@ export async function resolveEventCoverImage(
     localRoots: opts?.localRoots,
   });
   const contentType = media.contentType?.toLowerCase();
-  if (!contentType || !ALLOWED_EVENT_COVER_TYPES.includes(contentType)) {
+  if (!contentType || !ALLOWED_EVENT_COVER_TYPES.has(contentType)) {
     throw new Error(
       `Discord event cover images must be PNG, JPG, or GIF (got ${contentType ?? "unknown"})`,
     );

--- a/extensions/discord/src/send.ts
+++ b/extensions/discord/src/send.ts
@@ -15,6 +15,7 @@ export {
   addRoleDiscord,
   banMemberDiscord,
   createScheduledEventDiscord,
+  resolveEventCoverImage,
   fetchChannelInfoDiscord,
   fetchMemberInfoDiscord,
   fetchRoleInfoDiscord,

--- a/extensions/discord/src/send.types.ts
+++ b/extensions/discord/src/send.types.ts
@@ -22,6 +22,7 @@ export class DiscordSendError extends Error {
 
 export const DISCORD_MAX_EMOJI_BYTES = 256 * 1024;
 export const DISCORD_MAX_STICKER_BYTES = 512 * 1024;
+export const DISCORD_MAX_EVENT_COVER_BYTES = 8 * 1024 * 1024;
 
 export type DiscordSendResult = {
   messageId: string;

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -283,6 +283,9 @@ function buildEventSchema() {
     endTime: Type.Optional(Type.String()),
     desc: Type.Optional(Type.String()),
     location: Type.Optional(Type.String()),
+    image: Type.Optional(
+      Type.String({ description: "Cover image URL or local file path for the event." }),
+    ),
     durationMin: Type.Optional(Type.Number()),
     until: Type.Optional(Type.String()),
   };

--- a/src/cli/program/message/register.discord-admin.ts
+++ b/src/cli/program/message/register.discord-admin.ts
@@ -109,6 +109,7 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
     .option("--channel-id <id>", "Channel id")
     .option("--location <text>", "Event location")
     .option("--event-type <stage|external|voice>", "Event type")
+    .option("--image <url>", "Cover image URL or local file path")
     .action(async (opts) => {
       await helpers.runMessageAction("event-create", opts);
     });


### PR DESCRIPTION
## Summary

Discord scheduled events support cover images, but the CLI and agent tool have no way to provide one. This adds an optional `--image` parameter that accepts a URL or local file path, validates the image (PNG/JPG/GIF, max 8MB), and passes it to the Discord API.

No behavior change when the parameter is omitted.

## Linked Issue

Closes #60889

## Usage

CLI:
```
openclaw message event create --guild-id 123 --event-name "Show" --start-time 2026-04-10T20:00:00Z --image /path/to/cover.png
```

Agent tool:
```json
{ "action": "event-create", "guildId": "123", "eventName": "Show", "startTime": "2026-04-10T20:00:00Z", "image": "https://example.com/cover.jpg" }
```

## What changed

| File | Change |
|------|--------|
| `extensions/discord/src/send.types.ts` | `DISCORD_MAX_EVENT_COVER_BYTES` constant (8MB) |
| `extensions/discord/src/send.guild.ts` | `resolveEventCoverImage` - loads, validates, and converts to data URI |
| `extensions/discord/src/send.ts` | Barrel export |
| `extensions/discord/src/actions/runtime.ts` | Forward `options` to guild action handler |
| `extensions/discord/src/actions/runtime.guild.ts` | Pass image and `mediaLocalRoots` through `eventCreate` case |
| `extensions/discord/src/actions/handle-action.guild-admin.ts` | Read image param and forward with `mediaLocalRoots` |
| `src/agents/tools/message-tool.ts` | Added `image` to event schema |
| `src/cli/program/message/register.discord-admin.ts` | Added `--image` CLI option |

## Notes

- Follows the same `loadWebMediaRaw` + MIME validation + data URI pattern as `uploadEmojiDiscord`
- Threads `mediaLocalRoots` through the guild action path so configured local directories work
- Backward compatible, no config or migration needed
- Typecheck and formatting pass
