### PR TITLE
feat(control-ui): add New Session button to chat header with modal

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -896,6 +896,16 @@
   text-overflow: ellipsis;
 }
 
+.chat-controls__new-session {
+  padding: 6px 8px;
+  line-height: 1;
+}
+
+.chat-controls__new-session svg {
+  width: 16px;
+  height: 16px;
+}
+
 .chat-controls__model select {
   max-width: 320px;
 }

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -207,6 +207,15 @@ export function renderChatSessionSelect(state: AppViewState) {
           )}
         </select>
       </label>
+      <button
+        class="btn btn--ghost chat-controls__new-session"
+        title="New session"
+        aria-label="New session"
+        ?disabled=${!state.connected}
+        @click=${() => state.handleNewSessionOpen()}
+      >
+        ${icons.plus}
+      </button>
       ${modelSelect} ${thinkingSelect}
     </div>
   `;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -130,6 +130,7 @@ import { renderDreaming } from "./views/dreaming.ts";
 import { renderExecApprovalPrompt } from "./views/exec-approval.ts";
 import { renderGatewayUrlConfirmation } from "./views/gateway-url-confirmation.ts";
 import { renderLoginGate } from "./views/login-gate.ts";
+import { renderNewSessionModal } from "./views/new-session-modal.ts";
 import { renderOverview } from "./views/overview.ts";
 
 // Lazy-loaded view modules – deferred so the initial bundle stays small.
@@ -2006,7 +2007,8 @@ export function renderApp(state: AppViewState) {
             })
           : nothing}
       </main>
-      ${renderExecApprovalPrompt(state)} ${renderGatewayUrlConfirmation(state)} ${nothing}
+      ${renderExecApprovalPrompt(state)} ${renderGatewayUrlConfirmation(state)}
+      ${renderNewSessionModal(state)} ${nothing}
     </div>
   `;
 }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -114,6 +114,8 @@ export type AppViewState = {
   execApprovalBusy: boolean;
   execApprovalError: string | null;
   pendingGatewayUrl: string | null;
+  newSessionModalOpen: boolean;
+  newSessionName: string;
   configLoading: boolean;
   configRaw: string;
   configRawOriginal: string;
@@ -383,6 +385,9 @@ export type AppViewState = {
     handleExecApprovalDecision: (decision: "allow-once" | "allow-always" | "deny") => Promise<void>;
     handleGatewayUrlConfirm: () => void;
     handleGatewayUrlCancel: () => void;
+    handleNewSessionOpen: () => void;
+    handleNewSessionConfirm: () => Promise<void>;
+    handleNewSessionCancel: () => void;
     handleConfigLoad: () => Promise<void>;
     handleConfigSave: () => Promise<void>;
     handleConfigApply: () => Promise<void>;

--- a/ui/src/ui/app.new-session-fallback.test.ts
+++ b/ui/src/ui/app.new-session-fallback.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { shouldUseOptimisticNewSessionFallback } from "./app.ts";
+import { resolveNewSessionAgentId, shouldUseOptimisticNewSessionFallback } from "./app.ts";
 import { GatewayRequestError } from "./gateway.ts";
+import type { SessionsListResult } from "./types.ts";
+
+function makeSessionsResult(keys: string[]): SessionsListResult {
+  return {
+    ts: 0,
+    path: "sessions.json",
+    count: keys.length,
+    defaults: {
+      modelProvider: null,
+      model: null,
+      contextTokens: null,
+    },
+    sessions: keys.map((key) => ({
+      key,
+      kind: "direct",
+      updatedAt: 0,
+    })),
+  };
+}
 
 describe("shouldUseOptimisticNewSessionFallback", () => {
   it("allows fallback for transport errors", () => {
@@ -29,5 +48,37 @@ describe("shouldUseOptimisticNewSessionFallback", () => {
       message: "missing scope: operator.write",
     });
     expect(shouldUseOptimisticNewSessionFallback(error)).toBe(false);
+  });
+});
+
+describe("resolveNewSessionAgentId", () => {
+  it("uses agent id from active server-known session", () => {
+    const agentId = resolveNewSessionAgentId({
+      sessionKey: "agent:ops:dashboard:abc",
+      sessionsResult: makeSessionsResult(["agent:ops:dashboard:abc"]),
+      assistantAgentId: "main",
+    });
+
+    expect(agentId).toBe("ops");
+  });
+
+  it("ignores URL-injected unknown session keys and falls back to assistant agent", () => {
+    const agentId = resolveNewSessionAgentId({
+      sessionKey: "agent:victim:dashboard:evil",
+      sessionsResult: makeSessionsResult(["agent:trusted:main"]),
+      assistantAgentId: "trusted",
+    });
+
+    expect(agentId).toBe("trusted");
+  });
+
+  it("falls back to main when no trusted source is available", () => {
+    const agentId = resolveNewSessionAgentId({
+      sessionKey: "main",
+      sessionsResult: null,
+      assistantAgentId: null,
+    });
+
+    expect(agentId).toBe("main");
   });
 });

--- a/ui/src/ui/app.new-session-fallback.test.ts
+++ b/ui/src/ui/app.new-session-fallback.test.ts
@@ -81,4 +81,14 @@ describe("resolveNewSessionAgentId", () => {
 
     expect(agentId).toBe("main");
   });
+
+  it("waits for trusted context when active key is scoped to a non-main agent", () => {
+    const agentId = resolveNewSessionAgentId({
+      sessionKey: "agent:ops:dashboard:pending",
+      sessionsResult: null,
+      assistantAgentId: null,
+    });
+
+    expect(agentId).toBeNull();
+  });
 });

