### PR TITLE
fix(feishu): gate reasoning previews to stream sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ Docs: https://docs.openclaw.ai
 - Plugin SDK/context engines: export the missing context-engine result and subagent lifecycle types from `openclaw/plugin-sdk` so context engine plugins can type `ContextEngine` implementations without local workarounds. (#61251) Thanks @DaevMithran.
 - Agents/errors: surface an explicit disk-full message when local session or transcript writes fail with `ENOSPC`/`disk full`, so those runs stop degrading into opaque `NO_REPLY`-style failures. Thanks @vincentkoc.
 - Telegram/reasoning: only create a Telegram reasoning preview lane when the session is explicitly `reasoning:stream`, so hidden `<think>` traces from streamed replies stop surfacing as chat previews on normal sessions. Thanks @vincentkoc.
+- Feishu/reasoning: only expose streamed reasoning previews when the session is explicitly `reasoning:stream`, so hidden reasoning traces do not surface on normal streaming sessions. Thanks @vincentkoc.
 
 ## 2026.4.2
 

--- a/extensions/feishu/runtime-api.ts
+++ b/extensions/feishu/runtime-api.ts
@@ -39,6 +39,7 @@ export {
   filterSupplementalContextItems,
   resolveChannelContextVisibilityMode,
 } from "openclaw/plugin-sdk/config-runtime";
+export { loadSessionStore, resolveSessionStoreEntry } from "openclaw/plugin-sdk/config-runtime";
 export { readJsonFileWithFallback } from "openclaw/plugin-sdk/json-store";
 export { createPersistentDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 export { normalizeAgentId } from "openclaw/plugin-sdk/routing";

--- a/extensions/feishu/src/bot-runtime-api.ts
+++ b/extensions/feishu/src/bot-runtime-api.ts
@@ -9,3 +9,4 @@ export {
   filterSupplementalContextItems,
   normalizeAgentId,
 } from "../runtime-api.js";
+export { loadSessionStore, resolveSessionStoreEntry } from "../runtime-api.js";

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -236,6 +236,7 @@ const {
   mockEnsureConfiguredBindingRouteReady,
   mockResolveBoundConversation,
   mockTouchBinding,
+  mockResolveFeishuReasoningPreviewEnabled,
 } = vi.hoisted(() => ({
   mockCreateFeishuReplyDispatcher: vi.fn(() => ({
     dispatcher: createReplyDispatcher(),
@@ -269,10 +270,15 @@ const {
   ),
   mockResolveBoundConversation: vi.fn(() => null as BoundConversation),
   mockTouchBinding: vi.fn(),
+  mockResolveFeishuReasoningPreviewEnabled: vi.fn(() => false),
 }));
 
 vi.mock("./reply-dispatcher.js", () => ({
   createFeishuReplyDispatcher: mockCreateFeishuReplyDispatcher,
+}));
+
+vi.mock("./reasoning-preview.js", () => ({
+  resolveFeishuReasoningPreviewEnabled: mockResolveFeishuReasoningPreviewEnabled,
 }));
 
 vi.mock("./send.js", () => ({
@@ -332,6 +338,7 @@ describe("handleFeishuMessage ACP routing", () => {
     mockEnsureConfiguredBindingRouteReady.mockReset().mockResolvedValue({ ok: true });
     mockResolveBoundConversation.mockReset().mockReturnValue(null);
     mockTouchBinding.mockReset();
+    mockResolveFeishuReasoningPreviewEnabled.mockReset().mockReturnValue(false);
     mockResolveAgentRoute.mockReset().mockReturnValue({
       ...buildDefaultResolveRoute(),
       sessionKey: "agent:main:feishu:direct:ou_sender_1",
@@ -443,6 +450,31 @@ describe("handleFeishuMessage ACP routing", () => {
       }),
     );
     expect(mockTouchBinding).toHaveBeenCalledWith("default:oc_group_chat:topic:om_topic_root");
+  });
+
+  it("passes reasoning preview permission from session state into the dispatcher", async () => {
+    mockResolveFeishuReasoningPreviewEnabled.mockReturnValue(true);
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "msg-reasoning",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello" }),
+        },
+      },
+    });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({ allowReasoningPreview: true }),
+    );
   });
 });
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -49,6 +49,7 @@ import {
   resolveFeishuAllowlistMatch,
   isFeishuGroupAllowed,
 } from "./policy.js";
+import { resolveFeishuReasoningPreviewEnabled } from "./reasoning-preview.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, listFeishuThreadMessages, sendMessageFeishu } from "./send.js";
@@ -1112,6 +1113,10 @@ export async function handleFeishuMessage(params: {
         }
 
         const agentSessionKey = buildBroadcastSessionKey(route.sessionKey, route.agentId, agentId);
+        const allowReasoningPreview = resolveFeishuReasoningPreviewEnabled({
+          storePath: core.channel.session.resolveStorePath(cfg.session?.store, { agentId }),
+          sessionKey: agentSessionKey,
+        });
         const agentCtx = await buildCtxPayloadForAgent(
           agentId,
           agentSessionKey,
@@ -1127,6 +1132,7 @@ export async function handleFeishuMessage(params: {
             agentId,
             runtime: runtime as RuntimeEnv,
             chatId: ctx.chatId,
+            allowReasoningPreview,
             replyToMessageId: replyTargetMessageId,
             skipReplyToInMessages: !isGroup,
             replyInThread,
@@ -1224,11 +1230,18 @@ export async function handleFeishuMessage(params: {
       );
 
       const identity = resolveAgentOutboundIdentity(cfg, route.agentId);
+      const allowReasoningPreview = resolveFeishuReasoningPreviewEnabled({
+        storePath: core.channel.session.resolveStorePath(cfg.session?.store, {
+          agentId: route.agentId,
+        }),
+        sessionKey: route.sessionKey,
+      });
       const { dispatcher, replyOptions, markDispatchIdle } = createFeishuReplyDispatcher({
         cfg,
         agentId: route.agentId,
         runtime: runtime as RuntimeEnv,
         chatId: ctx.chatId,
+        allowReasoningPreview,
         replyToMessageId: replyTargetMessageId,
         skipReplyToInMessages: !isGroup,
         replyInThread,

--- a/extensions/feishu/src/reasoning-preview.test.ts
+++ b/extensions/feishu/src/reasoning-preview.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveFeishuReasoningPreviewEnabled } from "./reasoning-preview.js";
+
+const { loadSessionStoreMock } = vi.hoisted(() => ({
+  loadSessionStoreMock: vi.fn(),
+}));
+
+vi.mock("./bot-runtime-api.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./bot-runtime-api.js")>("./bot-runtime-api.js");
+  return {
+    ...actual,
+    loadSessionStore: loadSessionStoreMock,
+  };
+});
+
+describe("resolveFeishuReasoningPreviewEnabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enables previews only for stream reasoning sessions", () => {
+    loadSessionStoreMock.mockReturnValue({
+      "agent:main:feishu:dm:ou_sender_1": { reasoningLevel: "stream" },
+      "agent:main:feishu:dm:ou_sender_2": { reasoningLevel: "on" },
+    });
+
+    expect(
+      resolveFeishuReasoningPreviewEnabled({
+        storePath: "/tmp/feishu-sessions.json",
+        sessionKey: "agent:main:feishu:dm:ou_sender_1",
+      }),
+    ).toBe(true);
+    expect(
+      resolveFeishuReasoningPreviewEnabled({
+        storePath: "/tmp/feishu-sessions.json",
+        sessionKey: "agent:main:feishu:dm:ou_sender_2",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for missing sessions or load failures", () => {
+    loadSessionStoreMock.mockImplementationOnce(() => {
+      throw new Error("disk unavailable");
+    });
+
+    expect(
+      resolveFeishuReasoningPreviewEnabled({
+        storePath: "/tmp/feishu-sessions.json",
+        sessionKey: "agent:main:feishu:dm:ou_sender_1",
+      }),
+    ).toBe(false);
+    expect(
+      resolveFeishuReasoningPreviewEnabled({
+        storePath: "/tmp/feishu-sessions.json",
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/feishu/src/reasoning-preview.ts
+++ b/extensions/feishu/src/reasoning-preview.ts
@@ -1,0 +1,20 @@
+import { loadSessionStore, resolveSessionStoreEntry } from "./bot-runtime-api.js";
+
+export function resolveFeishuReasoningPreviewEnabled(params: {
+  storePath: string;
+  sessionKey?: string;
+}): boolean {
+  if (!params.sessionKey) {
+    return false;
+  }
+
+  try {
+    const store = loadSessionStore(params.storePath, { skipCache: true });
+    return (
+      resolveSessionStoreEntry({ store, sessionKey: params.sessionKey }).existing
+        ?.reasoningLevel === "stream"
+    );
+  } catch {
+    return false;
+  }
+}

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -524,6 +524,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   it("streams reasoning content as blockquote before answer", async () => {
     const { result, options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),
+      allowReasoningPreview: true,
     });
 
     await options.onReplyStart?.();
@@ -557,13 +558,23 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(closeArg).toContain("answer part final");
   });
 
-  it("provides onReasoningStream and onReasoningEnd when streaming is enabled", () => {
+  it("provides onReasoningStream and onReasoningEnd when reasoning previews are allowed", () => {
     const { result } = createDispatcherHarness({
       runtime: createRuntimeLogger(),
+      allowReasoningPreview: true,
     });
 
     expect(result.replyOptions.onReasoningStream).toBeTypeOf("function");
     expect(result.replyOptions.onReasoningEnd).toBeTypeOf("function");
+  });
+
+  it("omits reasoning callbacks unless reasoning previews are allowed", () => {
+    const { result } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+    });
+
+    expect(result.replyOptions.onReasoningStream).toBeUndefined();
+    expect(result.replyOptions.onReasoningEnd).toBeUndefined();
   });
 
   it("omits reasoning callbacks when streaming is disabled", () => {
@@ -589,6 +600,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   it("renders reasoning-only card when no answer text arrives", async () => {
     const { result, options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),
+      allowReasoningPreview: true,
     });
 
     await options.onReplyStart?.();
@@ -608,6 +620,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   it("ignores empty reasoning payloads", async () => {
     const { result, options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),
+      allowReasoningPreview: true,
     });
 
     await options.onReplyStart?.();
@@ -624,6 +637,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
   it("deduplicates final text by raw answer payload, not combined card text", async () => {
     const { result, options } = createDispatcherHarness({
       runtime: createRuntimeLogger(),
+      allowReasoningPreview: true,
     });
 
     await options.onReplyStart?.();

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -77,6 +77,7 @@ export type CreateFeishuReplyDispatcherParams = {
   agentId: string;
   runtime: RuntimeEnv;
   chatId: string;
+  allowReasoningPreview?: boolean;
   replyToMessageId?: string;
   /** When true, preserve typing indicator on reply target but send messages without reply metadata */
   skipReplyToInMessages?: boolean;
@@ -188,6 +189,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   // Card streaming may miss thread affinity in topic contexts; use direct replies there.
   const streamingEnabled =
     !threadReplyMode && account.config?.streaming !== false && renderMode !== "raw";
+  const reasoningPreviewEnabled = streamingEnabled && params.allowReasoningPreview === true;
 
   let streaming: FeishuStreamingSession | null = null;
   let streamText = "";
@@ -491,7 +493,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             });
           }
         : undefined,
-      onReasoningStream: streamingEnabled
+      onReasoningStream: reasoningPreviewEnabled
         ? (payload: ReplyPayload) => {
             if (!payload.text) {
               return;
@@ -500,7 +502,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             queueReasoningUpdate(payload.text);
           }
         : undefined,
-      onReasoningEnd: streamingEnabled ? () => {} : undefined,
+      onReasoningEnd: reasoningPreviewEnabled ? () => {} : undefined,
     },
     markDispatchIdle,
   };


### PR DESCRIPTION
## Summary

- Problem: Feishu still exposed streamed reasoning previews on any streaming session, even when the persisted session reasoning level was not `stream`.
- Why it matters: hidden reasoning traces can leak into normal Feishu chat cards while other channels already suppress or status-only this path.
- What changed: gate Feishu reasoning previews on persisted `reasoning:stream`, thread that permission into the reply dispatcher, and add regression coverage plus a changelog entry.
- What did NOT change (scope boundary): this does not change normal answer streaming, comment-thread replies, or other channels that already suppress/status-only reasoning previews.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #61266
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Feishu reply dispatch treated `streaming: true` as permission to expose `onReasoningStream`, without checking the session's persisted reasoning mode.
- Missing detection / guardrail: Feishu had streaming-card reasoning tests, but no guard that tied those callbacks to `reasoningLevel === "stream"`.
- Contributing context (if known): Telegram had already needed the same narrowing, and Feishu kept the older broader behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/reasoning-preview.test.ts`, `extensions/feishu/src/reply-dispatcher.test.ts`, `extensions/feishu/src/bot.test.ts`
- Scenario the test should lock in: Feishu only exposes reasoning preview callbacks when the session is explicitly `reasoning:stream`.
- Why this is the smallest reliable guardrail: the leak boundary is a session-state + dispatcher wiring decision, so helper and dispatcher tests are the tightest checks.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Feishu no longer shows streamed reasoning previews in normal streaming sessions unless the session is explicitly `reasoning:stream`.

## Diagram (if applicable)

```text
Before:
[Feishu streaming session] -> [reasoning callback exposed] -> [thinking text can render in card]

After:
[Feishu streaming session] -> [check persisted reasoningLevel]
  -> [stream] -> [reasoning callback exposed]
  -> [off/on/unknown] -> [reasoning callback suppressed]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local worktree
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): Feishu account with `streaming: true`; session store entry toggled between `reasoningLevel: stream` and `reasoningLevel: on`

### Steps

1. Start a Feishu streaming session whose persisted session entry is not `reasoning:stream`.
2. Send a prompt that produces streamed reasoning tokens.
3. Observe whether the dispatcher exposes a visible reasoning preview lane.

### Expected

- Feishu only exposes streamed reasoning previews when the session is explicitly `reasoning:stream`.

### Actual

- Before this patch, Feishu exposed reasoning previews for any streaming session.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: direct Bun sanity check covering persisted `reasoningLevel` lookup and dispatcher callback gating; `git diff --check` after rebase.
- Edge cases checked: missing session key, non-stream reasoning level, and load failures all disable previews.
- What you did **not** verify: `pnpm test:serial -- ...` for the touched Feishu tests kept hanging in this workspace after startup, so I did not get a clean local Vitest result to claim.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: sessions intentionally using `reasoning:stream` could stop showing previews if the store lookup path regresses.
  - Mitigation: helper regression test plus bot wiring assertion.
