### PR TITLE
fix(msteams): replace deprecated HttpPlugin with httpServerAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/avatar: honor `ui.assistant.avatar` when serving `/avatar/:agentId` so Appearance UI avatar paths stop falling back to initials placeholders. (#60778) Thanks @hannasdev.
 - Control UI/Overview: prevent gateway access token/password visibility toggle buttons from overlapping their inputs at narrow widths. (#56924) Thanks @bbddbb1.
 - Control UI/cron: highlight the Cron refresh button while refresh is in flight so the page's loading state stays visible even when prior data remains on screen. (#60394) Thanks @coder-zhuzm.
+- MS Teams: replace the deprecated Teams SDK HttpPlugin stub with `httpServerAdapter` so recurring gateway deprecation warnings stop firing and the Express 5 compatibility workaround stays on the supported SDK path. (#60939) Thanks @coolramukaka-sys.
 
 ## 2026.4.2
 

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -81,9 +81,8 @@ function createSdkStub(): MSTeamsTeamsSdk {
 describe("createMSTeamsApp", () => {
   it("does not crash with express 5 path-to-regexp (#55161)", async () => {
     // Regression test for: https://github.com/openclaw/openclaw/issues/55161
-    // The default HttpPlugin in @microsoft/teams.apps uses `express().use('/api*', ...)`
-    // which throws in express 5 (path-to-regexp v8+). createMSTeamsApp injects a no-op
-    // HTTP plugin stub to prevent the SDK from creating the default HttpPlugin.
+    // createMSTeamsApp passes a no-op httpServerAdapter to prevent the SDK from
+    // creating its default HttpPlugin (which registers `/api*` — invalid in Express 5).
     const { App } = await import("@microsoft/teams.apps");
     const { Client } = await import("@microsoft/teams.api");
     const sdk: MSTeamsTeamsSdk = { App, Client };

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -1,3 +1,4 @@
+import type { IHttpServerAdapter } from "@microsoft/teams.apps/dist/http/index.js";
 import { formatUnknownError } from "./errors.js";
 import type { MSTeamsAdapter } from "./messenger.js";
 import type { MSTeamsCredentials } from "./token.js";
@@ -55,65 +56,22 @@ export async function loadMSTeamsSdk(): Promise<MSTeamsTeamsSdk> {
 }
 
 /**
- * Create a lightweight no-op HTTP plugin stub that satisfies the Teams SDK's
- * plugin discovery by name ("http") but does NOT spin up an Express server.
- *
- * The default HttpPlugin in @microsoft/teams.apps registers an Express
- * middleware with the pattern `/api*`.  When the host application (OpenClaw)
- * uses Express 5 — which depends on path-to-regexp v8 — that pattern is
- * invalid and throws:
- *
- *   Missing parameter name at index 5: /api*
+ * Create a no-op HTTP server adapter that satisfies the Teams SDK's
+ * IHttpServerAdapter interface without spinning up an Express server.
  *
  * OpenClaw manages its own Express server for the Teams webhook endpoint, so
- * the SDK's built-in HTTP server is unnecessary.  Passing this stub prevents
- * the SDK from creating the default HttpPlugin and avoids the crash.
+ * the SDK's built-in HTTP server is unnecessary.  Passing this adapter via the
+ * `httpServerAdapter` option prevents the SDK from creating the default
+ * HttpPlugin (which uses the deprecated `plugins` array and registers an
+ * Express middleware with the pattern `/api*` — invalid in Express 5).
  *
  * See: https://github.com/openclaw/openclaw/issues/55161
+ * See: https://github.com/openclaw/openclaw/issues/60732
  */
-async function createNoOpHttpPlugin(): Promise<unknown> {
-  // Lazy-import reflect-metadata (required by the Teams SDK decorator system)
-  // and the decorator key constants so we can tag the stub class correctly.
-  //
-  // FRAGILE: these are internal SDK paths (not public API).  If
-  // @microsoft/teams.apps changes its dist layout, these imports will break.
-  // Pin the SDK version and re-verify after any upgrade.
-  await import("reflect-metadata");
-  const { PLUGIN_METADATA_KEY } =
-    await import("@microsoft/teams.apps/dist/types/plugin/decorators/plugin.js");
-  const { PLUGIN_DEPENDENCIES_METADATA_KEY } =
-    await import("@microsoft/teams.apps/dist/types/plugin/decorators/dependency.js");
-  const { PLUGIN_EVENTS_METADATA_KEY } =
-    await import("@microsoft/teams.apps/dist/types/plugin/decorators/event.js");
-
-  class NoOpHttpPlugin {
-    onInit() {}
-    async onStart() {}
-    onStop() {}
-    asServer() {
-      return {
-        onRequest: undefined as unknown,
-        initialize: async () => {},
-        start: async () => {},
-        stop: async () => {},
-      } as {
-        onRequest: unknown;
-        initialize: (opts?: unknown) => Promise<void>;
-        start: (port?: number | string) => Promise<void>;
-        stop: () => Promise<void>;
-      };
-    }
-  }
-
-  Reflect.defineMetadata(
-    PLUGIN_METADATA_KEY,
-    { name: "http", version: "0.0.0", description: "no-op stub (express 5 compat)" },
-    NoOpHttpPlugin,
-  );
-  Reflect.defineMetadata(PLUGIN_DEPENDENCIES_METADATA_KEY, [], NoOpHttpPlugin);
-  Reflect.defineMetadata(PLUGIN_EVENTS_METADATA_KEY, [], NoOpHttpPlugin);
-
-  return new NoOpHttpPlugin();
+function createNoOpHttpServerAdapter(): IHttpServerAdapter {
+  return {
+    registerRoute() {},
+  };
 }
 
 /**
@@ -127,15 +85,11 @@ export async function createMSTeamsApp(
   creds: MSTeamsCredentials,
   sdk: MSTeamsTeamsSdk,
 ): Promise<MSTeamsApp> {
-  const noOpHttp = await createNoOpHttpPlugin();
-  // Use type assertion: the SDK's AppOptions generic narrows `plugins` to
-  // Array<TPlugin>, but our no-op stub satisfies the runtime contract without
-  // matching the decorator-heavy IPlugin type at compile time.
   return new sdk.App({
     clientId: creds.appId,
     clientSecret: creds.appPassword,
     tenantId: creds.tenantId,
-    plugins: [noOpHttp],
+    httpServerAdapter: createNoOpHttpServerAdapter(),
   } as ConstructorParameters<MSTeamsTeamsSdk["App"]>[0]);
 }
 

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -1,3 +1,5 @@
+// IHttpServerAdapter is re-exported via the public barrel (`export * from './http'`)
+// but tsgo cannot resolve the chain. Use the dist subpath directly (type-only import).
 import type { IHttpServerAdapter } from "@microsoft/teams.apps/dist/http/index.js";
 import { formatUnknownError } from "./errors.js";
 import type { MSTeamsAdapter } from "./messenger.js";
@@ -345,7 +347,7 @@ async function deleteActivityViaRest(params: {
  * Build a CloudAdapter-compatible adapter using the Teams SDK REST client.
  *
  * This replaces the previous CloudAdapter from @microsoft/agents-hosting.
- * For incoming requests: the App's HttpPlugin handles JWT validation.
+ * For incoming requests: the App's HTTP server handles JWT validation.
  * For proactive sends: uses the Bot Framework REST API via
  * @microsoft/teams.api Client.
  */


### PR DESCRIPTION
## Summary

- Migrate from the deprecated `plugins: [noOpHttpPlugin]` pattern to the SDK's public `httpServerAdapter` option in `createMSTeamsApp()`
- Eliminates the `[DEPRECATED] HttpPlugin in plugins array` warning that fires every ~60s in the gateway error log
- Removes ~40 lines of fragile code that used `reflect-metadata` hacks against internal SDK decorator paths

## What changed

**`extensions/msteams/src/sdk.ts`**
- Replaced the `createNoOpHttpPlugin()` function (~40 lines of reflect-metadata decorator hacks) with a 3-line `createNoOpHttpServerAdapter()` that implements `IHttpServerAdapter`
- `createMSTeamsApp()` now passes `httpServerAdapter` instead of `plugins: [noOpHttp]`
- Added type-only import for `IHttpServerAdapter` (dist subpath required — tsgo can't resolve the public barrel re-export chain)
- Fixed stale JSDoc referencing removed HttpPlugin

**`extensions/msteams/src/sdk.test.ts`**
- Updated test comment to reflect the new approach

## Before / After

**Before (main, unpatched)** — HttpPlugin warning fires every ~60s ([full log](https://github.com/SidU/ocmaintenance/blob/main/teams/testing/screenshots/2026-04-04/before-fix-gateway-warnings.txt)):
```
Apr 04 17:39:47 [WARN] @teams/app [DEPRECATED] HttpPlugin in plugins array will be deprecated...
Apr 04 17:40:47 [WARN] @teams/app [DEPRECATED] HttpPlugin in plugins array will be deprecated...
Apr 04 17:41:47 [WARN] @teams/app [DEPRECATED] HttpPlugin in plugins array will be deprecated...
```

**After (this PR)** — zero warnings over 2+ minute observation ([full log](https://github.com/SidU/ocmaintenance/blob/main/teams/testing/screenshots/2026-04-04/after-fix-gateway-logs.txt)):
```
Apr 04 17:42:49 [gateway] ready (6 plugins, 1.9s)
Apr 04 17:42:53 [msteams] starting provider (port 3979)
Apr 04 17:42:55 [msteams] users resolved: 11f44b5b...
(no HttpPlugin warnings)
```

**Teams UI** — bot receives messages, streams responses, shows AI label and feedback buttons:

![Streaming and feedback working](https://raw.githubusercontent.com/SidU/ocmaintenance/main/teams/testing/screenshots/2026-04-04/A1-A4-A6-streaming-feedback.png)

## Testing

- All 7 existing msteams SDK tests pass
- Deployed to Azure VM (`riley-inbestments.westus2.cloudapp.azure.com`) — before/after log comparison
- msteams channel starts, users resolve, messages flow end-to-end
- Verified in Teams via Playwright automation
- Zero HttpPlugin deprecation warnings after sustained activity
- Local gateway verified on macOS

### Smoke test results ([test plan](https://github.com/SidU/ocmaintenance/blob/main/teams/testing/test-plan.md))

| Test | Result | Notes |
|------|--------|-------|
| A1 Basic reply | PASS | Bot received and responded in 1:1 chat |
| A4 Streaming | PASS | Typing indicator + progress bar visible |
| A6 Feedback | PASS | Like/Dislike buttons render on bot messages |
| E4 HTTPS | PASS | `curl` returns 401 (rejects unauthenticated) |

All evidence: [SidU/ocmaintenance/teams/testing/screenshots/2026-04-04/](https://github.com/SidU/ocmaintenance/tree/main/teams/testing/screenshots/2026-04-04)

## Known issues (pre-existing, not caused by this PR)

- **openclaw/openclaw#60821**: OpenAI strict mode rejects tool schemas missing `additionalProperties: false` and `required` arrays. This affects all tools (`read`, `exec`, `cron`) on main — not introduced by this change.

Fixes: https://github.com/openclaw/openclaw/issues/60732
See also: https://github.com/openclaw/openclaw/issues/55161

🤖 Generated with [Claude Code](https://claude.com/claude-code)