### PR TITLE
fix(control-ui): preserve configured model metadata in picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Cron/scheduling: treat `nextRunAtMs <= 0` as invalid across cron update, maintenance, timer, and stale-delivery paths so corrupted zero timestamps self-heal instead of causing immediate runs or skipped deliveries. (#63507) Thanks @WarrenJones.
 - Status: show configured fallback models in `/status` and shared session status cards so per-agent fallback configuration is visible before a live failover happens. (#33111) Thanks @AnCoSONG.
 - Fireworks/FirePass: disable Kimi K2.5 Turbo reasoning output by forcing thinking off on the FirePass path and hardening the provider wrapper so hidden reasoning no longer leaks into visible replies. (#63607) Thanks @frankekn.
+- Sessions/model selection: preserve catalog-backed session model labels and keep already-qualified session model refs stable when catalog metadata is unavailable, so Control UI model selection survives reloads without bogus provider-prefixed values. (#61382) Thanks @Mule-ME.
 
 ## 2026.4.9
 
@@ -69,8 +70,6 @@ Docs: https://docs.openclaw.ai
 - Plugins/contracts: keep test-only helpers out of production contract barrels, load shared contract harnesses through bundled test surfaces, and harden guardrails so indirect re-exports and canonical `*.test.ts` files stay blocked. (#63311) Thanks @altaywtf.
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
-
-- Sessions/model selection: preserve catalog-backed session model labels and keep already-qualified session model refs stable when catalog metadata is unavailable, so Control UI model selection survives reloads without bogus provider-prefixed values. (#61382) Thanks @Mule-ME.
 
 ## 2026.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,7 @@ Docs: https://docs.openclaw.ai
 - Agents/model resolution: let explicit `openai-codex/gpt-5.4` selection prefer provider runtime metadata when it reports a larger context window, keeping configured Codex runs aligned with the live provider limits. (#62694) Thanks @ruclaw7.
 - Agents/model resolution: keep explicit-model runtime comparisons on the configured workspace plugin registry, so workspace-installed providers do not silently fall back to stale explicit metadata during runtime model lookup.
 - Providers/Z.AI: default onboarding and endpoint detection to GLM-5.1 instead of GLM-5. (#61998) Thanks @serg0x.
+- Sessions/model selection: preserve catalog-backed session model labels and keep already-qualified session model refs stable when catalog metadata is unavailable, so Control UI model selection survives reloads without bogus provider-prefixed values. (#61382) Thanks @Mule-ME.
 
 ## 2026.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,7 +187,6 @@ Docs: https://docs.openclaw.ai
 - Agents/model resolution: let explicit `openai-codex/gpt-5.4` selection prefer provider runtime metadata when it reports a larger context window, keeping configured Codex runs aligned with the live provider limits. (#62694) Thanks @ruclaw7.
 - Agents/model resolution: keep explicit-model runtime comparisons on the configured workspace plugin registry, so workspace-installed providers do not silently fall back to stale explicit metadata during runtime model lookup.
 - Providers/Z.AI: default onboarding and endpoint detection to GLM-5.1 instead of GLM-5. (#61998) Thanks @serg0x.
-- Sessions/model selection: preserve catalog-backed session model labels and keep already-qualified session model refs stable when catalog metadata is unavailable, so Control UI model selection survives reloads without bogus provider-prefixed values. (#61382) Thanks @Mule-ME.
 
 ## 2026.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Docs: https://docs.openclaw.ai
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
 
+- Sessions/model selection: preserve catalog-backed session model labels and keep already-qualified session model refs stable when catalog metadata is unavailable, so Control UI model selection survives reloads without bogus provider-prefixed values. (#61382) Thanks @Mule-ME.
+
 ## 2026.4.8
 
 ### Fixes

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -233,6 +233,58 @@ describe("live model switch", () => {
     });
   });
 
+  it("keeps nested model ids under the persisted provider override", async () => {
+    state.loadSessionStoreMock.mockReturnValue({
+      main: {
+        providerOverride: "nvidia",
+        modelOverride: "moonshotai/kimi-k2.5",
+      },
+    });
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/custom-store.json" } },
+        sessionKey: "main",
+        agentId: "reply",
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      }),
+    ).toEqual({
+      provider: "nvidia",
+      model: "moonshotai/kimi-k2.5",
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    });
+  });
+
+  it("strips duplicated provider prefixes from persisted overrides", async () => {
+    state.loadSessionStoreMock.mockReturnValue({
+      main: {
+        providerOverride: "openai-codex",
+        modelOverride: "openai-codex/gpt-5.4",
+      },
+    });
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    expect(
+      resolveLiveSessionModelSelection({
+        cfg: { session: { store: "/tmp/custom-store.json" } },
+        sessionKey: "main",
+        agentId: "reply",
+        defaultProvider: "anthropic",
+        defaultModel: "claude-opus-4-6",
+      }),
+    ).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      authProfileId: undefined,
+      authProfileIdSource: undefined,
+    });
+  });
+
   it("queues a live switch only when an active run was aborted", async () => {
     state.abortEmbeddedPiRunMock.mockReturnValue(true);
 

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -27,6 +27,26 @@ vi.mock("./pi-embedded-runner/runs.js", () => ({
 }));
 
 vi.mock("./model-selection.js", () => ({
+  normalizeStoredOverrideModel: (params: {
+    providerOverride?: string;
+    modelOverride?: string;
+  }) => {
+    const providerOverride = params.providerOverride?.trim();
+    const modelOverride = params.modelOverride?.trim();
+    if (!providerOverride || !modelOverride) {
+      return {
+        providerOverride,
+        modelOverride,
+      };
+    }
+    const providerPrefix = `${providerOverride.toLowerCase()}/`;
+    return {
+      providerOverride,
+      modelOverride: modelOverride.toLowerCase().startsWith(providerPrefix)
+        ? modelOverride.slice(providerOverride.length + 1).trim() || modelOverride
+        : modelOverride,
+    };
+  },
   resolveDefaultModelForAgent: (...args: unknown[]) =>
     state.resolveDefaultModelForAgentMock(...args),
   resolvePersistedSelectedModelRef: (...args: unknown[]) =>

--- a/src/agents/live-model-switch.test.ts
+++ b/src/agents/live-model-switch.test.ts
@@ -305,6 +305,33 @@ describe("live model switch", () => {
     });
   });
 
+  it("routes normalized overrides back through persisted ref resolution", async () => {
+    state.loadSessionStoreMock.mockReturnValue({
+      main: {
+        providerOverride: "z-ai",
+        modelOverride: "z-ai/deepseek-chat",
+      },
+    });
+
+    const { resolveLiveSessionModelSelection } = await loadModule();
+
+    resolveLiveSessionModelSelection({
+      cfg: { session: { store: "/tmp/custom-store.json" } },
+      sessionKey: "main",
+      agentId: "reply",
+      defaultProvider: "anthropic",
+      defaultModel: "claude-opus-4-6",
+    });
+
+    expect(state.resolvePersistedSelectedModelRefMock).toHaveBeenCalledWith({
+      defaultProvider: "anthropic",
+      runtimeProvider: undefined,
+      runtimeModel: undefined,
+      overrideProvider: "z-ai",
+      overrideModel: "deepseek-chat",
+    });
+  });
+
   it("queues a live switch only when an active run was aborted", async () => {
     state.abortEmbeddedPiRunMock.mockReturnValue(true);
 

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -16,6 +16,21 @@ export { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 export type LiveSessionModelSelection = EmbeddedRunModelSwitchRequest;
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
+function normalizeStoredOverrideSelection(
+  providerOverride?: string | null,
+  modelOverride?: string | null,
+): { provider: string; model: string } | null {
+  const provider = providerOverride?.trim();
+  const model = modelOverride?.trim();
+  if (!provider || !model) {
+    return null;
+  }
+  const providerPrefix = `${provider.toLowerCase()}/`;
+  const normalizedModel = model.toLowerCase().startsWith(providerPrefix)
+    ? model.slice(provider.length + 1).trim() || model
+    : model;
+  return { provider, model: normalizedModel };
+}
 export function resolveLiveSessionModelSelection(params: {
   cfg?: { session?: { store?: string } } | undefined;
   sessionKey?: string;
@@ -39,15 +54,19 @@ export function resolveLiveSessionModelSelection(params: {
     agentId,
   });
   const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+  const normalizedOverride = normalizeStoredOverrideSelection(
+    entry?.providerOverride,
+    entry?.modelOverride,
+  );
   const persisted = resolvePersistedSelectedModelRef({
     defaultProvider: defaultModelRef.provider,
     runtimeProvider: entry?.modelProvider,
     runtimeModel: entry?.model,
-    overrideProvider: entry?.providerOverride,
-    overrideModel: entry?.modelOverride,
+    overrideProvider: normalizedOverride?.provider,
+    overrideModel: normalizedOverride?.model,
   });
   const provider =
-    persisted?.provider ?? entry?.providerOverride?.trim() ?? defaultModelRef.provider;
+    persisted?.provider ?? normalizedOverride?.provider ?? entry?.providerOverride?.trim() ?? defaultModelRef.provider;
   const model = persisted?.model ?? defaultModelRef.model;
   const authProfileId = normalizeOptionalString(entry?.authProfileOverride);
   return {

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -3,6 +3,7 @@ import { loadSessionStore, updateSessionStore } from "../config/sessions/store.j
 import type { SessionEntry } from "../config/sessions/types.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
+  normalizeStoredOverrideModel,
   resolveDefaultModelForAgent,
   resolvePersistedSelectedModelRef,
 } from "./model-selection.js";
@@ -15,22 +16,6 @@ import {
 export { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 export type LiveSessionModelSelection = EmbeddedRunModelSwitchRequest;
 import { normalizeOptionalString } from "../shared/string-coerce.js";
-
-function normalizeStoredOverrideSelection(
-  providerOverride?: string | null,
-  modelOverride?: string | null,
-): { provider: string; model: string } | null {
-  const provider = providerOverride?.trim();
-  const model = modelOverride?.trim();
-  if (!provider || !model) {
-    return null;
-  }
-  const providerPrefix = `${provider.toLowerCase()}/`;
-  const normalizedModel = model.toLowerCase().startsWith(providerPrefix)
-    ? model.slice(provider.length + 1).trim() || model
-    : model;
-  return { provider, model: normalizedModel };
-}
 export function resolveLiveSessionModelSelection(params: {
   cfg?: { session?: { store?: string } } | undefined;
   sessionKey?: string;
@@ -54,10 +39,17 @@ export function resolveLiveSessionModelSelection(params: {
     agentId,
   });
   const entry = loadSessionStore(storePath, { skipCache: true })[sessionKey];
-  const normalizedOverride = normalizeStoredOverrideSelection(
-    entry?.providerOverride,
-    entry?.modelOverride,
-  );
+  const normalizedSelection = normalizeStoredOverrideModel({
+    providerOverride: entry?.providerOverride,
+    modelOverride: entry?.modelOverride,
+  });
+  const normalizedOverride =
+    normalizedSelection?.providerOverride && normalizedSelection.modelOverride
+      ? {
+          provider: normalizedSelection.providerOverride,
+          model: normalizedSelection.modelOverride,
+        }
+      : null;
   const persisted = resolvePersistedSelectedModelRef({
     defaultProvider: defaultModelRef.provider,
     runtimeProvider: entry?.modelProvider,

--- a/src/agents/live-model-switch.ts
+++ b/src/agents/live-model-switch.ts
@@ -43,22 +43,18 @@ export function resolveLiveSessionModelSelection(params: {
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
   });
-  const normalizedOverride =
-    normalizedSelection?.providerOverride && normalizedSelection.modelOverride
-      ? {
-          provider: normalizedSelection.providerOverride,
-          model: normalizedSelection.modelOverride,
-        }
-      : null;
   const persisted = resolvePersistedSelectedModelRef({
     defaultProvider: defaultModelRef.provider,
     runtimeProvider: entry?.modelProvider,
     runtimeModel: entry?.model,
-    overrideProvider: normalizedOverride?.provider,
-    overrideModel: normalizedOverride?.model,
+    overrideProvider: normalizedSelection.providerOverride,
+    overrideModel: normalizedSelection.modelOverride,
   });
   const provider =
-    persisted?.provider ?? normalizedOverride?.provider ?? entry?.providerOverride?.trim() ?? defaultModelRef.provider;
+    persisted?.provider ??
+    normalizedSelection.providerOverride ??
+    entry?.providerOverride?.trim() ??
+    defaultModelRef.provider;
   const model = persisted?.model ?? defaultModelRef.model;
   const authProfileId = normalizeOptionalString(entry?.authProfileOverride);
   return {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -17,6 +17,7 @@ export type ModelCatalogEntry = {
   id: string;
   name: string;
   provider: string;
+  alias?: string;
   contextWindow?: number;
   reasoning?: boolean;
   input?: ModelInputType[];

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -552,11 +552,102 @@ describe("model-selection", () => {
       expect(result.allowAny).toBe(false);
       expect(result.allowedKeys.has("anthropic/claude-sonnet-4-6")).toBe(true);
       expect(result.allowedCatalog).toEqual([
-        expect.objectContaining({
+        {
           provider: "anthropic",
           id: "claude-sonnet-4-6",
-          name: expect.any(String),
-        }),
+          name: "Claude Sonnet 4.5",
+          alias: "sonnet",
+        },
+      ]);
+    });
+
+    it("overlays configured provider metadata and alias onto matching catalog entries", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-test-z" },
+            models: {
+              "openai/gpt-test-z": { alias: "GPT Test Z Alias" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://openai.example.com",
+              models: [
+                {
+                  id: "gpt-test-z",
+                  name: "Configured GPT Test Z",
+                  contextWindow: 64_000,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = buildAllowedModelSet({
+        cfg,
+        catalog: [{ provider: "openai", id: "gpt-test-z", name: "gpt-test-z" }],
+        defaultProvider: "anthropic",
+      });
+
+      expect(result.allowAny).toBe(false);
+      expect(result.allowedCatalog).toEqual([
+        {
+          provider: "openai",
+          id: "gpt-test-z",
+          name: "Configured GPT Test Z",
+          alias: "GPT Test Z Alias",
+          contextWindow: 64_000,
+        },
+      ]);
+    });
+
+    it("applies configured provider metadata and alias to synthetic allowlist entries", () => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "nvidia/moonshotai/kimi-k2.5" },
+            models: {
+              "nvidia/moonshotai/kimi-k2.5": { alias: "Kimi K2.5 (NVIDIA)" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            nvidia: {
+              baseUrl: "https://nvidia.example.com",
+              models: [
+                {
+                  id: "moonshotai/kimi-k2.5",
+                  name: "Kimi K2.5 (Configured)",
+                  contextWindow: 32_000,
+                  reasoning: true,
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = buildAllowedModelSet({
+        cfg,
+        catalog: [],
+        defaultProvider: "anthropic",
+      });
+
+      expect(result.allowAny).toBe(false);
+      expect(result.allowedCatalog).toEqual([
+        {
+          provider: "nvidia",
+          id: "moonshotai/kimi-k2.5",
+          name: "Kimi K2.5 (Configured)",
+          alias: "Kimi K2.5 (NVIDIA)",
+          contextWindow: 32_000,
+          reasoning: true,
+        },
       ]);
     });
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -169,6 +169,28 @@ export function resolvePersistedSelectedModelRef(params: {
   });
 }
 
+export function normalizeStoredOverrideModel(params: {
+  providerOverride?: string | null;
+  modelOverride?: string | null;
+}): { providerOverride?: string; modelOverride?: string } {
+  const providerOverride = params.providerOverride?.trim();
+  const modelOverride = params.modelOverride?.trim();
+  if (!providerOverride || !modelOverride) {
+    return {
+      providerOverride,
+      modelOverride,
+    };
+  }
+
+  const providerPrefix = `${providerOverride.toLowerCase()}/`;
+  return {
+    providerOverride,
+    modelOverride: modelOverride.toLowerCase().startsWith(providerPrefix)
+      ? modelOverride.slice(providerOverride.length + 1).trim() || modelOverride
+      : modelOverride,
+  };
+}
+
 export function inferUniqueProviderFromConfiguredModels(params: {
   cfg: OpenClawConfig;
   model: string;

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -294,6 +294,84 @@ export function buildModelAliasIndex(params: {
   return { byAlias, byKey };
 }
 
+type ModelCatalogMetadata = {
+  configuredByKey: Map<string, ModelCatalogEntry>;
+  aliasByKey: Map<string, string>;
+};
+
+function buildModelCatalogMetadata(params: {
+  cfg: OpenClawConfig;
+  defaultProvider: string;
+}): ModelCatalogMetadata {
+  const configuredByKey = new Map<string, ModelCatalogEntry>();
+  for (const entry of buildConfiguredModelCatalog({ cfg: params.cfg })) {
+    configuredByKey.set(modelKey(entry.provider, entry.id), entry);
+  }
+
+  const aliasByKey = new Map<string, string>();
+  const configuredModels = params.cfg.agents?.defaults?.models ?? {};
+  for (const [rawKey, entryRaw] of Object.entries(configuredModels)) {
+    const key = resolveAllowlistModelKey(String(rawKey ?? ""), params.defaultProvider);
+    if (!key) {
+      continue;
+    }
+    const alias = String((entryRaw as { alias?: string } | undefined)?.alias ?? "").trim();
+    if (!alias) {
+      continue;
+    }
+    aliasByKey.set(key, alias);
+  }
+
+  return { configuredByKey, aliasByKey };
+}
+
+function applyModelCatalogMetadata(params: {
+  entry: ModelCatalogEntry;
+  metadata: ModelCatalogMetadata;
+}): ModelCatalogEntry {
+  const key = modelKey(params.entry.provider, params.entry.id);
+  const configuredEntry = params.metadata.configuredByKey.get(key);
+  const alias = params.metadata.aliasByKey.get(key);
+  if (!configuredEntry && !alias) {
+    return params.entry;
+  }
+  const nextAlias = alias ?? params.entry.alias;
+  const nextContextWindow = configuredEntry?.contextWindow ?? params.entry.contextWindow;
+  const nextReasoning = configuredEntry?.reasoning ?? params.entry.reasoning;
+  const nextInput = configuredEntry?.input ?? params.entry.input;
+
+  return {
+    ...params.entry,
+    name: configuredEntry?.name ?? params.entry.name,
+    ...(nextAlias ? { alias: nextAlias } : {}),
+    ...(nextContextWindow !== undefined ? { contextWindow: nextContextWindow } : {}),
+    ...(nextReasoning !== undefined ? { reasoning: nextReasoning } : {}),
+    ...(nextInput ? { input: nextInput } : {}),
+  };
+}
+
+function buildSyntheticAllowedCatalogEntry(params: {
+  parsed: ModelRef;
+  metadata: ModelCatalogMetadata;
+}): ModelCatalogEntry {
+  const key = modelKey(params.parsed.provider, params.parsed.model);
+  const configuredEntry = params.metadata.configuredByKey.get(key);
+  const alias = params.metadata.aliasByKey.get(key);
+  const nextContextWindow = configuredEntry?.contextWindow;
+  const nextReasoning = configuredEntry?.reasoning;
+  const nextInput = configuredEntry?.input;
+
+  return {
+    id: params.parsed.model,
+    name: configuredEntry?.name ?? params.parsed.model,
+    provider: params.parsed.provider,
+    ...(alias ? { alias } : {}),
+    ...(nextContextWindow !== undefined ? { contextWindow: nextContextWindow } : {}),
+    ...(nextReasoning !== undefined ? { reasoning: nextReasoning } : {}),
+    ...(nextInput ? { input: nextInput } : {}),
+  };
+}
+
 export function resolveModelRefFromString(params: {
   raw: string;
   defaultProvider: string;
@@ -472,6 +550,11 @@ export function buildAllowedModelSet(params: {
   allowedCatalog: ModelCatalogEntry[];
   allowedKeys: Set<string>;
 } {
+  const metadata = buildModelCatalogMetadata({
+    cfg: params.cfg,
+    defaultProvider: params.defaultProvider,
+  });
+  const catalog = params.catalog.map((entry) => applyModelCatalogMetadata({ entry, metadata }));
   const rawAllowlist = (() => {
     const modelMap = params.cfg.agents?.defaults?.models ?? {};
     return Object.keys(modelMap);
@@ -483,7 +566,7 @@ export function buildAllowedModelSet(params: {
       ? parseModelRef(defaultModel, params.defaultProvider)
       : null;
   const defaultKey = defaultRef ? modelKey(defaultRef.provider, defaultRef.model) : undefined;
-  const catalogKeys = new Set(params.catalog.map((entry) => modelKey(entry.provider, entry.id)));
+  const catalogKeys = new Set(catalog.map((entry) => modelKey(entry.provider, entry.id)));
 
   if (allowAny) {
     if (defaultKey) {
@@ -491,42 +574,13 @@ export function buildAllowedModelSet(params: {
     }
     return {
       allowAny: true,
-      allowedCatalog: params.catalog,
+      allowedCatalog: catalog,
       allowedKeys: catalogKeys,
     };
   }
 
   const allowedKeys = new Set<string>();
   const syntheticCatalogEntries = new Map<string, ModelCatalogEntry>();
-  const resolveConfiguredSyntheticEntry = (
-    provider: string,
-    model: string,
-  ): ModelCatalogEntry | null => {
-    const configuredModels = params.cfg.models?.providers?.[provider]?.models;
-    if (!Array.isArray(configuredModels)) {
-      return null;
-    }
-    const configured = configuredModels.find(
-      (entry) => typeof entry?.id === "string" && entry.id.trim() === model,
-    );
-    if (!configured) {
-      return null;
-    }
-    return {
-      provider,
-      id: model,
-      name:
-        typeof configured.name === "string" && configured.name.trim().length > 0
-          ? configured.name.trim()
-          : model,
-      contextWindow:
-        typeof configured.contextWindow === "number" && configured.contextWindow > 0
-          ? configured.contextWindow
-          : undefined,
-      reasoning: typeof configured.reasoning === "boolean" ? configured.reasoning : undefined,
-      input: Array.isArray(configured.input) ? configured.input : undefined,
-    };
-  };
   for (const raw of rawAllowlist) {
     const parsed = parseModelRef(String(raw), params.defaultProvider);
     if (!parsed) {
@@ -538,13 +592,7 @@ export function buildAllowedModelSet(params: {
     allowedKeys.add(key);
 
     if (!catalogKeys.has(key) && !syntheticCatalogEntries.has(key)) {
-      const configuredSynthetic = resolveConfiguredSyntheticEntry(parsed.provider, parsed.model);
-      syntheticCatalogEntries.set(key, {
-        ...configuredSynthetic,
-        id: parsed.model,
-        name: configuredSynthetic?.name ?? parsed.model,
-        provider: parsed.provider,
-      });
+      syntheticCatalogEntries.set(key, buildSyntheticAllowedCatalogEntry({ parsed, metadata }));
     }
   }
 
@@ -558,11 +606,7 @@ export function buildAllowedModelSet(params: {
       allowedKeys.add(key);
 
       if (!catalogKeys.has(key) && !syntheticCatalogEntries.has(key)) {
-        syntheticCatalogEntries.set(key, {
-          id: parsed.model,
-          name: parsed.model,
-          provider: parsed.provider,
-        });
+        syntheticCatalogEntries.set(key, buildSyntheticAllowedCatalogEntry({ parsed, metadata }));
       }
     }
   }
@@ -572,10 +616,7 @@ export function buildAllowedModelSet(params: {
   }
 
   const allowedCatalog = [
-    ...params.catalog.filter((entry) => {
-      const key = modelKey(entry.provider, entry.id);
-      return allowedKeys.has(key) && !syntheticCatalogEntries.has(key);
-    }),
+    ...catalog.filter((entry) => allowedKeys.has(modelKey(entry.provider, entry.id))),
     ...syntheticCatalogEntries.values(),
   ];
 
@@ -585,7 +626,7 @@ export function buildAllowedModelSet(params: {
     }
     return {
       allowAny: true,
-      allowedCatalog: params.catalog,
+      allowedCatalog: catalog,
       allowedKeys: catalogKeys,
     };
   }

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -6,6 +6,7 @@ export const ModelChoiceSchema = Type.Object(
     id: NonEmptyString,
     name: NonEmptyString,
     provider: NonEmptyString,
+    alias: Type.Optional(NonEmptyString),
     contextWindow: Type.Optional(Type.Integer({ minimum: 1 })),
     reasoning: Type.Optional(Type.Boolean()),
   },

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -88,6 +88,7 @@ type ModelCatalogRpcEntry = {
   id: string;
   name: string;
   provider: string;
+  alias?: string;
   contextWindow?: number;
 };
 
@@ -357,6 +358,92 @@ describe("gateway server models + voicewake", () => {
         },
       ],
     });
+  });
+
+  test("models.list applies configured metadata and alias to synthetic allowlist entries", async () => {
+    await withModelsConfig(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "nvidia/moonshotai/kimi-k2.5" },
+            models: {
+              "nvidia/moonshotai/kimi-k2.5": { alias: "Kimi K2.5 (NVIDIA)" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            nvidia: {
+              baseUrl: "https://nvidia.example.com",
+              models: [
+                {
+                  id: "moonshotai/kimi-k2.5",
+                  name: "Kimi K2.5 (Configured)",
+                  contextWindow: 32_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+      async () => {
+        seedPiCatalog();
+        const res = await listModels();
+        expect(res.ok).toBe(true);
+        expect(res.payload?.models).toEqual([
+          {
+            id: "moonshotai/kimi-k2.5",
+            name: "Kimi K2.5 (Configured)",
+            alias: "Kimi K2.5 (NVIDIA)",
+            provider: "nvidia",
+            contextWindow: 32_000,
+          },
+        ]);
+      },
+    );
+  });
+
+  test("models.list prefers configured provider metadata over discovered entries", async () => {
+    await withModelsConfig(
+      {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-test-z" },
+            models: {
+              "openai/gpt-test-z": { alias: "GPT Test Z Alias" },
+            },
+          },
+        },
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://openai.example.com",
+              models: [
+                {
+                  id: "gpt-test-z",
+                  name: "Configured GPT Test Z",
+                  contextWindow: 64_000,
+                },
+              ],
+            },
+          },
+        },
+      },
+      async () => {
+        seedPiCatalog();
+        const res = await listModels();
+        expect(res.ok).toBe(true);
+        expect(res.payload?.models).toEqual([
+          {
+            id: "gpt-test-z",
+            name: "Configured GPT Test Z",
+            alias: "GPT Test Z Alias",
+            provider: "openai",
+            contextWindow: 64_000,
+          },
+        ]);
+      },
+    );
   });
 
   test("models.list rejects unknown params", async () => {

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -10,6 +10,7 @@ import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.j
 import { loadConfig } from "../config/config.js";
 import { withSessionStoreLockForTest } from "../config/sessions/store.js";
 import { isSessionPatchEvent, type InternalHookEvent } from "../hooks/internal-hooks.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "./protocol/client-info.js";
 import { startGatewayServerHarness, type GatewayServerHarness } from "./server.e2e-ws-harness.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
@@ -20,6 +21,7 @@ import {
   installGatewayTestHooks,
   piSdkMock,
   rpcReq,
+  startConnectedServerWithClient,
   testState,
   trackConnectChallengeNonce,
   writeSessionStore,
@@ -1495,6 +1497,82 @@ describe("gateway server sessions", () => {
     expect(store["agent:main:main"]?.totalTokensFresh).toBe(true);
 
     ws.close();
+  });
+
+  test("sessions.patch preserves nested model ids under provider overrides", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-sessions-nested-"));
+    const storePath = path.join(dir, "sessions.json");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+        },
+      }),
+      "utf-8",
+    );
+
+    await withEnvAsync({ OPENCLAW_CONFIG_PATH: undefined }, async () => {
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+      const cfg = {
+        session: { store: storePath, mainKey: "main" },
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-test-a" },
+          },
+          list: [{ id: "main", default: true, workspace: dir }],
+        },
+      };
+      const configPath = path.join(dir, "openclaw.json");
+      await fs.writeFile(configPath, JSON.stringify(cfg, null, 2), "utf-8");
+
+      await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, async () => {
+        const started = await startConnectedServerWithClient();
+        const { server, ws } = started;
+        try {
+          piSdkMock.enabled = true;
+          piSdkMock.models = [
+            { id: "moonshotai/kimi-k2.5", name: "Kimi K2.5 (NVIDIA)", provider: "nvidia" },
+          ];
+
+          const patched = await rpcReq<{
+            ok: true;
+            entry: {
+              modelOverride?: string;
+              providerOverride?: string;
+              model?: string;
+              modelProvider?: string;
+            };
+            resolved?: { model?: string; modelProvider?: string };
+          }>(ws, "sessions.patch", {
+            key: "agent:main:main",
+            model: "nvidia/moonshotai/kimi-k2.5",
+          });
+          expect(patched.ok).toBe(true);
+          expect(patched.payload?.entry.modelOverride).toBe("moonshotai/kimi-k2.5");
+          expect(patched.payload?.entry.providerOverride).toBe("nvidia");
+          expect(patched.payload?.entry.model).toBeUndefined();
+          expect(patched.payload?.entry.modelProvider).toBeUndefined();
+          expect(patched.payload?.resolved?.modelProvider).toBe("nvidia");
+          expect(patched.payload?.resolved?.model).toBe("moonshotai/kimi-k2.5");
+
+          const listed = await rpcReq<{
+            sessions: Array<{ key: string; modelProvider?: string; model?: string }>;
+          }>(ws, "sessions.list", {});
+          expect(listed.ok).toBe(true);
+          const mainSession = listed.payload?.sessions.find(
+            (session) => session.key === "agent:main:main",
+          );
+          expect(mainSession?.modelProvider).toBe("nvidia");
+          expect(mainSession?.model).toBe("moonshotai/kimi-k2.5");
+        } finally {
+          ws.close();
+          await server.close();
+        }
+      });
+    });
   });
 
   test("sessions.preview returns transcript previews", async () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -619,6 +619,21 @@ describe("resolveSessionModelRef", () => {
     expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.4" });
   });
 
+  test("keeps nested model ids under the stored provider override", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-opus-4-6",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-nested",
+      updatedAt: Date.now(),
+      providerOverride: "nvidia",
+      modelOverride: "moonshotai/kimi-k2.5",
+    });
+
+    expect(resolved).toEqual({ provider: "nvidia", model: "moonshotai/kimi-k2.5" });
+  });
+
   test("preserves explicit wrapper providers for vendor-prefixed override models", () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-6",
@@ -637,6 +652,21 @@ describe("resolveSessionModelRef", () => {
       provider: "openrouter",
       model: "anthropic/claude-haiku-4.5",
     });
+  });
+
+  test("strips a duplicated provider prefix from stored overrides", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-opus-4-6",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-qualified-override",
+      updatedAt: Date.now(),
+      providerOverride: "openai-codex",
+      modelOverride: "openai-codex/gpt-5.4",
+    });
+
+    expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.4" });
   });
 
   test("falls back to resolved provider for unprefixed legacy runtime model", () => {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1037,6 +1037,28 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
   };
 }
 
+function normalizeStoredSessionOverride(params: {
+  providerOverride?: string | null;
+  modelOverride?: string | null;
+}): { providerOverride?: string; modelOverride?: string } {
+  const providerOverride = params.providerOverride?.trim();
+  const modelOverride = params.modelOverride?.trim();
+  if (!providerOverride || !modelOverride) {
+    return {
+      providerOverride,
+      modelOverride,
+    };
+  }
+
+  const providerPrefix = `${providerOverride.toLowerCase()}/`;
+  return {
+    providerOverride,
+    modelOverride: modelOverride.toLowerCase().startsWith(providerPrefix)
+      ? modelOverride.slice(providerOverride.length + 1).trim() || modelOverride
+      : modelOverride,
+  };
+}
+
 export function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
@@ -1052,12 +1074,17 @@ export function resolveSessionModelRef(
         defaultModel: DEFAULT_MODEL,
       });
 
+  const normalizedOverride = normalizeStoredSessionOverride({
+    providerOverride: entry?.providerOverride,
+    modelOverride: entry?.modelOverride,
+  });
+
   const persisted = resolvePersistedSelectedModelRef({
     defaultProvider: resolved.provider || DEFAULT_PROVIDER,
     runtimeProvider: entry?.modelProvider,
     runtimeModel: entry?.model,
-    overrideProvider: entry?.providerOverride,
-    overrideModel: entry?.modelOverride,
+    overrideProvider: normalizedOverride.providerOverride,
+    overrideModel: normalizedOverride.modelOverride,
   });
   if (persisted) {
     return persisted;

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -11,6 +11,7 @@ import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agen
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   inferUniqueProviderFromConfiguredModels,
+  normalizeStoredOverrideModel,
   parseModelRef,
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
@@ -1037,28 +1038,6 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
   };
 }
 
-function normalizeStoredSessionOverride(params: {
-  providerOverride?: string | null;
-  modelOverride?: string | null;
-}): { providerOverride?: string; modelOverride?: string } {
-  const providerOverride = params.providerOverride?.trim();
-  const modelOverride = params.modelOverride?.trim();
-  if (!providerOverride || !modelOverride) {
-    return {
-      providerOverride,
-      modelOverride,
-    };
-  }
-
-  const providerPrefix = `${providerOverride.toLowerCase()}/`;
-  return {
-    providerOverride,
-    modelOverride: modelOverride.toLowerCase().startsWith(providerPrefix)
-      ? modelOverride.slice(providerOverride.length + 1).trim() || modelOverride
-      : modelOverride,
-  };
-}
-
 export function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
@@ -1074,7 +1053,7 @@ export function resolveSessionModelRef(
         defaultModel: DEFAULT_MODEL,
       });
 
-  const normalizedOverride = normalizeStoredSessionOverride({
+  const normalizedOverride = normalizeStoredOverrideModel({
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
   });

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -212,7 +212,7 @@ describe("chat-model-ref helpers", () => {
 
   it("falls back to the server-qualified value for slash-containing ids when the catalog is empty", () => {
     expect(resolvePreferredServerChatModelValue("moonshotai/kimi-k2.5", "nvidia", [])).toBe(
-      "nvidia/moonshotai/kimi-k2.5",
+      "moonshotai/kimi-k2.5",
     );
   });
 
@@ -226,6 +226,12 @@ describe("chat-model-ref helpers", () => {
     expect(
       resolvePreferredServerChatModelValue("openai/gpt-5-mini", "zai", [OPENAI_GPT5_MINI_MODEL]),
     ).toBe("openai/gpt-5-mini");
+  });
+
+  it("preserves already-qualified server model values when the provider is stale and the catalog is empty", () => {
+    expect(resolvePreferredServerChatModelValue("openai/gpt-5-mini", "zai", [])).toBe(
+      "openai/gpt-5-mini",
+    );
   });
 
   it("uses catalog resolution for provider-less raw server model values", () => {

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -198,6 +198,18 @@ describe("chat-model-ref helpers", () => {
     ).toBe("nvidia/moonshotai/kimi-k2.5");
   });
 
+  it("uses the catalog-backed provider for slash-containing nested ids before stale provider fallback", () => {
+    expect(
+      resolvePreferredServerChatModelValue("moonshotai/kimi-k2.5", "zai", [
+        {
+          id: "moonshotai/kimi-k2.5",
+          name: "Kimi K2.5 (NVIDIA)",
+          provider: "nvidia",
+        },
+      ]),
+    ).toBe("nvidia/moonshotai/kimi-k2.5");
+  });
+
   it("falls back to the server-qualified value for slash-containing ids when the catalog is empty", () => {
     expect(resolvePreferredServerChatModelValue("moonshotai/kimi-k2.5", "nvidia", [])).toBe(
       "nvidia/moonshotai/kimi-k2.5",

--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   buildChatModelOption,
   createChatModelOverride,
+  formatCatalogChatModelDisplay,
   formatChatModelDisplay,
   normalizeChatModelOverrideValue,
-  resolveChatModelOverride,
-  resolvePreferredServerChatModel,
+  resolvePreferredServerChatModelValue,
   resolveServerChatModelValue,
 } from "./chat-model-ref.ts";
 import {
@@ -22,10 +22,10 @@ const catalog = createModelCatalog(OPENAI_GPT5_MINI_MODEL, {
 });
 
 describe("chat-model-ref helpers", () => {
-  it("builds provider-qualified option values and labels", () => {
-    expect(buildChatModelOption(catalog[0])).toEqual({
+  it("builds provider-qualified option values and prefers catalog names for labels", () => {
+    expect(buildChatModelOption(catalog[0], catalog)).toEqual({
       value: "openai/gpt-5-mini",
-      label: "gpt-5-mini · openai",
+      label: "GPT-5 Mini",
     });
   });
 
@@ -35,35 +35,105 @@ describe("chat-model-ref helpers", () => {
     );
   });
 
-  it("prefixes provider-native model ids that already contain slashes", () => {
-    expect(
-      buildChatModelOption({
-        id: "google/gemma-4-26b-a4b-it",
-        provider: "openrouter",
-      } as never),
-    ).toEqual({
+  it("prefixes provider-native catalog ids that already contain slashes", () => {
+    const providerNativeModel = {
+      id: "google/gemma-4-26b-a4b-it",
+      name: "Gemma 4 26B A4B IT",
+      provider: "openrouter",
+    };
+
+    expect(buildChatModelOption(providerNativeModel, [providerNativeModel])).toEqual({
       value: "openrouter/google/gemma-4-26b-a4b-it",
-      label: "google/gemma-4-26b-a4b-it · openrouter",
+      label: "Gemma 4 26B A4B IT",
     });
     expect(
-      resolvePreferredServerChatModel("Google/Gemma-4-26b-a4b-it", "openrouter", [
-        { id: "google/gemma-4-26b-a4b-it", provider: "openrouter" } as never,
+      resolvePreferredServerChatModelValue("google/gemma-4-26b-a4b-it", "openrouter", [
+        providerNativeModel,
       ]),
-    ).toEqual({
-      value: "openrouter/google/gemma-4-26b-a4b-it",
-      source: "server",
-    });
+    ).toBe("openrouter/google/gemma-4-26b-a4b-it");
   });
 
-  it("reuses already-qualified catalog ids without double-prefixing them", () => {
-    expect(
-      resolvePreferredServerChatModel("OpenAI/GPT-4O", "openai", [
-        { id: "openai/gpt-4o", provider: "openai" } as never,
-      ]),
-    ).toEqual({
-      value: "openai/gpt-4o",
-      source: "server",
+  it("prefers alias over name for picker labels", () => {
+    const aliasedModel = {
+      id: "moonshotai/kimi-k2.5",
+      alias: "Kimi K2.5 (NVIDIA)",
+      name: "Kimi K2.5",
+      provider: "nvidia",
+    };
+
+    expect(buildChatModelOption(aliasedModel, [aliasedModel])).toEqual({
+      value: "nvidia/moonshotai/kimi-k2.5",
+      label: "Kimi K2.5 (NVIDIA)",
     });
+    expect(formatCatalogChatModelDisplay("nvidia/moonshotai/kimi-k2.5", [aliasedModel])).toBe(
+      "Kimi K2.5 (NVIDIA)",
+    );
+  });
+
+  it("uses friendly catalog names for qualified nested model ids", () => {
+    const nestedModel = {
+      id: "moonshotai/kimi-k2.5",
+      name: "Kimi K2.5 (NVIDIA)",
+      provider: "nvidia",
+    };
+    expect(buildChatModelOption(nestedModel, [nestedModel])).toEqual({
+      value: "nvidia/moonshotai/kimi-k2.5",
+      label: "Kimi K2.5 (NVIDIA)",
+    });
+    expect(formatCatalogChatModelDisplay("nvidia/moonshotai/kimi-k2.5", [nestedModel])).toBe(
+      "Kimi K2.5 (NVIDIA)",
+    );
+  });
+
+  it("disambiguates duplicate friendly names with the provider", () => {
+    const duplicateNameCatalog = createModelCatalog(
+      {
+        id: "claude-3-7-sonnet",
+        name: "Claude Sonnet",
+        provider: "anthropic",
+      },
+      {
+        id: "claude-3-7-sonnet",
+        name: "Claude Sonnet",
+        provider: "openrouter",
+      },
+    );
+
+    expect(buildChatModelOption(duplicateNameCatalog[0], duplicateNameCatalog)).toEqual({
+      value: "anthropic/claude-3-7-sonnet",
+      label: "Claude Sonnet · anthropic",
+    });
+    expect(
+      formatCatalogChatModelDisplay("openrouter/claude-3-7-sonnet", duplicateNameCatalog),
+    ).toBe("Claude Sonnet · openrouter");
+  });
+
+  it("falls back to the raw catalog label when name and provider still collide", () => {
+    const duplicateNameAndProviderCatalog = createModelCatalog(
+      {
+        id: "claude-3-7-sonnet",
+        name: "Claude Sonnet",
+        provider: "anthropic",
+      },
+      {
+        id: "claude-3-7-sonnet-thinking",
+        name: "Claude Sonnet",
+        provider: "anthropic",
+      },
+    );
+
+    expect(
+      buildChatModelOption(duplicateNameAndProviderCatalog[0], duplicateNameAndProviderCatalog),
+    ).toEqual({
+      value: "anthropic/claude-3-7-sonnet",
+      label: "Claude Sonnet · claude-3-7-sonnet · anthropic",
+    });
+    expect(
+      formatCatalogChatModelDisplay(
+        "anthropic/claude-3-7-sonnet-thinking",
+        duplicateNameAndProviderCatalog,
+      ),
+    ).toBe("Claude Sonnet · claude-3-7-sonnet-thinking · anthropic");
   });
 
   it("normalizes raw overrides when the catalog match is unique", () => {
@@ -91,48 +161,64 @@ describe("chat-model-ref helpers", () => {
     expect(resolveServerChatModelValue("alias-only", null)).toBe("alias-only");
   });
 
-  it("reports the override resolution source for unique catalog matches", () => {
-    expect(resolveChatModelOverride(createChatModelOverride("gpt-5-mini"), catalog)).toEqual({
-      value: "openai/gpt-5-mini",
-      source: "catalog",
-    });
-  });
-
-  it("reports ambiguous raw overrides without guessing a provider", () => {
+  it("uses the recorded server provider when it is present", () => {
     expect(
-      resolveChatModelOverride(
-        createChatModelOverride("gpt-5-mini"),
-        createAmbiguousModelCatalog("gpt-5-mini", "openai", "openrouter"),
-      ),
-    ).toEqual({
-      value: "gpt-5-mini",
-      source: "raw",
-      reason: "ambiguous",
-    });
+      resolvePreferredServerChatModelValue("deepseek-chat", "deepseek", [DEEPSEEK_CHAT_MODEL]),
+    ).toBe("deepseek/deepseek-chat");
   });
 
-  it("prefers the catalog provider over a stale server provider when the match is unique", () => {
-    expect(resolvePreferredServerChatModel("deepseek-chat", "zai", [DEEPSEEK_CHAT_MODEL])).toEqual({
-      value: "deepseek/deepseek-chat",
-      source: "catalog",
-    });
+  it("corrects stale server providers for unique plain-id catalog matches", () => {
+    expect(
+      resolvePreferredServerChatModelValue("deepseek-chat", "zai", [DEEPSEEK_CHAT_MODEL]),
+    ).toBe("deepseek/deepseek-chat");
   });
 
   it("falls back to the server provider when the catalog misses or is ambiguous", () => {
-    expect(resolvePreferredServerChatModel("gpt-5-mini", "openai", [])).toEqual({
-      value: "openai/gpt-5-mini",
-      source: "server",
-      reason: "missing",
-    });
+    expect(resolvePreferredServerChatModelValue("gpt-5-mini", "openai", [])).toBe(
+      "openai/gpt-5-mini",
+    );
     expect(
-      resolvePreferredServerChatModel(
+      resolvePreferredServerChatModelValue(
         "gpt-5-mini",
         "openai",
         createAmbiguousModelCatalog("gpt-5-mini", "openai", "openrouter"),
       ),
-    ).toEqual({
-      value: "openai/gpt-5-mini",
-      source: "server",
-    });
+    ).toBe("openai/gpt-5-mini");
+  });
+
+  it("qualifies slash-containing server model ids with the recorded provider", () => {
+    expect(
+      resolvePreferredServerChatModelValue("moonshotai/kimi-k2.5", "nvidia", [
+        {
+          id: "moonshotai/kimi-k2.5",
+          name: "Kimi K2.5 (NVIDIA)",
+          provider: "nvidia",
+        },
+      ]),
+    ).toBe("nvidia/moonshotai/kimi-k2.5");
+  });
+
+  it("falls back to the server-qualified value for slash-containing ids when the catalog is empty", () => {
+    expect(resolvePreferredServerChatModelValue("moonshotai/kimi-k2.5", "nvidia", [])).toBe(
+      "nvidia/moonshotai/kimi-k2.5",
+    );
+  });
+
+  it("preserves already-qualified server model values when the provider matches", () => {
+    expect(
+      resolvePreferredServerChatModelValue("openai/gpt-5-mini", "openai", [OPENAI_GPT5_MINI_MODEL]),
+    ).toBe("openai/gpt-5-mini");
+  });
+
+  it("preserves already-qualified server model values when the provider is stale", () => {
+    expect(
+      resolvePreferredServerChatModelValue("openai/gpt-5-mini", "zai", [OPENAI_GPT5_MINI_MODEL]),
+    ).toBe("openai/gpt-5-mini");
+  });
+
+  it("uses catalog resolution for provider-less raw server model values", () => {
+    expect(resolvePreferredServerChatModelValue("gpt-5-mini", null, [OPENAI_GPT5_MINI_MODEL])).toBe(
+      "openai/gpt-5-mini",
+    );
   });
 });

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -52,24 +52,7 @@ export function normalizeChatModelOverrideValue(
     return trimmed;
   }
 
-  let matchedValue = "";
-  const normalizedTrimmed = normalizeLowercaseStringOrEmpty(trimmed);
-  for (const entry of catalog) {
-    if (normalizeLowercaseStringOrEmpty(entry.id) !== normalizedTrimmed) {
-      continue;
-    }
-    const candidate = buildQualifiedChatModelValue(entry.id, entry.provider);
-    if (!matchedValue) {
-      matchedValue = candidate;
-      continue;
-    }
-    if (
-      normalizeLowercaseStringOrEmpty(matchedValue) !== normalizeLowercaseStringOrEmpty(candidate)
-    ) {
-      return trimmed;
-    }
-  }
-  return matchedValue || trimmed;
+  return resolveUniqueCatalogValueById(trimmed, catalog) || trimmed;
 }
 
 export function resolveServerChatModelValue(
@@ -105,6 +88,30 @@ function hasCatalogQualifiedValue(catalog: ModelCatalogEntry[], value: string): 
   return catalog.some((entry) => createQualifiedCatalogKey(entry) === normalized);
 }
 
+function resolveUniqueCatalogValueById(model: string, catalog: ModelCatalogEntry[]): string {
+  const normalizedModel = model.trim().toLowerCase();
+  if (!normalizedModel) {
+    return "";
+  }
+
+  let matchedValue = "";
+  for (const entry of catalog) {
+    if (entry.id.trim().toLowerCase() !== normalizedModel) {
+      continue;
+    }
+    const candidate = buildQualifiedChatModelValue(entry.id, entry.provider);
+    if (!matchedValue) {
+      matchedValue = candidate;
+      continue;
+    }
+    if (matchedValue.toLowerCase() !== candidate.toLowerCase()) {
+      return "";
+    }
+  }
+
+  return matchedValue;
+}
+
 export function resolvePreferredServerChatModelValue(
   model: string | null | undefined,
   provider: string | null | undefined,
@@ -136,6 +143,11 @@ export function resolvePreferredServerChatModelValue(
 
   if (hasCatalogQualifiedValue(catalog, trimmedModel)) {
     return trimmedModel;
+  }
+
+  const matchedCatalogValue = resolveUniqueCatalogValueById(trimmedModel, catalog);
+  if (matchedCatalogValue) {
+    return matchedCatalogValue;
   }
 
   const qualifiedServerValue = buildQualifiedChatModelValue(trimmedModel, trimmedProvider);

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -155,12 +155,10 @@ export function resolvePreferredServerChatModelValue(
     return qualifiedServerValue;
   }
 
-  const providerPrefix = `${trimmedProvider.toLowerCase()}/`;
-  if (trimmedModel.toLowerCase().startsWith(providerPrefix)) {
-    return resolveServerChatModelValue(trimmedModel, trimmedProvider);
-  }
-
-  return qualifiedServerValue;
+  // Without catalog confirmation, preserve slash-containing server values as-is.
+  // Re-qualifying them here can turn an already-qualified ref under a stale
+  // provider into a nonsense double-prefix like "zai/openai/gpt-5-mini".
+  return resolveServerChatModelValue(trimmedModel, trimmedProvider);
 }
 
 export function formatChatModelDisplay(value: string): string {

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -1,4 +1,3 @@
-import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 import type { ModelCatalogEntry } from "./types.ts";
 
 export type ChatModelOverride =

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -11,28 +11,19 @@ export type ChatModelOverride =
       value: string;
     };
 
-export type ChatModelResolutionSource = "empty" | "qualified" | "catalog" | "raw" | "server";
-
-export type ChatModelResolutionReason = "empty" | "missing" | "ambiguous";
-
-export type ChatModelResolution = {
-  value: string;
-  source: ChatModelResolutionSource;
-  reason?: ChatModelResolutionReason;
-};
-
 export function buildQualifiedChatModelValue(model: string, provider?: string | null): string {
   const trimmedModel = model.trim();
   if (!trimmedModel) {
     return "";
   }
-  // Preserve already-qualified model refs (provider/model) as-is.
-  // This avoids prepending an unrelated/default provider.
-  if (trimmedModel.includes("/")) {
+  const trimmedProvider = provider?.trim();
+  if (!trimmedProvider) {
     return trimmedModel;
   }
-  const trimmedProvider = provider?.trim();
-  return trimmedProvider ? `${trimmedProvider}/${trimmedModel}` : trimmedModel;
+  const providerPrefix = `${trimmedProvider.toLowerCase()}/`;
+  return trimmedModel.toLowerCase().startsWith(providerPrefix)
+    ? trimmedModel
+    : `${trimmedProvider}/${trimmedModel}`;
 }
 
 export function createChatModelOverride(value: string): ChatModelOverride | null {
@@ -50,22 +41,15 @@ export function normalizeChatModelOverrideValue(
   override: ChatModelOverride | null | undefined,
   catalog: ModelCatalogEntry[],
 ): string {
-  return resolveChatModelOverride(override, catalog).value;
-}
-
-export function resolveChatModelOverride(
-  override: ChatModelOverride | null | undefined,
-  catalog: ModelCatalogEntry[],
-): ChatModelResolution {
   if (!override) {
-    return { value: "", source: "empty", reason: "empty" };
+    return "";
   }
   const trimmed = override?.value.trim();
   if (!trimmed) {
-    return { value: "", source: "empty", reason: "empty" };
+    return "";
   }
   if (override.kind === "qualified") {
-    return { value: trimmed, source: "qualified" };
+    return trimmed;
   }
 
   let matchedValue = "";
@@ -82,13 +66,10 @@ export function resolveChatModelOverride(
     if (
       normalizeLowercaseStringOrEmpty(matchedValue) !== normalizeLowercaseStringOrEmpty(candidate)
     ) {
-      return { value: trimmed, source: "raw", reason: "ambiguous" };
+      return trimmed;
     }
   }
-  if (matchedValue) {
-    return { value: matchedValue, source: "catalog" };
-  }
-  return { value: trimmed, source: "raw", reason: "missing" };
+  return matchedValue || trimmed;
 }
 
 export function resolveServerChatModelValue(
@@ -98,49 +79,30 @@ export function resolveServerChatModelValue(
   if (typeof model !== "string") {
     return "";
   }
-  return buildQualifiedChatModelValue(model, provider);
-}
-
-export function resolvePreferredServerChatModel(
-  model: string | null | undefined,
-  provider: string | null | undefined,
-  catalog: ModelCatalogEntry[],
-): ChatModelResolution {
-  if (typeof model !== "string") {
-    return { value: "", source: "empty", reason: "empty" };
-  }
   const trimmedModel = model.trim();
   if (!trimmedModel) {
-    return { value: "", source: "empty", reason: "empty" };
+    return "";
   }
   const trimmedProvider = provider?.trim();
-  if (trimmedProvider) {
-    const providerMatch = catalog.find(
-      (entry) =>
-        entry.provider?.trim().toLowerCase() === trimmedProvider.toLowerCase() &&
-        entry.id.trim().toLowerCase() === trimmedModel.toLowerCase(),
-    );
-    if (providerMatch) {
-      return {
-        value: buildChatModelOption(providerMatch).value,
-        source: "server",
-      };
-    }
+  if (!trimmedProvider) {
+    return trimmedModel;
   }
-
-  const overrideResolution = resolveChatModelOverride(
-    createChatModelOverride(trimmedModel),
-    catalog,
-  );
-  if (overrideResolution.source === "qualified" || overrideResolution.source === "catalog") {
-    return overrideResolution;
+  const providerPrefix = `${trimmedProvider.toLowerCase()}/`;
+  if (trimmedModel.toLowerCase().startsWith(providerPrefix)) {
+    return trimmedModel;
   }
+  if (trimmedModel.includes("/")) {
+    return trimmedModel;
+  }
+  return buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
+}
 
-  return {
-    value: resolveServerChatModelValue(trimmedModel, provider),
-    source: "server",
-    reason: overrideResolution.reason,
-  };
+function hasCatalogQualifiedValue(catalog: ModelCatalogEntry[], value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return catalog.some((entry) => createQualifiedCatalogKey(entry) === normalized);
 }
 
 export function resolvePreferredServerChatModelValue(
@@ -148,7 +110,45 @@ export function resolvePreferredServerChatModelValue(
   provider: string | null | undefined,
   catalog: ModelCatalogEntry[],
 ): string {
-  return resolvePreferredServerChatModel(model, provider, catalog).value;
+  if (typeof model !== "string") {
+    return "";
+  }
+  const trimmedModel = model.trim();
+  if (!trimmedModel) {
+    return "";
+  }
+
+  const trimmedProvider = provider?.trim();
+
+  if (!trimmedProvider) {
+    return normalizeChatModelOverrideValue(createChatModelOverride(trimmedModel), catalog);
+  }
+
+  if (!trimmedModel.includes("/")) {
+    const normalized = normalizeChatModelOverrideValue(
+      createChatModelOverride(trimmedModel),
+      catalog,
+    );
+    return normalized !== trimmedModel
+      ? normalized
+      : resolveServerChatModelValue(trimmedModel, trimmedProvider);
+  }
+
+  if (hasCatalogQualifiedValue(catalog, trimmedModel)) {
+    return trimmedModel;
+  }
+
+  const qualifiedServerValue = buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
+  if (hasCatalogQualifiedValue(catalog, qualifiedServerValue)) {
+    return qualifiedServerValue;
+  }
+
+  const providerPrefix = `${trimmedProvider.toLowerCase()}/`;
+  if (trimmedModel.toLowerCase().startsWith(providerPrefix)) {
+    return resolveServerChatModelValue(trimmedModel, trimmedProvider);
+  }
+
+  return qualifiedServerValue;
 }
 
 export function formatChatModelDisplay(value: string): string {
@@ -163,7 +163,109 @@ export function formatChatModelDisplay(value: string): string {
   return `${trimmed.slice(separator + 1)} · ${trimmed.slice(0, separator)}`;
 }
 
-export function buildChatModelOption(entry: ModelCatalogEntry): { value: string; label: string } {
+function formatRawCatalogLabel(entry: ModelCatalogEntry): string {
+  const provider = entry.provider?.trim();
+  return provider ? `${entry.id} · ${provider}` : entry.id;
+}
+
+function resolveCatalogDisplayName(entry: ModelCatalogEntry): string {
+  return entry.alias?.trim() || entry.name.trim();
+}
+
+function createQualifiedCatalogKey(entry: ModelCatalogEntry): string {
+  return buildQualifiedChatModelValue(entry.id, entry.provider).trim().toLowerCase();
+}
+
+function createNameProviderKey(name: string, provider?: string | null): string {
+  return `${name.toLowerCase()}\u0000${provider?.trim().toLowerCase() ?? ""}`;
+}
+
+export type ChatModelDisplayLookup = ReadonlyMap<string, string>;
+
+export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<string, string> {
+  const nameToValues = new Map<string, Set<string>>();
+  const nameProviderToValues = new Map<string, Set<string>>();
+
+  for (const entry of catalog) {
+    const name = resolveCatalogDisplayName(entry);
+    if (!name) {
+      continue;
+    }
+
+    const qualifiedKey = createQualifiedCatalogKey(entry);
+    const normalizedName = name.toLowerCase();
+    const providerKey = createNameProviderKey(name, entry.provider);
+
+    const nameValues = nameToValues.get(normalizedName) ?? new Set<string>();
+    nameValues.add(qualifiedKey);
+    nameToValues.set(normalizedName, nameValues);
+
+    const nameProviderValues = nameProviderToValues.get(providerKey) ?? new Set<string>();
+    nameProviderValues.add(qualifiedKey);
+    nameProviderToValues.set(providerKey, nameProviderValues);
+  }
+
+  const displayLookup = new Map<string, string>();
+  for (const entry of catalog) {
+    const qualifiedKey = createQualifiedCatalogKey(entry);
+    const name = resolveCatalogDisplayName(entry);
+    if (!name) {
+      displayLookup.set(qualifiedKey, formatRawCatalogLabel(entry));
+      continue;
+    }
+
+    const normalizedName = name.toLowerCase();
+    if ((nameToValues.get(normalizedName)?.size ?? 0) <= 1) {
+      displayLookup.set(qualifiedKey, name);
+      continue;
+    }
+
+    const provider = entry.provider?.trim();
+    if ((nameProviderToValues.get(createNameProviderKey(name, provider))?.size ?? 0) <= 1) {
+      displayLookup.set(qualifiedKey, provider ? `${name} · ${provider}` : `${name} · ${entry.id}`);
+      continue;
+    }
+
+    displayLookup.set(qualifiedKey, `${name} · ${formatRawCatalogLabel(entry)}`);
+  }
+
+  return displayLookup;
+}
+
+export function formatCatalogEntryDisplay(
+  entry: ModelCatalogEntry,
+  displayLookup: ChatModelDisplayLookup,
+): string {
+  return displayLookup.get(createQualifiedCatalogKey(entry)) ?? formatRawCatalogLabel(entry);
+}
+
+export function formatCatalogChatModelDisplayFromLookup(
+  value: string,
+  displayLookup: ChatModelDisplayLookup,
+): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  return displayLookup.get(trimmed.toLowerCase()) ?? formatChatModelDisplay(trimmed);
+}
+
+export function formatCatalogChatModelDisplay(value: string, catalog: ModelCatalogEntry[]): string {
+  return formatCatalogChatModelDisplayFromLookup(value, buildCatalogDisplayLookup(catalog));
+}
+
+export function buildChatModelOption(
+  entry: ModelCatalogEntry,
+  catalog: ModelCatalogEntry[] = [entry],
+): { value: string; label: string } {
+  return buildChatModelOptionFromLookup(entry, buildCatalogDisplayLookup(catalog));
+}
+
+export function buildChatModelOptionFromLookup(
+  entry: ModelCatalogEntry,
+  displayLookup: ChatModelDisplayLookup,
+): { value: string; label: string } {
   const provider = entry.provider?.trim();
   const value = (() => {
     if (!provider) {
@@ -173,7 +275,7 @@ export function buildChatModelOption(entry: ModelCatalogEntry): { value: string;
     return entry.id.toLowerCase().startsWith(providerPrefix) ? entry.id : `${provider}/${entry.id}`;
   })();
   return {
-    value,
-    label: provider ? `${entry.id} · ${provider}` : entry.id,
+    value: buildQualifiedChatModelValue(entry.id, provider),
+    label: formatCatalogEntryDisplay(entry, displayLookup),
   };
 }

--- a/ui/src/ui/chat-model-select-state.test.ts
+++ b/ui/src/ui/chat-model-select-state.test.ts
@@ -39,6 +39,23 @@ describe("chat-model-select-state", () => {
     expect(resolveChatModelOverrideValue(state)).toBe("openai/gpt-5-mini");
   });
 
+  it("preserves already-qualified active-session models when the provider is stale and the catalog is empty", () => {
+    const state = {
+      sessionKey: "main",
+      chatModelOverrides: {},
+      chatModelCatalog: [],
+      sessionsResult: createSessionsListResult({
+        model: "openai/gpt-5-mini",
+        modelProvider: "zai",
+      }),
+    };
+
+    const resolved = resolveChatModelSelectState(state);
+    expect(resolved.currentOverride).toBe("openai/gpt-5-mini");
+    expect(resolved.options.map((option) => option.value)).toContain("openai/gpt-5-mini");
+    expect(resolved.options.map((option) => option.value)).not.toContain("zai/openai/gpt-5-mini");
+  });
+
   it("builds picker options without introducing a bare duplicate", () => {
     const state = {
       sessionKey: "main",

--- a/ui/src/ui/chat-model-select-state.test.ts
+++ b/ui/src/ui/chat-model-select-state.test.ts
@@ -11,14 +11,14 @@ import {
 } from "./chat-model.test-helpers.ts";
 
 describe("chat-model-select-state", () => {
-  it("prefers the catalog provider when the active session provider is stale", () => {
+  it("uses the server-qualified value when the active session provider is present", () => {
     const state = {
       sessionKey: "main",
       chatModelOverrides: {},
       chatModelCatalog: createModelCatalog(DEEPSEEK_CHAT_MODEL),
       sessionsResult: createSessionsListResult({
         model: "deepseek-chat",
-        modelProvider: "zai",
+        modelProvider: "deepseek",
       }),
     };
 
@@ -54,5 +54,108 @@ describe("chat-model-select-state", () => {
     expect(resolved.currentOverride).toBe("openai/gpt-5-mini");
     expect(resolved.options.map((option) => option.value)).toContain("openai/gpt-5-mini");
     expect(resolved.options.map((option) => option.value)).not.toContain("gpt-5-mini");
+  });
+
+  it("uses catalog names for the default label and matching picker options", () => {
+    const state = {
+      sessionKey: "main",
+      chatModelOverrides: {},
+      chatModelCatalog: createModelCatalog({
+        id: "moonshotai/kimi-k2.5",
+        alias: "Kimi K2.5 (NVIDIA)",
+        name: "Kimi K2.5 (NVIDIA)",
+        provider: "nvidia",
+      }),
+      sessionsResult: createSessionsListResult({
+        model: "moonshotai/kimi-k2.5",
+        modelProvider: "nvidia",
+        defaultsModel: "moonshotai/kimi-k2.5",
+        defaultsProvider: "nvidia",
+      }),
+    };
+
+    const resolved = resolveChatModelSelectState(state);
+    expect(resolved.currentOverride).toBe("nvidia/moonshotai/kimi-k2.5");
+    expect(resolved.defaultLabel).toBe("Default (Kimi K2.5 (NVIDIA))");
+    expect(resolved.options).toContainEqual({
+      value: "nvidia/moonshotai/kimi-k2.5",
+      label: "Kimi K2.5 (NVIDIA)",
+    });
+  });
+
+  it("disambiguates duplicate friendly names in picker options and default labels", () => {
+    const state = {
+      sessionKey: "main",
+      chatModelOverrides: {},
+      chatModelCatalog: createModelCatalog(
+        {
+          id: "claude-3-7-sonnet",
+          name: "Claude Sonnet",
+          provider: "anthropic",
+        },
+        {
+          id: "claude-3-7-sonnet",
+          name: "Claude Sonnet",
+          provider: "openrouter",
+        },
+      ),
+      sessionsResult: createSessionsListResult({
+        model: "claude-3-7-sonnet",
+        modelProvider: "anthropic",
+        defaultsModel: "claude-3-7-sonnet",
+        defaultsProvider: "openrouter",
+      }),
+    };
+
+    const resolved = resolveChatModelSelectState(state);
+    expect(resolved.currentOverride).toBe("anthropic/claude-3-7-sonnet");
+    expect(resolved.defaultLabel).toBe("Default (Claude Sonnet · openrouter)");
+    expect(resolved.options).toContainEqual({
+      value: "anthropic/claude-3-7-sonnet",
+      label: "Claude Sonnet · anthropic",
+    });
+    expect(resolved.options).toContainEqual({
+      value: "openrouter/claude-3-7-sonnet",
+      label: "Claude Sonnet · openrouter",
+    });
+  });
+
+  it("falls back to id and provider when duplicate names share the same provider", () => {
+    const state = {
+      sessionKey: "main",
+      chatModelOverrides: {},
+      chatModelCatalog: createModelCatalog(
+        {
+          id: "claude-3-7-sonnet",
+          name: "Claude Sonnet",
+          provider: "anthropic",
+        },
+        {
+          id: "claude-3-7-sonnet-thinking",
+          name: "Claude Sonnet",
+          provider: "anthropic",
+        },
+      ),
+      sessionsResult: createSessionsListResult({
+        model: "claude-3-7-sonnet",
+        modelProvider: "anthropic",
+        defaultsModel: "claude-3-7-sonnet-thinking",
+        defaultsProvider: "anthropic",
+      }),
+    };
+
+    const resolved = resolveChatModelSelectState(state);
+    expect(resolved.currentOverride).toBe("anthropic/claude-3-7-sonnet");
+    expect(resolved.defaultLabel).toBe(
+      "Default (Claude Sonnet · claude-3-7-sonnet-thinking · anthropic)",
+    );
+    expect(resolved.options).toContainEqual({
+      value: "anthropic/claude-3-7-sonnet",
+      label: "Claude Sonnet · claude-3-7-sonnet · anthropic",
+    });
+    expect(resolved.options).toContainEqual({
+      value: "anthropic/claude-3-7-sonnet-thinking",
+      label: "Claude Sonnet · claude-3-7-sonnet-thinking · anthropic",
+    });
   });
 });

--- a/ui/src/ui/chat-model-select-state.ts
+++ b/ui/src/ui/chat-model-select-state.ts
@@ -57,12 +57,12 @@ function resolveDefaultModelValue(state: ChatModelSelectStateInput): string {
 
 function buildChatModelOptions(
   catalog: ModelCatalogEntry[],
+  displayLookup: ReturnType<typeof buildCatalogDisplayLookup>,
   currentOverride: string,
   defaultModel: string,
 ): ChatModelSelectOption[] {
   const seen = new Set<string>();
   const options: ChatModelSelectOption[] = [];
-  const displayLookup = buildCatalogDisplayLookup(catalog);
 
   const addOption = (value: string, label?: string) => {
     const trimmed = value.trim();
@@ -108,6 +108,6 @@ export function resolveChatModelSelectState(
     defaultModel,
     defaultDisplay,
     defaultLabel: defaultModel ? `Default (${defaultDisplay})` : "Default model",
-    options: buildChatModelOptions(catalog, currentOverride, defaultModel),
+    options: buildChatModelOptions(catalog, displayLookup, currentOverride, defaultModel),
   };
 }

--- a/ui/src/ui/chat-model-select-state.ts
+++ b/ui/src/ui/chat-model-select-state.ts
@@ -1,7 +1,8 @@
 import type { AppViewState } from "./app-view-state.ts";
 import {
-  buildChatModelOption,
-  formatChatModelDisplay,
+  buildCatalogDisplayLookup,
+  buildChatModelOptionFromLookup,
+  formatCatalogChatModelDisplayFromLookup,
   normalizeChatModelOverrideValue,
   resolvePreferredServerChatModelValue,
 } from "./chat-model-ref.ts";
@@ -61,6 +62,7 @@ function buildChatModelOptions(
 ): ChatModelSelectOption[] {
   const seen = new Set<string>();
   const options: ChatModelSelectOption[] = [];
+  const displayLookup = buildCatalogDisplayLookup(catalog);
 
   const addOption = (value: string, label?: string) => {
     const trimmed = value.trim();
@@ -76,15 +78,18 @@ function buildChatModelOptions(
   };
 
   for (const entry of catalog) {
-    const option = buildChatModelOption(entry);
+    const option = buildChatModelOptionFromLookup(entry, displayLookup);
     addOption(option.value, option.label);
   }
 
   if (currentOverride) {
-    addOption(currentOverride);
+    addOption(
+      currentOverride,
+      formatCatalogChatModelDisplayFromLookup(currentOverride, displayLookup),
+    );
   }
   if (defaultModel) {
-    addOption(defaultModel);
+    addOption(defaultModel, formatCatalogChatModelDisplayFromLookup(defaultModel, displayLookup));
   }
   return options;
 }
@@ -92,15 +97,17 @@ function buildChatModelOptions(
 export function resolveChatModelSelectState(
   state: ChatModelSelectStateInput,
 ): ChatModelSelectState {
+  const catalog = state.chatModelCatalog ?? [];
+  const displayLookup = buildCatalogDisplayLookup(catalog);
   const currentOverride = resolveChatModelOverrideValue(state);
   const defaultModel = resolveDefaultModelValue(state);
-  const defaultDisplay = formatChatModelDisplay(defaultModel);
+  const defaultDisplay = formatCatalogChatModelDisplayFromLookup(defaultModel, displayLookup);
 
   return {
     currentOverride,
     defaultModel,
     defaultDisplay,
     defaultLabel: defaultModel ? `Default (${defaultDisplay})` : "Default model",
-    options: buildChatModelOptions(state.chatModelCatalog ?? [], currentOverride, defaultModel),
+    options: buildChatModelOptions(catalog, currentOverride, defaultModel),
   };
 }

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -414,6 +414,30 @@ describe("executeSlashCommand directives", () => {
     });
   });
 
+  it("keeps provider-qualified nested ids when the patched catalog lookup fails", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return createResolvedModelPatch("moonshotai/kimi-k2.5", "nvidia");
+      }
+      if (method === "models.list") {
+        throw new Error("models unavailable");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "nvidia/moonshotai/kimi-k2.5",
+    );
+
+    expect(result.sessionPatch?.modelOverride).toEqual({
+      kind: "qualified",
+      value: "nvidia/moonshotai/kimi-k2.5",
+    });
+  });
+
   it("reuses a provided model catalog for /model updates without refetching", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.patch") {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -3,14 +3,14 @@
  * Calls gateway RPC methods and returns formatted results.
  */
 
-import { createChatModelOverride, resolvePreferredServerChatModel } from "../chat-model-ref.ts";
+import { createChatModelOverride, resolvePreferredServerChatModelValue } from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import {
   DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
   isSubagentSessionKey,
   parseAgentSessionKey,
-} from "../session-key.ts";
+} from "../../../../src/routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -214,11 +214,11 @@ async function executeModel(
         ? Promise.resolve(modelCatalog)
         : loadModelCatalog(client, { allowFailure: true }),
     ]);
-    const resolvedValue = resolvePreferredServerChatModel(
+    const resolvedValue = resolvePreferredServerChatModelValue(
       patched.resolved?.model ?? args.trim(),
       patched.resolved?.modelProvider,
       resolvedModelCatalog,
-    ).value;
+    );
     return {
       content: `Model set to \`${args.trim()}\`.`,
       action: "refresh",

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -208,22 +208,35 @@ async function executeModel(
   }
 
   try {
+    const requestedModel = args.trim();
     const [patched, resolvedModelCatalog] = await Promise.all([
       client.request<SessionsPatchResult>("sessions.patch", {
         key: sessionKey,
-        model: args.trim(),
+        model: requestedModel,
       }),
       modelCatalog
         ? Promise.resolve(modelCatalog)
         : loadModelCatalog(client, { allowFailure: true }),
     ]);
-    const resolvedValue = resolvePreferredServerChatModelValue(
-      patched.resolved?.model ?? args.trim(),
+    const resolvedModel = patched.resolved?.model ?? requestedModel;
+    let resolvedValue = resolvePreferredServerChatModelValue(
+      resolvedModel,
       patched.resolved?.modelProvider,
       resolvedModelCatalog,
     );
+    const requestedOverride = createChatModelOverride(requestedModel);
+    const resolvedProvider = patched.resolved?.modelProvider?.trim();
+    if (
+      requestedOverride?.kind === "qualified" &&
+      resolvedProvider &&
+      resolvedValue &&
+      !resolvedValue.toLowerCase().startsWith(`${resolvedProvider.toLowerCase()}/`) &&
+      requestedOverride.value.toLowerCase().endsWith(`/${resolvedModel.trim().toLowerCase()}`)
+    ) {
+      resolvedValue = requestedOverride.value;
+    }
     return {
-      content: `Model set to \`${args.trim()}\`.`,
+      content: `Model set to \`${requestedModel}\`.`,
       action: "refresh",
       sessionPatch: { modelOverride: createChatModelOverride(resolvedValue) },
     };

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -3,14 +3,17 @@
  * Calls gateway RPC methods and returns formatted results.
  */
 
-import { createChatModelOverride, resolvePreferredServerChatModelValue } from "../chat-model-ref.ts";
+import {
+  createChatModelOverride,
+  resolvePreferredServerChatModelValue,
+} from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
 import {
   DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
   isSubagentSessionKey,
   parseAgentSessionKey,
-} from "../../../../src/routing/session-key.js";
+} from "../session-key.ts";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -223,6 +223,36 @@ describe("loadToolsEffective", () => {
     expect(state.toolsEffectiveError).toContain("gateway unavailable");
     expect(state.toolsEffectiveLoading).toBe(false);
   });
+
+  it("uses the catalog provider when the active session reports a stale provider", async () => {
+    const { state, request } = createState();
+    const sessionsResult = state.sessionsResult!;
+    state.sessionsResult = {
+      ts: sessionsResult.ts,
+      path: sessionsResult.path,
+      count: 1,
+      defaults: sessionsResult.defaults,
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: 0,
+          model: "deepseek-chat",
+          modelProvider: "zai",
+        },
+      ],
+    };
+    state.chatModelCatalog = [{ id: "deepseek-chat", name: "DeepSeek Chat", provider: "deepseek" }];
+    request.mockResolvedValue({
+      agentId: "main",
+      profile: "coding",
+      groups: [],
+    });
+
+    await loadToolsEffective(state, { agentId: "main", sessionKey: "main" });
+
+    expect(state.toolsEffectiveResultKey).toBe("main:main:model=deepseek/deepseek-chat");
+  });
 });
 
 describe("saveAgentsConfig", () => {

--- a/ui/src/ui/controllers/agents.test.ts
+++ b/ui/src/ui/controllers/agents.test.ts
@@ -253,6 +253,36 @@ describe("loadToolsEffective", () => {
 
     expect(state.toolsEffectiveResultKey).toBe("main:main:model=deepseek/deepseek-chat");
   });
+
+  it("preserves already-qualified session models when the active session provider is stale and the catalog is empty", async () => {
+    const { state, request } = createState();
+    const sessionsResult = state.sessionsResult!;
+    state.sessionsResult = {
+      ts: sessionsResult.ts,
+      path: sessionsResult.path,
+      count: 1,
+      defaults: sessionsResult.defaults,
+      sessions: [
+        {
+          key: "main",
+          kind: "direct",
+          updatedAt: 0,
+          model: "openai/gpt-5-mini",
+          modelProvider: "zai",
+        },
+      ],
+    };
+    state.chatModelCatalog = [];
+    request.mockResolvedValue({
+      agentId: "main",
+      profile: "coding",
+      groups: [],
+    });
+
+    await loadToolsEffective(state, { agentId: "main", sessionKey: "main" });
+
+    expect(state.toolsEffectiveResultKey).toBe("main:main:model=openai/gpt-5-mini");
+  });
 });
 
 describe("saveAgentsConfig", () => {

--- a/ui/src/ui/controllers/agents.ts
+++ b/ui/src/ui/controllers/agents.ts
@@ -1,5 +1,5 @@
 import {
-  resolveChatModelOverride,
+  normalizeChatModelOverrideValue,
   resolvePreferredServerChatModelValue,
 } from "../chat-model-ref.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
@@ -227,7 +227,7 @@ function resolveEffectiveToolsModelKey(
     return defaultModel;
   }
   if (cachedOverride) {
-    return resolveChatModelOverride(cachedOverride, catalog).value;
+    return normalizeChatModelOverrideValue(cachedOverride, catalog);
   }
   const activeRow = state.sessionsResult?.sessions?.find((row) => row.key === resolvedSessionKey);
   if (activeRow?.model) {

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -707,6 +707,7 @@ export type ModelCatalogEntry = {
   id: string;
   name: string;
   provider: string;
+  alias?: string;
   contextWindow?: number;
   reasoning?: boolean;
   input?: Array<"text" | "image" | "document">;


### PR DESCRIPTION
## Summary

- Problem: the Control UI model picker lost configured model metadata and could restore nested model refs against the wrong provider after refresh.
- Why it matters: users saw raw `model-id · provider` labels instead of configured aliases/names, and models like `nvidia/moonshotai/kimi-k2.5` could jump to the wrong provider after refresh.
- What changed: the gateway now preserves configured model `alias`/`name` metadata in the catalog, session and live-switch normalization preserve nested provider/model refs, and the Control UI picker now prefers `alias || name || raw`.
- What did NOT change (scope boundary): this PR does not introduce a global label-normalization policy; mixed label styles still come from upstream/provider metadata and local config.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #58835
- Related #59831
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: configured model metadata was dropped while building the allowed-model catalog, `alias` was not exposed in the catalog contract, and session override normalization did not preserve nested provider/model refs consistently across refresh paths.
- Missing detection / guardrail: there was no focused coverage for alias propagation, nested override normalization, stale-provider correction, or the `/model` caching path for nested ids.
- Prior context (`git blame`, prior PR, issue, or refactor if known): reported in #58835; an earlier UI-only attempt in #59831 improved display but still pushed too much identity repair into the frontend.
- Why this regressed now: this appears to be longstanding behavior from how model metadata and session overrides were merged rather than a recent single-point regression.
- If unknown, what was ruled out: ruled out “UI-only” root cause; the missing alias/name data and nested-ref handling both required gateway-side fixes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/model-selection.test.ts`
  - `src/gateway/session-utils.test.ts`
  - `src/agents/live-model-switch.test.ts`
  - `src/gateway/server.models-voicewake-misc.test.ts`
  - `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
  - `ui/src/ui/chat-model-ref.test.ts`
  - `ui/src/ui/chat-model-select-state.test.ts`
  - `ui/src/ui/chat/slash-command-executor.node.test.ts`
  - `ui/src/ui/controllers/agents.test.ts`
- Scenario the test should lock in:
  - configured `alias`/`name` propagate into `models.list`
  - synthetic allowed-model entries preserve configured metadata
  - nested model refs remain provider-qualified across session/live-switch normalization
  - picker labels prefer `alias || name || raw`
  - `/model` caching preserves nested refs when catalog lookup is present or unavailable
- Why this is the smallest reliable guardrail: the bug crosses gateway contract, session normalization, and picker rendering, so it needs both narrow unit coverage and gateway seam tests.
- Existing test that already covers this (if any): none before this PR
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- The Control UI model picker now shows configured aliases and friendly names when available.
- Nested refs like `nvidia/moonshotai/kimi-k2.5` stay provider-qualified after refresh.
- `/model` updates and tools-effective resolution now use the same normalized model identity.
- The picker still reflects provider-specific naming differences from upstream/config metadata instead of rewriting them into a single global style.

## Diagram (if applicable)

```text
Before:
[config alias/name] -> [allowed-model catalog drops metadata] -> [UI falls back to raw "model-id · provider"]
[nested model ref + refresh] -> [stale/partial normalization] -> [wrong provider mapping]

After:
[config alias/name] -> [gateway catalog preserves metadata] -> [UI picker shows alias/name]
[nested model ref + refresh] -> [gateway/session normalization preserves provider-qualified ref] -> [stable picker/default state]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw `main`, built-in Control UI
- Model/provider: `nvidia/moonshotai/kimi-k2.5` and other catalog-backed models
- Integration/channel (if any): none
- Relevant config (redacted): provider model entries with configured `name` plus `agents.defaults.models` aliases

### Steps

1. Start the gateway and open the built-in Control UI.
2. Open the chat model picker and inspect the displayed labels.
3. Select a nested model ref such as `nvidia/moonshotai/kimi-k2.5`.
4. Refresh or reload the session state.

### Expected

- The picker shows configured alias/name instead of raw `model-id · provider`.
- The selected nested ref stays on the same provider after refresh.

### Actual

- Before this change, aliases/names were ignored and the picker showed raw labels.
- Before this change, nested refs could be cached/restored under the wrong provider.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Before: raw provider/model labels in the picker.**
<img width="1728" height="1117" alt="Screenshot 2026-04-05 at 19 31 43" src="https://github.com/user-attachments/assets/c5bd920b-c9da-4988-a635-79145f1c0822" />

**After: friendly alias/name labels from the catalog.**
<img width="1728" height="1117" alt="Screenshot 2026-04-05 at 16 07 14" src="https://github.com/user-attachments/assets/82688649-9e2e-4131-8a20-5c7f4753bda8" />


## Human Verification (required)

- Verified scenarios:
  - rebuilt the Control UI and confirmed the picker shows configured aliases/names
  - confirmed nested model refs stay provider-qualified after refresh
  - confirmed `/model` and tools-effective paths use the normalized ref
- Edge cases checked:
  - stale provider on plain ids with a unique catalog match
  - nested slash-containing ids with and without catalog availability
  - duplicate friendly names across providers
- What you did **not** verify:
  - a global label-normalization policy across all provider metadata styles
  - unrelated Control UI surfaces outside model selection / tools-effective model resolution

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: provider catalogs/config can still contain visually inconsistent naming styles.
  - Mitigation: preserve configured/upstream metadata exactly; avoid introducing a subjective UI rewrite policy in this bug fix.
- Risk: nested ref handling spans gateway and UI paths, so regressions could reappear in less common flows.
  - Mitigation: added coverage for gateway normalization, `/model`, tools-effective resolution, and picker rendering.
