### PR TITLE
fix(openrouter): remove redundant null coercion in stream wrapper

### DIFF
--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -91,16 +91,14 @@ export default definePluginEntry({
       const routedStreamFn = providerRouting
         ? injectOpenRouterRouting(ctx.streamFn, providerRouting)
         : ctx.streamFn;
-      const wrapStreamFn = OPENROUTER_THINKING_STREAM_HOOKS.wrapStreamFn ?? undefined;
+      const wrapStreamFn = OPENROUTER_THINKING_STREAM_HOOKS.wrapStreamFn;
       if (!wrapStreamFn) {
         return routedStreamFn;
       }
-      return (
-        wrapStreamFn({
-          ...ctx,
-          streamFn: routedStreamFn,
-        }) ?? undefined
-      );
+      return wrapStreamFn({
+        ...ctx,
+        streamFn: routedStreamFn,
+      });
     }
 
     function isOpenRouterCacheTtlModel(modelId: string): boolean {


### PR DESCRIPTION
## Summary

- Remove redundant `?? undefined` coercions in `wrapOpenRouterProviderStream`
  - Line 94: `OPENROUTER_THINKING_STREAM_HOOKS.wrapStreamFn ?? undefined` was a no-op (property is already `undefined` when absent)
  - Lines 98-103: `wrapStreamFn({...}) ?? undefined` was dead code since fb59b5c widened the return type to `StreamFn | null | undefined`

Closes #60884

## Root cause

`a6707c2` (`refactor(providers): flatten shared stream hooks`) introduced two `tsgo` type errors in `extensions/openrouter/`:

| File | Line | Error |
|------|------|-------|
| `index.test.ts` | 46:41 | `TS2493`: Tuple type `[]` has no element at index `0` — `mock.calls[0]` on untyped vi.fn() |
| `index.ts` | 94:7 | `TS2322`: `StreamFn \| null \| undefined` not assignable to `StreamFn \| undefined` |

These were addressed by `9cc300b` and `fb59b5c` (direct pushes to main), but left behind two no-op `?? undefined` expressions. This PR removes them.

## Test plan

- [x] `pnpm check` passes (tsgo + oxlint + all policy checks)
- [x] `tsc --noEmit` passes
- [x] Grepped `extensions/` for similar `?? undefined` no-op patterns — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)