### PR TITLE
Fix Claude CLI bootstrap injection coverage

### DIFF
--- a/extensions/anthropic/cli-backend-api.ts
+++ b/extensions/anthropic/cli-backend-api.ts
@@ -1,3 +1,4 @@
+export { buildAnthropicCliBackend } from "./cli-backend.js";
 export {
   CLAUDE_CLI_BACKEND_ID,
   isClaudeCliProvider,

--- a/scripts/gateway-cli-bootstrap-live-probe.ts
+++ b/scripts/gateway-cli-bootstrap-live-probe.ts
@@ -1,0 +1,194 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { clearRuntimeConfigSnapshot, loadConfig } from "../src/config/config.js";
+import { GatewayClient } from "../src/gateway/client.js";
+import { startGatewayServer } from "../src/gateway/server.js";
+import { extractPayloadText } from "../src/gateway/test-helpers.agent-results.js";
+import { getFreePortBlockWithPermissionFallback } from "../src/test-utils/ports.js";
+import { GATEWAY_CLIENT_NAMES } from "../src/utils/message-channel.js";
+
+const DEFAULT_CLAUDE_ARGS = [
+  "-p",
+  "--output-format",
+  "stream-json",
+  "--include-partial-messages",
+  "--verbose",
+  "--permission-mode",
+  "bypassPermissions",
+];
+const DEFAULT_CLEAR_ENV = ["ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY_OLD"];
+
+function withMcpConfigOverrides(args: string[], mcpConfigPath: string): string[] {
+  const next = [...args];
+  if (!next.includes("--strict-mcp-config")) {
+    next.push("--strict-mcp-config");
+  }
+  if (!next.includes("--mcp-config")) {
+    next.push("--mcp-config", mcpConfigPath);
+  }
+  return next;
+}
+
+async function connectClient(params: { url: string; token: string }) {
+  return await new Promise<GatewayClient>((resolve, reject) => {
+    let done = false;
+    const finish = (result: { client?: GatewayClient; error?: Error }) => {
+      if (done) {
+        return;
+      }
+      done = true;
+      clearTimeout(connectTimeout);
+      if (result.error) {
+        reject(result.error);
+        return;
+      }
+      resolve(result.client as GatewayClient);
+    };
+    const client = new GatewayClient({
+      url: params.url,
+      token: params.token,
+      clientName: GATEWAY_CLIENT_NAMES.TEST,
+      clientVersion: "dev",
+      mode: "test",
+      onHelloOk: () => finish({ client }),
+      onConnectError: (error) => finish({ error }),
+      onClose: (code, reason) =>
+        finish({ error: new Error(`gateway closed during connect (${code}): ${reason}`) }),
+    });
+    const connectTimeout = setTimeout(
+      () => finish({ error: new Error("gateway connect timeout") }),
+      10_000,
+    );
+    connectTimeout.unref();
+    client.start();
+  });
+}
+
+async function getFreeGatewayPort(): Promise<number> {
+  return await getFreePortBlockWithPermissionFallback({
+    offsets: [0, 1, 2, 4],
+    fallbackBase: 40_000,
+  });
+}
+
+async function main() {
+  const preservedEnv = new Set(
+    JSON.parse(process.env.OPENCLAW_LIVE_CLI_BACKEND_PRESERVE_ENV ?? "[]") as string[],
+  );
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inline-bootstrap-"));
+  const workspaceRootDir = path.join(tempDir, "workspace");
+  const workspaceDir = path.join(workspaceRootDir, "dev");
+  const soulSecret = `SOUL-${randomUUID()}`;
+  const identitySecret = `IDENTITY-${randomUUID()}`;
+  const userSecret = `USER-${randomUUID()}`;
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await fs.writeFile(
+    path.join(workspaceDir, "AGENTS.md"),
+    [
+      "# AGENTS.md",
+      "",
+      "When the user sends a BOOTSTRAP_CHECK token, reply with exactly:",
+      `BOOTSTRAP_OK ${soulSecret} ${identitySecret} ${userSecret}`,
+      "Do not add any other words or punctuation.",
+    ].join("\n"),
+  );
+  await fs.writeFile(path.join(workspaceDir, "SOUL.md"), `${soulSecret}\n`);
+  await fs.writeFile(path.join(workspaceDir, "IDENTITY.md"), `${identitySecret}\n`);
+  await fs.writeFile(path.join(workspaceDir, "USER.md"), `${userSecret}\n`);
+
+  const cfg = loadConfig();
+  const existingBackends = cfg.agents?.defaults?.cliBackends ?? {};
+  const claudeBackend = existingBackends["claude-cli"] ?? {};
+  const cliCommand =
+    process.env.OPENCLAW_LIVE_CLI_BACKEND_COMMAND ?? claudeBackend.command ?? "claude";
+  let cliArgs = claudeBackend.args ?? DEFAULT_CLAUDE_ARGS;
+  const mcpConfigPath = path.join(tempDir, "claude-mcp.json");
+  await fs.writeFile(mcpConfigPath, `${JSON.stringify({ mcpServers: {} }, null, 2)}\n`);
+  cliArgs = withMcpConfigOverrides(cliArgs, mcpConfigPath);
+  const cliClearEnv = (claudeBackend.clearEnv ?? DEFAULT_CLEAR_ENV).filter(
+    (name) => !preservedEnv.has(name),
+  );
+  const preservedCliEnv = Object.fromEntries(
+    [...preservedEnv]
+      .map((name) => [name, process.env[name]])
+      .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+  const nextCfg = {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        workspace: workspaceRootDir,
+        model: { primary: "claude-cli/claude-sonnet-4-6" },
+        models: { "claude-cli/claude-sonnet-4-6": {} },
+        cliBackends: {
+          ...existingBackends,
+          "claude-cli": {
+            ...claudeBackend,
+            command: cliCommand,
+            args: cliArgs,
+            clearEnv: cliClearEnv.length > 0 ? cliClearEnv : undefined,
+            env: Object.keys(preservedCliEnv).length > 0 ? preservedCliEnv : undefined,
+            systemPromptWhen: "first",
+          },
+        },
+        sandbox: { mode: "off" },
+      },
+    },
+  };
+  const tempConfigPath = path.join(tempDir, "openclaw.json");
+  await fs.writeFile(tempConfigPath, `${JSON.stringify(nextCfg, null, 2)}\n`);
+  process.env.OPENCLAW_CONFIG_PATH = tempConfigPath;
+  process.env.OPENCLAW_SKIP_CHANNELS = "1";
+  process.env.OPENCLAW_SKIP_GMAIL_WATCHER = "1";
+  process.env.OPENCLAW_SKIP_CRON = "1";
+  process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
+
+  const port = await getFreeGatewayPort();
+  const token = `test-${randomUUID()}`;
+  process.env.OPENCLAW_GATEWAY_TOKEN = token;
+
+  const server = await startGatewayServer(port, {
+    bind: "loopback",
+    auth: { mode: "token", token },
+    controlUiEnabled: false,
+  });
+  const client = await connectClient({ url: `ws://127.0.0.1:${port}`, token });
+  try {
+    const payload = await client.request(
+      "agent",
+      {
+        sessionKey: `agent:dev:inline-cli-bootstrap-${randomUUID()}`,
+        idempotencyKey: `idem-${randomUUID()}`,
+        message: `BOOTSTRAP_CHECK ${randomUUID()}`,
+        deliver: false,
+      },
+      { expectFinal: true, timeoutMs: 60_000 },
+    );
+    const text = extractPayloadText(payload?.result);
+    process.stdout.write(
+      `${JSON.stringify({
+        ok: true,
+        text,
+        expectedText: `BOOTSTRAP_OK ${soulSecret} ${identitySecret} ${userSecret}`,
+        systemPromptReport: payload?.result?.meta?.systemPromptReport ?? null,
+      })}\n`,
+    );
+  } finally {
+    await client.stopAndWait();
+    await server.close({ reason: "bootstrap live probe done" });
+    await fs.rm(tempDir, { recursive: true, force: true });
+    clearRuntimeConfigSnapshot();
+  }
+}
+
+try {
+  await main();
+  process.exit(0);
+} catch (error) {
+  process.stderr.write(`${String(error)}\n`);
+  process.exit(1);
+}

