### PR TITLE
fix: ensure bypassPermissions when custom CLI backend args override defaults

### DIFF
--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -165,4 +165,35 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(resolved?.config.args).not.toContain("bypassPermissions");
     expect(resolved?.config.resumeArgs).not.toContain("bypassPermissions");
   });
+
+  it("injects bypassPermissions when custom args omit any permission flag", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              args: ["-p", "--output-format", "stream-json", "--verbose"],
+              resumeArgs: [
+                "-p",
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--resume",
+                "{sessionId}",
+              ],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveCliBackendConfig("claude-cli", cfg);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.config.args).toContain("--permission-mode");
+    expect(resolved?.config.args).toContain("bypassPermissions");
+    expect(resolved?.config.resumeArgs).toContain("--permission-mode");
+    expect(resolved?.config.resumeArgs).toContain("bypassPermissions");
+  });
 });

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -165,12 +165,10 @@ function normalizeClaudePermissionArgs(args?: string[]): string[] | undefined {
     return args;
   }
   const normalized: string[] = [];
-  let sawLegacySkip = false;
   let hasPermissionMode = false;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG) {
-      sawLegacySkip = true;
       continue;
     }
     if (arg === CLAUDE_PERMISSION_MODE_ARG) {
@@ -188,7 +186,7 @@ function normalizeClaudePermissionArgs(args?: string[]): string[] | undefined {
     }
     normalized.push(arg);
   }
-  if (sawLegacySkip && !hasPermissionMode) {
+  if (!hasPermissionMode) {
     normalized.push(CLAUDE_PERMISSION_MODE_ARG, CLAUDE_BYPASS_PERMISSIONS_MODE);
   }
   return normalized;


### PR DESCRIPTION
## Summary

- When users customize `cliBackends.claude-cli.args` (e.g. adding `--verbose` or changing `--output-format`), the user's array completely replaces the default args via `mergeBackendConfig()`. This drops `--permission-mode bypassPermissions` from the resolved config.
- The `normalizeClaudePermissionArgs()` function was only re-injecting `bypassPermissions` when the legacy `--dangerously-skip-permissions` flag was present. If *neither* permission flag existed in the custom args, it did nothing.
- This causes all cron/heartbeat runs to silently fail with `"exec denied: Cron runs cannot wait for interactive exec approval"` because the CLI subprocess launches in default interactive permission mode.

**Fix:** Always inject `--permission-mode bypassPermissions` when no explicit `--permission-mode` flag is found in the resolved args, regardless of whether the legacy flag was present. Users who explicitly set a different permission mode (e.g. `acceptEdits`) are unaffected — their explicit value is preserved.

## Reproduction

1. Configure a custom `cliBackends.claude-cli.args` in `openclaw.json`:
   ```json
   "args": ["-p", "--output-format", "stream-json", "--verbose"]
   ```
2. Set up a cron job that triggers an agent using `claude-cli/*` models
3. The cron run fails with: `exec denied: Cron runs cannot wait for interactive exec approval`

## Test plan

- [x] Existing tests pass (no regressions on default args, legacy normalization, explicit overrides)
- [x] New test: custom args without any permission flag → `bypassPermissions` is injected
- [x] Full lint suite passes (`oxlint`, `oxfmt`, boundary checks)
- [ ] Manual: verify cron heartbeats succeed after applying this fix on a gateway using custom CLI backend args