### PR TITLE
fix(android): follow up voice reply playback on top of #60954

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -747,7 +747,7 @@ class NodeRuntime(
     prefs.setTalkEnabled(value)
     if (value) {
       // Tapping mic on interrupts any active TTS (barge-in)
-      talkMode.stopTts()
+      stopVoicePlayback()
       talkMode.ttsOnAllResponses = false
       scope.launch { talkMode.ensureChatSubscribed() }
     }
@@ -769,10 +769,17 @@ class NodeRuntime(
 
   private fun stopActiveVoiceSession() {
     talkMode.ttsOnAllResponses = false
-    talkMode.stopTts()
+    stopVoicePlayback()
     micCapture.setMicEnabled(false)
     prefs.setTalkEnabled(false)
     externalAudioCaptureActive.value = false
+  }
+
+  private fun stopVoicePlayback() {
+    talkMode.stopTts()
+    if (voiceReplySpeakerLazy.isInitialized()) {
+      voiceReplySpeaker.stopTts()
+    }
   }
 
   fun refreshGatewayConnection() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -373,11 +373,10 @@ class NodeRuntime(
         parseChatSendRunId(response) ?: idempotencyKey
       },
       speakAssistantReply = { text ->
-        // Skip if TalkModeManager is handling TTS (ttsOnAllResponses) to avoid
-        // double-speaking the same assistant reply from both pipelines.
-        if (!talkMode.ttsOnAllResponses) {
-          voiceReplySpeaker.speakAssistantReply(text)
-        }
+        // Voice-tab replies should speak through the dedicated reply speaker.
+        // Relying on talkMode.ttsOnAllResponses here can drop playback if the
+        // chat-event path misses the terminal event for this turn.
+        voiceReplySpeaker.speakAssistantReply(text)
       },
     )
   }
