### PR TITLE
fix(telegram): trim menu descriptions before dropping commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/cron: highlight the Cron refresh button while refresh is in flight so the page's loading state stays visible even when prior data remains on screen. (#60394) Thanks @coder-zhuzm.
 - MS Teams: replace the deprecated Teams SDK HttpPlugin stub with `httpServerAdapter` so recurring gateway deprecation warnings stop firing and the Express 5 compatibility workaround stays on the supported SDK path. (#60939) Thanks @coolramukaka-sys.
 - CLI/Commander: preserve Commander-computed exit codes for argument and help-error paths, and cover the user-argv parse mode in the regression tests so invalid CLI invocations no longer report success when exits are intercepted. (#60923) Thanks @Linux2010.
+- Telegram/native command menu: trim long menu descriptions before dropping commands so sub-100 command sets can still fit Telegram's payload budget and keep more `/` entries visible. (#61129) Thanks @neeravmakwana.
 
 ## 2026.4.2
 

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -4,6 +4,7 @@ import {
   buildPluginTelegramMenuCommands,
   hashCommandList,
   syncTelegramMenuCommands,
+  TELEGRAM_TOTAL_COMMAND_TEXT_BUDGET,
 } from "./bot-native-command-menu.js";
 
 type SyncMenuOptions = {
@@ -50,6 +51,47 @@ describe("bot-native-command-menu", () => {
       command: "cmd_99",
       description: "Command 99",
     });
+  });
+
+  it("shortens descriptions before dropping commands to fit Telegram payload budget", () => {
+    const allCommands = Array.from({ length: 92 }, (_, i) => ({
+      command: `cmd_${i}`,
+      description: "x".repeat(100),
+    }));
+
+    const result = buildCappedTelegramMenuCommands({ allCommands });
+
+    expect(result.commandsToRegister).toHaveLength(92);
+    expect(result.descriptionTrimmed).toBe(true);
+    expect(result.textBudgetDropCount).toBe(0);
+    const totalText = result.commandsToRegister.reduce(
+      (total, command) => total + command.command.length + command.description.length,
+      0,
+    );
+    expect(totalText).toBeLessThanOrEqual(TELEGRAM_TOTAL_COMMAND_TEXT_BUDGET);
+    expect(result.commandsToRegister.every((command) => command.description.length <= 56)).toBe(
+      true,
+    );
+  });
+
+  it("drops tail commands only when minimal descriptions still cannot fit the payload budget", () => {
+    const allCommands = [
+      { command: "alpha_cmd", description: "First command" },
+      { command: "bravo_cmd", description: "Second command" },
+      { command: "charlie_cmd", description: "Third command" },
+    ];
+
+    const result = buildCappedTelegramMenuCommands({
+      allCommands,
+      maxTotalChars: 20,
+    });
+
+    expect(result.commandsToRegister).toEqual([
+      { command: "alpha_cmd", description: "F" },
+      { command: "bravo_cmd", description: "S" },
+    ]);
+    expect(result.descriptionTrimmed).toBe(true);
+    expect(result.textBudgetDropCount).toBe(1);
   });
 
   it("validates plugin command specs and reports conflicts", () => {

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -10,7 +10,9 @@ import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { normalizeTelegramCommandName, TELEGRAM_COMMAND_NAME_PATTERN } from "./command-config.js";
 
 export const TELEGRAM_MAX_COMMANDS = 100;
+export const TELEGRAM_TOTAL_COMMAND_TEXT_BUDGET = 5700;
 const TELEGRAM_COMMAND_RETRY_RATIO = 0.8;
+const TELEGRAM_MIN_COMMAND_DESCRIPTION_LENGTH = 1;
 
 export type TelegramMenuCommand = {
   command: string;
@@ -21,6 +23,73 @@ type TelegramPluginCommandSpec = {
   name: unknown;
   description: unknown;
 };
+
+function countTelegramCommandText(value: string): number {
+  return Array.from(value).length;
+}
+
+function truncateTelegramCommandText(value: string, maxLength: number): string {
+  if (maxLength <= 0) {
+    return "";
+  }
+  const chars = Array.from(value);
+  if (chars.length <= maxLength) {
+    return value;
+  }
+  if (maxLength === 1) {
+    return chars[0] ?? "";
+  }
+  return `${chars.slice(0, maxLength - 1).join("")}…`;
+}
+
+function fitTelegramCommandsWithinTextBudget(
+  commands: TelegramMenuCommand[],
+  maxTotalChars: number,
+): {
+  commands: TelegramMenuCommand[];
+  descriptionTrimmed: boolean;
+  textBudgetDropCount: number;
+} {
+  let candidateCommands = [...commands];
+  while (candidateCommands.length > 0) {
+    const commandNameChars = candidateCommands.reduce(
+      (total, command) => total + countTelegramCommandText(command.command),
+      0,
+    );
+    const descriptionBudget = maxTotalChars - commandNameChars;
+    const minimumDescriptionBudget =
+      candidateCommands.length * TELEGRAM_MIN_COMMAND_DESCRIPTION_LENGTH;
+    if (descriptionBudget < minimumDescriptionBudget) {
+      candidateCommands = candidateCommands.slice(0, -1);
+      continue;
+    }
+
+    const descriptionCap = Math.max(
+      TELEGRAM_MIN_COMMAND_DESCRIPTION_LENGTH,
+      Math.floor(descriptionBudget / candidateCommands.length),
+    );
+    let descriptionTrimmed = false;
+    const fittedCommands = candidateCommands.map((command) => {
+      const description = truncateTelegramCommandText(command.description, descriptionCap);
+      if (description !== command.description) {
+        descriptionTrimmed = true;
+        return { ...command, description };
+      }
+      return command;
+    });
+    return {
+      commands: fittedCommands,
+      descriptionTrimmed,
+      textBudgetDropCount: commands.length - fittedCommands.length,
+    };
+  }
+
+  return {
+    commands: [],
+    descriptionTrimmed: false,
+    textBudgetDropCount: commands.length,
+  };
+}
 
 function readErrorTextField(value: unknown, key: "description" | "message"): string | undefined {
   if (!value || typeof value !== "object" || !(key in value)) {
@@ -109,18 +178,35 @@ export function buildPluginTelegramMenuCommands(params: {
 export function buildCappedTelegramMenuCommands(params: {
   allCommands: TelegramMenuCommand[];
   maxCommands?: number;
+  maxTotalChars?: number;
 }): {
   commandsToRegister: TelegramMenuCommand[];
   totalCommands: number;
   maxCommands: number;
   overflowCount: number;
+  maxTotalChars: number;
+  descriptionTrimmed: boolean;
+  textBudgetDropCount: number;
 } {
   const { allCommands } = params;
   const maxCommands = params.maxCommands ?? TELEGRAM_MAX_COMMANDS;
+  const maxTotalChars = params.maxTotalChars ?? TELEGRAM_TOTAL_COMMAND_TEXT_BUDGET;
   const totalCommands = allCommands.length;
   const overflowCount = Math.max(0, totalCommands - maxCommands);
-  const commandsToRegister = allCommands.slice(0, maxCommands);
-  return { commandsToRegister, totalCommands, maxCommands, overflowCount };
+  const {
+    commands: commandsToRegister,
+    descriptionTrimmed,
+    textBudgetDropCount,
+  } = fitTelegramCommandsWithinTextBudget(allCommands.slice(0, maxCommands), maxTotalChars);
+  return {
+    commandsToRegister,
+    totalCommands,
+    maxCommands,
+    overflowCount,
+    maxTotalChars,
+    descriptionTrimmed,
+    textBudgetDropCount,
+  };
 }
 
 /** Compute a stable hash of the command list for change detection. */

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -101,6 +101,44 @@ describe("registerTelegramNativeCommands", () => {
     );
   });
 
+  it("keeps sub-100 commands by shortening long descriptions to fit Telegram payload budget", async () => {
+    const cfg: OpenClawConfig = {
+      commands: { native: false },
+    };
+    const customCommands = Array.from({ length: 92 }, (_, index) => ({
+      command: `cmd_${index}`,
+      description: `Command ${index} ` + "x".repeat(120),
+    }));
+    const setMyCommands = vi.fn().mockResolvedValue(undefined);
+    const runtimeLog = vi.fn();
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams(cfg),
+      bot: {
+        api: {
+          setMyCommands,
+          sendMessage: vi.fn().mockResolvedValue(undefined),
+        },
+        command: vi.fn(),
+      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+      runtime: { log: runtimeLog } as unknown as RuntimeEnv,
+      telegramCfg: { customCommands } as TelegramAccountConfig,
+      nativeEnabled: false,
+      nativeSkillsEnabled: false,
+    });
+
+    const registeredCommands = await waitForRegisteredCommands(setMyCommands);
+    expect(registeredCommands).toHaveLength(92);
+    expect(
+      registeredCommands.some(
+        (entry) => entry.description.length < customCommands[0]!.description.length,
+      ),
+    ).toBe(true);
+    expect(runtimeLog).toHaveBeenCalledWith(
+      "Telegram menu text exceeded the conservative 5700-character payload budget; shortening descriptions to keep 92 commands visible.",
+    );
+  });
+
   it("normalizes hyphenated native command names for Telegram registration", async () => {
     const setMyCommands = vi.fn().mockResolvedValue(undefined);
     const command = vi.fn();

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -560,15 +560,32 @@ export const registerTelegramNativeCommands = ({
     ...(nativeEnabled ? pluginCatalog.commands : []),
     ...customCommands,
   ];
-  const { commandsToRegister, totalCommands, maxCommands, overflowCount } =
-    buildCappedTelegramMenuCommands({
-      allCommands: allCommandsFull,
-    });
+  const {
+    commandsToRegister,
+    totalCommands,
+    maxCommands,
+    overflowCount,
+    maxTotalChars,
+    descriptionTrimmed,
+    textBudgetDropCount,
+  } = buildCappedTelegramMenuCommands({
+    allCommands: allCommandsFull,
+  });
   if (overflowCount > 0) {
     runtime.log?.(
       `Telegram limits bots to ${maxCommands} commands. ` +
         `${totalCommands} configured; registering first ${maxCommands}. ` +
         `Use channels.telegram.commands.native: false to disable, or reduce plugin/skill/custom commands.`,
+    );
+  }
+  if (descriptionTrimmed) {
+    runtime.log?.(
+      `Telegram menu text exceeded the conservative ${maxTotalChars}-character payload budget; shortening descriptions to keep ${commandsToRegister.length} commands visible.`,
+    );
+  }
+  if (textBudgetDropCount > 0) {
+    runtime.log?.(
+      `Telegram menu text still exceeded the conservative ${maxTotalChars}-character payload budget after shortening descriptions; registering first ${commandsToRegister.length} commands.`,
     );
   }
   const syncTelegramMenuCommands =


### PR DESCRIPTION
## Summary

- Problem: Telegram menu registration only capped by command count and retried `BOT_COMMANDS_TOO_MUCH` by dropping tail commands, even when the bot had fewer than 100 commands.
- Why it matters: long skill/plugin/custom descriptions can silently push `setMyCommands` over Telegram's total payload budget and hide later commands from the `/` menu.
- What changed: cap the menu at 100 entries, then fit that set into a conservative total text budget by shortening descriptions first and only dropping tail commands when even minimal descriptions cannot fit.
- What did NOT change (scope boundary): the existing retry-on-`BOT_COMMANDS_TOO_MUCH` fallback remains in place for unexpected API-side rejections, and command ordering/handler registration semantics are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61060
- Related #61060
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/telegram/src/bot-native-command-menu.ts` only enforced Telegram's 100-command count cap, while `syncTelegramMenuCommands()` handled `BOT_COMMANDS_TOO_MUCH` by repeatedly slicing the command list instead of first reducing description length.
- Missing detection / guardrail: there was no preflight fit check for the total command-name-plus-description payload sent to `setMyCommands`.
- Contributing context (if known): skill descriptions can still be up to 100 chars, so a workspace with many visible commands can overflow Telegram's undocumented total menu budget even when the count is under 100.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/telegram/src/bot-native-command-menu.test.ts`
  - `extensions/telegram/src/bot-native-commands.test.ts`
- Scenario the test should lock in: keep sub-100 command sets visible by shortening long descriptions to fit the Telegram payload budget, and only drop tail commands when even minimally short descriptions cannot fit.
- Why this is the smallest reliable guardrail: it covers both the pure budgeting logic and the registration path that feeds `setMyCommands` without needing live Telegram API calls.
- Existing test that already covers this (if any): the existing `BOT_COMMANDS_TOO_MUCH` retry tests still cover the API fallback path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Telegram `/` menus now keep more visible commands when the menu exceeds Telegram's total payload budget because descriptions are shortened before commands are dropped.
- If command names alone still leave too little room, OpenClaw continues to drop tail commands, but only after trimming descriptions as far as possible.

## Diagram (if applicable)

```text
Before:
[build command menu] -> [under 100 commands but payload too large] -> [Telegram rejects] -> [drop tail commands]

After:
[build command menu] -> [under 100 commands but payload too large] -> [shorten descriptions] -> [register full set when possible]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.3
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.customCommands` with 92 commands and long descriptions

### Steps

1. Configure a Telegram bot with a command set below 100 entries but with long command descriptions.
2. Start native Telegram command registration.
3. Inspect the payload passed to `setMyCommands`.

### Expected

- Descriptions are shortened first so the full command set remains visible when it can fit within Telegram's total menu payload budget.

### Actual

- Before this change, later commands were dropped once Telegram returned `BOT_COMMANDS_TOO_MUCH`, even when shortening descriptions would have allowed the full set to register.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/telegram/src/bot-native-command-menu.test.ts extensions/telegram/src/bot-native-commands.test.ts`
  - `pnpm build`
  - confirmed the registration path keeps 92 long-description commands and logs the description-shortening path instead of dropping commands immediately
- Edge cases checked:
  - payload fits after description trimming
  - payload still cannot fit with one-character descriptions, so tail commands are dropped deterministically
  - existing `BOT_COMMANDS_TOO_MUCH` retry fallback still has coverage
- What you did **not** verify:
  - live Telegram API registration
  - full `pnpm check` is currently blocked on unrelated existing `extensions/diffs/src/language-hints.test.ts` type errors on the current base branch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the conservative text-budget constant may trim descriptions a little more than strictly necessary for some Telegram payloads.
  - Mitigation: it preserves menu stability by fitting the full command set first and still leaves the existing API retry fallback in place.

## Additional Notes

- AI assistance: cursor-assisted implementation and review.
- Testing level: build plus focused Telegram regression tests.

Made with [Cursor](https://cursor.com)