### PR TITLE
fix(cron): catch unsupported job spec throw in enqueueRun handler

### DIFF
--- a/extensions/whatsapp/src/doctor-contract.test.ts
+++ b/extensions/whatsapp/src/doctor-contract.test.ts
@@ -92,6 +92,24 @@ describe("normalizeCompatibilityConfig (whatsapp ackReaction migration)", () => 
     });
   });
 
+  it("no-ops when ackReactionScope is off", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: "👍", ackReactionScope: "off" },
+    } as Partial<Cfg>);
+    const { config, changes } = normalizeCompatibilityConfig({ cfg });
+    expect(config).toBe(cfg);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("no-ops when ackReactionScope is none", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: "👍", ackReactionScope: "none" },
+    } as Partial<Cfg>);
+    const { config, changes } = normalizeCompatibilityConfig({ cfg });
+    expect(config).toBe(cfg);
+    expect(changes).toHaveLength(0);
+  });
+
   it("trims whitespace from legacy ackReaction value", () => {
     const cfg = baseCfg({
       messages: { ackReaction: "  👍  " },

--- a/extensions/whatsapp/src/doctor-contract.test.ts
+++ b/extensions/whatsapp/src/doctor-contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCompatibilityConfig } from "./doctor-contract.js";
+
+type Cfg = Parameters<typeof normalizeCompatibilityConfig>[0]["cfg"];
+
+const baseCfg = (overrides: Partial<Cfg> = {}): Cfg =>
+  ({ channels: { whatsapp: {} }, ...overrides }) as Cfg;
+
+describe("normalizeCompatibilityConfig (whatsapp ackReaction migration)", () => {
+  it("no-ops when messages.ackReaction is absent", () => {
+    const cfg = baseCfg();
+    const { config, changes } = normalizeCompatibilityConfig({ cfg });
+    expect(config).toBe(cfg);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("no-ops when whatsapp channel is not configured", () => {
+    const cfg = { messages: { ackReaction: "👍" } } as unknown as Cfg;
+    const { config, changes } = normalizeCompatibilityConfig({ cfg });
+    expect(config).toBe(cfg);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("no-ops when ackReaction is already set on whatsapp channel", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: "👍" },
+      channels: { whatsapp: { ackReaction: { emoji: "👍", direct: true, group: "always" } } },
+    } as Partial<Cfg>);
+    const { config, changes } = normalizeCompatibilityConfig({ cfg });
+    expect(config).toBe(cfg);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("migrates scope=all → direct:true group:always", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: "👍", ackReactionScope: "all" },
+    } as Partial<Cfg>);
+    const { config, changes } = normalizeCompatibilityConfig({ cfg });
+    expect((config as Cfg).channels?.whatsapp?.ackReaction).toEqual({
+      emoji: "👍",
+      direct: true,
+      group: "always",
+    });
+    expect(changes).toHaveLength(1);
+  });
+
+  it("migrates scope=direct → direct:true group:never", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: "✅", ackReactionScope: "direct" },
+    } as Partial<Cfg>);
+    const { config } = normalizeCompatibilityConfig({ cfg });
+    expect((config as Cfg).channels?.whatsapp?.ackReaction).toEqual({
+      emoji: "✅",
+      direct: true,
+      group: "never",
+    });
+  });
+
+  it("migrates scope=group-all → direct:false group:always", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: "🎉", ackReactionScope: "group-all" },
+    } as Partial<Cfg>);
+    const { config } = normalizeCompatibilityConfig({ cfg });
+    expect((config as Cfg).channels?.whatsapp?.ackReaction).toEqual({
+      emoji: "🎉",
+      direct: false,
+      group: "always",
+    });
+  });
+
+  it("migrates scope=group-mentions (default) → direct:false group:mentions", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: "👀", ackReactionScope: "group-mentions" },
+    } as Partial<Cfg>);
+    const { config } = normalizeCompatibilityConfig({ cfg });
+    expect((config as Cfg).channels?.whatsapp?.ackReaction).toEqual({
+      emoji: "👀",
+      direct: false,
+      group: "mentions",
+    });
+  });
+
+  it("defaults missing ackReactionScope to group-mentions behavior", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: "🔔" },
+    } as Partial<Cfg>);
+    const { config } = normalizeCompatibilityConfig({ cfg });
+    expect((config as Cfg).channels?.whatsapp?.ackReaction).toEqual({
+      emoji: "🔔",
+      direct: false,
+      group: "mentions",
+    });
+  });
+
+  it("trims whitespace from legacy ackReaction value", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: "  👍  " },
+    } as Partial<Cfg>);
+    const { config } = normalizeCompatibilityConfig({ cfg });
+    expect((config as Cfg).channels?.whatsapp?.ackReaction?.emoji).toBe("👍");
+  });
+});

