### PR TITLE
fix: ensure bypassPermissions when custom CLI backend args override defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ Docs: https://docs.openclaw.ai
 - MS Teams: replace the deprecated Teams SDK HttpPlugin stub with `httpServerAdapter` so recurring gateway deprecation warnings stop firing and the Express 5 compatibility workaround stays on the supported SDK path. (#60939) Thanks @coolramukaka-sys.
 - CLI/Commander: preserve Commander-computed exit codes for argument and help-error paths, and cover the user-argv parse mode in the regression tests so invalid CLI invocations no longer report success when exits are intercepted. (#60923) Thanks @Linux2010.
 - Telegram/native command menu: trim long menu descriptions before dropping commands so sub-100 command sets can still fit Telegram's payload budget and keep more `/` entries visible. (#61129) Thanks @neeravmakwana.
+- Agents/Claude CLI: keep non-interactive `--permission-mode bypassPermissions` when custom `cliBackends.claude-cli.args` override defaults, so cron and heartbeat Claude CLI runs do not regress to interactive approval mode. (#61114) Thanks @cathrynlavery and @thewilloftheshadow.
 
 ## 2026.4.2
 

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { buildAnthropicCliBackend } from "./cli-backend.js";
+import { normalizeClaudeBackendConfig, normalizeClaudePermissionArgs } from "./cli-shared.js";
+
+describe("normalizeClaudePermissionArgs", () => {
+  it("injects bypassPermissions when args omit permission flags", () => {
+    expect(
+      normalizeClaudePermissionArgs(["-p", "--output-format", "stream-json", "--verbose"]),
+    ).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+  });
+
+  it("removes legacy skip-permissions and injects bypassPermissions", () => {
+    expect(
+      normalizeClaudePermissionArgs(["-p", "--dangerously-skip-permissions", "--verbose"]),
+    ).toEqual(["-p", "--verbose", "--permission-mode", "bypassPermissions"]);
+  });
+
+  it("keeps explicit permission-mode overrides", () => {
+    expect(normalizeClaudePermissionArgs(["-p", "--permission-mode", "acceptEdits"])).toEqual([
+      "-p",
+      "--permission-mode",
+      "acceptEdits",
+    ]);
+    expect(normalizeClaudePermissionArgs(["-p", "--permission-mode=acceptEdits"])).toEqual([
+      "-p",
+      "--permission-mode=acceptEdits",
+    ]);
+  });
+});
+
+describe("normalizeClaudeBackendConfig", () => {
+  it("normalizes both args and resumeArgs for custom overrides", () => {
+    const normalized = normalizeClaudeBackendConfig({
+      command: "claude",
+      args: ["-p", "--output-format", "stream-json", "--verbose"],
+      resumeArgs: ["-p", "--output-format", "stream-json", "--verbose", "--resume", "{sessionId}"],
+    });
+
+    expect(normalized.args).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+    expect(normalized.resumeArgs).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--resume",
+      "{sessionId}",
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+  });
+
+  it("is wired through the anthropic cli backend normalize hook", () => {
+    const backend = buildAnthropicCliBackend();
+    const normalizeConfig = backend.normalizeConfig;
+
+    expect(normalizeConfig).toBeTypeOf("function");
+
+    const normalized = normalizeConfig?.({
+      ...backend.config,
+      args: ["-p", "--output-format", "stream-json", "--verbose"],
+      resumeArgs: ["-p", "--output-format", "stream-json", "--verbose", "--resume", "{sessionId}"],
+    });
+
+    expect(normalized?.args).toContain("--permission-mode");
+    expect(normalized?.args).toContain("bypassPermissions");
+    expect(normalized?.resumeArgs).toContain("--permission-mode");
+    expect(normalized?.resumeArgs).toContain("bypassPermissions");
+  });
+});

--- a/extensions/anthropic/cli-shared.ts
+++ b/extensions/anthropic/cli-shared.ts
@@ -46,12 +46,10 @@ export function normalizeClaudePermissionArgs(args?: string[]): string[] | undef
     return args;
   }
   const normalized: string[] = [];
-  let sawLegacySkip = false;
   let hasPermissionMode = false;
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === CLAUDE_LEGACY_SKIP_PERMISSIONS_ARG) {
-      sawLegacySkip = true;
       continue;
     }
     if (arg === CLAUDE_PERMISSION_MODE_ARG) {
@@ -69,7 +67,7 @@ export function normalizeClaudePermissionArgs(args?: string[]): string[] | undef
     }
     normalized.push(arg);
   }
-  if (sawLegacySkip && !hasPermissionMode) {
+  if (!hasPermissionMode) {
     normalized.push(CLAUDE_PERMISSION_MODE_ARG, CLAUDE_BYPASS_PERMISSIONS_MODE);
   }
   return normalized;

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -300,6 +300,37 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(resolved?.config.resumeArgs).not.toContain("bypassPermissions");
   });
 
+  it("injects bypassPermissions when custom args omit any permission flag", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              command: "claude",
+              args: ["-p", "--output-format", "stream-json", "--verbose"],
+              resumeArgs: [
+                "-p",
+                "--output-format",
+                "stream-json",
+                "--verbose",
+                "--resume",
+                "{sessionId}",
+              ],
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveCliBackendConfig("claude-cli", cfg);
+
+    expect(resolved).not.toBeNull();
+    expect(resolved?.config.args).toContain("--permission-mode");
+    expect(resolved?.config.args).toContain("bypassPermissions");
+    expect(resolved?.config.resumeArgs).toContain("--permission-mode");
+    expect(resolved?.config.resumeArgs).toContain("bypassPermissions");
+  });
+
   it("keeps bundle MCP enabled for override-only claude-cli config when the plugin registry is absent", () => {
     const registry = createEmptyPluginRegistry();
     setActivePluginRegistry(registry);


### PR DESCRIPTION
## Summary

- When users customize `cliBackends.claude-cli.args` (e.g. adding `--verbose` or changing `--output-format`), the user's array completely replaces the default args via `mergeBackendConfig()`. This drops `--permission-mode bypassPermissions` from the resolved config.
- `normalizeClaudePermissionArgs()` in `extensions/anthropic/cli-shared.ts` only re-injected `bypassPermissions` when the legacy `--dangerously-skip-permissions` flag was present. If *neither* permission flag existed in the custom args, it did nothing.
- This causes all cron/heartbeat runs to silently fail with `"exec denied: Cron runs cannot wait for interactive exec approval"` because the CLI subprocess launches in default interactive permission mode.

**Fix:** Always inject `--permission-mode bypassPermissions` when no explicit `--permission-mode` flag is found in the resolved args. Users who explicitly set a different permission mode (e.g. `acceptEdits`) are unaffected.

## Reproduction

1. Configure custom `cliBackends.claude-cli.args` in `openclaw.json`:
   ```json
   "args": ["-p", "--output-format", "stream-json", "--verbose"]
   ```
2. Set up a cron job that triggers an agent using `claude-cli/*` models
3. The cron run fails with: `exec denied: Cron runs cannot wait for interactive exec approval`

## Test plan

- [x] Existing tests pass (no regressions on default args, legacy normalization, explicit overrides)
- [x] New test: custom args without any permission flag -> `bypassPermissions` is injected
- [x] Manual: verify cron heartbeats succeed after applying this fix

Rebased onto current main. Supersedes #61109.