### PR TITLE
fix(agents): honor light bootstrap context paths

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -212,6 +212,7 @@ Behavior details:
 - Content: delivery uses the isolated run's outbound payloads (text/media) with normal chunking and
   channel formatting.
 - Heartbeat-only responses (`HEARTBEAT_OK` with no real content) are not delivered.
+- Exact silent responses (`NO_REPLY`, after trimming) are not delivered.
 - If the isolated run already sent a message to the same target via the message tool, delivery is
   skipped to avoid duplicates.
 - Missing or invalid delivery targets fail the job unless `delivery.bestEffort = true`.

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -18,6 +18,8 @@ Tip: run `openclaw cron --help` for the full command surface.
 
 Note: isolated `cron add` jobs default to `--announce` delivery. Use `--no-deliver` to keep
 output internal. `--deliver` remains as a deprecated alias for `--announce`.
+When an announced isolated run replies with exact `NO_REPLY` (after trimming), OpenClaw suppresses
+the outbound delivery.
 
 Note: one-shot (`--at`) jobs delete after success by default. Use `--keep-after-run` to keep them.
 

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -69,6 +69,7 @@ export const resolveSessionAgentIdMock = vi.fn(() => "main");
 export const estimateTokensMock = vi.fn((_message?: unknown) => 10);
 export const sessionAbortCompactionMock: Mock<(reason?: unknown) => void> = vi.fn();
 export const createOpenClawCodingToolsMock = vi.fn(() => []);
+export const resolveBootstrapContextForRunMock = vi.fn(async () => ({ contextFiles: [] }));
 
 export function resetCompactHooksHarnessMocks(): void {
   hookRunner.hasHooks.mockReset();
@@ -137,6 +138,8 @@ export function resetCompactHooksHarnessMocks(): void {
   sessionAbortCompactionMock.mockReset();
   createOpenClawCodingToolsMock.mockReset();
   createOpenClawCodingToolsMock.mockReturnValue([]);
+  resolveBootstrapContextForRunMock.mockReset();
+  resolveBootstrapContextForRunMock.mockResolvedValue({ contextFiles: [] });
 }
 
 export async function loadCompactHooksHarness(): Promise<{
@@ -267,7 +270,7 @@ export async function loadCompactHooksHarness(): Promise<{
 
   vi.doMock("../bootstrap-files.js", () => ({
     makeBootstrapWarn: vi.fn(() => () => {}),
-    resolveBootstrapContextForRun: vi.fn(async () => ({ contextFiles: [] })),
+    resolveBootstrapContextForRun: resolveBootstrapContextForRunMock,
   }));
 
   vi.doMock("../docs-path.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -12,6 +12,7 @@ import {
   resolveContextEngineMock,
   resolveMemorySearchConfigMock,
   resolveModelMock,
+  resolveBootstrapContextForRunMock,
   resolveSessionAgentIdMock,
   resetCompactHooksHarnessMocks,
   sanitizeSessionHistoryMock,
@@ -194,6 +195,27 @@ describe("compactEmbeddedPiSessionDirect hooks", () => {
     expect(createOpenClawCodingToolsMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowGatewaySubagentBinding: true,
+      }),
+    );
+  });
+
+  it("passes lightweight bootstrap context settings into compaction bootstrap resolution", async () => {
+    await compactEmbeddedPiSessionDirect({
+      sessionId: "session-1",
+      sessionKey: "cron:job-1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp/workspace",
+      bootstrapContextMode: "lightweight",
+      bootstrapContextRunKind: "cron",
+    });
+
+    expect(resolveBootstrapContextForRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: "/tmp/workspace",
+        sessionKey: "cron:job-1",
+        sessionId: "session-1",
+        contextMode: "lightweight",
+        runKind: "cron",
       }),
     );
   });

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -142,6 +142,8 @@ export type CompactEmbeddedPiSessionParams = {
   model?: string;
   thinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
+  bootstrapContextMode?: "full" | "lightweight";
+  bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   bashElevated?: ExecElevatedDefaults;
   customInstructions?: string;
   tokenBudget?: number;
@@ -548,6 +550,8 @@ export async function compactEmbeddedPiSessionDirect(
       sessionKey: params.sessionKey,
       sessionId: params.sessionId,
       warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+      contextMode: params.bootstrapContextMode,
+      runKind: params.bootstrapContextRunKind,
     });
     // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
     // threshold uses the effective limit, not the native context window.

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.test.ts
@@ -23,6 +23,8 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
         modelId: "gpt-5.3-codex",
         thinkLevel: "off",
         reasoningLevel: "on",
+        bootstrapContextMode: "lightweight",
+        bootstrapContextRunKind: "cron",
         extraSystemPrompt: "extra",
         ownerNumbers: ["+15555550123"],
       }),
@@ -40,6 +42,8 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
       senderId: "user-123",
       provider: "openai-codex",
       model: "gpt-5.3-codex",
