### PR TITLE
fix(google): resolve Gemini CLI credentials from hoisted npm global layouts

### DIFF
--- a/extensions/google/oauth.credentials.ts
+++ b/extensions/google/oauth.credentials.ts
@@ -164,6 +164,8 @@ function parseGeminiCliCredentials(
 function readGeminiCliCredentialsFromKnownPaths(
   geminiCliDir: string,
 ): { clientId: string; clientSecret: string } | null {
+  const hoistedCoreDir = join(dirname(geminiCliDir), "gemini-cli-core");
+
   const searchPaths = [
     join(
       geminiCliDir,
@@ -184,6 +186,8 @@ function readGeminiCliCredentialsFromKnownPaths(
       "code_assist",
       "oauth2.js",
     ),
+    join(hoistedCoreDir, "dist", "src", "code_assist", "oauth2.js"),
+    join(hoistedCoreDir, "dist", "code_assist", "oauth2.js"),
   ];
 
   for (const path of searchPaths) {

--- a/extensions/google/oauth.test.ts
+++ b/extensions/google/oauth.test.ts
@@ -511,6 +511,62 @@ describe("extractGeminiCliCredentials", () => {
     expect(mockReadFileSync.mock.calls.length).toBe(readCount);
   });
 
+  it("extracts credentials when gemini-cli-core is hoisted to parent node_modules", async () => {
+    const binDir = join(rootDir, "fake", "npm-global", "bin");
+    const geminiPath = join(binDir, "gemini");
+    const resolvedPath = join(
+      rootDir,
+      "fake",
+      "npm-global",
+      "lib",
+      "node_modules",
+      "@google",
+      "gemini-cli",
+      "bundle",
+      "gemini.js",
+    );
+    const geminiCliDir = join(
+      rootDir,
+      "fake",
+      "npm-global",
+      "lib",
+      "node_modules",
+      "@google",
+      "gemini-cli",
+    );
+    const packageJsonPath = normalizePath(join(geminiCliDir, "package.json"));
+    const hoistedOauth2Path = join(
+      rootDir,
+      "fake",
+      "npm-global",
+      "lib",
+      "node_modules",
+      "@google",
+      "gemini-cli-core",
+      "dist",
+      "src",
+      "code_assist",
+      "oauth2.js",
+    );
+
+    process.env.PATH = binDir;
+    mockExistsSync.mockImplementation((p: string) => {
+      const normalized = normalizePath(p);
+      return (
+        normalized === normalizePath(geminiPath) ||
+        normalized === packageJsonPath ||
+        normalized === normalizePath(hoistedOauth2Path)
+      );
+    });
+    mockRealpathSync.mockReturnValue(resolvedPath);
+    mockReadFileSync.mockReturnValue(FAKE_OAUTH2_CONTENT);
+
+    clearCredentialsCache();
+    const result = extractGeminiCliCredentials();
+
+    expectFakeCliCredentials(result);
+  });
+
   it("skips unrelated oauth2.js files when gemini resolves inside a Windows nvm root", async () => {
     const { unrelatedOauth2Path } = installWindowsNvmLayoutWithUnrelatedOauth({
       oauth2Content: FAKE_OAUTH2_CONTENT,


### PR DESCRIPTION
## Summary

- Problem: `readGeminiCliCredentialsFromKnownPaths` only checks for `@google/gemini-cli-core` nested inside `gemini-cli/node_modules/`, but npm v7+ hoists it to a sibling under the parent `node_modules/@google/` directory in global installs, so credential extraction silently fails and `resolveOAuthClientConfig` throws the misleading "Gemini CLI not found" error even though the binary was found in PATH.
- Why it matters: users with a working `gemini` binary on PATH get a false "not found" error during OAuth setup, the kind of failure that sends you chasing environment variables and systemd PATH configs when the real issue is a directory traversal assumption two levels deep in the credential extractor.
- What changed: added hoisted sibling paths (`dirname(geminiCliDir)/gemini-cli-core/dist/...`) to the known-path search, plus a test that reproduces the exact npm global hoisted layout.
- What did NOT change (scope boundary): no changes to `findInPath`, `resolveGeminiCliDirs`, bundle search, or recursive tree search. The fix is strictly additive search paths in `readGeminiCliCredentialsFromKnownPaths`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: #27585 (previous npm shim layout fix for the same credential discovery surface)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `readGeminiCliCredentialsFromKnownPaths` assumed `@google/gemini-cli-core` would always be nested under `@google/gemini-cli/node_modules/`. npm v7+ flat-installs (hoists) scoped dependencies to sibling positions under the same parent `node_modules/@google/` in global installs. The hoisted `oauth2.js` path was never checked.
- Missing detection / guardrail: no test covering the hoisted npm global layout where `gemini-cli-core` is a sibling of `gemini-cli`.
- Contributing context (if known): the intermittent nature maps to npm's deduplication behavior varying across install/update operations, combined with whether the fallback bundle search happens to contain parseable OAuth credentials for a given Gemini CLI version.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/google/oauth.test.ts`
- Scenario the test should lock in: `extractGeminiCliCredentials` returns valid credentials when `gemini-cli-core` is hoisted to a sibling of `gemini-cli` under the parent `node_modules/@google/` directory (npm v7+ global install layout).
- Why this is the smallest reliable guardrail: the mock filesystem reproduces the exact directory structure that triggers the bug without requiring a real Gemini CLI installation.
- Existing test that already covers this (if any): the "npm global shim" test covers the non-symlink shim case but assumes nested (non-hoisted) `gemini-cli-core`.

## User-visible / Behavior Changes

Gemini CLI OAuth setup no longer fails with "Gemini CLI not found" when the CLI is installed globally via npm v7+ and `@google/gemini-cli-core` is hoisted to a sibling directory.

## Diagram (if applicable)

```text
Before:
[findInPath finds gemini] -> [realpathSync resolves to gemini-cli/bundle/gemini.js]
  -> [looks for gemini-cli-core NESTED in gemini-cli/node_modules/] -> not found -> null
  -> "Gemini CLI not found"

After:
[findInPath finds gemini] -> [realpathSync resolves to gemini-cli/bundle/gemini.js]
  -> [looks for gemini-cli-core NESTED in gemini-cli/node_modules/] -> not found
  -> [looks for gemini-cli-core as SIBLING under parent @google/] -> found -> credentials extracted
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (systemd user service)
- Runtime/container: Node 22+
- Model/provider: google-gemini-cli
- Integration/channel (if any): N/A
- Relevant config (redacted): `gemini` installed at `~/.npm-global/bin/gemini` via `npm install -g @google/gemini-cli`

### Steps

1. Install Gemini CLI globally with npm v7+: `npm install -g @google/gemini-cli`
2. Verify `gemini-cli-core` is hoisted (sibling of `gemini-cli`, not nested): `ls ~/.npm-global/lib/node_modules/@google/`
3. Run OAuth setup for `google-gemini-cli` provider

### Expected

- OAuth flow starts, credentials extracted from hoisted `gemini-cli-core/dist/src/code_assist/oauth2.js`

### Actual

- "Gemini CLI not found" error despite binary being on PATH

## Evidence

- [x] Failing test/log before + passing after

New test `"extracts credentials when gemini-cli-core is hoisted to parent node_modules"` passes with the fix, would fail without it (known paths would miss the hoisted sibling).

## Human Verification (required)

- Verified scenarios: ran `bunx vitest run extensions/google/oauth.test.ts` — all 19 tests pass including the new hoisted layout test. Verified the new test fails when the hoisted paths are removed from `readGeminiCliCredentialsFromKnownPaths`.
- Edge cases checked: existing nested layout tests still pass (no regression). Bundle and recursive tree search paths are untouched.
- What you did **not** verify: live Gemini CLI 0.36.0 global install on a systemd service. The fix is validated through the mock filesystem test that reproduces the exact directory structure.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: the hoisted path assumption (`dirname(geminiCliDir)/gemini-cli-core`) could match an unrelated `gemini-cli-core` directory in unusual layouts.
  - Mitigation: the credential file is still validated by regex for OAuth client ID/secret patterns before being accepted — a false directory match produces no credentials, not wrong credentials.