### PR TITLE
fix(fetch): restore dispatcher-aware guarded fetches on Node v25

### DIFF
--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
-import { downloadGoogleChatMedia, sendGoogleChatMessage } from "./api.js";
 import { resolveGoogleChatGroupRequireMention } from "./group-policy.js";
 import { isSenderAllowed } from "./monitor.js";
 import {
@@ -12,6 +11,7 @@ import {
 const mocks = vi.hoisted(() => ({
   verifyIdToken: vi.fn(),
   getGoogleChatAccessToken: vi.fn().mockResolvedValue("token"),
+  fetchWithSsrFGuard: vi.fn(),
 }));
 
 vi.mock("google-auth-library", () => ({
@@ -29,6 +29,15 @@ vi.mock("./auth.js", async () => {
   };
 });
 
+vi.mock("../runtime-api.js", async () => {
+  const actual = await vi.importActual<typeof import("../runtime-api.js")>("../runtime-api.js");
+  return {
+    ...actual,
+    fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
+  };
+});
+
+const { downloadGoogleChatMedia, sendGoogleChatMessage } = await import("./api.js");
 const { verifyGoogleChatRequest } = await import("./auth.js");
 
 const account = {
@@ -38,16 +47,20 @@ const account = {
   config: {},
 } as ResolvedGoogleChatAccount;
 
+function stubGuardedFetch(response: Response) {
+  mocks.fetchWithSsrFGuard.mockResolvedValue({
+    response,
+    finalUrl: "https://chat.googleapis.com/final",
+    release: async () => {},
+  });
+}
+
 function stubSuccessfulSend(name: string) {
-  const fetchMock = vi
-    .fn()
-    .mockResolvedValue(new Response(JSON.stringify({ name }), { status: 200 }));
-  vi.stubGlobal("fetch", fetchMock);
-  return fetchMock;
+  stubGuardedFetch(new Response(JSON.stringify({ name }), { status: 200 }));
 }
 
 async function expectDownloadToRejectForResponse(response: Response) {
-  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
+  stubGuardedFetch(response);
   await expect(
     downloadGoogleChatMedia({ account, resourceName: "media/123", maxBytes: 10 }),
   ).rejects.toThrow(/max bytes/i);
@@ -127,7 +140,7 @@ describe("isSenderAllowed", () => {
 
 describe("downloadGoogleChatMedia", () => {
   afterEach(() => {
-    vi.unstubAllGlobals();
+    mocks.fetchWithSsrFGuard.mockReset();
   });
 
   it("rejects when content-length exceeds max bytes", async () => {
@@ -166,11 +179,11 @@ describe("downloadGoogleChatMedia", () => {
 
 describe("sendGoogleChatMessage", () => {
   afterEach(() => {
-    vi.unstubAllGlobals();
+    mocks.fetchWithSsrFGuard.mockReset();
   });
 
   it("adds messageReplyOption when sending to an existing thread", async () => {
-    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/123");
+    stubSuccessfulSend("spaces/AAA/messages/123");
 
     await sendGoogleChatMessage({
       account,
@@ -179,16 +192,18 @@ describe("sendGoogleChatMessage", () => {
       thread: "spaces/AAA/threads/xyz",
     });
 
-    const [url, init] = fetchMock.mock.calls[0] ?? [];
-    expect(String(url)).toContain("messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
-    expect(JSON.parse(String(init?.body))).toMatchObject({
+    const [request] = mocks.fetchWithSsrFGuard.mock.calls[0] ?? [];
+    expect(String(request?.url)).toContain(
+      "messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD",
+    );
+    expect(JSON.parse(String(request?.init?.body))).toMatchObject({
       text: "hello",
       thread: { name: "spaces/AAA/threads/xyz" },
     });
   });
 
   it("does not set messageReplyOption for non-thread sends", async () => {
-    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/124");
+    stubSuccessfulSend("spaces/AAA/messages/124");
 
     await sendGoogleChatMessage({
       account,
@@ -196,8 +211,8 @@ describe("sendGoogleChatMessage", () => {
       text: "hello",
     });
 
-    const [url] = fetchMock.mock.calls[0] ?? [];
-    expect(String(url)).not.toContain("messageReplyOption=");
+    const [request] = mocks.fetchWithSsrFGuard.mock.calls[0] ?? [];
+    expect(String(request?.url)).not.toContain("messageReplyOption=");
   });
 });
 

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchWithSsrFGuard,
   GUARDED_FETCH_MODE,
@@ -230,12 +230,8 @@ describe("fetchWithSsrFGuard hardening", () => {
     await result.release();
   });
 
-  it("uses runtime undici fetch when attaching a dispatcher", async () => {
+  it("uses runtime undici fetch when attaching a dispatcher and the default global fetch is active", async () => {
     const runtimeFetch = vi.fn(async () => okResponse());
-    const originalGlobalFetch = globalThis.fetch;
-    const globalFetch = vi.fn(async () => {
-      throw new Error("global fetch should not be used when a dispatcher is attached");
-    });
 
     class MockAgent {
       constructor(readonly options: unknown) {}
@@ -247,7 +243,6 @@ describe("fetchWithSsrFGuard hardening", () => {
       constructor(readonly options: unknown) {}
     }
 
-    (globalThis as Record<string, unknown>).fetch = globalFetch as typeof fetch;
     (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
       Agent: MockAgent,
       EnvHttpProxyAgent: MockEnvHttpProxyAgent,
@@ -262,10 +257,9 @@ describe("fetchWithSsrFGuard hardening", () => {
       });
 
       expect(runtimeFetch).toHaveBeenCalledTimes(1);
-      expect(globalFetch).not.toHaveBeenCalled();
       await result.release();
     } finally {
-      (globalThis as Record<string, unknown>).fetch = originalGlobalFetch;
+      Reflect.deleteProperty(globalThis as object, TEST_UNDICI_RUNTIME_DEPS_KEY);
     }
   });
 
@@ -692,5 +686,84 @@ describe("fetchWithSsrFGuard hardening", () => {
       mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
       expectEnvProxy: true,
     });
+  });
+});
+
+describe("fetchWithSsrFGuard undici fetcher override", () => {
+  // Regression guard: Node v25.9.0 native fetch ignores the undici dispatcher option.
+  // When a dispatcher is active and no custom fetchImpl was provided, fetchWithSsrFGuard
+  // must use undici's own fetch so the dispatcher is honoured.
+
+  type LookupFn = NonNullable<Parameters<typeof fetchWithSsrFGuard>[0]["lookupFn"]>;
+  const createPublicLookup = (): LookupFn =>
+    vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]) as unknown as LookupFn;
+
+  const undiciFetchSpy = vi.fn();
+
+  function MockAgent(this: object) {}
+  function MockEnvHttpProxyAgent(this: object) {}
+  function MockProxyAgent(this: object) {}
+
+  beforeEach(() => {
+    undiciFetchSpy.mockReset();
+    undiciFetchSpy.mockResolvedValue(new Response("ok", { status: 200 }));
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: MockAgent,
+      EnvHttpProxyAgent: MockEnvHttpProxyAgent,
+      ProxyAgent: MockProxyAgent,
+      fetch: undiciFetchSpy,
+    };
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis as object, TEST_UNDICI_RUNTIME_DEPS_KEY);
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses undici fetch when a dispatcher is active and no fetchImpl was provided", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const lookupFn = createPublicLookup();
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://public.example/resource",
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      lookupFn,
+    });
+
+    expect(undiciFetchSpy).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = undiciFetchSpy.mock.calls[0] as [
+      string,
+      RequestInit & { dispatcher?: unknown },
+    ];
+    expect(calledUrl).toBe("https://public.example/resource");
+    expect(calledInit.dispatcher).toBeInstanceOf(MockEnvHttpProxyAgent);
+    await result.release();
+  });
+
+  it("preserves a dispatcher-compatible global fetch when a dispatcher is active", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const lookupFn = createPublicLookup();
+    const customFetch = Object.assign(
+      vi.fn().mockResolvedValue(new Response("ok", { status: 200 })),
+      { __openclawAcceptsDispatcher: true as const },
+    );
+    vi.stubGlobal("fetch", customFetch as typeof fetch);
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://public.example/resource",
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+      lookupFn,
+    });
+
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = customFetch.mock.calls[0] as [
+      string,
+      RequestInit & { dispatcher?: unknown },
+    ];
+    expect(calledUrl).toBe("https://public.example/resource");
+    expect(calledInit.dispatcher).toBeInstanceOf(MockEnvHttpProxyAgent);
+    expect(undiciFetchSpy).not.toHaveBeenCalled();
+    await result.release();
   });
 });


### PR DESCRIPTION
## Summary

On Node v25.9.0, the built-in `fetch` does not reliably honour the undici `dispatcher` option on guarded fetch paths. When `fetchWithSsrFGuard` constructs a dispatcher and passes it through `RequestInit`, the request can bypass the intended runtime fetch path and fail in real tool flows.

This showed up in practice on a Linux VPS with no outbound proxy configured: Brave-backed `web_search` calls failed with `fetch failed` even though the issue was not proxy configuration, but the guarded fetch path itself.

This change switches to undici's `fetch` whenever a dispatcher is active and no custom `fetchImpl` was provided. It also wires `fetch` through `UndiciRuntimeDeps`, tightens the runtime type guard, updates the dispatcher test override, and adds regression coverage for the fetcher-selection path.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Root Cause

`fetchWithSsrFGuard` can attach an undici dispatcher for guarded outbound requests, including trusted web-tool traffic. On Node v25.9.0, the built-in `fetch` did not honour that dispatcher correctly in this path.

As a result, requests that depended on dispatcher-aware execution could fail even when no explicit outbound proxy was configured. Proxy-backed flows were one manifestation, but trusted web-tool requests such as Brave `web_search` could also surface the problem.

Existing tests all supplied an explicit `fetchImpl`, so the branch that selects the runtime fetch implementation was never exercised.

## Regression Test Plan

- Added regression coverage in `src/infra/net/fetch-guard.ssrf.test.ts`
- Verified undici's `fetch` is used when a dispatcher is active and no custom `fetchImpl` was provided
- Updated `src/infra/net/ssrf.dispatcher.test.ts` mock to satisfy the stricter runtime deps guard

## User-visible / Behavior Changes

On Node v25.9.0+, guarded outbound fetches once again respect the intended dispatcher-aware execution path.

This fixes real tool behavior such as Brave-backed `web_search`, which could otherwise fail with a generic `fetch failed` error even on a Linux VPS with no proxy configured.

## Security Impact

This restores the intended guarded-fetch execution path when a dispatcher is attached. It does not expand network access, permissions, or data scope.

## Repro + Verification

**Environment**
- OS: Linux (GCP VPS)
- Runtime: Node v25.9.0
- Gateway: systemd-managed OpenClaw Gateway
- Web search provider: Brave
- Outbound proxy: not required / not configured for this repro

**Repro steps**
1. Run the gateway on Node v25.9.0.
2. Enable Brave as the `web_search` provider.
3. Invoke `web_search` with a normal public query.
4. Observe gateway logs.

**Actual (before fix):**
- `web_search` fails with:
- `web_search failed: fetch failed`

**Expected:**
- Brave `web_search` succeeds and returns results normally.

**Evidence**
- Targeted regression test added and passing
- `pnpm lint`
- `pnpm check`

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

The switch to undici's `fetch` only applies when a dispatcher is explicitly active and no custom `fetchImpl` was injected. Calls without a dispatcher continue to use the existing fetch path.