### PR TITLE
[codex] Android: harden assistant launch handling

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AssistantLaunch.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 
 const val actionAskOpenClaw = "ai.openclaw.app.action.ASK_OPENCLAW"
 const val extraAssistantPrompt = "prompt"
+internal const val maxAssistantPromptChars = 2_000
 
 enum class HomeDestination {
   Connect,
@@ -19,6 +20,26 @@ data class AssistantLaunchRequest(
   val autoSend: Boolean,
 )
 
+internal fun sanitizeAssistantPrompt(prompt: String?): String? {
+  return prompt?.trim()?.take(maxAssistantPromptChars)?.ifEmpty { null }
+}
+
+internal fun assistantLaunchFingerprint(request: AssistantLaunchRequest): String {
+  return listOf(request.source, request.autoSend.toString(), request.prompt.orEmpty()).joinToString("\n")
+}
+
+internal fun assistantLaunchFingerprint(intent: Intent?): String? {
+  return parseAssistantLaunchIntent(intent)?.let(::assistantLaunchFingerprint)
+}
+
+internal fun isRestoredAssistantLaunch(
+  intent: Intent?,
+  restoredFingerprint: String?,
+): Boolean {
+  val fingerprint = assistantLaunchFingerprint(intent) ?: return false
+  return fingerprint == restoredFingerprint
+}
+
 fun parseAssistantLaunchIntent(intent: Intent?): AssistantLaunchRequest? {
   val action = intent?.action ?: return null
   return when (action) {
@@ -30,7 +51,7 @@ fun parseAssistantLaunchIntent(intent: Intent?): AssistantLaunchRequest? {
       )
 
     actionAskOpenClaw -> {
-      val prompt = intent.getStringExtra(extraAssistantPrompt)?.trim()?.ifEmpty { null }
+      val prompt = sanitizeAssistantPrompt(intent.getStringExtra(extraAssistantPrompt))
       AssistantLaunchRequest(
         source = "app_action",
         prompt = prompt,

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainActivity.kt
@@ -20,10 +20,14 @@ class MainActivity : ComponentActivity() {
   private lateinit var permissionRequester: PermissionRequester
   private var didAttachRuntimeUi = false
   private var didStartNodeService = false
+  private var restoredAssistantLaunchFingerprint: String? = null
+  private var handledAssistantLaunchFingerprint: String? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    restoredAssistantLaunchFingerprint = savedInstanceState?.getString(assistantLaunchFingerprintStateKey)
     handleAssistantIntent(intent)
+    restoredAssistantLaunchFingerprint = null
     WindowCompat.setDecorFitsSystemWindows(window, false)
     permissionRequester = PermissionRequester(this)
 
@@ -78,8 +82,24 @@ class MainActivity : ComponentActivity() {
     handleAssistantIntent(intent)
   }
 
+  override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    handledAssistantLaunchFingerprint?.let {
+      outState.putString(assistantLaunchFingerprintStateKey, it)
+    }
+  }
+
   private fun handleAssistantIntent(intent: android.content.Intent?) {
     val request = parseAssistantLaunchIntent(intent) ?: return
+    if (isRestoredAssistantLaunch(intent, restoredAssistantLaunchFingerprint)) {
+      handledAssistantLaunchFingerprint = restoredAssistantLaunchFingerprint
+      return
+    }
     viewModel.handleAssistantLaunch(request)
+    handledAssistantLaunchFingerprint = assistantLaunchFingerprint(request)
+  }
+
+  private companion object {
+    const val assistantLaunchFingerprintStateKey = "assistantLaunchFingerprint"
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -3,6 +3,7 @@ package ai.openclaw.app
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatPendingToolCall
@@ -22,16 +23,21 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class MainViewModel(app: Application) : AndroidViewModel(app) {
+class MainViewModel(
+  app: Application,
+  private val savedStateHandle: SavedStateHandle,
+) : AndroidViewModel(app) {
   private val nodeApp = app as NodeApp
   private val prefs = nodeApp.prefs
   private val runtimeRef = MutableStateFlow<NodeRuntime?>(null)
   private var foreground = true
-  private val _requestedHomeDestination = MutableStateFlow<HomeDestination?>(null)
+  private val _requestedHomeDestination =
+    MutableStateFlow(savedStateHandle.get<String>(requestedHomeDestinationStateKey)?.let(::decodeHomeDestination))
   val requestedHomeDestination: StateFlow<HomeDestination?> = _requestedHomeDestination
-  private val _chatDraft = MutableStateFlow<String?>(null)
+  private val _chatDraft = MutableStateFlow(savedStateHandle.get<String>(chatDraftStateKey))
   val chatDraft: StateFlow<String?> = _chatDraft
-  private val _pendingAssistantAutoSend = MutableStateFlow<String?>(null)
+  private val _pendingAssistantAutoSend =
+    MutableStateFlow(savedStateHandle.get<String>(pendingAssistantAutoSendStateKey))
   val pendingAssistantAutoSend: StateFlow<String?> = _pendingAssistantAutoSend
 
   private fun ensureRuntime(): NodeRuntime {
@@ -253,26 +259,41 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
   }
 
   fun handleAssistantLaunch(request: AssistantLaunchRequest) {
-    _requestedHomeDestination.value = HomeDestination.Chat
+    setRequestedHomeDestination(HomeDestination.Chat)
     if (request.autoSend) {
-      _pendingAssistantAutoSend.value = request.prompt
-      _chatDraft.value = null
+      setPendingAssistantAutoSend(request.prompt)
+      setChatDraft(null)
       return
     }
-    _pendingAssistantAutoSend.value = null
-    _chatDraft.value = request.prompt
+    setPendingAssistantAutoSend(null)
+    setChatDraft(request.prompt)
   }
 
   fun clearRequestedHomeDestination() {
-    _requestedHomeDestination.value = null
+    setRequestedHomeDestination(null)
   }
 
   fun clearChatDraft() {
-    _chatDraft.value = null
+    setChatDraft(null)
   }
 
   fun clearPendingAssistantAutoSend() {
-    _pendingAssistantAutoSend.value = null
+    setPendingAssistantAutoSend(null)
+  }
+
+  private fun setRequestedHomeDestination(value: HomeDestination?) {
+    _requestedHomeDestination.value = value
+    savedStateHandle[requestedHomeDestinationStateKey] = value?.name
+  }
+
+  private fun setChatDraft(value: String?) {
+    _chatDraft.value = value
+    savedStateHandle[chatDraftStateKey] = value
+  }
+
+  private fun setPendingAssistantAutoSend(value: String?) {
+    _pendingAssistantAutoSend.value = value
+    savedStateHandle[pendingAssistantAutoSendStateKey] = value
   }
 
   fun setMicEnabled(enabled: Boolean) {
@@ -377,5 +398,15 @@ class MainViewModel(app: Application) : AndroidViewModel(app) {
       thinking = thinking,
       attachments = attachments,
     )
+  }
+
+  private companion object {
+    const val requestedHomeDestinationStateKey = "requestedHomeDestination"
+    const val chatDraftStateKey = "chatDraft"
+    const val pendingAssistantAutoSendStateKey = "pendingAssistantAutoSend"
+
+    fun decodeHomeDestination(value: String): HomeDestination? {
+      return enumValues<HomeDestination>().firstOrNull { it.name == value }
+    }
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/AssistantLaunchTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AssistantLaunchTest.kt
@@ -37,6 +37,35 @@ class AssistantLaunchTest {
   }
 
   @Test
+  fun trimsAndBoundsAppActionPrompt() {
+    val oversized = "x".repeat(maxAssistantPromptChars + 123)
+    val parsed =
+      parseAssistantLaunchIntent(
+        Intent(actionAskOpenClaw).putExtra(extraAssistantPrompt, "  $oversized  "),
+      )
+
+    requireNotNull(parsed)
+    assertEquals(maxAssistantPromptChars, parsed.prompt?.length)
+    assertTrue(parsed.autoSend)
+  }
+
+  @Test
+  fun consumesAssistantLaunchIntentAfterHandling() {
+    val assist = Intent(Intent.ACTION_ASSIST)
+    val appAction = Intent(actionAskOpenClaw).putExtra(extraAssistantPrompt, "summarize mail")
+
+    assertTrue(isRestoredAssistantLaunch(assist, assistantLaunchFingerprint(assist)))
+    assertTrue(isRestoredAssistantLaunch(appAction, assistantLaunchFingerprint(appAction)))
+  }
+
+  @Test
+  fun treatsFreshIdenticalPromptAsNewWhenNoRestoredFingerprintExists() {
+    val intent = Intent(actionAskOpenClaw).putExtra(extraAssistantPrompt, "summarize mail")
+
+    assertFalse(isRestoredAssistantLaunch(intent, restoredFingerprint = null))
+  }
+
+  @Test
   fun ignoresUnrelatedIntents() {
     assertNull(parseAssistantLaunchIntent(Intent(Intent.ACTION_VIEW)))
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/MainViewModelTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/MainViewModelTest.kt
@@ -1,0 +1,35 @@
+package ai.openclaw.app
+
+import androidx.lifecycle.SavedStateHandle
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class MainViewModelTest {
+  @Test
+  fun restoresPendingAssistantAutoSendFromSavedStateHandle() {
+    val app = RuntimeEnvironment.getApplication() as NodeApp
+    val state = SavedStateHandle()
+    val viewModel = MainViewModel(app, state)
+
+    viewModel.handleAssistantLaunch(
+      AssistantLaunchRequest(
+        source = "app_action",
+        prompt = "summarize my unread mail",
+        autoSend = true,
+      ),
+    )
+
+    val restored = MainViewModel(app, state)
+
+    assertEquals(HomeDestination.Chat, restored.requestedHomeDestination.value)
+    assertEquals("summarize my unread mail", restored.pendingAssistantAutoSend.value)
+    assertNull(restored.chatDraft.value)
+  }
+}


### PR DESCRIPTION
## Summary

- Problem: Android assistant launches could be replayed or dropped across activity/task recreation, and App Action prompts were accepted without bounded sanitization.
- Why it matters: `ACTION_ASSIST` / `ASK_OPENCLAW` entrypoints can silently no-op or retrigger stale chat state after low-memory process death, which makes the default-assistant flow unreliable.
- What changed: assistant launch prompts are trimmed and capped, launch state is restored through `SavedStateHandle`, and `MainActivity` now fingerprints/restores handled assistant launches instead of relying on `setIntent()` to consume them.
- What did NOT change (scope boundary): no `VoiceInteractionService` implementation, no manifest role changes, and no new assistant capabilities beyond the existing Android assistant/app-action entrypoints.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: assistant launch handling kept transient routing state only in-memory and initially tried to suppress stale launches using activity-instance state (`savedInstanceState` guard, then `setIntent()`), neither of which reliably models Android task/process recreation.
- Missing detection / guardrail: there was no persistence/identity check for already-consumed assistant launches, and prompt input from app actions was not bounded.
- Contributing context (if known): the Android assistant entrypoints were added recently and review feedback exposed multiple process-recreation edge cases.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `apps/android/app/src/test/java/ai/openclaw/app/AssistantLaunchTest.kt`, `apps/android/app/src/test/java/ai/openclaw/app/MainViewModelTest.kt`
- Scenario the test should lock in: bounded prompt sanitization, restored-launch fingerprint detection, and restoration of pending assistant launch state from `SavedStateHandle`.
- Why this is the smallest reliable guardrail: the failure modes are launch-state and lifecycle bookkeeping bugs that can be exercised without a full device/UI test harness.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Android assistant/app-action launches are more reliable after low-memory process death or activity recreation.
- Oversized App Action prompts are trimmed and capped before entering the chat flow.

## Diagram (if applicable)

```text
Before:
[assistant launch] -> [activity recreate / process death] -> [stale launch replay or dropped launch]

After:
[assistant launch] -> [fingerprint + saved launch state] -> [restore path skips only already-handled launch] -> [fresh launches still route to chat]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Android Gradle unit test / Kotlin compile
- Model/provider: N/A
- Integration/channel (if any): Android assistant / Google App Actions entrypoints
- Relevant config (redacted): default app test configuration

### Steps

1. Trigger OpenClaw from `ACTION_ASSIST` or `ASK_OPENCLAW`.
2. Simulate activity/task recreation or low-memory process death restore.
3. Trigger the same launch path again and inspect whether chat routing is replayed, dropped, or restored correctly.

### Expected

- Previously handled restored launches are not replayed.
- Fresh launches still route into Chat.
- App Action prompts are trimmed and bounded.

### Actual

- With this patch, the expected behavior is observed in the covered unit tests and compile validation.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran targeted Android assistant launch unit tests and Kotlin compile validation for the touched flavor(s).
- Edge cases checked: repeated identical prompts, restored assistant launches, pending auto-send restoration, bounded prompt sanitization.
- What you did **not** verify: end-to-end device behavior for actual process death / task restoration, and no screenshots are included because this is launch-state logic rather than a visual UI change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: assistant launch fingerprinting could suppress a legitimate restored launch if Android reuses an identical launch as part of task restoration semantics.
  - Mitigation: fingerprint suppression is scoped to restored instance state only; fresh `onNewIntent` launches still execute normally.

- Risk: `SavedStateHandle` persistence could retain transient chat routing longer than intended.
  - Mitigation: existing clear paths now write through to `SavedStateHandle`, and regression tests cover restoration of the transient state.

AI-assisted: Codex

## Testing

- `ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.AssistantLaunchTest' --tests 'ai.openclaw.app.MainViewModelTest' :app:testThirdPartyDebugUnitTest --tests 'ai.openclaw.app.AssistantLaunchTest' --tests 'ai.openclaw.app.MainViewModelTest'`
- `ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew :app:compileThirdPartyDebugKotlin`