--- a/extensions/whatsapp/src/doctor-contract.test.ts
+++ b/extensions/whatsapp/src/doctor-contract.test.ts
@@ -110,6 +110,15 @@ describe("normalizeCompatibilityConfig (whatsapp ackReaction migration)", () => 
     expect(changes).toHaveLength(0);
   });
 
+  it("no-ops when ackReaction is not a string", () => {
+    const cfg = baseCfg({
+      messages: { ackReaction: false },
+    } as unknown as Partial<Cfg>);
+    const { config, changes } = normalizeCompatibilityConfig({ cfg });
+    expect(config).toBe(cfg);
+    expect(changes).toHaveLength(0);
+  });
+
   it("trims whitespace from legacy ackReaction value", () => {
     const cfg = baseCfg({
       messages: { ackReaction: "  👍  " },

--- a/extensions/whatsapp/src/doctor-contract.ts
+++ b/extensions/whatsapp/src/doctor-contract.ts
@@ -1,11 +1,49 @@
 import type { ChannelDoctorConfigMutation } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { normalizeCompatibilityConfig as normalizeCompatibilityConfigImpl } from "./doctor.js";
 
 export function normalizeCompatibilityConfig({
   cfg,
 }: {
   cfg: OpenClawConfig;
 }): ChannelDoctorConfigMutation {
-  return normalizeCompatibilityConfigImpl({ cfg });
+  const legacyAckReaction = cfg.messages?.ackReaction?.trim();
+  if (!legacyAckReaction || cfg.channels?.whatsapp === undefined) {
+    return { config: cfg, changes: [] };
+  }
+  if (cfg.channels.whatsapp?.ackReaction !== undefined) {
+    return { config: cfg, changes: [] };
+  }
+
+  const legacyScope = cfg.messages?.ackReactionScope ?? "group-mentions";
+  let direct = true;
+  let group: "always" | "mentions" | "never" = "mentions";
+  if (legacyScope === "all") {
+    direct = true;
+    group = "always";
+  } else if (legacyScope === "direct") {
+    direct = true;
+    group = "never";
+  } else if (legacyScope === "group-all") {
+    direct = false;
+    group = "always";
+  } else if (legacyScope === "group-mentions") {
+    direct = false;
+    group = "mentions";
+  }
+
+  return {
+    config: {
+      ...cfg,
+      channels: {
+        ...cfg.channels,
+        whatsapp: {
+          ...cfg.channels?.whatsapp,
+          ackReaction: { emoji: legacyAckReaction, direct, group },
+        },
+      },
+    },
+    changes: [
+      `Copied messages.ackReaction → channels.whatsapp.ackReaction (scope: ${legacyScope}).`,
+    ],
+  };
 }

--- a/extensions/whatsapp/src/doctor-contract.ts
+++ b/extensions/whatsapp/src/doctor-contract.ts
@@ -15,6 +15,10 @@ export function normalizeCompatibilityConfig({
   }
 
   const legacyScope = cfg.messages?.ackReactionScope ?? "group-mentions";
+  // "off"/"none" means the user explicitly disabled ack reactions; do not migrate.
+  if (legacyScope === "off" || legacyScope === "none") {
+    return { config: cfg, changes: [] };
+  }
   let direct = true;
   let group: "always" | "mentions" | "never" = "mentions";
   if (legacyScope === "all") {

--- a/extensions/whatsapp/src/doctor-contract.ts
+++ b/extensions/whatsapp/src/doctor-contract.ts
@@ -6,7 +6,8 @@ export function normalizeCompatibilityConfig({
 }: {
   cfg: OpenClawConfig;
 }): ChannelDoctorConfigMutation {
-  const legacyAckReaction = cfg.messages?.ackReaction?.trim();
+  const rawAckReaction = cfg.messages?.ackReaction;
+  const legacyAckReaction = typeof rawAckReaction === "string" ? rawAckReaction.trim() : undefined;
   if (!legacyAckReaction || cfg.channels?.whatsapp === undefined) {
     return { config: cfg, changes: [] };
   }

--- a/extensions/whatsapp/src/doctor.ts
+++ b/extensions/whatsapp/src/doctor.ts
@@ -1,55 +1,5 @@
-import type {
-  ChannelDoctorAdapter,
-  ChannelDoctorConfigMutation,
-} from "openclaw/plugin-sdk/channel-contract";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-
-export function normalizeCompatibilityConfig({
-  cfg,
-}: {
-  cfg: OpenClawConfig;
-}): ChannelDoctorConfigMutation {
-  const legacyAckReaction = cfg.messages?.ackReaction?.trim();
-  if (!legacyAckReaction || cfg.channels?.whatsapp === undefined) {
-    return { config: cfg, changes: [] };
-  }
-  if (cfg.channels.whatsapp?.ackReaction !== undefined) {
-    return { config: cfg, changes: [] };
-  }
-
-  const legacyScope = cfg.messages?.ackReactionScope ?? "group-mentions";
-  let direct = true;
-  let group: "always" | "mentions" | "never" = "mentions";
-  if (legacyScope === "all") {
-    direct = true;
-    group = "always";
-  } else if (legacyScope === "direct") {
-    direct = true;
-    group = "never";
-  } else if (legacyScope === "group-all") {
-    direct = false;
-    group = "always";
-  } else if (legacyScope === "group-mentions") {
-    direct = false;
-    group = "mentions";
-  }
-
-  return {
-    config: {
-      ...cfg,
-      channels: {
-        ...cfg.channels,
-        whatsapp: {
-          ...cfg.channels?.whatsapp,
-          ackReaction: { emoji: legacyAckReaction, direct, group },
-        },
-      },
-    },
-    changes: [
-      `Copied messages.ackReaction → channels.whatsapp.ackReaction (scope: ${legacyScope}).`,
-    ],
-  };
-}
+import type { ChannelDoctorAdapter } from "openclaw/plugin-sdk/channel-contract";
+import { normalizeCompatibilityConfig } from "./doctor-contract.js";
 
 export const whatsappDoctor: ChannelDoctorAdapter = {
   normalizeCompatibilityConfig,

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -245,18 +245,17 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const result = await context.cron.enqueueRun(jobId, p.mode ?? "force");
-    if (
-      result.ok &&
-      "ran" in result &&
-      !result.ran &&
-      "reason" in result &&
-      result.reason === "unsupported-spec"
-    ) {
+    let result;
+    try {
+      result = await context.cron.enqueueRun(jobId, p.mode ?? "force");
+    } catch (err) {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "invalid cron sessionTarget session id"),
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          err instanceof Error ? err.message : "invalid cron job spec",
+        ),
       );
       return;
     }


### PR DESCRIPTION
## Summary

Commit 20803dac14 added a comparison against `"unsupported-spec"` in the `cron.run` gateway handler, but `assertSupportedJobSpec` throws instead of returning a typed reason. This makes the comparison unreachable, causing a `TS2367` type error that breaks `pnpm check` on CI.

- Replace the dead-code narrowing with a `try/catch` around `enqueueRun` so the handler properly surfaces the assertion error message to the caller

## Test plan

- [x] `pnpm tsgo` — passes (previously failed with TS2367)
- [x] `pnpm check` — no warnings or errors
- [x] Pre-existing test failure in `service.store-load-invalid-main-job.test.ts` is unrelated (fails on current `origin/main` without this change)