### PR TITLE
matrix: add exec approval reaction shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,8 +175,8 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: restore `channels.whatsapp.blockStreaming` and reset watchdog timeouts after reconnect so quiet chats stop falling into reconnect loops. (#60007, #60069) Thanks @MonkeyLeeT and @mcaxtr.
 - Windows/restart: fall back to the installed Startup-entry launcher when the scheduled task was never registered, so `/restart` can relaunch the gateway on Windows setups where `schtasks` install fell back during onboarding. (#58943) Thanks @imechZhangLY.
 - Agents/Claude CLI: persist routed Claude session bindings, rotate them on `/new` and `/reset`, and keep live Claude CLI model switches moving across the configured Claude family so resumed sessions follow the real active thread and model. Thanks @vincentkoc.
-- Matrix/exec approvals: anchor seeded approval reactions to the primary Matrix prompt event, resolve them from event metadata instead of prompt text, and clean up chunked approval prompts correctly. (#60931) thanks @gumadeiras.
 - Providers/Anthropic: when Claude CLI auth becomes the default, write a real `claude-cli` auth profile so local and gateway agent runs can use Claude CLI immediately without missing-API-key failures. Thanks @vincentkoc.
+- Matrix/exec approvals: anchor seeded approval reactions to the primary Matrix prompt event, resolve them from event metadata instead of prompt text, and clean up chunked approval prompts correctly. (#60931) thanks @gumadeiras.
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,6 @@ Docs: https://docs.openclaw.ai
 - Auth/failover: persist selected fallback overrides before retrying, shorten `auth_permanent` lockouts, and refresh websocket/shared-auth sessions only when real auth changes occur so retries and secret rotations behave predictably. (#60404, #60323, #60387) Thanks @extrasmall0 and @mappel-nv.
 - CLI/Commander: preserve Commander-computed exit codes for argument and help-error paths, and cover the user-argv parse mode in the regression tests so invalid CLI invocations no longer report success when exits are intercepted. (#60923) Thanks @Linux2010.
 - CLI/skills JSON: route `skills list --json`, `skills info --json`, and `skills check --json` output to stdout instead of stderr so machine-readable consumers receive JSON on the expected stream again. (#60914; fixes #57599; landed from contributor PR #57611 by @Aftabbs) Thanks @Aftabbs.
-<<<<<<< HEAD
 - Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the rendered snapshot. (#28214) Thanks @solodmd.
 - Control UI/avatar: honor `ui.assistant.avatar` when serving `/avatar/:agentId` so Appearance UI avatar paths stop falling back to initials placeholders. (#60778) Thanks @hannasdev.
 - Control UI/chat: add a per-session thinking-level picker in the chat header and mobile chat settings, and keep the browser bundle on UI-local thinking/session-key helpers so Safari no longer crashes on Node-only imports before rendering chat controls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Docs: https://docs.openclaw.ai
 - Auth/failover: persist selected fallback overrides before retrying, shorten `auth_permanent` lockouts, and refresh websocket/shared-auth sessions only when real auth changes occur so retries and secret rotations behave predictably. (#60404, #60323, #60387) Thanks @extrasmall0 and @mappel-nv.
 - CLI/Commander: preserve Commander-computed exit codes for argument and help-error paths, and cover the user-argv parse mode in the regression tests so invalid CLI invocations no longer report success when exits are intercepted. (#60923) Thanks @Linux2010.
 - CLI/skills JSON: route `skills list --json`, `skills info --json`, and `skills check --json` output to stdout instead of stderr so machine-readable consumers receive JSON on the expected stream again. (#60914; fixes #57599; landed from contributor PR #57611 by @Aftabbs) Thanks @Aftabbs.
+<<<<<<< HEAD
 - Config/All Settings: keep the raw config view intact when sensitive fields are blank instead of corrupting or dropping the rendered snapshot. (#28214) Thanks @solodmd.
 - Control UI/avatar: honor `ui.assistant.avatar` when serving `/avatar/:agentId` so Appearance UI avatar paths stop falling back to initials placeholders. (#60778) Thanks @hannasdev.
 - Control UI/chat: add a per-session thinking-level picker in the chat header and mobile chat settings, and keep the browser bundle on UI-local thinking/session-key helpers so Safari no longer crashes on Node-only imports before rendering chat controls.
@@ -175,6 +176,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: restore `channels.whatsapp.blockStreaming` and reset watchdog timeouts after reconnect so quiet chats stop falling into reconnect loops. (#60007, #60069) Thanks @MonkeyLeeT and @mcaxtr.
 - Windows/restart: fall back to the installed Startup-entry launcher when the scheduled task was never registered, so `/restart` can relaunch the gateway on Windows setups where `schtasks` install fell back during onboarding. (#58943) Thanks @imechZhangLY.
 - Agents/Claude CLI: persist routed Claude session bindings, rotate them on `/new` and `/reset`, and keep live Claude CLI model switches moving across the configured Claude family so resumed sessions follow the real active thread and model. Thanks @vincentkoc.
+- Matrix/exec approvals: anchor seeded approval reactions to the primary Matrix prompt event, resolve them from event metadata instead of prompt text, and clean up chunked approval prompts correctly. (#60931) thanks @gumadeiras.
 - Providers/Anthropic: when Claude CLI auth becomes the default, write a real `claude-cli` auth profile so local and gateway agent runs can use Claude CLI immediately without missing-API-key failures. Thanks @vincentkoc.
 
 ## 2026.4.2

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -19,16 +19,6 @@ packaged builds do not need a separate install.
 If you are on an older build or a custom install that excludes Matrix, install
 it manually:
 
-## Exec approvals
-
-When `channels.matrix.execApprovals.enabled` is on, Matrix approval prompts seed reaction shortcuts on the pending approval message:
-
-- `✅` = allow once
-- `❌` = deny
-- `♾️` = allow always when that decision is allowed by the effective exec policy
-
-The original `/approve ...` commands stay in the message as a fallback.
-
 Install from npm:
 
 ```bash
@@ -689,7 +679,13 @@ Delivery rules:
 - `target: "channel"` sends the prompt back to the originating Matrix room or DM
 - `target: "both"` sends to approver DMs and the originating Matrix room or DM
 
-Matrix uses text approval prompts today. Approvers resolve them with `/approve <id> allow-once`, `/approve <id> allow-always`, or `/approve <id> deny`.
+Matrix approval prompts seed reaction shortcuts on the primary approval message:
+
+- `✅` = allow once
+- `❌` = deny
+- `♾️` = allow always when that decision is allowed by the effective exec policy
+
+Approvers can react on that message or use the fallback slash commands: `/approve <id> allow-once`, `/approve <id> allow-always`, or `/approve <id> deny`.
 
 Only resolved approvers can approve or deny. Channel delivery includes the command text, so only enable `channel` or `both` in trusted rooms.
 

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -19,6 +19,16 @@ packaged builds do not need a separate install.
 If you are on an older build or a custom install that excludes Matrix, install
 it manually:
 
+## Exec approvals
+
+When `channels.matrix.execApprovals.enabled` is on, Matrix approval prompts seed reaction shortcuts on the pending approval message:
+
+- `✅` = allow once
+- `❌` = deny
+- `♾️` = allow always when that decision is allowed by the effective exec policy
+
+The original `/approve ...` commands stay in the message as a fallback.
+
 Install from npm:
 
 ```bash

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -24,6 +24,11 @@ host policy sources, and the effective result.
 If the companion app UI is **not available**, any request that requires a prompt is
 resolved by the **ask fallback** (default: deny).
 
+Native chat approval clients can also expose channel-specific affordances on the
+pending approval message. For example, Matrix can seed reaction shortcuts on the
+approval prompt (`✅` allow once, `❌` deny, and `♾️` allow always when available)
+while still leaving the `/approve ...` commands in the message as a fallback.
+
 ## Where it applies
 
 Exec approvals are enforced locally on the execution host:

--- a/extensions/matrix/src/approval-reactions.test.ts
+++ b/extensions/matrix/src/approval-reactions.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildMatrixApprovalReactionHint,
+  clearMatrixApprovalReactionTargetsForTest,
   listMatrixApprovalReactionBindings,
+  registerMatrixApprovalReactionTarget,
   resolveMatrixApprovalReactionTarget,
+  unregisterMatrixApprovalReactionTarget,
 } from "./approval-reactions.js";
+
+afterEach(() => {
+  clearMatrixApprovalReactionTargetsForTest();
+});
 
 describe("matrix approval reactions", () => {
   it("lists reactions in stable decision order", () => {
@@ -20,73 +27,81 @@ describe("matrix approval reactions", () => {
     );
   });
 
-  it("resolves a reaction back to the approval decision exposed in the prompt text", () => {
-    const text = [
-      "Approval required.",
-      "",
-      "Run:",
-      "```txt",
-      "/approve req-123 allow-once",
-      "```",
-      "",
-      "Other options:",
-      "```txt",
-      "/approve req-123 allow-always",
-      "/approve req-123 deny",
-      "```",
-    ].join("\n");
+  it("resolves a registered approval anchor event back to an approval decision", () => {
+    registerMatrixApprovalReactionTarget({
+      roomId: "!ops:example.org",
+      eventId: "$approval-msg",
+      approvalId: "req-123",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
 
-    expect(resolveMatrixApprovalReactionTarget(text, "✅")).toEqual({
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:example.org",
+        eventId: "$approval-msg",
+        reactionKey: "✅",
+      }),
+    ).toEqual({
       approvalId: "req-123",
       decision: "allow-once",
     });
-    expect(resolveMatrixApprovalReactionTarget(text, "♾️")).toEqual({
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:example.org",
+        eventId: "$approval-msg",
+        reactionKey: "♾️",
+      }),
+    ).toEqual({
       approvalId: "req-123",
       decision: "allow-always",
     });
-    expect(resolveMatrixApprovalReactionTarget(text, "❌")).toEqual({
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:example.org",
+        eventId: "$approval-msg",
+        reactionKey: "❌",
+      }),
+    ).toEqual({
       approvalId: "req-123",
       decision: "deny",
     });
   });
 
-  it("ignores reactions that are not available in the prompt text", () => {
-    const text = [
-      "Approval required.",
-      "",
-      "Run:",
-      "```txt",
-      "/approve req-123 allow-once",
-      "```",
-      "",
-      "Other options:",
-      "```txt",
-      "/approve req-123 deny",
-      "```",
-    ].join("\n");
+  it("ignores reactions that are not allowed on the registered approval anchor event", () => {
+    registerMatrixApprovalReactionTarget({
+      roomId: "!ops:example.org",
+      eventId: "$approval-msg",
+      approvalId: "req-123",
+      allowedDecisions: ["allow-once", "deny"],
+    });
 
-    expect(resolveMatrixApprovalReactionTarget(text, "♾️")).toBeNull();
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:example.org",
+        eventId: "$approval-msg",
+        reactionKey: "♾️",
+      }),
+    ).toBeNull();
   });
 
-  it("reuses the shared command parser for mention and legacy alias forms", () => {
-    const text = [
-      "Approval required.",
-      "",
-      "Run:",
-      "```txt",
-      "/approve@claw req-123 allow-once",
-      "```",
-      "",
-      "Other options:",
-      "```txt",
-      "/approve req-123 always",
-      "/approve req-123 deny",
-      "```",
-    ].join("\n");
-
-    expect(resolveMatrixApprovalReactionTarget(text, "♾️")).toEqual({
+  it("stops resolving reactions after the approval anchor event is unregistered", () => {
+    registerMatrixApprovalReactionTarget({
+      roomId: "!ops:example.org",
+      eventId: "$approval-msg",
       approvalId: "req-123",
-      decision: "allow-always",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
     });
+    unregisterMatrixApprovalReactionTarget({
+      roomId: "!ops:example.org",
+      eventId: "$approval-msg",
+    });
+
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:example.org",
+        eventId: "$approval-msg",
+        reactionKey: "✅",
+      }),
+    ).toBeNull();
   });
 });

--- a/extensions/matrix/src/approval-reactions.test.ts
+++ b/extensions/matrix/src/approval-reactions.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMatrixApprovalReactionHint,
+  listMatrixApprovalReactionBindings,
+  resolveMatrixApprovalReactionTarget,
+} from "./approval-reactions.js";
+
+describe("matrix approval reactions", () => {
+  it("lists reactions in stable decision order", () => {
+    expect(listMatrixApprovalReactionBindings(["allow-once", "deny", "allow-always"])).toEqual([
+      { decision: "allow-once", emoji: "✅", label: "Allow once" },
+      { decision: "allow-always", emoji: "♾️", label: "Allow always" },
+      { decision: "deny", emoji: "❌", label: "Deny" },
+    ]);
+  });
+
+  it("builds a compact reaction hint", () => {
+    expect(buildMatrixApprovalReactionHint(["allow-once", "deny"])).toBe(
+      "React here: ✅ Allow once, ❌ Deny",
+    );
+  });
+
+  it("resolves a reaction back to the approval decision exposed in the prompt text", () => {
+    const text = [
+      "Approval required.",
+      "",
+      "Run:",
+      "```txt",
+      "/approve req-123 allow-once",
+      "```",
+      "",
+      "Other options:",
+      "```txt",
+      "/approve req-123 allow-always",
+      "/approve req-123 deny",
+      "```",
+    ].join("\n");
+
+    expect(resolveMatrixApprovalReactionTarget(text, "✅")).toEqual({
+      approvalId: "req-123",
+      decision: "allow-once",
+    });
+    expect(resolveMatrixApprovalReactionTarget(text, "♾️")).toEqual({
+      approvalId: "req-123",
+      decision: "allow-always",
+    });
+    expect(resolveMatrixApprovalReactionTarget(text, "❌")).toEqual({
+      approvalId: "req-123",
+      decision: "deny",
+    });
+  });
+
+  it("ignores reactions that are not available in the prompt text", () => {
+    const text = [
+      "Approval required.",
+      "",
+      "Run:",
+      "```txt",
+      "/approve req-123 allow-once",
+      "```",
+      "",
+      "Other options:",
+      "```txt",
+      "/approve req-123 deny",
+      "```",
+    ].join("\n");
+
+    expect(resolveMatrixApprovalReactionTarget(text, "♾️")).toBeNull();
+  });
+
+  it("reuses the shared command parser for mention and legacy alias forms", () => {
+    const text = [
+      "Approval required.",
+      "",
+      "Run:",
+      "```txt",
+      "/approve@claw req-123 allow-once",
+      "```",
+      "",
+      "Other options:",
+      "```txt",
+      "/approve req-123 always",
+      "/approve req-123 deny",
+      "```",
+    ].join("\n");
+
+    expect(resolveMatrixApprovalReactionTarget(text, "♾️")).toEqual({
+      approvalId: "req-123",
+      decision: "allow-always",
+    });
+  });
+});

--- a/extensions/matrix/src/approval-reactions.ts
+++ b/extensions/matrix/src/approval-reactions.ts
@@ -1,24 +1,5 @@
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-runtime";
 
-const APPROVE_COMMAND_REGEX =
-  /\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(allow-once|allow-always|always|deny)\b/i;
-
-function parseExecApprovalCommandText(
-  raw: string,
-): { approvalId: string; decision: ExecApprovalReplyDecision } | null {
-  const trimmed = raw.trim();
-  const match = trimmed.match(APPROVE_COMMAND_REGEX);
-  if (!match) {
-    return null;
-  }
-  const rawDecision = (match[2] ?? "").toLowerCase();
-  return {
-    approvalId: match[1] ?? "",
-    decision:
-      rawDecision === "always" ? "allow-always" : (rawDecision as ExecApprovalReplyDecision),
-  };
-}
-
 const MATRIX_APPROVAL_REACTION_META = {
   "allow-once": {
     emoji: "✅",
@@ -50,6 +31,22 @@ export type MatrixApprovalReactionResolution = {
   approvalId: string;
   decision: ExecApprovalReplyDecision;
 };
+
+type MatrixApprovalReactionTarget = {
+  approvalId: string;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+};
+
+const matrixApprovalReactionTargets = new Map<string, MatrixApprovalReactionTarget>();
+
+function buildReactionTargetKey(roomId: string, eventId: string): string | null {
+  const normalizedRoomId = roomId.trim();
+  const normalizedEventId = eventId.trim();
+  if (!normalizedRoomId || !normalizedEventId) {
+    return null;
+  }
+  return `${normalizedRoomId}:${normalizedEventId}`;
+}
 
 export function listMatrixApprovalReactionBindings(
   allowedDecisions: readonly ExecApprovalReplyDecision[],
@@ -94,32 +91,68 @@ export function resolveMatrixApprovalReactionDecision(
   return null;
 }
 
-export function resolveMatrixApprovalReactionTarget(
-  messageText: string,
-  reactionKey: string,
-): MatrixApprovalReactionResolution | null {
-  const allowedDecisions = new Set<ExecApprovalReplyDecision>();
-  let approvalId: string | null = null;
-  for (const line of messageText.split(/\r?\n/)) {
-    const parsed = parseExecApprovalCommandText(line);
-    if (!parsed) {
-      continue;
-    }
-    if (approvalId && approvalId !== parsed.approvalId) {
-      return null;
-    }
-    approvalId = parsed.approvalId;
-    allowedDecisions.add(parsed.decision);
+export function registerMatrixApprovalReactionTarget(params: {
+  roomId: string;
+  eventId: string;
+  approvalId: string;
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+}): void {
+  const key = buildReactionTargetKey(params.roomId, params.eventId);
+  const approvalId = params.approvalId.trim();
+  const allowedDecisions = Array.from(
+    new Set(
+      params.allowedDecisions.filter(
+        (decision): decision is ExecApprovalReplyDecision =>
+          decision === "allow-once" || decision === "allow-always" || decision === "deny",
+      ),
+    ),
+  );
+  if (!key || !approvalId || allowedDecisions.length === 0) {
+    return;
   }
-  if (!approvalId || allowedDecisions.size === 0) {
+  matrixApprovalReactionTargets.set(key, {
+    approvalId,
+    allowedDecisions,
+  });
+}
+
+export function unregisterMatrixApprovalReactionTarget(params: {
+  roomId: string;
+  eventId: string;
+}): void {
+  const key = buildReactionTargetKey(params.roomId, params.eventId);
+  if (!key) {
+    return;
+  }
+  matrixApprovalReactionTargets.delete(key);
+}
+
+export function resolveMatrixApprovalReactionTarget(params: {
+  roomId: string;
+  eventId: string;
+  reactionKey: string;
+}): MatrixApprovalReactionResolution | null {
+  const key = buildReactionTargetKey(params.roomId, params.eventId);
+  if (!key) {
     return null;
   }
-  const decision = resolveMatrixApprovalReactionDecision(reactionKey, Array.from(allowedDecisions));
+  const target = matrixApprovalReactionTargets.get(key);
+  if (!target) {
+    return null;
+  }
+  const decision = resolveMatrixApprovalReactionDecision(
+    params.reactionKey,
+    target.allowedDecisions,
+  );
   if (!decision) {
     return null;
   }
   return {
-    approvalId,
+    approvalId: target.approvalId,
     decision,
   };
+}
+
+export function clearMatrixApprovalReactionTargetsForTest(): void {
+  matrixApprovalReactionTargets.clear();
 }

--- a/extensions/matrix/src/approval-reactions.ts
+++ b/extensions/matrix/src/approval-reactions.ts
@@ -1,0 +1,125 @@
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-runtime";
+
+const APPROVE_COMMAND_REGEX =
+  /\/approve(?:@[^\s]+)?\s+([A-Za-z0-9][A-Za-z0-9._:-]*)\s+(allow-once|allow-always|always|deny)\b/i;
+
+function parseExecApprovalCommandText(
+  raw: string,
+): { approvalId: string; decision: ExecApprovalReplyDecision } | null {
+  const trimmed = raw.trim();
+  const match = trimmed.match(APPROVE_COMMAND_REGEX);
+  if (!match) {
+    return null;
+  }
+  const rawDecision = (match[2] ?? "").toLowerCase();
+  return {
+    approvalId: match[1] ?? "",
+    decision:
+      rawDecision === "always" ? "allow-always" : (rawDecision as ExecApprovalReplyDecision),
+  };
+}
+
+const MATRIX_APPROVAL_REACTION_META = {
+  "allow-once": {
+    emoji: "✅",
+    label: "Allow once",
+  },
+  "allow-always": {
+    emoji: "♾️",
+    label: "Allow always",
+  },
+  deny: {
+    emoji: "❌",
+    label: "Deny",
+  },
+} satisfies Record<ExecApprovalReplyDecision, { emoji: string; label: string }>;
+
+const MATRIX_APPROVAL_REACTION_ORDER = [
+  "allow-once",
+  "allow-always",
+  "deny",
+] as const satisfies readonly ExecApprovalReplyDecision[];
+
+export type MatrixApprovalReactionBinding = {
+  decision: ExecApprovalReplyDecision;
+  emoji: string;
+  label: string;
+};
+
+export type MatrixApprovalReactionResolution = {
+  approvalId: string;
+  decision: ExecApprovalReplyDecision;
+};
+
+export function listMatrixApprovalReactionBindings(
+  allowedDecisions: readonly ExecApprovalReplyDecision[],
+): MatrixApprovalReactionBinding[] {
+  const allowed = new Set(allowedDecisions);
+  return MATRIX_APPROVAL_REACTION_ORDER.filter((decision) => allowed.has(decision)).map(
+    (decision) => ({
+      decision,
+      emoji: MATRIX_APPROVAL_REACTION_META[decision].emoji,
+      label: MATRIX_APPROVAL_REACTION_META[decision].label,
+    }),
+  );
+}
+
+export function buildMatrixApprovalReactionHint(
+  allowedDecisions: readonly ExecApprovalReplyDecision[],
+): string | null {
+  const bindings = listMatrixApprovalReactionBindings(allowedDecisions);
+  if (bindings.length === 0) {
+    return null;
+  }
+  return `React here: ${bindings.map((binding) => `${binding.emoji} ${binding.label}`).join(", ")}`;
+}
+
+export function resolveMatrixApprovalReactionDecision(
+  reactionKey: string,
+  allowedDecisions: readonly ExecApprovalReplyDecision[],
+): ExecApprovalReplyDecision | null {
+  const normalizedReaction = reactionKey.trim();
+  if (!normalizedReaction) {
+    return null;
+  }
+  const allowed = new Set(allowedDecisions);
+  for (const decision of MATRIX_APPROVAL_REACTION_ORDER) {
+    if (!allowed.has(decision)) {
+      continue;
+    }
+    if (MATRIX_APPROVAL_REACTION_META[decision].emoji === normalizedReaction) {
+      return decision;
+    }
+  }
+  return null;
+}
+
+export function resolveMatrixApprovalReactionTarget(
+  messageText: string,
+  reactionKey: string,
+): MatrixApprovalReactionResolution | null {
+  const allowedDecisions = new Set<ExecApprovalReplyDecision>();
+  let approvalId: string | null = null;
+  for (const line of messageText.split(/\r?\n/)) {
+    const parsed = parseExecApprovalCommandText(line);
+    if (!parsed) {
+      continue;
+    }
+    if (approvalId && approvalId !== parsed.approvalId) {
+      return null;
+    }
+    approvalId = parsed.approvalId;
+    allowedDecisions.add(parsed.decision);
+  }
+  if (!approvalId || allowedDecisions.size === 0) {
+    return null;
+  }
+  const decision = resolveMatrixApprovalReactionDecision(reactionKey, Array.from(allowedDecisions));
+  if (!decision) {
+    return null;
+  }
+  return {
+    approvalId,
+    decision,
+  };
+}

--- a/extensions/matrix/src/exec-approval-resolver.test.ts
+++ b/extensions/matrix/src/exec-approval-resolver.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const gatewayRuntimeHoisted = vi.hoisted(() => ({
+  requestSpy: vi.fn(),
+  startSpy: vi.fn(),
+  stopSpy: vi.fn(),
+  stopAndWaitSpy: vi.fn(async () => undefined),
+  createClientSpy: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/gateway-runtime", () => ({
+  createOperatorApprovalsGatewayClient: gatewayRuntimeHoisted.createClientSpy,
+}));
+
+describe("resolveMatrixExecApproval", () => {
+  beforeEach(() => {
+    gatewayRuntimeHoisted.requestSpy.mockReset();
+    gatewayRuntimeHoisted.startSpy.mockReset();
+    gatewayRuntimeHoisted.stopSpy.mockReset();
+    gatewayRuntimeHoisted.stopAndWaitSpy.mockReset().mockResolvedValue(undefined);
+    gatewayRuntimeHoisted.createClientSpy.mockReset().mockImplementation((opts) => ({
+      start: () => {
+        gatewayRuntimeHoisted.startSpy();
+        opts.onHelloOk?.();
+      },
+      request: gatewayRuntimeHoisted.requestSpy,
+      stop: gatewayRuntimeHoisted.stopSpy,
+      stopAndWait: gatewayRuntimeHoisted.stopAndWaitSpy,
+    }));
+  });
+
+  it("submits exec approval resolutions through the gateway approvals client", async () => {
+    const { resolveMatrixExecApproval } = await import("./exec-approval-resolver.js");
+
+    await resolveMatrixExecApproval({
+      cfg: {} as never,
+      approvalId: "req-123",
+      decision: "allow-once",
+      senderId: "@owner:example.org",
+    });
+
+    expect(gatewayRuntimeHoisted.requestSpy).toHaveBeenCalledWith("exec.approval.resolve", {
+      id: "req-123",
+      decision: "allow-once",
+    });
+  });
+
+  it("recognizes structured approval-not-found errors", async () => {
+    const { isApprovalNotFoundError } = await import("./exec-approval-resolver.js");
+    const err = new Error("approval not found");
+    (err as Error & { gatewayCode?: string; details?: { reason?: string } }).gatewayCode =
+      "INVALID_REQUEST";
+    (err as Error & { gatewayCode?: string; details?: { reason?: string } }).details = {
+      reason: "APPROVAL_NOT_FOUND",
+    };
+
+    expect(isApprovalNotFoundError(err)).toBe(true);
+  });
+});

--- a/extensions/matrix/src/exec-approval-resolver.ts
+++ b/extensions/matrix/src/exec-approval-resolver.ts
@@ -1,0 +1,91 @@
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { createOperatorApprovalsGatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
+
+const INVALID_REQUEST = "INVALID_REQUEST";
+const APPROVAL_NOT_FOUND = "APPROVAL_NOT_FOUND";
+
+function readErrorCode(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function readApprovalNotFoundDetailsReason(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const reason = (value as { reason?: unknown }).reason;
+  return typeof reason === "string" && reason.trim() ? reason : null;
+}
+
+export function isApprovalNotFoundError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const gatewayCode = readErrorCode((err as { gatewayCode?: unknown }).gatewayCode);
+  if (gatewayCode === APPROVAL_NOT_FOUND) {
+    return true;
+  }
+  const detailsReason = readApprovalNotFoundDetailsReason((err as { details?: unknown }).details);
+  if (gatewayCode === INVALID_REQUEST && detailsReason === APPROVAL_NOT_FOUND) {
+    return true;
+  }
+  return /unknown or expired approval id/i.test(err.message);
+}
+
+export async function resolveMatrixExecApproval(params: {
+  cfg: OpenClawConfig;
+  approvalId: string;
+  decision: ExecApprovalReplyDecision;
+  senderId?: string | null;
+  gatewayUrl?: string;
+}): Promise<void> {
+  let readySettled = false;
+  let resolveReady!: () => void;
+  let rejectReady!: (err: unknown) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  const markReady = () => {
+    if (readySettled) {
+      return;
+    }
+    readySettled = true;
+    resolveReady();
+  };
+  const failReady = (err: unknown) => {
+    if (readySettled) {
+      return;
+    }
+    readySettled = true;
+    rejectReady(err);
+  };
+
+  const gatewayClient = await createOperatorApprovalsGatewayClient({
+    config: params.cfg,
+    gatewayUrl: params.gatewayUrl,
+    clientDisplayName: `Matrix approval (${params.senderId?.trim() || "unknown"})`,
+    onHelloOk: () => {
+      markReady();
+    },
+    onConnectError: (err) => {
+      failReady(err);
+    },
+    onClose: (code, reason) => {
+      failReady(new Error(`gateway closed (${code}): ${reason}`));
+    },
+  });
+
+  try {
+    gatewayClient.start();
+    await ready;
+    await gatewayClient.request("exec.approval.resolve", {
+      id: params.approvalId,
+      decision: params.decision,
+    });
+  } finally {
+    await gatewayClient.stopAndWait().catch(() => {
+      gatewayClient.stop();
+    });
+  }
+}

--- a/extensions/matrix/src/exec-approval-resolver.ts
+++ b/extensions/matrix/src/exec-approval-resolver.ts
@@ -1,36 +1,9 @@
 import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import { createOperatorApprovalsGatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
 
-const INVALID_REQUEST = "INVALID_REQUEST";
-const APPROVAL_NOT_FOUND = "APPROVAL_NOT_FOUND";
-
-function readErrorCode(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value : null;
-}
-
-function readApprovalNotFoundDetailsReason(value: unknown): string | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const reason = (value as { reason?: unknown }).reason;
-  return typeof reason === "string" && reason.trim() ? reason : null;
-}
-
-export function isApprovalNotFoundError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-  const gatewayCode = readErrorCode((err as { gatewayCode?: unknown }).gatewayCode);
-  if (gatewayCode === APPROVAL_NOT_FOUND) {
-    return true;
-  }
-  const detailsReason = readApprovalNotFoundDetailsReason((err as { details?: unknown }).details);
-  if (gatewayCode === INVALID_REQUEST && detailsReason === APPROVAL_NOT_FOUND) {
-    return true;
-  }
-  return /unknown or expired approval id/i.test(err.message);
-}
+export { isApprovalNotFoundError };
 
 export async function resolveMatrixExecApproval(params: {
   cfg: OpenClawConfig;

--- a/extensions/matrix/src/exec-approvals-handler.test.ts
+++ b/extensions/matrix/src/exec-approvals-handler.test.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearMatrixApprovalReactionTargetsForTest } from "./approval-reactions.js";
 import { MatrixExecApprovalHandler } from "./exec-approvals-handler.js";
 
 const baseRequest = {
@@ -57,6 +58,7 @@ function createHandler(cfg: OpenClawConfig, accountId = "default") {
 
 afterEach(() => {
   vi.useRealTimers();
+  clearMatrixApprovalReactionTargetsForTest();
 });
 
 describe("MatrixExecApprovalHandler", () => {
@@ -303,6 +305,62 @@ describe("MatrixExecApprovalHandler", () => {
     );
   });
 
+  it("anchors reactions on the first chunk and clears stale chunks on resolve", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "channel",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, sendMessage, reactMessage, editMessage, deleteMessage } = createHandler(cfg);
+    sendMessage.mockReset().mockResolvedValue({
+      messageId: "$m3",
+      primaryMessageId: "$m1",
+      messageIds: ["$m1", "$m2", "$m3"],
+      roomId: "!ops:example.org",
+    });
+
+    await handler.handleRequested(baseRequest);
+    await handler.handleResolved({
+      id: baseRequest.id,
+      decision: "allow-once",
+      resolvedBy: "matrix:@owner:example.org",
+      ts: 2000,
+    });
+
+    expect(reactMessage).toHaveBeenNthCalledWith(
+      1,
+      "!ops:example.org",
+      "$m1",
+      "✅",
+      expect.anything(),
+    );
+    expect(editMessage).toHaveBeenCalledWith(
+      "!ops:example.org",
+      "$m1",
+      expect.stringContaining("Exec approval: Allowed once"),
+      expect.anything(),
+    );
+    expect(deleteMessage).toHaveBeenCalledWith(
+      "!ops:example.org",
+      "$m2",
+      expect.objectContaining({ reason: "approval resolved" }),
+    );
+    expect(deleteMessage).toHaveBeenCalledWith(
+      "!ops:example.org",
+      "$m3",
+      expect.objectContaining({ reason: "approval resolved" }),
+    );
+  });
+
   it("deletes tracked approval messages when they expire", async () => {
     vi.useFakeTimers();
     const cfg = {
@@ -331,6 +389,50 @@ describe("MatrixExecApprovalHandler", () => {
         accountId: "default",
         reason: "approval expired",
       }),
+    );
+  });
+
+  it("deletes every chunk of a tracked approval prompt when it expires", async () => {
+    vi.useFakeTimers();
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "channel",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, sendMessage, deleteMessage } = createHandler(cfg);
+    sendMessage.mockReset().mockResolvedValue({
+      messageId: "$m3",
+      primaryMessageId: "$m1",
+      messageIds: ["$m1", "$m2", "$m3"],
+      roomId: "!ops:example.org",
+    });
+
+    await handler.handleRequested(baseRequest);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(deleteMessage).toHaveBeenCalledWith(
+      "!ops:example.org",
+      "$m1",
+      expect.objectContaining({ reason: "approval expired" }),
+    );
+    expect(deleteMessage).toHaveBeenCalledWith(
+      "!ops:example.org",
+      "$m2",
+      expect.objectContaining({ reason: "approval expired" }),
+    );
+    expect(deleteMessage).toHaveBeenCalledWith(
+      "!ops:example.org",
+      "$m3",
+      expect.objectContaining({ reason: "approval expired" }),
     );
   });
 

--- a/extensions/matrix/src/exec-approvals-handler.test.ts
+++ b/extensions/matrix/src/exec-approvals-handler.test.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { clearMatrixApprovalReactionTargetsForTest } from "./approval-reactions.js";
+import {
+  clearMatrixApprovalReactionTargetsForTest,
+  resolveMatrixApprovalReactionTarget,
+} from "./approval-reactions.js";
 import { MatrixExecApprovalHandler } from "./exec-approvals-handler.js";
 
 const baseRequest = {
@@ -434,6 +437,35 @@ describe("MatrixExecApprovalHandler", () => {
       "$m3",
       expect.objectContaining({ reason: "approval expired" }),
     );
+  });
+
+  it("clears tracked approval anchors when the handler stops", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "channel",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler } = createHandler(cfg);
+
+    await handler.handleRequested(baseRequest);
+    await handler.stop();
+
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:example.org",
+        eventId: "$m1",
+        reactionKey: "✅",
+      }),
+    ).toBeNull();
   });
 
   it("honors request decision constraints in pending approval text", async () => {

--- a/extensions/matrix/src/exec-approvals-handler.test.ts
+++ b/extensions/matrix/src/exec-approvals-handler.test.ts
@@ -23,6 +23,7 @@ function createHandler(cfg: OpenClawConfig, accountId = "default") {
     .fn()
     .mockResolvedValueOnce({ messageId: "$m1", roomId: "!ops:example.org" })
     .mockResolvedValue({ messageId: "$m2", roomId: "!dm-owner:example.org" });
+  const reactMessage = vi.fn().mockResolvedValue(undefined);
   const editMessage = vi.fn().mockResolvedValue({ eventId: "$edit1" });
   const deleteMessage = vi.fn().mockResolvedValue(undefined);
   const repairDirectRooms = vi.fn().mockResolvedValue({
@@ -37,12 +38,21 @@ function createHandler(cfg: OpenClawConfig, accountId = "default") {
     {
       nowMs: () => 1000,
       sendMessage,
+      reactMessage,
       editMessage,
       deleteMessage,
       repairDirectRooms,
     },
   );
-  return { client, handler, sendMessage, editMessage, deleteMessage, repairDirectRooms };
+  return {
+    client,
+    handler,
+    sendMessage,
+    reactMessage,
+    editMessage,
+    deleteMessage,
+    repairDirectRooms,
+  };
 }
 
 afterEach(() => {
@@ -76,6 +86,54 @@ describe("MatrixExecApprovalHandler", () => {
         accountId: "default",
         threadId: "$thread",
       }),
+    );
+  });
+
+  it("seeds emoji reactions for each allowed approval decision", async () => {
+    const cfg = {
+      channels: {
+        matrix: {
+          homeserver: "https://matrix.example.org",
+          userId: "@bot:example.org",
+          accessToken: "tok",
+          execApprovals: {
+            enabled: true,
+            approvers: ["@owner:example.org"],
+            target: "channel",
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { handler, reactMessage, sendMessage } = createHandler(cfg);
+
+    await handler.handleRequested(baseRequest);
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "room:!ops:example.org",
+      expect.stringContaining("React here: ✅ Allow once, ♾️ Allow always, ❌ Deny"),
+      expect.anything(),
+    );
+    expect(reactMessage).toHaveBeenCalledTimes(3);
+    expect(reactMessage).toHaveBeenNthCalledWith(
+      1,
+      "!ops:example.org",
+      "$m1",
+      "✅",
+      expect.anything(),
+    );
+    expect(reactMessage).toHaveBeenNthCalledWith(
+      2,
+      "!ops:example.org",
+      "$m1",
+      "♾️",
+      expect.anything(),
+    );
+    expect(reactMessage).toHaveBeenNthCalledWith(
+      3,
+      "!ops:example.org",
+      "$m1",
+      "❌",
+      expect.anything(),
     );
   });
 
@@ -291,7 +349,7 @@ describe("MatrixExecApprovalHandler", () => {
         },
       },
     } as OpenClawConfig;
-    const { handler, sendMessage } = createHandler(cfg);
+    const { handler, sendMessage, reactMessage } = createHandler(cfg);
 
     await handler.handleRequested({
       ...baseRequest,
@@ -305,6 +363,26 @@ describe("MatrixExecApprovalHandler", () => {
     expect(sendMessage).toHaveBeenCalledWith(
       "room:!ops:example.org",
       expect.not.stringContaining("allow-always"),
+      expect.anything(),
+    );
+    expect(sendMessage).toHaveBeenCalledWith(
+      "room:!ops:example.org",
+      expect.stringContaining("React here: ✅ Allow once, ❌ Deny"),
+      expect.anything(),
+    );
+    expect(reactMessage).toHaveBeenCalledTimes(2);
+    expect(reactMessage).toHaveBeenNthCalledWith(
+      1,
+      "!ops:example.org",
+      "$m1",
+      "✅",
+      expect.anything(),
+    );
+    expect(reactMessage).toHaveBeenNthCalledWith(
+      2,
+      "!ops:example.org",
+      "$m1",
+      "❌",
       expect.anything(),
     );
   });

--- a/extensions/matrix/src/exec-approvals-handler.ts
+++ b/extensions/matrix/src/exec-approvals-handler.ts
@@ -15,6 +15,8 @@ import { matrixNativeApprovalAdapter } from "./approval-native.js";
 import {
   buildMatrixApprovalReactionHint,
   listMatrixApprovalReactionBindings,
+  registerMatrixApprovalReactionTarget,
+  unregisterMatrixApprovalReactionTarget,
 } from "./approval-reactions.js";
 import {
   isMatrixExecApprovalClientEnabled,
@@ -32,7 +34,8 @@ type ApprovalRequest = ExecApprovalRequest;
 type ApprovalResolved = ExecApprovalResolved;
 type PendingMessage = {
   roomId: string;
-  messageId: string;
+  messageIds: readonly string[];
+  reactionEventId: string;
 };
 
 type PreparedMatrixTarget = {
@@ -41,6 +44,7 @@ type PreparedMatrixTarget = {
   threadId?: string;
 };
 type PendingApprovalContent = {
+  approvalId: string;
   text: string;
   allowedDecisions: readonly ("allow-once" | "allow-always" | "deny")[];
 };
@@ -60,6 +64,10 @@ export type MatrixExecApprovalHandlerDeps = {
   deleteMessage?: typeof deleteMatrixMessage;
   repairDirectRooms?: typeof repairMatrixDirectRooms;
 };
+
+function normalizePendingMessageIds(entry: PendingMessage): string[] {
+  return Array.from(new Set(entry.messageIds.map((messageId) => messageId.trim()).filter(Boolean)));
+}
 
 function isHandlerConfigured(params: { cfg: OpenClawConfig; accountId: string }): boolean {
   return isMatrixExecApprovalClientEnabled(params);
@@ -96,6 +104,7 @@ function buildPendingApprovalContent(params: {
   const hint = buildMatrixApprovalReactionHint(allowedDecisions);
   const text = payload.text ?? "";
   return {
+    approvalId: params.request.id,
     text: hint ? `${text}\n\n${hint}` : text,
     allowedDecisions,
   };
@@ -191,10 +200,25 @@ export class MatrixExecApprovalHandler {
           client: this.opts.client,
           threadId: preparedTarget.threadId,
         });
+        const messageIds = Array.from(
+          new Set(
+            (result.messageIds ?? [result.messageId])
+              .map((messageId) => messageId.trim())
+              .filter(Boolean),
+          ),
+        );
+        const reactionEventId =
+          result.primaryMessageId?.trim() || messageIds[0] || result.messageId.trim();
+        registerMatrixApprovalReactionTarget({
+          roomId: result.roomId,
+          eventId: reactionEventId,
+          approvalId: pendingContent.approvalId,
+          allowedDecisions: pendingContent.allowedDecisions,
+        });
         await Promise.allSettled(
           listMatrixApprovalReactionBindings(pendingContent.allowedDecisions).map(
             async ({ emoji }) => {
-              await this.reactMessage(result.roomId, result.messageId, emoji, {
+              await this.reactMessage(result.roomId, reactionEventId, emoji, {
                 cfg: this.opts.cfg as CoreConfig,
                 accountId: this.opts.accountId,
                 client: this.opts.client,
@@ -204,7 +228,8 @@ export class MatrixExecApprovalHandler {
         );
         return {
           roomId: result.roomId,
-          messageId: result.messageId,
+          messageIds,
+          reactionEventId,
         };
       },
       finalizeResolved: async ({ request, resolved, entries }) => {
@@ -275,11 +300,29 @@ export class MatrixExecApprovalHandler {
     const text = buildResolvedApprovalText({ request, resolved });
     await Promise.allSettled(
       entries.map(async (entry) => {
-        await this.editMessage(entry.roomId, entry.messageId, text, {
-          cfg: this.opts.cfg as CoreConfig,
-          accountId: this.opts.accountId,
-          client: this.opts.client,
+        unregisterMatrixApprovalReactionTarget({
+          roomId: entry.roomId,
+          eventId: entry.reactionEventId,
         });
+        const [primaryMessageId, ...staleMessageIds] = normalizePendingMessageIds(entry);
+        if (!primaryMessageId) {
+          return;
+        }
+        await Promise.allSettled([
+          this.editMessage(entry.roomId, primaryMessageId, text, {
+            cfg: this.opts.cfg as CoreConfig,
+            accountId: this.opts.accountId,
+            client: this.opts.client,
+          }),
+          ...staleMessageIds.map(async (messageId) => {
+            await this.deleteMessage(entry.roomId, messageId, {
+              cfg: this.opts.cfg as CoreConfig,
+              accountId: this.opts.accountId,
+              client: this.opts.client,
+              reason: "approval resolved",
+            });
+          }),
+        ]);
       }),
     );
   }
@@ -287,12 +330,20 @@ export class MatrixExecApprovalHandler {
   private async clearPending(entries: PendingMessage[]): Promise<void> {
     await Promise.allSettled(
       entries.map(async (entry) => {
-        await this.deleteMessage(entry.roomId, entry.messageId, {
-          cfg: this.opts.cfg as CoreConfig,
-          accountId: this.opts.accountId,
-          client: this.opts.client,
-          reason: "approval expired",
+        unregisterMatrixApprovalReactionTarget({
+          roomId: entry.roomId,
+          eventId: entry.reactionEventId,
         });
+        await Promise.allSettled(
+          normalizePendingMessageIds(entry).map(async (messageId) => {
+            await this.deleteMessage(entry.roomId, messageId, {
+              cfg: this.opts.cfg as CoreConfig,
+              accountId: this.opts.accountId,
+              client: this.opts.client,
+              reason: "approval expired",
+            });
+          }),
+        );
       }),
     );
   }

--- a/extensions/matrix/src/exec-approvals-handler.ts
+++ b/extensions/matrix/src/exec-approvals-handler.ts
@@ -1,6 +1,7 @@
 import {
   buildExecApprovalPendingReplyPayload,
   getExecApprovalApproverDmNoticeText,
+  resolveExecApprovalAllowedDecisions,
   resolveExecApprovalCommandDisplay,
 } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
@@ -12,6 +13,10 @@ import {
 } from "openclaw/plugin-sdk/infra-runtime";
 import { matrixNativeApprovalAdapter } from "./approval-native.js";
 import {
+  buildMatrixApprovalReactionHint,
+  listMatrixApprovalReactionBindings,
+} from "./approval-reactions.js";
+import {
   isMatrixExecApprovalClientEnabled,
   shouldHandleMatrixExecApprovalRequest,
 } from "./exec-approvals.js";
@@ -19,7 +24,7 @@ import { resolveMatrixAccount } from "./matrix/accounts.js";
 import { deleteMatrixMessage, editMatrixMessage } from "./matrix/actions/messages.js";
 import { repairMatrixDirectRooms } from "./matrix/direct-management.js";
 import type { MatrixClient } from "./matrix/sdk.js";
-import { sendMessageMatrix } from "./matrix/send.js";
+import { reactMatrixMessage, sendMessageMatrix } from "./matrix/send.js";
 import { resolveMatrixTargetIdentity } from "./matrix/target-ids.js";
 import type { CoreConfig } from "./types.js";
 
@@ -35,6 +40,10 @@ type PreparedMatrixTarget = {
   roomId: string;
   threadId?: string;
 };
+type PendingApprovalContent = {
+  text: string;
+  allowedDecisions: readonly ("allow-once" | "allow-always" | "deny")[];
+};
 
 export type MatrixExecApprovalHandlerOpts = {
   client: MatrixClient;
@@ -46,6 +55,7 @@ export type MatrixExecApprovalHandlerOpts = {
 export type MatrixExecApprovalHandlerDeps = {
   nowMs?: () => number;
   sendMessage?: typeof sendMessageMatrix;
+  reactMessage?: typeof reactMatrixMessage;
   editMessage?: typeof editMatrixMessage;
   deleteMessage?: typeof deleteMatrixMessage;
   repairDirectRooms?: typeof repairMatrixDirectRooms;
@@ -60,14 +70,20 @@ function normalizeThreadId(value?: string | number | null): string | undefined {
   return trimmed || undefined;
 }
 
-function buildPendingApprovalText(params: { request: ApprovalRequest; nowMs: number }): string {
-  return buildExecApprovalPendingReplyPayload({
+function buildPendingApprovalContent(params: {
+  request: ApprovalRequest;
+  nowMs: number;
+}): PendingApprovalContent {
+  const allowedDecisions =
+    params.request.request.allowedDecisions ??
+    resolveExecApprovalAllowedDecisions({ ask: params.request.request.ask ?? undefined });
+  const payload = buildExecApprovalPendingReplyPayload({
     approvalId: params.request.id,
     approvalSlug: params.request.id.slice(0, 8),
     approvalCommandId: params.request.id,
     ask: params.request.request.ask ?? undefined,
     agentId: params.request.request.agentId ?? undefined,
-    allowedDecisions: params.request.request.allowedDecisions,
+    allowedDecisions,
     command: resolveExecApprovalCommandDisplay((params.request as ExecApprovalRequest).request)
       .commandText,
     cwd: (params.request as ExecApprovalRequest).request.cwd ?? undefined,
@@ -76,7 +92,13 @@ function buildPendingApprovalText(params: { request: ApprovalRequest; nowMs: num
     sessionKey: params.request.request.sessionKey ?? undefined,
     expiresAtMs: params.request.expiresAtMs,
     nowMs: params.nowMs,
-  }).text!;
+  });
+  const hint = buildMatrixApprovalReactionHint(allowedDecisions);
+  const text = payload.text ?? "";
+  return {
+    text: hint ? `${text}\n\n${hint}` : text,
+    allowedDecisions,
+  };
 }
 
 function buildResolvedApprovalText(params: {
@@ -97,6 +119,7 @@ export class MatrixExecApprovalHandler {
   private readonly runtime: ExecApprovalChannelRuntime<ApprovalRequest, ApprovalResolved>;
   private readonly nowMs: () => number;
   private readonly sendMessage: typeof sendMessageMatrix;
+  private readonly reactMessage: typeof reactMatrixMessage;
   private readonly editMessage: typeof editMatrixMessage;
   private readonly deleteMessage: typeof deleteMatrixMessage;
   private readonly repairDirectRooms: typeof repairMatrixDirectRooms;
@@ -107,13 +130,14 @@ export class MatrixExecApprovalHandler {
   ) {
     this.nowMs = deps.nowMs ?? Date.now;
     this.sendMessage = deps.sendMessage ?? sendMessageMatrix;
+    this.reactMessage = deps.reactMessage ?? reactMatrixMessage;
     this.editMessage = deps.editMessage ?? editMatrixMessage;
     this.deleteMessage = deps.deleteMessage ?? deleteMatrixMessage;
     this.repairDirectRooms = deps.repairDirectRooms ?? repairMatrixDirectRooms;
     this.runtime = createChannelNativeApprovalRuntime<
       PendingMessage,
       PreparedMatrixTarget,
-      string,
+      PendingApprovalContent,
       ApprovalRequest,
       ApprovalResolved
     >({
@@ -134,7 +158,7 @@ export class MatrixExecApprovalHandler {
           request,
         }),
       buildPendingContent: ({ request, nowMs }) =>
-        buildPendingApprovalText({
+        buildPendingApprovalContent({
           request,
           nowMs,
         }),
@@ -161,12 +185,23 @@ export class MatrixExecApprovalHandler {
         };
       },
       deliverTarget: async ({ preparedTarget, pendingContent }) => {
-        const result = await this.sendMessage(preparedTarget.to, pendingContent, {
+        const result = await this.sendMessage(preparedTarget.to, pendingContent.text, {
           cfg: this.opts.cfg as CoreConfig,
           accountId: this.opts.accountId,
           client: this.opts.client,
           threadId: preparedTarget.threadId,
         });
+        await Promise.allSettled(
+          listMatrixApprovalReactionBindings(pendingContent.allowedDecisions).map(
+            async ({ emoji }) => {
+              await this.reactMessage(result.roomId, result.messageId, emoji, {
+                cfg: this.opts.cfg as CoreConfig,
+                accountId: this.opts.accountId,
+                client: this.opts.client,
+              });
+            },
+          ),
+        );
         return {
           roomId: result.roomId,
           messageId: result.messageId,

--- a/extensions/matrix/src/exec-approvals-handler.ts
+++ b/extensions/matrix/src/exec-approvals-handler.ts
@@ -1,5 +1,6 @@
 import {
   buildExecApprovalPendingReplyPayload,
+  type ExecApprovalReplyDecision,
   getExecApprovalApproverDmNoticeText,
   resolveExecApprovalAllowedDecisions,
   resolveExecApprovalCommandDisplay,
@@ -46,7 +47,11 @@ type PreparedMatrixTarget = {
 type PendingApprovalContent = {
   approvalId: string;
   text: string;
-  allowedDecisions: readonly ("allow-once" | "allow-always" | "deny")[];
+  allowedDecisions: readonly ExecApprovalReplyDecision[];
+};
+type ReactionTargetRef = {
+  roomId: string;
+  eventId: string;
 };
 
 export type MatrixExecApprovalHandlerOpts = {
@@ -67,6 +72,23 @@ export type MatrixExecApprovalHandlerDeps = {
 
 function normalizePendingMessageIds(entry: PendingMessage): string[] {
   return Array.from(new Set(entry.messageIds.map((messageId) => messageId.trim()).filter(Boolean)));
+}
+
+function normalizeReactionTargetRef(params: ReactionTargetRef): ReactionTargetRef | null {
+  const roomId = params.roomId.trim();
+  const eventId = params.eventId.trim();
+  if (!roomId || !eventId) {
+    return null;
+  }
+  return { roomId, eventId };
+}
+
+function buildReactionTargetRefKey(params: ReactionTargetRef): string | null {
+  const normalized = normalizeReactionTargetRef(params);
+  if (!normalized) {
+    return null;
+  }
+  return `${normalized.roomId}\u0000${normalized.eventId}`;
 }
 
 function isHandlerConfigured(params: { cfg: OpenClawConfig; accountId: string }): boolean {
@@ -126,6 +148,7 @@ function buildResolvedApprovalText(params: {
 
 export class MatrixExecApprovalHandler {
   private readonly runtime: ExecApprovalChannelRuntime<ApprovalRequest, ApprovalResolved>;
+  private readonly trackedReactionTargets = new Map<string, ReactionTargetRef>();
   private readonly nowMs: () => number;
   private readonly sendMessage: typeof sendMessageMatrix;
   private readonly reactMessage: typeof reactMatrixMessage;
@@ -209,7 +232,7 @@ export class MatrixExecApprovalHandler {
         );
         const reactionEventId =
           result.primaryMessageId?.trim() || messageIds[0] || result.messageId.trim();
-        registerMatrixApprovalReactionTarget({
+        this.trackReactionTarget({
           roomId: result.roomId,
           eventId: reactionEventId,
           approvalId: pendingContent.approvalId,
@@ -247,6 +270,7 @@ export class MatrixExecApprovalHandler {
 
   async stop(): Promise<void> {
     await this.runtime.stop();
+    this.clearTrackedReactionTargets();
   }
 
   async handleRequested(request: ApprovalRequest): Promise<void> {
@@ -300,7 +324,7 @@ export class MatrixExecApprovalHandler {
     const text = buildResolvedApprovalText({ request, resolved });
     await Promise.allSettled(
       entries.map(async (entry) => {
-        unregisterMatrixApprovalReactionTarget({
+        this.untrackReactionTarget({
           roomId: entry.roomId,
           eventId: entry.reactionEventId,
         });
@@ -330,7 +354,7 @@ export class MatrixExecApprovalHandler {
   private async clearPending(entries: PendingMessage[]): Promise<void> {
     await Promise.allSettled(
       entries.map(async (entry) => {
-        unregisterMatrixApprovalReactionTarget({
+        this.untrackReactionTarget({
           roomId: entry.roomId,
           eventId: entry.reactionEventId,
         });
@@ -346,5 +370,42 @@ export class MatrixExecApprovalHandler {
         );
       }),
     );
+  }
+
+  private trackReactionTarget(
+    params: ReactionTargetRef & {
+      approvalId: string;
+      allowedDecisions: readonly ExecApprovalReplyDecision[];
+    },
+  ): void {
+    const normalized = normalizeReactionTargetRef(params);
+    const key = normalized ? buildReactionTargetRefKey(normalized) : null;
+    if (!normalized || !key) {
+      return;
+    }
+    registerMatrixApprovalReactionTarget({
+      roomId: normalized.roomId,
+      eventId: normalized.eventId,
+      approvalId: params.approvalId,
+      allowedDecisions: params.allowedDecisions,
+    });
+    this.trackedReactionTargets.set(key, normalized);
+  }
+
+  private untrackReactionTarget(params: ReactionTargetRef): void {
+    const normalized = normalizeReactionTargetRef(params);
+    const key = normalized ? buildReactionTargetRefKey(normalized) : null;
+    if (!normalized || !key) {
+      return;
+    }
+    unregisterMatrixApprovalReactionTarget(normalized);
+    this.trackedReactionTargets.delete(key);
+  }
+
+  private clearTrackedReactionTargets(): void {
+    for (const target of this.trackedReactionTargets.values()) {
+      unregisterMatrixApprovalReactionTarget(target);
+    }
+    this.trackedReactionTargets.clear();
   }
 }

--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -1,4 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearMatrixApprovalReactionTargetsForTest,
+  registerMatrixApprovalReactionTarget,
+} from "../../approval-reactions.js";
+import type { CoreConfig } from "../../types.js";
 import { handleInboundMatrixReaction } from "./reaction-events.js";
 
 const resolveMatrixExecApproval = vi.fn();
@@ -11,9 +16,10 @@ vi.mock("../../exec-approval-resolver.js", () => ({
 
 beforeEach(() => {
   resolveMatrixExecApproval.mockReset();
+  clearMatrixApprovalReactionTargetsForTest();
 });
 
-function buildConfig() {
+function buildConfig(): CoreConfig {
   return {
     channels: {
       matrix: {
@@ -28,7 +34,7 @@ function buildConfig() {
         },
       },
     },
-  };
+  } as CoreConfig;
 }
 
 function buildCore() {
@@ -52,26 +58,17 @@ function buildCore() {
 describe("matrix approval reactions", () => {
   it("resolves approval reactions instead of enqueueing a generic reaction event", async () => {
     const core = buildCore();
+    registerMatrixApprovalReactionTarget({
+      roomId: "!ops:example.org",
+      eventId: "$approval-msg",
+      approvalId: "req-123",
+      allowedDecisions: ["allow-once", "allow-always", "deny"],
+    });
     const client = {
       getEvent: vi.fn().mockResolvedValue({
         event_id: "$approval-msg",
         sender: "@bot:example.org",
-        content: {
-          body: [
-            "Approval required.",
-            "",
-            "Run:",
-            "```txt",
-            "/approve req-123 allow-once",
-            "```",
-            "",
-            "Other options:",
-            "```txt",
-            "/approve req-123 allow-always",
-            "/approve req-123 deny",
-            "```",
-          ].join("\n"),
-        },
+        content: { body: "approval prompt" },
       }),
     } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
 
@@ -156,14 +153,22 @@ describe("matrix approval reactions", () => {
   it("still resolves approval reactions when generic reaction notifications are off", async () => {
     const core = buildCore();
     const cfg = buildConfig();
-    cfg.channels.matrix.reactionNotifications = "off";
+    const matrixCfg = cfg.channels?.matrix;
+    if (!matrixCfg) {
+      throw new Error("matrix config missing");
+    }
+    matrixCfg.reactionNotifications = "off";
+    registerMatrixApprovalReactionTarget({
+      roomId: "!ops:example.org",
+      eventId: "$approval-msg",
+      approvalId: "req-123",
+      allowedDecisions: ["deny"],
+    });
     const client = {
       getEvent: vi.fn().mockResolvedValue({
         event_id: "$approval-msg",
         sender: "@bot:example.org",
-        content: {
-          body: "/approve req-123 deny",
-        },
+        content: { body: "approval prompt" },
       }),
     } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
 

--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { handleInboundMatrixReaction } from "./reaction-events.js";
+
+const resolveMatrixExecApproval = vi.fn();
+
+vi.mock("../../exec-approval-resolver.js", () => ({
+  isApprovalNotFoundError: (err: unknown) =>
+    err instanceof Error && /unknown or expired approval id/i.test(err.message),
+  resolveMatrixExecApproval: (...args: unknown[]) => resolveMatrixExecApproval(...args),
+}));
+
+beforeEach(() => {
+  resolveMatrixExecApproval.mockReset();
+});
+
+function buildConfig() {
+  return {
+    channels: {
+      matrix: {
+        homeserver: "https://matrix.example.org",
+        userId: "@bot:example.org",
+        accessToken: "tok",
+        reactionNotifications: "own",
+        execApprovals: {
+          enabled: true,
+          approvers: ["@owner:example.org"],
+          target: "channel",
+        },
+      },
+    },
+  };
+}
+
+function buildCore() {
+  return {
+    channel: {
+      routing: {
+        resolveAgentRoute: vi.fn().mockReturnValue({
+          sessionKey: "agent:main:matrix:channel:!ops:example.org",
+          mainSessionKey: "agent:main:matrix:channel:!ops:example.org",
+          agentId: "main",
+          matchedBy: "peer",
+        }),
+      },
+    },
+    system: {
+      enqueueSystemEvent: vi.fn(),
+    },
+  } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["core"];
+}
+
+describe("matrix approval reactions", () => {
+  it("resolves approval reactions instead of enqueueing a generic reaction event", async () => {
+    const core = buildCore();
+    const client = {
+      getEvent: vi.fn().mockResolvedValue({
+        event_id: "$approval-msg",
+        sender: "@bot:example.org",
+        content: {
+          body: [
+            "Approval required.",
+            "",
+            "Run:",
+            "```txt",
+            "/approve req-123 allow-once",
+            "```",
+            "",
+            "Other options:",
+            "```txt",
+            "/approve req-123 allow-always",
+            "/approve req-123 deny",
+            "```",
+          ].join("\n"),
+        },
+      }),
+    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+
+    await handleInboundMatrixReaction({
+      client,
+      core,
+      cfg: buildConfig(),
+      accountId: "default",
+      roomId: "!ops:example.org",
+      event: {
+        event_id: "$reaction-1",
+        origin_server_ts: 123,
+        content: {
+          "m.relates_to": {
+            rel_type: "m.annotation",
+            event_id: "$approval-msg",
+            key: "✅",
+          },
+        },
+      } as never,
+      senderId: "@owner:example.org",
+      senderLabel: "Owner",
+      selfUserId: "@bot:example.org",
+      isDirectMessage: false,
+      logVerboseMessage: vi.fn(),
+    });
+
+    expect(resolveMatrixExecApproval).toHaveBeenCalledWith({
+      cfg: buildConfig(),
+      approvalId: "req-123",
+      decision: "allow-once",
+      senderId: "@owner:example.org",
+    });
+    expect(core.system.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("keeps ordinary reactions on bot messages as generic reaction events", async () => {
+    const core = buildCore();
+    const client = {
+      getEvent: vi.fn().mockResolvedValue({
+        event_id: "$msg-1",
+        sender: "@bot:example.org",
+        content: {
+          body: "normal bot message",
+        },
+      }),
+    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+
+    await handleInboundMatrixReaction({
+      client,
+      core,
+      cfg: buildConfig(),
+      accountId: "default",
+      roomId: "!ops:example.org",
+      event: {
+        event_id: "$reaction-1",
+        origin_server_ts: 123,
+        content: {
+          "m.relates_to": {
+            rel_type: "m.annotation",
+            event_id: "$msg-1",
+            key: "👍",
+          },
+        },
+      } as never,
+      senderId: "@owner:example.org",
+      senderLabel: "Owner",
+      selfUserId: "@bot:example.org",
+      isDirectMessage: false,
+      logVerboseMessage: vi.fn(),
+    });
+
+    expect(resolveMatrixExecApproval).not.toHaveBeenCalled();
+    expect(core.system.enqueueSystemEvent).toHaveBeenCalledWith(
+      "Matrix reaction added: 👍 by Owner on msg $msg-1",
+      expect.objectContaining({
+        contextKey: "matrix:reaction:add:!ops:example.org:$msg-1:@owner:example.org:👍",
+      }),
+    );
+  });
+
+  it("still resolves approval reactions when generic reaction notifications are off", async () => {
+    const core = buildCore();
+    const cfg = buildConfig();
+    cfg.channels.matrix.reactionNotifications = "off";
+    const client = {
+      getEvent: vi.fn().mockResolvedValue({
+        event_id: "$approval-msg",
+        sender: "@bot:example.org",
+        content: {
+          body: "/approve req-123 deny",
+        },
+      }),
+    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+
+    await handleInboundMatrixReaction({
+      client,
+      core,
+      cfg,
+      accountId: "default",
+      roomId: "!ops:example.org",
+      event: {
+        event_id: "$reaction-1",
+        origin_server_ts: 123,
+        content: {
+          "m.relates_to": {
+            rel_type: "m.annotation",
+            event_id: "$approval-msg",
+            key: "❌",
+          },
+        },
+      } as never,
+      senderId: "@owner:example.org",
+      senderLabel: "Owner",
+      selfUserId: "@bot:example.org",
+      isDirectMessage: false,
+      logVerboseMessage: vi.fn(),
+    });
+
+    expect(resolveMatrixExecApproval).toHaveBeenCalledWith({
+      cfg,
+      approvalId: "req-123",
+      decision: "deny",
+      senderId: "@owner:example.org",
+    });
+    expect(core.system.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearMatrixApprovalReactionTargetsForTest,
   registerMatrixApprovalReactionTarget,
+  resolveMatrixApprovalReactionTarget,
 } from "../../approval-reactions.js";
 import type { CoreConfig } from "../../types.js";
 import { handleInboundMatrixReaction } from "./reaction-events.js";
@@ -202,6 +203,142 @@ describe("matrix approval reactions", () => {
       decision: "deny",
       senderId: "@owner:example.org",
     });
+    expect(core.system.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("resolves registered approval reactions without fetching the target event", async () => {
+    const core = buildCore();
+    registerMatrixApprovalReactionTarget({
+      roomId: "!ops:example.org",
+      eventId: "$approval-msg",
+      approvalId: "req-123",
+      allowedDecisions: ["allow-once"],
+    });
+    const client = {
+      getEvent: vi.fn().mockRejectedValue(new Error("boom")),
+    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+
+    await handleInboundMatrixReaction({
+      client,
+      core,
+      cfg: buildConfig(),
+      accountId: "default",
+      roomId: "!ops:example.org",
+      event: {
+        event_id: "$reaction-1",
+        origin_server_ts: 123,
+        content: {
+          "m.relates_to": {
+            rel_type: "m.annotation",
+            event_id: "$approval-msg",
+            key: "✅",
+          },
+        },
+      } as never,
+      senderId: "@owner:example.org",
+      senderLabel: "Owner",
+      selfUserId: "@bot:example.org",
+      isDirectMessage: false,
+      logVerboseMessage: vi.fn(),
+    });
+
+    expect(client.getEvent).not.toHaveBeenCalled();
+    expect(resolveMatrixExecApproval).toHaveBeenCalledWith({
+      cfg: buildConfig(),
+      approvalId: "req-123",
+      decision: "allow-once",
+      senderId: "@owner:example.org",
+    });
+    expect(core.system.enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("unregisters stale approval anchors after not-found resolution", async () => {
+    const core = buildCore();
+    resolveMatrixExecApproval.mockRejectedValueOnce(
+      new Error("unknown or expired approval id req-123"),
+    );
+    registerMatrixApprovalReactionTarget({
+      roomId: "!ops:example.org",
+      eventId: "$approval-msg",
+      approvalId: "req-123",
+      allowedDecisions: ["deny"],
+    });
+    const client = {
+      getEvent: vi.fn(),
+    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+
+    await handleInboundMatrixReaction({
+      client,
+      core,
+      cfg: buildConfig(),
+      accountId: "default",
+      roomId: "!ops:example.org",
+      event: {
+        event_id: "$reaction-1",
+        origin_server_ts: 123,
+        content: {
+          "m.relates_to": {
+            rel_type: "m.annotation",
+            event_id: "$approval-msg",
+            key: "❌",
+          },
+        },
+      } as never,
+      senderId: "@owner:example.org",
+      senderLabel: "Owner",
+      selfUserId: "@bot:example.org",
+      isDirectMessage: false,
+      logVerboseMessage: vi.fn(),
+    });
+
+    expect(client.getEvent).not.toHaveBeenCalled();
+    expect(
+      resolveMatrixApprovalReactionTarget({
+        roomId: "!ops:example.org",
+        eventId: "$approval-msg",
+        reactionKey: "❌",
+      }),
+    ).toBeNull();
+  });
+
+  it("skips target fetches for ordinary reactions when notifications are off", async () => {
+    const core = buildCore();
+    const cfg = buildConfig();
+    const matrixCfg = cfg.channels?.matrix;
+    if (!matrixCfg) {
+      throw new Error("matrix config missing");
+    }
+    matrixCfg.reactionNotifications = "off";
+    const client = {
+      getEvent: vi.fn(),
+    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+
+    await handleInboundMatrixReaction({
+      client,
+      core,
+      cfg,
+      accountId: "default",
+      roomId: "!ops:example.org",
+      event: {
+        event_id: "$reaction-1",
+        origin_server_ts: 123,
+        content: {
+          "m.relates_to": {
+            rel_type: "m.annotation",
+            event_id: "$msg-1",
+            key: "👍",
+          },
+        },
+      } as never,
+      senderId: "@owner:example.org",
+      senderLabel: "Owner",
+      selfUserId: "@bot:example.org",
+      isDirectMessage: false,
+      logVerboseMessage: vi.fn(),
+    });
+
+    expect(client.getEvent).not.toHaveBeenCalled();
+    expect(resolveMatrixExecApproval).not.toHaveBeenCalled();
     expect(core.system.enqueueSystemEvent).not.toHaveBeenCalled();
   });
 });

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -28,30 +28,13 @@ export function resolveMatrixReactionNotificationMode(params: {
   return accountConfig.reactionNotifications ?? matrixConfig?.reactionNotifications ?? "own";
 }
 
-function readTargetEventText(event: MatrixRawEvent | null): string {
-  if (!event?.content || typeof event.content !== "object") {
-    return "";
-  }
-  const content = event.content as {
-    body?: unknown;
-    "m.new_content"?: {
-      body?: unknown;
-    };
-  };
-  const body =
-    typeof content.body === "string"
-      ? content.body
-      : typeof content["m.new_content"]?.body === "string"
-        ? content["m.new_content"].body
-        : "";
-  return body.trim();
-}
-
 async function maybeResolveMatrixApprovalReaction(params: {
   cfg: CoreConfig;
   accountId: string;
   senderId: string;
+  roomId: string;
   reactionKey: string;
+  targetEventId: string;
   targetEvent: MatrixRawEvent | null;
   targetSender: string;
   selfUserId: string;
@@ -69,10 +52,11 @@ async function maybeResolveMatrixApprovalReaction(params: {
   ) {
     return false;
   }
-  const target = resolveMatrixApprovalReactionTarget(
-    readTargetEventText(params.targetEvent),
-    params.reactionKey,
-  );
+  const target = resolveMatrixApprovalReactionTarget({
+    roomId: params.roomId,
+    eventId: params.targetEventId,
+    reactionKey: params.reactionKey,
+  });
   if (!target) {
     return false;
   }
@@ -138,7 +122,9 @@ export async function handleInboundMatrixReaction(params: {
       cfg: params.cfg,
       accountId: params.accountId,
       senderId: params.senderId,
+      roomId: params.roomId,
       reactionKey: reaction.key,
+      targetEventId: reaction.eventId,
       targetEvent: targetEvent as MatrixRawEvent | null,
       targetSender,
       selfUserId: params.selfUserId,

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -1,5 +1,8 @@
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
-import { resolveMatrixApprovalReactionTarget } from "../../approval-reactions.js";
+import {
+  resolveMatrixApprovalReactionTarget,
+  unregisterMatrixApprovalReactionTarget,
+} from "../../approval-reactions.js";
 import {
   isApprovalNotFoundError,
   resolveMatrixExecApproval,
@@ -32,15 +35,12 @@ async function maybeResolveMatrixApprovalReaction(params: {
   cfg: CoreConfig;
   accountId: string;
   senderId: string;
-  roomId: string;
-  reactionKey: string;
+  target: ReturnType<typeof resolveMatrixApprovalReactionTarget>;
   targetEventId: string;
-  targetEvent: MatrixRawEvent | null;
-  targetSender: string;
-  selfUserId: string;
+  roomId: string;
   logVerboseMessage: (message: string) => void;
 }): Promise<boolean> {
-  if (params.targetSender !== params.selfUserId) {
+  if (!params.target) {
     return false;
   }
   if (
@@ -52,34 +52,30 @@ async function maybeResolveMatrixApprovalReaction(params: {
   ) {
     return false;
   }
-  const target = resolveMatrixApprovalReactionTarget({
-    roomId: params.roomId,
-    eventId: params.targetEventId,
-    reactionKey: params.reactionKey,
-  });
-  if (!target) {
-    return false;
-  }
   try {
     await resolveMatrixExecApproval({
       cfg: params.cfg,
-      approvalId: target.approvalId,
-      decision: target.decision,
+      approvalId: params.target.approvalId,
+      decision: params.target.decision,
       senderId: params.senderId,
     });
     params.logVerboseMessage(
-      `matrix: approval reaction resolved id=${target.approvalId} sender=${params.senderId} decision=${target.decision}`,
+      `matrix: approval reaction resolved id=${params.target.approvalId} sender=${params.senderId} decision=${params.target.decision}`,
     );
     return true;
   } catch (err) {
     if (isApprovalNotFoundError(err)) {
+      unregisterMatrixApprovalReactionTarget({
+        roomId: params.roomId,
+        eventId: params.targetEventId,
+      });
       params.logVerboseMessage(
-        `matrix: approval reaction ignored for expired approval id=${target.approvalId} sender=${params.senderId}`,
+        `matrix: approval reaction ignored for expired approval id=${params.target.approvalId} sender=${params.senderId}`,
       );
       return true;
     }
     params.logVerboseMessage(
-      `matrix: approval reaction failed id=${target.approvalId} sender=${params.senderId}: ${String(err)}`,
+      `matrix: approval reaction failed id=${params.target.approvalId} sender=${params.senderId}: ${String(err)}`,
     );
     return true;
   }
@@ -105,29 +101,19 @@ export async function handleInboundMatrixReaction(params: {
   if (params.senderId === params.selfUserId) {
     return;
   }
-
-  const targetEvent = await params.client.getEvent(params.roomId, reaction.eventId).catch((err) => {
-    params.logVerboseMessage(
-      `matrix: failed resolving reaction target room=${params.roomId} id=${reaction.eventId}: ${String(err)}`,
-    );
-    return null;
+  const approvalTarget = resolveMatrixApprovalReactionTarget({
+    roomId: params.roomId,
+    eventId: reaction.eventId,
+    reactionKey: reaction.key,
   });
-  const targetSender =
-    targetEvent && typeof targetEvent.sender === "string" ? targetEvent.sender.trim() : "";
-  if (!targetSender) {
-    return;
-  }
   if (
     await maybeResolveMatrixApprovalReaction({
       cfg: params.cfg,
       accountId: params.accountId,
       senderId: params.senderId,
-      roomId: params.roomId,
-      reactionKey: reaction.key,
+      target: approvalTarget,
       targetEventId: reaction.eventId,
-      targetEvent: targetEvent as MatrixRawEvent | null,
-      targetSender,
-      selfUserId: params.selfUserId,
+      roomId: params.roomId,
       logVerboseMessage: params.logVerboseMessage,
     })
   ) {
@@ -138,6 +124,18 @@ export async function handleInboundMatrixReaction(params: {
     accountId: params.accountId,
   });
   if (notificationMode === "off") {
+    return;
+  }
+
+  const targetEvent = await params.client.getEvent(params.roomId, reaction.eventId).catch((err) => {
+    params.logVerboseMessage(
+      `matrix: failed resolving reaction target room=${params.roomId} id=${reaction.eventId}: ${String(err)}`,
+    );
+    return null;
+  });
+  const targetSender =
+    targetEvent && typeof targetEvent.sender === "string" ? targetEvent.sender.trim() : "";
+  if (!targetSender) {
     return;
   }
   if (notificationMode === "own" && targetSender !== params.selfUserId) {

--- a/extensions/matrix/src/matrix/monitor/reaction-events.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.ts
@@ -1,4 +1,10 @@
 import { getSessionBindingService } from "openclaw/plugin-sdk/conversation-runtime";
+import { resolveMatrixApprovalReactionTarget } from "../../approval-reactions.js";
+import {
+  isApprovalNotFoundError,
+  resolveMatrixExecApproval,
+} from "../../exec-approval-resolver.js";
+import { isMatrixExecApprovalAuthorizedSender } from "../../exec-approvals.js";
 import type { CoreConfig } from "../../types.js";
 import { resolveMatrixAccountConfig } from "../account-config.js";
 import { extractMatrixReactionAnnotation } from "../reaction-common.js";
@@ -22,6 +28,79 @@ export function resolveMatrixReactionNotificationMode(params: {
   return accountConfig.reactionNotifications ?? matrixConfig?.reactionNotifications ?? "own";
 }
 
+function readTargetEventText(event: MatrixRawEvent | null): string {
+  if (!event?.content || typeof event.content !== "object") {
+    return "";
+  }
+  const content = event.content as {
+    body?: unknown;
+    "m.new_content"?: {
+      body?: unknown;
+    };
+  };
+  const body =
+    typeof content.body === "string"
+      ? content.body
+      : typeof content["m.new_content"]?.body === "string"
+        ? content["m.new_content"].body
+        : "";
+  return body.trim();
+}
+
+async function maybeResolveMatrixApprovalReaction(params: {
+  cfg: CoreConfig;
+  accountId: string;
+  senderId: string;
+  reactionKey: string;
+  targetEvent: MatrixRawEvent | null;
+  targetSender: string;
+  selfUserId: string;
+  logVerboseMessage: (message: string) => void;
+}): Promise<boolean> {
+  if (params.targetSender !== params.selfUserId) {
+    return false;
+  }
+  if (
+    !isMatrixExecApprovalAuthorizedSender({
+      cfg: params.cfg,
+      accountId: params.accountId,
+      senderId: params.senderId,
+    })
+  ) {
+    return false;
+  }
+  const target = resolveMatrixApprovalReactionTarget(
+    readTargetEventText(params.targetEvent),
+    params.reactionKey,
+  );
+  if (!target) {
+    return false;
+  }
+  try {
+    await resolveMatrixExecApproval({
+      cfg: params.cfg,
+      approvalId: target.approvalId,
+      decision: target.decision,
+      senderId: params.senderId,
+    });
+    params.logVerboseMessage(
+      `matrix: approval reaction resolved id=${target.approvalId} sender=${params.senderId} decision=${target.decision}`,
+    );
+    return true;
+  } catch (err) {
+    if (isApprovalNotFoundError(err)) {
+      params.logVerboseMessage(
+        `matrix: approval reaction ignored for expired approval id=${target.approvalId} sender=${params.senderId}`,
+      );
+      return true;
+    }
+    params.logVerboseMessage(
+      `matrix: approval reaction failed id=${target.approvalId} sender=${params.senderId}: ${String(err)}`,
+    );
+    return true;
+  }
+}
+
 export async function handleInboundMatrixReaction(params: {
   client: MatrixClient;
   core: PluginRuntime;
@@ -35,16 +114,11 @@ export async function handleInboundMatrixReaction(params: {
   isDirectMessage: boolean;
   logVerboseMessage: (message: string) => void;
 }): Promise<void> {
-  const notificationMode = resolveMatrixReactionNotificationMode({
-    cfg: params.cfg,
-    accountId: params.accountId,
-  });
-  if (notificationMode === "off") {
-    return;
-  }
-
   const reaction = extractMatrixReactionAnnotation(params.event.content);
   if (!reaction?.eventId) {
+    return;
+  }
+  if (params.senderId === params.selfUserId) {
     return;
   }
 
@@ -57,6 +131,27 @@ export async function handleInboundMatrixReaction(params: {
   const targetSender =
     targetEvent && typeof targetEvent.sender === "string" ? targetEvent.sender.trim() : "";
   if (!targetSender) {
+    return;
+  }
+  if (
+    await maybeResolveMatrixApprovalReaction({
+      cfg: params.cfg,
+      accountId: params.accountId,
+      senderId: params.senderId,
+      reactionKey: reaction.key,
+      targetEvent: targetEvent as MatrixRawEvent | null,
+      targetSender,
+      selfUserId: params.selfUserId,
+      logVerboseMessage: params.logVerboseMessage,
+    })
+  ) {
+    return;
+  }
+  const notificationMode = resolveMatrixReactionNotificationMode({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  if (notificationMode === "off") {
     return;
   }
   if (notificationMode === "own" && targetSender !== params.selfUserId) {

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -29,6 +29,7 @@ const resolveTextChunkLimitMock = vi.fn<
 >(() => 4000);
 const resolveMarkdownTableModeMock = vi.fn(() => "code");
 const convertMarkdownTablesMock = vi.fn((text: string) => text);
+const chunkMarkdownTextWithModeMock = vi.fn((text: string) => (text ? [text] : []));
 
 vi.mock("./outbound-media-runtime.js", () => ({
   loadOutboundMediaFromUrl: loadOutboundMediaFromUrlMock,
@@ -52,7 +53,7 @@ const runtimeStub = {
         resolveTextChunkLimitMock(cfg, channel, accountId),
       resolveChunkMode: () => "length",
       chunkMarkdownText: (text: string) => (text ? [text] : []),
-      chunkMarkdownTextWithMode: (text: string) => (text ? [text] : []),
+      chunkMarkdownTextWithMode: (text: string) => chunkMarkdownTextWithModeMock(text),
       resolveMarkdownTableMode: () => resolveMarkdownTableModeMock(),
       convertMarkdownTables: (text: string) => convertMarkdownTablesMock(text),
     },
@@ -143,6 +144,9 @@ function resetMatrixSendRuntimeMocks() {
   resolveTextChunkLimitMock.mockReset().mockReturnValue(4000);
   resolveMarkdownTableModeMock.mockReset().mockReturnValue("code");
   convertMarkdownTablesMock.mockReset().mockImplementation((text: string) => text);
+  chunkMarkdownTextWithModeMock
+    .mockReset()
+    .mockImplementation((text: string) => (text ? [text] : []));
   applyMatrixSendRuntimeStub();
 }
 
@@ -554,6 +558,28 @@ describe("sendMessageMatrix threads", () => {
     });
 
     expect(resolveTextChunkLimitMock).toHaveBeenCalledWith(expect.anything(), "matrix", "ops");
+  });
+
+  it("returns ordered event ids for chunked text sends", async () => {
+    const { client, sendMessage } = makeClient();
+    sendMessage
+      .mockReset()
+      .mockResolvedValueOnce("$m1")
+      .mockResolvedValueOnce("$m2")
+      .mockResolvedValueOnce("$m3");
+    convertMarkdownTablesMock.mockImplementation(() => "part1|part2|part3");
+    chunkMarkdownTextWithModeMock.mockImplementation((text: string) => text.split("|"));
+
+    const result = await sendMessageMatrix("room:!room:example", "ignored", {
+      client,
+    });
+
+    expect(result).toMatchObject({
+      roomId: "!room:example",
+      primaryMessageId: "$m1",
+      messageId: "$m3",
+      messageIds: ["$m1", "$m2", "$m3"],
+    });
   });
 });
 

--- a/extensions/matrix/src/matrix/send.ts
+++ b/extensions/matrix/src/matrix/send.ts
@@ -202,6 +202,7 @@ export async function sendMessageMatrix(
         return eventId;
       };
 
+      const messageIds: string[] = [];
       let lastMessageId = "";
       if (opts.mediaUrl) {
         const maxBytes = resolveMediaMaxBytes(opts.accountId, cfg);
@@ -259,6 +260,9 @@ export async function sendMessageMatrix(
         });
         const eventId = await sendContent(content);
         lastMessageId = eventId ?? lastMessageId;
+        if (eventId) {
+          messageIds.push(eventId);
+        }
         const textChunks = useVoice ? chunks : rest;
         // Voice messages use a generic media body ("Voice message"), so keep any
         // transcript follow-up attached to the same reply/thread context.
@@ -276,6 +280,9 @@ export async function sendMessageMatrix(
           });
           const followupEventId = await sendContent(followup);
           lastMessageId = followupEventId ?? lastMessageId;
+          if (followupEventId) {
+            messageIds.push(followupEventId);
+          }
         }
       } else {
         for (const chunk of chunks.length ? chunks : [""]) {
@@ -291,12 +298,17 @@ export async function sendMessageMatrix(
           });
           const eventId = await sendContent(content);
           lastMessageId = eventId ?? lastMessageId;
+          if (eventId) {
+            messageIds.push(eventId);
+          }
         }
       }
 
       return {
         messageId: lastMessageId || "unknown",
         roomId,
+        primaryMessageId: messageIds[0] ?? (lastMessageId || "unknown"),
+        messageIds,
       };
     },
   );
@@ -423,6 +435,8 @@ export async function sendSingleTextMessageMatrix(
       return {
         messageId: eventId ?? "unknown",
         roomId: resolvedRoom,
+        primaryMessageId: eventId ?? "unknown",
+        messageIds: eventId ? [eventId] : [],
       };
     },
   );

--- a/extensions/matrix/src/matrix/send/types.ts
+++ b/extensions/matrix/src/matrix/send/types.ts
@@ -82,6 +82,8 @@ export type ReactionEventContent = MatrixReactionEventContent;
 export type MatrixSendResult = {
   messageId: string;
   roomId: string;
+  primaryMessageId?: string;
+  messageIds?: string[];
 };
 
 export type MatrixSendOpts = {


### PR DESCRIPTION
## Summary

- Problem: Matrix exec approvals only had text `/approve` commands; no Matrix-native click/tap affordance.
- Why it matters: Matrix clients here do not expose the buttons UI used by other approval surfaces, so approvals were slower and easier to mistype.
- What changed: Matrix approval prompts now seed emoji reaction shortcuts, reaction events resolve approvals, and docs/tests cover the flow.
- What did NOT change (scope boundary): No cross-channel approval transport changes, no Telegram/core approval plumbing cleanup in this PR.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Matrix approval handling relied on text commands only, and the first reaction-event implementation accidentally gated approval reactions behind generic reaction notification settings.
- Missing detection / guardrail: No regression test covered approval reactions with `reactionNotifications: "off"`.
- Contributing context (if known): Matrix does not have the same buttons UI path available here, so the native affordance had to be channel-specific.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/approval-reactions.test.ts`, `extensions/matrix/src/exec-approvals-handler.test.ts`, `extensions/matrix/src/matrix/monitor/reaction-events.test.ts`
- Scenario the test should lock in: approval prompts advertise the correct emoji set, seed matching reactions, and still resolve approvals when generic reaction notifications are off.
- Why this is the smallest reliable guardrail: the bug lives in Matrix-only prompt rendering and reaction routing.
- Existing test that already covers this (if any): None
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Matrix approval prompts now include `✅` allow once, `❌` deny, and `♾️` allow always when available.
- Reacting on the approval message resolves the approval without typing `/approve ...`.

## Diagram (if applicable)

```text
Before:
[approval prompt] -> [copy or type /approve command] -> [approval resolved]

After:
[approval prompt] -> [react with emoji] -> [approval resolved]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm dev env
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): `channels.matrix.execApprovals.enabled=true` with Matrix approvers configured

### Steps

1. Request host exec from a Matrix conversation that routes to Matrix-native approvals.
2. Open the pending approval message in Matrix.
3. React with `✅`, `❌`, or `♾️` (when allowed).

### Expected

- Approval resolves from the reaction; ordinary non-approval reactions still stay ordinary.

### Actual

- Fixed by this PR.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: build passes; Matrix approval prompt text/reaction mapping reviewed; reaction-resolution path reviewed after rebase.
- Edge cases checked: approval reactions still resolve when `reactionNotifications` is `off`; `allow-always` omitted when effective ask mode disallows it.
- What you did **not** verify: reliable local Vitest completion for the touched Matrix test files in this environment; targeted runs timed out locally even after the code path review.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Matrix clients that normalize or skin emoji differently could behave differently than expected.
  - Mitigation: resolution is keyed off exact reaction values seeded by the bot prompt, and text `/approve` commands remain as fallback.
