### PR TITLE
fix(google): support gemini cli personal oauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,7 +137,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat: skip wake delivery when the target session lane is already busy so the pending event is retried instead of getting drained too early. (#40526) Thanks @lucky7323.
 - Plugin SDK/context engines: export the missing context-engine result and subagent lifecycle types from `openclaw/plugin-sdk` so context engine plugins can type `ContextEngine` implementations without local workarounds. (#61251) Thanks @DaevMithran.
 - Agents/errors: surface an explicit disk-full message when local session or transcript writes fail with `ENOSPC`/`disk full`, so those runs stop degrading into opaque `NO_REPLY`-style failures. Thanks @vincentkoc.
-<<<<<<< HEAD
+  <<<<<<< HEAD
 - Google Gemini CLI models: add forward-compat support for stable `gemini-2.5-*` model ids by letting the bundled CLI provider clone them from Google templates, so `gemini-2.5-flash-lite` and related configured models stop showing up as missing. (#35274) Thanks @mySebbe.
 - Telegram/reasoning: only create a Telegram reasoning preview lane when the session is explicitly `reasoning:stream`, so hidden `<think>` traces from streamed replies stop surfacing as chat previews on normal sessions. Thanks @vincentkoc.
 - Feishu/reasoning: only expose streamed reasoning previews when the session is explicitly `reasoning:stream`, so hidden reasoning traces do not surface on normal streaming sessions. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Docs: https://docs.openclaw.ai
 - Heartbeat: skip wake delivery when the target session lane is already busy so the pending event is retried instead of getting drained too early. (#40526) Thanks @lucky7323.
 - Plugin SDK/context engines: export the missing context-engine result and subagent lifecycle types from `openclaw/plugin-sdk` so context engine plugins can type `ContextEngine` implementations without local workarounds. (#61251) Thanks @DaevMithran.
 - Agents/errors: surface an explicit disk-full message when local session or transcript writes fail with `ENOSPC`/`disk full`, so those runs stop degrading into opaque `NO_REPLY`-style failures. Thanks @vincentkoc.
+<<<<<<< HEAD
 - Google Gemini CLI models: add forward-compat support for stable `gemini-2.5-*` model ids by letting the bundled CLI provider clone them from Google templates, so `gemini-2.5-flash-lite` and related configured models stop showing up as missing. (#35274) Thanks @mySebbe.
 - Telegram/reasoning: only create a Telegram reasoning preview lane when the session is explicitly `reasoning:stream`, so hidden `<think>` traces from streamed replies stop surfacing as chat previews on normal sessions. Thanks @vincentkoc.
 - Feishu/reasoning: only expose streamed reasoning previews when the session is explicitly `reasoning:stream`, so hidden reasoning traces do not surface on normal streaming sessions. Thanks @vincentkoc.
@@ -149,6 +150,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Claude CLI/security: clear inherited Claude Code config-root and plugin-root env overrides like `CLAUDE_CONFIG_DIR` and `CLAUDE_CODE_PLUGIN_*`, so OpenClaw-launched Claude CLI runs cannot be silently pointed at an alternate Claude config/plugin tree with different hooks, plugins, or auth context. Thanks @vincentkoc.
 - Agents/Claude CLI/security: force host-managed Claude CLI backdoor runs to `--setting-sources user`, even under custom backend arg overrides, so repo-local `.claude` project/local settings, hooks, and plugin discovery do not silently execute inside non-interactive OpenClaw sessions. Thanks @vincentkoc.
 - Agents/Claude CLI/images: reuse stable hydrated image file paths and preserve shared media extensions like HEIC when passing image refs to local CLI runs, so Claude CLI image prompts stop thrashing KV cache prefixes and oddball image formats do not fall back to `.bin`. Thanks @vincentkoc.
+- Google Gemini CLI auth: detect personal OAuth mode from local Gemini settings and skip Code Assist project discovery for those logins, so personal Google accounts stop failing with `loadCodeAssist 400 Bad Request`. (#49226) Thanks @bobworrall.
 
 ## 2026.4.2
 

--- a/extensions/google/gemini-cli-provider.ts
+++ b/extensions/google/gemini-cli-provider.ts
@@ -83,8 +83,14 @@ export function registerGoogleGeminiCliProvider(api: OpenClawPluginApi) {
               refresh: result.refresh,
               expires: result.expires,
               email: result.email,
-              credentialExtra: { projectId: result.projectId },
-              notes: ["If requests fail, set GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID."],
+              ...(result.projectId ? { credentialExtra: { projectId: result.projectId } } : {}),
+              ...(result.projectId
+                ? {
+                    notes: [
+                      "If requests fail, set GOOGLE_CLOUD_PROJECT or GOOGLE_CLOUD_PROJECT_ID.",
+                    ],
+                  }
+                : {}),
             });
           } catch (err) {
             spin.stop("Gemini CLI OAuth failed");

--- a/extensions/google/oauth.project.ts
+++ b/extensions/google/oauth.project.ts
@@ -84,11 +84,18 @@ async function pollOperation(
 
 export async function resolveGoogleOAuthIdentity(accessToken: string): Promise<{
   email?: string;
-  projectId: string;
+  projectId?: string;
 }> {
   const email = await getUserEmail(accessToken);
   const projectId = await discoverProject(accessToken);
   return { email, projectId };
+}
+
+export async function resolveGooglePersonalOAuthIdentity(accessToken: string): Promise<{
+  email?: string;
+  projectId?: string;
+}> {
+  return { email: await getUserEmail(accessToken) };
 }
 
 async function discoverProject(accessToken: string): Promise<string> {

--- a/extensions/google/oauth.settings.ts
+++ b/extensions/google/oauth.settings.ts
@@ -1,0 +1,77 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+type OAuthSettingsFs = {
+  existsSync: (path: Parameters<typeof existsSync>[0]) => ReturnType<typeof existsSync>;
+  readFileSync: (path: Parameters<typeof readFileSync>[0], encoding: "utf8") => string;
+  homedir: typeof homedir;
+};
+
+const defaultFs: OAuthSettingsFs = {
+  existsSync,
+  readFileSync,
+  homedir,
+};
+
+let oauthSettingsFs: OAuthSettingsFs = defaultFs;
+
+type GeminiCliAuthSettings = {
+  security?: {
+    auth?: {
+      selectedType?: unknown;
+      enforcedType?: unknown;
+    };
+  };
+  selectedAuthType?: unknown;
+  enforcedAuthType?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function readSettingsFile(): GeminiCliAuthSettings | null {
+  const settingsPath = join(oauthSettingsFs.homedir(), ".gemini", "settings.json");
+  if (!oauthSettingsFs.existsSync(settingsPath)) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(oauthSettingsFs.readFileSync(settingsPath, "utf8")) as unknown;
+    return isRecord(parsed) ? (parsed as GeminiCliAuthSettings) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setOAuthSettingsFsForTest(overrides?: Partial<OAuthSettingsFs>): void {
+  oauthSettingsFs = overrides ? { ...defaultFs, ...overrides } : defaultFs;
+}
+
+export function resolveGeminiCliSelectedAuthType(): string | undefined {
+  if (process.env.GOOGLE_GENAI_USE_GCA === "true") {
+    return "oauth-personal";
+  }
+
+  const settings = readSettingsFile();
+  if (!settings) {
+    return undefined;
+  }
+
+  const security = isRecord(settings.security) ? settings.security : undefined;
+  const auth = isRecord(security?.auth) ? security.auth : undefined;
+  return (
+    readString(auth?.selectedType) ??
+    readString(auth?.enforcedType) ??
+    readString(settings.selectedAuthType) ??
+    readString(settings.enforcedAuthType)
+  );
+}
+
+export function isGeminiCliPersonalOAuth(): boolean {
+  return resolveGeminiCliSelectedAuthType() === "oauth-personal";
+}

--- a/extensions/google/oauth.settings.ts
+++ b/extensions/google/oauth.settings.ts
@@ -53,23 +53,25 @@ export function setOAuthSettingsFsForTest(overrides?: Partial<OAuthSettingsFs>):
 }
 
 export function resolveGeminiCliSelectedAuthType(): string | undefined {
+  const settings = readSettingsFile();
+  if (settings) {
+    const security = isRecord(settings.security) ? settings.security : undefined;
+    const auth = isRecord(security?.auth) ? security.auth : undefined;
+    const selectedAuthType =
+      readString(auth?.selectedType) ??
+      readString(auth?.enforcedType) ??
+      readString(settings.selectedAuthType) ??
+      readString(settings.enforcedAuthType);
+    if (selectedAuthType) {
+      return selectedAuthType;
+    }
+  }
+
   if (process.env.GOOGLE_GENAI_USE_GCA === "true") {
     return "oauth-personal";
   }
 
-  const settings = readSettingsFile();
-  if (!settings) {
-    return undefined;
-  }
-
-  const security = isRecord(settings.security) ? settings.security : undefined;
-  const auth = isRecord(security?.auth) ? security.auth : undefined;
-  return (
-    readString(auth?.selectedType) ??
-    readString(auth?.enforcedType) ??
-    readString(settings.selectedAuthType) ??
-    readString(settings.enforcedAuthType)
-  );
+  return undefined;
 }
 
 export function isGeminiCliPersonalOAuth(): boolean {

--- a/extensions/google/oauth.settings.ts
+++ b/extensions/google/oauth.settings.ts
@@ -32,7 +32,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function readString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined;
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function readSettingsFile(): GeminiCliAuthSettings | null {

--- a/extensions/google/oauth.shared.ts
+++ b/extensions/google/oauth.shared.ts
@@ -31,7 +31,7 @@ export type GeminiCliOAuthCredentials = {
   refresh: string;
   expires: number;
   email?: string;
-  projectId: string;
+  projectId?: string;
 };
 
 export type GeminiCliOAuthContext = {

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -64,11 +64,27 @@ describe("resolveGeminiCliSelectedAuthType", () => {
     setOAuthSettingsFsForTest();
   });
 
-  it("prefers GOOGLE_GENAI_USE_GCA personal auth mode over settings detection", () => {
+  it("uses GOOGLE_GENAI_USE_GCA as an oauth-personal fallback when settings are absent", () => {
     process.env.GOOGLE_GENAI_USE_GCA = "true";
     mockSettingsExistsSync.mockReturnValue(false);
 
     expect(resolveGeminiCliSelectedAuthType()).toBe("oauth-personal");
+  });
+
+  it("prefers settings auth selection over the GOOGLE_GENAI_USE_GCA fallback", () => {
+    process.env.GOOGLE_GENAI_USE_GCA = "true";
+    mockSettingsExistsSync.mockReturnValue(true);
+    mockSettingsReadFileSync.mockReturnValue(
+      JSON.stringify({
+        security: {
+          auth: {
+            selectedType: "oauth-code-assist",
+          },
+        },
+      }),
+    );
+
+    expect(resolveGeminiCliSelectedAuthType()).toBe("oauth-code-assist");
   });
 
   it("reads the nested security auth selection from ~/.gemini/settings.json", () => {

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -25,6 +25,76 @@ const mockExistsSync = vi.fn();
 const mockReadFileSync = vi.fn();
 const mockRealpathSync = vi.fn();
 const mockReaddirSync = vi.fn();
+const mockSettingsExistsSync = vi.fn();
+const mockSettingsReadFileSync = vi.fn();
+
+describe("resolveGeminiCliSelectedAuthType", () => {
+  const ENV_KEYS = ["GOOGLE_GENAI_USE_GCA"] as const;
+
+  let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>>;
+  let resolveGeminiCliSelectedAuthType: typeof import("./oauth.settings.js").resolveGeminiCliSelectedAuthType;
+  let setOAuthSettingsFsForTest: typeof import("./oauth.settings.js").setOAuthSettingsFsForTest;
+
+  beforeAll(async () => {
+    ({ resolveGeminiCliSelectedAuthType, setOAuthSettingsFsForTest } =
+      await import("./oauth.settings.js"));
+  });
+
+  beforeEach(() => {
+    envSnapshot = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+    delete process.env.GOOGLE_GENAI_USE_GCA;
+    mockSettingsExistsSync.mockReset();
+    mockSettingsReadFileSync.mockReset();
+    setOAuthSettingsFsForTest({
+      existsSync: (...args) => mockSettingsExistsSync(...args),
+      readFileSync: (...args) => mockSettingsReadFileSync(...args),
+      homedir: () => "/mock/home",
+    });
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = envSnapshot[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    setOAuthSettingsFsForTest();
+  });
+
+  it("prefers GOOGLE_GENAI_USE_GCA personal auth mode over settings detection", () => {
+    process.env.GOOGLE_GENAI_USE_GCA = "true";
+    mockSettingsExistsSync.mockReturnValue(false);
+
+    expect(resolveGeminiCliSelectedAuthType()).toBe("oauth-personal");
+  });
+
+  it("reads the nested security auth selection from ~/.gemini/settings.json", () => {
+    mockSettingsExistsSync.mockReturnValue(true);
+    mockSettingsReadFileSync.mockReturnValue(
+      JSON.stringify({
+        security: {
+          auth: {
+            selectedType: "oauth-personal",
+          },
+        },
+      }),
+    );
+
+    expect(resolveGeminiCliSelectedAuthType()).toBe("oauth-personal");
+  });
+
+  it("falls back to legacy top-level selectedAuthType keys", () => {
+    mockSettingsExistsSync.mockReturnValue(true);
+    mockSettingsReadFileSync.mockReturnValue(
+      JSON.stringify({ selectedAuthType: "oauth-personal" }),
+    );
+
+    expect(resolveGeminiCliSelectedAuthType()).toBe("oauth-personal");
+  });
+});
 
 describe("extractGeminiCliCredentials", () => {
   const normalizePath = (value: string) =>
@@ -458,6 +528,7 @@ describe("loginGeminiCliOAuth", () => {
     "GEMINI_CLI_OAUTH_CLIENT_SECRET",
     "GOOGLE_CLOUD_PROJECT",
     "GOOGLE_CLOUD_PROJECT_ID",
+    "GOOGLE_GENAI_USE_GCA",
   ] as const;
 
   const EXPECTED_LOAD_CODE_ASSIST_METADATA = {
@@ -504,7 +575,7 @@ describe("loginGeminiCliOAuth", () => {
     note: () => Promise<void>;
     prompt: () => Promise<string>;
     progress: { update: () => void; stop: () => void };
-  }) => Promise<{ projectId: string }>;
+  }) => Promise<{ projectId?: string }>;
 
   async function runRemoteLoginWithCapturedAuthUrl(loginGeminiCliOAuth: LoginGeminiCliOAuthFn) {
     let authUrl = "";
@@ -536,6 +607,12 @@ describe("loginGeminiCliOAuth", () => {
   }
 
   let envSnapshot: Partial<Record<(typeof ENV_KEYS)[number], string>>;
+  let setOAuthSettingsFsForTest: typeof import("./oauth.settings.js").setOAuthSettingsFsForTest;
+
+  beforeAll(async () => {
+    ({ setOAuthSettingsFsForTest } = await import("./oauth.settings.js"));
+  });
+
   beforeEach(() => {
     envSnapshot = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
     process.env.OPENCLAW_GEMINI_OAUTH_CLIENT_ID = "test-client-id.apps.googleusercontent.com";
@@ -544,6 +621,15 @@ describe("loginGeminiCliOAuth", () => {
     delete process.env.GEMINI_CLI_OAUTH_CLIENT_SECRET;
     delete process.env.GOOGLE_CLOUD_PROJECT;
     delete process.env.GOOGLE_CLOUD_PROJECT_ID;
+    delete process.env.GOOGLE_GENAI_USE_GCA;
+    mockSettingsExistsSync.mockReset();
+    mockSettingsReadFileSync.mockReset();
+    setOAuthSettingsFsForTest({
+      existsSync: (...args) => mockSettingsExistsSync(...args),
+      readFileSync: (...args) => mockSettingsReadFileSync(...args),
+      homedir: () => "/mock/home",
+    });
+    mockSettingsExistsSync.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -555,6 +641,7 @@ describe("loginGeminiCliOAuth", () => {
         process.env[key] = value;
       }
     }
+    setOAuthSettingsFsForTest();
     vi.unstubAllGlobals();
   });
 
@@ -693,5 +780,43 @@ describe("loginGeminiCliOAuth", () => {
     await runRemoteLoginExpectingProjectId(loginGeminiCliOAuth, "env-project");
     expect(requests.filter((url) => url.includes("v1internal:loadCodeAssist"))).toHaveLength(3);
     expect(requests.some((url) => url.includes("v1internal:onboardUser"))).toBe(false);
+  });
+
+  it("skips loadCodeAssist entirely when Gemini CLI is configured for personal OAuth", async () => {
+    mockSettingsExistsSync.mockReturnValue(true);
+    mockSettingsReadFileSync.mockReturnValue(
+      JSON.stringify({
+        security: {
+          auth: {
+            selectedType: "oauth-personal",
+          },
+        },
+      }),
+    );
+
+    const requests: string[] = [];
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = getRequestUrl(input);
+      requests.push(url);
+
+      if (url === TOKEN_URL) {
+        return responseJson({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+        });
+      }
+      if (url === USERINFO_URL) {
+        return responseJson({ email: "lobster@openclaw.ai" });
+      }
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { loginGeminiCliOAuth } = await import("./oauth.js");
+    const { result } = await runRemoteLoginWithCapturedAuthUrl(loginGeminiCliOAuth);
+
+    expect(result.projectId).toBeUndefined();
+    expect(requests).toEqual([TOKEN_URL, USERINFO_URL]);
   });
 });

--- a/extensions/google/oauth.token.ts
+++ b/extensions/google/oauth.token.ts
@@ -1,6 +1,7 @@
 import { resolveOAuthClientConfig } from "./oauth.credentials.js";
 import { fetchWithTimeout } from "./oauth.http.js";
-import { resolveGoogleOAuthIdentity } from "./oauth.project.js";
+import { resolveGoogleOAuthIdentity, resolveGooglePersonalOAuthIdentity } from "./oauth.project.js";
+import { isGeminiCliPersonalOAuth } from "./oauth.settings.js";
 import { REDIRECT_URI, TOKEN_URL, type GeminiCliOAuthCredentials } from "./oauth.shared.js";
 
 export async function exchangeCodeForTokens(
@@ -44,7 +45,9 @@ export async function exchangeCodeForTokens(
     throw new Error("No refresh token received. Please try again.");
   }
 
-  const identity = await resolveGoogleOAuthIdentity(data.access_token);
+  const identity = isGeminiCliPersonalOAuth()
+    ? await resolveGooglePersonalOAuthIdentity(data.access_token)
+    : await resolveGoogleOAuthIdentity(data.access_token);
   const expiresAt = Date.now() + data.expires_in * 1000 - 5 * 60 * 1000;
 
   return {


### PR DESCRIPTION
## Summary

- Problem: OpenClaw always routes Gemini CLI OAuth logins through Code Assist project discovery, even when the local Gemini CLI is configured for personal OAuth.
- Why it matters: personal Google accounts fail login with `loadCodeAssist 400 Bad Request`, so the bundled Gemini CLI provider is unusable for that auth mode.
- What changed: detect personal OAuth mode from local Gemini settings or `GOOGLE_GENAI_USE_GCA`, skip Code Assist project discovery for that path, and only persist `projectId` metadata when a workspace/project-backed login actually returned one.
- What did NOT change (scope boundary): the existing workspace / Code Assist onboarding path, token exchange flow, and Gemini CLI credential discovery remain intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #49226
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Gemini CLI plugin assumed every OAuth login was a Code Assist / project-backed login and unconditionally called `loadCodeAssist` after token exchange.
- Missing detection / guardrail: we were not reading the local Gemini CLI auth mode, so personal OAuth users were forced down the wrong post-login identity path.
- Contributing context (if known): Gemini CLI itself has a real `oauth-personal` mode and uses settings/env to decide it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/google/oauth.test.ts`
- Scenario the test should lock in: personal OAuth logins never call `loadCodeAssist`, while workspace OAuth still does.
- Why this is the smallest reliable guardrail: the bug lives in the post-token routing branch, so the OAuth seam test is enough to prove the mode split without needing real Google auth.
- Existing test that already covers this (if any): existing workspace OAuth tests in `extensions/google/oauth.test.ts`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Google Gemini CLI OAuth now works when the local Gemini CLI is configured for personal Google login.
- Workspace / project-backed Gemini CLI OAuth behavior is unchanged.

## Diagram (if applicable)

```text
Before:
[Gemini CLI personal OAuth token] -> [always loadCodeAssist] -> [400 Bad Request]

After:
[Gemini CLI personal OAuth token] -> [detect oauth-personal] -> [resolve email only] -> [login succeeds]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: `google-gemini-cli`
- Integration/channel (if any): N/A
- Relevant config (redacted): local `~/.gemini/settings.json` with `security.auth.selectedType = "oauth-personal"`

### Steps

1. Configure Gemini CLI for personal OAuth.
2. Start OpenClaw Gemini CLI OAuth login.
3. Complete the browser flow.

### Expected

- Token exchange succeeds without any `loadCodeAssist` call.
- The provider profile is stored without fake project metadata.

### Actual

- Before this PR, OpenClaw always called `loadCodeAssist` and personal OAuth logins failed with `400 Bad Request`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: personal OAuth mode from local settings; legacy top-level settings fallback; existing workspace OAuth login path; optional `projectId` credential storage shape.
- Edge cases checked: `GOOGLE_GENAI_USE_GCA=true` override; missing settings file; no accidental `loadCodeAssist` or `onboardUser` calls in personal mode.
- What you did **not** verify: live Google OAuth with a real personal account in this session.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a malformed or stale local Gemini settings file could mis-detect auth mode.
  - Mitigation: detection is intentionally narrow, falls back safely, and the existing workspace path remains the default when no explicit personal mode is found.
