### PR TITLE
fix(minimax): write portal model catalog during OAuth onboard & honor Bearer auth in transport

### DIFF
--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -1,6 +1,16 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
+import { MINIMAX_API_BASE_URL } from "./model-definitions.js";
+
+vi.mock("./oauth.runtime.js", () => ({
+  loginMiniMaxPortalOAuth: vi.fn(async () => ({
+    access: "minimax-oauth-access-token",
+    refresh: "minimax-oauth-refresh-token",
+    expires: Date.now() + 60_000,
+    resourceUrl: MINIMAX_API_BASE_URL,
+  })),
+}));
 import {
   registerProviderPlugin,
   requireRegisteredProvider,
@@ -175,5 +185,49 @@ describe("minimax provider hooks", () => {
 
     expect(resolveOAuthToken).toHaveBeenCalledWith({ provider: "minimax-portal" });
     expect(resolveApiKeyFromConfigAndStore).not.toHaveBeenCalled();
+  });
+
+  it("writes the MiniMax portal catalog into the OAuth config patch", async () => {
+    const registeredProviders: Array<Record<string, unknown>> = [];
+    minimaxPlugin.register({
+      registerProvider(provider: Record<string, unknown>) {
+        registeredProviders.push(provider);
+      },
+      registerMediaUnderstandingProvider() {},
+      registerImageGenerationProvider() {},
+      registerSpeechProvider() {},
+      registerWebSearchProvider() {},
+    } as never);
+
+    const portalProvider = registeredProviders.find((provider) => provider.id === "minimax-portal") as {
+      auth: Array<{ id: string; run: (ctx: unknown) => Promise<unknown> }>;
+    };
+    const oauthMethod = portalProvider.auth.find((method) => method.id === "oauth");
+    expect(oauthMethod).toBeDefined();
+
+    const result = (await oauthMethod?.run({
+      prompter: {
+        progress() {
+          return { stop() {} };
+        },
+        note: vi.fn(async () => undefined),
+      },
+      openUrl: vi.fn(async () => undefined),
+    } as never)) as {
+      configPatch?: {
+        models?: {
+          providers?: Record<string, { baseUrl?: string; api?: string; authHeader?: boolean; models?: Array<{ id: string }> }>;
+        };
+      };
+    };
+
+    const portalConfig = result.configPatch?.models?.providers?.["minimax-portal"];
+    expect(portalConfig).toMatchObject({
+      baseUrl: "https://api.minimax.io/anthropic",
+      api: "anthropic-messages",
+      authHeader: true,
+    });
+    expect(portalConfig?.models?.length).toBeGreaterThan(0);
+    expect(portalConfig?.models?.some((model) => model.id === "MiniMax-M2.7")).toBe(true);
   });
 });

--- a/extensions/minimax/index.ts
+++ b/extensions/minimax/index.ts
@@ -73,6 +73,16 @@ function buildPortalProviderCatalog(params: { baseUrl: string; apiKey: string })
   };
 }
 
