### PR TITLE
CLI: refresh skills snapshot for agent runs

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -79,7 +79,12 @@ import {
 } from "./model-selection.js";
 import { buildWorkspaceSkillSnapshot } from "./skills.js";
 import { matchesSkillFilter } from "./skills/filter.js";
-import { getSkillsSnapshotVersion, shouldRefreshSnapshotForVersion } from "./skills/refresh.js";
+import {
+  bumpSkillsSnapshotVersion,
+  ensureSkillsWatcher,
+  getSkillsSnapshotVersion,
+  shouldRefreshSnapshotForVersion,
+} from "./skills/refresh.js";
 import { normalizeSpawnedRunMetadata } from "./spawned-context.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 import { ensureAgentWorkspace } from "./workspace.js";
@@ -328,7 +333,7 @@ async function prepareAgentCommandExecution(
 }
 
 async function agentCommandInternal(
-  opts: AgentCommandOpts & { senderIsOwner: boolean },
+  opts: AgentCommandOpts & { senderIsOwner: boolean; forceSkillsSnapshotRefresh?: boolean },
   runtime: RuntimeEnv = defaultRuntime,
   deps: CliDeps = createDefaultDeps(),
 ) {
@@ -498,6 +503,13 @@ async function agentCommandInternal(
       });
     }
 
+    ensureSkillsWatcher({ workspaceDir, config: cfg });
+    if (opts.forceSkillsSnapshotRefresh) {
+      // One-shot CLI runs do not keep a long-lived watcher process alive, so
+      // skill changes made between invocations would otherwise leave reused
+      // session snapshots stale. Force a snapshot version bump for this entrypoint.
+      bumpSkillsSnapshotVersion({ workspaceDir, reason: "manual" });
+    }
     const skillsSnapshotVersion = getSkillsSnapshotVersion(workspaceDir);
     const skillFilter = resolveAgentSkillsFilter(cfg, sessionAgentId);
     const currentSkillsSnapshot = sessionEntry?.skillsSnapshot;
@@ -890,6 +902,7 @@ export async function agentCommand(
       senderIsOwner: opts.senderIsOwner ?? true,
       // Local/CLI callers are trusted by default for per-run model overrides.
       allowModelOverride: opts.allowModelOverride ?? true,
+      forceSkillsSnapshotRefresh: true,
     },
     runtime,
     deps,
