### PR TITLE
fix(skills): exclude .git and node_modules when copying skills to workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Docs: https://docs.openclaw.ai
 - CLI/Commander: preserve Commander-computed exit codes for argument and help-error paths, and cover the user-argv parse mode in the regression tests so invalid CLI invocations no longer report success when exits are intercepted. (#60923) Thanks @Linux2010.
 - Telegram/native command menu: trim long menu descriptions before dropping commands so sub-100 command sets can still fit Telegram's payload budget and keep more `/` entries visible. (#61129) Thanks @neeravmakwana.
 - Agents/Claude CLI: keep non-interactive `--permission-mode bypassPermissions` when custom `cliBackends.claude-cli.args` override defaults, so cron and heartbeat Claude CLI runs do not regress to interactive approval mode. (#61114) Thanks @cathrynlavery and @thewilloftheshadow.
+- Agents/skills: skip `.git` and `node_modules` when mirroring skills into sandbox workspaces so read-only sandboxes do not copy repo history or dependency trees. (#61090) Thanks @joelnishanth.
 
 ## 2026.4.2
 

--- a/src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts
+++ b/src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts
@@ -100,6 +100,15 @@ describe("buildWorkspaceSkillsPrompt", () => {
     const extraDir = path.join(sourceWorkspace, ".extra");
     const bundledDir = path.join(sourceWorkspace, ".bundled");
     const managedDir = path.join(sourceWorkspace, ".managed");
+    const workspaceSkillDir = path.join(sourceWorkspace, "skills", "demo-skill");
+
+    await fs.mkdir(path.join(workspaceSkillDir, ".git"), { recursive: true });
+    await fs.writeFile(path.join(workspaceSkillDir, ".git", "config"), "gitdir");
+    await fs.mkdir(path.join(workspaceSkillDir, "node_modules", "pkg"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceSkillDir, "node_modules", "pkg", "index.js"),
+      "export {}",
+    );
 
     await withEnv({ HOME: sourceWorkspace, PATH: "" }, () =>
       syncSkillsToWorkspace({
@@ -121,6 +130,12 @@ describe("buildWorkspaceSkillsPrompt", () => {
     expect(prompt).not.toContain("Bundled version");
     expect(prompt).not.toContain("Extra version");
     expect(prompt.replaceAll("\\", "/")).toContain("demo-skill/SKILL.md");
+    expect(await pathExists(path.join(targetWorkspace, "skills", "demo-skill", ".git"))).toBe(
+      false,
+    );
+    expect(
+      await pathExists(path.join(targetWorkspace, "skills", "demo-skill", "node_modules")),
+    ).toBe(false);
   });
 
   it("syncs the explicit agent skill subset instead of inherited defaults", async () => {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -825,6 +825,10 @@ export async function syncSkillsToWorkspace(params: {
         await fsp.cp(entry.skill.baseDir, dest, {
           recursive: true,
           force: true,
+          filter: (src) => {
+            const name = path.basename(src);
+            return name !== ".git" && name !== "node_modules";
+          },
         });
       } catch (error) {
         const message = error instanceof Error ? error.message : JSON.stringify(error);

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -827,7 +827,7 @@ export async function syncSkillsToWorkspace(params: {
           force: true,
           filter: (src) => {
             const name = path.basename(src);
-            return name !== ".git" && name !== "node_modules";
+            return !(name === ".git" || name === "node_modules");
           },
         });
       } catch (error) {


### PR DESCRIPTION
Closes #60879

## Summary

- Added a filter to the `fsp.cp` call in `syncSkillsToWorkspace` that excludes `.git` and `node_modules` directories when copying skill trees to the sandbox workspace.

## Root Cause

`syncSkillsToWorkspace` in `src/agents/skills/workspace.ts` uses `fsp.cp` with `recursive: true` but no `filter` option, so the entire skill directory tree is copied verbatim, including `.git` (which can contain large binary pack files) and `node_modules`.

Other file-walking code in the repo (e.g. `computeSkillFingerprint`, `walkDirWithLimit` in the skill scanner, `listCandidateSkillDirs`) already skips dot-directories and `node_modules`, so this was the one path that was missing the exclusion.

## Changes

**`src/agents/skills/workspace.ts`** - added a `filter` callback to `fsp.cp` that rejects entries named `.git` or `node_modules`.

## Test Plan

- [x] `npx vitest run src/agents/skills/` - 34/34 pass
- [x] No lint errors on touched files

## Risks and Mitigations

- The filter is conservative: it only skips `.git` and `node_modules` by basename, matching the patterns used by the rest of the skill file-walking code.
- No user-facing skill data lives in `.git` or `node_modules`, so excluding them has no functional impact.

---

[Joel Nishanth](https://offlyn.ai) - [offlyn.AI](https://offlyn.ai)
