### PR TITLE
ACPX: bump pinned version to 0.4.1

### DIFF
--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw ACP runtime backend via acpx",
   "type": "module",
   "dependencies": {
-    "acpx": "0.4.0"
+    "acpx": "0.4.1"
   },
   "openclaw": {
     "extensions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,8 +257,8 @@ importers:
   extensions/acpx:
     dependencies:
       acpx:
-        specifier: 0.4.0
-        version: 0.4.0(zod@4.3.6)
+        specifier: 0.4.1
+        version: 0.4.1(zod@4.3.6)
 
   extensions/amazon-bedrock:
     dependencies:
@@ -3622,8 +3622,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acpx@0.4.0:
-    resolution: {integrity: sha512-JyMw9+loIEuy+jUyv7Irx+qNDhrL0ToR+wAfX3ucBACrSBfsWKFmGJWewH+c1gr+MuzTG1Jd/0kIM6/+ZL67OA==}
+  acpx@0.4.1:
+    resolution: {integrity: sha512-3Hay6yvjyHXSt9qMlU+1jGhtyXJgwA4SkrzMMf50wQAuk8Njt+LCI4Cwze8+Sj/1nPDmiQFKTUiPsQIJXmqAEQ==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -10041,7 +10041,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  acpx@0.4.0(zod@4.3.6):
+  acpx@0.4.1(zod@4.3.6):
     dependencies:
       '@agentclientprotocol/sdk': 0.17.1(zod@4.3.6)
       commander: 14.0.3

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -68,7 +68,7 @@ describe("bundled plugin postinstall", () => {
     const packageRoot = path.dirname(path.dirname(extensionsDir));
     await writePluginPackage(extensionsDir, "acpx", {
       dependencies: {
-        acpx: "0.4.0",
+        acpx: "0.4.1",
       },
     });
     const spawnSync = vi.fn();
@@ -82,7 +82,7 @@ describe("bundled plugin postinstall", () => {
         "--omit=dev",
         "--no-save",
         "--package-lock=false",
-        "acpx@0.4.0",
+        "acpx@0.4.1",
       ]),
       spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
@@ -96,7 +96,7 @@ describe("bundled plugin postinstall", () => {
     const packageRoot = path.dirname(path.dirname(extensionsDir));
     await writePluginPackage(extensionsDir, "acpx", {
       dependencies: {
-        acpx: "0.4.0",
+        acpx: "0.4.1",
       },
     });
     const spawnSync = vi.fn(() => ({ status: 0, stderr: "", stdout: "" }));
@@ -115,7 +115,7 @@ describe("bundled plugin postinstall", () => {
         "--omit=dev",
         "--no-save",
         "--package-lock=false",
-        "acpx@0.4.0",
+        "acpx@0.4.1",
       ]),
       spawnSync,
       log: { log: vi.fn(), warn: vi.fn() },
@@ -123,7 +123,7 @@ describe("bundled plugin postinstall", () => {
 
     expect(spawnSync).toHaveBeenCalledWith(
       "npm",
-      ["install", "--omit=dev", "--no-save", "--package-lock=false", "acpx@0.4.0"],
+      ["install", "--omit=dev", "--no-save", "--package-lock=false", "acpx@0.4.1"],
       {
         cwd: packageRoot,
         encoding: "utf8",
@@ -143,7 +143,7 @@ describe("bundled plugin postinstall", () => {
     const packageRoot = path.dirname(path.dirname(extensionsDir));
     await writePluginPackage(extensionsDir, "acpx", {
       dependencies: {
-        acpx: "0.4.0",
+        acpx: "0.4.1",
       },
     });
     await fs.mkdir(path.join(packageRoot, "node_modules", "acpx"), { recursive: true });


### PR DESCRIPTION
## Summary
- bump the bundled ACPX pin from `0.4.0` to `0.4.1`
- update bundled plugin postinstall expectations to match

## Verification
- direct runtime check: `extensions/acpx/package.json` now resolves `dependencies.acpx` to `0.4.1`
- direct source check: `test/scripts/postinstall-bundled-plugins.test.ts` now expects `acpx@0.4.1`
- note: local `pnpm test -- test/scripts/postinstall-bundled-plugins.test.ts extensions/acpx/src/config.test.ts` hung before reporting results
- note: full pre-commit `pnpm check` currently fails in unrelated `src/agents/skills/*` tsgo errors on latest local `main`