### PR TITLE
fix(dotenv): load gateway.env compatibility fallback

### DIFF
--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -19,7 +19,7 @@ OpenClaw pulls environment variables from multiple sources. The rule is **never 
 4. **Config `env` block** in `~/.openclaw/openclaw.json` (applied only if missing).
 5. **Optional login-shell import** (`env.shellEnv.enabled` or `OPENCLAW_LOAD_SHELL_ENV=1`), applied only for missing expected keys.
 
-On Ubuntu fresh installs, OpenClaw also treats `~/.config/openclaw/gateway.env` as a compatibility fallback after the global `.env`. If both files exist and disagree, OpenClaw keeps `~/.openclaw/.env` and prints a warning.
+On Ubuntu fresh installs that use the default state dir, OpenClaw also treats `~/.config/openclaw/gateway.env` as a compatibility fallback after the global `.env`. If both files exist and disagree, OpenClaw keeps `~/.openclaw/.env` and prints a warning.
 
 If the config file is missing entirely, step 4 is skipped; shell import still runs if enabled.
 

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -19,6 +19,8 @@ OpenClaw pulls environment variables from multiple sources. The rule is **never 
 4. **Config `env` block** in `~/.openclaw/openclaw.json` (applied only if missing).
 5. **Optional login-shell import** (`env.shellEnv.enabled` or `OPENCLAW_LOAD_SHELL_ENV=1`), applied only for missing expected keys.
 
+On Ubuntu fresh installs, OpenClaw also treats `~/.config/openclaw/gateway.env` as a compatibility fallback after the global `.env`. If both files exist and disagree, OpenClaw keeps `~/.openclaw/.env` and prints a warning.
+
 If the config file is missing entirely, step 4 is skipped; shell import still runs if enabled.
 
 ## Config `env` block

