### PR TITLE
fix(cron): preserve tz in applyJobPatch to prevent spurious restart catch-up fires

### DIFF
--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -362,4 +362,91 @@ describe("CronService restart catch-up", () => {
 
     await store.cleanup();
   });
+
+  // Regression tests for https://github.com/openclaw/openclaw/issues/61028
+  // A cron job with a non-UTC tz must use the stored nextRunAtMs (which reflects
+  // the tz-correct scheduled slot) to decide whether to fire on restart.  Before
+  // the fix, patching a job's expr without re-supplying tz caused nextRunAtMs to
+  // be recomputed in the server's local timezone (UTC), producing a UTC-naive value
+  // that would trigger spurious catch-up runs on the next restart.
+
+  it("does not spuriously fire a non-UTC job whose tz-correct nextRunAtMs is still in the future (#61028)", async () => {
+    // nowMs = 2025-12-13T17:00:00Z (UTC).
+    // Job schedule: "0 21 * * *" America/Sao_Paulo (BRT = UTC-3).
+    //   → 21:00 BRT = 00:00 UTC next day.
+    // Last ran at 00:00 UTC Dec 13 (= 21:00 BRT Dec 12).
+    // Tz-correct nextRunAtMs = 00:00 UTC Dec 14 — still 7 hours away.
+    // A UTC-naive nextRunAtMs would be 21:00 UTC Dec 13, which has also not
+    // yet passed at nowMs=17:00 UTC, so this test specifically confirms the
+    // job stays quiet when the tz-correct value is stored.
+    const nextRunAtMs = Date.parse("2025-12-14T00:00:00.000Z"); // 21:00 BRT Dec 13
+    const lastRunAtMs = Date.parse("2025-12-13T00:00:00.000Z"); // 21:00 BRT Dec 12
+
+    await withRestartedCron(
+      [
+        {
+          id: "brt-future-job",
+          name: "BRT daily at 21:00",
+          enabled: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-13T00:01:00.000Z"),
+          schedule: { kind: "cron", expr: "0 21 * * *", tz: "America/Sao_Paulo" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "BRT tick" },
+          state: {
+            nextRunAtMs,
+            lastRunAtMs,
+            lastStatus: "ok",
+          },
+        },
+      ],
+      async ({ enqueueSystemEvent, requestHeartbeatNow }) => {
+        // The next BRT slot is 7 hours away — must NOT fire on restart.
+        expect(enqueueSystemEvent).not.toHaveBeenCalled();
+        expect(requestHeartbeatNow).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  it("fires a non-UTC job whose tz-correct nextRunAtMs is overdue on restart (#61028)", async () => {
+    // nowMs = 2025-12-13T17:00:00Z (UTC).
+    // Job schedule: "0 19 * * *" America/Sao_Paulo (BRT = UTC-3).
+    //   → 19:00 BRT = 22:00 UTC.
+    // But store has nextRunAtMs = yesterday's 22:00 UTC = 2025-12-12T22:00:00Z,
+    // and lastRunAtMs = the run before that.
+    // At nowMs=17:00 UTC Dec 13, the previous BRT slot (19:00 BRT Dec 12 = 22:00 UTC Dec 12)
+    // was genuinely missed — the job should fire on restart.
+    const nextRunAtMs = Date.parse("2025-12-12T22:00:00.000Z"); // 19:00 BRT Dec 12 (missed)
+    const lastRunAtMs = Date.parse("2025-12-11T22:00:00.000Z"); // 19:00 BRT Dec 11
+
+    await withRestartedCron(
+      [
+        {
+          id: "brt-overdue-job",
+          name: "BRT daily at 19:00",
+          enabled: true,
+          createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
+          updatedAtMs: Date.parse("2025-12-12T22:01:00.000Z"),
+          schedule: { kind: "cron", expr: "0 19 * * *", tz: "America/Sao_Paulo" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "BRT overdue tick" },
+          state: {
+            nextRunAtMs,
+            lastRunAtMs,
+            lastStatus: "ok",
+          },
+        },
+      ],
+      async ({ enqueueSystemEvent, requestHeartbeatNow }) => {
+        // The 19:00 BRT Dec 12 slot was missed — must fire on restart.
+        expect(enqueueSystemEvent).toHaveBeenCalledWith(
+          "BRT overdue tick",
+          expect.objectContaining({ agentId: undefined }),
+        );
+        expect(requestHeartbeatNow).toHaveBeenCalled();
+      },
+    );
+  });
 });

--- a/src/cron/service.restart-catchup.test.ts
+++ b/src/cron/service.restart-catchup.test.ts
@@ -372,25 +372,24 @@ describe("CronService restart catch-up", () => {
 
   it("does not spuriously fire a non-UTC job whose tz-correct nextRunAtMs is still in the future (#61028)", async () => {
     // nowMs = 2025-12-13T17:00:00Z (UTC).
-    // Job schedule: "0 21 * * *" America/Sao_Paulo (BRT = UTC-3).
-    //   → 21:00 BRT = 00:00 UTC next day.
-    // Last ran at 00:00 UTC Dec 13 (= 21:00 BRT Dec 12).
-    // Tz-correct nextRunAtMs = 00:00 UTC Dec 14 — still 7 hours away.
-    // A UTC-naive nextRunAtMs would be 21:00 UTC Dec 13, which has also not
-    // yet passed at nowMs=17:00 UTC, so this test specifically confirms the
-    // job stays quiet when the tz-correct value is stored.
-    const nextRunAtMs = Date.parse("2025-12-14T00:00:00.000Z"); // 21:00 BRT Dec 13
-    const lastRunAtMs = Date.parse("2025-12-13T00:00:00.000Z"); // 21:00 BRT Dec 12
+    // Job schedule: "0 16 * * *" America/Sao_Paulo (BRT = UTC-3).
+    //   → 16:00 BRT = 19:00 UTC.
+    // Last ran at 19:00 UTC Dec 12 (= 16:00 BRT Dec 12).
+    // Tz-correct nextRunAtMs = 19:00 UTC Dec 13 — still 2 hours away.
+    // A UTC-naive nextRunAtMs would be 16:00 UTC Dec 13, which is already
+    // 1 hour past at nowMs=17:00 UTC and would spuriously fire with the bug.
+    const nextRunAtMs = Date.parse("2025-12-13T19:00:00.000Z"); // 16:00 BRT Dec 13
+    const lastRunAtMs = Date.parse("2025-12-12T19:00:00.000Z"); // 16:00 BRT Dec 12
 
     await withRestartedCron(
       [
         {
           id: "brt-future-job",
-          name: "BRT daily at 21:00",
+          name: "BRT daily at 16:00",
           enabled: true,
           createdAtMs: Date.parse("2025-12-10T12:00:00.000Z"),
-          updatedAtMs: Date.parse("2025-12-13T00:01:00.000Z"),
-          schedule: { kind: "cron", expr: "0 21 * * *", tz: "America/Sao_Paulo" },
+          updatedAtMs: Date.parse("2025-12-12T19:01:00.000Z"),
+          schedule: { kind: "cron", expr: "0 16 * * *", tz: "America/Sao_Paulo" },
           sessionTarget: "main",
           wakeMode: "next-heartbeat",
           payload: { kind: "systemEvent", text: "BRT tick" },
@@ -402,7 +401,7 @@ describe("CronService restart catch-up", () => {
         },
       ],
       async ({ enqueueSystemEvent, requestHeartbeatNow }) => {
-        // The next BRT slot is 7 hours away — must NOT fire on restart.
+        // The next BRT slot is still 2 hours away — must NOT fire on restart.
         expect(enqueueSystemEvent).not.toHaveBeenCalled();
         expect(requestHeartbeatNow).not.toHaveBeenCalled();
       },

--- a/src/cron/service/jobs.apply-patch.test.ts
+++ b/src/cron/service/jobs.apply-patch.test.ts
@@ -35,3 +35,80 @@ describe("applyJobPatch delivery merge", () => {
     });
   });
 });
+
+describe("applyJobPatch cron schedule tz preservation (#61028)", () => {
+  // Regression test: patching a cron job's expr without re-supplying tz must not
+  // silently drop the previously-configured timezone.  If it does, nextRunAtMs is
+  // recomputed in the server's local timezone (usually UTC) and the job fires at
+  // the wrong wall-clock time on the next gateway restart.
+  // See: https://github.com/openclaw/openclaw/issues/61028
+
+  it("preserves existing tz when patch omits it (non-UTC timezone)", () => {
+    const job = makeJob({
+      schedule: { kind: "cron", expr: "0 21 * * *", tz: "America/Sao_Paulo" },
+    });
+
+    // Patch changes only the expression; no tz field included.
+    applyJobPatch(job, { schedule: { kind: "cron", expr: "0 22 * * *" } });
+
+    expect(job.schedule).toMatchObject({
+      kind: "cron",
+      expr: "0 22 * * *",
+      tz: "America/Sao_Paulo",
+    });
+  });
+
+  it("preserves existing tz when patch omits it (Asia/Shanghai timezone)", () => {
+    const job = makeJob({
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "Asia/Shanghai" },
+    });
+
+    applyJobPatch(job, { schedule: { kind: "cron", expr: "0 9 * * *" } });
+
+    expect(job.schedule).toMatchObject({
+      kind: "cron",
+      expr: "0 9 * * *",
+      tz: "Asia/Shanghai",
+    });
+  });
+
+  it("applies a new tz when patch explicitly provides one", () => {
+    const job = makeJob({
+      schedule: { kind: "cron", expr: "0 21 * * *", tz: "America/Sao_Paulo" },
+    });
+
+    applyJobPatch(job, { schedule: { kind: "cron", expr: "0 21 * * *", tz: "Asia/Tokyo" } });
+
+    expect(job.schedule).toMatchObject({
+      kind: "cron",
+      expr: "0 21 * * *",
+      tz: "Asia/Tokyo",
+    });
+  });
+
+  it("clears tz when patch explicitly sets it to undefined", () => {
+    const job = makeJob({
+      schedule: { kind: "cron", expr: "0 21 * * *", tz: "America/Sao_Paulo" },
+    });
+
+    // Explicitly providing tz:undefined in the patch should clear the timezone.
+    applyJobPatch(job, { schedule: { kind: "cron", expr: "0 21 * * *", tz: undefined } });
+
+    expect((job.schedule as { tz?: string }).tz).toBeUndefined();
+  });
+
+  it("preserves existing tz when patch omits it while also changing staggerMs", () => {
+    const job = makeJob({
+      schedule: { kind: "cron", expr: "0 21 * * *", tz: "Europe/Berlin" },
+    });
+
+    applyJobPatch(job, { schedule: { kind: "cron", expr: "0 21 * * *", staggerMs: 60_000 } });
+
+    expect(job.schedule).toMatchObject({
+      kind: "cron",
+      expr: "0 21 * * *",
+      tz: "Europe/Berlin",
+      staggerMs: 60_000,
+    });
+  });
+});

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -587,16 +587,26 @@ export function applyJobPatch(
   if (patch.schedule) {
     if (patch.schedule.kind === "cron") {
       const explicitStaggerMs = normalizeCronStaggerMs(patch.schedule.staggerMs);
+      // Preserve the existing tz when the patch omits it.  A partial schedule
+      // update (e.g. changing only the expr or stagger) should never silently
+      // drop a previously-configured timezone, which would cause nextRunAtMs
+      // to be recomputed in the server's local timezone and fire incorrectly
+      // on the next gateway restart.  The caller must explicitly pass tz to
+      // change or clear it.  See: https://github.com/openclaw/openclaw/issues/61028
+      const existingTz = job.schedule.kind === "cron" ? job.schedule.tz : undefined;
+      const resolvedTz = "tz" in patch.schedule ? patch.schedule.tz : existingTz;
+      const patchSchedule =
+        resolvedTz !== undefined ? { ...patch.schedule, tz: resolvedTz } : patch.schedule;
       if (explicitStaggerMs !== undefined) {
-        job.schedule = { ...patch.schedule, staggerMs: explicitStaggerMs };
+        job.schedule = { ...patchSchedule, staggerMs: explicitStaggerMs };
       } else if (job.schedule.kind === "cron") {
-        job.schedule = { ...patch.schedule, staggerMs: job.schedule.staggerMs };
+        job.schedule = { ...patchSchedule, staggerMs: job.schedule.staggerMs };
       } else {
         const defaultStaggerMs = resolveDefaultCronStaggerMs(patch.schedule.expr);
         job.schedule =
           defaultStaggerMs !== undefined
-            ? { ...patch.schedule, staggerMs: defaultStaggerMs }
-            : patch.schedule;
+            ? { ...patchSchedule, staggerMs: defaultStaggerMs }
+            : patchSchedule;
       }
     } else {
       job.schedule = patch.schedule;


### PR DESCRIPTION
## Summary

A cron job with an explicit `tz` (e.g. `America/Sao_Paulo`) was silently losing its timezone when patched without re-supplying `tz`. On the next gateway restart, the UTC-naive `nextRunAtMs` triggered a spurious catch-up run at the wrong local time.

**Root cause** — `src/cron/service/jobs.ts` `applyJobPatch()` line 588, commit `e3ac0f4`:
```typescript
// BEFORE — tz silently dropped when patch.schedule has no tz key:
job.schedule = { ...patch.schedule, staggerMs: ... };
```
The spread uses patch.schedule verbatim; if `tz` is absent in the patch object the field is absent in the result.

**Call path (G9)**:
```
openclaw cron edit <id> --cron "0 22 * * *"   (no --tz flag)
 → register.cron-edit.ts: patch.schedule = scheduleRequest.schedule   (tz absent)
 → server-methods/cron.ts: cron.update(jobId, patch)
 → ops.ts update(): applyJobPatch(job, patch)    ← tz dropped here
 → computeJobNextRunAtMs(job, now)               ← uses tz-less schedule → UTC-naive nextRunAtMs
 → gateway restart: PATH A fires spuriously
```

**Grep for same pattern (G8)**:
`git grep -n "patch\.schedule"` in non-test source — only `applyJobPatch` in `jobs.ts` constructs a new cron schedule from patch fields; all other sites pass through to this function or do validation only.

**Fix**: use `"tz" in patch.schedule` (not `=== undefined`) to distinguish "caller omitted tz" from "caller explicitly cleared tz". When omitted, fall back to the existing schedule's `tz`. When explicitly provided (including `undefined`), use the caller's value.

**Tests added (G5)**:
- `src/cron/service/jobs.apply-patch.test.ts`: 5 unit tests — tz preserved when omitted, tz changed when explicit, tz cleared when explicitly `undefined`, tz preserved alongside staggerMs change
- `src/cron/service.restart-catchup.test.ts`: 2 integration tests — BRT job with future `nextRunAtMs` must not fire on restart; BRT job with overdue `nextRunAtMs` must fire on restart

Closes #61028
Related: #60985
