### PR TITLE
fix for mcp connection issue (closes #60903)

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -29,6 +29,7 @@ type ChromeMcpSession = {
 type ChromeMcpSessionFactory = (
   profileName: string,
   userDataDir?: string,
+  cdpUrl?: string,
 ) => Promise<ChromeMcpSession>;
 
 const DEFAULT_CHROME_MCP_COMMAND = "npx";
@@ -171,6 +172,16 @@ function extractJsonMessage(result: ChromeMcpToolResult): unknown {
   return null;
 }
 
+function getCdpUrlForProfile(profileName: string): string | undefined {
+  try {
+    const state = require("../server-context").state;
+    const profile = state()?.resolved?.profiles?.[profileName];
+    return profile?.cdpUrl || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function normalizeChromeMcpUserDataDir(userDataDir?: string): string | undefined {
   const trimmed = userDataDir?.trim();
   return trimmed ? trimmed : undefined;
@@ -213,20 +224,28 @@ async function closeChromeMcpSessionsForProfile(
   return closed;
 }
 
-export function buildChromeMcpArgs(userDataDir?: string): string[] {
+export function buildChromeMcpArgs(userDataDir?: string, cdpUrl?: string): string[] {
   const normalizedUserDataDir = normalizeChromeMcpUserDataDir(userDataDir);
-  return normalizedUserDataDir
-    ? [...DEFAULT_CHROME_MCP_ARGS, "--userDataDir", normalizedUserDataDir]
-    : [...DEFAULT_CHROME_MCP_ARGS];
+
+  const base = [
+    "-y",
+    "chrome-devtools-mcp@latest",
+    ...(cdpUrl ? ["--browserUrl", cdpUrl] : ["--autoConnect"]),
+    "--experimentalStructuredContent",
+    "--experimental-page-id-routing",
+  ];
+
+  return normalizedUserDataDir ? [...base, "--userDataDir", normalizedUserDataDir] : base;
 }
 
 async function createRealSession(
   profileName: string,
   userDataDir?: string,
+  cdpUrl?: string,
 ): Promise<ChromeMcpSession> {
   const transport = new StdioClientTransport({
     command: DEFAULT_CHROME_MCP_COMMAND,
-    args: buildChromeMcpArgs(userDataDir),
+    args: buildChromeMcpArgs(userDataDir, cdpUrl),
     stderr: "pipe",
   });
   const client = new Client(
@@ -277,7 +296,11 @@ async function getSession(profileName: string, userDataDir?: string): Promise<Ch
     let pending = pendingSessions.get(cacheKey);
     if (!pending) {
       pending = (async () => {
-        const created = await (sessionFactory ?? createRealSession)(profileName, userDataDir);
+        const created = await (sessionFactory ?? createRealSession)(
+          profileName,
+          userDataDir,
+          getCdpUrlForProfile(profileName),
+        );
         if (pendingSessions.get(cacheKey) === pending) {
           sessions.set(cacheKey, created);
         } else {


### PR DESCRIPTION
## Summary

- Problem:
  Chrome MCP existing-session attach ignored configured `cdpUrl` and always used `--autoConnect`, causing connection failures to running Chrome instances.
- Why it matters:
  Users with explicit CDP endpoints (e.g. `http://127.0.0.1:9222`) could not attach, breaking browser control via MCP.
- What changed:
  Propagated `cdpUrl` from profile → session → CLI args and switched to `--browserUrl` when provided.
- What did NOT change (scope boundary):
  No changes to MCP protocol, gateway routing, or browser interaction logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60903
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause:
  `cdpUrl` was defined in profile config but never propagated into Chrome MCP session creation, causing fallback to `--autoConnect`.
- Missing detection / guardrail:
  No test verifying attach behavior with explicit `cdpUrl`.
- Contributing context (if known):
  Recent MCP attach changes introduced structuredContent flags but did not update argument handling.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  `chrome-mcp session creation / args construction`
- Scenario the test should lock in:
  Given profile with `cdpUrl`, MCP must launch with `--browserUrl` instead of `--autoConnect`.
- Why this is the smallest reliable guardrail:
  Verifies argument construction without requiring full browser runtime.
- Existing test that already covers this (if any):
  None
- If no new test is added, why not:
  Focused fix; can be covered in follow-up

## User-visible / Behavior Changes

- MCP can now correctly attach to existing Chrome sessions when `cdpUrl` is configured.

## Diagram (if applicable)

```text
Before:
CLI -> MCP (--autoConnect) -> fails to attach

After:
CLI -> MCP (--browserUrl=http://127.0.0.1:9222) -> attaches -> works
````

## Security Impact (required)

* New permissions/capabilities? No
* Secrets/tokens handling changed? No
* New/changed network calls? No
* Command/tool execution surface changed? No
* Data access scope changed? No

## Repro + Verification

### Environment

* OS: Ubuntu 22
* Runtime/container: local
* Model/provider: N/A
* Integration/channel: browser MCP
* Relevant config: profile with `cdpUrl=http://127.0.0.1:9222`

### Steps

1. Start Chrome with remote debugging
2. Run `openclaw browser status`
3. Attempt MCP attach

### Expected

* Successfully attaches and lists pages

### Actual

* Previously failed with connection closed / MCP attach error

## Evidence

* [x] Trace/log snippets

## Human Verification (required)

* Verified scenarios:

  * MCP attaches using `cdpUrl`
  * Tabs can be listed
* Edge cases checked:

  * No `cdpUrl` still uses `--autoConnect`
* What you did not verify:

  * Remote (non-localhost) CDP endpoints

## Review Conversations

* [x] I replied to or resolved every bot review conversation I addressed in this PR.
* [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

* Backward compatible? Yes
* Config/env changes? No
* Migration needed? No

## Risks and Mitigations

* Risk:
  Incorrect `cdpUrl` could break attach

  * Mitigation:
    Falls back to existing behavior when undefined