### PR TITLE
feat: integrate meta-harness runtime tracing

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 import { promises as fs } from "node:fs";
-import { recordDelegation } from "../meta-harness/hooks.js";
+import { triggerInternalHook, createInternalHookEvent } from "../hooks/internal-hooks.js";
 import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
 import {
   isValidAgentId,
@@ -833,17 +833,16 @@ export async function spawnSubagentDirect(
       attachmentsRootDir: attachmentRootDir,
       retainAttachmentsOnKeep: retainOnSessionKeep,
     });
-    // Record delegation in meta-harness (fire-and-forget, workspace-gated)
-    if (spawnedMetadata.workspaceDir) {
-      recordDelegation({
-        sessionKey: requesterInternalKey,
-        workspaceDir: spawnedMetadata.workspaceDir,
+    // Record delegation in meta-harness via internal hook (fire-and-forget, workspace-gated)
+    void triggerInternalHook(
+      createInternalHookEvent("session", "delegation", requesterInternalKey, {
         childSessionId: childSessionKey,
         agentType: targetAgentId,
         taskBrief: task,
+        workspaceDir: spawnedMetadata.workspaceDir,
         status: "completed",
-      }).catch(() => {});
-    }
+      }),
+    );
   } catch (err) {
     if (attachmentAbsDir) {
       try {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { promises as fs } from "node:fs";
+import { recordDelegation } from "../meta-harness/hooks.js";
 import type { SubagentLifecycleHookRunner } from "../plugins/hooks.js";
 import {
   isValidAgentId,
@@ -832,6 +833,17 @@ export async function spawnSubagentDirect(
       attachmentsRootDir: attachmentRootDir,
       retainAttachmentsOnKeep: retainOnSessionKeep,
     });
+    // Record delegation in meta-harness (fire-and-forget, workspace-gated)
+    if (spawnedMetadata.workspaceDir) {
+      recordDelegation({
+        sessionKey: requesterInternalKey,
+        workspaceDir: spawnedMetadata.workspaceDir,
+        childSessionId: childSessionKey,
+        agentType: targetAgentId,
+        taskBrief: task,
+        status: "completed",
+      }).catch(() => {});
+    }
   } catch (err) {
     if (attachmentAbsDir) {
       try {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1,6 +1,6 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { isParentOwnedBackgroundAcpSession } from "../../acp/session-interaction-mode.js";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveSessionAgentId, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import {
   resolveConversationBindingRecord,
   touchConversationBindingRecord,
@@ -25,6 +25,7 @@ import {
   logMessageQueued,
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
+import { wrapMetaHarnessOnToolResult, finalizeSessionFlowTrace } from "../../meta-harness/hooks.js";
 import {
   buildPluginBindingDeclinedText,
   buildPluginBindingErrorText,
@@ -171,7 +172,9 @@ export async function dispatchReplyFromConfig(params: {
   const channel = String(ctx.Surface ?? ctx.Provider ?? "unknown").toLowerCase();
   const chatId = ctx.To ?? ctx.From;
   const messageId = ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
-  const sessionKey = ctx.SessionKey;
+  const sessionKey = ctx.SessionKey ?? "";
+  const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const startTime = diagnosticsEnabled ? Date.now() : 0;
   const canTrackSession = diagnosticsEnabled && Boolean(sessionKey);
 
@@ -677,28 +680,32 @@ export async function dispatchReplyFromConfig(params: {
         ...params.replyOptions,
         typingPolicy: typing.typingPolicy,
         suppressTyping: typing.suppressTyping,
-        onToolResult: (payload: ReplyPayload) => {
-          const run = async () => {
-            const ttsPayload = await maybeApplyTtsToPayload({
-              payload,
-              cfg,
-              channel: ttsChannel,
-              kind: "tool",
-              inboundAudio,
-              ttsAuto: sessionTtsAuto,
-            });
-            const deliveryPayload = resolveToolDeliveryPayload(ttsPayload);
-            if (!deliveryPayload) {
-              return;
-            }
-            if (shouldRouteToOriginating) {
-              await sendPayloadAsync(deliveryPayload, undefined, false);
-            } else {
-              dispatcher.sendToolResult(deliveryPayload);
-            }
-          };
-          return run();
-        },
+        onToolResult: wrapMetaHarnessOnToolResult(
+          sessionKey,
+          workspaceDir,
+          (payload: ReplyPayload) => {
+            const run = async () => {
+              const ttsPayload = await maybeApplyTtsToPayload({
+                payload,
+                cfg,
+                channel: ttsChannel,
+                kind: "tool",
+                inboundAudio,
+                ttsAuto: sessionTtsAuto,
+              });
+              const deliveryPayload = resolveToolDeliveryPayload(ttsPayload);
+              if (!deliveryPayload) {
+                return;
+              }
+              if (shouldRouteToOriginating) {
+                await sendPayloadAsync(deliveryPayload, undefined, false);
+              } else {
+                dispatcher.sendToolResult(deliveryPayload);
+              }
+            };
+            return run();
+          },
+        ),
         onBlockReply: (payload: ReplyPayload, context?: BlockReplyContext) => {
           const run = async () => {
             // Suppress reasoning payloads — channels using this generic dispatch
@@ -858,10 +865,14 @@ export async function dispatchReplyFromConfig(params: {
       pluginFallbackReason ? { reason: pluginFallbackReason } : undefined,
     );
     markIdle("message_completed");
+    // Finalize meta-harness flow trace (fire-and-forget)
+    finalizeSessionFlowTrace(sessionKey, workspaceDir, "completed").catch(() => {});
     return { queuedFinal, counts };
   } catch (err) {
     recordProcessed("error", { error: String(err) });
     markIdle("message_error");
+    // Finalize meta-harness flow trace as failed (fire-and-forget)
+    finalizeSessionFlowTrace(sessionKey, workspaceDir, "failed").catch(() => {});
     throw err;
   }
 }

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -24,6 +24,7 @@ import {
 } from "../hooks/internal-hooks.js";
 import { loadInternalHooks } from "../hooks/loader.js";
 import { isTruthyEnvValue } from "../infra/env.js";
+import { registerMetaHarnessHooks } from "../meta-harness/hooks.js";
 import type { loadOpenClawPlugins } from "../plugins/loader.js";
 import { type PluginServicesHandle, startPluginServices } from "../plugins/services.js";
 import {
@@ -136,6 +137,8 @@ export async function startGatewaySidecars(params: {
   try {
     // Clear any previously registered hooks to ensure fresh loading
     clearInternalHooks();
+    // Register meta-harness built-in hooks (before user hooks load)
+    registerMetaHarnessHooks();
     const loadedCount = await loadInternalHooks(params.cfg, params.defaultWorkspaceDir);
     if (loadedCount > 0) {
       params.logHooks.info(

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -35,6 +35,7 @@ import { saveSessionStore, updateSessionStore } from "../config/sessions/store.j
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import { resolveCronSession } from "../cron/isolated-agent/session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { startHeartbeatFlowTrace, finalizeSessionFlowTrace } from "../meta-harness/hooks.js";
 import { getQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import {
@@ -737,6 +738,10 @@ export async function runHeartbeatOnce(opts: {
       : { isHeartbeat: true, suppressToolErrorWarnings, bootstrapContextMode };
     const getReplyFromConfig =
       opts.deps?.getReplyFromConfig ?? (await loadHeartbeatRunnerRuntime()).getReplyFromConfig;
+
+    // Start meta-harness flow trace for heartbeat (fire-and-forget, never blocks)
+    startHeartbeatFlowTrace(runSessionKey, workspaceDir, opts.reason);
+
     const replyResult = await getReplyFromConfig(ctx, replyOpts, cfg);
     const replyPayload = resolveHeartbeatReplyPayload(replyResult);
     const includeReasoning = heartbeat?.includeReasoning === true;
@@ -960,6 +965,9 @@ export async function runHeartbeatOnce(opts: {
     });
     log.error(`heartbeat failed: ${reason}`, { error: reason });
     return { status: "failed", reason };
+  } finally {
+    // Finalize meta-harness flow trace (fire-and-forget)
+    finalizeSessionFlowTrace(runSessionKey, workspaceDir, "completed").catch(() => {});
   }
 }
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -36,6 +36,7 @@ import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import { resolveCronSession } from "../cron/isolated-agent/session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { startHeartbeatFlowTrace, finalizeSessionFlowTrace } from "../meta-harness/hooks.js";
+import { generateDailySummary } from "../meta-harness/index.js";
 import { getQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
 import {
@@ -968,6 +969,9 @@ export async function runHeartbeatOnce(opts: {
   } finally {
     // Finalize meta-harness flow trace (fire-and-forget)
     finalizeSessionFlowTrace(runSessionKey, workspaceDir, "completed").catch(() => {});
+    // Generate daily summary after heartbeat run (fire-and-forget, idempotent)
+    const today = new Date().toISOString().slice(0, 10);
+    generateDailySummary(workspaceDir, today).catch(() => {});
   }
 }
 

--- a/src/meta-harness/__tests__/e2e-wiring.test.ts
+++ b/src/meta-harness/__tests__/e2e-wiring.test.ts
@@ -178,13 +178,25 @@ describe("e2e: delegation recording", () => {
       status: "completed",
     });
 
+    // Also test via internal hook (the real runtime path from subagent-spawn)
+    await triggerInternalHook(
+      createInternalHookEvent("session", "delegation", sessionKey, {
+        childSessionId: "child-002",
+        agentType: "codex",
+        taskBrief: "review PR",
+        workspaceDir: tmpDir,
+        status: "completed",
+      }),
+    );
+
     await finalizeSessionFlowTrace(sessionKey, tmpDir, "completed");
 
     const traces = await listTraces<FlowTrace>(tmpDir, "traces");
     expect(traces).toHaveLength(1);
-    expect(traces[0].data.delegation_list).toHaveLength(1);
+    expect(traces[0].data.delegation_list).toHaveLength(2);
     expect(traces[0].data.delegation_list[0].agent_type).toBe("claude-code");
-    expect(traces[0].data.delegation_list[0].status).toBe("completed");
+    expect(traces[0].data.delegation_list[1].agent_type).toBe("codex");
+    expect(traces[0].data.delegation_list[1].child_trace_id).toBe("child-002");
   });
 });
 

--- a/src/meta-harness/__tests__/e2e-wiring.test.ts
+++ b/src/meta-harness/__tests__/e2e-wiring.test.ts
@@ -1,0 +1,293 @@
+/**
+ * End-to-end smoke test — verifies runtime wiring
+ *
+ * Tests that the meta-harness hooks module correctly integrates
+ * with the hook system without actually running a gateway.
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import {
+  clearInternalHooks,
+  createInternalHookEvent,
+  triggerInternalHook,
+} from "../../hooks/internal-hooks.js";
+import { ensureRuntimeLayout } from "../gating.js";
+import {
+  registerMetaHarnessHooks,
+  wrapMetaHarnessOnToolResult,
+  finalizeSessionFlowTrace,
+  recordDelegation,
+  startHeartbeatFlowTrace,
+  resetMetaHarnessState,
+} from "../hooks.js";
+import type { FlowTrace } from "../types.js";
+import { listTraces } from "../writer.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mh-e2e-"));
+  await ensureRuntimeLayout(tmpDir);
+  clearInternalHooks();
+  resetMetaHarnessState();
+  registerMetaHarnessHooks();
+});
+
+afterEach(async () => {
+  clearInternalHooks();
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("e2e: session lifecycle wiring", () => {
+  it("starts flow trace on message:received and finalizes on complete", async () => {
+    const sessionKey = "e2e-session-001";
+
+    // Simulate gateway startup
+    await triggerInternalHook(
+      createInternalHookEvent("gateway", "startup", "gateway", {
+        workspaceDir: tmpDir,
+      }),
+    );
+
+    // Simulate message received
+    await triggerInternalHook(
+      createInternalHookEvent("message", "received", sessionKey, {
+        workspaceDir: tmpDir,
+        content: "test message",
+        channelId: "feishu",
+        from: "user",
+      }),
+    );
+
+    // Finalize
+    await finalizeSessionFlowTrace(sessionKey, tmpDir, "completed");
+
+    // Verify trace was written
+    const traces = await listTraces<FlowTrace>(tmpDir, "traces");
+    const sessionTraces = traces.filter(
+      (t) => t.data.session_id === sessionKey && t.data.trigger === "session",
+    );
+    expect(sessionTraces).toHaveLength(1);
+    expect(sessionTraces[0].data.outcome).toBe("completed");
+    expect(sessionTraces[0].data.task_summary).toBe("test message");
+  });
+
+  it("finalizes flow trace on failure", async () => {
+    const sessionKey = "e2e-session-002";
+
+    await triggerInternalHook(
+      createInternalHookEvent("gateway", "startup", "gateway", {
+        workspaceDir: tmpDir,
+      }),
+    );
+
+    await triggerInternalHook(
+      createInternalHookEvent("message", "received", sessionKey, {
+        workspaceDir: tmpDir,
+        content: "fail test",
+        channelId: "telegram",
+        from: "user",
+      }),
+    );
+
+    await finalizeSessionFlowTrace(sessionKey, tmpDir, "failed");
+
+    const traces = await listTraces<FlowTrace>(tmpDir, "traces");
+    expect(traces).toHaveLength(1);
+    expect(traces[0].data.outcome).toBe("failed");
+  });
+
+  it("skips heartbeat messages in message:received", async () => {
+    const sessionKey = "e2e-session-003";
+
+    await triggerInternalHook(
+      createInternalHookEvent("gateway", "startup", "gateway", {
+        workspaceDir: tmpDir,
+      }),
+    );
+
+    // Heartbeat messages should not create traces
+    await triggerInternalHook(
+      createInternalHookEvent("message", "received", sessionKey, {
+        workspaceDir: tmpDir,
+        content: "Read HEARTBEAT.md if it exists...",
+        channelId: "feishu",
+        from: "system",
+      }),
+    );
+
+    const traces = await listTraces<FlowTrace>(tmpDir, "traces");
+    expect(traces).toHaveLength(0);
+  });
+});
+
+describe("e2e: heartbeat flow trace", () => {
+  it("starts and finalizes heartbeat flow trace", async () => {
+    const sessionKey = "e2e-heartbeat-001";
+
+    startHeartbeatFlowTrace(sessionKey, tmpDir, "interval");
+    await finalizeSessionFlowTrace(sessionKey, tmpDir, "completed");
+
+    const traces = await listTraces<FlowTrace>(tmpDir, "traces");
+    const hbTraces = traces.filter((t) => t.data.trigger === "heartbeat");
+    expect(hbTraces).toHaveLength(1);
+    expect(hbTraces[0].data.outcome).toBe("completed");
+  });
+
+  it("starts cron flow trace", async () => {
+    const sessionKey = "e2e-cron-001";
+
+    startHeartbeatFlowTrace(sessionKey, tmpDir, "cron");
+    await finalizeSessionFlowTrace(sessionKey, tmpDir, "completed");
+
+    const traces = await listTraces<FlowTrace>(tmpDir, "traces");
+    const cronTraces = traces.filter((t) => t.data.trigger === "cron");
+    expect(cronTraces).toHaveLength(1);
+  });
+});
+
+describe("e2e: delegation recording", () => {
+  it("records delegation in active flow trace", async () => {
+    const sessionKey = "e2e-delegation-001";
+
+    await triggerInternalHook(
+      createInternalHookEvent("gateway", "startup", "gateway", {
+        workspaceDir: tmpDir,
+      }),
+    );
+
+    await triggerInternalHook(
+      createInternalHookEvent("message", "received", sessionKey, {
+        workspaceDir: tmpDir,
+        content: "dispatch task",
+        channelId: "feishu",
+        from: "user",
+      }),
+    );
+
+    await recordDelegation({
+      sessionKey,
+      workspaceDir: tmpDir,
+      childSessionId: "child-001",
+      agentType: "claude-code",
+      taskBrief: "implement feature",
+      status: "completed",
+    });
+
+    await finalizeSessionFlowTrace(sessionKey, tmpDir, "completed");
+
+    const traces = await listTraces<FlowTrace>(tmpDir, "traces");
+    expect(traces).toHaveLength(1);
+    expect(traces[0].data.delegation_list).toHaveLength(1);
+    expect(traces[0].data.delegation_list[0].agent_type).toBe("claude-code");
+    expect(traces[0].data.delegation_list[0].status).toBe("completed");
+  });
+});
+
+describe("e2e: tool result wrapping", () => {
+  it("wrapMetaHarnessOnToolResult records tool outcomes", async () => {
+    const sessionKey = "e2e-tool-001";
+    let toolResultCalled = false;
+
+    await triggerInternalHook(
+      createInternalHookEvent("gateway", "startup", "gateway", {
+        workspaceDir: tmpDir,
+      }),
+    );
+
+    await triggerInternalHook(
+      createInternalHookEvent("message", "received", sessionKey, {
+        workspaceDir: tmpDir,
+        content: "use tools",
+        channelId: "feishu",
+        from: "user",
+      }),
+    );
+
+    // Simulate tool result
+    const wrappedHandler = wrapMetaHarnessOnToolResult(
+      sessionKey,
+      tmpDir,
+      async () => {
+        toolResultCalled = true;
+      },
+      { toolName: "exec", success: true, durationMs: 500 },
+    );
+
+    await wrappedHandler({ text: "output" } as unknown as ReplyPayload);
+    expect(toolResultCalled).toBe(true);
+
+    await finalizeSessionFlowTrace(sessionKey, tmpDir, "completed");
+
+    const traces = await listTraces<FlowTrace>(tmpDir, "traces");
+    expect(traces).toHaveLength(1);
+    expect(traces[0].data.tool_outcomes).toHaveLength(1);
+    expect(traces[0].data.tool_outcomes[0].tool_name).toBe("exec");
+    expect(traces[0].data.tool_outcomes[0].success).toBe(true);
+  });
+
+  it("records failed tool outcomes", async () => {
+    const sessionKey = "e2e-tool-002";
+
+    await triggerInternalHook(
+      createInternalHookEvent("gateway", "startup", "gateway", {
+        workspaceDir: tmpDir,
+      }),
+    );
+
+    await triggerInternalHook(
+      createInternalHookEvent("message", "received", sessionKey, {
+        workspaceDir: tmpDir,
+        content: "fail tool",
+        channelId: "feishu",
+        from: "user",
+      }),
+    );
+
+    const wrappedHandler = wrapMetaHarnessOnToolResult(sessionKey, tmpDir, async () => {}, {
+      toolName: "web_search",
+      success: false,
+      error: "CAPTCHA",
+      durationMs: 3000,
+    });
+
+    await wrappedHandler({ text: "blocked" } as unknown as ReplyPayload);
+    await finalizeSessionFlowTrace(sessionKey, tmpDir, "completed");
+
+    const traces = await listTraces<FlowTrace>(tmpDir, "traces");
+    expect(traces[0].data.tool_outcomes[0].success).toBe(false);
+    expect(traces[0].data.tool_outcomes[0].error).toBe("CAPTCHA");
+  });
+});
+
+describe("e2e: workspace gating", () => {
+  it("no-ops when workspace has no manifest", async () => {
+    const sessionKey = "e2e-nomanifest";
+    const noManifestDir = await fs.mkdtemp(path.join(os.tmpdir(), "mh-no-"));
+
+    await triggerInternalHook(
+      createInternalHookEvent("message", "received", sessionKey, {
+        workspaceDir: noManifestDir,
+        content: "test",
+        channelId: "feishu",
+        from: "user",
+      }),
+    );
+
+    await finalizeSessionFlowTrace(sessionKey, noManifestDir, "completed");
+
+    // No traces directory should exist
+    try {
+      await fs.access(path.join(noManifestDir, "data/meta-harness/traces"));
+      expect.unreachable("traces directory should not exist");
+    } catch {
+      // Expected
+    }
+
+    await fs.rm(noManifestDir, { recursive: true, force: true });
+  });
+});

--- a/src/meta-harness/__tests__/e2e-wiring.test.ts
+++ b/src/meta-harness/__tests__/e2e-wiring.test.ts
@@ -196,7 +196,10 @@ describe("e2e: delegation recording", () => {
     expect(traces[0].data.delegation_list).toHaveLength(2);
     expect(traces[0].data.delegation_list[0].agent_type).toBe("claude-code");
     expect(traces[0].data.delegation_list[1].agent_type).toBe("codex");
-    expect(traces[0].data.delegation_list[1].child_trace_id).toBe("child-002");
+    // After fix: child_trace_id uses stable UUID instead of session key
+    expect(traces[0].data.delegation_list[1].child_trace_id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
   });
 });
 

--- a/src/meta-harness/__tests__/meta-harness.test.ts
+++ b/src/meta-harness/__tests__/meta-harness.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Meta-Harness unit tests
+ */
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { checkWorkspaceGating, ensureRuntimeLayout } from "../gating.js";
+import { createFlowTraceBuilder, generateDailySummary } from "../index.js";
+import type { FlowTrace, ChildTrace, DailySummary } from "../types.js";
+import {
+  generateTraceId,
+  writeFlowTrace,
+  writeChildTrace,
+  writeRichTrace,
+  listTraces,
+} from "../writer.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mh-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+// ─── Workspace Gating ────────────────────────────────────────────
+
+describe("workspace gating", () => {
+  it("returns disabled when manifest is missing", async () => {
+    const result = await checkWorkspaceGating(tmpDir);
+    expect(result.enabled).toBe(false);
+    if (!result.enabled) {
+      expect(result.reason).toContain("manifest");
+    }
+  });
+
+  it("returns enabled when manifest exists", async () => {
+    await ensureRuntimeLayout(tmpDir);
+    const result = await checkWorkspaceGating(tmpDir);
+    expect(result.enabled).toBe(true);
+    if (result.enabled) {
+      expect(result.manifest.version).toBe("1.0.0");
+    }
+  });
+
+  it("creates full runtime layout", async () => {
+    const ok = await ensureRuntimeLayout(tmpDir);
+    expect(ok).toBe(true);
+
+    const expectedDirs = [
+      "data/meta-harness/traces",
+      "data/meta-harness/children",
+      "data/meta-harness/rich",
+      "data/meta-harness/daily",
+      "data/meta-harness/weekly",
+      "data/meta-harness/indexes",
+    ];
+    for (const rel of expectedDirs) {
+      const stat = await fs.stat(path.join(tmpDir, rel));
+      expect(stat.isDirectory()).toBe(true);
+    }
+
+    const manifest = await fs.readFile(
+      path.join(tmpDir, "data/meta-harness/manifest.json"),
+      "utf-8",
+    );
+    const parsed = JSON.parse(manifest);
+    expect(parsed.version).toBe("1.0.0");
+    expect(parsed.created_at).toBeTruthy();
+  });
+});
+
+// ─── Trace ID Generation ─────────────────────────────────────────
+
+describe("trace ID generation", () => {
+  it("generates unique UUIDs", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateTraceId()));
+    expect(ids.size).toBe(100);
+  });
+});
+
+// ─── Flow Trace Writer ───────────────────────────────────────────
+
+describe("flow trace writer", () => {
+  it("writes a flow trace JSON file", async () => {
+    await ensureRuntimeLayout(tmpDir);
+    const trace: FlowTrace = {
+      trace_id: generateTraceId(),
+      timestamp: new Date().toISOString(),
+      session_id: "test-session",
+      flow_id: "flow-1",
+      trigger: "session",
+      task_summary: "test task",
+      triage_domain: "research",
+      automation_level: "A",
+      delegation_list: [],
+      outcome: "completed",
+      observations: [],
+      harness_version: "1.0.0",
+      tool_outcomes: [],
+      duration_ms: 100,
+    };
+    const filePath = await writeFlowTrace(tmpDir, trace);
+    expect(filePath).toContain("traces/");
+    expect(filePath).toContain(trace.trace_id);
+
+    const content = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.trace_id).toBe(trace.trace_id);
+    expect(parsed.trigger).toBe("session");
+  });
+});
+
+// ─── Child Trace Writer ──────────────────────────────────────────
+
+describe("child trace writer", () => {
+  it("writes a child trace linked to parent", async () => {
+    await ensureRuntimeLayout(tmpDir);
+    const parentId = generateTraceId();
+    const child: ChildTrace = {
+      child_trace_id: generateTraceId(),
+      parent_trace_id: parentId,
+      child_session_id: "child-1",
+      agent_type: "claude-code",
+      task_brief: "implement feature X",
+      status: "completed",
+      verification_summary: "tests pass",
+      summarized_tool_calls: [],
+      timestamp: new Date().toISOString(),
+    };
+    const filePath = await writeChildTrace(tmpDir, child);
+    expect(filePath).toContain("children/");
+
+    const content = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.parent_trace_id).toBe(parentId);
+    expect(parsed.agent_type).toBe("claude-code");
+  });
+});
+
+// ─── Rich Trace Writer ───────────────────────────────────────────
+
+describe("rich trace writer", () => {
+  it("writes a rich trace on escalation", async () => {
+    await ensureRuntimeLayout(tmpDir);
+    const richTrace = {
+      trace_id: generateTraceId(),
+      escalation_reason: "rule violation detected",
+      timestamp: new Date().toISOString(),
+      raw_content: '{"detail": "some raw data"}',
+    };
+    const filePath = await writeRichTrace(tmpDir, richTrace);
+    expect(filePath).toContain("rich/");
+    expect(filePath).toContain("rich-");
+  });
+});
+
+// ─── FlowTraceBuilder ────────────────────────────────────────────
+
+describe("FlowTraceBuilder", () => {
+  it("builds and finalizes a complete flow trace", async () => {
+    await ensureRuntimeLayout(tmpDir);
+    const builder = createFlowTraceBuilder({
+      workspaceDir: tmpDir,
+      sessionId: "session-123",
+      flowId: "flow-abc",
+      trigger: "session",
+      taskSummary: "investigate issue",
+      triageDomain: "research",
+      automationLevel: "B",
+    });
+    expect(builder).not.toBeNull();
+
+    if (!builder) {
+      return;
+    }
+
+    builder.recordToolOutcome({
+      tool_name: "web_search",
+      success: true,
+      duration_ms: 500,
+    });
+    builder.recordToolOutcome({
+      tool_name: "exec",
+      success: false,
+      error: "command timed out",
+      duration_ms: 10000,
+    });
+    builder.recordObservation({
+      kind: "OBSERVED",
+      summary: "search returned 5 results",
+    });
+    builder.recordObservation({
+      kind: "INFERRED",
+      summary: "issue is likely a config problem",
+    });
+
+    const filePath = await builder.finalize("completed");
+    expect(filePath).not.toBeNull();
+
+    const content = await fs.readFile(filePath!, "utf-8");
+    const parsed: FlowTrace = JSON.parse(content);
+    expect(parsed.session_id).toBe("session-123");
+    expect(parsed.tool_outcomes).toHaveLength(2);
+    expect(parsed.tool_outcomes[1].success).toBe(false);
+    expect(parsed.observations).toHaveLength(2);
+    expect(parsed.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(parsed.harness_version).toBe("1.0.0");
+  });
+
+  it("returns null when finalizing without manifest", async () => {
+    const builder = createFlowTraceBuilder({
+      workspaceDir: tmpDir,
+      sessionId: "s",
+      flowId: "f",
+      trigger: "heartbeat",
+      taskSummary: "check",
+      triageDomain: "ops",
+      automationLevel: "A",
+    });
+
+    const filePath = await builder!.finalize("completed");
+    expect(filePath).toBeNull();
+  });
+
+  it("writes child trace via builder", async () => {
+    await ensureRuntimeLayout(tmpDir);
+    const builder = createFlowTraceBuilder({
+      workspaceDir: tmpDir,
+      sessionId: "s",
+      flowId: "f",
+      trigger: "session",
+      taskSummary: "dispatch work",
+      triageDomain: "build",
+      automationLevel: "B",
+    });
+
+    const filePath = await builder!.writeChildTrace({
+      child_trace_id: generateTraceId(),
+      child_session_id: "child-1",
+      agent_type: "claude-code",
+      task_brief: "fix bug #42",
+      status: "completed",
+      verification_summary: "2 tests pass",
+      summarized_tool_calls: [{ tool_name: "edit", success: true }],
+      timestamp: new Date().toISOString(),
+    });
+    expect(filePath).not.toBeNull();
+  });
+
+  it("writes rich trace via builder on escalation", async () => {
+    await ensureRuntimeLayout(tmpDir);
+    const builder = createFlowTraceBuilder({
+      workspaceDir: tmpDir,
+      sessionId: "s",
+      flowId: "f",
+      trigger: "cron",
+      taskSummary: "daily check",
+      triageDomain: "ops",
+      automationLevel: "A",
+    });
+
+    const filePath = await builder!.writeRichTrace(
+      "terminal failure",
+      '{"error": "unrecoverable"}',
+    );
+    expect(filePath).not.toBeNull();
+  });
+});
+
+// ─── Daily Summary ───────────────────────────────────────────────
+
+describe("daily summary", () => {
+  it("generates daily summary from traces", async () => {
+    await ensureRuntimeLayout(tmpDir);
+    const date = new Date().toISOString().slice(0, 10);
+
+    // Write 2 flow traces for today
+    for (let i = 0; i < 2; i++) {
+      const trace: FlowTrace = {
+        trace_id: generateTraceId(),
+        timestamp: new Date().toISOString(),
+        session_id: `s-${i}`,
+        flow_id: `f-${i}`,
+        trigger: i === 0 ? "session" : "heartbeat",
+        task_summary: `task ${i}`,
+        triage_domain: i === 0 ? "research" : "ops",
+        automation_level: "A",
+        delegation_list: [],
+        outcome: i === 0 ? "completed" : "partial",
+        observations: [],
+        harness_version: "1.0.0",
+        tool_outcomes: [
+          { tool_name: "exec", success: true, duration_ms: 100 },
+          { tool_name: "web_fetch", success: false, error: "404" },
+        ],
+        duration_ms: 1000,
+      };
+      await writeFlowTrace(tmpDir, trace);
+    }
+
+    const filePath = await generateDailySummary(tmpDir, date);
+    expect(filePath).not.toBeNull();
+
+    const content = await fs.readFile(filePath!, "utf-8");
+    const summary: DailySummary = JSON.parse(content);
+    expect(summary.date).toBe(date);
+    expect(summary.total_runs).toBe(2);
+    expect(summary.outcomes.completed).toBe(1);
+    expect(summary.outcomes.partial).toBe(1);
+    expect(summary.tool_call_count).toBe(4);
+    expect(summary.tool_error_count).toBe(2);
+    expect(summary.tool_error_frequency).toBe(0.5);
+  });
+});
+
+// ─── List Traces ─────────────────────────────────────────────────
+
+describe("list traces", () => {
+  it("lists all trace files in a directory", async () => {
+    await ensureRuntimeLayout(tmpDir);
+    await writeFlowTrace(tmpDir, {
+      trace_id: "test-1",
+      timestamp: new Date().toISOString(),
+      session_id: "s",
+      flow_id: "f",
+      trigger: "session",
+      task_summary: "t",
+      triage_domain: "research",
+      automation_level: "A",
+      delegation_list: [],
+      outcome: "completed",
+      observations: [],
+      harness_version: "1.0.0",
+      tool_outcomes: [],
+      duration_ms: 100,
+    });
+
+    const traces = await listTraces<FlowTrace>(tmpDir, "traces");
+    expect(traces).toHaveLength(1);
+    expect(traces[0].data.trace_id).toBe("test-1");
+  });
+});

--- a/src/meta-harness/__tests__/smoke-workspace.test.ts
+++ b/src/meta-harness/__tests__/smoke-workspace.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Smoke test — verifies actual workspace trace writing
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import { createFlowTraceBuilder, generateDailySummary } from "../index.js";
+import { generateTraceId } from "../writer.js";
+
+const WORKSPACE = "/home/openclaw/.openclaw/workspace";
+
+describe("smoke test: actual workspace", () => {
+  it("writes a flow trace to real workspace", async () => {
+    const builder = createFlowTraceBuilder({
+      workspaceDir: WORKSPACE,
+      sessionId: "smoke-test-session",
+      flowId: "smoke-flow-001",
+      trigger: "session",
+      taskSummary: "Meta-Harness smoke test",
+      triageDomain: "ops",
+      automationLevel: "A",
+    });
+    expect(builder).not.toBeNull();
+
+    builder!.recordToolOutcome({ tool_name: "read", success: true, duration_ms: 50 });
+    builder!.recordToolOutcome({
+      tool_name: "exec",
+      success: false,
+      error: "not found",
+      duration_ms: 200,
+    });
+
+    const filePath = await builder!.finalize("completed");
+    expect(filePath).not.toBeNull();
+    expect(filePath!).toContain("traces/");
+
+    // Verify file exists and is valid JSON
+    const content = await fs.readFile(filePath!, "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.trace_id).toBeTruthy();
+    expect(parsed.tool_outcomes).toHaveLength(2);
+    expect(parsed.outcome).toBe("completed");
+  });
+
+  it("writes a child trace linked to parent", async () => {
+    const builder = createFlowTraceBuilder({
+      workspaceDir: WORKSPACE,
+      sessionId: "smoke-parent",
+      flowId: "smoke-flow-002",
+      trigger: "session",
+      taskSummary: "parent for child test",
+      triageDomain: "build",
+      automationLevel: "B",
+    });
+
+    const childPath = await builder!.writeChildTrace({
+      child_trace_id: generateTraceId(),
+      child_session_id: "child-smoke-001",
+      agent_type: "claude-code",
+      task_brief: "fix bug",
+      status: "completed",
+      verification_summary: "tests pass",
+      summarized_tool_calls: [
+        { tool_name: "edit", success: true },
+        { tool_name: "exec", success: false, error: "failed" },
+      ],
+      timestamp: new Date().toISOString(),
+    });
+    expect(childPath).not.toBeNull();
+    expect(childPath!).toContain("children/");
+
+    // Verify child links to parent
+    const content = await fs.readFile(childPath!, "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.parent_trace_id).toBe(builder!.traceId);
+  });
+
+  it("writes a rich trace on escalation", async () => {
+    const builder = createFlowTraceBuilder({
+      workspaceDir: WORKSPACE,
+      sessionId: "smoke-rich",
+      flowId: "smoke-flow-003",
+      trigger: "cron",
+      taskSummary: "escalation test",
+      triageDomain: "governance",
+      automationLevel: "B",
+    });
+
+    const richPath = await builder!.writeRichTrace("rule violation", '{"detail": "test"}');
+    expect(richPath).not.toBeNull();
+    expect(richPath!).toContain("rich/");
+
+    await builder!.finalize("escalated");
+  });
+
+  it("generates daily summary", async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const summaryPath = await generateDailySummary(WORKSPACE, today);
+    expect(summaryPath).not.toBeNull();
+    expect(summaryPath!).toContain("daily/");
+
+    const content = await fs.readFile(summaryPath!, "utf-8");
+    const parsed = JSON.parse(content);
+    expect(parsed.date).toBe(today);
+    expect(parsed.total_runs).toBeGreaterThanOrEqual(0);
+    // Tool errors from parent + child traces should be counted
+    expect(typeof parsed.tool_error_count).toBe("number");
+  });
+
+  it("verifies all runtime directories exist", async () => {
+    const dirs = ["traces", "children", "rich", "daily", "weekly", "indexes"];
+    for (const d of dirs) {
+      const p = path.join(WORKSPACE, "data/meta-harness", d);
+      const stat = await fs.stat(p);
+      expect(stat.isDirectory()).toBe(true);
+    }
+  });
+});

--- a/src/meta-harness/aggregation.ts
+++ b/src/meta-harness/aggregation.ts
@@ -1,0 +1,158 @@
+/**
+ * Daily/Weekly summary aggregation
+ *
+ * Reads flow traces and child traces from the runtime directories
+ * and produces aggregated summaries for observability.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import type {
+  FlowTrace,
+  ChildTrace,
+  DailySummary,
+  WeeklySummary,
+  RunOutcome,
+  TriageDomain,
+  AutomationLevel,
+} from "./types.js";
+import { listTraces } from "./writer.js";
+
+/**
+ * Build a daily summary from all traces for a given date.
+ */
+export async function buildDailySummary(
+  workspaceDir: string,
+  date: string, // YYYY-MM-DD
+): Promise<DailySummary> {
+  const allFlowTraces = await listTraces<FlowTrace>(workspaceDir, "traces");
+  const allChildTraces = await listTraces<ChildTrace>(workspaceDir, "children");
+
+  // Filter flow traces by date
+  const dayTraces = allFlowTraces.filter((t) => t.data.timestamp.startsWith(date));
+
+  // Also collect child traces linked to today's flows
+  const todayFlowIds = new Set(dayTraces.map((t) => t.data.trace_id));
+  const linkedChildren = allChildTraces.filter(
+    (t) => todayFlowIds.has(t.data.parent_trace_id) || t.data.timestamp.startsWith(date),
+  );
+
+  const summary: DailySummary = {
+    date,
+    total_runs: dayTraces.length,
+    outcomes: emptyCount<RunOutcome>(["completed", "partial", "failed", "escalated", "aborted"]),
+    domains: emptyCount<TriageDomain>([
+      "strategy",
+      "research",
+      "build",
+      "delivery",
+      "growth",
+      "ops",
+      "governance",
+      "unknown",
+    ]),
+    automation_levels: emptyCount<AutomationLevel>(["A", "B", "C", "D", "X"]),
+    tool_error_frequency: 0,
+    tool_error_count: 0,
+    tool_call_count: 0,
+    delegation_count: linkedChildren.length,
+    delegation_failures: 0,
+    escalations: 0,
+    flow_trace_ids: dayTraces.map((t) => t.data.trace_id),
+    child_trace_ids: linkedChildren.map((t) => t.data.child_trace_id),
+  };
+
+  let totalToolCalls = 0;
+  let totalToolErrors = 0;
+
+  for (const trace of dayTraces) {
+    const t = trace.data;
+    summary.outcomes[t.outcome] = (summary.outcomes[t.outcome] || 0) + 1;
+    summary.domains[t.triage_domain] = (summary.domains[t.triage_domain] || 0) + 1;
+    summary.automation_levels[t.automation_level] =
+      (summary.automation_levels[t.automation_level] || 0) + 1;
+    if (t.outcome === "escalated") {
+      summary.escalations++;
+    }
+    summary.delegation_count += t.delegation_list.length;
+
+    for (const tool of t.tool_outcomes) {
+      totalToolCalls++;
+      if (!tool.success) {
+        totalToolErrors++;
+      }
+    }
+  }
+
+  for (const child of linkedChildren) {
+    const c = child.data;
+    if (c.status === "failed" || c.status === "escalated") {
+      summary.delegation_failures++;
+    }
+    for (const tool of c.summarized_tool_calls) {
+      totalToolCalls++;
+      if (!tool.success) {
+        totalToolErrors++;
+      }
+    }
+  }
+
+  summary.tool_call_count = totalToolCalls;
+  summary.tool_error_count = totalToolErrors;
+  summary.tool_error_frequency = totalToolCalls > 0 ? totalToolErrors / totalToolCalls : 0;
+
+  return summary;
+}
+
+/**
+ * Build a weekly summary from daily summaries.
+ */
+export async function buildWeeklySummary(
+  workspaceDir: string,
+  weekStart: string, // YYYY-MM-DD (Monday)
+  weekEnd: string, // YYYY-MM-DD (Sunday)
+): Promise<WeeklySummary> {
+  const dailyDir = path.join(workspaceDir, "data/meta-harness/daily");
+  const dailyCounts: number[] = [];
+  let totalToolErrors = 0;
+  let totalEscalations = 0;
+
+  // Iterate each day of the week
+  const start = new Date(weekStart);
+  const end = new Date(weekEnd);
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const dateStr = d.toISOString().slice(0, 10);
+    const filePath = path.join(dailyDir, `daily-${dateStr}.json`);
+    try {
+      const raw = await fs.readFile(filePath, "utf-8");
+      const daily: DailySummary = JSON.parse(raw);
+      dailyCounts.push(daily.total_runs);
+      totalToolErrors += daily.tool_error_count;
+      totalEscalations += daily.escalations;
+    } catch {
+      dailyCounts.push(0);
+    }
+  }
+
+  const avgRuns =
+    dailyCounts.length > 0 ? dailyCounts.reduce((a, b) => a + b, 0) / dailyCounts.length : 0;
+
+  return {
+    week_start: weekStart,
+    week_end: weekEnd,
+    daily_counts: dailyCounts,
+    avg_runs_per_day: Math.round(avgRuns * 100) / 100,
+    total_tool_errors: totalToolErrors,
+    total_escalations: totalEscalations,
+    top_failure_domains: [],
+    top_failure_tools: [],
+  };
+}
+
+function emptyCount<T extends string>(keys: T[]): Record<T, number> {
+  const result = {} as Record<T, number>;
+  for (const key of keys) {
+    result[key] = 0;
+  }
+  return result;
+}

--- a/src/meta-harness/gating.ts
+++ b/src/meta-harness/gating.ts
@@ -1,0 +1,71 @@
+/**
+ * Workspace gating — checks if Meta-Harness is enabled for a workspace.
+ *
+ * Meta-Harness is only active when `data/meta-harness/manifest.json` exists
+ * in the workspace directory. Otherwise, all trace operations are no-ops.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { GatingResult, MetaHarnessManifest } from "./types.js";
+
+const MANIFEST_RELATIVE = "data/meta-harness/manifest.json";
+
+/**
+ * Check if Meta-Harness is enabled for the given workspace directory.
+ */
+export async function checkWorkspaceGating(workspaceDir: string): Promise<GatingResult> {
+  const manifestPath = path.join(workspaceDir, MANIFEST_RELATIVE);
+  try {
+    const raw = await fs.readFile(manifestPath, "utf-8");
+    const manifest: MetaHarnessManifest = JSON.parse(raw);
+    return { enabled: true, manifest };
+  } catch {
+    return { enabled: false, reason: "manifest not found or invalid" };
+  }
+}
+
+/**
+ * Initialize the Meta-Harness runtime layout for a workspace.
+ * Creates required directories and manifest if not present.
+ *
+ * @returns true if layout was created or already existed, false on error.
+ */
+export async function ensureRuntimeLayout(workspaceDir: string): Promise<boolean> {
+  const dirs = [
+    "data/meta-harness/traces",
+    "data/meta-harness/children",
+    "data/meta-harness/rich",
+    "data/meta-harness/daily",
+    "data/meta-harness/weekly",
+    "data/meta-harness/indexes",
+  ];
+
+  for (const rel of dirs) {
+    const abs = path.join(workspaceDir, rel);
+    try {
+      await fs.mkdir(abs, { recursive: true });
+    } catch {
+      return false;
+    }
+  }
+
+  // Create manifest if missing
+  const manifestPath = path.join(workspaceDir, MANIFEST_RELATIVE);
+  try {
+    await fs.access(manifestPath);
+  } catch {
+    const manifest: MetaHarnessManifest = {
+      version: "1.0.0",
+      created_at: new Date().toISOString(),
+      workspace_path: workspaceDir,
+    };
+    try {
+      await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+    } catch {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/meta-harness/hooks.ts
+++ b/src/meta-harness/hooks.ts
@@ -1,0 +1,366 @@
+/**
+ * Meta-Harness runtime wiring
+ *
+ * Connects the meta-harness module to OpenClaw's runtime via the internal
+ * hook system and a lightweight onToolResult wrapper.
+ *
+ * Design principles:
+ * - No new event types — only listens to existing hooks
+ * - Workspace-gated — no-ops when manifest.json is absent
+ * - Session-keyed — tracks active flow builders per session
+ * - Fire-and-forget — trace errors never block the main reply path
+ */
+
+import type { InternalHookEvent } from "../hooks/internal-hooks.js";
+import { registerInternalHook } from "../hooks/internal-hooks.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { createFlowTraceBuilder, checkWorkspaceGating } from "./index.js";
+import type { FlowTraceBuilder } from "./index.js";
+import type {
+  RunOutcome,
+  ToolOutcome,
+  TriggerKind,
+  TriageDomain,
+  AutomationLevel,
+} from "./types.js";
+
+const log = createSubsystemLogger("meta-harness");
+
+// ---------------------------------------------------------------------------
+// Session-keyed active flow builder tracking
+// ---------------------------------------------------------------------------
+
+// Use a wrapper to avoid "error type in union" lint issues with FlowTraceBuilder
+type ActiveBuilder = { builder: FlowTraceBuilder };
+
+const activeBuilders = new Map<string, ActiveBuilder>();
+
+function getBuilder(sessionKey: string): ActiveBuilder | undefined {
+  return activeBuilders.get(sessionKey);
+}
+
+function setBuilder(sessionKey: string, builder: FlowTraceBuilder): void {
+  // Clean up any previous builder (leaked sessions)
+  const prev = activeBuilders.get(sessionKey);
+  if (prev) {
+    finalizeBuilder(prev.builder, "aborted").catch(() => {});
+  }
+  activeBuilders.set(sessionKey, { builder });
+}
+
+function removeBuilder(sessionKey: string): void {
+  activeBuilders.delete(sessionKey);
+}
+
+// ---------------------------------------------------------------------------
+// Workspace resolution
+// ---------------------------------------------------------------------------
+
+let defaultWorkspaceDir: string | null = null;
+
+function getWorkspaceDir(context: Record<string, unknown>): string | null {
+  // Prefer explicit workspace dir from hook context
+  if (typeof context.workspaceDir === "string" && context.workspaceDir) {
+    return context.workspaceDir;
+  }
+  return defaultWorkspaceDir;
+}
+
+async function initializeWorkspace(workspaceDir: string): Promise<boolean> {
+  const gating = await checkWorkspaceGating(workspaceDir);
+  if (!gating.enabled) {
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Flow lifecycle
+// ---------------------------------------------------------------------------
+
+function inferTriageDomain(trigger: TriggerKind): TriageDomain {
+  if (trigger === "heartbeat" || trigger === "cron") {
+    return "ops";
+  }
+  return "research";
+}
+
+function inferAutomationLevel(trigger: TriggerKind): AutomationLevel {
+  if (trigger === "heartbeat" || trigger === "cron") {
+    return "A";
+  }
+  return "B";
+}
+
+function startFlowTrace(params: {
+  sessionKey: string;
+  workspaceDir: string;
+  trigger: TriggerKind;
+  taskSummary: string;
+  // eslint-disable-next-line typescript-eslint/no-redundant-type-constituents
+}): FlowTraceBuilder | undefined {
+  const builder = createFlowTraceBuilder({
+    workspaceDir: params.workspaceDir,
+    sessionId: params.sessionKey,
+    flowId: params.sessionKey,
+    trigger: params.trigger,
+    taskSummary: params.taskSummary,
+    triageDomain: inferTriageDomain(params.trigger),
+    automationLevel: inferAutomationLevel(params.trigger),
+  });
+  if (builder) {
+    setBuilder(params.sessionKey, builder);
+    log.debug(`flow trace started: ${builder.traceId} (${params.trigger})`);
+  }
+  return builder ?? undefined;
+}
+
+async function finalizeBuilder(builder: FlowTraceBuilder, outcome: RunOutcome): Promise<void> {
+  try {
+    const filePath = await builder.finalize(outcome);
+    if (filePath) {
+      log.debug(`flow trace finalized: ${builder.traceId} -> ${outcome}`);
+    }
+  } catch (err) {
+    log.error(`flow trace finalize failed: ${String(err)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook: gateway:startup — initialize workspace
+// ---------------------------------------------------------------------------
+
+async function handleGatewayStartup(event: InternalHookEvent): Promise<void> {
+  const ctx = event.context as { workspaceDir?: string };
+  const workspaceDir = ctx.workspaceDir;
+  if (!workspaceDir) {
+    return;
+  }
+
+  defaultWorkspaceDir = workspaceDir;
+
+  const enabled = await initializeWorkspace(workspaceDir);
+  if (!enabled) {
+    log.debug("meta-harness disabled (no manifest)");
+    return;
+  }
+
+  log.info("meta-harness initialized for workspace");
+}
+
+// ---------------------------------------------------------------------------
+// Hook: message:received — start session flow trace
+// ---------------------------------------------------------------------------
+
+async function handleMessageReceived(event: InternalHookEvent): Promise<void> {
+  const workspaceDir = getWorkspaceDir(event.context);
+  if (!workspaceDir) {
+    return;
+  }
+
+  const gating = await checkWorkspaceGating(workspaceDir);
+  if (!gating.enabled) {
+    return;
+  }
+
+  const ctx = event.context as {
+    content?: string;
+    channelId?: string;
+    from?: string;
+  };
+
+  // Don't trace heartbeat messages (those have their own trigger)
+  const content = typeof ctx.content === "string" ? ctx.content.trim() : "";
+  if (content.startsWith("Read HEARTBEAT.md") || content === "HEARTBEAT_OK") {
+    return;
+  }
+
+  startFlowTrace({
+    sessionKey: event.sessionKey,
+    workspaceDir,
+    trigger: "session",
+    taskSummary: content.slice(0, 500),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Hook: session:compact:before — finalize current flow trace before compaction
+// ---------------------------------------------------------------------------
+
+async function handleSessionCompactBefore(event: InternalHookEvent): Promise<void> {
+  const entry = getBuilder(event.sessionKey);
+  if (!entry) {
+    return;
+  }
+
+  await finalizeBuilder(entry.builder, "completed");
+  removeBuilder(event.sessionKey);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: wrap onToolResult to capture tool outcomes
+// ---------------------------------------------------------------------------
+
+export type MetaHarnessToolResultInfo = {
+  toolName?: string;
+  success?: boolean;
+  error?: string;
+  durationMs?: number;
+};
+
+/**
+ * Creates an onToolResult wrapper that records tool outcomes to the active flow trace.
+ *
+ * Usage in dispatch-from-config.ts:
+ * ```ts
+ * import { wrapMetaHarnessOnToolResult } from "../meta-harness/hooks.js";
+ *
+ * onToolResult: wrapMetaHarnessOnToolResult(sessionKey, workspaceDir, existingOnToolResult)
+ * ```
+ */
+export function wrapMetaHarnessOnToolResult(
+  sessionKey: string,
+  workspaceDir: string,
+  existingOnToolResult?: (
+    payload: import("../auto-reply/types.js").ReplyPayload,
+  ) => Promise<void> | void,
+  toolInfo?: MetaHarnessToolResultInfo,
+): (payload: import("../auto-reply/types.js").ReplyPayload) => Promise<void> {
+  return async (payload) => {
+    // Record tool outcome (fire-and-forget, never blocks main path)
+    recordToolOutcome(sessionKey, workspaceDir, toolInfo).catch(() => {});
+
+    // Call the original handler
+    await existingOnToolResult?.(payload);
+  };
+}
+
+async function recordToolOutcome(
+  sessionKey: string,
+  workspaceDir: string,
+  toolInfo?: MetaHarnessToolResultInfo,
+): Promise<void> {
+  const entry = getBuilder(sessionKey);
+  if (!entry) {
+    return;
+  }
+
+  const gating = await checkWorkspaceGating(workspaceDir);
+  if (!gating.enabled) {
+    return;
+  }
+
+  const outcome: ToolOutcome = {
+    tool_name: toolInfo?.toolName ?? "unknown",
+    success: toolInfo?.success ?? true,
+    duration_ms: toolInfo?.durationMs ?? 0,
+  };
+  if (toolInfo?.error) {
+    outcome.error = toolInfo.error;
+  }
+
+  entry.builder.recordToolOutcome(outcome);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: finalize a session flow trace (call after reply completes)
+// ---------------------------------------------------------------------------
+
+export async function finalizeSessionFlowTrace(
+  sessionKey: string,
+  workspaceDir: string,
+  outcome: RunOutcome,
+): Promise<void> {
+  const entry = getBuilder(sessionKey);
+  if (!entry) {
+    return;
+  }
+
+  await finalizeBuilder(entry.builder, outcome);
+  removeBuilder(sessionKey);
+}
+
+// ---------------------------------------------------------------------------
+// Public API: record a delegation (call after sessions_spawn)
+// ---------------------------------------------------------------------------
+
+export async function recordDelegation(params: {
+  sessionKey: string;
+  workspaceDir: string;
+  childSessionId: string;
+  agentType: string;
+  taskBrief: string;
+  status: "completed" | "failed" | "escalated";
+}): Promise<void> {
+  const entry = getBuilder(params.sessionKey);
+  if (!entry) {
+    return;
+  }
+
+  const gating = await checkWorkspaceGating(params.workspaceDir);
+  if (!gating.enabled) {
+    return;
+  }
+
+  entry.builder.recordDelegation({
+    child_trace_id: params.childSessionId,
+    agent_type: params.agentType,
+    task_brief: params.taskBrief,
+    status: params.status,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Public API: start heartbeat flow trace
+// ---------------------------------------------------------------------------
+
+export function startHeartbeatFlowTrace(
+  sessionKey: string,
+  workspaceDir: string,
+  reason?: string,
+): ActiveBuilder | undefined {
+  const trigger: TriggerKind = reason === "cron" || reason === "exec-event" ? "cron" : "heartbeat";
+
+  const builder = startFlowTrace({
+    sessionKey,
+    workspaceDir,
+    trigger,
+    taskSummary: `heartbeat run (${reason ?? "interval"})`,
+  });
+  if (!builder) {
+    return undefined;
+  }
+  return getBuilder(sessionKey);
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+let registered = false;
+
+/**
+ * Register meta-harness hook handlers.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function registerMetaHarnessHooks(): void {
+  if (registered) {
+    return;
+  }
+  registered = true;
+
+  registerInternalHook("gateway:startup", handleGatewayStartup);
+  registerInternalHook("message:received", handleMessageReceived);
+  registerInternalHook("session:compact:before", handleSessionCompactBefore);
+
+  log.debug("meta-harness hooks registered");
+}
+
+/**
+ * Reset meta-harness state (for testing only).
+ */
+export function resetMetaHarnessState(): void {
+  registered = false;
+  defaultWorkspaceDir = null;
+  activeBuilders.clear();
+}

--- a/src/meta-harness/hooks.ts
+++ b/src/meta-harness/hooks.ts
@@ -374,6 +374,20 @@ async function handleDelegation(event: InternalHookEvent): Promise<void> {
     task_brief: taskBrief,
     status: (ctx.status as import("./types.js").RunOutcome) ?? "completed",
   });
+
+  // Write independent child trace file (fire-and-forget, never blocks main path)
+  entry.builder
+    .writeChildTrace({
+      child_trace_id: childSessionId,
+      child_session_id: childSessionId,
+      agent_type: agentType,
+      task_brief: taskBrief,
+      status: (ctx.status as import("./types.js").RunOutcome) ?? "completed",
+      verification_summary: "",
+      summarized_tool_calls: [],
+      timestamp: new Date().toISOString(),
+    })
+    .catch(() => {});
 }
 
 // ---------------------------------------------------------------------------

--- a/src/meta-harness/hooks.ts
+++ b/src/meta-harness/hooks.ts
@@ -334,6 +334,49 @@ export function startHeartbeatFlowTrace(
 }
 
 // ---------------------------------------------------------------------------
+// Hook: session:delegation — record delegation from sessions_spawn
+// ---------------------------------------------------------------------------
+
+async function handleDelegation(event: InternalHookEvent): Promise<void> {
+  const ctx = event.context as {
+    childSessionId?: string;
+    agentType?: string;
+    taskBrief?: string;
+    workspaceDir?: string;
+    status?: string;
+  };
+
+  const workspaceDir = getWorkspaceDir(event.context);
+  if (!workspaceDir) {
+    return;
+  }
+
+  const childSessionId = ctx.childSessionId;
+  const agentType = ctx.agentType;
+  const taskBrief = ctx.taskBrief;
+  if (!childSessionId || !agentType || !taskBrief) {
+    return;
+  }
+
+  const entry = getBuilder(event.sessionKey);
+  if (!entry) {
+    return;
+  }
+
+  const gating = await checkWorkspaceGating(workspaceDir);
+  if (!gating.enabled) {
+    return;
+  }
+
+  entry.builder.recordDelegation({
+    child_trace_id: childSessionId,
+    agent_type: agentType,
+    task_brief: taskBrief,
+    status: (ctx.status as import("./types.js").RunOutcome) ?? "completed",
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
 
@@ -352,6 +395,7 @@ export function registerMetaHarnessHooks(): void {
   registerInternalHook("gateway:startup", handleGatewayStartup);
   registerInternalHook("message:received", handleMessageReceived);
   registerInternalHook("session:compact:before", handleSessionCompactBefore);
+  registerInternalHook("session:delegation", handleDelegation);
 
   log.debug("meta-harness hooks registered");
 }

--- a/src/meta-harness/hooks.ts
+++ b/src/meta-harness/hooks.ts
@@ -14,7 +14,7 @@
 import type { InternalHookEvent } from "../hooks/internal-hooks.js";
 import { registerInternalHook } from "../hooks/internal-hooks.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { createFlowTraceBuilder, checkWorkspaceGating } from "./index.js";
+import { createFlowTraceBuilder, checkWorkspaceGating, generateDailySummary } from "./index.js";
 import type { FlowTraceBuilder } from "./index.js";
 import type {
   RunOutcome,
@@ -23,6 +23,7 @@ import type {
   TriageDomain,
   AutomationLevel,
 } from "./types.js";
+import { generateTraceId } from "./writer.js";
 
 const log = createSubsystemLogger("meta-harness");
 
@@ -303,7 +304,7 @@ export async function recordDelegation(params: {
   }
 
   entry.builder.recordDelegation({
-    child_trace_id: params.childSessionId,
+    child_trace_id: generateTraceId(), // Use stable UUID instead of session key
     agent_type: params.agentType,
     task_brief: params.taskBrief,
     status: params.status,
@@ -368,8 +369,10 @@ async function handleDelegation(event: InternalHookEvent): Promise<void> {
     return;
   }
 
+  const childTraceId = generateTraceId(); // Use stable UUID instead of session key
+
   entry.builder.recordDelegation({
-    child_trace_id: childSessionId,
+    child_trace_id: childTraceId,
     agent_type: agentType,
     task_brief: taskBrief,
     status: (ctx.status as import("./types.js").RunOutcome) ?? "completed",
@@ -378,7 +381,7 @@ async function handleDelegation(event: InternalHookEvent): Promise<void> {
   // Write independent child trace file (fire-and-forget, never blocks main path)
   entry.builder
     .writeChildTrace({
-      child_trace_id: childSessionId,
+      child_trace_id: childTraceId,
       child_session_id: childSessionId,
       agent_type: agentType,
       task_brief: taskBrief,
@@ -388,6 +391,10 @@ async function handleDelegation(event: InternalHookEvent): Promise<void> {
       timestamp: new Date().toISOString(),
     })
     .catch(() => {});
+
+  // Refresh daily summary after delegation (fire-and-forget, idempotent)
+  const today = new Date().toISOString().slice(0, 10);
+  generateDailySummary(workspaceDir, today).catch(() => {});
 }
 
 // ---------------------------------------------------------------------------

--- a/src/meta-harness/index.ts
+++ b/src/meta-harness/index.ts
@@ -1,0 +1,219 @@
+/**
+ * Meta-Harness public API
+ *
+ * Main entry point for the meta-harness subsystem.
+ * All methods are workspace-gated: if manifest.json is missing, they are no-ops.
+ */
+
+import { buildDailySummary, buildWeeklySummary } from "./aggregation.js";
+import { checkWorkspaceGating, ensureRuntimeLayout } from "./gating.js";
+import type {
+  FlowTrace,
+  ChildTrace,
+  RichTrace,
+  DailySummary,
+  WeeklySummary,
+  TraceId,
+  TriggerKind,
+  TriageDomain,
+  AutomationLevel,
+  RunOutcome,
+  ToolOutcome,
+  Observation,
+} from "./types.js";
+import {
+  generateTraceId,
+  writeFlowTrace,
+  writeChildTrace,
+  writeRichTrace,
+  writeDailySummary,
+  writeWeeklySummary,
+} from "./writer.js";
+
+export type {
+  FlowTrace,
+  ChildTrace,
+  RichTrace,
+  DailySummary,
+  WeeklySummary,
+  TraceId,
+  TriggerKind,
+  TriageDomain,
+  AutomationLevel,
+  RunOutcome,
+  ToolOutcome,
+  Observation,
+  GatingResult,
+  MetaHarnessManifest,
+} from "./types.js";
+export { checkWorkspaceGating, ensureRuntimeLayout } from "./gating.js";
+export { generateTraceId } from "./writer.js";
+export { buildDailySummary, buildWeeklySummary } from "./aggregation.js";
+
+const HARNESS_VERSION = "1.0.0";
+
+/**
+ * Create a flow trace builder for a specific run.
+ * Returns null if Meta-Harness is not enabled for this workspace.
+ */
+export function createFlowTraceBuilder(params: {
+  workspaceDir: string;
+  sessionId: string;
+  flowId: string;
+  trigger: TriggerKind;
+  taskSummary: string;
+  triageDomain: TriageDomain;
+  automationLevel: AutomationLevel;
+}): FlowTraceBuilder | null {
+  // We check gating lazily (on finalize) to avoid blocking normal operations.
+  return new FlowTraceBuilder(params);
+}
+
+/**
+ * FlowTraceBuilder — accumulates data during a run and writes on finalize.
+ */
+export class FlowTraceBuilder {
+  private _traceId: TraceId;
+  private startTime: number;
+  private toolOutcomes: ToolOutcome[] = [];
+  private delegations: import("./types.js").DelegationEntry[] = [];
+  private observations: Observation[] = [];
+
+  constructor(
+    private params: {
+      workspaceDir: string;
+      sessionId: string;
+      flowId: string;
+      trigger: TriggerKind;
+      taskSummary: string;
+      triageDomain: TriageDomain;
+      automationLevel: AutomationLevel;
+    },
+  ) {
+    this._traceId = generateTraceId();
+    this.startTime = Date.now();
+  }
+
+  get traceId(): TraceId {
+    return this._traceId;
+  }
+
+  /**
+   * Record a tool call outcome.
+   */
+  recordToolOutcome(outcome: ToolOutcome): void {
+    this.toolOutcomes.push(outcome);
+  }
+
+  /**
+   * Record a delegation to a child agent.
+   */
+  recordDelegation(delegation: import("./types.js").DelegationEntry): void {
+    this.delegations.push(delegation);
+  }
+
+  /**
+   * Record an observation.
+   */
+  recordObservation(observation: Observation): void {
+    this.observations.push(observation);
+  }
+
+  /**
+   * Finalize and write the flow trace.
+   * Returns the written file path, or null if Meta-Harness is disabled.
+   */
+  async finalize(outcome: RunOutcome): Promise<string | null> {
+    const gating = await checkWorkspaceGating(this.params.workspaceDir);
+    if (!gating.enabled) {
+      return null;
+    }
+
+    const trace: FlowTrace = {
+      trace_id: this.traceId,
+      timestamp: new Date(this.startTime).toISOString(),
+      session_id: this.params.sessionId,
+      flow_id: this.params.flowId,
+      trigger: this.params.trigger,
+      task_summary: this.params.taskSummary,
+      triage_domain: this.params.triageDomain,
+      automation_level: this.params.automationLevel,
+      delegation_list: this.delegations,
+      outcome,
+      observations: this.observations,
+      harness_version: HARNESS_VERSION,
+      tool_outcomes: this.toolOutcomes,
+      duration_ms: Date.now() - this.startTime,
+    };
+
+    return writeFlowTrace(this.params.workspaceDir, trace);
+  }
+
+  /**
+   * Write a child trace linked to this flow.
+   */
+  async writeChildTrace(childTrace: Omit<ChildTrace, "parent_trace_id">): Promise<string | null> {
+    const gating = await checkWorkspaceGating(this.params.workspaceDir);
+    if (!gating.enabled) {
+      return null;
+    }
+
+    const full: ChildTrace = {
+      ...childTrace,
+      parent_trace_id: this._traceId,
+    };
+    return writeChildTrace(this.params.workspaceDir, full);
+  }
+
+  /**
+   * Write a rich trace (only on escalation conditions).
+   */
+  async writeRichTrace(escalationReason: string, rawContent: string): Promise<string | null> {
+    const gating = await checkWorkspaceGating(this.params.workspaceDir);
+    if (!gating.enabled) {
+      return null;
+    }
+
+    const richTrace: RichTrace = {
+      trace_id: this.traceId,
+      parent_trace_id: undefined,
+      escalation_reason: escalationReason,
+      timestamp: new Date().toISOString(),
+      raw_content: rawContent,
+    };
+    return writeRichTrace(this.params.workspaceDir, richTrace);
+  }
+}
+
+/**
+ * Generate and write a daily summary for a given date.
+ */
+export async function generateDailySummary(
+  workspaceDir: string,
+  date: string,
+): Promise<string | null> {
+  const gating = await checkWorkspaceGating(workspaceDir);
+  if (!gating.enabled) {
+    return null;
+  }
+
+  const summary = await buildDailySummary(workspaceDir, date);
+  return writeDailySummary(workspaceDir, summary);
+}
+
+/**
+ * Generate and write a weekly summary for a given week range.
+ */
+export async function generateWeeklySummary(
+  workspaceDir: string,
+  weekStart: string,
+  weekEnd: string,
+): Promise<string | null> {
+  const gating = await checkWorkspaceGating(workspaceDir);
+  if (!gating.enabled) {
+    return null;
+  }
+
+  const summary = await buildWeeklySummary(workspaceDir, weekStart, weekEnd);
+  return writeWeeklySummary(workspaceDir, summary);
+}

--- a/src/meta-harness/types.ts
+++ b/src/meta-harness/types.ts
@@ -1,0 +1,136 @@
+/**
+ * Meta-Harness type definitions
+ *
+ * Runtime types for flow traces, child traces, rich traces,
+ * and daily/weekly summaries as specified by the quantum-rules contract.
+ */
+
+/** Unique trace identifier (UUID v4) */
+export type TraceId = string;
+
+/** Trigger type for a top-level run */
+export type TriggerKind = "session" | "heartbeat" | "cron";
+
+/** Automation level per quantum-self/automation-governance.md */
+export type AutomationLevel = "A" | "B" | "C" | "D" | "X";
+
+/** Triage domain per quantum-self/capability-map.md */
+export type TriageDomain =
+  | "strategy"
+  | "research"
+  | "build"
+  | "delivery"
+  | "growth"
+  | "ops"
+  | "governance"
+  | "unknown";
+
+/** Run outcome */
+export type RunOutcome = "completed" | "partial" | "failed" | "escalated" | "aborted";
+
+/** Flow trace — one per top-level session/heartbeat/cron run */
+export type FlowTrace = {
+  trace_id: TraceId;
+  timestamp: string; // ISO 8601
+  session_id: string;
+  flow_id: string;
+  trigger: TriggerKind;
+  task_summary: string;
+  triage_domain: TriageDomain;
+  automation_level: AutomationLevel;
+  delegation_list: DelegationEntry[];
+  outcome: RunOutcome;
+  observations: Observation[];
+  harness_version: string;
+  /** Tool call outcomes from this run */
+  tool_outcomes: ToolOutcome[];
+  /** Total duration in ms */
+  duration_ms: number;
+};
+
+/** Child trace — one per delegated agent task */
+export type ChildTrace = {
+  child_trace_id: TraceId;
+  parent_trace_id: TraceId;
+  child_session_id: string;
+  agent_type: string;
+  task_brief: string;
+  status: RunOutcome;
+  verification_summary: string;
+  failure_or_escalation_reason?: string;
+  summarized_tool_calls: ToolOutcome[];
+  timestamp: string; // ISO 8601
+  duration_ms?: number;
+};
+
+/** Rich trace — full raw transcript, only written on escalation */
+export type RichTrace = {
+  trace_id: TraceId;
+  parent_trace_id?: TraceId;
+  escalation_reason: string;
+  timestamp: string;
+  raw_content: string; // JSON-serialized raw trace data
+};
+
+/** Delegation entry in a flow trace */
+export type DelegationEntry = {
+  child_trace_id: TraceId;
+  agent_type: string;
+  task_brief: string;
+  status: RunOutcome;
+};
+
+/** Observation with evidence grading */
+export type Observation = {
+  kind: "OBSERVED" | "INFERRED" | "NOT_VERIFIED";
+  summary: string;
+};
+
+/** Tool call outcome */
+export type ToolOutcome = {
+  tool_name: string;
+  success: boolean;
+  error?: string;
+  duration_ms?: number;
+};
+
+/** Daily summary */
+export type DailySummary = {
+  date: string; // YYYY-MM-DD
+  total_runs: number;
+  outcomes: Record<RunOutcome, number>;
+  domains: Record<TriageDomain, number>;
+  automation_levels: Record<AutomationLevel, number>;
+  tool_error_frequency: number;
+  tool_error_count: number;
+  tool_call_count: number;
+  delegation_count: number;
+  delegation_failures: number;
+  escalations: number;
+  flow_trace_ids: TraceId[];
+  child_trace_ids: TraceId[];
+};
+
+/** Weekly summary */
+export type WeeklySummary = {
+  week_start: string; // YYYY-MM-DD
+  week_end: string; // YYYY-MM-DD
+  daily_counts: number[];
+  avg_runs_per_day: number;
+  total_tool_errors: number;
+  total_escalations: number;
+  top_failure_domains: TriageDomain[];
+  top_failure_tools: string[];
+};
+
+/** Manifest file content */
+export type MetaHarnessManifest = {
+  version: string;
+  created_at: string;
+  workspace_path: string;
+};
+
+/** Workspace gating result */
+export type GatingResult =
+  | { enabled: true; manifest: MetaHarnessManifest }
+  | { enabled: false; reason: string };

--- a/src/meta-harness/writer.ts
+++ b/src/meta-harness/writer.ts
@@ -1,0 +1,112 @@
+/**
+ * Flow trace writer — writes top-level flow traces to data/meta-harness/traces/
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { FlowTrace, TraceId } from "./types.js";
+
+/**
+ * Generate a stable trace ID (UUID v4).
+ */
+export function generateTraceId(): TraceId {
+  return crypto.randomUUID();
+}
+
+/**
+ * Write a flow trace to the traces directory.
+ * File name: `{trace_id}.json`
+ */
+export async function writeFlowTrace(workspaceDir: string, trace: FlowTrace): Promise<string> {
+  const tracesDir = path.join(workspaceDir, "data/meta-harness/traces");
+  const filePath = path.join(tracesDir, `${trace.trace_id}.json`);
+  await fs.writeFile(filePath, JSON.stringify(trace, null, 2) + "\n", "utf-8");
+  return filePath;
+}
+
+/**
+ * Write a child trace to the children directory.
+ * File name: `{child_trace_id}.json`
+ */
+export async function writeChildTrace(
+  workspaceDir: string,
+  childTrace: import("./types.js").ChildTrace,
+): Promise<string> {
+  const childrenDir = path.join(workspaceDir, "data/meta-harness/children");
+  const filePath = path.join(childrenDir, `${childTrace.child_trace_id}.json`);
+  await fs.writeFile(filePath, JSON.stringify(childTrace, null, 2) + "\n", "utf-8");
+  return filePath;
+}
+
+/**
+ * Write a rich trace to the rich directory (only on escalation).
+ * File name: `rich-{trace_id}-{timestamp}.json`
+ */
+export async function writeRichTrace(
+  workspaceDir: string,
+  richTrace: import("./types.js").RichTrace,
+): Promise<string> {
+  const richDir = path.join(workspaceDir, "data/meta-harness/rich");
+  const ts = richTrace.timestamp.replace(/[:.]/g, "-").slice(0, 19);
+  const filePath = path.join(richDir, `rich-${richTrace.trace_id}-${ts}.json`);
+  await fs.writeFile(filePath, JSON.stringify(richTrace, null, 2) + "\n", "utf-8");
+  return filePath;
+}
+
+/**
+ * Write a daily summary to the daily directory.
+ * File name: `daily-{date}.json`
+ */
+export async function writeDailySummary(
+  workspaceDir: string,
+  summary: import("./types.js").DailySummary,
+): Promise<string> {
+  const dailyDir = path.join(workspaceDir, "data/meta-harness/daily");
+  const filePath = path.join(dailyDir, `daily-${summary.date}.json`);
+  await fs.writeFile(filePath, JSON.stringify(summary, null, 2) + "\n", "utf-8");
+  return filePath;
+}
+
+/**
+ * Write a weekly summary to the weekly directory.
+ * File name: `weekly-{week_start}-{week_end}.json`
+ */
+export async function writeWeeklySummary(
+  workspaceDir: string,
+  summary: import("./types.js").WeeklySummary,
+): Promise<string> {
+  const weeklyDir = path.join(workspaceDir, "data/meta-harness/weekly");
+  const filePath = path.join(weeklyDir, `weekly-${summary.week_start}-${summary.week_end}.json`);
+  await fs.writeFile(filePath, JSON.stringify(summary, null, 2) + "\n", "utf-8");
+  return filePath;
+}
+
+/**
+ * List all trace files in a directory, returning parsed content.
+ */
+export async function listTraces<T>(
+  workspaceDir: string,
+  subDir: string,
+): Promise<{ filePath: string; data: T }[]> {
+  const dir = path.join(workspaceDir, "data/meta-harness", subDir);
+  try {
+    const files = await fs.readdir(dir);
+    const results: { filePath: string; data: T }[] = [];
+    for (const file of files) {
+      if (!file.endsWith(".json")) {
+        continue;
+      }
+      try {
+        const filePath = path.join(dir, file);
+        const raw = await fs.readFile(filePath, "utf-8");
+        results.push({ filePath, data: JSON.parse(raw) as T });
+      } catch {
+        // skip unreadable files
+      }
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

This PR integrates Meta-Harness runtime tracing into OpenClaw.

It adds:

- runtime flow trace capture for session / heartbeat / cron paths
- delegated child trace recording
- tool outcome capture in trace data
- daily summary refresh after delegation
- stable UUID-based `child_trace_id` for new writes

## Verified

- runtime flow trace write
- runtime child trace write
- runtime daily summary update
- TypeScript compile passed
- lint passed
- tests passed
- real runtime verification completed

## Deferred Follow-up

- weekly summary automation, if we want it later
- historical trace data may still contain older `child_trace_id` formats, but new writes are normalized
- any further cleanup can be handled in follow-up PRs

## Risk Notes

- touches core runtime paths
- runtime verification has been completed
- rules contract remains in `quantum-rules`
- implementation lives in `openclaw`

## Notes

- nothing was pushed to `quantum-rules`
- `main` was not pushed directly
