### PR TITLE
feat(plugin-sdk): add discord subpath export

### DIFF
--- a/package.json
+++ b/package.json
@@ -403,6 +403,10 @@
       "types": "./dist/plugin-sdk/compat.d.ts",
       "default": "./dist/plugin-sdk/compat.js"
     },
+    "./plugin-sdk/discord": {
+      "types": "./dist/plugin-sdk/discord.d.ts",
+      "default": "./dist/plugin-sdk/discord.js"
+    },
     "./plugin-sdk/direct-dm": {
       "types": "./dist/plugin-sdk/direct-dm.d.ts",
       "default": "./dist/plugin-sdk/direct-dm.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -90,6 +90,7 @@
   "command-surface",
   "collection-runtime",
   "compat",
+  "discord",
   "direct-dm",
   "device-bootstrap",
   "diagnostic-runtime",

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -1,0 +1,12 @@
+// plugin-sdk/discord — public re-export surface for Discord component helpers.
+//
+// Plugins that depend on `openclaw/plugin-sdk/discord` can import the Discord
+// component-message utilities and account resolver from this subpath without
+// needing to reach into internal extension paths directly.
+export type { DiscordComponentMessageSpec } from "../../extensions/discord/src/components.js";
+export { buildDiscordComponentMessage } from "../../extensions/discord/src/components.js";
+export { resolveDiscordAccount } from "../../extensions/discord/src/accounts.js";
+export {
+  editDiscordComponentMessage,
+  registerBuiltDiscordComponentMessage,
+} from "../../extensions/discord/src/send.components.js";


### PR DESCRIPTION
## Summary

Adds `openclaw/plugin-sdk/discord` as a public plugin SDK subpath, re-exporting Discord component-message helpers that plugins need to build interactive Discord UI.

## Changes

- `src/plugin-sdk/discord.ts` — new re-export surface
- `scripts/lib/plugin-sdk-entrypoints.json` — adds `"discord"` so the entrypoint is picked up by the build, tsdown config, and `sync-plugin-sdk-exports`
- `package.json` — exports synced automatically via `sync-plugin-sdk-exports.mjs`

## Exported surface

```ts
import {
  buildDiscordComponentMessage,
  editDiscordComponentMessage,
  registerBuiltDiscordComponentMessage,
  resolveDiscordAccount,
  type DiscordComponentMessageSpec,
} from "openclaw/plugin-sdk/discord";
```

## Motivation

`openclaw-codex-app-server` v0.6.0 imports from `openclaw/plugin-sdk/discord` to build Discord interactive component messages. Without this subpath the plugin fails to load with:

```
Error: Cannot find module '...dist/plugin-sdk/root-alias.cjs/discord'
```

The functions already exist in the discord extension. This PR just exposes them via the stable plugin SDK subpath surface so plugins can import them without reaching into internal extension paths.