### PR TITLE
fix: write nested plugin wizard config paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Claude CLI: keep non-interactive `--permission-mode bypassPermissions` when custom `cliBackends.claude-cli.args` override defaults, so cron and heartbeat Claude CLI runs do not regress to interactive approval mode. (#61114) Thanks @cathrynlavery and @thewilloftheshadow.
 - Agents/skills: skip `.git` and `node_modules` when mirroring skills into sandbox workspaces so read-only sandboxes do not copy repo history or dependency trees. (#61090) Thanks @joelnishanth.
 - Android/Talk Mode: cancel in-flight `talk.speak` playback when speech is explicitly stopped, so stale replies stop starting after barge-in or manual stop. (#61164) Thanks @obviyus.
+- Plugins/onboarding: write dotted plugin uiHint paths like Brave `webSearch.mode` as nested plugin config so `llm-context` setup stops failing validation. (#61159) Thanks @obviyus.
 
 ## 2026.4.2
 

--- a/src/secrets/path-utils.test.ts
+++ b/src/secrets/path-utils.test.ts
@@ -76,4 +76,15 @@ describe("secrets path utils", () => {
     expect(changed).toBe(false);
     expect(getPath(config, ["talk", "apiKey"])).toBe("same");
   });
+
+  it("setPathCreateStrict works on nested config sub-objects", () => {
+    const pluginConfig: Record<string, unknown> = {};
+    const changed = setPathCreateStrict(pluginConfig, ["webSearch", "mode"], "llm-context");
+    expect(changed).toBe(true);
+    expect(pluginConfig).toEqual({
+      webSearch: {
+        mode: "llm-context",
+      },
+    });
+  });
 });

--- a/src/secrets/path-utils.ts
+++ b/src/secrets/path-utils.ts
@@ -1,5 +1,4 @@
 import { isDeepStrictEqual } from "node:util";
-import type { OpenClawConfig } from "../config/config.js";
 import { isRecord } from "./shared.js";
 
 function isArrayIndexSegment(segment: string): boolean {
@@ -89,7 +88,7 @@ export function getPath(root: unknown, segments: string[]): unknown {
 }
 
 export function setPathCreateStrict(
-  root: OpenClawConfig,
+  root: Record<string, unknown>,
   segments: string[],
   value: unknown,
 ): boolean {
@@ -153,7 +152,7 @@ export function setPathCreateStrict(
 }
 
 export function setPathExistingStrict(
-  root: OpenClawConfig,
+  root: Record<string, unknown>,
   segments: string[],
   value: unknown,
 ): boolean {
@@ -184,7 +183,7 @@ export function setPathExistingStrict(
   return false;
 }
 
-export function deletePathStrict(root: OpenClawConfig, segments: string[]): boolean {
+export function deletePathStrict(root: Record<string, unknown>, segments: string[]): boolean {
   const cursor = traverseToLeafParent({ root, segments, requireExistingSegment: false });
 
   const leaf = segments[segments.length - 1] ?? "";

--- a/src/wizard/setup.plugin-config.test.ts
+++ b/src/wizard/setup.plugin-config.test.ts
@@ -1,7 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginConfigUiHint } from "../plugins/types.js";
-import { discoverConfigurablePlugins, discoverUnconfiguredPlugins } from "./setup.plugin-config.js";
+import type { WizardPrompter } from "./prompts.js";
+import {
+  discoverConfigurablePlugins,
+  discoverUnconfiguredPlugins,
+  setupPluginConfig,
+} from "./setup.plugin-config.js";
+
+const loadPluginManifestRegistry = vi.fn();
+
+vi.mock("../plugins/manifest-registry.js", () => ({
+  loadPluginManifestRegistry,
+}));
 
 function makeManifestPlugin(
   id: string,
@@ -157,5 +168,111 @@ describe("discoverUnconfiguredPlugins", () => {
       config: {},
     });
     expect(result).toHaveLength(0);
+  });
+
+  it("treats dotted uiHint paths as configured when nested config exists", () => {
+    const plugins = [
+      makeManifestPlugin(
+        "brave",
+        {
+          "webSearch.mode": { label: "Brave Search Mode" },
+        },
+        {
+          type: "object",
+          properties: {
+            webSearch: {
+              type: "object",
+              properties: {
+                mode: {
+                  type: "string",
+                  enum: ["web", "llm-context"],
+                },
+              },
+            },
+          },
+        },
+      ),
+    ];
+    const config: OpenClawConfig = {
+      plugins: {
+        entries: {
+          brave: {
+            config: {
+              webSearch: {
+                mode: "llm-context",
+              },
+            },
+          },
+        },
+      },
+    };
+    const result = discoverUnconfiguredPlugins({
+      manifestPlugins: plugins,
+      config,
+    });
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("setupPluginConfig", () => {
+  it("writes dotted uiHint values into nested plugin config", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          ...makeManifestPlugin(
+            "brave",
+            {
+              "webSearch.mode": { label: "Brave Search Mode" },
+            },
+            {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                webSearch: {
+                  type: "object",
+                  additionalProperties: false,
+                  properties: {
+                    mode: {
+                      type: "string",
+                      enum: ["web", "llm-context"],
+                    },
+                  },
+                },
+              },
+            },
+          ),
+          enabledByDefault: true,
+        },
+      ],
+    });
+
+    const result = await setupPluginConfig({
+      config: {
+        plugins: {
+          entries: {
+            brave: {
+              enabled: true,
+            },
+          },
+        },
+      },
+      prompter: {
+        intro: vi.fn(async () => {}),
+        outro: vi.fn(async () => {}),
+        note: vi.fn(async () => {}),
+        select: vi.fn(async () => "llm-context") as unknown as WizardPrompter["select"],
+        multiselect: vi.fn(async () => ["brave"]) as unknown as WizardPrompter["multiselect"],
+        text: vi.fn(async () => ""),
+        confirm: vi.fn(async () => true),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      },
+    });
+
+    expect(result.plugins?.entries?.brave?.config).toEqual({
+      webSearch: {
+        mode: "llm-context",
+      },
+    });
+    expect(result.plugins?.entries?.brave?.config?.["webSearch.mode"]).toBeUndefined();
   });
 });

--- a/src/wizard/setup.plugin-config.ts
+++ b/src/wizard/setup.plugin-config.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginConfigUiHint } from "../plugins/types.js";
+import { getPath, setPathCreateStrict } from "../secrets/path-utils.js";
 import type { WizardPrompter } from "./prompts.js";
 
 /**
@@ -27,15 +28,18 @@ function resolveJsonSchemaProperty(
   if (!jsonSchema) {
     return undefined;
   }
-  const properties = jsonSchema.properties;
-  if (!properties || typeof properties !== "object") {
-    return undefined;
+  let cursor: unknown = jsonSchema;
+  for (const segment of fieldKey.split(".")) {
+    if (!cursor || typeof cursor !== "object") {
+      return undefined;
+    }
+    const properties = (cursor as Record<string, unknown>).properties;
+    if (!properties || typeof properties !== "object") {
+      return undefined;
+    }
+    cursor = (properties as Record<string, unknown>)[segment];
   }
-  const prop = (properties as Record<string, unknown>)[fieldKey];
-  if (!prop || typeof prop !== "object") {
-    return undefined;
-  }
-  return prop as JsonSchemaProperty;
+  return cursor && typeof cursor === "object" ? (cursor as JsonSchemaProperty) : undefined;
 }
 
 function getExistingPluginConfig(
@@ -43,6 +47,10 @@ function getExistingPluginConfig(
   pluginId: string,
 ): Record<string, unknown> {
   return (config.plugins?.entries?.[pluginId]?.config as Record<string, unknown>) ?? {};
+}
+
+function toPathSegments(fieldKey: string): string[] {
+  return fieldKey.split(".").filter(Boolean);
 }
 
 function formatCurrentValue(value: unknown): string {
@@ -117,7 +125,7 @@ export function discoverUnconfiguredPlugins(params: {
   return all.filter((plugin) => {
     const existing = getExistingPluginConfig(params.config, plugin.id);
     return Object.keys(plugin.uiHints).some((key) => {
-      const val = existing[key];
+      const val = getPath(existing, toPathSegments(key));
       return val === undefined || val === null || val === "";
     });
   });
@@ -136,11 +144,12 @@ async function promptPluginFields(params: {
 }): Promise<OpenClawConfig> {
   const { plugin, config, prompter } = params;
   const existing = getExistingPluginConfig(config, plugin.id);
-  const updatedConfig: Record<string, unknown> = { ...existing };
+  const updatedConfig = structuredClone(existing);
   let changed = false;
 
   for (const [key, hint] of Object.entries(plugin.uiHints)) {
-    const currentValue = existing[key];
+    const pathSegments = toPathSegments(key);
+    const currentValue = getPath(existing, pathSegments);
     const hasValue = currentValue !== undefined && currentValue !== null && currentValue !== "";
 
     // In onboard mode, skip already-configured fields
@@ -180,7 +189,7 @@ async function promptPluginFields(params: {
         initialValue: hasValue ? "__keep__" : undefined,
       });
       if (selected !== "__keep__") {
-        updatedConfig[key] = selected;
+        setPathCreateStrict(updatedConfig, pathSegments, selected);
         changed = true;
       }
       continue;
@@ -193,7 +202,7 @@ async function promptPluginFields(params: {
         initialValue: typeof currentValue === "boolean" ? currentValue : false,
       });
       if (confirmed !== currentValue) {
-        updatedConfig[key] = confirmed;
+        setPathCreateStrict(updatedConfig, pathSegments, confirmed);
         changed = true;
       }
       continue;
@@ -214,9 +223,9 @@ async function promptPluginFields(params: {
             .split(",")
             .map((v) => v.trim())
             .filter(Boolean);
-          updatedConfig[key] = values;
+          setPathCreateStrict(updatedConfig, pathSegments, values);
         } else {
-          updatedConfig[key] = undefined;
+          setPathCreateStrict(updatedConfig, pathSegments, undefined);
         }
         changed = true;
       }
@@ -235,17 +244,17 @@ async function promptPluginFields(params: {
       // Try to parse as number if schema says number
       if (schemaProp?.type === "number") {
         if (trimmed === "") {
-          updatedConfig[key] = undefined;
+          setPathCreateStrict(updatedConfig, pathSegments, undefined);
           changed = true;
         } else {
           const parsed = Number(trimmed);
           if (Number.isFinite(parsed)) {
-            updatedConfig[key] = parsed;
+            setPathCreateStrict(updatedConfig, pathSegments, parsed);
             changed = true;
           }
         }
       } else {
-        updatedConfig[key] = trimmed || undefined;
+        setPathCreateStrict(updatedConfig, pathSegments, trimmed || undefined);
         changed = true;
       }
     }
@@ -359,7 +368,7 @@ export async function configurePluginConfig(params: {
       ...configurable.map((p) => {
         const existing = getExistingPluginConfig(params.config, p.id);
         const configuredCount = Object.keys(p.uiHints).filter((k) => {
-          const val = existing[k];
+          const val = getPath(existing, toPathSegments(k));
           return val !== undefined && val !== null && val !== "";
         }).length;
         const totalCount = Object.keys(p.uiHints).length;


### PR DESCRIPTION
Fixes Brave onboarding/configure wizard handling for dotted plugin uiHint keys like `webSearch.mode`.

Before, the wizard wrote a flat config key, which made Brave `llm-context` selection fail plugin config validation.

This change reads and writes dotted uiHint paths as nested plugin config and adds a regression test.