### PR TITLE
fix: respect directory entry kind in target resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Outbound targets: preserve authoritative directory match kinds for user, group, and channel entries during target resolution. (#61190) Thanks @auyua9.
 - Gateway/status: label Linux managed gateway services as `systemd user`, making status output explicit about the user-service scope instead of implying a system-level unit. Thanks @vincentkoc.
 - Plugins/install: remove the previous managed plugin directory when a reinstall switches sources, so stale ClawHub and npm copies no longer keep duplicate plugin ids in discovery after the new install wins. Thanks @vincentkoc.
 - Plugins/install: let official plugin reinstall recovery repair source-only installed runtime shadows, so `openclaw plugins install npm:@openclaw/discord --force` can replace the bad package instead of stopping at stale config validation. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -410,6 +410,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+
+- Outbound: preserve the matched directory entry kind when resolving messaging targets from the channel directory, so user/group/channel directory entries are not coerced to the input fallback kind.
 - WebChat: summarize internal message-tool source replies so tool cards no longer duplicate the visible reply body. (#84773) Thanks @jason-allen-oneal.
 - Gateway: preserve deferred lifecycle-error cleanup across later non-terminal events so provider timeouts can persist failed session state instead of leaving sessions stuck running. (#85256, fixes #63819) Thanks @samzong.
 - Agents/subagents: report tool-only child progress during timeout summaries instead of showing no visible output.
@@ -578,6 +580,7 @@ Docs: https://docs.openclaw.ai
 - Installer: require a real controlling terminal before launching onboarding so headless `curl | bash` installs finish cleanly after installing the CLI.
 - Agents/Codex: promote a completed final assistant response when a prompt timeout races Codex app-server completion instead of returning an empty timeout envelope. Refs #84516.
 - Codex app-server: keep interrupted turn statuses from being treated as OpenClaw aborts by themselves, so tool-only turns remain eligible for no-visible-answer recovery. Fixes #84492.
+
 - Agents: cap heartbeat model bleed context hints by the stored session window when runtime model metadata is unavailable, so overflow recovery advice does not suggest a larger window than the active session actually has.
 - Control UI/Web Push: use `https://openclaw.ai` as the generated default VAPID subject instead of the old localhost mailbox so iOS PWA push setup uses an Apple-acceptable subject when `OPENCLAW_VAPID_SUBJECT` is unset. Fixes #83134. (#83317) Thanks @IWhatsskill.
 - Control UI: distinguish inherited thinking-off settings from explicit Off selections so the thinking selector no longer shows two identical Off rows. (#85223) Thanks @amknight.

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -111,6 +111,70 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.listGroupsLive).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves the matched directory entry kind for single matches", async () => {
+    const entry: ChannelDirectoryEntry = { kind: "user", id: "staff_bob", name: "Bob" };
+    mocks.listGroups.mockResolvedValue([entry]);
+    mocks.listGroupsLive.mockResolvedValue([]);
+
+    const result = await expectOkResolution({
+      cfg,
+      channel: "dingtalk",
+      input: "Bob",
+    });
+
+    expect(result.target).toEqual({
+      to: "staff_bob",
+      kind: "user",
+      display: "Bob",
+      source: "directory",
+    });
+  });
+
+  it('preserves "channel" directory entries as channel targets', async () => {
+    const entry: ChannelDirectoryEntry = {
+      kind: "channel",
+      id: "channel:support-room",
+      name: "Support Room",
+    };
+    mocks.listGroups.mockResolvedValue([entry]);
+    mocks.listGroupsLive.mockResolvedValue([]);
+
+    const result = await expectOkResolution({
+      cfg,
+      channel: "dingtalk",
+      input: "Support Room",
+    });
+
+    expect(result.target).toEqual({
+      to: "channel:support-room",
+      kind: "channel",
+      display: "Support Room",
+      source: "directory",
+    });
+  });
+
+  it("preserves the selected directory entry kind for non-error ambiguous matches", async () => {
+    mocks.listGroups.mockResolvedValue([
+      { kind: "group", id: "group:support", name: "Support", rank: 1 },
+      { kind: "channel", id: "channel:support", name: "Support", rank: 5 },
+    ] satisfies ChannelDirectoryEntry[]);
+    mocks.listGroupsLive.mockResolvedValue([]);
+
+    const result = await expectOkResolution({
+      cfg,
+      channel: "dingtalk",
+      input: "Support",
+      resolveAmbiguous: "best",
+    });
+
+    expect(result.target).toEqual({
+      to: "channel:support",
+      kind: "channel",
+      display: "Support",
+      source: "directory",
+    });
+  });
+
   it("skips directory lookup for direct ids", async () => {
     const result = await expectOkResolution({
       cfg,

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -66,21 +66,6 @@ async function expectOkResolution(
   return result;
 }
 
-function firstMockArg(
-  mock: { mock: { calls: readonly unknown[][] } },
-  label: string,
-): Record<string, unknown> {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  const [arg] = call;
-  if (typeof arg !== "object" || arg === null || Array.isArray(arg)) {
-    throw new Error(`expected ${label} input to be an object`);
-  }
-  return arg as Record<string, unknown>;
-}
-
 describe("resolveMessagingTarget (directory fallback)", () => {
   const cfg = {} as OpenClawConfig;
 
@@ -126,6 +111,73 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.listGroupsLive).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves the matched directory entry kind for single matches", async () => {
+    const entry: ChannelDirectoryEntry = { kind: "user", id: "staff_bob", name: "Bob" };
+    mocks.listGroups.mockResolvedValue([entry]);
+    mocks.listGroupsLive.mockResolvedValue([]);
+
+    const result = await expectOkResolution({
+      cfg,
+      channel: "dingtalk",
+      input: "Bob",
+    });
+
+    expect(result.target).toEqual({
+      to: "staff_bob",
+      kind: "user",
+      display: "Bob",
+      source: "directory",
+      resolutionSource: "directory",
+    });
+  });
+
+  it('preserves "channel" directory entries as channel targets', async () => {
+    const entry: ChannelDirectoryEntry = {
+      kind: "channel",
+      id: "channel:support-room",
+      name: "Support Room",
+    };
+    mocks.listGroups.mockResolvedValue([entry]);
+    mocks.listGroupsLive.mockResolvedValue([]);
+
+    const result = await expectOkResolution({
+      cfg,
+      channel: "dingtalk",
+      input: "Support Room",
+    });
+
+    expect(result.target).toEqual({
+      to: "channel:support-room",
+      kind: "channel",
+      display: "Support Room",
+      source: "directory",
+      resolutionSource: "directory",
+    });
+  });
+
+  it("preserves the selected directory entry kind for non-error ambiguous matches", async () => {
+    mocks.listGroups.mockResolvedValue([
+      { kind: "group", id: "group:support", name: "Support", rank: 1 },
+      { kind: "channel", id: "channel:support", name: "Support", rank: 5 },
+    ] satisfies ChannelDirectoryEntry[]);
+    mocks.listGroupsLive.mockResolvedValue([]);
+
+    const result = await expectOkResolution({
+      cfg,
+      channel: "dingtalk",
+      input: "Support",
+      resolveAmbiguous: "best",
+    });
+
+    expect(result.target).toEqual({
+      to: "channel:support",
+      kind: "channel",
+      display: "Support",
+      source: "directory",
+      resolutionSource: "directory",
+    });
+  });
+
   it("skips directory lookup for direct ids", async () => {
     const result = await expectOkResolution({
       cfg,
@@ -165,9 +217,10 @@ describe("resolveMessagingTarget (directory fallback)", () => {
       resolutionSource: "plugin",
       display: undefined,
     });
-    expect(mocks.resolveTarget).toHaveBeenCalledOnce();
-    expect(firstMockArg(mocks.resolveTarget, "target resolver").input).toBe(
-      "dthcxgoxhifn3pwh65cut3ud3w",
+    expect(mocks.resolveTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: "dthcxgoxhifn3pwh65cut3ud3w",
+      }),
     );
     expect(mocks.listGroups).not.toHaveBeenCalled();
     expect(mocks.listGroupsLive).not.toHaveBeenCalled();
@@ -244,8 +297,11 @@ describe("resolveMessagingTarget (directory fallback)", () => {
     expect(mocks.listPeers).toHaveBeenCalledTimes(1);
     expect(mocks.listPeersLive).toHaveBeenCalledTimes(1);
     expect(mocks.listGroups).not.toHaveBeenCalled();
-    expect(mocks.resolveTarget).toHaveBeenCalledOnce();
-    expect(firstMockArg(mocks.resolveTarget, "target resolver").input).toBe("+15551234567");
+    expect(mocks.resolveTarget).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: "+15551234567",
+      }),
+    );
   });
 
   it("keeps plugin-owned id casing when resolver returns a normalized target", async () => {

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -316,6 +316,16 @@ function buildNormalizedResolveResult(params: {
   };
 }
 
+function resolveDirectoryEntryKind(
+  entry: ChannelDirectoryEntry,
+  fallbackKind: TargetResolveKind,
+): TargetResolveKind {
+  if (entry.kind === "user" || entry.kind === "group" || entry.kind === "channel") {
+    return entry.kind;
+  }
+  return fallbackKind;
+}
+
 function pickAmbiguousMatch(
   entries: ChannelDirectoryEntry[],
   mode: ResolveAmbiguousMode,
@@ -397,7 +407,7 @@ export async function resolveMessagingTarget(params: {
       ok: true,
       target: {
         to: normalizeDirectoryEntryId(params.channel, entry),
-        kind,
+        kind: resolveDirectoryEntryKind(entry, kind),
         display: entry.name ?? entry.handle ?? stripTargetPrefixes(entry.id),
         source: "directory",
       },
@@ -412,7 +422,7 @@ export async function resolveMessagingTarget(params: {
           ok: true,
           target: {
             to: normalizeDirectoryEntryId(params.channel, best),
-            kind,
+            kind: resolveDirectoryEntryKind(best, kind),
             display: best.name ?? best.handle ?? stripTargetPrefixes(best.id),
             source: "directory",
           },

--- a/src/infra/outbound/target-resolver.ts
+++ b/src/infra/outbound/target-resolver.ts
@@ -320,6 +320,16 @@ function buildNormalizedResolveResult(params: {
   };
 }
 
+function resolveDirectoryEntryKind(
+  entry: ChannelDirectoryEntry,
+  fallbackKind: TargetResolveKind,
+): TargetResolveKind {
+  if (entry.kind === "user" || entry.kind === "group" || entry.kind === "channel") {
+    return entry.kind;
+  }
+  return fallbackKind;
+}
+
 function pickAmbiguousMatch(
   entries: ChannelDirectoryEntry[],
   mode: ResolveAmbiguousMode,
@@ -402,7 +412,7 @@ export async function resolveMessagingTarget(params: {
       ok: true,
       target: {
         to: normalizeDirectoryEntryId(params.channel, entry),
-        kind,
+        kind: resolveDirectoryEntryKind(entry, kind),
         display: entry.name ?? entry.handle ?? stripTargetPrefixes(entry.id),
         source: "directory",
         resolutionSource: "directory",
@@ -418,7 +428,7 @@ export async function resolveMessagingTarget(params: {
           ok: true,
           target: {
             to: normalizeDirectoryEntryId(params.channel, best),
-            kind,
+            kind: resolveDirectoryEntryKind(best, kind),
             display: best.name ?? best.handle ?? stripTargetPrefixes(best.id),
             source: "directory",
             resolutionSource: "directory",


### PR DESCRIPTION
Summary
- respect the matched directory entry kind when resolving a single target match
- do the same for the selected entry in non-error ambiguous resolution modes
- add a regression test for the case where a group lookup returns a user directory entry

Why
Some channel plugins intentionally return user entries from listGroups as a temporary compatibility path because the current resolver defaults bare names to group and only queries listGroups for those inputs. In that situation, the current resolver keeps the initial guessed kind instead of the matched entry kind, which can leak the wrong peer/chat type into later session routing.

This surfaced concretely in DingTalk private-chat person lookups: a bare person name could resolve through the group directory path, but the resulting target still kept kind=group even when the matched entry itself was a user.

Testing
- pnpm exec vitest run src/infra/outbound/target-resolver.test.ts
- commit hook also passed the repo pre-commit check chain before commit 322c8f1199

## Real behavior proof

- **Behavior or issue addressed**: DingTalk-style directory lookup can return a `user` or `channel` entry from the group directory path for a bare target name; after this patch the resolved messaging target keeps the matched directory entry kind instead of the fallback guessed kind.
- **Real environment tested**: Local OpenClaw source checkout on macOS arm64, rebuilt on upstream `main` commit `78d226bb3b`, with workspace dependencies installed through pnpm.
- **Exact steps or command run after this patch**: Ran the resolver path in the local OpenClaw checkout and then ran the focused outbound resolver command: `pnpm exec vitest run src/infra/outbound/target-resolver.test.ts src/infra/outbound/outbound-session.test.ts`.
- **Evidence after fix**: Terminal output from the local OpenClaw checkout after applying this patch:

  ```text
  $ git diff --name-only origin/main...HEAD
  CHANGELOG.md
  src/infra/outbound/target-resolver.test.ts
  src/infra/outbound/target-resolver.ts

  $ pnpm exec vitest run src/infra/outbound/target-resolver.test.ts src/infra/outbound/outbound-session.test.ts
  RUN  v4.1.6 /Users/ming/code/pr-fixes/openclaw-61190
  Test Files  2 passed (2)
  Tests  40 passed (40)
  ```

- **Observed result after fix**: The local resolver output path now preserves `user`, `group`, and `channel` directory entry kinds for matched directory entries; the command completed with 40 passing checks covering the changed resolver branch and adjacent outbound-session behavior.
- **What was not tested**: No live DingTalk tenant message was sent from this checkout; the proof used the local OpenClaw resolver runtime path and captured terminal output for the after-fix behavior.
