### PR TITLE
Fix(whatsapp): skip self-message (from===to) to prevent infinite reply loop

### DIFF
--- a/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor/on-message.ts
@@ -86,7 +86,8 @@ export function createWebOnMessageHandler(params: {
 
     // Same-phone mode logging retained
     if (msg.from === msg.to) {
-      logVerbose(`📱 Same-phone mode detected (from === to: ${msg.from})`);
+      logVerbose(`📱 Skipping self-message (from === to: ${msg.from}) to prevent infinite loop`);
+      return;
     }
 
     // Skip if this is a message we just sent (echo detection)


### PR DESCRIPTION
Good day,

This PR addresses issue #61033: WhatsApp self-message loop causes infinite reply loop.

## Problem
When using WhatsApp as a channel with OpenClaw, any message sent to oneself (via the same phone number) is received back as an inbound message. This causes an infinite loop where:
1. User sends message → received as inbound
2. OpenClaw auto-replies → sent as outbound
3. WhatsApp webhook echoes the outbound message back as inbound
4. OpenClaw auto-replies → sent as outbound → loop continues

## Solution
Skip processing messages where the sender phone number equals the recipient phone number (from === to) by adding an early return.

## Changes
- Modified  to return early when 

## Testing
- Verified the fix prevents infinite loop in test environment

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee
https://github.com/Jah-yee