### PR TITLE
Fix/bedrock aws sdk apikey injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Docs: https://docs.openclaw.ai
 - Android/Talk Mode: cancel in-flight `talk.speak` playback when speech is explicitly stopped, so stale replies stop starting after barge-in or manual stop. (#61164) Thanks @obviyus.
 - Plugins/onboarding: write dotted plugin uiHint paths like Brave `webSearch.mode` as nested plugin config so `llm-context` setup stops failing validation. (#61159) Thanks @obviyus.
 - Android/Talk Mode: restore voice replies on gateway-backed talk mode sessions by updating embedded runner transport overrides to the current agent transport API. (#61214) Thanks @obviyus.
+- Amazon Bedrock/aws-sdk auth: stop injecting the fake `AWS_PROFILE` apiKey marker when no AWS auth env vars exist, so instance-role and other default-chain setups keep working without poisoning provider config. (#61194) Thanks @wirjo.
 
 ## 2026.4.2
 

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -142,7 +142,14 @@ describe("bedrock discovery", () => {
       }),
     ).toBe("AWS_BEARER_TOKEN_BEDROCK");
 
-    expect(resolveBedrockConfigApiKey({} as NodeJS.ProcessEnv)).toBe("AWS_PROFILE");
+    // When no AWS env vars are present (e.g. instance role), no marker should be injected.
+    // The aws-sdk credential chain handles auth at request time. (#49891)
+    expect(resolveBedrockConfigApiKey({} as NodeJS.ProcessEnv)).toBeUndefined();
+
+    // When AWS_PROFILE is explicitly set, it should return the marker.
+    expect(
+      resolveBedrockConfigApiKey({ AWS_PROFILE: "default" } as NodeJS.ProcessEnv),
+    ).toBe("AWS_PROFILE");
   });
 
   it("merges implicit Bedrock models into explicit provider overrides", () => {

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -150,8 +150,10 @@ export function resetBedrockDiscoveryCacheForTest(): void {
   hasLoggedBedrockError = false;
 }
 
-export function resolveBedrockConfigApiKey(env: NodeJS.ProcessEnv = process.env): string {
-  return resolveAwsSdkEnvVarName(env) ?? "AWS_PROFILE";
+export function resolveBedrockConfigApiKey(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return resolveAwsSdkEnvVarName(env);
 }
 
 export async function discoverBedrockModels(params: {

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -153,6 +153,8 @@ export function resetBedrockDiscoveryCacheForTest(): void {
 export function resolveBedrockConfigApiKey(
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
+  // When no AWS auth env marker is present, Bedrock should fall back to the
+  // AWS SDK default credential chain instead of persisting a fake apiKey marker.
   return resolveAwsSdkEnvVarName(env);
 }
 

--- a/src/agents/models-config.providers.secrets.bedrock-apikey.test.ts
+++ b/src/agents/models-config.providers.secrets.bedrock-apikey.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
-import { resolveMissingProviderApiKey } from "./models-config.providers.secrets.js";
+import {
+  resolveAwsSdkApiKeyVarName,
+  resolveMissingProviderApiKey,
+} from "./models-config.providers.secrets.js";
 
 /**
  * Regression tests for #49891 / #50699 / #54274:
@@ -131,5 +134,25 @@ describe("resolveMissingProviderApiKey — aws-sdk auth", () => {
     });
 
     expect(result.apiKey).toBe("AWS_ACCESS_KEY_ID");
+  });
+});
+
+describe("resolveAwsSdkApiKeyVarName", () => {
+  it("returns undefined when AWS auth env markers are absent", () => {
+    expect(resolveAwsSdkApiKeyVarName({})).toBeUndefined();
+  });
+
+  it("preserves the AWS auth env precedence order", () => {
+    expect(
+      resolveAwsSdkApiKeyVarName({
+        AWS_BEARER_TOKEN_BEDROCK: "bearer",
+        AWS_PROFILE: "default",
+      }),
+    ).toBe("AWS_BEARER_TOKEN_BEDROCK");
+    expect(
+      resolveAwsSdkApiKeyVarName({
+        AWS_PROFILE: "default",
+      }),
+    ).toBe("AWS_PROFILE");
   });
 });

--- a/src/agents/models-config.providers.secrets.bedrock-apikey.test.ts
+++ b/src/agents/models-config.providers.secrets.bedrock-apikey.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderConfig } from "./models-config.providers.secrets.js";
+import { resolveMissingProviderApiKey } from "./models-config.providers.secrets.js";
+
+/**
+ * Regression tests for #49891 / #50699 / #54274:
+ *
+ * When the Bedrock provider uses `auth: "aws-sdk"` and no AWS environment
+ * variables are set (e.g. EC2 instance role, ECS task role), the
+ * normalisation step must NOT inject a fake `apiKey: "AWS_PROFILE"` marker.
+ * Doing so poisons the downstream auth resolver and causes
+ * "No API key found for amazon-bedrock" errors.
+ */
+describe("resolveMissingProviderApiKey — aws-sdk auth", () => {
+  const baseProvider: ProviderConfig = {
+    baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+    api: "bedrock-converse-stream",
+    auth: "aws-sdk",
+    models: [
+      {
+        id: "anthropic.claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        input: ["text"],
+        reasoning: false,
+        cost: { input: 0.003, output: 0.015, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      },
+    ],
+  };
+
+  const emptyEnv: NodeJS.ProcessEnv = {};
+
+  it("does NOT inject apiKey when no AWS env vars are set (instance role)", () => {
+    const result = resolveMissingProviderApiKey({
+      providerKey: "amazon-bedrock",
+      provider: baseProvider,
+      env: emptyEnv,
+      profileApiKey: undefined,
+    });
+
+    // Provider should be returned unchanged — no apiKey field added
+    expect(result).toBe(baseProvider);
+    expect(result.apiKey).toBeUndefined();
+  });
+
+  it("does NOT inject apiKey via providerApiKeyResolver when it returns undefined", () => {
+    const result = resolveMissingProviderApiKey({
+      providerKey: "amazon-bedrock",
+      provider: baseProvider,
+      env: emptyEnv,
+      profileApiKey: undefined,
+      providerApiKeyResolver: () => undefined,
+    });
+
+    expect(result).toBe(baseProvider);
+    expect(result.apiKey).toBeUndefined();
+  });
+
+  it("injects apiKey marker when AWS_ACCESS_KEY_ID + SECRET are present", () => {
+    const envWithKeys: NodeJS.ProcessEnv = {
+      AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE",
+      AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", // pragma: allowlist secret
+    };
+
+    const result = resolveMissingProviderApiKey({
+      providerKey: "amazon-bedrock",
+      provider: baseProvider,
+      env: envWithKeys,
+      profileApiKey: undefined,
+    });
+
+    expect(result.apiKey).toBe("AWS_ACCESS_KEY_ID");
+  });
+
+  it("injects apiKey marker when AWS_PROFILE is set", () => {
+    const envWithProfile: NodeJS.ProcessEnv = {
+      AWS_PROFILE: "my-profile",
+    };
+
+    const result = resolveMissingProviderApiKey({
+      providerKey: "amazon-bedrock",
+      provider: baseProvider,
+      env: envWithProfile,
+      profileApiKey: undefined,
+    });
+
+    expect(result.apiKey).toBe("AWS_PROFILE");
+  });
+
+  it("injects apiKey marker when AWS_BEARER_TOKEN_BEDROCK is set", () => {
+    const envWithBearer: NodeJS.ProcessEnv = {
+      AWS_BEARER_TOKEN_BEDROCK: "some-bearer-token",
+    };
+
+    const result = resolveMissingProviderApiKey({
+      providerKey: "amazon-bedrock",
+      provider: baseProvider,
+      env: envWithBearer,
+      profileApiKey: undefined,
+    });
+
+    expect(result.apiKey).toBe("AWS_BEARER_TOKEN_BEDROCK");
+  });
+
+  it("skips injection when provider already has apiKey configured", () => {
+    const providerWithKey: ProviderConfig = {
+      ...baseProvider,
+      apiKey: "existing-key",
+    };
+
+    const result = resolveMissingProviderApiKey({
+      providerKey: "amazon-bedrock",
+      provider: providerWithKey,
+      env: emptyEnv,
+      profileApiKey: undefined,
+    });
+
+    // Should return unchanged — already has apiKey
+    expect(result).toBe(providerWithKey);
+    expect(result.apiKey).toBe("existing-key");
+  });
+
+  it("uses providerApiKeyResolver result when it returns a value", () => {
+    const result = resolveMissingProviderApiKey({
+      providerKey: "amazon-bedrock",
+      provider: baseProvider,
+      env: emptyEnv,
+      profileApiKey: undefined,
+      providerApiKeyResolver: () => "AWS_ACCESS_KEY_ID",
+    });
+
+    expect(result.apiKey).toBe("AWS_ACCESS_KEY_ID");
+  });
+});

--- a/src/agents/models-config.providers.secrets.ts
+++ b/src/agents/models-config.providers.secrets.ts
@@ -73,8 +73,10 @@ export function resolveEnvApiKeyVarName(
   return match ? match[1] : undefined;
 }
 
-export function resolveAwsSdkApiKeyVarName(env: NodeJS.ProcessEnv = process.env): string {
-  return resolveAwsSdkEnvVarName(env) ?? "AWS_PROFILE";
+export function resolveAwsSdkApiKeyVarName(
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  return resolveAwsSdkEnvVarName(env);
 }
 
 export function normalizeHeaderValues(params: {
@@ -277,15 +279,28 @@ export function resolveMissingProviderApiKey(params: {
 
   const authMode = params.provider.auth;
   if (params.providerApiKeyResolver && (!authMode || authMode === "aws-sdk")) {
+    const resolvedApiKey = params.providerApiKeyResolver(params.env);
+    if (!resolvedApiKey) {
+      // Resolver returned nothing (e.g. no AWS env vars on an instance-role setup).
+      // Don't inject an undefined/empty apiKey — let the sdk credential chain handle it.
+      return params.provider;
+    }
     return {
       ...params.provider,
-      apiKey: params.providerApiKeyResolver(params.env),
+      apiKey: resolvedApiKey,
     };
   }
   if (authMode === "aws-sdk") {
+    const awsEnvVar = resolveAwsSdkApiKeyVarName(params.env);
+    if (!awsEnvVar) {
+      // No AWS env vars found — don't inject a fake apiKey marker.
+      // The aws-sdk credential chain (instance roles, ECS task roles, etc.)
+      // will resolve credentials at request time without needing an apiKey field.
+      return params.provider;
+    }
     return {
       ...params.provider,
-      apiKey: resolveAwsSdkApiKeyVarName(params.env),
+      apiKey: awsEnvVar,
     };
   }
 


### PR DESCRIPTION
# fix(bedrock): stop injecting fake apiKey marker for aws-sdk auth when no env vars exist

Problem
When the Bedrock provider uses auth: "aws-sdk" with no AWS environment variables set (EC2 instance roles, ECS task roles, Lambda, etc.), the gateway startup injects apiKey: "AWS_PROFILE" into the provider config — even though AWS_PROFILE is not set.

This happens because resolveAwsSdkApiKeyVarName() unconditionally falls back to "AWS_PROFILE":
// Before
function resolveAwsSdkApiKeyVarName(env): string {
  return resolveAwsSdkEnvVarName(env) ?? "AWS_PROFILE"; // always returns a string
}

The same pattern exists in the extension's resolveBedrockConfigApiKey().

The downstream auth resolver then sees apiKey: "AWS_PROFILE", recognizes it as an AWS SDK marker via isNonSecretApiKeyMarker(), but isKnownEnvApiKeyMarker() excludes AWS SDK markers — so resolveUsableCustomProviderApiKey() returns null. The auth chain eventually fails with:

No API key found for amazon-bedrock.

This is the root cause behind three separate bug reports:

• #49891 — Gateway injects apiKey: "AWS_PROFILE" on every startup, breaking auth
• #50699 — Bedrock provider does not recognize environment AWS credentials
• #54274 — Intermittent main session failures after upgrade (instance role)

Root Cause

Two functions (resolveAwsSdkApiKeyVarName and resolveBedrockConfigApiKey) fall back to "AWS_PROFILE" when resolveAwsSdkEnvVarName() returns undefined (no AWS env vars detected). The write path then persists this string as an apiKey marker, but the read path doesn't resolve it to a usable credential — creating a permanent auth failure state.

Fix

**resolveAwsSdkApiKeyVarName()** (src/agents/models-config.providers.secrets.ts):

• Return undefined instead of "AWS_PROFILE" when no AWS env vars exist

**resolveBedrockConfigApiKey()** (extensions/amazon-bedrock/discovery.ts):

• Same fix — return undefined instead of falling back to "AWS_PROFILE"

**resolveMissingProviderApiKey()** (src/agents/models-config.providers.secrets.ts):
• Guard both the providerApiKeyResolver branch and the direct aws-sdk branch
• If the resolver returns nothing, return the provider config unchanged (no apiKey injected)
• The AWS SDK credential chain then resolves credentials at request time via IMDS/ECS/etc.

When AWS env vars are present (AWS_ACCESS_KEY_ID, AWS_PROFILE, AWS_BEARER_TOKEN_BEDROCK), the marker is still injected correctly — no behavior change for those setups.

Verification

• New test file: src/agents/models-config.providers.secrets.bedrock-apikey.test.ts (7 tests)
  • ✅ No apiKey injection when no env vars set (instance role scenario)
  • ✅ No apiKey injection when providerApiKeyResolver returns undefined
  • ✅ Correct marker injection for AWS_ACCESS_KEY_ID
  • ✅ Correct marker injection for AWS_PROFILE
  • ✅ Correct marker injection for AWS_BEARER_TOKEN_BEDROCK
  • ✅ Skip injection when apiKey already configured
  • ✅ providerApiKeyResolver result used when it returns a value
• Existing normalize tests: pass
• Existing auth-provenance tests: pass
• Existing model-auth-markers tests: pass
• Lint: clean

Files changed

| File                                                              | Change                                                              |
| ----------------------------------------------------------------- | ------------------------------------------------------------------- |
| src/agents/models-config.providers.secrets.ts                     | Fix resolveAwsSdkApiKeyVarName + guard resolveMissingProviderApiKey |
| extensions/amazon-bedrock/discovery.ts                            | Fix resolveBedrockConfigApiKey                                      |
| src/agents/models-config.providers.secrets.bedrock-apikey.test.ts | New regression tests                                                |

Closes #49891
Closes #50699
Fixes #54274