### PR TITLE
fix(agents): suppress commentary partial visibility and buffer unphased early deltas

### DIFF
--- a/src/agents/openai-ws-message-conversion.ts
+++ b/src/agents/openai-ws-message-conversion.ts
@@ -349,10 +349,21 @@ export function convertMessagesToInputItems(
 
     if (m.role === "assistant") {
       const content = m.content;
-      let assistantPhase = normalizeAssistantPhase(m.phase);
+      const assistantMessagePhase = normalizeAssistantPhase(m.phase);
       if (Array.isArray(content)) {
         const textParts: string[] = [];
-        const pushAssistantText = () => {
+        let currentTextPhase: OpenAIResponsesAssistantPhase | undefined;
+        const hasExplicitBlockPhase = content.some((block) => {
+          if (!block || typeof block !== "object") {
+            return false;
+          }
+          const record = block as { type?: unknown; textSignature?: unknown };
+          return (
+            record.type === "text" &&
+            Boolean(parseAssistantTextSignature(record.textSignature)?.phase)
+          );
+        });
+        const pushAssistantText = (phase?: OpenAIResponsesAssistantPhase) => {
           if (textParts.length === 0) {
             return;
           }
@@ -360,7 +371,7 @@ export function convertMessagesToInputItems(
             type: "message",
             role: "assistant",
             content: textParts.join(""),
-            ...(assistantPhase ? { phase: assistantPhase } : {}),
+            ...(phase ? { phase } : {}),
           });
           textParts.length = 0;
         };
@@ -376,15 +387,18 @@ export function convertMessagesToInputItems(
         }>) {
           if (block.type === "text" && typeof block.text === "string") {
             const parsedSignature = parseAssistantTextSignature(block.textSignature);
-            if (!assistantPhase) {
-              assistantPhase = parsedSignature?.phase;
+            const blockPhase =
+              parsedSignature?.phase ?? (hasExplicitBlockPhase ? undefined : assistantMessagePhase);
+            if (textParts.length > 0 && blockPhase !== currentTextPhase) {
+              pushAssistantText(currentTextPhase);
             }
             textParts.push(block.text);
+            currentTextPhase = blockPhase;
             continue;
           }
 
           if (block.type === "thinking") {
-            pushAssistantText();
+            pushAssistantText(currentTextPhase);
             const reasoningItem = parseThinkingSignature(block.thinkingSignature);
             if (reasoningItem) {
               items.push(reasoningItem);
@@ -396,7 +410,7 @@ export function convertMessagesToInputItems(
             continue;
           }
 
-          pushAssistantText();
+          pushAssistantText(currentTextPhase);
           const replayId = decodeToolCallReplayId(block.id);
           const toolName = toNonEmptyString(block.name);
           if (!replayId || !toolName) {
@@ -414,7 +428,7 @@ export function convertMessagesToInputItems(
           });
         }
 
-        pushAssistantText();
+        pushAssistantText(currentTextPhase);
         continue;
       }
 
@@ -426,7 +440,7 @@ export function convertMessagesToInputItems(
         type: "message",
         role: "assistant",
         content: text,
-        ...(assistantPhase ? { phase: assistantPhase } : {}),
+        ...(assistantMessagePhase ? { phase: assistantMessagePhase } : {}),
       });
       continue;
     }
@@ -471,16 +485,20 @@ export function buildAssistantMessageFromResponse(
   modelInfo: { api: string; provider: string; id: string },
 ): AssistantMessage {
   const content: AssistantMessage["content"] = [];
-  let assistantPhase: OpenAIResponsesAssistantPhase | undefined;
+  const assistantPhases = new Set<OpenAIResponsesAssistantPhase>();
+  let hasUnphasedAssistantText = false;
 
   for (const item of response.output ?? []) {
     if (item.type === "message") {
       const itemPhase = normalizeAssistantPhase(item.phase);
       if (itemPhase) {
-        assistantPhase = itemPhase;
+        assistantPhases.add(itemPhase);
       }
       for (const part of item.content ?? []) {
         if (part.type === "output_text" && part.text) {
+          if (!itemPhase) {
+            hasUnphasedAssistantText = true;
+          }
           content.push({
             type: "text",
             text: part.text,
@@ -553,7 +571,10 @@ export function buildAssistantMessageFromResponse(
     }),
   });
 
-  return assistantPhase
-    ? ({ ...message, phase: assistantPhase } as AssistantMessageWithPhase)
+  const finalAssistantPhase =
+    assistantPhases.size === 1 && !hasUnphasedAssistantText ? [...assistantPhases][0] : undefined;
+
+  return finalAssistantPhase
+    ? ({ ...message, phase: finalAssistantPhase } as AssistantMessageWithPhase)
     : message;
 }

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -1856,6 +1856,175 @@ describe("createOpenAIWebSocketStreamFn", () => {
     );
   });
 
+  it("buffers early text deltas until late final_answer phase metadata arrives and emits them", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-phase-late-final");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+    );
+
+    const events: Array<{
+      type?: string;
+      delta?: string;
+      partial?: { phase?: string; content?: Array<{ text?: string; textSignature?: string }> };
+    }> = [];
+    const done = (async () => {
+      for await (const ev of await resolveStream(stream)) {
+        events.push(ev as (typeof events)[number]);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_final",
+      content_index: 0,
+      delta: "Done",
+      output_index: 0,
+      response_id: "resp_phase_late_final",
+    });
+
+    await new Promise((r) => setImmediate(r));
+    expect(events.filter((event) => event.type === "text_delta")).toHaveLength(0);
+
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      item: { type: "message", id: "item_final", phase: "final_answer" },
+      output_index: 0,
+      response_id: "resp_phase_late_final",
+    });
+    manager.simulateEvent({
+      type: "response.completed",
+      response: makeResponseObject("resp_phase_late_final", "Done", undefined, "final_answer"),
+    });
+
+    await done;
+
+    const textDeltaEvents = events.filter((event) => event.type === "text_delta");
+    expect(textDeltaEvents).toHaveLength(1);
+    expect(textDeltaEvents[0]?.delta).toBe("Done");
+    expect(textDeltaEvents[0]?.partial?.phase).toBe("final_answer");
+  });
+
+  it("coalesces multiple unphased deltas before late final_answer mapping", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-phase-coalesce");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+    );
+
+    const events: Array<{
+      type?: string;
+      delta?: string;
+      partial?: { phase?: string; content?: Array<{ text?: string; textSignature?: string }> };
+    }> = [];
+    const done = (async () => {
+      for await (const ev of await resolveStream(stream)) {
+        events.push(ev as (typeof events)[number]);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_final",
+      content_index: 0,
+      delta: "Hel",
+      output_index: 0,
+      response_id: "resp_phase_coalesce",
+    });
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_final",
+      content_index: 0,
+      delta: "lo",
+      output_index: 0,
+      response_id: "resp_phase_coalesce",
+    });
+
+    await new Promise((r) => setImmediate(r));
+    expect(events.filter((event) => event.type === "text_delta")).toHaveLength(0);
+
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      item: { type: "message", id: "item_final", phase: "final_answer" },
+      output_index: 0,
+      response_id: "resp_phase_coalesce",
+    });
+    manager.simulateEvent({
+      type: "response.completed",
+      response: makeResponseObject("resp_phase_coalesce", "Hello", undefined, "final_answer"),
+    });
+
+    await done;
+
+    const textDeltaEvents = events.filter((event) => event.type === "text_delta");
+    expect(textDeltaEvents).toHaveLength(1);
+    expect(textDeltaEvents[0]?.delta).toBe("Hello");
+    expect(textDeltaEvents[0]?.partial?.content?.[0]?.text).toBe("Hello");
+  });
+
+  it("falls back to visible output when phase never arrives before response completion", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-phase-missing");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+    );
+
+    const events: Array<{
+      type?: string;
+      delta?: string;
+      partial?: { phase?: string; content?: Array<{ text?: string; textSignature?: string }> };
+      message?: { content?: Array<{ text?: string }> };
+    }> = [];
+    const done = (async () => {
+      for await (const ev of await resolveStream(stream)) {
+        events.push(ev as (typeof events)[number]);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_unphased",
+      content_index: 0,
+      delta: "Visible answer",
+      output_index: 0,
+      response_id: "resp_phase_missing",
+    });
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        id: "resp_phase_missing",
+        object: "response",
+        created_at: Date.now(),
+        status: "completed",
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            id: "item_unphased",
+            role: "assistant",
+            content: [{ type: "output_text", text: "Visible answer" }],
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      } as ResponseObject,
+    });
+
+    await done;
+
+    const textDeltaEvents = events.filter((event) => event.type === "text_delta");
+    expect(textDeltaEvents).toHaveLength(1);
+    expect(textDeltaEvents[0]?.delta).toBe("Visible answer");
+    expect(textDeltaEvents[0]?.partial?.phase).toBe("final_answer");
+    const doneEvent = events.find((event) => event.type === "done");
+    expect(doneEvent?.message?.content?.[0]?.text).toBe("Visible answer");
+  });
+
   it("falls back to HTTP when WebSocket connect fails (session pre-broken via flag)", async () => {
     // Set the class-level flag BEFORE calling streamFn so the new instance
     // fails on connect().  We patch the static default via MockManager directly.

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -570,6 +570,142 @@ describe("convertMessagesToInputItems", () => {
     });
   });
 
