### PR TITLE
fix(image_generate): include MEDIA: path in tool content to prevent model hallucinating wrong delivery path

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -214,6 +214,33 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(ctx.state.pendingToolAudioAsVoice).toBe(true);
   });
 
+  it("does not queue structured media already emitted from verbose tool output", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: true, onToolResult: vi.fn() });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [
+          {
+            type: "text",
+            text: "Generated 1 image with google/gemini-3.1-flash-image-preview.\nMEDIA:/tmp/generated.png",
+          },
+        ],
+        details: {
+          media: {
+            mediaUrls: ["/tmp/generated.png"],
+          },
+        },
+      },
+    });
+
+    expect(ctx.emitToolOutput).toHaveBeenCalled();
+    expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+  });
+
   it("does NOT emit media for error results", async () => {
     const onToolResult = vi.fn();
     const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -9,6 +9,7 @@ import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handler
 function createMockContext(overrides?: {
   shouldEmitToolOutput?: boolean;
   onToolResult?: ReturnType<typeof vi.fn>;
+  toolResultFormat?: "markdown" | "plain";
 }): EmbeddedPiSubscribeContext {
   const onToolResult = overrides?.onToolResult ?? vi.fn();
   return {
@@ -16,6 +17,7 @@ function createMockContext(overrides?: {
       runId: "test-run",
       onToolResult,
       onAgentEvent: vi.fn(),
+      toolResultFormat: overrides?.toolResultFormat,
     },
     state: {
       toolMetaById: new Map(),
@@ -215,7 +217,11 @@ describe("handleToolExecutionEnd media emission", () => {
   });
 
   it("does not queue structured media already emitted from verbose tool output", async () => {
-    const ctx = createMockContext({ shouldEmitToolOutput: true, onToolResult: vi.fn() });
+    const ctx = createMockContext({
+      shouldEmitToolOutput: true,
+      onToolResult: vi.fn(),
+      toolResultFormat: "plain",
+    });
 
     await handleToolExecutionEnd(ctx, {
       type: "tool_execution_end",
@@ -239,6 +245,37 @@ describe("handleToolExecutionEnd media emission", () => {
 
     expect(ctx.emitToolOutput).toHaveBeenCalled();
     expect(ctx.state.pendingToolMediaUrls).toEqual([]);
+  });
+
+  it("still queues structured media for markdown verbose output", async () => {
+    const ctx = createMockContext({
+      shouldEmitToolOutput: true,
+      onToolResult: vi.fn(),
+      toolResultFormat: "markdown",
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "image_generate",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        content: [
+          {
+            type: "text",
+            text: "Generated 1 image with google/gemini-3.1-flash-image-preview.\nMEDIA:/tmp/generated.png",
+          },
+        ],
+        details: {
+          media: {
+            mediaUrls: ["/tmp/generated.png"],
+          },
+        },
+      },
+    });
+
+    expect(ctx.emitToolOutput).toHaveBeenCalled();
+    expect(ctx.state.pendingToolMediaUrls).toEqual(["/tmp/generated.png"]);
   });
 
   it("does NOT emit media for error results", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -5,6 +5,7 @@ import {
   buildExecApprovalUnavailableReplyPayload,
 } from "../infra/exec-approval-reply.js";
 import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
+import { splitMediaFromOutput } from "../media/parse.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
@@ -163,6 +164,18 @@ function queuePendingToolMedia(
   }
 }
 
+function collectEmittedToolOutputMediaUrls(
+  toolName: string,
+  outputText: string,
+  result: unknown,
+): string[] {
+  const mediaUrls = splitMediaFromOutput(outputText).mediaUrls ?? [];
+  if (mediaUrls.length === 0) {
+    return [];
+  }
+  return filterToolResultMediaUrls(toolName, mediaUrls, result);
+}
+
 function readExecApprovalPendingDetails(result: unknown): {
   approvalId: string;
   approvalSlug: string;
@@ -263,6 +276,7 @@ async function emitToolResultOutput(params: {
       "object" &&
     !Array.isArray((result as { details?: { media?: unknown } }).details?.media);
   const approvalPending = readExecApprovalPendingDetails(result);
+  let emittedToolOutputMediaUrls: string[] = [];
   if (!isToolError && approvalPending) {
     if (!ctx.params.onToolResult) {
       return;
@@ -312,6 +326,7 @@ async function emitToolResultOutput(params: {
   if (ctx.shouldEmitToolOutput()) {
     const outputText = extractToolResultText(sanitizedResult);
     if (outputText) {
+      emittedToolOutputMediaUrls = collectEmittedToolOutputMediaUrls(toolName, outputText, result);
       ctx.emitToolOutput(toolName, meta, outputText, result);
     }
     if (!hasStructuredMedia) {
@@ -328,11 +343,15 @@ async function emitToolResultOutput(params: {
     return;
   }
   const mediaUrls = filterToolResultMediaUrls(toolName, mediaReply.mediaUrls, result);
-  if (mediaUrls.length === 0) {
+  const pendingMediaUrls =
+    mediaReply.audioAsVoice || emittedToolOutputMediaUrls.length === 0
+      ? mediaUrls
+      : mediaUrls.filter((url) => !emittedToolOutputMediaUrls.includes(url));
+  if (pendingMediaUrls.length === 0) {
     return;
   }
   queuePendingToolMedia(ctx, {
-    mediaUrls,
+    mediaUrls: pendingMediaUrls,
     ...(mediaReply.audioAsVoice ? { audioAsVoice: true } : {}),
   });
 }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -326,7 +326,13 @@ async function emitToolResultOutput(params: {
   if (ctx.shouldEmitToolOutput()) {
     const outputText = extractToolResultText(sanitizedResult);
     if (outputText) {
-      emittedToolOutputMediaUrls = collectEmittedToolOutputMediaUrls(toolName, outputText, result);
+      if (ctx.params.toolResultFormat === "plain") {
+        emittedToolOutputMediaUrls = collectEmittedToolOutputMediaUrls(
+          toolName,
+          outputText,
+          result,
+        );
+      }
       ctx.emitToolOutput(toolName, meta, outputText, result);
     }
     if (!hasStructuredMedia) {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -137,6 +137,7 @@ export type ToolHandlerParams = Pick<
   | "sessionKey"
   | "sessionId"
   | "agentId"
+  | "toolResultFormat"
 >;
 
 export type ToolHandlerState = Pick<

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -364,8 +364,66 @@ describe("createImageGenerateTool", () => {
         revisedPrompts: ["A more cinematic cat"],
       },
     });
+    // The content text must include MEDIA: paths so the model sees the actual
+    // saved locations and does not hallucinate a wrong path in its reply.
     const text = (result.content?.[0] as { text: string } | undefined)?.text ?? "";
-    expect(text).not.toContain("MEDIA:");
+    expect(text).toContain("MEDIA:/tmp/generated-1.png");
+    expect(text).toContain("MEDIA:/tmp/generated-2.png");
+  });
+
+  it("includes MEDIA: path in content text so model does not hallucinate a wrong path (regression #61029)", async () => {
+    // Regression test: before the fix the content text had no MEDIA: line, so
+    // the model would guess a path like "media/output/<name>.png" which does not
+    // exist and triggers LocalMediaAccessError on delivery.
+    vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "google",
+      model: "gemini-3.1-flash-image-preview",
+      attempts: [],
+      images: [
+        {
+          buffer: Buffer.from("jpg-data"),
+          mimeType: "image/jpeg",
+          fileName: "kodo_sawaki_zazen.jpg",
+        },
+      ],
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValueOnce({
+      path: "/home/openclaw/.openclaw/media/tool-image-generation/kodo_sawaki_zazen---3337a0ed-898a-4572-8950-0d288719f4f8.jpg",
+      id: "kodo_sawaki_zazen---3337a0ed-898a-4572-8950-0d288719f4f8.jpg",
+      size: 8,
+      contentType: "image/jpeg",
+    });
+
+    const tool = createImageGenerateTool({
+      config: {
+        agents: {
+          defaults: {
+            imageGenerationModel: { primary: "google/gemini-3.1-flash-image-preview" },
+          },
+        },
+      },
+    });
+    expect(tool).not.toBeNull();
+    if (!tool) {
+      throw new Error("expected image_generate tool");
+    }
+
+    const result = await tool.execute("call-reg", { prompt: "kodo sawaki zazen" });
+    const text = (result.content?.[0] as { text: string } | undefined)?.text ?? "";
+
+    // Content text must contain the actual saved path so the model does not
+    // hallucinate media/output/<name>.png or any other wrong path.
+    expect(text).toContain(
+      "MEDIA:/home/openclaw/.openclaw/media/tool-image-generation/kodo_sawaki_zazen---3337a0ed-898a-4572-8950-0d288719f4f8.jpg",
+    );
+    // The structured delivery path must also be correct.
+    expect(result.details).toMatchObject({
+      media: {
+        mediaUrls: [
+          "/home/openclaw/.openclaw/media/tool-image-generation/kodo_sawaki_zazen---3337a0ed-898a-4572-8950-0d288719f4f8.jpg",
+        ],
+      },
+    });
   });
 
   it("rejects counts outside the supported range", async () => {

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -618,6 +618,11 @@ export function createImageGenerateTool(options?: {
         .filter((entry): entry is string => Boolean(entry));
       const lines = [
         `Generated ${savedImages.length} image${savedImages.length === 1 ? "" : "s"} with ${result.provider}/${result.model}.`,
+        // Expose the saved paths so the model sees the actual file locations and
+        // does not hallucinate a different path (e.g. media/output/<name>.png)
+        // when referencing the image in its reply.  Delivery is driven by
+        // details.media.mediaUrls; these MEDIA: lines are informational only.
+        ...savedImages.map((image) => `MEDIA:${image.path}`),
       ];
 
       return {


### PR DESCRIPTION
## Summary

- **Root cause**: `image_generate` tool (commit 759373e, `src/agents/tools/image-generate-tool.ts:619-624`) returned only `"Generated N image(s) with provider/model."` in the content text block, with no file path. Without seeing the actual saved path, the model hallucinated a delivery path like `media/output/<name>.png` in its reply text. `splitMediaFromOutput` accepted this as a valid local path (it contains `/`), `assertLocalMediaAllowed` passed it (it resolves under `configDir/media`), but the file never existed → `LocalMediaAccessError: not-found`.

- **Fix** (`src/agents/tools/image-generate-tool.ts`): append `MEDIA:<absolute-path>` lines to the content text for each saved image. The model now sees the real path and no longer guesses. Delivery is still driven by `details.media.mediaUrls` (which `extractToolResultMediaArtifact` gives priority over text-based `MEDIA:` tokens), so there is no double delivery.

- **G8 cross-channel check**: the same `MEDIA:`-from-LLM-reply path applies to Discord, Matrix, Mattermost, and Feishu (all use `splitMediaFromOutput` via `parseReplyDirectives`). This single change fixes all channels because it prevents the bad path from ever reaching any delivery layer.

- **Call path verified**: `createImageGenerateTool → execute → saveMediaBuffer("tool-image-generation") → content text (was missing path, now includes MEDIA:<path>) → LLM reply → splitMediaFromOutput → loadWebMedia → LocalMediaAccessError: not-found`.

## Test plan

- [x] Updated existing test `generates images and returns details.media paths` to assert `MEDIA:<path>` lines are present in content text (was asserting absence of `MEDIA:`)
- [x] Added regression test `includes MEDIA: path in content text … (regression #61029)` with exact path from the issue report
- [x] All 15 tests in `image-generate-tool.test.ts` pass
- [x] All related tests (`openclaw-tools.image-generation.test.ts`, `pi-embedded-subscribe.tools.media.test.ts`) pass

Closes #61029

🤖 Generated with [Claude Code](https://claude.com/claude-code)