### PR TITLE
fix(macos): strip commit hash from CLI version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Discord/forwarding: recover forwarded referenced message text and attachments when Discord omits snapshot payloads, so forwarded-message relays keep the original content. (#61670) Thanks @artwalker.
 - Docs/i18n: remove the zh-CN homepage redirect override so Mintlify can resolve the localized Chinese homepage without self-redirecting `/zh-CN/index`.
 - Agents/heartbeat: stop truncating live session transcripts after no-op heartbeat acks, move heartbeat cleanup to prompt assembly and compaction, and keep post-filter context-engine ingestion aligned with the real session baseline. (#60998) Thanks @nxmxbbd.
+- macOS/gateway version: strip trailing commit metadata from CLI version output before semver parsing so the Mac app recognizes installed gateway versions like `OpenClaw 2026.4.2 (d74a122)` again. (#61111) Thanks @oliviareid-svg.
 
 ## 2026.4.5
 

--- a/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEnvironment.swift
@@ -299,6 +299,10 @@ enum GatewayEnvironment {
         if normalized.lowercased().hasPrefix("openclaw ") {
             normalized = String(normalized.dropFirst("openclaw ".count))
         }
+        // Strip trailing commit metadata, e.g. "2026.4.2 (d74a122)" → "2026.4.2"
+        if let parenRange = normalized.range(of: #"\s*\([0-9a-fA-F]+\)\s*$"#, options: .regularExpression) {
+            normalized = String(normalized[normalized.startIndex..<parenRange.lowerBound])
+        }
         return normalized
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
@@ -34,6 +34,11 @@ struct GatewayEnvironmentTests {
         let normalized = GatewayEnvironment.normalizeGatewayVersionOutput("OpenClaw 2026.4.2 (d74a122)")
         #expect(normalized == "2026.4.2")
         #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 4, patch: 2))
+
+        // Pre-release suffix + commit hash combined
+        let normalized2 = GatewayEnvironment.normalizeGatewayVersionOutput("OpenClaw 2026.4.2-1 (d74a122)")
+        #expect(normalized2 == "2026.4.2-1")
+        #expect(Semver.parse(normalized2) == Semver(major: 2026, minor: 4, patch: 2))
     }
 
     @Test func `semver compatibility requires same major and not older`() {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift
@@ -30,6 +30,12 @@ struct GatewayEnvironmentTests {
         #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 3, patch: 23))
     }
 
+    @Test func `gateway version output strips trailing commit hash`() {
+        let normalized = GatewayEnvironment.normalizeGatewayVersionOutput("OpenClaw 2026.4.2 (d74a122)")
+        #expect(normalized == "2026.4.2")
+        #expect(Semver.parse(normalized) == Semver(major: 2026, minor: 4, patch: 2))
+    }
+
     @Test func `semver compatibility requires same major and not older`() {
         let required = Semver(major: 2, minor: 1, patch: 0)
         #expect(Semver(major: 2, minor: 1, patch: 0).compatible(with: required))


### PR DESCRIPTION
## Summary
- `normalizeGatewayVersionOutput` now strips trailing `(hexhash)` commit metadata from CLI version strings
- Fixes `Semver.parse` failure when `openclaw --version` outputs `"OpenClaw 2026.4.2 (d74a122)"` — the `(d74a122)` suffix caused `Int("2 (d74a122)")` to return nil, showing "unknown" in Settings

## Root cause
`normalizeGatewayVersionOutput` only stripped the `"OpenClaw "` prefix, leaving `"2026.4.2 (d74a122)"`. After splitting by `.`, `parts[2]` became `"2 (d74a122)"` which failed the `Int()` parse in `Semver.parse()`.

## Changes
- `apps/macos/Sources/OpenClaw/GatewayEnvironment.swift` — Added regex to strip trailing `\s*\([0-9a-fA-F]+\)\s*$` in `normalizeGatewayVersionOutput`
- `apps/macos/Tests/OpenClawIPCTests/GatewayEnvironmentTests.swift` — Added test case for commit-hash-suffixed version string

Fixes #60925

## Test plan
- [ ] New test `gateway version output strips trailing commit hash` passes
- [ ] Existing `semver parses common forms` and `gateway version output strips product prefix before parsing` tests still pass
- [ ] macOS app Settings screen shows correct version when CLI outputs `"OpenClaw 2026.4.2 (d74a122)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)