### PR TITLE
fix(cli-runner): strip null bytes from system prompt and prompt args before spawn

### DIFF
--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -133,6 +133,34 @@ describe("buildCliArgs", () => {
       }),
     ).toEqual(["-p", "--append-system-prompt", "Stable prefix\nDynamic suffix"]);
   });
+
+  it("strips null bytes from system prompt arg before spawn (fixes #61055)", () => {
+    const result = buildCliArgs({
+      backend: {
+        command: "claude",
+        systemPromptArg: "--append-system-prompt",
+      },
+      baseArgs: ["-p"],
+      modelId: "claude-sonnet-4-6",
+      systemPrompt: "Conversation info (untrusted metadata)\0\0more text",
+      useResume: false,
+    });
+    const systemPromptValue = result[result.indexOf("--append-system-prompt") + 1] ?? "";
+    expect(systemPromptValue).not.toContain("\0");
+    expect(systemPromptValue).toBe("Conversation info (untrusted metadata)more text");
+  });
+
+  it("strips null bytes from prompt arg before spawn (fixes #61055)", () => {
+    const result = buildCliArgs({
+      backend: { command: "codex" },
+      baseArgs: [],
+      modelId: "gpt-5.4",
+      promptArg: "Hello\0world",
+      useResume: false,
+    });
+    expect(result).toContain("Helloworld");
+    expect(result.join("")).not.toContain("\0");
+  });
 });
 
 describe("resolveCliRunQueueKey", () => {

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -263,6 +263,10 @@ export async function writeCliImages(
   return { paths, cleanup };
 }
 
+function stripNullBytes(value: string): string {
+  return value.replaceAll("\0", "");
+}
+
 export function buildCliArgs(params: {
   backend: CliBackendConfig;
   baseArgs: string[];
@@ -278,7 +282,10 @@ export function buildCliArgs(params: {
     args.push(params.backend.modelArg, params.modelId);
   }
   if (!params.useResume && params.systemPrompt && params.backend.systemPromptArg) {
-    args.push(params.backend.systemPromptArg, stripSystemPromptCacheBoundary(params.systemPrompt));
+    args.push(
+      params.backend.systemPromptArg,
+      stripNullBytes(stripSystemPromptCacheBoundary(params.systemPrompt)),
+    );
   }
   if (!params.useResume && params.sessionId) {
     if (params.backend.sessionArgs && params.backend.sessionArgs.length > 0) {
@@ -303,7 +310,7 @@ export function buildCliArgs(params: {
     }
   }
   if (params.promptArg !== undefined) {
-    args.push(params.promptArg);
+    args.push(stripNullBytes(params.promptArg));
   }
   return args;
 }


### PR DESCRIPTION
## Summary

`child_process.spawn` hard-crashes when any CLI arg contains a null byte (`\0`). With `systemPromptWhen: "first"`, accumulated conversation metadata (e.g. iMessage thread history, group context) passed through `extraSystemPrompt` can carry null bytes, which flow unsanitized into the `--append-system-prompt` arg → Node.js throws `ERR_INVALID_ARG_VALUE: "args[N] must be a string without null bytes"` → "Something went wrong".

**Root cause:** `buildCliArgs()` in `src/agents/cli-runner/helpers.ts:281` (commit `e3ac0f4`) applied `stripSystemPromptCacheBoundary()` but never stripped `\0` characters before pushing to the argv array. The `promptArg` path (line 306) had the same exposure.

**Call path:**
```
extraSystemPrompt (iMessage metadata with \0)
  → buildSystemPrompt() [prepare.ts:151]
  → buildCliArgs() [helpers.ts:281]  ← \0 pushed to args array
  → supervisor.spawn({ argv }) [execute.ts:212]
  → Node child_process → ERR_INVALID_ARG_VALUE crash
```

**Git blame:** Line 281 introduced in commit `e3ac0f4` (Peter Steinberger, 2026-04-04).

## Fix

Added a local `stripNullBytes()` helper in `helpers.ts` and applied it to:
1. The `systemPrompt` value before passing as `--append-system-prompt` arg (primary crash path)
2. The `promptArg` value (same exposure for short prompts passed as CLI args)

## G8 Scope Check

`buildCliArgs()` is the single function that constructs all spawn argv entries from string content. No other code paths push raw user-controlled strings directly to spawn args. The `promptArg` fix covers the only other content-bearing arg in the same function.

## Tests

Two new tests added to `src/agents/cli-runner.helpers.test.ts`:
- `strips null bytes from system prompt arg before spawn (fixes #61055)` — verifies `\0` are removed from the system prompt value
- `strips null bytes from prompt arg before spawn (fixes #61055)` — verifies `\0` are removed from inline prompt args

All 11 tests in the helpers suite pass.

Closes #61055

🤖 Generated with [Claude Code](https://claude.com/claude-code)
