### PR TITLE
fix(ui): drop stale redacted gateway placeholders

### DIFF
--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -371,6 +371,35 @@ describe("saveConfig", () => {
     expect(parsed.gateway.port).toBe("18789");
     expect(params.baseHash).toBe("hash-save-2");
   });
+
+  it("drops unresolved redacted placeholders before config.set", async () => {
+    const request = createRequestWithConfigGet();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "form";
+    state.configForm = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          token: "__OPENCLAW_REDACTED__",
+        },
+      },
+    };
+    state.configRawOriginal = '{\n  gateway: {\n    mode: "remote"\n  }\n}\n';
+    state.configSnapshot = { hash: "hash-save-3" };
+
+    await saveConfig(state);
+
+    expect(request.mock.calls[0]?.[0]).toBe("config.set");
+    const params = request.mock.calls[0]?.[1] as { raw: string; baseHash: string };
+    const parsed = JSON.parse(params.raw) as {
+      gateway: { mode: string; remote?: { token?: string } };
+    };
+    expect(parsed.gateway.mode).toBe("remote");
+    expect(parsed.gateway.remote).toBeUndefined();
+    expect(params.baseHash).toBe("hash-save-3");
+  });
 });
 
 describe("runUpdate", () => {

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -7,6 +7,7 @@ import {
   removePathValue,
   serializeConfigForm,
   setPathValue,
+  stripUnrestorableRedactedValues,
 } from "./config/form-utils.ts";
 
 export type ConfigState = {
@@ -131,7 +132,10 @@ function serializeFormForSubmit(state: ConfigState): string {
   const form = schema
     ? (coerceFormValues(state.configForm, schema) as Record<string, unknown>)
     : state.configForm;
-  return serializeConfigForm(form);
+  const sanitized = state.configRawOriginal
+    ? stripUnrestorableRedactedValues(form, state.configRawOriginal)
+    : form;
+  return serializeConfigForm(sanitized);
 }
 
 export async function saveConfig(state: ConfigState) {

--- a/ui/src/ui/controllers/config/form-utils.node.test.ts
+++ b/ui/src/ui/controllers/config/form-utils.node.test.ts
@@ -6,6 +6,7 @@ import {
   removePathValue,
   serializeConfigForm,
   setPathValue,
+  stripUnrestorableRedactedValues,
 } from "./form-utils.ts";
 
 /**
@@ -131,6 +132,45 @@ describe("form-utils preserves numeric types", () => {
     expectNumericModelCore(first);
     expect(typeof first.cost).toBe("object");
     expect(typeof (first.cost as Record<string, unknown>).input).toBe("number");
+  });
+});
+
+describe("stripUnrestorableRedactedValues", () => {
+  it("drops redacted placeholders for paths missing from the original raw config", () => {
+    const form = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          token: "__OPENCLAW_REDACTED__",
+        },
+      },
+    };
+
+    expect(
+      stripUnrestorableRedactedValues(form, '{\n  gateway: {\n    mode: "remote"\n  }\n}\n'),
+    ).toEqual({
+      gateway: {
+        mode: "remote",
+      },
+    });
+  });
+
+  it("keeps redacted placeholders that already exist in the original raw config", () => {
+    const form = {
+      gateway: {
+        mode: "remote",
+        remote: {
+          token: "__OPENCLAW_REDACTED__",
+        },
+      },
+    };
+
+    expect(
+      stripUnrestorableRedactedValues(
+        form,
+        '{\n  gateway: {\n    mode: "remote",\n    remote: {\n      token: "__OPENCLAW_REDACTED__"\n    }\n  }\n}\n',
+      ),
+    ).toEqual(form);
   });
 });
 

--- a/ui/src/ui/controllers/config/form-utils.ts
+++ b/ui/src/ui/controllers/config/form-utils.ts
@@ -1,3 +1,5 @@
+import JSON5 from "json5";
+
 export function cloneConfigObject<T>(value: T): T {
   if (typeof structuredClone === "function") {
     return structuredClone(value);
@@ -5,8 +7,68 @@ export function cloneConfigObject<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
+const REDACTED_SENTINEL = "__OPENCLAW_REDACTED__";
+const OMIT_VALUE = Symbol("omit-redacted-sentinel");
+
 export function serializeConfigForm(form: Record<string, unknown>): string {
   return `${JSON.stringify(form, null, 2).trimEnd()}\n`;
+}
+
+function stripUnrestorableValue(value: unknown, original: unknown): unknown | typeof OMIT_VALUE {
+  if (value === REDACTED_SENTINEL) {
+    return original === REDACTED_SENTINEL ? value : OMIT_VALUE;
+  }
+
+  if (Array.isArray(value)) {
+    const originalItems = Array.isArray(original) ? original : [];
+    const next = value
+      .map((item, index) => stripUnrestorableValue(item, originalItems[index]))
+      .filter((item) => item !== OMIT_VALUE);
+    return next;
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const originalRecord =
+    original && typeof original === "object" && !Array.isArray(original)
+      ? (original as Record<string, unknown>)
+      : null;
+  const next: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    const stripped = stripUnrestorableValue(item, originalRecord?.[key]);
+    if (stripped !== OMIT_VALUE) {
+      next[key] = stripped;
+    }
+  }
+
+  if (Object.keys(next).length === 0 && !originalRecord) {
+    return OMIT_VALUE;
+  }
+  return next;
+}
+
+/**
+ * Drop redaction sentinels that only exist because the form was populated from
+ * normalized snapshot defaults rather than real on-disk config keys.
+ */
+export function stripUnrestorableRedactedValues(
+  form: Record<string, unknown>,
+  originalRaw: string,
+): Record<string, unknown> {
+  let original: unknown;
+  try {
+    original = JSON5.parse(originalRaw);
+  } catch {
+    return form;
+  }
+
+  const stripped = stripUnrestorableValue(form, original);
+  if (!stripped || typeof stripped !== "object" || Array.isArray(stripped)) {
+    return form;
+  }
+  return stripped as Record<string, unknown>;
 }
 
 const FORBIDDEN_KEYS = new Set(["__proto__", "prototype", "constructor"]);


### PR DESCRIPTION
## Summary
- drop unresolved `__OPENCLAW_REDACTED__` placeholders before submitting config form saves
- keep existing redacted secret paths intact when the original raw config already contains them
- add UI regression coverage for the save path and raw-aware stripping helper

Closes #60917

## Verification
- `pnpm --dir ui test -- src/ui/controllers/config.test.ts src/ui/controllers/config/form-utils.node.test.ts`
- `pnpm exec oxfmt --check ui/src/ui/controllers/config.ts ui/src/ui/controllers/config.test.ts ui/src/ui/controllers/config/form-utils.ts ui/src/ui/controllers/config/form-utils.node.test.ts`
