### PR TITLE
feat(plugins): add session followup turn API and gateway-restart extension

### DIFF
--- a/extensions/gateway-restart/index.test.ts
+++ b/extensions/gateway-restart/index.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
+
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  rmSync: vi.fn(),
+}));
+
+const execSyncMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs", () => ({
+  default: fsMocks,
+  ...fsMocks,
+}));
+
+vi.mock("node:child_process", () => ({
+  execSync: execSyncMock,
+}));
+
+// Suppress process.exit in tool execute
+vi.spyOn(global, "setTimeout").mockImplementation(() => 0 as unknown as ReturnType<typeof setTimeout>);
+
+import gatewayRestartPlugin from "./index.js";
+
+const STATE_DIR = "/tmp/gateway-restart-state";
+const MARKER_FILE = "restart-pending.json";
+const MARKER_PATH = `${STATE_DIR}/${MARKER_FILE}`;
+
+function createApi() {
+  const registerTool = vi.fn();
+  const registerService = vi.fn();
+  const followupRuntime = {
+    enqueueFollowupTurn: vi.fn(),
+  };
+
+  const api = createTestPluginApi({
+    id: "gateway-restart",
+    name: "Gateway Restart",
+    source: "test",
+    config: {},
+    runtime: {
+      followup: followupRuntime,
+      state: {
+        resolveStateDir: vi.fn().mockReturnValue(STATE_DIR),
+      },
+    } as unknown as Parameters<typeof createTestPluginApi>[0]["runtime"],
+    registerTool,
+    registerService,
+  });
+
+  return { api, registerTool, registerService, followupRuntime };
+}
+
+function getRegisteredTool(registerTool: ReturnType<typeof vi.fn>) {
+  const call = registerTool.mock.calls[0]?.[0];
+  if (!call) throw new Error("No tool registered");
+  return call as { execute: (toolCallId: string, params: unknown) => Promise<unknown> };
+}
+
+function getRegisteredService(registerService: ReturnType<typeof vi.fn>) {
+  const call = registerService.mock.calls[0]?.[0];
+  if (!call) throw new Error("No service registered");
+  return call as { start: (ctx: unknown) => Promise<void> };
+}
+
+function makeServiceCtx(overrides: Partial<{ stateDir: string }> = {}) {
+  return {
+    stateDir: overrides.stateDir ?? STATE_DIR,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fsMocks.mkdirSync.mockReturnValue(undefined);
+  fsMocks.writeFileSync.mockReturnValue(undefined);
+  fsMocks.rmSync.mockReturnValue(undefined);
+  execSyncMock.mockReturnValue("success output\n");
+});
+
+describe("gateway-restart plugin tool", () => {
+  it("rejects commands not in allowlist", async () => {
+    const { api, registerTool } = createApi();
+    gatewayRestartPlugin.register(api);
+
+    const tool = getRegisteredTool(registerTool);
+    const result = (await tool.execute("call-1", {
+      sessionKey: "agent:main:telegram:direct:123",
+      commands: ["rm -rf /"],
+    })) as { content: { text: string }[] };
+
+    expect(result.content[0]?.text).toMatch(/not allowed/i);
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("writes marker after pre-commands succeed", async () => {
+    const { api, registerTool } = createApi();
+    gatewayRestartPlugin.register(api);
+
+    const tool = getRegisteredTool(registerTool);
+    execSyncMock.mockReturnValue("installed\n");
+
+    await tool.execute("call-2", {
+      sessionKey: "agent:main:telegram:direct:123",
+      commands: ["openclaw gateway install --force"],
+      reason: "upgrade",
+    });
+
+    expect(execSyncMock).toHaveBeenCalledWith(
+      "openclaw gateway install --force",
+      expect.objectContaining({ encoding: "utf8" }),
+    );
+    expect(fsMocks.writeFileSync).toHaveBeenCalledWith(
+      MARKER_PATH,
+      expect.stringContaining("agent:main:telegram:direct:123"),
+      "utf8",
+    );
+  });
+
+  it("does not write marker when pre-command fails", async () => {
+    const { api, registerTool } = createApi();
+    gatewayRestartPlugin.register(api);
+
+    const tool = getRegisteredTool(registerTool);
+    execSyncMock.mockImplementation(() => {
+      throw new Error("command failed");
+    });
+
+    await expect(
+      tool.execute("call-3", {
+        sessionKey: "agent:main:telegram:direct:123",
+        commands: ["openclaw gateway install --force"],
+      }),
+    ).rejects.toThrow("command failed");
+
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled();
+  });
+});
+
+describe("gateway-restart plugin watcher service", () => {
+  it("does nothing when no marker exists", async () => {
+    const { api, registerService, followupRuntime } = createApi();
+    gatewayRestartPlugin.register(api);
+
+    fsMocks.existsSync.mockReturnValue(false);
+
+    const service = getRegisteredService(registerService);
+    await service.start(makeServiceCtx());
+
+    expect(followupRuntime.enqueueFollowupTurn).not.toHaveBeenCalled();
+  });
+
+  it("enqueues followup and deletes marker on success", async () => {
+    const { api, registerService, followupRuntime } = createApi();
+    gatewayRestartPlugin.register(api);
+
+    const marker = {
+      sessionKey: "agent:main:telegram:direct:123",
+      requestedAt: new Date().toISOString(),
+      preCommands: [],
+      reason: "test restart",
+      message: "All done",
+    };
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readFileSync.mockReturnValue(JSON.stringify(marker, null, 2));
+    followupRuntime.enqueueFollowupTurn.mockResolvedValue(true);
+
+    const service = getRegisteredService(registerService);
+    await service.start(makeServiceCtx());
+
+    expect(followupRuntime.enqueueFollowupTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:telegram:direct:123",
+        source: "gateway-restart",
+      }),
+    );
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(MARKER_PATH, { force: true });
+  });
+
+  it("leaves marker when enqueue fails", async () => {
+    const { api, registerService, followupRuntime } = createApi();
+    gatewayRestartPlugin.register(api);
+
+    const marker = {
+      sessionKey: "agent:main:telegram:direct:123",
+      requestedAt: new Date().toISOString(),
+      preCommands: [],
+    };
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readFileSync.mockReturnValue(JSON.stringify(marker, null, 2));
+    followupRuntime.enqueueFollowupTurn.mockResolvedValue(false);
+
+    const service = getRegisteredService(registerService);
+    await service.start(makeServiceCtx());
+
+    expect(followupRuntime.enqueueFollowupTurn).toHaveBeenCalled();
+    expect(fsMocks.rmSync).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/gateway-restart/index.test.ts
+++ b/extensions/gateway-restart/index.test.ts
@@ -1,3 +1,4 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
 
@@ -21,7 +22,9 @@ vi.mock("node:child_process", () => ({
 }));
 
 // Suppress process.exit in tool execute
-vi.spyOn(global, "setTimeout").mockImplementation(() => 0 as unknown as ReturnType<typeof setTimeout>);
+vi.spyOn(global, "setTimeout").mockImplementation(
+  () => 0 as unknown as ReturnType<typeof setTimeout>,
+);
 
 import gatewayRestartPlugin from "./index.js";
 
@@ -46,7 +49,7 @@ function createApi() {
       state: {
         resolveStateDir: vi.fn().mockReturnValue(STATE_DIR),
       },
-    } as unknown as Parameters<typeof createTestPluginApi>[0]["runtime"],
+    } as unknown as OpenClawPluginApi["runtime"],
     registerTool,
     registerService,
   });

--- a/extensions/gateway-restart/index.ts
+++ b/extensions/gateway-restart/index.ts
@@ -1,0 +1,223 @@
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { Type } from "@sinclair/typebox";
+import type { Static } from "@sinclair/typebox";
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+/**
+ * ## Security Considerations
+ *
+ * - **Shell command execution:** The tool runs commands from a plugin-config-defined
+ *   allowlist. Agents cannot specify arbitrary commands — only commands explicitly
+ *   listed in `config.allowedCommands` are permitted.
+ *
+ * - **Process termination:** `process.exit(0)` terminates the entire gateway process,
+ *   disconnecting all active sessions — not just the requesting agent. This is
+ *   intentional: the gateway restart is a global operation.
+ *
+ * - **Opt-in only:** The plugin is disabled by default (`enabledByDefault: false`
+ *   in the manifest). Operators must explicitly enable it via
+ *   `plugins.entries.gateway-restart.enabled: true`.
+ *
+ * - **Marker file contents:** The restart marker contains the session key and
+ *   optional message text. No credentials, API keys, or sensitive data are persisted.
+ *
+ * - **Followup turn trust level:** Plugin-initiated followup turns run with
+ *   `senderIsOwner: true`, establishing trusted execution context. This matches
+ *   the trust model for system-initiated turns (heartbeats, cron).
+ */
+
+type PluginConfig = {
+  allowedCommands?: string[];
+  markerFileName?: string;
+};
+
+const gatewayRestartParameters = Type.Object({
+  sessionKey: Type.String({
+    description: "Session key that should receive the post-restart callback event.",
+  }),
+  commands: Type.Optional(
+    Type.Array(Type.String(), {
+      description: "Optional allowlisted commands to execute before restart.",
+    }),
+  ),
+  reason: Type.Optional(
+    Type.String({
+      description: "Optional reason for logging and restart marker metadata.",
+    }),
+  ),
+  message: Type.Optional(
+    Type.String({
+      description: "Optional message to include in the post-restart callback event.",
+    }),
+  ),
+});
+
+type GatewayRestartParams = Static<typeof gatewayRestartParameters>;
+
+type RestartMarker = {
+  sessionKey: string;
+  requestedAt: string;
+  preCommands: string[];
+  reason?: string;
+  message?: string;
+};
+
+function resolveConfig(input: unknown): Required<PluginConfig> {
+  const raw = (input ?? {}) as PluginConfig;
+  return {
+    allowedCommands: raw.allowedCommands ?? ["openclaw gateway install --force"],
+    markerFileName: raw.markerFileName ?? "restart-pending.json",
+  };
+}
+
+function getMarkerPath(stateDir: string, markerFileName: string): string {
+  return path.join(stateDir, markerFileName);
+}
+
+export default definePluginEntry({
+  id: "gateway-restart",
+  name: "Gateway Restart",
+  description: "Agent-initiated gateway restart with post-restart session callback.",
+  register(api) {
+    const config = resolveConfig(api.pluginConfig);
+    // Fix 4 & 5: local const, type inferred from SDK (no module-level let, no manual FollowupRuntime type)
+    const followupRuntime = api.runtime.followup;
+    const stateDir = api.runtime.state.resolveStateDir();
+
+    api.registerTool({
+      name: "gateway_restart",
+      label: "Gateway Restart",
+      description:
+        "Restart the current OpenClaw gateway process, optionally run allowlisted commands first, and deliver a completion callback to the provided session.",
+      parameters: gatewayRestartParameters,
+      async execute(_toolCallId, params) {
+        const parsed = params as GatewayRestartParams;
+        const commands = parsed.commands ?? [];
+        const allowedCommands = new Set(config.allowedCommands);
+
+        if (commands.length > 0 && allowedCommands.size === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "ERROR: Pre-restart commands are disabled by plugin configuration.",
+              },
+            ],
+            details: null,
+          };
+        }
+
+        for (const command of commands) {
+          if (!allowedCommands.has(command)) {
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: `ERROR: Command not allowed: ${command}`,
+                },
+              ],
+              details: null,
+            };
+          }
+        }
+
+        const markerPath = getMarkerPath(stateDir, config.markerFileName);
+
+        const marker: RestartMarker = {
+          sessionKey: parsed.sessionKey,
+          requestedAt: new Date().toISOString(),
+          preCommands: commands,
+          reason: parsed.reason,
+          message: parsed.message,
+        };
+
+        // Fix 1: Execute pre-commands BEFORE writing marker.
+        // If execSync throws, we never write the marker, preventing stale markers.
+        const commandOutputs: string[] = [];
+        for (const command of commands) {
+          const output = execSync(command, {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+          commandOutputs.push(output);
+        }
+
+        // Fix 1: Write marker only after all pre-commands succeed.
+        fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+        fs.writeFileSync(markerPath, `${JSON.stringify(marker, null, 2)}\n`, "utf8");
+
+        setTimeout(() => process.exit(0), 500);
+
+        const outputSuffix =
+          commandOutputs.length > 0
+            ? `\n\nCommand output:\n${commandOutputs
+                .map((output, index) => `#${index + 1}\n${output.trim() || "(no output)"}`)
+                .join("\n\n")}`
+            : "";
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text:
+                `Gateway restart initiated. Pre-commands executed: ${commands.length}. ` +
+                "You will receive a callback when the gateway is back online." +
+                outputSuffix,
+            },
+          ],
+          details: null,
+        };
+      },
+    });
+
+    api.registerService({
+      id: "gateway-restart-watcher",
+      async start(ctx) {
+        const markerPath = getMarkerPath(ctx.stateDir, config.markerFileName);
+
+        if (!fs.existsSync(markerPath)) {
+          return;
+        }
+
+        let marker: RestartMarker;
+        try {
+          marker = JSON.parse(fs.readFileSync(markerPath, "utf8")) as RestartMarker;
+        } catch (error) {
+          ctx.logger.error(
+            `[gateway-restart] Failed to read restart marker ${markerPath}: ${String(error)}`,
+          );
+          return;
+        }
+
+        const requestedAtMs = Date.parse(marker.requestedAt);
+        const durationSeconds = Number.isFinite(requestedAtMs)
+          ? ((Date.now() - requestedAtMs) / 1000).toFixed(1)
+          : "unknown";
+        const completionText =
+          `[gateway-restart] Gateway restart complete (took ${durationSeconds}s). ${marker.message ?? ""}`.trim();
+
+        // Fix 2: Enqueue first, then conditionally delete marker.
+        const enqueued = await followupRuntime.enqueueFollowupTurn({
+          sessionKey: marker.sessionKey,
+          prompt: `${completionText} Continue with any remaining work.`,
+          source: "gateway-restart",
+        });
+
+        if (enqueued) {
+          // Fix 2: Only delete marker after successful enqueue.
+          fs.rmSync(markerPath, { force: true });
+          ctx.logger.info(
+            `[gateway-restart] Enqueued followup turn for session ${marker.sessionKey}.`,
+          );
+        } else {
+          ctx.logger.warn(
+            `[gateway-restart] Failed to enqueue followup turn for session ${marker.sessionKey} (session not found or deduped). Marker preserved for retry on next restart.`,
+          );
+          // Leave marker on disk so the next restart attempt can retry.
+        }
+      },
+    });
+  },
+});

--- a/extensions/gateway-restart/openclaw.plugin.json
+++ b/extensions/gateway-restart/openclaw.plugin.json
@@ -1,0 +1,24 @@
+{
+  "id": "gateway-restart",
+  "enabledByDefault": false,
+  "contracts": {
+    "tools": ["gateway_restart"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "allowedCommands": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Allowlist of commands that can be run before restart. Empty = no pre-commands allowed.",
+        "default": ["openclaw gateway install --force"]
+      },
+      "markerFileName": {
+        "type": "string",
+        "description": "Name of the restart marker file",
+        "default": "restart-pending.json"
+      }
+    }
+  }
+}

--- a/extensions/gateway-restart/package.json
+++ b/extensions/gateway-restart/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/gateway-restart-plugin",
+  "version": "2026.4.4-beta.1",
+  "private": true,
+  "description": "OpenClaw gateway restart plugin with session follow-up resume",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ],
+    "install": {
+      "npmSpec": "@openclaw/gateway-restart-plugin"
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,8 @@ importers:
 
   extensions/fireworks: {}
 
+  extensions/gateway-restart: {}
+
   extensions/github-copilot: {}
 
   extensions/google:

--- a/src/auto-reply/reply/queue/build-followup-run.test.ts
+++ b/src/auto-reply/reply/queue/build-followup-run.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../config/config.js", () => ({
+  loadConfig: vi.fn(),
+}));
+vi.mock("../../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(),
+  resolveStorePath: vi.fn(),
+  resolveSessionFilePath: vi.fn(),
+}));
+vi.mock("../../../agents/agent-scope.js", () => ({
+  resolveAgentDir: vi.fn(),
+  resolveAgentWorkspaceDir: vi.fn(),
+}));
+vi.mock("../../../agents/timeout.js", () => ({
+  resolveAgentTimeoutMs: vi.fn(),
+}));
+vi.mock("../../../routing/session-key.js", () => ({
+  resolveAgentIdFromSessionKey: vi.fn(),
+}));
+vi.mock("../../../agents/model-selection.js", () => ({
+  resolveDefaultModelForAgent: vi.fn(),
+  isReasoningTagProvider: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../../../globals.js", () => ({
+  logVerbose: vi.fn(),
+  shouldLogVerbose: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../../../utils/provider-utils.js", () => ({
+  isReasoningTagProvider: vi.fn().mockReturnValue(false),
+}));
+
+import { loadConfig } from "../../../config/config.js";
+import {
+  loadSessionStore,
+  resolveSessionFilePath,
+  resolveStorePath,
+} from "../../../config/sessions.js";
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import { resolveAgentTimeoutMs } from "../../../agents/timeout.js";
+import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
+import { resolveDefaultModelForAgent } from "../../../agents/model-selection.js";
+import { buildFollowupRunForSession } from "./build-followup-run.js";
+
+const SESSION_KEY = "agent:main:telegram:direct:123";
+
+function makeCfg() {
+  return { session: { store: "/tmp/store" } } as ReturnType<typeof loadConfig>;
+}
+
+function makeSessionEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: "session-abc",
+    updatedAt: Date.now(),
+    lastChannel: "telegram",
+    lastTo: "123",
+    lastAccountId: "acc-1",
+    lastThreadId: 456,
+    chatType: "direct" as const,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(loadConfig).mockReturnValue(makeCfg());
+  vi.mocked(resolveStorePath).mockReturnValue("/tmp/store/main");
+  vi.mocked(resolveAgentDir).mockReturnValue("/tmp/agents/main");
+  vi.mocked(resolveAgentWorkspaceDir).mockReturnValue("/tmp/workspace");
+  vi.mocked(resolveAgentTimeoutMs).mockReturnValue(300_000);
+  vi.mocked(resolveAgentIdFromSessionKey).mockReturnValue("main");
+  vi.mocked(resolveDefaultModelForAgent).mockReturnValue({
+    provider: "anthropic",
+    model: "claude-opus-4-6",
+  } as ReturnType<typeof resolveDefaultModelForAgent>);
+  vi.mocked(resolveSessionFilePath).mockReturnValue("/tmp/store/main/session-abc.jsonl");
+});
+
+describe("buildFollowupRunForSession", () => {
+  it("returns null when session key not found", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({});
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("populates provider/model from session overrides", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry({
+        providerOverride: "openai",
+        modelOverride: "gpt-4o",
+      }),
+    });
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+    expect(result).not.toBeNull();
+    expect(result?.run.provider).toBe("openai");
+    expect(result?.run.model).toBe("gpt-4o");
+  });
+
+  it("falls back to agent defaults when no session overrides", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry(),
+    });
+    vi.mocked(resolveDefaultModelForAgent).mockReturnValue({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    } as ReturnType<typeof resolveDefaultModelForAgent>);
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+    expect(result?.run.provider).toBe("anthropic");
+    expect(result?.run.model).toBe("claude-sonnet-4-6");
+  });
+
+  it("resolves delivery context from session entry", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry({
+        lastChannel: "telegram",
+        lastTo: "456",
+        lastAccountId: "acc-2",
+        lastThreadId: 789,
+        chatType: "group",
+      }),
+    });
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+    expect(result?.originatingChannel).toBe("telegram");
+    expect(result?.originatingTo).toBe("456");
+    expect(result?.originatingAccountId).toBe("acc-2");
+    expect(result?.originatingThreadId).toBe(789);
+    expect(result?.originatingChatType).toBe("group");
+  });
+
+  it("prefers params delivery context over session entry", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry(),
+    });
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+      originatingChannel: "discord",
+      originatingTo: "param-to",
+      originatingAccountId: "param-acc",
+      originatingThreadId: 99,
+      originatingChatType: "group",
+    });
+    expect(result?.originatingChannel).toBe("discord");
+    expect(result?.originatingTo).toBe("param-to");
+    expect(result?.originatingAccountId).toBe("param-acc");
+    expect(result?.originatingThreadId).toBe(99);
+    expect(result?.originatingChatType).toBe("group");
+  });
+
+  it("populates auth profile from session entry", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry({
+        authProfileOverride: "profile-x",
+        authProfileOverrideSource: "user",
+      }),
+    });
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+    expect(result?.run.authProfileId).toBe("profile-x");
+    expect(result?.run.authProfileIdSource).toBe("user");
+  });
+
+  it("always sets senderIsOwner to true", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry(),
+    });
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+    expect(result?.run.senderIsOwner).toBe(true);
+  });
+
+  it("propagates session runtime levels", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry({
+        thinkingLevel: "high",
+        verboseLevel: "verbose",
+        reasoningLevel: "on",
+        elevatedLevel: "on",
+      }),
+    });
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+    expect(result?.run.thinkLevel).toBe("high");
+    expect(result?.run.verboseLevel).toBe("verbose");
+    expect(result?.run.reasoningLevel).toBe("on");
+    expect(result?.run.elevatedLevel).toBe("on");
+  });
+
+  it("uses sessionFile from entry when present", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry({
+        sessionFile: "/custom/path/session.jsonl",
+      }),
+    });
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+    expect(result?.run.sessionFile).toBe("/custom/path/session.jsonl");
+  });
+
+  it("falls back to resolveSessionFilePath when no sessionFile", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry(),
+    });
+    vi.mocked(resolveSessionFilePath).mockReturnValue("/fallback/session.jsonl");
+    const result = await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+    expect(result?.run.sessionFile).toBe("/fallback/session.jsonl");
+  });
+});

--- a/src/auto-reply/reply/queue/build-followup-run.test.ts
+++ b/src/auto-reply/reply/queue/build-followup-run.test.ts
@@ -7,6 +7,7 @@ vi.mock("../../../config/sessions.js", () => ({
   loadSessionStore: vi.fn(),
   resolveStorePath: vi.fn(),
   resolveSessionFilePath: vi.fn(),
+  resolveSessionFilePathOptions: vi.fn(),
 }));
 vi.mock("../../../agents/agent-scope.js", () => ({
   resolveAgentDir: vi.fn(),
@@ -30,16 +31,17 @@ vi.mock("../../../utils/provider-utils.js", () => ({
   isReasoningTagProvider: vi.fn().mockReturnValue(false),
 }));
 
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import { resolveDefaultModelForAgent } from "../../../agents/model-selection.js";
+import { resolveAgentTimeoutMs } from "../../../agents/timeout.js";
 import { loadConfig } from "../../../config/config.js";
 import {
   loadSessionStore,
   resolveSessionFilePath,
+  resolveSessionFilePathOptions,
   resolveStorePath,
 } from "../../../config/sessions.js";
-import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
-import { resolveAgentTimeoutMs } from "../../../agents/timeout.js";
 import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
-import { resolveDefaultModelForAgent } from "../../../agents/model-selection.js";
 import { buildFollowupRunForSession } from "./build-followup-run.js";
 
 const SESSION_KEY = "agent:main:telegram:direct:123";
@@ -74,6 +76,10 @@ beforeEach(() => {
     model: "claude-opus-4-6",
   } as ReturnType<typeof resolveDefaultModelForAgent>);
   vi.mocked(resolveSessionFilePath).mockReturnValue("/tmp/store/main/session-abc.jsonl");
+  vi.mocked(resolveSessionFilePathOptions).mockReturnValue({
+    agentId: "main",
+    sessionsDir: "/tmp/store",
+  });
 });
 
 describe("buildFollowupRunForSession", () => {
@@ -227,5 +233,31 @@ describe("buildFollowupRunForSession", () => {
       prompt: "hello",
     });
     expect(result?.run.sessionFile).toBe("/fallback/session.jsonl");
+  });
+
+  it("passes store path to resolveSessionFilePathOptions for correct fallback dir", async () => {
+    vi.mocked(loadSessionStore).mockReturnValue({
+      [SESSION_KEY]: makeSessionEntry(),
+    });
+    vi.mocked(resolveStorePath).mockReturnValue("/custom/store/main");
+    vi.mocked(resolveSessionFilePathOptions).mockReturnValue({
+      agentId: "main",
+      sessionsDir: "/custom/store",
+    });
+    vi.mocked(resolveSessionFilePath).mockReturnValue("/custom/store/session-abc.jsonl");
+
+    await buildFollowupRunForSession({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+
+    expect(resolveSessionFilePathOptions).toHaveBeenCalledWith({
+      agentId: "main",
+      storePath: "/custom/store/main",
+    });
+    expect(resolveSessionFilePath).toHaveBeenCalledWith("session-abc", expect.anything(), {
+      agentId: "main",
+      sessionsDir: "/custom/store",
+    });
   });
 });

--- a/src/auto-reply/reply/queue/build-followup-run.ts
+++ b/src/auto-reply/reply/queue/build-followup-run.ts
@@ -1,0 +1,129 @@
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../../agents/defaults.js";
+import { resolveDefaultModelForAgent } from "../../../agents/model-selection.js";
+import { resolveAgentTimeoutMs } from "../../../agents/timeout.js";
+import { loadConfig } from "../../../config/config.js";
+import {
+  loadSessionStore,
+  resolveSessionFilePath,
+  resolveStorePath,
+} from "../../../config/sessions.js";
+import { logVerbose } from "../../../globals.js";
+import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
+import type { FollowupRun } from "./types.js";
+
+export type BuildFollowupRunParams = {
+  sessionKey: string;
+  prompt: string;
+  agentId?: string;
+  originatingChannel?: string;
+  originatingTo?: string;
+  originatingAccountId?: string;
+  originatingThreadId?: string | number;
+  originatingChatType?: string;
+  /** Override model for this turn */
+  model?: string;
+  /** Override provider for this turn */
+  provider?: string;
+  /** Extra system prompt injected for this turn */
+  extraSystemPrompt?: string;
+  /** Timeout in ms (default: agent config or 300_000) */
+  timeoutMs?: number;
+  /** Source attribution for logging */
+  source?: string;
+};
+
+export async function buildFollowupRunForSession(
+  params: BuildFollowupRunParams,
+): Promise<FollowupRun | null> {
+  const source = params.source ?? "plugin.followup";
+  const agentId = params.agentId?.trim() || resolveAgentIdFromSessionKey(params.sessionKey);
+  const cfg = loadConfig();
+  const agentDir = resolveAgentDir(cfg, agentId);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+  const store = loadSessionStore(resolveStorePath(cfg.session?.store, { agentId }));
+  const sessionEntry = store[params.sessionKey];
+
+  if (!sessionEntry) {
+    logVerbose(
+      `[${source}] session not found for key "${params.sessionKey}"; skipping followup enqueue`,
+    );
+    return null;
+  }
+
+  const agentDefaults = resolveDefaultModelForAgent({ cfg, agentId });
+  const provider =
+    params.provider?.trim() ||
+    sessionEntry.providerOverride?.trim() ||
+    sessionEntry.modelProvider?.trim() ||
+    agentDefaults.provider ||
+    DEFAULT_PROVIDER;
+  const model =
+    params.model?.trim() ||
+    sessionEntry.modelOverride?.trim() ||
+    sessionEntry.model?.trim() ||
+    agentDefaults.model ||
+    DEFAULT_MODEL;
+  const sessionFile =
+    sessionEntry.sessionFile?.trim() ||
+    resolveSessionFilePath(sessionEntry.sessionId, sessionEntry, { agentId });
+  const timeoutMs = resolveAgentTimeoutMs({
+    cfg,
+    overrideMs: params.timeoutMs,
+    minMs: 1,
+  });
+
+  logVerbose(
+    `[${source}] building followup run for session "${params.sessionKey}" (agent=${agentId}, provider=${provider}, model=${model})`,
+  );
+
+  return {
+    prompt: params.prompt,
+    enqueuedAt: Date.now(),
+    originatingChannel:
+      (params.originatingChannel as FollowupRun["originatingChannel"] | undefined) ??
+      sessionEntry.lastChannel,
+    originatingTo: params.originatingTo ?? sessionEntry.lastTo,
+    originatingAccountId: params.originatingAccountId ?? sessionEntry.lastAccountId,
+    originatingThreadId: params.originatingThreadId ?? sessionEntry.lastThreadId,
+    originatingChatType: params.originatingChatType ?? sessionEntry.chatType,
+    run: {
+      agentId,
+      agentDir,
+      sessionId: sessionEntry.sessionId,
+      sessionKey: params.sessionKey,
+      senderIsOwner: true,
+      sessionFile,
+      workspaceDir,
+      config: cfg,
+      provider,
+      model,
+      timeoutMs,
+      blockReplyBreak: "text_end",
+      authProfileId: sessionEntry.authProfileOverride?.trim() || undefined,
+      authProfileIdSource: sessionEntry.authProfileOverrideSource,
+      extraSystemPrompt: params.extraSystemPrompt,
+      // Session runtime levels
+      thinkLevel: (sessionEntry.thinkingLevel as FollowupRun["run"]["thinkLevel"]) ?? undefined,
+      verboseLevel: (sessionEntry.verboseLevel as FollowupRun["run"]["verboseLevel"]) ?? undefined,
+      reasoningLevel: (sessionEntry.reasoningLevel as FollowupRun["run"]["reasoningLevel"]) ?? undefined,
+      elevatedLevel: (sessionEntry.elevatedLevel as FollowupRun["run"]["elevatedLevel"]) ?? undefined,
+      // Exec overrides from session
+      execOverrides: (sessionEntry.execHost || sessionEntry.execSecurity || sessionEntry.execAsk || sessionEntry.execNode)
+        ? ({
+            host: sessionEntry.execHost,
+            security: sessionEntry.execSecurity,
+            ask: sessionEntry.execAsk,
+            node: sessionEntry.execNode,
+          } as FollowupRun["run"]["execOverrides"])
+        : undefined,
+      // Message provider for reply routing
+      messageProvider: sessionEntry.lastChannel ?? undefined,
+      // Enforce final reasoning tag for providers that use tagged reasoning output
+      ...(isReasoningTagProvider(provider, { config: cfg, workspaceDir, modelId: model })
+        ? { enforceFinalTag: true }
+        : {}),
+    },
+  };
+}

--- a/src/auto-reply/reply/queue/build-followup-run.ts
+++ b/src/auto-reply/reply/queue/build-followup-run.ts
@@ -1,5 +1,4 @@
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
-import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../../agents/defaults.js";
 import { resolveDefaultModelForAgent } from "../../../agents/model-selection.js";
 import { resolveAgentTimeoutMs } from "../../../agents/timeout.js";
@@ -7,10 +6,12 @@ import { loadConfig } from "../../../config/config.js";
 import {
   loadSessionStore,
   resolveSessionFilePath,
+  resolveSessionFilePathOptions,
   resolveStorePath,
 } from "../../../config/sessions.js";
 import { logVerbose } from "../../../globals.js";
 import { resolveAgentIdFromSessionKey } from "../../../routing/session-key.js";
+import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import type { FollowupRun } from "./types.js";
 
 export type BuildFollowupRunParams = {
@@ -42,7 +43,8 @@ export async function buildFollowupRunForSession(
   const cfg = loadConfig();
   const agentDir = resolveAgentDir(cfg, agentId);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
-  const store = loadSessionStore(resolveStorePath(cfg.session?.store, { agentId }));
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  const store = loadSessionStore(storePath);
   const sessionEntry = store[params.sessionKey];
 
   if (!sessionEntry) {
@@ -65,9 +67,10 @@ export async function buildFollowupRunForSession(
     sessionEntry.model?.trim() ||
     agentDefaults.model ||
     DEFAULT_MODEL;
+  const sessionFileOpts = resolveSessionFilePathOptions({ agentId, storePath });
   const sessionFile =
     sessionEntry.sessionFile?.trim() ||
-    resolveSessionFilePath(sessionEntry.sessionId, sessionEntry, { agentId });
+    resolveSessionFilePath(sessionEntry.sessionId, sessionEntry, sessionFileOpts);
   const timeoutMs = resolveAgentTimeoutMs({
     cfg,
     overrideMs: params.timeoutMs,
@@ -107,17 +110,23 @@ export async function buildFollowupRunForSession(
       // Session runtime levels
       thinkLevel: (sessionEntry.thinkingLevel as FollowupRun["run"]["thinkLevel"]) ?? undefined,
       verboseLevel: (sessionEntry.verboseLevel as FollowupRun["run"]["verboseLevel"]) ?? undefined,
-      reasoningLevel: (sessionEntry.reasoningLevel as FollowupRun["run"]["reasoningLevel"]) ?? undefined,
-      elevatedLevel: (sessionEntry.elevatedLevel as FollowupRun["run"]["elevatedLevel"]) ?? undefined,
+      reasoningLevel:
+        (sessionEntry.reasoningLevel as FollowupRun["run"]["reasoningLevel"]) ?? undefined,
+      elevatedLevel:
+        (sessionEntry.elevatedLevel as FollowupRun["run"]["elevatedLevel"]) ?? undefined,
       // Exec overrides from session
-      execOverrides: (sessionEntry.execHost || sessionEntry.execSecurity || sessionEntry.execAsk || sessionEntry.execNode)
-        ? ({
-            host: sessionEntry.execHost,
-            security: sessionEntry.execSecurity,
-            ask: sessionEntry.execAsk,
-            node: sessionEntry.execNode,
-          } as FollowupRun["run"]["execOverrides"])
-        : undefined,
+      execOverrides:
+        sessionEntry.execHost ||
+        sessionEntry.execSecurity ||
+        sessionEntry.execAsk ||
+        sessionEntry.execNode
+          ? ({
+              host: sessionEntry.execHost,
+              security: sessionEntry.execSecurity,
+              ask: sessionEntry.execAsk,
+              node: sessionEntry.execNode,
+            } as FollowupRun["run"]["execOverrides"])
+          : undefined,
       // Message provider for reply routing
       messageProvider: sessionEntry.lastChannel ?? undefined,
       // Enforce final reasoning tag for providers that use tagged reasoning output

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -20,6 +20,7 @@ import { defineCachedValue } from "./runtime-cache.js";
 import { createRuntimeChannel } from "./runtime-channel.js";
 import { createRuntimeConfig } from "./runtime-config.js";
 import { createRuntimeEvents } from "./runtime-events.js";
+import { createRuntimeFollowup } from "./runtime-followup.js";
 import { createRuntimeLogging } from "./runtime-logging.js";
 import { createRuntimeMedia } from "./runtime-media.js";
 import { createRuntimeSystem } from "./runtime-system.js";
@@ -209,6 +210,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     state: { resolveStateDir },
     tasks,
     taskFlow,
+    followup: createRuntimeFollowup(),
   } satisfies Omit<
     PluginRuntime,
     "tts" | "mediaUnderstanding" | "stt" | "modelAuth" | "imageGeneration" | "videoGeneration"

--- a/src/plugins/runtime/runtime-followup.test.ts
+++ b/src/plugins/runtime/runtime-followup.test.ts
@@ -28,6 +28,10 @@ vi.mock("../../runtime.js", () => ({
 vi.mock("../../agents/defaults.js", () => ({
   DEFAULT_MODEL: "gpt-5.4",
 }));
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(),
+  resolveStorePath: vi.fn(),
+}));
 
 import { createFollowupRunner } from "../../auto-reply/reply/followup-runner.js";
 import { buildFollowupRunForSession } from "../../auto-reply/reply/queue/build-followup-run.js";
@@ -38,6 +42,7 @@ import {
 import { enqueueFollowupRun } from "../../auto-reply/reply/queue/enqueue.js";
 import { getExistingFollowupQueue } from "../../auto-reply/reply/queue/state.js";
 import { createTypingController } from "../../auto-reply/reply/typing.js";
+import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { createRuntimeFollowup } from "./runtime-followup.js";
 
 const SESSION_KEY = "agent:main:telegram:direct:123:thread:123:456";
@@ -53,7 +58,7 @@ function makeFollowupRun() {
       sessionKey: SESSION_KEY,
       sessionFile: "/tmp/session-abc.jsonl",
       workspaceDir: "/tmp/workspace",
-      config: {},
+      config: { session: { store: "/tmp/custom-sessions.json" } },
       provider: "anthropic",
       model: "claude-opus-4-6",
       timeoutMs: 300_000,
@@ -78,6 +83,13 @@ beforeEach(() => {
   (enqueueFollowupRun as ReturnType<typeof vi.fn>).mockReturnValue(true);
   // Default: followup run built successfully
   (buildFollowupRunForSession as ReturnType<typeof vi.fn>).mockResolvedValue(makeFollowupRun());
+  (resolveStorePath as ReturnType<typeof vi.fn>).mockReturnValue("/tmp/custom-sessions.json");
+  (loadSessionStore as ReturnType<typeof vi.fn>).mockReturnValue({
+    [SESSION_KEY]: {
+      sessionId: "session-abc",
+      sessionFile: "/tmp/session-abc.jsonl",
+    },
+  });
 });
 
 describe("createRuntimeFollowup", () => {
@@ -169,6 +181,37 @@ describe("createRuntimeFollowup", () => {
     // Should register fresh runner and kick again
     expect(rememberFollowupDrainCallback).toHaveBeenCalled();
     expect(kickFollowupDrainIfIdle).toHaveBeenCalledTimes(2);
+  });
+
+  it("passes session metadata into cold followup runner", async () => {
+    (getExistingFollowupQueue as ReturnType<typeof vi.fn>).mockReturnValue({ draining: false });
+    const sessionStore = {
+      [SESSION_KEY]: {
+        sessionId: "session-abc",
+        sessionFile: "/tmp/session-abc.jsonl",
+      },
+    };
+    (loadSessionStore as ReturnType<typeof vi.fn>).mockReturnValue(sessionStore);
+
+    const followup = createRuntimeFollowup();
+    const result = await followup.enqueueFollowupTurn({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+
+    expect(result).toBe(true);
+    expect(resolveStorePath).toHaveBeenCalledWith("/tmp/custom-sessions.json", {
+      agentId: "main",
+    });
+    expect(createFollowupRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionEntry: sessionStore[SESSION_KEY],
+        sessionStore,
+        sessionKey: SESSION_KEY,
+        storePath: "/tmp/custom-sessions.json",
+        defaultModel: "claude-opus-4-6",
+      }),
+    );
   });
 
   it("catches errors and returns false", async () => {

--- a/src/plugins/runtime/runtime-followup.test.ts
+++ b/src/plugins/runtime/runtime-followup.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../auto-reply/reply/queue/build-followup-run.js", () => ({
+  buildFollowupRunForSession: vi.fn(),
+}));
+vi.mock("../../auto-reply/reply/queue/enqueue.js", () => ({
+  enqueueFollowupRun: vi.fn(),
+}));
+vi.mock("../../auto-reply/reply/queue/drain.js", () => ({
+  kickFollowupDrainIfIdle: vi.fn(),
+  rememberFollowupDrainCallback: vi.fn(),
+}));
+vi.mock("../../auto-reply/reply/queue/state.js", () => ({
+  getExistingFollowupQueue: vi.fn(),
+}));
+vi.mock("../../auto-reply/reply/followup-runner.js", () => ({
+  createFollowupRunner: vi.fn(),
+}));
+vi.mock("../../auto-reply/reply/typing.js", () => ({
+  createTypingController: vi.fn(),
+}));
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: { error: vi.fn() },
+}));
+vi.mock("../../agents/defaults.js", () => ({
+  DEFAULT_MODEL: "gpt-5.4",
+}));
+
+import { buildFollowupRunForSession } from "../../auto-reply/reply/queue/build-followup-run.js";
+import { enqueueFollowupRun } from "../../auto-reply/reply/queue/enqueue.js";
+import {
+  kickFollowupDrainIfIdle,
+  rememberFollowupDrainCallback,
+} from "../../auto-reply/reply/queue/drain.js";
+import { getExistingFollowupQueue } from "../../auto-reply/reply/queue/state.js";
+import { createFollowupRunner } from "../../auto-reply/reply/followup-runner.js";
+import { createTypingController } from "../../auto-reply/reply/typing.js";
+import { createRuntimeFollowup } from "./runtime-followup.js";
+
+const SESSION_KEY = "agent:main:telegram:direct:123:thread:123:456";
+
+function makeFollowupRun() {
+  return {
+    prompt: "continue",
+    enqueuedAt: Date.now(),
+    run: {
+      agentId: "main",
+      agentDir: "/tmp/agent",
+      sessionId: "session-abc",
+      sessionKey: SESSION_KEY,
+      sessionFile: "/tmp/session-abc.jsonl",
+      workspaceDir: "/tmp/workspace",
+      config: {},
+      provider: "anthropic",
+      model: "claude-opus-4-6",
+      timeoutMs: 300_000,
+      blockReplyBreak: "text_end" as const,
+      senderIsOwner: true,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  const mockTypingController = {};
+  (createTypingController as ReturnType<typeof vi.fn>).mockReturnValue(mockTypingController);
+
+  const mockRunner = { run: vi.fn() };
+  (createFollowupRunner as ReturnType<typeof vi.fn>).mockReturnValue(mockRunner);
+
+  // Default: no existing queue
+  (getExistingFollowupQueue as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+  // Default: enqueue succeeds
+  (enqueueFollowupRun as ReturnType<typeof vi.fn>).mockReturnValue(true);
+  // Default: followup run built successfully
+  (buildFollowupRunForSession as ReturnType<typeof vi.fn>).mockResolvedValue(makeFollowupRun());
+});
+
+describe("createRuntimeFollowup", () => {
+  it("returns false when session not found", async () => {
+    (buildFollowupRunForSession as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const followup = createRuntimeFollowup();
+    const result = await followup.enqueueFollowupTurn({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+
+    expect(result).toBe(false);
+    expect(enqueueFollowupRun).not.toHaveBeenCalled();
+  });
+
+  it("returns true and enqueues run on happy path", async () => {
+    // Cold session: no existing callback, queue is not draining after kick
+    (getExistingFollowupQueue as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+
+    const followup = createRuntimeFollowup();
+    const result = await followup.enqueueFollowupTurn({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+
+    expect(result).toBe(true);
+    expect(enqueueFollowupRun).toHaveBeenCalledWith(
+      SESSION_KEY,
+      expect.objectContaining({ prompt: "continue" }),
+      { mode: "followup" },
+      "none",
+      undefined,
+      false,
+    );
+  });
+
+  it("uses existing drain callback for hot sessions (kickFollowupDrainIfIdle started drain)", async () => {
+    // Simulate hot session: after kick, queue shows draining=true
+    (getExistingFollowupQueue as ReturnType<typeof vi.fn>).mockReturnValue({ draining: true });
+
+    const followup = createRuntimeFollowup();
+    const result = await followup.enqueueFollowupTurn({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+
+    expect(result).toBe(true);
+    // Should kick but NOT register a new callback (hot session handled by existing runner)
+    expect(kickFollowupDrainIfIdle).toHaveBeenCalledWith(SESSION_KEY);
+    expect(rememberFollowupDrainCallback).not.toHaveBeenCalled();
+  });
+
+  it("creates fresh runner for cold sessions when queue not draining", async () => {
+    // Cold session: queue exists but not draining
+    (getExistingFollowupQueue as ReturnType<typeof vi.fn>).mockReturnValue({ draining: false });
+
+    const followup = createRuntimeFollowup();
+    const result = await followup.enqueueFollowupTurn({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+
+    expect(result).toBe(true);
+    // Should register fresh runner and kick again
+    expect(rememberFollowupDrainCallback).toHaveBeenCalled();
+    expect(kickFollowupDrainIfIdle).toHaveBeenCalledTimes(2);
+  });
+
+  it("catches errors and returns false", async () => {
+    (buildFollowupRunForSession as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("session store unavailable"),
+    );
+
+    const followup = createRuntimeFollowup();
+    const result = await followup.enqueueFollowupTurn({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+
+    expect(result).toBe(false);
+  });
+});

--- a/src/plugins/runtime/runtime-followup.test.ts
+++ b/src/plugins/runtime/runtime-followup.test.ts
@@ -29,14 +29,14 @@ vi.mock("../../agents/defaults.js", () => ({
   DEFAULT_MODEL: "gpt-5.4",
 }));
 
+import { createFollowupRunner } from "../../auto-reply/reply/followup-runner.js";
 import { buildFollowupRunForSession } from "../../auto-reply/reply/queue/build-followup-run.js";
-import { enqueueFollowupRun } from "../../auto-reply/reply/queue/enqueue.js";
 import {
   kickFollowupDrainIfIdle,
   rememberFollowupDrainCallback,
 } from "../../auto-reply/reply/queue/drain.js";
+import { enqueueFollowupRun } from "../../auto-reply/reply/queue/enqueue.js";
 import { getExistingFollowupQueue } from "../../auto-reply/reply/queue/state.js";
-import { createFollowupRunner } from "../../auto-reply/reply/followup-runner.js";
 import { createTypingController } from "../../auto-reply/reply/typing.js";
 import { createRuntimeFollowup } from "./runtime-followup.js";
 
@@ -94,8 +94,8 @@ describe("createRuntimeFollowup", () => {
     expect(enqueueFollowupRun).not.toHaveBeenCalled();
   });
 
-  it("returns true and enqueues run on happy path", async () => {
-    // Cold session: no existing callback, queue is not draining after kick
+  it("returns true and enqueues run on happy path (cold session defaults to followup mode)", async () => {
+    // Cold session: no existing queue
     (getExistingFollowupQueue as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
 
     const followup = createRuntimeFollowup();
@@ -109,6 +109,30 @@ describe("createRuntimeFollowup", () => {
       SESSION_KEY,
       expect.objectContaining({ prompt: "continue" }),
       { mode: "followup" },
+      "none",
+      undefined,
+      false,
+    );
+  });
+
+  it("preserves existing queue mode instead of forcing followup", async () => {
+    // Hot session with "collect" mode already set
+    (getExistingFollowupQueue as ReturnType<typeof vi.fn>).mockReturnValue({
+      mode: "collect",
+      draining: true,
+    });
+
+    const followup = createRuntimeFollowup();
+    const result = await followup.enqueueFollowupTurn({
+      sessionKey: SESSION_KEY,
+      prompt: "hello",
+    });
+
+    expect(result).toBe(true);
+    expect(enqueueFollowupRun).toHaveBeenCalledWith(
+      SESSION_KEY,
+      expect.objectContaining({ prompt: "continue" }),
+      { mode: "collect" },
       "none",
       undefined,
       false,

--- a/src/plugins/runtime/runtime-followup.ts
+++ b/src/plugins/runtime/runtime-followup.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_MODEL } from "../../agents/defaults.js";
+import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import type { PluginRuntimeCore } from "./types-core.js";
@@ -20,6 +21,21 @@ export function createRuntimeFollowup(): PluginRuntimeCore["followup"] {
           return false;
         }
 
+        let runnerStorePath: string | undefined;
+        let runnerSessionStore: ReturnType<typeof loadSessionStore> | undefined;
+        let runnerSessionEntry: ReturnType<typeof loadSessionStore>[string] | undefined;
+        try {
+          runnerStorePath = resolveStorePath(followupRun.run.config.session?.store, {
+            agentId: followupRun.run.agentId,
+          });
+          runnerSessionStore = loadSessionStore(runnerStorePath);
+          runnerSessionEntry = runnerSessionStore[params.sessionKey];
+        } catch (err) {
+          logVerbose(
+            `[runtime.followup] failed to preload session metadata for "${params.sessionKey}": ${String(err)}`,
+          );
+        }
+
         // Preserve an existing queue's mode instead of forcing "followup".
         const existingMode = getExistingFollowupQueue(params.sessionKey)?.mode;
         const enqueued = enqueueFollowupRun(
@@ -34,24 +50,29 @@ export function createRuntimeFollowup(): PluginRuntimeCore["followup"] {
           return false;
         }
 
-        const { createFollowupRunner } = await import("../../auto-reply/reply/followup-runner.js");
-        const { createTypingController } = await import("../../auto-reply/reply/typing.js");
-
-        const noopTyping = createTypingController({});
-        const runner = createFollowupRunner({
-          typing: noopTyping,
-          typingMode: "never",
-          defaultModel: followupRun.run.model ?? DEFAULT_MODEL,
-        });
-
-        // Fix 3: Try existing callback first (hot session) to avoid overwriting
+        // Try existing callback first (hot session) to avoid overwriting
         // a channel-aware runner that's already active.
         kickFollowupDrainIfIdle(params.sessionKey);
 
         // Check if drain started from existing callback.
         const queue = getExistingFollowupQueue(params.sessionKey);
         if (!queue?.draining) {
-          // Cold session — no existing callback found. Register the fresh noop runner.
+          // Cold session — no existing callback found. Register a fresh noop runner
+          // with session metadata so accounting/session refresh paths still work.
+          const { createFollowupRunner } =
+            await import("../../auto-reply/reply/followup-runner.js");
+          const { createTypingController } = await import("../../auto-reply/reply/typing.js");
+
+          const noopTyping = createTypingController({});
+          const runner = createFollowupRunner({
+            typing: noopTyping,
+            typingMode: "never",
+            sessionEntry: runnerSessionEntry,
+            sessionStore: runnerSessionStore,
+            sessionKey: params.sessionKey,
+            storePath: runnerStorePath,
+            defaultModel: followupRun.run.model ?? DEFAULT_MODEL,
+          });
           rememberFollowupDrainCallback(params.sessionKey, runner);
           kickFollowupDrainIfIdle(params.sessionKey);
         }

--- a/src/plugins/runtime/runtime-followup.ts
+++ b/src/plugins/runtime/runtime-followup.ts
@@ -1,0 +1,65 @@
+import { DEFAULT_MODEL } from "../../agents/defaults.js";
+import { logVerbose } from "../../globals.js";
+import { defaultRuntime } from "../../runtime.js";
+import type { PluginRuntimeCore } from "./types-core.js";
+
+export function createRuntimeFollowup(): PluginRuntimeCore["followup"] {
+  return {
+    async enqueueFollowupTurn(params) {
+      try {
+        const { buildFollowupRunForSession } =
+          await import("../../auto-reply/reply/queue/build-followup-run.js");
+        const { enqueueFollowupRun } = await import("../../auto-reply/reply/queue/enqueue.js");
+        const { kickFollowupDrainIfIdle, rememberFollowupDrainCallback } =
+          await import("../../auto-reply/reply/queue/drain.js");
+
+        const followupRun = await buildFollowupRunForSession(params);
+        if (!followupRun) {
+          return false;
+        }
+
+        const enqueued = enqueueFollowupRun(
+          params.sessionKey,
+          followupRun,
+          { mode: "followup" },
+          "none",
+          undefined,
+          false,
+        );
+        if (!enqueued) {
+          return false;
+        }
+
+        const { createFollowupRunner } = await import("../../auto-reply/reply/followup-runner.js");
+        const { createTypingController } = await import("../../auto-reply/reply/typing.js");
+
+        const noopTyping = createTypingController({});
+        const runner = createFollowupRunner({
+          typing: noopTyping,
+          typingMode: "never",
+          defaultModel: followupRun.run.model ?? DEFAULT_MODEL,
+        });
+
+        // Fix 3: Try existing callback first (hot session) to avoid overwriting
+        // a channel-aware runner that's already active.
+        kickFollowupDrainIfIdle(params.sessionKey);
+
+        // Check if drain started from existing callback.
+        const { getExistingFollowupQueue } = await import("../../auto-reply/reply/queue/state.js");
+        const queue = getExistingFollowupQueue(params.sessionKey);
+        if (!queue?.draining) {
+          // Cold session — no existing callback found. Register the fresh noop runner.
+          rememberFollowupDrainCallback(params.sessionKey, runner);
+          kickFollowupDrainIfIdle(params.sessionKey);
+        }
+        logVerbose(`[runtime.followup] enqueued followup turn for session "${params.sessionKey}"`);
+        return true;
+      } catch (err) {
+        defaultRuntime.error?.(
+          `[runtime.followup] enqueueFollowupTurn failed for session "${params.sessionKey}": ${String(err)}`,
+        );
+        return false;
+      }
+    },
+  };
+}

--- a/src/plugins/runtime/runtime-followup.ts
+++ b/src/plugins/runtime/runtime-followup.ts
@@ -13,15 +13,19 @@ export function createRuntimeFollowup(): PluginRuntimeCore["followup"] {
         const { kickFollowupDrainIfIdle, rememberFollowupDrainCallback } =
           await import("../../auto-reply/reply/queue/drain.js");
 
+        const { getExistingFollowupQueue } = await import("../../auto-reply/reply/queue/state.js");
+
         const followupRun = await buildFollowupRunForSession(params);
         if (!followupRun) {
           return false;
         }
 
+        // Preserve an existing queue's mode instead of forcing "followup".
+        const existingMode = getExistingFollowupQueue(params.sessionKey)?.mode;
         const enqueued = enqueueFollowupRun(
           params.sessionKey,
           followupRun,
-          { mode: "followup" },
+          { mode: existingMode ?? "followup" },
           "none",
           undefined,
           false,
@@ -45,7 +49,6 @@ export function createRuntimeFollowup(): PluginRuntimeCore["followup"] {
         kickFollowupDrainIfIdle(params.sessionKey);
 
         // Check if drain started from existing callback.
-        const { getExistingFollowupQueue } = await import("../../auto-reply/reply/queue/state.js");
         const queue = getExistingFollowupQueue(params.sessionKey);
         if (!queue?.draining) {
           // Cold session — no existing callback found. Register the fresh noop runner.

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -127,4 +127,26 @@ export type PluginRuntimeCore = {
       cfg?: import("../../config/config.js").OpenClawConfig;
     }) => Promise<import("../../agents/model-auth.js").ResolvedProviderAuth>;
   };
+  followup: {
+    /**
+     * Schedule a proactive agent turn for a session.
+     * The turn runs asynchronously — the returned boolean indicates whether
+     * the item was successfully enqueued (false if session not found or deduped).
+     */
+    enqueueFollowupTurn: (params: {
+      sessionKey: string;
+      prompt: string;
+      agentId?: string;
+      originatingChannel?: string;
+      originatingTo?: string;
+      originatingAccountId?: string;
+      originatingThreadId?: string | number;
+      originatingChatType?: string;
+      model?: string;
+      provider?: string;
+      extraSystemPrompt?: string;
+      timeoutMs?: number;
+      source?: string;
+    }) => Promise<boolean>;
+  };
 };

--- a/test/helpers/plugins/plugin-runtime-mock.ts
+++ b/test/helpers/plugins/plugin-runtime-mock.ts
@@ -384,7 +384,9 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
       getSession: vi.fn(),
       deleteSession: vi.fn(),
     },
+    followup: {
+      enqueueFollowupTurn: vi.fn(() => Promise.resolve(false)),
+    },
   };
-
   return mergeDeep(base, overrides);
 }


### PR DESCRIPTION
## Summary

Add a new `runtime.followup.enqueueFollowupTurn()` method to the plugin runtime, enabling plugins to schedule proactive agent turns for any session — including cold sessions with no active user interaction.

## Problem

Plugins have no way to inject a user-role message into an existing session and trigger an agent turn. The available primitives (`enqueueSystemEvent`, `subagent.run`) either don't initiate turns or create new sessions instead of continuing the original conversation. This blocks use cases like:

- **Post-restart session resume** — an agent restarts its own gateway and needs to automatically continue working after the restart completes
- **Proactive plugin notifications** — a service detects an external event and needs to wake a sleeping session
- **Deferred task completion** — a plugin schedules follow-up work after a long-running background operation

## Solution

### Core API: `runtime.followup.enqueueFollowupTurn()`

A new `followup` namespace on `PluginRuntimeCore` that:

1. **Reconstructs a full `FollowupRun`** from the session store via `buildFollowupRunForSession()` — resolving agent identity, workspace, provider/model, session file, and delivery context from the persisted `SessionEntry`.

2. **Enqueues the run** into the existing followup queue infrastructure with `mode: "followup"`.

3. **Handles cold-start drain** by creating a fresh followup runner with a no-op typing controller and registering it as the drain callback, so the turn executes immediately even when no prior drain loop exists for that session key.

```typescript
// Plugin usage
const enqueued = await api.runtime.followup.enqueueFollowupTurn({
  sessionKey: "agent:my-agent:telegram:direct:12345",
  prompt: "Background task complete. Here are the results...",
  source: "my-plugin",
});
```

### Bundled Extension: `gateway-restart`

A reference implementation that demonstrates the followup turn API:

- **Tool** (`gateway_restart`): Agent calls this to write a restart marker, run optional allowlisted pre-commands, then exit the process. Systemd (or equivalent) auto-restarts the gateway.

- **Service** (`gateway-restart-watcher`): On startup, checks for the restart marker. If found, calls `enqueueFollowupTurn()` to resume the original session with a completion message. The agent wakes up with full session context and continues working.

Disabled by default (`enabledByDefault: false` in manifest). Opt-in via `plugins.entries.gateway-restart.enabled: true`.

## Files Changed

| File | Description |
|------|-------------|
| `src/auto-reply/reply/queue/build-followup-run.ts` | New: cold-session FollowupRun builder |
| `src/plugins/runtime/runtime-followup.ts` | New: plugin runtime followup namespace |
| `src/plugins/runtime/types-core.ts` | Add `followup` type to `PluginRuntimeCore` |
| `src/plugins/runtime/index.ts` | Wire `createRuntimeFollowup()` |
| `extensions/gateway-restart/index.ts` | New: gateway-restart plugin |
| `extensions/gateway-restart/openclaw.plugin.json` | New: plugin manifest |
| `extensions/gateway-restart/package.json` | New: package metadata |
| `test/helpers/plugins/plugin-runtime-mock.ts` | Add `followup` to mock |

## Testing

End-to-end verified on an isolated sandbox gateway (separate user, separate port, no channel conflicts):

1. ✅ Plugin loads and registers `gateway_restart` tool
2. ✅ Agent reads config, makes a change, calls `gateway_restart`
3. ✅ Gateway exits, restarts, watcher service consumes restart marker
4. ✅ `enqueueFollowupTurn()` enqueues and drains a cold-session followup turn
5. ✅ Agent resumes with full session context, validates the config change, reports success
6. ✅ All repo checks pass (`tsgo`, `oxlint`, commit hooks)

## Design Decisions

- **Lazy imports** in `runtime-followup.ts` — all heavy dependencies (`buildFollowupRunForSession`, `createFollowupRunner`, `createTypingController`) are dynamically imported to keep module load lightweight.
- **Session delivery context fallback** — if `originatingChannel`/`originatingTo` aren't provided, the builder falls back to the session entry's `lastChannel`/`lastTo`, so replies route to wherever the session was last active.
- **`senderIsOwner: true`** for plugin-initiated turns — these are trusted system actions, not external user messages.
- **Extension in `extensions/`** rather than `src/plugins/bundled/` — follows the repo's plugin discovery convention.
