### PR TITLE
fix(discord): strip leaked thinking from final replies

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -713,6 +713,56 @@ describe("processDiscordMessage draft streaming", () => {
     expectSinglePreviewEdit();
   });
 
+  it("sanitizes leaked thinking before finalizing via preview edit", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({
+        text: "```txt\nassistant:\n```\n<thinking>internal</thinking>\nVisible answer",
+      });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(editMessageDiscord).toHaveBeenCalledWith(
+      "c1",
+      "preview-1",
+      { content: "```txt\nassistant:\n```\n\nVisible answer" },
+      { rest: {} },
+    );
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps the streamed preview when final text sanitizes to empty", async () => {
+    const draftStream = createMockDraftStreamForTest();
+
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onPartialReply?.({ text: "Visible partial" });
+      await params?.dispatcher.sendFinalReply({ text: "<thinking>internal only</thinking>" });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(editMessageDiscord).toHaveBeenCalledWith(
+      "c1",
+      "preview-1",
+      { content: "Visible partial" },
+      { rest: {} },
+    );
+    expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
   it("keeps preview streaming off by default when streaming is unset", async () => {
     await runSingleChunkFinalScenario({ maxLinesPerMessage: 5 });
     expect(editMessageDiscord).not.toHaveBeenCalled();

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -62,6 +62,7 @@ import {
 } from "./message-utils.js";
 import { buildDirectLabel, buildGuildLabel, resolveReplyContext } from "./reply-context.js";
 import { deliverDiscordReply } from "./reply-delivery.js";
+import { sanitizeOutboundText } from "./sanitize-outbound.js";
 import { resolveDiscordAutoThreadReplyPlan, resolveDiscordThreadStarter } from "./threading.js";
 import {
   DISCORD_ATTACHMENT_IDLE_TIMEOUT_MS,
@@ -575,10 +576,19 @@ export async function processDiscordMessage(
   let finalizedViaPreviewMessage = false;
 
   const resolvePreviewFinalText = (text?: string) => {
+    const currentPreviewText = discordStreamMode === "block" ? draftText : lastPartialText;
     if (typeof text !== "string") {
-      return undefined;
+      return { text: undefined, sanitizedEmpty: false };
     }
-    const formatted = convertMarkdownTables(text, tableMode);
+    const sanitized = sanitizeOutboundText(text);
+    if (!sanitized) {
+      const trimmedPreview = currentPreviewText.trim();
+      return {
+        text: trimmedPreview || undefined,
+        sanitizedEmpty: true,
+      };
+    }
+    const formatted = convertMarkdownTables(sanitized, tableMode);
     const chunks = chunkDiscordTextWithMode(formatted, {
       maxChars: draftMaxChars,
       maxLines: maxLinesPerMessage,
@@ -588,21 +598,20 @@ export async function processDiscordMessage(
       chunks.push(formatted);
     }
     if (chunks.length !== 1) {
-      return undefined;
+      return { text: undefined, sanitizedEmpty: false };
     }
     const trimmed = chunks[0].trim();
     if (!trimmed) {
-      return undefined;
+      return { text: undefined, sanitizedEmpty: false };
     }
-    const currentPreviewText = discordStreamMode === "block" ? draftText : lastPartialText;
     if (
       currentPreviewText &&
       currentPreviewText.startsWith(trimmed) &&
       trimmed.length < currentPreviewText.length
     ) {
-      return undefined;
+      return { text: undefined, sanitizedEmpty: false };
     }
-    return trimmed;
+    return { text: trimmed, sanitizedEmpty: false };
   };
 
   const updateDraftFromPartial = (text?: string) => {
@@ -708,7 +717,8 @@ export async function processDiscordMessage(
           const reply = resolveSendableOutboundReplyParts(payload);
           const hasMedia = reply.hasMedia;
           const finalText = payload.text;
-          const previewFinalText = resolvePreviewFinalText(finalText);
+          const previewFinal = resolvePreviewFinalText(finalText);
+          const previewFinalText = previewFinal.text;
           const previewMessageId = draftStream.messageId();
 
           // Try to finalize via preview edit (text-only, fits in 2000 chars, not an error)
@@ -774,6 +784,14 @@ export async function processDiscordMessage(
                 );
               }
             }
+          }
+
+          if (!finalizedViaPreviewMessage && previewFinal.sanitizedEmpty && hasStreamedMessage) {
+            notifyFinalReplyStart();
+            finalizedViaPreviewMessage = true;
+            replyReference.markSent();
+            observer?.onFinalReplyDelivered?.();
+            return;
           }
 
           // Clear the preview and fall through to standard delivery

--- a/extensions/discord/src/monitor/reply-delivery.test.ts
+++ b/extensions/discord/src/monitor/reply-delivery.test.ts
@@ -328,6 +328,106 @@ describe("deliverDiscordReply", () => {
     );
   });
 
+  it("strips leaked thinking tags from delivered text", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: "<thinking>internal</thinking>\nVisible answer" }],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      cfg,
+      textLimit: 2000,
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageDiscordMock).toHaveBeenCalledWith(
+      "channel:789",
+      "Visible answer",
+      expect.objectContaining({ token: "token" }),
+    );
+  });
+
+  it("strips leaked relevant-memories scaffolding from delivered text", async () => {
+    await deliverDiscordReply({
+      replies: [
+        {
+          text: [
+            "<relevant-memories>",
+            "Internal note",
+            "</relevant-memories>",
+            "",
+            "Visible answer",
+          ].join("\n"),
+        },
+      ],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      cfg,
+      textLimit: 2000,
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageDiscordMock).toHaveBeenCalledWith(
+      "channel:789",
+      "Visible answer",
+      expect.objectContaining({ token: "token" }),
+    );
+  });
+
+  it("preserves code-fenced role markers while stripping leaked thinking", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: "```txt\nassistant:\n```\n<thinking>internal</thinking>\nVisible answer" }],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      cfg,
+      textLimit: 2000,
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageDiscordMock).toHaveBeenCalledWith(
+      "channel:789",
+      "```txt\nassistant:\n```\n\nVisible answer",
+      expect.objectContaining({ token: "token" }),
+    );
+  });
+
+  it("strips dotted assistant-to markers from delivered text", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: "assistant to=functions.exec_command\nVisible answer" }],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      cfg,
+      textLimit: 2000,
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageDiscordMock).toHaveBeenCalledWith(
+      "channel:789",
+      "Visible answer",
+      expect.objectContaining({ token: "token" }),
+    );
+  });
+
+  it("strips tool-call scaffolding while preserving leading indentation", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: '  Visible prefix\n<tool_call>{"name":"read"}</tool_call>\nDone' }],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      cfg,
+      textLimit: 2000,
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageDiscordMock).toHaveBeenCalledWith(
+      "channel:789",
+      "  Visible prefix\n\nDone",
+      expect.objectContaining({ token: "token" }),
+    );
+  });
+
   it("sends text chunks in order via sendDiscordText when rest is provided", async () => {
     const fakeRest = {} as import("@buape/carbon").RequestClient;
     const callOrder: string[] = [];

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -22,6 +22,7 @@ import { chunkDiscordTextWithMode } from "../chunk.js";
 import { createDiscordRetryRunner } from "../retry.js";
 import { sendMessageDiscord, sendVoiceMessageDiscord, sendWebhookMessageDiscord } from "../send.js";
 import { sendDiscordText } from "../send.shared.js";
+import { sanitizeOutboundText } from "./sanitize-outbound.js";
 
 export type DiscordThreadBindingLookupRecord = {
   accountId: string;
@@ -270,8 +271,9 @@ export async function deliverDiscordReply(params: {
   let deliveredAny = false;
   for (const payload of params.replies) {
     const tableMode = params.tableMode ?? "code";
+    const sanitizedText = sanitizeOutboundText(payload.text ?? "");
     const reply = resolveSendableOutboundReplyParts(payload, {
-      text: convertMarkdownTables(payload.text ?? "", tableMode),
+      text: convertMarkdownTables(sanitizedText, tableMode),
     });
     if (!reply.hasContent) {
       continue;

--- a/extensions/discord/src/monitor/sanitize-outbound.ts
+++ b/extensions/discord/src/monitor/sanitize-outbound.ts
@@ -1,0 +1,74 @@
+import {
+  findCodeRegions,
+  isInsideCode,
+  stripAssistantInternalScaffolding,
+} from "openclaw/plugin-sdk/text-runtime";
+
+/**
+ * Patterns that indicate assistant-internal metadata leaked into text.
+ * These must never reach a user-facing channel.
+ */
+const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/g;
+const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*[^\s]+/gi;
+const ROLE_TURN_MARKER_RE = /^(?:user|system|assistant)\s*:\s*$/gm;
+
+function replaceOutsideCode(text: string, pattern: RegExp, replacement: string): string {
+  pattern.lastIndex = 0;
+  const codeRegions = findCodeRegions(text);
+  let result = "";
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(pattern)) {
+    const index = match.index ?? 0;
+    if (isInsideCode(index, codeRegions)) {
+      continue;
+    }
+    result += text.slice(lastIndex, index);
+    result += replacement;
+    lastIndex = index + match[0].length;
+  }
+
+  if (!result && lastIndex === 0) {
+    return text;
+  }
+
+  result += text.slice(lastIndex);
+  return result;
+}
+
+/**
+ * Strip assistant-internal scaffolding from outbound Discord text before delivery.
+ * Applies reasoning/thinking tag removal, memory tag removal, and
+ * model-specific internal separator stripping.
+ */
+export function sanitizeOutboundText(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  const leadingWhitespace = text.match(/^\s+/)?.[0] ?? "";
+  const withoutLeadingWhitespace = leadingWhitespace ? text.slice(leadingWhitespace.length) : text;
+  let cleaned = stripAssistantInternalScaffolding(text);
+
+  // The shared stripper trims leading whitespace after removing scaffolding.
+  // Put harmless indentation back when stripping the de-indented text produces
+  // the same visible result, so ordinary indented replies stay unchanged.
+  if (
+    leadingWhitespace &&
+    cleaned === stripAssistantInternalScaffolding(withoutLeadingWhitespace)
+  ) {
+    cleaned = `${leadingWhitespace}${cleaned}`;
+  }
+
+  cleaned = replaceOutsideCode(cleaned, INTERNAL_SEPARATOR_RE, "");
+  cleaned = replaceOutsideCode(cleaned, ASSISTANT_ROLE_MARKER_RE, "");
+  cleaned = replaceOutsideCode(cleaned, ROLE_TURN_MARKER_RE, "");
+
+  // Collapse excessive blank lines left after stripping without eating
+  // intentional leading indentation in user-visible content.
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n");
+  cleaned = cleaned.replace(/^\n+/, "");
+  cleaned = cleaned.trimEnd();
+
+  return cleaned;
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Discord final replies could leak assistant-internal `<thinking>` and `<relevant-memories>` scaffolding into visible chat output.
- Why it matters: reasoning is supposed to stay hidden unless explicitly enabled, and leaking internal scaffolding is a user-facing regression.
- What changed: final Discord outbound text is sanitized before table conversion, chunking, and delivery.
- What did NOT change (scope boundary): no provider/runtime reasoning generation behavior changed, and no Discord chunking behavior changed beyond sanitizing leaked internal text.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Discord partial preview streaming stripped leaked reasoning tags, but the final outbound delivery path sent `payload.text` without the same sanitization step.
- Missing detection / guardrail: Discord final-delivery regression coverage did not assert that leaked thinking/memory scaffolding is removed before send.
- Contributing context (if known): the leak sits at the final channel-delivery boundary rather than the provider/runtime reasoning path.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/reply-delivery.test.ts`
- Scenario the test should lock in: leaked `<thinking>` and `<relevant-memories>` scaffolding is stripped before Discord final delivery.
- Why this is the smallest reliable guardrail: the regression is in the final outbound formatting/delivery boundary for Discord, so a delivery-unit test hits the implicated path directly without needing provider/runtime setup.
- Existing test that already covers this (if any): partial stream updates already had reasoning-tag coverage in `extensions/discord/src/monitor/message-handler.process.test.ts`.
- If no new test is added, why not:

## User-visible / Behavior Changes

- Discord users no longer see leaked assistant-internal thinking or relevant-memories scaffolding in final replies when that text reaches the outbound payload.

## Diagram (if applicable)

```text
Before:
[assistant final payload with leaked <thinking>/<relevant-memories>] -> [Discord final delivery] -> [leaked internal text visible]

After:
[assistant final payload with leaked <thinking>/<relevant-memories>] -> [sanitize outbound text] -> [Discord final delivery] -> [visible answer only]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local dev shell
- Model/provider: any provider that can leak thinking/memory scaffolding into the final payload
- Integration/channel (if any): Discord
- Relevant config (redacted): reasoning visibility expected off for the Discord session

### Steps

1. Produce a Discord final reply payload containing leaked `<thinking>` or `<relevant-memories>` text plus visible answer text.
2. Deliver that payload through the Discord final reply path.
3. Inspect the sent Discord message text.

### Expected

- Only the visible answer text is delivered.

### Actual

- Internal scaffolding text could be delivered along with the answer.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the Discord final delivery path and confirmed sanitization is now applied before conversion/chunking/send; added regression cases for leaked `<thinking>` and `<relevant-memories>`.
- Edge cases checked: preserves visible answer text while stripping internal scaffolding blocks.
- What you did **not** verify: full `pnpm check` is currently blocked by unrelated repo-local typecheck failures in `extensions/diffs/src/language-hints.test.ts` under `pnpm tsgo`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: sanitizer could remove user-intended literal tag text if it appears in normal prose.
  - Mitigation: reuse the existing assistant-internal scaffolding stripper, which is already code-region aware and intended for user-visible output sanitization.
