### PR TITLE
fix: skip local DNS resolution in trusted env proxy mode for web_search

### DIFF
--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -595,4 +595,47 @@ describe("fetchWithSsrFGuard hardening", () => {
       expectEnvProxy: true,
     });
   });
+
+  it("succeeds in trusted env proxy mode even when local DNS resolution fails", async () => {
+    vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    const failingLookup: LookupFn = vi.fn(async () => {
+      throw new Error("getaddrinfo ENOTFOUND api.search.brave.com");
+    }) as unknown as LookupFn;
+
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const requestInit = init as RequestInit & { dispatcher?: unknown };
+      expect(getDispatcherClassName(requestInit.dispatcher)).toBe("EnvHttpProxyAgent");
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.search.brave.com/res/v1/web/search?q=test",
+      fetchImpl,
+      lookupFn: failingLookup,
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+    });
+
+    expect(failingLookup).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(result.response.status).toBe(200);
+    await result.release();
+  });
+
+  it("still fails on DNS resolution in strict mode when local DNS is broken", async () => {
+    const failingLookup: LookupFn = vi.fn(async () => {
+      throw new Error("getaddrinfo ENOTFOUND api.search.brave.com");
+    }) as unknown as LookupFn;
+
+    const fetchImpl = vi.fn();
+
+    await expect(
+      fetchWithSsrFGuard({
+        url: "https://api.search.brave.com/res/v1/web/search?q=test",
+        fetchImpl,
+        lookupFn: failingLookup,
+        mode: GUARDED_FETCH_MODE.STRICT,
+      }),
+    ).rejects.toThrow(/ENOTFOUND/);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -227,19 +227,25 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
 
     let dispatcher: Dispatcher | null = null;
     try {
-      assertExplicitProxySupportsPinnedDns(parsedUrl, params.dispatcherPolicy, params.pinDns);
-      await assertExplicitProxyAllowed(params.dispatcherPolicy, params.lookupFn, params.policy);
-      const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
-        lookupFn: params.lookupFn,
-        policy: params.policy,
-      });
       const canUseTrustedEnvProxy =
         mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
       if (canUseTrustedEnvProxy) {
+        // When using a trusted env proxy, skip local DNS resolution and SSRF
+        // pinning — the proxy server handles DNS. This avoids "fetch failed"
+        // on networks where external hostnames are only resolvable through
+        // the proxy (e.g. corporate firewalls, restricted networks).
         const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
         dispatcher = new EnvHttpProxyAgent();
-      } else if (params.pinDns !== false) {
-        dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy, params.policy);
+      } else {
+        assertExplicitProxySupportsPinnedDns(parsedUrl, params.dispatcherPolicy, params.pinDns);
+        await assertExplicitProxyAllowed(params.dispatcherPolicy, params.lookupFn, params.policy);
+        const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+          lookupFn: params.lookupFn,
+          policy: params.policy,
+        });
+        if (params.pinDns !== false) {
+          dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy, params.policy);
+        }
       }
 
       const init: RequestInit & { dispatcher?: Dispatcher } = {


### PR DESCRIPTION
## Summary

- **Fix**: In trusted env proxy mode (`GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY`), skip local DNS resolution and SSRF pinning entirely — the proxy server handles DNS. This fixes `web_search` "fetch failed" errors on Windows (and other platforms) where external hostnames are only resolvable through the configured proxy (e.g. corporate firewalls, restricted networks).
- **Before**: `fetchWithSsrFGuard` always attempted local DNS resolution *before* checking whether to delegate to the env proxy, causing `ENOTFOUND` failures when the host machine cannot resolve external names directly.
- **After**: When `TRUSTED_ENV_PROXY` mode is active and `HTTP_PROXY`/`HTTPS_PROXY` is set, the function skips straight to `EnvHttpProxyAgent` without local DNS lookups.

## Test plan

- Added test: trusted env proxy mode succeeds even when local DNS lookup would fail (`ENOTFOUND`).
- Added test: strict mode still fails on DNS resolution errors as expected.
- Existing SSRF guard tests remain green.

## Changed files

- `src/infra/net/fetch-guard.ts` — reorder DNS resolution to run only outside trusted proxy path
- `src/infra/net/fetch-guard.ssrf.test.ts` — two new test cases