### PR TITLE
fix: normalize macOS gateway version output with commit metadata

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -293,13 +293,47 @@ enum GatewayEnvironment {
 
     /// Exposed for tests so CLI version output normalization stays local to gateway checks.
     static func normalizeGatewayVersionOutput(_ raw: String?) -> String? {
-        guard var normalized = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !normalized.isEmpty else {
-            return nil
+        guard let raw else { return nil }
+
+        let lines = raw
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        let prefixedPattern = #"^openclaw\s+(v?\d+\.\d+\.\d+(?:[-+][^\s()]+)?)\s*(?:\([^\n]+\))?$"#
+        let barePattern = #"^(v?\d+\.\d+\.\d+(?:[-+][^\s()]+)?)\s*(?:\([^\n]+\))?$"#
+
+        func extractVersion(from line: String, pattern: String) -> String? {
+            guard let range = line.range(of: pattern, options: [.regularExpression, .caseInsensitive]),
+                  let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
+            else {
+                return nil
+            }
+
+            let nsRange = NSRange(range, in: line)
+            guard let match = regex.firstMatch(in: line, options: [], range: nsRange),
+                  match.numberOfRanges > 1,
+                  let versionRange = Range(match.range(at: 1), in: line)
+            else {
+                return nil
+            }
+
+            return String(line[versionRange])
         }
-        if normalized.lowercased().hasPrefix("openclaw ") {
-            normalized = String(normalized.dropFirst("openclaw ".count))
+
+        for line in lines {
+            if let version = extractVersion(from: line, pattern: prefixedPattern) {
+                return version
+            }
         }
-        return normalized
+
+        for line in lines {
+            if let version = extractVersion(from: line, pattern: barePattern) {
+                return version
+            }
+        }
+
+        return nil
     }
 
     private static func readGatewayVersion(binary: String) -> Semver? {

--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -302,16 +302,12 @@ enum GatewayEnvironment {
 
         let prefixedPattern = #"^openclaw\s+(v?\d+\.\d+\.\d+(?:[-+][^\s()]+)?)\s*(?:\([^\n]+\))?$"#
         let barePattern = #"^(v?\d+\.\d+\.\d+(?:[-+][^\s()]+)?)\s*(?:\([^\n]+\))?$"#
+        let prefixedRegex = try? NSRegularExpression(pattern: prefixedPattern, options: [.caseInsensitive])
+        let bareRegex = try? NSRegularExpression(pattern: barePattern, options: [.caseInsensitive])
 
-        func extractVersion(from line: String, pattern: String) -> String? {
-            guard let range = line.range(of: pattern, options: [.regularExpression, .caseInsensitive]),
-                  let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive])
-            else {
-                return nil
-            }
-
-            let nsRange = NSRange(range, in: line)
-            guard let match = regex.firstMatch(in: line, options: [], range: nsRange),
+        func extractVersion(from line: String, regex: NSRegularExpression?) -> String? {
+            let fullRange = NSRange(line.startIndex..<line.endIndex, in: line)
+            guard let match = regex?.firstMatch(in: line, options: [], range: fullRange),
                   match.numberOfRanges > 1,
                   let versionRange = Range(match.range(at: 1), in: line)
             else {
@@ -322,13 +318,13 @@ enum GatewayEnvironment {
         }
 
         for line in lines {
-            if let version = extractVersion(from: line, pattern: prefixedPattern) {
+            if let version = extractVersion(from: line, regex: prefixedRegex) {
                 return version
             }
         }
 
         for line in lines {
-            if let version = extractVersion(from: line, pattern: barePattern) {
+            if let version = extractVersion(from: line, regex: bareRegex) {
                 return version
             }
         }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
@@ -30,6 +30,24 @@ struct GatewayEnvironmentTests {
         #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 3, patch: 23))
     }
 
+    @Test func `gateway version output strips trailing commit metadata`() {
+        let normalized = GatewayEnvironment.normalizeGatewayVersionOutput("  OpenClaw 2026.4.2 (d74a122) \n")
+        #expect(normalized == "2026.4.2")
+        #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 4, patch: 2))
+    }
+
+    @Test func `gateway version output ignores extra lines`() {
+        let normalized = GatewayEnvironment.normalizeGatewayVersionOutput("warning: something else\nOpenClaw 2026.4.2 (d74a122)\n")
+        #expect(normalized == "2026.4.2")
+        #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 4, patch: 2))
+    }
+
+    @Test func `gateway version output prefers OpenClaw line over bare semver line`() {
+        let normalized = GatewayEnvironment.normalizeGatewayVersionOutput("2026.99.99\nOpenClaw 2026.4.2 (d74a122)\n")
+        #expect(normalized == "2026.4.2")
+        #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 4, patch: 2))
+    }
+
     @Test func `semver compatibility requires same major and not older`() {
         let required = Semver(major: 2, minor: 1, patch: 0)
         #expect(Semver(major: 2, minor: 1, patch: 0).compatible(with: required))

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
@@ -30,6 +30,18 @@ struct GatewayEnvironmentTests {
         #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 3, patch: 23))
     }
 
+    @Test func `gateway version output handles bare semver without prefix`() {
+        let normalized = GatewayEnvironment.normalizeGatewayVersionOutput("2026.4.2")
+        #expect(normalized == "2026.4.2")
+        #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 4, patch: 2))
+    }
+
+    @Test func `gateway version output strips commit metadata from bare semver`() {
+        let normalized = GatewayEnvironment.normalizeGatewayVersionOutput("2026.4.2 (d74a122)")
+        #expect(normalized == "2026.4.2")
+        #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 4, patch: 2))
+    }
+
     @Test func `gateway version output strips trailing commit metadata`() {
         let normalized = GatewayEnvironment.normalizeGatewayVersionOutput("  OpenClaw 2026.4.2 (d74a122) \n")
         #expect(normalized == "2026.4.2")


### PR DESCRIPTION
Closes #60925

## Summary

- normalize macOS gateway version output before semver parsing
- handle CLI output like `OpenClaw 2026.4.2 (d74a122)`
- add regression tests for prefixed, multiline, and commit-metadata cases

## What changed

The macOS app reads the installed gateway version from `openclaw --version`. In practice, the CLI can return output in this format:

```text
OpenClaw 2026.4.2 (d74a122)
```

This change keeps semver parsing strict and narrows the fix to the normalization step so the app extracts `2026.4.2` before parsing.

The tests cover:

- `OpenClaw`-prefixed version strings
- trailing commit metadata
- extra surrounding whitespace / extra lines
- preferring the `OpenClaw ...` line over unrelated bare semver-looking lines

## Why

Without this normalization, the macOS Settings UI can show the installed CLI / gateway version as `unknown` even when the installed CLI is valid and the gateway is working.

## Testing

- `swift test --filter GatewayEnvironmentTests` from `apps/macos`

## Screenshots

This is a narrow parsing fix and does not change layout or interaction. If maintainers prefer, I can attach before/after Settings screenshots from the macOS app.

## AI disclosure

This PR was prepared with AI assistance.