### PR TITLE
fix(models): resolve correct provider for bare model keys in models list

### DIFF
--- a/src/commands/models/list.configured.test.ts
+++ b/src/commands/models/list.configured.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveConfiguredEntries } from "./list.configured.js";
+
+function findEntry(entries: ReturnType<typeof resolveConfiguredEntries>["entries"], key: string) {
+  return entries.find((e) => e.key === key);
+}
+
+describe("resolveConfiguredEntries", () => {
+  it("infers correct provider for bare model keys in agents.defaults.models from models.providers", () => {
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            baseUrl: "https://google.example.com",
+            models: [{ id: "gemini-2.0-flash-001" }],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "google/gemini-2.0-flash-001" },
+          models: {
+            "gemini-2.0-flash-001": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const { entries } = resolveConfiguredEntries(cfg);
+
+    // The bare "gemini-2.0-flash-001" key in agents.defaults.models should be
+    // resolved to google/gemini-2.0-flash-001, not openai/gemini-2.0-flash-001.
+    const googleEntry = findEntry(entries, "google/gemini-2.0-flash-001");
+    expect(googleEntry).toBeDefined();
+    expect(googleEntry?.tags.has("configured")).toBe(true);
+
+    // Must not appear under the wrong provider.
+    const wrongEntry = findEntry(entries, "openai/gemini-2.0-flash-001");
+    expect(wrongEntry).toBeUndefined();
+  });
+
+  it("infers correct provider for bare model fallback values from models.providers", () => {
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            baseUrl: "https://google.example.com",
+            models: [{ id: "gemini-2.0-flash-001" }],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: {
+            primary: "google/gemini-2.0-flash-001",
+            fallbacks: ["gemini-2.0-flash-001"],
+          },
+          models: {
+            "google/gemini-2.0-flash-001": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const { entries } = resolveConfiguredEntries(cfg);
+
+    // The fallback "gemini-2.0-flash-001" should resolve to google/gemini-2.0-flash-001.
+    const googleEntry = findEntry(entries, "google/gemini-2.0-flash-001");
+    expect(googleEntry).toBeDefined();
+    expect(googleEntry?.tags.has("fallback#1")).toBe(true);
+
+    // Must not appear under the wrong provider.
+    const wrongEntry = findEntry(entries, "openai/gemini-2.0-flash-001");
+    expect(wrongEntry).toBeUndefined();
+  });
+
+  it("does not misattribute bare model keys when multiple providers configure the same model", () => {
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            models: [{ id: "gemini-2.0-flash-001" }],
+          },
+          "google-vertex": {
+            models: [{ id: "gemini-2.0-flash-001" }],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "google/gemini-2.0-flash-001" },
+          models: {
+            "gemini-2.0-flash-001": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const { entries } = resolveConfiguredEntries(cfg);
+
+    // When ambiguous, fallback to DEFAULT_PROVIDER (openai) since inference
+    // cannot determine a unique provider. This is the existing behavior and
+    // matches the guard in inferUniqueProviderFromConfiguredModels.
+    const entry = findEntry(entries, "openai/gemini-2.0-flash-001");
+    expect(entry).toBeDefined();
+    expect(entry?.tags.has("configured")).toBe(true);
+  });
+
+  it("keeps explicitly prefixed model keys unchanged", () => {
+    const cfg = {
+      models: {
+        providers: {
+          google: {
+            models: [{ id: "gemini-2.0-flash-001" }],
+          },
+        },
+      },
+      agents: {
+        defaults: {
+          model: { primary: "google/gemini-2.0-flash-001" },
+          models: {
+            "google/gemini-2.0-flash-001": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const { entries } = resolveConfiguredEntries(cfg);
+
+    const entry = findEntry(entries, "google/gemini-2.0-flash-001");
+    expect(entry).toBeDefined();
+    expect(entry?.tags.has("configured")).toBe(true);
+  });
+});

--- a/src/commands/models/list.configured.ts
+++ b/src/commands/models/list.configured.ts
@@ -1,5 +1,6 @@
 import {
   buildModelAliasIndex,
+  inferUniqueProviderFromConfiguredModels,
   parseModelRef,
   resolveConfiguredModelRef,
   resolveModelRefFromString,
@@ -40,9 +41,12 @@ export function resolveConfiguredEntries(cfg: OpenClawConfig) {
   };
 
   const addResolvedModelRef = (raw: string, tag: string) => {
+    const effectiveDefault = !raw.includes("/")
+      ? (inferUniqueProviderFromConfiguredModels({ cfg, model: raw.trim() }) ?? DEFAULT_PROVIDER)
+      : DEFAULT_PROVIDER;
     const resolved = resolveModelRefFromString({
       raw,
-      defaultProvider: DEFAULT_PROVIDER,
+      defaultProvider: effectiveDefault,
       aliasIndex,
     });
     if (resolved) {
@@ -69,7 +73,11 @@ export function resolveConfiguredEntries(cfg: OpenClawConfig) {
   });
 
   for (const key of Object.keys(cfg.agents?.defaults?.models ?? {})) {
-    const parsed = parseModelRef(String(key ?? ""), DEFAULT_PROVIDER);
+    const raw = String(key ?? "");
+    const effectiveDefault = !raw.includes("/")
+      ? (inferUniqueProviderFromConfiguredModels({ cfg, model: raw.trim() }) ?? DEFAULT_PROVIDER)
+      : DEFAULT_PROVIDER;
+    const parsed = parseModelRef(raw, effectiveDefault);
     if (!parsed) {
       continue;
     }


### PR DESCRIPTION
## Summary

- Fix bare model keys in `agents.defaults.models` and fallback entries resolving to the wrong provider in `openclaw models list`
- When a model like `gemini-2.0-flash-001` is configured under `models.providers.google`, referencing it without a provider prefix now correctly displays as `google/gemini-2.0-flash-001` instead of defaulting to `openai/gemini-2.0-flash-001`
- Uses `inferUniqueProviderFromConfiguredModels()` to look up the actual provider from `models.providers` before falling back to `DEFAULT_PROVIDER`

## Change Type

- [x] Bug fix

## Linked Issue

Fixes #61007

## Root Cause

`resolveConfiguredEntries()` in `src/commands/models/list.configured.ts` used `DEFAULT_PROVIDER` ("openai") as the provider for all bare (unprefixed) model keys in `agents.defaults.models` and for bare fallback entries. It did not consult `models.providers` to determine which provider actually owns the model.

## Tests

New test file: `src/commands/models/list.configured.test.ts`

- Bare model key resolves to correct provider from `models.providers`
- Bare fallback value resolves to correct provider
- Ambiguous models (same ID in multiple providers) fall back to `DEFAULT_PROVIDER`
- Explicitly prefixed keys remain unchanged