### PR TITLE
[codex] Agents: protect current tool outputs from guard compaction

### DIFF
--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -344,6 +344,35 @@ describe("session_status tool", () => {
     expect(details.statusText).not.toContain("OAuth/token status");
   });
 
+  it("includes the unique session ID in session_status output", async () => {
+    resetSessionStore({
+      main: {
+        sessionId: "sess-unique",
+        updatedAt: 10,
+      },
+    });
+
+    const tool = getSessionStatusTool();
+
+    const result = await tool.execute("call-session-id", {});
+    const details = result.details as {
+      ok?: boolean;
+      sessionId?: string;
+      statusText?: string;
+    };
+    expect(details.ok).toBe(true);
+    expect(details.sessionId).toBe("sess-unique");
+    expect(details.statusText).toContain("🆔 Session ID: sess-unique");
+    expect(result.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("🆔 Session ID: sess-unique"),
+        }),
+      ]),
+    );
+  });
+
   it("enables transcript usage fallback for session_status", async () => {
     resetSessionStore({
       main: {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.tool-result-context-guard.test.ts
@@ -1,0 +1,77 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  getHoisted,
+  resetEmbeddedAttemptHarness,
+  testModel,
+} from "./attempt.spawn-workspace.test-support.js";
+
+const hoisted = getHoisted();
+
+describe("runEmbeddedAttempt tool-result context guard budget", () => {
+  const sessionKey = "agent:main:test-tool-result-guard-budget";
+  const tempPaths: string[] = [];
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness();
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+  });
+
+  it("uses resolved context-window tokens instead of maxTokens fallback", async () => {
+    await createContextEngineAttemptRunner({
+      contextEngine: {
+        assemble: async ({ messages }) => ({
+          messages,
+          estimatedTokens: 1,
+        }),
+      },
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        config: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://example.invalid",
+                models: [
+                  {
+                    id: "gpt-test",
+                    name: "gpt-test",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: {
+                      input: 0,
+                      output: 0,
+                      cacheRead: 0,
+                      cacheWrite: 0,
+                    },
+                    contextWindow: 200_000,
+                    maxTokens: 64,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        resolvedApiKey: "test-key",
+        model: {
+          ...(testModel as unknown as Record<string, unknown>),
+          contextWindow: undefined,
+          contextTokens: undefined,
+          maxTokens: 64,
+        } as unknown as Model<Api>,
+      },
+    });
+
+    expect(hoisted.installToolResultContextGuardMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contextWindowTokens: 200_000,
+      }),
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -45,6 +45,7 @@ import {
   resolveChannelMessageToolHints,
   resolveChannelReactionGuidance,
 } from "../../channel-tools.js";
+import { resolveContextWindowInfo } from "../../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
@@ -880,14 +881,20 @@ export async function runEmbeddedAttempt(
       queueYieldInterruptForSession = () => {
         queueSessionsYieldInterruptMessage(activeSession);
       };
+      const toolResultGuardContextWindowTokens = resolveContextWindowInfo({
+        cfg: params.config,
+        provider: params.provider,
+        modelId: params.modelId,
+        modelContextTokens: (params.model as { contextTokens?: number }).contextTokens,
+        modelContextWindow: params.model.contextWindow,
+        defaultTokens: DEFAULT_CONTEXT_TOKENS,
+      }).tokens;
       removeToolResultContextGuard = installToolResultContextGuard({
         agent: activeSession.agent,
-        contextWindowTokens: Math.max(
-          1,
-          Math.floor(
-            params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
-          ),
-        ),
+        // maxTokens is an output cap for many providers and can be far smaller than
+        // the real context window, which makes the guard compact fresh tool results
+        // immediately. Reuse the normal context-window resolver here instead.
+        contextWindowTokens: toolResultGuardContextWindowTokens,
       });
       const cacheTrace = createCacheTrace({
         cfg: params.config,

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -27,6 +27,14 @@ function makeToolResult(id: string, text: string): AgentMessage {
   });
 }
 
+function makeAssistant(text: string): AgentMessage {
+  return castAgentMessage({
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp: Date.now(),
+  });
+}
+
 function makeLegacyToolResult(id: string, text: string): AgentMessage {
   return castAgentMessage({
     role: "tool",
@@ -111,8 +119,8 @@ describe("installToolResultContextGuard", () => {
     const contextForNextCall = makeTwoToolResultOverflowContext();
     const transformed = await applyGuardToContext(agent, contextForNextCall);
 
-    expect(transformed).toBe(contextForNextCall);
-    expectCompactedToolResultsWithoutContextNotice(contextForNextCall, 1, 2);
+    expect(transformed).not.toBe(contextForNextCall);
+    expectCompactedToolResultsWithoutContextNotice(transformed as AgentMessage[], 1, 2);
   });
 
   it("keeps compacting newest-first until context is back under budget", async () => {
@@ -130,11 +138,14 @@ describe("installToolResultContextGuard", () => {
       makeToolResult("call_3", "c".repeat(800)),
     ];
 
-    await agent.transformContext?.(contextForNextCall, new AbortController().signal);
+    const transformed = (await agent.transformContext?.(
+      contextForNextCall,
+      new AbortController().signal,
+    )) as AgentMessage[];
 
-    const first = getToolResultText(contextForNextCall[1]);
-    const second = getToolResultText(contextForNextCall[2]);
-    const third = getToolResultText(contextForNextCall[3]);
+    const first = getToolResultText(transformed[1]);
+    const second = getToolResultText(transformed[2]);
+    const third = getToolResultText(transformed[3]);
 
     expect(first).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
     expect(second).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
@@ -150,12 +161,16 @@ describe("installToolResultContextGuard", () => {
     });
 
     const contextForNextCall: AgentMessage[] = [makeUser("stress")];
+    let transformed: AgentMessage[] = contextForNextCall;
     for (let i = 1; i <= 4; i++) {
       contextForNextCall.push(makeToolResult(`call_${i}`, String(i).repeat(95_000)));
-      await agent.transformContext?.(contextForNextCall, new AbortController().signal);
+      transformed = (await agent.transformContext?.(
+        contextForNextCall,
+        new AbortController().signal,
+      )) as AgentMessage[];
     }
 
-    const toolResultTexts = contextForNextCall
+    const toolResultTexts = transformed
       .filter((msg) => msg.role === "toolResult")
       .map((msg) => getToolResultText(msg as AgentMessage));
 
@@ -176,14 +191,17 @@ describe("installToolResultContextGuard", () => {
 
     const contextForNextCall = [makeToolResult("call_big", "z".repeat(5_000))];
 
-    await agent.transformContext?.(contextForNextCall, new AbortController().signal);
+    const transformed = (await agent.transformContext?.(
+      contextForNextCall,
+      new AbortController().signal,
+    )) as AgentMessage[];
 
-    const newResultText = getToolResultText(contextForNextCall[0]);
+    const newResultText = getToolResultText(transformed[0]);
     expect(newResultText.length).toBeLessThan(5_000);
     expect(newResultText).toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
   });
 
-  it("keeps compacting newest-first until overflow clears, reaching older tool results when needed", async () => {
+  it("protects tool results after the latest assistant message from full compaction", async () => {
     const agent = makeGuardableAgent();
 
     installToolResultContextGuard({
@@ -194,11 +212,17 @@ describe("installToolResultContextGuard", () => {
     const contextForNextCall = [
       makeUser("u".repeat(2_600)),
       makeToolResult("call_old", "x".repeat(700)),
-      makeToolResult("call_new", "y".repeat(1_000)),
+      makeAssistant("tool call"),
+      makeToolResult("call_new", "fresh output"),
     ];
 
-    await agent.transformContext?.(contextForNextCall, new AbortController().signal);
-    expectCompactedToolResultsWithoutContextNotice(contextForNextCall, 1, 2);
+    const transformed = (await agent.transformContext?.(
+      contextForNextCall,
+      new AbortController().signal,
+    )) as AgentMessage[];
+
+    expect(getToolResultText(transformed[1])).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
+    expect(getToolResultText(transformed[3])).toBe("fresh output");
   });
 
   it("wraps an existing transformContext and guards the transformed output", async () => {
@@ -232,10 +256,13 @@ describe("installToolResultContextGuard", () => {
       makeLegacyToolResult("call_new", "y".repeat(1_000)),
     ];
 
-    await agent.transformContext?.(contextForNextCall, new AbortController().signal);
+    const transformed = (await agent.transformContext?.(
+      contextForNextCall,
+      new AbortController().signal,
+    )) as AgentMessage[];
 
-    const oldResultText = (contextForNextCall[1] as { content?: unknown }).content;
-    const newResultText = (contextForNextCall[2] as { content?: unknown }).content;
+    const oldResultText = (transformed[1] as { content?: unknown }).content;
+    const newResultText = (transformed[2] as { content?: unknown }).content;
 
     expect(oldResultText).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
     expect(newResultText).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
@@ -255,16 +282,19 @@ describe("installToolResultContextGuard", () => {
       makeToolResultWithDetails("call_new", "y".repeat(900), "d".repeat(8_000)),
     ];
 
-    await agent.transformContext?.(contextForNextCall, new AbortController().signal);
+    const transformed = (await agent.transformContext?.(
+      contextForNextCall,
+      new AbortController().signal,
+    )) as AgentMessage[];
 
-    const oldResult = contextForNextCall[1] as {
+    const oldResult = transformed[1] as {
       details?: unknown;
     };
-    const newResult = contextForNextCall[2] as {
+    const newResult = transformed[2] as {
       details?: unknown;
     };
-    const oldResultText = getToolResultText(contextForNextCall[1]);
-    const newResultText = getToolResultText(contextForNextCall[2]);
+    const oldResultText = getToolResultText(transformed[1]);
+    const newResultText = getToolResultText(transformed[2]);
 
     expect(oldResultText).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
     expect(newResultText).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
@@ -306,7 +336,19 @@ describe("installToolResultContextGuard", () => {
     ).resolves.not.toThrow();
   });
 
-  it("compacts tool results before checking the preemptive overflow threshold", async () => {
+  it("does not mutate the source context when compaction happens", async () => {
+    const agent = makeGuardableAgent();
+
+    const contextForNextCall = makeTwoToolResultOverflowContext();
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
+
+    expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(1_000));
+    expect(getToolResultText(contextForNextCall[2])).toBe("y".repeat(1_000));
+    expect(getToolResultText(transformed[1])).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
+    expect(getToolResultText(transformed[2])).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
+  });
+
+  it("does not mutate the source context when the overflow guard throws", async () => {
     const agent = makeGuardableAgent();
 
     installToolResultContextGuard({
@@ -326,8 +368,6 @@ describe("installToolResultContextGuard", () => {
       agent.transformContext?.(contextForNextCall, new AbortController().signal),
     ).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
 
-    // Tool result should have been compacted before the overflow check.
-    const toolResultText = getToolResultText(contextForNextCall[1]);
-    expect(toolResultText).toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
+    expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(2_000));
   });
 });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -7,7 +7,6 @@ import {
   estimateContextChars,
   estimateMessageCharsCached,
   getToolResultText,
-  invalidateMessageCharsCacheEntry,
   isToolResultMessage,
 } from "./tool-result-char-estimator.js";
 
@@ -97,22 +96,50 @@ function truncateToolResultToChars(
   return replaceToolResultText(msg, truncatedText);
 }
 
-function compactExistingToolResultsInPlace(params: {
+function findLastAssistantIndex(messages: AgentMessage[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "assistant") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function collectProtectedCurrentTurnToolResultIndexes(messages: AgentMessage[]): Set<number> {
+  const lastAssistantIndex = findLastAssistantIndex(messages);
+  if (lastAssistantIndex < 0) {
+    return new Set<number>();
+  }
+
+  const protectedIndexes = new Set<number>();
+  for (let i = lastAssistantIndex + 1; i < messages.length; i++) {
+    if (isToolResultMessage(messages[i])) {
+      protectedIndexes.add(i);
+    }
+  }
+  return protectedIndexes;
+}
+
+function compactExistingToolResults(params: {
   messages: AgentMessage[];
   charsNeeded: number;
   cache: MessageCharEstimateCache;
-}): number {
-  const { messages, charsNeeded, cache } = params;
+  protectedIndexes: ReadonlySet<number>;
+}): AgentMessage[] {
+  const { messages, charsNeeded, cache, protectedIndexes } = params;
   if (charsNeeded <= 0) {
-    return 0;
+    return messages;
   }
 
+  let next: AgentMessage[] | null = null;
   let reduced = 0;
-  // Compact newest-first so more of the cached prefix survives: rewriting
-  // messages[k] for small k invalidates the provider prompt cache from that point onward.
-  // Tradeoff: the model loses recent tool output instead of old.
+  // Compact newest-first among eligible older tool results so more of the cached prefix
+  // survives without stripping the outputs from the active tool loop.
   for (let i = messages.length - 1; i >= 0; i--) {
-    const msg = messages[i];
+    if (protectedIndexes.has(i)) {
+      continue;
+    }
+    const msg = (next ?? messages)[i];
     if (!isToolResultMessage(msg)) {
       continue;
     }
@@ -123,71 +150,65 @@ function compactExistingToolResultsInPlace(params: {
     }
 
     const compacted = replaceToolResultText(msg, PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
-    applyMessageMutationInPlace(msg, compacted, cache);
-    const after = estimateMessageCharsCached(msg, cache);
+    const after = estimateMessageCharsCached(compacted, cache);
     if (after >= before) {
       continue;
     }
 
+    if (!next) {
+      next = messages.slice();
+    }
+    next[i] = compacted;
     reduced += before - after;
     if (reduced >= charsNeeded) {
       break;
     }
   }
 
-  return reduced;
+  return next ?? messages;
 }
 
-function applyMessageMutationInPlace(
-  target: AgentMessage,
-  source: AgentMessage,
-  cache?: MessageCharEstimateCache,
-): void {
-  if (target === source) {
-    return;
-  }
-
-  const targetRecord = target as unknown as Record<string, unknown>;
-  const sourceRecord = source as unknown as Record<string, unknown>;
-  for (const key of Object.keys(targetRecord)) {
-    if (!(key in sourceRecord)) {
-      delete targetRecord[key];
-    }
-  }
-  Object.assign(targetRecord, sourceRecord);
-  if (cache) {
-    invalidateMessageCharsCacheEntry(cache, target);
-  }
-}
-
-function enforceToolResultContextBudgetInPlace(params: {
+function enforceToolResultContextBudget(params: {
   messages: AgentMessage[];
   contextBudgetChars: number;
   maxSingleToolResultChars: number;
-}): void {
+}): AgentMessage[] {
   const { messages, contextBudgetChars, maxSingleToolResultChars } = params;
   const estimateCache = createMessageCharEstimateCache();
+  let next: AgentMessage[] | null = null;
 
   // Ensure each tool result has an upper bound before considering total context usage.
-  for (const message of messages) {
+  for (let i = 0; i < messages.length; i++) {
+    const message = (next ?? messages)[i];
     if (!isToolResultMessage(message)) {
       continue;
     }
     const truncated = truncateToolResultToChars(message, maxSingleToolResultChars, estimateCache);
-    applyMessageMutationInPlace(message, truncated, estimateCache);
+    if (truncated === message) {
+      continue;
+    }
+    if (!next) {
+      next = messages.slice();
+    }
+    next[i] = truncated;
   }
 
-  let currentChars = estimateContextChars(messages, estimateCache);
+  const truncatedMessages = next ?? messages;
+  let currentChars = estimateContextChars(truncatedMessages, estimateCache);
   if (currentChars <= contextBudgetChars) {
-    return;
+    return truncatedMessages;
   }
 
-  // Compact newest tool outputs first so more of the cached prefix survives;
-  // stop once the context is back under budget.
-  compactExistingToolResultsInPlace({
-    messages,
+  const protectedIndexes = collectProtectedCurrentTurnToolResultIndexes(truncatedMessages);
+
+  // Compact older tool outputs first so the active tool loop still sees the
+  // fresh results it just asked for. If that's not enough, the 90% overflow
+  // guard below will still trigger full session compaction.
+  return compactExistingToolResults({
+    messages: truncatedMessages,
     charsNeeded: currentChars - contextBudgetChars,
     cache: estimateCache,
+    protectedIndexes,
   });
 }
 
@@ -222,7 +243,7 @@ export function installToolResultContextGuard(params: {
       : messages;
 
     const contextMessages = Array.isArray(transformed) ? transformed : messages;
-    enforceToolResultContextBudgetInPlace({
+    const guardedMessages = enforceToolResultContextBudget({
       messages: contextMessages,
       contextBudgetChars,
       maxSingleToolResultChars,
@@ -233,14 +254,14 @@ export function installToolResultContextGuard(params: {
     // compaction can reduce context size. Throwing a context overflow error triggers
     // the existing overflow recovery cascade in run.ts.
     const postEnforcementChars = estimateContextChars(
-      contextMessages,
+      guardedMessages,
       createMessageCharEstimateCache(),
     );
     if (postEnforcementChars > preemptiveOverflowChars) {
       throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
     }
 
-    return contextMessages;
+    return guardedMessages;
   }) as GuardableTransformContext;
 
   return () => {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -502,14 +502,23 @@ export function createSessionStatusTool(opts?: {
         ...(providerForCard ? {} : { modelAuthOverride: undefined }),
         includeTranscriptUsage: true,
       });
-      const fullStatusText =
-        taskLine && !statusText.includes(taskLine) ? `${statusText}\n${taskLine}` : statusText;
+      const sessionIdLine = resolved.entry.sessionId?.trim()
+        ? `🆔 Session ID: ${resolved.entry.sessionId.trim()}`
+        : undefined;
+      const fullStatusText = [
+        statusText,
+        sessionIdLine,
+        taskLine && !statusText.includes(taskLine) ? taskLine : undefined,
+      ]
+        .filter(Boolean)
+        .join("\n");
 
       return {
         content: [{ type: "text", text: fullStatusText }],
         details: {
           ok: true,
           sessionKey: resolved.key,
+          sessionId: resolved.entry.sessionId,
           changedModel,
           statusText: fullStatusText,
         },


### PR DESCRIPTION
## Summary
- resolve the preemptive tool-result guard budget from the normal context-window resolver instead of falling back to `model.maxTokens`
- protect tool results from the active tool loop from full placeholder compaction, compacting older tool outputs first
- stop the guard from mutating the source transcript objects in place
- add regression coverage for the guard-budget path and the protected-tool-output behavior

## Why
Tool results were still being replaced with `[compacted: tool output removed to free context]` immediately during active tool loops.

## Root cause
Two separate issues were contributing:
- `runEmbeddedAttempt` sized the preemptive tool-result guard with `model.maxTokens` when `contextWindow` was missing, which can be far smaller than the real context budget.
- the guard compacted the newest tool results first and rewrote the passed-in context objects in place, so fresh outputs from the current tool loop could be replaced before the model used them and the rewritten placeholder could leak back into the source transcript state.

## Impact
Fresh tool outputs from the current tool loop now remain available unless the session is genuinely near its real context limit. Older tool outputs are still eligible for compaction first, and the guard no longer mutates the source transcript objects in place.

## Validation
- `pnpm test src/agents/pi-embedded-runner/tool-result-context-guard.test.ts`
- `pnpm test src/agents/pi-embedded-runner/run/attempt.spawn-workspace.tool-result-context-guard.test.ts`
- `pnpm test src/agents/pi-embedded-runner/run/attempt.spawn-workspace.cache-ttl.test.ts`
- `pnpm check`
- `pnpm build`
