### PR TITLE
fix(agents): continue fallback after OpenRouter no-endpoints 404

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions: preserve announce `threadId` when `sessions.list` fallback rehydrates agent-to-agent announce targets so final announce messages stay in the originating thread/topic. (#63506) Thanks @SnowSky1.
 - iMessage/self-chat: remember ambiguous `sender === chat_identifier` outbound rows with missing `destination_caller_id` in self-chat dedupe state so the later reflected inbound copy still drops instead of re-entering inbound handling when the echo cache misses. Thanks @neeravmakwana.
 - Claude CLI: stop marking spawned Claude Code runs as host-managed so they keep using normal CLI subscription behavior. (#64023) Thanks @Alex-Alaniz.
+- Agents/failover: classify OpenRouter `404 No endpoints found for <model>` responses as `model_not_found` so fallback chains continue past retired OpenRouter candidates. (#61472) Thanks @MonkeyLeeT.
 
 ## 2026.4.9
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -181,6 +181,20 @@ describe("failover-error", () => {
     ).toBe("overloaded");
   });
 
+  it("classifies OpenRouter no-endpoints 404s as model_not_found", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 404,
+        message: "No endpoints found for deepseek/deepseek-r1:free.",
+      }),
+    ).toBe("model_not_found");
+    expect(
+      resolveFailoverReasonFromError({
+        message: "404 No endpoints found for deepseek/deepseek-r1:free.",
+      }),
+    ).toBe("model_not_found");
+  });
+
   it("keeps status-only 503s conservative unless the payload is clearly overloaded", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -211,6 +211,14 @@ describe("failover-error", () => {
     ).toBeNull();
   });
 
+  it("does not classify generic deprecation transition messages as model_not_found", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: "The endpoint has been deprecated. Transition to v2 API for continued access.",
+      }),
+    ).toBeNull();
+  });
+
   it("keeps status-only 503s conservative unless the payload is clearly overloaded", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -195,6 +195,14 @@ describe("failover-error", () => {
     ).toBe("model_not_found");
   });
 
+  it("classifies generic model-does-not-exist messages as model_not_found", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: "The model gpt-foo does not exist.",
+      }),
+    ).toBe("model_not_found");
+  });
+
   it("keeps status-only 503s conservative unless the payload is clearly overloaded", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -203,6 +203,14 @@ describe("failover-error", () => {
     ).toBe("model_not_found");
   });
 
