### PR TITLE
feat(bedrock): add inference profile discovery and region injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - Providers/request overrides: add shared model and media request transport overrides across OpenAI-, Anthropic-, Google-, and compatible provider paths, including headers, auth, proxy, and TLS controls. (#60200)
 - Providers/StepFun: add the bundled StepFun provider plugin with standard and Step Plan endpoints, China/global onboarding choices, `step-3.5-flash` on both catalogs, and `step-3.5-flash-2603` currently exposed on Step Plan. (#60032) Thanks @hengm3467.
 - Tools/web_search: add a bundled MiniMax Search provider backed by the Coding Plan search API, with region reuse from `MINIMAX_API_HOST` and plugin-owned credential config. (#54648) Thanks @fengmk2.
+- Providers/Amazon Bedrock: discover regional and global inference profiles, inherit their backing model capabilities, and inject the Bedrock request region automatically so cross-region Claude profiles work without manual provider overrides. (#61299) Thanks @wirjo.
 
 ### Fixes
 

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -182,32 +182,43 @@ describe("bedrock discovery", () => {
           {
             inferenceProfileId: "us.anthropic.claude-sonnet-4-6",
             inferenceProfileName: "US Anthropic Claude Sonnet 4.6",
-            inferenceProfileArn: "arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-sonnet-4-6",
+            inferenceProfileArn:
+              "arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-sonnet-4-6",
             status: "ACTIVE",
             type: "SYSTEM_DEFINED",
             models: [
-              { modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6" },
-              { modelArn: "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-4-6" },
+              {
+                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
+              },
+              {
+                modelArn: "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-4-6",
+              },
             ],
           },
           {
             inferenceProfileId: "eu.anthropic.claude-sonnet-4-6",
             inferenceProfileName: "EU Anthropic Claude Sonnet 4.6",
-            inferenceProfileArn: "arn:aws:bedrock:eu-west-1::inference-profile/eu.anthropic.claude-sonnet-4-6",
+            inferenceProfileArn:
+              "arn:aws:bedrock:eu-west-1::inference-profile/eu.anthropic.claude-sonnet-4-6",
             status: "ACTIVE",
             type: "SYSTEM_DEFINED",
             models: [
-              { modelArn: "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-sonnet-4-6" },
+              {
+                modelArn: "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-sonnet-4-6",
+              },
             ],
           },
           {
             inferenceProfileId: "global.anthropic.claude-sonnet-4-6",
             inferenceProfileName: "Global Anthropic Claude Sonnet 4.6",
-            inferenceProfileArn: "arn:aws:bedrock:us-east-1::inference-profile/global.anthropic.claude-sonnet-4-6",
+            inferenceProfileArn:
+              "arn:aws:bedrock:us-east-1::inference-profile/global.anthropic.claude-sonnet-4-6",
             status: "ACTIVE",
             type: "SYSTEM_DEFINED",
             models: [
-              { modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6" },
+              {
+                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
+              },
             ],
           },
           // Inactive profile should be filtered out.
@@ -263,6 +274,91 @@ describe("bedrock discovery", () => {
     // Foundation model should still be discovered despite profile discovery failure.
     expect(models).toHaveLength(1);
     expect(models[0]?.id).toBe("anthropic.claude-3-7-sonnet-20250219-v1:0");
+  });
+
+  it("keeps matching inference profiles when provider filters are enabled", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [
+          {
+            modelId: "anthropic.claude-sonnet-4-6",
+            modelName: "Claude Sonnet 4.6",
+            providerName: "anthropic",
+            inputModalities: ["TEXT", "IMAGE"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "global.anthropic.claude-sonnet-4-6",
+            inferenceProfileName: "Global Anthropic Claude Sonnet 4.6",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [
+              {
+                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
+              },
+            ],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({
+      region: "us-east-1",
+      config: { providerFilter: ["anthropic"] },
+      clientFactory,
+    });
+
+    expect(models.map((model) => model.id)).toEqual([
+      "global.anthropic.claude-sonnet-4-6",
+      "anthropic.claude-sonnet-4-6",
+    ]);
+  });
+
+  it("prefers backing model ARNs for application profiles with region-like ids", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [
+          {
+            modelId: "anthropic.claude-sonnet-4-6",
+            modelName: "Claude Sonnet 4.6",
+            providerName: "anthropic",
+            inputModalities: ["TEXT", "IMAGE"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "us.my-prod-profile",
+            inferenceProfileName: "Prod Claude Profile",
+            status: "ACTIVE",
+            type: "APPLICATION",
+            models: [
+              {
+                modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6",
+              },
+            ],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    const profile = models.find((model) => model.id === "us.my-prod-profile");
+
+    expect(profile).toMatchObject({
+      id: "us.my-prod-profile",
+      input: ["text", "image"],
+      contextWindow: 32000,
+      maxTokens: 4096,
+    });
   });
 
   it("merges implicit Bedrock models into explicit provider overrides", () => {

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -22,9 +22,12 @@ const baseActiveAnthropicSummary = {
 };
 
 function mockSingleActiveSummary(overrides: Partial<typeof baseActiveAnthropicSummary> = {}): void {
-  sendMock.mockResolvedValueOnce({
-    modelSummaries: [{ ...baseActiveAnthropicSummary, ...overrides }],
-  });
+  sendMock
+    .mockResolvedValueOnce({
+      modelSummaries: [{ ...baseActiveAnthropicSummary, ...overrides }],
+    })
+    // ListInferenceProfiles response (empty — no inference profiles in basic tests).
+    .mockResolvedValueOnce({ inferenceProfileSummaries: [] });
 }
 
 describe("bedrock discovery", () => {
@@ -34,46 +37,48 @@ describe("bedrock discovery", () => {
   });
 
   it("filters to active streaming text models and maps modalities", async () => {
-    sendMock.mockResolvedValueOnce({
-      modelSummaries: [
-        {
-          modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
-          modelName: "Claude 3.7 Sonnet",
-          providerName: "anthropic",
-          inputModalities: ["TEXT", "IMAGE"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-        {
-          modelId: "anthropic.claude-3-haiku-20240307-v1:0",
-          modelName: "Claude 3 Haiku",
-          providerName: "anthropic",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: false,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-        {
-          modelId: "meta.llama3-8b-instruct-v1:0",
-          modelName: "Llama 3 8B",
-          providerName: "meta",
-          inputModalities: ["TEXT"],
-          outputModalities: ["TEXT"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "INACTIVE" },
-        },
-        {
-          modelId: "amazon.titan-embed-text-v1",
-          modelName: "Titan Embed",
-          providerName: "amazon",
-          inputModalities: ["TEXT"],
-          outputModalities: ["EMBEDDING"],
-          responseStreamingSupported: true,
-          modelLifecycle: { status: "ACTIVE" },
-        },
-      ],
-    });
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [
+          {
+            modelId: "anthropic.claude-3-7-sonnet-20250219-v1:0",
+            modelName: "Claude 3.7 Sonnet",
+            providerName: "anthropic",
+            inputModalities: ["TEXT", "IMAGE"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+          {
+            modelId: "anthropic.claude-3-haiku-20240307-v1:0",
+            modelName: "Claude 3 Haiku",
+            providerName: "anthropic",
+            inputModalities: ["TEXT"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: false,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+          {
+            modelId: "meta.llama3-8b-instruct-v1:0",
+            modelName: "Llama 3 8B",
+            providerName: "meta",
+            inputModalities: ["TEXT"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "INACTIVE" },
+          },
+          {
+            modelId: "amazon.titan-embed-text-v1",
+            modelName: "Titan Embed",
+            providerName: "amazon",
+            inputModalities: ["TEXT"],
+            outputModalities: ["EMBEDDING"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ inferenceProfileSummaries: [] });
 
     const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
     expect(models).toHaveLength(1);
@@ -114,13 +119,16 @@ describe("bedrock discovery", () => {
 
     await discoverBedrockModels({ region: "us-east-1", clientFactory });
     await discoverBedrockModels({ region: "us-east-1", clientFactory });
-    expect(sendMock).toHaveBeenCalledTimes(1);
+    // 2 calls on first discovery (ListFoundationModels + ListInferenceProfiles), 0 on cached second.
+    expect(sendMock).toHaveBeenCalledTimes(2);
   });
 
   it("skips cache when refreshInterval is 0", async () => {
     sendMock
       .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
-      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] });
+      .mockResolvedValueOnce({ inferenceProfileSummaries: [] })
+      .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
+      .mockResolvedValueOnce({ inferenceProfileSummaries: [] });
 
     await discoverBedrockModels({
       region: "us-east-1",
@@ -132,7 +140,8 @@ describe("bedrock discovery", () => {
       config: { refreshInterval: 0 },
       clientFactory,
     });
-    expect(sendMock).toHaveBeenCalledTimes(2);
+    // 2 calls per discovery (ListFoundationModels + ListInferenceProfiles) × 2 runs.
+    expect(sendMock).toHaveBeenCalledTimes(4);
   });
 
   it("resolves the Bedrock config apiKey from AWS auth env vars", () => {
@@ -151,6 +160,109 @@ describe("bedrock discovery", () => {
     expect(resolveBedrockConfigApiKey({ AWS_PROFILE: "default" } as NodeJS.ProcessEnv)).toBe(
       "AWS_PROFILE",
     );
+  });
+
+  it("discovers inference profiles and inherits foundation model capabilities", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [
+          {
+            modelId: "anthropic.claude-sonnet-4-6",
+            modelName: "Claude Sonnet 4.6",
+            providerName: "anthropic",
+            inputModalities: ["TEXT", "IMAGE"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "us.anthropic.claude-sonnet-4-6",
+            inferenceProfileName: "US Anthropic Claude Sonnet 4.6",
+            inferenceProfileArn: "arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-sonnet-4-6",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [
+              { modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6" },
+              { modelArn: "arn:aws:bedrock:us-west-2::foundation-model/anthropic.claude-sonnet-4-6" },
+            ],
+          },
+          {
+            inferenceProfileId: "eu.anthropic.claude-sonnet-4-6",
+            inferenceProfileName: "EU Anthropic Claude Sonnet 4.6",
+            inferenceProfileArn: "arn:aws:bedrock:eu-west-1::inference-profile/eu.anthropic.claude-sonnet-4-6",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [
+              { modelArn: "arn:aws:bedrock:eu-west-1::foundation-model/anthropic.claude-sonnet-4-6" },
+            ],
+          },
+          {
+            inferenceProfileId: "global.anthropic.claude-sonnet-4-6",
+            inferenceProfileName: "Global Anthropic Claude Sonnet 4.6",
+            inferenceProfileArn: "arn:aws:bedrock:us-east-1::inference-profile/global.anthropic.claude-sonnet-4-6",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [
+              { modelArn: "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6" },
+            ],
+          },
+          // Inactive profile should be filtered out.
+          {
+            inferenceProfileId: "ap.anthropic.claude-sonnet-4-6",
+            inferenceProfileName: "AP Claude Sonnet 4.6",
+            status: "LEGACY",
+            type: "SYSTEM_DEFINED",
+            models: [],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+
+    // Foundation model + 3 active inference profiles = 4 models.
+    expect(models).toHaveLength(4);
+
+    // Global profiles should be sorted first (recommended for most users).
+    expect(models[0]?.id).toBe("global.anthropic.claude-sonnet-4-6");
+
+    const foundationModel = models.find((m) => m.id === "anthropic.claude-sonnet-4-6");
+    const usProfile = models.find((m) => m.id === "us.anthropic.claude-sonnet-4-6");
+    const euProfile = models.find((m) => m.id === "eu.anthropic.claude-sonnet-4-6");
+    const globalProfile = models.find((m) => m.id === "global.anthropic.claude-sonnet-4-6");
+
+    // Foundation model has image input.
+    expect(foundationModel).toMatchObject({ input: ["text", "image"] });
+
+    // Inference profiles inherit image input from the foundation model.
+    expect(usProfile).toMatchObject({
+      name: "US Anthropic Claude Sonnet 4.6",
+      input: ["text", "image"],
+      contextWindow: 32000,
+      maxTokens: 4096,
+    });
+    expect(euProfile).toMatchObject({ input: ["text", "image"] });
+    expect(globalProfile).toMatchObject({ input: ["text", "image"] });
+
+    // Inactive profile should not be present.
+    expect(models.find((m) => m.id === "ap.anthropic.claude-sonnet-4-6")).toBeUndefined();
+  });
+
+  it("gracefully handles ListInferenceProfiles permission errors", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [baseActiveAnthropicSummary],
+      })
+      // Simulate AccessDeniedException for ListInferenceProfiles.
+      .mockRejectedValueOnce(new Error("AccessDeniedException"));
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+    // Foundation model should still be discovered despite profile discovery failure.
+    expect(models).toHaveLength(1);
+    expect(models[0]?.id).toBe("anthropic.claude-3-7-sonnet-20250219-v1:0");
   });
 
   it("merges implicit Bedrock models into explicit provider overrides", () => {
@@ -204,7 +316,8 @@ describe("bedrock discovery", () => {
     });
 
     expect(pluginEnabled?.baseUrl).toBe("https://bedrock-runtime.us-east-1.amazonaws.com");
-    expect(sendMock).toHaveBeenCalledTimes(1);
+    // 2 calls per discovery (ListFoundationModels + ListInferenceProfiles).
+    expect(sendMock).toHaveBeenCalledTimes(2);
 
     mockSingleActiveSummary();
 
@@ -222,6 +335,6 @@ describe("bedrock discovery", () => {
     });
 
     expect(legacyEnabled?.baseUrl).toBe("https://bedrock-runtime.us-west-2.amazonaws.com");
-    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock).toHaveBeenCalledTimes(4);
   });
 });

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -174,15 +174,15 @@ function toModelDefinition(
  *   → "anthropic.claude-sonnet-4-6"
  */
 function resolveBaseModelId(profile: InferenceProfileSummary): string | undefined {
-  const id = profile.inferenceProfileId ?? "";
-  // System-defined: strip the region prefix (us., eu., ap., jp., global.)
-  const prefixMatch = /^(?:us|eu|ap|jp|global)\.(.+)$/i.exec(id);
-  if (prefixMatch) return prefixMatch[1];
-  // Application: extract model ID from the first model ARN.
   const firstArn = profile.models?.[0]?.modelArn;
   if (firstArn) {
     const arnMatch = /foundation-model\/(.+)$/.exec(firstArn);
     if (arnMatch) return arnMatch[1];
+  }
+  if (profile.type === "SYSTEM_DEFINED") {
+    const id = profile.inferenceProfileId ?? "";
+    const prefixMatch = /^(?:us|eu|ap|jp|global)\.(.+)$/i.exec(id);
+    if (prefixMatch) return prefixMatch[1];
   }
   return undefined;
 }

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -2,6 +2,8 @@ import {
   BedrockClient,
   ListFoundationModelsCommand,
   type ListFoundationModelsCommandOutput,
+  ListInferenceProfilesCommand,
+  type ListInferenceProfilesCommandOutput,
 } from "@aws-sdk/client-bedrock";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/core";
 import { resolveAwsSdkEnvVarName } from "openclaw/plugin-sdk/provider-auth-runtime";
@@ -25,6 +27,10 @@ const DEFAULT_COST = {
 
 type BedrockModelSummary = NonNullable<ListFoundationModelsCommandOutput["modelSummaries"]>[number];
 
+type InferenceProfileSummary = NonNullable<
+  ListInferenceProfilesCommandOutput["inferenceProfileSummaries"]
+>[number];
+
 type BedrockDiscoveryCacheEntry = {
   expiresAt: number;
   value?: ModelDefinitionConfig[];
@@ -33,6 +39,10 @@ type BedrockDiscoveryCacheEntry = {
 
 const discoveryCache = new Map<string, BedrockDiscoveryCacheEntry>();
 let hasLoggedBedrockError = false;
+
+// ---------------------------------------------------------------------------
+// Helper utilities
+// ---------------------------------------------------------------------------
 
 function normalizeProviderFilter(filter?: string[]): string[] {
   if (!filter || filter.length === 0) {
@@ -96,6 +106,10 @@ function resolveDefaultMaxTokens(config?: BedrockDiscoveryConfig): number {
   return value > 0 ? value : DEFAULT_MAX_TOKENS;
 }
 
+// ---------------------------------------------------------------------------
+// Foundation model helpers
+// ---------------------------------------------------------------------------
+
 function matchesProviderFilter(summary: BedrockModelSummary, filter: string[]): boolean {
   if (filter.length === 0) {
     return true;
@@ -144,6 +158,117 @@ function toModelDefinition(
     maxTokens: defaults.maxTokens,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Inference profile helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the base foundation model ID from an inference profile.
+ *
+ * System-defined profiles use a region prefix:
+ *   "us.anthropic.claude-sonnet-4-6" → "anthropic.claude-sonnet-4-6"
+ *
+ * Application profiles carry the model ARN in their models[] array:
+ *   models[0].modelArn = "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6"
+ *   → "anthropic.claude-sonnet-4-6"
+ */
+function resolveBaseModelId(profile: InferenceProfileSummary): string | undefined {
+  const id = profile.inferenceProfileId ?? "";
+  // System-defined: strip the region prefix (us., eu., ap., jp., global.)
+  const prefixMatch = /^(?:us|eu|ap|jp|global)\.(.+)$/i.exec(id);
+  if (prefixMatch) return prefixMatch[1];
+  // Application: extract model ID from the first model ARN.
+  const firstArn = profile.models?.[0]?.modelArn;
+  if (firstArn) {
+    const arnMatch = /foundation-model\/(.+)$/.exec(firstArn);
+    if (arnMatch) return arnMatch[1];
+  }
+  return undefined;
+}
+
+/**
+ * Fetch raw inference profile summaries from the Bedrock control plane.
+ * Handles pagination. Best-effort: silently returns empty array if IAM lacks
+ * bedrock:ListInferenceProfiles permission.
+ */
+async function fetchInferenceProfileSummaries(
+  client: BedrockClient,
+): Promise<InferenceProfileSummary[]> {
+  try {
+    const profiles: InferenceProfileSummary[] = [];
+    let nextToken: string | undefined;
+    do {
+      const response: ListInferenceProfilesCommandOutput = await client.send(
+        new ListInferenceProfilesCommand({ nextToken }),
+      );
+      for (const summary of response.inferenceProfileSummaries ?? []) {
+        profiles.push(summary);
+      }
+      nextToken = response.nextToken;
+    } while (nextToken);
+    return profiles;
+  } catch (error) {
+    log.debug?.("Skipping inference profile discovery", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}
+
+/**
+ * Convert raw inference profile summaries into model definitions.
+ *
+ * Each profile inherits capabilities (modalities, reasoning, context window,
+ * cost) from its underlying foundation model. This ensures that
+ * "us.anthropic.claude-sonnet-4-6" has the same capabilities as
+ * "anthropic.claude-sonnet-4-6" — including image input, reasoning support,
+ * and token limits.
+ *
+ * When the foundation model isn't found in the map (e.g. the model is only
+ * available via inference profiles in this region), safe defaults are used.
+ */
+function resolveInferenceProfiles(
+  profiles: InferenceProfileSummary[],
+  defaults: { contextWindow: number; maxTokens: number },
+  providerFilter: string[],
+  foundationModels: Map<string, ModelDefinitionConfig>,
+): ModelDefinitionConfig[] {
+  const discovered: ModelDefinitionConfig[] = [];
+  for (const profile of profiles) {
+    if (!profile.inferenceProfileId?.trim()) continue;
+    if (profile.status !== "ACTIVE") continue;
+
+    // Apply provider filter: check if any of the underlying models match.
+    if (providerFilter.length > 0) {
+      const models = profile.models ?? [];
+      const matchesFilter = models.some((m) => {
+        const provider = m.modelArn?.split("/")?.[1]?.split(".")?.[0];
+        return provider ? providerFilter.includes(provider.toLowerCase()) : false;
+      });
+      if (!matchesFilter) continue;
+    }
+
+    // Look up the underlying foundation model to inherit its capabilities.
+    const baseModelId = resolveBaseModelId(profile);
+    const baseModel = baseModelId ? foundationModels.get(baseModelId.toLowerCase()) : undefined;
+
+    discovered.push({
+      id: profile.inferenceProfileId,
+      name: profile.inferenceProfileName?.trim() || profile.inferenceProfileId,
+      reasoning: baseModel?.reasoning ?? false,
+      input: baseModel?.input ?? ["text"],
+      cost: baseModel?.cost ?? DEFAULT_COST,
+      contextWindow: baseModel?.contextWindow ?? defaults.contextWindow,
+      maxTokens: baseModel?.maxTokens ?? defaults.maxTokens,
+    });
+  }
+  return discovered;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 export function resetBedrockDiscoveryCacheForTest(): void {
   discoveryCache.clear();
@@ -194,20 +319,56 @@ export async function discoverBedrockModels(params: {
   const client = clientFactory(params.region);
 
   const discoveryPromise = (async () => {
-    const response = await client.send(new ListFoundationModelsCommand({}));
+    // Discover foundation models and inference profiles in parallel.
+    // Both API calls are independent, but we need the foundation model data
+    // to resolve inference profile capabilities — so we fetch in parallel,
+    // then build the lookup map before processing profiles.
+    const [foundationResponse, profileSummaries] = await Promise.all([
+      client.send(new ListFoundationModelsCommand({})),
+      fetchInferenceProfileSummaries(client),
+    ]);
+
     const discovered: ModelDefinitionConfig[] = [];
-    for (const summary of response.modelSummaries ?? []) {
+    const seenIds = new Set<string>();
+    const foundationModels = new Map<string, ModelDefinitionConfig>();
+
+    // Foundation models first — build both the results list and the lookup map.
+    for (const summary of foundationResponse.modelSummaries ?? []) {
       if (!shouldIncludeSummary(summary, providerFilter)) {
         continue;
       }
-      discovered.push(
-        toModelDefinition(summary, {
-          contextWindow: defaultContextWindow,
-          maxTokens: defaultMaxTokens,
-        }),
-      );
+      const def = toModelDefinition(summary, {
+        contextWindow: defaultContextWindow,
+        maxTokens: defaultMaxTokens,
+      });
+      discovered.push(def);
+      seenIds.add(def.id.toLowerCase());
+      foundationModels.set(def.id.toLowerCase(), def);
     }
-    return discovered.toSorted((a, b) => a.name.localeCompare(b.name));
+
+    // Merge inference profiles — inherit capabilities from foundation models.
+    const inferenceProfiles = resolveInferenceProfiles(
+      profileSummaries,
+      { contextWindow: defaultContextWindow, maxTokens: defaultMaxTokens },
+      providerFilter,
+      foundationModels,
+    );
+    for (const profile of inferenceProfiles) {
+      if (!seenIds.has(profile.id.toLowerCase())) {
+        discovered.push(profile);
+        seenIds.add(profile.id.toLowerCase());
+      }
+    }
+
+    // Sort: global cross-region profiles first (recommended for most users —
+    // better capacity, automatic failover, no data sovereignty constraints),
+    // then remaining profiles/models alphabetically.
+    return discovered.toSorted((a, b) => {
+      const aGlobal = a.id.startsWith("global.") ? 0 : 1;
+      const bGlobal = b.id.startsWith("global.") ? 0 : 1;
+      if (aGlobal !== bGlobal) return aGlobal - bGlobal;
+      return a.name.localeCompare(b.name);
+    });
   })();
 
   if (refreshIntervalSeconds > 0) {

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -1,6 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
+import { buildProviderReplayFamilyHooks, normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   createBedrockNoCacheWrapper,
   isAnthropicBedrockModel,
@@ -61,6 +61,9 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
   // initialization during test bootstrap cannot trip TDZ reads.
   const providerId = "amazon-bedrock";
   const claude46ModelRe = /claude-(?:opus|sonnet)-4(?:\.|-)6(?:$|[-.])/i;
+  // Match region from bedrock-runtime (Converse API) URLs.
+  // e.g. https://bedrock-runtime.us-east-1.amazonaws.com
+  const bedrockRegionRe = /bedrock-runtime\.([a-z0-9-]+)\.amazonaws\./;
   const bedrockContextOverflowPatterns = [
     /ValidationException.*(?:input is too long|max input token|input token.*exceed)/i,
     /ValidationException.*(?:exceeds? the (?:maximum|max) (?:number of )?(?:input )?tokens)/i,
@@ -75,10 +78,44 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
   const baseWrapStreamFn = ({ modelId, streamFn }: { modelId: string; streamFn?: StreamFn }) =>
     isAnthropicBedrockModel(modelId) ? streamFn : createBedrockNoCacheWrapper(streamFn);
 
-  const wrapStreamFn =
+  const cacheWrapStreamFn =
     guardrail?.guardrailIdentifier && guardrail?.guardrailVersion
       ? createGuardrailWrapStreamFn(baseWrapStreamFn, guardrail)
       : baseWrapStreamFn;
+
+  /** Extract the AWS region from a bedrock-runtime baseUrl. */
+  function extractRegionFromBaseUrl(baseUrl: string | undefined): string | undefined {
+    if (!baseUrl) return undefined;
+    return bedrockRegionRe.exec(baseUrl)?.[1];
+  }
+
+  /**
+   * Resolve the AWS region for Bedrock API calls.
+   * Provider-specific baseUrl wins over global bedrockDiscovery to avoid signing
+   * with the wrong region when discovery and provider target different regions.
+   */
+  function resolveBedrockRegion(
+    config:
+      | { models?: { bedrockDiscovery?: { region?: string }; providers?: Record<string, unknown> } }
+      | undefined,
+  ): string | undefined {
+    // Try provider-specific baseUrl first.
+    const providers = config?.models?.providers;
+    if (providers) {
+      const exact = (providers[providerId] as { baseUrl?: string } | undefined)?.baseUrl;
+      if (exact) {
+        const region = extractRegionFromBaseUrl(exact);
+        if (region) return region;
+      }
+      // Fall back to alias matches (e.g. "bedrock" instead of "amazon-bedrock").
+      for (const [key, value] of Object.entries(providers)) {
+        if (key === providerId || normalizeProviderId(key) !== providerId) continue;
+        const region = extractRegionFromBaseUrl((value as { baseUrl?: string }).baseUrl);
+        if (region) return region;
+      }
+    }
+    return config?.models?.bedrockDiscovery?.region;
+  }
 
   api.registerProvider({
     id: providerId,
@@ -106,7 +143,29 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
     },
     resolveConfigApiKey: ({ env }) => resolveBedrockConfigApiKey(env),
     ...anthropicByModelReplayHooks,
-    wrapStreamFn,
+    wrapStreamFn: ({ modelId, config, model, streamFn }) => {
+      // Apply cache + guardrail wrapping.
+      const wrapped = cacheWrapStreamFn({ modelId, streamFn });
+      const region = resolveBedrockRegion(config) ?? extractRegionFromBaseUrl(model?.baseUrl);
+
+      if (!region) {
+        return wrapped;
+      }
+
+      // Wrap to inject the region into every stream call so pi-ai's Bedrock
+      // client connects to the right region for inference profile IDs.
+      const underlying = wrapped ?? streamFn;
+      if (!underlying) {
+        return wrapped;
+      }
+      return (streamModel, context, options) => {
+        // pi-ai's bedrock provider reads `options.region` at runtime but the
+        // StreamFn type does not declare it. Merge via Object.assign to avoid
+        // an unsafe type assertion.
+        const merged = Object.assign({}, options, { region });
+        return underlying(streamModel, context, merged);
+      };
+    },
     matchesContextOverflowError: ({ errorMessage }) =>
       bedrockContextOverflowPatterns.some((pattern) => pattern.test(errorMessage)),
     classifyFailoverReason: ({ errorMessage }) => {

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -1,6 +1,9 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
-import { buildProviderReplayFamilyHooks, normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  buildProviderReplayFamilyHooks,
+  normalizeProviderId,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import {
   createBedrockNoCacheWrapper,
   isAnthropicBedrockModel,

--- a/src/agents/pi-embedded-runner/anthropic-family-cache-semantics.ts
+++ b/src/agents/pi-embedded-runner/anthropic-family-cache-semantics.ts
@@ -7,9 +7,37 @@ export function isAnthropicModelRef(modelId: string): boolean {
   return modelId.trim().toLowerCase().startsWith("anthropic/");
 }
 
+/** Matches Application Inference Profile ARNs across all AWS partitions with Bedrock. */
+const BEDROCK_APP_INFERENCE_PROFILE_ARN_RE = /^arn:aws(-cn|-us-gov)?:bedrock:/;
+
 export function isAnthropicBedrockModel(modelId: string): boolean {
   const normalized = modelId.trim().toLowerCase();
-  return normalized.includes("anthropic.claude") || normalized.includes("anthropic/claude");
+
+  // Direct Anthropic Claude model IDs and regional inference profiles
+  // e.g. "anthropic.claude-sonnet-4-6", "us.anthropic.claude-sonnet-4-6", "global.anthropic.claude-opus-4-6-v1"
+  if (normalized.includes("anthropic.claude") || normalized.includes("anthropic/claude")) {
+    return true;
+  }
+
+  // Application Inference Profile ARN — detect Claude via profile ID segment.
+  // e.g. "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-claude-profile"
+  //
+  // Limitation: This is a name-heuristic only. Application inference profiles have
+  // user-defined names, so a profile named "my-prod-assistant" routing to Claude would
+  // miss cache semantics, while "my-claude-compat-llama" on a non-Claude model would
+  // incorrectly get them. The Bedrock API does not expose the underlying model in the
+  // profile ID itself — resolving this would require a GetInferenceProfile call, which
+  // is too expensive for a per-request check. System-defined profiles (us., eu., global.)
+  // always contain "anthropic.claude" and are matched above.
+  if (
+    BEDROCK_APP_INFERENCE_PROFILE_ARN_RE.test(normalized) &&
+    normalized.includes(":application-inference-profile/")
+  ) {
+    const profileId = normalized.split(":application-inference-profile/")[1] ?? "";
+    return profileId.includes("claude");
+  }
+
+  return false;
 }
 
 export function isOpenRouterAnthropicModelRef(provider: string, modelId: string): boolean {


### PR DESCRIPTION
Inference profiles (cross-region and application) work with ConverseStream but require the SDK client region to match the profile region. Without this, users get "The provided model identifier is invalid" errors when using cross-region profiles like us.anthropic.claude-sonnet-4-6.

Changes:

1. Inference profile discovery (discovery.ts):
   - Call ListInferenceProfiles alongside ListFoundationModels (parallel)
   - Inference profiles INHERIT capabilities from their underlying foundation model (modalities, reasoning, context window, cost)
   - resolveBaseModelId() maps profile → foundation model: "us.anthropic.claude-sonnet-4-6" → "anthropic.claude-sonnet-4-6" Application ARNs → extract model ID from models[].modelArn
   - Graceful degradation if IAM lacks bedrock:ListInferenceProfiles
   - Provider filter applies to profiles via underlying model ARNs

2. Region injection (register.sync.runtime.ts):
   - Extract region from provider baseUrl or bedrockDiscovery.region
   - Pass through to pi-ai options.region in wrapStreamFn
   - Ensures SDK client connects to correct regional endpoint

3. Inference profile model detection (anthropic-family-cache-semantics.ts):
   - isAnthropicBedrockModel() now recognizes application inference profile ARNs (arn:aws:bedrock:...:application-inference-profile/*)

4. Tests (discovery.test.ts):
   - New: inference profile inheritance test (4 models: 1 foundation + 3 profiles, verifies capability inheritance, inactive filtering)
   - New: graceful AccessDeniedException handling test
   - Updated: all existing tests for dual-API discovery pattern

Fixes #55642