### PR TITLE
fix(macos): watchdog timer clears stale jobs when AI provider overloads/times out

### DIFF
--- a/apps/macos/Sources/OpenClaw/WorkActivityStore.swift
+++ b/apps/macos/Sources/OpenClaw/WorkActivityStore.swift
@@ -4,6 +4,15 @@ import OpenClawKit
 import OpenClawProtocol
 import SwiftUI
 
+/// Helper class to store task reference outside of @MainActor context for proper cleanup
+private final class TaskStorage {
+    var task: Task<Void, Never>?
+
+    deinit {
+        task?.cancel()
+    }
+}
+
 @MainActor
 @Observable
 final class WorkActivityStore {
@@ -16,6 +25,10 @@ final class WorkActivityStore {
         let label: String
         let startedAt: Date
         var lastUpdate: Date
+
+        mutating func refreshTimestamp() {
+            self.lastUpdate = Date()
+        }
     }
 
     private(set) var current: Activity?
@@ -23,13 +36,40 @@ final class WorkActivityStore {
     private(set) var lastToolLabel: String?
     private(set) var lastToolUpdatedAt: Date?
 
-    private var jobs: [String: Activity] = [:]
+    internal var jobs: [String: Activity] = [:]
     private var tools: [String: Activity] = [:]
     private var currentSessionKey: String?
     private var toolSeqBySession: [String: Int] = [:]
 
+    // MARK: - Watchdog Configuration
+
+    /// Watchdog system to clear stale jobs that never received a "done" event.
+    /// This prevents the menubar icon from freezing when AI providers (e.g. Anthropic)
+    /// return overload/timeout errors and the gateway never sends run-end events.
+    ///
+    /// The watchdog runs every 30 seconds and evicts jobs/tools that haven't been
+    /// updated in over 120 seconds. Job timestamps are refreshed on streaming updates
+    /// and tool activity to prevent false evictions of healthy long-running tasks.
+    private static let jobWatchdogInterval: TimeInterval = 30.0
+    private static let jobStaleThreshold: TimeInterval = 120.0
+    private let watchdogTaskStorage: TaskStorage = TaskStorage()
+
+    /// Access the watchdog task for testing purposes
+    internal var watchdogTask: Task<Void, Never>? {
+        get { watchdogTaskStorage.task }
+        set { watchdogTaskStorage.task = newValue }
+    }
+
     private var mainSessionKeyStorage = "main"
     private let toolResultGrace: TimeInterval = 2.0
+
+    init() {
+        self.startWatchdog()
+    }
+
+    deinit {
+        // TaskStorage will automatically cancel the task in its own deinit
+    }
 
     var mainSessionKey: String {
         self.mainSessionKeyStorage
@@ -38,14 +78,21 @@ final class WorkActivityStore {
     func handleJob(sessionKey: String, state: String) {
         let isStart = state.lowercased() == "started" || state.lowercased() == "streaming"
         if isStart {
-            let activity = Activity(
-                sessionKey: sessionKey,
-                role: self.role(for: sessionKey),
-                kind: .job,
-                label: "job",
-                startedAt: Date(),
-                lastUpdate: Date())
-            self.setJobActive(activity)
+            if var existing = self.jobs[sessionKey], state.lowercased() == "streaming" {
+                // Update timestamp for streaming updates on existing jobs
+                existing.refreshTimestamp()
+                self.setJobActive(existing)
+            } else {
+                // Create new job activity
+                let activity = Activity(
+                    sessionKey: sessionKey,
+                    role: self.role(for: sessionKey),
+                    kind: .job,
+                    label: "job",
+                    startedAt: Date(),
+                    lastUpdate: Date())
+                self.setJobActive(activity)
+            }
         } else {
             // Job ended (done/error/aborted/etc). Clear everything for this session.
             self.clearTool(sessionKey: sessionKey)
@@ -66,6 +113,13 @@ final class WorkActivityStore {
             self.lastToolLabel = label
             self.lastToolUpdatedAt = Date()
             self.toolSeqBySession[sessionKey, default: 0] += 1
+
+            // Refresh the job's lastUpdate timestamp to keep it alive during tool activity
+            if var job = self.jobs[sessionKey] {
+                job.refreshTimestamp()
+                self.jobs[sessionKey] = job
+            }
+
             let activity = Activity(
                 sessionKey: sessionKey,
                 role: self.role(for: sessionKey),
@@ -256,5 +310,59 @@ final class WorkActivityStore {
             return array.map { self.unwrapJSONValue($0) }
         }
         return value
+    }
+
+    // MARK: - Watchdog
+
+    /// Periodically evicts jobs and tools that have been stuck with no completion event.
+    /// This prevents the menubar icon from freezing when the AI provider (e.g. Anthropic)
+    /// returns an overload/timeout error and the gateway never sends the run-end event.
+    private func startWatchdog() {
+        self.watchdogTask?.cancel()
+        self.watchdogTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(Self.jobWatchdogInterval * 1_000_000_000))
+                guard !Task.isCancelled else { return }
+                await MainActor.run { self?.evictStaleActivities() }
+            }
+        }
+    }
+
+    internal func evictStaleActivities() {
+        let now = Date()
+        let threshold = Self.jobStaleThreshold
+        var changed = false
+
+        // Collect stale keys first to avoid mutation during iteration
+        var staleJobKeys: [String] = []
+        var staleToolKeys: [String] = []
+
+        for (key, activity) in self.jobs {
+            if now.timeIntervalSince(activity.lastUpdate) > threshold {
+                staleJobKeys.append(key)
+            }
+        }
+        for (key, activity) in self.tools {
+            if now.timeIntervalSince(activity.lastUpdate) > threshold {
+                staleToolKeys.append(key)
+            }
+        }
+
+        // Remove stale activities
+        for key in staleJobKeys {
+            self.jobs.removeValue(forKey: key)
+            changed = true
+        }
+        for key in staleToolKeys {
+            self.tools.removeValue(forKey: key)
+            changed = true
+        }
+
+        if changed {
+            if let key = self.currentSessionKey, !self.isActive(sessionKey: key) {
+                self.pickNextSession()
+            }
+            self.refreshDerivedState()
+        }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/WorkActivityStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WorkActivityStoreTests.swift
@@ -95,4 +95,157 @@ struct WorkActivityStoreTests {
         store.resolveIconState(override: .otherEdit)
         #expect(store.iconState == .overridden(.tool(.edit)))
     }
+
+    @Test func `watchdog evicts stale activities`() async {
+        let store = WorkActivityStore()
+
+        // Start a job that will become stale
+        store.handleJob(sessionKey: "stale-session", state: "started")
+        #expect(store.iconState == .workingOther(.job))
+        #expect(store.current?.sessionKey == "stale-session")
+
+        // Manually invoke the eviction with a fake old timestamp
+        // We'll manipulate the lastUpdate directly for testing
+        if var activity = store.jobs["stale-session"] {
+            activity.lastUpdate = Date(timeIntervalSinceNow: -150) // 150 seconds ago (stale)
+            store.jobs["stale-session"] = activity
+        }
+
+        // Invoke the eviction logic
+        store.evictStaleActivities()
+
+        // Verify the stale job was removed
+        #expect(store.iconState == .idle)
+        #expect(store.current == nil)
+    }
+
+    @Test func `streaming updates refresh job timestamp`() {
+        let store = WorkActivityStore()
+
+        // Start a job
+        store.handleJob(sessionKey: "main", state: "started")
+        let initialUpdate = store.jobs["main"]?.lastUpdate
+
+        // Small delay to ensure timestamp difference
+        Thread.sleep(forTimeInterval: 0.01)
+
+        // Send streaming update
+        store.handleJob(sessionKey: "main", state: "streaming")
+        let updatedTimestamp = store.jobs["main"]?.lastUpdate
+
+        #expect(updatedTimestamp != nil)
+        #expect(updatedTimestamp! > initialUpdate!)
+    }
+
+    @Test func `tool events refresh parent job timestamp`() {
+        let store = WorkActivityStore()
+
+        // Start a job
+        store.handleJob(sessionKey: "main", state: "started")
+        let initialJobUpdate = store.jobs["main"]?.lastUpdate
+
+        // Small delay to ensure timestamp difference
+        Thread.sleep(forTimeInterval: 0.01)
+
+        // Start a tool - this should refresh the parent job's timestamp
+        store.handleTool(
+            sessionKey: "main",
+            phase: "start",
+            name: "bash",
+            meta: nil,
+            args: ["command": AnyCodable("echo hello")])
+
+        let refreshedJobUpdate = store.jobs["main"]?.lastUpdate
+
+        #expect(refreshedJobUpdate != nil)
+        #expect(refreshedJobUpdate! > initialJobUpdate!)
+    }
+
+    @Test func `long running job with tool activity stays alive`() {
+        let store = WorkActivityStore()
+
+        // Start a job
+        store.handleJob(sessionKey: "long-session", state: "started")
+        #expect(store.iconState == .workingOther(.job))
+
+        // Simulate a job that's been running for a while by backdating its start
+        if var job = store.jobs["long-session"] {
+            job.lastUpdate = Date(timeIntervalSinceNow: -150) // 150 seconds ago (would be stale)
+            store.jobs["long-session"] = job
+        }
+
+        // Simulate ongoing tool activity refreshing the timestamp
+        store.handleTool(
+            sessionKey: "long-session",
+            phase: "start",
+            name: "read",
+            meta: nil,
+            args: ["path": AnyCodable("/some/file")])
+
+        // Even though the job was old, tool activity should have refreshed it
+        let jobTimestamp = store.jobs["long-session"]?.lastUpdate
+        #expect(jobTimestamp != nil)
+        #expect(Date().timeIntervalSince(jobTimestamp!) < 5) // Should be very recent
+
+        // Run eviction - job should NOT be removed because it was recently refreshed
+        store.evictStaleActivities()
+        #expect(store.iconState != .idle) // Should still be working
+        #expect(store.jobs["long-session"] != nil) // Job should still exist
+    }
+
+    @Test func `eviction handles mixed stale and fresh activities`() {
+        let store = WorkActivityStore()
+
+        // Create multiple sessions
+        store.handleJob(sessionKey: "fresh-session", state: "started")
+        store.handleJob(sessionKey: "stale-session", state: "started")
+        store.handleJob(sessionKey: "old-session", state: "started")
+
+        // Make some sessions stale by backdating
+        if var staleJob = store.jobs["stale-session"] {
+            staleJob.lastUpdate = Date(timeIntervalSinceNow: -150) // Stale
+            store.jobs["stale-session"] = staleJob
+        }
+        if var oldJob = store.jobs["old-session"] {
+            oldJob.lastUpdate = Date(timeIntervalSinceNow: -200) // Very stale
+            store.jobs["old-session"] = oldJob
+        }
+
+        // Fresh session should remain untouched
+        #expect(store.jobs["fresh-session"] != nil)
+        #expect(store.jobs["stale-session"] != nil)
+        #expect(store.jobs["old-session"] != nil)
+
+        // Run eviction
+        store.evictStaleActivities()
+
+        // Only fresh session should remain
+        #expect(store.jobs["fresh-session"] != nil)
+        #expect(store.jobs["stale-session"] == nil)
+        #expect(store.jobs["old-session"] == nil)
+    }
+
+    @Test func `eviction gracefully handles empty state`() {
+        let store = WorkActivityStore()
+
+        // Running eviction on empty state should not crash
+        store.evictStaleActivities()
+        #expect(store.iconState == .idle)
+        #expect(store.current == nil)
+    }
+
+    @Test func `resource cleanup cancels watchdog task`() {
+        var store: WorkActivityStore? = WorkActivityStore()
+
+        // Verify the task exists
+        #expect(store?.watchdogTask != nil)
+
+        // When store is deallocated, deinit should cancel the task
+        // We can't directly test this without accessing internals, but we can verify the structure
+        let taskExists = store?.watchdogTask != nil
+        #expect(taskExists == true)
+
+        store = nil // This should trigger deinit
+        // If we got here without crashing, deinit worked properly
+    }
 }


### PR DESCRIPTION
## Problem

When the AI provider (e.g. Anthropic) returns an `overloaded_error` or times out mid-run, the gateway never sends the run-end event to the macOS app. This leaves `WorkActivityStore` with a dangling active job indefinitely.

**Result:** The menubar icon stays stuck in the working/spinning animation and becomes completely unresponsive — the only fix is force-killing the process from Activity Monitor.

Confirmed from gateway error logs:
```
embedded run failover decision: decision=surface_error reason=overloaded
embedded run failover decision: decision=surface_error reason=timeout
```

## Fix

Added a periodic watchdog in `WorkActivityStore` that runs every **30 seconds** and evicts any job or tool activity that has not received an update in over **120 seconds**.

This ensures:
- The icon returns to idle state automatically after a stale run
- The menubar remains interactive without requiring a force-kill
- Normal runs (which complete in under 120s) are completely unaffected

## Changes

- `apps/macos/Sources/OpenClaw/WorkActivityStore.swift`
  - Added `jobWatchdogInterval` (30s) and `jobStaleThreshold` (120s) constants
  - Added `watchdogTask` and `startWatchdog()` — starts on `init`
  - Added `evictStaleActivities()` — removes stale jobs/tools and refreshes icon state