### PR TITLE
Fix: exec allowlist trailing star matches paths with slashes

### DIFF
--- a/src/agents/pi-tools.before-tool-call.integration.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { isToolWrappedWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+
+describe("before_tool_call hook integration", () => {
+  it("should wrap message tool with before_tool_call hook", async () => {
+    const tools = await createOpenClawTools({});
+    const messageTool = tools.find(t => t.name === "message");
+    expect(messageTool).toBeDefined();
+    
+    // Check if wrapped
+    if (messageTool) {
+      expect(isToolWrappedWithBeforeToolCallHook(messageTool)).toBe(true);
+    }
+  });
+});

--- a/src/infra/exec-allowlist-pattern.test.ts
+++ b/src/infra/exec-allowlist-pattern.test.ts
@@ -24,6 +24,20 @@ describe("matchesExecAllowlistPattern", () => {
     expect(matchesExecAllowlistPattern(pattern, target)).toBe(expected);
   });
 
+  it.each([
+    // Trailing star should match anything including slashes (for exec command patterns like "python3 *")
+    { pattern: "python3 *", target: "python3 /path/to/script.py", expected: true },
+    { pattern: "python3 *", target: "python3 script.py", expected: true },
+    { pattern: "python3 *", target: "python3 -c 'print(1)'", expected: true },
+    { pattern: "bash *", target: "bash /tmp/script.sh", expected: true },
+    { pattern: "bash *", target: "bash -c \"echo hi\"", expected: true },
+    // Non-trailing star should still restrict to non-slash
+    { pattern: "/tmp/*/tool", target: "/tmp/a/tool", expected: true },
+    { pattern: "/tmp/*/tool", target: "/tmp/a/b/tool", expected: false },
+  ])("trailing star matches any characters including slashes for %j", ({ pattern, target, expected }) => {
+    expect(matchesExecAllowlistPattern(pattern, target)).toBe(expected);
+  });
+
   it("expands home-prefix patterns", () => {
     const prevOpenClawHome = process.env.OPENCLAW_HOME;
     const prevHome = process.env.HOME;

--- a/src/infra/exec-allowlist-pattern.ts
+++ b/src/infra/exec-allowlist-pattern.ts
@@ -33,7 +33,10 @@ function compileGlobRegex(pattern: string): RegExp {
 
   let regex = "^";
   let i = 0;
-  while (i < pattern.length) {
+  const len = pattern.length;
+  // Track if pattern ends with a trailing star (which should match anything, including slashes)
+  let trailingStar = false;
+  while (i < len) {
     const ch = pattern[i];
     if (ch === "*") {
       const next = pattern[i + 1];
@@ -42,7 +45,13 @@ function compileGlobRegex(pattern: string): RegExp {
         i += 2;
         continue;
       }
-      regex += "[^/]*";
+      // Check if this is a trailing star - if so, allow matching any characters including /
+      trailingStar = i === len - 1;
+      if (trailingStar) {
+        regex += ".*";
+      } else {
+        regex += "[^/]*";
+      }
       i += 1;
       continue;
     }
@@ -54,7 +63,10 @@ function compileGlobRegex(pattern: string): RegExp {
     regex += escapeRegExpLiteral(ch);
     i += 1;
   }
-  regex += "$";
+  // Only append $ anchor if no trailing star
+  if (!trailingStar) {
+    regex += "$";
+  }
 
   const compiled = new RegExp(regex, process.platform === "win32" ? "i" : "");
   if (globRegexCache.size >= GLOB_REGEX_CACHE_LIMIT) {


### PR DESCRIPTION
## Summary

Fixes issue #61193 - exec approvals allowlist glob pattern not matching commands.

## Problem

Pattern  was not matching  because the glob regex used  which excludes slashes.

## Solution

When a pattern ends with a trailing star (), allow it to match any characters including slashes. This makes command patterns like , ,  work correctly with arguments containing paths.

For non-trailing stars in path patterns like , the restriction to non-slash is preserved.

## Test

Added tests for command patterns with arguments:
- `python3 *` → matches `python3 /path/to/script.py` ✓
- `bash *` → matches `bash -c "echo hi"` ✓

Good day,

This PR addresses the issue where exec allowlist patterns ending with  would not match commands with path arguments.

After applying this fix:
1. `openclaw approvals allowlist add --agent main "python3 *"`
2. `openclaw approvals set --file ~/.openclaw/exec-approvals.json --gateway`
3. Commands like `python3 /path/to/script.py` will correctly match and execute

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
Jah-yee
https://github.com/Jah-yee