### PR TITLE
fix(agents): suppress commentary-phase output leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/reasoning: only create a Telegram reasoning preview lane when the session is explicitly `reasoning:stream`, so hidden `<think>` traces from streamed replies stop surfacing as chat previews on normal sessions. Thanks @vincentkoc.
 - Feishu/reasoning: only expose streamed reasoning previews when the session is explicitly `reasoning:stream`, so hidden reasoning traces do not surface on normal streaming sessions. Thanks @vincentkoc.
 - Providers/OpenAI: support GPT-5.4 assistant `phase` metadata across OpenAI-family Responses replay and the Gateway `/v1/responses` compatibility layer, including `commentary` tool preambles and `final_answer` replies.
+<<<<<<< HEAD
 - Models/Anthropic CLI auth: replace migrated `agents.defaults.models` allowlists when `openclaw models auth login --provider anthropic --method cli --set-default` switches to `claude-cli/*`, so stale `anthropic/*` entries do not linger beside the migrated Claude CLI defaults. Thanks @vincentkoc.
 - Plugins/auth-choice: apply provider-owned auth config patches without recursively preserving replaced default-model maps, so Anthropic Claude CLI and similar migrations can intentionally swap model allowlists during onboarding and setup instead of accumulating stale entries. Thanks @vincentkoc.
 - Anthropic CLI onboarding: rewrite migrated fallback model refs during non-interactive Claude CLI setup too, so onboarding and scripted setup no longer keep stale `anthropic/*` fallbacks after switching the primary model to `claude-cli/*`. Thanks @vincentkoc.
