### PR TITLE
fix: remove heartbeat transcript pruning to prevent session corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Docs: https://docs.openclaw.ai
 - Providers/Anthropic: skip `service_tier` injection for OAuth-authenticated stream wrapper requests so Claude OAuth requests stop failing with HTTP 401. (#60356) thanks @openperf.
 - Agents/exec: preserve explicit `host=node` routing under elevated defaults when `tools.exec.host=auto`, and fail loud on invalid elevated cross-host overrides. (#61739) Thanks @obviyus.
 - Docs/i18n: remove the zh-CN homepage redirect override so Mintlify can resolve the localized Chinese homepage without self-redirecting `/zh-CN/index`.
+- Agents/heartbeat: stop truncating live session transcripts after no-op heartbeat acks, move heartbeat cleanup to prompt assembly and compaction, and keep post-filter context-engine ingestion aligned with the real session baseline. (#60998) Thanks @nxmxbbd.
+
 ## 2026.4.5
 
 ### Breaking

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1005,10 +1005,14 @@ export async function compactEmbeddedPiSessionDirect(
           // Truncate session file to remove compacted entries (#39953)
           if (params.config?.agents?.defaults?.compaction?.truncateAfterCompaction) {
             try {
+              const heartbeatSummary = resolveHeartbeatSummaryForAgent(
+                params.config,
+                sessionAgentId,
+              );
               const truncResult = await truncateSessionAfterCompaction({
                 sessionFile: params.sessionFile,
-                ackMaxChars: resolveHeartbeatSummaryForAgent(params.config, sessionAgentId)
-                  .ackMaxChars,
+                ackMaxChars: heartbeatSummary.ackMaxChars,
+                heartbeatPrompt: heartbeatSummary.prompt,
               });
               if (truncResult.truncated) {
                 log.info(

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -15,6 +15,7 @@ import {
   ensureContextEnginesInitialized,
   resolveContextEngine,
 } from "../../context-engine/index.js";
+import { resolveHeartbeatSummaryForAgent } from "../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
@@ -1006,6 +1007,8 @@ export async function compactEmbeddedPiSessionDirect(
             try {
               const truncResult = await truncateSessionAfterCompaction({
                 sessionFile: params.sessionFile,
+                ackMaxChars: resolveHeartbeatSummaryForAgent(params.config, sessionAgentId)
+                  .ackMaxChars,
               });
               if (truncResult.truncated) {
                 log.info(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1513,7 +1513,7 @@ export async function runEmbeddedAttempt(
 
       let promptError: unknown = null;
       let promptErrorSource: "prompt" | "compaction" | null = null;
-      const prePromptMessageCount = activeSession.messages.length;
+      let prePromptMessageCount = activeSession.messages.length;
       try {
         const promptStartedAt = Date.now();
 
@@ -1679,6 +1679,7 @@ export async function runEmbeddedAttempt(
           if (filteredMessages.length < activeSession.messages.length) {
             activeSession.agent.state.messages = filteredMessages;
           }
+          prePromptMessageCount = activeSession.messages.length;
 
           // Detect and load images referenced in the prompt for vision-capable models.
           // Images are prompt-local only (pi-like behavior).

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -6,12 +6,6 @@ import {
   DefaultResourceLoader,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
-import {
-  isOllamaCompatProvider,
-  resolveOllamaCompatNumCtxEnabled,
-  shouldInjectOllamaCompatNumCtx,
-  wrapOllamaCompatNumCtx,
-} from "../../../../extensions/ollama/runtime-api.js";
 import { filterHeartbeatPairs } from "../../../auto-reply/heartbeat-filter.js";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
@@ -22,6 +16,12 @@ import {
   ensureGlobalUndiciStreamTimeouts,
 } from "../../../infra/net/undici-global-dispatcher.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
+import {
+  isOllamaCompatProvider,
+  resolveOllamaCompatNumCtxEnabled,
+  shouldInjectOllamaCompatNumCtx,
+  wrapOllamaCompatNumCtx,
+} from "../../../plugin-sdk/ollama-runtime.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { resolveToolCallArgumentsEncoding } from "../../../plugins/provider-model-compat.js";
 import { resolveProviderSystemPromptContribution } from "../../../plugins/provider-runtime.js";
@@ -1667,11 +1667,14 @@ export async function runEmbeddedAttempt(
             activeSession.agent.state.messages = activeSession.messages;
           }
 
+          const heartbeatSummary =
+            params.config && sessionAgentId
+              ? resolveHeartbeatSummaryForAgent(params.config, sessionAgentId)
+              : undefined;
           const filteredMessages = filterHeartbeatPairs(
             activeSession.messages,
-            params.config
-              ? resolveHeartbeatSummaryForAgent(params.config, sessionAgentId).ackMaxChars
-              : undefined,
+            heartbeatSummary?.ackMaxChars,
+            heartbeatSummary?.prompt,
           );
           if (filteredMessages.length < activeSession.messages.length) {
             activeSession.agent.state.messages = filteredMessages;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -6,6 +6,13 @@ import {
   DefaultResourceLoader,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
+import {
+  isOllamaCompatProvider,
+  resolveOllamaCompatNumCtxEnabled,
+  shouldInjectOllamaCompatNumCtx,
+  wrapOllamaCompatNumCtx,
+} from "../../../../extensions/ollama/runtime-api.js";
+import { filterHeartbeatPairs } from "../../../auto-reply/heartbeat-filter.js";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
@@ -1663,6 +1670,14 @@ export async function runEmbeddedAttempt(
           const didPruneImages = pruneProcessedHistoryImages(activeSession.messages);
           if (didPruneImages) {
             activeSession.agent.state.messages = activeSession.messages;
+          }
+
+          // Filter out no-op heartbeat user+assistant pairs from session context.
+          // Heartbeat entries are now kept in the JSONL (append-only) to avoid the
+          // fs.truncate race that caused orphaned parentId chains (#39609).
+          const filteredMessages = filterHeartbeatPairs(activeSession.messages);
+          if (filteredMessages.length < activeSession.messages.length) {
+            activeSession.agent.state.messages = filteredMessages;
           }
 
           // Detect and load images referenced in the prompt for vision-capable models.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -21,12 +21,6 @@ import {
   ensureGlobalUndiciStreamTimeouts,
 } from "../../../infra/net/undici-global-dispatcher.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
-import {
-  isOllamaCompatProvider,
-  resolveOllamaCompatNumCtxEnabled,
-  shouldInjectOllamaCompatNumCtx,
-  wrapOllamaCompatNumCtx,
-} from "../../../plugin-sdk/ollama-runtime.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import { resolveToolCallArgumentsEncoding } from "../../../plugins/provider-model-compat.js";
 import { resolveProviderSystemPromptContribution } from "../../../plugins/provider-runtime.js";

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -15,6 +15,7 @@ import {
 import { filterHeartbeatPairs } from "../../../auto-reply/heartbeat-filter.js";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
+import { resolveHeartbeatSummaryForAgent } from "../../../infra/heartbeat-summary.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import {
   ensureGlobalUndiciEnvProxyDispatcher,
@@ -1669,7 +1670,12 @@ export async function runEmbeddedAttempt(
           // Filter out no-op heartbeat user+assistant pairs from session context.
           // Heartbeat entries are now kept in the JSONL (append-only) to avoid the
           // fs.truncate race that caused orphaned parentId chains (#39609).
-          const filteredMessages = filterHeartbeatPairs(activeSession.messages);
+          const filteredMessages = filterHeartbeatPairs(
+            activeSession.messages,
+            params.config
+              ? resolveHeartbeatSummaryForAgent(params.config, sessionAgentId).ackMaxChars
+              : undefined,
+          );
           if (filteredMessages.length < activeSession.messages.length) {
             activeSession.agent.state.messages = filteredMessages;
           }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1667,9 +1667,6 @@ export async function runEmbeddedAttempt(
             activeSession.agent.state.messages = activeSession.messages;
           }
 
-          // Filter out no-op heartbeat user+assistant pairs from session context.
-          // Heartbeat entries are now kept in the JSONL (append-only) to avoid the
-          // fs.truncate race that caused orphaned parentId chains (#39609).
           const filteredMessages = filterHeartbeatPairs(
             activeSession.messages,
             params.config

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -38,6 +38,7 @@ export async function truncateSessionAfterCompaction(params: {
   sessionFile: string;
   /** Optional path to archive the pre-truncation file. */
   archivePath?: string;
+  ackMaxChars?: number;
 }): Promise<TruncationResult> {
   const { sessionFile } = params;
 
@@ -131,7 +132,7 @@ export async function truncateSessionAfterCompaction(params: {
       !removedIds.has(userEntry.id) &&
       !removedIds.has(assistantEntry.id) &&
       isHeartbeatUserMessage(userEntry.message) &&
-      isHeartbeatOkResponse(assistantEntry.message)
+      isHeartbeatOkResponse(assistantEntry.message, params.ackMaxChars)
     ) {
       removedIds.add(userEntry.id);
       removedIds.add(assistantEntry.id);

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -39,6 +39,7 @@ export async function truncateSessionAfterCompaction(params: {
   /** Optional path to archive the pre-truncation file. */
   archivePath?: string;
   ackMaxChars?: number;
+  heartbeatPrompt?: string;
 }): Promise<TruncationResult> {
   const { sessionFile } = params;
 
@@ -126,7 +127,7 @@ export async function truncateSessionAfterCompaction(params: {
       summarizedBranchIds.has(assistantEntry.id) &&
       !removedIds.has(userEntry.id) &&
       !removedIds.has(assistantEntry.id) &&
-      isHeartbeatUserMessage(userEntry.message) &&
+      isHeartbeatUserMessage(userEntry.message, params.heartbeatPrompt) &&
       isHeartbeatOkResponse(assistantEntry.message, params.ackMaxChars)
     ) {
       removedIds.add(userEntry.id);

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { CompactionEntry, SessionEntry } from "@mariozechner/pi-coding-agent";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
+import {
+  isHeartbeatOkResponse,
+  isHeartbeatUserMessage,
+} from "../../auto-reply/heartbeat-filter.js";
 import { log } from "./logger.js";
 
 /**
@@ -108,6 +112,25 @@ export async function truncateSessionAfterCompaction(params: {
   for (const entry of allEntries) {
     if (summarizedBranchIds.has(entry.id) && entry.type === "message") {
       removedIds.add(entry.id);
+    }
+  }
+
+  // Drop no-op heartbeat user+assistant pairs from the branch to prevent
+  // unbounded disk growth now that heartbeat entries are append-only (#39609).
+  for (let i = 0; i < branch.length - 1; i++) {
+    const userEntry = branch[i];
+    const assistantEntry = branch[i + 1];
+    if (
+      userEntry.type === "message" &&
+      assistantEntry.type === "message" &&
+      !removedIds.has(userEntry.id) &&
+      !removedIds.has(assistantEntry.id) &&
+      isHeartbeatUserMessage(userEntry.message) &&
+      isHeartbeatOkResponse(assistantEntry.message)
+    ) {
+      removedIds.add(userEntry.id);
+      removedIds.add(assistantEntry.id);
+      i++; // Skip the assistant entry
     }
   }
 

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -115,14 +115,19 @@ export async function truncateSessionAfterCompaction(params: {
     }
   }
 
-  // Drop no-op heartbeat user+assistant pairs from the branch to prevent
-  // unbounded disk growth now that heartbeat entries are append-only (#39609).
+  // Drop no-op heartbeat user+assistant pairs from the *summarized* portion
+  // of the branch to prevent unbounded disk growth now that heartbeat entries
+  // are append-only (#39609).  Pairs in the unsummarized tail (from
+  // firstKeptEntryId onward) are preserved — buildSessionContext() expects
+  // them to reconstruct the session after compaction.
   for (let i = 0; i < branch.length - 1; i++) {
     const userEntry = branch[i];
     const assistantEntry = branch[i + 1];
     if (
       userEntry.type === "message" &&
       assistantEntry.type === "message" &&
+      summarizedBranchIds.has(userEntry.id) &&
+      summarizedBranchIds.has(assistantEntry.id) &&
       !removedIds.has(userEntry.id) &&
       !removedIds.has(assistantEntry.id) &&
       isHeartbeatUserMessage(userEntry.message) &&

--- a/src/agents/pi-embedded-runner/session-truncation.ts
+++ b/src/agents/pi-embedded-runner/session-truncation.ts
@@ -116,11 +116,6 @@ export async function truncateSessionAfterCompaction(params: {
     }
   }
 
-  // Drop no-op heartbeat user+assistant pairs from the *summarized* portion
-  // of the branch to prevent unbounded disk growth now that heartbeat entries
-  // are append-only (#39609).  Pairs in the unsummarized tail (from
-  // firstKeptEntryId onward) are preserved — buildSessionContext() expects
-  // them to reconstruct the session after compaction.
   for (let i = 0; i < branch.length - 1; i++) {
     const userEntry = branch[i];
     const assistantEntry = branch[i + 1];
@@ -136,7 +131,7 @@ export async function truncateSessionAfterCompaction(params: {
     ) {
       removedIds.add(userEntry.id);
       removedIds.add(assistantEntry.id);
-      i++; // Skip the assistant entry
+      i++;
     }
   }
 

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -129,13 +129,22 @@ describe("isHeartbeatOkResponse", () => {
     ).toBe(false);
   });
 
-  it("returns false for empty content", () => {
+  it("returns true for empty content (ok-empty no-op heartbeat)", () => {
     expect(
       isHeartbeatOkResponse({
         role: "assistant",
         content: "",
       }),
-    ).toBe(false);
+    ).toBe(true);
+  });
+
+  it("returns true for whitespace-only content", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "   ",
+      }),
+    ).toBe(true);
   });
 
   it("returns true for HEARTBEAT_OK with responsePrefix", () => {

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -72,6 +72,15 @@ describe("isHeartbeatUserMessage", () => {
       }),
     ).toBe(true);
   });
+
+  it("returns true for custom prompt using 'return'", () => {
+    expect(
+      isHeartbeatUserMessage({
+        role: "user",
+        content: "return HEARTBEAT_OK if nothing is needed",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("isHeartbeatOkResponse", () => {
@@ -154,6 +163,31 @@ describe("isHeartbeatOkResponse", () => {
         content: "<b>HEARTBEAT_OK</b>",
       }),
     ).toBe(true);
+  });
+
+  it("returns true for HEARTBEAT_OK with short alphanumeric suffix", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "HEARTBEAT_OK all good",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for HEARTBEAT_OK followed by long real content", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content:
+          "HEARTBEAT_OK " +
+          "but I noticed you have 3 urgent emails and a calendar event in 30 minutes. " +
+          "Also your Tesla is at 15% charge and the weather forecast shows heavy rain. " +
+          "I recommend charging the car now and bringing an umbrella. " +
+          "Additionally there are 5 open PRs that need your review and the CI pipeline " +
+          "has been failing for the last 3 hours due to a flaky test in the extension shards. " +
+          "I have drafted a summary of all action items for your review.",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -111,13 +111,13 @@ describe("isHeartbeatOkResponse", () => {
     ).toBe(true);
   });
 
-  it("returns false for response with real content", () => {
+  it("returns true for short text ending in HEARTBEAT_OK", () => {
     expect(
       isHeartbeatOkResponse({
         role: "assistant",
         content: "You have 3 unread urgent emails. HEARTBEAT_OK",
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("returns false for user messages", () => {
@@ -196,6 +196,36 @@ describe("isHeartbeatOkResponse", () => {
           "has been failing for the last 3 hours due to a flaky test in the extension shards. " +
           "I have drafted a summary of all action items for your review.",
       }),
+    ).toBe(false);
+  });
+
+  it("returns false for HEARTBEAT_OK mentioned mid-sentence", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "Status HEARTBEAT_OK due to watchdog failure",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for non-text content blocks", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tool-1", name: "search", input: {} }],
+      }),
+    ).toBe(false);
+  });
+
+  it("respects ackMaxChars overrides", () => {
+    expect(
+      isHeartbeatOkResponse(
+        {
+          role: "assistant",
+          content: "HEARTBEAT_OK all good",
+        },
+        0,
+      ),
     ).toBe(false);
   });
 });

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -4,21 +4,25 @@ import {
   isHeartbeatOkResponse,
   isHeartbeatUserMessage,
 } from "./heartbeat-filter.js";
+import { HEARTBEAT_PROMPT } from "./heartbeat.js";
 
 describe("isHeartbeatUserMessage", () => {
   it("matches heartbeat prompts", () => {
     expect(
-      isHeartbeatUserMessage({
-        role: "user",
-        content:
-          "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. If nothing needs attention, reply HEARTBEAT_OK.",
-      }),
+      isHeartbeatUserMessage(
+        {
+          role: "user",
+          content: `${HEARTBEAT_PROMPT}\nWhen reading HEARTBEAT.md, use workspace file /tmp/HEARTBEAT.md (exact case). Do not read docs/heartbeat.md.`,
+        },
+        HEARTBEAT_PROMPT,
+      ),
     ).toBe(true);
 
     expect(
       isHeartbeatUserMessage({
         role: "user",
-        content: "return HEARTBEAT_OK if nothing is needed",
+        content:
+          "Run the following periodic tasks (only those due based on their intervals):\n\n- email-check: Check for urgent unread emails\n\nAfter completing all due tasks, reply HEARTBEAT_OK.",
       }),
     ).toBe(true);
   });
@@ -27,7 +31,7 @@ describe("isHeartbeatUserMessage", () => {
     expect(
       isHeartbeatUserMessage({
         role: "user",
-        content: "What does HEARTBEAT_OK mean? I keep seeing it in logs.",
+        content: "Please reply HEARTBEAT_OK so I can test something.",
       }),
     ).toBe(false);
 
@@ -91,13 +95,13 @@ describe("filterHeartbeatPairs", () => {
     const messages = [
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi there!" },
-      { role: "user", content: "reply HEARTBEAT_OK if nothing." },
+      { role: "user", content: HEARTBEAT_PROMPT },
       { role: "assistant", content: "HEARTBEAT_OK" },
       { role: "user", content: "What time is it?" },
       { role: "assistant", content: "It is 3pm." },
     ];
 
-    expect(filterHeartbeatPairs(messages)).toEqual([
+    expect(filterHeartbeatPairs(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi there!" },
       { role: "user", content: "What time is it?" },
@@ -107,18 +111,31 @@ describe("filterHeartbeatPairs", () => {
 
   it("keeps meaningful heartbeat results and non-text assistant turns", () => {
     const meaningfulMessages = [
-      { role: "user", content: "reply HEARTBEAT_OK if nothing." },
+      { role: "user", content: HEARTBEAT_PROMPT },
       { role: "assistant", content: "Status HEARTBEAT_OK due to watchdog failure" },
     ];
-    expect(filterHeartbeatPairs(meaningfulMessages)).toEqual(meaningfulMessages);
+    expect(filterHeartbeatPairs(meaningfulMessages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      meaningfulMessages,
+    );
 
     const nonTextMessages = [
-      { role: "user", content: "reply HEARTBEAT_OK if nothing." },
+      { role: "user", content: HEARTBEAT_PROMPT },
       {
         role: "assistant",
         content: [{ type: "tool_use", id: "tool-1", name: "search", input: {} }],
       },
     ];
-    expect(filterHeartbeatPairs(nonTextMessages)).toEqual(nonTextMessages);
+    expect(filterHeartbeatPairs(nonTextMessages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      nonTextMessages,
+    );
+  });
+
+  it("keeps ordinary chats that mention the token", () => {
+    const messages = [
+      { role: "user", content: "Please reply HEARTBEAT_OK so I can test something." },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+    ];
+
+    expect(filterHeartbeatPairs(messages, undefined, HEARTBEAT_PROMPT)).toEqual(messages);
   });
 });

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -54,6 +54,24 @@ describe("isHeartbeatUserMessage", () => {
       }),
     ).toBe(false);
   });
+
+  it("returns false for normal conversation that quotes the token", () => {
+    expect(
+      isHeartbeatUserMessage({
+        role: "user",
+        content: "What does HEARTBEAT_OK mean? I keep seeing it in logs.",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for respond-style heartbeat prompt", () => {
+    expect(
+      isHeartbeatUserMessage({
+        role: "user",
+        content: "Check on things and respond with HEARTBEAT_OK if all clear.",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("isHeartbeatOkResponse", () => {
@@ -109,6 +127,33 @@ describe("isHeartbeatOkResponse", () => {
         content: "",
       }),
     ).toBe(false);
+  });
+
+  it("returns true for HEARTBEAT_OK with responsePrefix", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "Nex HEARTBEAT_OK",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for HEARTBEAT_OK with emoji suffix", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "HEARTBEAT_OK 👍",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for HEARTBEAT_OK with HTML wrapper", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "<b>HEARTBEAT_OK</b>",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterHeartbeatPairs,
+  isHeartbeatOkResponse,
+  isHeartbeatUserMessage,
+} from "./heartbeat-filter.js";
+
+describe("isHeartbeatUserMessage", () => {
+  it("returns true for default heartbeat prompt (string content)", () => {
+    expect(
+      isHeartbeatUserMessage({
+        role: "user",
+        content:
+          "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for task-based heartbeat prompt", () => {
+    expect(
+      isHeartbeatUserMessage({
+        role: "user",
+        content:
+          "Run the following periodic tasks:\n- email-check: Check for urgent unread emails\nAfter completing all due tasks, reply HEARTBEAT_OK.",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for content block array containing HEARTBEAT_OK", () => {
+    expect(
+      isHeartbeatUserMessage({
+        role: "user",
+        content: [
+          { type: "text", text: "Check workspace and reply HEARTBEAT_OK if nothing to do." },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for normal user message", () => {
+    expect(
+      isHeartbeatUserMessage({
+        role: "user",
+        content: "What is the weather today?",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for assistant messages", () => {
+    expect(
+      isHeartbeatUserMessage({
+        role: "assistant",
+        content: "HEARTBEAT_OK",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("isHeartbeatOkResponse", () => {
+  it("returns true for plain HEARTBEAT_OK", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "HEARTBEAT_OK",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for HEARTBEAT_OK with markup", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "**HEARTBEAT_OK**",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for HEARTBEAT_OK in content blocks", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: [{ type: "text", text: "HEARTBEAT_OK" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for response with real content", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "You have 3 unread urgent emails. HEARTBEAT_OK",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for user messages", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "user",
+        content: "HEARTBEAT_OK",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for empty content", () => {
+    expect(
+      isHeartbeatOkResponse({
+        role: "assistant",
+        content: "",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("filterHeartbeatPairs", () => {
+  it("removes heartbeat user+HEARTBEAT_OK assistant pairs", () => {
+    const messages = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there!" },
+      { role: "user", content: "Read HEARTBEAT.md if it exists. reply HEARTBEAT_OK." },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "What time is it?" },
+      { role: "assistant", content: "It is 3pm." },
+    ];
+
+    const filtered = filterHeartbeatPairs(messages);
+    expect(filtered).toEqual([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there!" },
+      { role: "user", content: "What time is it?" },
+      { role: "assistant", content: "It is 3pm." },
+    ]);
+  });
+
+  it("preserves heartbeat turns that produced real content", () => {
+    const messages = [
+      { role: "user", content: "Read HEARTBEAT.md. reply HEARTBEAT_OK if nothing to do." },
+      { role: "assistant", content: "You have 3 urgent emails to review." },
+    ];
+
+    const filtered = filterHeartbeatPairs(messages);
+    expect(filtered).toEqual(messages);
+  });
+
+  it("removes multiple consecutive heartbeat pairs", () => {
+    const messages = [
+      { role: "user", content: "reply HEARTBEAT_OK if nothing." },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "reply HEARTBEAT_OK if nothing." },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "What is 2+2?" },
+      { role: "assistant", content: "4" },
+    ];
+
+    const filtered = filterHeartbeatPairs(messages);
+    expect(filtered).toEqual([
+      { role: "user", content: "What is 2+2?" },
+      { role: "assistant", content: "4" },
+    ]);
+  });
+
+  it("returns original array if no heartbeat pairs found", () => {
+    const messages = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
+    ];
+
+    const filtered = filterHeartbeatPairs(messages);
+    expect(filtered).toEqual(messages);
+  });
+
+  it("handles empty message array", () => {
+    expect(filterHeartbeatPairs([])).toEqual([]);
+  });
+
+  it("handles single message", () => {
+    const messages = [{ role: "user", content: "Hello" }];
+    expect(filterHeartbeatPairs(messages)).toEqual(messages);
+  });
+
+  it("does not filter heartbeat user message without matching assistant response", () => {
+    const messages = [
+      { role: "user", content: "reply HEARTBEAT_OK." },
+      { role: "user", content: "Actually, check my calendar." },
+      { role: "assistant", content: "You have a meeting at 3pm." },
+    ];
+
+    const filtered = filterHeartbeatPairs(messages);
+    expect(filtered).toEqual(messages);
+  });
+});

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -6,74 +6,15 @@ import {
 } from "./heartbeat-filter.js";
 
 describe("isHeartbeatUserMessage", () => {
-  it("returns true for default heartbeat prompt (string content)", () => {
+  it("matches heartbeat prompts", () => {
     expect(
       isHeartbeatUserMessage({
         role: "user",
         content:
-          "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.",
+          "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. If nothing needs attention, reply HEARTBEAT_OK.",
       }),
     ).toBe(true);
-  });
 
-  it("returns true for task-based heartbeat prompt", () => {
-    expect(
-      isHeartbeatUserMessage({
-        role: "user",
-        content:
-          "Run the following periodic tasks:\n- email-check: Check for urgent unread emails\nAfter completing all due tasks, reply HEARTBEAT_OK.",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns true for content block array containing HEARTBEAT_OK", () => {
-    expect(
-      isHeartbeatUserMessage({
-        role: "user",
-        content: [
-          { type: "text", text: "Check workspace and reply HEARTBEAT_OK if nothing to do." },
-        ],
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false for normal user message", () => {
-    expect(
-      isHeartbeatUserMessage({
-        role: "user",
-        content: "What is the weather today?",
-      }),
-    ).toBe(false);
-  });
-
-  it("returns false for assistant messages", () => {
-    expect(
-      isHeartbeatUserMessage({
-        role: "assistant",
-        content: "HEARTBEAT_OK",
-      }),
-    ).toBe(false);
-  });
-
-  it("returns false for normal conversation that quotes the token", () => {
-    expect(
-      isHeartbeatUserMessage({
-        role: "user",
-        content: "What does HEARTBEAT_OK mean? I keep seeing it in logs.",
-      }),
-    ).toBe(false);
-  });
-
-  it("returns true for respond-style heartbeat prompt", () => {
-    expect(
-      isHeartbeatUserMessage({
-        role: "user",
-        content: "Check on things and respond with HEARTBEAT_OK if all clear.",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns true for custom prompt using 'return'", () => {
     expect(
       isHeartbeatUserMessage({
         role: "user",
@@ -81,37 +22,33 @@ describe("isHeartbeatUserMessage", () => {
       }),
     ).toBe(true);
   });
-});
 
-describe("isHeartbeatOkResponse", () => {
-  it("returns true for plain HEARTBEAT_OK", () => {
+  it("ignores quoted or non-user token mentions", () => {
     expect(
-      isHeartbeatOkResponse({
+      isHeartbeatUserMessage({
+        role: "user",
+        content: "What does HEARTBEAT_OK mean? I keep seeing it in logs.",
+      }),
+    ).toBe(false);
+
+    expect(
+      isHeartbeatUserMessage({
         role: "assistant",
         content: "HEARTBEAT_OK",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
+});
 
-  it("returns true for HEARTBEAT_OK with markup", () => {
+describe("isHeartbeatOkResponse", () => {
+  it("matches no-op heartbeat acknowledgements", () => {
     expect(
       isHeartbeatOkResponse({
         role: "assistant",
         content: "**HEARTBEAT_OK**",
       }),
     ).toBe(true);
-  });
 
-  it("returns true for HEARTBEAT_OK in content blocks", () => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "assistant",
-        content: [{ type: "text", text: "HEARTBEAT_OK" }],
-      }),
-    ).toBe(true);
-  });
-
-  it("returns true for short text ending in HEARTBEAT_OK", () => {
     expect(
       isHeartbeatOkResponse({
         role: "assistant",
@@ -120,95 +57,14 @@ describe("isHeartbeatOkResponse", () => {
     ).toBe(true);
   });
 
-  it("returns false for user messages", () => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "user",
-        content: "HEARTBEAT_OK",
-      }),
-    ).toBe(false);
-  });
-
-  it("returns true for empty content (ok-empty no-op heartbeat)", () => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "assistant",
-        content: "",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns true for whitespace-only content", () => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "assistant",
-        content: "   ",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns true for HEARTBEAT_OK with responsePrefix", () => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "assistant",
-        content: "Nex HEARTBEAT_OK",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns true for HEARTBEAT_OK with emoji suffix", () => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "assistant",
-        content: "HEARTBEAT_OK 👍",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns true for HEARTBEAT_OK with HTML wrapper", () => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "assistant",
-        content: "<b>HEARTBEAT_OK</b>",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns true for HEARTBEAT_OK with short alphanumeric suffix", () => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "assistant",
-        content: "HEARTBEAT_OK all good",
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false for HEARTBEAT_OK followed by long real content", () => {
-    expect(
-      isHeartbeatOkResponse({
-        role: "assistant",
-        content:
-          "HEARTBEAT_OK " +
-          "but I noticed you have 3 urgent emails and a calendar event in 30 minutes. " +
-          "Also your Tesla is at 15% charge and the weather forecast shows heavy rain. " +
-          "I recommend charging the car now and bringing an umbrella. " +
-          "Additionally there are 5 open PRs that need your review and the CI pipeline " +
-          "has been failing for the last 3 hours due to a flaky test in the extension shards. " +
-          "I have drafted a summary of all action items for your review.",
-      }),
-    ).toBe(false);
-  });
-
-  it("returns false for HEARTBEAT_OK mentioned mid-sentence", () => {
+  it("preserves meaningful or non-text responses", () => {
     expect(
       isHeartbeatOkResponse({
         role: "assistant",
         content: "Status HEARTBEAT_OK due to watchdog failure",
       }),
     ).toBe(false);
-  });
 
-  it("returns false for non-text content blocks", () => {
     expect(
       isHeartbeatOkResponse({
         role: "assistant",
@@ -231,18 +87,17 @@ describe("isHeartbeatOkResponse", () => {
 });
 
 describe("filterHeartbeatPairs", () => {
-  it("removes heartbeat user+HEARTBEAT_OK assistant pairs", () => {
+  it("removes no-op heartbeat pairs", () => {
     const messages = [
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi there!" },
-      { role: "user", content: "Read HEARTBEAT.md if it exists. reply HEARTBEAT_OK." },
+      { role: "user", content: "reply HEARTBEAT_OK if nothing." },
       { role: "assistant", content: "HEARTBEAT_OK" },
       { role: "user", content: "What time is it?" },
       { role: "assistant", content: "It is 3pm." },
     ];
 
-    const filtered = filterHeartbeatPairs(messages);
-    expect(filtered).toEqual([
+    expect(filterHeartbeatPairs(messages)).toEqual([
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi there!" },
       { role: "user", content: "What time is it?" },
@@ -250,60 +105,20 @@ describe("filterHeartbeatPairs", () => {
     ]);
   });
 
-  it("preserves heartbeat turns that produced real content", () => {
-    const messages = [
-      { role: "user", content: "Read HEARTBEAT.md. reply HEARTBEAT_OK if nothing to do." },
-      { role: "assistant", content: "You have 3 urgent emails to review." },
-    ];
-
-    const filtered = filterHeartbeatPairs(messages);
-    expect(filtered).toEqual(messages);
-  });
-
-  it("removes multiple consecutive heartbeat pairs", () => {
-    const messages = [
+  it("keeps meaningful heartbeat results and non-text assistant turns", () => {
+    const meaningfulMessages = [
       { role: "user", content: "reply HEARTBEAT_OK if nothing." },
-      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "assistant", content: "Status HEARTBEAT_OK due to watchdog failure" },
+    ];
+    expect(filterHeartbeatPairs(meaningfulMessages)).toEqual(meaningfulMessages);
+
+    const nonTextMessages = [
       { role: "user", content: "reply HEARTBEAT_OK if nothing." },
-      { role: "assistant", content: "HEARTBEAT_OK" },
-      { role: "user", content: "What is 2+2?" },
-      { role: "assistant", content: "4" },
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tool-1", name: "search", input: {} }],
+      },
     ];
-
-    const filtered = filterHeartbeatPairs(messages);
-    expect(filtered).toEqual([
-      { role: "user", content: "What is 2+2?" },
-      { role: "assistant", content: "4" },
-    ]);
-  });
-
-  it("returns original array if no heartbeat pairs found", () => {
-    const messages = [
-      { role: "user", content: "Hello" },
-      { role: "assistant", content: "Hi" },
-    ];
-
-    const filtered = filterHeartbeatPairs(messages);
-    expect(filtered).toEqual(messages);
-  });
-
-  it("handles empty message array", () => {
-    expect(filterHeartbeatPairs([])).toEqual([]);
-  });
-
-  it("handles single message", () => {
-    const messages = [{ role: "user", content: "Hello" }];
-    expect(filterHeartbeatPairs(messages)).toEqual(messages);
-  });
-
-  it("does not filter heartbeat user message without matching assistant response", () => {
-    const messages = [
-      { role: "user", content: "reply HEARTBEAT_OK." },
-      { role: "user", content: "Actually, check my calendar." },
-      { role: "assistant", content: "You have a meeting at 3pm." },
-    ];
-
-    const filtered = filterHeartbeatPairs(messages);
-    expect(filtered).toEqual(messages);
+    expect(filterHeartbeatPairs(nonTextMessages)).toEqual(nonTextMessages);
   });
 });

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -1,5 +1,8 @@
 import { stripHeartbeatToken } from "./heartbeat.js";
-import { HEARTBEAT_TOKEN } from "./tokens.js";
+
+const HEARTBEAT_TASK_PROMPT_PREFIX =
+  "Run the following periodic tasks (only those due based on their intervals):";
+const HEARTBEAT_TASK_PROMPT_ACK = "After completing all due tasks, reply HEARTBEAT_OK.";
 
 function resolveMessageText(content: unknown): { text: string; hasNonTextContent: boolean } {
   if (typeof content === "string") {
@@ -30,14 +33,24 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
   return { text, hasNonTextContent };
 }
 
-export function isHeartbeatUserMessage(message: { role: string; content?: unknown }): boolean {
+export function isHeartbeatUserMessage(
+  message: { role: string; content?: unknown },
+  heartbeatPrompt?: string,
+): boolean {
   if (message.role !== "user") {
     return false;
   }
   const { text } = resolveMessageText(message.content);
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const normalizedHeartbeatPrompt = heartbeatPrompt?.trim();
+  if (normalizedHeartbeatPrompt && trimmed.startsWith(normalizedHeartbeatPrompt)) {
+    return true;
+  }
   return (
-    text.includes(HEARTBEAT_TOKEN) &&
-    /(?:reply|respond|return|say|output|answer)\s+(?:with\s+)?HEARTBEAT_OK/i.test(text)
+    trimmed.startsWith(HEARTBEAT_TASK_PROMPT_PREFIX) && trimmed.includes(HEARTBEAT_TASK_PROMPT_ACK)
   );
 }
 
@@ -58,6 +71,7 @@ export function isHeartbeatOkResponse(
 export function filterHeartbeatPairs<T extends { role: string; content?: unknown }>(
   messages: T[],
   ackMaxChars?: number,
+  heartbeatPrompt?: string,
 ): T[] {
   if (messages.length < 2) {
     return messages;
@@ -68,7 +82,7 @@ export function filterHeartbeatPairs<T extends { role: string; content?: unknown
   while (i < messages.length) {
     if (
       i + 1 < messages.length &&
-      isHeartbeatUserMessage(messages[i]) &&
+      isHeartbeatUserMessage(messages[i], heartbeatPrompt) &&
       isHeartbeatOkResponse(messages[i + 1], ackMaxChars)
     ) {
       i += 2;

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -25,17 +25,25 @@ function extractMessageText(content: unknown): string {
 }
 
 /**
- * Check if a user message looks like a heartbeat prompt.
+ * Check if a user message looks like a system-generated heartbeat prompt.
+ *
  * Heartbeat prompts instruct the model to "reply HEARTBEAT_OK" when nothing
- * needs attention — this pattern is present in all heartbeat prompt variants
- * (default, task-based, custom).
+ * needs attention.  To avoid false positives on normal conversation turns
+ * that merely quote or discuss the token (e.g. debugging heartbeat behaviour),
+ * we require the instruction phrase pattern — not just the bare token.
  */
 export function isHeartbeatUserMessage(message: { role: string; content?: unknown }): boolean {
   if (message.role !== "user") {
     return false;
   }
   const text = extractMessageText(message.content);
-  return text.includes(HEARTBEAT_TOKEN);
+  // All heartbeat prompt variants (default, task-based, custom) use one of
+  // these instruction phrases.  A plain mention of "HEARTBEAT_OK" in normal
+  // conversation (e.g. "what does HEARTBEAT_OK mean?") won't match.
+  return (
+    text.includes(HEARTBEAT_TOKEN) &&
+    (/reply\s+HEARTBEAT_OK/i.test(text) || /respond.*HEARTBEAT_OK/i.test(text))
+  );
 }
 
 /**
@@ -59,8 +67,12 @@ function stripMarkup(text: string): string {
  * Check if an assistant message is effectively a HEARTBEAT_OK response
  * (no actionable content beyond the token itself).
  *
- * Only matches responses that are purely the HEARTBEAT_OK token, possibly
- * wrapped in markup. Responses with additional real content are preserved.
+ * Matches responses that are purely the HEARTBEAT_OK token — possibly
+ * wrapped in markup, preceded by a responsePrefix, or followed by
+ * lightweight suffixes (emoji, punctuation) that don't carry real content.
+ * This mirrors the detection logic in heartbeat-events-filter.ts.
+ *
+ * Responses with additional real content are preserved.
  */
 export function isHeartbeatOkResponse(message: { role: string; content?: unknown }): boolean {
   if (message.role !== "assistant") {
@@ -71,8 +83,30 @@ export function isHeartbeatOkResponse(message: { role: string; content?: unknown
     return false;
   }
   const normalized = stripMarkup(text);
-  // Match only when the entire response (after normalizing markup) is just the token
-  return normalized === HEARTBEAT_TOKEN;
+  if (!normalized.includes(HEARTBEAT_TOKEN)) {
+    return false;
+  }
+
+  // Strip the HEARTBEAT_OK token and check if only lightweight noise remains.
+  // Handles: "HEARTBEAT_OK", "Nex HEARTBEAT_OK", "HEARTBEAT_OK 👍",
+  //          "**HEARTBEAT_OK**", responsePrefix + token, etc.
+  const tokenIdx = normalized.indexOf(HEARTBEAT_TOKEN);
+  const before = normalized.slice(0, tokenIdx).trim();
+  const after = normalized.slice(tokenIdx + HEARTBEAT_TOKEN.length).trim();
+
+  // Content before the token must be empty or a short prefix (responsePrefix
+  // is typically just the agent name — a single word).
+  if (before && before.split(/\s+/).length > 2) {
+    return false;
+  }
+
+  // Content after the token must be empty or non-alphanumeric noise (emoji,
+  // punctuation).  Any word character after the token means real content.
+  if (after && /[a-zA-Z0-9]/.test(after)) {
+    return false;
+  }
+
+  return true;
 }
 
 /**

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -1,28 +1,33 @@
-import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from "./heartbeat.js";
+import { stripHeartbeatToken } from "./heartbeat.js";
 import { HEARTBEAT_TOKEN } from "./tokens.js";
 
-/**
- * Extract text content from a message's content field.
- * Handles both string content and content block arrays.
- */
-function extractMessageText(content: unknown): string {
+function resolveMessageText(content: unknown): { text: string; hasNonTextContent: boolean } {
   if (typeof content === "string") {
-    return content;
+    return { text: content, hasNonTextContent: false };
   }
   if (!Array.isArray(content)) {
-    return "";
+    return { text: "", hasNonTextContent: content != null };
   }
-  return content
-    .filter(
-      (block): block is { type: "text"; text: string } =>
-        typeof block === "object" &&
-        block !== null &&
-        "type" in block &&
-        block.type === "text" &&
-        typeof (block as { text?: unknown }).text === "string",
-    )
+  let hasNonTextContent = false;
+  const text = content
+    .filter((block): block is { type: "text"; text: string } => {
+      if (typeof block !== "object" || block === null || !("type" in block)) {
+        hasNonTextContent = true;
+        return false;
+      }
+      if (block.type !== "text") {
+        hasNonTextContent = true;
+        return false;
+      }
+      if (typeof (block as { text?: unknown }).text !== "string") {
+        hasNonTextContent = true;
+        return false;
+      }
+      return true;
+    })
     .map((block) => block.text)
     .join("");
+  return { text, hasNonTextContent };
 }
 
 /**
@@ -37,7 +42,7 @@ export function isHeartbeatUserMessage(message: { role: string; content?: unknow
   if (message.role !== "user") {
     return false;
   }
-  const text = extractMessageText(message.content);
+  const { text } = resolveMessageText(message.content);
   // Heartbeat prompts instruct the model with a verb + HEARTBEAT_OK pattern.
   // A plain mention of "HEARTBEAT_OK" in normal conversation (e.g. "what does
   // HEARTBEAT_OK mean?") won't match.  We accept common instruction verbs to
@@ -49,71 +54,24 @@ export function isHeartbeatUserMessage(message: { role: string; content?: unknow
 }
 
 /**
- * Strip lightweight markup (HTML tags, markdown bold/italic/code wrappers)
- * so "**HEARTBEAT_OK**" normalizes to "HEARTBEAT_OK".
- */
-function stripMarkup(text: string): string {
-  return (
-    text
-      .replace(/<[^>]*>/g, " ")
-      .replace(/&nbsp;/gi, " ")
-      .trim()
-      // Strip leading/trailing markdown wrappers
-      .replace(/^[*`~_]+/, "")
-      .replace(/[*`~_]+$/, "")
-      .trim()
-  );
-}
-
-/**
  * Check if an assistant message is effectively a HEARTBEAT_OK response
  * (no actionable content beyond the token itself).
  *
- * Matches responses that are purely the HEARTBEAT_OK token — possibly
- * wrapped in markup, preceded by a responsePrefix, or followed by
- * lightweight suffixes (emoji, punctuation) that don't carry real content.
- * This mirrors the detection logic in heartbeat-events-filter.ts.
- *
- * Responses with additional real content are preserved.
+ * Reuse the runtime heartbeat suppression rule so prompt filtering and
+ * compaction deletion make the same keep/remove decision as heartbeat send.
  */
-export function isHeartbeatOkResponse(message: { role: string; content?: unknown }): boolean {
+export function isHeartbeatOkResponse(
+  message: { role: string; content?: unknown },
+  ackMaxChars?: number,
+): boolean {
   if (message.role !== "assistant") {
     return false;
   }
-  const text = extractMessageText(message.content);
-  // Empty/blank assistant responses from heartbeat runs are classified as
-  // "ok-empty" no-ops by runHeartbeatOnce — treat them as removable acks
-  // so they don't accumulate in history after transcript pruning was removed.
-  if (!text || !text.trim()) {
-    return true;
-  }
-  const normalized = stripMarkup(text);
-  if (!normalized.includes(HEARTBEAT_TOKEN)) {
+  const { text, hasNonTextContent } = resolveMessageText(message.content);
+  if (hasNonTextContent) {
     return false;
   }
-
-  // Strip the HEARTBEAT_OK token and check if only lightweight noise remains.
-  // Handles: "HEARTBEAT_OK", "Nex HEARTBEAT_OK", "HEARTBEAT_OK 👍",
-  //          "**HEARTBEAT_OK**", responsePrefix + token, etc.
-  const tokenIdx = normalized.indexOf(HEARTBEAT_TOKEN);
-  const before = normalized.slice(0, tokenIdx).trim();
-  const after = normalized.slice(tokenIdx + HEARTBEAT_TOKEN.length).trim();
-
-  // Content before the token must be empty or a short prefix (responsePrefix
-  // is typically just the agent name — a single word).
-  if (before && before.split(/\s+/).length > 2) {
-    return false;
-  }
-
-  // Content after the token is allowed up to DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
-  // matching the suppression logic in heartbeat.ts (stripHeartbeatToken).
-  // Short suffixes like "all good" or "👍" are treated as ack noise.
-  // Anything longer is real content worth preserving.
-  if (after.length > DEFAULT_HEARTBEAT_ACK_MAX_CHARS) {
-    return false;
-  }
-
-  return true;
+  return stripHeartbeatToken(text, { mode: "heartbeat", maxAckChars: ackMaxChars }).shouldSkip;
 }
 
 /**
@@ -128,6 +86,7 @@ export function isHeartbeatOkResponse(message: { role: string; content?: unknown
  */
 export function filterHeartbeatPairs<T extends { role: string; content?: unknown }>(
   messages: T[],
+  ackMaxChars?: number,
 ): T[] {
   if (messages.length < 2) {
     return messages;
@@ -140,7 +99,7 @@ export function filterHeartbeatPairs<T extends { role: string; content?: unknown
     if (
       i + 1 < messages.length &&
       isHeartbeatUserMessage(messages[i]) &&
-      isHeartbeatOkResponse(messages[i + 1])
+      isHeartbeatOkResponse(messages[i + 1], ackMaxChars)
     ) {
       // Skip both the user message and the HEARTBEAT_OK response
       i += 2;

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -81,8 +81,11 @@ export function isHeartbeatOkResponse(message: { role: string; content?: unknown
     return false;
   }
   const text = extractMessageText(message.content);
-  if (!text) {
-    return false;
+  // Empty/blank assistant responses from heartbeat runs are classified as
+  // "ok-empty" no-ops by runHeartbeatOnce — treat them as removable acks
+  // so they don't accumulate in history after transcript pruning was removed.
+  if (!text || !text.trim()) {
+    return true;
   }
   const normalized = stripMarkup(text);
   if (!normalized.includes(HEARTBEAT_TOKEN)) {

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS } from "./heartbeat.js";
 import { HEARTBEAT_TOKEN } from "./tokens.js";
 
 /**
@@ -37,12 +38,13 @@ export function isHeartbeatUserMessage(message: { role: string; content?: unknow
     return false;
   }
   const text = extractMessageText(message.content);
-  // All heartbeat prompt variants (default, task-based, custom) use one of
-  // these instruction phrases.  A plain mention of "HEARTBEAT_OK" in normal
-  // conversation (e.g. "what does HEARTBEAT_OK mean?") won't match.
+  // Heartbeat prompts instruct the model with a verb + HEARTBEAT_OK pattern.
+  // A plain mention of "HEARTBEAT_OK" in normal conversation (e.g. "what does
+  // HEARTBEAT_OK mean?") won't match.  We accept common instruction verbs to
+  // cover default, task-based, and custom heartbeat prompts.
   return (
     text.includes(HEARTBEAT_TOKEN) &&
-    (/reply\s+HEARTBEAT_OK/i.test(text) || /respond.*HEARTBEAT_OK/i.test(text))
+    /(?:reply|respond|return|say|output|answer)\s+(?:with\s+)?HEARTBEAT_OK/i.test(text)
   );
 }
 
@@ -100,9 +102,11 @@ export function isHeartbeatOkResponse(message: { role: string; content?: unknown
     return false;
   }
 
-  // Content after the token must be empty or non-alphanumeric noise (emoji,
-  // punctuation).  Any word character after the token means real content.
-  if (after && /[a-zA-Z0-9]/.test(after)) {
+  // Content after the token is allowed up to DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
+  // matching the suppression logic in heartbeat.ts (stripHeartbeatToken).
+  // Short suffixes like "all good" or "👍" are treated as ack noise.
+  // Anything longer is real content worth preserving.
+  if (after.length > DEFAULT_HEARTBEAT_ACK_MAX_CHARS) {
     return false;
   }
 

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -47,6 +47,7 @@ function stripMarkup(text: string): string {
     text
       .replace(/<[^>]*>/g, " ")
       .replace(/&nbsp;/gi, " ")
+      .trim()
       // Strip leading/trailing markdown wrappers
       .replace(/^[*`~_]+/, "")
       .replace(/[*`~_]+$/, "")

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -30,36 +30,17 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
   return { text, hasNonTextContent };
 }
 
-/**
- * Check if a user message looks like a system-generated heartbeat prompt.
- *
- * Heartbeat prompts instruct the model to "reply HEARTBEAT_OK" when nothing
- * needs attention.  To avoid false positives on normal conversation turns
- * that merely quote or discuss the token (e.g. debugging heartbeat behaviour),
- * we require the instruction phrase pattern — not just the bare token.
- */
 export function isHeartbeatUserMessage(message: { role: string; content?: unknown }): boolean {
   if (message.role !== "user") {
     return false;
   }
   const { text } = resolveMessageText(message.content);
-  // Heartbeat prompts instruct the model with a verb + HEARTBEAT_OK pattern.
-  // A plain mention of "HEARTBEAT_OK" in normal conversation (e.g. "what does
-  // HEARTBEAT_OK mean?") won't match.  We accept common instruction verbs to
-  // cover default, task-based, and custom heartbeat prompts.
   return (
     text.includes(HEARTBEAT_TOKEN) &&
     /(?:reply|respond|return|say|output|answer)\s+(?:with\s+)?HEARTBEAT_OK/i.test(text)
   );
 }
 
-/**
- * Check if an assistant message is effectively a HEARTBEAT_OK response
- * (no actionable content beyond the token itself).
- *
- * Reuse the runtime heartbeat suppression rule so prompt filtering and
- * compaction deletion make the same keep/remove decision as heartbeat send.
- */
 export function isHeartbeatOkResponse(
   message: { role: string; content?: unknown },
   ackMaxChars?: number,
@@ -74,16 +55,6 @@ export function isHeartbeatOkResponse(
   return stripHeartbeatToken(text, { mode: "heartbeat", maxAckChars: ackMaxChars }).shouldSkip;
 }
 
-/**
- * Filter out heartbeat user+assistant pairs from a message array.
- *
- * Only removes pairs where:
- * 1. The user message matches the heartbeat prompt pattern (contains HEARTBEAT_OK instruction)
- * 2. The immediately following assistant message is effectively HEARTBEAT_OK (no real content)
- *
- * Heartbeat turns that produced actual content (calendar reminders, email alerts, etc.)
- * are preserved because their assistant response won't match the HEARTBEAT_OK pattern.
- */
 export function filterHeartbeatPairs<T extends { role: string; content?: unknown }>(
   messages: T[],
   ackMaxChars?: number,
@@ -95,13 +66,11 @@ export function filterHeartbeatPairs<T extends { role: string; content?: unknown
   const result: T[] = [];
   let i = 0;
   while (i < messages.length) {
-    // Check for heartbeat user+assistant pair
     if (
       i + 1 < messages.length &&
       isHeartbeatUserMessage(messages[i]) &&
       isHeartbeatOkResponse(messages[i + 1], ackMaxChars)
     ) {
-      // Skip both the user message and the HEARTBEAT_OK response
       i += 2;
       continue;
     }

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -1,0 +1,112 @@
+import { HEARTBEAT_TOKEN } from "./tokens.js";
+
+/**
+ * Extract text content from a message's content field.
+ * Handles both string content and content block arrays.
+ */
+function extractMessageText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .filter(
+      (block): block is { type: "text"; text: string } =>
+        typeof block === "object" &&
+        block !== null &&
+        "type" in block &&
+        block.type === "text" &&
+        typeof (block as { text?: unknown }).text === "string",
+    )
+    .map((block) => block.text)
+    .join("");
+}
+
+/**
+ * Check if a user message looks like a heartbeat prompt.
+ * Heartbeat prompts instruct the model to "reply HEARTBEAT_OK" when nothing
+ * needs attention — this pattern is present in all heartbeat prompt variants
+ * (default, task-based, custom).
+ */
+export function isHeartbeatUserMessage(message: { role: string; content?: unknown }): boolean {
+  if (message.role !== "user") {
+    return false;
+  }
+  const text = extractMessageText(message.content);
+  return text.includes(HEARTBEAT_TOKEN);
+}
+
+/**
+ * Strip lightweight markup (HTML tags, markdown bold/italic/code wrappers)
+ * so "**HEARTBEAT_OK**" normalizes to "HEARTBEAT_OK".
+ */
+function stripMarkup(text: string): string {
+  return (
+    text
+      .replace(/<[^>]*>/g, " ")
+      .replace(/&nbsp;/gi, " ")
+      // Strip leading/trailing markdown wrappers
+      .replace(/^[*`~_]+/, "")
+      .replace(/[*`~_]+$/, "")
+      .trim()
+  );
+}
+
+/**
+ * Check if an assistant message is effectively a HEARTBEAT_OK response
+ * (no actionable content beyond the token itself).
+ *
+ * Only matches responses that are purely the HEARTBEAT_OK token, possibly
+ * wrapped in markup. Responses with additional real content are preserved.
+ */
+export function isHeartbeatOkResponse(message: { role: string; content?: unknown }): boolean {
+  if (message.role !== "assistant") {
+    return false;
+  }
+  const text = extractMessageText(message.content);
+  if (!text) {
+    return false;
+  }
+  const normalized = stripMarkup(text);
+  // Match only when the entire response (after normalizing markup) is just the token
+  return normalized === HEARTBEAT_TOKEN;
+}
+
+/**
+ * Filter out heartbeat user+assistant pairs from a message array.
+ *
+ * Only removes pairs where:
+ * 1. The user message matches the heartbeat prompt pattern (contains HEARTBEAT_OK instruction)
+ * 2. The immediately following assistant message is effectively HEARTBEAT_OK (no real content)
+ *
+ * Heartbeat turns that produced actual content (calendar reminders, email alerts, etc.)
+ * are preserved because their assistant response won't match the HEARTBEAT_OK pattern.
+ */
+export function filterHeartbeatPairs<T extends { role: string; content?: unknown }>(
+  messages: T[],
+): T[] {
+  if (messages.length < 2) {
+    return messages;
+  }
+
+  const result: T[] = [];
+  let i = 0;
+  while (i < messages.length) {
+    // Check for heartbeat user+assistant pair
+    if (
+      i + 1 < messages.length &&
+      isHeartbeatUserMessage(messages[i]) &&
+      isHeartbeatOkResponse(messages[i + 1])
+    ) {
+      // Skip both the user message and the HEARTBEAT_OK response
+      i += 2;
+      continue;
+    }
+    result.push(messages[i]);
+    i++;
+  }
+
+  return result;
+}

--- a/src/infra/heartbeat-runner.transcript-prune.test.ts
+++ b/src/infra/heartbeat-runner.transcript-prune.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
   setupTelegramHeartbeatPluginRuntimeForTests();
 });
 
-describe("heartbeat transcript pruning", () => {
+describe("heartbeat transcript append-only (#39609)", () => {
   async function createTranscriptWithContent(transcriptPath: string, sessionId: string) {
     const header = {
       type: "session",
@@ -40,13 +40,12 @@ describe("heartbeat transcript pruning", () => {
         cacheWriteTokens: number;
       };
     };
-    expectPruned: boolean;
   }) {
     await withTempTelegramHeartbeatSandbox(
       async ({ tmpDir, storePath, replySpy }) => {
         const sessionKey = resolveMainSessionKey(undefined);
         const transcriptPath = path.join(tmpDir, `${params.sessionId}.jsonl`);
-        const originalContent = await createTranscriptWithContent(transcriptPath, params.sessionId);
+        await createTranscriptWithContent(transcriptPath, params.sessionId);
         const originalSize = (await fs.stat(transcriptPath)).size;
 
         await seedSessionStore(storePath, sessionKey, {
@@ -77,37 +76,32 @@ describe("heartbeat transcript pruning", () => {
         });
 
         const finalSize = (await fs.stat(transcriptPath)).size;
-        if (params.expectPruned) {
-          const finalContent = await fs.readFile(transcriptPath, "utf-8");
-          expect(finalContent).toBe(originalContent);
-          expect(finalSize).toBe(originalSize);
-          return;
-        }
+        // Transcript must never be truncated — entries are append-only now.
+        // HEARTBEAT_OK entries stay in the file and are filtered at context
+        // build time instead of being removed via fs.truncate (#39609).
         expect(finalSize).toBeGreaterThanOrEqual(originalSize);
       },
       { prefix: "openclaw-hb-prune-" },
     );
   }
 
-  it("prunes transcript when heartbeat returns HEARTBEAT_OK", async () => {
+  it("does not truncate transcript when heartbeat returns HEARTBEAT_OK", async () => {
     await runTranscriptScenario({
-      sessionId: "test-session-prune",
+      sessionId: "test-session-no-prune",
       reply: {
         text: "HEARTBEAT_OK",
         usage: { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
       },
-      expectPruned: true,
     });
   });
 
-  it("does not prune transcript when heartbeat returns meaningful content", async () => {
+  it("does not truncate transcript when heartbeat returns meaningful content", async () => {
     await runTranscriptScenario({
-      sessionId: "test-session-no-prune",
+      sessionId: "test-session-content",
       reply: {
         text: "Alert: Something needs your attention!",
         usage: { inputTokens: 10, outputTokens: 20, cacheReadTokens: 0, cacheWriteTokens: 0 },
       },
-      expectPruned: false,
     });
   });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -33,7 +33,7 @@ import {
   canonicalizeMainSessionAlias,
   resolveAgentMainSessionKey,
 } from "../config/sessions/main-session.js";
-import { resolveSessionFilePath, resolveStorePath } from "../config/sessions/paths.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
 import { saveSessionStore, updateSessionStore } from "../config/sessions/store.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
@@ -298,58 +298,6 @@ async function restoreHeartbeatUpdatedAt(params: {
     }
     nextStore[sessionKey] = { ...nextEntry, updatedAt: resolvedUpdatedAt };
   });
-}
-
-/**
- * Prune heartbeat transcript entries by truncating the file back to a previous size.
- * This removes the user+assistant turns that were written during a HEARTBEAT_OK run,
- * preventing context pollution from zero-information exchanges.
- */
-async function pruneHeartbeatTranscript(params: {
-  transcriptPath?: string;
-  preHeartbeatSize?: number;
-}) {
-  const { transcriptPath, preHeartbeatSize } = params;
-  if (!transcriptPath || typeof preHeartbeatSize !== "number" || preHeartbeatSize < 0) {
-    return;
-  }
-  try {
-    const stat = await fs.stat(transcriptPath);
-    // Only truncate if the file has grown during the heartbeat run
-    if (stat.size > preHeartbeatSize) {
-      await fs.truncate(transcriptPath, preHeartbeatSize);
-    }
-  } catch {
-    // File may not exist or may have been removed - ignore errors
-  }
-}
-
-/**
- * Get the transcript file path and its current size before a heartbeat run.
- * Returns undefined values if the session or transcript doesn't exist yet.
- */
-async function captureTranscriptState(params: {
-  storePath: string;
-  sessionKey: string;
-  agentId?: string;
-}): Promise<{ transcriptPath?: string; preHeartbeatSize?: number }> {
-  const { storePath, sessionKey, agentId } = params;
-  try {
-    const store = loadSessionStore(storePath);
-    const entry = store[sessionKey];
-    if (!entry?.sessionId) {
-      return {};
-    }
-    const transcriptPath = resolveSessionFilePath(entry.sessionId, entry, {
-      agentId,
-      sessionsDir: path.dirname(storePath),
-    });
-    const stat = await fs.stat(transcriptPath);
-    return { transcriptPath, preHeartbeatSize: stat.size };
-  } catch {
-    // Session or transcript doesn't exist yet - nothing to prune
-    return {};
-  }
 }
 
 function stripLeadingHeartbeatResponsePrefix(
@@ -715,7 +663,6 @@ export async function runHeartbeatOnce(opts: {
   }
 
   let runSessionKey = sessionKey;
-  let runStorePath = storePath;
   if (useIsolatedSession) {
     const isolatedKey = `${sessionKey}:heartbeat`;
     const cronSession = resolveCronSession({
@@ -728,7 +675,6 @@ export async function runHeartbeatOnce(opts: {
     cronSession.store[isolatedKey] = cronSession.sessionEntry;
     await saveSessionStore(cronSession.storePath, cronSession.store);
     runSessionKey = isolatedKey;
-    runStorePath = cronSession.storePath;
   }
 
   // Update task last run times AFTER successful heartbeat completion
@@ -822,14 +768,6 @@ export async function runHeartbeatOnce(opts: {
   };
 
   try {
-    // Capture transcript state before the heartbeat run so we can prune if HEARTBEAT_OK.
-    // For isolated sessions, capture the isolated transcript (not the main session's).
-    const transcriptState = await captureTranscriptState({
-      storePath: runStorePath,
-      sessionKey: runSessionKey,
-      agentId,
-    });
-
     const heartbeatModelOverride = heartbeat?.model?.trim() || undefined;
     const suppressToolErrorWarnings = heartbeat?.suppressToolErrorWarnings === true;
     const bootstrapContextMode: "lightweight" | undefined =
@@ -857,8 +795,7 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
-      // Prune the transcript to remove HEARTBEAT_OK turns
-      await pruneHeartbeatTranscript(transcriptState);
+
       const okSent = await maybeSendHeartbeatOk();
       emitHeartbeatEvent({
         status: "ok-empty",
@@ -894,8 +831,7 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
-      // Prune the transcript to remove HEARTBEAT_OK turns
-      await pruneHeartbeatTranscript(transcriptState);
+
       const okSent = await maybeSendHeartbeatOk();
       emitHeartbeatEvent({
         status: "ok-token",
@@ -932,8 +868,7 @@ export async function runHeartbeatOnce(opts: {
         sessionKey,
         updatedAt: previousUpdatedAt,
       });
-      // Prune the transcript to remove duplicate heartbeat turns
-      await pruneHeartbeatTranscript(transcriptState);
+
       emitHeartbeatEvent({
         status: "skipped",
         reason: "duplicate",


### PR DESCRIPTION
## Summary

Fixes #39609 — heartbeat transcript pruning via `fs.truncate` races with concurrent session writers, causing orphaned `parentId` chains, context collapse, and data loss.

### Changes

1. **Remove `pruneHeartbeatTranscript()` and `captureTranscriptState()`** from `src/infra/heartbeat-runner.ts`. These used `fs.truncate` on live session JSONL files without holding the session write lock. HEARTBEAT_OK entries now stay in the JSONL file (append-only).

2. **Filter heartbeat pairs at context build time** — New `filterHeartbeatPairs()` in `src/auto-reply/heartbeat-filter.ts` removes no-op heartbeat user+assistant pairs from the message array before each model prompt. Only filters pairs where the user message contains the HEARTBEAT_OK instruction AND the assistant response is purely the token (no real content). Applied in `src/agents/pi-embedded-runner/run/attempt.ts`.

3. **Clean up heartbeat pairs during compaction** — `truncateSessionAfterCompaction()` in `src/agents/pi-embedded-runner/session-truncation.ts` now also drops filtered heartbeat pairs when rewriting the session file. Compaction already holds the session write lock, so this is safe.

### Excluded alternatives

- **Acquiring the session write lock for heartbeat**: too invasive, blocks normal turns during heartbeat I/O which can be slow
- **Writing heartbeat entries to a separate file**: adds complexity to session reconstruction and compaction without clear benefit
- **Using file-level locking (flock)**: not portable and doesn't compose with the existing session lock model

## Test plan

- [x] New unit tests for `filterHeartbeatPairs`, `isHeartbeatUserMessage`, `isHeartbeatOkResponse` (18 cases)
- [x] Updated transcript prune tests to verify append-only behavior
- [x] Existing session-truncation tests pass (9 cases)
- [x] `pnpm check` passes (pre-existing TS errors only, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)