### PR TITLE
fix(web-fetch): prefer runtime plugin providers when requested

### DIFF
--- a/src/web-fetch/runtime.test.ts
+++ b/src/web-fetch/runtime.test.ts
@@ -164,6 +164,26 @@ describe("web fetch runtime", () => {
     });
   });
 
+  it("uses runtime-only providers when runtime providers are preferred", () => {
+    const runtimeOnly = createProvider({
+      pluginId: "third-party-fetch",
+      id: "thirdparty",
+      credentialPath: "plugins.entries.third-party-fetch.config.webFetch.apiKey",
+      autoDetectOrder: 0,
+      getConfiguredCredentialValue: () => "runtime-key",
+    });
+    resolveBundledPluginWebFetchProvidersMock.mockReturnValue([]);
+    resolveRuntimeWebFetchProvidersMock.mockReturnValue([runtimeOnly]);
+
+    const resolved = resolveWebFetchDefinition({
+      config: {},
+      sandboxed: false,
+      preferRuntimeProviders: true,
+    });
+
+    expect(resolved?.provider.id).toBe("thirdparty");
+  });
+
   it("auto-detects providers from provider-declared env vars", () => {
     const provider = createProvider({
       pluginId: "firecrawl",
@@ -233,7 +253,7 @@ describe("web fetch runtime", () => {
     expect(resolved?.provider.id).toBe("firecrawl");
   });
 
-  it("keeps non-sandboxed web fetch on bundled providers even when runtime providers are preferred", () => {
+  it("prefers runtime providers for non-sandboxed web fetch when requested", () => {
     const bundled = createProvider({
       pluginId: "firecrawl",
       id: "firecrawl",
@@ -257,6 +277,6 @@ describe("web fetch runtime", () => {
       preferRuntimeProviders: true,
     });
 
-    expect(resolved?.provider.id).toBe("firecrawl");
+    expect(resolved?.provider.id).toBe("thirdparty");
   });
 });

--- a/src/web-fetch/runtime.ts
+++ b/src/web-fetch/runtime.ts
@@ -154,10 +154,15 @@ export function resolveWebFetchDefinition(
   }
 
   const providers = sortWebFetchProvidersForAutoDetect(
-    resolveBundledPluginWebFetchProviders({
-      config: options?.config,
-      bundledAllowlistCompat: true,
-    }),
+    options?.preferRuntimeProviders && !options?.sandboxed
+      ? resolvePluginWebFetchProviders({
+          config: options?.config,
+          bundledAllowlistCompat: true,
+        })
+      : resolveBundledPluginWebFetchProviders({
+          config: options?.config,
+          bundledAllowlistCompat: true,
+        }),
   ).filter(Boolean);
   if (providers.length === 0) {
     return null;


### PR DESCRIPTION
## Summary

- Problem: `resolveWebFetchDefinition()` only resolved bundled web-fetch providers, even when `preferRuntimeProviders` was set.
- Why it matters: runtime-only third-party web-fetch providers could not be selected or auto-detected by the `web_fetch` tool.
- What changed: non-sandboxed `web-fetch` now uses runtime/plugin providers when `preferRuntimeProviders` is requested, and regression coverage locks that in.
- What did NOT change (scope boundary): sandboxed `web-fetch` still stays on bundled providers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/web-fetch/runtime.ts` built the provider list with `resolveBundledPluginWebFetchProviders(...)` unconditionally, so third-party runtime providers never entered provider selection.
- Missing detection / guardrail: there was no regression test for a runtime-only web-fetch provider with `preferRuntimeProviders: true`.
- Contributing context (if known): `web-search` already had the runtime-provider switch, but `web-fetch` had not been updated to match.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/web-fetch/runtime.test.ts`
- Scenario the test should lock in: a runtime-only external web-fetch provider is selected when `preferRuntimeProviders` is true, while sandboxed mode stays bundled-only.
- Why this is the smallest reliable guardrail: the bug is in provider resolution before any network call or plugin execution.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Non-sandboxed `web_fetch` can now resolve runtime-only third-party providers when runtime provider selection is requested.

## Diagram (if applicable)

```text
Before:
web_fetch + preferRuntimeProviders -> bundled providers only -> runtime-only provider missing

After:
web_fetch + preferRuntimeProviders + non-sandboxed -> runtime/plugin providers -> runtime-only provider resolves
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: local dev tree
- Model/provider: N/A
- Integration/channel (if any): `web_fetch`
- Relevant config (redacted): runtime-only third-party web-fetch provider enabled

### Steps

1. Mock bundled providers as empty and runtime providers with a third-party entry.
2. Call `resolveWebFetchDefinition({ preferRuntimeProviders: true, sandboxed: false })`.
3. Observe the selected provider.

### Expected

- The runtime-only provider is selected.

### Actual

- Before this fix, no provider was resolved or the bundled provider won.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted regression in `src/web-fetch/runtime.test.ts`, adjacent provider fallback behavior in `src/agents/tools/web-fetch.provider-fallback.test.ts`, repo `pnpm check`, repo `pnpm build`.
- Edge cases checked: sandboxed mode stays bundled-only; non-sandboxed runtime-only provider resolves.
- What you did **not** verify: full `pnpm test` suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: sandboxed behavior could accidentally switch to runtime providers in a future refactor.
  - Mitigation: regression test keeps sandboxed mode on bundled providers.