+  it("splits replayed assistant text on phase changes from block signatures", () => {
+    const msg = {
+      role: "assistant" as const,
+      phase: "final_answer" as const,
+      content: [
+        {
+          type: "text" as const,
+          text: "Working... ",
+          textSignature: JSON.stringify({ v: 1, id: "item_commentary", phase: "commentary" }),
+        },
+        {
+          type: "text" as const,
+          text: "Done.",
+          textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+        },
+      ],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+
+    expect(
+      convertMessagesToInputItems([msg] as Parameters<typeof convertMessagesToInputItems>[0]),
+    ).toEqual([
+      {
+        type: "message",
+        role: "assistant",
+        content: "Working... ",
+        phase: "commentary",
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: "Done.",
+        phase: "final_answer",
+      },
+    ]);
+  });
+
+  it("splits legacy unphased text from later phased text during replay", () => {
+    const msg = {
+      role: "assistant" as const,
+      phase: "final_answer" as const,
+      content: [
+        {
+          type: "text" as const,
+          text: "Legacy. ",
+        },
+        {
+          type: "text" as const,
+          text: "Done.",
+          textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+        },
+      ],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+
+    expect(
+      convertMessagesToInputItems([msg] as Parameters<typeof convertMessagesToInputItems>[0]),
+    ).toEqual([
+      {
+        type: "message",
+        role: "assistant",
+        content: "Legacy. ",
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: "Done.",
+        phase: "final_answer",
+      },
+    ]);
+  });
+
+  it("preserves ordering when commentary text, tool calls, and final answer share one stored assistant message", () => {
+    const msg = {
+      role: "assistant" as const,
+      content: [
+        {
+          type: "text" as const,
+          text: "Working... ",
+          textSignature: JSON.stringify({ v: 1, id: "item_commentary", phase: "commentary" }),
+        },
+        {
+          type: "toolCall" as const,
+          id: "call_1|fc_1",
+          name: "exec",
+          arguments: { cmd: "ls" },
+        },
+        {
+          type: "text" as const,
+          text: "Done.",
+          textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+        },
+      ],
+      stopReason: "toolUse",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+
+    expect(
+      convertMessagesToInputItems([msg] as Parameters<typeof convertMessagesToInputItems>[0]),
+    ).toEqual([
+      {
+        type: "message",
+        role: "assistant",
+        content: "Working... ",
+        phase: "commentary",
+      },
+      {
+        type: "function_call",
+        id: "fc_1",
+        call_id: "call_1",
+        name: "exec",
+        arguments: JSON.stringify({ cmd: "ls" }),
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: "Done.",
+        phase: "final_answer",
+      },
+    ]);
+  });
+
   it("preserves assistant phase from textSignature metadata without local phase field", () => {
     const msg = {
       role: "assistant" as const,
@@ -926,6 +1062,97 @@ describe("buildAssistantMessageFromResponse", () => {
     expect(msg.content[0]?.text).toBe("Final answer");
   });
 
+  it("omits top-level phase when a response contains mixed assistant phases", () => {
+    const response = {
+      id: "resp_mixed_phase",
+      object: "response",
+      created_at: Date.now(),
+      status: "completed",
+      model: "gpt-5.2",
+      output: [
+        {
+          type: "message",
+          id: "item_commentary",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "Working... " }],
+        },
+        {
+          type: "message",
+          id: "item_final",
+          role: "assistant",
+          phase: "final_answer",
+          content: [{ type: "output_text", text: "Done." }],
+        },
+      ],
+      usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+    } as unknown as ResponseObject;
+
+    const msg = buildAssistantMessageFromResponse(response, modelInfo) as {
+      phase?: string;
+      content: Array<{ type: string; text?: string; textSignature?: string }>;
+    };
+
+    expect(msg.phase).toBeUndefined();
+    expect(msg.content).toMatchObject([
+      {
+        type: "text",
+        text: "Working... ",
+        textSignature: JSON.stringify({ v: 1, id: "item_commentary", phase: "commentary" }),
+      },
+      {
+        type: "text",
+        text: "Done.",
+        textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+      },
+    ]);
+  });
+
+  it("omits top-level phase when unphased legacy text and phased final text coexist", () => {
+    const response = {
+      id: "resp_unphased_plus_final",
+      object: "response",
+      created_at: Date.now(),
+      status: "completed",
+      model: "gpt-5.2",
+      output: [
+        {
+          type: "message",
+          id: "item_legacy",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Legacy. " }],
+        },
+        {
+          type: "message",
+          id: "item_final",
+          role: "assistant",
+          phase: "final_answer",
+          content: [{ type: "output_text", text: "Done." }],
+        },
+      ],
+      usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+    } as unknown as ResponseObject;
+
+    const msg = buildAssistantMessageFromResponse(response, modelInfo) as {
+      phase?: string;
+      content: Array<{ type: string; text?: string; textSignature?: string }>;
+    };
+
+    expect(msg.phase).toBeUndefined();
+    expect(msg.content).toMatchObject([
+      {
+        type: "text",
+        text: "Legacy. ",
+        textSignature: JSON.stringify({ v: 1, id: "item_legacy" }),
+      },
+      {
+        type: "text",
+        text: "Done.",
+        textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+      },
+    ]);
+  });
+
   it("maps reasoning output items to thinking blocks with signature", () => {
     const response = {
       id: "resp_reasoning",
@@ -1244,6 +1471,8 @@ describe("createOpenAIWebSocketStreamFn", () => {
     releaseWsSession("sess-incremental");
     releaseWsSession("sess-full");
     releaseWsSession("sess-phase");
+    releaseWsSession("sess-phase-stream");
+    releaseWsSession("sess-phase-late-map");
     releaseWsSession("sess-tools");
     releaseWsSession("sess-store-default");
     releaseWsSession("sess-store-compat");
@@ -1480,6 +1709,151 @@ describe("createOpenAIWebSocketStreamFn", () => {
       | undefined;
     expect(doneEvent?.message.phase).toBe("commentary");
     expect(doneEvent?.message.stopReason).toBe("toolUse");
+  });
+
+  it("emits phase-aware partials only after output item mapping is available", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-phase-stream");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+    );
+
+    const events: Array<{
+      type?: string;
+      delta?: string;
+      partial?: { phase?: string; content?: Array<{ text?: string; textSignature?: string }> };
+    }> = [];
+    const done = (async () => {
+      for await (const ev of await resolveStream(stream)) {
+        events.push(ev as (typeof events)[number]);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      item: { type: "message", id: "item_final", phase: "final_answer" },
+      output_index: 0,
+      response_id: "resp_phase_stream",
+    });
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_final",
+      content_index: 0,
+      delta: "Done",
+      output_index: 0,
+      response_id: "resp_phase_stream",
+    });
+    manager.simulateEvent({
+      type: "response.completed",
+      response: makeResponseObject("resp_phase_stream", "Done", undefined, "final_answer"),
+    });
+
+    await done;
+
+    const textDeltaEvents = events.filter((event) => event.type === "text_delta");
+    expect(textDeltaEvents).toHaveLength(1);
+    expect(textDeltaEvents[0]?.delta).toBe("Done");
+    expect(textDeltaEvents[0]?.partial?.phase).toBe("final_answer");
+    expect(textDeltaEvents[0]?.partial?.content?.[0]?.textSignature).toBe(
+      JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+    );
+  });
+
+  it("buffers early text deltas until phase metadata arrives and suppresses commentary output", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-phase-late-map");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+    );
+
+    const events: Array<{
+      type?: string;
+      delta?: string;
+      partial?: { phase?: string; content?: Array<{ text?: string; textSignature?: string }> };
+    }> = [];
+    const done = (async () => {
+      for await (const ev of await resolveStream(stream)) {
+        events.push(ev as (typeof events)[number]);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_commentary",
+      content_index: 0,
+      delta: "Working",
+      output_index: 0,
+      response_id: "resp_phase_late",
+    });
+
+    await new Promise((r) => setImmediate(r));
+    expect(events.filter((event) => event.type === "text_delta")).toHaveLength(0);
+
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      item: { type: "message", id: "item_commentary", phase: "commentary" },
+      output_index: 0,
+      response_id: "resp_phase_late",
+    });
+
+    await new Promise((r) => setImmediate(r));
+    expect(events.filter((event) => event.type === "text_delta")).toHaveLength(0);
+
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      item: { type: "message", id: "item_final", phase: "final_answer" },
+      output_index: 1,
+      response_id: "resp_phase_late",
+    });
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_final",
+      content_index: 0,
+      delta: "Done",
+      output_index: 1,
+      response_id: "resp_phase_late",
+    });
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        id: "resp_phase_late",
+        object: "response",
+        created_at: Date.now(),
+        status: "completed",
+        model: "gpt-5.4",
+        output: [
+          {
+            type: "message",
+            id: "item_commentary",
+            role: "assistant",
+            phase: "commentary",
+            content: [{ type: "output_text", text: "Working" }],
+          },
+          {
+            type: "message",
+            id: "item_final",
+            role: "assistant",
+            phase: "final_answer",
+            content: [{ type: "output_text", text: "Done" }],
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      } as ResponseObject,
+    });
+
+    await done;
+
+    const textDeltaEvents = events.filter((event) => event.type === "text_delta");
+    expect(textDeltaEvents).toHaveLength(1);
+    expect(textDeltaEvents[0]?.delta).toBe("Done");
+    expect(textDeltaEvents[0]?.partial?.phase).toBe("final_answer");
+    expect(textDeltaEvents[0]?.partial?.content?.[0]?.textSignature).toBe(
+      JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+    );
   });
 
   it("falls back to HTTP when WebSocket connect fails (session pre-broken via flag)", async () => {

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -954,14 +954,13 @@ export function createOpenAIWebSocketStreamFn(
                 partial: partialMsg,
               });
             };
