### PR TITLE
refactor(test): hoist skill status fixture to module-level constant

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -2,52 +2,38 @@ import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSkillsCli } from "./skills-cli.js";
 
+const SKILL_STATUS_FIXTURE = {
+  workspaceDir: "/tmp/workspace",
+  managedSkillsDir: "/tmp/workspace/skills",
+  skills: [
+    {
+      name: "calendar",
+      description: "Calendar helpers",
+      source: "bundled",
+      bundled: false,
+      filePath: "/tmp/workspace/skills/calendar/SKILL.md",
+      baseDir: "/tmp/workspace/skills/calendar",
+      skillKey: "calendar",
+      emoji: "📅",
+      homepage: "https://example.com/calendar",
+      always: false,
+      disabled: false,
+      blockedByAllowlist: false,
+      eligible: true,
+      primaryEnv: "CALENDAR_API_KEY",
+      requirements: { bins: [], anyBins: [], env: ["CALENDAR_API_KEY"], config: [], os: [] },
+      missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+      configChecks: [],
+      install: [],
+    },
+  ],
+};
+
 const mocks = vi.hoisted(() => {
   const runtimeLogs: string[] = [];
   const runtimeStdout: string[] = [];
   const runtimeErrors: string[] = [];
   const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");
-  const skillStatusReportFixture = {
-    workspaceDir: "/tmp/workspace",
-    managedSkillsDir: "/tmp/workspace/skills",
-    skills: [
-      {
-        name: "calendar",
-        description: "Calendar helpers",
-        source: "bundled",
-        bundled: false,
-        filePath: "/tmp/workspace/skills/calendar/SKILL.md",
-        baseDir: "/tmp/workspace/skills/calendar",
-        skillKey: "calendar",
-        emoji: "📅",
-        homepage: "https://example.com/calendar",
-        always: false,
-        disabled: false,
-        blockedByAllowlist: false,
-        eligible: true,
-        primaryEnv: "CALENDAR_API_KEY",
-        requirements: {
-          bins: [],
-          anyBins: [],
-          env: ["CALENDAR_API_KEY"],
-          config: [],
-          os: [],
-        },
-        missing: {
-          bins: [],
-          anyBins: [],
-          env: [],
-          config: [],
-          os: [],
-        },
-        configChecks: [],
-        install: [],
-      },
-    ],
-  };
-  const defaultRuntime = {
-    log: vi.fn((...args: unknown[]) => {
-      runtimeLogs.push(stringifyArgs(args));
     }),
     error: vi.fn((...args: unknown[]) => {
       runtimeErrors.push(stringifyArgs(args));
@@ -62,11 +48,7 @@ const mocks = vi.hoisted(() => {
       throw new Error(`__exit__:${code}`);
     }),
   };
-  const buildWorkspaceSkillStatusMock = vi.fn((workspaceDir: string, options?: unknown) => {
-    void workspaceDir;
-    void options;
-    return skillStatusReportFixture;
-  });
+  const buildWorkspaceSkillStatusMock = vi.fn();
   return {
     loadConfigMock: vi.fn(() => ({})),
     resolveDefaultAgentIdMock: vi.fn(() => "main"),
@@ -76,7 +58,6 @@ const mocks = vi.hoisted(() => {
     updateSkillsFromClawHubMock: vi.fn(),
     readTrackedClawHubSkillSlugsMock: vi.fn(),
     buildWorkspaceSkillStatusMock,
-    skillStatusReportFixture,
     defaultRuntime,
     runtimeLogs,
     runtimeStdout,
@@ -93,7 +74,6 @@ const {
   updateSkillsFromClawHubMock,
   readTrackedClawHubSkillSlugsMock,
   buildWorkspaceSkillStatusMock,
-  skillStatusReportFixture,
   defaultRuntime,
   runtimeLogs,
   runtimeStdout,
@@ -159,7 +139,7 @@ describe("skills cli commands", () => {
     });
     updateSkillsFromClawHubMock.mockResolvedValue([]);
     readTrackedClawHubSkillSlugsMock.mockResolvedValue([]);
-    buildWorkspaceSkillStatusMock.mockReturnValue(skillStatusReportFixture);
+    buildWorkspaceSkillStatusMock.mockReturnValue(SKILL_STATUS_FIXTURE);
     defaultRuntime.log.mockClear();
     defaultRuntime.error.mockClear();
     defaultRuntime.writeStdout.mockClear();

--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -21,8 +21,20 @@ const SKILL_STATUS_FIXTURE = {
       blockedByAllowlist: false,
       eligible: true,
       primaryEnv: "CALENDAR_API_KEY",
-      requirements: { bins: [], anyBins: [], env: ["CALENDAR_API_KEY"], config: [], os: [] },
-      missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+      requirements: {
+        bins: [],
+        anyBins: [],
+        env: ["CALENDAR_API_KEY"],
+        config: [],
+        os: [],
+      },
+      missing: {
+        bins: [],
+        anyBins: [],
+        env: [],
+        config: [],
+        os: [],
+      },
       configChecks: [],
       install: [],
     },
@@ -34,6 +46,9 @@ const mocks = vi.hoisted(() => {
   const runtimeStdout: string[] = [];
   const runtimeErrors: string[] = [];
   const stringifyArgs = (args: unknown[]) => args.map((value) => String(value)).join(" ");
+  const defaultRuntime = {
+    log: vi.fn((...args: unknown[]) => {
+      runtimeLogs.push(stringifyArgs(args));
     }),
     error: vi.fn((...args: unknown[]) => {
       runtimeErrors.push(stringifyArgs(args));


### PR DESCRIPTION
Follow-up to #60914 addressing Codex feedback noted by @altaywtf.

## Problem

`skillStatusReportFixture` was defined inside `vi.hoisted()` and also exported in the return object so `beforeEach` could reference it. This duplicated the fixture data across two locations.

Additionally, `buildWorkspaceSkillStatusMock` had a dead initial implementation — `beforeEach` calls `mockReset()` followed by `mockReturnValue(...)` before every test, so the factory inside `vi.hoisted()` was never actually invoked.

## Fix

- Move the fixture to a module-level constant `SKILL_STATUS_FIXTURE` (defined once, before `vi.hoisted`)
- Remove `skillStatusReportFixture` from the `vi.hoisted()` return object and destructuring
- Replace the dead `buildWorkspaceSkillStatusMock` factory with a plain `vi.fn()`
- Update `beforeEach` to reference the module-level `SKILL_STATUS_FIXTURE`

No behaviour changes — all existing test assertions are preserved.