### PR TITLE
fix: reuse active plugin registry for non-activating snapshot loads

### DIFF
--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 });
 
 describe("getCompatibleActivePluginRegistry", () => {
-  it("reuses the active registry for non-activating loads regardless of cache key", () => {
+  it("requires cache key match when activate is omitted (default activating)", () => {
     const registry = createEmptyPluginRegistry();
     const loadOptions = {
       config: {
@@ -38,30 +38,73 @@ describe("getCompatibleActivePluginRegistry", () => {
     const { cacheKey } = __testing.resolvePluginLoadCacheContext(loadOptions);
     setActivePluginRegistry(registry, cacheKey);
 
-    // Non-activating loads (snapshot / metadata-only) always reuse the active
-    // registry — it is a superset of any narrower snapshot request.
     expect(__testing.getCompatibleActivePluginRegistry(loadOptions)).toBe(registry);
     expect(
       __testing.getCompatibleActivePluginRegistry({
         ...loadOptions,
         workspaceDir: "/tmp/workspace-b",
       }),
-    ).toBe(registry);
+    ).toBeUndefined();
     expect(
       __testing.getCompatibleActivePluginRegistry({
         ...loadOptions,
         onlyPluginIds: ["demo"],
       }),
-    ).toBe(registry);
+    ).toBeUndefined();
     expect(
       __testing.getCompatibleActivePluginRegistry({
         ...loadOptions,
         runtimeOptions: undefined,
       }),
+    ).toBeUndefined();
+  });
+
+  it("reuses active registry for explicit non-activating loads regardless of cache key", () => {
+    const registry = createEmptyPluginRegistry();
+    const baseOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+          load: { paths: ["/tmp/demo.js"] },
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    };
+    const { cacheKey } = __testing.resolvePluginLoadCacheContext(baseOptions);
+    setActivePluginRegistry(registry, cacheKey);
+
+    // activate:false (snapshot / metadata-only) always reuses the active
+    // registry — it is a superset of any narrower snapshot request.
+    expect(__testing.getCompatibleActivePluginRegistry({ ...baseOptions, activate: false })).toBe(
+      registry,
+    );
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...baseOptions,
+        activate: false,
+        workspaceDir: "/tmp/workspace-b",
+      }),
+    ).toBe(registry);
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...baseOptions,
+        activate: false,
+        onlyPluginIds: ["demo"],
+      }),
+    ).toBe(registry);
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...baseOptions,
+        activate: false,
+        runtimeOptions: undefined,
+      }),
     ).toBe(registry);
   });
 
