### PR TITLE
fix: cancel in-flight Android talk playback on stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/native command menu: trim long menu descriptions before dropping commands so sub-100 command sets can still fit Telegram's payload budget and keep more `/` entries visible. (#61129) Thanks @neeravmakwana.
 - Agents/Claude CLI: keep non-interactive `--permission-mode bypassPermissions` when custom `cliBackends.claude-cli.args` override defaults, so cron and heartbeat Claude CLI runs do not regress to interactive approval mode. (#61114) Thanks @cathrynlavery and @thewilloftheshadow.
 - Agents/skills: skip `.git` and `node_modules` when mirroring skills into sandbox workspaces so read-only sandboxes do not copy repo history or dependency trees. (#61090) Thanks @joelnishanth.
+- Android/Talk Mode: cancel in-flight `talk.speak` playback when speech is explicitly stopped, so stale replies stop starting after barge-in or manual stop. (#61164) Thanks @obviyus.
 
 ## 2026.4.2
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -266,7 +266,6 @@ class TalkModeManager(
     if (playbackEnabled == enabled) return
     playbackEnabled = enabled
     if (!enabled) {
-      playbackGeneration.incrementAndGet()
       stopSpeaking()
     }
   }
@@ -742,6 +741,7 @@ class TalkModeManager(
         ttsJob
       }
     activeJob?.cancel()
+    talkAudioPlayer.stop()
     stopTextToSpeechPlayback()
   }
 
@@ -829,17 +829,16 @@ class TalkModeManager(
   }
 
   private fun stopSpeaking(resetInterrupt: Boolean = true) {
+    playbackGeneration.incrementAndGet()
     if (!_isSpeaking.value) {
-      talkAudioPlayer.stop()
-      stopTextToSpeechPlayback()
+      cancelActivePlayback()
       abandonAudioFocus()
       return
     }
     if (resetInterrupt) {
       lastInterruptedAtSeconds = null
     }
-    talkAudioPlayer.stop()
-    stopTextToSpeechPlayback()
+    cancelActivePlayback()
     _isSpeaking.value = false
     abandonAudioFocus()
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -1,0 +1,96 @@
+package ai.openclaw.app.voice
+
+import ai.openclaw.app.gateway.DeviceAuthEntry
+import ai.openclaw.app.gateway.DeviceAuthTokenStore
+import ai.openclaw.app.gateway.DeviceIdentityStore
+import ai.openclaw.app.gateway.GatewaySession
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class TalkModeManagerTest {
+  @Test
+  fun stopTtsCancelsTrackedPlaybackJob() {
+    val manager = createManager()
+    val playbackJob = Job()
+
+    setPrivateField(manager, "ttsJob", playbackJob)
+    playbackGeneration(manager).set(7L)
+
+    manager.stopTts()
+
+    assertTrue(playbackJob.isCancelled)
+    assertEquals(8L, playbackGeneration(manager).get())
+  }
+
+  @Test
+  fun disablingPlaybackCancelsTrackedJobOnce() {
+    val manager = createManager()
+    val playbackJob = Job()
+
+    setPrivateField(manager, "ttsJob", playbackJob)
+    playbackGeneration(manager).set(11L)
+
+    manager.setPlaybackEnabled(false)
+
+    assertTrue(playbackJob.isCancelled)
+    assertEquals(12L, playbackGeneration(manager).get())
+  }
+
+  private fun createManager(): TalkModeManager {
+    val app = RuntimeEnvironment.getApplication()
+    val sessionJob = SupervisorJob()
+    val session =
+      GatewaySession(
+        scope = CoroutineScope(sessionJob + Dispatchers.Default),
+        identityStore = DeviceIdentityStore(app),
+        deviceAuthStore = InMemoryDeviceAuthStore(),
+        onConnected = { _, _, _ -> },
+        onDisconnected = {},
+        onEvent = { _, _ -> },
+      )
+    return TalkModeManager(
+      context = app,
+      scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+      session = session,
+      supportsChatSubscribe = false,
+      isConnected = { true },
+    )
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun playbackGeneration(manager: TalkModeManager): AtomicLong {
+    return readPrivateField(manager, "playbackGeneration") as AtomicLong
+  }
+
+  private fun setPrivateField(target: Any, name: String, value: Any?) {
+    val field = target.javaClass.getDeclaredField(name)
+    field.isAccessible = true
+    field.set(target, value)
+  }
+
+  private fun readPrivateField(target: Any, name: String): Any? {
+    val field = target.javaClass.getDeclaredField(name)
+    field.isAccessible = true
+    return field.get(target)
+  }
+}
+
+private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
+  override fun loadEntry(deviceId: String, role: String): DeviceAuthEntry? = null
+
+  override fun saveToken(deviceId: String, role: String, token: String, scopes: List<String>) = Unit
+
+  override fun clearToken(deviceId: String, role: String) = Unit
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -43,6 +43,7 @@ class TalkModeManagerTest {
     playbackGeneration(manager).set(11L)
 
     manager.setPlaybackEnabled(false)
+    manager.setPlaybackEnabled(false)
 
     assertTrue(playbackJob.isCancelled)
     assertEquals(12L, playbackGeneration(manager).get())


### PR DESCRIPTION
## Summary
Cancel in-flight `talk.speak` playback when Android speech is explicitly stopped.

## Testing
- `./gradlew :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.voice.TalkModeManagerTest'