### PR TITLE
Fix: status shows 'unavailable' for third-party memory plugins

### DIFF
--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -138,6 +138,23 @@ export async function resolveSharedMemoryStatusSnapshot(params: {
     return null;
   }
   const agentId = agentStatus.defaultId ?? "main";
+
+  // For third-party memory plugins (not memory-core), skip built-in config checks
+  // and directly query the plugin's memory search manager
+  if (memoryPlugin.slot !== "memory-core") {
+    const { manager } = await params.getMemorySearchManager({ cfg, agentId, purpose: "status" });
+    if (!manager) {
+      return null;
+    }
+    try {
+      await manager.probeVectorAvailability();
+    } catch {}
+    const status = manager.status();
+    await manager.close?.().catch(() => {});
+    return { agentId, ...status };
+  }
+
+  // For memory-core, use existing built-in config checks
   const defaultStorePath = params.requireDefaultStore?.(agentId);
   if (
     defaultStorePath &&


### PR DESCRIPTION
Good day,

## Summary

This PR fixes issue #56968 where the status command incorrectly displays "unavailable" for third-party memory plugins like .

## Root Cause

The  function was calling built-in config checks () which only read  configuration. Since third-party plugin users have this disabled (using the plugin instead), it returned , showing "unavailable".

## Fix

For third-party memory plugins (not ), skip built-in config checks and directly query the plugin's memory search manager:



## Testing

The fix was verified against the reproduction steps in #56968.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee
https://github.com/Jah-yee