-  it("requires cache key match for activating loads", () => {
+  it("requires cache key match for explicitly activating loads", () => {
     const registry = createEmptyPluginRegistry();
     const loadOptions = {
       activate: true as const,
@@ -159,7 +202,7 @@ describe("getCompatibleActivePluginRegistry", () => {
     ).toBeUndefined();
   });
 
-  it("reuses the active registry for non-activating loads even when gateway handlers differ", () => {
+  it("reuses the active registry for explicit non-activating loads even when gateway handlers differ", () => {
     const registry = createEmptyPluginRegistry();
     const loadOptions = {
       config: {
@@ -179,6 +222,7 @@ describe("getCompatibleActivePluginRegistry", () => {
     expect(
       __testing.getCompatibleActivePluginRegistry({
         ...loadOptions,
+        activate: false,
         coreGatewayHandlers: {
           "sessions.get": () => undefined,
           "sessions.list": () => undefined,

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -59,7 +59,7 @@ describe("getCompatibleActivePluginRegistry", () => {
     ).toBeUndefined();
   });
 
-  it("reuses active registry for explicit non-activating loads regardless of cache key", () => {
+  it("reuses active registry for non-activating loads when only onlyPluginIds differs", () => {
     const registry = createEmptyPluginRegistry();
     const baseOptions = {
       config: {
@@ -76,8 +76,8 @@ describe("getCompatibleActivePluginRegistry", () => {
     const { cacheKey } = __testing.resolvePluginLoadCacheContext(baseOptions);
     setActivePluginRegistry(registry, cacheKey);
 
-    // activate:false (snapshot / metadata-only) always reuses the active
-    // registry — it is a superset of any narrower snapshot request.
+    // activate:false with matching base key (only onlyPluginIds differs) →
+    // reuse active registry since it is a superset of any subset request.
     expect(__testing.getCompatibleActivePluginRegistry({ ...baseOptions, activate: false })).toBe(
       registry,
     );
@@ -85,23 +85,26 @@ describe("getCompatibleActivePluginRegistry", () => {
       __testing.getCompatibleActivePluginRegistry({
         ...baseOptions,
         activate: false,
-        workspaceDir: "/tmp/workspace-b",
+        onlyPluginIds: ["demo"],
       }),
     ).toBe(registry);
+
+    // activate:false with different structural inputs (workspaceDir,
+    // runtimeOptions) → cache miss, because the registry content may differ.
     expect(
       __testing.getCompatibleActivePluginRegistry({
         ...baseOptions,
         activate: false,
-        onlyPluginIds: ["demo"],
+        workspaceDir: "/tmp/workspace-b",
       }),
-    ).toBe(registry);
+    ).toBeUndefined();
     expect(
       __testing.getCompatibleActivePluginRegistry({
         ...baseOptions,
         activate: false,
         runtimeOptions: undefined,
       }),
-    ).toBe(registry);
+    ).toBeUndefined();
   });
 
   it("requires cache key match for explicitly activating loads", () => {
@@ -202,7 +205,7 @@ describe("getCompatibleActivePluginRegistry", () => {
     ).toBeUndefined();
   });
 
-  it("reuses the active registry for explicit non-activating loads even when gateway handlers differ", () => {
+  it("does not reuse active registry for non-activating loads when gateway handlers differ", () => {
     const registry = createEmptyPluginRegistry();
     const loadOptions = {
       config: {
@@ -219,6 +222,8 @@ describe("getCompatibleActivePluginRegistry", () => {
     const { cacheKey } = __testing.resolvePluginLoadCacheContext(loadOptions);
     setActivePluginRegistry(registry, cacheKey);
 
+    // Even with activate:false, structural differences (gateway handlers)
+    // still cause a cache miss — only onlyPluginIds is ignored.
     expect(
       __testing.getCompatibleActivePluginRegistry({
         ...loadOptions,
@@ -228,7 +233,7 @@ describe("getCompatibleActivePluginRegistry", () => {
           "sessions.list": () => undefined,
         },
       }),
-    ).toBe(registry);
+    ).toBeUndefined();
   });
 });
 

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -21,9 +21,50 @@ afterEach(() => {
 });
 
 describe("getCompatibleActivePluginRegistry", () => {
-  it("reuses the active registry only when the load context cache key matches", () => {
+  it("reuses the active registry for non-activating loads regardless of cache key", () => {
     const registry = createEmptyPluginRegistry();
     const loadOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+          load: { paths: ["/tmp/demo.js"] },
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    };
+    const { cacheKey } = __testing.resolvePluginLoadCacheContext(loadOptions);
+    setActivePluginRegistry(registry, cacheKey);
+
+    // Non-activating loads (snapshot / metadata-only) always reuse the active
+    // registry — it is a superset of any narrower snapshot request.
+    expect(__testing.getCompatibleActivePluginRegistry(loadOptions)).toBe(registry);
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...loadOptions,
+        workspaceDir: "/tmp/workspace-b",
+      }),
+    ).toBe(registry);
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...loadOptions,
+        onlyPluginIds: ["demo"],
+      }),
+    ).toBe(registry);
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...loadOptions,
+        runtimeOptions: undefined,
+      }),
+    ).toBe(registry);
+  });
+
+  it("requires cache key match for activating loads", () => {
+    const registry = createEmptyPluginRegistry();
+    const loadOptions = {
+      activate: true as const,
       config: {
         plugins: {
           allow: ["demo"],
@@ -49,12 +90,6 @@ describe("getCompatibleActivePluginRegistry", () => {
       __testing.getCompatibleActivePluginRegistry({
         ...loadOptions,
         onlyPluginIds: ["demo"],
-      }),
-    ).toBeUndefined();
-    expect(
-      __testing.getCompatibleActivePluginRegistry({
-        ...loadOptions,
-        runtimeOptions: undefined,
       }),
     ).toBeUndefined();
   });
@@ -94,9 +129,10 @@ describe("getCompatibleActivePluginRegistry", () => {
     expect(__testing.getCompatibleActivePluginRegistry()).toBe(registry);
   });
 
-  it("does not reuse the active registry when core gateway method names differ", () => {
+  it("does not reuse the active registry when core gateway method names differ in activating loads", () => {
     const registry = createEmptyPluginRegistry();
     const loadOptions = {
+      activate: true as const,
       config: {
         plugins: {
           allow: ["demo"],
@@ -121,6 +157,34 @@ describe("getCompatibleActivePluginRegistry", () => {
         },
       }),
     ).toBeUndefined();
+  });
+
+  it("reuses the active registry for non-activating loads even when gateway handlers differ", () => {
+    const registry = createEmptyPluginRegistry();
+    const loadOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+          load: { paths: ["/tmp/demo.js"] },
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+      coreGatewayHandlers: {
+        "sessions.get": () => undefined,
+      },
+    };
+    const { cacheKey } = __testing.resolvePluginLoadCacheContext(loadOptions);
+    setActivePluginRegistry(registry, cacheKey);
+
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...loadOptions,
+        coreGatewayHandlers: {
+          "sessions.get": () => undefined,
+          "sessions.list": () => undefined,
+        },
+      }),
+    ).toBe(registry);
   });
 });
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -433,6 +433,15 @@ function getCompatibleActivePluginRegistry(
   if (!hasExplicitCompatibilityInputs(options)) {
     return activeRegistry;
   }
+  // Non-activating (snapshot) loads only read provider/tool metadata from the
+  // registry — they never register commands or mutate global state. The active
+  // registry was loaded with activate:true and contains ALL enabled plugins,
+  // making it a superset of any snapshot request. Reuse it directly to avoid
+  // redundant loadOpenClawPlugins calls caused by cache-key mismatches when
+  // callers omit workspaceDir or pass a narrower onlyPluginIds scope.
+  if (options.activate !== true) {
+    return activeRegistry;
+  }
   const activeCacheKey = getActivePluginRegistryKey();
   if (!activeCacheKey) {
     return undefined;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -433,20 +433,22 @@ function getCompatibleActivePluginRegistry(
   if (!hasExplicitCompatibilityInputs(options)) {
     return activeRegistry;
   }
-  // Non-activating (snapshot) loads only read provider/tool metadata from the
-  // registry — they never register commands or mutate global state. The active
-  // registry was loaded with activate:true and contains ALL enabled plugins,
-  // making it a superset of any snapshot request. Reuse it directly to avoid
-  // redundant loadOpenClawPlugins calls caused by cache-key mismatches when
-  // callers omit workspaceDir or pass a narrower onlyPluginIds scope.
-  // Note: activate:undefined is treated as activating (shouldActivate defaults
-  // true), so only explicit activate:false qualifies as a snapshot-only load.
-  if (options.activate === false) {
-    return activeRegistry;
-  }
   const activeCacheKey = getActivePluginRegistryKey();
   if (!activeCacheKey) {
     return undefined;
+  }
+  // Non-activating (snapshot) loads only read provider/tool metadata — they
+  // never register commands or mutate global state. The active registry was
+  // loaded with activate:true and contains ALL enabled plugins, so it is a
+  // superset of any onlyPluginIds subset. For these loads, compare a base key
+  // that strips onlyPluginIds to avoid false cache misses while still
+  // validating config, env, workspaceDir, and other structural inputs.
+  if (options.activate === false) {
+    const baseKey = resolvePluginLoadCacheContext({
+      ...options,
+      onlyPluginIds: undefined,
+    }).cacheKey;
+    return baseKey === activeCacheKey ? activeRegistry : undefined;
   }
   return resolvePluginLoadCacheContext(options).cacheKey === activeCacheKey
     ? activeRegistry

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -439,7 +439,9 @@ function getCompatibleActivePluginRegistry(
   // making it a superset of any snapshot request. Reuse it directly to avoid
   // redundant loadOpenClawPlugins calls caused by cache-key mismatches when
   // callers omit workspaceDir or pass a narrower onlyPluginIds scope.
-  if (options.activate !== true) {
+  // Note: activate:undefined is treated as activating (shouldActivate defaults
+  // true), so only explicit activate:false qualifies as a snapshot-only load.
+  if (options.activate === false) {
     return activeRegistry;
   }
   const activeCacheKey = getActivePluginRegistryKey();


### PR DESCRIPTION
## Summary

Non-activating (snapshot) plugin loads with `onlyPluginIds` now reuse the active registry instead of triggering full plugin reloads on cache-key mismatch.

**Root cause:** `getCompatibleActivePluginRegistry` compared full cache keys including `onlyPluginIds`, but snapshot callers often pass a narrower scope (e.g. `["firecrawl", "searxng-pro"]`). The active registry contains ALL enabled plugins, so `onlyPluginIds` is always a subset — yet the key comparison failed → miss → full reload.

**Fix:** For `activate: false` loads, compare a base cache key that strips `onlyPluginIds` while preserving full validation for config, env, workspaceDir, runtimeOptions, gateway handlers, and all other structural inputs. This ensures:
- Different `onlyPluginIds` → reuse (active registry is a superset)
- Different config/env/workspace/handlers → cache miss → correct reload

## Changes

- `src/plugins/loader.ts`: for `activate === false`, compute base key without `onlyPluginIds` before comparing to active cache key
- `src/plugins/loader.runtime-registry.test.ts`: updated tests covering all three modes (omitted activate, explicit true, explicit false) with both matching and mismatching inputs

## Test plan

- [x] `loader.runtime-registry.test.ts` — 10/10 passing
- [x] `loader.test.ts` — 134/134 passing
- [x] `pnpm check` (lint + typecheck) — green
- [ ] Note: `loader.contract.test.ts` has pre-existing failures on `main` unrelated to this change