+  it("does not classify generic access errors as model_not_found", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        message: "The deployment does not exist or you do not have access.",
+      }),
+    ).toBeNull();
+  });
+
   it("keeps status-only 503s conservative unless the payload is clearly overloaded", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -8,6 +8,7 @@ describe("live model error helpers", () => {
   it("detects generic model-not-found messages", () => {
     expect(isModelNotFoundErrorMessage("Model not found: openai/gpt-6")).toBe(true);
     expect(isModelNotFoundErrorMessage("model_not_found")).toBe(true);
+    expect(isModelNotFoundErrorMessage("The model gpt-foo does not exist.")).toBe(true);
     expect(isModelNotFoundErrorMessage('{"code":404,"message":"model not found"}')).toBe(true);
     expect(isModelNotFoundErrorMessage("model: MiniMax-M2.7-highspeed not found")).toBe(true);
     expect(

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -24,6 +24,9 @@ describe("live model error helpers", () => {
         "404 The free model has been deprecated. Transition to qwen/qwen3.6-plus for continued paid access.",
       ),
     ).toBe(true);
+    expect(
+      isModelNotFoundErrorMessage("The deployment does not exist or you do not have access."),
+    ).toBe(false);
     expect(isModelNotFoundErrorMessage("request ended without sending any chunks")).toBe(false);
   });
 

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -21,9 +21,9 @@ describe("live model error helpers", () => {
     ).toBe(true);
     expect(
       isModelNotFoundErrorMessage(
-        "404 The free model has been deprecated. Transition to qwen/qwen3.6-plus for continued paid access.",
+        "The endpoint has been deprecated. Transition to v2 API for continued access.",
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isModelNotFoundErrorMessage("The deployment does not exist or you do not have access."),
     ).toBe(false);

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -9,6 +9,9 @@ describe("live model error helpers", () => {
     expect(isModelNotFoundErrorMessage('{"code":404,"message":"model not found"}')).toBe(true);
     expect(isModelNotFoundErrorMessage("model: MiniMax-M2.7-highspeed not found")).toBe(true);
     expect(
+      isModelNotFoundErrorMessage("404 No endpoints found for deepseek/deepseek-r1:free."),
+    ).toBe(true);
+    expect(
       isModelNotFoundErrorMessage(
         "HTTP 400 not_found_error: model: claude-3-5-haiku-20241022 (request_id: req_123)",
       ),

--- a/src/agents/live-model-errors.test.ts
+++ b/src/agents/live-model-errors.test.ts
@@ -6,6 +6,8 @@ import {
 
 describe("live model error helpers", () => {
   it("detects generic model-not-found messages", () => {
+    expect(isModelNotFoundErrorMessage("Model not found: openai/gpt-6")).toBe(true);
+    expect(isModelNotFoundErrorMessage("model_not_found")).toBe(true);
     expect(isModelNotFoundErrorMessage('{"code":404,"message":"model not found"}')).toBe(true);
     expect(isModelNotFoundErrorMessage("model: MiniMax-M2.7-highspeed not found")).toBe(true);
     expect(

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -31,9 +31,6 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/model/i.test(msg) && /does not exist/i.test(msg)) {
     return true;
   }
-  if (/deprecated/i.test(msg) && /(upgrade|transition) to/i.test(msg)) {
-    return true;
-  }
   if (/stealth model/i.test(msg) && /find it here/i.test(msg)) {
     return true;
   }

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -28,6 +28,9 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/models\/[^\s]+ is not found/i.test(msg)) {
     return true;
   }
+  if (/model/i.test(msg) && /does not exist/i.test(msg)) {
+    return true;
+  }
   if (/does not exist or you do not have access/i.test(msg)) {
     return true;
   }

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -13,6 +13,9 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/unknown model/i.test(msg)) {
     return true;
   }
+  if (/model(?:[_\-\s])?not(?:[_\-\s])?found/i.test(msg)) {
+    return true;
+  }
   if (/\b404\b/.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {
     return true;
   }

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -1,7 +1,17 @@
+/**
+ * Shared model-not-found heuristics used by live probes and runtime failover.
+ * Keep this helper dependency-light so both paths can import it directly.
+ */
 export function isModelNotFoundErrorMessage(raw: string): boolean {
   const msg = raw.trim();
   if (!msg) {
     return false;
+  }
+  if (/no endpoints found for/i.test(msg)) {
+    return true;
+  }
+  if (/unknown model/i.test(msg)) {
+    return true;
   }
   if (/\b404\b/.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {
     return true;
@@ -9,7 +19,10 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/not_found_error/i.test(msg)) {
     return true;
   }
-  if (/model:\s*[a-z0-9._-]+/i.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {
+  if (/model:\s*[a-z0-9._/-]+/i.test(msg) && /not(?:[_\-\s])?found/i.test(msg)) {
+    return true;
+  }
+  if (/models\/[^\s]+ is not found/i.test(msg)) {
     return true;
   }
   if (/does not exist or you do not have access/i.test(msg)) {
@@ -22,6 +35,9 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
     return true;
   }
   if (/is not a valid model id/i.test(msg)) {
+    return true;
+  }
+  if (/invalid model/i.test(msg) && !/invalid model reference/i.test(msg)) {
     return true;
   }
   return false;

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -31,9 +31,6 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
   if (/model/i.test(msg) && /does not exist/i.test(msg)) {
     return true;
   }
-  if (/does not exist or you do not have access/i.test(msg)) {
-    return true;
-  }
   if (/deprecated/i.test(msg) && /(upgrade|transition) to/i.test(msg)) {
     return true;
   }

--- a/src/agents/live-model-errors.ts
+++ b/src/agents/live-model-errors.ts
@@ -1,7 +1,3 @@
-/**
- * Shared model-not-found heuristics used by live probes and runtime failover.
- * Keep this helper dependency-light so both paths can import it directly.
- */
 export function isModelNotFoundErrorMessage(raw: string): boolean {
   const msg = raw.trim();
   if (!msg) {

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -99,6 +99,7 @@ beforeEach(() => {
 const OVERLOADED_ERROR_PAYLOAD =
   '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}';
 const RATE_LIMIT_ERROR_MESSAGE = "rate limit exceeded";
+const NO_ENDPOINTS_FOUND_ERROR_MESSAGE = "404 No endpoints found for deepseek/deepseek-r1:free.";
 
 function makeConfig(): OpenClawConfig {
   const apiKeyField = ["api", "Key"].join("");
@@ -388,7 +389,28 @@ function mockAllProvidersOverloaded() {
   });
 }
 
-describe("runWithModelFallback + runEmbeddedPiAgent overload policy", () => {
+describe("runWithModelFallback + runEmbeddedPiAgent failover behavior", () => {
+  it("falls back on OpenRouter-style no-endpoints assistant errors", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir);
+      mockPrimaryErrorThenFallbackSuccess(NO_ENDPOINTS_FOUND_ERROR_MESSAGE);
+
+      const result = await runEmbeddedFallback({
+        agentDir,
+        workspaceDir,
+        sessionKey: "agent:test:model-not-found-no-endpoints",
+        runId: "run:model-not-found-no-endpoints",
+      });
+
+      expect(result.provider).toBe("groq");
+      expect(result.model).toBe("mock-2");
+      expect(result.attempts[0]?.reason).toBe("model_not_found");
+      expect(result.result.payloads?.[0]?.text ?? "").toContain("fallback ok");
+
+      expectOpenAiThenGroqAttemptOrder();
+    });
+  });
+
   it("falls back across providers after overloaded primary failure and persists transient cooldown", async () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeAuthStore(agentDir);

--- a/src/agents/models.profiles.live.test.ts
+++ b/src/agents/models.profiles.live.test.ts
@@ -9,6 +9,7 @@ import {
   isAnthropicBillingError,
   isAnthropicRateLimitError,
 } from "./live-auth-keys.js";
+import { isModelNotFoundErrorMessage } from "./live-model-errors.js";
 import {
   isHighSignalLiveModelRef,
   resolveHighSignalLiveModelLimit,
@@ -135,35 +136,6 @@ function isGoogleModelNotFoundError(err: unknown): boolean {
   return false;
 }
 
-function isModelNotFoundErrorMessage(raw: string): boolean {
-  const msg = raw.trim();
-  if (!msg) {
-    return false;
-  }
-  if (/\b404\b/.test(msg) && /not(?:[\s_-]+)?found/i.test(msg)) {
-    return true;
-  }
-  if (/not_found_error/i.test(msg)) {
-    return true;
-  }
-  if (/model:\s*[a-z0-9._-]+/i.test(msg) && /not(?:[\s_-]+)?found/i.test(msg)) {
-    return true;
-  }
-  if (/does not exist or you do not have access/i.test(msg)) {
-    return true;
-  }
-  if (/deprecated/i.test(msg) && /(upgrade|transition) to/i.test(msg)) {
-    return true;
-  }
-  if (/stealth model/i.test(msg) && /find it here/i.test(msg)) {
-    return true;
-  }
-  if (/is not a valid model id/i.test(msg)) {
-    return true;
-  }
-  return false;
-}
-
 describe("isModelNotFoundErrorMessage", () => {
   it("matches whitespace-separated not found errors", () => {
     expect(isModelNotFoundErrorMessage("404 model not found")).toBe(true);
@@ -180,6 +152,12 @@ describe("isModelNotFoundErrorMessage", () => {
       isModelNotFoundErrorMessage(
         "404 The free model has been deprecated. Transition to qwen/qwen3.6-plus for continued paid access.",
       ),
+    ).toBe(true);
+  });
+
+  it("matches OpenRouter no-endpoints wording", () => {
+    expect(
+      isModelNotFoundErrorMessage("404 No endpoints found for deepseek/deepseek-r1:free."),
     ).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -20,6 +20,7 @@ export {
 } from "../../shared/assistant-error-format.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
+import { isModelNotFoundErrorMessage } from "../live-model-errors.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox/runtime-status.js";
 import { stableStringify } from "../stable-stringify.js";
 import {
@@ -1240,36 +1241,7 @@ export function isAuthAssistantError(msg: AssistantMessage | undefined): boolean
   return isAuthErrorMessage(msg.errorMessage ?? "");
 }
 
-export function isModelNotFoundErrorMessage(raw: string): boolean {
-  if (!raw) {
-    return false;
-  }
-  const lower = normalizeLowercaseStringOrEmpty(raw);
-
-  // Direct pattern matches from OpenClaw internals and common providers.
-  if (
-    lower.includes("unknown model") ||
-    lower.includes("model not found") ||
-    lower.includes("model_not_found") ||
-    lower.includes("not_found_error") ||
-    (lower.includes("does not exist") && lower.includes("model")) ||
-    (lower.includes("invalid model") && !lower.includes("invalid model reference"))
-  ) {
-    return true;
-  }
-
-  // Google Gemini: "models/X is not found for api version"
-  if (/models\/[^\s]+ is not found/i.test(raw)) {
-    return true;
-  }
-
-  // JSON error payloads: {"status": "NOT_FOUND"} or {"code": 404} combined with not-found text.
-  if (/\b404\b/.test(raw) && /not[-_ ]?found/i.test(raw)) {
-    return true;
-  }
-
-  return false;
-}
+export { isModelNotFoundErrorMessage };
 
 function isCliSessionExpiredErrorMessage(raw: string): boolean {
   if (!raw) {


### PR DESCRIPTION
## Summary

- Problem: OpenRouter `404 No endpoints found for <model>` errors were not classified as `model_not_found`, so fallback could stop on a dead candidate.
- Why it matters: a retired OpenRouter endpoint could halt the configured fallback chain and leave healthy later candidates unused.
- What changed: taught the shared model-not-found matcher to recognize OpenRouter's `No endpoints found for` wording, reused that matcher in failover classification, and added regression coverage for classification plus embedded fallback behavior.
- What did NOT change (scope boundary): no broader HTTP error remapping, no provider auth changes, and no fallback-policy changes outside this exact not-found detection path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61411
- Related #51571
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the shared model-not-found heuristic did not recognize OpenRouter's `No endpoints found for <model>` wording, so assistant-side failover classification could miss the not-found path.
- Missing detection / guardrail: there was no regression test for this OpenRouter-specific 404 wording, and the matcher logic had drifted across helpers.
- Contributing context (if known): the fallback loop already handled `model_not_found` correctly once the error was classified.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/failover-error.test.ts`, `src/agents/live-model-errors.test.ts`, `src/agents/model-fallback.run-embedded.e2e.test.ts`, `src/agents/models.profiles.live.test.ts`
- Scenario the test should lock in: OpenRouter `404 No endpoints found for ...` is classified as `model_not_found` and the embedded fallback chain advances to the next candidate.
- Why this is the smallest reliable guardrail: it covers both the shared matcher and the runtime failover seam without needing a live OpenRouter dependency.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Fallback chains now continue past OpenRouter models that return `404 No endpoints found for <model>` instead of stopping on that dead candidate.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout
- Model/provider: OpenRouter fallback classification
- Integration/channel (if any): N/A
- Relevant config (redacted): fallback chain with an OpenRouter model that returns `404 No endpoints found for <model>`

### Steps

1. Configure a fallback chain that can reach a retired OpenRouter model.
2. Trigger a run so the chain reaches that OpenRouter candidate.
3. Observe whether the runner classifies the 404 as `model_not_found` and advances.

### Expected

- The candidate is recorded as `model_not_found` and the next fallback model is tried.

### Actual

- Before this fix, the OpenRouter candidate could stop the chain instead of continuing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted regression tests for shared matcher coverage and embedded fallback continuation.
- Edge cases checked: bare `404 No endpoints found for ...`, explicit `status: 404` payloads, and reuse of the shared matcher in live-helper tests.
- What you did **not** verify: no live OpenRouter call; repo-wide `pnpm check` remains blocked by unrelated existing `tsgo` failures outside this diff.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: broadening the generic model-not-found matcher could accidentally catch an unrelated provider message.
  - Mitigation: the new wording is narrow and backed by unit plus failover-seam regression tests.