@@ -583,12 +582,11 @@ class NodeRuntime(
 
     scope.launch {
       prefs.talkEnabled.collect { enabled ->
-        // MicCaptureManager handles STT + send to gateway.
-        // TalkModeManager plays TTS on assistant responses.
+        // MicCaptureManager handles STT + send to gateway, while the dedicated
+        // reply speaker handles TTS for assistant replies in the voice tab.
         micCapture.setMicEnabled(enabled)
         if (enabled) {
-          // Mic on = user is on voice screen and wants TTS responses.
-          talkMode.ttsOnAllResponses = true
+          talkMode.ttsOnAllResponses = false
           scope.launch { talkMode.ensureChatSubscribed() }
         }
         externalAudioCaptureActive.value = enabled
@@ -750,7 +748,7 @@ class NodeRuntime(
     if (value) {
       // Tapping mic on interrupts any active TTS (barge-in)
       talkMode.stopTts()
-      talkMode.ttsOnAllResponses = true
+      talkMode.ttsOnAllResponses = false
       scope.launch { talkMode.ensureChatSubscribed() }
     }
     micCapture.setMicEnabled(value)
@@ -765,7 +763,7 @@ class NodeRuntime(
     if (voiceReplySpeakerLazy.isInitialized()) {
       voiceReplySpeaker.setPlaybackEnabled(value)
     }
-    // Keep TalkMode in sync so speaker mute works when ttsOnAllResponses is active.
+    // Keep TalkMode in sync so any active Talk playback also respects speaker mute.
     talkMode.setPlaybackEnabled(value)
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -174,7 +174,7 @@ class MicCaptureManager(
     pendingRunId = null
     pendingAssistantEntryId = null
     _isSending.value = false
-    if (messageQueue.isNotEmpty()) {
+    if (hasQueuedMessages()) {
       _statusText.value = queuedWaitingStatus()
     }
   }
@@ -282,7 +282,7 @@ class MicCaptureManager(
     _statusText.value =
       when {
         _isSending.value -> "Listening · sending queued voice"
-        messageQueue.isNotEmpty() -> "Listening · ${messageQueue.size} queued"
+        hasQueuedMessages() -> "Listening · ${queuedMessageCount()} queued"
         else -> "Listening"
       }
     _isListening.value = true

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -88,6 +88,7 @@ class MicCaptureManager(
   val isSending: StateFlow<Boolean> = _isSending
 
   private val messageQueue = ArrayDeque<String>()
+  private val messageQueueLock = Any()
   private var flushedPartialTranscript: String? = null
   private var pendingRunId: String? = null
   private var pendingAssistantEntryId: String? = null
@@ -99,6 +100,42 @@ class MicCaptureManager(
   private var transcriptFlushJob: Job? = null
   private var pendingRunTimeoutJob: Job? = null
   private var stopRequested = false
+
+  private fun enqueueMessage(message: String) {
+    synchronized(messageQueueLock) {
+      messageQueue.addLast(message)
+    }
+  }
+
+  private fun snapshotMessageQueue(): List<String> {
+    return synchronized(messageQueueLock) {
+      messageQueue.toList()
+    }
+  }
+
+  private fun hasQueuedMessages(): Boolean {
+    return synchronized(messageQueueLock) {
+      messageQueue.isNotEmpty()
+    }
+  }
+
+  private fun firstQueuedMessage(): String? {
+    return synchronized(messageQueueLock) {
+      messageQueue.firstOrNull()
+    }
+  }
+
+  private fun removeFirstQueuedMessage(): String? {
+    return synchronized(messageQueueLock) {
+      if (messageQueue.isEmpty()) null else messageQueue.removeFirst()
+    }
+  }
+
+  private fun queuedMessageCount(): Int {
+    return synchronized(messageQueueLock) {
+      messageQueue.size
+    }
+  }
 
   fun setMicEnabled(enabled: Boolean) {
     if (_micEnabled.value == enabled) return
@@ -278,7 +315,7 @@ class MicCaptureManager(
       role = VoiceConversationRole.User,
       text = message,
     )
-    messageQueue.addLast(message)
+    enqueueMessage(message)
     publishQueue()
   }
 
@@ -297,12 +334,12 @@ class MicCaptureManager(
   }
 
   private fun publishQueue() {
-    _queuedMessages.value = messageQueue.toList()
+    _queuedMessages.value = snapshotMessageQueue()
   }
 
   private fun sendQueuedIfIdle() {
     if (_isSending.value) return
-    if (messageQueue.isEmpty()) {
+    if (!hasQueuedMessages()) {
       if (_micEnabled.value) {
         _statusText.value = "Listening"
       } else {
@@ -315,7 +352,7 @@ class MicCaptureManager(
       return
     }
 
-    val next = messageQueue.first()
+    val next = firstQueuedMessage() ?: return
     _isSending.value = true
     pendingRunTimeoutJob?.cancel()
     pendingRunTimeoutJob = null
@@ -333,7 +370,7 @@ class MicCaptureManager(
         if (runId == null) {
           pendingRunTimeoutJob?.cancel()
           pendingRunTimeoutJob = null
-          messageQueue.removeFirst()
+          removeFirstQueuedMessage()
           publishQueue()
           _isSending.value = false
           pendingAssistantEntryId = null
@@ -379,8 +416,7 @@ class MicCaptureManager(
   private fun completePendingTurn() {
     pendingRunTimeoutJob?.cancel()
     pendingRunTimeoutJob = null
-    if (messageQueue.isNotEmpty()) {
-      messageQueue.removeFirst()
+    if (removeFirstQueuedMessage() != null) {
       publishQueue()
     }
     pendingRunId = null
@@ -390,7 +426,7 @@ class MicCaptureManager(
   }
 
   private fun queuedWaitingStatus(): String {
-    return "${messageQueue.size} queued · waiting for gateway"
+    return "${queuedMessageCount()} queued · waiting for gateway"
   }
 
   private fun appendConversation(

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { talkHandlers } from "./talk.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn<() => OpenClawConfig>(),
+  readConfigFileSnapshot: vi.fn(),
+  canonicalizeSpeechProviderId: vi.fn((providerId: string | undefined) => providerId),
+  getSpeechProvider: vi.fn(),
+  synthesizeSpeech: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+}));
+
+vi.mock("../../tts/provider-registry.js", () => ({
+  canonicalizeSpeechProviderId: mocks.canonicalizeSpeechProviderId,
+  getSpeechProvider: mocks.getSpeechProvider,
+}));
+
+vi.mock("../../tts/tts.js", () => ({
+  synthesizeSpeech: mocks.synthesizeSpeech,
+}));
+
+function createTalkConfig(apiKey: unknown): OpenClawConfig {
+  return {
+    talk: {
+      provider: "elevenlabs",
+      providers: {
+        elevenlabs: {
+          apiKey,
+          voiceId: "voice-default",
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("talk.speak handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the active runtime config snapshot instead of the raw config snapshot", async () => {
+    const runtimeConfig = createTalkConfig("env-elevenlabs-key");
+    const diskConfig = createTalkConfig({
+      source: "env",
+      provider: "default",
+      id: "ELEVENLABS_API_KEY",
+    });
+
+    mocks.loadConfig.mockReturnValue(runtimeConfig);
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/openclaw.json",
+      hash: "test-hash",
+      valid: true,
+      config: diskConfig,
+    });
+    mocks.getSpeechProvider.mockReturnValue({
+      id: "elevenlabs",
+      label: "ElevenLabs",
+      resolveTalkConfig: ({
+        talkProviderConfig,
+      }: {
+        talkProviderConfig: Record<string, unknown>;
+      }) => talkProviderConfig,
+    });
+    mocks.synthesizeSpeech.mockImplementation(
+      async ({ cfg }: { cfg: OpenClawConfig; text: string; disableFallback: boolean }) => {
+        expect(cfg.messages?.tts?.provider).toBe("elevenlabs");
+        expect(cfg.messages?.tts?.providers?.elevenlabs?.apiKey).toBe("env-elevenlabs-key");
+        return {
+          success: true,
+          provider: "elevenlabs",
+          audioBuffer: Buffer.from([1, 2, 3]),
+          outputFormat: "mp3",
+          voiceCompatible: false,
+          fileExtension: ".mp3",
+        };
+      },
+    );
+
+    const respond = vi.fn();
+    await talkHandlers["talk.speak"]({
+      req: { type: "req", id: "1", method: "talk.speak" },
+      params: { text: "Hello from talk mode." },
+      client: null,
+      isWebchatConnect: () => false,
+      respond: respond as never,
+      context: {} as never,
+    });
+
+    expect(mocks.loadConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+    expect(mocks.synthesizeSpeech).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Hello from talk mode.",
+        disableFallback: true,
+      }),
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        provider: "elevenlabs",
+        audioBase64: Buffer.from([1, 2, 3]).toString("base64"),
+        outputFormat: "mp3",
+        mimeType: "audio/mpeg",
+        fileExtension: ".mp3",
+      }),
+      undefined,
+    );
+  });
+});

--- a/src/gateway/server-methods/talk.ts
+++ b/src/gateway/server-methods/talk.ts
@@ -1,4 +1,4 @@
-import { readConfigFileSnapshot } from "../../config/config.js";
+import { loadConfig, readConfigFileSnapshot } from "../../config/config.js";
 import { redactConfigObject } from "../../config/redact-snapshot.js";
 import { buildTalkConfigResponse, resolveActiveTalkProviderConfig } from "../../config/talk.js";
 import type { TalkProviderConfig } from "../../config/types.gateway.js";
@@ -304,8 +304,8 @@ export const talkHandlers: GatewayRequestHandlers = {
     }
 
     try {
-      const snapshot = await readConfigFileSnapshot();
-      const setup = buildTalkTtsConfig(snapshot.config);
+      const runtimeConfig = loadConfig();
+      const setup = buildTalkTtsConfig(runtimeConfig);
       if ("error" in setup) {
         respond(false, undefined, talkSpeakError(setup.reason, setup.error));
         return;
@@ -314,7 +314,7 @@ export const talkHandlers: GatewayRequestHandlers = {
       const overrides = buildTalkSpeakOverrides(
         setup.provider,
         setup.providerConfig,
-        snapshot.config,
+        runtimeConfig,
         typedParams,
       );
       const result = await synthesizeSpeech({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- AI-assisted: built and iterated with Codex, plus additional Claude Opus review and manual real-device/VPS verification by the author.
- Testing level: fully tested for the reproduced Android + gateway + ElevenLabs path.
- Problem: `#60954` fixes the Android `talk.speak` path, but three follow-up issues still showed up in local/VPS/real-device testing.
- Why it matters: with the current branch alone, Android voice replies could stay silent either because `talk.speak` read an unresolved SecretRef, because the mic queue raced, or because voice-tab replies depended on the `ttsOnAllResponses` chat-event path.
- What changed: `talk.speak` now reads the active runtime config, `MicCaptureManager` now guards its queue mutations, and voice-tab replies speak through the dedicated reply speaker again instead of depending on `ttsOnAllResponses`.
- What did NOT change (scope boundary): no further Android playback refactor, no UI changes, no broader protocol/doc changes beyond the existing `#60954` work.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #60954
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Android voice replies were still split across multiple pathways after `talk.speak` wiring. In testing, `talk.speak` could fail against unresolved Talk provider SecretRefs, `MicCaptureManager` could lose or race queue state across consecutive replies, and voice-tab reply playback could be skipped when the app relied on `talkMode.ttsOnAllResponses` rather than the dedicated reply speaker.
- Missing detection / guardrail: there was no focused handler test for the `talk.speak` runtime-config path, no Android test covering the MicCapture queue race, and no end-to-end Android check covering voice-tab reply routing on a real device.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this is a direct follow-up to `#60954`, based on local reproduction plus Android-device and VPS verification against both patched and unpatched gateway builds.
- Why this regressed now: `#60954` fixed the main Android playback path, but these adjacent seams were still vulnerable under real Talk provider + SecretRef + voice-tab usage.
- If unknown, what was ruled out: ruled out a general ElevenLabs/provider outage; ruled out the Android-only playback path as the sole issue by reproducing the unresolved SecretRef on the unpatched gateway and restoring output once the runtime-config fix was present.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server-methods/talk.test.ts`
  - Real Android device voice-tab smoke
- Scenario the test should lock in:
  - `talk.speak` must use the active runtime config instead of the raw snapshot
  - consecutive Android voice replies must not drop or corrupt queue state
  - voice-tab replies must still speak when the `ttsOnAllResponses` event path misses the playback handoff
- Why this is the smallest reliable guardrail:
  - the SecretRef bug is best isolated in a handler test
  - the reply-routing issue was only reliably reproducible on a real Android device with a real gateway/provider setup
- Existing test that already covers this (if any):
  - `#60954` already adds Android helper tests; this PR adds the focused gateway handler test
- If no new test is added, why not:
  - no automated Android e2e coverage exists for the real voice-tab + gateway + provider playback path; that part was manually verified on device

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Android voice-tab replies no longer go silent in the reproduced follow-up cases.
- Android `talk.speak` works with Talk provider configs that depend on runtime-resolved SecretRefs.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[voice-tab mic reply] -> [chat final event] -> [ttsOnAllResponses path] -> [sometimes no playback]
[talk.speak] -> [raw config snapshot] -> [unresolved SecretRef] -> [no audio]

After:
[voice-tab mic reply] -> [MicCapture final text] -> [voiceReplySpeaker] -> [playback]
[talk.speak] -> [active runtime config] -> [resolved Talk provider config] -> [audio]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - `talk.speak` now reads the active runtime config via `loadConfig()` so Talk provider SecretRefs resolve against the gateway runtime instead of the raw snapshot. This narrows behavior to the already-active runtime path; it does not expand secret exposure or scopes.

## Repro + Verification

### Environment

- OS: Android 15 on Pixel 8 Pro; macOS host; Linux VPS gateway
- Runtime/container: Android app `playDebug`, OpenClaw gateway from source checkout
- Model/provider: Talk provider `elevenlabs`
- Integration/channel (if any): Android Voice tab / voice replies
- Relevant config (redacted):
  - `talk.provider=elevenlabs`
  - `talk.providers.elevenlabs.apiKey` via runtime SecretRef
  - patched and unpatched gateway variants tested

### Steps

1. Install the Android build from `#60954` and connect to a gateway with ElevenLabs Talk config backed by a SecretRef.
2. Run a voice-tab reply test against the unpatched gateway and observe silent playback plus `unresolved SecretRef` in Android logs.
3. Run the same flow against the patched gateway and patched Android client and confirm provider speech plays.

### Expected

- Voice-tab replies should produce spoken output.
- `talk.speak` should resolve Talk provider SecretRefs from the active gateway runtime.

### Actual

- Without this follow-up, Android could stay silent due to unresolved SecretRef, MicCapture queue races, or the voice-tab routing gap.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Android voice-tab reply playback with the patched gateway
  - Android voice-tab reply playback with this follow-up client patch
  - A/B check against the unpatched gateway, which reproduced `unresolved SecretRef`
- Edge cases checked:
  - consecutive voice replies after the MicCapture queue-race fix
  - real provider speech on device rather than local system TTS
- What you did **not** verify:
  - no additional iOS/macOS retest
  - no broader repo-wide `pnpm check` because of existing unrelated failures on this repo state

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - the direct voice-reply speaker path could overlap with `ttsOnAllResponses` if the surrounding voice-tab state changes again
  - Mitigation:
    - this PR keeps the voice-tab path explicit and leaves the broader `talkMode` playback behavior otherwise unchanged
- Risk:
  - the Android queue-race fix has no focused unit test yet
  - Mitigation:
    - verified on-device with consecutive voice replies; Android unit tests and ktlint remain green

