### PR TITLE
core: dedupe approval not-found handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Docs: https://docs.openclaw.ai
 - Agents/compaction: keep assistant tool calls and displaced tool results in the same compaction chunk so strict summarization providers stop rejecting orphaned tool pairs. (#58849) Thanks @openperf.
 - Cron: suppress exact `NO_REPLY` sentinel direct-delivery payloads, keep silent direct replies from falling back into duplicate main-summary sends, and treat structured `deleteAfterRun` silent replies the same as text silent replies. (#45737) Thanks @openperf.
 - Cron: keep exact silent-token detection case-insensitive again so mixed-case `NO_REPLY` outputs still stay silent in text and direct delivery paths. Thanks @obviyus.
+- Core/approvals: share approval-not-found fallback classification through the narrow `plugin-sdk/error-runtime` seam so core `/approve` and Telegram stay aligned without widening `plugin-sdk/infra-runtime`. (#60932) Thanks @gumadeiras.
 
 ## 2026.4.2
 
@@ -154,7 +155,6 @@ Docs: https://docs.openclaw.ai
 - Gateway/Windows scheduled tasks: preserve Task Scheduler settings on reinstall, fail loud when Scheduled Task `/Run` does not start, and report fast failed restarts with the actual elapsed time instead of a fake 60s timeout. (#59335) Thanks @tmimmanuel.
 - Control UI/model picker: preserve already-qualified `provider/model` refs from the server so models whose ids already contain slashes stop being double-prefixed and remapped to the wrong provider. (#49874) Thanks @ShionEria.
 - Models/selection: resolve bare model ids in session model switches against the configured allowlist before falling back to the current session provider, so Control UI model picks stop drifting into `google/k2p5` and similar wrong-provider refs. (#51580) Thanks @honwee.
-- Core/approvals: share approval-not-found fallback classification through the narrow `plugin-sdk/error-runtime` seam so core `/approve` and Telegram stay aligned without widening `plugin-sdk/infra-runtime`. (#60932) Thanks @gumadeiras.
 
 ## 2026.4.1-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Windows scheduled tasks: preserve Task Scheduler settings on reinstall, fail loud when Scheduled Task `/Run` does not start, and report fast failed restarts with the actual elapsed time instead of a fake 60s timeout. (#59335) Thanks @tmimmanuel.
 - Control UI/model picker: preserve already-qualified `provider/model` refs from the server so models whose ids already contain slashes stop being double-prefixed and remapped to the wrong provider. (#49874) Thanks @ShionEria.
 - Models/selection: resolve bare model ids in session model switches against the configured allowlist before falling back to the current session provider, so Control UI model picks stop drifting into `google/k2p5` and similar wrong-provider refs. (#51580) Thanks @honwee.
+- Core/approvals: share approval-not-found fallback classification through the narrow `plugin-sdk/error-runtime` seam so core `/approve` and Telegram stay aligned without widening `plugin-sdk/infra-runtime`. (#60932) Thanks @gumadeiras.
 
 ## 2026.4.1-beta.1
 
@@ -221,7 +222,6 @@ Docs: https://docs.openclaw.ai
 - Agents/scheduling: route delayed follow-up requests toward cron only when cron is actually available, while keeping background `exec`/`process` guidance scoped to work that starts now. (#60811) Thanks @vincentkoc.
 - Cron/security: reject unsafe custom `sessionTarget: "session:..."` IDs earlier during cron add, update, and execution so malformed custom session keys fail closed with clear errors.
 - Feishu/cards: replace the legacy `wide_screen_mode` schema 1.x config with schema 2.0 `width_mode: "fill"` in interactive approval, launcher, markdown, and structured card builders so Feishu card sends stop failing with parse-card errors while preserving wide-card rendering. (#53395) Thanks @drvoss
-- Core/approvals: share approval-not-found fallback classification through the narrow `plugin-sdk/error-runtime` seam so core `/approve` and Telegram stay aligned without widening `plugin-sdk/infra-runtime`. (#60932) Thanks @gumadeiras.
 
 ## 2026.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,7 @@ Docs: https://docs.openclaw.ai
 - Agents/scheduling: route delayed follow-up requests toward cron only when cron is actually available, while keeping background `exec`/`process` guidance scoped to work that starts now. (#60811) Thanks @vincentkoc.
 - Cron/security: reject unsafe custom `sessionTarget: "session:..."` IDs earlier during cron add, update, and execution so malformed custom session keys fail closed with clear errors.
 - Feishu/cards: replace the legacy `wide_screen_mode` schema 1.x config with schema 2.0 `width_mode: "fill"` in interactive approval, launcher, markdown, and structured card builders so Feishu card sends stop failing with parse-card errors while preserving wide-card rendering. (#53395) Thanks @drvoss
+- Core/approvals: share approval-not-found fallback classification through the narrow `plugin-sdk/error-runtime` seam so core `/approve` and Telegram stay aligned without widening `plugin-sdk/infra-runtime`. (#60932) Thanks @gumadeiras.
 
 ## 2026.4.1
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8c38d3e2d0a61c02db70070e0d032b54b1de474000e1c1221332efc495e8681d  plugin-sdk-api-baseline.json
-d057310712f83b27f64b53dbe45ef2e92795407e56503a255de0f29d915c1ee4  plugin-sdk-api-baseline.jsonl
+0cd9a43c490bb5511890171543a3029754d44c9f1fe1ebf6f5c845fb49f44452  plugin-sdk-api-baseline.json
+66e1a9dff2b6c170dd1caceef1f15ad63c18f89c897d98f502cac1f2f46d26c2  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -207,7 +207,7 @@ Current bundled provider examples:
   | `plugin-sdk/ssrf-runtime` | SSRF runtime helpers | Pinned-dispatcher, guarded fetch, SSRF policy helpers |
   | `plugin-sdk/collection-runtime` | Bounded cache helpers | `pruneMapToMaxSize` |
   | `plugin-sdk/diagnostic-runtime` | Diagnostic gating helpers | `isDiagnosticFlagEnabled`, `isDiagnosticsEnabled` |
-  | `plugin-sdk/error-runtime` | Error formatting helpers | `formatUncaughtError`, error graph helpers |
+  | `plugin-sdk/error-runtime` | Error formatting helpers | `formatUncaughtError`, `isApprovalNotFoundError`, error graph helpers |
   | `plugin-sdk/fetch-runtime` | Wrapped fetch/proxy helpers | `resolveFetch`, proxy helpers |
   | `plugin-sdk/host-runtime` | Host normalization helpers | `normalizeHostname`, `normalizeScpRemoteHost` |
   | `plugin-sdk/retry-runtime` | Retry helpers | `RetryConfig`, `retryAsync`, policy runners |

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -210,7 +210,7 @@ explicitly promotes one as public.
     | `plugin-sdk/infra-runtime` | System event/heartbeat helpers |
     | `plugin-sdk/collection-runtime` | Small bounded cache helpers |
     | `plugin-sdk/diagnostic-runtime` | Diagnostic flag and event helpers |
-    | `plugin-sdk/error-runtime` | Error graph and formatting helpers |
+    | `plugin-sdk/error-runtime` | Error graph, formatting, and shared error classification helpers |
     | `plugin-sdk/fetch-runtime` | Wrapped fetch, proxy, and pinned lookup helpers |
     | `plugin-sdk/host-runtime` | Hostname and SCP host normalization helpers |
     | `plugin-sdk/retry-runtime` | Retry config and retry runner helpers |

--- a/extensions/telegram/src/exec-approval-resolver.ts
+++ b/extensions/telegram/src/exec-approval-resolver.ts
@@ -1,9 +1,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { isApprovalNotFoundError } from "openclaw/plugin-sdk/error-runtime";
 import { createOperatorApprovalsGatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
-import {
-  isApprovalNotFoundError,
-  type ExecApprovalReplyDecision,
-} from "openclaw/plugin-sdk/infra-runtime";
+import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/infra-runtime";
 
 export type ResolveTelegramExecApprovalParams = {
   cfg: OpenClawConfig;

--- a/extensions/telegram/src/exec-approval-resolver.ts
+++ b/extensions/telegram/src/exec-approval-resolver.ts
@@ -1,6 +1,9 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { createOperatorApprovalsGatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
-import type { ExecApprovalReplyDecision } from "openclaw/plugin-sdk/infra-runtime";
+import {
+  isApprovalNotFoundError,
+  type ExecApprovalReplyDecision,
+} from "openclaw/plugin-sdk/infra-runtime";
 
 export type ResolveTelegramExecApprovalParams = {
   cfg: OpenClawConfig;
@@ -10,38 +13,6 @@ export type ResolveTelegramExecApprovalParams = {
   allowPluginFallback?: boolean;
   gatewayUrl?: string;
 };
-
-const INVALID_REQUEST = "INVALID_REQUEST";
-const APPROVAL_NOT_FOUND = "APPROVAL_NOT_FOUND";
-
-function readErrorCode(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value : null;
-}
-
-function readApprovalNotFoundDetailsReason(value: unknown): string | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const reason = (value as { reason?: unknown }).reason;
-  return typeof reason === "string" && reason.trim() ? reason : null;
-}
-
-function isApprovalNotFoundError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-  const gatewayCode = readErrorCode((err as { gatewayCode?: unknown }).gatewayCode);
-  if (gatewayCode === APPROVAL_NOT_FOUND) {
-    return true;
-  }
-
-  const detailsReason = readApprovalNotFoundDetailsReason((err as { details?: unknown }).details);
-  if (gatewayCode === INVALID_REQUEST && detailsReason === APPROVAL_NOT_FOUND) {
-    return true;
-  }
-
-  return /unknown or expired approval id/i.test(err.message);
-}
 
 export async function resolveTelegramExecApproval(
   params: ResolveTelegramExecApprovalParams,

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -3,8 +3,8 @@ import {
   resolveChannelApprovalCapability,
 } from "../../channels/plugins/index.js";
 import { callGateway } from "../../gateway/call.js";
-import { ErrorCodes } from "../../gateway/protocol/index.js";
 import { logVerbose } from "../../globals.js";
+import { isApprovalNotFoundError } from "../../infra/approval-errors.js";
 import { resolveApprovalCommandAuthorization } from "../../infra/channel-approval-auth.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { resolveChannelAccountId } from "./channel-context.js";
@@ -76,39 +76,6 @@ function buildResolvedByLabel(params: Parameters<CommandHandler>[0]): string {
   const channel = params.command.channel;
   const sender = params.command.senderId ?? "unknown";
   return `${channel}:${sender}`;
-}
-
-function readErrorCode(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value : null;
-}
-
-function readApprovalNotFoundDetailsReason(value: unknown): string | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  const reason = (value as { reason?: unknown }).reason;
-  return typeof reason === "string" && reason.trim() ? reason : null;
-}
-
-function isApprovalNotFoundError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
-    return false;
-  }
-  const gatewayCode = readErrorCode((err as { gatewayCode?: unknown }).gatewayCode);
-  if (gatewayCode === ErrorCodes.APPROVAL_NOT_FOUND) {
-    return true;
-  }
-
-  const detailsReason = readApprovalNotFoundDetailsReason((err as { details?: unknown }).details);
-  if (
-    gatewayCode === ErrorCodes.INVALID_REQUEST &&
-    detailsReason === ErrorCodes.APPROVAL_NOT_FOUND
-  ) {
-    return true;
-  }
-
-  // Legacy server/client combinations may only include the message text.
-  return /unknown or expired approval id/i.test(err.message);
 }
 
 function formatApprovalSubmitError(error: unknown): string {

--- a/src/infra/approval-errors.test.ts
+++ b/src/infra/approval-errors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isApprovalNotFoundError } from "./approval-errors.js";
+
+describe("isApprovalNotFoundError", () => {
+  it("matches direct approval-not-found gateway codes", () => {
+    const err = new Error("approval not found") as Error & { gatewayCode?: string };
+    err.gatewayCode = "APPROVAL_NOT_FOUND";
+    expect(isApprovalNotFoundError(err)).toBe(true);
+  });
+
+  it("matches structured invalid-request approval-not-found details", () => {
+    const err = new Error("approval not found") as Error & {
+      gatewayCode?: string;
+      details?: { reason?: string };
+    };
+    err.gatewayCode = "INVALID_REQUEST";
+    err.details = { reason: "APPROVAL_NOT_FOUND" };
+    expect(isApprovalNotFoundError(err)).toBe(true);
+  });
+
+  it("matches legacy message-only not-found errors", () => {
+    expect(isApprovalNotFoundError(new Error("unknown or expired approval id"))).toBe(true);
+  });
+
+  it("ignores unrelated errors", () => {
+    expect(isApprovalNotFoundError(new Error("network timeout"))).toBe(false);
+    expect(isApprovalNotFoundError("unknown or expired approval id")).toBe(false);
+  });
+});

--- a/src/infra/approval-errors.ts
+++ b/src/infra/approval-errors.ts
@@ -1,0 +1,29 @@
+const INVALID_REQUEST = "INVALID_REQUEST";
+const APPROVAL_NOT_FOUND = "APPROVAL_NOT_FOUND";
+
+function readErrorCode(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function readApprovalNotFoundDetailsReason(value: unknown): string | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const reason = (value as { reason?: unknown }).reason;
+  return typeof reason === "string" && reason.trim() ? reason : null;
+}
+
+export function isApprovalNotFoundError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+  const gatewayCode = readErrorCode((err as { gatewayCode?: unknown }).gatewayCode);
+  if (gatewayCode === APPROVAL_NOT_FOUND) {
+    return true;
+  }
+  const detailsReason = readApprovalNotFoundDetailsReason((err as { details?: unknown }).details);
+  if (gatewayCode === INVALID_REQUEST && detailsReason === APPROVAL_NOT_FOUND) {
+    return true;
+  }
+  return /unknown or expired approval id/i.test(err.message);
+}

--- a/src/plugin-sdk/error-runtime.ts
+++ b/src/plugin-sdk/error-runtime.ts
@@ -7,3 +7,4 @@ export {
   formatUncaughtError,
   readErrorName,
 } from "../infra/errors.js";
+export { isApprovalNotFoundError } from "../infra/approval-errors.ts";

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -14,6 +14,7 @@ export * from "../infra/exec-approval-session-target.ts";
 export * from "../infra/exec-approvals.ts";
 export * from "../infra/approval-native-delivery.ts";
 export * from "../infra/approval-native-runtime.ts";
+export * from "../infra/approval-errors.ts";
 export * from "../infra/plugin-approvals.ts";
 export * from "../infra/fetch.js";
 export * from "../infra/file-lock.js";

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -14,7 +14,6 @@ export * from "../infra/exec-approval-session-target.ts";
 export * from "../infra/exec-approvals.ts";
 export * from "../infra/approval-native-delivery.ts";
 export * from "../infra/approval-native-runtime.ts";
-export * from "../infra/approval-errors.ts";
 export * from "../infra/plugin-approvals.ts";
 export * from "../infra/fetch.js";
 export * from "../infra/file-lock.js";

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -841,6 +841,7 @@ describe("plugin-sdk subpath exports", () => {
 
     expectSourceMentions("infra-runtime", ["createRuntimeOutboundDelegates"]);
     expectSourceContains("infra-runtime", "../infra/outbound/send-deps.js");
+    expectSourceMentions("error-runtime", ["formatUncaughtError", "isApprovalNotFoundError"]);
 
     expect(typeof channelLifecycleSdk.createDraftStreamLoop).toBe("function");
     expect(typeof channelLifecycleSdk.createFinalizableDraftLifecycle).toBe("function");


### PR DESCRIPTION
## Summary

- Problem: approval-not-found detection was duplicated in core `/approve` handling and the Telegram resolver.
- Why it matters: duplicated gateway-error parsing drifts easily and makes future approval-path fixes more expensive.
- What changed: moved approval-not-found classification into one shared infra helper and updated the core + Telegram callers to use it.
- What did NOT change (scope boundary): No Matrix UX changes, no approval prompt rendering changes, no protocol changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the same approval-not-found error decoding logic lived in multiple places instead of one shared helper.
- Missing detection / guardrail: no shared utility enforced consistent handling across approval submitters.
- Contributing context (if known): approval resolution spans legacy and structured gateway errors, so drift is easy when each caller hand-rolls the parser.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: existing approval submitter tests plus shared helper call sites
- Scenario the test should lock in: structured and legacy unknown/expired approval errors are classified consistently across callers.
- Why this is the smallest reliable guardrail: the behavior is pure error classification with thin caller wiring.
- Existing test that already covers this (if any): Telegram approval resolver coverage exercises not-found fallback behavior.
- If no new test is added, why not: this split keeps the already-covered shared-core extraction small and behavior-preserving.

## User-visible / Behavior Changes

- None

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm dev env
- Model/provider: N/A
- Integration/channel (if any): core approval routing + Telegram approval resolver
- Relevant config (redacted): N/A

### Steps

1. Trigger an approval resolution path that receives a structured or legacy unknown/expired approval error.
2. Observe fallback/handling in the caller.

### Expected

- Callers classify the error consistently using one shared helper.

### Actual

- Fixed by this PR.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: build passes; static checks pass; shared helper matches the prior caller behavior.
- Edge cases checked: structured `INVALID_REQUEST` + `APPROVAL_NOT_FOUND`, direct `APPROVAL_NOT_FOUND`, legacy message-text fallback.
- What you did **not** verify: full targeted Vitest reruns in this local environment beyond prior focused coverage.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: subtle mismatch with one callers previous local implementation.
  - Mitigation: the shared helper is a direct extraction of the existing logic and build/static checks passed.
