### PR TITLE
fix(usage): handle Daylight saving time (DST) hour boundaries

### DIFF
--- a/ui/src/ui/views/usage-metrics.node.test.ts
+++ b/ui/src/ui/views/usage-metrics.node.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __test, buildPeakErrorHours } from "./usage-metrics.ts";
+import { renderUsage } from "./usage.ts";
+import type { UsageColumnId, UsageSessionEntry } from "./usageTypes.ts";
+
+const ORIGINAL_TZ = process.env.TZ;
+
+function makeSession(startIso: string, endIso: string): UsageSessionEntry {
+  const firstActivity = new Date(startIso).getTime();
+  const lastActivity = new Date(endIso).getTime();
+  return {
+    key: `${startIso}-${endIso}`,
+    updatedAt: lastActivity,
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 100,
+      totalCost: 1,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+      firstActivity,
+      lastActivity,
+      durationMs: lastActivity - firstActivity,
+      messageCounts: {
+        total: 100,
+        user: 50,
+        assistant: 50,
+        toolCalls: 0,
+        toolResults: 0,
+        errors: 10,
+      },
+    },
+  };
+}
+
+function makeUsageProps(sessions: UsageSessionEntry[], selectedHours: number[] = []) {
+  const totals = sessions.reduce(
+    (acc, session) => {
+      const usage = session.usage;
+      if (!usage) {
+        return acc;
+      }
+      acc.input += usage.input;
+      acc.output += usage.output;
+      acc.cacheRead += usage.cacheRead;
+      acc.cacheWrite += usage.cacheWrite;
+      acc.totalTokens += usage.totalTokens;
+      acc.totalCost += usage.totalCost;
+      acc.inputCost += usage.inputCost;
+      acc.outputCost += usage.outputCost;
+      acc.cacheReadCost += usage.cacheReadCost;
+      acc.cacheWriteCost += usage.cacheWriteCost;
+      acc.missingCostEntries += usage.missingCostEntries;
+      return acc;
+    },
+    {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      totalCost: 0,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    },
+  );
+
+  return {
+    data: {
+      loading: false,
+      error: null,
+      sessions,
+      sessionsLimitReached: false,
+      totals,
+      aggregates: {
+        messages: {
+          total: 100,
+          user: 50,
+          assistant: 50,
+          toolCalls: 0,
+          toolResults: 0,
+          errors: 10,
+        },
+        tools: { totalCalls: 0, uniqueTools: 0, tools: [] },
+        byModel: [],
+        byProvider: [],
+        byAgent: [],
+        byChannel: [],
+        daily: [],
+      },
+      costDaily: [],
+    },
+    filters: {
+      startDate: "2026-04-05",
+      endDate: "2026-04-05",
+      selectedSessions: [],
+      selectedDays: [],
+      selectedHours,
+      query: "",
+      queryDraft: "",
+      timeZone: "local" as const,
+    },
+    display: {
+      chartMode: "tokens" as const,
+      dailyChartMode: "total" as const,
+      sessionSort: "tokens" as const,
+      sessionSortDir: "desc" as const,
+      recentSessions: [],
+      sessionsTab: "all" as const,
+      visibleColumns: [
+        "channel",
+        "agent",
+        "provider",
+        "model",
+        "messages",
+        "tools",
+        "errors",
+        "duration",
+      ] as UsageColumnId[],
+      contextExpanded: false,
+      headerPinned: false,
+    },
+    detail: {
+      timeSeriesMode: "cumulative" as const,
+      timeSeriesBreakdownMode: "total" as const,
+      timeSeries: null,
+      timeSeriesLoading: false,
+      timeSeriesCursorStart: null,
+      timeSeriesCursorEnd: null,
+      sessionLogs: null,
+      sessionLogsLoading: false,
+      sessionLogsExpanded: false,
+      logFilters: {
+        roles: [],
+        tools: [],
+        hasTools: false,
+        query: "",
+      },
+    },
+    callbacks: {
+      filters: {
+        onStartDateChange() {},
+        onEndDateChange() {},
+        onRefresh() {},
+        onTimeZoneChange() {},
+        onToggleHeaderPinned() {},
+        onSelectDay() {},
+        onSelectHour() {},
+        onClearDays() {},
+        onClearHours() {},
+        onClearSessions() {},
+        onClearFilters() {},
+        onQueryDraftChange() {},
+        onApplyQuery() {},
+        onClearQuery() {},
+      },
+      display: {
+        onChartModeChange() {},
+        onDailyChartModeChange() {},
+        onSessionSortChange() {},
+        onSessionSortDirChange() {},
+        onSessionsTabChange() {},
+        onToggleColumn() {},
+      },
+      details: {
+        onToggleContextExpanded() {},
+        onToggleSessionLogsExpanded() {},
+        onLogFilterRolesChange() {},
+        onLogFilterToolsChange() {},
+        onLogFilterHasToolsChange() {},
+        onLogFilterQueryChange() {},
+        onLogFilterClear() {},
+        onSelectSession() {},
+        onTimeSeriesModeChange() {},
+        onTimeSeriesBreakdownChange() {},
+        onTimeSeriesCursorRangeChange() {},
+      },
+    },
+  };
+}
+
+describe("usage DST hour boundaries", () => {
+  beforeEach(() => {
+    process.env.TZ = "Australia/Sydney";
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_TZ === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = ORIGINAL_TZ;
+    }
+  });
+
+  it("moves forward through the repeated hour at DST fallback", () => {
+    const current = new Date("2026-04-05T02:00:00+10:00");
+    const next = __test.getNextHourStart(current, "local");
+
+    expect(next.getTime()).toBeGreaterThan(current.getTime());
+    expect(next.getTime()).toBe(new Date("2026-04-05T03:00:00+10:00").getTime());
+  });
+
+  it("skips the missing hour at DST spring forward", () => {
+    const current = new Date("2026-10-04T01:30:00+10:00");
+    const next = __test.getNextHourStart(current, "local");
+
+    expect(next.getTime()).toBe(new Date("2026-10-04T03:00:00+11:00").getTime());
+  });
+
+  it(
+    "builds peak error stats for sessions that span the fallback rollover",
+    { timeout: 1_000 },
+    () => {
+      const stats = buildPeakErrorHours(
+        [makeSession("2026-04-05T02:30:00+11:00", "2026-04-05T02:30:00+10:00")],
+        "local",
+      );
+
+      // Vitest runs this file in a worker thread, so runtime TZ changes are not
+      // guaranteed to alter the worker's local timezone on every host. The same
+      // instant range can appear as one Sydney repeated-hour bucket or two
+      // ordinary buckets elsewhere, but every bucket must preserve the rate.
+      expect(stats.length).toBeGreaterThan(0);
+      expect(stats.length).toBeLessThanOrEqual(2);
+      expect(stats.every((entry) => entry.value === "10.00%")).toBe(true);
+    },
+  );
+
+  it(
+    "renders the usage view with an hour filter across the fallback rollover",
+    { timeout: 1_000 },
+    () => {
+      const result = renderUsage(
+        makeUsageProps(
+          [makeSession("2026-04-05T02:30:00+11:00", "2026-04-05T02:30:00+10:00")],
+          [2],
+        ),
+      );
+
+      expect(result).toBeTruthy();
+    },
+  );
+});

