### PR TITLE
fix(cli): set non-zero exit code on argument errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/Overview: prevent gateway access token/password visibility toggle buttons from overlapping their inputs at narrow widths. (#56924) Thanks @bbddbb1.
 - Control UI/cron: highlight the Cron refresh button while refresh is in flight so the page's loading state stays visible even when prior data remains on screen. (#60394) Thanks @coder-zhuzm.
 - MS Teams: replace the deprecated Teams SDK HttpPlugin stub with `httpServerAdapter` so recurring gateway deprecation warnings stop firing and the Express 5 compatibility workaround stays on the supported SDK path. (#60939) Thanks @coolramukaka-sys.
+- CLI/Commander: preserve Commander-computed exit codes for argument and help-error paths, and cover the user-argv parse mode in the regression tests so invalid CLI invocations no longer report success when exits are intercepted. (#60923) Thanks @Linux2010.
 
 ## 2026.4.2
 

--- a/src/cli/program/build-program.test.ts
+++ b/src/cli/program/build-program.test.ts
@@ -1,6 +1,6 @@
 import process from "node:process";
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildProgram } from "./build-program.js";
 import type { ProgramContext } from "./context.js";
 
@@ -41,6 +41,11 @@ describe("buildProgram", () => {
     } satisfies ProgramContext);
   });
 
