### PR TITLE
fix(pi-embedded-runner): scope lastAssistant to current turn to prevent stale response replay on idle timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1903,8 +1903,12 @@ export async function runEmbeddedAttempt(
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
 
+      // Only consider assistant messages from the current turn. Without this
+      // guard, an idle timeout (zero streamed tokens) causes the PREVIOUS
+      // turn's assistant response to be delivered again via the fallback in
+      // buildEmbeddedRunPayloads. See: fork fix for repeat-response bug.
       const lastAssistant = messagesSnapshot
-        .slice()
+        .slice(prePromptMessageCount)
         .toReversed()
         .find((m) => m.role === "assistant");
 

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -213,6 +213,16 @@ describe("buildEmbeddedRunPayloads", () => {
     });
   });
 
+  it("produces no answer text when assistantTexts is empty and lastAssistant is undefined (idle timeout)", () => {
+    // When an LLM idle timeout fires before any tokens stream, attempt.ts
+    // now scopes lastAssistant to the current turn only, yielding undefined.
+    // The payload builder must not produce stale text from a prior turn.
+    expectNoPayloads({
+      assistantTexts: [],
+      lastAssistant: undefined,
+    });
+  });
+
   it("adds tool error fallback when the assistant only invoked tools and verbose mode is on", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({


### PR DESCRIPTION
## Problem

When an LLM idle timeout fires before any tokens are streamed, `lastAssistant` was extracted from the **entire session history** using `.slice()` (no offset). This caused the previous turn's assistant response to be re-delivered verbatim as the current turn's reply.

The bug triggers when:
1. The LLM starts a response but nothing streams within the idle timeout window
2. The timeout fires and `runEmbeddedAttempt` returns with `promptError`
3. `buildEmbeddedRunPayloads` falls back to `lastAssistant?.text` as the payload
4. `lastAssistant` points to the *previous* turn's message — wrong turn

## Fix

Scope `lastAssistant` to only messages from the current turn by slicing at `prePromptMessageCount`:

```ts
// Before
const lastAssistant = messagesSnapshot
  .slice()
  .toReversed()
  .find((m) => m.role === "assistant");

// After
const lastAssistant = messagesSnapshot
  .slice(prePromptMessageCount)   // current-turn messages only
  .toReversed()
  .find((m) => m.role === "assistant");
```

`prePromptMessageCount` is already computed earlier in the same scope as the snapshot length before the prompt call — it's the right boundary.

## Behavior

- **Idle timeout with no streamed tokens**: `lastAssistant` is `undefined` (correct — no current-turn response), payload falls back to error message
- **Idle timeout mid-stream**: `lastAssistant` reflects partial current-turn content (correct)
- **Normal completion**: unaffected — `lastAssistant` was already the latest message