### PR TITLE
fix(agents): block unbacked exec-looking replies

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -337,10 +337,6 @@ export function handleMessageUpdate(
       shouldEmit = false;
     }
 
-    if (blockedExecutionIntent) {
-      shouldEmit = false;
-    }
-
     if (shouldEmit) {
       const data = buildAssistantStreamData({
         text: cleanedText,
@@ -445,12 +441,18 @@ export function handleMessageEnd(
 
   if (
     !ctx.params.silentExpected &&
-    !ctx.state.emittedAssistantUpdate &&
+    (!ctx.state.emittedAssistantUpdate || blockedExecutionIntent) &&
     (cleanedText || hasMedia)
   ) {
+    const replace = Boolean(
+      blockedExecutionIntent &&
+      ctx.state.lastStreamedAssistantCleaned &&
+      ctx.state.lastStreamedAssistantCleaned !== cleanedText,
+    );
     const data = buildAssistantStreamData({
       text: cleanedText,
-      delta: cleanedText,
+      delta: replace ? "" : cleanedText,
+      replace,
       mediaUrls,
     });
     emitAgentEvent({

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -22,6 +22,7 @@ import {
   extractThinkingFromTaggedText,
   formatReasoningMessage,
   promoteThinkingTagsToBlocks,
+  UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK,
 } from "./pi-embedded-utils.js";
 
 const stripTrailingDirective = (text: string): string => {
@@ -306,7 +307,12 @@ export function handleMessageUpdate(
     }
     const parsedDelta = visibleDelta ? ctx.consumePartialReplyDirectives(visibleDelta) : null;
     const parsedFull = parseReplyDirectives(stripTrailingDirective(next));
-    const cleanedText = parsedFull.text;
+    const blockedExecutionIntent = parsedFull.text
+      ? ctx.markUnbackedExecutionIntentReply(parsedFull.text)
+      : false;
+    const cleanedText = blockedExecutionIntent
+      ? UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK
+      : parsedFull.text;
     const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedDelta ?? {});
     const hasAudio = Boolean(parsedDelta?.audioAsVoice);
     const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
@@ -328,6 +334,10 @@ export function handleMessageUpdate(
     ctx.state.lastStreamedAssistantCleaned = cleanedText;
 
     if (ctx.params.silentExpected) {
+      shouldEmit = false;
+    }
+
+    if (blockedExecutionIntent) {
       shouldEmit = false;
     }
 
@@ -404,10 +414,14 @@ export function handleMessageEnd(
     rawThinking: extractAssistantThinking(assistantMessage),
   });
 
-  const text = resolveSilentReplyFallbackText({
+  let text = resolveSilentReplyFallbackText({
     text: ctx.stripBlockTags(rawText, { thinking: false, final: false }),
     messagingToolSentTexts: ctx.state.messagingToolSentTexts,
   });
+  const blockedExecutionIntent = text ? ctx.markUnbackedExecutionIntentReply(text) : false;
+  if (blockedExecutionIntent) {
+    text = UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK;
+  }
   const rawThinking =
     ctx.state.includeReasoning || ctx.state.streamReasoning
       ? extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText)
@@ -454,7 +468,11 @@ export function handleMessageEnd(
   const silentExpectedWithoutSentinel =
     ctx.params.silentExpected && !isSilentReplyText(trimmedText, SILENT_REPLY_TOKEN);
   const finalAssistantText = silentExpectedWithoutSentinel ? "" : text;
-  const addedDuringMessage = ctx.state.assistantTexts.length > ctx.state.assistantTextBaseline;
+  let addedDuringMessage = ctx.state.assistantTexts.length > ctx.state.assistantTextBaseline;
+  if (blockedExecutionIntent) {
+    ctx.replaceCurrentAssistantMessageText(finalAssistantText);
+    addedDuringMessage = false;
+  }
   const chunkerHasBuffered = ctx.blockChunker?.hasBuffered() ?? false;
   ctx.finalizeAssistantTexts({
     text: finalAssistantText,
@@ -545,6 +563,17 @@ export function handleMessageEnd(
   }
   if (!ctx.params.silentExpected && ctx.state.streamReasoning && rawThinking) {
     ctx.emitReasoningStream(rawThinking);
+  }
+
+  if (
+    blockedExecutionIntent &&
+    !ctx.params.silentExpected &&
+    ctx.state.blockReplyBreak === "text_end" &&
+    onBlockReply &&
+    !ctx.state.executionIntentFallbackSent
+  ) {
+    ctx.state.executionIntentFallbackSent = true;
+    ctx.emitBlockReply({ text: UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK });
   }
 
   if (!ctx.params.silentExpected && ctx.state.blockReplyBreak === "text_end" && onBlockReply) {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -50,6 +50,8 @@ function createTestContext(): {
       deterministicApprovalPromptSent: false,
       executionIntentReplyBlocked: false,
       executionIntentFallbackSent: false,
+      currentAssistantMessageHasToolActivity: false,
+      pendingToolActivityForNextAssistantMessage: false,
     },
     shouldEmitToolResult: () => false,
     shouldEmitToolOutput: () => false,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -48,6 +48,8 @@ function createTestContext(): {
       messagingToolSentTargets: [],
       successfulCronAdds: 0,
       deterministicApprovalPromptSent: false,
+      executionIntentReplyBlocked: false,
+      executionIntentFallbackSent: false,
     },
     shouldEmitToolResult: () => false,
     shouldEmitToolOutput: () => false,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -282,6 +282,8 @@ async function emitToolResultOutput(params: {
         }),
       );
       ctx.state.deterministicApprovalPromptSent = true;
+      ctx.state.currentAssistantMessageHasToolActivity = true;
+      ctx.state.pendingToolActivityForNextAssistantMessage = true;
     } catch {
       // ignore delivery failures
     }
@@ -303,6 +305,8 @@ async function emitToolResultOutput(params: {
         }),
       );
       ctx.state.deterministicApprovalPromptSent = true;
+      ctx.state.currentAssistantMessageHasToolActivity = true;
+      ctx.state.pendingToolActivityForNextAssistantMessage = true;
     } catch {
       // ignore delivery failures
     }
@@ -357,6 +361,9 @@ export function handleToolExecutionStart(
     const toolCallId = String(evt.toolCallId);
     const args = evt.args;
     const runId = ctx.params.runId;
+
+    ctx.state.currentAssistantMessageHasToolActivity = true;
+    ctx.state.pendingToolActivityForNextAssistantMessage = true;
 
     // Track start time and args for after_tool_call hook
     toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: Date.now(), args });

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -75,6 +75,8 @@ export type EmbeddedPiSubscribeState = {
   deterministicApprovalPromptSent: boolean;
   executionIntentReplyBlocked: boolean;
   executionIntentFallbackSent: boolean;
+  currentAssistantMessageHasToolActivity: boolean;
+  pendingToolActivityForNextAssistantMessage: boolean;
   lastAssistant?: AgentMessage;
 };
 
@@ -163,6 +165,8 @@ export type ToolHandlerState = Pick<
   | "deterministicApprovalPromptSent"
   | "executionIntentReplyBlocked"
   | "executionIntentFallbackSent"
+  | "currentAssistantMessageHasToolActivity"
+  | "pendingToolActivityForNextAssistantMessage"
 >;
 
 export type ToolHandlerContext = {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -73,6 +73,8 @@ export type EmbeddedPiSubscribeState = {
   pendingToolMediaUrls: string[];
   pendingToolAudioAsVoice: boolean;
   deterministicApprovalPromptSent: boolean;
+  executionIntentReplyBlocked: boolean;
+  executionIntentFallbackSent: boolean;
   lastAssistant?: AgentMessage;
 };
 
@@ -121,6 +123,9 @@ export type EmbeddedPiSubscribeContext = {
   getUsageTotals: () => NormalizedUsage | undefined;
   getCompactionCount: () => number;
   emitBlockReply: (payload: BlockReplyPayload) => void;
+  hasToolActivityForAssistantReply: () => boolean;
+  markUnbackedExecutionIntentReply: (text: string) => boolean;
+  replaceCurrentAssistantMessageText: (text: string) => void;
 };
 
 /**
@@ -156,6 +161,8 @@ export type ToolHandlerState = Pick<
   | "messagingToolSentTargets"
   | "successfulCronAdds"
   | "deterministicApprovalPromptSent"
+  | "executionIntentReplyBlocked"
+  | "executionIntentFallbackSent"
 >;
 
 export type ToolHandlerContext = {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -10,6 +10,7 @@ import {
   findLifecycleErrorAgentEvent,
 } from "./pi-embedded-subscribe.e2e-harness.js";
 import { subscribeEmbeddedPiSession } from "./pi-embedded-subscribe.js";
+import { UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK } from "./pi-embedded-utils.js";
 
 describe("subscribeEmbeddedPiSession", () => {
   async function flushBlockReplyCallbacks(): Promise<void> {
@@ -207,6 +208,82 @@ describe("subscribeEmbeddedPiSession", () => {
 
     expect(resolveToolResult).toBeTypeOf("function");
     resolveToolResult?.();
+  });
+
+  it("replaces fake execution-intent shell replies when no tool call ran", async () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+    const onAgentEvent = vi.fn();
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onBlockReply,
+      onAgentEvent,
+      blockReplyBreak: "message_end",
+    });
+    const text = `I will install/check this now.
+
+\`\`\`bash
+exec npx -y @tencent-weixin/openclaw-weixin-cli@latest install
+\`\`\``;
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, text);
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text }],
+      } as AssistantMessage,
+    });
+    await flushBlockReplyCallbacks();
+
+    expect(subscription.assistantTexts).toEqual([UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK]);
+    expect(onBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK }),
+    );
+    const payloadTexts = extractAgentEventPayloads(onAgentEvent.mock.calls)
+      .map((payload) => payload.text)
+      .filter((value): value is string => typeof value === "string");
+    expect(payloadTexts).toContain(UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK);
+    expect(payloadTexts.join("\n")).not.toContain("exec npx -y");
+  });
+
+  it("keeps execution-intent shell replies when real tool activity exists", async () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onBlockReply,
+      blockReplyBreak: "message_end",
+    });
+    const text = `Let me check that now.
+
+\`\`\`bash
+git status
+\`\`\``;
+
+    emitToolRun({
+      emit,
+      toolName: "read",
+      toolCallId: "tool-1",
+      args: { path: "/tmp/file.txt" },
+      isError: false,
+      result: { text: "ok" },
+    });
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, text);
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text }],
+      } as AssistantMessage,
+    });
+    await flushBlockReplyCallbacks();
+
+    expect(onBlockReply).toHaveBeenCalledWith(expect.objectContaining({ text }));
   });
 
   it.each(THINKING_TAG_CASES)(

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -249,6 +249,56 @@ exec npx -y @tencent-weixin/openclaw-weixin-cli@latest install
     expect(payloadTexts.join("\n")).not.toContain("exec npx -y");
   });
 
+  it("replaces previously streamed exec-looking text once the closing fence arrives", async () => {
+    const { session, emit } = createStubSessionHarness();
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onAgentEvent,
+      onPartialReply,
+      blockReplyBreak: "message_end",
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, "I will install/check this now.\n\n```bash\n");
+    emitAssistantTextDelta(emit, "exec npx -y pkg install\n```");
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: `I will install/check this now.
+
+\`\`\`bash
+exec npx -y pkg install
+\`\`\``,
+          },
+        ],
+      } as AssistantMessage,
+    });
+    await flushBlockReplyCallbacks();
+
+    const assistantPayloads = extractAgentEventPayloads(onAgentEvent.mock.calls).filter(
+      (payload) => payload.delta !== undefined || payload.text !== undefined,
+    );
+    expect(assistantPayloads).toContainEqual(
+      expect.objectContaining({
+        text: UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK,
+        replace: true,
+      }),
+    );
+    expect(onPartialReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK,
+        replace: true,
+      }),
+    );
+  });
+
   it("keeps execution-intent shell replies when real tool activity exists", async () => {
     const { session, emit } = createStubSessionHarness();
     const onBlockReply = vi.fn();
@@ -284,6 +334,61 @@ git status
     await flushBlockReplyCallbacks();
 
     expect(onBlockReply).toHaveBeenCalledWith(expect.objectContaining({ text }));
+  });
+
+  it("does not let prior-turn tool activity bypass the later-turn guard", async () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onBlockReply,
+      blockReplyBreak: "message_end",
+    });
+
+    emitToolRun({
+      emit,
+      toolName: "read",
+      toolCallId: "tool-1",
+      args: { path: "/tmp/file.txt" },
+      isError: false,
+      result: { text: "ok" },
+    });
+    emit({
+      type: "message_start",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the result." }],
+      } as AssistantMessage,
+    });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Here is the result." }],
+      } as AssistantMessage,
+    });
+
+    const fakeExecText = `I'll restart the service now.
+
+\`\`\`bash
+systemctl restart openclaw
+\`\`\``;
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta(emit, fakeExecText);
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: fakeExecText }],
+      } as AssistantMessage,
+    });
+    await flushBlockReplyCallbacks();
+
+    expect(subscription.assistantTexts.at(-1)).toBe(UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK);
+    expect(onBlockReply).toHaveBeenLastCalledWith(
+      expect.objectContaining({ text: UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK }),
+    );
   });
 
   it.each(THINKING_TAG_CASES)(

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -23,7 +23,12 @@ import type {
 import { isPromiseLike } from "./pi-embedded-subscribe.promise.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
-import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
+import {
+  formatReasoningMessage,
+  looksLikeUnbackedExecutionIntentReply,
+  stripDowngradedToolCallText,
+  UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK,
+} from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
@@ -86,6 +91,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingToolMediaUrls: [],
     pendingToolAudioAsVoice: false,
     deterministicApprovalPromptSent: false,
+    executionIntentReplyBlocked: false,
+    executionIntentFallbackSent: false,
   };
   const usageTotals = {
     input: 0,
@@ -167,6 +174,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastReasoningSent = undefined;
     state.reasoningStreamOpen = false;
     state.suppressBlockChunks = false;
+    state.executionIntentReplyBlocked = false;
+    state.executionIntentFallbackSent = false;
     state.assistantMessageIndex += 1;
     state.lastAssistantTextMessageIndex = -1;
     state.lastAssistantTextNormalized = undefined;
@@ -208,6 +217,35 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
     assistantTexts.push(text);
     rememberAssistantText(text);
+  };
+
+  const hasToolActivityForAssistantReply = () =>
+    state.toolSummaryById.size > 0 ||
+    state.toolMetas.length > 0 ||
+    state.deterministicApprovalPromptSent;
+
+  const replaceCurrentAssistantMessageText = (text: string) => {
+    assistantTexts.splice(state.assistantTextBaseline);
+    state.lastAssistantTextMessageIndex = -1;
+    state.lastAssistantTextNormalized = undefined;
+    state.lastAssistantTextTrimmed = undefined;
+    state.lastBlockReplyText = undefined;
+    if (text) {
+      pushAssistantText(text);
+    }
+  };
+
+  const markUnbackedExecutionIntentReply = (text: string) => {
+    if (state.executionIntentReplyBlocked) {
+      return true;
+    }
+    if (hasToolActivityForAssistantReply() || !looksLikeUnbackedExecutionIntentReply(text)) {
+      return false;
+    }
+    state.executionIntentReplyBlocked = true;
+    state.executionIntentFallbackSent = false;
+    replaceCurrentAssistantMessageText("");
+    return true;
   };
 
   const finalizeAssistantTexts = (args: {
@@ -519,6 +557,20 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     if (state.suppressBlockChunks || params.silentExpected) {
       return;
     }
+    if (state.executionIntentReplyBlocked) {
+      if (state.executionIntentFallbackSent) {
+        return;
+      }
+      state.executionIntentFallbackSent = true;
+      replaceCurrentAssistantMessageText(UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK);
+      emitBlockReply(
+        { text: UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK },
+        {
+          assistantMessageIndex: options?.assistantMessageIndex ?? state.assistantMessageIndex,
+        },
+      );
+      return;
+    }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
     const chunk = stripDowngradedToolCallText(stripBlockTags(text, state.blockState)).trimEnd();
@@ -657,6 +709,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.pendingToolMediaUrls = [];
     state.pendingToolAudioAsVoice = false;
     state.deterministicApprovalPromptSent = false;
+    state.executionIntentReplyBlocked = false;
+    state.executionIntentFallbackSent = false;
     resetAssistantMessageState(0);
   };
 
@@ -697,6 +751,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     incrementCompactionCount,
     getUsageTotals,
     getCompactionCount: () => compactionCount,
+    hasToolActivityForAssistantReply,
+    markUnbackedExecutionIntentReply,
+    replaceCurrentAssistantMessageText,
   };
 
   const sessionUnsubscribe = params.session.subscribe(createEmbeddedPiSessionEventHandler(ctx));

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -93,6 +93,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     deterministicApprovalPromptSent: false,
     executionIntentReplyBlocked: false,
     executionIntentFallbackSent: false,
+    currentAssistantMessageHasToolActivity: false,
+    pendingToolActivityForNextAssistantMessage: false,
   };
   const usageTotals = {
     input: 0,
@@ -176,6 +178,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.suppressBlockChunks = false;
     state.executionIntentReplyBlocked = false;
     state.executionIntentFallbackSent = false;
+    state.currentAssistantMessageHasToolActivity = state.pendingToolActivityForNextAssistantMessage;
+    state.pendingToolActivityForNextAssistantMessage = false;
     state.assistantMessageIndex += 1;
     state.lastAssistantTextMessageIndex = -1;
     state.lastAssistantTextNormalized = undefined;
@@ -220,8 +224,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
 
   const hasToolActivityForAssistantReply = () =>
-    state.toolSummaryById.size > 0 ||
-    state.toolMetas.length > 0 ||
+    state.currentAssistantMessageHasToolActivity ||
+    state.pendingToolActivityForNextAssistantMessage ||
     state.deterministicApprovalPromptSent;
 
   const replaceCurrentAssistantMessageText = (text: string) => {
@@ -711,6 +715,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.deterministicApprovalPromptSent = false;
     state.executionIntentReplyBlocked = false;
     state.executionIntentFallbackSent = false;
+    state.currentAssistantMessageHasToolActivity = false;
+    state.pendingToolActivityForNextAssistantMessage = false;
     resetAssistantMessageState(0);
   };
 

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractAssistantText,
   formatReasoningMessage,
+  looksLikeUnbackedExecutionIntentReply,
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
 } from "./pi-embedded-utils.js";
@@ -566,6 +567,26 @@ describe("stripDowngradedToolCallText", () => {
     for (const testCase of cases) {
       expect(stripDowngradedToolCallText(testCase.text), testCase.name).toBe(testCase.expected);
     }
+  });
+});
+
+describe("looksLikeUnbackedExecutionIntentReply", () => {
+  it("matches first-person execution intent paired with a runnable shell fence", () => {
+    const text = `I will install/check this now.
+
+\`\`\`bash
+exec npx -y @tencent-weixin/openclaw-weixin-cli@latest install
+\`\`\``;
+    expect(looksLikeUnbackedExecutionIntentReply(text)).toBe(true);
+  });
+
+  it("ignores ordinary command examples without execution-intent phrasing", () => {
+    const text = `Run this command locally if you want to install it:
+
+\`\`\`bash
+npm install
+\`\`\``;
+    expect(looksLikeUnbackedExecutionIntentReply(text)).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -580,6 +580,15 @@ exec npx -y @tencent-weixin/openclaw-weixin-cli@latest install
     expect(looksLikeUnbackedExecutionIntentReply(text)).toBe(true);
   });
 
+  it("matches other execution verbs that can start real work", () => {
+    const text = `I'll restart the service now.
+
+\`\`\`bash
+systemctl restart openclaw
+\`\`\``;
+    expect(looksLikeUnbackedExecutionIntentReply(text)).toBe(true);
+  });
+
   it("ignores ordinary command examples without execution-intent phrasing", () => {
     const text = `Run this command locally if you want to install it:
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -224,6 +224,32 @@ export function stripDowngradedToolCallText(text: string): string {
   return cleaned.trim();
 }
 
+export const UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK =
+  "I didn't actually run that command because no tool call was executed.";
+
+const EXECUTION_INTENT_PHRASE_RE =
+  /\b(?:i(?:'|’)ll|i will|i am going to|i'm going to|let me)\s+(?:run|check|install|execute|verify|inspect|test)\b/i;
+const EXECUTION_INTENT_SHELL_FENCE_RE = /```(?:bash|sh|shell|zsh)\b[^\n]*\n([\s\S]*?)```/i;
+const EXECUTION_INTENT_COMMAND_LINE_RE = /^(?:exec\s+)?[a-z0-9@_.:/-]+(?:\s|$)/i;
+
+export function looksLikeUnbackedExecutionIntentReply(text: string): boolean {
+  if (!text || !EXECUTION_INTENT_PHRASE_RE.test(text)) {
+    return false;
+  }
+  const fenceMatch = text.match(EXECUTION_INTENT_SHELL_FENCE_RE);
+  if (!fenceMatch) {
+    return false;
+  }
+  const commandBody = fenceMatch[1]
+    ?.split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  if (!commandBody) {
+    return false;
+  }
+  return EXECUTION_INTENT_COMMAND_LINE_RE.test(commandBody);
+}
+
 /**
  * Strip thinking tags and their content from text.
  * This is a safety net for cases where the model outputs <think> tags

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -228,7 +228,7 @@ export const UNBACKED_EXECUTION_INTENT_REPLY_FALLBACK =
   "I didn't actually run that command because no tool call was executed.";
 
 const EXECUTION_INTENT_PHRASE_RE =
-  /\b(?:i(?:'|’)ll|i will|i am going to|i'm going to|let me)\s+(?:run|check|install|execute|verify|inspect|test)\b/i;
+  /\b(?:i(?:'|’)ll|i will|i am going to|i'm going to|let me)\s+(?:run|check|install|execute|verify|inspect|test|update|upgrade|start|deploy|build|restart)\b/i;
 const EXECUTION_INTENT_SHELL_FENCE_RE = /```(?:bash|sh|shell|zsh)\b[^\n]*\n([\s\S]*?)```/i;
 const EXECUTION_INTENT_COMMAND_LINE_RE = /^(?:exec\s+)?[a-z0-9@_.:/-]+(?:\s|$)/i;
 

--- a/src/agents/pi-tool-handler-state.test-helpers.ts
+++ b/src/agents/pi-tool-handler-state.test-helpers.ts
@@ -13,6 +13,8 @@ export function createBaseToolHandlerState() {
     messagingToolSentMediaUrls: [] as string[],
     messagingToolSentTargets: [] as unknown[],
     deterministicApprovalPromptSent: false,
+    executionIntentReplyBlocked: false,
+    executionIntentFallbackSent: false,
     blockBuffer: "",
   };
 }

--- a/src/agents/pi-tool-handler-state.test-helpers.ts
+++ b/src/agents/pi-tool-handler-state.test-helpers.ts
@@ -15,6 +15,8 @@ export function createBaseToolHandlerState() {
     deterministicApprovalPromptSent: false,
     executionIntentReplyBlocked: false,
     executionIntentFallbackSent: false,
+    currentAssistantMessageHasToolActivity: false,
+    pendingToolActivityForNextAssistantMessage: false,
     blockBuffer: "",
   };
 }


### PR DESCRIPTION
## Summary

- Problem: assistant turns could emit first-person execution-intent text plus runnable fenced shell blocks even when no real tool call or tool result existed.
- Why it matters: Telegram/direct replies could look operationally real, which creates false execution confidence and hidden idle time.
- What changed: added a narrow guard in the embedded assistant reply pipeline that rewrites strong unbacked execution-intent shell replies to a truthful fallback unless the turn already has real tool activity, and added regression coverage for blocked and tool-backed cases.
- What did NOT change (scope boundary): this does not change legitimate tool-backed exec/approval replies, Telegram formatting, or general command/example rendering.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60955
- Related #40631
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the assistant visible-text path stripped downgraded/internal tool markers, but it still treated ordinary first-person shell fences as safe user-facing text even when the turn had no tool lifecycle at all.
- Missing detection / guardrail: there was no guard tying execution-intent shell text to actual tool activity before the reply was emitted to chat surfaces.
- Contributing context (if known): Telegram renders fenced shell blocks as code blocks, which made the no-tool reply look especially operationally real.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts`
  - `src/agents/pi-embedded-utils.test.ts`
- Scenario the test should lock in: block a no-tool assistant turn that says it will run/install/check something and includes a runnable fenced shell block, while preserving similar text once real tool activity exists.
- Why this is the smallest reliable guardrail: the bug lives in the embedded assistant reply seam that decides what reaches user-facing chat delivery, so a seam-level test exercises the exact emission path without requiring a full Telegram e2e harness.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Assistant turns that claim they are running a shell command and include a runnable fenced shell block without any real tool activity now return a truthful fallback instead of fake execution-looking text.
- Legitimate tool-backed exec/approval flows continue to render normally.

## Diagram (if applicable)

```text
Before:
[user asks to run something] -> [assistant emits "I'll run/check this" + fenced shell block] -> [reply delivered with no tool activity]

After:
[user asks to run something] -> [assistant emits execution-intent shell text without tool activity] -> [guard rewrites reply] -> [truthful fallback delivered]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15 / Darwin 25
- Runtime/container: local Node 22 + pnpm workspace
- Model/provider: simulated embedded assistant session
- Integration/channel (if any): assistant reply pipeline with Telegram-style shell-fence rendering behavior reproduced locally
- Relevant config (redacted): default local test config

### Steps

1. Simulate an assistant turn with text like `I will install/check this now.` followed by a runnable fenced `bash` block.
2. Do not emit any `tool_execution_start` or `tool_execution_end` events for that turn.
3. Observe the emitted assistant reply payload.

### Expected

- No execution-looking reply should be delivered as if work started successfully without a real tool event.

### Actual

- Before this fix, the reply pipeline emitted the execution-intent text and fenced shell block as user-visible output even though no tool activity existed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Reproduced the bad no-tool assistant turn locally and confirmed the current code emitted the fake execution-looking reply before the fix.
  - Verified the new fallback path with focused tests and local reproduction against the patched reply pipeline.
  - Verified a similar reply still passes when the turn has real tool activity.
- Edge cases checked:
  - tool-backed replies are not blocked
  - fenced shell examples without first-person execution-intent wording are not matched by the detector
  - both streaming/message-end and final assistant text paths are covered by the guard
- What you did **not** verify:
  - a live Telegram roundtrip in a real chat session
  - the full `pnpm test` suite did not complete cleanly in this branch because it failed in untouched ACP coverage at `src/acp/control-plane/manager.test.ts` (`tracks parented direct ACP turns in the task registry`)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the guard could over-match benign instructional shell examples.
  - Mitigation: detection is intentionally narrow and requires both first-person execution-intent wording and a runnable fenced shell block, and tool-backed turns bypass it.

AI-assisted: yes.

Made with [Cursor](https://cursor.com)