+function buildPortalProviderConfigPatch(baseUrl: string) {
+  const provider = buildMinimaxPortalProvider();
+  return {
+    baseUrl,
+    api: provider.api,
+    authHeader: provider.authHeader,
+    models: provider.models,
+  };
+}
+
 function resolveApiCatalog(ctx: ProviderCatalogContext) {
   const apiKey = ctx.resolveProviderApiKey(API_PROVIDER_ID).apiKey;
   if (!apiKey) {
@@ -143,10 +153,7 @@ function createOAuthHandler(region: MiniMaxRegion) {
         configPatch: {
           models: {
             providers: {
-              [PORTAL_PROVIDER_ID]: {
-                baseUrl,
-                models: [],
-              },
+              [PORTAL_PROVIDER_ID]: buildPortalProviderConfigPatch(baseUrl),
             },
           },
           agents: {

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -220,6 +220,52 @@ describe("anthropic transport stream", () => {
     );
   });
 
+  it("uses authToken when Anthropic-compatible providers inject a Bearer Authorization header", async () => {
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "MiniMax-M2.7",
+        name: "MiniMax M2.7",
+        api: "anthropic-messages",
+        provider: "minimax-portal",
+        baseUrl: "https://api.minimax.io/anthropic",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+        headers: {
+          Authorization: "Bearer minimax-oauth-token",
+        },
+      } satisfies Model<"anthropic-messages">,
+      undefined,
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "hello" }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "minimax-oauth-token",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    await stream.result();
+
+    expect(anthropicCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: null,
+        authToken: "minimax-oauth-token",
+        baseURL: "https://api.minimax.io/anthropic",
+        defaultHeaders: expect.objectContaining({
+          Authorization: "Bearer minimax-oauth-token",
+        }),
+      }),
+    );
+  });
+
   it("maps adaptive thinking effort for Claude 4.6 transport runs", async () => {
     const model = attachModelProviderRequestTransport(
       {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -153,6 +153,24 @@ function isAnthropicOAuthToken(apiKey: string): boolean {
   return apiKey.includes("sk-ant-oat");
 }
 
+function hasBearerAuthorizationHeader(
+  headers: Record<string, string> | undefined,
+  apiKey: string,
+): boolean {
+  if (!headers) {
+    return false;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== "authorization") {
+      continue;
+    }
+    if (value.trim() === `Bearer ${apiKey}`) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function toClaudeCodeName(name: string): string {
   return CLAUDE_CODE_TOOL_LOOKUP.get(name.toLowerCase()) ?? name;
 }
@@ -426,7 +444,18 @@ function createAnthropicTransportClient(params: {
   if (needsInterleavedBeta) {
     betaFeatures.push("interleaved-thinking-2025-05-14");
   }
-  if (isAnthropicOAuthToken(apiKey)) {
+  const usesBearerAuthToken =
+    isAnthropicOAuthToken(apiKey) || hasBearerAuthorizationHeader(model.headers, apiKey);
+  if (usesBearerAuthToken) {
+    const oauthHeaders: Record<string, string> = isAnthropicOAuthToken(apiKey)
+      ? {
+          "anthropic-beta": `claude-code-20250219,oauth-2025-04-20,${betaFeatures.join(",")}`,
+          "user-agent": `claude-cli/${CLAUDE_CODE_VERSION}`,
+          "x-app": "cli",
+        }
+      : {
+          "anthropic-beta": betaFeatures.join(","),
+        };
     return {
       client: new Anthropic({
         apiKey: null,
@@ -437,16 +466,14 @@ function createAnthropicTransportClient(params: {
           {
             accept: "application/json",
             "anthropic-dangerous-direct-browser-access": "true",
-            "anthropic-beta": `claude-code-20250219,oauth-2025-04-20,${betaFeatures.join(",")}`,
-            "user-agent": `claude-cli/${CLAUDE_CODE_VERSION}`,
-            "x-app": "cli",
+            ...oauthHeaders,
           },
           model.headers,
           options?.headers,
         ),
         fetch,
       }),
-      isOAuthToken: true,
+      isOAuthToken: isAnthropicOAuthToken(apiKey),
     };
   }
   return {


### PR DESCRIPTION
## Summary

Fixes two related bugs that prevent the `minimax-portal` OAuth provider from working:

### Bug 1: OAuth onboard writes empty models array (#60987)

The OAuth `configPatch` in `createOAuthHandler()` hardcoded `models: []`, which told the gateway the provider has zero models and blocked model resolution.

**Fix:** Build the config patch from the real built-in provider catalog so OAuth writes the full model definitions (matching what the API-key path does), including `baseUrl`, `api`, `authHeader`, and model entries.

### Bug 2: Transport sends wrong auth header for MiniMax OAuth (#60988)

The Anthropic transport stream (`anthropic-transport-stream.ts`) only used `authToken` (Bearer) mode for Anthropic-native OAuth tokens (`sk-ant-oat...`). MiniMax OAuth tokens fell through to the `apiKey` path, causing the SDK to send `x-api-key` instead of `Authorization: Bearer`. MiniMax's endpoint rejects `x-api-key` with a bare nginx 404.

**Fix:** Detect providers that carry Bearer auth (via `authHeader: true` in their config) and construct the Anthropic client with `apiKey: null` + `authToken: <token>` so the token is sent as `Authorization: Bearer`.

### Testing

- Added unit test for OAuth config patch contents
- Added transport test for MiniMax-style Bearer auth path
- Could not run full test suite locally (missing offline dependencies on ARM64)

Closes #60987
Closes #60988