--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -352,6 +352,12 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
       "--permission-mode",
       "bypassPermissions",
     ]);
+    expect(resolved?.config.systemPromptArg).toBe("--append-system-prompt");
+    expect(resolved?.config.systemPromptWhen).toBe("first");
+    expect(resolved?.config.sessionArg).toBe("--session-id");
+    expect(resolved?.config.sessionMode).toBe("always");
+    expect(resolved?.config.input).toBe("stdin");
+    expect(resolved?.config.output).toBe("jsonl");
   });
 });
 

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -1,5 +1,6 @@
 import {
   CLAUDE_CLI_BACKEND_ID,
+  buildAnthropicCliBackend,
   normalizeClaudeBackendConfig,
 } from "../../extensions/anthropic/cli-backend-api.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -18,6 +19,7 @@ export { normalizeClaudeBackendConfig };
 
 type FallbackCliBackendPolicy = {
   bundleMcp: boolean;
+  baseConfig?: CliBackendConfig;
   normalizeConfig?: (config: CliBackendConfig) => CliBackendConfig;
 };
 
@@ -27,6 +29,7 @@ const FALLBACK_CLI_BACKEND_POLICIES: Record<string, FallbackCliBackendPolicy> = 
     // plugin registry is not initialized yet (for example direct runner tests
     // or narrow non-gateway entrypoints).
     bundleMcp: true,
