### PR TITLE
feat: add Mistral TTS support to iOS app

### DIFF
--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -7,31 +7,82 @@ struct TalkModeGatewayConfigState {
     let missingResolvedPayload: Bool
     let defaultVoiceId: String?
     let voiceAliases: [String: String]
-    let defaultModelId: String
-    let defaultOutputFormat: String?
+    let preferredModelId: String?
+    let preferredOutputFormat: String?
     let rawConfigApiKey: String?
     let interruptOnSpeech: Bool?
     let silenceTimeoutMs: Int
+    let mistralBaseUrl: String?
 }
 
 enum TalkModeGatewayConfigParser {
     static func parse(
         config: [String: Any],
         defaultProvider: String,
-        defaultModelIdFallback: String,
         defaultSilenceTimeoutMs: Int
     ) -> TalkModeGatewayConfigState {
-        let talk = TalkConfigParsing.bridgeFoundationDictionary(config["talk"] as? [String: Any])
+        let talkRaw = config["talk"] as? [String: Any]
+        if let talkRaw = talkRaw {
+            let keys = talkRaw.keys.joined(separator: ", ")
+            GatewayDiagnostics.log("talk config parsing: found 'talk' dictionary with keys: [\(keys)]")
+        } else {
+            GatewayDiagnostics.log("talk config parsing: 'talk' dictionary is missing in server response")
+        }
+        let talk = TalkConfigParsing.bridgeFoundationDictionary(talkRaw)
         let selection = TalkConfigParsing.selectProviderConfig(
             talk,
             defaultProvider: defaultProvider,
             allowLegacyFallback: false)
         let activeProvider = selection?.provider ?? defaultProvider
         let activeConfig = selection?.config
-        let defaultVoiceId = activeConfig?["voiceId"]?.stringValue?
+        
+        if activeConfig == nil {
+             GatewayDiagnostics.log("talk config parsing: activeConfig (resolved) is missing for provider \(activeProvider)")
+        }
+
+        let modelIdKeys = ["modelId", "model"]
+        var model: String?
+        for key in modelIdKeys {
+            if let val = activeConfig?[key]?.stringValue {
+                model = val
+                break
+            }
+        }
+        if model == nil {
+            for key in modelIdKeys {
+                if let val = talk?[key]?.stringValue {
+                    model = val
+                    break
+                }
+            }
+        }
+
+        let voiceIdKeys = ["voiceId", "voice"]
+        var voice: String?
+        for key in voiceIdKeys {
+            if let val = activeConfig?[key]?.stringValue {
+                voice = val
+                break
+            }
+        }
+        if voice == nil {
+            for key in voiceIdKeys {
+                if let val = talk?[key]?.stringValue {
+                    voice = val
+                    break
+                }
+            }
+        }
+
+        let preferredModelId = (model?.isEmpty == false) ? model : nil
+        let preferredOutputFormat = (activeConfig?["outputFormat"]?.stringValue ?? 
+                                    talk?["outputFormat"]?.stringValue)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let rawConfigApiKey = (activeConfig?["apiKey"]?.stringValue ?? talk?["apiKey"]?.stringValue)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        
         let voiceAliases: [String: String]
-        if let aliases = activeConfig?["voiceAliases"]?.dictionaryValue {
+        if let aliases = activeConfig?["voiceAliases"]?.dictionaryValue ?? talk?["voiceAliases"]?.dictionaryValue {
             var resolved: [String: String] = [:]
             for (key, value) in aliases {
                 guard let id = value.stringValue else { continue }
@@ -44,26 +95,25 @@ enum TalkModeGatewayConfigParser {
         } else {
             voiceAliases = [:]
         }
-        let model = activeConfig?["modelId"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let defaultModelId = (model?.isEmpty == false) ? model! : defaultModelIdFallback
-        let defaultOutputFormat = activeConfig?["outputFormat"]?.stringValue?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let rawConfigApiKey = activeConfig?["apiKey"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let interruptOnSpeech = talk?["interruptOnSpeech"]?.boolValue
+
+        let interruptOnSpeech = (activeConfig?["interruptOnSpeech"]?.boolValue ?? talk?["interruptOnSpeech"]?.boolValue)
         let silenceTimeoutMs = TalkConfigParsing.resolvedSilenceTimeoutMs(
             talk,
             fallback: defaultSilenceTimeoutMs)
 
-        return TalkModeGatewayConfigState(
-            activeProvider: activeProvider,
-            normalizedPayload: selection?.normalizedPayload == true,
-            missingResolvedPayload: talk != nil && selection == nil,
-            defaultVoiceId: defaultVoiceId,
-            voiceAliases: voiceAliases,
-            defaultModelId: defaultModelId,
-            defaultOutputFormat: defaultOutputFormat,
-            rawConfigApiKey: rawConfigApiKey,
-            interruptOnSpeech: interruptOnSpeech,
-            silenceTimeoutMs: silenceTimeoutMs)
+        let mistralBaseUrl = activeConfig?["baseUrl"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
+ 
+         return TalkModeGatewayConfigState(
+             activeProvider: activeProvider,
+             normalizedPayload: selection?.normalizedPayload == true,
+             missingResolvedPayload: talk != nil && selection == nil,
+             defaultVoiceId: voice,
+             voiceAliases: voiceAliases,
+             preferredModelId: preferredModelId,
+             preferredOutputFormat: (preferredOutputFormat?.isEmpty == false) ? preferredOutputFormat : nil,
+             rawConfigApiKey: rawConfigApiKey,
+             interruptOnSpeech: interruptOnSpeech,
+             silenceTimeoutMs: silenceTimeoutMs,
+             mistralBaseUrl: (mistralBaseUrl?.isEmpty == false) ? mistralBaseUrl : nil)
     }
 }

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -87,7 +87,7 @@ final class TalkModeManager: NSObject {
     private var voiceAliases: [String: String] = [:]
     private var interruptOnSpeech: Bool = true
     private var mainSessionKey: String = "main"
-    private var fallbackVoiceId: String?
+    private var fallbackElevenLabsVoiceId: String?
     private var lastPlaybackWasPCM: Bool = false
     /// Set when the ElevenLabs API rejects PCM format (e.g. 403 subscription_required).
     /// Once set, all subsequent requests in this session use MP3 instead of re-trying PCM.
@@ -1042,7 +1042,7 @@ final class TalkModeManager: NSObject {
                     responseFormat: outputFormat)
                 
                 let client = self.getOrCreateMistralClient(apiKey: apiKey)
-                let rawStream = await client.streamSynthesize(voiceId: voiceId, request: request)
+                let rawStream = await client.streamSynthesize(request: request)
                 
                 if self.interruptOnSpeech {
                     do {
@@ -1688,7 +1688,7 @@ final class TalkModeManager: NSObject {
         if context.canUseMistral, let apiKey = context.apiKey {
             let request = self.makeMistralTTSRequest(text: text, context: context, outputFormat: context.outputFormat)
             let client = self.getOrCreateMistralClient(apiKey: apiKey)
-            let rawStream = await client.streamSynthesize(voiceId: context.voiceId, request: request)
+            let rawStream = await client.streamSynthesize(request: request)
             
             self.lastPlaybackWasPCM = false
             let result = await self.mp3Player.play(stream: rawStream)
@@ -2016,7 +2016,7 @@ extension TalkModeManager {
 
         if provider == "mistral" {
             let client = self.getOrCreateMistralClient(apiKey: apiKey)
-            return try? await client.resolveVoiceId(requested: trimmed, fallback: self.fallbackVoiceId ?? MistralTTSClient.defaultVoiceId)
+            return try? await client.resolveVoiceId(requested: trimmed, fallback: MistralTTSClient.defaultVoiceId)
         } else {
             return await resolveElevenLabsVoice(requested: trimmed, apiKey: apiKey)
         }
@@ -2032,7 +2032,7 @@ extension TalkModeManager {
     }
 
     private func resolveElevenLabsVoice(requested: String, apiKey: String) async -> String? {
-        if let fallbackVoiceId { return fallbackVoiceId }
+        if let fallbackElevenLabsVoiceId { return fallbackElevenLabsVoiceId }
 
         do {
             let voices = try await ElevenLabsTTSClient(apiKey: apiKey).listVoices()
@@ -2040,7 +2040,7 @@ extension TalkModeManager {
                 self.logger.warning("elevenlabs voices list empty")
                 return nil
             }
-            self.fallbackVoiceId = first.voiceId
+            self.fallbackElevenLabsVoiceId = first.voiceId
             if self.defaultVoiceId == nil {
                 self.defaultVoiceId = first.voiceId
             }

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -32,7 +32,6 @@ private final class StreamFailureBox: @unchecked Sendable {
 @Observable
 final class TalkModeManager: NSObject {
     private typealias SpeechRequest = SFSpeechAudioBufferRecognitionRequest
-    private static let defaultModelIdFallback = "eleven_v3"
     private static let defaultTalkProvider = "elevenlabs"
     private static let defaultSilenceTimeoutMs = TalkDefaults.silenceTimeoutMs
     private static let redactedConfigSentinel = "__OPENCLAW_REDACTED__"
@@ -95,6 +94,10 @@ final class TalkModeManager: NSObject {
     private var pcmFormatUnavailable: Bool = false
     var pcmPlayer: PCMStreamingAudioPlaying = PCMStreamingAudioPlayer.shared
     var mp3Player: StreamingAudioPlaying = StreamingAudioPlayer.shared
+
+    private var activeProvider: String = defaultTalkProvider
+    private var mistralBaseUrl: String?
+    private var mistralClient: MistralTTSClient?
 
     private var gateway: GatewayNodeSession?
     private var gatewayConnected = false
@@ -1017,13 +1020,47 @@ final class TalkModeManager: NSObject {
             let apiKey = resolvedKey?.trimmingCharacters(in: .whitespacesAndNewlines)
             let preferredVoice = resolvedVoice ?? self.currentVoiceId ?? self.defaultVoiceId
             let voiceId: String? = if let apiKey, !apiKey.isEmpty {
-                await self.resolveVoiceId(preferred: preferredVoice, apiKey: apiKey)
+                await self.resolveVoiceId(preferred: preferredVoice, apiKey: apiKey, provider: activeProvider)
             } else {
                 nil
             }
-            let canUseElevenLabs = (voiceId?.isEmpty == false) && (apiKey?.isEmpty == false)
+            let canUseElevenLabs = activeProvider == Self.defaultTalkProvider && (voiceId?.isEmpty == false) && (apiKey?.isEmpty == false)
+            let canUseMistral = activeProvider == "mistral" && (apiKey?.isEmpty == false)
 
-            if canUseElevenLabs, let voiceId, let apiKey {
+            if canUseMistral, let apiKey {
+                GatewayDiagnostics.log("talk tts: provider=mistral voiceId=\(voiceId ?? "default")")
+                let desiredOutputFormat = (directive?.outputFormat ?? self.defaultOutputFormat)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let outputFormat = (desiredOutputFormat?.isEmpty == false) ? desiredOutputFormat! : MistralTTSClient.defaultOutputFormat
+                
+                let modelId = directive?.modelId ?? self.currentModelId ?? self.defaultModelId ?? MistralTTSClient.defaultModelId
+                let request = MistralTTSRequest(
+                    text: cleaned,
+                    modelId: modelId,
+                    voiceId: voiceId ?? MistralTTSClient.defaultVoiceId,
+                    speed: TalkTTSValidation.resolveSpeed(speed: directive?.speed, rateWPM: directive?.rateWPM),
+                    responseFormat: outputFormat)
+                
+                let client = self.getOrCreateMistralClient(apiKey: apiKey)
+                let rawStream = await client.streamSynthesize(voiceId: voiceId, request: request)
+                
+                if self.interruptOnSpeech {
+                    do {
+                        try self.startRecognition()
+                    } catch {
+                        self.logger.warning("startRecognition during speak failed: \(error.localizedDescription, privacy: .public)")
+                    }
+                }
+                
+                self.statusText = "Speaking…"
+                self.lastPlaybackWasPCM = false
+                let result = await self.mp3Player.play(stream: rawStream)
+                let duration = Date().timeIntervalSince(started)
+                self.logger.info("mistral stream finished=\(result.finished, privacy: .public) dur=\(duration, privacy: .public)s")
+                if !result.finished, let interruptedAt = result.interruptedAt {
+                    self.lastInterruptedAtSeconds = interruptedAt
+                }
+            } else if canUseElevenLabs, let voiceId, let apiKey {
                 GatewayDiagnostics.log("talk tts: provider=elevenlabs voiceId=\(voiceId)")
                 let desiredOutputFormat = (directive?.outputFormat ?? self.defaultOutputFormat)?
                     .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1481,13 +1518,16 @@ final class TalkModeManager: NSObject {
         if let existing = self.incrementalSpeechContext, directive == self.incrementalSpeechDirective {
             if existing.language != self.incrementalSpeechLanguage {
                 self.incrementalSpeechContext = IncrementalSpeechContext(
+                    activeProvider: existing.activeProvider,
                     apiKey: existing.apiKey,
                     voiceId: existing.voiceId,
                     modelId: existing.modelId,
                     outputFormat: existing.outputFormat,
                     language: self.incrementalSpeechLanguage,
                     directive: existing.directive,
-                    canUseElevenLabs: existing.canUseElevenLabs)
+                    canUseElevenLabs: existing.canUseElevenLabs,
+                    canUseMistral: existing.canUseMistral,
+                    mistralBaseUrl: existing.mistralBaseUrl)
             }
             return
         }
@@ -1497,44 +1537,60 @@ final class TalkModeManager: NSObject {
     }
 
     private func buildIncrementalSpeechContext(directive: TalkDirective?) async -> IncrementalSpeechContext {
+        let activeProvider = self.activeProvider
         let requestedVoice = directive?.voiceId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedVoice = self.resolveVoiceAlias(requestedVoice)
-        if requestedVoice?.isEmpty == false, resolvedVoice == nil {
-            self.logger.warning("unknown voice alias \(requestedVoice ?? "?", privacy: .public)")
-        }
+        
         let preferredVoice = resolvedVoice ?? self.currentVoiceId ?? self.defaultVoiceId
         let modelId = directive?.modelId ?? self.currentModelId ?? self.defaultModelId
-        let desiredOutputFormat = (directive?.outputFormat ?? self.defaultOutputFormat)?
+        
+        let requestedOutputFormat = (directive?.outputFormat ?? self.defaultOutputFormat)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let requestedOutputFormat = (desiredOutputFormat?.isEmpty == false) ? desiredOutputFormat : nil
-        let outputFormat = ElevenLabsTTSClient.validatedOutputFormat(
-            requestedOutputFormat ?? self.effectiveDefaultOutputFormat)
+            .lowercased()
+
+        let outputFormat: String? = if activeProvider == "mistral" {
+            requestedOutputFormat ?? MistralTTSClient.defaultOutputFormat
+        } else {
+            ElevenLabsTTSClient.validatedOutputFormat(requestedOutputFormat ?? self.effectiveDefaultOutputFormat)
+        }
+        
         if outputFormat == nil, let requestedOutputFormat {
             self.logger.warning(
                 "talk output_format unsupported for local playback: \(requestedOutputFormat, privacy: .public)")
         }
 
-        let configuredKey = self.apiKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? self.apiKey : nil
+        let configuredKey = (self.apiKey?.isEmpty == false) ? self.apiKey : nil
         #if DEBUG
-        let resolvedKey = configuredKey ?? ProcessInfo.processInfo.environment["ELEVENLABS_API_KEY"]
+        let envKeyName = (activeProvider == "mistral") ? "MISTRAL_API_KEY" : "ELEVENLABS_API_KEY"
+        let resolvedKey = configuredKey ?? ProcessInfo.processInfo.environment[envKeyName]
         #else
         let resolvedKey = configuredKey
         #endif
         let apiKey = resolvedKey?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let voiceId: String? = if let apiKey, !apiKey.isEmpty {
-            await self.resolveVoiceId(preferred: preferredVoice, apiKey: apiKey)
+        
+        let voiceId: String?
+        if activeProvider == "mistral" {
+            voiceId = preferredVoice
+        } else if let apiKey, !apiKey.isEmpty {
+            voiceId = await self.resolveVoiceId(preferred: preferredVoice, apiKey: apiKey, provider: activeProvider)
         } else {
-            nil
+            voiceId = nil
         }
-        let canUseElevenLabs = (voiceId?.isEmpty == false) && (apiKey?.isEmpty == false)
+        
+        let canUseElevenLabs = activeProvider == Self.defaultTalkProvider && (voiceId?.isEmpty == false) && (apiKey?.isEmpty == false)
+        let canUseMistral = activeProvider == "mistral" && (apiKey?.isEmpty == false)
+        
         return IncrementalSpeechContext(
+            activeProvider: activeProvider,
             apiKey: apiKey,
             voiceId: voiceId,
             modelId: modelId,
             outputFormat: outputFormat,
             language: self.incrementalSpeechLanguage,
             directive: directive,
-            canUseElevenLabs: canUseElevenLabs)
+            canUseElevenLabs: canUseElevenLabs,
+            canUseMistral: canUseMistral,
+            mistralBaseUrl: self.mistralBaseUrl)
     }
 
     private func makeIncrementalTTSRequest(
@@ -1629,6 +1685,19 @@ final class TalkModeManager: NSObject {
             context = resolvedContext
         }
 
+        if context.canUseMistral, let apiKey = context.apiKey {
+            let request = self.makeMistralTTSRequest(text: text, context: context, outputFormat: context.outputFormat)
+            let client = self.getOrCreateMistralClient(apiKey: apiKey)
+            let rawStream = await client.streamSynthesize(voiceId: context.voiceId, request: request)
+            
+            self.lastPlaybackWasPCM = false
+            let result = await self.mp3Player.play(stream: rawStream)
+            if !result.finished, let interruptedAt = result.interruptedAt {
+                self.lastInterruptedAtSeconds = interruptedAt
+            }
+            return
+        }
+
         guard context.canUseElevenLabs, let apiKey = context.apiKey, let voiceId = context.voiceId else {
             try? await TalkSystemSpeechSynthesizer.shared.speak(
                 text: text,
@@ -1678,6 +1747,20 @@ final class TalkModeManager: NSObject {
         if !result.finished, let interruptedAt = result.interruptedAt {
             self.lastInterruptedAtSeconds = interruptedAt
         }
+    }
+
+    private func makeMistralTTSRequest(
+        text: String,
+        context: IncrementalSpeechContext,
+        outputFormat: String?
+    ) -> MistralTTSRequest
+    {
+        MistralTTSRequest(
+            text: text,
+            modelId: context.modelId ?? MistralTTSClient.defaultModelId,
+            voiceId: context.voiceId ?? MistralTTSClient.defaultVoiceId,
+            speed: TalkTTSValidation.resolveSpeed(speed: context.directive?.speed, rateWPM: context.directive?.rateWPM),
+            responseFormat: outputFormat ?? MistralTTSClient.defaultOutputFormat)
     }
 
 }
@@ -1920,17 +2003,35 @@ extension TalkModeManager {
         return Self.isLikelyVoiceId(trimmed) ? trimmed : nil
     }
 
-    func resolveVoiceId(preferred: String?, apiKey: String) async -> String? {
+    func resolveVoiceId(preferred: String?, apiKey: String, provider: String = TalkModeManager.defaultTalkProvider) async -> String? {
         let trimmed = preferred?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !trimmed.isEmpty {
-            // Config / directives can provide a raw ElevenLabs voiceId (not an alias).
-            // Accept it directly to avoid unnecessary listVoices calls (and accidental fallback selection).
+            // Already a UUID? Use it directly for either provider.
             if Self.isLikelyVoiceId(trimmed) {
                 return trimmed
             }
+            // Check alias mapping (shared)
             if let resolved = self.resolveVoiceAlias(trimmed) { return resolved }
-            self.logger.warning("unknown voice alias \(trimmed, privacy: .public)")
         }
+
+        if provider == "mistral" {
+            let client = self.getOrCreateMistralClient(apiKey: apiKey)
+            return try? await client.resolveVoiceId(requested: trimmed, fallback: self.fallbackVoiceId ?? MistralTTSClient.defaultVoiceId)
+        } else {
+            return await resolveElevenLabsVoice(requested: trimmed, apiKey: apiKey)
+        }
+    }
+
+    private func getOrCreateMistralClient(apiKey: String) -> MistralTTSClient {
+        if let client = self.mistralClient {
+            return client
+        }
+        let client = MistralTTSClient(apiKey: apiKey, baseUrl: self.mistralBaseUrl ?? "https://api.mistral.ai/v1")
+        self.mistralClient = client
+        return client
+    }
+
+    private func resolveElevenLabsVoice(requested: String, apiKey: String) async -> String? {
         if let fallbackVoiceId { return fallbackVoiceId }
 
         do {
@@ -1971,6 +2072,8 @@ extension TalkModeManager {
     }
 
     func reloadConfig() async {
+        await self.mistralClient?.clearCache()
+        self.mistralClient = nil
         guard let gateway else { return }
         self.pcmFormatUnavailable = false
         do {
@@ -1984,23 +2087,44 @@ extension TalkModeManager {
             let parsed = TalkModeGatewayConfigParser.parse(
                 config: config,
                 defaultProvider: Self.defaultTalkProvider,
-                defaultModelIdFallback: Self.defaultModelIdFallback,
                 defaultSilenceTimeoutMs: Self.defaultSilenceTimeoutMs)
             if parsed.missingResolvedPayload {
                 GatewayDiagnostics.log(
                     "talk config ignored: normalized payload missing talk.resolved")
             }
             let activeProvider = parsed.activeProvider
+            self.activeProvider = activeProvider
+            self.mistralBaseUrl = parsed.mistralBaseUrl
             self.defaultVoiceId = parsed.defaultVoiceId
             self.voiceAliases = parsed.voiceAliases
             if !self.voiceOverrideActive {
                 self.currentVoiceId = self.defaultVoiceId
             }
-            self.defaultModelId = parsed.defaultModelId
+
+            // Resolve default model ID based on provider if not preferred by gateway
+            let defaultModelId: String = if let preferred = parsed.preferredModelId {
+                preferred
+            } else if activeProvider == "mistral" {
+                MistralTTSClient.defaultModelId
+            } else {
+                ElevenLabsTTSClient.defaultModelId
+            }
+            self.defaultModelId = defaultModelId
+
             if !self.modelOverrideActive {
                 self.currentModelId = self.defaultModelId
             }
-            self.defaultOutputFormat = parsed.defaultOutputFormat
+
+            // Resolve output format
+            let defaultOutputFormat: String? = if let preferred = parsed.preferredOutputFormat {
+                preferred
+            } else if activeProvider == "mistral" {
+                MistralTTSClient.defaultOutputFormat
+            } else {
+                nil // Fallback to PCM for ElevenLabs if not specified
+            }
+            self.defaultOutputFormat = defaultOutputFormat
+
             let rawConfigApiKey = parsed.rawConfigApiKey
             let configApiKey = Self.normalizedTalkApiKey(rawConfigApiKey)
             let localApiKey = Self.normalizedTalkApiKey(
@@ -2011,7 +2135,7 @@ extension TalkModeManager {
             } else {
                 self.apiKey = (localApiKey?.isEmpty == false) ? localApiKey : configApiKey
             }
-            if activeProvider != Self.defaultTalkProvider {
+            if activeProvider != Self.defaultTalkProvider && activeProvider != "mistral" {
                 self.apiKey = nil
                 GatewayDiagnostics.log(
                     "talk provider '\(activeProvider)' not yet supported on iOS; using system voice fallback")
@@ -2029,7 +2153,7 @@ extension TalkModeManager {
                     "talk config provider=\(activeProvider) silenceTimeoutMs=\(parsed.silenceTimeoutMs)")
             }
         } catch {
-            self.defaultModelId = Self.defaultModelIdFallback
+            self.defaultModelId = ElevenLabsTTSClient.defaultModelId
             if !self.modelOverrideActive {
                 self.currentModelId = self.defaultModelId
             }
@@ -2174,6 +2298,7 @@ extension TalkModeManager {
 #endif
 
 private struct IncrementalSpeechContext: Equatable {
+    let activeProvider: String
     let apiKey: String?
     let voiceId: String?
     let modelId: String?
@@ -2181,6 +2306,8 @@ private struct IncrementalSpeechContext: Equatable {
     let language: String?
     let directive: TalkDirective?
     let canUseElevenLabs: Bool
+    let canUseMistral: Bool
+    let mistralBaseUrl: String?
 }
 
 private struct IncrementalSpeechPrefetchState {

--- a/apps/ios/Tests/TalkModeGatewayConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeGatewayConfigParsingTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+import OpenClawKit
+@testable import OpenClaw
+
+@Suite struct TalkModeGatewayConfigParsingTests {
+    private let defaultProvider = "elevenlabs"
+    private let defaultSilenceTimeoutMs = 1500
+
+    @Test func returnsNilPreferredModelWhenConfigIsEmpty() {
+        let config: [String: Any] = [
+            "talk": [
+                "resolved": [
+                    "provider": "mistral",
+                    "config": [:]
+                ]
+            ]
+        ]
+        
+        let state = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: defaultProvider,
+            defaultSilenceTimeoutMs: defaultSilenceTimeoutMs
+        )
+        
+        #expect(state.activeProvider == "mistral")
+        #expect(state.preferredModelId == nil)
+    }
+
+    @Test func extractsPreferredModelFromResolvedConfig() {
+        let config: [String: Any] = [
+            "talk": [
+                "resolved": [
+                    "provider": "mistral",
+                    "config": [
+                        "modelId": "custom-mistral-model"
+                    ]
+                ]
+            ]
+        ]
+        
+        let state = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: defaultProvider,
+            defaultSilenceTimeoutMs: defaultSilenceTimeoutMs
+        )
+        
+        #expect(state.activeProvider == "mistral")
+        #expect(state.preferredModelId == "custom-mistral-model")
+    }
+
+    @Test func extractsPreferredModelFromLegacyTalkRoot() {
+        let config: [String: Any] = [
+            "talk": [
+                "modelId": "legacy-root-model",
+                "resolved": [
+                    "provider": "elevenlabs",
+                    "config": [:]
+                ]
+            ]
+        ]
+        
+        let state = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: defaultProvider,
+            defaultSilenceTimeoutMs: defaultSilenceTimeoutMs
+        )
+        
+        #expect(state.preferredModelId == "legacy-root-model")
+    }
+
+    @Test func extractsMistralBaseUrl() {
+        let config: [String: Any] = [
+            "talk": [
+                "resolved": [
+                    "provider": "mistral",
+                    "config": [
+                        "baseUrl": "https://proxy.example.com/v1"
+                    ]
+                ]
+            ]
+        ]
+        
+        let state = TalkModeGatewayConfigParser.parse(
+            config: config,
+            defaultProvider: defaultProvider,
+            defaultSilenceTimeoutMs: defaultSilenceTimeoutMs
+        )
+        
+        #expect(state.mistralBaseUrl == "https://proxy.example.com/v1")
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ElevenLabsKitShim.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ElevenLabsKitShim.swift
@@ -7,3 +7,7 @@ public typealias TalkTTSValidation = ElevenLabsKit.TalkTTSValidation
 public typealias StreamingAudioPlayer = ElevenLabsKit.StreamingAudioPlayer
 public typealias PCMStreamingAudioPlayer = ElevenLabsKit.PCMStreamingAudioPlayer
 public typealias StreamingPlaybackResult = ElevenLabsKit.StreamingPlaybackResult
+
+extension ElevenLabsTTSClient {
+    public static let defaultModelId = "eleven_v3"
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/MistralTTSClient.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/MistralTTSClient.swift
@@ -1,0 +1,186 @@
+import Foundation
+
+public enum MistralTTSError: Error, LocalizedError {
+    case invalidBaseUrl(String)
+    case requestFailed(status: Int, message: String)
+    case decodingFailed(Error)
+    case missingAudioData
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidBaseUrl(let url):
+            return "Invalid Mistral base URL: \(url)"
+        case .requestFailed(let status, let message):
+            return "Mistral API error (\(status)): \(message)"
+        case .decodingFailed(let error):
+            return "Failed to decode Mistral response: \(error.localizedDescription)"
+        case .missingAudioData:
+            return "Mistral TTS response missing or invalid audio_data"
+        }
+    }
+}
+
+public struct MistralTTSVoice: Codable, Sendable {
+    public let id: String
+    public let name: String?
+    public let slug: String?
+    public let languages: [String]?
+
+    public init(id: String, name: String?, slug: String? = nil, languages: [String]? = nil) {
+        self.id = id
+        self.name = name
+        self.slug = slug
+        self.languages = languages
+    }
+}
+
+public struct MistralVoicesResponse: Codable, Sendable {
+    public let items: [MistralTTSVoice]
+}
+
+public struct MistralTTSRequest: Codable, Sendable {
+    public let text: String
+    public let modelId: String
+    public let voiceId: String?
+    public let speed: Double?
+    public let responseFormat: String
+    
+    enum CodingKeys: String, CodingKey {
+        case text = "input"
+        case modelId = "model"
+        case voiceId = "voice"
+        case speed
+        case responseFormat = "response_format"
+    }
+
+    public init(text: String, modelId: String, voiceId: String?, speed: Double?, responseFormat: String) {
+        self.text = text
+        self.modelId = modelId
+        self.voiceId = voiceId
+        self.speed = speed
+        self.responseFormat = responseFormat
+    }
+}
+
+private struct MistralTTSResponse: Codable {
+    let audio_data: String?
+}
+
+public actor MistralTTSClient {
+    public static let defaultModelId = "voxtral-mini-tts-2603"
+    public static let defaultVoiceId = "1024d823-a11e-43ee-bf3d-d440dccc0577" // Paul - Happy
+    public static let defaultOutputFormat = "mp3"
+    
+    private let apiKey: String
+    private let baseUrl: String
+    private var cachedVoices: [MistralTTSVoice]?
+
+    public init(apiKey: String, baseUrl: String = "https://api.mistral.ai/v1") {
+        self.apiKey = apiKey
+        self.baseUrl = baseUrl
+    }
+
+    public func clearCache() {
+        self.cachedVoices = nil
+    }
+
+    public func resolveVoiceId(requested: String, fallback: String? = nil) async throws -> String? {
+        if requested.isEmpty {
+            return fallback
+        }
+        
+        // Step 1: Already a UUID?
+        if requested.count >= 32 && requested.contains("-") {
+            return requested
+        }
+        
+        // Step 2: Slug match
+        let voices = try await self.listVoices()
+        if let matched = voices.first(where: { $0.slug == requested }) {
+            return matched.id
+        }
+        
+        return fallback
+    }
+
+    public func listVoices() async throws -> [MistralTTSVoice] {
+        if let cached = cachedVoices {
+            return cached
+        }
+        
+        guard var url = URL(string: self.baseUrl), url.scheme != nil else {
+            throw MistralTTSError.invalidBaseUrl(self.baseUrl)
+        }
+        url.appendPathComponent("audio/voices")
+        
+        if var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            components.queryItems = [URLQueryItem(name: "limit", value: "100")]
+            if let finalUrl = components.url {
+                url = finalUrl
+            }
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("Bearer \(self.apiKey)", forHTTPHeaderField: "Authorization")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+            let errorMsg = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw MistralTTSError.requestFailed(status: status, message: errorMsg)
+        }
+        
+        do {
+            let decoded = try JSONDecoder().decode(MistralVoicesResponse.self, from: data)
+            self.cachedVoices = decoded.items
+            return decoded.items
+        } catch {
+            throw MistralTTSError.decodingFailed(error)
+        }
+    }
+
+    /// Returns an asynchronous stream of audio data.
+    /// Note: Mistral TTS currently provides a single-shot response in JSON.
+    /// This method wraps it in an AsyncThrowingStream for compatibility with streaming players.
+    public func streamSynthesize(voiceId: String?, request: MistralTTSRequest) -> AsyncThrowingStream<Data, Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    guard var url = URL(string: self.baseUrl), url.scheme != nil else {
+                        throw MistralTTSError.invalidBaseUrl(self.baseUrl)
+                    }
+                    url.appendPathComponent("audio/speech")
+                    
+                    var urlRequest = URLRequest(url: url)
+                    urlRequest.httpMethod = "POST"
+                    urlRequest.addValue("Bearer \(self.apiKey)", forHTTPHeaderField: "Authorization")
+                    urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+                    
+                    let body = try JSONEncoder().encode(request)
+                    urlRequest.httpBody = body
+                    
+                    let (data, response) = try await URLSession.shared.data(for: urlRequest)
+                    
+                    guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+                        let errorMsg = String(data: data, encoding: .utf8) ?? "Unknown error"
+                        throw MistralTTSError.requestFailed(status: status, message: errorMsg)
+                    }
+                    
+                    let decoded = try JSONDecoder().decode(MistralTTSResponse.self, from: data)
+                    guard let audioBase64 = decoded.audio_data,
+                          let audioData = Data(base64Encoded: audioBase64) else {
+                        throw MistralTTSError.missingAudioData
+                    }
+                    
+                    continuation.yield(audioData)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/MistralTTSClient.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/MistralTTSClient.swift
@@ -85,22 +85,17 @@ public actor MistralTTSClient {
     }
 
     public func resolveVoiceId(requested: String, fallback: String? = nil) async throws -> String? {
-        if requested.isEmpty {
-            return fallback
-        }
-        
-        // Step 1: Already a UUID?
-        if requested.count >= 32 && requested.contains("-") {
+        // 1. Fail fast for empty input
+        guard !requested.isEmpty else { return fallback }        
+
+        // 2. If it's a valid UUID, return it immediately.
+        if UUID(uuidString: requested) != nil {
             return requested
         }
         
-        // Step 2: Slug match
+        // 3. Only fetch the list if we haven't found a UUID match
         let voices = try await self.listVoices()
-        if let matched = voices.first(where: { $0.slug == requested }) {
-            return matched.id
-        }
-        
-        return fallback
+        return voices.first { $0.slug == requested }?.id ?? fallback
     }
 
     public func listVoices() async throws -> [MistralTTSVoice] {
@@ -144,7 +139,7 @@ public actor MistralTTSClient {
     /// Returns an asynchronous stream of audio data.
     /// Note: Mistral TTS currently provides a single-shot response in JSON.
     /// This method wraps it in an AsyncThrowingStream for compatibility with streaming players.
-    public func streamSynthesize(voiceId: String?, request: MistralTTSRequest) -> AsyncThrowingStream<Data, Error> {
+    public func streamSynthesize(request: MistralTTSRequest) -> AsyncThrowingStream<Data, Error> {
         AsyncThrowingStream { continuation in
             Task {
                 do {

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -49,6 +49,7 @@ Notes:
 - If `gateway.auth.token`/`gateway.auth.password` are SecretRef-managed and unavailable in the current command path, doctor reports a read-only warning and does not write plaintext fallback credentials.
 - If channel SecretRef inspection fails in a fix path, doctor continues and reports a warning instead of exiting early.
 - Telegram `allowFrom` username auto-resolution (`doctor --fix`) requires a resolvable Telegram token in the current command path. If token inspection is unavailable, doctor reports a warning and skips auto-resolution for that pass.
+- Doctor detects legacy Talk Mode configuration (root-level `voiceId`, `apiKey`, etc.) and recommends migrating to the modern `providers` namespace.
 
 ## macOS: `launchctl` env overrides
 

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -49,27 +49,70 @@ Supported keys:
 
 ## Config (`~/.openclaw/openclaw.json`)
 
+Talk mode supports multiple providers. It is recommended to use the `providers` block for provider-specific settings.
+
+### ElevenLabs (Default)
+
 ```json5
 {
   talk: {
-    voiceId: "elevenlabs_voice_id",
-    modelId: "eleven_v3",
-    outputFormat: "mp3_44100_128",
-    apiKey: "elevenlabs_api_key",
+    provider: "elevenlabs",
+    providers: {
+      elevenlabs: {
+        voiceId: "elevenlabs_voice_id",
+        modelId: "eleven_v3",
+        outputFormat: "mp3_44100_128",
+        apiKey: "elevenlabs_api_key",
+      },
+    },
     silenceTimeoutMs: 1500,
     interruptOnSpeech: true,
   },
 }
 ```
 
-Defaults:
+### Mistral (Voxtral)
 
-- `interruptOnSpeech`: true
-- `silenceTimeoutMs`: when unset, Talk keeps the platform default pause window before sending the transcript (`700 ms on macOS and Android, 900 ms on iOS`)
-- `voiceId`: falls back to `ELEVENLABS_VOICE_ID` / `SAG_VOICE_ID` (or first ElevenLabs voice when API key is available)
-- `modelId`: defaults to `eleven_v3` when unset
-- `apiKey`: falls back to `ELEVENLABS_API_KEY` (or gateway shell profile if available)
-- `outputFormat`: defaults to `pcm_44100` on macOS/iOS and `pcm_24000` on Android (set `mp3_*` to force MP3 streaming)
+Mistral supports native field names (`model`, `voice`) or the generic OpenClaw names (`modelId`, `voiceId`).
+
+```json5
+{
+  talk: {
+    provider: "mistral",
+    providers: {
+      mistral: {
+        model: "voxtral-mini-tts-2603",
+        voice: "cbe96cf0-85ec-4a10-accb-0b35c93b6dfd", // Jane - Confident
+        outputFormat: "mp3",
+        apiKey: "mistral_api_key",
+      },
+    },
+  },
+}
+```
+
+- **ElevenLabs Defaults**: `eleven_v3` model, `pcm_44100` output.
+- **Mistral Defaults**: `voxtral-mini-tts-2603` model, `mp3` output.
+
+### Merging & Overrides
+
+Talk mode configuration follows a hierarchical merging strategy:
+
+1. **Provider-specific**: Settings inside `talk.providers.<providerID>.*` take the highest precedence.
+2. **Root-level**: Settings at `talk.*` (like `silenceTimeoutMs` or `voiceId`) act as defaults if not overridden in the provider block.
+3. **Environment**: If keys are missing in both, environment-based defaults (like `ELEVENLABS_API_KEY`) or hardcoded client defaults apply.
+
+### Legacy Configuration & Migration
+
+Prior versions of OpenClaw used root-level keys for all Talk settings (e.g. `talk.voiceId`). While these are still supported for backwards compatibility, migration to the `providers` block is recommended for more flexible multi-provider setups.
+
+**Migration via `doctor`**:
+The `openclaw doctor` command will automatically identify legacy configurations and provide migration examples to the modern `providers` structure.
+
+```bash
+# Check for legacy configuration warnings
+openclaw doctor
+```
 
 ## macOS UI
 

--- a/src/commands/doctor-config-analysis.test.ts
+++ b/src/commands/doctor-config-analysis.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { note } from "../terminal/note.js";
 import {
   formatConfigPath,
+  noteLegacyTalkConfig,
   resolveConfigPathTarget,
   stripUnknownConfigKeys,
 } from "./doctor-config-analysis.js";
+
+vi.mock("../terminal/note.js", () => ({
+  note: vi.fn(),
+}));
 
 describe("doctor config analysis helpers", () => {
   it("formats config paths predictably", () => {
@@ -30,5 +37,45 @@ describe("doctor config analysis helpers", () => {
     expect(result.removed).toContain("unexpected");
     expect((result.config as Record<string, unknown>).unexpected).toBeUndefined();
     expect((result.config as Record<string, unknown>).hooks).toEqual({});
+  });
+
+  it("notes legacy talk configuration fields", () => {
+    const cfg = {
+      talk: {
+        voiceId: "some-voice",
+        apiKey: "some-key",
+        providers: {
+          elevenlabs: {
+            voiceId: "another-voice",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    noteLegacyTalkConfig(cfg);
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Found legacy Talk Mode configuration fields at the root level: talk.voiceId, talk.apiKey",
+      ),
+      "Talk Mode Migration",
+    );
+  });
+
+  it("does not note legacy talk fields when none are present", () => {
+    vi.mocked(note).mockClear();
+    const cfg = {
+      talk: {
+        provider: "mistral",
+        providers: {
+          mistral: {
+            voiceId: "v1",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    noteLegacyTalkConfig(cfg);
+    expect(note).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/doctor-config-analysis.ts
+++ b/src/commands/doctor-config-analysis.ts
@@ -154,3 +154,45 @@ export function noteIncludeConfinementWarning(snapshot: {
     "Doctor warnings",
   );
 }
+
+export function noteLegacyTalkConfig(cfg: OpenClawConfig): void {
+  const talk = cfg.talk;
+  if (!talk) {
+    return;
+  }
+
+  const legacyFields = [
+    talk.voiceId ? "talk.voiceId" : null,
+    talk.voiceAliases ? "talk.voiceAliases" : null,
+    talk.modelId ? "talk.modelId" : null,
+    talk.outputFormat ? "talk.outputFormat" : null,
+    talk.apiKey ? "talk.apiKey" : null,
+  ].filter((f): f is string => Boolean(f));
+
+  if (legacyFields.length === 0) {
+    return;
+  }
+
+  const lines = [
+    `- Found legacy Talk Mode configuration fields at the root level: ${legacyFields.join(", ")}`,
+    "- While these are currently supported for compatibility (mapping to 'elevenlabs'), migration is recommended.",
+    "",
+    "Migration example for 'elevenlabs':",
+    "```json",
+    '// In openclaw.json "talk" section:',
+    "{",
+    '  "provider": "elevenlabs",',
+    '  "providers": {',
+    '    "elevenlabs": {',
+    '      "voiceId": "...",',
+    '      "modelId": "...",',
+    '      "apiKey": "..."',
+    "    }",
+    "  }",
+    "}",
+    "```",
+    "- See https://docs.openclaw.ai/configuration#talk for more details.",
+  ];
+
+  note(lines.join("\n"), "Talk Mode Migration");
+}

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -3,7 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { note } from "../terminal/note.js";
-import { noteOpencodeProviderOverrides } from "./doctor-config-analysis.js";
+import { noteOpencodeProviderOverrides, noteLegacyTalkConfig } from "./doctor-config-analysis.js";
 import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
 import { normalizeCompatibilityConfigValues } from "./doctor-legacy-config.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
@@ -191,6 +191,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   cfg = finalized.cfg;
 
   noteOpencodeProviderOverrides(cfg);
+  noteLegacyTalkConfig(cfg);
 
   return {
     cfg,

--- a/src/config/talk.compat.test.ts
+++ b/src/config/talk.compat.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import { buildTalkConfigResponse, LEGACY_TALK_PROVIDER_ID, normalizeTalkSection } from "./talk.js";
+import type { TalkConfig } from "./types.gateway.js";
+
+describe("Talk Configuration Compatibility", () => {
+  test("normalizes legacy root-level config to elevenlabs provider", () => {
+    const legacyConfig = {
+      voiceId: "paul-legacy-id",
+      modelId: "eleven_turbo_v2",
+      apiKey: "sk-legacy-key",
+      silenceTimeoutMs: 2000,
+      interruptOnSpeech: true,
+    };
+
+    const normalized = normalizeTalkSection(legacyConfig as TalkConfig);
+
+    expect(normalized).toBeDefined();
+    // Should have moved values into providers.elevenlabs
+    expect(normalized?.providers?.[LEGACY_TALK_PROVIDER_ID]).toMatchObject({
+      voiceId: "paul-legacy-id",
+      modelId: "eleven_turbo_v2",
+      apiKey: "sk-legacy-key",
+    });
+
+    // Root level should also still have these for backwards compatibility with older clients
+    expect(normalized?.voiceId).toBe("paul-legacy-id");
+    expect(normalized?.modelId).toBe("eleven_turbo_v2");
+    expect(normalized?.silenceTimeoutMs).toBe(2000);
+    expect(normalized?.interruptOnSpeech).toBe(true);
+  });
+
+  test("buildTalkConfigResponse includes both 'resolved' and compatibility fields", () => {
+    const legacyConfig = {
+      voiceId: "legacy-voice",
+      modelId: "legacy-model",
+      apiKey: "legacy-key",
+    };
+
+    const response = buildTalkConfigResponse(legacyConfig);
+
+    expect(response).toBeDefined();
+    // 'resolved' is what modern apps use
+    expect(response?.resolved).toBeDefined();
+    expect(response?.resolved?.provider).toBe(LEGACY_TALK_PROVIDER_ID);
+    expect(response?.resolved?.config?.voiceId).toBe("legacy-voice");
+
+    // Root level fields are what older apps (or apps using simple parsers) use
+    expect(response?.voiceId).toBe("legacy-voice");
+    expect(response?.modelId).toBe("legacy-model");
+    expect(response?.apiKey).toBe("legacy-key");
+  });
+
+  test("provider-specific config overrides legacy root config in response", () => {
+    const mixedConfig = {
+      voiceId: "root-voice",
+      provider: "mistral",
+      providers: {
+        mistral: {
+          voiceId: "mistral-voice",
+          modelId: "mistral-model",
+        },
+      },
+    };
+
+    const response = buildTalkConfigResponse(mixedConfig);
+
+    expect(response?.resolved?.provider).toBe("mistral");
+    expect(response?.resolved?.config?.voiceId).toBe("mistral-voice");
+
+    // The compatibility fields should reflect the ACTIVE provider's values
+    expect(response?.voiceId).toBe("mistral-voice");
+    expect(response?.modelId).toBe("mistral-model");
+  });
+});

--- a/src/config/talk.ts
+++ b/src/config/talk.ts
@@ -115,6 +115,35 @@ function normalizeTalkProviders(value: unknown): Record<string, TalkProviderConf
   return Object.keys(providers).length > 0 ? providers : undefined;
 }
 
+function normalizedLegacyTalkFields(source: Record<string, unknown>): Partial<TalkConfig> {
+  const legacy: Partial<TalkConfig> = {};
+  const voiceId = normalizeString(source.voiceId);
+  if (voiceId) {
+    legacy.voiceId = voiceId;
+  }
+  const voiceAliases = normalizeVoiceAliases(source.voiceAliases);
+  if (voiceAliases) {
+    legacy.voiceAliases = voiceAliases;
+  }
+  const modelId = normalizeString(source.modelId);
+  if (modelId) {
+    legacy.modelId = modelId;
+  }
+  const outputFormat = normalizeString(source.outputFormat);
+  if (outputFormat) {
+    legacy.outputFormat = outputFormat;
+  }
+  const apiKey = normalizeTalkSecretInput(source.apiKey);
+  if (apiKey !== undefined) {
+    legacy.apiKey = apiKey;
+  }
+  const silenceTimeoutMs = normalizeSilenceTimeoutMs(source.silenceTimeoutMs);
+  if (silenceTimeoutMs !== undefined) {
+    legacy.silenceTimeoutMs = silenceTimeoutMs;
+  }
+  return legacy;
+}
+
 function legacyProviderConfigFromTalk(
   source: Record<string, unknown>,
 ): TalkProviderConfig | undefined {
@@ -140,6 +169,38 @@ function activeProviderFromTalk(talk: TalkConfig): string | undefined {
   return providerIds.length === 1 ? providerIds[0] : undefined;
 }
 
+function legacyTalkFieldsFromProviderConfig(
+  config: TalkProviderConfig | undefined,
+): Partial<TalkConfig> {
+  if (!config) {
+    return {};
+  }
+  const legacy: Partial<TalkConfig> = {};
+  if (typeof config.voiceId === "string") {
+    legacy.voiceId = config.voiceId;
+  }
+  if (
+    config.voiceAliases &&
+    typeof config.voiceAliases === "object" &&
+    !Array.isArray(config.voiceAliases)
+  ) {
+    const aliases = normalizeVoiceAliases(config.voiceAliases);
+    if (aliases) {
+      legacy.voiceAliases = aliases;
+    }
+  }
+  if (typeof config.modelId === "string") {
+    legacy.modelId = config.modelId;
+  }
+  if (typeof config.outputFormat === "string") {
+    legacy.outputFormat = config.outputFormat;
+  }
+  if (config.apiKey !== undefined) {
+    legacy.apiKey = config.apiKey;
+  }
+  return legacy;
+}
+
 export function normalizeTalkSection(value: TalkConfig | undefined): TalkConfig | undefined {
   if (!isPlainObject(value)) {
     return undefined;
@@ -148,6 +209,10 @@ export function normalizeTalkSection(value: TalkConfig | undefined): TalkConfig 
   const source = value as Record<string, unknown>;
   const hasNormalizedShape = typeof source.provider === "string" || isPlainObject(source.providers);
   const normalized: TalkConfig = {};
+  const legacy = normalizedLegacyTalkFields(source);
+  if (Object.keys(legacy).length > 0) {
+    Object.assign(normalized, legacy);
+  }
   if (typeof source.interruptOnSpeech === "boolean") {
     normalized.interruptOnSpeech = source.interruptOnSpeech;
   }
@@ -234,6 +299,13 @@ export function buildTalkConfigResponse(value: unknown): TalkConfigResponse | un
   if (resolved) {
     payload.resolved = resolved;
   }
+
+  const providerConfig = resolved?.config;
+  const compatibilityLegacy = {
+    ...normalizedLegacyTalkFields(normalized as unknown as Record<string, unknown>),
+    ...legacyTalkFieldsFromProviderConfig(providerConfig),
+  };
+  Object.assign(payload, compatibilityLegacy);
 
   return Object.keys(payload).length > 0 ? payload : undefined;
 }

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -75,6 +75,16 @@ export type TalkConfig = {
   provider?: string;
   /** Provider-specific Talk config keyed by provider id. */
   providers?: Record<string, TalkProviderConfig>;
+  /** @deprecated Use talk.providers.elevenlabs.voiceId instead. */
+  voiceId?: string;
+  /** @deprecated Use talk.providers.elevenlabs.voiceAliases instead. */
+  voiceAliases?: Record<string, string>;
+  /** @deprecated Use talk.providers.elevenlabs.modelId instead. */
+  modelId?: string;
+  /** @deprecated Use talk.providers.elevenlabs.outputFormat instead. */
+  outputFormat?: string;
+  /** @deprecated Use talk.providers.elevenlabs.apiKey instead. */
+  apiKey?: SecretInput;
   /** Stop speaking when user starts talking (default: true). */
   interruptOnSpeech?: boolean;
   /** Milliseconds of user silence before Talk mode sends the transcript after a pause. */

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -61,6 +61,7 @@ const TalkConfigSchema = Type.Object(
     resolved: ResolvedTalkConfigSchema,
     interruptOnSpeech: Type.Optional(Type.Boolean()),
     silenceTimeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+    ...talkProviderFieldSchemas,
   },
   { additionalProperties: false },
 );


### PR DESCRIPTION
## Summary

This PR completes the vendor encapsulation refactor for TTS in the iOS app, and establishes a robust backward-compatibility layer for legacy Talk Mode configurations.

- **Problem**: ElevenLabs (model, voice, and format) were previously the only provider in `TalkModeManager`. This change introduces Mistral's Voxtral API as a second voice provider. Additionally, it implements  a transition to a `providers` configuration schema, and provides a migration from legacy root-level settings under the 'talk' key.

- **Why it matters**: Going multi-client, multi-provider gives us flexibility. Maintaining backward compatibility prevents breaking existing mobile app installations during Gateway upgrades.

- **What changed**: 
    - **OpenClawKit**: Implemented `MistralTTSClient` to encapsulate default IDs and formats; updated `TalkModeManager` to use client-side defaults.
    - **Gateway Core**: Updated `TalkConfig` to support dual-payload responses (modern `resolved` provider + `@deprecated` root fields).
    - **Diagnostics**: Added a `doctor` check (`noteLegacyTalkConfig`) to guide users toward the new `providers` schema.
    - **Docs**: Updated `docs/nodes/talk.md` with merging rules and migration guidance.

- **What did NOT change**: The core TTS inference loop and existing environment variable fallbacks remain intact.

## Change Type
- [ ] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes
Users with legacy `talk` configurations at the root level will now see a diagnostic note when running `openclaw doctor`, advising them to migrate to the `talk.providers` structure. The Gateway remains fully compatible with these legacy configs.

## Security Impact
- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification
### Environment
- OS: macOS (Gateway & iOS)
- Model/provider: Mistral TTS, ElevenLabs

### Verification Steps
1. Configured a node with legacy root-level `talk.voiceId` and `talk.apiKey`.
2. Verified `openclaw doctor` flags the configuration for migration.
3. Verified the Gateway `/config` response includes both the `resolved` provider object and root-level compatibility fields.
4. Ran unit tests for Talk compatibility and Doctor diagnostics.

### Evidence
- [x] Trace/log snippets (Verified with `pnpm vitest`)
- [x] Passing tests: `src/config/talk.compat.test.ts`, `src/commands/doctor-config-analysis.test.ts`

## Compatibility / Migration
- **Backward compatible?** `Yes`
- **Config/env changes?** `Yes` (Soft-deprecated root-level talk fields)
- **Migration needed?** `No` (Optional migration encouraged via `doctor` if found)

## Risks and Mitigations
- **Risk**: Potential confusion between root-level and provider-level settings.
  - **Mitigation**: Updated documentation explicitly defines the precedence rules (Provider > Root > Env).

## Diagram / Configuration Comparison
Below is a comparison of the legacy flat structure versus the new provider-based hierarchy. The Gateway now handles both but encourages the move to the latter.
```json
// BEFORE: Legacy Flat Structure (Implicitly ElevenLabs)
{
  "talk": {
    "modelId": "eleven_v3",
    "apiKey": "sk-legacy-key",
    "silenceTimeoutMs": 1500,
    "interruptOnSpeech": true
  }
}

// AFTER: Modern Provider-Based Structure
{
  "talk": {
    "provider": "mistral", // Explicit active provider
    "providers": {
      "mistral": {
        "modelId": "mistral-model-id",
        "voiceId": "mistral-voice-id",
        "apiKey": "mistral_api_key"
      },
      "elevenlabs": {
        "modelId": "eleven_v3",
        "apiKey": "sk-legacy-key"
      }
    },
    "silenceTimeoutMs": 1500,
    "interruptOnSpeech": true
  }
}
```
## User-visible / Behavior Changes

- **Migration Alerts**: Users with legacy `talk` configurations (the "Flat" structure above) will now see a diagnostic note when running `openclaw doctor` advising them to migrate.
- **Hierarchical Merging**: Root-level fields (like `silenceTimeoutMs`) now act as defaults that can be overridden within specific provider blocks if needed.
- **Response Shape**: The Gateway `/config` API response now mirrors this structure, explicitly including a `resolved` object for modern clients while maintaining root fields for older app versions.
