### PR TITLE
webchat: allow default peer-based session routing

### DIFF
--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -64,6 +64,27 @@ Full configuration: [Configuration](/gateway/configuration)
 WebChat options:
 
 - `gateway.webchat.chatHistoryMaxChars`: maximum character count for text fields in `chat.history` responses. When a transcript entry exceeds this limit, Gateway truncates long text fields and may replace oversized messages with a placeholder. Per-request `maxChars` can also be sent by the client to override this default for a single `chat.history` call.
+- `gateway.webchat.defaultPeerId`: optional canonical/operator peer id for default WebChat/TUI routing. When set, WebChat/TUI defaults to the DM session resolved from this peer identity via normal DM routing rules (`session.dmScope`, `session.identityLinks`) instead of the legacy main session.
+
+Example:
+
+```json5
+{
+  gateway: {
+    webchat: {
+      defaultPeerId: "operator",
+    },
+  },
+  session: {
+    dmScope: "per-peer",
+    identityLinks: {
+      operator: ["telegram:1234567890"],
+    },
+  },
+}
+```
+
+With this config, WebChat/TUI defaults to `agent:<agentId>:direct:operator` instead of `agent:<agentId>:main`.
 
 Related global options:
 

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -383,6 +383,12 @@ export type GatewayToolsConfig = {
 export type GatewayWebchatConfig = {
   /** Max characters per text field in chat.history responses before truncation (default: 12000). */
   chatHistoryMaxChars?: number;
+  /**
+   * Optional canonical/operator peer id for WebChat/TUI default session routing.
+   * When set, WebChat/TUI defaults to the DM session resolved from this peer id
+   * instead of the legacy main session.
+   */
+  defaultPeerId?: string;
 };
 
 export type GatewayConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -728,6 +728,7 @@ export const OpenClawSchema = z
         webchat: z
           .object({
             chatHistoryMaxChars: z.number().int().positive().max(500_000).optional(),
+            defaultPeerId: z.string().min(1).optional(),
           })
           .strict()
           .optional(),

--- a/src/gateway/protocol/schema/snapshot.ts
+++ b/src/gateway/protocol/schema/snapshot.ts
@@ -31,6 +31,7 @@ export const SessionDefaultsSchema = Type.Object(
     mainKey: NonEmptyString,
     mainSessionKey: NonEmptyString,
     scope: Type.Optional(NonEmptyString),
+    dmScope: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -20,6 +20,7 @@ export function buildGatewaySnapshot(opts?: { includeSensitive?: boolean }): Sna
   const mainKey = normalizeMainKey(cfg.session?.mainKey);
   const mainSessionKey = resolveMainSessionKey(cfg);
   const scope = cfg.session?.scope ?? "per-sender";
+  const dmScope = cfg.session?.dmScope ?? "main";
   const presence = listSystemPresence();
   const uptimeMs = Math.round(process.uptime() * 1000);
   const updateAvailable = getUpdateAvailable() ?? undefined;
@@ -35,6 +36,7 @@ export function buildGatewaySnapshot(opts?: { includeSensitive?: boolean }): Sna
       mainKey,
       mainSessionKey,
       scope,
+      dmScope,
     },
     updateAvailable,
   };

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -107,6 +107,33 @@ describe("resolveTuiSessionKey", () => {
       }),
     ).toBe("agent:main:test1");
   });
