### PR TITLE
fix(auth): respect auth override by filtering profiles (token/oauth) (closes #60930)

### DIFF
--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -335,6 +335,7 @@ export async function resolveApiKeyForProvider(params: {
   }
 
   const authOverride = resolveProviderAuthOverride(cfg, provider);
+
   if (authOverride === "aws-sdk") {
     return resolveAwsSdkAuthInfo();
   }
@@ -345,7 +346,17 @@ export async function resolveApiKeyForProvider(params: {
     provider,
     preferredProfile,
   });
-  for (const candidate of order) {
+
+  const filteredOrder =
+    authOverride === "token"
+      ? order.filter((id) => store.profiles[id]?.type === "token")
+      : authOverride === "oauth"
+        ? order.filter((id) => store.profiles[id]?.type === "oauth")
+        : order;
+
+  const finalOrder = filteredOrder.length > 0 ? filteredOrder : order;
+
+  for (const candidate of finalOrder) {
     try {
       const resolved = await resolveApiKeyForProfile({
         cfg,


### PR DESCRIPTION
## Summary

- Problem: Auth profile resolution ignored `auth` override and selected OAuth profiles even when `mode: "token"` was configured
- Why it matters: Telegram and other integrations incorrectly used OAuth, consuming credits instead of billing via API key
- What changed: Filtered auth profile resolution order to respect `auth` override (`token` or `oauth`) with fallback to original order
- What did NOT change (scope boundary): No changes to env resolution, custom provider keys, or downstream auth handling

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens

## Linked Issue/PR

- Closes #60920
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Auth resolution loop iterated over all profiles without considering configured `auth` override, allowing higher-priority OAuth profiles to be selected
- Missing detection / guardrail: No filtering or prioritization based on explicit `auth` mode in config
- Contributing context (if known): Mixed auth profiles (OAuth + token) combined with default ordering led to unintended selection

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `model-auth.ts` auth resolution logic
- Scenario the test should lock in: When `auth: "token"` is set, only token profiles are selected unless none exist
- Why this is the smallest reliable guardrail: Directly validates core resolution logic without requiring full integration setup
- Existing test that already covers this (if any): None
- If no new test is added, why not: Can be added separately to avoid blocking fix

## User-visible / Behavior Changes

- Auth override (`auth: "token"` or `"oauth"`) is now strictly respected during profile selection

## Diagram (if applicable)

```text
Before:
[request] -> [all profiles considered] -> [OAuth selected] -> [credits used]

After:
[request] -> [filter by auth override] -> [token selected] -> [API key billing]