-            const flushPendingUnknownPhaseText = (itemId: string) => {
-              const itemPhase = normalizeAssistantPhase(outputItemPhaseById.get(itemId));
+            const flushPendingUnknownPhaseText = (
+              itemId: string,
+              fallbackPhase?: OpenAIResponsesAssistantPhase,
+            ) => {
+              const itemPhase =
+                normalizeAssistantPhase(outputItemPhaseById.get(itemId)) ?? fallbackPhase;
               if (!itemPhase) {
-                pendingUnknownPhaseTextByPart.forEach((_, key) => {
-                  if (key.startsWith(`${itemId}:`)) {
-                    pendingUnknownPhaseTextByPart.delete(key);
-                  }
-                });
                 return;
               }
               const pendingEntries = [...pendingUnknownPhaseTextByPart.entries()]
@@ -1104,6 +1103,21 @@ export function createOpenAIWebSocketStreamFn(
                   provider: model.provider,
                   id: model.id,
                 });
+                if (Array.isArray(event.response.output)) {
+                  for (const item of event.response.output) {
+                    if (!item || item.type !== "message" || typeof item.id !== "string") {
+                      continue;
+                    }
+                    const resolvedPhase = normalizeAssistantPhase(
+                      (item as { phase?: unknown }).phase,
+                    );
+                    const fallbackPhase = resolvedPhase ?? "final_answer";
+                    if (resolvedPhase) {
+                      outputItemPhaseById.set(item.id, resolvedPhase);
+                    }
+                    flushPendingUnknownPhaseText(item.id, fallbackPhase);
+                  }
+                }
                 clearOutputTracking();
                 const reason: Extract<StopReason, "stop" | "length" | "toolUse"> =
                   assistantMsg.stopReason === "toolUse" ? "toolUse" : "stop";

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -39,6 +39,7 @@ import {
   getOpenAIWebSocketErrorDetails,
   OpenAIWebSocketManager,
   type FunctionToolDefinition,
+  type OpenAIResponsesAssistantPhase,
   type OpenAIWebSocketManagerOptions,
 } from "./openai-ws-connection.js";
 import {
@@ -85,6 +86,23 @@ type OpenAIWsStreamDeps = {
   createHttpFallbackStreamFn: (model: ProviderRuntimeModel) => StreamFn | undefined;
   streamSimple: typeof piAi.streamSimple;
 };
+
+type AssistantMessageWithPhase = AssistantMessage & { phase?: OpenAIResponsesAssistantPhase };
+
+function normalizeAssistantPhase(value: unknown): OpenAIResponsesAssistantPhase | undefined {
+  return value === "commentary" || value === "final_answer" ? value : undefined;
+}
+
+function encodeAssistantTextSignature(params: {
+  id: string;
+  phase?: OpenAIResponsesAssistantPhase;
+}): string {
+  return JSON.stringify({
+    v: 1,
+    id: params.id,
+    ...(params.phase ? { phase: params.phase } : {}),
+  });
+}
 
 const defaultOpenAIWsStreamDeps: OpenAIWsStreamDeps = {
   createManager: (options) => new OpenAIWebSocketManager(options),
@@ -893,7 +911,80 @@ export function createOpenAIWebSocketStreamFn(
 
         try {
           await new Promise<void>((resolve, reject) => {
+            const outputItemPhaseById = new Map<string, OpenAIResponsesAssistantPhase | undefined>();
+            const outputTextByPart = new Map<string, string>();
+            const pendingUnknownPhaseTextByPart = new Map<
+              string,
+              { itemId: string; contentIndex: number; fullText: string }
+            >();
+            const getOutputTextKey = (itemId: string, contentIndex: number) =>
+              `${itemId}:${contentIndex}`;
+            const emitTextDelta = (params: {
+              fullText: string;
+              deltaText: string;
+              itemId: string;
+              contentIndex: number;
+            }) => {
+              const itemPhase = normalizeAssistantPhase(outputItemPhaseById.get(params.itemId));
+              if (!itemPhase) {
+                return;
+              }
+              const partialBase = buildAssistantMessageWithZeroUsage({
+                model,
+                content: [
+                  {
+                    type: "text",
+                    text: params.fullText,
+                    textSignature: encodeAssistantTextSignature({
+                      id: params.itemId,
+                      phase: itemPhase,
+                    }),
+                  },
+                ],
+                stopReason: "stop",
+              });
+              const partialMsg: AssistantMessageWithPhase = {
+                ...partialBase,
+                phase: itemPhase,
+              };
+              eventStream.push({
+                type: "text_delta",
+                contentIndex: params.contentIndex,
+                delta: params.deltaText,
+                partial: partialMsg,
+              });
+            };
+            const flushPendingUnknownPhaseText = (itemId: string) => {
+              const itemPhase = normalizeAssistantPhase(outputItemPhaseById.get(itemId));
+              if (!itemPhase) {
+                pendingUnknownPhaseTextByPart.forEach((_, key) => {
+                  if (key.startsWith(`${itemId}:`)) {
+                    pendingUnknownPhaseTextByPart.delete(key);
+                  }
+                });
+                return;
+              }
+              const pendingEntries = [...pendingUnknownPhaseTextByPart.entries()]
+                .filter(([key]) => key.startsWith(`${itemId}:`))
+                .sort((a, b) => a[0].localeCompare(b[0]));
+              for (const [key, pending] of pendingEntries) {
+                pendingUnknownPhaseTextByPart.delete(key);
+                emitTextDelta({
+                  fullText: pending.fullText,
+                  deltaText: pending.fullText,
+                  itemId: pending.itemId,
+                  contentIndex: pending.contentIndex,
+                });
+              }
+            };
+            const clearOutputTracking = () => {
+              outputItemPhaseById.clear();
+              outputTextByPart.clear();
+              pendingUnknownPhaseTextByPart.clear();
+            };
+
             const abortHandler = () => {
+              clearOutputTracking();
               cleanup();
               reject(new Error("aborted"));
             };
@@ -904,6 +995,7 @@ export function createOpenAIWebSocketStreamFn(
             signal?.addEventListener("abort", abortHandler, { once: true });
 
             const closeHandler = (code: number, reason: string) => {
+              clearOutputTracking();
               cleanup();
               const closeInfo = session.manager.lastCloseInfo;
               reject(
@@ -940,6 +1032,70 @@ export function createOpenAIWebSocketStreamFn(
                 sawWsOutput = true;
               }
 
+              if (
+                event.type === "response.output_item.added" ||
+                event.type === "response.output_item.done"
+              ) {
+                if (typeof event.item.id === "string") {
+                  const itemPhase =
+                    event.item.type === "message"
+                      ? normalizeAssistantPhase((event.item as { phase?: unknown }).phase)
+                      : undefined;
+                  outputItemPhaseById.set(event.item.id, itemPhase);
+                  flushPendingUnknownPhaseText(event.item.id);
+                }
+                return;
+              }
+
+              if (event.type === "response.output_text.delta") {
+                const key = getOutputTextKey(event.item_id, event.content_index);
+                const nextText = `${outputTextByPart.get(key) ?? ""}${event.delta}`;
+                outputTextByPart.set(key, nextText);
+                const itemPhase = normalizeAssistantPhase(outputItemPhaseById.get(event.item_id));
+                if (!itemPhase) {
+                  pendingUnknownPhaseTextByPart.set(key, {
+                    itemId: event.item_id,
+                    contentIndex: event.content_index,
+                    fullText: nextText,
+                  });
+                  return;
+                }
+                emitTextDelta({
+                  fullText: nextText,
+                  deltaText: event.delta,
+                  itemId: event.item_id,
+                  contentIndex: event.content_index,
+                });
+                return;
+              }
+
+              if (event.type === "response.output_text.done") {
+                const key = getOutputTextKey(event.item_id, event.content_index);
+                const previousText = outputTextByPart.get(key) ?? "";
+                if (event.text && event.text !== previousText) {
+                  outputTextByPart.set(key, event.text);
+                  const itemPhase = normalizeAssistantPhase(outputItemPhaseById.get(event.item_id));
+                  if (!itemPhase) {
+                    pendingUnknownPhaseTextByPart.set(key, {
+                      itemId: event.item_id,
+                      contentIndex: event.content_index,
+                      fullText: event.text,
+                    });
+                    return;
+                  }
+                  const deltaText = event.text.startsWith(previousText)
+                    ? event.text.slice(previousText.length)
+                    : event.text;
+                  emitTextDelta({
+                    fullText: event.text,
+                    deltaText,
+                    itemId: event.item_id,
+                    contentIndex: event.content_index,
+                  });
+                }
+                return;
+              }
+
               if (event.type === "response.completed") {
                 cleanup();
                 session.lastContextLength = capturedContextLength;
@@ -948,11 +1104,13 @@ export function createOpenAIWebSocketStreamFn(
                   provider: model.provider,
                   id: model.id,
                 });
+                clearOutputTracking();
                 const reason: Extract<StopReason, "stop" | "length" | "toolUse"> =
                   assistantMsg.stopReason === "toolUse" ? "toolUse" : "stop";
                 eventStream.push({ type: "done", reason, message: assistantMsg });
                 resolve();
               } else if (event.type === "response.failed") {
+                clearOutputTracking();
                 cleanup();
                 reject(
                   new OpenAIWebSocketRuntimeError(
@@ -964,6 +1122,7 @@ export function createOpenAIWebSocketStreamFn(
                   ),
                 );
               } else if (event.type === "error") {
+                clearOutputTracking();
                 cleanup();
                 reject(
                   new OpenAIWebSocketRuntimeError(
@@ -974,18 +1133,6 @@ export function createOpenAIWebSocketStreamFn(
                     },
                   ),
                 );
-              } else if (event.type === "response.output_text.delta") {
-                const partialMsg: AssistantMessage = buildAssistantMessageWithZeroUsage({
-                  model,
-                  content: [{ type: "text", text: event.delta }],
-                  stopReason: "stop",
-                });
-                eventStream.push({
-                  type: "text_delta",
-                  contentIndex: 0,
-                  delta: event.delta,
-                  partial: partialMsg,
-                });
               }
             });
           });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -417,4 +417,184 @@ describe("handleMessageEnd", () => {
     expect(emitBlockReply).not.toHaveBeenCalled();
     expect(finalizeAssistantTexts).not.toHaveBeenCalled();
   });
+
+  it("falls back to raw assistant text when nothing visible was emitted during streaming", () => {
+    const onAgentEvent = vi.fn();
+    const finalizeAssistantTexts = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onAgentEvent,
+        onBlockReply: vi.fn(),
+      },
+      state: {
+        assistantTexts: [],
+        assistantTextBaseline: 0,
+        emittedAssistantUpdate: false,
+        deterministicApprovalPromptSent: false,
+        reasoningStreamOpen: false,
+        includeReasoning: false,
+        streamReasoning: false,
+        blockReplyBreak: "message_end",
+        deltaBuffer: "",
+        blockBuffer: "",
+        blockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+        lastStreamedAssistant: undefined,
+        lastStreamedAssistantCleaned: undefined,
+      },
+      noteLastAssistant: vi.fn(),
+      recordAssistantUsage: vi.fn(),
+      log: { debug: vi.fn(), warn: vi.fn() },
+      stripBlockTags: vi.fn(() => ""),
+      finalizeAssistantTexts,
+      emitBlockReply: vi.fn(),
+      consumeReplyDirectives: vi.fn((text: string) => ({ text })),
+      emitReasoningStream: vi.fn(),
+      flushBlockReplyBuffer: vi.fn(),
+      blockChunker: null,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Final answer only" }],
+        usage: { input: 1, output: 1, total: 2 },
+      },
+    } as never);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "assistant",
+      data: {
+        text: "Final answer only",
+        delta: "Final answer only",
+        replace: undefined,
+        mediaUrls: undefined,
+      },
+    });
+    expect(finalizeAssistantTexts).toHaveBeenCalled();
+  });
+
+  it("does not emit an empty visible reply for commentary-only turns", () => {
+    const onAgentEvent = vi.fn();
+    const finalizeAssistantTexts = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onAgentEvent,
+        onBlockReply: vi.fn(),
+      },
+      state: {
+        assistantTexts: [],
+        assistantTextBaseline: 0,
+        emittedAssistantUpdate: false,
+        deterministicApprovalPromptSent: false,
+        reasoningStreamOpen: false,
+        includeReasoning: false,
+        streamReasoning: false,
+        blockReplyBreak: "message_end",
+        deltaBuffer: "",
+        blockBuffer: "",
+        blockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+        lastStreamedAssistant: undefined,
+        lastStreamedAssistantCleaned: undefined,
+      },
+      noteLastAssistant: vi.fn(),
+      recordAssistantUsage: vi.fn(),
+      log: { debug: vi.fn(), warn: vi.fn() },
+      stripBlockTags: vi.fn(() => ""),
+      finalizeAssistantTexts,
+      emitBlockReply: vi.fn(),
+      consumeReplyDirectives: vi.fn((text: string) => ({ text })),
+      emitReasoningStream: vi.fn(),
+      flushBlockReplyBuffer: vi.fn(),
+      blockChunker: null,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        phase: "commentary",
+        content: [{ type: "text", text: "Thinking only" }],
+        usage: { input: 1, output: 1, total: 2 },
+      },
+    } as never);
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+    expect(finalizeAssistantTexts).not.toHaveBeenCalled();
+  });
+
+  it("keeps final-answer-only turns emitting normally", () => {
+    const onAgentEvent = vi.fn();
+    const finalizeAssistantTexts = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onAgentEvent,
+        onBlockReply: vi.fn(),
+      },
+      state: {
+        assistantTexts: [],
+        assistantTextBaseline: 0,
+        emittedAssistantUpdate: false,
+        deterministicApprovalPromptSent: false,
+        reasoningStreamOpen: false,
+        includeReasoning: false,
+        streamReasoning: false,
+        blockReplyBreak: "message_end",
+        deltaBuffer: "",
+        blockBuffer: "",
+        blockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+        lastStreamedAssistant: undefined,
+        lastStreamedAssistantCleaned: undefined,
+      },
+      noteLastAssistant: vi.fn(),
+      recordAssistantUsage: vi.fn(),
+      log: { debug: vi.fn(), warn: vi.fn() },
+      stripBlockTags: (text: string) => text,
+      finalizeAssistantTexts,
+      emitBlockReply: vi.fn(),
+      consumeReplyDirectives: vi.fn((text: string) => ({ text })),
+      emitReasoningStream: vi.fn(),
+      flushBlockReplyBuffer: vi.fn(),
+      blockChunker: null,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        phase: "final_answer",
+        content: [{ type: "text", text: "Visible final answer" }],
+        usage: { input: 1, output: 1, total: 2 },
+      },
+    } as never);
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "assistant",
+      data: {
+        text: "Visible final answer",
+        delta: "Visible final answer",
+        replace: undefined,
+        mediaUrls: undefined,
+      },
+    });
+    expect(finalizeAssistantTexts).toHaveBeenCalled();
+  });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -500,6 +500,20 @@ export function handleMessageEnd(
   if (
     !ctx.params.silentExpected &&
     !ctx.state.emittedAssistantUpdate &&
+    !cleanedText &&
+    !hasMedia
+  ) {
+    const rawAssistantText = coerceText(extractAssistantText(assistantMessage)).trim();
+    if (rawAssistantText) {
+      const parsedRawFallback = parseReplyDirectives(stripTrailingDirective(rawAssistantText));
+      cleanedText = parsedRawFallback.text ?? rawAssistantText;
+      ({ mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedRawFallback));
+    }
+  }
+
+  if (
+    !ctx.params.silentExpected &&
+    !ctx.state.emittedAssistantUpdate &&
     (cleanedText || hasMedia)
   ) {
     const data = buildAssistantStreamData({


### PR DESCRIPTION
## Summary

Addresses the two specific blockers from the maintainer review on #59643, building on the architectural direction of that PR while fixing the behaviors that blocked its merge.

### Blocker 1: Commentary partials must stay suppressed
The merged fix from #61282 already suppresses commentary-phase output at the embedded subscribe delivery boundary on current `main`. This PR preserves that behavior and does not reintroduce the commentary-preview-then-replace pattern that was rejected in #59643.

### Blocker 2: Late-map unphased deltas must be buffered
In `src/agents/openai-ws-stream.ts`, when `response.output_text.delta` arrives before `response.output_item.added`, the delta is now **buffered** instead of emitted as an unphased visible partial. When item metadata arrives:
- `final_answer` buffered text is emitted with correct phase/signature
- `commentary` buffered text stays suppressed

### Architectural improvements (from #59643 direction)
- Phase-aware replay conversion in `openai-ws-message-conversion.ts`: stored/replayed assistant text respects per-block `textSignature.phase` and splits by phase instead of flattening
- Phase attribution on WS partials via `textSignature`
- Top-level assistant `phase` only set when response is consistently single-phase

### What this does NOT cover (known follow-up scope)
- `src/agents/tools/sessions-helpers.ts` still uses phase-blind `extractAssistantText()` — follow-up PR recommended
- TUI render path (`tui-formatters.ts`, `tui-stream-assembler.ts`) still phase-blind — follow-up PR recommended
- Webchat/dashboard history consumers may still render generic assistant text — follow-up PR recommended

These are explicitly out of scope per the maintainer direction to make the core WS → embedded subscribe path correct first.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration
- [x] Integrations

## Linked Issues
- Closes #59150
- Related #59643
- Related #61282

## Tests
Tests added for:
- Phase-aware replay splitting
- Mixed-phase stored message reconstruction
- WS partial emission only after item-phase mapping exists
- Suppression of buffered commentary deltas when late phase resolves to commentary

## Credits
Architectural direction from @ringlochid in #59643. Review feedback from @steipete that identified the two specific blockers addressed here.