### PR TITLE
fix: use pinned channel registry for channel plugin validation

### DIFF
--- a/src/channels/registry.ts
+++ b/src/channels/registry.ts
@@ -1,4 +1,7 @@
-import { getActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  getActivePluginRegistry,
+  getActivePluginChannelRegistry,
+} from "../plugins/runtime.js";
 import { getChatChannelMeta, listChatChannels, type ChatChannelMeta } from "./chat-meta.js";
 import {
   CHANNEL_IDS,
@@ -19,7 +22,21 @@ type RegisteredChannelPluginEntry = {
   };
 };
 
+/**
+ * List registered channel plugin entries.
+ *
+ * Uses the pinned channel registry (stable after gateway startup) as the primary
+ * source, falling back to the mutable active registry. This prevents intermittent
+ * "unknown channel" errors when the active registry is temporarily empty during
+ * plugin reload cycles.
+ *
+ * Fixes: https://github.com/openclaw/openclaw/issues/61358
+ */
 function listRegisteredChannelPluginEntries(): RegisteredChannelPluginEntry[] {
+  const pinned = getActivePluginChannelRegistry();
+  if (pinned && pinned.channels && pinned.channels.length > 0) {
+    return pinned.channels;
+  }
   return getActivePluginRegistry()?.channels ?? [];
 }
 


### PR DESCRIPTION
## Summary

Fixes #61358

 in `src/channels/registry.ts` reads from the **mutable** `getActivePluginRegistry()`, which can temporarily return an empty channel list during plugin reload cycles. This causes `sessions_spawn` to intermittently fail with `unknown channel: <plugin-id>` for all third-party channel plugins (openclaw-weixin, qqbot, etc.).

## Root Cause

The plugin system already has a **pinned channel surface** mechanism (`getActivePluginChannelRegistry()`) designed to keep channel plugins stable after gateway startup. However, the channel validation chain does not use it:

```
isGatewayMessageChannel() → listGatewayMessageChannels() → listPluginChannelIds()
  → listRegisteredChannelPluginEntries() → getActivePluginRegistry()  ❌ mutable
```

Bundled channels (telegram, discord, etc.) are unaffected because they are in the hardcoded `CHANNEL_IDS` array and never hit the plugin registry path.

## Fix

Change `listRegisteredChannelPluginEntries()` to prefer the **pinned** channel registry:

```typescript
// Before
function listRegisteredChannelPluginEntries() {
  return getActivePluginRegistry()?.channels ?? [];
}

// After
function listRegisteredChannelPluginEntries() {
  const pinned = getActivePluginChannelRegistry();
  if (pinned && pinned.channels && pinned.channels.length > 0) {
    return pinned.channels;
  }
  return getActivePluginRegistry()?.channels ?? [];
}
```

## Testing

- Verified against OpenClaw 2026.4.2 source code
- The pinned registry is populated during `reloadDeferredGatewayPlugins()` which runs after startup
- Fallback to mutable registry ensures backward compatibility

## Affected

- Third-party channel plugins: openclaw-weixin, qqbot, and any non-bundled channel
- No impact on bundled channels (telegram, discord, whatsapp, etc.)