### PR TITLE
fix(contracts): align Teams guard and MiniMax loader

### DIFF
--- a/src/plugins/contracts/bundled-extension-config-api-guardrails.test.ts
+++ b/src/plugins/contracts/bundled-extension-config-api-guardrails.test.ts
@@ -35,9 +35,11 @@ const BUNDLED_EXTENSION_CONFIG_IMPORT_GUARDS = [
     path: "extensions/googlechat/src/config-schema.ts",
     allowedSpecifier: "openclaw/plugin-sdk/googlechat",
   },
+  // Teams keeps a package-local config barrel so production code does not
+  // self-import via openclaw/plugin-sdk/msteams from inside the same extension.
   {
     path: "extensions/msteams/src/config-schema.ts",
-    allowedSpecifier: "openclaw/plugin-sdk/msteams",
+    allowedSpecifier: "../config-api.js",
   },
 ] as const;
 

--- a/src/plugins/contracts/speech-vitest-registry.ts
+++ b/src/plugins/contracts/speech-vitest-registry.ts
@@ -84,6 +84,19 @@ function resolveNamedBuilder<T>(moduleExport: unknown, pattern: RegExp): (() => 
   return undefined;
 }
 
+function resolveNamedBuilders<T>(moduleExport: unknown, pattern: RegExp): Array<() => T> {
+  if (!moduleExport || typeof moduleExport !== "object") {
+    return [];
+  }
+  const matches: Array<() => T> = [];
+  for (const [key, value] of Object.entries(moduleExport as Record<string, unknown>)) {
+    if (pattern.test(key) && typeof value === "function") {
+      matches.push(value as () => T);
+    }
+  }
+  return matches;
+}
+
 function resolveNamedValues<T>(
   moduleExport: unknown,
   pattern: RegExp,
@@ -315,17 +328,19 @@ export function loadVitestImageGenerationProviderContractRegistry(): ImageGenera
     if (!fs.existsSync(testApiPath)) {
       continue;
     }
-    const builder = resolveNamedBuilder<ImageGenerationProviderPlugin>(
+    const builders = resolveNamedBuilders<ImageGenerationProviderPlugin>(
       createVitestCapabilityLoader(testApiPath)(testApiPath),
       /^build.+ImageGenerationProvider$/u,
     );
-    if (!builder) {
+    if (builders.length === 0) {
       continue;
     }
-    registrations.push({
-      pluginId: plugin.id,
-      provider: builder(),
-    });
+    registrations.push(
+      ...builders.map((builder) => ({
+        pluginId: plugin.id,
+        provider: builder(),
+      })),
+    );
     unresolvedPluginIds.delete(plugin.id);
   }
 


### PR DESCRIPTION
## Summary
Fix the non-Telegram failures in the `checks-fast-contracts-protocol` lane.

## Changes
- update the Teams bundled config guardrail to match the current local `config-api` import seam
- load every exported `build*ImageGenerationProvider` helper from bundled plugin `test-api.ts` files so MiniMax contract tests see both `minimax` and `minimax-portal`

## Validation
- `pnpm build`
- `pnpm test src/plugins/contracts/bundled-extension-config-api-guardrails.test.ts`
- `JITI_REBUILD_FS_CACHE=1 pnpm test src/plugins/contracts/plugin-registration.minimax.contract.test.ts`
