### PR TITLE
fix(agents): drop partialJson streaming artifacts from session history repair

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -411,6 +411,40 @@ describe("sanitizeToolCallInputs", () => {
     expect(ids).toEqual(expectedIds);
   });
 
+  it("drops tool calls with partialJson (streaming artifact from interrupted stream)", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          // complete tool call — should be kept
+          { type: "toolCall", id: "call_ok", name: "read", arguments: { path: "/a" } },
+          // has partialJson — streaming artifact, should be dropped even if arguments is set
+          {
+            type: "toolCall",
+            id: "call_partial",
+            name: "Bash",
+            arguments: { command: "ls" },
+            partialJson: '{"command": "ls"',
+          },
+          // has partialJson and no arguments — also dropped
+          {
+            type: "toolUse",
+            id: "call_partial2",
+            name: "read",
+            input: null,
+            partialJson: '{"path":',
+          },
+        ],
+      },
+      { role: "user", content: "retry" },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    const toolCalls = getAssistantToolCallBlocks(out);
+    const ids = toolCalls.map((t) => (t as { id?: unknown }).id);
+    expect(ids).toEqual(["call_ok"]);
+  });
+
   it("keeps valid tool calls and preserves text blocks", () => {
     const input = castAgentMessages([
       {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -411,22 +411,23 @@ describe("sanitizeToolCallInputs", () => {
     expect(ids).toEqual(expectedIds);
   });
 
-  it("drops tool calls with partialJson (streaming artifact from interrupted stream)", () => {
+  it("strips partialJson from completed blocks and drops incomplete streaming artifacts", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
         content: [
-          // complete tool call — should be kept
+          // complete tool call — kept as-is
           { type: "toolCall", id: "call_ok", name: "read", arguments: { path: "/a" } },
-          // has partialJson — streaming artifact, should be dropped even if arguments is set
+          // has partialJson but complete id/name/arguments — partialJson is stripped, block kept
+          // (OpenAI Responses transport retains partialJson on finalized blocks)
           {
             type: "toolCall",
             id: "call_partial",
             name: "Bash",
             arguments: { command: "ls" },
-            partialJson: '{"command": "ls"',
+            partialJson: '{"command": "ls"}',
           },
-          // has partialJson and no arguments — also dropped
+          // has partialJson and missing input — genuine interrupted stream artifact, dropped
           {
             type: "toolUse",
             id: "call_partial2",
@@ -442,7 +443,10 @@ describe("sanitizeToolCallInputs", () => {
     const out = sanitizeToolCallInputs(input);
     const toolCalls = getAssistantToolCallBlocks(out);
     const ids = toolCalls.map((t) => (t as { id?: unknown }).id);
-    expect(ids).toEqual(["call_ok"]);
+    expect(ids).toEqual(["call_ok", "call_partial"]);
+    // Verify partialJson was stripped from the completed block
+    const keptPartial = toolCalls.find((t) => (t as { id?: unknown }).id === "call_partial");
+    expect(keptPartial).not.toHaveProperty("partialJson");
   });
 
   it("keeps valid tool calls and preserves text blocks", () => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -449,6 +449,33 @@ describe("sanitizeToolCallInputs", () => {
     expect(keptPartial).not.toHaveProperty("partialJson");
   });
 
+  it("strips partialJson and still redacts sessions_spawn attachment content", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_spawn",
+            name: "sessions_spawn",
+            arguments: { attachments: [{ content: "secret data" }] },
+            partialJson: '{"attachments":[{"content":"secret data"}]}',
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    const toolCalls = getAssistantToolCallBlocks(out);
+    expect(toolCalls).toHaveLength(1);
+    const spawn = toolCalls[0] as { id?: unknown; arguments?: unknown };
+    // partialJson must be stripped
+    expect(spawn).not.toHaveProperty("partialJson");
+    // sessions_spawn attachment content must be redacted
+    const args = spawn.arguments as { attachments?: Array<{ content?: unknown }> };
+    expect(args?.attachments?.[0]?.content).not.toBe("secret data");
+  });
+
   it("keeps valid tool calls and preserves text blocks", () => {
     const input = castAgentMessages([
       {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -489,23 +489,34 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     expect(ids).toEqual(expectedIds);
   });
 
-  it("strips partialJson from completed blocks and drops incomplete streaming artifacts", () => {
+  it("keeps finalized OpenAI Responses blocks and drops interrupted partialJson artifacts", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
         content: [
           // complete tool call — kept as-is
           { type: "toolCall", id: "call_ok", name: "read", arguments: { path: "/a" } },
-          // has partialJson but complete id/name/arguments — partialJson is stripped, block kept
-          // (OpenAI Responses transport retains partialJson on finalized blocks)
+          // Finalized OpenAI Responses blocks keep parsed arguments plus
+          // partialJson in persisted history; repair should strip only
+          // partialJson and keep the finished tool call.
           {
             type: "toolCall",
-            id: "call_partial",
+            id: "call_partial|fc_123",
             name: "Bash",
             arguments: { command: "ls" },
             partialJson: '{"command": "ls"}',
           },
-          // has partialJson and missing input — genuine interrupted stream artifact, dropped
+          // Anthropic can persist initialized tool calls with arguments: {}
+          // plus partialJson if the stream aborts before content_block_stop.
+          // Those incomplete artifacts must be dropped.
+          {
+            type: "toolCall",
+            id: "toolu_123",
+            name: "Bash",
+            arguments: {},
+            partialJson: '{"command":',
+          },
+          // Missing required input is also an interrupted artifact and should drop.
           {
             type: "toolUse",
             id: "call_partial2",
@@ -517,24 +528,22 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
       },
       { role: "user", content: "retry" },
     ]);
-
     const out = sanitizeToolCallInputs(input);
     const toolCalls = getAssistantToolCallBlocks(out);
     const ids = toolCalls.map((t) => (t as { id?: unknown }).id);
-    expect(ids).toEqual(["call_ok", "call_partial"]);
-    // Verify partialJson was stripped from the completed block
-    const keptPartial = toolCalls.find((t) => (t as { id?: unknown }).id === "call_partial");
+    expect(ids).toEqual(["call_ok", "call_partial|fc_123"]);
+    const keptPartial = toolCalls.find((t) => (t as { id?: unknown }).id === "call_partial|fc_123");
     expect(keptPartial).not.toHaveProperty("partialJson");
   });
 
-  it("strips partialJson and still redacts sessions_spawn attachment content", () => {
+  it("strips partialJson and preserves sessions_spawn attachment content", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
         content: [
           {
             type: "toolCall",
-            id: "call_spawn",
+            id: "call_spawn|fc_456",
             name: "sessions_spawn",
             arguments: { attachments: [{ content: "secret data" }] },
             partialJson: '{"attachments":[{"content":"secret data"}]}',
@@ -549,9 +558,9 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     const spawn = toolCalls[0] as { id?: unknown; arguments?: unknown };
     // partialJson must be stripped
     expect(spawn).not.toHaveProperty("partialJson");
-    // sessions_spawn attachment content must be redacted
+    // sessions_spawn attachment content must be preserved on current main.
     const args = spawn.arguments as { attachments?: Array<{ content?: unknown }> };
-    expect(args?.attachments?.[0]?.content).not.toBe("secret data");
+    expect(args?.attachments?.[0]?.content).toBe("secret data");
   });
 
   it("keeps valid tool calls and preserves text blocks", () => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -527,6 +527,33 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     expect(keptPartial).not.toHaveProperty("partialJson");
   });
 
+  it("strips partialJson and still redacts sessions_spawn attachment content", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_spawn",
+            name: "sessions_spawn",
+            arguments: { attachments: [{ content: "secret data" }] },
+            partialJson: '{"attachments":[{"content":"secret data"}]}',
+          },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    const toolCalls = getAssistantToolCallBlocks(out);
+    expect(toolCalls).toHaveLength(1);
+    const spawn = toolCalls[0] as { id?: unknown; arguments?: unknown };
+    // partialJson must be stripped
+    expect(spawn).not.toHaveProperty("partialJson");
+    // sessions_spawn attachment content must be redacted
+    const args = spawn.arguments as { attachments?: Array<{ content?: unknown }> };
+    expect(args?.attachments?.[0]?.content).not.toBe("secret data");
+  });
+
   it("keeps valid tool calls and preserves text blocks", () => {
     const input = castAgentMessages([
       {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -493,6 +493,7 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
+        stopReason: "stop",
         content: [
           // complete tool call — kept as-is
           { type: "toolCall", id: "call_ok", name: "read", arguments: { path: "/a" } },
@@ -540,6 +541,7 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
+        stopReason: "stop",
         content: [
           {
             type: "toolCall",
@@ -562,6 +564,31 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     const args = spawn.arguments as { attachments?: Array<{ content?: unknown }> };
     expect(args?.attachments?.[0]?.content).toBe("secret data");
   });
+
+  it.each(["aborted", "error"] as const)(
+    "drops OpenAI Responses partialJson blocks on %s assistant turns",
+    (stopReason) => {
+      const input = castAgentMessages([
+        {
+          role: "assistant",
+          stopReason,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_partial|fc_123",
+              name: "Bash",
+              arguments: { command: "ls" },
+              partialJson: '{"command":"ls"',
+            },
+          ],
+        },
+        { role: "user", content: "retry" },
+      ]);
+
+      const out = sanitizeToolCallInputs(input);
+      expect(getAssistantToolCallBlocks(out)).toHaveLength(0);
+    },
+  );
 
   it("keeps valid tool calls and preserves text blocks", () => {
     const input = castAgentMessages([

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -489,22 +489,23 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     expect(ids).toEqual(expectedIds);
   });
 
-  it("drops tool calls with partialJson (streaming artifact from interrupted stream)", () => {
+  it("strips partialJson from completed blocks and drops incomplete streaming artifacts", () => {
     const input = castAgentMessages([
       {
         role: "assistant",
         content: [
-          // complete tool call — should be kept
+          // complete tool call — kept as-is
           { type: "toolCall", id: "call_ok", name: "read", arguments: { path: "/a" } },
-          // has partialJson — streaming artifact, should be dropped even if arguments is set
+          // has partialJson but complete id/name/arguments — partialJson is stripped, block kept
+          // (OpenAI Responses transport retains partialJson on finalized blocks)
           {
             type: "toolCall",
             id: "call_partial",
             name: "Bash",
             arguments: { command: "ls" },
-            partialJson: '{"command": "ls"',
+            partialJson: '{"command": "ls"}',
           },
-          // has partialJson and no arguments — also dropped
+          // has partialJson and missing input — genuine interrupted stream artifact, dropped
           {
             type: "toolUse",
             id: "call_partial2",
@@ -520,7 +521,10 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     const out = sanitizeToolCallInputs(input);
     const toolCalls = getAssistantToolCallBlocks(out);
     const ids = toolCalls.map((t) => (t as { id?: unknown }).id);
-    expect(ids).toEqual(["call_ok"]);
+    expect(ids).toEqual(["call_ok", "call_partial"]);
+    // Verify partialJson was stripped from the completed block
+    const keptPartial = toolCalls.find((t) => (t as { id?: unknown }).id === "call_partial");
+    expect(keptPartial).not.toHaveProperty("partialJson");
   });
 
   it("keeps valid tool calls and preserves text blocks", () => {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -489,6 +489,40 @@ describe("sanitizeToolCallInputs allowed-name filtering", () => {
     expect(ids).toEqual(expectedIds);
   });
 
+  it("drops tool calls with partialJson (streaming artifact from interrupted stream)", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          // complete tool call — should be kept
+          { type: "toolCall", id: "call_ok", name: "read", arguments: { path: "/a" } },
+          // has partialJson — streaming artifact, should be dropped even if arguments is set
+          {
+            type: "toolCall",
+            id: "call_partial",
+            name: "Bash",
+            arguments: { command: "ls" },
+            partialJson: '{"command": "ls"',
+          },
+          // has partialJson and no arguments — also dropped
+          {
+            type: "toolUse",
+            id: "call_partial2",
+            name: "read",
+            input: null,
+            partialJson: '{"path":',
+          },
+        ],
+      },
+      { role: "user", content: "retry" },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    const toolCalls = getAssistantToolCallBlocks(out);
+    const ids = toolCalls.map((t) => (t as { id?: unknown }).id);
+    expect(ids).toEqual(["call_ok"]);
+  });
+
   it("keeps valid tool calls and preserves text blocks", () => {
     const input = castAgentMessages([
       {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -330,7 +330,6 @@ export function repairToolCallInputs(
           messageChanged = true;
           continue;
         }
-<<<<<<< HEAD
       }
       // Strip partialJson early so sessions_spawn sanitization still runs on
       // otherwise-complete blocks retained from the OpenAI Responses transport.

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -317,21 +317,30 @@ export function repairToolCallInputs(
     let messageChanged = false;
 
     for (const block of msg.content) {
-      if (
-        isRawToolCallBlock(block) &&
-        // partialJson is a streaming-only assembly field that should be deleted when the
-        // stream completes.  Its presence means the stream was interrupted before the block
-        // was finalized — treat it as an incomplete artifact and drop it.
-        ("partialJson" in block ||
+      if (isRawToolCallBlock(block)) {
+        // Drop blocks that are missing required fields — they are genuine artifacts.
+        if (
           !hasToolCallInput(block) ||
           !hasToolCallId(block) ||
-          !isAllowedToolCallName((block as RawToolCallBlock).name, allowedToolNames))
-      ) {
-        droppedToolCalls += 1;
-        droppedInMessage += 1;
-        changed = true;
-        messageChanged = true;
-        continue;
+          !isAllowedToolCallName((block as RawToolCallBlock).name, allowedToolNames)
+        ) {
+          droppedToolCalls += 1;
+          droppedInMessage += 1;
+          changed = true;
+          messageChanged = true;
+          continue;
+        }
+        // partialJson is a streaming-only assembly field. The OpenAI Responses
+        // transport can retain it on finalized blocks; strip it instead of
+        // dropping the otherwise-complete call.
+        if ("partialJson" in block) {
+          const stripped = { ...(block as object) } as Record<string, unknown>;
+          delete stripped.partialJson;
+          changed = true;
+          messageChanged = true;
+          nextContent.push(stripped as typeof block);
+          continue;
+        }
       }
       if (isRawToolCallBlock(block)) {
         if (

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -318,7 +318,7 @@ export function repairToolCallInputs(
 
     for (const block of msg.content) {
       if (isRawToolCallBlock(block)) {
-        // Drop blocks that are missing required fields — they are genuine artifacts.
+        // Drop genuinely incomplete streaming artifacts (missing required fields).
         if (
           !hasToolCallInput(block) ||
           !hasToolCallId(block) ||
@@ -330,57 +330,57 @@ export function repairToolCallInputs(
           messageChanged = true;
           continue;
         }
-        // partialJson is a streaming-only assembly field. The OpenAI Responses
-        // transport can retain it on finalized blocks; strip it instead of
-        // dropping the otherwise-complete call.
-        if ("partialJson" in block) {
-          const stripped = { ...(block as object) } as Record<string, unknown>;
-          delete stripped.partialJson;
-          changed = true;
-          messageChanged = true;
-          nextContent.push(stripped as typeof block);
-          continue;
-        }
+<<<<<<< HEAD
       }
-      if (isRawToolCallBlock(block)) {
+      // Strip partialJson early so sessions_spawn sanitization still runs on
+      // otherwise-complete blocks retained from the OpenAI Responses transport.
+      let workBlock = block;
+      if (isRawToolCallBlock(block) && "partialJson" in block) {
+        const stripped = { ...(block as object) } as Record<string, unknown>;
+        delete stripped.partialJson;
+        workBlock = stripped as typeof block;
+        changed = true;
+        messageChanged = true;
+      }
+      if (isRawToolCallBlock(workBlock)) {
         if (
-          (block as { type?: unknown }).type === "toolCall" ||
-          (block as { type?: unknown }).type === "toolUse" ||
-          (block as { type?: unknown }).type === "functionCall"
+          (workBlock as { type?: unknown }).type === "toolCall" ||
+          (workBlock as { type?: unknown }).type === "toolUse" ||
+          (workBlock as { type?: unknown }).type === "functionCall"
         ) {
           // Only sanitize (redact) sessions_spawn blocks; all others are passed through
           // unchanged to preserve provider-specific shapes (e.g. toolUse.input for Anthropic).
           const blockName =
-            typeof (block as { name?: unknown }).name === "string"
-              ? (block as { name: string }).name.trim()
+            typeof (workBlock as { name?: unknown }).name === "string"
+              ? (workBlock as { name: string }).name.trim()
               : undefined;
           if (normalizeLowercaseStringOrEmpty(blockName) === "sessions_spawn") {
-            const sanitized = sanitizeToolCallBlock(block);
-            if (sanitized !== block) {
+            const sanitized = sanitizeToolCallBlock(workBlock);
+            if (sanitized !== workBlock) {
               changed = true;
               messageChanged = true;
             }
             nextContent.push(sanitized as typeof block);
           } else {
-            if (typeof (block as { name?: unknown }).name === "string") {
-              const rawName = (block as { name: string }).name;
+            if (typeof (workBlock as { name?: unknown }).name === "string") {
+              const rawName = (workBlock as { name: string }).name;
               const trimmedName = rawName.trim();
               if (rawName !== trimmedName && trimmedName) {
-                const renamed = { ...(block as object), name: trimmedName } as typeof block;
+                const renamed = { ...(workBlock as object), name: trimmedName } as typeof block;
                 nextContent.push(renamed);
                 changed = true;
                 messageChanged = true;
               } else {
-                nextContent.push(block);
+                nextContent.push(workBlock);
               }
             } else {
-              nextContent.push(block);
+              nextContent.push(workBlock);
             }
           }
           continue;
         }
       } else {
-        nextContent.push(block);
+        nextContent.push(workBlock);
       }
     }
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -319,7 +319,11 @@ export function repairToolCallInputs(
     for (const block of msg.content) {
       if (
         isRawToolCallBlock(block) &&
-        (!hasToolCallInput(block) ||
+        // partialJson is a streaming-only assembly field that should be deleted when the
+        // stream completes.  Its presence means the stream was interrupted before the block
+        // was finalized — treat it as an incomplete artifact and drop it.
+        ("partialJson" in block ||
+          !hasToolCallInput(block) ||
           !hasToolCallId(block) ||
           !isAllowedToolCallName((block as RawToolCallBlock).name, allowedToolNames))
       ) {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -350,7 +350,7 @@ function repairToolCallInputs(
 
     for (const block of msg.content) {
       if (isRawToolCallBlock(block)) {
-        // Drop blocks that are missing required fields — they are genuine artifacts.
+        // Drop genuinely incomplete streaming artifacts (missing required fields).
         if (
           !hasToolCallInput(block) ||
           !hasToolCallId(block) ||
@@ -362,31 +362,61 @@ function repairToolCallInputs(
           messageChanged = true;
           continue;
         }
-        // partialJson is a streaming-only assembly field. The OpenAI Responses
-        // transport can retain it on finalized blocks; strip it instead of
-        // dropping the otherwise-complete call.
-        if ("partialJson" in block) {
-          const stripped = { ...(block as object) } as Record<string, unknown>;
-          delete stripped.partialJson;
+      }
+      let workBlock = block;
+      if (isRawToolCallBlock(block) && hasPartialJson(block)) {
+        if (isInterruptedAssistantTurn(msg) || !isFinalizedOpenAIResponsesToolCall(block)) {
+          droppedToolCalls += 1;
+          droppedInMessage += 1;
           changed = true;
           messageChanged = true;
-          nextContent.push(stripped as typeof block);
           continue;
         }
+
+        // OpenAI Responses persists finalized function calls with both parsed
+        // arguments and the original partialJson bytes. Strip only the
+        // redundant partialJson field so replay keeps the finalized call.
+        const stripped = { ...block };
+        delete (stripped as RawToolCallBlock & { partialJson?: unknown }).partialJson;
+        workBlock = stripped;
+        changed = true;
+        messageChanged = true;
       }
-      if (isRawToolCallBlock(block)) {
-        if (RAW_TOOL_CALL_BLOCK_TYPES.has((block as { type?: string }).type ?? "")) {
-          const sanitized = sanitizeToolCallBlock(block);
-          if (sanitized !== block) {
-            changed = true;
-            messageChanged = true;
+      if (isRawToolCallBlock(workBlock)) {
+        if (RAW_TOOL_CALL_BLOCK_TYPES.has((workBlock as { type?: string }).type ?? "")) {
+          // Only sanitize (redact) sessions_spawn blocks; all others are passed through
+          // unchanged to preserve provider-specific shapes (e.g. toolUse.input for Anthropic).
+          const blockName =
+            typeof (workBlock as { name?: unknown }).name === "string"
+              ? (workBlock as { name: string }).name.trim()
+              : undefined;
+          if (normalizeLowercaseStringOrEmpty(blockName) === "sessions_spawn") {
+            const sanitized = sanitizeToolCallBlock(workBlock);
+            if (sanitized !== workBlock) {
+              changed = true;
+              messageChanged = true;
+            }
+            nextContent.push(sanitized as typeof block);
+          } else {
+            if (typeof (workBlock as { name?: unknown }).name === "string") {
+              const rawName = (workBlock as { name: string }).name;
+              const trimmedName = rawName.trim();
+              if (rawName !== trimmedName && trimmedName) {
+                const renamed = { ...(workBlock as object), name: trimmedName } as typeof block;
+                nextContent.push(renamed);
+                changed = true;
+                messageChanged = true;
+              } else {
+                nextContent.push(workBlock);
+              }
+            } else {
+              nextContent.push(workBlock);
+            }
           }
-          nextContent.push(sanitized as typeof block);
           continue;
         }
-      } else {
-        nextContent.push(block);
       }
+      nextContent.push(workBlock);
     }
 
     if (droppedInMessage > 0) {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -1,5 +1,6 @@
 import {
   hasNonEmptyString as hasNonEmptyStringField,
+  normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
   readStringValue,
 } from "../shared/string-coerce.js";

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -22,6 +22,7 @@ type RawToolCallBlock = {
   name?: unknown;
   input?: unknown;
   arguments?: unknown;
+  partialJson?: unknown;
 };
 
 const RAW_TOOL_CALL_BLOCK_TYPES = new Set([
@@ -65,6 +66,31 @@ function hasToolCallId(block: RawToolCallBlock): boolean {
     hasNonEmptyStringField(block.tool_call_id) ||
     hasNonEmptyStringField(block.tool_use_id)
   );
+}
+
+function hasPartialJson(
+  block: RawToolCallBlock,
+): block is RawToolCallBlock & { partialJson: string } {
+  return typeof block.partialJson === "string";
+}
+
+function isFinalizedOpenAIResponsesToolCall(block: RawToolCallBlock): boolean {
+  if (!hasPartialJson(block) || typeof block.id !== "string" || "input" in block) {
+    return false;
+  }
+
+  const separator = block.id.indexOf("|");
+  if (separator <= 0 || separator === block.id.length - 1) {
+    return false;
+  }
+
+  return "arguments" in block && block.arguments !== undefined && block.arguments !== null;
+}
+function isInterruptedAssistantTurn(message: AgentMessage): boolean {
+  if (message.role !== "assistant" || !("stopReason" in message)) {
+    return false;
+  }
+  return message.stopReason === "aborted" || message.stopReason === "error";
 }
 
 function sanitizeToolCallBlock(block: RawToolCallBlock): RawToolCallBlock {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -349,21 +349,30 @@ function repairToolCallInputs(
     let messageChanged = false;
 
     for (const block of msg.content) {
-      if (
-        isRawToolCallBlock(block) &&
-        // partialJson is a streaming-only assembly field that should be deleted when the
-        // stream completes.  Its presence means the stream was interrupted before the block
-        // was finalized — treat it as an incomplete artifact and drop it.
-        ("partialJson" in block ||
+      if (isRawToolCallBlock(block)) {
+        // Drop blocks that are missing required fields — they are genuine artifacts.
+        if (
           !hasToolCallInput(block) ||
           !hasToolCallId(block) ||
-          !isAllowedToolCallName((block as RawToolCallBlock).name, allowedToolNames))
-      ) {
-        droppedToolCalls += 1;
-        droppedInMessage += 1;
-        changed = true;
-        messageChanged = true;
-        continue;
+          !isAllowedToolCallName((block as RawToolCallBlock).name, allowedToolNames)
+        ) {
+          droppedToolCalls += 1;
+          droppedInMessage += 1;
+          changed = true;
+          messageChanged = true;
+          continue;
+        }
+        // partialJson is a streaming-only assembly field. The OpenAI Responses
+        // transport can retain it on finalized blocks; strip it instead of
+        // dropping the otherwise-complete call.
+        if ("partialJson" in block) {
+          const stripped = { ...(block as object) } as Record<string, unknown>;
+          delete stripped.partialJson;
+          changed = true;
+          messageChanged = true;
+          nextContent.push(stripped as typeof block);
+          continue;
+        }
       }
       if (isRawToolCallBlock(block)) {
         if (RAW_TOOL_CALL_BLOCK_TYPES.has((block as { type?: string }).type ?? "")) {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -351,7 +351,11 @@ function repairToolCallInputs(
     for (const block of msg.content) {
       if (
         isRawToolCallBlock(block) &&
-        (!hasToolCallInput(block) ||
+        // partialJson is a streaming-only assembly field that should be deleted when the
+        // stream completes.  Its presence means the stream was interrupted before the block
+        // was finalized — treat it as an incomplete artifact and drop it.
+        ("partialJson" in block ||
+          !hasToolCallInput(block) ||
           !hasToolCallId(block) ||
           !isAllowedToolCallName((block as RawToolCallBlock).name, allowedToolNames))
       ) {


### PR DESCRIPTION
## Summary

- Problem: session transcript repair was stripping `partialJson` from every otherwise-complete tool-call block, which could keep interrupted Anthropic artifacts as replayable calls.
- Why it matters: replaying an interrupted tool call can corrupt paired `toolResult` repair and preserve bad session state; finalized OpenAI Responses calls still need to survive cleanup, including retained `sessions_spawn` payloads.
- What changed: `repairToolCallInputs()` now drops `partialJson` blocks unless they match the finalized OpenAI Responses shape, strips redundant `partialJson` only from those retained OpenAI blocks, and preserves the current `sessions_spawn` attachment content on the kept block.
- What did NOT change (scope boundary): missing-field artifacts are still dropped, signed-thinking replay rules are unchanged, and this PR does not add provider-specific transport mutations outside transcript repair.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Memory / storage
- [ ] Auth / tokens
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #57523
- Related #61151
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: interrupted Anthropic tool-call artifacts that still have `id`, `name`, `arguments: {}`, and `partialJson` should be dropped, while finalized OpenAI Responses tool calls should keep valid arguments, lose `partialJson`, and preserve retained `sessions_spawn` attachment content.
- Real environment tested: local OpenClaw checkout on Windows 11 with Node 22.
- Exact steps or command run after this patch:
  1. Ran a temporary TypeScript proof script through `pnpm exec tsx` that imports `sanitizeToolCallInputs()` from `src/agents/session-transcript-repair.ts`.
  2. Fed that script one finalized OpenAI-style `sessions_spawn` block (`call_spawn|fc_456`) plus one interrupted Anthropic-style block (`toolu_123` with `arguments: {}` and `partialJson`).
  3. Printed the repaired assistant content from the current PR head.
- Evidence after fix: terminal output

```json
{
  "droppedAnthropicArtifact": true,
  "assistantContent": [
    {
      "type": "toolCall",
      "id": "call_spawn|fc_456",
      "name": "sessions_spawn",
      "arguments": {
        "attachments": [
          {
            "content": "secret data",
            "name": "a.txt"
          }
        ]
      }
    }
  ],
  "sessionsSpawnAttachmentContent": "secret data"
}
```

- Observed result after fix:
  - the interrupted Anthropic artifact was removed
  - the finalized OpenAI-style `sessions_spawn` block stayed
  - `partialJson` was removed from the retained block
  - attachment content was preserved
- What was not tested: a live remote-provider replay round-trip against Anthropic or OpenAI Responses in this environment.
- Before evidence (optional but encouraged): the previous branch behavior kept the initialized Anthropic shape after deleting `partialJson`, which is the blocker called out in the ClawSweeper review.

## Root Cause (if applicable)

- Root cause: transcript repair treated any tool call with non-null `arguments` as complete, then removed `partialJson` without checking whether the remaining block was a finalized OpenAI Responses call or an interrupted Anthropic artifact.
- Missing detection / guardrail: there was no regression coverage for the initialized Anthropic `id + name + arguments: {} + partialJson` shape versus the finalized OpenAI Responses `call_id|item_id` shape.
- Contributing context (if known): Anthropic persists `partialJson` only until `content_block_stop`, while OpenAI Responses persists finalized function-call blocks with parsed arguments plus `partialJson` in history.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/session-transcript-repair.test.ts`
- Scenario the test should lock in: finalized OpenAI Responses tool calls with `partialJson` are kept after stripping that field, initialized Anthropic artifacts with `partialJson` are dropped, and retained `sessions_spawn` attachment content is preserved on the kept block.
- Why this is the smallest reliable guardrail: the bug is isolated to transcript-repair normalization, so direct unit coverage on `repairToolCallInputs()` proves the exact keep/drop/preserve behavior without needing a full provider replay harness.
- Existing test that already covers this (if any): this PR now adds the Anthropic interrupted-shape regression to the existing `partialJson` coverage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Transcript repair now drops interrupted Anthropic `partialJson` artifacts instead of replaying them as valid tool calls, while still preserving finalized OpenAI Responses calls and retained `sessions_spawn` payloads.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node 22 local checkout
- Model/provider: N/A
- Integration/channel (if any): transcript repair for agent tool-call history
- Relevant config (redacted): default local checkout

### Steps

1. Feed transcript repair one finalized OpenAI-style `sessions_spawn` tool-call block with `partialJson` and one interrupted Anthropic-style block with `arguments: {}` plus `partialJson`.
2. Run the local proof script through `pnpm exec tsx` on this branch.
3. Run `node scripts/run-vitest.mjs src/agents/session-transcript-repair.test.ts src/agents/session-transcript-repair.attachments.test.ts --run`.

### Expected

- The finalized OpenAI-style tool-call block should stay, lose `partialJson`, and preserve `sessions_spawn` attachment content.
- The interrupted Anthropic artifact should be dropped.

### Actual

- The finalized `sessions_spawn` block stayed and its attachment content remained `secret data`.
- The interrupted Anthropic artifact was dropped.
- `src/agents/session-transcript-repair.test.ts` and `src/agents/session-transcript-repair.attachments.test.ts` passed locally.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: direct local execution of `sanitizeToolCallInputs()` on the current PR branch with one finalized OpenAI-style `partialJson` block and one interrupted Anthropic artifact; focused transcript-repair test files.
- Edge cases checked: `sessions_spawn` attachment content remains intact after `partialJson` stripping, and the initialized Anthropic shape is no longer replayed.
- What you did **not** verify: a live remote-provider replay round-trip in this environment.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the new shape check could drop a valid non-OpenAI tool call that still carries `partialJson`.
  - Mitigation: current source only persists `partialJson` on Anthropic streaming artifacts and finalized OpenAI Responses blocks; the regression tests pin the keep/drop split and the preserved `sessions_spawn` payload path.

Made with Copilot | fully reviewed by human | fully tested
