### PR TITLE
fix(agents): omit empty tools array in OpenAI transport params

### DIFF
--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1148,4 +1148,70 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("store");
     expect(params).not.toHaveProperty("reasoning_effort");
   });
+
+  it("omits tools from params when context.tools is empty", () => {
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params).not.toHaveProperty("tools");
+  });
+
+  it("omits tools from params when context.tools is empty even with tool history in messages", () => {
+    // Regression guard: the removed hasToolHistory fallback used to send tools: []
+    // when prior tool calls appeared in message history. Strict OpenAI-compatible
+    // providers reject an empty tools array; OpenAI does not require it to be present.
+    const params = buildOpenAICompletionsParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-completions",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-completions">,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call_1", name: "search", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            toolName: "search",
+            isError: false,
+            timestamp: 0,
+            content: [{ type: "text", text: "ok" }],
+          },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    );
+
+    expect(params).not.toHaveProperty("tools");
+  });
 });

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -933,14 +933,6 @@ function buildAzureOpenAIResponsesParams(
   return params;
 }
 
-function hasToolHistory(messages: Context["messages"]): boolean {
-  return messages.some(
-    (message) =>
-      message.role === "toolResult" ||
-      (message.role === "assistant" && message.content.some((block) => block.type === "toolCall")),
-  );
-}
-
 function createOpenAICompletionsClient(
   model: Model<Api>,
   context: Context,
@@ -1344,10 +1336,8 @@ export function buildOpenAICompletionsParams(
   if (options?.temperature !== undefined) {
     params.temperature = options.temperature;
   }
-  if (context.tools) {
+  if (context.tools && context.tools.length > 0) {
     params.tools = convertTools(context.tools, compat, model);
-  } else if (hasToolHistory(context.messages)) {
-    params.tools = [];
   }
   if (options?.toolChoice) {
     params.tool_choice = options.toolChoice;


### PR DESCRIPTION
## Summary

Old code could send `tools: []` in two cases: when `context.tools` existed but was empty, and when `hasToolHistory` inferred prior tool calls from message history. Strict OpenAI-compatible providers (e.g. vLLM, LocalAI) reject requests with an empty `tools` array, causing inference to fail even when no tools should be active.

This change only sets `params.tools` when `context.tools.length > 0`, and removes the now-unneeded `hasToolHistory` fallback. No changes to tool conversion, compat flags, or provider routing.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Root Cause

Two paths could emit `tools: []`:

1. `context.tools` was truthy but empty, so `convertTools([])` produced `[]` and forwarded it.
2. `hasToolHistory` unconditionally set `params.tools = []` when prior tool calls existed in message history, even if no tools were currently registered.

Targeted regression coverage was missing for the no-active-tools path.

## Regression Test Plan

- Added regression coverage in `src/agents/openai-transport-stream.test.ts`
- Verified `tools` is omitted when `context.tools` is empty
- Verified `tools` is omitted when tool call history exists but no tools are currently registered

## User-visible / Behavior Changes

Requests to strict OpenAI-compatible providers (e.g. vLLM, LocalAI) no longer fail due to an empty `tools` array when no tools are active for the current turn.

## Repro + Verification

**Environment**
- OS: Linux
- Runtime: Node 22+
- Provider: vLLM / LocalAI (strict OpenAI-compatible)

**Evidence**
- [x] Targeted regression tests added and passing
- [x] `pnpm lint`
- [x] `pnpm check`

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

Omitting an empty `tools` field is the correct OpenAI-compatible behavior. Providers that need explicit tool disablement should use `tool_choice: "none"` rather than rely on `tools: []`.