### PR TITLE
WhatsApp: restore doctor contract export

### DIFF
--- a/extensions/whatsapp/contract-surfaces.ts
+++ b/extensions/whatsapp/contract-surfaces.ts
@@ -3,7 +3,7 @@ type UnsupportedSecretRefConfigCandidate = {
   value: unknown;
 };
 
-export { normalizeCompatibilityConfig } from "./src/doctor-contract.js";
+export { normalizeCompatibilityConfig } from "./src/doctor.js";
 import { hasAnyWhatsAppAuth } from "./src/accounts.js";
 export { canonicalizeLegacySessionKey, isLegacyGroupSessionKey } from "./src/session-contract.js";
 

--- a/extensions/whatsapp/src/doctor.ts
+++ b/extensions/whatsapp/src/doctor.ts
@@ -47,6 +47,14 @@ function normalizeWhatsAppAckReactionConfig(cfg: OpenClawConfig): ChannelDoctorC
   };
 }
 
+export function normalizeCompatibilityConfig({
+  cfg,
+}: {
+  cfg: OpenClawConfig;
+}): ChannelDoctorConfigMutation {
+  return normalizeWhatsAppAckReactionConfig(cfg);
+}
+
 export const whatsappDoctor: ChannelDoctorAdapter = {
-  normalizeCompatibilityConfig: ({ cfg }) => normalizeWhatsAppAckReactionConfig(cfg),
+  normalizeCompatibilityConfig,
 };


### PR DESCRIPTION
## What
Restore the WhatsApp contract export for compatibility-config normalization.

## Why
`extensions/whatsapp/contract-surfaces.ts` currently re-exports `normalizeCompatibilityConfig` from a file that does not exist on `main`, which breaks `pnpm check` / `pnpm build`.

## Included
- export `normalizeCompatibilityConfig` from `extensions/whatsapp/src/doctor.ts`
- point the public contract surface at the real implementation

## Notes
This is intentionally small and self-contained so it can land independently.
