### PR TITLE
fix(plugin-sdk): resolve facade post-load re-entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,6 @@ Docs: https://docs.openclaw.ai
 - Heartbeat: skip wake delivery when the target session lane is already busy so the pending event is retried instead of getting drained too early. (#40526) Thanks @lucky7323.
 - Plugin SDK/context engines: export the missing context-engine result and subagent lifecycle types from `openclaw/plugin-sdk` so context engine plugins can type `ContextEngine` implementations without local workarounds. (#61251) Thanks @DaevMithran.
 - Agents/errors: surface an explicit disk-full message when local session or transcript writes fail with `ENOSPC`/`disk full`, so those runs stop degrading into opaque `NO_REPLY`-style failures. Thanks @vincentkoc.
-  <<<<<<< HEAD
 - Google Gemini CLI models: add forward-compat support for stable `gemini-2.5-*` model ids by letting the bundled CLI provider clone them from Google templates, so `gemini-2.5-flash-lite` and related configured models stop showing up as missing. (#35274) Thanks @mySebbe.
 - Telegram/reasoning: only create a Telegram reasoning preview lane when the session is explicitly `reasoning:stream`, so hidden `<think>` traces from streamed replies stop surfacing as chat previews on normal sessions. Thanks @vincentkoc.
 - Feishu/reasoning: only expose streamed reasoning previews when the session is explicitly `reasoning:stream`, so hidden reasoning traces do not surface on normal streaming sessions. Thanks @vincentkoc.
@@ -153,6 +152,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Claude CLI/security: force host-managed Claude CLI backdoor runs to `--setting-sources user`, even under custom backend arg overrides, so repo-local `.claude` project/local settings, hooks, and plugin discovery do not silently execute inside non-interactive OpenClaw sessions. Thanks @vincentkoc.
 - Agents/Claude CLI/images: reuse stable hydrated image file paths and preserve shared media extensions like HEIC when passing image refs to local CLI runs, so Claude CLI image prompts stop thrashing KV cache prefixes and oddball image formats do not fall back to `.bin`. Thanks @vincentkoc.
 - Google Gemini CLI auth: detect personal OAuth mode from local Gemini settings and skip Code Assist project discovery for those logins, so personal Google accounts stop failing with `loadCodeAssist 400 Bad Request`. (#49226) Thanks @bobworrall.
+- Plugin SDK/facades: back-fill bundled plugin facade sentinels before plugin-id tracking re-enters config loading, so CLI/provider startup no longer crashes with `shouldNormalizeGoogleProviderConfig is not a function` or other empty-facade reads during bundled plugin re-entry. Thanks @adam91holt.
 
 ## 2026.4.2
 

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -75,6 +75,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   clearRuntimeConfigSnapshot();
   resetFacadeRuntimeStateForTest();
+  vi.doUnmock("../plugins/manifest-registry.js");
   delete (globalThis as typeof globalThis & Record<string, unknown>)[FACADE_RUNTIME_GLOBAL];
   if (originalBundledPluginsDir === undefined) {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
@@ -137,6 +138,56 @@ describe("plugin-sdk facade runtime", () => {
     expect(loaded.marker).toBe("circular-ok");
   });
 
+  it("back-fills the sentinel before post-load facade tracking re-enters", async () => {
+    const dir = createBundledPluginDir("openclaw-facade-post-load-", "post-load-ok");
+    const reentryMarkers: Array<string | undefined> = [];
+
+    vi.resetModules();
+    vi.doMock("../plugins/manifest-registry.js", () => ({
+      loadPluginManifestRegistry: vi.fn(() => {
+        const load = (
+          globalThis as typeof globalThis & {
+            [FACADE_RUNTIME_GLOBAL]?: typeof loadBundledPluginPublicSurfaceModuleSync;
+          }
+        )[FACADE_RUNTIME_GLOBAL];
+        if (typeof load !== "function") {
+          throw new Error("missing facade runtime test loader");
+        }
+        const reentered = load<{ marker?: string }>({
+          dirName: "demo",
+          artifactBasename: "api.js",
+        });
+        reentryMarkers.push(reentered.marker);
+        return {
+          plugins: [
+            {
+              id: "demo",
+              rootDir: path.join(dir, "demo"),
+              origin: "bundled",
+            },
+          ],
+        };
+      }),
+    }));
+
+    const facadeRuntime = await import("./facade-runtime.js");
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = dir;
+    (globalThis as typeof globalThis & Record<string, unknown>)[FACADE_RUNTIME_GLOBAL] =
+      facadeRuntime.loadBundledPluginPublicSurfaceModuleSync;
+
+    const loaded = facadeRuntime.loadBundledPluginPublicSurfaceModuleSync<{ marker: string }>({
+      dirName: "demo",
+      artifactBasename: "api.js",
+    });
+
+    expect(loaded.marker).toBe("post-load-ok");
+    expect(reentryMarkers).toEqual(["post-load-ok"]);
+    expect(facadeRuntime.listImportedBundledPluginFacadeIds()).toEqual(["demo"]);
+    facadeRuntime.resetFacadeRuntimeStateForTest();
+    vi.doUnmock("../plugins/manifest-registry.js");
+    vi.resetModules();
+  });
+
   it("clears the cache on load failure so retries re-execute", () => {
     const dir = createThrowingPluginDir("openclaw-facade-throw-");
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = dir;
@@ -148,7 +199,7 @@ describe("plugin-sdk facade runtime", () => {
       }),
     ).toThrow("plugin load failure");
 
-    expect(listImportedBundledPluginFacadeIds()).toEqual(["bad"]);
+    expect(listImportedBundledPluginFacadeIds()).toEqual([]);
 
     // A second call must also throw (not return a stale empty sentinel).
     expect(() =>

--- a/src/plugin-sdk/facade-runtime.ts
+++ b/src/plugin-sdk/facade-runtime.ts
@@ -365,11 +365,14 @@ export function loadBundledPluginPublicSurfaceModuleSync<T extends object>(param
 
   let loaded: T;
   try {
-    // Track the owning plugin once module evaluation begins. Facade top-level
-    // code may have already executed even if the module later throws.
-    loadedFacadePluginIds.add(resolveTrackedFacadePluginId(params));
     loaded = getJiti(location.modulePath)(location.modulePath) as T;
+    // Back-fill the sentinel before resolving plugin ownership. That lookup can
+    // trigger config loading, plugin auto-enable, and other facade reads that
+    // re-enter this loader for the same module path.
     Object.assign(sentinel, loaded);
+    // Track the owning plugin after the module exports are visible through the
+    // sentinel, so re-entrant callers never observe an empty facade object.
+    loadedFacadePluginIds.add(resolveTrackedFacadePluginId(params));
   } catch (err) {
     loadedFacadeModules.delete(location.modulePath);
     throw err;


### PR DESCRIPTION
## Summary

- Problem: bundled plugin facade loading still had a post-load circular re-entry hole, where plugin-id tracking could trigger config loading before the cached sentinel was populated.
- Why it matters: CLI and provider startup could crash with empty-facade reads like `shouldNormalizeGoogleProviderConfig is not a function`, which then presents as random auth/provider/config breakage.
- What changed: back-fill the sentinel before resolving tracked plugin ownership, add a regression test for the post-load re-entry path, fix the stale failure-path assertion in facade runtime coverage, and add the changelog fix line.
- Credit: this follows up on the root-cause and fix direction from https://github.com/openclaw/openclaw/pull/61180 by @adam91holt.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related https://github.com/openclaw/openclaw/pull/61180
- Related https://github.com/openclaw/openclaw/issues/61262
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `loadBundledPluginPublicSurfaceModuleSync()` cached an empty sentinel before module load, but then called `resolveTrackedFacadePluginId()` before copying the loaded exports into that sentinel. Plugin-id resolution can trigger config loading and bundled facade lookups, so re-entrant callers could read the empty sentinel and see `undefined` exports.
- Missing detection / guardrail: existing facade-runtime coverage only covered circular re-entry during module evaluation, not the later post-load/plugin-tracking re-entry path.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugin-sdk/facade-runtime.test.ts`
- Scenario the test should lock in: post-load plugin-id tracking must never expose an empty sentinel during re-entrant facade reads, and failed loads must not report imported facade ids.
- Why this is the smallest reliable guardrail: the failure happens entirely inside the facade loader cache and plugin-manifest/config seam, so a targeted runtime test is enough.

## User-visible / Behavior Changes

- Bundled facade re-entry no longer crashes startup with empty export reads like `shouldNormalizeGoogleProviderConfig is not a function`.

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Human Verification

- Verified scenarios:
  - `pnpm test:serial src/plugin-sdk/facade-runtime.test.ts`
  - `pnpm build`
- Notes:
  - `pnpm check` hit a repo-global/local drift on `apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift` via `check:host-env-policy:swift`, but produced no diff in this branch and is unrelated to the touched facade runtime files.

## Review Conversations

- [x] I addressed the actionable review feedback from the prior PR thread by adding the missing regression test and fixing the stale failed-load assertion.
