### PR TITLE
fix(discord): persist model picker override fallback

### DIFF
--- a/extensions/discord/src/monitor/native-command-ui.ts
+++ b/extensions/discord/src/monitor/native-command-ui.ts
@@ -26,7 +26,11 @@ import {
   type CommandArgs,
 } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig, loadConfig } from "openclaw/plugin-sdk/config-runtime";
-import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  updateSessionStore,
+} from "openclaw/plugin-sdk/config-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { chunkItems, withTimeout } from "openclaw/plugin-sdk/text-runtime";
@@ -371,6 +375,32 @@ function resolveDiscordModelPickerCurrentModel(params: {
   } catch {
     return fallback;
   }
+}
+
+async function persistDiscordModelPickerOverride(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  route: ResolvedAgentRoute;
+  provider: string;
+  model: string;
+}): Promise<boolean> {
+  const storePath = resolveStorePath(params.cfg.session?.store, {
+    agentId: params.route.agentId,
+  });
+  let persisted = false;
+  await updateSessionStore(storePath, (store) => {
+    const entry = store[params.route.sessionKey];
+    if (!entry) {
+      return;
+    }
+    entry.providerOverride = params.provider;
+    entry.modelOverride = params.model;
+    delete entry.model;
+    delete entry.modelProvider;
+    delete entry.contextTokens;
+    entry.updatedAt = Date.now();
+    persisted = true;
+  });
+  return persisted;
 }
 
 export async function replyWithDiscordModelPickerProviders(params: {
@@ -808,17 +838,35 @@ export async function handleDiscordModelPickerInteraction(params: {
 
     await new Promise((resolve) => setTimeout(resolve, 250));
 
-    const effectiveModelRef = resolveDiscordModelPickerCurrentModel({
+    let effectiveModelRef = resolveDiscordModelPickerCurrentModel({
       cfg: ctx.cfg,
       route,
       data: pickerData,
     });
-    const persisted = effectiveModelRef === resolvedModelRef;
+    let persisted = effectiveModelRef === resolvedModelRef;
 
     if (!persisted) {
       logVerbose(
-        `discord: model picker override mismatch — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}`,
+        `discord: model picker override mismatch — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}; attempting direct session override persist`,
       );
+      const directlyPersisted = await persistDiscordModelPickerOverride({
+        cfg: ctx.cfg,
+        route,
+        provider: parsedModelRef.provider,
+        model: parsedModelRef.model,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      effectiveModelRef = resolveDiscordModelPickerCurrentModel({
+        cfg: ctx.cfg,
+        route,
+        data: pickerData,
+      });
+      persisted = directlyPersisted && effectiveModelRef === resolvedModelRef;
+      if (!persisted) {
+        logVerbose(
+          `discord: direct session override persist failed — expected ${resolvedModelRef} but read ${effectiveModelRef} from session key ${route.sessionKey}`,
+        );
+      }
     }
 
     if (persisted) {

--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -1,8 +1,16 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { ChannelType } from "discord-api-types/v10";
 import * as commandRegistryModule from "openclaw/plugin-sdk/command-auth";
 import type { ChatCommandDefinition, CommandArgsParsing } from "openclaw/plugin-sdk/command-auth";
 import type { ModelsProviderData } from "openclaw/plugin-sdk/command-auth";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  saveSessionStore,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/config-runtime";
 import * as dispatcherModule from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import * as globalsModule from "openclaw/plugin-sdk/runtime-env";
 import * as commandTextModule from "openclaw/plugin-sdk/text-runtime";
@@ -39,6 +47,8 @@ type MockInteraction = {
   client: object;
 };
 
+let tempDir: string;
+
 function createModelsProviderData(entries: Record<string, string[]>): ModelsProviderData {
   return createBaseModelsProviderData(entries, { defaultProviderOrder: "sorted" });
 }
@@ -60,6 +70,9 @@ async function waitForCondition(
 
 function createModelPickerContext(): ModelPickerContext {
   const cfg = {
+    session: {
+      store: path.join(tempDir, "sessions.json"),
+    },
     channels: {
       discord: {
         dm: {
@@ -247,7 +260,8 @@ function createDispatchSpy() {
 }
 
 describe("Discord model picker interactions", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-discord-model-picker-"));
     vi.useRealTimers();
     vi.restoreAllMocks();
     nativeCommandTesting.setDispatchReplyWithDispatcher(
@@ -255,8 +269,9 @@ describe("Discord model picker interactions", () => {
     );
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
+    await rm(tempDir, { recursive: true, force: true });
   });
 
   it("registers distinct fallback ids for button and select handlers", () => {
@@ -469,6 +484,63 @@ describe("Discord model picker interactions", () => {
       String(call[0] ?? "").includes("model picker override mismatch"),
     )?.[0];
     expect(mismatchLog).toContain("session key agent:worker:subagent:bound");
+  });
+
+  it("persists the routed session override when dispatch leaves the session store stale", async () => {
+    const context = createModelPickerContext();
+    context.threadBindings = createBoundThreadBindingManager({
+      accountId: "default",
+      threadId: "thread-bound",
+      targetSessionKey: "agent:worker:subagent:bound",
+      agentId: "worker",
+    });
+    const pickerData = createDefaultModelPickerData();
+    const modelCommand = createModelCommandDefinition();
+    const storePath = resolveStorePath(context.cfg.session?.store, { agentId: "worker" });
+    await saveSessionStore(storePath, {
+      "agent:worker:subagent:bound": {
+        updatedAt: Date.now(),
+        sessionId: "bound-session",
+      },
+    });
+
+    vi.spyOn(modelPickerModule, "loadDiscordModelPickerData").mockResolvedValue(pickerData);
+    mockModelCommandPipeline(modelCommand);
+    createDispatchSpy();
+
+    const select = createDiscordModelPickerFallbackSelect(context);
+    const selectInteraction = createInteraction({
+      userId: "owner",
+      values: ["gpt-4o"],
+    });
+    selectInteraction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+    await select.run(
+      selectInteraction as unknown as PickerSelectInteraction,
+      createModelsViewSelectData(),
+    );
+
+    const button = createDiscordModelPickerFallbackButton(context);
+    const submitInteraction = createInteraction({ userId: "owner" });
+    submitInteraction.channel = {
+      type: ChannelType.PublicThread,
+      id: "thread-bound",
+    };
+
+    await button.run(
+      submitInteraction as unknown as PickerButtonInteraction,
+      createModelsViewSubmitData(),
+    );
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store["agent:worker:subagent:bound"]?.providerOverride).toBe("openai");
+    expect(store["agent:worker:subagent:bound"]?.modelOverride).toBe("gpt-4o");
+    expect(submitInteraction.followUp).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(submitInteraction.followUp.mock.calls[0]?.[0])).toContain(
+      "✅ Model set to openai/gpt-4o.",
+    );
   });
 
   it("loads model picker data from the effective bound route", async () => {


### PR DESCRIPTION
## Summary

- persist the Discord model-picker selection directly into the routed session store when the hidden `/model` dispatch leaves session state stale during the confirmation window
- keep the existing dispatch path intact, but add a narrow fallback persist step before showing the final success / mismatch notice
- add a regression test that reproduces a bound-thread session where dispatch does not update the session store and the picker still needs to persist the override

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs
- [ ] Test-only

## Scope

This PR is intentionally narrow.

It only changes Discord model-picker confirmation behavior on the fallback path where the picker dispatch completes but the routed session store still does not reflect the selected model.

It does not change:
- `/model` directive parsing rules
- general allowlist behavior for model selection
- provider/model catalog generation for the picker
- runtime model loading behavior after the override is persisted
- any non-Discord channel model-picker behavior

## Linked Issue/PR

- Related #61096
- Overlaps with open PR #53287
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

On current `upstream/main`, the Discord model picker dispatches a hidden `/model <provider/model>` command and then re-reads the routed session state to decide whether the selection persisted.

In the failure mode reproduced locally with LM Studio-backed selections that include an `@` suffix in the model id, such as:
- `lmstudio/unsloth/gemma-4-26b-a4b-it@iq4_xs`
- `lmstudio/unsloth/gemma-4-26b-a4b-it@iq3_xxs`

…the interaction succeeds and the picker reaches the confirmation step, but the routed session store still has no `providerOverride` / `modelOverride` for the target session key. The picker then re-reads the session, sees the default model, and emits the false warning:

`⚠️ Tried to set X, but current model is Y`

The key observed symptom is that the Discord interaction touches the session registry, but the target routed session entry never records the requested override. In local reproduction, the `@...` model-id suffix made this stale-confirmation path reproducible and easy to observe.

This patch keeps the existing dispatch path, but if the immediate read-back still shows a mismatch, it writes the selected provider/model directly into the routed session entry and re-checks once before deciding which confirmation to show.

## Behavior Changes

Before:
- the Discord model picker dispatched the hidden `/model` command
- if the routed session store was still stale during the confirmation window, the picker emitted a mismatch warning
- this was reproducible locally with LM Studio selections using suffixed model ids like `...@iq4_xs`
- the selected model could fail to persist even though the interaction itself succeeded

After:
- the picker still dispatches the hidden `/model` command first
- if the routed session store is still stale during confirmation, the picker persists the routed session override directly
- the final confirmation reflects the routed session state after that fallback persist step

## Regression Test Plan

Updated:
- `extensions/discord/src/monitor/native-command.model-picker.test.ts`

Coverage:
- creates a bound-thread routed session entry
- reproduces a picker dispatch path that does not update the session store
- verifies the fallback persist writes `providerOverride` and `modelOverride`
- verifies the picker follow-up reports success after the fallback persist path

## Repro + Verification

Observed locally with a Discord thread bound to a routed subagent session:
- selecting an LM Studio model with an `@` suffix, such as `lmstudio/unsloth/gemma-4-26b-a4b-it@iq4_xs`, could reach the confirmation step without persisting the routed session override
- `sessions.json` for the routed session was touched, but `providerOverride` / `modelOverride` remained unset
- the picker then reported a mismatch even though the user-selected model should have become the active selection for that routed session

With this patch:
- the picker falls back to directly persisting the routed session override when the first read-back is stale
- the routed session entry records the selected provider/model
- the picker follow-up can report success instead of the false mismatch warning

## Tests

Passed locally:
- `pnpm exec oxlint extensions/discord/src/monitor/native-command-ui.ts extensions/discord/src/monitor/native-command.model-picker.test.ts`

Not fully completed locally:
- `pnpm exec vitest run extensions/discord/src/monitor/native-command.model-picker.test.ts`
  This runner stalled in this environment and did not complete within an outer timeout.
- `pnpm exec tsc -p tsconfig.json --noEmit --pretty false`
  This full-project typecheck did not complete within an outer 120s timeout in this environment.

## Risks and Mitigations

Risk:
- the fallback persist path could mask a deeper routing / async persistence bug by repairing the routed session entry after dispatch rather than requiring dispatch to finish the write itself

Mitigation:
- the change is limited to the Discord model-picker confirmation path
- the original dispatch path remains unchanged
- the fallback only runs when the immediate routed-session read-back still mismatches the selected model
- a regression test now covers the stale-session fallback case directly

## AI assistance

AI-assisted: drafted and implemented with Codex, then locally reviewed and validated by me.
