### PR TITLE
fix(cli-backend): detect missing Claude conversations as expired sessions

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -940,6 +940,13 @@ describe("classifyFailoverReason", () => {
       classifyFailoverReason("AWS Bedrock: Too many tokens per day. Please try again tomorrow."),
     ).toBe("rate_limit");
   });
+  it('classifies Claude CLI "No conversation found" errors as session_expired', () => {
+    expect(
+      classifyFailoverReason(
+        "No conversation found with session ID: dfee08ff-0000-4000-8000-000000000000",
+      ),
+    ).toBe("session_expired");
+  });
   it("classifies provider high-demand / service-unavailable messages as overloaded", () => {
     expect(
       classifyFailoverReason(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -1235,6 +1235,7 @@ function isCliSessionExpiredErrorMessage(raw: string): boolean {
     lower.includes("session does not exist") ||
     lower.includes("session expired") ||
     lower.includes("session invalid") ||
+    lower.includes("no conversation found") ||
     lower.includes("conversation not found") ||
     lower.includes("conversation does not exist") ||
     lower.includes("conversation expired") ||


### PR DESCRIPTION
## Summary
- classify Claude CLI `"No conversation found with session ID: ..."` errors as `session_expired`
- let the existing stale-session recovery path clear the dead CLI session id and retry fresh
- add regression coverage for the missing `"no conversation found"` variant

## Why
Claude CLI currently returns `"No conversation found with session ID: ..."` for stale sessions, but `isCliSessionExpiredErrorMessage()` only matched `"conversation not found"`. That leaves the failure classified as `unknown`, so OpenClaw keeps retrying the same dead session id instead of clearing it.

Closes #61390

## Verification
- `pnpm exec vitest run --config vitest.config.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts --testNamePattern "Claude CLI"`
- `pnpm exec oxfmt --check src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`