--- a/ui/src/ui/app.new-session-fallback.test.ts
+++ b/ui/src/ui/app.new-session-fallback.test.ts
@@ -26,12 +26,12 @@ describe("shouldUseOptimisticNewSessionFallback", () => {
     expect(shouldUseOptimisticNewSessionFallback(new Error("gateway not connected"))).toBe(true);
   });
 
-  it("allows fallback for unavailable gateway responses", () => {
+  it("rejects fallback for unavailable gateway responses", () => {
     const error = new GatewayRequestError({
       code: "UNAVAILABLE",
       message: "temporary failure",
     });
-    expect(shouldUseOptimisticNewSessionFallback(error)).toBe(true);
+    expect(shouldUseOptimisticNewSessionFallback(error)).toBe(false);
   });
 
   it("allows fallback for compatibility unknown-method failures", () => {
@@ -62,14 +62,24 @@ describe("resolveNewSessionAgentId", () => {
     expect(agentId).toBe("ops");
   });
 
-  it("ignores URL-injected unknown session keys and falls back to assistant agent", () => {
+  it("normalizes agent id from an active server-known session key", () => {
+    const agentId = resolveNewSessionAgentId({
+      sessionKey: "agent:ops$$:dashboard:abc",
+      sessionsResult: makeSessionsResult(["agent:ops$$:dashboard:abc"]),
+      assistantAgentId: "main",
+    });
+
+    expect(agentId).toBe("ops");
+  });
+
+  it("ignores URL-injected unknown non-main keys and waits for trusted context", () => {
     const agentId = resolveNewSessionAgentId({
       sessionKey: "agent:victim:dashboard:evil",
       sessionsResult: makeSessionsResult(["agent:trusted:main"]),
       assistantAgentId: "trusted",
     });
 
-    expect(agentId).toBe("trusted");
+    expect(agentId).toBeNull();
   });
 
   it("falls back to main when no trusted source is available", () => {
@@ -87,6 +97,16 @@ describe("resolveNewSessionAgentId", () => {
       sessionKey: "agent:ops:dashboard:pending",
       sessionsResult: null,
       assistantAgentId: null,
+    });
+
+    expect(agentId).toBeNull();
+  });
+
+  it("defers assistant fallback when current key is an untrusted non-main scoped key", () => {
+    const agentId = resolveNewSessionAgentId({
+      sessionKey: "agent:ops:dashboard:pending",
+      sessionsResult: null,
+      assistantAgentId: "trusted",
     });
 
     expect(agentId).toBeNull();

--- a/ui/src/ui/app.new-session-fallback.test.ts
+++ b/ui/src/ui/app.new-session-fallback.test.ts
@@ -92,6 +92,16 @@ describe("resolveNewSessionAgentId", () => {
     expect(agentId).toBe("main");
   });
 
+  it("does not use assistant fallback for unscoped/main keys", () => {
+    const agentId = resolveNewSessionAgentId({
+      sessionKey: "main",
+      sessionsResult: null,
+      assistantAgentId: "ops",
+    });
+
+    expect(agentId).toBe("main");
+  });
+
   it("waits for trusted context when active key is scoped to a non-main agent", () => {
     const agentId = resolveNewSessionAgentId({
       sessionKey: "agent:ops:dashboard:pending",

--- a/ui/src/ui/app.new-session-fallback.test.ts
+++ b/ui/src/ui/app.new-session-fallback.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { shouldUseOptimisticNewSessionFallback } from "./app.ts";
+import { GatewayRequestError } from "./gateway.ts";
+
+describe("shouldUseOptimisticNewSessionFallback", () => {
+  it("allows fallback for transport errors", () => {
+    expect(shouldUseOptimisticNewSessionFallback(new Error("gateway not connected"))).toBe(true);
+  });
+
+  it("allows fallback for unavailable gateway responses", () => {
+    const error = new GatewayRequestError({
+      code: "UNAVAILABLE",
+      message: "temporary failure",
+    });
+    expect(shouldUseOptimisticNewSessionFallback(error)).toBe(true);
+  });
+
+  it("allows fallback for compatibility unknown-method failures", () => {
+    const error = new GatewayRequestError({
+      code: "INVALID_REQUEST",
+      message: "unknown method: sessions.create",
+    });
+    expect(shouldUseOptimisticNewSessionFallback(error)).toBe(true);
+  });
+
+  it("rejects fallback for authorization/scope failures", () => {
+    const error = new GatewayRequestError({
+      code: "INVALID_REQUEST",
+      message: "missing scope: operator.write",
+    });
+    expect(shouldUseOptimisticNewSessionFallback(error)).toBe(false);
+  });
+});

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -139,13 +139,23 @@ export function resolveNewSessionAgentId(params: {
   sessionKey: string;
   sessionsResult: OpenClawApp["sessionsResult"];
   assistantAgentId: string | null;
-}): string {
+}): string | null {
   const activeSessionExists =
     params.sessionsResult?.sessions?.some((row) => row.key === params.sessionKey) ?? false;
   const sessionAgentId = activeSessionExists
     ? parseAgentSessionKey(params.sessionKey)?.agentId
     : null;
-  return sessionAgentId ?? params.assistantAgentId ?? "main";
+  if (sessionAgentId) {
+    return sessionAgentId;
+  }
+  if (params.assistantAgentId) {
+    return params.assistantAgentId;
+  }
+  const scopedSessionAgentId = parseAgentSessionKey(params.sessionKey)?.agentId;
+  if (scopedSessionAgentId && scopedSessionAgentId !== "main") {
+    return null;
+  }
+  return "main";
 }
 
 function resolveOnboardingMode(): boolean {
@@ -817,13 +827,17 @@ export class OpenClawApp extends LitElement {
     if (!name) {
       return;
     }
-    this.newSessionModalOpen = false;
-    this.newSessionName = "";
     const agentId = resolveNewSessionAgentId({
       sessionKey: this.sessionKey,
       sessionsResult: this.sessionsResult,
       assistantAgentId: this.assistantAgentId,
     });
+    if (!agentId) {
+      this.lastError = "Still loading agent context. Try again in a moment.";
+      return;
+    }
+    this.newSessionModalOpen = false;
+    this.newSessionName = "";
     const newKey = buildAgentMainSessionKey({
       agentId,
       mainKey: buildDashboardSessionMainKey({

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -135,6 +135,19 @@ export function shouldUseOptimisticNewSessionFallback(error: unknown): boolean {
   return normalizeLowercaseStringOrEmpty(error.message).includes("unknown method");
 }
 
+export function resolveNewSessionAgentId(params: {
+  sessionKey: string;
+  sessionsResult: OpenClawApp["sessionsResult"];
+  assistantAgentId: string | null;
+}): string {
+  const activeSessionExists =
+    params.sessionsResult?.sessions?.some((row) => row.key === params.sessionKey) ?? false;
+  const sessionAgentId = activeSessionExists
+    ? parseAgentSessionKey(params.sessionKey)?.agentId
+    : null;
+  return sessionAgentId ?? params.assistantAgentId ?? "main";
+}
+
 function resolveOnboardingMode(): boolean {
   if (!window.location.search) {
     return false;
@@ -806,8 +819,11 @@ export class OpenClawApp extends LitElement {
     }
     this.newSessionModalOpen = false;
     this.newSessionName = "";
-    const sessionAgentId = parseAgentSessionKey(this.sessionKey)?.agentId;
-    const agentId = sessionAgentId ?? this.assistantAgentId ?? "main";
+    const agentId = resolveNewSessionAgentId({
+      sessionKey: this.sessionKey,
+      sessionsResult: this.sessionsResult,
+      assistantAgentId: this.assistantAgentId,
+    });
     const newKey = buildAgentMainSessionKey({
       agentId,
       mainKey: buildDashboardSessionMainKey({
@@ -819,6 +835,7 @@ export class OpenClawApp extends LitElement {
       try {
         const result = (await this.client.request("sessions.create", {
           key: newKey,
+          agentId,
           label: name,
         })) as {
           ok: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -830,8 +830,27 @@ export class OpenClawApp extends LitElement {
       sessionsResult: this.sessionsResult,
       assistantAgentId: this.assistantAgentId,
     });
-    if (!agentId && !this.sessionsResult && this.client && this.connected) {
-      await loadSessionsInternal(this as Parameters<typeof loadSessionsInternal>[0]);
+    const scopedSessionAgentId = parseAgentSessionKey(this.sessionKey)?.agentId;
+    const normalizedScopedSessionAgentId = scopedSessionAgentId
+      ? normalizeAgentId(scopedSessionAgentId)
+      : null;
+    const activeSessionMissingFromList =
+      this.sessionsResult?.sessions?.every((row) => row.key !== this.sessionKey) ?? false;
+    const shouldRetrySessionLookup =
+      !agentId &&
+      this.client &&
+      this.connected &&
+      (!this.sessionsResult ||
+        (normalizedScopedSessionAgentId !== null &&
+          normalizedScopedSessionAgentId !== "main" &&
+          activeSessionMissingFromList));
+    if (shouldRetrySessionLookup) {
+      await loadSessionsInternal(this as Parameters<typeof loadSessionsInternal>[0], {
+        activeMinutes: 0,
+        limit: 0,
+        includeGlobal: true,
+        includeUnknown: true,
+      });
       agentId = resolveNewSessionAgentId({
         sessionKey: this.sessionKey,
         sessionsResult: this.sessionsResult,

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -79,6 +79,7 @@ import type { Tab } from "./navigation.ts";
 import {
   buildAgentMainSessionKey,
   buildDashboardSessionMainKey,
+  parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "./session-key.ts";
 import type { SidebarContent } from "./sidebar-content.ts";
@@ -791,8 +792,8 @@ export class OpenClawApp extends LitElement {
     }
     this.newSessionModalOpen = false;
     this.newSessionName = "";
-    const agentId =
-      resolveAgentIdFromSessionKey(this.sessionKey) || this.assistantAgentId || "main";
+    const sessionAgentId = parseAgentSessionKey(this.sessionKey)?.agentId;
+    const agentId = sessionAgentId ?? this.assistantAgentId ?? "main";
     const newKey = buildAgentMainSessionKey({
       agentId,
       mainKey: buildDashboardSessionMainKey({

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -69,6 +69,7 @@ import type {
 } from "./controllers/dreaming.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import type { ExecApprovalsFile, ExecApprovalsSnapshot } from "./controllers/exec-approvals.ts";
+import { loadSessions as loadSessionsInternal } from "./controllers/sessions.ts";
 import type {
   ClawHubSearchResult,
   ClawHubSkillDetail,
@@ -823,11 +824,19 @@ export class OpenClawApp extends LitElement {
     if (!name) {
       return;
     }
-    const agentId = resolveNewSessionAgentId({
+    let agentId = resolveNewSessionAgentId({
       sessionKey: this.sessionKey,
       sessionsResult: this.sessionsResult,
       assistantAgentId: this.assistantAgentId,
     });
+    if (!agentId && !this.sessionsResult && this.client && this.connected) {
+      await loadSessionsInternal(this as Parameters<typeof loadSessionsInternal>[0]);
+      agentId = resolveNewSessionAgentId({
+        sessionKey: this.sessionKey,
+        sessionsResult: this.sessionsResult,
+        assistantAgentId: this.assistantAgentId,
+      });
+    }
     if (!agentId) {
       this.lastError = "Still loading agent context. Try again in a moment.";
       return;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -87,6 +87,7 @@ import {
 } from "./session-key.ts";
 import type { SidebarContent } from "./sidebar-content.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
 import { VALID_THEME_NAMES, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
 import type {
   AgentsListResult,
@@ -850,35 +851,36 @@ export class OpenClawApp extends LitElement {
         uniqueId: generateUUID(),
       }),
     });
-    if (this.client && this.connected) {
-      try {
-        const result = (await this.client.request("sessions.create", {
-          key: newKey,
-          agentId,
-          label: name,
-        })) as {
-          ok: boolean;
-          key?: string;
-        };
-        if (result?.ok && result.key) {
-          switchChatSession(this as Parameters<typeof switchChatSession>[0], result.key);
-          return;
-        }
-      } catch (error) {
-        if (shouldUseOptimisticNewSessionFallback(error)) {
-          switchChatSession(this as Parameters<typeof switchChatSession>[0], newKey);
-          return;
-        }
-        this.lastError =
-          error instanceof Error
-            ? `Failed to create session: ${error.message}`
-            : "Failed to create session";
-        return;
-      }
-      this.lastError = "Failed to create session";
+    if (!this.client || !this.connected) {
+      this.lastError = "Disconnected before creating session. Reconnect and try again.";
       return;
     }
-    switchChatSession(this as Parameters<typeof switchChatSession>[0], newKey);
+    try {
+      const result = (await this.client.request("sessions.create", {
+        key: newKey,
+        agentId,
+        label: name,
+      })) as {
+        ok: boolean;
+        key?: string;
+      };
+      if (result?.ok && result.key) {
+        switchChatSession(this as Parameters<typeof switchChatSession>[0], result.key);
+        return;
+      }
+    } catch (error) {
+      if (shouldUseOptimisticNewSessionFallback(error)) {
+        switchChatSession(this as Parameters<typeof switchChatSession>[0], newKey);
+        return;
+      }
+      this.lastError =
+        error instanceof Error
+          ? `Failed to create session: ${error.message}`
+          : "Failed to create session";
+      return;
+    }
+    this.lastError = "Failed to create session";
+    return;
   }
 
   handleNewSessionCancel() {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -1,6 +1,5 @@
 import { LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { resolveAgentIdFromSessionKey } from "../../../src/routing/session-key.js";
 import { i18n, I18nController, isSupportedLocale } from "../i18n/index.ts";
 import {
   handleChannelConfigReload as handleChannelConfigReloadInternal,
@@ -77,7 +76,11 @@ import type {
 } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
-import { buildAgentMainSessionKey, resolveAgentIdFromSessionKey } from "./session-key.ts";
+import {
+  buildAgentMainSessionKey,
+  buildDashboardSessionMainKey,
+  resolveAgentIdFromSessionKey,
+} from "./session-key.ts";
 import type { SidebarContent } from "./sidebar-content.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
 import { VALID_THEME_NAMES, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
@@ -783,16 +786,22 @@ export class OpenClawApp extends LitElement {
 
   async handleNewSessionConfirm() {
     const name = this.newSessionName.trim();
+    if (!name) {
+      return;
+    }
     this.newSessionModalOpen = false;
     this.newSessionName = "";
-    if (name) {
-      const agentId = this.agentsSelectedId ?? this.assistantAgentId ?? "main";
-      const sessionName = name.toLowerCase().replace(/\s+/g, "-");
-      const newKey = buildAgentMainSessionKey({
-        agentId,
-        mainKey: `dashboard:${sessionName}`,
-      });
-      if (this.client && this.connected) {
+    const agentId =
+      resolveAgentIdFromSessionKey(this.sessionKey) || this.assistantAgentId || "main";
+    const newKey = buildAgentMainSessionKey({
+      agentId,
+      mainKey: buildDashboardSessionMainKey({
+        name,
+        uniqueId: generateUUID(),
+      }),
+    });
+    if (this.client && this.connected) {
+      try {
         const result = (await this.client.request("sessions.create", { key: newKey })) as {
           ok: boolean;
           key?: string;
@@ -801,9 +810,11 @@ export class OpenClawApp extends LitElement {
           switchChatSession(this as Parameters<typeof switchChatSession>[0], result.key);
           return;
         }
+      } catch {
+        // fall through to optimistic local switch when RPC fails
       }
-      switchChatSession(this as Parameters<typeof switchChatSession>[0], newKey);
     }
+    switchChatSession(this as Parameters<typeof switchChatSession>[0], newKey);
   }
 
   handleNewSessionCancel() {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -151,9 +151,6 @@ export function resolveNewSessionAgentId(params: {
   if (normalizedScopedSessionAgentId && normalizedScopedSessionAgentId !== "main") {
     return null;
   }
-  if (params.assistantAgentId) {
-    return normalizeAgentId(params.assistantAgentId);
-  }
   return "main";
 }
 

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -29,6 +29,7 @@ import {
   handleFirstUpdated,
   handleUpdated,
 } from "./app-lifecycle.ts";
+import { switchChatSession } from "./app-render.helpers.ts";
 import { renderApp } from "./app-render.ts";
 import {
   exportLogs as exportLogsInternal,
@@ -215,6 +216,9 @@ export class OpenClawApp extends LitElement {
   @state() execApprovalError: string | null = null;
   @state() pendingGatewayUrl: string | null = null;
   pendingGatewayToken: string | null = null;
+
+  @state() newSessionModalOpen = false;
+  @state() newSessionName = "";
 
   @state() configLoading = false;
   @state() configRaw = "{\n}\n";
@@ -769,6 +773,38 @@ export class OpenClawApp extends LitElement {
   handleGatewayUrlCancel() {
     this.pendingGatewayUrl = null;
     this.pendingGatewayToken = null;
+  }
+
+  handleNewSessionOpen() {
+    this.newSessionModalOpen = true;
+    this.newSessionName = "";
+  }
+
+  async handleNewSessionConfirm() {
+    const name = this.newSessionName.trim();
+    this.newSessionModalOpen = false;
+    this.newSessionName = "";
+    if (name) {
+      const agentId = this.agentsSelectedId ?? this.assistantAgentId ?? "main";
+      const sessionName = name.toLowerCase().replace(/\s+/g, "-");
+      const newKey = `${agentId}:dashboard:${sessionName}`;
+      if (this.client && this.connected) {
+        const result = (await this.client.request("sessions.create", { key: newKey })) as {
+          ok: boolean;
+          key?: string;
+        };
+        if (result?.ok && result.key) {
+          switchChatSession(this as Parameters<typeof switchChatSession>[0], result.key);
+          return;
+        }
+      }
+      switchChatSession(this as Parameters<typeof switchChatSession>[0], newKey);
+    }
+  }
+
+  handleNewSessionCancel() {
+    this.newSessionModalOpen = false;
+    this.newSessionName = "";
   }
 
   // Sidebar handlers for tool output viewing

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -80,6 +80,7 @@ import type { Tab } from "./navigation.ts";
 import {
   buildAgentMainSessionKey,
   buildDashboardSessionMainKey,
+  normalizeAgentId,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "./session-key.ts";
@@ -126,9 +127,6 @@ export function shouldUseOptimisticNewSessionFallback(error: unknown): boolean {
   if (!(error instanceof GatewayRequestError)) {
     return true;
   }
-  if (error.gatewayCode === "UNAVAILABLE" || error.gatewayCode === "TIMEOUT") {
-    return true;
-  }
   if (error.gatewayCode !== "INVALID_REQUEST") {
     return false;
   }
@@ -140,20 +138,21 @@ export function resolveNewSessionAgentId(params: {
   sessionsResult: OpenClawApp["sessionsResult"];
   assistantAgentId: string | null;
 }): string | null {
+  const scopedSessionAgentId = parseAgentSessionKey(params.sessionKey)?.agentId;
+  const normalizedScopedSessionAgentId = scopedSessionAgentId
+    ? normalizeAgentId(scopedSessionAgentId)
+    : null;
   const activeSessionExists =
     params.sessionsResult?.sessions?.some((row) => row.key === params.sessionKey) ?? false;
-  const sessionAgentId = activeSessionExists
-    ? parseAgentSessionKey(params.sessionKey)?.agentId
-    : null;
+  const sessionAgentId = activeSessionExists ? normalizedScopedSessionAgentId : null;
   if (sessionAgentId) {
     return sessionAgentId;
   }
-  if (params.assistantAgentId) {
-    return params.assistantAgentId;
-  }
-  const scopedSessionAgentId = parseAgentSessionKey(params.sessionKey)?.agentId;
-  if (scopedSessionAgentId && scopedSessionAgentId !== "main") {
+  if (normalizedScopedSessionAgentId && normalizedScopedSessionAgentId !== "main") {
     return null;
+  }
+  if (params.assistantAgentId) {
+    return normalizeAgentId(params.assistantAgentId);
   }
   return "main";
 }

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -77,6 +77,7 @@ import type {
 } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
+import { buildAgentMainSessionKey, resolveAgentIdFromSessionKey } from "./session-key.ts";
 import type { SidebarContent } from "./sidebar-content.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
 import { VALID_THEME_NAMES, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
@@ -787,7 +788,10 @@ export class OpenClawApp extends LitElement {
     if (name) {
       const agentId = this.agentsSelectedId ?? this.assistantAgentId ?? "main";
       const sessionName = name.toLowerCase().replace(/\s+/g, "-");
-      const newKey = `${agentId}:dashboard:${sessionName}`;
+      const newKey = buildAgentMainSessionKey({
+        agentId,
+        mainKey: `dashboard:${sessionName}`,
+      });
       if (this.client && this.connected) {
         const result = (await this.client.request("sessions.create", { key: newKey })) as {
           ok: boolean;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -817,7 +817,10 @@ export class OpenClawApp extends LitElement {
     });
     if (this.client && this.connected) {
       try {
-        const result = (await this.client.request("sessions.create", { key: newKey })) as {
+        const result = (await this.client.request("sessions.create", {
+          key: newKey,
+          label: name,
+        })) as {
           ok: boolean;
           key?: string;
         };

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -75,6 +75,7 @@ import type {
   SkillMessage,
 } from "./controllers/skills.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
+import { GatewayRequestError } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import {
   buildAgentMainSessionKey,
@@ -120,6 +121,19 @@ declare global {
 }
 
 const bootAssistantIdentity = normalizeAssistantIdentity({});
+
+export function shouldUseOptimisticNewSessionFallback(error: unknown): boolean {
+  if (!(error instanceof GatewayRequestError)) {
+    return true;
+  }
+  if (error.gatewayCode === "UNAVAILABLE" || error.gatewayCode === "TIMEOUT") {
+    return true;
+  }
+  if (error.gatewayCode !== "INVALID_REQUEST") {
+    return false;
+  }
+  return normalizeLowercaseStringOrEmpty(error.message).includes("unknown method");
+}
 
 function resolveOnboardingMode(): boolean {
   if (!window.location.search) {
@@ -811,9 +825,19 @@ export class OpenClawApp extends LitElement {
           switchChatSession(this as Parameters<typeof switchChatSession>[0], result.key);
           return;
         }
-      } catch {
-        // fall through to optimistic local switch when RPC fails
+      } catch (error) {
+        if (shouldUseOptimisticNewSessionFallback(error)) {
+          switchChatSession(this as Parameters<typeof switchChatSession>[0], newKey);
+          return;
+        }
+        this.lastError =
+          error instanceof Error
+            ? `Failed to create session: ${error.message}`
+            : "Failed to create session";
+        return;
       }
+      this.lastError = "Failed to create session";
+      return;
     }
     switchChatSession(this as Parameters<typeof switchChatSession>[0], newKey);
   }

--- a/ui/src/ui/session-key.test.ts
+++ b/ui/src/ui/session-key.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   buildAgentMainSessionKey,
   buildDashboardSessionMainKey,
+  normalizeDashboardSessionPart,
+  normalizeDashboardSessionUniqueId,
   resolveAgentIdFromSessionKey,
 } from "./session-key.ts";
 
@@ -50,5 +52,33 @@ describe("buildDashboardSessionMainKey", () => {
     });
 
     expect(key).toBe("dashboard:my-session-name:abc");
+  });
+
+  it("sanitizes reserved delimiters and invalid characters", () => {
+    const key = buildDashboardSessionMainKey({
+      name: "foo:bar/baz",
+      uniqueId: "abc:def",
+    });
+
+    expect(key).toBe("dashboard:foo-bar-baz:abc-def");
+  });
+
+  it("bounds overlong names to a safe length", () => {
+    const overlong = "a".repeat(200);
+    const key = buildDashboardSessionMainKey({
+      name: overlong,
+      uniqueId: "id",
+    });
+    expect(key).toBe(`dashboard:${"a".repeat(64)}:id`);
+  });
+});
+
+describe("dashboard key normalizers", () => {
+  it("falls back to session for empty/invalid name parts", () => {
+    expect(normalizeDashboardSessionPart(":::")).toBe("session");
+  });
+
+  it("falls back to id for empty unique ids", () => {
+    expect(normalizeDashboardSessionUniqueId("   ")).toBe("id");
   });
 });

--- a/ui/src/ui/session-key.test.ts
+++ b/ui/src/ui/session-key.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildAgentMainSessionKey, resolveAgentIdFromSessionKey } from "./session-key.ts";
+import {
+  buildAgentMainSessionKey,
+  buildDashboardSessionMainKey,
+  resolveAgentIdFromSessionKey,
+} from "./session-key.ts";
 
 describe("buildAgentMainSessionKey", () => {
   it("keeps the selected agent in dashboard session keys", () => {
@@ -20,5 +24,31 @@ describe("buildAgentMainSessionKey", () => {
 
     expect(key).toBe("agent:main:dashboard:new-session");
     expect(resolveAgentIdFromSessionKey(key)).toBe("main");
+  });
+});
+
+describe("buildDashboardSessionMainKey", () => {
+  it("includes a unique suffix to avoid collisions for repeated names", () => {
+    const first = buildDashboardSessionMainKey({
+      name: "work",
+      uniqueId: "a1",
+    });
+    const second = buildDashboardSessionMainKey({
+      name: "work",
+      uniqueId: "b2",
+    });
+
+    expect(first).toBe("dashboard:work:a1");
+    expect(second).toBe("dashboard:work:b2");
+    expect(first).not.toBe(second);
+  });
+
+  it("normalizes spacing in session names", () => {
+    const key = buildDashboardSessionMainKey({
+      name: "My Session Name",
+      uniqueId: "abc",
+    });
+
+    expect(key).toBe("dashboard:my-session-name:abc");
   });
 });

--- a/ui/src/ui/session-key.test.ts
+++ b/ui/src/ui/session-key.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildAgentMainSessionKey, resolveAgentIdFromSessionKey } from "./session-key.ts";
+
+describe("buildAgentMainSessionKey", () => {
+  it("keeps the selected agent in dashboard session keys", () => {
+    const key = buildAgentMainSessionKey({
+      agentId: "research-agent",
+      mainKey: "dashboard:new-session",
+    });
+
+    expect(key).toBe("agent:research-agent:dashboard:new-session");
+    expect(resolveAgentIdFromSessionKey(key)).toBe("research-agent");
+  });
+
+  it("falls back to main when the agent id is missing", () => {
+    const key = buildAgentMainSessionKey({
+      agentId: "",
+      mainKey: "dashboard:new-session",
+    });
+
+    expect(key).toBe("agent:main:dashboard:new-session");
+    expect(resolveAgentIdFromSessionKey(key)).toBe("main");
+  });
+});

--- a/ui/src/ui/session-key.ts
+++ b/ui/src/ui/session-key.ts
@@ -66,6 +66,12 @@ export function buildAgentMainSessionKey(params: {
   return `agent:${agentId}:${mainKey}`;
 }
 
+export function buildDashboardSessionMainKey(params: { name: string; uniqueId: string }): string {
+  const sessionName = params.name.trim().toLowerCase().replace(/\s+/g, "-") || "session";
+  const uniqueId = params.uniqueId.trim().toLowerCase();
+  return `dashboard:${sessionName}:${uniqueId}`;
+}
+
 export function resolveAgentIdFromSessionKey(sessionKey: string | undefined | null): string {
   const parsed = parseAgentSessionKey(sessionKey);
   return normalizeAgentId(parsed?.agentId ?? DEFAULT_AGENT_ID);

--- a/ui/src/ui/session-key.ts
+++ b/ui/src/ui/session-key.ts
@@ -13,9 +13,11 @@ export const DEFAULT_AGENT_ID = "main";
 export const DEFAULT_MAIN_KEY = "main";
 
 const VALID_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/i;
+const VALID_SESSION_PART_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
 const INVALID_CHARS_RE = /[^a-z0-9_-]+/g;
 const LEADING_DASH_RE = /^-+/;
 const TRAILING_DASH_RE = /-+$/;
+const MAX_SESSION_PART_LENGTH = 64;
 
 export function parseAgentSessionKey(
   sessionKey: string | undefined | null,
@@ -66,9 +68,27 @@ export function buildAgentMainSessionKey(params: {
   return `agent:${agentId}:${mainKey}`;
 }
 
+export function normalizeDashboardSessionPart(value: string): string {
+  const cleaned = normalizeLowercaseStringOrEmpty(value)
+    .replace(INVALID_CHARS_RE, "-")
+    .replace(LEADING_DASH_RE, "")
+    .replace(TRAILING_DASH_RE, "")
+    .slice(0, MAX_SESSION_PART_LENGTH);
+  return VALID_SESSION_PART_RE.test(cleaned) ? cleaned : "session";
+}
+
+export function normalizeDashboardSessionUniqueId(value: string): string {
+  const cleaned = normalizeLowercaseStringOrEmpty(value)
+    .replace(INVALID_CHARS_RE, "-")
+    .replace(LEADING_DASH_RE, "")
+    .replace(TRAILING_DASH_RE, "")
+    .slice(0, MAX_SESSION_PART_LENGTH);
+  return cleaned || "id";
+}
+
 export function buildDashboardSessionMainKey(params: { name: string; uniqueId: string }): string {
-  const sessionName = params.name.trim().toLowerCase().replace(/\s+/g, "-") || "session";
-  const uniqueId = params.uniqueId.trim().toLowerCase();
+  const sessionName = normalizeDashboardSessionPart(params.name);
+  const uniqueId = normalizeDashboardSessionUniqueId(params.uniqueId);
   return `dashboard:${sessionName}:${uniqueId}`;
 }
 

--- a/ui/src/ui/views/new-session-modal.ts
+++ b/ui/src/ui/views/new-session-modal.ts
@@ -29,6 +29,7 @@ export function renderNewSessionModal(state: AppViewState) {
           <input
             type="text"
             placeholder="e.g. stocks, games, work"
+            maxlength="64"
             .value=${state.newSessionName}
             @input=${(e: Event) => {
               state.newSessionName = (e.target as HTMLInputElement).value;

--- a/ui/src/ui/views/new-session-modal.ts
+++ b/ui/src/ui/views/new-session-modal.ts
@@ -1,0 +1,53 @@
+import { html, nothing } from "lit";
+import type { AppViewState } from "../app-view-state.ts";
+
+export function renderNewSessionModal(state: AppViewState) {
+  if (!state.newSessionModalOpen) {
+    return nothing;
+  }
+
+  return html`
+    <div
+      class="exec-approval-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-live="polite"
+      @keydown=${(e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          state.handleNewSessionCancel();
+        }
+      }}
+    >
+      <div class="exec-approval-card">
+        <div class="exec-approval-header">
+          <div>
+            <div class="exec-approval-title">New Session</div>
+            <div class="exec-approval-sub">Enter a name for your new session</div>
+          </div>
+        </div>
+        <label class="field">
+          <input
+            type="text"
+            placeholder="e.g. stocks, games, work"
+            .value=${state.newSessionName}
+            @input=${(e: Event) => {
+              state.newSessionName = (e.target as HTMLInputElement).value;
+            }}
+            @keydown=${(e: KeyboardEvent) => {
+              if (e.key === "Enter") {
+                void state.handleNewSessionConfirm();
+              }
+            }}
+            autofocus
+          />
+        </label>
+        <div class="exec-approval-actions" style="margin-top: 16px;">
+          <button class="btn primary" @click=${() => void state.handleNewSessionConfirm()}>
+            Create
+          </button>
+          <button class="btn" @click=${() => state.handleNewSessionCancel()}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  `;
+}


### PR DESCRIPTION
## Summary

- Problem: Users had no discoverable way to create a new session from the Control UI. Session creation required a hidden `?session=...` URL workaround.
- Why it matters: Session creation is a core workflow that should be accessible without arcane knowledge.
- What changed: Added a "+" button to the chat header next to the session selector, which opens a modal for naming and creating a new session bound to the current agent.
- What did NOT change (scope boundary): Session management backend, existing session switching logic, agent selection flow.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61003 

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- New "+" button in chat header opens a modal to create a named session
- New session is bound to the currently selected agent (or `assistantAgentId`, falling back to `"main"`)
- Session is persisted via `sessions.create` RPC and immediately selected after creation
- Canceling the modal dismisses it without creating a session

## Diagram (if applicable)

Before:
[Chat header] -> [Session selector] [no create option]



After:
[Chat header] -> [Session selector] [+] -> [Modal: name input + Create/Cancel] -> [New session selected]



## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes — `sessions.create` RPC call
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel (if any): Control UI / webchat
- Relevant config (redacted): Default

### Steps

1. Connect to gateway and select an agent
2. Click the "+" button in the chat header
3. Enter a session name and click "Create"
4. Verify the new session appears in the session selector and is active

### Expected

New session is created, persisted, and immediately selected.

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Button renders, modal opens/closes, `sessions.create` RPC is called with correct key format
- Edge cases checked: Empty name, cancel, Escape key
- What you did **not** verify: Cross-browser testing

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No

## Risks and Mitigations

None.