### PR TITLE
fix(config): apply tools.exec.pathPrepend to process.env.PATH at startup

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1834,6 +1834,18 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         });
       }
 
+      // Apply tools.exec.pathPrepend to process.env.PATH so that hasBinary()
+      // (used for skill eligibility) sees the same paths the exec tool uses.
+      const pathPrepend = cfg.tools?.exec?.pathPrepend;
+      if (pathPrepend && pathPrepend.length > 0) {
+        const existing = deps.env.PATH ?? "";
+        const existingParts = new Set(existing.split(path.delimiter).filter(Boolean));
+        const newParts = pathPrepend.filter((p) => p.trim() && !existingParts.has(p));
+        if (newParts.length > 0) {
+          deps.env.PATH = [...newParts, existing].filter(Boolean).join(path.delimiter);
+        }
+      }
+
       const pendingSecret = AUTO_OWNER_DISPLAY_SECRET_BY_PATH.get(configPath);
       const ownerDisplaySecretResolution = ensureOwnerDisplaySecret(
         cfg,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1840,7 +1840,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       if (pathPrepend && pathPrepend.length > 0) {
         const existing = deps.env.PATH ?? "";
         const existingParts = new Set(existing.split(path.delimiter).filter(Boolean));
-        const newParts = pathPrepend.filter((p) => p.trim() && !existingParts.has(p));
+        const newParts = pathPrepend.map((p) => p.trim()).filter((p) => p && !existingParts.has(p));
         if (newParts.length > 0) {
           deps.env.PATH = [...newParts, existing].filter(Boolean).join(path.delimiter);
         }


### PR DESCRIPTION
## Summary

- `hasBinary()` (used for skill eligibility / "needs setup" checks) reads `process.env.PATH` directly
- On macOS apps, `process.env.PATH` is a minimal `/usr/bin:/bin:/usr/sbin:/sbin` — it never includes homebrew or user-installed tool paths
- `tools.exec.pathPrepend` only applied at exec-time, so skill status, media-understanding auto-detection, and other `hasBinary()` callers couldn't find brew-installed binaries like `memo`, `remindctl`, `whisper-cli`, etc.
- This prepends `tools.exec.pathPrepend` entries to `process.env.PATH` during config load so all PATH-dependent checks are consistent

## Test plan

- [x] Type-check clean
- [x] Verified that skills previously showing "needs setup" now show "ready" after adding pathPrepend config
- [ ] `pnpm test -- src/config/io` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)