+  afterEach(() => {
+    // Clean up exitCode after each test
+    process.exitCode = undefined;
+  });
+
   it("wires context/help/preaction/command registration with shared context", () => {
     const argv = ["node", "openclaw", "status"];
     const originalArgv = process.argv;
@@ -57,5 +62,51 @@ describe("buildProgram", () => {
     } finally {
       process.argv = originalArgv;
     }
+  });
+
+  it("sets exitCode to 1 on argument errors (fixes #60905)", () => {
+    // Reset exitCode before test
+    process.exitCode = undefined;
+    const program = buildProgram();
+    program.command("test").description("Test command");
+
+    // Simulate argument error: passing unexpected argument to command that doesn't accept any
+    try {
+      program.parse(["node", "openclaw", "test", "unexpected-arg"], { from: "user" });
+    } catch {
+      // exitOverride throws, but we expect exitCode to be set
+    }
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("preserves exitCode 0 for help display", () => {
+    // Reset exitCode before test
+    process.exitCode = undefined;
+    const program = buildProgram();
+    program.command("test").description("Test command");
+
+    try {
+      program.parse(["node", "openclaw", "--help"], { from: "user" });
+    } catch {
+      // exitOverride throws for help too
+    }
+
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("preserves exitCode 0 for version display", () => {
+    // Reset exitCode before test
+    process.exitCode = undefined;
+    const program = buildProgram();
+    program.version("1.0.0");
+
+    try {
+      program.parse(["node", "openclaw", "--version"], { from: "user" });
+    } catch {
+      // exitOverride throws for version too
+    }
+
+    expect(process.exitCode).toBe(0);
   });
 });

--- a/src/cli/program/build-program.test.ts
+++ b/src/cli/program/build-program.test.ts
@@ -82,6 +82,19 @@ describe("buildProgram", () => {
     expect(process.exitCode).toBe(1);
   });
 
+  it("does not run the command action after an argument error", async () => {
+    const program = buildProgram();
+    const exitSpy = mockProcessExit();
+    const actionSpy = vi.fn();
+    program.command("test").action(actionSpy);
+
+    await expect(program.parseAsync(["test", "unexpected-arg"], { from: "user" })).rejects.toThrow(
+      "process.exit:1",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(actionSpy).not.toHaveBeenCalled();
+  });
+
   it("preserves exitCode 0 for help display", async () => {
     const program = buildProgram();
     const exitSpy = mockProcessExit();

--- a/src/cli/program/build-program.test.ts
+++ b/src/cli/program/build-program.test.ts
@@ -31,6 +31,12 @@ vi.mock("./program-context.js", () => ({
 }));
 
 describe("buildProgram", () => {
+  function mockProcessExit() {
+    return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${String(code)}`);
+    }) as typeof process.exit);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     createProgramContextMock.mockReturnValue({
@@ -42,8 +48,8 @@ describe("buildProgram", () => {
   });
 
   afterEach(() => {
-    // Clean up exitCode after each test
     process.exitCode = undefined;
+    vi.restoreAllMocks();
   });
 
   it("wires context/help/preaction/command registration with shared context", () => {
@@ -64,49 +70,51 @@ describe("buildProgram", () => {
     }
   });
 
-  it("sets exitCode to 1 on argument errors (fixes #60905)", () => {
-    // Reset exitCode before test
-    process.exitCode = undefined;
+  it("sets exitCode to 1 on argument errors (fixes #60905)", async () => {
     const program = buildProgram();
+    const exitSpy = mockProcessExit();
     program.command("test").description("Test command");
 
-    // Simulate argument error: passing unexpected argument to command that doesn't accept any
-    try {
-      program.parse(["node", "openclaw", "test", "unexpected-arg"], { from: "user" });
-    } catch {
-      // exitOverride throws, but we expect exitCode to be set
-    }
-
+    await expect(program.parseAsync(["test", "unexpected-arg"], { from: "user" })).rejects.toThrow(
+      "process.exit:1",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
     expect(process.exitCode).toBe(1);
   });
 
-  it("preserves exitCode 0 for help display", () => {
-    // Reset exitCode before test
-    process.exitCode = undefined;
+  it("preserves exitCode 0 for help display", async () => {
     const program = buildProgram();
+    const exitSpy = mockProcessExit();
     program.command("test").description("Test command");
 
-    try {
-      program.parse(["node", "openclaw", "--help"], { from: "user" });
-    } catch {
-      // exitOverride throws for help too
-    }
-
+    await expect(program.parseAsync(["--help"], { from: "user" })).rejects.toThrow(
+      "process.exit:0",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(0);
     expect(process.exitCode).toBe(0);
   });
 
-  it("preserves exitCode 0 for version display", () => {
-    // Reset exitCode before test
-    process.exitCode = undefined;
+  it("preserves exitCode 0 for version display", async () => {
     const program = buildProgram();
+    const exitSpy = mockProcessExit();
     program.version("1.0.0");
 
-    try {
-      program.parse(["node", "openclaw", "--version"], { from: "user" });
-    } catch {
-      // exitOverride throws for version too
-    }
-
+    await expect(program.parseAsync(["--version"], { from: "user" })).rejects.toThrow(
+      "process.exit:0",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(0);
     expect(process.exitCode).toBe(0);
+  });
+
+  it("preserves non-zero exitCode for help error flows", async () => {
+    const program = buildProgram();
+    const exitSpy = mockProcessExit();
+    program.helpCommand("help [command]");
+
+    await expect(program.parseAsync(["help", "missing"], { from: "user" })).rejects.toThrow(
+      "process.exit:1",
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(process.exitCode).toBe(1);
   });
 });

--- a/src/cli/program/build-program.test.ts
+++ b/src/cli/program/build-program.test.ts
@@ -1,5 +1,5 @@
 import process from "node:process";
-import { Command } from "commander";
+import { Command, CommanderError } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildProgram } from "./build-program.js";
 import type { ProgramContext } from "./context.js";
@@ -31,14 +31,26 @@ vi.mock("./program-context.js", () => ({
 }));
 
 describe("buildProgram", () => {
-  function mockProcessExit() {
-    return vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`process.exit:${String(code)}`);
-    }) as typeof process.exit);
+  function mockProcessOutput() {
+    vi.spyOn(process.stdout, "write").mockImplementation(
+      ((() => true) as unknown) as typeof process.stdout.write,
+    );
+    vi.spyOn(process.stderr, "write").mockImplementation(
+      ((() => true) as unknown) as typeof process.stderr.write,
+    );
+  }
+
+  async function expectCommanderExit(promise: Promise<unknown>, exitCode: number) {
+    const error = await promise.catch((err) => err);
+
+    expect(error).toBeInstanceOf(CommanderError);
+    expect(error).toMatchObject({ exitCode });
+    return error as CommanderError;
   }
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockProcessOutput();
     createProgramContextMock.mockReturnValue({
       programVersion: "9.9.9-test",
       channelOptions: ["telegram"],
@@ -72,62 +84,57 @@ describe("buildProgram", () => {
 
   it("sets exitCode to 1 on argument errors (fixes #60905)", async () => {
     const program = buildProgram();
-    const exitSpy = mockProcessExit();
     program.command("test").description("Test command");
 
-    await expect(program.parseAsync(["test", "unexpected-arg"], { from: "user" })).rejects.toThrow(
-      "process.exit:1",
+    const error = await expectCommanderExit(
+      program.parseAsync(["test", "unexpected-arg"], { from: "user" }),
+      1,
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    expect(error.code).toBe("commander.excessArguments");
     expect(process.exitCode).toBe(1);
   });
 
   it("does not run the command action after an argument error", async () => {
     const program = buildProgram();
-    const exitSpy = mockProcessExit();
     const actionSpy = vi.fn();
     program.command("test").action(actionSpy);
 
-    await expect(program.parseAsync(["test", "unexpected-arg"], { from: "user" })).rejects.toThrow(
-      "process.exit:1",
-    );
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    await expectCommanderExit(program.parseAsync(["test", "unexpected-arg"], { from: "user" }), 1);
+
     expect(actionSpy).not.toHaveBeenCalled();
   });
 
   it("preserves exitCode 0 for help display", async () => {
     const program = buildProgram();
-    const exitSpy = mockProcessExit();
     program.command("test").description("Test command");
 
-    await expect(program.parseAsync(["--help"], { from: "user" })).rejects.toThrow(
-      "process.exit:0",
-    );
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    const error = await expectCommanderExit(program.parseAsync(["--help"], { from: "user" }), 0);
+
+    expect(error.code).toBe("commander.helpDisplayed");
     expect(process.exitCode).toBe(0);
   });
 
   it("preserves exitCode 0 for version display", async () => {
     const program = buildProgram();
-    const exitSpy = mockProcessExit();
     program.version("1.0.0");
 
-    await expect(program.parseAsync(["--version"], { from: "user" })).rejects.toThrow(
-      "process.exit:0",
-    );
-    expect(exitSpy).toHaveBeenCalledWith(0);
+    const error = await expectCommanderExit(program.parseAsync(["--version"], { from: "user" }), 0);
+
+    expect(error.code).toBe("commander.version");
     expect(process.exitCode).toBe(0);
   });
 
   it("preserves non-zero exitCode for help error flows", async () => {
     const program = buildProgram();
-    const exitSpy = mockProcessExit();
     program.helpCommand("help [command]");
 
-    await expect(program.parseAsync(["help", "missing"], { from: "user" })).rejects.toThrow(
-      "process.exit:1",
+    const error = await expectCommanderExit(
+      program.parseAsync(["help", "missing"], { from: "user" }),
+      1,
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    expect(error.code).toBe("commander.help");
     expect(process.exitCode).toBe(1);
   });
 });

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -8,6 +8,16 @@ import { setProgramContext } from "./program-context.js";
 export function buildProgram() {
   const program = new Command();
   program.enablePositionalOptions();
+  // Ensure Commander.js sets exit code on argument errors (fixes #60905)
+  // Without this, commands like `openclaw sessions list` would print an error
+  // but exit with code 0, breaking scripts and monitoring tools.
+  program.exitOverride((err) => {
+    if (err.code === "commander.help" || err.code === "commander.version") {
+      process.exitCode = 0;
+    } else {
+      process.exitCode = 1;
+    }
+  });
   const ctx = createProgramContext();
   const argv = process.argv;
 

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -12,7 +12,11 @@ export function buildProgram() {
   // Without this, commands like `openclaw sessions list` would print an error
   // but exit with code 0, breaking scripts and monitoring tools.
   program.exitOverride((err) => {
-    if (err.code === "commander.help" || err.code === "commander.version") {
+    if (
+      err.code === "commander.help" ||
+      err.code === "commander.helpDisplayed" ||
+      err.code === "commander.version"
+    ) {
       process.exitCode = 0;
     } else {
       process.exitCode = 1;

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -12,15 +12,7 @@ export function buildProgram() {
   // Without this, commands like `openclaw sessions list` would print an error
   // but exit with code 0, breaking scripts and monitoring tools.
   program.exitOverride((err) => {
-    if (
-      err.code === "commander.help" ||
-      err.code === "commander.helpDisplayed" ||
-      err.code === "commander.version"
-    ) {
-      process.exitCode = 0;
-    } else {
-      process.exitCode = 1;
-    }
+    process.exitCode = typeof err.exitCode === "number" ? err.exitCode : 1;
   });
   const ctx = createProgramContext();
   const argv = process.argv;

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { Command } from "commander";
 import { registerProgramCommands } from "./command-registry.js";
 import { createProgramContext } from "./context.js";
@@ -8,11 +9,12 @@ import { setProgramContext } from "./program-context.js";
 export function buildProgram() {
   const program = new Command();
   program.enablePositionalOptions();
-  // Ensure Commander.js sets exit code on argument errors (fixes #60905)
-  // Without this, commands like `openclaw sessions list` would print an error
-  // but exit with code 0, breaking scripts and monitoring tools.
+  // Preserve Commander-computed exit codes while still aborting parse flow.
+  // Without this, commands like `openclaw sessions list` can print an error
+  // but still report success when exits are intercepted.
   program.exitOverride((err) => {
     process.exitCode = typeof err.exitCode === "number" ? err.exitCode : 1;
+    throw err;
   });
   const ctx = createProgramContext();
   const argv = process.argv;

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -1,4 +1,5 @@
 import process from "node:process";
+import { CommanderError } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { runCli } from "./run-main.js";
 
@@ -14,6 +15,9 @@ const startTaskRegistryMaintenanceMock = vi.hoisted(() => vi.fn());
 const outputRootHelpMock = vi.hoisted(() => vi.fn());
 const outputPrecomputedRootHelpTextMock = vi.hoisted(() => vi.fn(() => false));
 const buildProgramMock = vi.hoisted(() => vi.fn());
+const getProgramContextMock = vi.hoisted(() => vi.fn(() => null));
+const registerCoreCliByNameMock = vi.hoisted(() => vi.fn());
+const registerSubCliByNameMock = vi.hoisted(() => vi.fn());
 const maybeRunCliInContainerMock = vi.hoisted(() =>
   vi.fn<
     (argv: string[]) => { handled: true; exitCode: number } | { handled: false; argv: string[] }
@@ -73,11 +77,24 @@ vi.mock("./program.js", () => ({
   buildProgram: buildProgramMock,
 }));
 
+vi.mock("./program/program-context.js", () => ({
+  getProgramContext: getProgramContextMock,
+}));
+
+vi.mock("./program/command-registry.js", () => ({
+  registerCoreCliByName: registerCoreCliByNameMock,
+}));
+
+vi.mock("./program/register.subclis.js", () => ({
+  registerSubCliByName: registerSubCliByNameMock,
+}));
+
 describe("runCli exit behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hasMemoryRuntimeMock.mockReturnValue(false);
     outputPrecomputedRootHelpTextMock.mockReturnValue(false);
+    getProgramContextMock.mockReturnValue(null);
   });
 
   it("does not force process.exit after successful routed command", async () => {
@@ -147,6 +164,24 @@ describe("runCli exit behavior", () => {
     await runCli(["node", "openclaw", "--container", "demo", "status"]);
 
     expect(process.exitCode).toBe(7);
+    process.exitCode = exitCode;
+  });
+
+  it("swallows Commander parse exits after recording the exit code", async () => {
+    const exitCode = process.exitCode;
+    buildProgramMock.mockReturnValueOnce({
+      commands: [{ name: () => "status" }],
+      parseAsync: vi
+        .fn()
+        .mockRejectedValueOnce(
+          new CommanderError(1, "commander.excessArguments", "too many arguments for 'status'"),
+        ),
+    });
+
+    await expect(runCli(["node", "openclaw", "status"])).resolves.toBeUndefined();
+
+    expect(registerSubCliByNameMock).toHaveBeenCalledWith(expect.anything(), "status");
+    expect(process.exitCode).toBe(1);
     process.exitCode = exitCode;
   });
 });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { CommanderError } from "commander";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { normalizeEnv } from "../infra/env.js";
@@ -231,7 +232,14 @@ export async function runCli(argv: string[] = process.argv) {
       }
     }
 
-    await program.parseAsync(parseArgv);
+    try {
+      await program.parseAsync(parseArgv);
+    } catch (error) {
+      if (!(error instanceof CommanderError)) {
+        throw error;
+      }
+      process.exitCode = error.exitCode;
+    }
   } finally {
     await closeCliMemoryManagers();
   }


### PR DESCRIPTION
## Summary

Fixes #60905

When CLI commands receive invalid arguments (e.g., `openclaw sessions list`), Commander.js prints an error but was returning exit code 0. This broke scripts and monitoring tools that rely on exit codes to detect failures.

## Solution

Call `program.exitOverride()` with a callback that sets `process.exitCode = 1` for all errors except help/version displays.

## Before

```bash
$ openclaw sessions list 2>&1
error: too many arguments for 'sessions'. Expected 0 arguments but got 1.
$ echo $?
0
```

## After

```bash
$ openclaw sessions list 2>&1
error: too many arguments for 'sessions'. Expected 0 arguments but got 1.
$ echo $?
1
```

## Test Coverage

Added 3 new unit tests to verify exit code behavior:
- ✅ Argument errors set `exitCode = 1`
- ✅ `--help` sets `exitCode = 0` (handles `commander.helpDisplayed`)
- ✅ `--version` sets `exitCode = 0`

## Test Plan

- [x] Unit tests pass: `pnpm test src/cli/program/build-program.test.ts`
- [x] Manual test confirms exit code is now 1 on argument errors
- [x] Help (`--help`) still exits with code 0
- [x] Version (`--version`) still exits with code 0