### PR TITLE
fix(pnpm-workspace): add acpx to `minimumReleaseAgeExclude`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,8 +512,6 @@ importers:
 
   extensions/mistral: {}
 
-  extensions/modelstudio: {}
-
   extensions/moonshot: {}
 
   extensions/msteams:
@@ -591,6 +589,8 @@ importers:
         specifier: workspace:*
         version: link:../..
 
+  extensions/qwen: {}
+
   extensions/searxng: {}
 
   extensions/sglang: {}
@@ -664,6 +664,8 @@ importers:
   extensions/venice: {}
 
   extensions/vercel-ai-gateway: {}
+
+  extensions/video-generation-core: {}
 
   extensions/vllm: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
+  - "acpx"
   - "openclaw"
   - "@mariozechner/*"
   - "@typescript/native-preview*"


### PR DESCRIPTION
adds `acpx` to `minimumReleaseAgeExclude` for `pnpm install` to pass