### PR TITLE
[codex] fix usage channel aggregation insights

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -149,6 +149,114 @@ describe("sessions.usage", () => {
     expect(sessions[1].agentId).toBe("main");
   });
 
+  it("keeps aggregates across all sessions even when limit trims the returned list", async () => {
+    vi.mocked(discoverAllSessions).mockImplementation(async (params?: { agentId?: string }) => {
+      if (params?.agentId === "main") {
+        return [
+          {
+            sessionId: "s-feishu",
+            sessionFile: "/tmp/agents/main/sessions/s-feishu.jsonl",
+            mtime: 300,
+            firstUserMessage: "feishu",
+          },
+          {
+            sessionId: "s-webchat",
+            sessionFile: "/tmp/agents/main/sessions/s-webchat.jsonl",
+            mtime: 200,
+            firstUserMessage: "webchat",
+          },
+        ];
+      }
+      return [];
+    });
+    vi.mocked(loadCombinedSessionStoreForGateway).mockReturnValue({
+      storePath: "(multiple)",
+      store: {
+        "agent:main:feishu:direct:ou_demo": {
+          sessionId: "s-feishu",
+          sessionFile: "s-feishu.jsonl",
+          updatedAt: 300,
+          channel: "feishu",
+          origin: { provider: "feishu" },
+        },
+        "agent:main:webchat:thread:t_demo": {
+          sessionId: "s-webchat",
+          sessionFile: "s-webchat.jsonl",
+          updatedAt: 200,
+          channel: "webchat",
+          origin: { provider: "webchat" },
+        },
+      },
+    });
+    vi.mocked(loadSessionCostSummary).mockImplementation(async ({ sessionId }) => {
+      if (sessionId === "s-feishu") {
+        return {
+          input: 10,
+          output: 2,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 72_800,
+          totalCost: 0,
+          inputCost: 0,
+          outputCost: 0,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 0,
+        };
+      }
+      if (sessionId === "s-webchat") {
+        return {
+          input: 5,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 12,
+          totalCost: 0,
+          inputCost: 0,
+          outputCost: 0,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 0,
+        };
+      }
+      return {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        totalCost: 0,
+        inputCost: 0,
+        outputCost: 0,
+        cacheReadCost: 0,
+        cacheWriteCost: 0,
+        missingCostEntries: 0,
+      };
+    });
+
+    const respond = await runSessionsUsage({
+      ...BASE_USAGE_RANGE,
+      limit: 1,
+    });
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    const result = respond.mock.calls[0]?.[1] as {
+      sessions: Array<{ channel?: string }>;
+      aggregates: { byChannel: Array<{ channel: string; totals: { totalTokens: number } }> };
+    };
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]?.channel).toBe("feishu");
+    expect(result.aggregates.byChannel).toEqual([
+      expect.objectContaining({
+        channel: "feishu",
+        totals: expect.objectContaining({ totalTokens: 72_800 }),
+      }),
+      expect.objectContaining({
+        channel: "webchat",
+        totals: expect.objectContaining({ totalTokens: 12 }),
+      }),
+    ]);
+  });
   it("resolves store entries by sessionId when queried via discovered agent-prefixed key", async () => {
     const storeKey = "agent:opus:slack:dm:u123";
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-test-"));

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -243,9 +243,16 @@ describe("sessions.usage", () => {
     const result = respond.mock.calls[0]?.[1] as {
       sessions: Array<{ channel?: string }>;
       aggregates: { byChannel: Array<{ channel: string; totals: { totalTokens: number } }> };
+      overview: { matchedSessions: number; returnedSessions: number };
     };
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0]?.channel).toBe("feishu");
+    expect(result.overview).toEqual({
+      matchedSessions: 2,
+      returnedSessions: 1,
+      durationCount: 0,
+      durationSumMs: 0,
+    });
     expect(result.aggregates.byChannel).toEqual([
       expect.objectContaining({
         channel: "feishu",
@@ -257,6 +264,57 @@ describe("sessions.usage", () => {
       }),
     ]);
   });
+  it("keeps the returned session list capped by the selected slice when duplicate entries collapse", async () => {
+    vi.mocked(discoverAllSessions).mockImplementation(async (params?: { agentId?: string }) => {
+      if (params?.agentId === "main") {
+        return [
+          {
+            sessionId: "s-dup",
+            sessionFile: "/tmp/agents/main/sessions/s-dup-a.jsonl",
+            mtime: 300,
+            firstUserMessage: "first",
+          },
+          {
+            sessionId: "s-dup",
+            sessionFile: "/tmp/agents/main/sessions/s-dup-b.jsonl",
+            mtime: 200,
+            firstUserMessage: "second",
+          },
+        ];
+      }
+      return [];
+    });
+    vi.mocked(loadCombinedSessionStoreForGateway).mockReturnValue({
+      storePath: "(multiple)",
+      store: {},
+    });
+
+    const respond = await runSessionsUsage({
+      ...BASE_USAGE_RANGE,
+      limit: 1,
+    });
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    const result = respond.mock.calls[0]?.[1] as {
+      sessions: Array<{ key: string; sessionId?: string }>;
+      overview: { matchedSessions: number; returnedSessions: number };
+    };
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0]).toEqual(
+      expect.objectContaining({
+        key: "agent:main:s-dup",
+        sessionId: "s-dup",
+      }),
+    );
+    expect(result.overview).toEqual({
+      matchedSessions: 2,
+      returnedSessions: 1,
+      durationCount: 0,
+      durationSumMs: 0,
+    });
+  });
+
   it("resolves store entries by sessionId when queried via discovered agent-prefixed key", async () => {
     const storeKey = "agent:opus:slack:dm:u123";
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-usage-test-"));

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -521,9 +521,9 @@ export const usageHandlers: GatewayRequestHandlers = {
     // Sort by most recent first
     mergedEntries.sort((a, b) => b.updatedAt - a.updatedAt);
 
-    // Apply limit only to the returned session list; aggregates should cover all entries.
+    // Apply limit only to the returned session list; overview aggregates cover all matched entries.
     const limitedEntries = mergedEntries.slice(0, limit);
-    const limitedEntryKeys = new Set(limitedEntries.map((entry) => `${entry.key}::${entry.sessionId}`));
+    const limitedEntrySet = new Set(limitedEntries);
 
     // Load usage for each session
     const sessions: SessionUsageEntry[] = [];
@@ -570,6 +570,12 @@ export const usageHandlers: GatewayRequestHandlers = {
       min: Number.POSITIVE_INFINITY,
       max: 0,
       p95Max: 0,
+    };
+    const overview = {
+      matchedSessions: mergedEntries.length,
+      returnedSessions: limitedEntries.length,
+      durationCount: 0,
+      durationSumMs: 0,
     };
     const dailyLatencyMap = new Map<
       string,
@@ -635,6 +641,11 @@ export const usageHandlers: GatewayRequestHandlers = {
 
       const channel = merged.storeEntry?.channel ?? merged.storeEntry?.origin?.provider;
       const chatType = merged.storeEntry?.chatType ?? merged.storeEntry?.origin?.chatType;
+
+      if (usage?.durationMs && usage.durationMs > 0) {
+        overview.durationCount += 1;
+        overview.durationSumMs += usage.durationMs;
+      }
 
       if (usage) {
         if (usage.messageCounts) {
@@ -751,7 +762,7 @@ export const usageHandlers: GatewayRequestHandlers = {
         }
       }
 
-      if (limitedEntryKeys.has(`${merged.key}::${merged.sessionId}`)) {
+      if (limitedEntrySet.has(merged)) {
         sessions.push({
           key: merged.key,
           label: merged.label,
@@ -823,6 +834,7 @@ export const usageHandlers: GatewayRequestHandlers = {
       sessions,
       totals: aggregateTotals,
       aggregates,
+      overview,
     };
 
     respond(true, result, undefined);

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -24,7 +24,7 @@ import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
 import {
   buildUsageAggregateTail,
-  compareUsageTotalsByTokensThenCost,
+  sortUsageRankingEntries,
   mergeUsageDailyLatency,
   mergeUsageLatency,
 } from "../../shared/usage-aggregates.js";
@@ -810,9 +810,9 @@ export const usageHandlers: GatewayRequestHandlers = {
         }
         return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
       }),
-      byAgent: Array.from(byAgentMap.entries())
-        .map(([id, totals]) => ({ agentId: id, totals }))
-        .toSorted((a, b) => compareUsageTotalsByTokensThenCost(a.totals, b.totals)),
+      byAgent: sortUsageRankingEntries(
+        Array.from(byAgentMap.entries()).map(([id, totals]) => ({ agentId: id, totals })),
+      ),
       ...tail,
     };
 

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -24,6 +24,7 @@ import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../../sessions/session-id-resolution.js";
 import {
   buildUsageAggregateTail,
+  compareUsageTotalsByTokensThenCost,
   mergeUsageDailyLatency,
   mergeUsageLatency,
 } from "../../shared/usage-aggregates.js";
@@ -520,8 +521,9 @@ export const usageHandlers: GatewayRequestHandlers = {
     // Sort by most recent first
     mergedEntries.sort((a, b) => b.updatedAt - a.updatedAt);
 
-    // Apply limit
+    // Apply limit only to the returned session list; aggregates should cover all entries.
     const limitedEntries = mergedEntries.slice(0, limit);
+    const limitedEntryKeys = new Set(limitedEntries.map((entry) => `${entry.key}::${entry.sessionId}`));
 
     // Load usage for each session
     const sessions: SessionUsageEntry[] = [];
@@ -605,7 +607,7 @@ export const usageHandlers: GatewayRequestHandlers = {
       target.missingCostEntries += source.missingCostEntries;
     };
 
-    for (const merged of limitedEntries) {
+    for (const merged of mergedEntries) {
       const agentId = parseAgentSessionKey(merged.key)?.agentId;
       const usage = await loadSessionCostSummary({
         sessionId: merged.sessionId,
@@ -749,24 +751,26 @@ export const usageHandlers: GatewayRequestHandlers = {
         }
       }
 
-      sessions.push({
-        key: merged.key,
-        label: merged.label,
-        sessionId: merged.sessionId,
-        updatedAt: merged.updatedAt,
-        agentId,
-        channel,
-        chatType,
-        origin: merged.storeEntry?.origin,
-        modelOverride: merged.storeEntry?.modelOverride,
-        providerOverride: merged.storeEntry?.providerOverride,
-        modelProvider: merged.storeEntry?.modelProvider,
-        model: merged.storeEntry?.model,
-        usage,
-        contextWeight: includeContextWeight
-          ? (merged.storeEntry?.systemPromptReport ?? null)
-          : undefined,
-      });
+      if (limitedEntryKeys.has(`${merged.key}::${merged.sessionId}`)) {
+        sessions.push({
+          key: merged.key,
+          label: merged.label,
+          sessionId: merged.sessionId,
+          updatedAt: merged.updatedAt,
+          agentId,
+          channel,
+          chatType,
+          origin: merged.storeEntry?.origin,
+          modelOverride: merged.storeEntry?.modelOverride,
+          providerOverride: merged.storeEntry?.providerOverride,
+          modelProvider: merged.storeEntry?.modelProvider,
+          model: merged.storeEntry?.model,
+          usage,
+          contextWeight: includeContextWeight
+            ? (merged.storeEntry?.systemPromptReport ?? null)
+            : undefined,
+        });
+      }
     }
 
     // Format dates back to YYYY-MM-DD strings
@@ -808,7 +812,7 @@ export const usageHandlers: GatewayRequestHandlers = {
       }),
       byAgent: Array.from(byAgentMap.entries())
         .map(([id, totals]) => ({ agentId: id, totals }))
-        .toSorted((a, b) => (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0)),
+        .toSorted((a, b) => compareUsageTotalsByTokensThenCost(a.totals, b.totals)),
       ...tail,
     };
 

--- a/src/shared/usage-aggregates.test.ts
+++ b/src/shared/usage-aggregates.test.ts
@@ -40,7 +40,7 @@ describe("shared/usage-aggregates", () => {
     });
   });
 
-  it("merges daily latency by date and computes aggregate tail sorting", () => {
+  it("merges daily latency by date and sorts channels by tokens before cost", () => {
     const dailyLatencyMap = new Map<
       string,
       {
@@ -62,8 +62,8 @@ describe("shared/usage-aggregates", () => {
 
     const tail = buildUsageAggregateTail({
       byChannelMap: new Map([
-        ["discord", { totalCost: 4 }],
-        ["telegram", { totalCost: 8 }],
+        ["discord", { totalCost: 0, totalTokens: 20 }],
+        ["telegram", { totalCost: 0, totalTokens: 80 }],
       ]),
       latencyTotals: {
         count: 3,

--- a/src/shared/usage-aggregates.test.ts
+++ b/src/shared/usage-aggregates.test.ts
@@ -40,7 +40,7 @@ describe("shared/usage-aggregates", () => {
     });
   });
 
-  it("merges daily latency by date and sorts channels by tokens before cost", () => {
+  it("merges daily latency by date and uses tokens for zero-cost channel ranking", () => {
     const dailyLatencyMap = new Map<
       string,
       {
@@ -102,6 +102,27 @@ describe("shared/usage-aggregates", () => {
       { date: "2026-03-12", cost: 1 },
     ]);
     expect(tail.daily).toEqual([{ date: "2026-03-11" }, { date: "2026-03-12" }]);
+  });
+
+  it("keeps cost-first ranking when channels have non-zero cost", () => {
+    const tail = buildUsageAggregateTail({
+      byChannelMap: new Map([
+        ["high-cost", { totalCost: 10, totalTokens: 5 }],
+        ["high-token", { totalCost: 1, totalTokens: 500 }],
+      ]),
+      latencyTotals: {
+        count: 0,
+        sum: 0,
+        min: Number.POSITIVE_INFINITY,
+        max: 0,
+        p95Max: 0,
+      },
+      dailyLatencyMap: new Map(),
+      modelDailyMap: new Map(),
+      dailyMap: new Map(),
+    });
+
+    expect(tail.byChannel.map((entry) => entry.channel)).toEqual(["high-cost", "high-token"]);
   });
 
   it("omits latency when no requests were counted", () => {

--- a/src/shared/usage-aggregates.ts
+++ b/src/shared/usage-aggregates.ts
@@ -34,11 +34,29 @@ type CostAndTokenTotalsLike = {
   totalTokens: number;
 };
 
+export function compareUsageTotalsByCostThenTokens<TTotals extends CostAndTokenTotalsLike>(
+  left: TTotals,
+  right: TTotals,
+): number {
+  return right.totalCost - left.totalCost || right.totalTokens - left.totalTokens;
+}
+
 export function compareUsageTotalsByTokensThenCost<TTotals extends CostAndTokenTotalsLike>(
   left: TTotals,
   right: TTotals,
 ): number {
   return right.totalTokens - left.totalTokens || right.totalCost - left.totalCost;
+}
+
+export function sortUsageRankingEntries<TEntry extends { totals: CostAndTokenTotalsLike }>(
+  entries: readonly TEntry[],
+): TEntry[] {
+  const rankByTokens = entries.length > 0 && entries.every((entry) => entry.totals.totalCost === 0);
+  return [...entries].toSorted((a, b) =>
+    rankByTokens
+      ? compareUsageTotalsByTokensThenCost(a.totals, b.totals)
+      : compareUsageTotalsByCostThenTokens(a.totals, b.totals),
+  );
 }
 
 export function mergeUsageLatency(
@@ -89,9 +107,9 @@ export function buildUsageAggregateTail<
   dailyMap: Map<string, TDaily>;
 }) {
   return {
-    byChannel: Array.from(params.byChannelMap.entries())
-      .map(([channel, totals]) => ({ channel, totals }))
-      .toSorted((a, b) => compareUsageTotalsByTokensThenCost(a.totals, b.totals)),
+    byChannel: sortUsageRankingEntries(
+      Array.from(params.byChannelMap.entries()).map(([channel, totals]) => ({ channel, totals })),
+    ),
     latency:
       params.latencyTotals.count > 0
         ? {

--- a/src/shared/usage-aggregates.ts
+++ b/src/shared/usage-aggregates.ts
@@ -29,6 +29,18 @@ type LatencyLike = {
 
 type DailyLatencyInput = LatencyLike & { date: string };
 
+type CostAndTokenTotalsLike = {
+  totalCost: number;
+  totalTokens: number;
+};
+
+export function compareUsageTotalsByTokensThenCost<TTotals extends CostAndTokenTotalsLike>(
+  left: TTotals,
+  right: TTotals,
+): number {
+  return right.totalTokens - left.totalTokens || right.totalCost - left.totalCost;
+}
+
 export function mergeUsageLatency(
   totals: LatencyTotalsLike,
   latency: LatencyLike | undefined,
@@ -66,7 +78,7 @@ export function mergeUsageDailyLatency(
 }
 
 export function buildUsageAggregateTail<
-  TTotals extends { totalCost: number },
+  TTotals extends CostAndTokenTotalsLike,
   TDaily extends DailyLike,
   TModelDaily extends { date: string; cost: number },
 >(params: {
@@ -79,7 +91,7 @@ export function buildUsageAggregateTail<
   return {
     byChannel: Array.from(params.byChannelMap.entries())
       .map(([channel, totals]) => ({ channel, totals }))
-      .toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
+      .toSorted((a, b) => compareUsageTotalsByTokensThenCost(a.totals, b.totals)),
     latency:
       params.latencyTotals.count > 0
         ? {

--- a/src/shared/usage-types.ts
+++ b/src/shared/usage-types.ts
@@ -56,6 +56,13 @@ export type SessionsUsageAggregates = {
   }>;
 };
 
+export type SessionsUsageOverview = {
+  matchedSessions: number;
+  returnedSessions: number;
+  durationCount: number;
+  durationSumMs: number;
+};
+
 export type SessionsUsageResult = {
   updatedAt: number;
   startDate: string;
@@ -63,4 +70,5 @@ export type SessionsUsageResult = {
   sessions: SessionUsageEntry[];
   totals: CostUsageSummary["totals"];
   aggregates: SessionsUsageAggregates;
+  overview: SessionsUsageOverview;
 };

--- a/ui/src/ui/app-render-usage-tab.ts
+++ b/ui/src/ui/app-render-usage-tab.ts
@@ -23,9 +23,12 @@ export function renderUsageTab(state: AppViewState) {
       loading: state.usageLoading,
       error: state.usageError,
       sessions: state.usageResult?.sessions ?? [],
-      sessionsLimitReached: (state.usageResult?.sessions?.length ?? 0) >= 1000,
+      sessionsLimitReached:
+        (state.usageResult?.overview?.matchedSessions ?? state.usageResult?.sessions?.length ?? 0) >
+        (state.usageResult?.sessions?.length ?? 0),
       totals: state.usageResult?.totals ?? null,
       aggregates: state.usageResult?.aggregates ?? null,
+      overview: state.usageResult?.overview ?? null,
       costDaily: state.usageCostSummary?.daily ?? [],
     },
     filters: {

--- a/ui/src/ui/views/usage-metrics.test.ts
+++ b/ui/src/ui/views/usage-metrics.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { buildAggregatesFromSessions, buildUsageInsightStats } from "./usage-metrics.ts";
+import type { UsageAggregates, UsageSessionEntry, UsageTotals } from "./usageTypes.ts";
+
+function createTotals(overrides: Partial<UsageTotals> = {}): UsageTotals {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    totalCost: 0,
+    inputCost: 0,
+    outputCost: 0,
+    cacheReadCost: 0,
+    cacheWriteCost: 0,
+    missingCostEntries: 0,
+    ...overrides,
+  };
+}
+
+function createAggregates(): UsageAggregates {
+  return {
+    messages: { total: 0, user: 0, assistant: 0, toolCalls: 0, toolResults: 0, errors: 0 },
+    tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
+    byModel: [],
+    byProvider: [],
+    byAgent: [],
+    byChannel: [],
+    daily: [],
+  };
+}
+
+function createSession(
+  key: string,
+  agentId: string,
+  channel: string,
+  usageOverrides: Partial<NonNullable<UsageSessionEntry["usage"]>> = {},
+): UsageSessionEntry {
+  return {
+    key,
+    agentId,
+    channel,
+    usage: {
+      ...createTotals(),
+      durationMs: 60_000,
+      firstActivity: 1,
+      lastActivity: 60_001,
+      messageCounts: { total: 1, user: 0, assistant: 1, toolCalls: 0, toolResults: 0, errors: 0 },
+      ...usageOverrides,
+    },
+  };
+}
+
+describe("usage metrics helpers", () => {
+  it("ranks agents by tokens when all aggregate costs are zero", () => {
+    const aggregates = buildAggregatesFromSessions([
+      createSession("alpha", "alpha", "webchat", { totalTokens: 10, totalCost: 0 }),
+      createSession("beta", "beta", "feishu", { totalTokens: 100, totalCost: 0 }),
+    ]);
+
+    expect(aggregates.byAgent.map((entry) => entry.agentId)).toEqual(["beta", "alpha"]);
+  });
+
+  it("uses the provided overview duration scope for throughput calculations", () => {
+    const sessions = [
+      createSession("session-1", "main", "webchat", {
+        totalTokens: 600,
+        totalCost: 6,
+        durationMs: 60_000,
+      }),
+    ];
+
+    const stats = buildUsageInsightStats(
+      sessions,
+      createTotals({ totalTokens: 600, totalCost: 6 }),
+      createAggregates(),
+      {
+        durationCount: 2,
+        durationSumMs: 120_000,
+      },
+    );
+
+    expect(stats.durationCount).toBe(2);
+    expect(stats.durationSumMs).toBe(120_000);
+    expect(stats.avgDurationMs).toBe(60_000);
+    expect(stats.throughputTokensPerMin).toBe(300);
+    expect(stats.throughputCostPerMin).toBe(3);
+  });
+});

--- a/ui/src/ui/views/usage-metrics.ts
+++ b/ui/src/ui/views/usage-metrics.ts
@@ -3,9 +3,10 @@ import {
   buildUsageAggregateTail,
   mergeUsageDailyLatency,
   mergeUsageLatency,
+  sortUsageRankingEntries,
 } from "../../../../src/shared/usage-aggregates.js";
 import { t } from "../../i18n/index.ts";
-import { UsageSessionEntry, UsageTotals, UsageAggregates } from "./usageTypes.ts";
+import { UsageSessionEntry, UsageTotals, UsageAggregates, UsageOverview } from "./usageTypes.ts";
 
 const CHARS_PER_TOKEN = 4;
 
@@ -534,9 +535,9 @@ const buildAggregatesFromSessions = (
     byProvider: Array.from(providerMap.values()).toSorted(
       (a, b) => b.totals.totalCost - a.totals.totalCost,
     ),
-    byAgent: Array.from(agentMap.entries())
-      .map(([agentId, totals]) => ({ agentId, totals }))
-      .toSorted((a, b) => b.totals.totalCost - a.totals.totalCost),
+    byAgent: sortUsageRankingEntries(
+      Array.from(agentMap.entries()).map(([agentId, totals]) => ({ agentId, totals })),
+    ),
     ...tail,
   };
 };
@@ -551,18 +552,23 @@ type UsageInsightStats = {
   peakErrorDay?: { date: string; errors: number; messages: number; rate: number };
 };
 
+type UsageInsightScope = Pick<UsageOverview, "durationCount" | "durationSumMs">;
+
 const buildUsageInsightStats = (
   sessions: UsageSessionEntry[],
   totals: UsageTotals | null,
   aggregates: UsageAggregates,
+  scope?: UsageInsightScope,
 ): UsageInsightStats => {
-  let durationSumMs = 0;
-  let durationCount = 0;
-  for (const session of sessions) {
-    const duration = session.usage?.durationMs ?? 0;
-    if (duration > 0) {
-      durationSumMs += duration;
-      durationCount += 1;
+  let durationSumMs = scope?.durationSumMs ?? 0;
+  let durationCount = scope?.durationCount ?? 0;
+  if (!scope) {
+    for (const session of sessions) {
+      const duration = session.usage?.durationMs ?? 0;
+      if (duration > 0) {
+        durationSumMs += duration;
+        durationCount += 1;
+      }
     }
   }
 

--- a/ui/src/ui/views/usage-render-overview.ts
+++ b/ui/src/ui/views/usage-render-overview.ts
@@ -552,13 +552,13 @@ function renderUsageInsights(
   }));
   const topAgents = aggregates.byAgent.slice(0, 5).map((entry) => ({
     label: entry.agentId,
-    value: formatCost(entry.totals.totalCost),
-    sub: formatTokens(entry.totals.totalTokens),
+    value: formatTokens(entry.totals.totalTokens),
+    sub: formatCost(entry.totals.totalCost),
   }));
   const topChannels = aggregates.byChannel.slice(0, 5).map((entry) => ({
     label: entry.channel,
-    value: formatCost(entry.totals.totalCost),
-    sub: formatTokens(entry.totals.totalTokens),
+    value: formatTokens(entry.totals.totalTokens),
+    sub: formatCost(entry.totals.totalCost),
   }));
 
   return html`

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -288,11 +288,16 @@ export function renderUsage(props: UsageProps) {
     displayTotals = computeSessionTotals(filteredSessions);
     displaySessionCount = filteredSessions.length;
   } else {
-    // No filters - show all
+    // No filters - show the full overview returned by the gateway.
     displayTotals = data.totals;
-    displaySessionCount = totalSessions;
+    displaySessionCount = data.overview?.matchedSessions ?? totalSessions;
   }
 
+  const useGatewayOverview =
+    filters.selectedSessions.length === 0 &&
+    filters.selectedDays.length === 0 &&
+    filters.selectedHours.length === 0 &&
+    !hasQuery;
   const aggregateSessions =
     filters.selectedSessions.length > 0
       ? filteredSessions.filter((s) => filters.selectedSessions.includes(s.key))
@@ -301,7 +306,11 @@ export function renderUsage(props: UsageProps) {
         : filters.selectedDays.length > 0
           ? dayFilteredSessions
           : sortedSessions;
-  const activeAggregates = buildAggregatesFromSessions(aggregateSessions, data.aggregates);
+  const activeAggregates =
+    useGatewayOverview && data.aggregates
+      ? data.aggregates
+      : buildAggregatesFromSessions(aggregateSessions, data.aggregates);
+  const insightScope = useGatewayOverview ? data.overview : null;
 
   // Filter daily chart data if sessions are selected
   const filteredDaily =
@@ -322,7 +331,12 @@ export function renderUsage(props: UsageProps) {
         })()
       : data.costDaily;
 
-  const insightStats = buildUsageInsightStats(aggregateSessions, displayTotals, activeAggregates);
+  const insightStats = buildUsageInsightStats(
+    insightScope ? [] : aggregateSessions,
+    displayTotals,
+    activeAggregates,
+    insightScope ?? undefined,
+  );
   const isEmpty = !data.loading && !data.totals && data.sessions.length === 0;
   const hasMissingCost =
     (displayTotals?.missingCostEntries ?? 0) > 0 ||

--- a/ui/src/ui/views/usageTypes.ts
+++ b/ui/src/ui/views/usageTypes.ts
@@ -1,6 +1,7 @@
 import type {
   CostUsageDailyEntry,
   SessionsUsageEntry,
+  SessionsUsageOverview,
   SessionsUsageResult,
   SessionsUsageTotals,
   SessionUsageTimePoint,
@@ -10,6 +11,7 @@ export type UsageSessionEntry = SessionsUsageEntry;
 export type UsageTotals = SessionsUsageTotals;
 export type CostDailyEntry = CostUsageDailyEntry;
 export type UsageAggregates = SessionsUsageResult["aggregates"];
+export type UsageOverview = SessionsUsageOverview;
 
 export type UsageColumnId =
   | "channel"
@@ -30,6 +32,7 @@ export type UsageDataState = {
   sessionsLimitReached: boolean; // True if 1000 session cap was hit
   totals: UsageTotals | null;
   aggregates: UsageAggregates | null;
+  overview: UsageOverview | null;
   costDaily: CostDailyEntry[];
 };
 


### PR DESCRIPTION
﻿## Summary
- fix incorrect usage overview aggregation for channels and agents
- fix usage insights so zero-cost channels still surface the correct token-heavy results
- keep `sessions.usage` aggregates scoped to the full matching session set even when `limit` trims the returned session list

## Problem
Usage data could already exist in session files, but the overview still looked wrong in two ways:

- token-heavy channels could appear as effectively `0` or fall out of the visible Top Channels results when the relevant channels had no cost data
- channel totals could be attributed incorrectly at the overview level because `sessions.usage` built aggregates from the limited session subset instead of the full matching session set

In practice this meant a channel such as `feishu` could have non-zero token usage in session records while the usage page still surfaced another channel first or failed to represent the channel totals correctly.

## What This Fix Does
- fixes channel and agent usage aggregation so token usage remains visible in zero-cost ranking cases
- keeps cost-first ranking behavior when cost data exists, instead of broadly changing leaderboard semantics
- updates the usage insight cards so the primary value reflects the token signal users are actually checking in this view
- computes `sessions.usage` aggregates from all matched sessions, while keeping `limit` restricted to the returned session list only
- adds regression coverage for zero-cost channel visibility, cost-first ranking when cost exists, and aggregate correctness when `limit=1`

## Scope
This PR improves token attribution and channel visibility inside the usage dashboard.

It does **not**:
- backfill historical session records that were already written with `usage.totalTokens = 0`
- change provider-side token collection behavior for old runs

## Testing
- `npm exec vitest run --config vitest.unit.config.ts src/shared/usage-aggregates.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts`
- `git diff --check`
