### PR TITLE
ui: default usage view to last 7 days instead of today-only

### DIFF
--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -316,7 +316,9 @@ export class OpenClawApp extends LitElement {
   @state() usageError: string | null = null;
   @state() usageStartDate = (() => {
     const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    const start = new Date(d);
+    start.setDate(start.getDate() - 6);
+    return `${start.getFullYear()}-${String(start.getMonth() + 1).padStart(2, "0")}-${String(start.getDate()).padStart(2, "0")}`;
   })();
   @state() usageEndDate = (() => {
     const d = new Date();


### PR DESCRIPTION
## Summary

Fix the Control UI Usage tab default date range.

The Usage view currently initializes with:
- `usageStartDate = today`
- `usageEndDate = today`

That makes the default view show only a single day.

This change updates the initial state to:
- `usageStartDate = today - 6 days`
- `usageEndDate = today`

So the default Usage view covers the last 7 calendar days inclusive.

## Root cause

The issue is in `ui/src/ui/app.ts`, where the default Usage state is initialized.
`ui/src/ui/controllers/usage.ts` correctly uses whatever dates are already in state.

## Files changed

- `ui/src/ui/app.ts`

## Testing

Manual verification:
- Open Control UI
- Go to Usage
- Confirm default range is `today - 6 days` through `today`
