### PR TITLE
[codex] fix: harden OpenAI strict tool schema routing

### DIFF
--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolvesToNativeOpenAIStrictTools } from "./openai-tool-schema.js";
+
+describe("resolvesToNativeOpenAIStrictTools", () => {
+  it("ignores non-string routing fields", () => {
+    expect(
+      resolvesToNativeOpenAIStrictTools(
+        {
+          provider: { value: "openai" },
+          api: 123,
+          baseUrl: false,
+          id: ["gpt-5.4"],
+          compat: { supportsStore: true },
+        },
+        "stream",
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -15,6 +15,10 @@ type ToolWithParameters = {
   parameters: unknown;
 };
 
+function toNullableString(value: unknown): string | null | undefined {
+  return typeof value === "string" || value === null ? value : undefined;
+}
+
 export function normalizeStrictOpenAIJsonSchema(schema: unknown): unknown {
   return normalizeStrictOpenAIJsonSchemaRecursive(normalizeToolParameterSchema(schema ?? {}));
 }
@@ -131,12 +135,12 @@ export function resolvesToNativeOpenAIStrictTools(
   transport: OpenAITransportKind,
 ): boolean {
   const capabilities = resolveProviderRequestCapabilities({
-    provider: model.provider,
-    api: model.api,
-    baseUrl: model.baseUrl,
+    provider: toNullableString(model.provider),
+    api: toNullableString(model.api),
+    baseUrl: toNullableString(model.baseUrl),
     capability: "llm",
     transport,
-    modelId: model.id,
+    modelId: toNullableString(model.id),
     compat:
       model.compat && typeof model.compat === "object"
         ? (model.compat as { supportsStore?: boolean })


### PR DESCRIPTION
## Summary

- normalize unknown OpenAI strict-tool routing fields before calling `resolveProviderRequestCapabilities`
- add a regression test covering non-string routing metadata on the model object

## Why

`pnpm build` could fail during `build:plugin-sdk:dts` after the provider capability resolver tightened its input types. `src/agents/openai-tool-schema.ts` was still forwarding `provider`, `api`, `baseUrl`, and `id` as `unknown`, which broke typechecking in the update flow.

## Impact

- keeps the strict-tool routing helper buildable under the current capability-resolver contract
- leaves non-string model metadata ignored instead of leaking into provider capability resolution
- gives `openclaw-update` a clean local fix to rerun against when this change is present

## Root Cause

The helper accepted a loose model shape, but the call into `resolveProviderRequestCapabilities` no longer did. That boundary had not been normalised to `string | null | undefined` before the typed call.

## Validation

- `pnpm test src/agents/openai-tool-schema.test.ts`
- `pnpm build`
