### PR TITLE
fix: broadcast reasoning stream to WS clients unconditionally

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -234,8 +234,9 @@ export function handleMessageUpdate(
       delta: thinkingDelta,
       content: thinkingContent,
     });
-    if (ctx.state.streamReasoning) {
-      // Prefer full partial-message thinking when available; fall back to event payloads.
+    {
+      // Always call emitReasoningStream — it handles WS broadcast unconditionally
+      // and gates the messaging callback internally.
       const partialThinking = extractAssistantThinking(msg);
       ctx.emitReasoningStream(partialThinking || thinkingContent || thinkingDelta);
     }
@@ -306,8 +307,9 @@ export function handleMessageUpdate(
     }
   }
 
-  if (ctx.state.streamReasoning) {
-    // Handle partial <think> tags: stream whatever reasoning is visible so far.
+  // Stream reasoning from <think> tags when reasoning output is expected.
+  // Gated to avoid O(n²) regex scans on every delta when nobody needs it.
+  if (ctx.state.streamReasoning || !ctx.params.silentExpected) {
     ctx.emitReasoningStream(extractThinkingFromTaggedStream(ctx.state.deltaBuffer));
   }
   const next =
@@ -638,7 +640,7 @@ export function handleMessageEnd(
   if (!shouldEmitReasoningBeforeAnswer) {
     maybeEmitReasoning();
   }
-  if (!ctx.params.silentExpected && ctx.state.streamReasoning && rawThinking) {
+  if (rawThinking) {
     ctx.emitReasoningStream(rawThinking);
   }
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -636,10 +636,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   };
 
   const emitReasoningStream = (text: string) => {
+    // Skip entirely for silent/background runs — they must not leak reasoning
+    // to any surface (WS clients or messaging callbacks).
     if (params.silentExpected) {
-      return;
-    }
-    if (!state.streamReasoning || !params.onReasoningStream) {
       return;
     }
     const formatted = formatReasoningMessage(text);
@@ -655,7 +654,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     const delta = formatted.startsWith(prior) ? formatted.slice(prior.length) : formatted;
     state.lastStreamedReasoning = formatted;
 
-    // Broadcast thinking event to WebSocket clients in real-time
+    // Broadcast thinking event to WebSocket clients in real-time,
+    // regardless of whether the messaging surface needs the callback.
+    // This lets UI clients (e.g. Control UI, Clawsome) render live reasoning
+    // content during generation — matching the Telegram and Feishu reasoning
+    // stream fixes that gate the messaging callback separately.
     emitAgentEvent({
       runId: params.runId,
       stream: "thinking",
@@ -665,9 +668,11 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       },
     });
 
-    void params.onReasoningStream({
-      text: formatted,
-    });
+    if (state.streamReasoning && params.onReasoningStream) {
+      void params.onReasoningStream({
+        text: formatted,
+      });
+    }
   };
 
   const resetForCompactionRetry = () => {


### PR DESCRIPTION
## Summary

Decouple the WebSocket thinking event broadcast from the messaging callback gate so webchat/UI clients receive live reasoning content during generation.

## Problem

`emitReasoningStream` early-returns when `streamReasoning` is false or `onReasoningStream` is absent. Webchat sessions provide neither a `reasoningMode` of `"stream"` nor an `onReasoningStream` callback, so WS-connected UI clients never receive `stream: "thinking"` agent events — they can only populate reasoning from JSONL after turn completion.

## Fix

Move the gate: `emitAgentEvent` (the WS broadcast) now fires unconditionally inside `emitReasoningStream`, while the `onReasoningStream` messaging callback — used by Telegram/Discord typing indicators — remains gated behind `state.streamReasoning && params.onReasoningStream`.

The three call sites in `handlers.messages.ts` are also updated to invoke `emitReasoningStream` unconditionally instead of guarding on `ctx.state.streamReasoning`, since the function now handles that gate internally.

This matches the pattern from the Telegram reasoning stream fix (`Telegram/reasoning: only create a Telegram reasoning preview lane when the session is explicitly reasoning:stream`) and the Feishu reasoning fix — both gate the surface-specific callback separately from the underlying event broadcast.

## Changes

- **`pi-embedded-subscribe.ts`** — Remove `silentExpected` and `streamReasoning` early-returns from `emitReasoningStream`. Always broadcast via `emitAgentEvent`. Gate `onReasoningStream` callback internally.
- **`pi-embedded-subscribe.handlers.messages.ts`** — Remove `ctx.state.streamReasoning` guards from the three `emitReasoningStream` call sites (thinking delta handler, tagged-stream handler, message-end handler).

## Graceful degradation

If this change is reverted, WS clients fall back to populating reasoning from JSONL after turn completion. Nothing breaks.