### PR TITLE
fix(macos): harden exec approval sockets against SIGPIPE

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -89,6 +89,33 @@ private func readLineFromHandle(_ handle: FileHandle, maxBytes: Int) throws -> S
     return String(data: lineData, encoding: .utf8)
 }
 
+enum ExecApprovalsSocketDescriptorGuardError: LocalizedError {
+    case setNoSigPipeFailed(code: Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case let .setNoSigPipeFailed(code):
+            "setsockopt SO_NOSIGPIPE failed (errno \(code))"
+        }
+    }
+}
+
+enum ExecApprovalsSocketDescriptorGuard {
+    static func suppressSigPipe(for fd: Int32) throws {
+        guard fd >= 0 else { return }
+        var enabled: Int32 = 1
+        if setsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_NOSIGPIPE,
+            &enabled,
+            socklen_t(MemoryLayout.size(ofValue: enabled))) != 0
+        {
+            throw ExecApprovalsSocketDescriptorGuardError.setNoSigPipeFailed(code: errno)
+        }
+    }
+}
+
 enum ExecApprovalsSocketClient {
     private struct TimeoutError: LocalizedError {
         var message: String
@@ -136,6 +163,13 @@ enum ExecApprovalsSocketClient {
                 NSLocalizedDescriptionKey: "socket create failed",
             ])
         }
+        var shouldCloseFD = true
+        defer {
+            if shouldCloseFD {
+                close(fd)
+            }
+        }
+        try ExecApprovalsSocketDescriptorGuard.suppressSigPipe(for: fd)
 
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
@@ -164,6 +198,7 @@ enum ExecApprovalsSocketClient {
         }
 
         let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+        shouldCloseFD = false
 
         let message = ExecApprovalSocketRequest(
             type: "request",
@@ -711,6 +746,14 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
                 if errno == EINTR { continue }
                 break
             }
+            do {
+                try ExecApprovalsSocketDescriptorGuard.suppressSigPipe(for: client)
+            } catch {
+                self.logger
+                    .warning("exec approvals client fd hardening failed: \(error.localizedDescription, privacy: .public)")
+                close(client)
+                continue
+            }
             Task.detached { [weak self] in
                 await self?.handleClient(fd: client)
             }
@@ -721,6 +764,13 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else {
             self.logger.error("exec approvals socket create failed")
+            return -1
+        }
+        do {
+            try ExecApprovalsSocketDescriptorGuard.suppressSigPipe(for: fd)
+        } catch {
+            self.logger.error("exec approvals socket fd hardening failed: \(error.localizedDescription, privacy: .public)")
+            close(fd)
             return -1
         }
         do {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketDescriptorGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketDescriptorGuardTests.swift
@@ -1,0 +1,31 @@
+import Darwin
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct ExecApprovalsSocketDescriptorGuardTests {
+    @Test func `suppress sigpipe enables SO_NOSIGPIPE on unix sockets`() throws {
+        var fds = [Int32](repeating: -1, count: 2)
+        let result = socketpair(AF_UNIX, SOCK_STREAM, 0, &fds)
+        #expect(result == 0)
+        guard result == 0 else { return }
+        defer {
+            for fd in fds where fd >= 0 {
+                close(fd)
+            }
+        }
+
+        try ExecApprovalsSocketDescriptorGuard.suppressSigPipe(for: fds[0])
+
+        var enabled: Int32 = 0
+        var length = socklen_t(MemoryLayout.size(ofValue: enabled))
+        #expect(
+            getsockopt(
+                fds[0],
+                SOL_SOCKET,
+                SO_NOSIGPIPE,
+                &enabled,
+                &length) == 0)
+        #expect(enabled == 1)
+    }
+}


### PR DESCRIPTION
## Summary
- harden macOS exec approval socket descriptors with `SO_NOSIGPIPE`
- apply the guard to both client and server-side accepted socket fds
- add a regression test proving the socket option is enabled

## Why
On macOS, we reproduced a failure where the OpenClaw app showed a real exec approval prompt, but after pressing **Allow Once** the app closed and the waiting client timed out instead of receiving `exec-res`.

This patch addresses a plausible app-side crash vector: writing to a socket whose peer has gone away can raise `SIGPIPE` and terminate the process unless the descriptor is hardened.

## Repro context
- real `~/.openclaw/exec-approvals.sock`
- real OpenClaw.app approval prompt
- user presses **Allow Once**
- app exits / client times out waiting for response

## Validation
- added `ExecApprovalsSocketDescriptorGuardTests`
- attempted local macOS Swift test/build validation
- full app build is currently blocked by an unrelated upstream Xcode/macOS SDK issue in `PeekabooAutomationKit` (`CGWindowListCreateImage` unavailable), so this PR is intentionally scoped to the socket hardening fix

## Notes
This is a surgical defensive fix. Even if there are additional causes behind the approval crash, suppressing `SIGPIPE` on these socket descriptors is the safer behavior for the approval IPC path.