--- a/ui/src/ui/views/usage-metrics.ts
+++ b/ui/src/ui/views/usage-metrics.ts
@@ -56,11 +56,12 @@ function forEachSessionHourSlice(
   const durationMs = Math.max(endMs - startMs, 1);
   const totalMinutes = durationMs / 60000;
 
+  // Use half-open slices [cursor, nextBoundary) so exact hour boundaries do
+  // not create zero-duration buckets and DST transitions remain monotonic.
   let cursor = startMs;
   while (cursor < endMs) {
     const date = new Date(cursor);
-    const nextHour = setToHourEnd(date, timeZone);
-    const nextMs = Math.min(nextHour.getTime(), endMs);
+    const nextMs = getNextHourBoundaryMs(cursor, endMs, timeZone);
     const minutes = Math.max((nextMs - cursor) / 60000, 0);
     visitor({
       usage,
@@ -68,7 +69,7 @@ function forEachSessionHourSlice(
       weekday: getZonedWeekday(date, timeZone),
       share: minutes / totalMinutes,
     });
-    cursor = nextMs + 1;
+    cursor = nextMs;
   }
 
   return true;
@@ -125,14 +126,54 @@ function getZonedWeekday(date: Date, zone: "local" | "utc"): number {
   return zone === "utc" ? date.getUTCDay() : date.getDay();
 }
 
-function setToHourEnd(date: Date, zone: "local" | "utc"): Date {
+function getNextHourStart(date: Date, zone: "local" | "utc"): Date {
   const next = new Date(date);
   if (zone === "utc") {
-    next.setUTCMinutes(59, 59, 999);
+    next.setUTCHours(next.getUTCHours() + 1, 0, 0, 0);
   } else {
-    next.setMinutes(59, 59, 999);
+    // Advance in local wall time so repeated and skipped hours are handled by
+    // the runtime's timezone rules instead of reconstructing an ambiguous end.
+    next.setHours(next.getHours() + 1, 0, 0, 0);
   }
   return next;
+}
+
+function getNextHourBoundaryMs(cursor: number, endMs: number, zone: "local" | "utc"): number {
+  const nextStartMs = getNextHourStart(new Date(cursor), zone).getTime();
+  const boundedNextMs = Math.min(nextStartMs, endMs);
+  // Guard against non-monotonic timezone transitions so the UI never stalls.
+  return boundedNextMs > cursor ? boundedNextMs : endMs;
+}
+
+function sessionTouchesHours(
+  session: UsageSessionEntry,
+  timeZone: "local" | "utc",
+  hours: number[],
+): boolean {
+  if (hours.length === 0) {
+    return true;
+  }
+
+  const usage = session.usage;
+  const start = usage?.firstActivity ?? session.updatedAt;
+  const end = usage?.lastActivity ?? session.updatedAt;
+  if (!start || !end) {
+    return false;
+  }
+
+  const startMs = Math.min(start, end);
+  const endMs = Math.max(start, end);
+  let cursor = startMs;
+
+  while (true) {
+    if (hours.includes(getZonedHour(new Date(cursor), timeZone))) {
+      return true;
+    }
+    if (cursor >= endMs) {
+      return false;
+    }
+    cursor = getNextHourBoundaryMs(cursor, endMs, timeZone);
+  }
 }
 
 function buildUsageMosaicStats(
@@ -610,6 +651,10 @@ const buildUsageInsightStats = (
   };
 };
 
+export const __test = {
+  getNextHourStart,
+};
+
 export type { UsageInsightStats };
 export {
   buildAggregatesFromSessions,
@@ -624,5 +669,5 @@ export {
   formatTokens,
   getZonedHour,
   renderUsageMosaic,
-  setToHourEnd,
+  sessionTouchesHours,
 };

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -8,9 +8,8 @@ import {
   formatCost,
   formatIsoDate,
   formatTokens,
-  getZonedHour,
   renderUsageMosaic,
-  setToHourEnd,
+  sessionTouchesHours,
 } from "./usage-metrics.ts";
 import {
   addQueryToken,
@@ -171,35 +170,11 @@ export function renderUsage(props: UsageProps) {
         })
       : sortedSessions;
 
-  const sessionTouchesHours = (session: UsageSessionEntry, hours: number[]): boolean => {
-    if (hours.length === 0) {
-      return true;
-    }
-    const usage = session.usage;
-    const start = usage?.firstActivity ?? session.updatedAt;
-    const end = usage?.lastActivity ?? session.updatedAt;
-    if (!start || !end) {
-      return false;
-    }
-    const startMs = Math.min(start, end);
-    const endMs = Math.max(start, end);
-    let cursor = startMs;
-    while (cursor <= endMs) {
-      const date = new Date(cursor);
-      const hour = getZonedHour(date, filters.timeZone);
-      if (hours.includes(hour)) {
-        return true;
-      }
-      const nextHour = setToHourEnd(date, filters.timeZone);
-      const nextMs = Math.min(nextHour.getTime(), endMs);
-      cursor = nextMs + 1;
-    }
-    return false;
-  };
-
   const hourFilteredSessions =
     filters.selectedHours.length > 0
-      ? dayFilteredSessions.filter((s) => sessionTouchesHours(s, filters.selectedHours))
+      ? dayFilteredSessions.filter((s) =>
+          sessionTouchesHours(s, filters.timeZone, filters.selectedHours),
+        )
       : dayFilteredSessions;
 
   // Filter sessions by query (client-side)


### PR DESCRIPTION
## Summary

This fixes a Control UI Usage-page freeze when a long session spans a local Daylight saving time (DST) transition.

Today the hour-slicing code computes a local `:59:59.999` hour end from the current wall-clock time. In a repeated local hour at Daylight saving time (DST) fallback, that can resolve to an earlier instant and stop cursor progress.

This change switches Usage hour slicing and selected-hour filtering to monotonic next-hour-boundary stepping so aggregation always moves forward in the selected timezone.

## Why

This fixes cases where:

- Usage is rendered in local time
- a session spans a Daylight saving time (DST) fallback or spring-forward boundary
- the page builds hour buckets or applies a selected-hour filter

Without this change, the Control UI can wedge the browser main thread while rendering Usage data for long sessions.

## Changes

- replace the ambiguous local end-of-hour calculation with `getNextHourStart()` plus bounded next-hour stepping in `ui/src/ui/views/usage-metrics.ts`
- convert session hour slicing to half-open intervals `[cursor, nextBoundary)` so exact boundaries do not create zero-duration buckets
- route the selected-hour filter in `ui/src/ui/views/usage.ts` through the same DST-safe helper instead of maintaining a duplicate loop
- add focused node-side regression coverage for Daylight saving time (DST) fallback, Daylight saving time (DST) spring-forward, peak-error aggregation, and full Usage render with an hour filter

## Testing

AI-assisted: yes
Built and tested in: Codex App
Model: GPT-5.4
Reasoning effort: Extra High
Testing: focused local test

- `pnpm --dir ui exec vitest run --config vitest.node.config.ts src/ui/views/usage-metrics.node.test.ts`