### PR TITLE
fix(model-ref): don't treat LM Studio @q8_0/@4bit as auth profiles

### DIFF
--- a/src/agents/model-ref-profile.test.ts
+++ b/src/agents/model-ref-profile.test.ts
@@ -66,4 +66,23 @@ describe("splitTrailingAuthProfile", () => {
       profile: "work",
     });
   });
+
+  it("keeps @q* quant suffixes in model ids", () => {
+    expect(splitTrailingAuthProfile("lmstudio-mb-pro/gemma-4-31b-it@q8_0")).toEqual({
+      model: "lmstudio-mb-pro/gemma-4-31b-it@q8_0",
+    });
+  });
+
+  it("supports auth profiles after @q* quant suffixes", () => {
+    expect(splitTrailingAuthProfile("lmstudio-mb-pro/gemma-4-31b-it@q8_0@work")).toEqual({
+      model: "lmstudio-mb-pro/gemma-4-31b-it@q8_0",
+      profile: "work",
+    });
+  });
+
+  it("keeps @4bit/@8bit quant suffixes in model ids", () => {
+    expect(splitTrailingAuthProfile("lmstudio-mb-pro/gemma-4-31b@4bit")).toEqual({
+      model: "lmstudio-mb-pro/gemma-4-31b@4bit",
+    });
+  });
 });

--- a/src/agents/model-ref-profile.test.ts
+++ b/src/agents/model-ref-profile.test.ts
@@ -84,5 +84,8 @@ describe("splitTrailingAuthProfile", () => {
     expect(splitTrailingAuthProfile("lmstudio-mb-pro/gemma-4-31b@4bit")).toEqual({
       model: "lmstudio-mb-pro/gemma-4-31b@4bit",
     });
+    expect(splitTrailingAuthProfile("lmstudio-mb-pro/gemma-4-31b@8bit")).toEqual({
+      model: "lmstudio-mb-pro/gemma-4-31b@8bit",
+    });
   });
 });

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -13,11 +13,11 @@ export function splitTrailingAuthProfile(raw: string): {
     return { model: trimmed };
   }
 
-  const versionSuffix = trimmed.slice(profileDelimiter + 1);
+  const suffixAfterDelimiter = () => trimmed.slice(profileDelimiter + 1);
 
   // Keep well-known "version" suffixes (ex: @20251001) as part of the model id,
   // but allow an auth profile suffix *after* them (ex: ...@20251001@work).
-  if (/^\d{8}(?:@|$)/.test(versionSuffix)) {
+  if (/^\d{8}(?:@|$)/.test(suffixAfterDelimiter())) {
     const nextDelimiter = trimmed.indexOf("@", profileDelimiter + 9);
     if (nextDelimiter < 0) {
       return { model: trimmed };
@@ -31,7 +31,7 @@ export function splitTrailingAuthProfile(raw: string): {
   //
   // If an auth profile is needed, it can still be specified as a second suffix:
   //   lmstudio/foo@q8_0@work
-  if (/^(?:q\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(versionSuffix)) {
+  if (/^(?:q\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(suffixAfterDelimiter())) {
     const nextDelimiter = trimmed.indexOf("@", profileDelimiter + 1);
     if (nextDelimiter < 0) {
       return { model: trimmed };

--- a/src/agents/model-ref-profile.ts
+++ b/src/agents/model-ref-profile.ts
@@ -14,8 +14,25 @@ export function splitTrailingAuthProfile(raw: string): {
   }
 
   const versionSuffix = trimmed.slice(profileDelimiter + 1);
+
+  // Keep well-known "version" suffixes (ex: @20251001) as part of the model id,
+  // but allow an auth profile suffix *after* them (ex: ...@20251001@work).
   if (/^\d{8}(?:@|$)/.test(versionSuffix)) {
     const nextDelimiter = trimmed.indexOf("@", profileDelimiter + 9);
+    if (nextDelimiter < 0) {
+      return { model: trimmed };
+    }
+    profileDelimiter = nextDelimiter;
+  }
+
+  // Keep local model quant suffixes (common in LM Studio/Ollama catalogs) as part
+  // of the model id. These often use '@' (ex: gemma-4-31b-it@q8_0) which would
+  // otherwise be misinterpreted as an auth profile delimiter.
+  //
+  // If an auth profile is needed, it can still be specified as a second suffix:
+  //   lmstudio/foo@q8_0@work
+  if (/^(?:q\d+(?:_[a-z0-9]+)*|\d+bit)(?:@|$)/i.test(versionSuffix)) {
+    const nextDelimiter = trimmed.indexOf("@", profileDelimiter + 1);
     if (nextDelimiter < 0) {
       return { model: trimmed };
     }


### PR DESCRIPTION
### Problem
OpenClaw uses `@` to parse trailing auth profiles (e.g. `openai/gpt-5@work`).
LM Studio and other local catalogs commonly include `@` in model IDs for quant suffixes (e.g. `gemma-4-31b-it@q8_0`).
This causes model selection (picker + CLI) to strip the quant suffix and makes these models effectively unselectable.

### Fix
Treat common quant suffix patterns as part of the model id (similar to existing `@YYYYMMDD` version suffix logic), while still allowing an auth profile *after* the quant suffix via a second `@`:

- `lmstudio/.../gemma@q8_0`  → model id includes `@q8_0`
- `lmstudio/.../gemma@q8_0@work` → model id includes `@q8_0`, profile=`work`
- `lmstudio/.../gemma@4bit` → model id includes `@4bit`

### Tests
Added unit tests for `@q*` and `@4bit` behavior in `splitTrailingAuthProfile`.

### Notes
I didn't run the full test suite locally (vitest not installed in this environment), but the change is small and covered by the new unit tests.