+      bootstrapContextMode: "lightweight",
+      bootstrapContextRunKind: "cron",
     });
   });
 

--- a/src/agents/pi-embedded-runner/compaction-runtime-context.ts
+++ b/src/agents/pi-embedded-runner/compaction-runtime-context.ts
@@ -22,6 +22,8 @@ export type EmbeddedCompactionRuntimeContext = {
   model?: string;
   thinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
+  bootstrapContextMode?: "full" | "lightweight";
+  bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   bashElevated?: ExecElevatedDefaults;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
@@ -46,6 +48,8 @@ export function buildEmbeddedCompactionRuntimeContext(params: {
   modelId?: string | null;
   thinkLevel?: ThinkLevel;
   reasoningLevel?: ReasoningLevel;
+  bootstrapContextMode?: "full" | "lightweight";
+  bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   bashElevated?: ExecElevatedDefaults;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
@@ -69,6 +73,8 @@ export function buildEmbeddedCompactionRuntimeContext(params: {
     model: params.modelId ?? undefined,
     thinkLevel: params.thinkLevel,
     reasoningLevel: params.reasoningLevel,
+    bootstrapContextMode: params.bootstrapContextMode,
+    bootstrapContextRunKind: params.bootstrapContextRunKind,
     bashElevated: params.bashElevated,
     extraSystemPrompt: params.extraSystemPrompt,
     ownerNumbers: params.ownerNumbers,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1161,6 +1161,8 @@ export async function runEmbeddedPiAgent(
                       modelId,
                       thinkLevel,
                       reasoningLevel: params.reasoningLevel,
+                      bootstrapContextMode: params.bootstrapContextMode,
+                      bootstrapContextRunKind: params.bootstrapContextRunKind,
                       bashElevated: params.bashElevated,
                       extraSystemPrompt: params.extraSystemPrompt,
                       ownerNumbers: params.ownerNumbers,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1294,6 +1294,8 @@ export function buildAfterTurnRuntimeContext(params: {
     | "modelId"
     | "thinkLevel"
     | "reasoningLevel"
+    | "bootstrapContextMode"
+    | "bootstrapContextRunKind"
     | "bashElevated"
     | "extraSystemPrompt"
     | "ownerNumbers"
@@ -1321,6 +1323,8 @@ export function buildAfterTurnRuntimeContext(params: {
     modelId: params.attempt.modelId,
     thinkLevel: params.attempt.thinkLevel,
     reasoningLevel: params.attempt.reasoningLevel,
+    bootstrapContextMode: params.attempt.bootstrapContextMode,
+    bootstrapContextRunKind: params.attempt.bootstrapContextRunKind,
     bashElevated: params.attempt.bashElevated,
     extraSystemPrompt: params.attempt.extraSystemPrompt,
     ownerNumbers: params.attempt.ownerNumbers,

--- a/src/auto-reply/reply/commands-system-prompt.test.ts
+++ b/src/auto-reply/reply/commands-system-prompt.test.ts
@@ -1,15 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HandleCommandsParams } from "./commands-types.js";
 
-const { createOpenClawCodingToolsMock } = vi.hoisted(() => ({
+const { createOpenClawCodingToolsMock, resolveBootstrapContextForRunMock } = vi.hoisted(() => ({
   createOpenClawCodingToolsMock: vi.fn(() => []),
-}));
-
-vi.mock("../../agents/bootstrap-files.js", () => ({
-  resolveBootstrapContextForRun: vi.fn(async () => ({
+  resolveBootstrapContextForRunMock: vi.fn(async () => ({
     bootstrapFiles: [],
     contextFiles: [],
   })),
+}));
+
+vi.mock("../../agents/bootstrap-files.js", () => ({
+  resolveBootstrapContextForRun: resolveBootstrapContextForRunMock,
 }));
 
 vi.mock("../../agents/pi-tools.js", () => ({
@@ -110,6 +111,11 @@ describe("resolveCommandsSystemPromptBundle", () => {
   beforeEach(() => {
     createOpenClawCodingToolsMock.mockClear();
     createOpenClawCodingToolsMock.mockReturnValue([]);
+    resolveBootstrapContextForRunMock.mockClear();
+    resolveBootstrapContextForRunMock.mockResolvedValue({
+      bootstrapFiles: [],
+      contextFiles: [],
+    });
   });
 
   it("opts command tool builds into gateway subagent binding", async () => {
@@ -121,6 +127,26 @@ describe("resolveCommandsSystemPromptBundle", () => {
         sessionKey: "agent:main:default",
         workspaceDir: "/tmp/workspace",
         messageProvider: "telegram",
+      }),
+    );
+  });
+
+  it("forwards lightweight heartbeat bootstrap context options", async () => {
+    const params = makeParams();
+    params.opts = {
+      isHeartbeat: true,
+      bootstrapContextMode: "lightweight",
+    };
+
+    await resolveCommandsSystemPromptBundle(params);
+
+    expect(resolveBootstrapContextForRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceDir: "/tmp/workspace",
+        sessionKey: "agent:main:default",
+        sessionId: "session-1",
+        contextMode: "lightweight",
+        runKind: "heartbeat",
       }),
     );
   });

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -33,6 +33,8 @@ export async function resolveCommandsSystemPromptBundle(
     config: params.cfg,
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
+    contextMode: params.opts?.bootstrapContextMode,
+    runKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
   });
   const skillsSnapshot = (() => {
     try {

--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -61,4 +61,46 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
       });
     });
   });
+
+  it('suppresses exact "NO_REPLY" for plain announce delivery', async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "NO_REPLY" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
+
+  it('suppresses exact "NO_REPLY" for forum-topic announce delivery', async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "NO_REPLY" }]);
+
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123:topic:42" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
+++ b/src/cron/isolated-agent.skips-delivery-without-whatsapp-recipient-besteffortdeliver-true.test.ts
@@ -407,6 +407,24 @@ describe("runCronIsolatedAgentTurn", () => {
     });
   });
 
+  it("skips announce when the agent reply is whitespace-padded NO_REPLY", async () => {
+    await withTelegramAnnounceFixture(async ({ home, storePath, deps }) => {
+      mockAgentPayloads([{ text: "  NO_REPLY \n" }]);
+      const res = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(res.status).toBe("ok");
+      expect(res.delivered).toBe(false);
+      expect(res.deliveryAttempted).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expect(deps.sendMessageTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("fails when structured direct delivery fails and best-effort is disabled", async () => {
     await expectStructuredTelegramFailure({
       payload: { text: "hello from cron", mediaUrl: "https://example.com/img.png" },

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -112,6 +112,24 @@ export type DispatchCronDeliveryState = {
   deliveryPayloads: ReplyPayload[];
 };
 
+function isDirectSilentReplyOnly(payloads: readonly ReplyPayload[]): boolean {
+  if (payloads.length !== 1) {
+    return false;
+  }
+  const [payload] = payloads;
+  if (!payload || !isSilentReplyText(payload.text, SILENT_REPLY_TOKEN)) {
+    return false;
+  }
+  return !(
+    payload.mediaUrl ||
+    (payload.mediaUrls?.length ?? 0) > 0 ||
+    payload.interactive ||
+    payload.btw ||
+    payload.audioAsVoice === true ||
+    Object.keys(payload.channelData ?? {}).length > 0
+  );
+}
+
 const TRANSIENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /\berrorcode=unavailable\b/i,
   /\bstatus\s*[:=]\s*"?unavailable\b/i,
@@ -339,6 +357,18 @@ export async function dispatchCronDelivery(
             : [];
       if (payloadsForDelivery.length === 0) {
         return null;
+      }
+      if (isDirectSilentReplyOnly(payloadsForDelivery)) {
+        deliveryAttempted = true;
+        delivered = false;
+        return params.withRunSession({
+          status: "ok",
+          summary,
+          outputText,
+          delivered: false,
+          deliveryAttempted: true,
+          ...params.telemetry,
+        });
       }
       if (params.isAborted()) {
         return params.withRunSession({

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,5 +1,5 @@
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -522,7 +522,7 @@ export async function dispatchCronDelivery(
       hadDescendants &&
       synthesizedText.trim() === initialSynthesizedText &&
       isLikelyInterimCronMessage(initialSynthesizedText) &&
-      initialSynthesizedText.toUpperCase() !== SILENT_REPLY_TOKEN.toUpperCase()
+      !isSilentReplyText(initialSynthesizedText, SILENT_REPLY_TOKEN)
     ) {
       // Descendants existed but no post-orchestration synthesis arrived AND
       // no descendant fallback reply was available. Suppress stale parent
@@ -537,12 +537,13 @@ export async function dispatchCronDelivery(
         ...params.telemetry,
       });
     }
-    if (synthesizedText.toUpperCase() === SILENT_REPLY_TOKEN.toUpperCase()) {
+    if (isSilentReplyText(synthesizedText, SILENT_REPLY_TOKEN)) {
       return params.withRunSession({
         status: "ok",
         summary,
         outputText,
-        delivered: true,
+        delivered: false,
+        deliveryAttempted: true,
         ...params.telemetry,
       });
     }


### PR DESCRIPTION
## Summary
- forward lightweight bootstrap context mode/run kind through system-prompt composition
- preserve bootstrap context mode/run kind through compaction runtime paths, including overflow recovery
- add regressions covering lightweight heartbeat system-prompt resolution and lightweight compaction bootstrap resolution

## Testing
- attempted: `pnpm test -- src/auto-reply/reply/commands-system-prompt.test.ts src/agents/pi-embedded-runner/compact.hooks.test.ts src/agents/pi-embedded-runner/compaction-runtime-context.test.ts`
- local dependency install was blocked by registry DNS failures in this environment (`EAI_AGAIN`), so tests were added but not executed here

Closes #61395