--- a/src/cli/dotenv.ts
+++ b/src/cli/dotenv.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
 import { loadGlobalRuntimeDotEnvFiles, loadWorkspaceDotEnvFile } from "../infra/dotenv.js";
 
 export function loadCliDotEnv(opts?: { quiet?: boolean }) {
@@ -9,5 +10,8 @@ export function loadCliDotEnv(opts?: { quiet?: boolean }) {
   // Then load the global fallback set without overriding any env vars that
   // were already set or loaded from CWD. This includes the Ubuntu fresh-install
   // gateway.env compatibility path.
-  loadGlobalRuntimeDotEnvFiles({ quiet });
+  loadGlobalRuntimeDotEnvFiles({
+    quiet,
+    stateEnvPath: path.join(resolveStateDir(process.env), ".env"),
+  });
 }

--- a/src/cli/dotenv.ts
+++ b/src/cli/dotenv.ts
@@ -1,14 +1,13 @@
 import path from "node:path";
-import { resolveStateDir } from "../config/paths.js";
-import { loadRuntimeDotEnvFile, loadWorkspaceDotEnvFile } from "../infra/dotenv.js";
+import { loadGlobalRuntimeDotEnvFiles, loadWorkspaceDotEnvFile } from "../infra/dotenv.js";
 
 export function loadCliDotEnv(opts?: { quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;
   const cwdEnvPath = path.join(process.cwd(), ".env");
   loadWorkspaceDotEnvFile(cwdEnvPath, { quiet });
 
-  // Then load the global fallback from the active state dir without overriding
-  // any env vars that were already set or loaded from CWD.
-  const globalEnvPath = path.join(resolveStateDir(process.env), ".env");
-  loadRuntimeDotEnvFile(globalEnvPath, { quiet });
+  // Then load the global fallback set without overriding any env vars that
+  // were already set or loaded from CWD. This includes the Ubuntu fresh-install
+  // gateway.env compatibility path.
+  loadGlobalRuntimeDotEnvFiles({ quiet });
 }

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -99,9 +99,11 @@ describe("loadDotEnv", () => {
 
   it("loads the Ubuntu gateway.env compatibility fallback after ~/.openclaw/.env", async () => {
     await withIsolatedEnvAndCwd(async () => {
-      await withDotEnvFixture(async ({ base, cwdDir, stateDir }) => {
+      await withDotEnvFixture(async ({ base, cwdDir }) => {
         process.env.HOME = base;
-        await writeEnvFile(path.join(stateDir, ".env"), "FOO=from-global\n");
+        const defaultStateDir = path.join(base, ".openclaw");
+        process.env.OPENCLAW_STATE_DIR = defaultStateDir;
+        await writeEnvFile(path.join(defaultStateDir, ".env"), "FOO=from-global\n");
         await writeEnvFile(
           path.join(base, ".config", "openclaw", "gateway.env"),
           ["FOO=from-gateway", "BAR=from-gateway"].join("\n"),
@@ -476,9 +478,11 @@ describe("loadCliDotEnv", () => {
 
   it("loads the gateway.env compatibility fallback during CLI startup", async () => {
     await withIsolatedEnvAndCwd(async () => {
-      await withDotEnvFixture(async ({ base, cwdDir, stateDir }) => {
+      await withDotEnvFixture(async ({ base, cwdDir }) => {
         process.env.HOME = base;
-        await writeEnvFile(path.join(stateDir, ".env"), "FOO=from-global\n");
+        const defaultStateDir = path.join(base, ".openclaw");
+        process.env.OPENCLAW_STATE_DIR = defaultStateDir;
+        await writeEnvFile(path.join(defaultStateDir, ".env"), "FOO=from-global\n");
         await writeEnvFile(
           path.join(base, ".config", "openclaw", "gateway.env"),
           "BAR=from-gateway\n",
@@ -492,6 +496,29 @@ describe("loadCliDotEnv", () => {
 
         expect(process.env.FOO).toBe("from-global");
         expect(process.env.BAR).toBe("from-gateway");
+      });
+    });
+  });
+
+  it("does not load gateway.env when OPENCLAW_STATE_DIR is explicitly set", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ base, cwdDir }) => {
+        const customStateDir = path.join(base, "custom-state");
+        process.env.HOME = base;
+        process.env.OPENCLAW_STATE_DIR = customStateDir;
+        await writeEnvFile(
+          path.join(base, ".config", "openclaw", "gateway.env"),
+          "FOO=from-gateway\n",
+        );
+
+        vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+        delete process.env.FOO;
+
+        loadCliDotEnv({ quiet: true });
+
+        expect(process.env.FOO).toBeUndefined();
+        expect(process.env.OPENCLAW_STATE_DIR).toBe(customStateDir);
+        expect(process.env.BAR).toBeUndefined();
       });
     });
   });

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -97,6 +97,31 @@ describe("loadDotEnv", () => {
     });
   });
 
+  it("loads the Ubuntu gateway.env compatibility fallback after ~/.openclaw/.env", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ base, cwdDir, stateDir }) => {
+        process.env.HOME = base;
+        await writeEnvFile(path.join(stateDir, ".env"), "FOO=from-global\n");
+        await writeEnvFile(
+          path.join(base, ".config", "openclaw", "gateway.env"),
+          ["FOO=from-gateway", "BAR=from-gateway"].join("\n"),
+        );
+
+        vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+        delete process.env.FOO;
+        delete process.env.BAR;
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.FOO).toBe("from-global");
+        expect(process.env.BAR).toBe("from-gateway");
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("Conflicting values in"));
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining("gateway.env"));
+      });
+    });
+  });
+
   it("blocks dangerous and workspace-control vars from CWD .env", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
@@ -423,6 +448,28 @@ describe("loadCliDotEnv", () => {
         loadCliDotEnv({ quiet: true });
 
         expect(process.env.OPENCLAW_STATE_DIR).toBeUndefined();
+      });
+    });
+  });
+
+  it("loads the gateway.env compatibility fallback during CLI startup", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ base, cwdDir, stateDir }) => {
+        process.env.HOME = base;
+        await writeEnvFile(path.join(stateDir, ".env"), "FOO=from-global\n");
+        await writeEnvFile(
+          path.join(base, ".config", "openclaw", "gateway.env"),
+          "BAR=from-gateway\n",
+        );
+
+        vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+        delete process.env.FOO;
+        delete process.env.BAR;
+
+        loadCliDotEnv({ quiet: true });
+
+        expect(process.env.FOO).toBe("from-global");
+        expect(process.env.BAR).toBe("from-gateway");
       });
     });
   });

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -122,6 +122,28 @@ describe("loadDotEnv", () => {
     });
   });
 
