### PR TITLE
fix(agents): honor adjusted message tool bookkeeping

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -5,6 +5,7 @@ import {
   handleToolExecutionEnd,
   handleToolExecutionStart,
 } from "./pi-embedded-subscribe.handlers.tools.js";
+import { __testing as beforeToolCallTesting } from "./pi-tools.before-tool-call.js";
 import type {
   ToolCallSummary,
   ToolHandlerContext,
@@ -332,6 +333,52 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
 });
 
 describe("messaging tool media URL tracking", () => {
+  it("commits adjusted message tool params after before_tool_call rewrites send args", async () => {
+    const { ctx } = createTestContext();
+    const adjustedKey = beforeToolCallTesting.buildAdjustedParamsKey({
+      runId: "run-test",
+      toolCallId: "tool-adjusted-message",
+    });
+    beforeToolCallTesting.adjustedParamsByToolCallId.set(adjustedKey, {
+      action: "send",
+      channel: "slack",
+      target: "C-adjusted",
+      message: "rewritten text",
+      media: "file:///adjusted.jpg",
+    });
+
+    await handleToolExecutionStart(ctx, {
+      type: "tool_execution_start",
+      toolName: "message",
+      toolCallId: "tool-adjusted-message",
+      args: {
+        action: "send",
+        channel: "slack",
+        target: "C-original",
+        message: "original text",
+        media: "file:///original.jpg",
+      },
+    });
+
+    await handleToolExecutionEnd(ctx, {
+      type: "tool_execution_end",
+      toolName: "message",
+      toolCallId: "tool-adjusted-message",
+      isError: false,
+      result: { ok: true },
+    });
+
+    expect(ctx.state.messagingToolSentTexts).toEqual(["rewritten text"]);
+    expect(ctx.state.messagingToolSentTargets).toEqual([
+      {
+        tool: "message",
+        provider: "slack",
+        to: "slack:C-adjusted",
+      },
+    ]);
+    expect(ctx.state.messagingToolSentMediaUrls).toEqual(["file:///adjusted.jpg"]);
+  });
+
   it("tracks media arg from messaging tool as pending", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -150,6 +150,45 @@ describe("handleToolExecutionEnd cron.add commitment tracking", () => {
     expect(ctx.state.successfulCronAdds).toBe(1);
   });
 
+  it("increments successfulCronAdds when before_tool_call rewrites cron args to add", async () => {
+    const { ctx } = createTestContext();
+    const adjustedKey = beforeToolCallTesting.buildAdjustedParamsKey({
+      runId: "run-test",
+      toolCallId: "tool-cron-adjusted",
+    });
+    beforeToolCallTesting.adjustedParamsByToolCallId.set(adjustedKey, {
+      action: "add",
+      job: { name: "adjusted reminder" },
+    });
+
+    try {
+      await handleToolExecutionStart(
+        ctx as never,
+        {
+          type: "tool_execution_start",
+          toolName: "cron",
+          toolCallId: "tool-cron-adjusted",
+          args: { action: "list" },
+        } as never,
+      );
+
+      await handleToolExecutionEnd(
+        ctx as never,
+        {
+          type: "tool_execution_end",
+          toolName: "cron",
+          toolCallId: "tool-cron-adjusted",
+          isError: false,
+          result: { details: { status: "ok" } },
+        } as never,
+      );
+    } finally {
+      beforeToolCallTesting.adjustedParamsByToolCallId.delete(adjustedKey);
+    }
+
+    expect(ctx.state.successfulCronAdds).toBe(1);
+  });
+
   it("does not increment successfulCronAdds when cron add fails", async () => {
     const { ctx } = createTestContext();
     await handleToolExecutionStart(
@@ -347,26 +386,30 @@ describe("messaging tool media URL tracking", () => {
       media: "file:///adjusted.jpg",
     });
 
-    await handleToolExecutionStart(ctx, {
-      type: "tool_execution_start",
-      toolName: "message",
-      toolCallId: "tool-adjusted-message",
-      args: {
-        action: "send",
-        channel: "slack",
-        target: "C-original",
-        message: "original text",
-        media: "file:///original.jpg",
-      },
-    });
+    try {
+      await handleToolExecutionStart(ctx, {
+        type: "tool_execution_start",
+        toolName: "message",
+        toolCallId: "tool-adjusted-message",
+        args: {
+          action: "send",
+          channel: "slack",
+          target: "C-original",
+          message: "original text",
+          media: "file:///original.jpg",
+        },
+      });
 
-    await handleToolExecutionEnd(ctx, {
-      type: "tool_execution_end",
-      toolName: "message",
-      toolCallId: "tool-adjusted-message",
-      isError: false,
-      result: { ok: true },
-    });
+      await handleToolExecutionEnd(ctx, {
+        type: "tool_execution_end",
+        toolName: "message",
+        toolCallId: "tool-adjusted-message",
+        isError: false,
+        result: { ok: true },
+      });
+    } finally {
+      beforeToolCallTesting.adjustedParamsByToolCallId.delete(adjustedKey);
+    }
 
     expect(ctx.state.messagingToolSentTexts).toEqual(["rewritten text"]);
     expect(ctx.state.messagingToolSentTargets).toEqual([

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -515,7 +515,7 @@ export async function handleToolExecutionEnd(
   }
 
   // Track committed reminders only when cron.add completed successfully.
-  if (!isToolError && toolName === "cron" && isCronAddAction(startData?.args)) {
+  if (!isToolError && toolName === "cron" && isCronAddAction(afterToolCallArgs)) {
     ctx.state.successfulCronAdds += 1;
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -469,27 +469,6 @@ export async function handleToolExecutionEnd(
     }
   }
 
-  // Commit messaging tool text on success, discard on error.
-  const pendingText = ctx.state.pendingMessagingTexts.get(toolCallId);
-  const pendingTarget = ctx.state.pendingMessagingTargets.get(toolCallId);
-  if (pendingText) {
-    ctx.state.pendingMessagingTexts.delete(toolCallId);
-    if (!isToolError) {
-      ctx.state.messagingToolSentTexts.push(pendingText);
-      ctx.state.messagingToolSentTextsNormalized.push(normalizeTextForComparison(pendingText));
-      ctx.log.debug(`Committed messaging text: tool=${toolName} len=${pendingText.length}`);
-      ctx.trimMessagingToolSent();
-    }
-  }
-  if (pendingTarget) {
-    ctx.state.pendingMessagingTargets.delete(toolCallId);
-    if (!isToolError) {
-      ctx.state.messagingToolSentTargets.push(pendingTarget);
-      ctx.trimMessagingToolSent();
-    }
-  }
-  const pendingMediaUrls = ctx.state.pendingMessagingMediaUrls.get(toolCallId) ?? [];
-  ctx.state.pendingMessagingMediaUrls.delete(toolCallId);
   const startArgs =
     startData?.args && typeof startData.args === "object"
       ? (startData.args as Record<string, unknown>)
@@ -499,12 +478,34 @@ export async function handleToolExecutionEnd(
     adjustedArgs && typeof adjustedArgs === "object"
       ? (adjustedArgs as Record<string, unknown>)
       : startArgs;
+  const pendingText = ctx.state.pendingMessagingTexts.get(toolCallId);
+  const pendingTarget = ctx.state.pendingMessagingTargets.get(toolCallId);
+  ctx.state.pendingMessagingTexts.delete(toolCallId);
+  ctx.state.pendingMessagingTargets.delete(toolCallId);
+  ctx.state.pendingMessagingMediaUrls.delete(toolCallId);
+
   const isMessagingSend =
-    pendingMediaUrls.length > 0 ||
-    (isMessagingTool(toolName) && isMessagingToolSendAction(toolName, startArgs));
+    isMessagingTool(toolName) && isMessagingToolSendAction(toolName, afterToolCallArgs);
+  const committedText =
+    (typeof afterToolCallArgs.content === "string" ? afterToolCallArgs.content : undefined) ??
+    (typeof afterToolCallArgs.message === "string" ? afterToolCallArgs.message : undefined) ??
+    pendingText;
+  const committedTarget = isMessagingSend
+    ? extractMessagingToolSend(toolName, afterToolCallArgs) ?? pendingTarget
+    : undefined;
   if (!isToolError && isMessagingSend) {
+    if (committedText) {
+      ctx.state.messagingToolSentTexts.push(committedText);
+      ctx.state.messagingToolSentTextsNormalized.push(normalizeTextForComparison(committedText));
+      ctx.log.debug(`Committed messaging text: tool=${toolName} len=${committedText.length}`);
+      ctx.trimMessagingToolSent();
+    }
+    if (committedTarget) {
+      ctx.state.messagingToolSentTargets.push(committedTarget);
+      ctx.trimMessagingToolSent();
+    }
     const committedMediaUrls = [
-      ...pendingMediaUrls,
+      ...collectMessagingMediaUrlsFromRecord(afterToolCallArgs),
       ...collectMessagingMediaUrlsFromToolResult(result),
     ];
     if (committedMediaUrls.length > 0) {

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -8,7 +8,14 @@ import {
 } from "./session-transcript-repair.js";
 import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
 
-const TOOL_CALL_BLOCK_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+const TOOL_CALL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "functionCall",
+  "tool_use",
+  "tool_call",
+  "function_call",
+]);
 
 function getAssistantToolCallBlocks(messages: AgentMessage[]) {
   const assistant = messages[0] as Extract<AgentMessage, { role: "assistant" }> | undefined;
@@ -343,6 +350,25 @@ describe("sanitizeToolCallInputs", () => {
       ? assistant.content.map((block) => (block as { type?: unknown }).type)
       : [];
     expect(types).toEqual(["text", "toolUse"]);
+  });
+
+  it("drops snake_case raw tool-call blocks that are missing input payloads", () => {
+    const input = castAgentMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "before" },
+          { type: "tool_use", id: "call_drop", name: "read" },
+        ],
+      },
+    ]);
+
+    const out = sanitizeToolCallInputs(input);
+    const assistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const types = Array.isArray(assistant.content)
+      ? assistant.content.map((block) => (block as { type?: unknown }).type)
+      : [];
+    expect(types).toEqual(["text"]);
   });
 
   it.each([

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -257,7 +257,10 @@ export function repairToolCallInputs(
         if (
           (block as { type?: unknown }).type === "toolCall" ||
           (block as { type?: unknown }).type === "toolUse" ||
-          (block as { type?: unknown }).type === "functionCall"
+          (block as { type?: unknown }).type === "functionCall" ||
+          (block as { type?: unknown }).type === "tool_use" ||
+          (block as { type?: unknown }).type === "tool_call" ||
+          (block as { type?: unknown }).type === "function_call"
         ) {
           // Only sanitize (redact) sessions_spawn blocks; all others are passed through
           // unchanged to preserve provider-specific shapes (e.g. toolUse.input for Anthropic).

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -3,6 +3,14 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 
 const TOOL_CALL_NAME_MAX_CHARS = 64;
 const TOOL_CALL_NAME_RE = /^[A-Za-z0-9_-]+$/;
+const RAW_TOOL_CALL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "functionCall",
+  "tool_use",
+  "tool_call",
+  "function_call",
+]);
 
 type RawToolCallBlock = {
   type?: unknown;
@@ -17,10 +25,7 @@ function isRawToolCallBlock(block: unknown): block is RawToolCallBlock {
     return false;
   }
   const type = (block as { type?: unknown }).type;
-  return (
-    typeof type === "string" &&
-    (type === "toolCall" || type === "toolUse" || type === "functionCall")
-  );
+  return typeof type === "string" && RAW_TOOL_CALL_BLOCK_TYPES.has(type);
 }
 
 function hasToolCallInput(block: RawToolCallBlock): boolean {

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1,9 +1,11 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelMessageCapability } from "../../channels/plugins/message-capabilities.js";
 import type { ChannelMessageActionName, ChannelPlugin } from "../../channels/plugins/types.js";
 import type { MessageActionRunResult } from "../../infra/outbound/message-action-runner.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { createOpenClawCodingTools } from "../pi-tools.js";
 import { createMessageTool } from "./message-tool.js";
 
 const mocks = vi.hoisted(() => ({
@@ -20,6 +22,8 @@ vi.mock("../../infra/outbound/message-action-runner.js", async () => {
   };
 });
 
+vi.mock("../../plugins/hook-runner-global.js");
+
 function mockSendResult(overrides: { channel?: string; to?: string } = {}) {
   mocks.runMessageAction.mockClear();
   mocks.runMessageAction.mockResolvedValue({
@@ -31,6 +35,25 @@ function mockSendResult(overrides: { channel?: string; to?: string } = {}) {
     payload: {},
     dryRun: true,
   } satisfies MessageActionRunResult);
+}
+
+const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
+
+function installMockHookRunner(params?: {
+  hasHooksReturn?: boolean;
+  runBeforeToolCallImpl?: (...args: unknown[]) => unknown;
+}) {
+  const hookRunner = {
+    hasHooks:
+      params?.hasHooksReturn === undefined
+        ? vi.fn()
+        : vi.fn(() => params.hasHooksReturn as boolean),
+    runBeforeToolCall: params?.runBeforeToolCallImpl
+      ? vi.fn(params.runBeforeToolCallImpl)
+      : vi.fn(),
+  };
+  mockGetGlobalHookRunner.mockReturnValue(hookRunner as never);
+  return hookRunner;
 }
 
 function getToolProperties(tool: ReturnType<typeof createMessageTool>) {
@@ -102,6 +125,10 @@ async function executeSend(params: {
 }
 
 describe("message tool agent routing", () => {
+  beforeEach(() => {
+    installMockHookRunner();
+  });
+
   it("derives agentId from the session key", async () => {
     mockSendResult();
 
@@ -498,5 +525,62 @@ describe("message tool sandbox passthrough", () => {
     });
 
     expect(call?.requesterSenderId).toBe("1234567890");
+  });
+});
+
+describe("message tool before_tool_call integration", () => {
+  beforeEach(() => {
+    mockSendResult({ to: "slack:C-adjusted" });
+  });
+
+  it("passes hook-adjusted params to runMessageAction before send", async () => {
+    const hookRunner = installMockHookRunner({
+      hasHooksReturn: true,
+      runBeforeToolCallImpl: async () => ({
+        params: {
+          channel: "slack",
+          target: "C-adjusted",
+          message: "rewritten by hook",
+        },
+      }),
+    });
+
+    const tool = createOpenClawCodingTools({ config: {} as never }).find(
+      (entry) => entry.name === "message",
+    );
+    if (!tool) {
+      throw new Error("missing message tool");
+    }
+
+    await tool.execute("tool-message-hook", {
+      action: "send",
+      channel: "slack",
+      target: "C-original",
+      message: "original",
+    });
+
+    expect(hookRunner.runBeforeToolCall).toHaveBeenCalledWith(
+      {
+        toolName: "message",
+        params: {
+          action: "send",
+          channel: "slack",
+          target: "C-original",
+          message: "original",
+        },
+        toolCallId: "tool-message-hook",
+      },
+      {
+        toolName: "message",
+        toolCallId: "tool-message-hook",
+      },
+    );
+    const call = mocks.runMessageAction.mock.calls[0]?.[0];
+    expect(call?.params).toMatchObject({
+      action: "send",
+      channel: "slack",
+      target: "C-adjusted",
+      message: "rewritten by hook",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- make embedded message bookkeeping commit the adjusted `before_tool_call` params rather than stale start-event args
- keep message text / target / media tracking aligned with the actual rewritten send payload
- add regressions for direct `message` tool hook rewrites and embedded bookkeeping state

## Testing
- not run locally: this environment is missing dependencies and `pnpm install` hit registry DNS failures (`EAI_AGAIN`)
- added targeted regression tests in:
  - `src/agents/tools/message-tool.test.ts`
  - `src/agents/pi-embedded-subscribe.handlers.tools.test.ts`

## Issue
Closes #61157