@@ -914,6 +927,7 @@ export async function agentCommandFromIngress(
       ...opts,
       senderIsOwner: opts.senderIsOwner,
       allowModelOverride: opts.allowModelOverride,
+      forceSkillsSnapshotRefresh: false,
     },
     runtime,
     deps,

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -82,7 +82,14 @@ vi.mock("../agents/skills.js", () => ({
 }));
 
 vi.mock("../agents/skills/refresh.js", () => ({
+  bumpSkillsSnapshotVersion: vi.fn(() => 1),
+  ensureSkillsWatcher: vi.fn(),
   getSkillsSnapshotVersion: vi.fn(() => 0),
+  shouldRefreshSnapshotForVersion: vi.fn((cached?: number, next?: number) => {
+    const cachedValue = typeof cached === "number" ? cached : 0;
+    const nextValue = typeof next === "number" ? next : 0;
+    return nextValue === 0 ? cachedValue > 0 : cachedValue < nextValue;
+  }),
 }));
 
 const runtime: RuntimeEnv = {
@@ -356,6 +363,7 @@ describe("agentCommand", () => {
         loadModelCatalogMock,
         isCliProviderMock,
       } = await loadFreshAgentCommandModulesForTest();
+      const skillsRefreshModuleFresh = await import("../agents/skills/refresh.js");
       const freshConfigSpy = vi.spyOn(configModuleFresh, "loadConfig");
       const freshReadConfigFileSnapshotForWriteSpy = vi.spyOn(
         configModuleFresh,
@@ -434,6 +442,14 @@ describe("agentCommand", () => {
         config: loadedConfig,
         commandName: "agent",
         targetIds: expect.any(Set),
+      });
+      expect(skillsRefreshModuleFresh.ensureSkillsWatcher).toHaveBeenCalledWith({
+        workspaceDir: path.join(home, "openclaw"),
+        config: resolvedConfig,
+      });
+      expect(skillsRefreshModuleFresh.bumpSkillsSnapshotVersion).toHaveBeenCalledWith({
+        workspaceDir: path.join(home, "openclaw"),
+        reason: "manual",
       });
       expect(freshSetRuntimeConfigSnapshotSpy).toHaveBeenCalledWith(resolvedConfig, sourceConfig);
       expect(runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0]?.config).toBe(resolvedConfig);


### PR DESCRIPTION
## Summary

- Problem: `openclaw agent` could reuse a stale `skillsSnapshot` for long-lived sessions, so newly added `skills.load.extraDirs` skills showed up in `openclaw skills list` but did not reach the actual main-agent prompt.
- Why it matters: this breaks real skill validation flows, especially when testing temporary skills against the main agent without resetting session state.
- What changed: CLI/trusted-operator agent runs now start the skills watcher and force a one-shot skills snapshot version bump before rebuilding the snapshot; the existing agent command test now asserts that behavior.
- What did NOT change (scope boundary): ingress/gateway agent runs do not force a manual bump; this change is limited to the `openclaw agent` CLI path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the CLI `agentCommand()` path reused persisted session `skillsSnapshot` state but did not have a persistent watcher lifecycle to bump the snapshot version when local skill files changed.
- Missing detection / guardrail: the command path did not force a refresh for one-shot CLI invocations, and tests did not assert refresh behavior for that path.
- Contributing context (if known): `openclaw skills list` uses live discovery, so the skill looked available even though the reused main-agent session prompt stayed stale.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/agent.test.ts`
- Scenario the test should lock in: CLI agent runs start the skills watcher and manually bump the snapshot version before rebuilding the runtime snapshot.
- Why this is the smallest reliable guardrail: it exercises the exact command path that was stale without introducing full runtime/provider dependence.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw agent` now picks up newly added or edited skills for CLI/main-agent validation flows without requiring a manual session reset.

## Diagram (if applicable)

```text
Before:
edit extraDirs skill -> openclaw skills list sees it -> openclaw agent reuses stale snapshot -> skill missing at runtime

After:
edit extraDirs skill -> openclaw agent bumps snapshot version -> snapshot rebuilt -> runtime sees correct skill path
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local CLI / embedded agent runtime
- Model/provider: `minimax-cn/MiniMax-M2.7`
- Integration/channel (if any): none (`--local`)
- Relevant config (redacted): `skills.load.extraDirs` pointed at a temporary shared skills directory

### Steps

1. Add a temporary skill under a directory configured in `skills.load.extraDirs`.
2. Confirm `openclaw skills list` shows the skill.
3. Run `pnpm openclaw agent --agent main --session-id <fixed> --local --message "What is the incubator phrase?"`.

### Expected

- The main agent prompt includes the new skill and the run follows it.

### Actual

- Before this patch, the CLI reused a stale `skillsSnapshot`, so the skill was missing from the prompt and the agent either answered generically or guessed a wrong path.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Confirmed the bug before the fix: `openclaw skills list` showed the temporary extra-dir skill, but `openclaw agent --agent main --local` reused a stale snapshot and did not apply it.
  - Confirmed the fix after the change with `pnpm openclaw agent --agent main --session-id tmp-skill-check-fix-20260404-natural --local --message "What is the incubator phrase?"`, which returned `TEMP-SKILL-OK-9842`.
- Edge cases checked:
  - Explicit skill mention also resolved to the real extra-dir `SKILL.md` path after the fix.
  - Ingress path remains on the non-forced-refresh behavior.
- What you did **not** verify:
  - Full repo `pnpm test` and `pnpm build` were not run for this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: CLI agent runs now force a one-shot skills snapshot refresh even when a reused session exists.
  - Mitigation: the forced bump is scoped to the trusted local CLI path only; ingress/gateway paths keep existing behavior.