+
+  it("uses peer-based default session when webchat defaultPeerId is configured", () => {
+    expect(
+      resolveTuiSessionKey({
+        raw: "",
+        sessionScope: "per-sender",
+        currentAgentId: "main",
+        sessionMainKey: "main",
+        dmScope: "per-peer",
+        identityLinks: {
+          operator: ["telegram:1234567890", "webchat:operator"],
+        },
+        webchatDefaultPeerId: "operator",
+      }),
+    ).toBe("agent:main:direct:operator");
+  });
+
+  it("keeps legacy main-session default when webchat defaultPeerId is unset", () => {
+    expect(
+      resolveTuiSessionKey({
+        raw: "",
+        sessionScope: "per-sender",
+        currentAgentId: "main",
+        sessionMainKey: "main",
+      }),
+    ).toBe("agent:main:main");
+  });
 });
 
 describe("resolveInitialTuiAgentId", () => {

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -11,6 +11,7 @@ import {
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import {
+  buildAgentPeerSessionKey,
   buildAgentMainSessionKey,
   normalizeAgentId,
   normalizeMainKey,
@@ -54,12 +55,29 @@ export function resolveTuiSessionKey(params: {
   sessionScope: SessionScope;
   currentAgentId: string;
   sessionMainKey: string;
+  dmScope?: "main" | "per-peer" | "per-channel-peer" | "per-account-channel-peer";
+  identityLinks?: Record<string, string[]>;
+  webchatDefaultPeerId?: string;
 }) {
   const trimmed = (params.raw ?? "").trim();
   if (!trimmed) {
     if (params.sessionScope === "global") {
       return "global";
     }
+
+    const defaultPeerId = (params.webchatDefaultPeerId ?? "").trim();
+    if (defaultPeerId) {
+      return buildAgentPeerSessionKey({
+        agentId: params.currentAgentId,
+        mainKey: params.sessionMainKey,
+        channel: "webchat",
+        peerKind: "direct",
+        peerId: defaultPeerId,
+        dmScope: params.dmScope ?? "main",
+        identityLinks: params.identityLinks,
+      });
+    }
+
     return buildAgentMainSessionKey({
       agentId: params.currentAgentId,
       mainKey: params.sessionMainKey,
@@ -189,6 +207,9 @@ export async function runTui(opts: TuiOptions) {
   const config = loadConfig();
   const initialSessionInput = (opts.session ?? "").trim();
   let sessionScope: SessionScope = (config.session?.scope ?? "per-sender") as SessionScope;
+  const dmScope = config.session?.dmScope;
+  const identityLinks = config.session?.identityLinks;
+  const webchatDefaultPeerId = config.gateway?.webchat?.defaultPeerId;
   let sessionMainKey = normalizeMainKey(config.session?.mainKey);
   let agentDefaultId = resolveDefaultAgentId(config);
   let currentAgentId = resolveInitialTuiAgentId({
@@ -457,6 +478,9 @@ export async function runTui(opts: TuiOptions) {
       sessionScope,
       currentAgentId,
       sessionMainKey,
+      dmScope,
+      identityLinks,
+      webchatDefaultPeerId,
     });
   };
 


### PR DESCRIPTION
## Summary

Add an opt-in `gateway.webchat.defaultPeerId` config so WebChat/TUI can default to a canonical peer-based DM session via existing `session.dmScope` and `session.identityLinks` logic.

- Problem: WebChat/TUI defaults to the agent main session, so `session.dmScope` + `session.identityLinks` cannot unify WebChat with the same operator’s DM session on channels like Telegram.
- Why it matters: per-peer cross-channel identity linking works for inbound DM routing, but not for WebChat/TUI, so a single operator still gets split context across WebChat and messaging channels.
- What changed: adds opt-in `gateway.webchat.defaultPeerId` and uses existing peer-session routing logic in TUI default session resolution when that value is set.
- What did NOT change (scope boundary): default behavior is unchanged when `gateway.webchat.defaultPeerId` is unset; this PR does not change inbound Telegram/Discord/etc. routing semantics.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: WebChat/TUI default session selection used the legacy main-session path directly instead of resolving through the existing DM peer session key builder.
- Missing detection / guardrail: there was no config or test coverage for “WebChat/TUI should default to a canonical peer session” in per-peer identity-link setups.
- Contributing context (if known): `session.identityLinks` only applies during peer-based session key construction, so WebChat/TUI never benefited from it while defaulting to `main`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/tui/tui.test.ts`
- Scenario the test should lock in:
  - when `gateway.webchat.defaultPeerId` is set, empty/default TUI session selection resolves to the peer-based DM session key
  - when unset, TUI keeps the legacy main-session default
- Why this is the smallest reliable guardrail:
  - the behavior change is isolated to TUI default session resolution and can be validated deterministically without full gateway/channel setup
- Existing test that already covers this (if any):
  - existing `resolveTuiSessionKey` tests cover legacy/default and normalization behavior
- If no new test is added, why not:
  - N/A

## User-visible / Behavior Changes

- New optional config: `gateway.webchat.defaultPeerId`
- When set, WebChat/TUI defaults to a peer-based DM session resolved via `session.dmScope` and `session.identityLinks`
- When unset, WebChat/TUI behavior remains unchanged and defaults to the legacy main session

## Diagram (if applicable)

```text
Before:
[open WebChat/TUI] -> [default main session] -> [agent:main:main]

After:
[open WebChat/TUI]
  -> [gateway.webchat.defaultPeerId set]
  -> [peer-based session resolution using dmScope + identityLinks]
  -> [agent:main:direct:<canonical-peer>]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation:
  - Risk: WebChat/TUI can intentionally default into a canonical peer session instead of `main`, which changes which existing transcript/context is opened by default.
  - Mitigation: behavior is strictly opt-in via `gateway.webchat.defaultPeerId`; default behavior is unchanged.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw dev checkout
- Model/provider: N/A
- Integration/channel (if any): WebChat/TUI + Telegram identity-link scenario
- Relevant config (redacted):

```json5
{
  gateway: {
    webchat: {
      defaultPeerId: "operator",
    },
  },
  session: {
    dmScope: "per-peer",
    identityLinks: {
      operator: ["telegram:1234567890"],
    },
  },
}
```

### Steps

1. Configure `session.dmScope: "per-peer"` and a canonical identity in `session.identityLinks`.
2. Set `gateway.webchat.defaultPeerId` to that canonical identity.
3. Open TUI/WebChat without explicitly selecting a session.

### Expected

- WebChat/TUI defaults to `agent:<agentId>:direct:<canonical-peer>`.

### Actual

- Before this change, WebChat/TUI defaulted to `agent:<agentId>:main`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - inspected source flow showing TUI default session previously resolved directly to main
  - added unit coverage for peer-based default session resolution and legacy fallback
  - verified config/schema/docs updates line up with the code path
- Edge cases checked:
  - unset `gateway.webchat.defaultPeerId` preserves legacy behavior
  - explicit session keys still bypass default selection
  - global session scope still preserves `global`
- What you did **not** verify:
  - full build/test suite in this environment
  - end-to-end WebChat app/manual UI verification against a running patched gateway

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:
  - Optional only: set `gateway.webchat.defaultPeerId` if you want WebChat/TUI to default to a canonical peer-based DM session

## Risks and Mitigations

- Risk:
  - Misconfiguration of `gateway.webchat.defaultPeerId` could point WebChat/TUI at an unintended canonical peer session.
  - Mitigation:
    - opt-in only
    - existing `session.identityLinks` and `dmScope` rules still determine final peer-session resolution