+  it("does not warn about dotenv conflicts when the key is already set", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ base, cwdDir, stateDir }) => {
+        process.env.HOME = base;
+        process.env.FOO = "from-shell";
+        await writeEnvFile(path.join(stateDir, ".env"), "FOO=from-global\n");
+        await writeEnvFile(
+          path.join(base, ".config", "openclaw", "gateway.env"),
+          "FOO=from-gateway\n",
+        );
+
+        vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.FOO).toBe("from-shell");
+        expect(warn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   it("blocks dangerous and workspace-control vars from CWD .env", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
@@ -471,6 +493,26 @@ describe("loadCliDotEnv", () => {
         expect(process.env.FOO).toBe("from-global");
         expect(process.env.BAR).toBe("from-gateway");
       });
+    });
+  });
+
+  it("keeps the legacy state-dir fallback for CLI dotenv loading", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-legacy-"));
+      const cwdDir = path.join(base, "cwd");
+      const legacyStateDir = path.join(base, ".clawdbot");
+      process.env.HOME = base;
+      delete process.env.OPENCLAW_STATE_DIR;
+      delete process.env.OPENCLAW_TEST_FAST;
+      await fs.mkdir(cwdDir, { recursive: true });
+      await writeEnvFile(path.join(legacyStateDir, ".env"), "LEGACY_ONLY=from-legacy\n");
+
+      vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+      delete process.env.LEGACY_ONLY;
+
+      loadCliDotEnv({ quiet: true });
+
+      expect(process.env.LEGACY_ONLY).toBe("from-legacy");
     });
   });
 

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -200,25 +200,37 @@ function loadParsedDotEnvFiles(files: LoadedDotEnvFile[]) {
 export function loadGlobalRuntimeDotEnvFiles(opts?: { quiet?: boolean; stateEnvPath?: string }) {
   const quiet = opts?.quiet ?? true;
   const stateEnvPath = opts?.stateEnvPath ?? path.join(resolveConfigDir(process.env), ".env");
-  const compatGatewayEnvPath = path.join(
+  const defaultStateEnvPath = path.join(
     resolveRequiredHomeDir(process.env, os.homedir),
-    ".config",
-    "openclaw",
-    "gateway.env",
+    ".openclaw",
+    ".env",
   );
+  const hasExplicitNonDefaultStateDir =
+    process.env.OPENCLAW_STATE_DIR?.trim() !== undefined &&
+    path.resolve(stateEnvPath) !== path.resolve(defaultStateEnvPath);
   const parsedFiles = [
     readDotEnvFile({
       filePath: stateEnvPath,
       shouldBlockKey: shouldBlockRuntimeDotEnvKey,
       quiet,
     }),
-    readDotEnvFile({
-      filePath: compatGatewayEnvPath,
-      shouldBlockKey: shouldBlockRuntimeDotEnvKey,
-      quiet,
-    }),
-  ].filter((file): file is LoadedDotEnvFile => file !== null);
-  loadParsedDotEnvFiles(parsedFiles);
+  ];
+  if (!hasExplicitNonDefaultStateDir) {
+    parsedFiles.push(
+      readDotEnvFile({
+        filePath: path.join(
+          resolveRequiredHomeDir(process.env, os.homedir),
+          ".config",
+          "openclaw",
+          "gateway.env",
+        ),
+        shouldBlockKey: shouldBlockRuntimeDotEnvKey,
+        quiet,
+      }),
+    );
+  }
+  const parsed = parsedFiles.filter((file): file is LoadedDotEnvFile => file !== null);
+  loadParsedDotEnvFiles(parsed);
 }
 
 export function loadDotEnv(opts?: { quiet?: boolean }) {

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -153,11 +153,15 @@ export function loadWorkspaceDotEnvFile(filePath: string, opts?: { quiet?: boole
 }
 
 function loadParsedDotEnvFiles(files: LoadedDotEnvFile[]) {
+  const preExistingKeys = new Set(Object.keys(process.env));
   const conflicts = new Map<string, { keptPath: string; ignoredPath: string; keys: Set<string> }>();
   const firstSeen = new Map<string, { value: string; filePath: string }>();
 
   for (const file of files) {
     for (const { key, value } of file.entries) {
+      if (preExistingKeys.has(key)) {
+        continue;
+      }
       const previous = firstSeen.get(key);
       if (previous) {
         if (previous.value !== value) {
@@ -193,9 +197,9 @@ function loadParsedDotEnvFiles(files: LoadedDotEnvFile[]) {
   }
 }
 
-export function loadGlobalRuntimeDotEnvFiles(opts?: { quiet?: boolean }) {
+export function loadGlobalRuntimeDotEnvFiles(opts?: { quiet?: boolean; stateEnvPath?: string }) {
   const quiet = opts?.quiet ?? true;
-  const stateEnvPath = path.join(resolveConfigDir(process.env), ".env");
+  const stateEnvPath = opts?.stateEnvPath ?? path.join(resolveConfigDir(process.env), ".env");
   const compatGatewayEnvPath = path.join(
     resolveRequiredHomeDir(process.env, os.homedir),
     ".config",

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import dotenv from "dotenv";
 import { resolveConfigDir } from "../utils.js";
+import { resolveRequiredHomeDir } from "./home-dir.js";
 import {
   isDangerousHostEnvOverrideVarName,
   isDangerousHostEnvVarName,
@@ -67,11 +69,21 @@ function shouldBlockWorkspaceDotEnvKey(key: string): boolean {
   );
 }
 
-function loadDotEnvFile(params: {
+type DotEnvEntry = {
+  key: string;
+  value: string;
+};
+
+type LoadedDotEnvFile = {
+  filePath: string;
+  entries: DotEnvEntry[];
+};
+
+function readDotEnvFile(params: {
   filePath: string;
   shouldBlockKey: (key: string) => boolean;
   quiet?: boolean;
-}) {
+}): LoadedDotEnvFile | null {
   let content: string;
   try {
     content = fs.readFileSync(params.filePath, "utf8");
@@ -83,7 +95,7 @@ function loadDotEnvFile(params: {
         console.warn(`[dotenv] Failed to read ${params.filePath}: ${String(error)}`);
       }
     }
-    return;
+    return null;
   }
 
   let parsed: Record<string, string>;
@@ -93,13 +105,29 @@ function loadDotEnvFile(params: {
     if (!params.quiet) {
       console.warn(`[dotenv] Failed to parse ${params.filePath}: ${String(error)}`);
     }
-    return;
+    return null;
   }
+  const entries: DotEnvEntry[] = [];
   for (const [rawKey, value] of Object.entries(parsed)) {
     const key = normalizeEnvVarKey(rawKey, { portable: true });
     if (!key || params.shouldBlockKey(key)) {
       continue;
     }
+    entries.push({ key, value });
+  }
+  return { filePath: params.filePath, entries };
+}
+
+export function loadRuntimeDotEnvFile(filePath: string, opts?: { quiet?: boolean }) {
+  const parsed = readDotEnvFile({
+    filePath,
+    shouldBlockKey: shouldBlockRuntimeDotEnvKey,
+    quiet: opts?.quiet ?? true,
+  });
+  if (!parsed) {
+    return;
+  }
+  for (const { key, value } of parsed.entries) {
     if (process.env[key] !== undefined) {
       continue;
     }
@@ -107,20 +135,86 @@ function loadDotEnvFile(params: {
   }
 }
 
-export function loadRuntimeDotEnvFile(filePath: string, opts?: { quiet?: boolean }) {
-  loadDotEnvFile({
-    filePath,
-    shouldBlockKey: shouldBlockRuntimeDotEnvKey,
-    quiet: opts?.quiet ?? true,
-  });
-}
-
 export function loadWorkspaceDotEnvFile(filePath: string, opts?: { quiet?: boolean }) {
-  loadDotEnvFile({
+  const parsed = readDotEnvFile({
     filePath,
     shouldBlockKey: shouldBlockWorkspaceDotEnvKey,
     quiet: opts?.quiet ?? true,
   });
+  if (!parsed) {
+    return;
+  }
+  for (const { key, value } of parsed.entries) {
+    if (process.env[key] !== undefined) {
+      continue;
+    }
+    process.env[key] = value;
+  }
+}
+
+function loadParsedDotEnvFiles(files: LoadedDotEnvFile[]) {
+  const conflicts = new Map<string, { keptPath: string; ignoredPath: string; keys: Set<string> }>();
+  const firstSeen = new Map<string, { value: string; filePath: string }>();
+
+  for (const file of files) {
+    for (const { key, value } of file.entries) {
+      const previous = firstSeen.get(key);
+      if (previous) {
+        if (previous.value !== value) {
+          const conflictKey = `${previous.filePath}\u0000${file.filePath}`;
+          const existing = conflicts.get(conflictKey);
+          if (existing) {
+            existing.keys.add(key);
+          } else {
+            conflicts.set(conflictKey, {
+              keptPath: previous.filePath,
+              ignoredPath: file.filePath,
+              keys: new Set([key]),
+            });
+          }
+        }
+        continue;
+      }
+      firstSeen.set(key, { value, filePath: file.filePath });
+      if (process.env[key] === undefined) {
+        process.env[key] = value;
+      }
+    }
+  }
+
+  for (const conflict of conflicts.values()) {
+    const keys = [...conflict.keys].toSorted();
+    if (keys.length === 0) {
+      continue;
+    }
+    console.warn(
+      `[dotenv] Conflicting values in ${conflict.keptPath} and ${conflict.ignoredPath} for ${keys.join(", ")}; keeping ${conflict.keptPath}.`,
+    );
+  }
+}
+
+export function loadGlobalRuntimeDotEnvFiles(opts?: { quiet?: boolean }) {
+  const quiet = opts?.quiet ?? true;
+  const stateEnvPath = path.join(resolveConfigDir(process.env), ".env");
+  const compatGatewayEnvPath = path.join(
+    resolveRequiredHomeDir(process.env, os.homedir),
+    ".config",
+    "openclaw",
+    "gateway.env",
+  );
+  const parsedFiles = [
+    readDotEnvFile({
+      filePath: stateEnvPath,
+      shouldBlockKey: shouldBlockRuntimeDotEnvKey,
+      quiet,
+    }),
+    readDotEnvFile({
+      filePath: compatGatewayEnvPath,
+      shouldBlockKey: shouldBlockRuntimeDotEnvKey,
+      quiet,
+    }),
+  ].filter((file): file is LoadedDotEnvFile => file !== null);
+  loadParsedDotEnvFiles(parsedFiles);
 }
 
 export function loadDotEnv(opts?: { quiet?: boolean }) {
@@ -130,6 +224,5 @@ export function loadDotEnv(opts?: { quiet?: boolean }) {
 
   // Then load global fallback: ~/.openclaw/.env (or OPENCLAW_STATE_DIR/.env),
   // without overriding any env vars already present.
-  const globalEnvPath = path.join(resolveConfigDir(process.env), ".env");
-  loadRuntimeDotEnvFile(globalEnvPath, { quiet });
+  loadGlobalRuntimeDotEnvFiles({ quiet });
 }


### PR DESCRIPTION
## Summary

- Problem: Ubuntu fresh installs can leave secrets only in `~/.config/openclaw/gateway.env`, but startup dotenv loading only read `~/.openclaw/.env`.
- Why it matters: the Gateway can start without expected provider/channel secrets and fail auth silently.
- What changed: load `~/.config/openclaw/gateway.env` as a compatibility fallback after `~/.openclaw/.env`, keep the canonical `.openclaw/.env` value when both disagree, warn on conflicts, and add coverage/docs.
- What did NOT change (scope boundary): service/runtime env precedence is otherwise unchanged, and `~/.openclaw/.env` remains the canonical env file.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61057
- Related #61057
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: CLI/runtime dotenv loading only read the canonical state-dir file and ignored the Ubuntu fresh-install compatibility path.
- Missing detection / guardrail: no test covered `~/.config/openclaw/gateway.env` fallback or conflict handling.
- Prior context (`git blame`, prior PR, issue, or refactor if known): current docs already point users at `~/.openclaw/.env`, but the issue shows fresh installs can also create `~/.config/openclaw/gateway.env`.
- Why this regressed now: compatibility handling never existed in the dotenv startup path.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/dotenv.test.ts`
- Scenario the test should lock in: when both files exist, `.openclaw/.env` wins, missing keys fall back from `gateway.env`, and conflicts warn.
- Why this is the smallest reliable guardrail: the bug lives in the shared dotenv loader used by both runtime and CLI startup.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Fresh installs that only have `~/.config/openclaw/gateway.env` now load those env vars during startup.
- If both env files define different values, OpenClaw warns and keeps `~/.openclaw/.env`.

## Diagram (if applicable)

```text
Before:
[startup] -> [load ~/.openclaw/.env only] -> [gateway.env ignored]

After:
[startup] -> [load ~/.openclaw/.env] -> [load gateway.env for missing keys] -> [warn on conflicts]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: startup now reads one additional trusted home-directory compatibility file only. `~/.openclaw/.env` remains canonical and conflicts warn instead of silently overriding.

## Repro + Verification

### Environment

- OS: reproduced from issue on Ubuntu 24.04; verified locally with a temp HOME fixture
- Runtime/container: Node + CLI startup loaders
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): env files only

### Steps

1. Create `~/.openclaw/.env` and `~/.config/openclaw/gateway.env` with overlapping keys.
2. Run `loadDotEnv()` or `loadCliDotEnv()`.
3. Check which values are applied.

### Expected

- Canonical `.openclaw/.env` values win.
- Missing keys can fall back from `gateway.env`.
- Conflicts warn.

### Actual

- Verified with direct runtime check and targeted dotenv coverage.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: direct `node --import tsx` check for both `loadDotEnv()` and `loadCliDotEnv()` with temp `~/.openclaw/.env` and `~/.config/openclaw/gateway.env`; formatter check on touched files.
- Edge cases checked: conflict warning plus canonical precedence.
- What you did **not** verify: full repo Vitest lane, because `pnpm test -- src/infra/dotenv.test.ts` pulled an unrelated `src/plugins/contracts/plugin-sdk-subpaths.test.ts` failure.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: another compatibility env file could be introduced later with unclear precedence.
  - Mitigation: this change documents the current fallback explicitly and warns on conflicts.
