### PR TITLE
fix: web_search fails with transparent proxies when no proxy env vars are set

### DIFF
--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -57,6 +57,49 @@ describe("pi tool definition adapter", () => {
     });
   });
 
+  it("includes error cause chain in tool error messages", async () => {
+    const innerCause = new Error("ENOTFOUND api.search.brave.com");
+    const outerCause = new TypeError("fetch failed", { cause: innerCause });
+
+    const tool = {
+      name: "web_search",
+      label: "Web Search",
+      description: "throws with cause chain",
+      parameters: Type.Object({}),
+      execute: async () => {
+        throw outerCause;
+      },
+    } satisfies AgentTool;
+
+    const result = await executeTool(tool, "call-cause");
+    const details = result.details as { error?: string };
+    expect(details.error).toContain("fetch failed");
+    expect(details.error).toContain("ENOTFOUND api.search.brave.com");
+    expect(details.error).toContain("cause:");
+  });
+
+  it("includes deeply nested error cause chain (max 3 levels)", async () => {
+    const level3 = new Error("connection refused");
+    const level2 = new Error("connect ECONNREFUSED", { cause: level3 });
+    const level1 = new TypeError("fetch failed", { cause: level2 });
+
+    const tool = {
+      name: "web_search",
+      label: "Web Search",
+      description: "throws with deep cause chain",
+      parameters: Type.Object({}),
+      execute: async () => {
+        throw level1;
+      },
+    } satisfies AgentTool;
+
+    const result = await executeTool(tool, "call-deep-cause");
+    const details = result.details as { error?: string };
+    expect(details.error).toContain("fetch failed");
+    expect(details.error).toContain("connect ECONNREFUSED");
+    expect(details.error).toContain("connection refused");
+  });
+
   it("coerces details-only tool results to include content", async () => {
     const tool = {
       name: "memory_query",

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -52,12 +52,39 @@ function isLegacyToolExecuteArgs(args: ToolExecuteArgsAny): args is ToolExecuteA
   return isAbortSignal(fifth);
 }
 
+/**
+ * Walk the `.cause` chain (max depth 3) and return a human-readable summary.
+ * Many network errors (e.g. undici `TypeError: fetch failed`) store the
+ * actionable detail in nested `.cause` properties that would otherwise be lost.
+ */
+function describeCauseChain(err: Error, maxDepth = 3): string | undefined {
+  const parts: string[] = [];
+  let current: unknown = err.cause;
+  for (let i = 0; i < maxDepth && current; i++) {
+    if (current instanceof Error) {
+      if (current.message?.trim()) {
+        parts.push(current.message);
+      }
+      current = current.cause;
+    } else {
+      const desc = typeof current === "string" ? current : JSON.stringify(current);
+      if (desc?.trim()) {
+        parts.push(desc);
+      }
+      break;
+    }
+  }
+  return parts.length > 0 ? parts.join(" → ") : undefined;
+}
+
 function describeToolExecutionError(err: unknown): {
   message: string;
   stack?: string;
 } {
   if (err instanceof Error) {
-    const message = err.message?.trim() ? err.message : String(err);
+    const base = err.message?.trim() ? err.message : String(err);
+    const causeDetail = describeCauseChain(err);
+    const message = causeDetail ? `${base} (cause: ${causeDetail})` : base;
     return { message, stack: err.stack };
   }
   return { message: String(err) };

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -734,4 +734,29 @@ describe("fetchWithSsrFGuard hardening", () => {
       expectEnvProxy: true,
     });
   });
+
+  it("skips pinned dispatcher in trusted proxy mode when no proxy env vars are set", async () => {
+    // Simulates transparent proxy setups (e.g. Proxifier + V2Ray) where no
+    // HTTP_PROXY / HTTPS_PROXY env vars exist. The default fetch path should
+    // be used so the OS / transparent proxy can intercept the connection.
+    const lookupFn = createPublicLookup();
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const requestInit = init as RequestInit & { dispatcher?: unknown };
+      // No dispatcher should be attached — globalThis.fetch default path
+      expect(requestInit.dispatcher).toBeUndefined();
+      return okResponse();
+    });
+
+    const result = await fetchWithSsrFGuard({
+      url: "https://api.search.brave.com/res/v1/web/search",
+      fetchImpl,
+      lookupFn,
+      mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // lookupFn should NOT have been called — DNS pinning is skipped entirely
+    expect(lookupFn).not.toHaveBeenCalled();
+    await result.release();
+  });
 });

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -279,19 +279,31 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
     try {
       assertExplicitProxySupportsPinnedDns(parsedUrl, params.dispatcherPolicy, params.pinDns);
       await assertExplicitProxyAllowed(params.dispatcherPolicy, params.lookupFn, params.policy);
-      const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
-        lookupFn: params.lookupFn,
-        policy: params.policy,
-      });
-      const canUseTrustedEnvProxy =
-        mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
-      if (canUseTrustedEnvProxy) {
-        const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
-        dispatcher = new EnvHttpProxyAgent();
-      } else if (params.pinDns === false) {
-        dispatcher = createPolicyDispatcherWithoutPinnedDns(params.dispatcherPolicy);
+
+      if (mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY) {
+        // Trusted-endpoint mode (web_search, operator-controlled URLs):
+        // - With explicit proxy env vars: route through EnvHttpProxyAgent.
+        // - Without proxy env vars: skip DNS pinning and custom dispatcher
+        //   entirely so the default fetch path works with system-level
+        //   transparent proxies (e.g. Proxifier, V2Ray) that cannot intercept
+        //   connections made through a custom undici Agent/connect callback.
+        if (hasProxyEnvConfigured()) {
+          const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
+          dispatcher = new EnvHttpProxyAgent();
+        }
+        // else: dispatcher stays null — use globalThis.fetch default path
       } else {
-        dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy, params.policy);
+        // STRICT mode (web_fetch, untrusted user URLs): always pin DNS for
+        // SSRF protection.
+        const pinned = await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+          lookupFn: params.lookupFn,
+          policy: params.policy,
+        });
+        if (params.pinDns === false) {
+          dispatcher = createPolicyDispatcherWithoutPinnedDns(params.dispatcherPolicy);
+        } else {
+          dispatcher = createPinnedDispatcher(pinned, params.dispatcherPolicy, params.policy);
+        }
       }
 
       const init: DispatcherAwareRequestInit = {


### PR DESCRIPTION
## Summary

- **Fix `web_search` failing with `"fetch failed"` when using transparent proxies** (e.g. Proxifier + V2Ray) instead of `HTTP_PROXY`/`HTTPS_PROXY` env vars. In `TRUSTED_ENV_PROXY` mode (used by `web_search`), skip DNS pinning and custom undici dispatcher when no proxy env vars are configured, allowing the default fetch path to work with system-level transparent proxies.
- **Improve tool error diagnostics** by walking the `.cause` chain (up to 3 levels) in `describeToolExecutionError()`. Previously, undici's `TypeError: fetch failed` lost the actual network error (e.g. `ENOTFOUND`, `ECONNREFUSED`) buried in nested `.cause` properties, making debugging very difficult.

## Problem

`fetchWithSsrFGuard()` always created a custom undici `Agent` with a `connect: { lookup: pinnedLookup }` callback for SSRF protection. This custom dispatcher bypasses transparent proxy interception (Proxifier, V2Ray, etc.), causing `web_search` and `web_fetch` to fail with a generic `"fetch failed"` error — while model API calls (which use `globalThis.fetch` with the default dispatcher) work fine through the same proxy.

## Changes

### `src/infra/net/fetch-guard.ts`
- In `TRUSTED_ENV_PROXY` mode (web_search, operator-controlled URLs):
  - With proxy env vars set → route through `EnvHttpProxyAgent` (unchanged)
  - Without proxy env vars → skip DNS pinning entirely, leave dispatcher null, use default `globalThis.fetch` path (new behavior — enables transparent proxy interception)
- In `STRICT` mode (web_fetch, untrusted user URLs): behavior is unchanged — always pins DNS for SSRF protection

### `src/agents/pi-tool-definition-adapter.ts`
- Add `describeCauseChain()` helper that walks `err.cause` up to 3 levels
- Enhance `describeToolExecutionError()` to include cause chain in error messages (e.g. `"fetch failed (cause: connect ECONNREFUSED → connection refused)"`)

### Tests
- New test: `skips pinned dispatcher in trusted proxy mode when no proxy env vars are set` — verifies no dispatcher is attached and `lookupFn` is not called
- New tests: `includes error cause chain in tool error messages` and `includes deeply nested error cause chain (max 3 levels)` — verify cause chain is surfaced in tool error results
- All existing tests pass unchanged

## Security note

This change only affects `TRUSTED_ENV_PROXY` mode (used by `web_search` for operator-controlled API endpoints like Brave Search). `STRICT` mode (used by `web_fetch` for arbitrary user URLs) retains full SSRF DNS pinning protection.