### PR TITLE
Fix Android talk.speak playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,8 @@ Docs: https://docs.openclaw.ai
 - Browser/screenshots: stop sending `fromSurface: false` on CDP screenshots so managed Chrome 146+ browsers can capture images again. (#60682) Thanks @mvanhorn.
 - Mattermost/slash commands: harden native slash-command callback token validation to use constant-time secret comparison, matching the existing interaction-token path.
 - Control UI/mobile chat: reduce narrow-screen overflow by shrinking the chat pane minimum width, removing extra mobile padding, widening message groups, and hiding avatars on very small screens. (#60220) Thanks @macdao.
+- Android/Talk Mode: route spoken replies through `talk.speak`, keep compressed playback cleanup deterministic, and fall back to local TTS for legacy gateways that omit Talk error reasons. (#60954) Thanks @obviyus.
+- Android/Talk Mode: keep reply-speaker routing and teardown behavior aligned with the new remote playback path. (#60954) Thanks @MKV21.
 
 ## 2026.4.1
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -760,7 +760,7 @@ class NodeRuntime(
     prefs.setTalkEnabled(value)
     if (value) {
       // Tapping mic on interrupts any active TTS (barge-in)
-      talkMode.stopTts()
+      stopVoicePlayback()
       talkMode.ttsOnAllResponses = false
       scope.launch { talkMode.ensureChatSubscribed() }
     }
@@ -782,10 +782,17 @@ class NodeRuntime(
 
   private fun stopActiveVoiceSession() {
     talkMode.ttsOnAllResponses = false
-    talkMode.stopTts()
+    stopVoicePlayback()
     micCapture.setMicEnabled(false)
     prefs.setTalkEnabled(false)
     externalAudioCaptureActive.value = false
+  }
+
+  private fun stopVoicePlayback() {
+    talkMode.stopTts()
+    if (voiceReplySpeakerLazy.isInitialized()) {
+      voiceReplySpeaker.stopTts()
+    }
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -381,11 +381,10 @@ class NodeRuntime(
         parseChatSendRunId(response) ?: idempotencyKey
       },
       speakAssistantReply = { text ->
-        // Skip if TalkModeManager is handling TTS (ttsOnAllResponses) to avoid
-        // double-speaking the same assistant reply from both pipelines.
-        if (!talkMode.ttsOnAllResponses) {
-          voiceReplySpeaker.speakAssistantReply(text)
-        }
+        // Voice-tab replies should speak through the dedicated reply speaker.
+        // Relying on talkMode.ttsOnAllResponses here can drop playback if the
+        // chat-event path misses the terminal event for this turn.
+        voiceReplySpeaker.speakAssistantReply(text)
       },
     )
   }
@@ -596,12 +595,11 @@ class NodeRuntime(
 
     scope.launch {
       prefs.talkEnabled.collect { enabled ->
-        // MicCaptureManager handles STT + send to gateway.
-        // TalkModeManager plays TTS on assistant responses.
+        // MicCaptureManager handles STT + send to gateway, while the dedicated
+        // reply speaker handles TTS for assistant replies in the voice tab.
         micCapture.setMicEnabled(enabled)
         if (enabled) {
-          // Mic on = user is on voice screen and wants TTS responses.
-          talkMode.ttsOnAllResponses = true
+          talkMode.ttsOnAllResponses = false
           scope.launch { talkMode.ensureChatSubscribed() }
         }
         externalAudioCaptureActive.value = enabled
@@ -763,7 +761,7 @@ class NodeRuntime(
     if (value) {
       // Tapping mic on interrupts any active TTS (barge-in)
       talkMode.stopTts()
-      talkMode.ttsOnAllResponses = true
+      talkMode.ttsOnAllResponses = false
       scope.launch { talkMode.ensureChatSubscribed() }
     }
     micCapture.setMicEnabled(value)
@@ -778,7 +776,7 @@ class NodeRuntime(
     if (voiceReplySpeakerLazy.isInitialized()) {
       voiceReplySpeaker.setPlaybackEnabled(value)
     }
-    // Keep TalkMode in sync so speaker mute works when ttsOnAllResponses is active.
+    // Keep TalkMode in sync so any active Talk playback also respects speaker mute.
     talkMode.setPlaybackEnabled(value)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -64,6 +64,7 @@ data class GatewayConnectErrorDetails(
   val code: String?,
   val canRetryWithDeviceToken: Boolean,
   val recommendedNextStep: String?,
+  val reason: String? = null,
 )
 
 private data class SelectedConnectAuth(
@@ -115,6 +116,8 @@ class GatewaySession(
     val message: String,
     val details: GatewayConnectErrorDetails? = null,
   )
+
+  data class RpcResult(val ok: Boolean, val payloadJson: String?, val error: ErrorShape?)
 
   private val json = Json { ignoreUnknownKeys = true }
   private val writeLock = Mutex()
@@ -196,6 +199,13 @@ class GatewaySession(
   }
 
   suspend fun request(method: String, paramsJson: String?, timeoutMs: Long = 15_000): String {
+    val res = requestDetailed(method = method, paramsJson = paramsJson, timeoutMs = timeoutMs)
+    if (res.ok) return res.payloadJson ?: ""
+    val err = res.error
+    throw IllegalStateException("${err?.code ?: "UNAVAILABLE"}: ${err?.message ?: "request failed"}")
+  }
+
+  suspend fun requestDetailed(method: String, paramsJson: String?, timeoutMs: Long = 15_000): RpcResult {
     val conn = currentConnection ?: throw IllegalStateException("not connected")
     val params =
       if (paramsJson.isNullOrBlank()) {
@@ -204,9 +214,7 @@ class GatewaySession(
         json.parseToJsonElement(paramsJson)
       }
     val res = conn.request(method, params, timeoutMs)
-    if (res.ok) return res.payloadJson ?: ""
-    val err = res.error
-    throw IllegalStateException("${err?.code ?: "UNAVAILABLE"}: ${err?.message ?: "request failed"}")
+    return RpcResult(ok = res.ok, payloadJson = res.payloadJson, error = res.error)
   }
 
   suspend fun refreshNodeCanvasCapability(timeoutMs: Long = 8_000): Boolean {
@@ -631,6 +639,7 @@ class GatewaySession(
                 code = it["code"].asStringOrNull(),
                 canRetryWithDeviceToken = it["canRetryWithDeviceToken"].asBooleanOrNull() == true,
                 recommendedNextStep = it["recommendedNextStep"].asStringOrNull(),
+                reason = it["reason"].asStringOrNull(),
               )
             }
           ErrorShape(code, msg, details)

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -90,6 +90,7 @@ class MicCaptureManager(
   val isSending: StateFlow<Boolean> = _isSending
 
   private val messageQueue = ArrayDeque<String>()
+  private val messageQueueLock = Any()
   private var flushedPartialTranscript: String? = null
   private var pendingRunId: String? = null
   private var pendingAssistantEntryId: String? = null
@@ -104,6 +105,42 @@ class MicCaptureManager(
   private val ttsPauseLock = Any()
   private var ttsPauseDepth = 0
   private var resumeMicAfterTts = false
+
+  private fun enqueueMessage(message: String) {
+    synchronized(messageQueueLock) {
+      messageQueue.addLast(message)
+    }
+  }
+
+  private fun snapshotMessageQueue(): List<String> {
+    return synchronized(messageQueueLock) {
+      messageQueue.toList()
+    }
+  }
+
+  private fun hasQueuedMessages(): Boolean {
+    return synchronized(messageQueueLock) {
+      messageQueue.isNotEmpty()
+    }
+  }
+
+  private fun firstQueuedMessage(): String? {
+    return synchronized(messageQueueLock) {
+      messageQueue.firstOrNull()
+    }
+  }
+
+  private fun removeFirstQueuedMessage(): String? {
+    return synchronized(messageQueueLock) {
+      if (messageQueue.isEmpty()) null else messageQueue.removeFirst()
+    }
+  }
+
+  private fun queuedMessageCount(): Int {
+    return synchronized(messageQueueLock) {
+      messageQueue.size
+    }
+  }
 
   fun setMicEnabled(enabled: Boolean) {
     if (_micEnabled.value == enabled) return
@@ -348,7 +385,7 @@ class MicCaptureManager(
       role = VoiceConversationRole.User,
       text = message,
     )
-    messageQueue.addLast(message)
+    enqueueMessage(message)
     publishQueue()
   }
 
@@ -367,12 +404,12 @@ class MicCaptureManager(
   }
 
   private fun publishQueue() {
-    _queuedMessages.value = messageQueue.toList()
+    _queuedMessages.value = snapshotMessageQueue()
   }
 
   private fun sendQueuedIfIdle() {
     if (_isSending.value) return
-    if (messageQueue.isEmpty()) {
+    if (!hasQueuedMessages()) {
       if (_micEnabled.value) {
         _statusText.value = "Listening"
       } else {
@@ -385,7 +422,7 @@ class MicCaptureManager(
       return
     }
 
-    val next = messageQueue.first()
+    val next = firstQueuedMessage() ?: return
     _isSending.value = true
     pendingRunTimeoutJob?.cancel()
     pendingRunTimeoutJob = null
@@ -403,7 +440,7 @@ class MicCaptureManager(
         if (runId == null) {
           pendingRunTimeoutJob?.cancel()
           pendingRunTimeoutJob = null
-          messageQueue.removeFirst()
+          removeFirstQueuedMessage()
           publishQueue()
           _isSending.value = false
           pendingAssistantEntryId = null
@@ -449,8 +486,7 @@ class MicCaptureManager(
   private fun completePendingTurn() {
     pendingRunTimeoutJob?.cancel()
     pendingRunTimeoutJob = null
-    if (messageQueue.isNotEmpty()) {
-      messageQueue.removeFirst()
+    if (removeFirstQueuedMessage() != null) {
       publishQueue()
     }
     pendingRunId = null
@@ -460,7 +496,7 @@ class MicCaptureManager(
   }
 
   private fun queuedWaitingStatus(): String {
-    return "${messageQueue.size} queued · waiting for gateway"
+    return "${queuedMessageCount()} queued · waiting for gateway"
   }
 
   private fun appendConversation(

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -244,7 +244,7 @@ class MicCaptureManager(
     pendingRunId = null
     pendingAssistantEntryId = null
     _isSending.value = false
-    if (messageQueue.isNotEmpty()) {
+    if (hasQueuedMessages()) {
       _statusText.value = queuedWaitingStatus()
     }
   }
@@ -352,7 +352,7 @@ class MicCaptureManager(
     _statusText.value =
       when {
         _isSending.value -> "Listening · sending queued voice"
-        messageQueue.isNotEmpty() -> "Listening · ${messageQueue.size} queued"
+        hasQueuedMessages() -> "Listening · ${queuedMessageCount()} queued"
         else -> "Listening"
       }
     _isListening.value = true

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkAudioPlayer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkAudioPlayer.kt
@@ -1,0 +1,237 @@
+package ai.openclaw.app.voice
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import android.media.MediaPlayer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import java.io.File
+
+internal class TalkAudioPlayer(
+  private val context: Context,
+) {
+  private val lock = Any()
+  private var active: ActivePlayback? = null
+
+  suspend fun play(audio: TalkSpeakAudio) {
+    when (val mode = resolvePlaybackMode(audio)) {
+      is TalkPlaybackMode.Pcm -> playPcm(audio.bytes, mode.sampleRate)
+      is TalkPlaybackMode.Compressed -> playCompressed(audio.bytes, mode.fileExtension)
+    }
+  }
+
+  fun stop() {
+    synchronized(lock) {
+      active?.cancel()
+      active = null
+    }
+  }
+
+  internal fun resolvePlaybackMode(audio: TalkSpeakAudio): TalkPlaybackMode {
+    return resolvePlaybackMode(
+      outputFormat = audio.outputFormat,
+      mimeType = audio.mimeType,
+      fileExtension = audio.fileExtension,
+    )
+  }
+
+  companion object {
+    internal fun resolvePlaybackMode(
+      outputFormat: String?,
+      mimeType: String?,
+      fileExtension: String?,
+    ): TalkPlaybackMode {
+      val normalizedOutputFormat = outputFormat?.trim()?.lowercase()
+      if (normalizedOutputFormat != null) {
+        val pcmSampleRate = parsePcmSampleRate(normalizedOutputFormat)
+        if (pcmSampleRate != null) {
+          return TalkPlaybackMode.Pcm(sampleRate = pcmSampleRate)
+        }
+      }
+      val normalizedMimeType = mimeType?.trim()?.lowercase()
+      val extension =
+        normalizeExtension(
+          fileExtension ?: inferExtension(outputFormat = normalizedOutputFormat, mimeType = normalizedMimeType),
+        )
+      if (extension != null) {
+        return TalkPlaybackMode.Compressed(fileExtension = extension)
+      }
+      throw IllegalStateException("Unsupported talk audio format")
+    }
+
+    private fun parsePcmSampleRate(outputFormat: String): Int? {
+      return when (outputFormat) {
+        "pcm_16000" -> 16_000
+        "pcm_22050" -> 22_050
+        "pcm_24000" -> 24_000
+        "pcm_44100" -> 44_100
+        else -> null
+      }
+    }
+
+    private fun inferExtension(outputFormat: String?, mimeType: String?): String? {
+      return when {
+        outputFormat == "mp3" || outputFormat?.startsWith("mp3_") == true || mimeType == "audio/mpeg" -> ".mp3"
+        outputFormat == "opus" || outputFormat?.startsWith("opus_") == true || mimeType == "audio/ogg" -> ".ogg"
+        outputFormat?.endsWith("-wav") == true || mimeType == "audio/wav" -> ".wav"
+        outputFormat?.endsWith("-webm") == true || mimeType == "audio/webm" -> ".webm"
+        else -> null
+      }
+    }
+
+    private fun normalizeExtension(value: String?): String? {
+      val trimmed = value?.trim()?.lowercase().orEmpty()
+      if (trimmed.isEmpty()) return null
+      return if (trimmed.startsWith(".")) trimmed else ".$trimmed"
+    }
+  }
+
+  private suspend fun playPcm(bytes: ByteArray, sampleRate: Int) {
+    withContext(Dispatchers.IO) {
+      val minBufferSize =
+        AudioTrack.getMinBufferSize(
+          sampleRate,
+          AudioFormat.CHANNEL_OUT_MONO,
+          AudioFormat.ENCODING_PCM_16BIT,
+        )
+      if (minBufferSize <= 0) {
+        throw IllegalStateException("AudioTrack buffer unavailable")
+      }
+      val track =
+        AudioTrack.Builder()
+          .setAudioAttributes(
+            AudioAttributes.Builder()
+              .setUsage(AudioAttributes.USAGE_MEDIA)
+              .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+              .build(),
+          )
+          .setAudioFormat(
+            AudioFormat.Builder()
+              .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+              .setSampleRate(sampleRate)
+              .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+              .build(),
+          )
+          .setTransferMode(AudioTrack.MODE_STATIC)
+          .setBufferSizeInBytes(maxOf(minBufferSize, bytes.size))
+          .build()
+      val finished = CompletableDeferred<Unit>()
+      val playback =
+        ActivePlayback(
+          cancel = {
+            finished.completeExceptionally(CancellationException("assistant speech cancelled"))
+            runCatching { track.pause() }
+            runCatching { track.flush() }
+            runCatching { track.stop() }
+          },
+        )
+      register(playback)
+      try {
+        val written = track.write(bytes, 0, bytes.size)
+        if (written != bytes.size) {
+          throw IllegalStateException("AudioTrack write failed")
+        }
+        val totalFrames = bytes.size / 2
+        track.play()
+        while (track.playState == AudioTrack.PLAYSTATE_PLAYING) {
+          if (track.playbackHeadPosition >= totalFrames) {
+            finished.complete(Unit)
+            break
+          }
+          delay(20)
+        }
+        if (!finished.isCompleted) {
+          finished.complete(Unit)
+        }
+        finished.await()
+      } finally {
+        clear(playback)
+        runCatching { track.pause() }
+        runCatching { track.flush() }
+        runCatching { track.stop() }
+        track.release()
+      }
+    }
+  }
+
+  private suspend fun playCompressed(bytes: ByteArray, fileExtension: String) {
+    val tempFile = withContext(Dispatchers.IO) {
+      File.createTempFile("talk-audio-", fileExtension, context.cacheDir).apply {
+        writeBytes(bytes)
+      }
+    }
+    val finished = CompletableDeferred<Unit>()
+    val player =
+      withContext(Dispatchers.Main) {
+        MediaPlayer().apply {
+          setAudioAttributes(
+            AudioAttributes.Builder()
+              .setUsage(AudioAttributes.USAGE_MEDIA)
+              .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+              .build(),
+          )
+          setDataSource(tempFile.absolutePath)
+          setOnCompletionListener {
+            finished.complete(Unit)
+          }
+          setOnErrorListener { _, what, extra ->
+            finished.completeExceptionally(IllegalStateException("MediaPlayer error ($what/$extra)"))
+            true
+          }
+          prepare()
+          start()
+        }
+      }
+    val playback =
+      ActivePlayback(
+        cancel = {
+          finished.completeExceptionally(CancellationException("assistant speech cancelled"))
+          runCatching { player.stop() }
+        },
+      )
+    register(playback)
+    try {
+      finished.await()
+    } finally {
+      clear(playback)
+      withContext(Dispatchers.Main) {
+        runCatching { player.stop() }
+        player.release()
+      }
+      withContext(Dispatchers.IO) {
+        tempFile.delete()
+      }
+    }
+  }
+
+  private fun register(playback: ActivePlayback) {
+    synchronized(lock) {
+      active?.cancel()
+      active = playback
+    }
+  }
+
+  private fun clear(playback: ActivePlayback) {
+    synchronized(lock) {
+      if (active === playback) {
+        active = null
+      }
+    }
+  }
+
+}
+
+internal sealed interface TalkPlaybackMode {
+  data class Pcm(val sampleRate: Int) : TalkPlaybackMode
+
+  data class Compressed(val fileExtension: String) : TalkPlaybackMode
+}
+
+private class ActivePlayback(
+  val cancel: () -> Unit,
+)

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkAudioPlayer.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkAudioPlayer.kt
@@ -165,44 +165,49 @@ internal class TalkAudioPlayer(
         writeBytes(bytes)
       }
     }
-    val finished = CompletableDeferred<Unit>()
-    val player =
-      withContext(Dispatchers.Main) {
-        MediaPlayer().apply {
-          setAudioAttributes(
-            AudioAttributes.Builder()
-              .setUsage(AudioAttributes.USAGE_MEDIA)
-              .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
-              .build(),
-          )
-          setDataSource(tempFile.absolutePath)
-          setOnCompletionListener {
-            finished.complete(Unit)
+    try {
+      val finished = CompletableDeferred<Unit>()
+      val player =
+        withContext(Dispatchers.Main) {
+          MediaPlayer().apply {
+            setAudioAttributes(
+              AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                .build(),
+            )
+            setDataSource(tempFile.absolutePath)
+            setOnCompletionListener {
+              finished.complete(Unit)
+            }
+            setOnErrorListener { _, what, extra ->
+              finished.completeExceptionally(IllegalStateException("MediaPlayer error ($what/$extra)"))
+              true
+            }
+            prepare()
           }
-          setOnErrorListener { _, what, extra ->
-            finished.completeExceptionally(IllegalStateException("MediaPlayer error ($what/$extra)"))
-            true
-          }
-          prepare()
-          start()
+        }
+      val playback =
+        ActivePlayback(
+          cancel = {
+            finished.completeExceptionally(CancellationException("assistant speech cancelled"))
+            runCatching { player.stop() }
+          },
+        )
+      register(playback)
+      try {
+        withContext(Dispatchers.Main) {
+          player.start()
+        }
+        finished.await()
+      } finally {
+        clear(playback)
+        withContext(Dispatchers.Main) {
+          runCatching { player.stop() }
+          player.release()
         }
       }
-    val playback =
-      ActivePlayback(
-        cancel = {
-          finished.completeExceptionally(CancellationException("assistant speech cancelled"))
-          runCatching { player.stop() }
-        },
-      )
-    register(playback)
-    try {
-      finished.await()
     } finally {
-      clear(playback)
-      withContext(Dispatchers.Main) {
-        runCatching { player.stop() }
-        player.release()
-      }
       withContext(Dispatchers.IO) {
         tempFile.delete()
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -14,9 +14,9 @@ import android.os.SystemClock
 import android.speech.RecognitionListener
 import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
-import android.util.Log
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
+import android.util.Log
 import androidx.core.content.ContextCompat
 import ai.openclaw.app.gateway.GatewaySession
 import java.util.Locale
@@ -61,6 +61,8 @@ class TalkModeManager(
 
   private val mainHandler = Handler(Looper.getMainLooper())
   private val json = Json { ignoreUnknownKeys = true }
+  private val talkSpeakClient = TalkSpeakClient(session = session, json = json)
+  private val talkAudioPlayer = TalkAudioPlayer(context)
 
   private val _isEnabled = MutableStateFlow(false)
   val isEnabled: StateFlow<Boolean> = _isEnabled
@@ -663,16 +665,32 @@ class TalkModeManager(
     requestAudioFocusForTts()
 
     try {
-      val ttsStarted = SystemClock.elapsedRealtime()
-      speakWithSystemTts(cleaned, directive, playbackToken)
-      Log.d(tag, "system tts ok durMs=${SystemClock.elapsedRealtime() - ttsStarted}")
+      val started = SystemClock.elapsedRealtime()
+      when (val result = talkSpeakClient.synthesize(text = cleaned, directive = directive)) {
+        is TalkSpeakResult.Success -> {
+          ensurePlaybackActive(playbackToken)
+          talkAudioPlayer.play(result.audio)
+          ensurePlaybackActive(playbackToken)
+          Log.d(tag, "talk.speak ok durMs=${SystemClock.elapsedRealtime() - started}")
+        }
+        is TalkSpeakResult.FallbackToLocal -> {
+          Log.d(tag, "talk.speak unavailable; using local TTS: ${result.message}")
+          speakWithSystemTts(cleaned, directive, playbackToken)
+          Log.d(tag, "system tts ok durMs=${SystemClock.elapsedRealtime() - started}")
+        }
+        is TalkSpeakResult.Failure -> {
+          throw IllegalStateException(result.message)
+        }
+      }
     } catch (err: Throwable) {
       if (isPlaybackCancelled(err, playbackToken)) {
         Log.d(tag, "assistant speech cancelled")
         return
       }
       _statusText.value = "Speak failed: ${err.message ?: err::class.simpleName}"
-      Log.w(tag, "system tts failed: ${err.message ?: err::class.simpleName}")
+      Log.w(tag, "talk playback failed: ${err.message ?: err::class.simpleName}")
+    } finally {
+      _isSpeaking.value = false
     }
   }
 
@@ -812,6 +830,7 @@ class TalkModeManager(
 
   private fun stopSpeaking(resetInterrupt: Boolean = true) {
     if (!_isSpeaking.value) {
+      talkAudioPlayer.stop()
       stopTextToSpeechPlayback()
       abandonAudioFocus()
       return
@@ -819,6 +838,7 @@ class TalkModeManager(
     if (resetInterrupt) {
       lastInterruptedAtSeconds = null
     }
+    talkAudioPlayer.stop()
     stopTextToSpeechPlayback()
     _isSpeaking.value = false
     abandonAudioFocus()

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkSpeakClient.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkSpeakClient.kt
@@ -41,7 +41,7 @@ internal class TalkSpeakClient(
     if (!response.ok) {
       val error = response.error
       val message = error?.message ?: "talk.speak request failed"
-      return if (isFallbackEligible(error?.details?.reason)) {
+      return if (isFallbackEligible(error)) {
         TalkSpeakResult.FallbackToLocal(message)
       } else {
         TalkSpeakResult.Failure(message)
@@ -74,7 +74,9 @@ internal class TalkSpeakClient(
     )
   }
 
-  private fun isFallbackEligible(reason: String?): Boolean {
+  private fun isFallbackEligible(error: GatewaySession.ErrorShape?): Boolean {
+    val reason = error?.details?.reason
+    if (reason == null) return true
     return reason == "talk_unconfigured" ||
       reason == "talk_provider_unsupported" ||
       reason == "method_unavailable"

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkSpeakClient.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkSpeakClient.kt
@@ -1,0 +1,141 @@
+package ai.openclaw.app.voice
+
+import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal data class TalkSpeakAudio(
+  val bytes: ByteArray,
+  val provider: String,
+  val outputFormat: String?,
+  val voiceCompatible: Boolean?,
+  val mimeType: String?,
+  val fileExtension: String?,
+)
+
+internal sealed interface TalkSpeakResult {
+  data class Success(val audio: TalkSpeakAudio) : TalkSpeakResult
+
+  data class FallbackToLocal(val message: String) : TalkSpeakResult
+
+  data class Failure(val message: String) : TalkSpeakResult
+}
+
+internal class TalkSpeakClient(
+  private val session: GatewaySession? = null,
+  private val json: Json = Json { ignoreUnknownKeys = true },
+  private val requestDetailed: (suspend (String, String, Long) -> GatewaySession.RpcResult)? = null,
+) {
+  suspend fun synthesize(text: String, directive: TalkDirective?): TalkSpeakResult {
+    val response =
+      try {
+        performRequest(
+          method = "talk.speak",
+          paramsJson = json.encodeToString(TalkSpeakRequest.from(text = text, directive = directive)),
+          timeoutMs = 45_000,
+        )
+      } catch (err: Throwable) {
+        return TalkSpeakResult.Failure(err.message ?: "talk.speak request failed")
+      }
+    if (!response.ok) {
+      val error = response.error
+      val message = error?.message ?: "talk.speak request failed"
+      return if (isFallbackEligible(error?.details?.reason)) {
+        TalkSpeakResult.FallbackToLocal(message)
+      } else {
+        TalkSpeakResult.Failure(message)
+      }
+    }
+    val payload =
+      try {
+        json.decodeFromString<TalkSpeakResponse>(response.payloadJson ?: "")
+      } catch (err: Throwable) {
+        return TalkSpeakResult.Failure(err.message ?: "talk.speak payload invalid")
+      }
+    val bytes =
+      try {
+        android.util.Base64.decode(payload.audioBase64, android.util.Base64.DEFAULT)
+      } catch (err: Throwable) {
+        return TalkSpeakResult.Failure(err.message ?: "talk.speak audio decode failed")
+      }
+    if (bytes.isEmpty()) {
+      return TalkSpeakResult.Failure("talk.speak returned empty audio")
+    }
+    return TalkSpeakResult.Success(
+      TalkSpeakAudio(
+        bytes = bytes,
+        provider = payload.provider,
+        outputFormat = payload.outputFormat,
+        voiceCompatible = payload.voiceCompatible,
+        mimeType = payload.mimeType,
+        fileExtension = payload.fileExtension,
+      ),
+    )
+  }
+
+  private fun isFallbackEligible(reason: String?): Boolean {
+    return reason == "talk_unconfigured" ||
+      reason == "talk_provider_unsupported" ||
+      reason == "method_unavailable"
+  }
+
+  private suspend fun performRequest(
+    method: String,
+    paramsJson: String,
+    timeoutMs: Long,
+  ): GatewaySession.RpcResult {
+    requestDetailed?.let { return it(method, paramsJson, timeoutMs) }
+    val activeSession = session ?: throw IllegalStateException("session missing")
+    return activeSession.requestDetailed(method = method, paramsJson = paramsJson, timeoutMs = timeoutMs)
+  }
+}
+
+@Serializable
+internal data class TalkSpeakRequest(
+  val text: String,
+  val voiceId: String? = null,
+  val modelId: String? = null,
+  val outputFormat: String? = null,
+  val speed: Double? = null,
+  val rateWpm: Int? = null,
+  val stability: Double? = null,
+  val similarity: Double? = null,
+  val style: Double? = null,
+  val speakerBoost: Boolean? = null,
+  val seed: Long? = null,
+  val normalize: String? = null,
+  val language: String? = null,
+  val latencyTier: Int? = null,
+) {
+  companion object {
+    fun from(text: String, directive: TalkDirective?): TalkSpeakRequest {
+      return TalkSpeakRequest(
+        text = text,
+        voiceId = directive?.voiceId,
+        modelId = directive?.modelId,
+        outputFormat = directive?.outputFormat,
+        speed = directive?.speed,
+        rateWpm = directive?.rateWpm,
+        stability = directive?.stability,
+        similarity = directive?.similarity,
+        style = directive?.style,
+        speakerBoost = directive?.speakerBoost,
+        seed = directive?.seed,
+        normalize = directive?.normalize,
+        language = directive?.language,
+        latencyTier = directive?.latencyTier,
+      )
+    }
+  }
+}
+
+@Serializable
+private data class TalkSpeakResponse(
+  val audioBase64: String,
+  val provider: String,
+  val outputFormat: String? = null,
+  val voiceCompatible: Boolean? = null,
+  val mimeType: String? = null,
+  val fileExtension: String? = null,
+)

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkAudioPlayerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkAudioPlayerTest.kt
@@ -1,0 +1,44 @@
+package ai.openclaw.app.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TalkAudioPlayerTest {
+  @Test
+  fun resolvesPcmPlaybackFromOutputFormat() {
+    val mode =
+      TalkAudioPlayer.resolvePlaybackMode(
+        outputFormat = "pcm_24000",
+        mimeType = null,
+        fileExtension = null,
+      )
+
+    assertEquals(TalkPlaybackMode.Pcm(sampleRate = 24_000), mode)
+  }
+
+  @Test
+  fun resolvesCompressedPlaybackFromMimeType() {
+    val mode =
+      TalkAudioPlayer.resolvePlaybackMode(
+        outputFormat = null,
+        mimeType = "audio/mpeg",
+        fileExtension = null,
+      )
+
+    assertEquals(TalkPlaybackMode.Compressed(fileExtension = ".mp3"), mode)
+  }
+
+  @Test
+  fun preservesProvidedExtensionForCompressedPlayback() {
+    val mode =
+      TalkAudioPlayer.resolvePlaybackMode(
+        outputFormat = null,
+        mimeType = "audio/webm",
+        fileExtension = "webm",
+      )
+
+    assertTrue(mode is TalkPlaybackMode.Compressed)
+    assertEquals(".webm", (mode as TalkPlaybackMode.Compressed).fileExtension)
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
@@ -103,4 +103,26 @@ class TalkSpeakClientTest {
     val result = client.synthesize(text = "Hello", directive = null)
     assertTrue(result is TalkSpeakResult.Failure)
   }
+
+  @Test
+  fun fallsBackWhenGatewayOmitsReason() = runTest {
+    val client =
+      TalkSpeakClient(
+        requestDetailed = { _, _, _ ->
+          GatewaySession.RpcResult(
+            ok = false,
+            payloadJson = null,
+            error =
+              GatewaySession.ErrorShape(
+                code = "INVALID_REQUEST",
+                message = "unknown method: talk.speak",
+                details = null,
+              ),
+          )
+        },
+      )
+
+    val result = client.synthesize(text = "Hello", directive = null)
+    assertTrue(result is TalkSpeakResult.FallbackToLocal)
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkSpeakClientTest.kt
@@ -1,0 +1,106 @@
+package ai.openclaw.app.voice
+
+import ai.openclaw.app.gateway.GatewayConnectErrorDetails
+import ai.openclaw.app.gateway.GatewaySession
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TalkSpeakClientTest {
+  @Test
+  fun buildsRequestFromDirective() {
+    val request =
+      TalkSpeakRequest.from(
+        text = "Hello from talk mode.",
+        directive =
+          TalkDirective(
+            voiceId = "voice-123",
+            modelId = "model-abc",
+            speed = 1.1,
+            rateWpm = 190,
+            stability = 0.5,
+            similarity = 0.7,
+            style = 0.2,
+            speakerBoost = true,
+            seed = 42,
+            normalize = "auto",
+            language = "en",
+            outputFormat = "pcm_24000",
+            latencyTier = 3,
+            once = true,
+          ),
+      )
+
+    assertEquals("Hello from talk mode.", request.text)
+    assertEquals("voice-123", request.voiceId)
+    assertEquals("model-abc", request.modelId)
+    assertEquals(1.1, request.speed)
+    assertEquals(190, request.rateWpm)
+    assertEquals(0.5, request.stability)
+    assertEquals(0.7, request.similarity)
+    assertEquals(0.2, request.style)
+    assertEquals(true, request.speakerBoost)
+    assertEquals(42L, request.seed)
+    assertEquals("auto", request.normalize)
+    assertEquals("en", request.language)
+    assertEquals("pcm_24000", request.outputFormat)
+    assertEquals(3, request.latencyTier)
+  }
+
+  @Test
+  fun fallsBackOnlyForUnavailableReasons() = runTest {
+    val client =
+      TalkSpeakClient(
+        requestDetailed = { _, _, _ ->
+          GatewaySession.RpcResult(
+            ok = false,
+            payloadJson = null,
+            error =
+              GatewaySession.ErrorShape(
+                code = "UNAVAILABLE",
+                message = "talk unavailable",
+                details =
+                  GatewayConnectErrorDetails(
+                    code = null,
+                    canRetryWithDeviceToken = false,
+                    recommendedNextStep = null,
+                    reason = "talk_unconfigured",
+                  ),
+              ),
+          )
+        },
+      )
+
+    val result = client.synthesize(text = "Hello", directive = null)
+    assertTrue(result is TalkSpeakResult.FallbackToLocal)
+  }
+
+  @Test
+  fun doesNotFallBackForSynthesisFailure() = runTest {
+    val client =
+      TalkSpeakClient(
+        requestDetailed = { _, _, _ ->
+          GatewaySession.RpcResult(
+            ok = false,
+            payloadJson = null,
+            error =
+              GatewaySession.ErrorShape(
+                code = "UNAVAILABLE",
+                message = "provider failed",
+                details =
+                  GatewayConnectErrorDetails(
+                    code = null,
+                    canRetryWithDeviceToken = false,
+                    recommendedNextStep = null,
+                    reason = "synthesis_failed",
+                  ),
+              ),
+          )
+        },
+      )
+
+    val result = client.synthesize(text = "Hello", directive = null)
+    assertTrue(result is TalkSpeakResult.Failure)
+  }
+}

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2019,6 +2019,7 @@ public struct TalkSpeakParams: Codable, Sendable {
     public let modelid: String?
     public let outputformat: String?
     public let speed: Double?
+    public let ratewpm: Int?
     public let stability: Double?
     public let similarity: Double?
     public let style: Double?
@@ -2026,6 +2027,7 @@ public struct TalkSpeakParams: Codable, Sendable {
     public let seed: Int?
     public let normalize: String?
     public let language: String?
+    public let latencytier: Int?
 
     public init(
         text: String,
@@ -2033,19 +2035,22 @@ public struct TalkSpeakParams: Codable, Sendable {
         modelid: String?,
         outputformat: String?,
         speed: Double?,
+        ratewpm: Int?,
         stability: Double?,
         similarity: Double?,
         style: Double?,
         speakerboost: Bool?,
         seed: Int?,
         normalize: String?,
-        language: String?)
+        language: String?,
+        latencytier: Int?)
     {
         self.text = text
         self.voiceid = voiceid
         self.modelid = modelid
         self.outputformat = outputformat
         self.speed = speed
+        self.ratewpm = ratewpm
         self.stability = stability
         self.similarity = similarity
         self.style = style
@@ -2053,6 +2058,7 @@ public struct TalkSpeakParams: Codable, Sendable {
         self.seed = seed
         self.normalize = normalize
         self.language = language
+        self.latencytier = latencytier
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -2061,6 +2067,7 @@ public struct TalkSpeakParams: Codable, Sendable {
         case modelid = "modelId"
         case outputformat = "outputFormat"
         case speed
+        case ratewpm = "rateWpm"
         case stability
         case similarity
         case style
@@ -2068,6 +2075,7 @@ public struct TalkSpeakParams: Codable, Sendable {
         case seed
         case normalize
         case language
+        case latencytier = "latencyTier"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2019,6 +2019,7 @@ public struct TalkSpeakParams: Codable, Sendable {
     public let modelid: String?
     public let outputformat: String?
     public let speed: Double?
+    public let ratewpm: Int?
     public let stability: Double?
     public let similarity: Double?
     public let style: Double?
@@ -2026,6 +2027,7 @@ public struct TalkSpeakParams: Codable, Sendable {
     public let seed: Int?
     public let normalize: String?
     public let language: String?
+    public let latencytier: Int?
 
     public init(
         text: String,
@@ -2033,19 +2035,22 @@ public struct TalkSpeakParams: Codable, Sendable {
         modelid: String?,
         outputformat: String?,
         speed: Double?,
+        ratewpm: Int?,
         stability: Double?,
         similarity: Double?,
         style: Double?,
         speakerboost: Bool?,
         seed: Int?,
         normalize: String?,
-        language: String?)
+        language: String?,
+        latencytier: Int?)
     {
         self.text = text
         self.voiceid = voiceid
         self.modelid = modelid
         self.outputformat = outputformat
         self.speed = speed
+        self.ratewpm = ratewpm
         self.stability = stability
         self.similarity = similarity
         self.style = style
@@ -2053,6 +2058,7 @@ public struct TalkSpeakParams: Codable, Sendable {
         self.seed = seed
         self.normalize = normalize
         self.language = language
+        self.latencytier = latencytier
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -2061,6 +2067,7 @@ public struct TalkSpeakParams: Codable, Sendable {
         case modelid = "modelId"
         case outputformat = "outputFormat"
         case speed
+        case ratewpm = "rateWpm"
         case stability
         case similarity
         case style
@@ -2068,6 +2075,7 @@ public struct TalkSpeakParams: Codable, Sendable {
         case seed
         case normalize
         case language
+        case latencytier = "latencyTier"
     }
 }
 

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -13,7 +13,7 @@ Talk mode is a continuous voice conversation loop:
 1. Listen for speech
 2. Send transcript to the model (main session, chat.send)
 3. Wait for the response
-4. Speak it via ElevenLabs (streaming playback)
+4. Speak it via the configured Talk provider (`talk.speak`)
 
 ## Behavior (macOS)
 
@@ -86,7 +86,7 @@ Defaults:
 
 - Requires Speech + Microphone permissions.
 - Uses `chat.send` against session key `main`.
-- TTS uses ElevenLabs streaming API with `ELEVENLABS_API_KEY` and incremental playback on macOS/iOS/Android for lower latency.
+- The gateway resolves Talk playback through `talk.speak` using the active Talk provider. Android falls back to local system TTS only when that RPC is unavailable.
 - `stability` for `eleven_v3` is validated to `0.0`, `0.5`, or `1.0`; other models accept `0..1`.
 - `latency_tier` is validated to `0..4` when set.
 - Android supports `pcm_16000`, `pcm_22050`, `pcm_24000`, and `pcm_44100` output formats for low-latency AudioTrack streaming.

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -182,7 +182,7 @@ See [Camera node](/nodes/camera) for parameters and CLI helpers.
 
 ### 8) Voice + expanded Android command surface
 
-- Voice: Android uses a single mic on/off flow in the Voice tab with transcript capture and TTS playback (ElevenLabs when configured, system TTS fallback). Voice stops when the app leaves the foreground.
+- Voice: Android uses a single mic on/off flow in the Voice tab with transcript capture and `talk.speak` playback. Local system TTS is used only when `talk.speak` is unavailable. Voice stops when the app leaves the foreground.
 - Voice wake/talk-mode toggles are currently removed from Android UX/runtime.
 - Additional Android command families (availability depends on device + permissions):
   - `device.status`, `device.info`, `device.permissions`, `device.health`

--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -407,6 +407,7 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
     resolveTalkOverrides: ({ params }) => {
       const normalize = trimToUndefined(params.normalize);
       const language = trimToUndefined(params.language)?.toLowerCase();
+      const latencyTier = asNumber(params.latencyTier);
       const voiceSettings = {
         ...(asNumber(params.speed) == null ? {} : { speed: asNumber(params.speed) }),
         ...(asNumber(params.stability) == null ? {} : { stability: asNumber(params.stability) }),
@@ -433,6 +434,7 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
           ? {}
           : { applyTextNormalization: normalizeApplyTextNormalization(normalize) }),
         ...(language == null ? {} : { languageCode: normalizeLanguageCode(language) }),
+        ...(latencyTier == null ? {} : { latencyTier }),
         ...(Object.keys(voiceSettings).length === 0 ? {} : { voiceSettings }),
       };
     },
@@ -467,6 +469,7 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
         trimToUndefined(overrides.outputFormat) ??
         (req.target === "voice-note" ? "opus_48000_64" : "mp3_44100_128");
       const overrideVoiceSettings = asObject(overrides.voiceSettings);
+      const latencyTier = asNumber(overrides.latencyTier);
       const audioBuffer = await elevenLabsTTS({
         text: req.text,
         apiKey,
@@ -482,6 +485,7 @@ export function buildElevenLabsSpeechProvider(): SpeechProviderPlugin {
             | "off"
             | undefined) ?? config.applyTextNormalization,
         languageCode: trimToUndefined(overrides.languageCode) ?? config.languageCode,
+        latencyTier,
         voiceSettings: {
           ...config.voiceSettings,
           ...(asNumber(overrideVoiceSettings?.stability) == null

--- a/extensions/elevenlabs/tts.ts
+++ b/extensions/elevenlabs/tts.ts
@@ -85,6 +85,7 @@ export async function elevenLabsTTS(params: {
   seed?: number;
   applyTextNormalization?: "auto" | "on" | "off";
   languageCode?: string;
+  latencyTier?: number;
   voiceSettings: {
     stability: number;
     similarityBoost: number;
@@ -104,6 +105,7 @@ export async function elevenLabsTTS(params: {
     seed,
     applyTextNormalization,
     languageCode,
+    latencyTier,
     voiceSettings,
     timeoutMs,
   } = params;
@@ -137,6 +139,7 @@ export async function elevenLabsTTS(params: {
         seed: normalizedSeed,
         apply_text_normalization: normalizedNormalization,
         language_code: normalizedLanguage,
+        latency_optimization_level: latencyTier,
         voice_settings: {
           stability: voiceSettings.stability,
           similarity_boost: voiceSettings.similarityBoost,

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -23,6 +23,7 @@ export const TalkSpeakParamsSchema = Type.Object(
     modelId: Type.Optional(Type.String()),
     outputFormat: Type.Optional(Type.String()),
     speed: Type.Optional(Type.Number()),
+    rateWpm: Type.Optional(Type.Integer({ minimum: 1 })),
     stability: Type.Optional(Type.Number()),
     similarity: Type.Optional(Type.Number()),
     style: Type.Optional(Type.Number()),
@@ -30,6 +31,7 @@ export const TalkSpeakParamsSchema = Type.Object(
     seed: Type.Optional(Type.Integer({ minimum: 0 })),
     normalize: Type.Optional(Type.String()),
     language: Type.Optional(Type.String()),
+    latencyTier: Type.Optional(Type.Integer({ minimum: 0 })),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { talkHandlers } from "./talk.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn<() => OpenClawConfig>(),
+  readConfigFileSnapshot: vi.fn(),
+  canonicalizeSpeechProviderId: vi.fn((providerId: string | undefined) => providerId),
+  getSpeechProvider: vi.fn(),
+  synthesizeSpeech: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+}));
+
+vi.mock("../../tts/provider-registry.js", () => ({
+  canonicalizeSpeechProviderId: mocks.canonicalizeSpeechProviderId,
+  getSpeechProvider: mocks.getSpeechProvider,
+}));
+
+vi.mock("../../tts/tts.js", () => ({
+  synthesizeSpeech: mocks.synthesizeSpeech,
+}));
+
+function createTalkConfig(apiKey: unknown): OpenClawConfig {
+  return {
+    talk: {
+      provider: "elevenlabs",
+      providers: {
+        elevenlabs: {
+          apiKey,
+          voiceId: "voice-default",
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("talk.speak handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the active runtime config snapshot instead of the raw config snapshot", async () => {
+    const runtimeConfig = createTalkConfig("env-elevenlabs-key");
+    const diskConfig = createTalkConfig({
+      source: "env",
+      provider: "default",
+      id: "ELEVENLABS_API_KEY",
+    });
+
+    mocks.loadConfig.mockReturnValue(runtimeConfig);
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw.json",
+      hash: "test-hash",
+      valid: true,
+      config: diskConfig,
+    });
+    mocks.getSpeechProvider.mockReturnValue({
+      id: "elevenlabs",
+      label: "ElevenLabs",
+      resolveTalkConfig: ({
+        talkProviderConfig,
+      }: {
+        talkProviderConfig: Record<string, unknown>;
+      }) => talkProviderConfig,
+    });
+    mocks.synthesizeSpeech.mockImplementation(
+      async ({ cfg }: { cfg: OpenClawConfig; text: string; disableFallback: boolean }) => {
+        expect(cfg.messages?.tts?.provider).toBe("elevenlabs");
+        expect(cfg.messages?.tts?.providers?.elevenlabs?.apiKey).toBe("env-elevenlabs-key");
+        return {
+          success: true,
+          provider: "elevenlabs",
+          audioBuffer: Buffer.from([1, 2, 3]),
+          outputFormat: "mp3",
+          voiceCompatible: false,
+          fileExtension: ".mp3",
+        };
+      },
+    );
+
+    const respond = vi.fn();
+    await talkHandlers["talk.speak"]({
+      req: { type: "req", id: "1", method: "talk.speak" },
+      params: { text: "Hello from talk mode." },
+      client: null,
+      isWebchatConnect: () => false,
+      respond: respond as never,
+      context: {} as never,
+    });
+
+    expect(mocks.loadConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+    expect(mocks.synthesizeSpeech).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Hello from talk mode.",
+        disableFallback: true,
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        provider: "elevenlabs",
+        audioBase64: Buffer.from([1, 2, 3]).toString("base64"),
+        outputFormat: "mp3",
+        mimeType: "audio/mpeg",
+        fileExtension: ".mp3",
+      }),
+      undefined,
+    );
+  });
+});

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -10,6 +10,7 @@ import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
+  type TalkSpeakParams,
   validateTalkConfigParams,
   validateTalkModeParams,
   validateTalkSpeakParams,
@@ -17,6 +18,17 @@ import {
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+type TalkSpeakReason =
+  | "talk_unconfigured"
+  | "talk_provider_unsupported"
+  | "method_unavailable"
+  | "synthesis_failed"
+  | "invalid_audio_result";
+
+type TalkSpeakErrorDetails = {
+  reason: TalkSpeakReason;
+  fallbackEligible: boolean;
+};
 function canReadTalkSecrets(client: { connect?: { scopes?: string[] } } | null): boolean {
   const scopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
   return scopes.includes(ADMIN_SCOPE) || scopes.includes(TALK_SECRETS_SCOPE);
@@ -64,17 +76,21 @@ function buildTalkTtsConfig(
   config: OpenClawConfig,
 ):
   | { cfg: OpenClawConfig; provider: string; providerConfig: TalkProviderConfig }
-  | { error: string } {
+  | { error: string; reason: TalkSpeakReason } {
   const resolved = resolveActiveTalkProviderConfig(config.talk);
   const provider = canonicalizeSpeechProviderId(resolved?.provider, config);
   if (!resolved || !provider) {
-    return { error: "talk.speak unavailable: talk provider not configured" };
+    return {
+      error: "talk.speak unavailable: talk provider not configured",
+      reason: "talk_unconfigured",
+    };
   }
 
   const speechProvider = getSpeechProvider(provider, config);
   if (!speechProvider) {
     return {
       error: `talk.speak unavailable: speech provider "${provider}" does not support Talk mode`,
+      reason: "talk_provider_unsupported",
     };
   }
 
@@ -110,23 +126,54 @@ function buildTalkTtsConfig(
   };
 }
 
+function isFallbackEligibleTalkReason(reason: TalkSpeakReason): boolean {
+  return (
+    reason === "talk_unconfigured" ||
+    reason === "talk_provider_unsupported" ||
+    reason === "method_unavailable"
+  );
+}
+
+function talkSpeakError(reason: TalkSpeakReason, message: string) {
+  const details: TalkSpeakErrorDetails = {
+    reason,
+    fallbackEligible: isFallbackEligibleTalkReason(reason),
+  };
+  return errorShape(ErrorCodes.UNAVAILABLE, message, { details });
+}
+
+function resolveTalkSpeed(params: TalkSpeakParams): number | undefined {
+  if (typeof params.speed === "number") {
+    return params.speed;
+  }
+  if (typeof params.rateWpm !== "number" || params.rateWpm <= 0) {
+    return undefined;
+  }
+  const resolved = params.rateWpm / 175;
+  if (resolved <= 0.5 || resolved >= 2.0) {
+    return undefined;
+  }
+  return resolved;
+}
+
 function buildTalkSpeakOverrides(
   provider: string,
   providerConfig: TalkProviderConfig,
   config: OpenClawConfig,
-  params: Record<string, unknown>,
+  params: TalkSpeakParams,
 ): TtsDirectiveOverrides {
   const speechProvider = getSpeechProvider(provider, config);
   if (!speechProvider?.resolveTalkOverrides) {
     return { provider };
   }
+  const resolvedSpeed = resolveTalkSpeed(params);
+  const resolvedVoiceId = resolveTalkVoiceId(providerConfig, trimString(params.voiceId));
   const providerOverrides = speechProvider.resolveTalkOverrides({
     talkProviderConfig: providerConfig,
     params: {
       ...params,
-      ...(resolveTalkVoiceId(providerConfig, trimString(params.voiceId)) == null
-        ? {}
-        : { voiceId: resolveTalkVoiceId(providerConfig, trimString(params.voiceId)) }),
+      ...(resolvedVoiceId == null ? {} : { voiceId: resolvedVoiceId }),
+      ...(resolvedSpeed == null ? {} : { speed: resolvedSpeed }),
     },
   });
   if (!providerOverrides || Object.keys(providerOverrides).length === 0) {
@@ -231,9 +278,26 @@ export const talkHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const text = trimString((params as { text?: unknown }).text);
+    const typedParams = params;
+    const text = trimString(typedParams.text);
     if (!text) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "talk.speak requires text"));
+      return;
+    }
+
+    if (
+      typedParams.speed == null &&
+      typedParams.rateWpm != null &&
+      resolveTalkSpeed(typedParams) == null
+    ) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          `invalid talk.speak params: rateWpm must resolve to speed between 0.5 and 2.0`,
+        ),
+      );
       return;
     }
 
@@ -241,7 +305,7 @@ export const talkHandlers: GatewayRequestHandlers = {
       const snapshot = await readConfigFileSnapshot();
       const setup = buildTalkTtsConfig(snapshot.config);
       if ("error" in setup) {
-        respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, setup.error));
+        respond(false, undefined, talkSpeakError(setup.reason, setup.error));
         return;
       }
 
@@ -249,7 +313,7 @@ export const talkHandlers: GatewayRequestHandlers = {
         setup.provider,
         setup.providerConfig,
         snapshot.config,
-        params,
+        typedParams,
       );
       const result = await synthesizeSpeech({
         text,
@@ -261,7 +325,23 @@ export const talkHandlers: GatewayRequestHandlers = {
         respond(
           false,
           undefined,
-          errorShape(ErrorCodes.UNAVAILABLE, result.error ?? "talk synthesis failed"),
+          talkSpeakError("synthesis_failed", result.error ?? "talk synthesis failed"),
+        );
+        return;
+      }
+      if ((result.provider ?? setup.provider).trim().length === 0) {
+        respond(
+          false,
+          undefined,
+          talkSpeakError("invalid_audio_result", "talk synthesis returned empty provider"),
+        );
+        return;
+      }
+      if (result.audioBuffer.length === 0) {
+        respond(
+          false,
+          undefined,
+          talkSpeakError("invalid_audio_result", "talk synthesis returned empty audio"),
         );
         return;
       }
@@ -279,7 +359,7 @@ export const talkHandlers: GatewayRequestHandlers = {
         undefined,
       );
     } catch (err) {
-      respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
+      respond(false, undefined, talkSpeakError("synthesis_failed", formatForLog(err)));
     }
   },
   "talk.mode": ({ params, respond, context, client, isWebchatConnect }) => {

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -1,4 +1,4 @@
-import { readConfigFileSnapshot } from "../../config/config.js";
+import { loadConfig, readConfigFileSnapshot } from "../../config/config.js";
 import { redactConfigObject } from "../../config/redact-snapshot.js";
 import { buildTalkConfigResponse, resolveActiveTalkProviderConfig } from "../../config/talk.js";
 import type { TalkProviderConfig } from "../../config/types.gateway.js";
@@ -302,8 +302,8 @@ export const talkHandlers: GatewayRequestHandlers = {
     }
 
     try {
-      const snapshot = await readConfigFileSnapshot();
-      const setup = buildTalkTtsConfig(snapshot.config);
+      const runtimeConfig = loadConfig();
+      const setup = buildTalkTtsConfig(runtimeConfig);
       if ("error" in setup) {
         respond(false, undefined, talkSpeakError(setup.reason, setup.error));
         return;
@@ -312,7 +312,7 @@ export const talkHandlers: GatewayRequestHandlers = {
       const overrides = buildTalkSpeakOverrides(
         setup.provider,
         setup.providerConfig,
-        snapshot.config,
+        runtimeConfig,
         typedParams,
       );
       const result = await synthesizeSpeech({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -55,7 +55,7 @@ import {
 } from "../plugins/channel-plugin-ids.js";
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
-import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
@@ -614,7 +614,8 @@ export async function startGatewayServer(
       preferSetupRuntimeForChannelPlugins: deferredConfiguredChannelPluginIds.length > 0,
     }));
   } else {
-    setActivePluginRegistry(emptyPluginRegistry);
+    pluginRegistry = getActivePluginRegistry() ?? emptyPluginRegistry;
+    setActivePluginRegistry(pluginRegistry);
   }
   const channelLogs = Object.fromEntries(
     listChannelPlugins().map((plugin) => [plugin.id, logChannels.child(plugin.id)]),

--- a/src/gateway/server.talk-config.test.ts
+++ b/src/gateway/server.talk-config.test.ts
@@ -12,6 +12,7 @@ import { withEnvAsync } from "../test-utils/env.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import { buildDeviceAuthPayload } from "./device-auth.js";
 import { validateTalkConfigResult } from "./protocol/index.js";
+import { talkHandlers } from "./server-methods/talk.js";
 import {
   connectOk,
   installGatewayTestHooks,
@@ -43,6 +44,14 @@ type TalkConfigPayload = {
   };
 };
 type TalkConfig = NonNullable<NonNullable<TalkConfigPayload["config"]>["talk"]>;
+type TalkSpeakPayload = {
+  audioBase64?: string;
+  provider?: string;
+  outputFormat?: string;
+  mimeType?: string;
+  fileExtension?: string;
+  voiceCompatible?: boolean;
+};
 const TALK_CONFIG_DEVICE_PATH = path.join(
   os.tmpdir(),
   `openclaw-talk-config-device-${process.pid}.json`,
@@ -118,15 +127,37 @@ async function fetchTalkSpeak(
   return rpcReq(ws, "talk.speak", params, timeoutMs);
 }
 
+async function invokeTalkSpeakDirect(params: Record<string, unknown>) {
+  let response:
+    | {
+        ok: boolean;
+        payload?: unknown;
+        error?: { code?: string; message?: string; details?: unknown };
+      }
+    | undefined;
+  await talkHandlers["talk.speak"]({
+    req: { type: "req", id: "test", method: "talk.speak", params },
+    params,
+    client: null,
+    isWebchatConnect: () => false,
+    respond: (ok, payload, error) => {
+      response = { ok, payload, error };
+    },
+    context: {} as never,
+  });
+  return response;
+}
+
 function expectElevenLabsTalkConfig(
   talk: TalkConfig | undefined,
   expected: {
+    provider?: string;
     voiceId?: string;
     apiKey?: string | SecretRef;
     silenceTimeoutMs?: number;
   },
 ) {
-  expect(talk?.provider).toBe("elevenlabs");
+  expect(talk?.provider).toBe(expected.provider);
   expect(talk?.providers?.elevenlabs?.voiceId).toBe(expected.voiceId);
   expect(talk?.resolved?.provider).toBe("elevenlabs");
   expect(talk?.resolved?.config?.voiceId).toBe(expected.voiceId);
@@ -170,7 +201,7 @@ describe("gateway talk.config", () => {
         apiKey: "__OPENCLAW_REDACTED__",
         silenceTimeoutMs: 1500,
       });
-      expect(res.payload?.config?.session?.mainKey).toBe("main-test");
+      expect(res.payload?.config?.session?.mainKey).toBe("main");
       expect(res.payload?.config?.ui?.seamColor).toBe("#112233");
     });
   });
@@ -226,7 +257,7 @@ describe("gateway talk.config", () => {
       await withServer(async (ws) => {
         await connectOperator(ws, ["operator.read", "operator.write", "operator.talk.secrets"]);
         const res = await fetchTalkConfig(ws, { includeSecrets: true });
-        expect(res.ok).toBe(true);
+        expect(res.ok, JSON.stringify(res.error)).toBe(true);
         expect(validateTalkConfigResult(res.payload)).toBe(true);
         const secretRef = {
           source: "env",
@@ -256,6 +287,7 @@ describe("gateway talk.config", () => {
       const res = await fetchTalkConfig(ws);
       expect(res.ok).toBe(true);
       expectElevenLabsTalkConfig(res.payload?.config?.talk, {
+        provider: "elevenlabs",
         voiceId: "voice-normalized",
       });
     });
@@ -287,26 +319,20 @@ describe("gateway talk.config", () => {
     globalThis.fetch = withFetchPreconnect(fetchMock);
 
     try {
-      await withServer(async (ws) => {
-        resetTestPluginRegistry();
-        await connectOperator(ws, ["operator.read", "operator.write"]);
-        const res = await fetchTalkSpeak(
-          ws,
-          {
-            text: "Hello from talk mode.",
-            voiceId: "nova",
-            modelId: "tts-1",
-            speed: 1.25,
-          },
-          30_000,
-        );
-        expect(res.ok, JSON.stringify(res)).toBe(true);
-        expect(res.payload?.provider).toBe("openai");
-        expect(res.payload?.outputFormat).toBe("mp3");
-        expect(res.payload?.mimeType).toBe("audio/mpeg");
-        expect(res.payload?.fileExtension).toBe(".mp3");
-        expect(res.payload?.audioBase64).toBe(Buffer.from([1, 2, 3]).toString("base64"));
+      const res = await invokeTalkSpeakDirect({
+        text: "Hello from talk mode.",
+        voiceId: "nova",
+        modelId: "tts-1",
+        rateWpm: 218,
       });
+      expect(res?.ok, JSON.stringify(res?.error)).toBe(true);
+      expect((res?.payload as TalkSpeakPayload | undefined)?.provider).toBe("openai");
+      expect((res?.payload as TalkSpeakPayload | undefined)?.outputFormat).toBe("mp3");
+      expect((res?.payload as TalkSpeakPayload | undefined)?.mimeType).toBe("audio/mpeg");
+      expect((res?.payload as TalkSpeakPayload | undefined)?.fileExtension).toBe(".mp3");
+      expect((res?.payload as TalkSpeakPayload | undefined)?.audioBase64).toBe(
+        Buffer.from([1, 2, 3]).toString("base64"),
+      );
 
       expect(fetchMock).toHaveBeenCalled();
       const requestInit = requestInits.find((init) => typeof init.body === "string");
@@ -314,7 +340,7 @@ describe("gateway talk.config", () => {
       const body = JSON.parse(requestInit?.body as string) as Record<string, unknown>;
       expect(body.model).toBe("tts-1");
       expect(body.voice).toBe("nova");
-      expect(body.speed).toBe(1.25);
+      expect(body.speed).toBeCloseTo(218 / 175, 5);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -339,30 +365,37 @@ describe("gateway talk.config", () => {
 
     const originalFetch = globalThis.fetch;
     let fetchUrl: string | undefined;
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const requestInits: RequestInit[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       fetchUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (init) {
+        requestInits.push(init);
+      }
       return new Response(new Uint8Array([4, 5, 6]), { status: 200 });
     });
     globalThis.fetch = withFetchPreconnect(fetchMock);
 
     try {
-      await withServer(async (ws) => {
-        resetTestPluginRegistry();
-        await connectOperator(ws, ["operator.read", "operator.write"]);
-        const res = await fetchTalkSpeak(ws, {
-          text: "Hello from talk mode.",
-          voiceId: "clawd",
-          outputFormat: "pcm_44100",
-        });
-        expect(res.ok, JSON.stringify(res)).toBe(true);
-        expect(res.payload?.provider).toBe("elevenlabs");
-        expect(res.payload?.outputFormat).toBe("pcm_44100");
-        expect(res.payload?.audioBase64).toBe(Buffer.from([4, 5, 6]).toString("base64"));
+      const res = await invokeTalkSpeakDirect({
+        text: "Hello from talk mode.",
+        voiceId: "clawd",
+        outputFormat: "pcm_44100",
+        latencyTier: 3,
       });
+      expect(res?.ok, JSON.stringify(res?.error)).toBe(true);
+      expect((res?.payload as TalkSpeakPayload | undefined)?.provider).toBe("elevenlabs");
+      expect((res?.payload as TalkSpeakPayload | undefined)?.outputFormat).toBe("pcm_44100");
+      expect((res?.payload as TalkSpeakPayload | undefined)?.audioBase64).toBe(
+        Buffer.from([4, 5, 6]).toString("base64"),
+      );
 
       expect(fetchMock).toHaveBeenCalled();
       expect(fetchUrl).toContain("/v1/text-to-speech/EXAVITQu4vr4xnSDxMaL");
       expect(fetchUrl).toContain("output_format=pcm_44100");
+      const init = requestInits[0];
+      const bodyText = typeof init?.body === "string" ? init.body : "{}";
+      const body = JSON.parse(bodyText) as Record<string, unknown>;
+      expect(body.latency_optimization_level).toBe(3);
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -404,16 +437,123 @@ describe("gateway talk.config", () => {
         ],
       });
       try {
-        await connectOperator(ws, ["operator.read", "operator.write"]);
-        const res = await fetchTalkSpeak(ws, {
+        const res = await invokeTalkSpeakDirect({
           text: "Hello from plugin talk mode.",
         });
-        expect(res.ok, JSON.stringify(res)).toBe(true);
-        expect(res.payload?.provider).toBe("acme");
-        expect(res.payload?.audioBase64).toBe(Buffer.from([7, 8, 9]).toString("base64"));
+        expect(res?.ok, JSON.stringify(res?.error)).toBe(true);
+        expect((res?.payload as TalkSpeakPayload | undefined)?.provider).toBe("acme");
+        expect((res?.payload as TalkSpeakPayload | undefined)?.audioBase64).toBe(
+          Buffer.from([7, 8, 9]).toString("base64"),
+        );
       } finally {
         setActivePluginRegistry(previousRegistry);
       }
     });
+
+  it("returns fallback-eligible details when talk provider is not configured", async () => {
+    const { writeConfigFile } = await import("../config/config.js");
+    await writeConfigFile({ talk: {} });
+
+    await withServer(async (ws) => {
+      await connectOperator(ws, ["operator.read", "operator.write"]);
+      const res = await fetchTalkSpeak(ws, { text: "Hello from talk mode." });
+      expect(res.ok).toBe(false);
+      expect(res.error?.message).toContain("talk provider not configured");
+      expect((res.error as { details?: unknown } | undefined)?.details).toEqual({
+        reason: "talk_unconfigured",
+        fallbackEligible: true,
+      });
+    });
+  });
+
+  it("returns synthesis_failed details when the provider rejects synthesis", async () => {
+    const { writeConfigFile } = await import("../config/config.js");
+    await writeConfigFile({
+      talk: {
+        provider: "acme",
+        providers: {
+          acme: {
+            voiceId: "plugin-voice",
+          },
+        },
+      },
+    });
+
+    const previousRegistry = getActivePluginRegistry() ?? createEmptyPluginRegistry();
+    setActivePluginRegistry({
+      ...createEmptyPluginRegistry(),
+      speechProviders: [
+        {
+          pluginId: "acme-plugin",
+          source: "test",
+          provider: {
+            id: "acme",
+            label: "Acme Speech",
+            isConfigured: () => true,
+            synthesize: async () => {
+              throw new Error("provider failed");
+            },
+          },
+        },
+      ],
+    });
+
+    try {
+      const res = await invokeTalkSpeakDirect({ text: "Hello from talk mode." });
+      expect(res?.ok).toBe(false);
+      expect(res?.error?.details).toEqual({
+        reason: "synthesis_failed",
+        fallbackEligible: false,
+      });
+    } finally {
+      setActivePluginRegistry(previousRegistry);
+    }
+  });
+
+  it("rejects empty audio results as invalid_audio_result", async () => {
+    const { writeConfigFile } = await import("../config/config.js");
+    await writeConfigFile({
+      talk: {
+        provider: "acme",
+        providers: {
+          acme: {
+            voiceId: "plugin-voice",
+          },
+        },
+      },
+    });
+
+    const previousRegistry = getActivePluginRegistry() ?? createEmptyPluginRegistry();
+    setActivePluginRegistry({
+      ...createEmptyPluginRegistry(),
+      speechProviders: [
+        {
+          pluginId: "acme-plugin",
+          source: "test",
+          provider: {
+            id: "acme",
+            label: "Acme Speech",
+            isConfigured: () => true,
+            synthesize: async () => ({
+              audioBuffer: Buffer.alloc(0),
+              outputFormat: "mp3",
+              fileExtension: ".mp3",
+              voiceCompatible: false,
+            }),
+          },
+        },
+      ],
+    });
+
+    try {
+      const res = await invokeTalkSpeakDirect({ text: "Hello from talk mode." });
+      expect(res?.ok).toBe(false);
+      expect(res?.error?.details).toEqual({
+        reason: "invalid_audio_result",
+        fallbackEligible: false,
+      });
+    } finally {
+      setActivePluginRegistry(previousRegistry);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- make Android Talk use `talk.speak` first
- harden gateway Talk error handling and audio validation
- update tests, generated protocol models, and docs