### PR TITLE
Discord/Voice: add /vc switch to hand off voice session to a different agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Agents/cache: diagnostics: add prompt-cache break diagnostics, trace live cache scenarios through embedded runner paths, and show cache reuse explicitly in `openclaw status --verbose`. Thanks @vincentkoc.
 - Agents/cache: stabilize cache-relevant system prompt fingerprints by normalizing equivalent structured prompt whitespace, line endings, hook-added system context, and runtime capability ordering so semantically unchanged prompts reuse KV/cache more reliably. Thanks @vincentkoc.
 - Plugin SDK/config: export `OpenClawSchema` via `openclaw/plugin-sdk/config-schema` so external tooling can validate and introspect full `openclaw.json` config through a supported public subpath. (#60557) Thanks @feniix.
+- Discord/Voice: add `/vc switch <agent>` subcommand to hand off an active voice session to a different agent without leaving the channel, so multiple agents can share a single voice session bidirectionally.
 
 ### Fixes
 

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1030,7 +1030,12 @@ Requirements:
 - Configure `channels.discord.voice`.
 - The bot needs Connect + Speak permissions in the target voice channel.
 
-Use the Discord-only native command `/vc join|leave|status` to control sessions. The command uses the account default agent and follows the same allowlist and group policy rules as other Discord commands.
+Use the Discord-only native command `/vc join|leave|switch|status` to control sessions. The command uses the account default agent and follows the same allowlist and group policy rules as other Discord commands.
+
+- `/vc join <channel>` — join a voice channel and start a session with the default (or binding-matched) agent
+- `/vc leave` — leave the current voice channel
+- `/vc switch <agent>` — hand off the active session to a different agent (e.g. `/vc switch maya`); the bot stays in the channel and continues responding as the new agent from that point forward. Switching is bidirectional and can be repeated at any time.
+- `/vc status` — show the current voice session
 
 Auto-join example:
 

--- a/extensions/discord/src/voice/command.test.ts
+++ b/extensions/discord/src/voice/command.test.ts
@@ -30,6 +30,7 @@ function createVoiceCommandHarness(manager: DiscordVoiceManager | null = null) {
     command,
     leave: findVoiceSubcommand(command, "leave"),
     status: findVoiceSubcommand(command, "status"),
+    switch: findVoiceSubcommand(command, "switch"),
   };
 }
 
@@ -73,6 +74,65 @@ describe("createDiscordVoiceCommand", () => {
     expect(reply).toHaveBeenCalledTimes(1);
     expect(reply).toHaveBeenCalledWith({
       content: "Voice manager is not available yet.",
+      ephemeral: true,
+    });
+  });
+
+  it("vc switch reports missing guild before manager lookup", async () => {
+    const { switch: switchCmd } = createVoiceCommandHarness(null);
+    const { interaction, reply } = createInteraction();
+
+    await switchCmd.run(interaction);
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    expect(reply).toHaveBeenCalledWith({
+      content: "Unable to resolve guild for this command.",
+      ephemeral: true,
+    });
+  });
+
+  it("vc switch reports unavailable voice manager", async () => {
+    const { switch: switchCmd } = createVoiceCommandHarness(null);
+    const { interaction, reply } = createInteraction({
+      guild: { id: "g1" } as CommandInteraction["guild"],
+    });
+
+    await switchCmd.run(interaction);
+
+    expect(reply).toHaveBeenCalledTimes(1);
+    expect(reply).toHaveBeenCalledWith({
+      content: "Voice manager is not available yet.",
+      ephemeral: true,
+    });
+  });
+
+  it("vc switch calls switchAgent and replies with result", async () => {
+    const switchAgentSpy = vi.fn(() => ({
+      ok: true,
+      message: "Switched from **ceo** to **maya**.",
+    }));
+    const statusSpy = vi.fn(() => [{ guildId: "g1", channelId: "111111111111111111" }]);
+    const manager = {
+      switchAgent: switchAgentSpy,
+      status: statusSpy,
+    } as unknown as DiscordVoiceManager;
+    const { switch: switchCmd } = createVoiceCommandHarness(manager);
+    const { interaction, reply } = createInteraction({
+      guild: { id: "g1", name: "Guild" } as CommandInteraction["guild"],
+      client: {
+        fetchChannel: vi.fn(async () => null),
+        fetchMember: vi.fn(async () => ({ roles: [] })),
+      } as unknown as CommandInteraction["client"],
+      options: {
+        getString: vi.fn(async () => "maya"),
+      } as unknown as CommandInteraction["options"],
+    });
+
+    await switchCmd.run(interaction);
+
+    expect(switchAgentSpy).toHaveBeenCalledWith({ guildId: "g1", agentId: "maya" });
+    expect(reply).toHaveBeenCalledWith({
+      content: "Switched from **ceo** to **maya**.",
       ephemeral: true,
     });
   });

