### PR TITLE
fix(slack): wake sessions for interactive block actions

### DIFF
--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -9,6 +9,7 @@ import type { DmPolicy, GroupPolicy } from "openclaw/plugin-sdk/config-runtime";
 import { createDedupeCache } from "openclaw/plugin-sdk/core";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveThreadSessionKeys } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -68,6 +69,7 @@ export type SlackMonitorContext = {
     channelId?: string | null;
     channelType?: string | null;
     senderId?: string | null;
+    threadTs?: string | null;
   }) => string;
   isChannelAllowed: (params: {
     channelId?: string;
@@ -158,6 +160,7 @@ export function createSlackMonitorContext(params: {
     channelId?: string | null;
     channelType?: string | null;
     senderId?: string | null;
+    threadTs?: string | null;
   }) => {
     const channelId = p.channelId?.trim() ?? "";
     if (!channelId) {
@@ -187,17 +190,27 @@ export function createSlackMonitorContext(params: {
           teamId: params.teamId,
           peer: { kind: peerKind, id: peerId },
         });
-        return route.sessionKey;
+        const threadKeys = resolveThreadSessionKeys({
+          baseSessionKey: route.sessionKey,
+          threadId: p.threadTs,
+          parentSessionKey: p.threadTs && params.threadInheritParent ? route.sessionKey : undefined,
+        });
+        return threadKeys.sessionKey;
       }
     } catch {
       // Fall through to legacy key derivation.
     }
 
-    return resolveSessionKey(
+    const baseSessionKey = resolveSessionKey(
       params.sessionScope,
       { From: from, ChatType: chatType, Provider: "slack" },
       params.mainKey,
     );
+    return resolveThreadSessionKeys({
+      baseSessionKey,
+      threadId: p.threadTs,
+      parentSessionKey: p.threadTs && params.threadInheritParent ? baseSessionKey : undefined,
+    }).sessionKey;
   };
 
   const resolveChannelName = async (channelId: string) => {

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -621,6 +621,7 @@ function enqueueSlackBlockActionEvent(params: {
     channelId: params.parsed.channelId,
     channelType: params.auth.channelType,
     senderId: params.parsed.userId,
+    threadTs: params.parsed.threadTs,
   });
   const contextParts = [
     "slack:interaction",
@@ -631,6 +632,10 @@ function enqueueSlackBlockActionEvent(params: {
   enqueueSystemEvent(params.formatSystemEvent(eventPayload), {
     sessionKey,
     contextKey: contextParts.join(":"),
+    wake: {
+      reason: "hook:slack-interaction",
+      coalesceMs: 0,
+    },
   });
 }
 

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -294,7 +294,18 @@ describe("registerSlackInteractionEvents", () => {
       channelId: "C1",
       channelType: "channel",
       senderId: "U123",
+      threadTs: "100.100",
     });
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        sessionKey: "agent:ops:slack:channel:C1",
+        wake: {
+          reason: "hook:slack-interaction",
+          coalesceMs: 0,
+        },
+      }),
+    );
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
   });
 
@@ -922,6 +933,7 @@ describe("registerSlackInteractionEvents", () => {
       channelId: "C222",
       channelType: "channel",
       senderId: "U111",
+      threadTs: "222.111",
     });
     expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
     const [eventText] = enqueueSystemEventMock.mock.calls[0] as [string];

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -215,6 +215,17 @@ describe("resolveSlackSystemEventSessionKey", () => {
     ).toBe("agent:ops:slack:channel:c123");
   });
 
