### PR TITLE
UI: localize markdown sidebar labels

### DIFF
--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -110,6 +110,12 @@ export const de: TranslationMap = {
       stayHttp: "Wenn Sie bei HTTP bleiben müssen, setzen Sie {config} (nur Token).",
     },
   },
+  markdownSidebar: {
+    title: "Tool Output",
+    closeTitle: "Close sidebar",
+    viewRawText: "View Raw Text",
+    empty: "No content available",
+  },
   chat: {
     disconnected: "Verbindung zum Gateway getrennt.",
     refreshTitle: "Chat-Daten aktualisieren",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -111,10 +111,10 @@ export const de: TranslationMap = {
     },
   },
   markdownSidebar: {
-    title: "Tool Output",
-    closeTitle: "Close sidebar",
-    viewRawText: "View Raw Text",
-    empty: "No content available",
+    title: "Tool-Ausgabe",
+    closeTitle: "Seitenleiste schließen",
+    viewRawText: "Rohtext anzeigen",
+    empty: "Kein Inhalt verfügbar",
   },
   chat: {
     disconnected: "Verbindung zum Gateway getrennt.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -155,6 +155,12 @@ export const en: TranslationMap = {
       noResults: "No results",
     },
   },
+  markdownSidebar: {
+    title: "Tool Output",
+    closeTitle: "Close sidebar",
+    viewRawText: "View Raw Text",
+    empty: "No content available",
+  },
   usage: {
     page: {
       subtitle: "See where tokens go, when sessions spike, and what drives cost.",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -127,6 +127,12 @@ export const es: TranslationMap = {
     de: "Deutsch (Alemán)",
     es: "Español",
   },
+  markdownSidebar: {
+    title: "Tool Output",
+    closeTitle: "Close sidebar",
+    viewRawText: "View Raw Text",
+    empty: "No content available",
+  },
   cron: {
     summary: {
       enabled: "Habilitado",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -128,10 +128,10 @@ export const es: TranslationMap = {
     es: "Español",
   },
   markdownSidebar: {
-    title: "Tool Output",
-    closeTitle: "Close sidebar",
-    viewRawText: "View Raw Text",
-    empty: "No content available",
+    title: "Salida de la herramienta",
+    closeTitle: "Cerrar barra lateral",
+    viewRawText: "Ver texto sin formato",
+    empty: "No hay contenido disponible",
   },
   cron: {
     summary: {

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -158,6 +158,12 @@ export const pt_BR: TranslationMap = {
     subtitle: "Painel do Gateway",
     passwordPlaceholder: "opcional",
   },
+  markdownSidebar: {
+    title: "Saída da ferramenta",
+    closeTitle: "Fechar barra lateral",
+    viewRawText: "Ver texto bruto",
+    empty: "Nenhum conteúdo disponível",
+  },
   chat: {
     disconnected: "Desconectado do gateway.",
     refreshTitle: "Atualizar dados do chat",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -156,10 +156,10 @@ export const zh_CN: TranslationMap = {
     passwordPlaceholder: "可选",
   },
   markdownSidebar: {
-    title: "Tool Output",
-    closeTitle: "Close sidebar",
-    viewRawText: "View Raw Text",
-    empty: "No content available",
+    title: "工具输出",
+    closeTitle: "关闭侧边栏",
+    viewRawText: "查看原始文本",
+    empty: "没有可用内容",
   },
   chat: {
     disconnected: "已断开与网关的连接。",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -155,6 +155,12 @@ export const zh_CN: TranslationMap = {
     subtitle: "网关仪表盘",
     passwordPlaceholder: "可选",
   },
+  markdownSidebar: {
+    title: "Tool Output",
+    closeTitle: "Close sidebar",
+    viewRawText: "View Raw Text",
+    empty: "No content available",
+  },
   chat: {
     disconnected: "已断开与网关的连接。",
     refreshTitle: "刷新聊天数据",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -156,10 +156,10 @@ export const zh_TW: TranslationMap = {
     passwordPlaceholder: "可選",
   },
   markdownSidebar: {
-    title: "Tool Output",
-    closeTitle: "Close sidebar",
-    viewRawText: "View Raw Text",
-    empty: "No content available",
+    title: "工具輸出",
+    closeTitle: "關閉側邊欄",
+    viewRawText: "檢視原始文字",
+    empty: "沒有可用內容",
   },
   chat: {
     disconnected: "已斷開與網關的連接。",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -155,6 +155,12 @@ export const zh_TW: TranslationMap = {
     subtitle: "閘道儀表板",
     passwordPlaceholder: "可選",
   },
+  markdownSidebar: {
+    title: "Tool Output",
+    closeTitle: "Close sidebar",
+    viewRawText: "View Raw Text",
+    empty: "No content available",
+  },
   chat: {
     disconnected: "已斷開與網關的連接。",
     refreshTitle: "刷新聊天數據",

--- a/ui/src/ui/views/markdown-sidebar.ts
+++ b/ui/src/ui/views/markdown-sidebar.ts
@@ -1,4 +1,5 @@
 import { html } from "lit";
+import { t } from "../../i18n/index.ts";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { icons } from "../icons.ts";
 import { toSanitizedMarkdownHtml } from "../markdown.ts";
@@ -14,22 +15,22 @@ export function renderMarkdownSidebar(props: MarkdownSidebarProps) {
   return html`
     <div class="sidebar-panel">
       <div class="sidebar-header">
-        <div class="sidebar-title">Tool Output</div>
-        <button @click=${props.onClose} class="btn" title="Close sidebar">${icons.x}</button>
+        <div class="sidebar-title">${t("markdownSidebar.title")}</div>
+        <button @click=${props.onClose} class="btn" title=${t("markdownSidebar.closeTitle")}>${icons.x}</button>
       </div>
       <div class="sidebar-content">
         ${props.error
           ? html`
               <div class="callout danger">${props.error}</div>
               <button @click=${props.onViewRawText} class="btn" style="margin-top: 12px;">
-                View Raw Text
+                ${t("markdownSidebar.viewRawText")}
               </button>
             `
           : props.content
             ? html`<div class="sidebar-markdown">
                 ${unsafeHTML(toSanitizedMarkdownHtml(props.content))}
               </div>`
-            : html` <div class="muted">No content available</div> `}
+            : html` <div class="muted">${t("markdownSidebar.empty")}</div> `}
       </div>
     </div>
   `;


### PR DESCRIPTION
## Summary

- Problem: the markdown sidebar still had a few hardcoded English labels even when a non-English locale was selected.
- Why it matters: these strings appear in a shared sidebar surface, so they create mixed-language UI despite the surrounding locale support.
- What changed: moved the markdown sidebar title, close tooltip, raw-text action label, and empty state into locale keys and wired `markdown-sidebar.ts` through `t(...)`.
- What did NOT change (scope boundary): no markdown rendering logic, sanitization logic, or sidebar behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #61036
- Related #61054
- Related #61062
- Related #61073
- Related #61080
- Related #61092
- Related #61104

## Root Cause (if applicable)

- Root cause: the markdown sidebar still embedded a few user-facing strings directly in the view instead of going through locale files.
- Missing detection / guardrail: locale infrastructure exists, but this sidebar surface still carried hardcoded copy.
- Contributing context (if known): this PR intentionally scopes the cleanup to one tiny shared surface.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `ui/src/i18n/test/translate.test.ts`
- Scenario the test should lock in:
  - locale lookups for the new `markdownSidebar.*` keys resolve correctly.
- Why this is the smallest reliable guardrail:
  - the change is isolated to locale keys plus one small sidebar view.
- Existing test that already covers this (if any):
  - `ui/src/i18n/test/translate.test.ts`
- If no new test is added, why not:
  - existing i18n coverage plus successful UI build were sufficient for this scoped change.

## User-visible / Behavior Changes

- The markdown sidebar no longer shows those hardcoded English labels when pt-BR is selected.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: local Node/pnpm dev environment
- Model/provider: N/A
- Integration/channel (if any): Control UI markdown sidebar
- Relevant config (redacted): N/A

### Steps

1. Switch the Control UI locale away from English.
2. Open markdown output in the sidebar.
3. Inspect the sidebar title, close button tooltip, raw-text button, and empty state.

### Expected

- Those sidebar labels should come from locale files instead of staying hardcoded in English.

### Actual

- The markdown sidebar now uses locale-backed strings for those labels.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation:

```text
pnpm --dir ui build
pnpm test ui/src/i18n/test/translate.test.ts -- --project ui
```

## Human Verification (required)

- Verified scenarios:
  - reviewed the markdown-sidebar diff to ensure only labels were moved to locale keys
  - confirmed local build passes
  - confirmed targeted UI translation test passes
- Edge cases checked:
  - preserved markdown rendering and raw-text fallback behavior
  - added locale stubs to all supported locales to avoid widening coverage gaps
- What you did **not** verify:
  - full browser walkthrough of every locale on the sidebar

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## Risks and Mitigations

- Risk: other small shared UI surfaces may still contain hardcoded strings.
  - Mitigation: this PR intentionally scopes the cleanup to the markdown sidebar only.