### PR TITLE
fix(failover): match finish_reason: network_error from OpenAI-compatible providers

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -696,6 +696,17 @@ describe("isFailoverErrorMessage", () => {
     ]);
   });
 
+  it("matches Provider finish_reason: network_error as timeout (#61281)", () => {
+    // OpenAI-compatible providers like Z.AI emit this exact format.
+    // `\breason:` does not match `finish_reason:` because `_` is a word
+    // character and there is no word boundary before `reason`.
+    expectTimeoutFailoverSamples([
+      "Provider finish_reason: network_error",
+      "Provider finish_reason: abort",
+      "Provider finish_reason: malformed_response",
+    ]);
+  });
+
   it("does not classify MALFORMED_FUNCTION_CALL as timeout", () => {
     const sample = "Unhandled stop reason: MALFORMED_FUNCTION_CALL";
     expect(isTimeoutErrorMessage(sample)).toBe(false);

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -63,6 +63,12 @@ const ERROR_PATTERNS = {
     /\bstop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     /\breason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     /\bunhandled stop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
+    // OpenAI-compatible providers (e.g. Z.AI) surface transport-level errors as
+    // `finish_reason: network_error` in the stream body. The `\breason:` pattern
+    // above does NOT match `finish_reason:` because `_` is a word character so
+    // there is no word boundary before `reason` in `finish_reason`. This covers
+    // that prefix explicitly.
+    /\bfinish_reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
     // AbortError messages from fetch/stream aborts (Ollama NDJSON stream
     // timeouts, signal aborts, etc.) — without these the flattened message
     // falls through to reason=unknown (#58315).


### PR DESCRIPTION
Was debugging a Z.AI fallback failure and traced it to a word-boundary gap in the timeout pattern matcher.

### The problem

When Z.AI (or any OpenAI-compatible provider) returns a transport-level failure, `openai-transport-stream.ts` sets the error message to:

```
Provider finish_reason: network_error
```

The failover classifier calls `isTimeoutErrorMessage()`, which checks the string against `ERROR_PATTERNS.timeout` in `failover-matches.ts`. The existing patterns that handle stop-reason errors are:

```ts
/\bstop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
/\breason:\s*(?:abort|error|malformed_response|network_error)\b/i,
/\bunhandled stop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
```

None of these match `Provider finish_reason: network_error`. The `\breason:` pattern looks promising, but it fails because the underscore in `finish_reason` is a `\w` character — so there is **no** `\b` word boundary between `_` and `r`. You can verify this:

```js
node -e "console.log(/\breason:\s*network_error\b/i.test('provider finish_reason: network_error'))"
// false
```

As a result, `classifyFailoverReason()` returns `null`, no failover classification fires, and the session fails with an error instead of retrying the next model in the chain.

Reproduction:
```js
node -e "
const patterns = [
  /\bstop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
  /\breason:\s*(?:abort|error|malformed_response|network_error)\b/i,
  /\bunhandled stop reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
];
const msg = 'Provider finish_reason: network_error';
const lower = msg.toLowerCase();
console.log('any match:', patterns.some(p => p.test(lower)));
// false — no pattern fires, fallback never triggers
"
```

### The fix

Add an explicit pattern for the `finish_reason:` prefix:

```ts
/\bfinish_reason:\s*(?:abort|error|malformed_response|network_error)\b/i,
```

The same alternation as the sibling patterns is used so the classification semantics are identical. `content_filter` is intentionally excluded (it is not a transient failure).

### Tests

Extended the existing "z.ai network_error stop reason" test group with the actual error string the transport layer emits, plus `abort` and `malformed_response` variants.

```
✓ matches Provider finish_reason: network_error as timeout (#61281)
94 tests passed
```

Fixes #61281