### PR TITLE
fix(telegram): honor defaultAccount in message actions

### DIFF
--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -721,6 +721,88 @@ describe("handleTelegramAction", () => {
     ).rejects.toThrow(/Telegram bot token missing/);
   });
 
+  it.each([
+    {
+      name: "react",
+      params: { action: "react", chatId: "123", messageId: 456, emoji: "✅" },
+      argIndex: 3,
+    },
+    {
+      name: "sendMessage",
+      params: { action: "sendMessage", to: "@testchannel", content: "Hello!" },
+      argIndex: 2,
+    },
+    {
+      name: "poll",
+      params: { action: "poll", to: "@testchannel", question: "Ready?", answers: ["Yes", "No"] },
+      argIndex: 2,
+    },
+    {
+      name: "deleteMessage",
+      params: { action: "deleteMessage", chatId: "123", messageId: 456 },
+      argIndex: 2,
+    },
+    {
+      name: "editMessage",
+      params: { action: "editMessage", chatId: "123", messageId: 456, content: "Updated" },
+      argIndex: 3,
+    },
+    {
+      name: "sendSticker",
+      params: { action: "sendSticker", to: "123", fileId: "sticker-id" },
+      argIndex: 2,
+    },
+    {
+      name: "createForumTopic",
+      params: { action: "createForumTopic", chatId: "-100123", name: "Topic" },
+      argIndex: 2,
+    },
+    {
+      name: "editForumTopic",
+      params: { action: "editForumTopic", chatId: "-100123", messageThreadId: 42, name: "Renamed" },
+      argIndex: 2,
+    },
+  ])(
+    "uses channels.telegram.defaultAccount token for omitted accountId on $name",
+    async ({ params, argIndex }) => {
+      delete process.env.TELEGRAM_BOT_TOKEN;
+      const cfg = {
+        channels: {
+          telegram: {
+            defaultAccount: "work",
+            reactionLevel: "minimal",
+            accounts: {
+              work: {
+                botToken: "tok-work",
+                actions: {
+                  sticker: true,
+                  createForumTopic: true,
+                  editForumTopic: true,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      await handleTelegramAction(params as Record<string, unknown>, cfg);
+
+      const runtimeCallMap = [
+        reactMessageTelegram.mock.calls,
+        sendMessageTelegram.mock.calls,
+        sendPollTelegram.mock.calls,
+        deleteMessageTelegram.mock.calls,
+        editMessageTelegram.mock.calls,
+        sendStickerTelegram.mock.calls,
+        createForumTopicTelegram.mock.calls,
+        editForumTopicTelegram.mock.calls,
+      ];
+      const call = runtimeCallMap.find((calls) => calls.length > 0)?.[0] as unknown[] | undefined;
+      const opts = call?.[argIndex] as Record<string, unknown> | undefined;
+      expect(opts).toMatchObject({ token: "tok-work" });
+    },
+  );
+
   it("allows inline buttons by default (allowlist)", async () => {
     const cfg = {
       channels: { telegram: { botToken: "tok" } },

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -11,7 +11,11 @@ import {
   resolvePollMaxSelections,
 } from "openclaw/plugin-sdk/channel-actions";
 import type { OpenClawConfig, TelegramActionConfig } from "openclaw/plugin-sdk/config-runtime";
-import { createTelegramActionGate, resolveTelegramPollActionGateState } from "./accounts.js";
+import {
+  createTelegramActionGate,
+  resolveTelegramAccount,
+  resolveTelegramPollActionGateState,
+} from "./accounts.js";
 import {
   fitsTelegramCallbackData,
   TELEGRAM_CALLBACK_DATA_MAX_BYTES,
@@ -35,7 +39,6 @@ import {
   sendStickerTelegram,
 } from "./send.js";
 import { getCacheStats, searchStickers } from "./sticker-cache.js";
-import { resolveTelegramToken } from "./token.js";
 
 export const telegramActionRuntime = {
   createForumTopicTelegram,
@@ -197,6 +200,10 @@ function readTelegramSendContent(params: {
   return content ?? "";
 }
 
+function resolveTelegramActionToken(cfg: OpenClawConfig, accountId?: string) {
+  return resolveTelegramAccount({ cfg, accountId }).token;
+}
+
 export async function handleTelegramAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
@@ -250,7 +257,7 @@ export async function handleTelegramAction(
     const { emoji, remove, isEmpty } = readReactionParams(params, {
       removeErrorMessage: "Emoji is required to remove a Telegram reaction.",
     });
-    const token = resolveTelegramToken(cfg, { accountId }).token;
+    const token = resolveTelegramActionToken(cfg, accountId ?? undefined);
     if (!token) {
       return jsonResult({
         ok: false,
@@ -342,7 +349,7 @@ export async function handleTelegramAction(
     const replyToMessageId = readTelegramReplyToMessageId(params);
     const messageThreadId = readTelegramThreadId(params);
     const quoteText = readStringParam(params, "quoteText");
-    const token = resolveTelegramToken(cfg, { accountId }).token;
+    const token = resolveTelegramActionToken(cfg, accountId ?? undefined);
     if (!token) {
       throw new Error(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
@@ -411,7 +418,7 @@ export async function handleTelegramAction(
         pollPublic: readBooleanParam(params, "pollPublic"),
       });
     const silent = readBooleanParam(params, "silent");
-    const token = resolveTelegramToken(cfg, { accountId }).token;
+    const token = resolveTelegramActionToken(cfg, accountId ?? undefined);
     if (!token) {
       throw new Error(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
@@ -453,7 +460,7 @@ export async function handleTelegramAction(
       required: true,
       integer: true,
     });
-    const token = resolveTelegramToken(cfg, { accountId }).token;
+    const token = resolveTelegramActionToken(cfg, accountId ?? undefined);
     if (!token) {
       throw new Error(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
@@ -491,7 +498,7 @@ export async function handleTelegramAction(
         );
       }
     }
-    const token = resolveTelegramToken(cfg, { accountId }).token;
+    const token = resolveTelegramActionToken(cfg, accountId ?? undefined);
     if (!token) {
       throw new Error(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
@@ -530,7 +537,7 @@ export async function handleTelegramAction(
     }
     const replyToMessageId = readTelegramReplyToMessageId(params);
     const messageThreadId = readTelegramThreadId(params);
-    const token = resolveTelegramToken(cfg, { accountId }).token;
+    const token = resolveTelegramActionToken(cfg, accountId ?? undefined);
     if (!token) {
       throw new Error(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
@@ -584,7 +591,7 @@ export async function handleTelegramAction(
     const name = readStringParam(params, "name", { required: true });
     const iconColor = readTelegramForumTopicIconColor(params);
     const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
-    const token = resolveTelegramToken(cfg, { accountId }).token;
+    const token = resolveTelegramActionToken(cfg, accountId ?? undefined);
     if (!token) {
       throw new Error(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
@@ -616,7 +623,7 @@ export async function handleTelegramAction(
     }
     const name = readStringParam(params, "name");
     const iconCustomEmojiId = readStringParam(params, "iconCustomEmojiId");
-    const token = resolveTelegramToken(cfg, { accountId }).token;
+    const token = resolveTelegramActionToken(cfg, accountId ?? undefined);
     if (!token) {
       throw new Error(
         "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",


### PR DESCRIPTION
## Summary

- Problem: Telegram message actions resolved tokens from the implicit `default` account before the send helper's fallback logic ran, so `channels.telegram.defaultAccount` could be ignored when `accountId` was omitted.
- Why it matters: `openclaw message send --channel telegram` and sibling Telegram message actions could fail with a missing-token error even when the configured default Telegram account was valid.
- What changed: route token lookup for Telegram message actions through `resolveTelegramAccount()` so omitted-account actions honor the same default-account fallback as direct Telegram sends, and add regression coverage for all token-gated Telegram actions.
- What did NOT change (scope boundary): this PR does not change Telegram client caching, routing bindings, or explicit `--account` behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #61012
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/telegram/src/action-runtime.ts` resolved action tokens with `resolveTelegramToken(cfg, { accountId })`, which treats an omitted `accountId` as the implicit `default` account instead of following `channels.telegram.defaultAccount`. The lower-level send helper already used `resolveTelegramAccount()`, so the two paths disagreed.
- Missing detection / guardrail: the action-runtime tests covered explicit accounts and missing-token handling, but not omitted-account actions with a named `defaultAccount` and no top-level Telegram token.
- Contributing context (if known): issue #61012 points at outgoing Telegram default-account behavior; the current repro is narrower than the original report and lives specifically on the message-action path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/action-runtime.test.ts`
- Scenario the test should lock in: omitted `accountId` plus `channels.telegram.defaultAccount` resolves the named account token for every token-gated Telegram message action.
- Why this is the smallest reliable guardrail: the bug is in action-runtime token resolution before transport dispatch, so a focused runtime test hits the exact failing seam without pulling in unrelated CLI/plugin setup.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

When Telegram has a named `channels.telegram.defaultAccount`, omitted-account message actions now use that account's token consistently instead of failing as if only the implicit `default` account existed.

## Diagram (if applicable)

```text
Before:
[message action with omitted accountId] -> [resolveTelegramToken(default)] -> [missing token] -> [action fails]

After:
[message action with omitted accountId] -> [resolveTelegramAccount(defaultAccount fallback)] -> [named account token] -> [action succeeds]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: token selection now matches the existing account-resolution path instead of bypassing it; regression tests cover all token-gated Telegram actions with omitted `accountId`.

## Repro + Verification

### Environment

- OS: macOS 15 / darwin 25.3.0
- Runtime/container: Node 22+ / pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.defaultAccount = work`, `channels.telegram.accounts.work.botToken = <redacted>`, no top-level Telegram token

### Steps

1. Configure Telegram with a named default account under `channels.telegram.defaultAccount` and no top-level `channels.telegram.botToken` or `TELEGRAM_BOT_TOKEN`.
2. Trigger a Telegram message action without an explicit `accountId` (for example the `openclaw message send --channel telegram ...` path).
3. Observe token resolution in the action runtime.

### Expected

- The action uses the named default Telegram account token and succeeds.

### Actual

- Before this change, the action runtime treated the request like the implicit `default` account and failed with `Telegram bot token missing`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reproduced the pre-fix failure in `handleTelegramAction(...)` with a named Telegram default account; confirmed the lower-level `sendMessageTelegram(...)` path already succeeded; ran targeted tests for `extensions/telegram/src/action-runtime.test.ts`, `extensions/telegram/src/accounts.test.ts`, `extensions/telegram/src/send.test.ts`, and `src/commands/message.test.ts`.
- Edge cases checked: omitted-account handling for send, poll, react, delete, edit, sticker, and forum-topic actions; explicit `accountId` behavior remained unchanged.
- What you did **not** verify: a live Telegram network send against a real bot/chat.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: action-runtime token selection now follows the merged account resolver, so a bug there would affect all token-gated Telegram actions.
  - Mitigation: the code now shares the same resolver semantics already used by the direct send helper, and the new regression matrix covers every action branch that consumes a Telegram token.

## Additional Notes

- Full `pnpm build` completed successfully.
- Full `pnpm check` currently hits an unrelated existing `tsgo` failure in `extensions/diffs/src/language-hints.test.ts` on this checkout.
- This PR was prepared with coding assistance and then reviewed against the current code paths and focused repro/testing above.

Made with [Cursor](https://cursor.com)