--- a/extensions/discord/src/voice/command.ts
+++ b/extensions/discord/src/voice/command.ts
@@ -266,6 +266,50 @@ export function createDiscordVoiceCommand(params: VoiceCommandContext): CommandW
     }
   }
 
+  class SwitchCommand extends Command {
+    name = "switch";
+    description = "Switch the active agent for this voice session";
+    defer = true;
+    ephemeral = params.ephemeralDefault;
+    options: CommandOptions = [
+      {
+        name: "agent",
+        description: "Agent ID to switch to (e.g. maya, ceo)",
+        type: ApplicationCommandOptionType.String,
+        required: true,
+      },
+    ];
+
+    async run(interaction: CommandInteraction) {
+      const runtimeContext = await resolveVoiceCommandRuntimeContext(interaction, params);
+      if (!runtimeContext) {
+        return;
+      }
+      const sessionChannelId = resolveSessionChannelId(
+        runtimeContext.manager,
+        runtimeContext.guildId,
+      );
+      const authorized = await ensureVoiceCommandAccess({
+        interaction,
+        context: params,
+        channelOverride: sessionChannelId ? { id: sessionChannelId } : undefined,
+      });
+      if (!authorized) {
+        return;
+      }
+      const agentId = (await interaction.options.getString("agent", true))?.trim() ?? "";
+      if (!agentId) {
+        await interaction.reply({ content: "Agent ID is required.", ephemeral: true });
+        return;
+      }
+      const result = runtimeContext.manager.switchAgent({
+        guildId: runtimeContext.guildId,
+        agentId,
+      });
+      await interaction.reply({ content: result.message, ephemeral: true });
+    }
+  }
+
   class StatusCommand extends Command {
     name = "status";
     description = "Show active voice sessions";
@@ -303,7 +347,7 @@ export function createDiscordVoiceCommand(params: VoiceCommandContext): CommandW
   return new (class extends CommandWithSubcommands {
     name = "vc";
     description = "Voice channel controls";
-    subcommands = [new JoinCommand(), new LeaveCommand(), new StatusCommand()];
+    subcommands = [new JoinCommand(), new LeaveCommand(), new SwitchCommand(), new StatusCommand()];
   })();
 }
 

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -11,7 +11,7 @@ import { resolveTtsConfig, type ResolvedTtsConfig } from "openclaw/plugin-sdk/ag
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig, TtsConfig } from "openclaw/plugin-sdk/config-runtime";
 import { transcribeAudioFile } from "openclaw/plugin-sdk/media-understanding-runtime";
