### PR TITLE
fix(agents): fall back to agents.defaults.timeoutSeconds for LLM idle timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -49,6 +49,30 @@ describe("resolveLlmIdleTimeoutMs", () => {
     } as OpenClawConfig;
     expect(resolveLlmIdleTimeoutMs(cfg)).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
   });
+
+  it("falls back to agents.defaults.timeoutSeconds when llm.idleTimeoutSeconds is not set", () => {
+    const cfg = { agents: { defaults: { timeoutSeconds: 300 } } } as OpenClawConfig;
+    expect(resolveLlmIdleTimeoutMs(cfg)).toBe(300_000);
+  });
+
+  it("prefers llm.idleTimeoutSeconds over agents.defaults.timeoutSeconds", () => {
+    const cfg = {
+      agents: { defaults: { timeoutSeconds: 300, llm: { idleTimeoutSeconds: 120 } } },
+    } as OpenClawConfig;
+    expect(resolveLlmIdleTimeoutMs(cfg)).toBe(120_000);
+  });
+
+  it("llm.idleTimeoutSeconds=0 disables timeout even when timeoutSeconds is set", () => {
+    const cfg = {
+      agents: { defaults: { timeoutSeconds: 300, llm: { idleTimeoutSeconds: 0 } } },
+    } as OpenClawConfig;
+    expect(resolveLlmIdleTimeoutMs(cfg)).toBe(0);
+  });
+
+  it("falls back to default when both are unset", () => {
+    const cfg = { agents: { defaults: {} } } as OpenClawConfig;
+    expect(resolveLlmIdleTimeoutMs(cfg)).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
+  });
 });
 
 describe("streamWithIdleTimeout", () => {

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -17,17 +17,33 @@ const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 /**
  * Resolves the LLM idle timeout from configuration.
+ *
+ * Priority:
+ * 1. `agents.defaults.llm.idleTimeoutSeconds` (explicit; 0 disables)
+ * 2. `agents.defaults.timeoutSeconds` (overall agent timeout as fallback)
+ * 3. DEFAULT_LLM_IDLE_TIMEOUT_MS (60 s)
+ *
  * @param cfg - OpenClaw configuration
  * @returns Idle timeout in milliseconds, or 0 to disable
  */
 export function resolveLlmIdleTimeoutMs(cfg?: OpenClawConfig): number {
   const raw = cfg?.agents?.defaults?.llm?.idleTimeoutSeconds;
-  // 0 means disabled (no timeout)
+  // 0 means explicitly disabled (no timeout)
   if (raw === 0) {
     return 0;
   }
   if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
     return Math.min(Math.floor(raw) * 1000, MAX_SAFE_TIMEOUT_MS);
+  }
+  // Fall back to the overall agent timeout so users who configure a large
+  // timeoutSeconds (e.g. for slow local models) don't hit the 60 s default.
+  const agentTimeoutSeconds = cfg?.agents?.defaults?.timeoutSeconds;
+  if (
+    typeof agentTimeoutSeconds === "number" &&
+    Number.isFinite(agentTimeoutSeconds) &&
+    agentTimeoutSeconds > 0
+  ) {
+    return Math.min(Math.floor(agentTimeoutSeconds) * 1000, MAX_SAFE_TIMEOUT_MS);
   }
   return DEFAULT_LLM_IDLE_TIMEOUT_MS;
 }


### PR DESCRIPTION
Made with Copilot | fully tested

## Summary

**Problem:** When gents.defaults.llm.idleTimeoutSeconds is not explicitly configured, the LLM idle timeout defaults to 60 s regardless of gents.defaults.timeoutSeconds. Users who set gents.defaults.timeoutSeconds to a large value (e.g. 86400 for slow local models or reasoning models that need more than 60 s to produce the first token) still see LLM request timed out errors.

**Why it matters:** Reasoning models and slow local models routinely exceed the hardcoded 60 s default, making gents.defaults.timeoutSeconds ineffective as a workaround.

**What changed:** esolveLlmIdleTimeoutMs now falls back to gents.defaults.timeoutSeconds (converted to ms) when llm.idleTimeoutSeconds is not explicitly set. Explicit llm.idleTimeoutSeconds (including   for disabled) is still respected without change.

**What did NOT change:** Default behavior when neither field is configured is unchanged (falls back to the built-in default). No schema or config type changes needed.

## Testing

- [x] pnpm test -- src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts - 18/18 pass
- [x] pnpm check

Closes #57488