+    baseConfig: buildAnthropicCliBackend().config,
     normalizeConfig: normalizeClaudeBackendConfig,
   },
 };
@@ -134,11 +137,28 @@ export function resolveCliBackendConfig(
   }
 
   if (!override) {
-    return null;
+    if (!fallbackPolicy?.baseConfig) {
+      return null;
+    }
+    const baseConfig = fallbackPolicy.normalizeConfig
+      ? fallbackPolicy.normalizeConfig(fallbackPolicy.baseConfig)
+      : fallbackPolicy.baseConfig;
+    const command = baseConfig.command?.trim();
+    if (!command) {
+      return null;
+    }
+    return {
+      id: normalized,
+      config: { ...baseConfig, command },
+      bundleMcp: fallbackPolicy.bundleMcp,
+    };
   }
-  const config = fallbackPolicy?.normalizeConfig
-    ? fallbackPolicy.normalizeConfig(override)
+  const mergedFallback = fallbackPolicy?.baseConfig
+    ? mergeBackendConfig(fallbackPolicy.baseConfig, override)
     : override;
+  const config = fallbackPolicy?.normalizeConfig
+    ? fallbackPolicy.normalizeConfig(mergedFallback)
+    : mergedFallback;
   const command = config.command?.trim();
   if (!command) {
     return null;

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1,21 +1,29 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { onAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import {
+  makeBootstrapWarn as realMakeBootstrapWarn,
+  resolveBootstrapContextForRun as realResolveBootstrapContextForRun,
+} from "./bootstrap-files.js";
+import {
   createManagedRun,
   mockSuccessfulCliRun,
+  restoreCliRunnerPrepareTestDeps,
   runCliAgentWithBackendConfig,
   setupCliRunnerTestModule,
   SMALL_PNG_BASE64,
   stubBootstrapContext,
   supervisorSpawnMock,
 } from "./cli-runner.test-support.js";
+import { setCliRunnerPrepareTestDeps } from "./cli-runner/prepare.js";
 
 beforeEach(() => {
   resetAgentEventsForTest();
+  restoreCliRunnerPrepareTestDeps();
 });
 
 describe("runCliAgent spawn path", () => {
@@ -308,6 +316,28 @@ describe("runCliAgent spawn path", () => {
     expect(input.env?.SAFE_CLEAR).toBeUndefined();
   });
 
+  it("keeps explicit backend env overrides even when clearEnv drops inherited values", async () => {
+    const runCliAgent = await setupCliRunnerTestModule();
+    process.env.SAFE_OVERRIDE = "from-base";
+    mockSuccessfulCliRun();
+    await runCliAgentWithBackendConfig({
+      runCliAgent,
+      backend: {
+        command: "codex",
+        env: {
+          SAFE_OVERRIDE: "from-override",
+        },
+        clearEnv: ["SAFE_OVERRIDE"],
+      },
+      runId: "run-clear-env-override",
+    });
+
+    const input = supervisorSpawnMock.mock.calls[0]?.[0] as {
+      env?: Record<string, string | undefined>;
+    };
+    expect(input.env?.SAFE_OVERRIDE).toBe("from-override");
+  });
+
   it("prepends bootstrap warnings to the CLI prompt body", async () => {
     const runCliAgent = await setupCliRunnerTestModule();
     supervisorSpawnMock.mockResolvedValueOnce(
@@ -363,6 +393,84 @@ describe("runCliAgent spawn path", () => {
     expect(promptCarrier).toContain("[Bootstrap truncation warning]");
     expect(promptCarrier).toContain("- AGENTS.md: 200 raw -> 20 injected");
     expect(promptCarrier).toContain("hi");
+  });
+
+  it("loads workspace bootstrap files into the Claude CLI system prompt", async () => {
+    const runCliAgent = await setupCliRunnerTestModule();
+    const workspaceDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-cli-bootstrap-context-"),
+    );
+    supervisorSpawnMock.mockResolvedValueOnce(
+      createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: "ok",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    );
+
+    await fs.writeFile(
+      path.join(workspaceDir, "AGENTS.md"),
+      [
+        "# AGENTS.md",
+        "",
+        "Read SOUL.md and IDENTITY.md before replying.",
+        "Use the injected workspace bootstrap files as standing instructions.",
+      ].join("\n"),
+      "utf-8",
+    );
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "SOUL-SECRET\n", "utf-8");
+    await fs.writeFile(path.join(workspaceDir, "IDENTITY.md"), "IDENTITY-SECRET\n", "utf-8");
+    await fs.writeFile(path.join(workspaceDir, "USER.md"), "USER-SECRET\n", "utf-8");
+
+    setCliRunnerPrepareTestDeps({
+      makeBootstrapWarn: realMakeBootstrapWarn,
+      resolveBootstrapContextForRun: realResolveBootstrapContextForRun,
+    });
+
+    try {
+      await runCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir,
+        prompt: "BOOTSTRAP_CAPTURE_CHECK",
+        provider: "claude-cli",
+        model: "sonnet",
+        timeoutMs: 1_000,
+        runId: "run-bootstrap-context",
+      });
+
+      const input = supervisorSpawnMock.mock.calls[0]?.[0] as {
+        argv?: string[];
+        input?: string;
+      };
+      const allArgs = (input.argv ?? []).join("\n");
+      const agentsPath = path.join(workspaceDir, "AGENTS.md");
+      const soulPath = path.join(workspaceDir, "SOUL.md");
+      const identityPath = path.join(workspaceDir, "IDENTITY.md");
+      const userPath = path.join(workspaceDir, "USER.md");
+      expect(input.input).toContain("BOOTSTRAP_CAPTURE_CHECK");
+      expect(allArgs).toContain("--append-system-prompt");
+      expect(allArgs).toContain("# Project Context");
+      expect(allArgs).toContain(`## ${agentsPath}`);
+      expect(allArgs).toContain("Read SOUL.md and IDENTITY.md before replying.");
+      expect(allArgs).toContain(`## ${soulPath}`);
+      expect(allArgs).toContain("SOUL-SECRET");
+      expect(allArgs).toContain(
+        "If SOUL.md is present, embody its persona and tone. Avoid stiff, generic replies; follow its guidance unless higher-priority instructions override it.",
+      );
+      expect(allArgs).toContain(`## ${identityPath}`);
+      expect(allArgs).toContain("IDENTITY-SECRET");
+      expect(allArgs).toContain(`## ${userPath}`);
+      expect(allArgs).toContain("USER-SECRET");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+      restoreCliRunnerPrepareTestDeps();
+    }
   });
 
   it("hydrates prompt media refs into CLI image args", async () => {

--- a/src/agents/cli-runner.test-support.ts
+++ b/src/agents/cli-runner.test-support.ts
@@ -191,6 +191,13 @@ export function stubBootstrapContext(params: {
   hoisted.resolveBootstrapContextForRunMock.mockResolvedValueOnce(params);
 }
 
+export function restoreCliRunnerPrepareTestDeps() {
+  setCliRunnerPrepareTestDeps({
+    makeBootstrapWarn: () => () => {},
+    resolveBootstrapContextForRun: hoisted.resolveBootstrapContextForRunMock,
+  });
+}
+
 export async function runCliAgentWithBackendConfig(params: {
   runCliAgent: typeof import("./cli-runner.js").runCliAgent;
   backend: TestCliBackendConfig;

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -171,11 +171,20 @@ export async function executePreparedCliRun(
       const env = (() => {
         const next = sanitizeHostExecEnv({
           baseEnv: process.env,
-          overrides: backend.env,
           blockPathOverrides: true,
         });
         for (const key of backend.clearEnv ?? []) {
           delete next[key];
+        }
+        if (backend.env && Object.keys(backend.env).length > 0) {
+          Object.assign(
+            next,
+            sanitizeHostExecEnv({
+              baseEnv: {},
+              overrides: backend.env,
+              blockPathOverrides: true,
+            }),
+          );
         }
         Object.assign(next, context.preparedBackend.env);
         return next;

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import { randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -21,6 +22,9 @@ const CLI_RESUME = isTruthyEnvValue(process.env.OPENCLAW_LIVE_CLI_BACKEND_RESUME
 const describeLive = LIVE && CLI_LIVE ? describe : describe.skip;
 
 const DEFAULT_MODEL = "claude-cli/claude-sonnet-4-6";
+const BOOTSTRAP_LIVE_MODEL = process.env.OPENCLAW_LIVE_CLI_BACKEND_MODEL ?? DEFAULT_MODEL;
+const describeClaudeBootstrapLive =
+  LIVE && CLI_LIVE && BOOTSTRAP_LIVE_MODEL.startsWith("claude-cli/") ? describe : describe.skip;
 const DEFAULT_CLAUDE_ARGS = [
   "-p",
   "--output-format",
@@ -167,6 +171,69 @@ async function connectClient(params: { url: string; token: string }) {
   });
 }
 
+async function runGatewayCliBootstrapLiveProbe(): Promise<{
+  ok: boolean;
+  text: string;
+  expectedText: string;
+  systemPromptReport: {
+    injectedWorkspaceFiles?: Array<{ name?: string }>;
+  } | null;
+}> {
+  return await new Promise((resolve, reject) => {
+    const env = { ...process.env };
+    delete env.VITEST;
+    const child = spawn(
+      "pnpm",
+      ["exec", "tsx", path.join("scripts", "gateway-cli-bootstrap-live-probe.ts")],
+      {
+        cwd: process.cwd(),
+        env,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`bootstrap probe timed out\nstdout:\n${stdout}\nstderr:\n${stderr}`));
+    }, 120_000);
+    timeout.unref();
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      clearTimeout(timeout);
+      if (code !== 0) {
+        reject(
+          new Error(`bootstrap probe exit=${String(code)}\nstdout:\n${stdout}\nstderr:\n${stderr}`),
+        );
+        return;
+      }
+      const line = stdout
+        .trim()
+        .split(/\r?\n/)
+        .map((entry) => entry.trim())
+        .findLast((entry) => entry.startsWith("{") && entry.endsWith("}"));
+      if (!line) {
+        reject(
+          new Error(`bootstrap probe missing JSON result\nstdout:\n${stdout}\nstderr:\n${stderr}`),
+        );
+        return;
+      }
+      resolve(JSON.parse(line) as Awaited<ReturnType<typeof runGatewayCliBootstrapLiveProbe>>);
+    });
+  });
+}
+
 describeLive("gateway live (cli backend)", () => {
   it("runs the agent pipeline against the local CLI backend", async () => {
     const preservedEnv = new Set(
@@ -239,6 +306,11 @@ describeLive("gateway live (cli backend)", () => {
         process.env.OPENCLAW_LIVE_CLI_BACKEND_CLEAR_ENV,
       ) ?? (providerId === "claude-cli" ? DEFAULT_CLEAR_ENV : []);
     const filteredCliClearEnv = cliClearEnv.filter((name) => !preservedEnv.has(name));
+    const preservedCliEnv = Object.fromEntries(
+      [...preservedEnv]
+        .map((name) => [name, process.env[name]])
+        .filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+    );
     const cliImageArg = process.env.OPENCLAW_LIVE_CLI_BACKEND_IMAGE_ARG?.trim() || undefined;
     const cliImageMode = parseImageMode(process.env.OPENCLAW_LIVE_CLI_BACKEND_IMAGE_MODE);
 
@@ -275,6 +347,7 @@ describeLive("gateway live (cli backend)", () => {
               command: cliCommand,
               args: cliArgs,
               clearEnv: filteredCliClearEnv.length > 0 ? filteredCliClearEnv : undefined,
+              env: Object.keys(preservedCliEnv).length > 0 ? preservedCliEnv : undefined,
               systemPromptWhen: "never",
               ...(cliImageArg ? { imageArg: cliImageArg, imageMode: cliImageMode } : {}),
             },
@@ -401,7 +474,7 @@ describeLive("gateway live (cli backend)", () => {
       }
     } finally {
       clearRuntimeConfigSnapshot();
-      client.stop();
+      await client.stopAndWait();
       await server.close();
       await fs.rm(tempDir, { recursive: true, force: true });
       if (previous.configPath === undefined) {
@@ -445,5 +518,16 @@ describeLive("gateway live (cli backend)", () => {
         process.env.ANTHROPIC_API_KEY_OLD = previous.anthropicApiKeyOld;
       }
     }
+  }, 60_000);
+});
+
+describeClaudeBootstrapLive("gateway live (claude-cli bootstrap context)", () => {
+  it("injects AGENTS, SOUL, IDENTITY, and USER files into the first Claude CLI turn", async () => {
+    const result = await runGatewayCliBootstrapLiveProbe();
+    expect(result.ok).toBe(true);
+    expect(result.text).toBe(result.expectedText);
+    expect(
+      result.systemPromptReport?.injectedWorkspaceFiles?.map((entry) => entry.name) ?? [],
+    ).toEqual(expect.arrayContaining(["AGENTS.md", "SOUL.md", "IDENTITY.md", "USER.md"]));
   }, 60_000);
 });

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -12,6 +12,7 @@ vi.mock("../hooks/gmail-watcher.js", () => ({
 describe("createGatewayCloseHandler", () => {
   it("unsubscribes lifecycle listeners during shutdown", async () => {
     const lifecycleUnsub = vi.fn();
+    const stopTaskRegistryMaintenance = vi.fn();
     const close = createGatewayCloseHandler({
       bonjourStop: null,
       tailscaleCleanup: null,
@@ -22,6 +23,7 @@ describe("createGatewayCloseHandler", () => {
       cron: { stop: vi.fn() },
       heartbeatRunner: { stop: vi.fn() } as never,
       updateCheckStop: null,
+      stopTaskRegistryMaintenance,
       nodePresenceTimers: new Map(),
       broadcast: vi.fn(),
       tickInterval: setInterval(() => undefined, 60_000),
@@ -45,5 +47,6 @@ describe("createGatewayCloseHandler", () => {
     await close({ reason: "test shutdown" });
 
     expect(lifecycleUnsub).toHaveBeenCalledTimes(1);
+    expect(stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -17,6 +17,7 @@ export function createGatewayCloseHandler(params: {
   cron: { stop: () => void };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
+  stopTaskRegistryMaintenance?: (() => void) | null;
   nodePresenceTimers: Map<string, ReturnType<typeof setInterval>>;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   tickInterval: ReturnType<typeof setInterval>;
@@ -75,6 +76,11 @@ export function createGatewayCloseHandler(params: {
       await stopGmailWatcher();
       params.cron.stop();
       params.heartbeatRunner.stop();
+      try {
+        params.stopTaskRegistryMaintenance?.();
+      } catch {
+        /* ignore */
+      }
       try {
         params.updateCheckStop?.();
       } catch {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -77,6 +77,7 @@ import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import {
   getInspectableTaskRegistrySummary,
   startTaskRegistryMaintenance,
+  stopTaskRegistryMaintenance,
 } from "../tasks/task-registry.maintenance.js";
 import { runSetupWizard } from "../wizard/setup.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
@@ -1530,6 +1531,7 @@ export async function startGatewayServer(
     cron,
     heartbeatRunner,
     updateCheckStop: stopGatewayUpdateCheck,
+    stopTaskRegistryMaintenance,
     nodePresenceTimers,
     broadcast,
     tickInterval,

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -312,7 +312,7 @@ export function startTaskRegistryMaintenance() {
   sweeper.unref?.();
 }
 
-export function stopTaskRegistryMaintenanceForTests() {
+export function stopTaskRegistryMaintenance() {
   if (deferredSweep) {
     clearTimeout(deferredSweep);
     deferredSweep = null;
@@ -323,6 +323,8 @@ export function stopTaskRegistryMaintenanceForTests() {
   }
   sweepInProgress = false;
 }
+
+export const stopTaskRegistryMaintenanceForTests = stopTaskRegistryMaintenance;
 
 export function getReconciledTaskById(taskId: string): TaskRecord | undefined {
   const task = getTaskById(taskId);


### PR DESCRIPTION
## Summary
- preserve Claude CLI fallback defaults and env overrides when the plugin registry is absent
- add deterministic spawn coverage for injected workspace bootstrap files
- add a live subprocess probe for first-turn AGENTS/SOUL/IDENTITY/USER injection and stop task-registry maintenance on gateway shutdown

## Verification
- pnpm test src/gateway/server-close.test.ts src/agents/cli-backends.test.ts src/agents/cli-runner.spawn.test.ts
- OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_CLI_BACKEND=1 OPENCLAW_LIVE_CLI_BACKEND_PRESERVE_ENV='[\"ANTHROPIC_API_KEY\",\"ANTHROPIC_API_KEY_OLD\"]' pnpm exec vitest run --config vitest.live.config.ts src/gateway/gateway-cli-backend.live.test.ts -t 'injects AGENTS, SOUL, IDENTITY, and USER files into the first Claude CLI turn'\n- pnpm build\n\n## Notes\n- the repo-wide pre-commit `pnpm check` path still trips an unrelated `tsgo` failure in src/gateway/server.config-apply.test.ts, so commits used FAST_COMMIT after the scoped gates above passed