### PR TITLE
fix(memory): allow Gemini multimodal fallback before registry hydration

### DIFF
--- a/packages/memory-host-sdk/src/multimodal.ts
+++ b/packages/memory-host-sdk/src/multimodal.ts
@@ -1,5 +1,6 @@
 export {
   isMemoryMultimodalEnabled,
   normalizeMemoryMultimodalSettings,
+  supportsMemoryMultimodalEmbeddings,
   type MemoryMultimodalSettings,
 } from "./host/multimodal.js";

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -8,21 +8,20 @@ import { resolveMemorySearchConfig } from "./memory-search.js";
 
 const asConfig = (cfg: OpenClawConfig): OpenClawConfig => cfg;
 
-describe("memory search config", () => {
-  beforeEach(() => {
-    clearMemoryEmbeddingProviders();
-    registerMemoryEmbeddingProvider({
-      id: "openai",
-      defaultModel: "text-embedding-3-small",
-      transport: "remote",
-      create: async () => ({ provider: null }),
-    });
-    registerMemoryEmbeddingProvider({
-      id: "local",
-      defaultModel: "local-default",
-      transport: "local",
-      create: async () => ({ provider: null }),
-    });
+function registerBaseMemoryEmbeddingProviders(options?: { includeGemini?: boolean }): void {
+  registerMemoryEmbeddingProvider({
+    id: "openai",
+    defaultModel: "text-embedding-3-small",
+    transport: "remote",
+    create: async () => ({ provider: null }),
+  });
+  registerMemoryEmbeddingProvider({
+    id: "local",
+    defaultModel: "local-default",
+    transport: "local",
+    create: async () => ({ provider: null }),
+  });
+  if (options?.includeGemini !== false) {
     registerMemoryEmbeddingProvider({
       id: "gemini",
       defaultModel: "gemini-embedding-001",
@@ -34,24 +33,31 @@ describe("memory search config", () => {
           .replace(/^(gemini|google)\//, "") === "gemini-embedding-2-preview",
       create: async () => ({ provider: null }),
     });
-    registerMemoryEmbeddingProvider({
-      id: "voyage",
-      defaultModel: "voyage-4-large",
-      transport: "remote",
-      create: async () => ({ provider: null }),
-    });
-    registerMemoryEmbeddingProvider({
-      id: "mistral",
-      defaultModel: "mistral-embed",
-      transport: "remote",
-      create: async () => ({ provider: null }),
-    });
-    registerMemoryEmbeddingProvider({
-      id: "ollama",
-      defaultModel: "nomic-embed-text",
-      transport: "remote",
-      create: async () => ({ provider: null }),
-    });
+  }
+  registerMemoryEmbeddingProvider({
+    id: "voyage",
+    defaultModel: "voyage-4-large",
+    transport: "remote",
+    create: async () => ({ provider: null }),
+  });
+  registerMemoryEmbeddingProvider({
+    id: "mistral",
+    defaultModel: "mistral-embed",
+    transport: "remote",
+    create: async () => ({ provider: null }),
+  });
+  registerMemoryEmbeddingProvider({
+    id: "ollama",
+    defaultModel: "nomic-embed-text",
+    transport: "remote",
+    create: async () => ({ provider: null }),
+  });
+}
+
+describe("memory search config", () => {
+  beforeEach(() => {
+    clearMemoryEmbeddingProviders();
+    registerBaseMemoryEmbeddingProviders();
   });
 
   afterEach(() => {
@@ -311,6 +317,29 @@ describe("memory search config", () => {
     expect(() => resolveMemorySearchConfig(cfg, "main")).toThrow(
       /memorySearch\.multimodal requires a provider adapter that supports multimodal embeddings/,
     );
+  });
+
+  it("accepts Gemini multimodal memory even when the runtime registry has not registered Gemini yet", () => {
+    clearMemoryEmbeddingProviders();
+    registerBaseMemoryEmbeddingProviders({ includeGemini: false });
+    const cfg = asConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "gemini",
+            model: "gemini-embedding-2-preview",
+            multimodal: { enabled: true, modalities: ["image"] },
+          },
+        },
+      },
+    });
+    const resolved = resolveMemorySearchConfig(cfg, "main");
+    expect(resolved?.provider).toBe("gemini");
+    expect(resolved?.multimodal).toEqual({
+      enabled: true,
+      modalities: ["image"],
+      maxFileBytes: 10 * 1024 * 1024,
+    });
   });
 
   it("rejects multimodal memory when fallback is configured", () => {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -390,9 +390,13 @@ export function resolveMemorySearchConfig(
   if (
     multimodalActive &&
     !(
-      multimodalProvider?.supportsMultimodalEmbeddings?.({
-        model: resolved.model,
-      }) ?? builtinMultimodalSupport
+      // Fall back to the built-in helper when the provider is not registered yet
+      // or when a registered adapter does not implement multimodal capability checks.
+      (
+        multimodalProvider?.supportsMultimodalEmbeddings?.({
+          model: resolved.model,
+        }) ?? builtinMultimodalSupport
+      )
     )
   ) {
     throw new Error(

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -6,6 +6,7 @@ import type { SecretInput } from "../config/types.secrets.js";
 import {
   isMemoryMultimodalEnabled,
   normalizeMemoryMultimodalSettings,
+  supportsMemoryMultimodalEmbeddings,
   type MemoryMultimodalSettings,
 } from "../memory-host-sdk/multimodal.js";
 import { getMemoryEmbeddingProvider } from "../plugins/memory-embedding-providers.js";
@@ -379,11 +380,20 @@ export function resolveMemorySearchConfig(
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider =
     resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);
+  const builtinMultimodalSupport =
+    resolved.provider === "auto"
+      ? false
+      : supportsMemoryMultimodalEmbeddings({
+          provider: resolved.provider,
+          model: resolved.model,
+        });
   if (
     multimodalActive &&
-    !multimodalProvider?.supportsMultimodalEmbeddings?.({
-      model: resolved.model,
-    })
+    !(
+      multimodalProvider?.supportsMultimodalEmbeddings?.({
+        model: resolved.model,
+      }) ?? builtinMultimodalSupport
+    )
   ) {
     throw new Error(
       "agents.*.memorySearch.multimodal requires a provider adapter that supports multimodal embeddings for the configured model.",


### PR DESCRIPTION
## Summary

- Problem: `memorySearch.multimodal` startup validation only trusted the live provider registry for multimodal support checks.
- Why it matters: Gemini multimodal memory can fail at startup even when the built-in Gemini embedding model supports it.
- What changed: export the built-in multimodal support helper, fall back to it when the runtime registry does not have the provider adapter yet, and add a regression test.
- What did NOT change (scope boundary): provider registration/runtime execution behavior is unchanged; this only fixes startup capability validation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61059
- Related #61059
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `resolveMemorySearchConfig()` required a registered provider adapter to answer multimodal capability checks, instead of using the built-in provider knowledge already available in the memory host SDK.
- Missing detection / guardrail: no regression test covered Gemini multimodal config before runtime registry hydration.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the built-in Gemini adapter already advertises multimodal support in the memory-core provider adapters.
- Why this regressed now: startup validation depended on registry timing instead of a stable built-in capability source.
- If unknown, what was ruled out: this was not a missing Gemini capability implementation; the issue was the validation lookup path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/memory-search.test.ts`
- Scenario the test should lock in: Gemini multimodal config resolves even when the runtime registry has not registered Gemini yet.
- Why this is the smallest reliable guardrail: the failure happens during config resolution before provider runtime execution.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Gemini multimodal memory search no longer fails startup just because the runtime registry is missing the Gemini adapter at validation time.

## Diagram (if applicable)

```text
Before:
[startup config validation] -> [registry missing Gemini adapter] -> [throw multimodal provider error]

After:
[startup config validation] -> [registry missing Gemini adapter] -> [fallback to built-in capability helper] -> [config accepted]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local worktree
- Runtime/container: direct Vitest run
- Model/provider: Gemini / `gemini-embedding-2-preview`
- Integration/channel (if any): N/A
- Relevant config (redacted): `memorySearch.provider = "gemini"`, `multimodal.enabled = true`, `fallback = "none"`

### Steps

1. Configure `memorySearch.multimodal.enabled = true` with Gemini embeddings.
2. Ensure the runtime registry does not register Gemini first.
3. Resolve memory search config.

### Expected

- Config resolves successfully because Gemini built-in multimodal support is known.

### Actual

- Verified with targeted regression test.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm exec vitest run --config vitest.config.ts src/agents/memory-search.test.ts -t "accepts Gemini multimodal memory even when the runtime registry has not registered Gemini yet"`
- Edge cases checked: registry-missing Gemini path only.
- What you did **not** verify: broader memory provider permutations beyond the built-in Gemini case.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: future built-in multimodal providers could hit the same pre-registration path if not included in the shared helper.
  - Mitigation: the fallback now lives in the shared memory host SDK helper, which is the right extension point for built-in capability knowledge.
