### PR TITLE
fix(cli): route skills list output to stdout when --json is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenRouter failover: classify `403 "Key limit exceeded"` spending-limit responses as billing so model fallback continues instead of stopping on generic auth. (#59892) Thanks @rockcent.
 - Device pairing/security: keep non-operator device scope checks bound to the requested role prefix so bootstrap verification cannot redeem `operator.*` scopes through `node` auth. (#57258) Thanks @jlapenna.
 - Gateway/device pairing: require non-admin paired-device sessions to manage only their own device for token rotate/revoke and paired-device removal, blocking cross-device token theft inside pairing-scoped sessions. (#50627) Thanks @coygeek.
+- CLI/skills JSON: route `skills list --json`, `skills info --json`, and `skills check --json` output to stdout instead of stderr so machine-readable consumers receive JSON on the expected stream again. (#60914; fixes #57599; landed from contributor PR #57611 by @Aftabbs) Thanks @Aftabbs.
 
 ## 2026.4.2
 

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -7,7 +7,7 @@ const mocks = vi.hoisted(() => {
   const runtimeStdout: string[] = [];
   const runtimeErrors: string[] = [];
   const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");
-  const createSkillStatusReport = () => ({
+  const skillStatusReportFixture = {
     workspaceDir: "/tmp/workspace",
     managedSkillsDir: "/tmp/workspace/skills",
     skills: [
@@ -40,9 +40,11 @@ const mocks = vi.hoisted(() => {
           config: [],
           os: [],
         },
+        configChecks: [],
+        install: [],
       },
     ],
-  });
+  };
   const defaultRuntime = {
     log: vi.fn((...args: unknown[]) => {
       runtimeLogs.push(stringifyArgs(args));
@@ -63,7 +65,7 @@ const mocks = vi.hoisted(() => {
   const buildWorkspaceSkillStatusMock = vi.fn((workspaceDir: string, options?: unknown) => {
     void workspaceDir;
     void options;
-    return createSkillStatusReport();
+    return skillStatusReportFixture;
   });
   return {
     loadConfigMock: vi.fn(() => ({})),
@@ -74,6 +76,7 @@ const mocks = vi.hoisted(() => {
     updateSkillsFromClawHubMock: vi.fn(),
     readTrackedClawHubSkillSlugsMock: vi.fn(),
     buildWorkspaceSkillStatusMock,
+    skillStatusReportFixture,
     defaultRuntime,
     runtimeLogs,
     runtimeStdout,
@@ -90,6 +93,7 @@ const {
   updateSkillsFromClawHubMock,
   readTrackedClawHubSkillSlugsMock,
   buildWorkspaceSkillStatusMock,
+  skillStatusReportFixture,
   defaultRuntime,
   runtimeLogs,
   runtimeStdout,
@@ -155,42 +159,7 @@ describe("skills cli commands", () => {
     });
     updateSkillsFromClawHubMock.mockResolvedValue([]);
     readTrackedClawHubSkillSlugsMock.mockResolvedValue([]);
-    buildWorkspaceSkillStatusMock.mockReturnValue({
-      workspaceDir: "/tmp/workspace",
-      managedSkillsDir: "/tmp/workspace/skills",
-      skills: [
-        {
-          name: "calendar",
-          description: "Calendar helpers",
-          source: "bundled",
-          bundled: false,
-          filePath: "/tmp/workspace/skills/calendar/SKILL.md",
-          baseDir: "/tmp/workspace/skills/calendar",
-          skillKey: "calendar",
-          emoji: "📅",
-          homepage: "https://example.com/calendar",
-          always: false,
-          disabled: false,
-          blockedByAllowlist: false,
-          eligible: true,
-          primaryEnv: "CALENDAR_API_KEY",
-          requirements: {
-            bins: [],
-            anyBins: [],
-            env: ["CALENDAR_API_KEY"],
-            config: [],
-            os: [],
-          },
-          missing: {
-            bins: [],
-            anyBins: [],
-            env: [],
-            config: [],
-            os: [],
-          },
-        },
-      ],
-    });
+    buildWorkspaceSkillStatusMock.mockReturnValue(skillStatusReportFixture);
     defaultRuntime.log.mockClear();
     defaultRuntime.error.mockClear();
     defaultRuntime.writeStdout.mockClear();
@@ -302,10 +271,12 @@ describe("skills cli commands", () => {
     expect(buildWorkspaceSkillStatusMock).toHaveBeenCalledWith("/tmp/workspace", {
       config: {},
     });
-    expect(defaultRuntime.writeStdout).toHaveBeenCalledTimes(1);
+    expect(
+      defaultRuntime.writeStdout.mock.calls.length + defaultRuntime.writeJson.mock.calls.length,
+    ).toBeGreaterThan(0);
     expect(defaultRuntime.log).not.toHaveBeenCalled();
-    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
     expect(runtimeErrors).toEqual([]);
+    expect(runtimeStdout.length).toBeGreaterThan(0);
 
     const payload = JSON.parse(runtimeStdout.at(-1) ?? "{}") as Record<string, unknown>;
     assert(payload);

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -4,8 +4,45 @@ import { registerSkillsCli } from "./skills-cli.js";
 
 const mocks = vi.hoisted(() => {
   const runtimeLogs: string[] = [];
+  const runtimeStdout: string[] = [];
   const runtimeErrors: string[] = [];
   const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");
+  const createSkillStatusReport = () => ({
+    workspaceDir: "/tmp/workspace",
+    managedSkillsDir: "/tmp/workspace/skills",
+    skills: [
+      {
+        name: "calendar",
+        description: "Calendar helpers",
+        source: "bundled",
+        bundled: false,
+        filePath: "/tmp/workspace/skills/calendar/SKILL.md",
+        baseDir: "/tmp/workspace/skills/calendar",
+        skillKey: "calendar",
+        emoji: "📅",
+        homepage: "https://example.com/calendar",
+        always: false,
+        disabled: false,
+        blockedByAllowlist: false,
+        eligible: true,
+        primaryEnv: "CALENDAR_API_KEY",
+        requirements: {
+          bins: [],
+          anyBins: [],
+          env: ["CALENDAR_API_KEY"],
+          config: [],
+          os: [],
+        },
+        missing: {
+          bins: [],
+          anyBins: [],
+          env: [],
+          config: [],
+          os: [],
+        },
+      },
+    ],
+  });
   const defaultRuntime = {
     log: vi.fn((...args: unknown[]) => {
       runtimeLogs.push(stringifyArgs(args));
@@ -14,15 +51,20 @@ const mocks = vi.hoisted(() => {
       runtimeErrors.push(stringifyArgs(args));
     }),
     writeStdout: vi.fn((value: string) => {
-      defaultRuntime.log(value.endsWith("\n") ? value.slice(0, -1) : value);
+      runtimeStdout.push(value.endsWith("\n") ? value.slice(0, -1) : value);
     }),
     writeJson: vi.fn((value: unknown, space = 2) => {
-      defaultRuntime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
+      runtimeStdout.push(JSON.stringify(value, null, space > 0 ? space : undefined));
     }),
     exit: vi.fn((code: number) => {
       throw new Error(`__exit__:${code}`);
     }),
   };
+  const buildWorkspaceSkillStatusMock = vi.fn((workspaceDir: string, options?: unknown) => {
+    void workspaceDir;
+    void options;
+    return createSkillStatusReport();
+  });
   return {
     loadConfigMock: vi.fn(() => ({})),
     resolveDefaultAgentIdMock: vi.fn(() => "main"),
@@ -31,8 +73,10 @@ const mocks = vi.hoisted(() => {
     installSkillFromClawHubMock: vi.fn(),
     updateSkillsFromClawHubMock: vi.fn(),
     readTrackedClawHubSkillSlugsMock: vi.fn(),
+    buildWorkspaceSkillStatusMock,
     defaultRuntime,
     runtimeLogs,
+    runtimeStdout,
     runtimeErrors,
   };
 });
@@ -45,8 +89,10 @@ const {
   installSkillFromClawHubMock,
   updateSkillsFromClawHubMock,
   readTrackedClawHubSkillSlugsMock,
+  buildWorkspaceSkillStatusMock,
   defaultRuntime,
   runtimeLogs,
+  runtimeStdout,
   runtimeErrors,
 } = mocks;
 
@@ -71,6 +117,11 @@ vi.mock("../agents/skills-clawhub.js", () => ({
     mocks.readTrackedClawHubSkillSlugsMock(...args),
 }));
 
+vi.mock("../agents/skills-status.js", () => ({
+  buildWorkspaceSkillStatus: (workspaceDir: string, options?: unknown) =>
+    mocks.buildWorkspaceSkillStatusMock(workspaceDir, options),
+}));
+
 describe("skills cli commands", () => {
   const createProgram = () => {
     const program = new Command();
@@ -83,6 +134,7 @@ describe("skills cli commands", () => {
 
   beforeEach(() => {
     runtimeLogs.length = 0;
+    runtimeStdout.length = 0;
     runtimeErrors.length = 0;
     loadConfigMock.mockReset();
     resolveDefaultAgentIdMock.mockReset();
@@ -91,6 +143,7 @@ describe("skills cli commands", () => {
     installSkillFromClawHubMock.mockReset();
     updateSkillsFromClawHubMock.mockReset();
     readTrackedClawHubSkillSlugsMock.mockReset();
+    buildWorkspaceSkillStatusMock.mockReset();
 
     loadConfigMock.mockReturnValue({});
     resolveDefaultAgentIdMock.mockReturnValue("main");
@@ -102,6 +155,42 @@ describe("skills cli commands", () => {
     });
     updateSkillsFromClawHubMock.mockResolvedValue([]);
     readTrackedClawHubSkillSlugsMock.mockResolvedValue([]);
+    buildWorkspaceSkillStatusMock.mockReturnValue({
+      workspaceDir: "/tmp/workspace",
+      managedSkillsDir: "/tmp/workspace/skills",
+      skills: [
+        {
+          name: "calendar",
+          description: "Calendar helpers",
+          source: "bundled",
+          bundled: false,
+          filePath: "/tmp/workspace/skills/calendar/SKILL.md",
+          baseDir: "/tmp/workspace/skills/calendar",
+          skillKey: "calendar",
+          emoji: "📅",
+          homepage: "https://example.com/calendar",
+          always: false,
+          disabled: false,
+          blockedByAllowlist: false,
+          eligible: true,
+          primaryEnv: "CALENDAR_API_KEY",
+          requirements: {
+            bins: [],
+            anyBins: [],
+            env: ["CALENDAR_API_KEY"],
+            config: [],
+            os: [],
+          },
+          missing: {
+            bins: [],
+            anyBins: [],
+            env: [],
+            config: [],
+            os: [],
+          },
+        },
+      ],
+    });
     defaultRuntime.log.mockClear();
     defaultRuntime.error.mockClear();
     defaultRuntime.writeStdout.mockClear();
@@ -177,5 +266,58 @@ describe("skills cli commands", () => {
       true,
     );
     expect(runtimeErrors).toEqual([]);
+  });
+
+  it.each([
+    {
+      label: "list",
+      argv: ["skills", "list", "--json"],
+      assert: (payload: Record<string, unknown>) => {
+        const skills = payload.skills as Array<Record<string, unknown>>;
+        expect(skills).toHaveLength(1);
+        expect(skills[0]?.name).toBe("calendar");
+      },
+    },
+    {
+      label: "info",
+      argv: ["skills", "info", "calendar", "--json"],
+      assert: (payload: Record<string, unknown>) => {
+        expect(payload.name).toBe("calendar");
+        expect(payload.primaryEnv).toBe("CALENDAR_API_KEY");
+      },
+    },
+    {
+      label: "check",
+      argv: ["skills", "check", "--json"],
+      assert: (payload: Record<string, unknown>) => {
+        expect(payload.summary).toMatchObject({
+          total: 1,
+          eligible: 1,
+        });
+      },
+    },
+  ])("routes skills $label JSON output through stdout", async ({ argv, assert }) => {
+    await runCommand(argv);
+
+    expect(buildWorkspaceSkillStatusMock).toHaveBeenCalledWith("/tmp/workspace", {
+      config: {},
+    });
+    expect(defaultRuntime.writeStdout).toHaveBeenCalledTimes(1);
+    expect(defaultRuntime.log).not.toHaveBeenCalled();
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(runtimeErrors).toEqual([]);
+
+    const payload = JSON.parse(runtimeStdout.at(-1) ?? "{}") as Record<string, unknown>;
+    assert(payload);
+  });
+
+  it("keeps non-JSON skills list output on stdout with human-readable formatting", async () => {
+    await runCommand(["skills", "list"]);
+
+    expect(defaultRuntime.writeStdout).toHaveBeenCalledTimes(1);
+    expect(defaultRuntime.log).not.toHaveBeenCalled();
+    expect(runtimeErrors).toEqual([]);
+    expect(runtimeStdout.at(-1)).toContain("calendar");
+    expect(runtimeStdout.at(-1)).toContain("openclaw skills search");
   });
 });

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -33,7 +33,7 @@ async function loadSkillsStatusReport(): Promise<SkillStatusReport> {
 async function runSkillsAction(render: (report: SkillStatusReport) => string): Promise<void> {
   try {
     const report = await loadSkillsStatusReport();
-    defaultRuntime.log(render(report));
+    defaultRuntime.writeStdout(render(report));
   } catch (err) {
     defaultRuntime.error(String(err));
     defaultRuntime.exit(1);


### PR DESCRIPTION
## Summary

Replacement for closed PR #57611.

`openclaw skills list --json` (and `skills info --json`, `skills check --json`) was writing JSON output to **stderr** instead of **stdout**, breaking tooling that captures stdout.

This branch includes:
- the original runtime fix: `runSkillsAction()` now uses `defaultRuntime.writeStdout(...)`
- added regression coverage in `src/cli/skills-cli.commands.test.ts` for:
  - `skills list --json`
  - `skills info <name> --json`
  - `skills check --json`
  - a non-JSON `skills list` path

Fixes #57599.

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/cli/skills-cli.commands.test.ts`
- live repro on the working branch showed `skills list --json` writing the JSON payload to stdout

## Notes

PR #57611 was closed after its fork branch head was accidentally moved to the wrong commit. This PR is the clean replacement from the corrected rebased branch.
