### PR TITLE
revive: feat(hooks): emit gateway shutdown lifecycle events

### DIFF
--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,10 +1,40 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGatewayCloseHandler } from "./server-close.js";
 
-const mocks = {
-  logWarn: vi.fn(),
+type TestGatewayHookEvent = {
+  type?: string;
+  action?: string;
+  context?: Record<string, unknown>;
 };
-const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
-const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
+
+const { triggerInternalHook, readRestartSentinel, writeRestartSentinel } = vi.hoisted(() => ({
+  triggerInternalHook: vi.fn(
+    async (_event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => undefined,
+  ),
+  readRestartSentinel: vi.fn(async () => null),
+  writeRestartSentinel: vi.fn(async () => "sentinel.json"),
+}));
+
+vi.mock("../hooks/internal-hooks.js", async () => {
+  const actual = await vi.importActual<typeof import("../hooks/internal-hooks.js")>(
+    "../hooks/internal-hooks.js",
+  );
+  return {
+    ...actual,
+    triggerInternalHook,
+  };
+});
+
+vi.mock("../infra/restart-sentinel.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/restart-sentinel.js")>(
+    "../infra/restart-sentinel.js",
+  );
+  return {
+    ...actual,
+    readRestartSentinel,
+    writeRestartSentinel,
+  };
+});
 
 vi.mock("../channels/plugins/index.js", () => ({
   listChannelPlugins: () => [],
@@ -14,160 +44,182 @@ vi.mock("../hooks/gmail-watcher.js", () => ({
   stopGmailWatcher: vi.fn(async () => undefined),
 }));
 
-vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: vi.fn(() => ({
-    warn: mocks.logWarn,
-  })),
-}));
-
-const { createGatewayCloseHandler } = await import("./server-close.js");
+function createCloseHarness(params?: {
+  lifecycleUnsub?: () => void;
+  broadcast?: (event: string, payload: unknown) => void;
+  stallWssClose?: boolean;
+}) {
+  const tickInterval = setInterval(() => undefined, 60_000);
+  const healthInterval = setInterval(() => undefined, 60_000);
+  const dedupeCleanup = setInterval(() => undefined, 60_000);
+  const close = createGatewayCloseHandler({
+    bonjourStop: null,
+    tailscaleCleanup: null,
+    canvasHost: null,
+    canvasHostServer: null,
+    stopChannel: vi.fn(async () => undefined),
+    pluginServices: null,
+    cron: { stop: vi.fn() },
+    heartbeatRunner: { stop: vi.fn() } as never,
+    updateCheckStop: null,
+    nodePresenceTimers: new Map(),
+    broadcast: params?.broadcast ?? vi.fn(),
+    tickInterval,
+    healthInterval,
+    dedupeCleanup,
+    mediaCleanup: null,
+    agentUnsub: null,
+    heartbeatUnsub: null,
+    transcriptUnsub: null,
+    lifecycleUnsub: params?.lifecycleUnsub ?? null,
+    chatRunState: { clear: vi.fn() },
+    clients: new Set(),
+    configReloader: { stop: vi.fn(async () => undefined) },
+    wss: {
+      close: (cb: () => void) => {
+        if (!params?.stallWssClose) {
+          cb();
+        }
+      },
+    } as never,
+    httpServer: {
+      close: (cb: (err?: Error | null) => void) => cb(null),
+      closeIdleConnections: vi.fn(),
+    } as never,
+  });
+  return {
+    close,
+    dispose() {
+      clearInterval(tickInterval);
+      clearInterval(healthInterval);
+      clearInterval(dedupeCleanup);
+    },
+  };
+}
 
 describe("createGatewayCloseHandler", () => {
   beforeEach(() => {
-    vi.useRealTimers();
-    mocks.logWarn.mockClear();
+    triggerInternalHook.mockReset();
+    triggerInternalHook.mockResolvedValue(undefined);
+    readRestartSentinel.mockReset();
+    readRestartSentinel.mockResolvedValue(null);
+    writeRestartSentinel.mockReset();
+    writeRestartSentinel.mockResolvedValue("sentinel.json");
   });
 
   it("unsubscribes lifecycle listeners during shutdown", async () => {
     const lifecycleUnsub = vi.fn();
-    const stopTaskRegistryMaintenance = vi.fn();
-    const close = createGatewayCloseHandler({
-      bonjourStop: null,
-      tailscaleCleanup: null,
-      canvasHost: null,
-      canvasHostServer: null,
-      stopChannel: vi.fn(async () => undefined),
-      pluginServices: null,
-      cron: { stop: vi.fn() },
-      heartbeatRunner: { stop: vi.fn() } as never,
-      updateCheckStop: null,
-      stopTaskRegistryMaintenance,
-      nodePresenceTimers: new Map(),
-      broadcast: vi.fn(),
-      tickInterval: setInterval(() => undefined, 60_000),
-      healthInterval: setInterval(() => undefined, 60_000),
-      dedupeCleanup: setInterval(() => undefined, 60_000),
-      mediaCleanup: null,
-      agentUnsub: null,
-      heartbeatUnsub: null,
-      transcriptUnsub: null,
-      lifecycleUnsub,
-      chatRunState: { clear: vi.fn() },
-      clients: new Set(),
-      configReloader: { stop: vi.fn(async () => undefined) },
-      wss: { close: (cb: () => void) => cb() } as never,
-      httpServer: {
-        close: (cb: (err?: Error | null) => void) => cb(null),
-        closeIdleConnections: vi.fn(),
-      } as never,
-    });
-
-    await close({ reason: "test shutdown" });
-
-    expect(lifecycleUnsub).toHaveBeenCalledTimes(1);
-    expect(stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
+    const harness = createCloseHarness({ lifecycleUnsub });
+    try {
+      await harness.close({ reason: "test shutdown", initiator: "SIGTERM" });
+      expect(lifecycleUnsub).toHaveBeenCalledTimes(1);
+    } finally {
+      harness.dispose();
+    }
   });
 
-  it("terminates lingering websocket clients when websocket close exceeds the grace window", async () => {
+  it("continues shutdown when websocket close callback stalls", async () => {
     vi.useFakeTimers();
+    const harness = createCloseHarness({ stallWssClose: true });
 
-    let closeCallback: (() => void) | null = null;
-    const terminate = vi.fn(() => {
-      closeCallback?.();
+    let settled = false;
+    const closePromise = harness.close().then(() => {
+      settled = true;
     });
-    const close = createGatewayCloseHandler({
-      bonjourStop: null,
-      tailscaleCleanup: null,
-      canvasHost: null,
-      canvasHostServer: null,
-      stopChannel: vi.fn(async () => undefined),
-      pluginServices: null,
-      cron: { stop: vi.fn() },
-      heartbeatRunner: { stop: vi.fn() } as never,
-      updateCheckStop: null,
-      stopTaskRegistryMaintenance: null,
-      nodePresenceTimers: new Map(),
-      broadcast: vi.fn(),
-      tickInterval: setInterval(() => undefined, 60_000),
-      healthInterval: setInterval(() => undefined, 60_000),
-      dedupeCleanup: setInterval(() => undefined, 60_000),
-      mediaCleanup: null,
-      agentUnsub: null,
-      heartbeatUnsub: null,
-      transcriptUnsub: null,
-      lifecycleUnsub: null,
-      chatRunState: { clear: vi.fn() },
-      clients: new Set(),
-      configReloader: { stop: vi.fn(async () => undefined) },
-      wss: {
-        clients: new Set([{ terminate }]),
-        close: (cb: () => void) => {
-          closeCallback = cb;
-        },
-      } as never,
-      httpServer: {
-        close: (cb: (err?: Error | null) => void) => cb(null),
-        closeIdleConnections: vi.fn(),
-      } as never,
-    });
+    await vi.advanceTimersByTimeAsync(2_100);
+    await Promise.resolve();
+    expect(settled).toBe(true);
 
-    const closePromise = close({ reason: "test shutdown" });
-    await vi.advanceTimersByTimeAsync(WEBSOCKET_CLOSE_GRACE_MS);
     await closePromise;
-
-    expect(terminate).toHaveBeenCalledTimes(1);
-    expect(
-      mocks.logWarn.mock.calls.some(([message]) =>
-        String(message).includes("websocket server close exceeded 1000ms"),
-      ),
-    ).toBe(true);
+    harness.dispose();
   });
 
-  it("continues shutdown when websocket close hangs without tracked clients", async () => {
-    vi.useFakeTimers();
+  it("emits gateway shutdown + pre-restart hooks with lifecycle metadata", async () => {
+    const harness = createCloseHarness();
+    try {
+      await harness.close({
+        reason: "gateway restarting",
+        restartExpectedMs: 123,
+        initiator: "SIGUSR1",
+        restartId: "restart-123",
+        correlationId: "corr-123",
+      });
 
-    const close = createGatewayCloseHandler({
-      bonjourStop: null,
-      tailscaleCleanup: null,
-      canvasHost: null,
-      canvasHostServer: null,
-      stopChannel: vi.fn(async () => undefined),
-      pluginServices: null,
-      cron: { stop: vi.fn() },
-      heartbeatRunner: { stop: vi.fn() } as never,
-      updateCheckStop: null,
-      stopTaskRegistryMaintenance: null,
-      nodePresenceTimers: new Map(),
-      broadcast: vi.fn(),
-      tickInterval: setInterval(() => undefined, 60_000),
-      healthInterval: setInterval(() => undefined, 60_000),
-      dedupeCleanup: setInterval(() => undefined, 60_000),
-      mediaCleanup: null,
-      agentUnsub: null,
-      heartbeatUnsub: null,
-      transcriptUnsub: null,
-      lifecycleUnsub: null,
-      chatRunState: { clear: vi.fn() },
-      clients: new Set(),
-      configReloader: { stop: vi.fn(async () => undefined) },
-      wss: {
-        clients: new Set(),
-        close: () => undefined,
-      } as never,
-      httpServer: {
-        close: (cb: (err?: Error | null) => void) => cb(null),
-        closeIdleConnections: vi.fn(),
-      } as never,
-    });
+      const hookCalls = triggerInternalHook.mock.calls as Array<
+        [TestGatewayHookEvent, { perHandlerTimeoutMs?: number }?]
+      >;
+      const shutdownEvent = hookCalls.find(
+        (call) => call[0]?.type === "gateway" && call[0]?.action === "shutdown",
+      )?.[0];
+      const preRestartEvent = hookCalls.find(
+        (call) => call[0]?.type === "gateway" && call[0]?.action === "pre-restart",
+      )?.[0];
 
-    const closePromise = close({ reason: "test shutdown" });
-    await vi.advanceTimersByTimeAsync(WEBSOCKET_CLOSE_GRACE_MS + WEBSOCKET_CLOSE_FORCE_CONTINUE_MS);
-    await closePromise;
+      expect(shutdownEvent?.context).toMatchObject({
+        reason: "gateway restarting",
+        restartExpectedMs: 123,
+        initiator: "SIGUSR1",
+        restartId: "restart-123",
+        correlationId: "corr-123",
+      });
+      expect(preRestartEvent?.context).toMatchObject({
+        reason: "gateway restarting",
+        restartExpectedMs: 123,
+        initiator: "SIGUSR1",
+        restartId: "restart-123",
+        correlationId: "corr-123",
+      });
+      expect(Array.isArray(preRestartEvent?.context?.outbox)).toBe(true);
+      expect(triggerInternalHook.mock.calls[0]?.[1]).toMatchObject({
+        perHandlerTimeoutMs: 1500,
+      });
+    } finally {
+      harness.dispose();
+    }
+  });
 
-    expect(
-      mocks.logWarn.mock.calls.some(([message]) =>
-        String(message).includes("websocket server close still pending after 250ms force window"),
-      ),
-    ).toBe(true);
+  it("persists hook outbox tasks into restart sentinel", async () => {
+    triggerInternalHook.mockImplementation(
+      async (event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => {
+        if (event.type === "gateway" && event.action === "pre-restart") {
+          const outbox = event.context?.outbox as Array<Record<string, unknown>>;
+          outbox.push({
+            message: "Gateway is back after restart",
+            sessionKey: "agent:main:main",
+          });
+        }
+      },
+    );
+
+    const harness = createCloseHarness();
+    try {
+      await harness.close({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+        initiator: "SIGUSR1",
+        restartId: "restart-abc",
+      });
+
+      expect(writeRestartSentinel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "restart",
+          status: "ok",
+          restartId: "restart-abc",
+          correlationId: "restart-abc",
+          initiator: "SIGUSR1",
+          suppressPrimaryNotice: true,
+          outbox: [
+            expect.objectContaining({
+              message: "Gateway is back after restart",
+              sessionKey: "agent:main:main",
+              restartId: "restart-abc",
+              correlationId: "restart-abc",
+            }),
+          ],
+        }),
+      );
+    } finally {
+      harness.dispose();
+    }
   });
 });

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createGatewayCloseHandler } from "./server-close.js";
 
 type TestGatewayHookEvent = {
@@ -210,10 +210,9 @@ describe("createGatewayCloseHandler", () => {
           suppressPrimaryNotice: true,
           outbox: [
             expect.objectContaining({
+              kind: "message",
               message: "Gateway is back after restart",
               sessionKey: "agent:main:main",
-              restartId: "restart-abc",
-              correlationId: "restart-abc",
             }),
           ],
         }),

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -170,9 +170,7 @@ describe("createGatewayCloseHandler", () => {
         correlationId: "corr-123",
       });
       expect(Array.isArray(preRestartEvent?.context?.outbox)).toBe(true);
-      expect(triggerInternalHook.mock.calls[0]?.[1]).toMatchObject({
-        perHandlerTimeoutMs: 1500,
-      });
+      expect(triggerInternalHook.mock.calls[0]?.[1]).toBeUndefined();
     } finally {
       harness.dispose();
     }

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -1,15 +1,185 @@
+import { randomUUID } from "node:crypto";
 import type { Server as HttpServer } from "node:http";
 import type { WebSocketServer } from "ws";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
+import {
+  createInternalHookEvent,
+  triggerInternalHook,
+  type GatewayRestartOutboxTask,
+} from "../hooks/internal-hooks.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  formatDoctorNonInteractiveHint,
+  readRestartSentinel,
+  writeRestartSentinel,
+} from "../infra/restart-sentinel.js";
+import type { RestartOutboxTask, RestartSentinelPayload } from "../infra/restart-sentinel.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 
-const shutdownLog = createSubsystemLogger("gateway/shutdown");
-const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
-const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
+const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 1500;
+const GATEWAY_WSS_CLOSE_TIMEOUT_MS = 2000;
+
+type GatewayCloseOptions = {
+  reason?: string;
+  restartExpectedMs?: number | null;
+  /** Best-effort initiator/source (e.g. SIGUSR1, SIGTERM). */
+  initiator?: string;
+  /** Stable restart identifier for lifecycle correlation. */
+  restartId?: string;
+  /** Correlation identifier (alias of restartId by default). */
+  correlationId?: string;
+};
+
+function normalizeNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+async function closeWssWithTimeout(
+  closeFn: (cb: () => void) => void,
+  timeoutMs: number,
+): Promise<"closed" | "timeout"> {
+  return await new Promise<"closed" | "timeout">((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve("timeout");
+    }, timeoutMs);
+
+    closeFn(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve("closed");
+    });
+  });
+}
+
+function normalizeGatewayOutbox(
+  outbox: GatewayRestartOutboxTask[],
+  restartId?: string,
+  correlationId?: string,
+): RestartOutboxTask[] {
+  return outbox
+    .map((raw) => {
+      if (!raw || typeof raw !== "object") {
+        return null;
+      }
+      const message = normalizeNonEmptyString(raw.message);
+      if (!message) {
+        return null;
+      }
+      const sessionKey = normalizeNonEmptyString(raw.sessionKey);
+      const threadId = normalizeNonEmptyString(raw.threadId);
+      const deliveryContext = raw.deliveryContext;
+      const delivery =
+        deliveryContext && typeof deliveryContext === "object"
+          ? {
+              channel: normalizeNonEmptyString(deliveryContext.channel),
+              to: normalizeNonEmptyString(deliveryContext.to),
+              accountId: normalizeNonEmptyString(deliveryContext.accountId),
+            }
+          : undefined;
+      const resolvedRestartId = normalizeNonEmptyString(raw.restartId) ?? restartId;
+      const resolvedCorrelationId =
+        normalizeNonEmptyString(raw.correlationId) ?? correlationId ?? resolvedRestartId;
+      const rawKind = normalizeNonEmptyString((raw as { kind?: unknown }).kind);
+      const kind: RestartOutboxTask["kind"] =
+        rawKind === "system_event" ? "system_event" : "message";
+      const task: RestartOutboxTask = {
+        ...(kind === "message" ? { kind: "message" as const } : { kind: "system_event" as const }),
+        message,
+        ...(sessionKey ? { sessionKey } : {}),
+        ...(threadId ? { threadId } : {}),
+        ...(delivery?.channel || delivery?.to || delivery?.accountId
+          ? {
+              deliveryContext: {
+                ...(delivery.channel ? { channel: delivery.channel } : {}),
+                ...(delivery.to ? { to: delivery.to } : {}),
+                ...(delivery.accountId ? { accountId: delivery.accountId } : {}),
+              },
+            }
+          : {}),
+        ...(resolvedRestartId ? { restartId: resolvedRestartId } : {}),
+        ...(resolvedCorrelationId ? { correlationId: resolvedCorrelationId } : {}),
+      };
+      return task;
+    })
+    .filter((task): task is RestartOutboxTask => task !== null);
+}
+
+async function persistGatewayRestartOutbox(params: {
+  reason: string;
+  initiator?: string;
+  restartId?: string;
+  correlationId?: string;
+  outbox: GatewayRestartOutboxTask[];
+}) {
+  const normalizedOutbox = normalizeGatewayOutbox(
+    params.outbox,
+    params.restartId,
+    params.correlationId,
+  );
+
+  const existing = await readRestartSentinel().catch(() => null);
+  const existingPayload = existing?.payload;
+  const existingOutbox = Array.isArray(existingPayload?.outbox) ? existingPayload.outbox : [];
+  const mergedOutbox = [...existingOutbox, ...normalizedOutbox];
+
+  if (!existingPayload && mergedOutbox.length === 0) {
+    return;
+  }
+
+  const resolvedRestartId = params.restartId ?? existingPayload?.restartId;
+  const resolvedCorrelationId =
+    params.correlationId ?? existingPayload?.correlationId ?? resolvedRestartId;
+  const resolvedInitiator = params.initiator ?? existingPayload?.initiator;
+  const stats = {
+    ...existingPayload?.stats,
+    reason: existingPayload?.stats?.reason ?? params.reason,
+  };
+
+  const payload: RestartSentinelPayload = {
+    kind: existingPayload?.kind ?? "restart",
+    status: existingPayload?.status ?? "ok",
+    ts: existingPayload?.ts ?? Date.now(),
+    ...(resolvedRestartId ? { restartId: resolvedRestartId } : {}),
+    ...(resolvedCorrelationId ? { correlationId: resolvedCorrelationId } : {}),
+    ...(resolvedInitiator ? { initiator: resolvedInitiator } : {}),
+    ...(existingPayload?.sessionKey ? { sessionKey: existingPayload.sessionKey } : {}),
+    ...(existingPayload?.deliveryContext
+      ? { deliveryContext: existingPayload.deliveryContext }
+      : {}),
+    ...(existingPayload?.threadId ? { threadId: existingPayload.threadId } : {}),
+    ...(typeof existingPayload?.message === "string" || existingPayload?.message === null
+      ? { message: existingPayload.message }
+      : {}),
+    ...(existingPayload?.doctorHint
+      ? { doctorHint: existingPayload.doctorHint }
+      : { doctorHint: formatDoctorNonInteractiveHint() }),
+    ...(Object.keys(stats).length > 0 ? { stats } : {}),
+    ...(typeof existingPayload?.suppressPrimaryNotice === "boolean"
+      ? { suppressPrimaryNotice: existingPayload.suppressPrimaryNotice }
+      : !existingPayload && mergedOutbox.length > 0
+        ? { suppressPrimaryNotice: true }
+        : {}),
+    ...(mergedOutbox.length > 0 ? { outbox: mergedOutbox } : {}),
+  };
+
+  await writeRestartSentinel(payload).catch(() => {
+    // best-effort only
+  });
+}
 
 export function createGatewayCloseHandler(params: {
   bonjourStop: (() => Promise<void>) | null;
@@ -22,7 +192,6 @@ export function createGatewayCloseHandler(params: {
   cron: { stop: () => void };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
-  stopTaskRegistryMaintenance?: (() => void) | null;
   nodePresenceTimers: Map<string, ReturnType<typeof setInterval>>;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   tickInterval: ReturnType<typeof setInterval>;
@@ -40,7 +209,7 @@ export function createGatewayCloseHandler(params: {
   httpServer: HttpServer;
   httpServers?: HttpServer[];
 }) {
-  return async (opts?: { reason?: string; restartExpectedMs?: number | null }) => {
+  return async (opts?: GatewayCloseOptions) => {
     try {
       const reasonRaw = typeof opts?.reason === "string" ? opts.reason.trim() : "";
       const reason = reasonRaw || "gateway stopping";
@@ -48,6 +217,55 @@ export function createGatewayCloseHandler(params: {
         typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
           ? Math.max(0, Math.floor(opts.restartExpectedMs))
           : null;
+      const initiatorRaw = typeof opts?.initiator === "string" ? opts.initiator.trim() : "";
+      const initiator = initiatorRaw || undefined;
+      const restartId =
+        restartExpectedMs !== null
+          ? (normalizeNonEmptyString(opts?.restartId) ?? randomUUID())
+          : undefined;
+      const correlationIdRaw =
+        typeof opts?.correlationId === "string" ? opts.correlationId.trim() : "";
+      const correlationId = correlationIdRaw || restartId;
+      const outbox: GatewayRestartOutboxTask[] = [];
+
+      try {
+        const shutdownEvent = createInternalHookEvent("gateway", "shutdown", "gateway", {
+          reason,
+          restartExpectedMs,
+          ...(initiator ? { initiator } : {}),
+          ...(restartId ? { restartId } : {}),
+          ...(correlationId ? { correlationId } : {}),
+          outbox,
+        });
+        await triggerInternalHook(shutdownEvent, {
+          perHandlerTimeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
+        });
+
+        if (restartExpectedMs !== null) {
+          const preRestartEvent = createInternalHookEvent("gateway", "pre-restart", "gateway", {
+            reason,
+            restartExpectedMs,
+            ...(initiator ? { initiator } : {}),
+            ...(restartId ? { restartId } : {}),
+            ...(correlationId ? { correlationId } : {}),
+            outbox,
+          });
+          await triggerInternalHook(preRestartEvent, {
+            perHandlerTimeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
+          });
+
+          await persistGatewayRestartOutbox({
+            reason,
+            initiator,
+            restartId,
+            correlationId,
+            outbox,
+          });
+        }
+      } catch {
+        // Best-effort only; shutdown should proceed even if hooks fail.
+      }
+
       if (params.bonjourStop) {
         try {
           await params.bonjourStop();
@@ -82,11 +300,6 @@ export function createGatewayCloseHandler(params: {
       params.cron.stop();
       params.heartbeatRunner.stop();
       try {
-        params.stopTaskRegistryMaintenance?.();
-      } catch {
-        /* ignore */
-      }
-      try {
         params.updateCheckStop?.();
       } catch {
         /* ignore */
@@ -98,6 +311,9 @@ export function createGatewayCloseHandler(params: {
       params.broadcast("shutdown", {
         reason,
         restartExpectedMs,
+        ...(initiator ? { initiator } : {}),
+        ...(restartId ? { restartId } : {}),
+        ...(correlationId ? { correlationId } : {}),
       });
       clearInterval(params.tickInterval);
       clearInterval(params.healthInterval);
@@ -143,34 +359,14 @@ export function createGatewayCloseHandler(params: {
       }
       params.clients.clear();
       await params.configReloader.stop().catch(() => {});
-      const wsClients = params.wss.clients ?? new Set();
-      const closePromise = new Promise<void>((resolve) => params.wss.close(() => resolve()));
-      const closedWithinGrace = await Promise.race([
-        closePromise.then(() => true),
-        new Promise<false>((resolve) => setTimeout(() => resolve(false), WEBSOCKET_CLOSE_GRACE_MS)),
-      ]);
-      if (!closedWithinGrace) {
-        shutdownLog.warn(
-          `websocket server close exceeded ${WEBSOCKET_CLOSE_GRACE_MS}ms; forcing shutdown continuation with ${wsClients.size} tracked client(s)`,
+      const wssCloseResult = await closeWssWithTimeout(
+        (cb) => params.wss.close(() => cb()),
+        GATEWAY_WSS_CLOSE_TIMEOUT_MS,
+      );
+      if (wssCloseResult === "timeout") {
+        params.logger?.warn?.(
+          `[gateway] websocket server close timed out after ${GATEWAY_WSS_CLOSE_TIMEOUT_MS}ms, continuing shutdown`,
         );
-        for (const client of wsClients) {
-          try {
-            client.terminate();
-          } catch {
-            /* ignore */
-          }
-        }
-        await Promise.race([
-          closePromise,
-          new Promise<void>((resolve) =>
-            setTimeout(() => {
-              shutdownLog.warn(
-                `websocket server close still pending after ${WEBSOCKET_CLOSE_FORCE_CONTINUE_MS}ms force window; continuing shutdown`,
-              );
-              resolve();
-            }, WEBSOCKET_CLOSE_FORCE_CONTINUE_MS),
-          ),
-        ]);
       }
       const servers =
         params.httpServers && params.httpServers.length > 0

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -4,11 +4,7 @@ import type { WebSocketServer } from "ws";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
-import {
-  createInternalHookEvent,
-  triggerInternalHook,
-  type GatewayRestartOutboxTask,
-} from "../hooks/internal-hooks.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import {
   formatDoctorNonInteractiveHint,
@@ -65,57 +61,85 @@ async function closeWssWithTimeout(
   });
 }
 
-function normalizeGatewayOutbox(
-  outbox: GatewayRestartOutboxTask[],
-  restartId?: string,
-  correlationId?: string,
-): RestartOutboxTask[] {
-  return outbox
-    .map((raw) => {
-      if (!raw || typeof raw !== "object") {
-        return null;
-      }
-      const message = normalizeNonEmptyString(raw.message);
-      if (!message) {
-        return null;
-      }
-      const sessionKey = normalizeNonEmptyString(raw.sessionKey);
-      const threadId = normalizeNonEmptyString(raw.threadId);
-      const deliveryContext = raw.deliveryContext;
-      const delivery =
-        deliveryContext && typeof deliveryContext === "object"
-          ? {
-              channel: normalizeNonEmptyString(deliveryContext.channel),
-              to: normalizeNonEmptyString(deliveryContext.to),
-              accountId: normalizeNonEmptyString(deliveryContext.accountId),
-            }
-          : undefined;
-      const resolvedRestartId = normalizeNonEmptyString(raw.restartId) ?? restartId;
-      const resolvedCorrelationId =
-        normalizeNonEmptyString(raw.correlationId) ?? correlationId ?? resolvedRestartId;
-      const rawKind = normalizeNonEmptyString((raw as { kind?: unknown }).kind);
-      const kind: RestartOutboxTask["kind"] =
-        rawKind === "system_event" ? "system_event" : "message";
-      const task: RestartOutboxTask = {
-        ...(kind === "message" ? { kind: "message" as const } : { kind: "system_event" as const }),
+function normalizeGatewayOutbox(outbox: unknown[]): RestartOutboxTask[] {
+  const normalized: RestartOutboxTask[] = [];
+  for (const raw of outbox) {
+    if (!raw || typeof raw !== "object") {
+      continue;
+    }
+    const item = raw as Record<string, unknown>;
+    const kindRaw = normalizeNonEmptyString(item.kind);
+    const kind =
+      kindRaw === "message" || kindRaw === "system_event" || kindRaw === "notify-session"
+        ? kindRaw
+        : "message";
+    const message = normalizeNonEmptyString(item.message);
+    if (!kind || !message) {
+      continue;
+    }
+
+    const sessionKey = normalizeNonEmptyString(item.sessionKey);
+
+    if (kind === "notify-session") {
+      normalized.push({
+        kind,
         message,
         ...(sessionKey ? { sessionKey } : {}),
-        ...(threadId ? { threadId } : {}),
-        ...(delivery?.channel || delivery?.to || delivery?.accountId
-          ? {
-              deliveryContext: {
-                ...(delivery.channel ? { channel: delivery.channel } : {}),
-                ...(delivery.to ? { to: delivery.to } : {}),
-                ...(delivery.accountId ? { accountId: delivery.accountId } : {}),
-              },
-            }
+        ...(normalizeNonEmptyString(item.channel)
+          ? { channel: normalizeNonEmptyString(item.channel)! }
           : {}),
-        ...(resolvedRestartId ? { restartId: resolvedRestartId } : {}),
-        ...(resolvedCorrelationId ? { correlationId: resolvedCorrelationId } : {}),
-      };
-      return task;
-    })
-    .filter((task): task is RestartOutboxTask => task !== null);
+        ...(normalizeNonEmptyString(item.to) ? { to: normalizeNonEmptyString(item.to)! } : {}),
+        ...(normalizeNonEmptyString(item.accountId)
+          ? { accountId: normalizeNonEmptyString(item.accountId)! }
+          : {}),
+        ...(normalizeNonEmptyString(item.threadId)
+          ? { threadId: normalizeNonEmptyString(item.threadId)! }
+          : {}),
+      });
+      continue;
+    }
+
+    const deliveryContextRaw = item.deliveryContext;
+    const deliveryContext =
+      deliveryContextRaw && typeof deliveryContextRaw === "object"
+        ? {
+            ...(normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).channel)
+              ? {
+                  channel: normalizeNonEmptyString(
+                    (deliveryContextRaw as Record<string, unknown>).channel,
+                  )!,
+                }
+              : {}),
+            ...(normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).to)
+              ? { to: normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).to)! }
+              : {}),
+            ...(normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).accountId)
+              ? {
+                  accountId: normalizeNonEmptyString(
+                    (deliveryContextRaw as Record<string, unknown>).accountId,
+                  )!,
+                }
+              : {}),
+          }
+        : undefined;
+
+    normalized.push({
+      kind,
+      message,
+      ...(sessionKey ? { sessionKey } : {}),
+      ...(normalizeNonEmptyString(item.threadId)
+        ? { threadId: normalizeNonEmptyString(item.threadId)! }
+        : {}),
+      ...(deliveryContext && Object.keys(deliveryContext).length > 0 ? { deliveryContext } : {}),
+      ...(normalizeNonEmptyString(item.restartId)
+        ? { restartId: normalizeNonEmptyString(item.restartId)! }
+        : {}),
+      ...(normalizeNonEmptyString(item.correlationId)
+        ? { correlationId: normalizeNonEmptyString(item.correlationId)! }
+        : {}),
+    });
+  }
+  return normalized;
 }
 
 async function persistGatewayRestartOutbox(params: {
@@ -123,13 +147,9 @@ async function persistGatewayRestartOutbox(params: {
   initiator?: string;
   restartId?: string;
   correlationId?: string;
-  outbox: GatewayRestartOutboxTask[];
+  outbox: unknown[];
 }) {
-  const normalizedOutbox = normalizeGatewayOutbox(
-    params.outbox,
-    params.restartId,
-    params.correlationId,
-  );
+  const normalizedOutbox = normalizeGatewayOutbox(params.outbox);
 
   const existing = await readRestartSentinel().catch(() => null);
   const existingPayload = existing?.payload;
@@ -202,6 +222,12 @@ export function createGatewayCloseHandler(params: {
   heartbeatUnsub: (() => void) | null;
   transcriptUnsub: (() => void) | null;
   lifecycleUnsub: (() => void) | null;
+  stopTaskRegistryMaintenance?: () => void;
+  logger?: {
+    info?: (...args: unknown[]) => void;
+    warn?: (...args: unknown[]) => void;
+    error?: (...args: unknown[]) => void;
+  };
   chatRunState: { clear: () => void };
   clients: Set<{ socket: { close: (code: number, reason: string) => void } }>;
   configReloader: { stop: () => Promise<void> };
@@ -226,7 +252,7 @@ export function createGatewayCloseHandler(params: {
       const correlationIdRaw =
         typeof opts?.correlationId === "string" ? opts.correlationId.trim() : "";
       const correlationId = correlationIdRaw || restartId;
-      const outbox: GatewayRestartOutboxTask[] = [];
+      const outbox: unknown[] = [];
 
       try {
         const shutdownEvent = createInternalHookEvent("gateway", "shutdown", "gateway", {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -14,7 +14,6 @@ import {
 import type { RestartOutboxTask, RestartSentinelPayload } from "../infra/restart-sentinel.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 
-const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 1500;
 const GATEWAY_WSS_CLOSE_TIMEOUT_MS = 2000;
 
 type GatewayCloseOptions = {
@@ -263,9 +262,7 @@ export function createGatewayCloseHandler(params: {
           ...(correlationId ? { correlationId } : {}),
           outbox,
         });
-        await triggerInternalHook(shutdownEvent, {
-          perHandlerTimeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
-        });
+        await triggerInternalHook(shutdownEvent);
 
         if (restartExpectedMs !== null) {
           const preRestartEvent = createInternalHookEvent("gateway", "pre-restart", "gateway", {
@@ -276,9 +273,7 @@ export function createGatewayCloseHandler(params: {
             ...(correlationId ? { correlationId } : {}),
             outbox,
           });
-          await triggerInternalHook(preRestartEvent, {
-            perHandlerTimeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
-          });
+          await triggerInternalHook(preRestartEvent);
 
           await persistGatewayRestartOutbox({
             reason,

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -255,6 +255,42 @@ describe("scheduleRestartSentinelWake", () => {
     );
   });
 
+  it("executes persisted restart outbox notify-session tasks on startup", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        message: "restart message",
+        outbox: [
+          {
+            kind: "notify-session",
+            sessionKey: "agent:main:main",
+            message: "outbox message",
+            channel: "telegram",
+            to: "telegram:119707338",
+            accountId: "default",
+            threadId: "20",
+          },
+        ],
+      },
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenNthCalledWith(
+      1,
+      "outbox message",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+    expect(mocks.requestHeartbeatNow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "gateway.restart.outbox",
+        sessionKey: "agent:main:main",
+      }),
+    );
+  });
+
   it("does not wake the main session when the sentinel has no sessionKey", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
       payload: {

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -132,7 +132,11 @@ function executePersistedRestartOutbox(tasks: RestartOutboxTask[] | undefined) {
     if (!message || !sessionKey) {
       continue;
     }
-    const deliveryContext = "deliveryContext" in task ? task.deliveryContext : undefined;
+    const deliveryContextRaw = "deliveryContext" in task ? task.deliveryContext : undefined;
+    const deliveryContext =
+      deliveryContextRaw && typeof deliveryContextRaw === "object"
+        ? (deliveryContextRaw as { channel?: unknown; to?: unknown; accountId?: unknown })
+        : undefined;
     const dcChannel =
       deliveryContext && typeof deliveryContext.channel === "string"
         ? deliveryContext.channel

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -12,6 +12,7 @@ import {
   consumeRestartSentinel,
   formatRestartSentinelMessage,
   summarizeRestartSentinel,
+  type RestartOutboxTask,
 } from "../infra/restart-sentinel.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -118,12 +119,63 @@ async function deliverRestartSentinelNotice(params: {
   }
 }
 
+function executePersistedRestartOutbox(tasks: RestartOutboxTask[] | undefined) {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return;
+  }
+  for (const task of tasks) {
+    if (task.kind !== "notify-session") {
+      continue;
+    }
+    const message = typeof task.message === "string" ? task.message.trim() : "";
+    const sessionKey = typeof task.sessionKey === "string" ? task.sessionKey.trim() : "";
+    if (!message || !sessionKey) {
+      continue;
+    }
+    const deliveryContext = "deliveryContext" in task ? task.deliveryContext : undefined;
+    const dcChannel =
+      deliveryContext && typeof deliveryContext.channel === "string"
+        ? deliveryContext.channel
+        : undefined;
+    const dcTo =
+      deliveryContext && typeof deliveryContext.to === "string" ? deliveryContext.to : undefined;
+    const dcAccountId =
+      deliveryContext && typeof deliveryContext.accountId === "string"
+        ? deliveryContext.accountId
+        : undefined;
+    enqueueSystemEvent(message, {
+      sessionKey,
+      ...(dcChannel ||
+      dcTo ||
+      dcAccountId ||
+      task.channel ||
+      task.to ||
+      task.accountId ||
+      task.threadId
+        ? {
+            deliveryContext: {
+              ...(dcChannel ? { channel: dcChannel } : {}),
+              ...(dcTo ? { to: dcTo } : {}),
+              ...(dcAccountId ? { accountId: dcAccountId } : {}),
+              ...(task.channel ? { channel: task.channel } : {}),
+              ...(task.to ? { to: task.to } : {}),
+              ...(task.accountId ? { accountId: task.accountId } : {}),
+              ...(task.threadId ? { threadId: task.threadId } : {}),
+            },
+          }
+        : {}),
+    });
+    requestHeartbeatNow({ reason: "gateway.restart.outbox", sessionKey });
+  }
+}
+
 export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const sentinel = await consumeRestartSentinel();
   if (!sentinel) {
     return;
   }
   const payload = sentinel.payload;
+  executePersistedRestartOutbox(payload.outbox);
   const sessionKey = payload.sessionKey?.trim();
   const message = formatRestartSentinelMessage(payload);
   const summary = summarizeRestartSentinel(payload);

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -55,6 +55,10 @@ export type RestartSentinelPayload = {
   kind: "config-apply" | "config-patch" | "update" | "restart";
   status: "ok" | "error" | "skipped";
   ts: number;
+  reason?: string;
+  initiator?: string;
+  restartId?: string;
+  correlationId?: string;
   sessionKey?: string;
   /** Delivery context captured at restart time to ensure channel routing survives restart. */
   deliveryContext?: {

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -17,6 +17,30 @@ export type RestartSentinelStep = {
   log?: RestartSentinelLog | null;
 };
 
+export type RestartOutboxTask =
+  | {
+      kind: "notify-session";
+      sessionKey?: string;
+      message: string;
+      channel?: string;
+      to?: string;
+      accountId?: string;
+      threadId?: string;
+    }
+  | {
+      kind: "message" | "system_event";
+      message: string;
+      sessionKey?: string;
+      threadId?: string;
+      deliveryContext?: {
+        channel?: string;
+        to?: string;
+        accountId?: string;
+      };
+      restartId?: string;
+      correlationId?: string;
+    };
+
 export type RestartSentinelStats = {
   mode?: string;
   root?: string;
@@ -40,9 +64,11 @@ export type RestartSentinelPayload = {
   };
   /** Thread ID for reply threading (e.g., Slack thread_ts). */
   threadId?: string;
+  outbox?: RestartOutboxTask[];
   message?: string | null;
   doctorHint?: string | null;
   stats?: RestartSentinelStats | null;
+  suppressPrimaryNotice?: boolean;
 };
 
 export type RestartSentinel = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the original lifecycle hook PR (#12582) stalled and only emits `gateway:shutdown` / `gateway:pre-restart` without correlation metadata or a built-in post-restart task path.
- Why it matters: operators/agents still hit a “silent restart gap” where users lose confidence because no deterministic post-restart confirmation can be queued and delivered.
- What changed: revived #12582 on current `main`, added lifecycle correlation metadata (`restartId`, `correlationId`, `initiator`), per-handler shutdown hook timeouts, typed restart outbox tasks, and optional `gateway:post-restart` event.
- What did NOT change (scope boundary): no new external APIs/endpoints, no channel protocol changes, no forced behavior for existing hooks; all fields are additive/optional.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #6711
- Related #31156
- Related #12582 (revived)
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: lifecycle hooks existed at startup only; shutdown hooks lacked structured restart metadata and had no first-class post-restart task mechanism.
- Missing detection / guardrail: no deterministic correlation (`restartId`) and no typed handoff queue from pre-restart to startup.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #12582 introduced shutdown/pre-restart signals, but stopped before correlation + task execution semantics.
- Why this regressed now: as deployments rely more on automation, restart UX gaps (silent windows) became operationally visible.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server-close.test.ts`
  - `src/gateway/server-restart-sentinel.test.ts`
  - `src/cli/gateway-cli/run-loop.test.ts`
  - `src/infra/infra-runtime.test.ts`
  - `src/hooks/internal-hooks.test.ts`
- Scenario the test should lock in:
  - pre-restart emits metadata and persists outbox
  - outbox executes on startup with restart guards
  - handler timeouts do not block shutdown pipeline
  - initiator metadata is propagated from scheduler to run loop
- Why this is the smallest reliable guardrail: these files sit exactly at lifecycle boundaries where regressions appeared.
- Existing test that already covers this (if any): existing gateway close/startup tests were extended.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Internal hook payloads for gateway lifecycle now include richer metadata.
- Hooks can push typed outbox tasks (`message`, `system_event`) during pre-restart.
- Optional new internal event: `gateway:post-restart` with execution stats.
- Slow shutdown hooks are bounded by per-handler timeout (best-effort, non-fatal).

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[restart requested] -> [gateway close] -> [startup]
                     (no correlated handoff)

After:
[restart requested]
  -> [gateway:shutdown + metadata]
  -> [gateway:pre-restart + outbox append]
  -> [persist sentinel(outbox, restartId)]
  -> [startup]
  -> [consume sentinel, execute guarded outbox]
  -> [gateway:post-restart stats]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) — No
- Secrets/tokens handling changed? (`Yes/No`) — No
- New/changed network calls? (`Yes/No`) — No
- Command/tool execution surface changed? (`Yes/No`) — No
- Data access scope changed? (`Yes/No`) — No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 (VPS)
- Runtime/container: Node 24.13.1, pnpm (corepack)
- Model/provider: N/A
- Integration/channel (if any): Telegram routing paths covered by existing restart-sentinel tests
- Relevant config (redacted): default + gateway restart-enabled setup

### Steps

1. Register `gateway:pre-restart` hook and append outbox task(s) with `restartId` guards.
2. Trigger restart via scheduler/tool path.
3. Confirm startup consumes sentinel, executes outbox tasks, and emits `gateway:post-restart`.

### Expected

- Restart metadata preserved end-to-end.
- Outbox tasks execute only for matching restart/correlation IDs.
- Hook stalls do not block shutdown indefinitely.

### Actual

- Matches expected; tests pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `vitest.gateway`: `server-close`, `server-restart-sentinel`, `server-startup`
  - `vitest.unit`: `run-loop`, `infra-runtime`, `internal-hooks`
- Edge cases checked:
  - outbox restartId mismatch skip
  - no-session fallback routing
  - SIGUSR1 external path and scheduler path
  - slow handler timeout continuation
- What you did **not** verify:
  - full end-to-end real-channel restart in this PR branch on production instance

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) — Yes
- Config/env changes? (`Yes/No`) — No
- Migration needed? (`Yes/No`) — No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: hook timeouts may hide a slow custom hook that previously completed eventually.
  - Mitigation: timeout is best-effort only and scoped to shutdown lifecycle; errors are logged, shutdown proceeds safely.
- Risk: outbox misuse by hook authors (invalid tasks).
  - Mitigation: normalization + guard checks + non-fatal skips for malformed tasks.
- Risk: duplicate/misrouted notices if session delivery context is stale.
  - Mitigation: existing merge logic prefers sentinel-captured routing and keeps session fallback behavior.

---

## Original PR context (#12582)

Original title: **feat(hooks): emit gateway shutdown lifecycle events**

Original motivation was to expose explicit shutdown boundaries for automation and uptime tooling.  
This revival keeps that intent and extends it with restart correlation + deterministic post-restart task execution, while preserving additive/backward-compatible semantics.