@@ -244,6 +245,7 @@ Docs: https://docs.openclaw.ai
 - Voice-call/OpenAI: pass full plugin config into realtime transcription provider resolution so streaming calls can discover the bundled OpenAI realtime transcription provider again. Fixes #60936. Thanks @sliekens and @vincentkoc.
 - WhatsApp: restore `channels.whatsapp.blockStreaming` and reset watchdog timeouts after reconnect so quiet chats stop falling into reconnect loops. (#60007, #60069) Thanks @MonkeyLeeT and @mcaxtr.
 - Windows/restart: fall back to the installed Startup-entry launcher when the scheduled task was never registered, so `/restart` can relaunch the gateway on Windows setups where `schtasks` install fell back during onboarding. (#58943) Thanks @imechZhangLY.
+- Agents/output delivery: suppress `phase:"commentary"` assistant text at the embedded subscribe boundary so internal planning text cannot leak into user-visible replies or Telegram partials. (#61282) Thanks @mbelinky.
 
 ## 2026.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,7 +121,6 @@ Docs: https://docs.openclaw.ai
 - Telegram/reasoning: only create a Telegram reasoning preview lane when the session is explicitly `reasoning:stream`, so hidden `<think>` traces from streamed replies stop surfacing as chat previews on normal sessions. Thanks @vincentkoc.
 - Feishu/reasoning: only expose streamed reasoning previews when the session is explicitly `reasoning:stream`, so hidden reasoning traces do not surface on normal streaming sessions. Thanks @vincentkoc.
 - Providers/OpenAI: support GPT-5.4 assistant `phase` metadata across OpenAI-family Responses replay and the Gateway `/v1/responses` compatibility layer, including `commentary` tool preambles and `final_answer` replies.
-<<<<<<< HEAD
 - Models/Anthropic CLI auth: replace migrated `agents.defaults.models` allowlists when `openclaw models auth login --provider anthropic --method cli --set-default` switches to `claude-cli/*`, so stale `anthropic/*` entries do not linger beside the migrated Claude CLI defaults. Thanks @vincentkoc.
 - Plugins/auth-choice: apply provider-owned auth config patches without recursively preserving replaced default-model maps, so Anthropic Claude CLI and similar migrations can intentionally swap model allowlists during onboarding and setup instead of accumulating stale entries. Thanks @vincentkoc.
 - Anthropic CLI onboarding: rewrite migrated fallback model refs during non-interactive Claude CLI setup too, so onboarding and scripted setup no longer keep stale `anthropic/*` fallbacks after switching the primary model to `claude-cli/*`. Thanks @vincentkoc.

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -4,6 +4,7 @@ import {
   buildAssistantStreamData,
   consumePendingToolMediaIntoReply,
   consumePendingToolMediaReply,
+  handleMessageEnd,
   handleMessageUpdate,
   hasAssistantVisibleReply,
   resolveSilentReplyFallbackText,
@@ -140,6 +141,119 @@ describe("consumePendingToolMediaReply", () => {
 });
 
 describe("handleMessageUpdate", () => {
+  it("suppresses commentary-phase partial delivery and text_end flush", async () => {
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const flushBlockReplyBuffer = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onAgentEvent,
+        onPartialReply,
+      },
+      state: {
+        deterministicApprovalPromptSent: false,
+        reasoningStreamOpen: false,
+        streamReasoning: false,
+        deltaBuffer: "",
+        blockBuffer: "",
+        partialBlockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+        lastStreamedAssistantCleaned: undefined,
+        emittedAssistantUpdate: false,
+        shouldEmitPartialReplies: true,
+        blockReplyBreak: "text_end",
+        assistantMessageIndex: 0,
+      },
+      log: { debug: vi.fn() },
+      noteLastAssistant: vi.fn(),
+      stripBlockTags: (text: string) => text,
+      consumePartialReplyDirectives: vi.fn(() => null),
+      flushBlockReplyBuffer,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: { role: "assistant", phase: "commentary", content: [] },
+      assistantMessageEvent: { type: "text_delta", delta: "Need send." },
+    } as never);
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: { role: "assistant", phase: "commentary", content: [] },
+      assistantMessageEvent: { type: "text_end", content: "Need send." },
+    } as never);
+
+    await Promise.resolve();
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(flushBlockReplyBuffer).not.toHaveBeenCalled();
+  });
+
+  it("suppresses commentary partials when phase exists only in textSignature metadata", async () => {
+    const onAgentEvent = vi.fn();
+    const onPartialReply = vi.fn();
+    const flushBlockReplyBuffer = vi.fn();
+    const commentaryBlock = {
+      type: "text",
+      text: "Need send.",
+      textSignature: JSON.stringify({ v: 1, id: "msg_sig", phase: "commentary" }),
+    };
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onAgentEvent,
+        onPartialReply,
+      },
+      state: {
+        deterministicApprovalPromptSent: false,
+        reasoningStreamOpen: false,
+        streamReasoning: false,
+        deltaBuffer: "",
+        blockBuffer: "",
+        partialBlockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+        lastStreamedAssistantCleaned: undefined,
+        emittedAssistantUpdate: false,
+        shouldEmitPartialReplies: true,
+        blockReplyBreak: "text_end",
+        assistantMessageIndex: 0,
+      },
+      log: { debug: vi.fn() },
+      noteLastAssistant: vi.fn(),
+      stripBlockTags: (text: string) => text,
+      consumePartialReplyDirectives: vi.fn(() => null),
+      flushBlockReplyBuffer,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: { role: "assistant", content: [commentaryBlock] },
+      assistantMessageEvent: { type: "text_delta", delta: "Need send." },
+    } as never);
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: { role: "assistant", content: [commentaryBlock] },
+      assistantMessageEvent: { type: "text_end", content: "Need send." },
+    } as never);
+
+    await Promise.resolve();
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(flushBlockReplyBuffer).not.toHaveBeenCalled();
+    expect(ctx.state.deltaBuffer).toBe("");
+    expect(ctx.state.blockBuffer).toBe("");
+  });
+
   it("contains synchronous text_end flush failures", async () => {
     const debug = vi.fn();
     const ctx = {
@@ -181,5 +295,126 @@ describe("handleMessageUpdate", () => {
     await vi.waitFor(() => {
       expect(debug).toHaveBeenCalledWith("text_end block reply flush failed: Error: boom");
     });
+  });
+});
+
+describe("handleMessageEnd", () => {
+  it("suppresses commentary-phase replies from user-visible output", () => {
+    const onAgentEvent = vi.fn();
+    const emitBlockReply = vi.fn();
+    const finalizeAssistantTexts = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onAgentEvent,
+        onBlockReply: vi.fn(),
+      },
+      state: {
+        assistantTexts: [],
+        assistantTextBaseline: 0,
+        emittedAssistantUpdate: false,
+        deterministicApprovalPromptSent: false,
+        reasoningStreamOpen: false,
+        includeReasoning: false,
+        streamReasoning: false,
+        blockReplyBreak: "message_end",
+        deltaBuffer: "Need send.",
+        blockBuffer: "Need send.",
+        blockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+        lastStreamedAssistant: undefined,
+        lastStreamedAssistantCleaned: undefined,
+      },
+      noteLastAssistant: vi.fn(),
+      recordAssistantUsage: vi.fn(),
+      log: { debug: vi.fn(), warn: vi.fn() },
+      stripBlockTags: (text: string) => text,
+      finalizeAssistantTexts,
+      emitBlockReply,
+      consumeReplyDirectives: vi.fn(() => ({ text: "Need send." })),
+      emitReasoningStream: vi.fn(),
+      flushBlockReplyBuffer: vi.fn(),
+      blockChunker: null,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        phase: "commentary",
+        content: [{ type: "text", text: "Need send." }],
+        usage: { input: 1, output: 1, total: 2 },
+      },
+    } as never);
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+    expect(emitBlockReply).not.toHaveBeenCalled();
+    expect(finalizeAssistantTexts).not.toHaveBeenCalled();
+  });
+
+  it("suppresses commentary message_end when phase exists only in textSignature metadata", () => {
+    const onAgentEvent = vi.fn();
+    const emitBlockReply = vi.fn();
+    const finalizeAssistantTexts = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onAgentEvent,
+        onBlockReply: vi.fn(),
+      },
+      state: {
+        assistantTexts: [],
+        assistantTextBaseline: 0,
+        emittedAssistantUpdate: false,
+        deterministicApprovalPromptSent: false,
+        reasoningStreamOpen: false,
+        includeReasoning: false,
+        streamReasoning: false,
+        blockReplyBreak: "message_end",
+        deltaBuffer: "Need send.",
+        blockBuffer: "Need send.",
+        blockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+        lastStreamedAssistant: undefined,
+        lastStreamedAssistantCleaned: undefined,
+      },
+      noteLastAssistant: vi.fn(),
+      recordAssistantUsage: vi.fn(),
+      log: { debug: vi.fn(), warn: vi.fn() },
+      stripBlockTags: (text: string) => text,
+      finalizeAssistantTexts,
+      emitBlockReply,
+      consumeReplyDirectives: vi.fn(() => ({ text: "Need send." })),
+      emitReasoningStream: vi.fn(),
+      flushBlockReplyBuffer: vi.fn(),
+      blockChunker: null,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "Need send.",
+            textSignature: JSON.stringify({ v: 1, id: "msg_sig", phase: "commentary" }),
+          },
+        ],
+        usage: { input: 1, output: 1, total: 2 },
+      },
+    } as never);
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+    expect(emitBlockReply).not.toHaveBeenCalled();
+    expect(finalizeAssistantTexts).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -24,6 +24,8 @@ import {
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
+type AssistantDeliveryPhase = "commentary" | "final_answer";
+
 const stripTrailingDirective = (text: string): string => {
   const openIndex = text.lastIndexOf("[[");
   if (openIndex < 0) {
@@ -63,6 +65,48 @@ const coerceText = (value: unknown): string => {
   }
   return "";
 };
+
+function normalizeAssistantDeliveryPhase(value: unknown): AssistantDeliveryPhase | undefined {
+  return value === "commentary" || value === "final_answer" ? value : undefined;
+}
+
+function resolveAssistantDeliveryPhase(
+  message: AgentMessage | undefined,
+): AssistantDeliveryPhase | undefined {
+  if (!message || message.role !== "assistant") {
+    return undefined;
+  }
+  const directPhase = normalizeAssistantDeliveryPhase((message as { phase?: unknown }).phase);
+  if (directPhase) {
+    return directPhase;
+  }
+  if (!Array.isArray(message.content)) {
+    return undefined;
+  }
+  for (const part of message.content) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    const block = part as { type?: unknown; textSignature?: unknown };
+    if (block.type !== "text" || typeof block.textSignature !== "string") {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(block.textSignature) as { phase?: unknown };
+      const phase = normalizeAssistantDeliveryPhase(parsed.phase);
+      if (phase) {
+        return phase;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+function shouldSuppressAssistantVisibleOutput(message: AgentMessage | undefined): boolean {
+  return resolveAssistantDeliveryPhase(message) === "commentary";
+}
 
 function isTranscriptOnlyOpenClawAssistantMessage(message: AgentMessage | undefined): boolean {
   if (!message || message.role !== "assistant") {
@@ -196,6 +240,7 @@ export function handleMessageUpdate(
   }
 
   ctx.noteLastAssistant(msg);
+  const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(msg);
   if (ctx.state.deterministicApprovalPromptSent) {
     return;
   }
@@ -253,6 +298,10 @@ export function handleMessageUpdate(
     delta,
     content,
   });
+
+  if (suppressVisibleAssistantOutput) {
+    return;
+  }
 
   let chunk = "";
   if (evtType === "text_delta") {
@@ -387,6 +436,7 @@ export function handleMessageEnd(
   }
 
   const assistantMessage = msg;
+  const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(assistantMessage);
   ctx.noteLastAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   if (ctx.state.deterministicApprovalPromptSent) {
@@ -417,6 +467,24 @@ export function handleMessageEnd(
   const parsedText = trimmedText ? parseReplyDirectives(stripTrailingDirective(trimmedText)) : null;
   let cleanedText = parsedText?.text ?? "";
   let { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedText ?? {});
+
+  const finalizeMessageEnd = () => {
+    ctx.state.deltaBuffer = "";
+    ctx.state.blockBuffer = "";
+    ctx.blockChunker?.reset();
+    ctx.state.blockState.thinking = false;
+    ctx.state.blockState.final = false;
+    ctx.state.blockState.inlineCode = createInlineCodeState();
+    ctx.state.lastStreamedAssistant = undefined;
+    ctx.state.lastStreamedAssistantCleaned = undefined;
+    ctx.state.reasoningStreamOpen = false;
+  };
+
+  if (suppressVisibleAssistantOutput) {
+    emitReasoningEnd(ctx);
+    finalizeMessageEnd();
+    return;
+  }
 
   if (!cleanedText && !hasMedia && !ctx.params.enforceFinalTag) {
     const rawTrimmed = coerceText(rawText).trim();
@@ -550,18 +618,6 @@ export function handleMessageEnd(
   if (!ctx.params.silentExpected && ctx.state.blockReplyBreak === "text_end" && onBlockReply) {
     emitSplitResultAsBlockReply(ctx.consumeReplyDirectives("", { final: true }));
   }
-
-  const finalizeMessageEnd = () => {
-    ctx.state.deltaBuffer = "";
-    ctx.state.blockBuffer = "";
-    ctx.blockChunker?.reset();
-    ctx.state.blockState.thinking = false;
-    ctx.state.blockState.final = false;
-    ctx.state.blockState.inlineCode = createInlineCodeState();
-    ctx.state.lastStreamedAssistant = undefined;
-    ctx.state.lastStreamedAssistantCleaned = undefined;
-    ctx.state.reasoningStreamOpen = false;
-  };
 
   if (
     !ctx.params.silentExpected &&

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
@@ -1,0 +1,65 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { createSubscribedSessionHarness } from "./pi-embedded-subscribe.e2e-harness.js";
+
+describe("subscribeEmbeddedPiSession", () => {
+  it("suppresses commentary-phase assistant messages before tool use", () => {
+    const onBlockReply = vi.fn();
+    const onPartialReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onBlockReply,
+      onPartialReply,
+      blockReplyBreak: "message_end",
+    });
+
+    const commentaryMessage = {
+      role: "assistant",
+      phase: "commentary",
+      content: [{ type: "text", text: "Need send." }],
+      stopReason: "toolUse",
+    } as AssistantMessage;
+
+    emit({ type: "message_start", message: commentaryMessage });
+    emit({ type: "message_end", message: commentaryMessage });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(subscription.assistantTexts).toEqual([]);
+  });
+
+  it("suppresses commentary when phase is only present in textSignature metadata", () => {
+    const onBlockReply = vi.fn();
+    const onPartialReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onBlockReply,
+      onPartialReply,
+      blockReplyBreak: "message_end",
+    });
+
+    const commentaryMessage = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need send.",
+          textSignature: JSON.stringify({ v: 1, id: "msg_sig", phase: "commentary" }),
+        },
+      ],
+      stopReason: "toolUse",
+    } as AssistantMessage;
+
+    emit({ type: "message_start", message: commentaryMessage });
+    emit({
+      type: "message_update",
+      message: commentaryMessage,
+      assistantMessageEvent: { type: "text_delta", delta: "Need send." },
+    });
+    emit({ type: "message_end", message: commentaryMessage });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(subscription.assistantTexts).toEqual([]);
+  });
+});

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
@@ -2,6 +2,10 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { createSubscribedSessionHarness } from "./pi-embedded-subscribe.e2e-harness.js";
 
+type AssistantMessageWithPhase = AssistantMessage & {
+  phase?: "commentary" | "final_answer";
+};
+
 describe("subscribeEmbeddedPiSession", () => {
   it("suppresses commentary-phase assistant messages before tool use", () => {
     const onBlockReply = vi.fn();
@@ -18,7 +22,7 @@ describe("subscribeEmbeddedPiSession", () => {
       phase: "commentary",
       content: [{ type: "text", text: "Need send." }],
       stopReason: "toolUse",
-    } as AssistantMessage;
+    } as AssistantMessageWithPhase;
 
     emit({ type: "message_start", message: commentaryMessage });
     emit({ type: "message_end", message: commentaryMessage });


### PR DESCRIPTION
## Summary

- Problem: assistant messages carrying `phase:"commentary"` were already being preserved by the OpenAI Responses conversion path, but the embedded subscribe delivery bridge still treated them like normal user-visible assistant output.
- Why it matters: internal planning shards like `Need send...` or `Need update tracker...` could leak into Telegram partials and final reply paths before the real answer.
- What changed: suppress commentary-phase assistant output at the shared embedded subscribe boundary, whether the phase arrives as `message.phase` or only inside `textSignature` metadata.
- Hardening: commentary `text_*` updates now bail out before mutating visible-output buffers, partial-reply state, or block-reply flush paths.

## Root Cause

- Root cause: `src/agents/pi-embedded-subscribe.handlers.messages.ts` ignored assistant delivery phase when deciding what to stream or flush to the user.
- Existing evidence in code: phase metadata is already preserved upstream, including the `textSignature`-only shape covered by `src/agents/openai-ws-stream.test.ts`.
- Failure mode: commentary text could enter `onPartialReply`, block-reply flush, or final assistant text emission even though it was internal-only output.

## Why This Layer

- This is the correct production boundary for OpenClaw because it controls the actual user-visible delivery paths.
- A Pi-side render/print fix is still reasonable upstream hygiene, but it does not replace fixing the OpenClaw delivery bridge that Telegram and other embedded surfaces actually use here.
- Fixing only Telegram lane wiring would be too narrow; the bug is broader than one preview transport.

## Red-Team / Hardening Review

- Checked whether the fix only covered `message.phase`: it did not originally, so this PR explicitly covers the `textSignature`-only commentary shape too.
- Checked whether commentary still polluted internal visible-output state even when suppressed: it did originally, so this PR now returns early before mutating partial/block buffers on commentary `text_*` updates.
- Checked whether the change accidentally suppresses legitimate final answers: suppression is limited to `phase:"commentary"`; `final_answer` and normal assistant messages still flow unchanged.
- Checked whether this belongs in a refactor instead: no. The minimal root-cause fix is small and local; broader dedupe with other phase helpers can wait.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## User-visible / Behavior Changes

- Commentary-phase planning text no longer leaks into user-visible assistant partials or final replies.
- This applies both to direct `message.phase` commentary and to replay/live shapes that only carry the phase in `textSignature` metadata.

## Tests

Targeted serial verification on `mb-air`:

```bash
bunx vitest run \
  src/agents/pi-embedded-subscribe.handlers.messages.test.ts \
  src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts \
  src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts \
  --pool forks --maxWorkers 1
```

Result: `3` files, `38` tests passed.

## AI / Testing Notes

- AI-assisted: yes
- Testing: targeted local serial tests passed