+  it("routes thread system events to the thread session key", () => {
+    const ctx = createSlackMonitorContext(baseParams());
+    expect(
+      ctx.resolveSlackSystemEventSessionKey({
+        channelId: "C123",
+        channelType: "channel",
+        threadTs: "1775397688.472349",
+      }),
+    ).toBe("agent:main:slack:channel:c123:thread:1775397688.472349");
+  });
+
   it("routes DM system events through direct-peer bindings when sender is known", () => {
     const ctx = createSlackMonitorContext({
       ...baseParams(),

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -1,8 +1,9 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { drainFormattedSystemEvents } from "../auto-reply/reply/session-updates.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
 import { isCronSystemEvent } from "./heartbeat-runner.js";
+import * as heartbeatWake from "./heartbeat-wake.js";
 import {
   drainSystemEventEntries,
   enqueueSystemEvent,
@@ -74,6 +75,39 @@ describe("system events (session routing)", () => {
 
     expect(first).toBe(true);
     expect(second).toBe(false);
+  });
+
+  it("requests a heartbeat wake when enqueue succeeds with wake enabled", () => {
+    const requestHeartbeatNowSpy = vi.spyOn(heartbeatWake, "requestHeartbeatNow");
+
+    const enqueued = enqueueSystemEvent("Slack interaction: clicked", {
+      sessionKey: "agent:main:slack:channel:c1:thread:100.100",
+      wake: {
+        reason: "hook:slack-interaction",
+        coalesceMs: 0,
+      },
+    });
+
+    expect(enqueued).toBe(true);
+    expect(requestHeartbeatNowSpy).toHaveBeenCalledWith({
+      reason: "hook:slack-interaction",
+      sessionKey: "agent:main:slack:channel:c1:thread:100.100",
+      coalesceMs: 0,
+    });
+    requestHeartbeatNowSpy.mockRestore();
+  });
+
+  it("does not request a heartbeat wake when enqueue is skipped as a duplicate", () => {
+    const requestHeartbeatNowSpy = vi.spyOn(heartbeatWake, "requestHeartbeatNow");
+    const options = {
+      sessionKey: "agent:main:slack:channel:c1",
+      wake: { reason: "hook:slack-interaction", coalesceMs: 0 },
+    };
+
+    expect(enqueueSystemEvent("Slack interaction: clicked", options)).toBe(true);
+    expect(enqueueSystemEvent("Slack interaction: clicked", options)).toBe(false);
+    expect(requestHeartbeatNowSpy).toHaveBeenCalledTimes(1);
+    requestHeartbeatNowSpy.mockRestore();
   });
 
   it("normalizes context keys when checking for context changes", () => {

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -8,6 +8,7 @@ import {
   normalizeDeliveryContext,
   type DeliveryContext,
 } from "../utils/delivery-context.js";
+import { requestHeartbeatNow } from "./heartbeat-wake.js";
 
 export type SystemEvent = {
   text: string;
@@ -34,6 +35,10 @@ type SystemEventOptions = {
   contextKey?: string | null;
   deliveryContext?: DeliveryContext;
   trusted?: boolean;
+  wake?: {
+    reason?: string;
+    coalesceMs?: number;
+  };
 };
 
 function requireSessionKey(key?: string | null): string {
@@ -113,6 +118,13 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
   });
   if (entry.queue.length > MAX_EVENTS) {
     entry.queue.shift();
+  }
+  if (options?.wake) {
+    requestHeartbeatNow({
+      reason: options.wake.reason,
+      sessionKey: key,
+      ...(options.wake.coalesceMs != null ? { coalesceMs: options.wake.coalesceMs } : {}),
+    });
   }
   return true;
 }


### PR DESCRIPTION
## Summary
- wake the owning session immediately after Slack block actions enqueue a system event
- include `threadTs` in Slack system-event session resolution so thread button clicks route back to the thread session
- cover the new wake path and thread routing with focused tests

## Problem
Slack interactive buttons/selects could render and enqueue a system event, but the target agent session would not wake immediately. In thread contexts, the interaction could also route back to the channel session instead of the thread session.

## Fix
- add an opt-in wake hint to `enqueueSystemEvent()`
- use that wake hint for Slack block actions with `reason: "hook:slack-interaction"`
- thread Slack system-event session keys through `resolveThreadSessionKeys()` when `threadTs` is present

## Verification
- `npx vitest run src/infra/system-events.test.ts extensions/slack/src/monitor/monitor.test.ts extensions/slack/src/monitor/events/interactions.test.ts`
- `pnpm build`

Fixes #54753
