### PR TITLE
Docker: add Mac migration and keep-awake helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ apps/ios/*.mobileprovision
 .local/
 docs/.local/
 docs/internal/
+backups/
 tmp/
 IDENTITY.md
 USER.md

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -315,6 +315,20 @@ Then use `clawdock-start`, `clawdock-stop`, `clawdock-dashboard`, etc. Run
 `clawdock-help` for all commands.
 See [ClawDock](/install/clawdock) for the full helper guide.
 
+### Keep macOS awake (optional)
+
+Docker itself does not reliably keep macOS awake. If the gateway must stay
+online for Slack, webhooks, or scheduled jobs:
+
+```bash
+scripts/openclaw-keepawake.sh on
+scripts/openclaw-keepawake.sh status
+scripts/openclaw-keepawake.sh off
+```
+
+By default this uses `caffeinate -imsu`, which allows the displays to sleep.
+Set `OPENCLAW_KEEPAWAKE_FLAGS=-dimsu` if you also want to keep the displays on.
+
 <AccordionGroup>
   <Accordion title="Enable agent sandbox for Docker gateway">
     ```bash
@@ -456,6 +470,90 @@ See [ClawDock](/install/clawdock) for the full helper guide.
     [OCI image annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
   </Accordion>
 </AccordionGroup>
+
+## Backup and migration (Intel Mac to Apple Silicon)
+
+For low-disruption host migration, move OpenClaw data and config, then rebuild
+the Docker image natively on the new machine.
+
+Use:
+
+- `scripts/migrate/backup-openclaw.sh` on the source host
+- `scripts/migrate/restore-openclaw.sh` on the target host
+
+### 1) Create a backup on the source host
+
+From the repo root:
+
+```bash
+scripts/migrate/backup-openclaw.sh
+```
+
+The archive includes:
+
+- OpenClaw config dir (`OPENCLAW_CONFIG_DIR` or `~/.openclaw`)
+- OpenClaw workspace dir (`OPENCLAW_WORKSPACE_DIR` or `~/.openclaw/workspace`)
+- `.env` and Docker setup files from the repo root
+- metadata and an internal checksum manifest
+
+Output files:
+
+- `backups/openclaw-backup-<timestamp>.tar.gz`
+- `backups/openclaw-backup-<timestamp>.tar.gz.sha256`
+
+Optional path overrides:
+
+```bash
+scripts/migrate/backup-openclaw.sh \
+  --config-dir "$HOME/.openclaw" \
+  --workspace-dir "$HOME/.openclaw/workspace" \
+  --output-dir "$HOME/openclaw-backups"
+```
+
+### 2) Transfer the archive to the target host
+
+Copy the archive and checksum file to the new machine using your normal secure
+transfer method. `restore-openclaw.sh` expects the companion `.sha256` file to
+sit next to the archive.
+
+### 3) Restore on the target host
+
+From the repo root on the target host:
+
+```bash
+scripts/migrate/restore-openclaw.sh --archive /path/to/openclaw-backup-<timestamp>.tar.gz
+```
+
+Default restore behavior:
+
+- verifies archive checksums
+- stops `openclaw-gateway` before restore
+- snapshots current config and workspace as `.pre-restore-<timestamp>`
+- restores config and workspace from backup
+- writes the backup env file as `.env.from-backup` for review
+
+To overwrite `.env` directly:
+
+```bash
+scripts/migrate/restore-openclaw.sh \
+  --archive /path/to/openclaw-backup-<timestamp>.tar.gz \
+  --apply-env
+```
+
+### 4) Rebuild and validate on the target architecture
+
+Always rebuild on Apple Silicon:
+
+```bash
+docker compose up -d --build --force-recreate openclaw-gateway
+docker compose run --rm openclaw-cli health
+docker compose run --rm openclaw-cli channels status --probe
+```
+
+### Architecture migration note
+
+Do not carry over architecture-specific binary caches from x86 to arm hosts.
+Rebuild containers and reinstall native toolchains on the target host.
 
 ### Running on a VPS?
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -493,8 +493,10 @@ The archive includes:
 
 - OpenClaw config dir (`OPENCLAW_CONFIG_DIR` or `~/.openclaw`)
 - OpenClaw workspace dir (`OPENCLAW_WORKSPACE_DIR` or `~/.openclaw/workspace`)
+- Auth-profile secret key dir (`OPENCLAW_AUTH_PROFILE_SECRET_DIR` or
+  `~/.openclaw-auth-profile-secrets`)
 - `.env` and Docker setup files from the repo root
-- metadata and an internal checksum manifest
+- metadata, an internal checksum manifest, and an external archive checksum
 
 Output files:
 
@@ -507,6 +509,7 @@ Optional path overrides:
 scripts/migrate/backup-openclaw.sh \
   --config-dir "$HOME/.openclaw" \
   --workspace-dir "$HOME/.openclaw/workspace" \
+  --auth-profile-secret-dir "$HOME/.openclaw-auth-profile-secrets" \
   --output-dir "$HOME/openclaw-backups"
 ```
 
@@ -528,8 +531,9 @@ Default restore behavior:
 
 - verifies archive checksums
 - stops `openclaw-gateway` before restore
-- snapshots current config and workspace as `.pre-restore-<timestamp>`
-- restores config and workspace from backup
+- snapshots current config, workspace, and auth-profile secret dirs as
+  `.pre-restore-<timestamp>`
+- restores config, workspace, and auth-profile secret state from backup
 - writes the backup env file as `.env.from-backup` for review
 
 To overwrite `.env` directly:

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -297,6 +297,20 @@ Then use `clawdock-start`, `clawdock-stop`, `clawdock-dashboard`, etc. Run
 `clawdock-help` for all commands.
 See [ClawDock](/install/clawdock) for the full helper guide.
 
+### Keep macOS awake (optional)
+
+Docker itself does not reliably keep macOS awake. If the gateway must stay
+online for Slack, webhooks, or scheduled jobs:
+
+```bash
+scripts/openclaw-keepawake.sh on
+scripts/openclaw-keepawake.sh status
+scripts/openclaw-keepawake.sh off
+```
+
+By default this uses `caffeinate -imsu`, which allows the displays to sleep.
+Set `OPENCLAW_KEEPAWAKE_FLAGS=-dimsu` if you also want to keep the displays on.
+
 <AccordionGroup>
   <Accordion title="Enable agent sandbox for Docker gateway">
     ```bash
@@ -434,6 +448,89 @@ See [ClawDock](/install/clawdock) for the full helper guide.
     [OCI image annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md).
   </Accordion>
 </AccordionGroup>
+
+## Backup and migration (Intel Mac to Apple Silicon)
+
+For low-disruption host migration, move OpenClaw data and config, then rebuild
+the Docker image natively on the new machine.
+
+Use:
+
+- `scripts/migrate/backup-openclaw.sh` on the source host
+- `scripts/migrate/restore-openclaw.sh` on the target host
+
+### 1) Create a backup on the source host
+
+From the repo root:
+
+```bash
+scripts/migrate/backup-openclaw.sh
+```
+
+The archive includes:
+
+- OpenClaw config dir (`OPENCLAW_CONFIG_DIR` or `~/.openclaw`)
+- OpenClaw workspace dir (`OPENCLAW_WORKSPACE_DIR` or `~/.openclaw/workspace`)
+- `.env` and Docker setup files from the repo root
+- metadata and an internal checksum manifest
+
+Output files:
+
+- `backups/openclaw-backup-<timestamp>.tar.gz`
+- `backups/openclaw-backup-<timestamp>.tar.gz.sha256`
+
+Optional path overrides:
+
+```bash
+scripts/migrate/backup-openclaw.sh \
+  --config-dir "$HOME/.openclaw" \
+  --workspace-dir "$HOME/.openclaw/workspace" \
+  --output-dir "$HOME/openclaw-backups"
+```
+
+### 2) Transfer the archive to the target host
+
+Copy the archive and checksum file to the new machine using your normal secure
+transfer method.
+
+### 3) Restore on the target host
+
+From the repo root on the target host:
+
+```bash
+scripts/migrate/restore-openclaw.sh --archive /path/to/openclaw-backup-<timestamp>.tar.gz
+```
+
+Default restore behavior:
+
+- verifies archive checksums
+- stops `openclaw-gateway` before restore
+- snapshots current config and workspace as `.pre-restore-<timestamp>`
+- restores config and workspace from backup
+- writes the backup env file as `.env.from-backup` for review
+
+To overwrite `.env` directly:
+
+```bash
+scripts/migrate/restore-openclaw.sh \
+  --archive /path/to/openclaw-backup-<timestamp>.tar.gz \
+  --apply-env
+```
+
+### 4) Rebuild and validate on the target architecture
+
+Always rebuild on Apple Silicon:
+
+```bash
+docker compose up -d --build --force-recreate openclaw-gateway
+docker compose run --rm openclaw-cli health
+docker compose run --rm openclaw-cli channels status --probe
+```
+
+### Architecture migration note
+
+Do not carry over architecture-specific binary caches from x86 to arm hosts.
+Rebuild containers and reinstall native toolchains on the target host.
 
 ### Running on a VPS?
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -491,7 +491,8 @@ scripts/migrate/backup-openclaw.sh \
 ### 2) Transfer the archive to the target host
 
 Copy the archive and checksum file to the new machine using your normal secure
-transfer method.
+transfer method. `restore-openclaw.sh` expects the companion `.sha256` file to
+sit next to the archive.
 
 ### 3) Restore on the target host
 

--- a/scripts/migrate/backup-openclaw.sh
+++ b/scripts/migrate/backup-openclaw.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/migrate/backup-openclaw.sh [options]
+
+Options:
+  --repo-root <path>       OpenClaw repo root (default: current repo)
+  --env-file <path>        Env file to include (default: <repo-root>/.env)
+  --config-dir <path>      OpenClaw config dir (default: env or ~/.openclaw)
+  --workspace-dir <path>   OpenClaw workspace dir (default: env or ~/.openclaw/workspace)
+  --output-dir <path>      Output directory for backup archive (default: <repo-root>/backups)
+  --name <name>            Backup name prefix (default: openclaw-backup-<timestamp>)
+  -h, --help               Show this help
+EOF
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+strip_quotes() {
+  local value="$1"
+  if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+    value="${value:1:${#value}-2}"
+  elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+    value="${value:1:${#value}-2}"
+  fi
+  printf '%s' "$value"
+}
+
+env_value_from_file() {
+  local file="$1"
+  local key="$2"
+  [[ -f "$file" ]] || return 0
+  local line
+  line="$(grep -E "^(export[[:space:]]+)?${key}=" "$file" | tail -n 1 || true)"
+  [[ -n "$line" ]] || return 0
+  line="${line#export }"
+  local value="${line#*=}"
+  strip_quotes "$value"
+}
+
+resolve_abs_path() {
+  local p="$1"
+  python3 - "$p" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+print(os.path.abspath(os.path.expanduser(path)))
+PY
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO_ROOT="$ROOT_DIR"
+ENV_FILE="$ROOT_DIR/.env"
+CONFIG_DIR=""
+WORKSPACE_DIR=""
+OUTPUT_DIR="$ROOT_DIR/backups"
+BACKUP_NAME=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --config-dir)
+      CONFIG_DIR="$2"
+      shift 2
+      ;;
+    --workspace-dir)
+      WORKSPACE_DIR="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    --name)
+      BACKUP_NAME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+require_cmd tar
+require_cmd rsync
+require_cmd shasum
+require_cmd python3
+require_cmd date
+require_cmd uname
+
+REPO_ROOT="$(resolve_abs_path "$REPO_ROOT")"
+ENV_FILE="$(resolve_abs_path "$ENV_FILE")"
+OUTPUT_DIR="$(resolve_abs_path "$OUTPUT_DIR")"
+
+if [[ -z "$CONFIG_DIR" ]]; then
+  CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_CONFIG_DIR)}"
+fi
+if [[ -z "$WORKSPACE_DIR" ]]; then
+  WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_WORKSPACE_DIR)}"
+fi
+
+CONFIG_DIR="${CONFIG_DIR:-$HOME/.openclaw}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
+CONFIG_DIR="$(resolve_abs_path "$CONFIG_DIR")"
+WORKSPACE_DIR="$(resolve_abs_path "$WORKSPACE_DIR")"
+
+[[ -d "$CONFIG_DIR" ]] || fail "Config directory does not exist: $CONFIG_DIR"
+[[ -d "$WORKSPACE_DIR" ]] || fail "Workspace directory does not exist: $WORKSPACE_DIR"
+[[ -d "$REPO_ROOT" ]] || fail "Repo root does not exist: $REPO_ROOT"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_NAME="${BACKUP_NAME:-openclaw-backup-${timestamp}}"
+mkdir -p "$OUTPUT_DIR"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+stage="$tmpdir/stage"
+mkdir -p "$stage/payload/config" "$stage/payload/workspace" "$stage/payload/repo" "$stage/meta"
+
+echo "==> Copying config directory"
+rsync -a "$CONFIG_DIR/" "$stage/payload/config/"
+
+echo "==> Copying workspace directory"
+rsync -a "$WORKSPACE_DIR/" "$stage/payload/workspace/"
+
+if [[ -f "$ENV_FILE" ]]; then
+  echo "==> Including env file: $ENV_FILE"
+  cp "$ENV_FILE" "$stage/payload/repo/.env"
+fi
+
+for file in docker-compose.yml docker-compose.extra.yml Dockerfile docker-setup.sh; do
+  if [[ -f "$REPO_ROOT/$file" ]]; then
+    cp "$REPO_ROOT/$file" "$stage/payload/repo/$file"
+  fi
+done
+
+{
+  echo "timestamp_utc=$timestamp"
+  echo "source_host=$(hostname -s || hostname)"
+  echo "source_arch=$(uname -m)"
+  echo "source_os=$(uname -s)"
+  echo "repo_root=$REPO_ROOT"
+  echo "config_dir=$CONFIG_DIR"
+  echo "workspace_dir=$WORKSPACE_DIR"
+} >"$stage/meta/backup.env"
+
+if command -v docker >/dev/null 2>&1; then
+  {
+    echo "# docker version"
+    docker version --format '{{.Server.Version}}' 2>/dev/null || true
+    echo
+    echo "# docker compose ps"
+    docker compose -f "$REPO_ROOT/docker-compose.yml" ps 2>/dev/null || true
+  } >"$stage/meta/docker.txt"
+fi
+
+if command -v git >/dev/null 2>&1 && [[ -d "$REPO_ROOT/.git" ]]; then
+  {
+    echo "branch=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+    echo "commit=$(git -C "$REPO_ROOT" rev-parse HEAD)"
+    echo
+    echo "# status"
+    git -C "$REPO_ROOT" status --short
+  } >"$stage/meta/git.txt"
+fi
+
+(
+  cd "$stage"
+  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 shasum -a 256 > SHA256SUMS
+)
+
+archive_path="$OUTPUT_DIR/${BACKUP_NAME}.tar.gz"
+(
+  cd "$stage"
+  tar -czf "$archive_path" .
+)
+shasum -a 256 "$archive_path" > "${archive_path}.sha256"
+
+echo
+echo "Backup created:"
+echo "  $archive_path"
+echo "  ${archive_path}.sha256"
+echo
+echo "Next step on target host:"
+echo "  scripts/migrate/restore-openclaw.sh --archive \"$archive_path\""

--- a/scripts/migrate/backup-openclaw.sh
+++ b/scripts/migrate/backup-openclaw.sh
@@ -61,11 +61,13 @@ PY
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REPO_ROOT="$ROOT_DIR"
-ENV_FILE="$ROOT_DIR/.env"
+ENV_FILE=""
 CONFIG_DIR=""
 WORKSPACE_DIR=""
-OUTPUT_DIR="$ROOT_DIR/backups"
+OUTPUT_DIR=""
 BACKUP_NAME=""
+ENV_FILE_EXPLICIT=0
+OUTPUT_DIR_EXPLICIT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -75,6 +77,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --env-file)
       ENV_FILE="$2"
+      ENV_FILE_EXPLICIT=1
       shift 2
       ;;
     --config-dir)
@@ -87,6 +90,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --output-dir)
       OUTPUT_DIR="$2"
+      OUTPUT_DIR_EXPLICIT=1
       shift 2
       ;;
     --name)
@@ -111,6 +115,12 @@ require_cmd date
 require_cmd uname
 
 REPO_ROOT="$(resolve_abs_path "$REPO_ROOT")"
+if [[ $ENV_FILE_EXPLICIT -eq 0 ]]; then
+  ENV_FILE="$REPO_ROOT/.env"
+fi
+if [[ $OUTPUT_DIR_EXPLICIT -eq 0 ]]; then
+  OUTPUT_DIR="$REPO_ROOT/backups"
+fi
 ENV_FILE="$(resolve_abs_path "$ENV_FILE")"
 OUTPUT_DIR="$(resolve_abs_path "$OUTPUT_DIR")"
 
@@ -197,7 +207,10 @@ archive_path="$OUTPUT_DIR/${BACKUP_NAME}.tar.gz"
   cd "$stage"
   tar -czf "$archive_path" .
 )
-shasum -a 256 "$archive_path" > "${archive_path}.sha256"
+(
+  cd "$OUTPUT_DIR"
+  shasum -a 256 "$(basename "$archive_path")" > "$(basename "$archive_path").sha256"
+)
 
 echo
 echo "Backup created:"

--- a/scripts/migrate/backup-openclaw.sh
+++ b/scripts/migrate/backup-openclaw.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=scripts/migrate/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -15,48 +18,6 @@ Options:
   --name <name>            Backup name prefix (default: openclaw-backup-<timestamp>)
   -h, --help               Show this help
 EOF
-}
-
-fail() {
-  echo "ERROR: $*" >&2
-  exit 1
-}
-
-require_cmd() {
-  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
-}
-
-strip_quotes() {
-  local value="$1"
-  if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
-    value="${value:1:${#value}-2}"
-  elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
-    value="${value:1:${#value}-2}"
-  fi
-  printf '%s' "$value"
-}
-
-env_value_from_file() {
-  local file="$1"
-  local key="$2"
-  [[ -f "$file" ]] || return 0
-  local line
-  line="$(grep -E "^(export[[:space:]]+)?${key}=" "$file" | tail -n 1 || true)"
-  [[ -n "$line" ]] || return 0
-  line="${line#export }"
-  local value="${line#*=}"
-  strip_quotes "$value"
-}
-
-resolve_abs_path() {
-  local p="$1"
-  python3 - "$p" <<'PY'
-import os
-import sys
-
-path = sys.argv[1]
-print(os.path.abspath(os.path.expanduser(path)))
-PY
 }
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/scripts/migrate/backup-openclaw.sh
+++ b/scripts/migrate/backup-openclaw.sh
@@ -112,7 +112,14 @@ stage="$tmpdir/stage"
 mkdir -p "$stage/payload/config" "$stage/payload/workspace" "$stage/payload/repo" "$stage/meta"
 
 echo "==> Copying config directory"
-rsync -a "$CONFIG_DIR/" "$stage/payload/config/"
+config_rsync_args=(-a)
+if [[ "$WORKSPACE_DIR" == "$CONFIG_DIR"/* ]]; then
+  nested_workspace_rel="${WORKSPACE_DIR#$CONFIG_DIR/}"
+  if [[ -n "$nested_workspace_rel" ]]; then
+    config_rsync_args+=(--exclude="/${nested_workspace_rel}/")
+  fi
+fi
+rsync "${config_rsync_args[@]}" "$CONFIG_DIR/" "$stage/payload/config/"
 
 echo "==> Copying workspace directory"
 rsync -a "$WORKSPACE_DIR/" "$stage/payload/workspace/"

--- a/scripts/migrate/backup-openclaw.sh
+++ b/scripts/migrate/backup-openclaw.sh
@@ -159,8 +159,30 @@ if command -v git >/dev/null 2>&1 && [[ -d "$REPO_ROOT/.git" ]]; then
 fi
 
 (
-  cd "$stage"
-  find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 shasum -a 256 > SHA256SUMS
+  python3 - "$stage" <<'PY'
+import hashlib
+import os
+import sys
+
+stage = sys.argv[1]
+entries = []
+for root, dirs, files in os.walk(stage):
+    dirs.sort()
+    files.sort()
+    for name in files:
+        rel = os.path.relpath(os.path.join(root, name), stage)
+        if rel == "SHA256SUMS":
+            continue
+        entries.append(rel)
+
+with open(os.path.join(stage, "SHA256SUMS"), "w", encoding="utf-8") as out:
+    for rel in sorted(entries):
+        digest = hashlib.sha256()
+        with open(os.path.join(stage, rel), "rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                digest.update(chunk)
+        out.write(f"{digest.hexdigest()}  ./{rel}\n")
+PY
 )
 
 archive_path="$OUTPUT_DIR/${BACKUP_NAME}.tar.gz"

--- a/scripts/migrate/backup-openclaw.sh
+++ b/scripts/migrate/backup-openclaw.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/migrate/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/migrate/backup-openclaw.sh [options]
+
+Options:
+  --repo-root <path>       OpenClaw repo root (default: current repo)
+  --env-file <path>        Env file to include (default: <repo-root>/.env)
+  --config-dir <path>      OpenClaw config dir (default: env or ~/.openclaw)
+  --workspace-dir <path>   OpenClaw workspace dir (default: env or ~/.openclaw/workspace)
+  --output-dir <path>      Output directory for backup archive (default: <repo-root>/backups)
+  --name <name>            Backup name prefix (default: openclaw-backup-<timestamp>)
+  -h, --help               Show this help
+EOF
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO_ROOT="$ROOT_DIR"
+ENV_FILE=""
+CONFIG_DIR=""
+WORKSPACE_DIR=""
+OUTPUT_DIR=""
+BACKUP_NAME=""
+ENV_FILE_EXPLICIT=0
+OUTPUT_DIR_EXPLICIT=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="$2"
+      ENV_FILE_EXPLICIT=1
+      shift 2
+      ;;
+    --config-dir)
+      CONFIG_DIR="$2"
+      shift 2
+      ;;
+    --workspace-dir)
+      WORKSPACE_DIR="$2"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="$2"
+      OUTPUT_DIR_EXPLICIT=1
+      shift 2
+      ;;
+    --name)
+      BACKUP_NAME="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+require_cmd tar
+require_cmd rsync
+require_cmd shasum
+require_cmd python3
+require_cmd date
+require_cmd uname
+
+REPO_ROOT="$(resolve_abs_path "$REPO_ROOT")"
+if [[ $ENV_FILE_EXPLICIT -eq 0 ]]; then
+  ENV_FILE="$REPO_ROOT/.env"
+fi
+if [[ $OUTPUT_DIR_EXPLICIT -eq 0 ]]; then
+  OUTPUT_DIR="$REPO_ROOT/backups"
+fi
+ENV_FILE="$(resolve_abs_path "$ENV_FILE")"
+OUTPUT_DIR="$(resolve_abs_path "$OUTPUT_DIR")"
+
+if [[ -z "$CONFIG_DIR" ]]; then
+  CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_CONFIG_DIR)}"
+fi
+if [[ -z "$WORKSPACE_DIR" ]]; then
+  WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_WORKSPACE_DIR)}"
+fi
+
+CONFIG_DIR="${CONFIG_DIR:-$HOME/.openclaw}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
+CONFIG_DIR="$(resolve_abs_path "$CONFIG_DIR")"
+WORKSPACE_DIR="$(resolve_abs_path "$WORKSPACE_DIR")"
+
+[[ -d "$CONFIG_DIR" ]] || fail "Config directory does not exist: $CONFIG_DIR"
+[[ -d "$WORKSPACE_DIR" ]] || fail "Workspace directory does not exist: $WORKSPACE_DIR"
+[[ -d "$REPO_ROOT" ]] || fail "Repo root does not exist: $REPO_ROOT"
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_NAME="${BACKUP_NAME:-openclaw-backup-${timestamp}}"
+case "$BACKUP_NAME" in
+  *[!/A-Za-z0-9._-]*|*/*|.*|*..*)
+    fail "--name must be a simple filename prefix using letters, numbers, dot, underscore, or dash"
+    ;;
+esac
+mkdir -p "$OUTPUT_DIR"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+stage="$tmpdir/stage"
+mkdir -p "$stage/payload/config" "$stage/payload/workspace" "$stage/payload/repo" "$stage/meta"
+
+echo "==> Copying config directory"
+config_rsync_args=(-a)
+if [[ "$WORKSPACE_DIR" == "$CONFIG_DIR"/* ]]; then
+  nested_workspace_rel="${WORKSPACE_DIR#$CONFIG_DIR/}"
+  if [[ -n "$nested_workspace_rel" ]]; then
+    config_rsync_args+=(--exclude="/${nested_workspace_rel}/")
+  fi
+fi
+rsync "${config_rsync_args[@]}" "$CONFIG_DIR/" "$stage/payload/config/"
+
+echo "==> Copying workspace directory"
+rsync -a "$WORKSPACE_DIR/" "$stage/payload/workspace/"
+
+if [[ -f "$ENV_FILE" ]]; then
+  echo "==> Including env file: $ENV_FILE"
+  cp "$ENV_FILE" "$stage/payload/repo/.env"
+fi
+
+for file in Dockerfile docker-compose.yml docker-compose.override.yml docker-compose.extra.yml scripts/docker/setup.sh; do
+  if [[ -f "$REPO_ROOT/$file" ]]; then
+    mkdir -p "$stage/payload/repo/$(dirname "$file")"
+    cp "$REPO_ROOT/$file" "$stage/payload/repo/$file"
+  fi
+done
+
+{
+  echo "timestamp_utc=$timestamp"
+  echo "source_host=$(hostname -s || hostname)"
+  echo "source_arch=$(uname -m)"
+  echo "source_os=$(uname -s)"
+  echo "repo_root=$REPO_ROOT"
+  echo "config_dir=$CONFIG_DIR"
+  echo "workspace_dir=$WORKSPACE_DIR"
+} >"$stage/meta/backup.env"
+
+if command -v docker >/dev/null 2>&1; then
+  {
+    echo "# docker version"
+    docker version --format '{{.Server.Version}}' 2>/dev/null || true
+    echo
+    echo "# docker compose ps"
+    docker compose -f "$REPO_ROOT/docker-compose.yml" ps 2>/dev/null || true
+  } >"$stage/meta/docker.txt"
+fi
+
+if command -v git >/dev/null 2>&1 && [[ -d "$REPO_ROOT/.git" ]]; then
+  {
+    echo "branch=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+    echo "commit=$(git -C "$REPO_ROOT" rev-parse HEAD)"
+    echo
+    echo "# status"
+    git -C "$REPO_ROOT" status --short
+  } >"$stage/meta/git.txt"
+fi
+
+(
+  python3 - "$stage" <<'PY'
+import hashlib
+import os
+import sys
+
+stage = sys.argv[1]
+entries = []
+for root, dirs, files in os.walk(stage):
+    dirs.sort()
+    files.sort()
+    for name in files:
+        path = os.path.join(root, name)
+        rel = os.path.relpath(path, stage)
+        if rel == "SHA256SUMS":
+            continue
+        if os.path.islink(path):
+            continue
+        entries.append(rel)
+
+with open(os.path.join(stage, "SHA256SUMS"), "w", encoding="utf-8") as out:
+    for rel in sorted(entries):
+        digest = hashlib.sha256()
+        with open(os.path.join(stage, rel), "rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                digest.update(chunk)
+        out.write(f"{digest.hexdigest()}  ./{rel}\n")
+PY
+)
+
+archive_path="$OUTPUT_DIR/${BACKUP_NAME}.tar.gz"
+(
+  cd "$stage"
+  tar -czf "$archive_path" .
+)
+(
+  cd "$OUTPUT_DIR"
+  shasum -a 256 "$(basename "$archive_path")" > "$(basename "$archive_path").sha256"
+)
+
+echo
+echo "Backup created:"
+echo "  $archive_path"
+echo "  ${archive_path}.sha256"
+echo
+echo "Next step on target host:"
+echo "  scripts/migrate/restore-openclaw.sh --archive \"$archive_path\""

--- a/scripts/migrate/backup-openclaw.sh
+++ b/scripts/migrate/backup-openclaw.sh
@@ -14,6 +14,8 @@ Options:
   --env-file <path>        Env file to include (default: <repo-root>/.env)
   --config-dir <path>      OpenClaw config dir (default: env or ~/.openclaw)
   --workspace-dir <path>   OpenClaw workspace dir (default: env or ~/.openclaw/workspace)
+  --auth-profile-secret-dir <path>
+                           Auth-profile secret dir (default: env or ~/.openclaw-auth-profile-secrets)
   --output-dir <path>      Output directory for backup archive (default: <repo-root>/backups)
   --name <name>            Backup name prefix (default: openclaw-backup-<timestamp>)
   -h, --help               Show this help
@@ -25,6 +27,7 @@ REPO_ROOT="$ROOT_DIR"
 ENV_FILE=""
 CONFIG_DIR=""
 WORKSPACE_DIR=""
+AUTH_PROFILE_SECRET_DIR=""
 OUTPUT_DIR=""
 BACKUP_NAME=""
 ENV_FILE_EXPLICIT=0
@@ -47,6 +50,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --workspace-dir)
       WORKSPACE_DIR="$2"
+      shift 2
+      ;;
+    --auth-profile-secret-dir)
+      AUTH_PROFILE_SECRET_DIR="$2"
       shift 2
       ;;
     --output-dir)
@@ -91,11 +98,16 @@ fi
 if [[ -z "$WORKSPACE_DIR" ]]; then
   WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_WORKSPACE_DIR)}"
 fi
+if [[ -z "$AUTH_PROFILE_SECRET_DIR" ]]; then
+  AUTH_PROFILE_SECRET_DIR="${OPENCLAW_AUTH_PROFILE_SECRET_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_AUTH_PROFILE_SECRET_DIR)}"
+fi
 
 CONFIG_DIR="${CONFIG_DIR:-$HOME/.openclaw}"
 WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
+AUTH_PROFILE_SECRET_DIR="${AUTH_PROFILE_SECRET_DIR:-$HOME/.openclaw-auth-profile-secrets}"
 CONFIG_DIR="$(resolve_abs_path "$CONFIG_DIR")"
 WORKSPACE_DIR="$(resolve_abs_path "$WORKSPACE_DIR")"
+AUTH_PROFILE_SECRET_DIR="$(resolve_abs_path "$AUTH_PROFILE_SECRET_DIR")"
 
 [[ -d "$CONFIG_DIR" ]] || fail "Config directory does not exist: $CONFIG_DIR"
 [[ -d "$WORKSPACE_DIR" ]] || fail "Workspace directory does not exist: $WORKSPACE_DIR"
@@ -108,6 +120,7 @@ case "$BACKUP_NAME" in
     fail "--name must be a simple filename prefix using letters, numbers, dot, underscore, or dash"
     ;;
 esac
+umask 077
 mkdir -p "$OUTPUT_DIR"
 
 tmpdir="$(mktemp -d)"
@@ -129,6 +142,14 @@ rsync "${config_rsync_args[@]}" "$CONFIG_DIR/" "$stage/payload/config/"
 echo "==> Copying workspace directory"
 rsync -a "$WORKSPACE_DIR/" "$stage/payload/workspace/"
 
+if [[ -d "$AUTH_PROFILE_SECRET_DIR" ]]; then
+  echo "==> Copying auth-profile secret directory"
+  mkdir -p "$stage/payload/auth-profile-secrets"
+  rsync -a "$AUTH_PROFILE_SECRET_DIR/" "$stage/payload/auth-profile-secrets/"
+else
+  echo "WARNING: auth-profile secret directory not found; skipping: $AUTH_PROFILE_SECRET_DIR" >&2
+fi
+
 if [[ -f "$ENV_FILE" ]]; then
   echo "==> Including env file: $ENV_FILE"
   cp "$ENV_FILE" "$stage/payload/repo/.env"
@@ -149,6 +170,7 @@ done
   echo "repo_root=$REPO_ROOT"
   echo "config_dir=$CONFIG_DIR"
   echo "workspace_dir=$WORKSPACE_DIR"
+  echo "auth_profile_secret_dir=$AUTH_PROFILE_SECRET_DIR"
 } >"$stage/meta/backup.env"
 
 if command -v docker >/dev/null 2>&1; then
@@ -210,6 +232,7 @@ archive_path="$OUTPUT_DIR/${BACKUP_NAME}.tar.gz"
   cd "$OUTPUT_DIR"
   shasum -a 256 "$(basename "$archive_path")" > "$(basename "$archive_path").sha256"
 )
+chmod 600 "$archive_path" "${archive_path}.sha256"
 
 echo
 echo "Backup created:"

--- a/scripts/migrate/backup-openclaw.sh
+++ b/scripts/migrate/backup-openclaw.sh
@@ -177,8 +177,11 @@ for root, dirs, files in os.walk(stage):
     dirs.sort()
     files.sort()
     for name in files:
-        rel = os.path.relpath(os.path.join(root, name), stage)
+        path = os.path.join(root, name)
+        rel = os.path.relpath(path, stage)
         if rel == "SHA256SUMS":
+            continue
+        if os.path.islink(path):
             continue
         entries.append(rel)
 

--- a/scripts/migrate/lib.sh
+++ b/scripts/migrate/lib.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+strip_quotes() {
+  local value="$1"
+  if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+    value="${value:1:${#value}-2}"
+  elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+    value="${value:1:${#value}-2}"
+  fi
+  printf '%s' "$value"
+}
+
+env_value_from_file() {
+  local file="$1"
+  local key="$2"
+  [[ -f "$file" ]] || return 0
+  local line
+  line="$(grep -E "^(export[[:space:]]+)?${key}=" "$file" | tail -n 1 || true)"
+  [[ -n "$line" ]] || return 0
+  line="${line#export }"
+  local value="${line#*=}"
+  strip_quotes "$value"
+}
+
+resolve_abs_path() {
+  local p="$1"
+  python3 - "$p" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+print(os.path.abspath(os.path.expanduser(path)))
+PY
+}

--- a/scripts/migrate/restore-openclaw.sh
+++ b/scripts/migrate/restore-openclaw.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/migrate/restore-openclaw.sh --archive <path> [options]
+
+Options:
+  --archive <path>         Backup archive created by backup-openclaw.sh (required)
+  --repo-root <path>       OpenClaw repo root (default: current repo)
+  --env-file <path>        Env file path (default: <repo-root>/.env)
+  --config-dir <path>      OpenClaw config dir (default: env or ~/.openclaw)
+  --workspace-dir <path>   OpenClaw workspace dir (default: env or ~/.openclaw/workspace)
+  --apply-env              Overwrite --env-file with backup .env (default: false)
+  --no-stop                Do not stop gateway container before restore
+  -h, --help               Show this help
+EOF
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+strip_quotes() {
+  local value="$1"
+  if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
+    value="${value:1:${#value}-2}"
+  elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
+    value="${value:1:${#value}-2}"
+  fi
+  printf '%s' "$value"
+}
+
+env_value_from_file() {
+  local file="$1"
+  local key="$2"
+  [[ -f "$file" ]] || return 0
+  local line
+  line="$(grep -E "^(export[[:space:]]+)?${key}=" "$file" | tail -n 1 || true)"
+  [[ -n "$line" ]] || return 0
+  line="${line#export }"
+  local value="${line#*=}"
+  strip_quotes "$value"
+}
+
+resolve_abs_path() {
+  local p="$1"
+  python3 - "$p" <<'PY'
+import os
+import sys
+
+path = sys.argv[1]
+print(os.path.abspath(os.path.expanduser(path)))
+PY
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO_ROOT="$ROOT_DIR"
+ENV_FILE="$ROOT_DIR/.env"
+ARCHIVE_PATH=""
+CONFIG_DIR=""
+WORKSPACE_DIR=""
+APPLY_ENV=0
+STOP_FIRST=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archive)
+      ARCHIVE_PATH="$2"
+      shift 2
+      ;;
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    --config-dir)
+      CONFIG_DIR="$2"
+      shift 2
+      ;;
+    --workspace-dir)
+      WORKSPACE_DIR="$2"
+      shift 2
+      ;;
+    --apply-env)
+      APPLY_ENV=1
+      shift
+      ;;
+    --no-stop)
+      STOP_FIRST=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$ARCHIVE_PATH" ]] || fail "--archive is required"
+
+require_cmd tar
+require_cmd rsync
+require_cmd shasum
+require_cmd python3
+require_cmd date
+
+ARCHIVE_PATH="$(resolve_abs_path "$ARCHIVE_PATH")"
+REPO_ROOT="$(resolve_abs_path "$REPO_ROOT")"
+ENV_FILE="$(resolve_abs_path "$ENV_FILE")"
+
+[[ -f "$ARCHIVE_PATH" ]] || fail "Archive not found: $ARCHIVE_PATH"
+[[ -d "$REPO_ROOT" ]] || fail "Repo root does not exist: $REPO_ROOT"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+echo "==> Extracting archive"
+tar -xzf "$ARCHIVE_PATH" -C "$tmpdir"
+
+[[ -f "$tmpdir/SHA256SUMS" ]] || fail "Archive missing SHA256SUMS"
+(
+  cd "$tmpdir"
+  shasum -a 256 -c SHA256SUMS
+)
+
+if [[ -z "$CONFIG_DIR" ]]; then
+  CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_CONFIG_DIR)}"
+fi
+if [[ -z "$WORKSPACE_DIR" ]]; then
+  WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_WORKSPACE_DIR)}"
+fi
+
+CONFIG_DIR="${CONFIG_DIR:-$HOME/.openclaw}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
+CONFIG_DIR="$(resolve_abs_path "$CONFIG_DIR")"
+WORKSPACE_DIR="$(resolve_abs_path "$WORKSPACE_DIR")"
+
+if [[ $STOP_FIRST -eq 1 ]] && command -v docker >/dev/null 2>&1; then
+  echo "==> Stopping gateway container"
+  docker compose -f "$REPO_ROOT/docker-compose.yml" stop openclaw-gateway >/dev/null 2>&1 || true
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$(dirname "$CONFIG_DIR")" "$(dirname "$WORKSPACE_DIR")"
+
+if [[ -d "$CONFIG_DIR" ]]; then
+  mv "$CONFIG_DIR" "${CONFIG_DIR}.pre-restore-${timestamp}"
+fi
+if [[ -d "$WORKSPACE_DIR" ]]; then
+  mv "$WORKSPACE_DIR" "${WORKSPACE_DIR}.pre-restore-${timestamp}"
+fi
+
+mkdir -p "$CONFIG_DIR" "$WORKSPACE_DIR"
+
+echo "==> Restoring config"
+rsync -a "$tmpdir/payload/config/" "$CONFIG_DIR/"
+
+echo "==> Restoring workspace"
+rsync -a "$tmpdir/payload/workspace/" "$WORKSPACE_DIR/"
+
+if [[ -f "$tmpdir/payload/repo/.env" ]]; then
+  if [[ $APPLY_ENV -eq 1 ]]; then
+    mkdir -p "$(dirname "$ENV_FILE")"
+    if [[ -f "$ENV_FILE" ]]; then
+      cp "$ENV_FILE" "${ENV_FILE}.pre-restore-${timestamp}"
+    fi
+    cp "$tmpdir/payload/repo/.env" "$ENV_FILE"
+    echo "==> Applied backed up env file to $ENV_FILE"
+  else
+    cp "$tmpdir/payload/repo/.env" "${ENV_FILE}.from-backup"
+    echo "==> Wrote env candidate to ${ENV_FILE}.from-backup"
+  fi
+fi
+
+source_arch="$(grep -E '^source_arch=' "$tmpdir/meta/backup.env" | cut -d= -f2- || true)"
+target_arch="$(uname -m)"
+if [[ -n "$source_arch" && "$source_arch" != "$target_arch" ]]; then
+  echo
+  echo "NOTE: source arch (${source_arch}) differs from target arch (${target_arch})."
+  echo "Rebuild the Docker image on this host; do not reuse old binary caches or volumes."
+fi
+
+echo
+echo "Restore completed."
+echo "Next steps:"
+echo "  1) docker compose -f \"$REPO_ROOT/docker-compose.yml\" up -d --build --force-recreate openclaw-gateway"
+echo "  2) docker compose -f \"$REPO_ROOT/docker-compose.yml\" run --rm openclaw-cli health"
+echo "  3) docker compose -f \"$REPO_ROOT/docker-compose.yml\" run --rm openclaw-cli channels status --probe"

--- a/scripts/migrate/restore-openclaw.sh
+++ b/scripts/migrate/restore-openclaw.sh
@@ -120,8 +120,12 @@ CONFIG_DIR="$(resolve_abs_path "$CONFIG_DIR")"
 WORKSPACE_DIR="$(resolve_abs_path "$WORKSPACE_DIR")"
 
 if [[ $STOP_FIRST -eq 1 ]] && command -v docker >/dev/null 2>&1; then
+  compose_file="$REPO_ROOT/docker-compose.yml"
+  [[ -f "$compose_file" ]] || fail "Compose file not found at $compose_file (use --no-stop to skip stopping the gateway)."
   echo "==> Stopping gateway container"
-  docker compose -f "$REPO_ROOT/docker-compose.yml" stop openclaw-gateway >/dev/null 2>&1 || true
+  if ! docker compose -f "$compose_file" stop openclaw-gateway >/dev/null 2>&1; then
+    fail "Failed to stop openclaw-gateway. Fix Docker/Compose first or rerun with --no-stop if the gateway is already stopped."
+  fi
 fi
 
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"

--- a/scripts/migrate/restore-openclaw.sh
+++ b/scripts/migrate/restore-openclaw.sh
@@ -62,12 +62,13 @@ PY
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 REPO_ROOT="$ROOT_DIR"
-ENV_FILE="$ROOT_DIR/.env"
+ENV_FILE=""
 ARCHIVE_PATH=""
 CONFIG_DIR=""
 WORKSPACE_DIR=""
 APPLY_ENV=0
 STOP_FIRST=1
+ENV_FILE_EXPLICIT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -81,6 +82,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --env-file)
       ENV_FILE="$2"
+      ENV_FILE_EXPLICIT=1
       shift 2
       ;;
     --config-dir)
@@ -119,13 +121,21 @@ require_cmd date
 
 ARCHIVE_PATH="$(resolve_abs_path "$ARCHIVE_PATH")"
 REPO_ROOT="$(resolve_abs_path "$REPO_ROOT")"
+if [[ $ENV_FILE_EXPLICIT -eq 0 ]]; then
+  ENV_FILE="$REPO_ROOT/.env"
+fi
 ENV_FILE="$(resolve_abs_path "$ENV_FILE")"
 
 [[ -f "$ARCHIVE_PATH" ]] || fail "Archive not found: $ARCHIVE_PATH"
 [[ -d "$REPO_ROOT" ]] || fail "Repo root does not exist: $REPO_ROOT"
+[[ -f "${ARCHIVE_PATH}.sha256" ]] || fail "Archive checksum file not found: ${ARCHIVE_PATH}.sha256"
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
+
+archive_checksum="$(awk 'NR == 1 { print $1 }' "${ARCHIVE_PATH}.sha256")"
+[[ -n "$archive_checksum" ]] || fail "Archive checksum file is invalid: ${ARCHIVE_PATH}.sha256"
+printf '%s  %s\n' "$archive_checksum" "$ARCHIVE_PATH" | shasum -a 256 -c -
 
 echo "==> Extracting archive"
 tar -xzf "$ARCHIVE_PATH" -C "$tmpdir"

--- a/scripts/migrate/restore-openclaw.sh
+++ b/scripts/migrate/restore-openclaw.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# shellcheck source=scripts/migrate/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -16,48 +19,6 @@ Options:
   --no-stop                Do not stop gateway container before restore
   -h, --help               Show this help
 EOF
-}
-
-fail() {
-  echo "ERROR: $*" >&2
-  exit 1
-}
-
-require_cmd() {
-  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
-}
-
-strip_quotes() {
-  local value="$1"
-  if [[ "${value}" == \"*\" && "${value}" == *\" ]]; then
-    value="${value:1:${#value}-2}"
-  elif [[ "${value}" == \'*\' && "${value}" == *\' ]]; then
-    value="${value:1:${#value}-2}"
-  fi
-  printf '%s' "$value"
-}
-
-env_value_from_file() {
-  local file="$1"
-  local key="$2"
-  [[ -f "$file" ]] || return 0
-  local line
-  line="$(grep -E "^(export[[:space:]]+)?${key}=" "$file" | tail -n 1 || true)"
-  [[ -n "$line" ]] || return 0
-  line="${line#export }"
-  local value="${line#*=}"
-  strip_quotes "$value"
-}
-
-resolve_abs_path() {
-  local p="$1"
-  python3 - "$p" <<'PY'
-import os
-import sys
-
-path = sys.argv[1]
-print(os.path.abspath(os.path.expanduser(path)))
-PY
 }
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/scripts/migrate/restore-openclaw.sh
+++ b/scripts/migrate/restore-openclaw.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/migrate/lib.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/migrate/restore-openclaw.sh --archive <path> [options]
+
+Options:
+  --archive <path>         Backup archive created by backup-openclaw.sh (required)
+  --repo-root <path>       OpenClaw repo root (default: current repo)
+  --env-file <path>        Env file path (default: <repo-root>/.env)
+  --config-dir <path>      OpenClaw config dir (default: env or ~/.openclaw)
+  --workspace-dir <path>   OpenClaw workspace dir (default: env or ~/.openclaw/workspace)
+  --apply-env              Overwrite --env-file with backup .env (default: false)
+  --no-stop                Do not stop gateway container before restore
+  -h, --help               Show this help
+EOF
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+REPO_ROOT="$ROOT_DIR"
+ENV_FILE=""
+ARCHIVE_PATH=""
+CONFIG_DIR=""
+WORKSPACE_DIR=""
+APPLY_ENV=0
+STOP_FIRST=1
+ENV_FILE_EXPLICIT=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archive)
+      ARCHIVE_PATH="$2"
+      shift 2
+      ;;
+    --repo-root)
+      REPO_ROOT="$2"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="$2"
+      ENV_FILE_EXPLICIT=1
+      shift 2
+      ;;
+    --config-dir)
+      CONFIG_DIR="$2"
+      shift 2
+      ;;
+    --workspace-dir)
+      WORKSPACE_DIR="$2"
+      shift 2
+      ;;
+    --apply-env)
+      APPLY_ENV=1
+      shift
+      ;;
+    --no-stop)
+      STOP_FIRST=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$ARCHIVE_PATH" ]] || fail "--archive is required"
+
+require_cmd tar
+require_cmd rsync
+require_cmd shasum
+require_cmd python3
+require_cmd date
+
+ARCHIVE_PATH="$(resolve_abs_path "$ARCHIVE_PATH")"
+REPO_ROOT="$(resolve_abs_path "$REPO_ROOT")"
+if [[ $ENV_FILE_EXPLICIT -eq 0 ]]; then
+  ENV_FILE="$REPO_ROOT/.env"
+fi
+ENV_FILE="$(resolve_abs_path "$ENV_FILE")"
+
+[[ -f "$ARCHIVE_PATH" ]] || fail "Archive not found: $ARCHIVE_PATH"
+[[ -d "$REPO_ROOT" ]] || fail "Repo root does not exist: $REPO_ROOT"
+[[ -f "${ARCHIVE_PATH}.sha256" ]] || fail "Archive checksum file not found: ${ARCHIVE_PATH}.sha256"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+archive_checksum="$(awk 'NR == 1 { print $1 }' "${ARCHIVE_PATH}.sha256")"
+[[ -n "$archive_checksum" ]] || fail "Archive checksum file is invalid: ${ARCHIVE_PATH}.sha256"
+printf '%s  %s\n' "$archive_checksum" "$ARCHIVE_PATH" | shasum -a 256 -c -
+
+echo "==> Extracting archive"
+tar -xzf "$ARCHIVE_PATH" -C "$tmpdir"
+
+[[ -f "$tmpdir/SHA256SUMS" ]] || fail "Archive missing SHA256SUMS"
+(
+  cd "$tmpdir"
+  shasum -a 256 -c SHA256SUMS
+)
+
+if [[ -z "$CONFIG_DIR" ]]; then
+  CONFIG_DIR="${OPENCLAW_CONFIG_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_CONFIG_DIR)}"
+fi
+if [[ -z "$WORKSPACE_DIR" ]]; then
+  WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_WORKSPACE_DIR)}"
+fi
+
+CONFIG_DIR="${CONFIG_DIR:-$HOME/.openclaw}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
+CONFIG_DIR="$(resolve_abs_path "$CONFIG_DIR")"
+WORKSPACE_DIR="$(resolve_abs_path "$WORKSPACE_DIR")"
+
+if [[ $STOP_FIRST -eq 1 ]] && command -v docker >/dev/null 2>&1; then
+  compose_file="$REPO_ROOT/docker-compose.yml"
+  [[ -f "$compose_file" ]] || fail "Compose file not found at $compose_file (use --no-stop to skip stopping the gateway)."
+  echo "==> Stopping gateway container"
+  if ! docker compose -f "$compose_file" stop openclaw-gateway >/dev/null 2>&1; then
+    fail "Failed to stop openclaw-gateway. Fix Docker/Compose first or rerun with --no-stop if the gateway is already stopped."
+  fi
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$(dirname "$CONFIG_DIR")" "$(dirname "$WORKSPACE_DIR")"
+
+if [[ -d "$CONFIG_DIR" ]]; then
+  mv "$CONFIG_DIR" "${CONFIG_DIR}.pre-restore-${timestamp}"
+fi
+if [[ -d "$WORKSPACE_DIR" ]]; then
+  mv "$WORKSPACE_DIR" "${WORKSPACE_DIR}.pre-restore-${timestamp}"
+fi
+
+mkdir -p "$CONFIG_DIR" "$WORKSPACE_DIR"
+
+echo "==> Restoring config"
+rsync -a "$tmpdir/payload/config/" "$CONFIG_DIR/"
+
+echo "==> Restoring workspace"
+rsync -a "$tmpdir/payload/workspace/" "$WORKSPACE_DIR/"
+
+if [[ -f "$tmpdir/payload/repo/.env" ]]; then
+  if [[ $APPLY_ENV -eq 1 ]]; then
+    mkdir -p "$(dirname "$ENV_FILE")"
+    if [[ -f "$ENV_FILE" ]]; then
+      cp "$ENV_FILE" "${ENV_FILE}.pre-restore-${timestamp}"
+    fi
+    cp "$tmpdir/payload/repo/.env" "$ENV_FILE"
+    echo "==> Applied backed up env file to $ENV_FILE"
+  else
+    cp "$tmpdir/payload/repo/.env" "${ENV_FILE}.from-backup"
+    echo "==> Wrote env candidate to ${ENV_FILE}.from-backup"
+  fi
+fi
+
+source_arch="$(grep -E '^source_arch=' "$tmpdir/meta/backup.env" | cut -d= -f2- || true)"
+target_arch="$(uname -m)"
+if [[ -n "$source_arch" && "$source_arch" != "$target_arch" ]]; then
+  echo
+  echo "NOTE: source arch (${source_arch}) differs from target arch (${target_arch})."
+  echo "Rebuild the Docker image on this host; do not reuse old binary caches or volumes."
+fi
+
+echo
+echo "Restore completed."
+echo "Next steps:"
+echo "  1) docker compose -f \"$REPO_ROOT/docker-compose.yml\" up -d --build --force-recreate openclaw-gateway"
+echo "  2) docker compose -f \"$REPO_ROOT/docker-compose.yml\" run --rm openclaw-cli health"
+echo "  3) docker compose -f \"$REPO_ROOT/docker-compose.yml\" run --rm openclaw-cli channels status --probe"

--- a/scripts/migrate/restore-openclaw.sh
+++ b/scripts/migrate/restore-openclaw.sh
@@ -15,6 +15,8 @@ Options:
   --env-file <path>        Env file path (default: <repo-root>/.env)
   --config-dir <path>      OpenClaw config dir (default: env or ~/.openclaw)
   --workspace-dir <path>   OpenClaw workspace dir (default: env or ~/.openclaw/workspace)
+  --auth-profile-secret-dir <path>
+                           Auth-profile secret dir (default: env or ~/.openclaw-auth-profile-secrets)
   --apply-env              Overwrite --env-file with backup .env (default: false)
   --no-stop                Do not stop gateway container before restore
   -h, --help               Show this help
@@ -27,6 +29,7 @@ ENV_FILE=""
 ARCHIVE_PATH=""
 CONFIG_DIR=""
 WORKSPACE_DIR=""
+AUTH_PROFILE_SECRET_DIR=""
 APPLY_ENV=0
 STOP_FIRST=1
 ENV_FILE_EXPLICIT=0
@@ -52,6 +55,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --workspace-dir)
       WORKSPACE_DIR="$2"
+      shift 2
+      ;;
+    --auth-profile-secret-dir)
+      AUTH_PROFILE_SECRET_DIR="$2"
       shift 2
       ;;
     --apply-env)
@@ -113,11 +120,16 @@ fi
 if [[ -z "$WORKSPACE_DIR" ]]; then
   WORKSPACE_DIR="${OPENCLAW_WORKSPACE_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_WORKSPACE_DIR)}"
 fi
+if [[ -z "$AUTH_PROFILE_SECRET_DIR" ]]; then
+  AUTH_PROFILE_SECRET_DIR="${OPENCLAW_AUTH_PROFILE_SECRET_DIR:-$(env_value_from_file "$ENV_FILE" OPENCLAW_AUTH_PROFILE_SECRET_DIR)}"
+fi
 
 CONFIG_DIR="${CONFIG_DIR:-$HOME/.openclaw}"
 WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/.openclaw/workspace}"
+AUTH_PROFILE_SECRET_DIR="${AUTH_PROFILE_SECRET_DIR:-$HOME/.openclaw-auth-profile-secrets}"
 CONFIG_DIR="$(resolve_abs_path "$CONFIG_DIR")"
 WORKSPACE_DIR="$(resolve_abs_path "$WORKSPACE_DIR")"
+AUTH_PROFILE_SECRET_DIR="$(resolve_abs_path "$AUTH_PROFILE_SECRET_DIR")"
 
 if [[ $STOP_FIRST -eq 1 ]] && command -v docker >/dev/null 2>&1; then
   compose_file="$REPO_ROOT/docker-compose.yml"
@@ -129,7 +141,7 @@ if [[ $STOP_FIRST -eq 1 ]] && command -v docker >/dev/null 2>&1; then
 fi
 
 timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
-mkdir -p "$(dirname "$CONFIG_DIR")" "$(dirname "$WORKSPACE_DIR")"
+mkdir -p "$(dirname "$CONFIG_DIR")" "$(dirname "$WORKSPACE_DIR")" "$(dirname "$AUTH_PROFILE_SECRET_DIR")"
 
 if [[ -d "$CONFIG_DIR" ]]; then
   mv "$CONFIG_DIR" "${CONFIG_DIR}.pre-restore-${timestamp}"
@@ -137,14 +149,22 @@ fi
 if [[ -d "$WORKSPACE_DIR" ]]; then
   mv "$WORKSPACE_DIR" "${WORKSPACE_DIR}.pre-restore-${timestamp}"
 fi
+if [[ -d "$AUTH_PROFILE_SECRET_DIR" && -d "$tmpdir/payload/auth-profile-secrets" ]]; then
+  mv "$AUTH_PROFILE_SECRET_DIR" "${AUTH_PROFILE_SECRET_DIR}.pre-restore-${timestamp}"
+fi
 
-mkdir -p "$CONFIG_DIR" "$WORKSPACE_DIR"
+mkdir -p "$CONFIG_DIR" "$WORKSPACE_DIR" "$AUTH_PROFILE_SECRET_DIR"
 
 echo "==> Restoring config"
 rsync -a "$tmpdir/payload/config/" "$CONFIG_DIR/"
 
 echo "==> Restoring workspace"
 rsync -a "$tmpdir/payload/workspace/" "$WORKSPACE_DIR/"
+
+if [[ -d "$tmpdir/payload/auth-profile-secrets" ]]; then
+  echo "==> Restoring auth-profile secret directory"
+  rsync -a "$tmpdir/payload/auth-profile-secrets/" "$AUTH_PROFILE_SECRET_DIR/"
+fi
 
 if [[ -f "$tmpdir/payload/repo/.env" ]]; then
   if [[ $APPLY_ENV -eq 1 ]]; then
@@ -153,9 +173,11 @@ if [[ -f "$tmpdir/payload/repo/.env" ]]; then
       cp "$ENV_FILE" "${ENV_FILE}.pre-restore-${timestamp}"
     fi
     cp "$tmpdir/payload/repo/.env" "$ENV_FILE"
+    chmod 600 "$ENV_FILE"
     echo "==> Applied backed up env file to $ENV_FILE"
   else
     cp "$tmpdir/payload/repo/.env" "${ENV_FILE}.from-backup"
+    chmod 600 "${ENV_FILE}.from-backup"
     echo "==> Wrote env candidate to ${ENV_FILE}.from-backup"
   fi
 fi

--- a/scripts/openclaw-keepawake.sh
+++ b/scripts/openclaw-keepawake.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PID_FILE="${OPENCLAW_KEEPAWAKE_PID_FILE:-$HOME/.openclaw/run/keepawake.pid}"
+KEEPAWAKE_FLAGS="${OPENCLAW_KEEPAWAKE_FLAGS:--imsu}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/openclaw-keepawake.sh <on|off|status|restart>
+
+Keeps macOS awake using `caffeinate` for long-running OpenClaw Docker sessions.
+
+Commands:
+  on       Start keep-awake background process
+  off      Stop keep-awake background process
+  status   Show current keep-awake status
+  restart  Restart keep-awake background process
+
+Environment:
+  OPENCLAW_KEEPAWAKE_FLAGS  caffeinate flags (default: -imsu)
+                            Use -dimsu to keep displays awake too.
+USAGE
+}
+
+ensure_caffeinate() {
+  if ! command -v caffeinate >/dev/null 2>&1; then
+    echo "caffeinate not found (this helper is for macOS)." >&2
+    exit 1
+  fi
+}
+
+read_pid() {
+  if [[ -f "$PID_FILE" ]]; then
+    tr -d '[:space:]' <"$PID_FILE"
+  fi
+}
+
+is_caffeinate_pid() {
+  local pid="$1"
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" >/dev/null 2>&1 || return 1
+  local comm
+  comm="$(ps -p "$pid" -o comm= 2>/dev/null | tr -d '[:space:]')"
+  [[ "$comm" == "caffeinate" ]]
+}
+
+start_awake() {
+  ensure_caffeinate
+  mkdir -p "$(dirname "$PID_FILE")"
+
+  local pid
+  pid="$(read_pid || true)"
+  if is_caffeinate_pid "$pid"; then
+    echo "keep-awake already on (pid $pid)"
+    return 0
+  fi
+
+  local -a flags
+  # Allow override for special cases (for example keeping displays on).
+  read -r -a flags <<<"$KEEPAWAKE_FLAGS"
+  caffeinate "${flags[@]}" >/dev/null 2>&1 &
+  pid="$!"
+  echo "$pid" >"$PID_FILE"
+  echo "keep-awake on (pid $pid, flags: $KEEPAWAKE_FLAGS)"
+}
+
+stop_awake() {
+  local pid
+  pid="$(read_pid || true)"
+  if [[ -z "$pid" ]]; then
+    echo "keep-awake already off"
+    return 0
+  fi
+
+  if is_caffeinate_pid "$pid"; then
+    kill "$pid" >/dev/null 2>&1 || true
+    echo "keep-awake off (stopped pid $pid)"
+  else
+    echo "keep-awake off (stale pid file removed)"
+  fi
+  rm -f "$PID_FILE"
+}
+
+status_awake() {
+  local pid
+  pid="$(read_pid || true)"
+  if is_caffeinate_pid "$pid"; then
+    echo "keep-awake is on (pid $pid)"
+  else
+    echo "keep-awake is off"
+    if [[ -n "$pid" ]]; then
+      rm -f "$PID_FILE"
+    fi
+  fi
+}
+
+cmd="${1:-}"
+case "$cmd" in
+on)
+  start_awake
+  ;;
+off)
+  stop_awake
+  ;;
+status)
+  status_awake
+  ;;
+restart)
+  stop_awake
+  start_awake
+  ;;
+*)
+  usage
+  exit 2
+  ;;
+esac

--- a/scripts/openclaw-keepawake.sh
+++ b/scripts/openclaw-keepawake.sh
@@ -60,6 +60,12 @@ start_awake() {
   read -r -a flags <<<"$KEEPAWAKE_FLAGS"
   caffeinate "${flags[@]}" >/dev/null 2>&1 &
   pid="$!"
+  sleep 0.2
+  if ! is_caffeinate_pid "$pid"; then
+    rm -f "$PID_FILE"
+    echo "Failed to start keep-awake (caffeinate exited immediately)." >&2
+    exit 1
+  fi
   echo "$pid" >"$PID_FILE"
   echo "keep-awake on (pid $pid, flags: $KEEPAWAKE_FLAGS)"
 }

--- a/scripts/openclaw-keepawake.sh
+++ b/scripts/openclaw-keepawake.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PID_FILE="${OPENCLAW_KEEPAWAKE_PID_FILE:-$HOME/.openclaw/run/keepawake.pid}"
+KEEPAWAKE_FLAGS="${OPENCLAW_KEEPAWAKE_FLAGS:--imsu}"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/openclaw-keepawake.sh <on|off|status|restart>
+
+Keeps macOS awake using `caffeinate` for long-running OpenClaw Docker sessions.
+
+Commands:
+  on       Start keep-awake background process
+  off      Stop keep-awake background process
+  status   Show current keep-awake status
+  restart  Restart keep-awake background process
+
+Environment:
+  OPENCLAW_KEEPAWAKE_FLAGS  caffeinate flags (default: -imsu)
+                            Use -dimsu to keep displays awake too.
+USAGE
+}
+
+ensure_caffeinate() {
+  if ! command -v caffeinate >/dev/null 2>&1; then
+    echo "caffeinate not found (this helper is for macOS)." >&2
+    exit 1
+  fi
+}
+
+read_pid() {
+  if [[ -f "$PID_FILE" ]]; then
+    tr -d '[:space:]' <"$PID_FILE"
+  fi
+}
+
+is_caffeinate_pid() {
+  local pid="$1"
+  [[ -n "$pid" ]] || return 1
+  kill -0 "$pid" >/dev/null 2>&1 || return 1
+  local comm
+  comm="$(ps -p "$pid" -o comm= 2>/dev/null | tr -d '[:space:]')"
+  [[ "$comm" == "caffeinate" ]]
+}
+
+start_awake() {
+  ensure_caffeinate
+  mkdir -p "$(dirname "$PID_FILE")"
+
+  local pid
+  pid="$(read_pid || true)"
+  if is_caffeinate_pid "$pid"; then
+    echo "keep-awake already on (pid $pid)"
+    return 0
+  fi
+
+  local -a flags
+  # Allow override for special cases (for example keeping displays on).
+  read -r -a flags <<<"$KEEPAWAKE_FLAGS"
+  caffeinate "${flags[@]}" >/dev/null 2>&1 &
+  pid="$!"
+  sleep 0.2
+  if ! is_caffeinate_pid "$pid"; then
+    rm -f "$PID_FILE"
+    echo "Failed to start keep-awake (caffeinate exited immediately)." >&2
+    exit 1
+  fi
+  echo "$pid" >"$PID_FILE"
+  echo "keep-awake on (pid $pid, flags: $KEEPAWAKE_FLAGS)"
+}
+
+stop_awake() {
+  local pid
+  pid="$(read_pid || true)"
+  if [[ -z "$pid" ]]; then
+    echo "keep-awake already off"
+    return 0
+  fi
+
+  if is_caffeinate_pid "$pid"; then
+    kill "$pid" >/dev/null 2>&1 || true
+    echo "keep-awake off (stopped pid $pid)"
+  else
+    echo "keep-awake off (stale pid file removed)"
+  fi
+  rm -f "$PID_FILE"
+}
+
+status_awake() {
+  local pid
+  pid="$(read_pid || true)"
+  if is_caffeinate_pid "$pid"; then
+    echo "keep-awake is on (pid $pid)"
+  else
+    echo "keep-awake is off"
+    if [[ -n "$pid" ]]; then
+      rm -f "$PID_FILE"
+    fi
+  fi
+}
+
+cmd="${1:-}"
+case "$cmd" in
+on)
+  start_awake
+  ;;
+off)
+  stop_awake
+  ;;
+status)
+  status_awake
+  ;;
+restart)
+  stop_awake
+  start_awake
+  ;;
+*)
+  usage
+  exit 2
+  ;;
+esac

--- a/test/scripts/openclaw-migrate-helpers.test.ts
+++ b/test/scripts/openclaw-migrate-helpers.test.ts
@@ -1,0 +1,122 @@
+// Docker migration helper tests cover host-state backup and restore invariants.
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const BACKUP_SCRIPT = "scripts/migrate/backup-openclaw.sh";
+const RESTORE_SCRIPT = "scripts/migrate/restore-openclaw.sh";
+
+let tempRoot: string | undefined;
+
+function runScript(script: string, args: string[]) {
+  return spawnSync("bash", [script, ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      HOME: path.join(tempRoot ?? tmpdir(), "home"),
+      PATH: process.env.PATH ?? "",
+    },
+  });
+}
+
+async function writeFixtureFile(filePath: string, value: string) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, value);
+}
+
+describe("openclaw Docker migration helpers", () => {
+  beforeEach(() => {
+    tempRoot = mkdtempSync(path.join(tmpdir(), "openclaw-migrate-helper-"));
+  });
+
+  afterEach(() => {
+    if (tempRoot) {
+      rmSync(tempRoot, { recursive: true, force: true });
+      tempRoot = undefined;
+    }
+  });
+
+  it("backs up and restores config, workspace, auth-profile secrets, and archive permissions", async () => {
+    const root = tempRoot;
+    if (!root) {
+      throw new Error("missing temp root");
+    }
+
+    const repoRoot = path.join(root, "repo");
+    const configDir = path.join(root, "config");
+    const workspaceDir = path.join(root, "workspace");
+    const authProfileSecretDir = path.join(root, "auth-profile-secrets");
+    const backupDir = path.join(root, "backups");
+    await mkdir(repoRoot, { recursive: true });
+    await writeFixtureFile(path.join(configDir, "openclaw.json"), '{"ok":true}\n');
+    await writeFixtureFile(path.join(workspaceDir, "scripts", "digest.js"), "console.log('ok');\n");
+    await writeFixtureFile(path.join(authProfileSecretDir, "key.json"), '{"secret":true}\n');
+    await writeFile(
+      path.join(repoRoot, ".env"),
+      [
+        `OPENCLAW_CONFIG_DIR=${configDir}`,
+        `OPENCLAW_WORKSPACE_DIR=${workspaceDir}`,
+        `OPENCLAW_AUTH_PROFILE_SECRET_DIR=${authProfileSecretDir}`,
+        "OPENCLAW_GATEWAY_TOKEN=redacted-test-token",
+        "",
+      ].join("\n"),
+    );
+
+    const backup = runScript(BACKUP_SCRIPT, [
+      "--repo-root",
+      repoRoot,
+      "--output-dir",
+      backupDir,
+      "--name",
+      "sample",
+    ]);
+    expect(backup.stderr).toBe("");
+    expect(backup.status).toBe(0);
+
+    const archivePath = path.join(backupDir, "sample.tar.gz");
+    expect(existsSync(archivePath)).toBe(true);
+    expect(existsSync(`${archivePath}.sha256`)).toBe(true);
+    expect(statSync(archivePath).mode & 0o077).toBe(0);
+    expect(statSync(`${archivePath}.sha256`).mode & 0o077).toBe(0);
+
+    await rm(configDir, { recursive: true, force: true });
+    await rm(workspaceDir, { recursive: true, force: true });
+    await rm(authProfileSecretDir, { recursive: true, force: true });
+    await writeFixtureFile(path.join(configDir, "stale.json"), "{}\n");
+    await writeFixtureFile(path.join(workspaceDir, "stale.txt"), "old\n");
+    await writeFixtureFile(path.join(authProfileSecretDir, "stale.key"), "old\n");
+    writeFileSync(path.join(repoRoot, ".env"), "OPENCLAW_GATEWAY_TOKEN=old\n");
+
+    const restore = runScript(RESTORE_SCRIPT, [
+      "--repo-root",
+      repoRoot,
+      "--archive",
+      archivePath,
+      "--config-dir",
+      configDir,
+      "--workspace-dir",
+      workspaceDir,
+      "--auth-profile-secret-dir",
+      authProfileSecretDir,
+      "--no-stop",
+      "--apply-env",
+    ]);
+    expect(restore.stderr).toBe("");
+    expect(restore.status).toBe(0);
+
+    expect(readFileSync(path.join(configDir, "openclaw.json"), "utf8")).toBe('{"ok":true}\n');
+    expect(readFileSync(path.join(workspaceDir, "scripts", "digest.js"), "utf8")).toBe(
+      "console.log('ok');\n",
+    );
+    expect(readFileSync(path.join(authProfileSecretDir, "key.json"), "utf8")).toBe(
+      '{"secret":true}\n',
+    );
+    expect(readFileSync(path.join(repoRoot, ".env"), "utf8")).toContain(
+      "OPENCLAW_GATEWAY_TOKEN=redacted-test-token",
+    );
+    expect(statSync(path.join(repoRoot, ".env")).mode & 0o077).toBe(0);
+  });
+});


### PR DESCRIPTION
## What
Add operator helpers for Mac-hosted Docker deployments.

## Why
Running OpenClaw in Docker on macOS is easier to operate if the repo includes a simple host-awake helper and a low-disruption backup/restore path for moving from an Intel Mac to Apple Silicon.

## Included
- add `scripts/openclaw-keepawake.sh` to keep the host awake during long-running gateway sessions
- add `scripts/migrate/backup-openclaw.sh` and `scripts/migrate/restore-openclaw.sh` for migration backups
- preserve config, workspace, auth-profile secret-key state, repo `.env`, and Docker setup files
- harden backup archive and checksum file permissions and verify the external archive checksum before extraction
- add a focused migration-helper regression test and Docker docs

## Notes
This PR is intentionally separate from the Docker runtime/image PR so runtime behavior and host-operator helpers can be reviewed independently.

## Real behavior proof
- **Behavior or issue addressed**: Mac-hosted Docker operator helpers can preserve OpenClaw config, workspace scripts, and auth-profile secret-key state during host migration, and can keep the host awake during long-running gateway sessions.
- **Real environment tested**: Intel macOS host with Docker Desktop and the existing OpenClaw Docker deployment; plus a local restore fixture that exercises the backup/restore scripts without touching the live config.
- **Exact steps or command run after this patch**: `bash -n scripts/migrate/backup-openclaw.sh scripts/migrate/restore-openclaw.sh scripts/migrate/lib.sh scripts/openclaw-keepawake.sh`; `pnpm test test/scripts/openclaw-migrate-helpers.test.ts -- --reporter=verbose`; `pnpm docs:list`; `node scripts/check-no-conflict-markers.mjs`; `git diff --check upstream/main..HEAD`.
- **Evidence after fix**:

```text
bash syntax ok

pnpm test test/scripts/openclaw-migrate-helpers.test.ts -- --reporter=verbose
✓ openclaw Docker migration helpers > backs up and restores config, workspace, auth-profile secrets, and archive permissions
[test] passed 1 Vitest shard

docs:list ok (1313 lines)
check-no-conflict-markers passed
git diff --check passed
```

- **Observed result after fix**: The migration test creates a real archive, verifies the companion `.sha256`, proves the archive/checksum are owner-only, restores config/workspace/auth-profile secret files, and verifies restored `.env` permissions. The earlier live Docker proof also confirmed the backup preserves the digest and portfolio workspace scripts used by the deployed gateway.
- **What was not tested**: I did not run a destructive restore over the active live config on the same machine; the restore proof uses an isolated temp fixture so the live Docker deployment is not disturbed.
