### PR TITLE
[codex] Embed ACP runtime in plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Docs: https://docs.openclaw.ai
 - Providers/request overrides: add shared model and media request transport overrides across OpenAI-, Anthropic-, Google-, and compatible provider paths, including headers, auth, proxy, and TLS controls. (#60200)
 - Providers/StepFun: add the bundled StepFun provider plugin with standard and Step Plan endpoints, China/global onboarding choices, `step-3.5-flash` on both catalogs, and `step-3.5-flash-2603` currently exposed on Step Plan. (#60032) Thanks @hengm3467.
 - Tools/web_search: add a bundled MiniMax Search provider backed by the Coding Plan search API, with region reuse from `MINIMAX_API_HOST` and plugin-owned credential config. (#54648) Thanks @fengmk2.
-- ACPX/runtime: embed the ACP runtime directly in the bundled `acpx` plugin, remove the extra external ACP CLI hop, and harden live ACP session binding and reuse. (#61319) Thanks @steipete.
+- ACPX/runtime: embed the ACP runtime directly in the bundled `acpx` plugin, remove the extra external ACP CLI hop, and harden live ACP session binding and reuse. (#61319)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 - Providers/request overrides: add shared model and media request transport overrides across OpenAI-, Anthropic-, Google-, and compatible provider paths, including headers, auth, proxy, and TLS controls. (#60200)
 - Providers/StepFun: add the bundled StepFun provider plugin with standard and Step Plan endpoints, China/global onboarding choices, `step-3.5-flash` on both catalogs, and `step-3.5-flash-2603` currently exposed on Step Plan. (#60032) Thanks @hengm3467.
 - Tools/web_search: add a bundled MiniMax Search provider backed by the Coding Plan search API, with region reuse from `MINIMAX_API_HOST` and plugin-owned credential config. (#54648) Thanks @fengmk2.
+- ACPX/runtime: embed the ACP runtime directly in the bundled `acpx` plugin, remove the extra external ACP CLI hop, and harden live ACP session binding and reuse. (#61319) Thanks @steipete.
 
 ### Fixes
 


### PR DESCRIPTION
## Summary

This rewrites the bundled `acpx` plugin to run as an embedded ACP runtime instead of shelling out to the external `acpx` CLI.

## What changed

- replaced the CLI-wrapper runtime/service path with a plugin-owned embedded runtime
- introduced native runtime domains under `extensions/acpx/src/` for:
  - agent registry
  - ACP transport/client
  - session lifecycle and persistence
  - history projection
  - health probing
- removed the old CLI-era `ensure` path and mock CLI fixtures
- updated plugin config/schema/metadata to describe embedded runtime behavior instead of CLI management
- added a real ACP adapter init probe so health reflects actual startup viability
- added the missing ACP runtime attachment type export in the plugin SDK surface

## Why

The previous structure treated the plugin as a thin wrapper around the `acpx` binary. This branch moves the responsibility into the plugin itself so we no longer need a separate CLI to manage ACP sessions.

That gives us a source layout closer to the real product boundary:
- thin OpenClaw plugin facade
- plugin-owned session/runtime logic
- direct ACP adapter spawn/init path

## Impact

- removes the bundled plugin's runtime dependency on the `acpx` CLI package
- makes ACP runtime behavior easier to evolve inside the plugin
- gives us a real health probe for embedded startup failures
- simplifies follow-on work for agent-specific config like Claude ACP startup options

## Validation

- `pnpm test extensions/acpx/src/config.test.ts extensions/acpx/src/runtime.test.ts extensions/acpx/src/service.test.ts`
- `pnpm check`
- `pnpm build`
