### PR TITLE
fix(whatsapp): prevent self-message infinite reply loop

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -254,12 +254,14 @@ export async function monitorWebInbox(options: {
     if (
       !group &&
       Boolean(msg.key?.fromMe) &&
-      !options.selfChatMode &&
-      self.e164 &&
-      from === self.e164
+      !options.selfChatMode
     ) {
-      logVerbose(`Dropping fromMe self-DM ${id ?? "?"} — selfChatMode not enabled`);
-      return null;
+      if (!self.e164) {
+        logVerbose(`Cannot apply self-DM loop guard for ${id ?? "?"}: self.e164 not resolved`);
+      } else if (from === self.e164) {
+        logVerbose(`Dropping fromMe self-DM ${id ?? "?"} — selfChatMode not enabled`);
+        return null;
+      }
     }
     const senderE164 = group
       ? participantJid

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -246,6 +246,21 @@ export async function monitorWebInbox(options: {
     if (!from) {
       return null;
     }
+    // Guard against self-message loops (#61033): when self-chat mode is not
+    // explicitly enabled, drop all fromMe DMs addressed to the bot's own
+    // number.  Without this, WhatsApp can echo the bot's replies with a
+    // different message ID, bypassing the outbound-ID echo check above and
+    // creating an infinite auto-reply loop.
+    if (
+      !group &&
+      Boolean(msg.key?.fromMe) &&
+      !options.selfChatMode &&
+      self.e164 &&
+      from === self.e164
+    ) {
+      logVerbose(`Dropping fromMe self-DM ${id ?? "?"} — selfChatMode not enabled`);
+      return null;
+    }
     const senderE164 = group
       ? participantJid
         ? await resolveInboundJid(participantJid)

--- a/extensions/whatsapp/src/monitor-inbox.self-message-loop.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.self-message-loop.test.ts
@@ -1,0 +1,115 @@
+import "./monitor-inbox.test-harness.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  type InboxOnMessage,
+  getSock,
+  installWebMonitorInboxUnitTestHooks,
+  mockLoadConfig,
+  settleInboundWork,
+  startInboxMonitor,
+  waitForMessageCalls,
+} from "./monitor-inbox.test-harness.js";
+
+describe("self-message loop prevention (#61033)", () => {
+  installWebMonitorInboxUnitTestHooks();
+
+  it("drops fromMe DMs to self when selfChatMode is not enabled", async () => {
+    mockLoadConfig.mockReturnValue({
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    });
+    const onMessage = vi.fn(async () => {});
+
+    // selfChatMode defaults to undefined (not enabled)
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+
+    // Simulate a fromMe message to the bot's own JID (self-chat)
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            id: "self-msg-1",
+            fromMe: true,
+            remoteJid: "123@s.whatsapp.net", // same as mock sock user
+          },
+          message: { conversation: "Hello self" },
+          messageTimestamp: 1_700_000_000,
+          pushName: "Me",
+        },
+      ],
+    });
+    await settleInboundWork();
+
+    expect(onMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("allows fromMe DMs to self when selfChatMode is enabled", async () => {
+    mockLoadConfig.mockReturnValue({
+      channels: { whatsapp: { allowFrom: ["*"], selfChatMode: true } },
+    });
+    const onMessage = vi.fn(async () => {});
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      selfChatMode: true,
+    });
+
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            id: "self-msg-2",
+            fromMe: true,
+            remoteJid: "123@s.whatsapp.net",
+          },
+          message: { conversation: "Hello self" },
+          messageTimestamp: 1_700_000_000,
+          pushName: "Me",
+        },
+      ],
+    });
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ body: "Hello self", fromMe: true }),
+    );
+
+    await listener.close();
+  });
+
+  it("still processes fromMe=false DMs from other senders", async () => {
+    mockLoadConfig.mockReturnValue({
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    });
+    const onMessage = vi.fn(async () => {});
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+
+    sock.ev.emit("messages.upsert", {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            id: "other-msg-1",
+            fromMe: false,
+            remoteJid: "999@s.whatsapp.net",
+          },
+          message: { conversation: "Hello from other" },
+          messageTimestamp: 1_700_000_000,
+          pushName: "Other User",
+        },
+      ],
+    });
+    await waitForMessageCalls(onMessage, 1);
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ body: "Hello from other", from: "+999" }),
+    );
+
+    await listener.close();
+  });
+});

--- a/extensions/whatsapp/src/monitor-inbox.self-message-loop.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.self-message-loop.test.ts
@@ -2,7 +2,6 @@ import "./monitor-inbox.test-harness.js";
 import { describe, expect, it, vi } from "vitest";
 import {
   type InboxOnMessage,
-  getSock,
   installWebMonitorInboxUnitTestHooks,
   mockLoadConfig,
   settleInboundWork,


### PR DESCRIPTION
## Summary
- Drop `fromMe` DMs addressed to the bot's own number when `selfChatMode` is not explicitly enabled
- Prevents infinite auto-reply loop when WhatsApp echoes the bot's replies with a different message ID, bypassing the existing outbound-ID echo check
- Users who intentionally want self-chat can enable `selfChatMode: true` in their WhatsApp channel config

## Root cause
The existing echo guard in `normalizeInboundMessage()` (monitor.ts:226-237) only catches echoes whose message IDs were tracked via `sendTrackedMessage`. WhatsApp can deliver echoes with different message IDs (e.g. during `append` upserts or network reordering), causing the bot's reply to be re-processed as new inbound → auto-reply → echo → loop.

## Changes
- `extensions/whatsapp/src/inbound/monitor.ts` — After resolving the sender, check if the message is a `fromMe` DM to self without `selfChatMode` enabled, and drop it
- `extensions/whatsapp/src/monitor-inbox.self-message-loop.test.ts` — 3 test cases: drops self-DM without selfChatMode, allows with selfChatMode, still processes other senders

Fixes #61033

## Test plan
- [ ] `vitest extensions/whatsapp/src/monitor-inbox.self-message-loop.test.ts` passes
- [ ] Existing `monitor-inbox.*.test.ts` tests still pass
- [ ] Manual: send message to self on WhatsApp without `selfChatMode` → no auto-reply loop
- [ ] Manual: enable `selfChatMode: true` → self-chat works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)