### PR TITLE
fix: resolve circular re-entry in facade module loading

### DIFF
--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -347,11 +347,16 @@ export function loadBundledPluginPublicSurfaceModuleSync<T extends object>(param
 
   let loaded: T;
   try {
-    // Track the owning plugin once module evaluation begins. Facade top-level
-    // code may have already executed even if the module later throws.
-    loadedFacadePluginIds.add(resolveTrackedFacadePluginId(params.dirName));
     loaded = getJiti(location.modulePath)(location.modulePath) as T;
+    // Back-fill the sentinel *before* resolving the plugin ID. The resolution
+    // triggers config loading (plugin auto-enable, channel discovery, etc.)
+    // which can re-enter this function for the same modulePath. If the
+    // sentinel is still empty at that point the caller sees undefined exports
+    // (e.g. shouldNormalizeGoogleProviderConfig). Populating first ensures any
+    // re-entrant lookup through the sentinel finds the real exports.
     Object.assign(sentinel, loaded);
+    // Track the owning plugin after the module is fully loaded.
+    loadedFacadePluginIds.add(resolveTrackedFacadePluginId(params.dirName));
   } catch (err) {
     loadedFacadeModules.delete(location.modulePath);
     throw err;


### PR DESCRIPTION
## Summary

- Fixes a circular re-entry bug in `loadBundledPluginPublicSurfaceModuleSync` where `resolveTrackedFacadePluginId` triggers config loading (plugin auto-enable, channel discovery) which re-enters the same function for the same module path
- The cached sentinel object was still empty at that point, so re-entrant callers saw `undefined` exports (e.g. `shouldNormalizeGoogleProviderConfig is not a function`)
- Moves `Object.assign(sentinel, loaded)` before the plugin ID resolution so any re-entrant lookup finds the real exports

## Reproduction

Any `openclaw` CLI command that triggers config validation with a Google provider facade call fails with:
```
TypeError: loadFacadeModule(...).shouldNormalizeGoogleProviderConfig is not a function
```

The call chain is:
1. `loadBundledPluginPublicSurfaceModuleSync({dirName: "google", artifactBasename: "api.js"})`
2. Sentinel `{}` placed in cache
3. `resolveTrackedFacadePluginId("google")` → `getFacadeBoundaryResolvedConfig()` → `applyPluginAutoEnable()` → channel discovery → config validation
4. Config validation calls `shouldNormalizeGoogleProviderConfig()` → `loadFacadeModule()` → finds empty sentinel → boom

## Test plan

- [ ] `openclaw models auth login --provider anthropic --method cli` no longer crashes with facade error
- [ ] `pnpm build` passes
- [ ] `pnpm check` passes
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)