### PR TITLE
fix(agents): surface disk full session write errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ Docs: https://docs.openclaw.ai
 - Exec/heartbeat: use the canonical `exec-event` wake reason for `notifyOnExit` so background exec completions still trigger follow-up turns when `HEARTBEAT.md` is empty or comments-only. (#41479) Thanks @rstar327.
 - Heartbeat: skip wake delivery when the target session lane is already busy so the pending event is retried instead of getting drained too early. (#40526) Thanks @lucky7323.
 - Plugin SDK/context engines: export the missing context-engine result and subagent lifecycle types from `openclaw/plugin-sdk` so context engine plugins can type `ContextEngine` implementations without local workarounds. (#61251) Thanks @DaevMithran.
+- Agents/errors: surface an explicit disk-full message when local session or transcript writes fail with `ENOSPC`/`disk full`, so those runs stop degrading into opaque `NO_REPLY`-style failures. Thanks @vincentkoc.
 
 ## 2026.4.2
 

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -191,6 +191,16 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it.each(["disk full", "ENOSPC: no space left on device, write"])(
+    "returns a friendly disk-space message for %s",
+    (errorMessage) => {
+      const msg = makeAssistantError(errorMessage);
+      expect(formatAssistantErrorText(msg)).toBe(
+        "OpenClaw could not write local session data because the disk is full. Free some disk space and try again.",
+      );
+    },
+  );
+
   it("returns a DNS-specific message for provider lookup failures", () => {
     const msg = makeAssistantError("dial tcp: lookup api.example.com: no such host (ENOTFOUND)");
     expect(formatAssistantErrorText(msg)).toBe(

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -149,6 +149,15 @@ describe("sanitizeUserFacingText", () => {
     ).toBe("LLM request failed: connection refused by the provider endpoint.");
   });
 
+  it.each(["disk full", "ENOSPC: no space left on device"])(
+    "rewrites disk-space failures with errorContext: %s",
+    (input) => {
+      expect(sanitizeUserFacingText(input, { errorContext: true })).toBe(
+        "OpenClaw could not write local session data because the disk is full. Free some disk space and try again.",
+      );
+    },
+  );
+
   it("sanitizes invalid streaming event order errors", () => {
     expect(
       sanitizeUserFacingText(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -167,6 +167,24 @@ function formatTransportErrorCopy(raw: string): string | undefined {
   return undefined;
 }
 
+function formatDiskSpaceErrorCopy(raw: string): string | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const lower = raw.toLowerCase();
+  if (
+    /\benospc\b/i.test(raw) ||
+    lower.includes("no space left on device") ||
+    lower.includes("disk full")
+  ) {
+    return (
+      "OpenClaw could not write local session data because the disk is full. " +
+      "Free some disk space and try again."
+    );
+  }
+  return undefined;
+}
+
 function isReasoningConstraintErrorMessage(raw: string): boolean {
   if (!raw) {
     return false;
@@ -925,6 +943,11 @@ export function formatAssistantErrorText(
     }
   }
 
+  const diskSpaceCopy = formatDiskSpaceErrorCopy(raw);
+  if (diskSpaceCopy) {
+    return diskSpaceCopy;
+  }
+
   if (isContextOverflowError(raw)) {
     return (
       "Context overflow: prompt too large for the model. " +
@@ -1021,6 +1044,11 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
     const execDeniedMessage = formatExecDeniedUserMessage(trimmed);
     if (execDeniedMessage) {
       return execDeniedMessage;
+    }
+
+    const diskSpaceCopy = formatDiskSpaceErrorCopy(trimmed);
+    if (diskSpaceCopy) {
+      return diskSpaceCopy;
     }
 
     if (/incorrect role information|roles must alternate/i.test(trimmed)) {


### PR DESCRIPTION
## Summary

- Problem: local session or transcript persistence failures like `ENOSPC`, `no space left on device`, or `disk full` currently fall through as opaque assistant errors.
- Why it matters: users can see silent or confusing `NO_REPLY`-style behavior when the actual problem is just exhausted disk.
- What changed: rewrite disk-full write failures into explicit user-facing copy in the shared assistant error formatter and cover both direct assistant-error formatting and error-context sanitization.
- What did NOT change (scope boundary): this PR does not change Telegram reasoning preview behavior or storage write/retry mechanics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: write-path disk exhaustion errors were not recognized by the shared assistant error formatter, so they surfaced as raw/opaque failure text.
- Missing detection / guardrail: no dedicated rewrite for `ENOSPC`, `disk full`, or `no space left on device` in the user-facing error path.
- Contributing context (if known): transcript/session persistence failures can happen outside normal tool-result warning flows, so generic `NO_REPLY`/silence reports hide the actual storage problem.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`, `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- Scenario the test should lock in: disk-full write failures are rewritten to explicit user-facing copy in both direct assistant error and generic error-context sanitization flows.
- Why this is the smallest reliable guardrail: both lifecycle and reply paths already funnel through the shared formatter/sanitizer.
- Existing test that already covers this (if any): `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts` already models `disk full` tool failures, but not the user-facing rewrite.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Users now see a direct “disk is full” message when local session/transcript writes fail with `ENOSPC`-style errors.

## Diagram (if applicable)

```text
Before:
[disk full write failure] -> [raw/opaque assistant error] -> [confusing silence or NO_REPLY-style report]

After:
[disk full write failure] -> [shared error rewrite] -> [explicit free-space guidance]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Codex worktree
- Model/provider: N/A
- Integration/channel (if any): agent embedded runner error handling
- Relevant config (redacted): N/A

### Steps

1. Trigger a local session/transcript write failure with `disk full`, `ENOSPC`, or `no space left on device`.
2. Let the assistant/lifecycle error path format the failure.
3. Observe the surfaced user-facing error text.

### Expected

- The surfaced message clearly says local session data could not be written because the disk is full.

### Actual

- Before this patch, these failures surfaced as raw or opaque errors and were easy to confuse with generic silent/no-reply behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the shared formatter/sanitizer paths and added direct regression assertions for `disk full` and `ENOSPC` variants.
- Edge cases checked: both `formatAssistantErrorText(...)` and `sanitizeUserFacingText(..., { errorContext: true })` now rewrite the storage failure consistently.
- What you did **not** verify: full local Vitest completion was unstable in this workspace; `pnpm test:serial` reached `RUN` but did not yield a clean exit signal.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the new rewrite could be overly broad if unrelated text includes `disk full` in a non-error context.
  - Mitigation: the formatter path only applies to explicit assistant error messages or `errorContext` sanitization.

## AI / Testing Notes

- AI-assisted: yes
- Testing: lightly tested locally; targeted `pnpm test:serial` invocations started but did not return a clean exit signal in this workspace.
