### PR TITLE
fix(sessions): remap stale same-agent paths into the current state dir

### DIFF
--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -598,6 +598,33 @@ describe("sessions", () => {
     });
   });
 
+  it("remaps same-agent cross-root absolute sessionFile paths into the current state dir", () => {
+    withStateDir(path.resolve("/different/state"), () => {
+      const originalBase = path.resolve("/home/rai/.openclaw");
+      const staleMainSession = path.join(
+        originalBase,
+        "agents",
+        "shikamaru",
+        "sessions",
+        "sess-1.jsonl",
+      );
+      const sessionFile = resolveSessionFilePath(
+        "sess-1",
+        { sessionFile: staleMainSession },
+        { agentId: "shikamaru" },
+      );
+      expect(sessionFile).toBe(
+        path.join(
+          path.resolve("/different/state"),
+          "agents",
+          "shikamaru",
+          "sessions",
+          "sess-1.jsonl",
+        ),
+      );
+    });
+  });
+
   it("falls back when structural cross-root path traverses after sessions", () => {
     withStateDir(path.resolve("/different/state"), () => {
       const originalBase = path.resolve("/original/state");

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -160,6 +160,34 @@ function resolveStructuralSessionFallbackPath(
   return path.normalize(path.resolve(candidateAbsPath));
 }
 
+function remapSameAgentCrossRootSessionPath(
+  candidateAbsPath: string,
+  expectedAgentId: string,
+): string | undefined {
+  const parsed = resolveAgentSessionsPathParts(candidateAbsPath);
+  if (!parsed) {
+    return undefined;
+  }
+  const { parts, sessionsIndex } = parsed;
+  const agentIdPart = parts[sessionsIndex - 1];
+  if (!agentIdPart) {
+    return undefined;
+  }
+  const normalizedAgentId = normalizeAgentId(agentIdPart);
+  if (normalizedAgentId !== normalizeAgentId(expectedAgentId)) {
+    return undefined;
+  }
+  const relativeSegments = parts.slice(sessionsIndex + 1);
+  if (relativeSegments.length !== 1) {
+    return undefined;
+  }
+  const fileName = relativeSegments[0];
+  if (!fileName || fileName === "." || fileName === "..") {
+    return undefined;
+  }
+  return path.join(resolveAgentSessionsDir(normalizedAgentId), fileName);
+}
+
 function safeRealpathSync(filePath: string): string | undefined {
   try {
     return fs.realpathSync(filePath);
@@ -207,6 +235,10 @@ function resolvePathWithinSessionsDir(
       const resolvedFromAgent = tryAgentFallback(explicitAgentId);
       if (resolvedFromAgent) {
         return resolvedFromAgent;
+      }
+      const remappedSameAgent = remapSameAgentCrossRootSessionPath(realTrimmed, explicitAgentId);
+      if (remappedSameAgent) {
+        return remappedSameAgent;
       }
     }
     const extractedAgentId = extractAgentIdFromAbsoluteSessionPath(realTrimmed);


### PR DESCRIPTION
## Summary

- Problem: persisted absolute `sessionFile` paths for the same agent can survive a state-root move (for example `/home/rai/.openclaw/...` to `/Users/rai/.openclaw/...`) and still be treated as structurally valid.
- Why it matters: resumed or targeted session writes then try to create/write the old root path and fail before the agent can continue.
- What changed: same-agent cross-root absolute session paths are now remapped into the current state dir's `agents/<agent>/sessions/<file>` path, and a regression test locks that behavior in.
- What did NOT change (scope boundary): cross-agent fallback behavior and unrelated absolute-path normalization logic were left intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61321
- Related #61321
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `resolvePathWithinSessionsDir()` preserved structurally valid absolute session paths even when they pointed at the same agent under an old state root.
- Missing detection / guardrail: there was no regression coverage for same-agent cross-root absolute `sessionFile` metadata.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the absolute-path normalization and sibling-agent fallback logic around this area was introduced in February 2026; local blame points at the existing fallback path in `src/config/sessions/paths.ts`.
- Why this regressed now: a machine carrying Linux-rooted persisted session metadata was later used on macOS, so the stale absolute path became invalid only after the root move.
- If unknown, what was ruled out: stale `HOME`, stale `OPENCLAW_HOME`, stale `session.store` override, and provider-specific causes were ruled out locally.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/sessions.test.ts`
- Scenario the test should lock in: a same-agent absolute `sessionFile` from an old root is remapped into the current state dir instead of being preserved.
- Why this is the smallest reliable guardrail: the failure is in pure path-resolution logic, before session execution or provider behavior.
- Existing test that already covers this (if any): nearby cross-root and cross-agent fallback tests cover adjacent logic but not this same-agent remap case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Resumed or targeted sessions with stale same-agent absolute transcript paths are recovered into the current state dir instead of failing on the old root path.

## Diagram (if applicable)

```text
Before:
old absolute sessionFile (/home/rai/.../agents/shikamaru/sessions/sess-1.jsonl)
  -> treated as structurally valid
  -> write lock tries old root
  -> ENOENT on /home/rai

After:
old absolute sessionFile (/home/rai/.../agents/shikamaru/sessions/sess-1.jsonl)
  -> recognized as same-agent stale root
  -> remapped to current state dir agents/shikamaru/sessions/sess-1.jsonl
  -> write proceeds
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.x
- Runtime/container: local source checkout + local CLI against live state
- Model/provider: `openai-codex/gpt-5.4` via `openai-codex:rai@rbutera.com`
- Integration/channel (if any): none required; reproduced through `openclaw agent --session-id ...`
- Relevant config (redacted): state rooted at `/Users/rai/.openclaw`, persisted session metadata contained `/home/rai/.openclaw/agents/shikamaru/sessions/<id>.jsonl`

### Steps

1. Seed or retain a `sessions.json` entry for `agent:shikamaru:main` whose `sessionFile` is `/home/rai/.openclaw/agents/shikamaru/sessions/<id>.jsonl`.
2. Run `openclaw agent --agent shikamaru --session-id <id> --message "smoke" --json` on macOS with state rooted at `/Users/rai/.openclaw`.
3. Observe the failure before this patch, then rerun after the patch.

### Expected

- OpenClaw remaps the stale same-agent path into the current state dir and writes to the current session file.

### Actual

- Before the patch, embedded execution attempted `mkdir '/home/rai/.openclaw/agents/shikamaru/sessions'` and failed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - added and ran the new unit regression test
  - ran `pnpm test -- src/config/sessions.test.ts src/config/sessions/sessions.test.ts src/config/sessions/targets.test.ts`
  - reproduced the real local dispatch failure before the fix
  - reran `~/navi/bin/navi-openclaw dispatch --agent shikamaru ...` after the fix and session-metadata repair; it returned `ok: true`
- Edge cases checked:
  - existing cross-agent cross-root fallback tests still pass
  - same-agent remap only applies when the parsed absolute path targets exactly one file under the same agent's sessions directory
- What you did **not** verify:
  - a full end-to-end migration across multiple host OSes from a clean fixture
  - gateway-only success without embedded fallback

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a malformed absolute path that merely resembles a same-agent sessions path could be remapped when it should instead fail fast.
  - Mitigation: the remap path is intentionally narrow; it only applies when the parsed path targets the same agent and exactly one file below `sessions/`.