-import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { buildAgentSessionKey, resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -523,6 +523,36 @@ export class DiscordVoiceManager {
     return {
       ok: true,
       message: `Left ${formatMention({ channelId: entry.channelId })}.`,
+      guildId,
+      channelId: entry.channelId,
+    };
+  }
+
+  switchAgent(params: { guildId: string; agentId: string }): VoiceOperationResult {
+    const guildId = params.guildId.trim();
+    const agentId = params.agentId.trim();
+    const entry = this.sessions.get(guildId);
+    if (!entry) {
+      return { ok: false, message: "Not connected to a voice channel in this guild." };
+    }
+    const agents = this.params.cfg.agents?.list ?? [];
+    if (!agents.some((a) => a.id === agentId)) {
+      return { ok: false, message: `Agent "${agentId}" not found.` };
+    }
+    const newSessionKey = buildAgentSessionKey({
+      agentId,
+      channel: "discord",
+      accountId: this.params.accountId,
+      peer: { kind: "channel", id: entry.sessionChannelId },
+    }).toLowerCase();
+    const previousAgentId = entry.route.agentId;
+    entry.route = { ...entry.route, agentId, sessionKey: newSessionKey };
+    logVoiceVerbose(
+      `switchAgent: guild ${guildId} channel ${entry.channelId} ${previousAgentId} -> ${agentId}`,
+    );
+    return {
+      ok: true,
+      message: `Switched from **${previousAgentId}** to **${agentId}**.`,
       guildId,
       channelId: entry.channelId,
     };

--- a/extensions/discord/src/voice/manager.ts
+++ b/extensions/discord/src/voice/manager.ts
@@ -11,7 +11,12 @@ import { resolveTtsConfig, type ResolvedTtsConfig } from "openclaw/plugin-sdk/ag
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import type { DiscordAccountConfig, TtsConfig } from "openclaw/plugin-sdk/config-runtime";
 import { transcribeAudioFile } from "openclaw/plugin-sdk/media-understanding-runtime";
-import { buildAgentSessionKey, resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import {
+  buildAgentMainSessionKey,
+  buildAgentSessionKey,
+  deriveLastRoutePolicy,
+  resolveAgentRoute,
+} from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -545,8 +550,18 @@ export class DiscordVoiceManager {
       accountId: this.params.accountId,
       peer: { kind: "channel", id: entry.sessionChannelId },
     }).toLowerCase();
+    const newMainSessionKey = buildAgentMainSessionKey({ agentId }).toLowerCase();
     const previousAgentId = entry.route.agentId;
-    entry.route = { ...entry.route, agentId, sessionKey: newSessionKey };
+    entry.route = {
+      ...entry.route,
+      agentId,
+      sessionKey: newSessionKey,
+      mainSessionKey: newMainSessionKey,
+      lastRoutePolicy: deriveLastRoutePolicy({
+        sessionKey: newSessionKey,
+        mainSessionKey: newMainSessionKey,
+      }),
+    };
     logVoiceVerbose(
       `switchAgent: guild ${guildId} channel ${entry.channelId} ${previousAgentId} -> ${agentId}`,
     );
@@ -623,8 +638,17 @@ export class DiscordVoiceManager {
       logVoiceVerbose(
         `capture ready (${durationSeconds.toFixed(2)}s): guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
       );
+      // Snapshot the route at queue time so a /vc switch between capture and
+      // execution does not silently reroute pre-switch utterances to the new agent.
+      const routeSnapshot = entry.route;
       this.enqueueProcessing(entry, async () => {
-        await this.processSegment({ entry, wavPath, userId, durationSeconds });
+        await this.processSegment({
+          entry,
+          route: routeSnapshot,
+          wavPath,
+          userId,
+          durationSeconds,
+        });
       });
     } finally {
       entry.activeSpeakers.delete(userId);
@@ -633,11 +657,12 @@ export class DiscordVoiceManager {
 
   private async processSegment(params: {
     entry: VoiceSessionEntry;
+    route: VoiceSessionEntry["route"];
     wavPath: string;
     userId: string;
     durationSeconds: number;
   }) {
-    const { entry, wavPath, userId, durationSeconds } = params;
+    const { entry, route, wavPath, userId, durationSeconds } = params;
     logVoiceVerbose(
       `segment processing (${durationSeconds.toFixed(2)}s): guild ${entry.guildId} channel ${entry.channelId}`,
     );
@@ -673,7 +698,7 @@ export class DiscordVoiceManager {
     }
     const transcript = await transcribeAudio({
       cfg: this.params.cfg,
-      agentId: entry.route.agentId,
+      agentId: route.agentId,
       filePath: wavPath,
     });
     if (!transcript) {
@@ -691,8 +716,8 @@ export class DiscordVoiceManager {
     const result = await agentCommandFromIngress(
       {
         message: prompt,
-        sessionKey: entry.route.sessionKey,
-        agentId: entry.route.agentId,
+        sessionKey: route.sessionKey,
+        agentId: route.agentId,
         messageChannel: "discord",
         senderIsOwner: speaker.senderIsOwner,
         allowModelOverride: false,


### PR DESCRIPTION
## Summary

- Adds a `/vc switch <agent>` subcommand to the existing `/vc` voice command
- Lets you swap the active agent mid-session without leaving the voice channel — fully bidirectional and repeatable
- Adds `DiscordVoiceManager.switchAgent()` which validates the agent exists, rebuilds the session key via `buildAgentSessionKey`, and updates `entry.route` in place
- Documents the new subcommand in `docs/channels/discord.md` alongside the existing `join/leave/status` commands

## Motivation

Currently `/vc join` binds the session to a single agent for the lifetime of the connection (the account default, or whatever the channel binding resolves to). If you have multiple agents configured — e.g. a general assistant and a specialized one — there's no way to switch between them without leaving and rejoining. This PR makes it possible to say `/vc switch maya` mid-conversation and have the bot continue responding as Maya from that point on.

## Test plan

- [x] `extensions/discord/src/voice/command.test.ts` — new tests covering missing guild, unavailable manager, and successful `switchAgent` call
- [x] `pnpm test extensions/discord/src/voice/command.test.ts` — all 6 tests pass
- [x] `pnpm check` — 0 errors, 0 warnings
- [x] TypeScript: no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)