### PR TITLE
feat(channels): defer setup validation until config assembly

### DIFF
--- a/src/channels/plugins/setup-wizard.async-validation.test.ts
+++ b/src/channels/plugins/setup-wizard.async-validation.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { createChannelTestPluginBase } from "../../test-utils/channel-plugins.js";
+import type { WizardPrompter } from "../../wizard/prompts.js";
+import { buildChannelSetupWizardAdapterFromSetupWizard } from "./setup-wizard.js";
+import type { ChannelPlugin } from "./types.js";
+
+function createPrompter(values: string[]): WizardPrompter {
+  const queue = [...values];
+  return {
+    intro: async () => {},
+    outro: async () => {},
+    note: async () => {},
+    select: async () => {
+      throw new Error("unexpected select prompt");
+    },
+    multiselect: async () => {
+      throw new Error("unexpected multiselect prompt");
+    },
+    text: async () => {
+      const next = queue.shift();
+      if (next === undefined) {
+        throw new Error("missing text prompt value");
+      }
+      return next;
+    },
+    confirm: async () => {
+      throw new Error("unexpected confirm prompt");
+    },
+    progress: () => ({
+      update: () => {},
+      stop: () => {},
+    }),
+  };
+}
+
+function createVkSetupTestPlugin(params?: {
+  validateCompleteInput?: NonNullable<NonNullable<ChannelPlugin["setup"]>["validateCompleteInput"]>;
+  validateInputAsync?: NonNullable<NonNullable<ChannelPlugin["setup"]>["validateInputAsync"]>;
+}): ChannelPlugin {
+  return {
+    ...createChannelTestPluginBase({
+      id: "vk",
+      label: "VK",
+      docsPath: "/channels/vk",
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+    }),
+    setup: {
+      applyAccountConfig: ({ cfg, input }) => {
+        const existing = (cfg.channels?.vk as Record<string, unknown> | undefined) ?? {};
+        return {
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            vk: {
+              ...existing,
+              enabled: true,
+              ...(input.communityId ? { communityId: input.communityId } : {}),
+              ...(input.token ? { communityAccessToken: input.token } : {}),
+            },
+          },
+        };
+      },
+      ...(params?.validateCompleteInput
+        ? { validateCompleteInput: params.validateCompleteInput }
+        : {}),
+      ...(params?.validateInputAsync ? { validateInputAsync: params.validateInputAsync } : {}),
+    },
+  } as ChannelPlugin;
+}
+
+const baseCfg: OpenClawConfig = {};
+
+describe("buildChannelSetupWizardAdapterFromSetupWizard", () => {
+  it("validates the fully assembled candidate config before returning", async () => {
+    const validateCompleteInput = vi.fn(({ cfg, candidateCfg, accountId, input }) => {
+      expect(cfg).toEqual(baseCfg);
+      expect(accountId).toBe("default");
+      expect(input).toMatchObject({
+        communityId: "123",
+        token: "vk-token",
+      });
+      expect(candidateCfg.channels?.vk).toMatchObject({
+        enabled: true,
+        communityId: "123",
+        communityAccessToken: "vk-token",
+      });
+      return null;
+    });
+    const validateInputAsync = vi.fn(async () => null);
+    const plugin = createVkSetupTestPlugin({
+      validateCompleteInput,
+      validateInputAsync,
+    });
+    const adapter = buildChannelSetupWizardAdapterFromSetupWizard({
+      plugin,
+      wizard: {
+        channel: "vk",
+        deferApplyUntilValidated: true,
+        status: {
+          configuredLabel: "Configured",
+          unconfiguredLabel: "Not configured",
+          resolveConfigured: () => false,
+        },
+        credentials: [],
+        textInputs: [
+          {
+            inputKey: "communityId",
+            message: "Community ID",
+          },
+          {
+            inputKey: "token",
+            message: "Community token",
+          },
+        ],
+      },
+    });
+
+    const result = await adapter.configure({
+      cfg: baseCfg,
+      runtime: {} as never,
+      prompter: createPrompter(["123", "vk-token"]),
+      accountOverrides: {},
+      shouldPromptAccountIds: false,
+      forceAllowFrom: false,
+    });
+
+    expect(validateCompleteInput).toHaveBeenCalledTimes(1);
+    expect(validateInputAsync).toHaveBeenCalledTimes(1);
+    expect(result.accountId).toBe("default");
+    expect(result.cfg.channels?.vk).toMatchObject({
+      enabled: true,
+      communityId: "123",
+      communityAccessToken: "vk-token",
+    });
+  });
+
+  it("surfaces deferred async validation failures", async () => {
+    const plugin = createVkSetupTestPlugin({
+      validateInputAsync: vi.fn(async ({ candidateCfg }) => {
+        expect(candidateCfg.channels?.vk).toMatchObject({
+          enabled: true,
+          communityId: "123",
+          communityAccessToken: "vk-token",
+        });
+        return "VK long poll probe failed";
+      }),
+    });
+    const adapter = buildChannelSetupWizardAdapterFromSetupWizard({
+      plugin,
+      wizard: {
+        channel: "vk",
+        deferApplyUntilValidated: true,
+        status: {
+          configuredLabel: "Configured",
+          unconfiguredLabel: "Not configured",
+          resolveConfigured: () => false,
+        },
+        credentials: [],
+        textInputs: [
+          {
+            inputKey: "communityId",
+            message: "Community ID",
+          },
+          {
+            inputKey: "token",
+            message: "Community token",
+          },
+        ],
+      },
+    });
+
+    await expect(
+      adapter.configure({
+        cfg: baseCfg,
+        runtime: {} as never,
+        prompter: createPrompter(["123", "vk-token"]),
+        accountOverrides: {},
+        shouldPromptAccountIds: false,
+        forceAllowFrom: false,
+      }),
+    ).rejects.toThrow("VK long poll probe failed");
+  });
+});

--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -80,6 +80,7 @@ export type ChannelSetupWizardCredential = {
   inputKey: keyof ChannelSetupInput;
   providerHint: string;
   credentialLabel: string;
+  secretInputMode?: "plaintext" | "ref";
   preferredEnvVar?: string;
   helpTitle?: string;
   helpLines?: string[];
@@ -252,6 +253,7 @@ export type ChannelSetupWizardFinalize = (params: {
 
 export type ChannelSetupWizard = {
   channel: string;
+  deferApplyUntilValidated?: boolean;
   status: ChannelSetupWizardStatus;
   introNote?: ChannelSetupWizardNote;
   envShortcut?: ChannelSetupWizardEnvShortcut;
@@ -283,6 +285,75 @@ export type ChannelSetupWizard = {
 };
 
 type ChannelSetupWizardPlugin = Pick<ChannelPlugin, "id" | "meta" | "config" | "setup">;
+
+function resolveSetupCandidate(params: {
+  plugin: ChannelSetupWizardPlugin;
+  cfg: OpenClawConfig;
+  accountId: string;
+  input: ChannelSetupInput;
+}) {
+  const setup = params.plugin.setup;
+  if (!setup?.applyAccountConfig) {
+    throw new Error(`${params.plugin.id} does not support setup`);
+  }
+  const resolvedAccountId =
+    setup.resolveAccountId?.({
+      cfg: params.cfg,
+      accountId: params.accountId,
+      input: params.input,
+    }) ?? params.accountId;
+  let next = setup.applyAccountConfig({
+    cfg: params.cfg,
+    accountId: resolvedAccountId,
+    input: params.input,
+  });
+  if (params.input.name?.trim() && setup.applyAccountName) {
+    next = setup.applyAccountName({
+      cfg: next,
+      accountId: resolvedAccountId,
+      name: params.input.name,
+    });
+  }
+  return {
+    cfg: next,
+    accountId: resolvedAccountId,
+  };
+}
+
+async function validateSetupCandidate(params: {
+  plugin: ChannelSetupWizardPlugin;
+  cfg: OpenClawConfig;
+  candidateCfg: OpenClawConfig;
+  accountId: string;
+  input: ChannelSetupInput;
+}) {
+  const setup = params.plugin.setup;
+  const validationError = setup?.validateInput?.({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    input: params.input,
+  });
+  if (validationError) {
+    return validationError;
+  }
+  const completeValidationError = setup?.validateCompleteInput?.({
+    cfg: params.cfg,
+    candidateCfg: params.candidateCfg,
+    accountId: params.accountId,
+    input: params.input,
+  });
+  if (completeValidationError) {
+    return completeValidationError;
+  }
+  return (
+    (await setup?.validateInputAsync?.({
+      cfg: params.cfg,
+      candidateCfg: params.candidateCfg,
+      accountId: params.accountId,
+      input: params.input,
+    })) ?? null
+  );
+}
 
 async function buildStatus(
   plugin: ChannelSetupWizardPlugin,
@@ -325,40 +396,16 @@ function applySetupInput(params: {
   accountId: string;
   input: ChannelSetupInput;
 }) {
-  const setup = params.plugin.setup;
-  if (!setup?.applyAccountConfig) {
-    throw new Error(`${params.plugin.id} does not support setup`);
-  }
-  const resolvedAccountId =
-    setup.resolveAccountId?.({
-      cfg: params.cfg,
-      accountId: params.accountId,
-      input: params.input,
-    }) ?? params.accountId;
-  const validationError = setup.validateInput?.({
+  const candidate = resolveSetupCandidate(params);
+  const validationError = params.plugin.setup?.validateInput?.({
     cfg: params.cfg,
-    accountId: resolvedAccountId,
+    accountId: candidate.accountId,
     input: params.input,
   });
   if (validationError) {
     throw new Error(validationError);
   }
-  let next = setup.applyAccountConfig({
-    cfg: params.cfg,
-    accountId: resolvedAccountId,
-    input: params.input,
-  });
-  if (params.input.name?.trim() && setup.applyAccountName) {
-    next = setup.applyAccountName({
-      cfg: next,
-      accountId: resolvedAccountId,
-      name: params.input.name,
-    });
-  }
-  return {
-    cfg: next,
-    accountId: resolvedAccountId,
-  };
+  return candidate;
 }
 
 function trimResolvedValue(value?: string): string | undefined {
@@ -457,12 +504,20 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
           }));
 
       let next = cfg;
+      let draftInput: ChannelSetupInput = {};
+      let draftAccountId = accountId;
       let credentialValues = collectCredentialValues({
         wizard,
         cfg: next,
         accountId,
       });
       let usedEnvShortcut = false;
+      const recordDraftInput = (patch: Partial<ChannelSetupInput>) => {
+        draftInput = {
+          ...draftInput,
+          ...patch,
+        };
+      };
 
       if (wizard.envShortcut?.isAvailable({ cfg: next, accountId })) {
         const useEnvShortcut = await prompter.confirm({
@@ -476,6 +531,7 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
             cfg: next,
             accountId,
           });
+          recordDraftInput({ useEnv: true });
           usedEnvShortcut = true;
         }
       }
@@ -544,7 +600,7 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
             prompter,
             providerHint: credential.providerHint,
             credentialLabel: credential.credentialLabel,
-            secretInputMode: options?.secretInputMode,
+            secretInputMode: credential.secretInputMode ?? options?.secretInputMode,
             accountConfigured: credentialState.accountConfigured,
             hasConfigToken: credentialState.hasConfiguredValue,
             allowEnv,
@@ -562,8 +618,12 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
                     );
                   }
                 : undefined,
-            applyUseEnv: async (currentCfg) =>
-              credential.applyUseEnv
+            applyUseEnv: async (currentCfg) => {
+              recordDraftInput({
+                [credential.inputKey]: undefined,
+                useEnv: true,
+              });
+              return credential.applyUseEnv
                 ? await credential.applyUseEnv({
                     cfg: currentCfg,
                     accountId,
@@ -576,9 +636,14 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
                       [credential.inputKey]: undefined,
                       useEnv: true,
                     },
-                  }).cfg,
+                  }).cfg;
+            },
             applySet: async (currentCfg, value, resolvedValue) => {
               resolvedCredentialValue = resolvedValue;
+              recordDraftInput({
+                [credential.inputKey]: value as ChannelSetupInput[keyof ChannelSetupInput],
+                useEnv: false,
+              });
               return credential.applySet
                 ? await credential.applySet({
                     cfg: currentCfg,
@@ -641,6 +706,9 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
             if (currentValue) {
               credentialValues[textInput.inputKey] = currentValue;
               if (textInput.applyCurrentValue) {
+                recordDraftInput({
+                  [textInput.inputKey]: currentValue as ChannelSetupInput[keyof ChannelSetupInput],
+                });
                 next = await applyWizardTextInputValue({
                   plugin,
                   input: textInput,
@@ -672,6 +740,9 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
             if (keep) {
               credentialValues[textInput.inputKey] = currentValue;
               if (textInput.applyCurrentValue) {
+                recordDraftInput({
+                  [textInput.inputKey]: currentValue as ChannelSetupInput[keyof ChannelSetupInput],
+                });
                 next = await applyWizardTextInputValue({
                   plugin,
                   input: textInput,
@@ -713,6 +784,9 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
           const trimmedValue = rawValue.trim();
           if (!trimmedValue && textInput.required === false) {
             if (textInput.applyEmptyValue) {
+              recordDraftInput({
+                [textInput.inputKey]: "" as ChannelSetupInput[keyof ChannelSetupInput],
+              });
               next = await applyWizardTextInputValue({
                 plugin,
                 input: textInput,
@@ -736,6 +810,9 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
             delete credentialValues[textInput.inputKey];
             continue;
           }
+          recordDraftInput({
+            [textInput.inputKey]: normalizedValue as ChannelSetupInput[keyof ChannelSetupInput],
+          });
           next = await applyWizardTextInputValue({
             plugin,
             input: textInput,
@@ -855,6 +932,25 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
             ...credentialValues,
             ...finalized.credentialValues,
           };
+        }
+      }
+
+      if (wizard.deferApplyUntilValidated) {
+        draftAccountId =
+          plugin.setup?.resolveAccountId?.({
+            cfg,
+            accountId,
+            input: draftInput,
+          }) ?? accountId;
+        const validationError = await validateSetupCandidate({
+          plugin,
+          cfg,
+          candidateCfg: next,
+          accountId: draftAccountId,
+          input: draftInput,
+        });
+        if (validationError) {
+          throw new Error(validationError);
         }
       }
 

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -97,6 +97,18 @@ export type ChannelSetupAdapter = {
     accountId: string;
     input: ChannelSetupInput;
   }) => string | null;
+  validateCompleteInput?: (params: {
+    cfg: OpenClawConfig;
+    candidateCfg: OpenClawConfig;
+    accountId: string;
+    input: ChannelSetupInput;
+  }) => string | null;
+  validateInputAsync?: (params: {
+    cfg: OpenClawConfig;
+    candidateCfg: OpenClawConfig;
+    accountId: string;
+    input: ChannelSetupInput;
+  }) => Promise<string | null>;
   singleAccountKeysToMove?: readonly string[];
   namedAccountPromotionKeys?: readonly string[];
   resolveSingleAccountPromotionTarget?: (params: {

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -4,6 +4,7 @@ import type { MsgContext } from "../../auto-reply/templating.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
+import type { SecretInput } from "../../config/types.secrets.js";
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import type { PollInput } from "../../polls.js";
 import type { GatewayClientMode, GatewayClientName } from "../../utils/message-channel.js";
@@ -65,6 +66,8 @@ export type ChannelMessageToolDiscovery = {
 export type ChannelSetupInput = {
   name?: string;
   token?: string;
+  communityId?: string;
+  communityAccessToken?: SecretInput;
   privateKey?: string;
   tokenFile?: string;
   botToken?: string;

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -14,6 +14,8 @@ const optionNamesAdd = [
   "account",
   "name",
   "token",
+  "communityId",
+  "communityAccessToken",
   "privateKey",
   "tokenFile",
   "botToken",
@@ -166,8 +168,10 @@ export function registerChannelsCli(program: Command) {
     .option("--account <id>", "Account id (default when omitted)")
     .option("--name <name>", "Display name for this account")
     .option("--token <token>", "Bot token (Telegram/Discord)")
+    .option("--community-id <id>", "VK community id")
+    .option("--community-access-token <token>", "VK community access token")
     .option("--private-key <key>", "Nostr private key (nsec... or hex)")
-    .option("--token-file <path>", "Bot token file (Telegram)")
+    .option("--token-file <path>", "Bot/community token file (Telegram/VK)")
     .option("--bot-token <token>", "Slack bot token (xoxb-...)")
     .option("--app-token <token>", "Slack app token (xapp-...)")
     .option("--signal-number <e164>", "Signal account number (E.164)")

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -22,6 +22,8 @@ import { channelLabel, requireValidConfigFileSnapshot, shouldUseWizard } from ".
 export type ChannelsAddOptions = {
   channel?: string;
   account?: string;
+  communityId?: string;
+  communityAccessToken?: string;
   initialSyncLimit?: number | string;
   groupChannels?: string;
   dmAllowlist?: string;
@@ -280,6 +282,8 @@ export async function channelsAddCommand(
   const input: ChannelSetupInput = {
     name: opts.name,
     token: opts.token,
+    communityId: opts.communityId,
+    communityAccessToken: opts.communityAccessToken,
     privateKey: opts.privateKey,
     tokenFile: opts.tokenFile,
     botToken: opts.botToken,
@@ -312,12 +316,19 @@ export async function channelsAddCommand(
     dmAllowlist,
     autoDiscoverChannels: opts.autoDiscoverChannels,
   };
-  const accountId =
-    plugin.setup.resolveAccountId?.({
-      cfg: nextConfig,
-      accountId: opts.account,
-      input,
-    }) ?? normalizeAccountId(opts.account);
+  let accountId: string;
+  try {
+    accountId =
+      plugin.setup.resolveAccountId?.({
+        cfg: nextConfig,
+        accountId: opts.account,
+        input,
+      }) ?? normalizeAccountId(opts.account);
+  } catch (error) {
+    runtime.error(error instanceof Error ? error.message : String(error));
+    runtime.exit(1);
+    return;
+  }
 
   const validationError = plugin.setup.validateInput?.({
     cfg: nextConfig,
@@ -331,21 +342,44 @@ export async function channelsAddCommand(
   }
 
   const prevConfig = nextConfig;
-
-  if (accountId !== DEFAULT_ACCOUNT_ID) {
-    nextConfig = moveSingleAccountChannelSectionToDefaultAccount({
-      cfg: nextConfig,
-      channelKey: channel,
-    });
-  }
-
-  nextConfig = applyChannelAccountConfig({
-    cfg: nextConfig,
+  const candidateBaseConfig =
+    accountId !== DEFAULT_ACCOUNT_ID
+      ? moveSingleAccountChannelSectionToDefaultAccount({
+          cfg: nextConfig,
+          channelKey: channel,
+        })
+      : nextConfig;
+  const candidateConfig = applyChannelAccountConfig({
+    cfg: candidateBaseConfig,
     channel,
     accountId,
     input,
     plugin,
   });
+  const completeValidationError = plugin.setup.validateCompleteInput?.({
+    cfg: prevConfig,
+    candidateCfg: candidateConfig,
+    accountId,
+    input,
+  });
+  if (completeValidationError) {
+    runtime.error(completeValidationError);
+    runtime.exit(1);
+    return;
+  }
+  const asyncValidationError = await plugin.setup.validateInputAsync?.({
+    cfg: prevConfig,
+    candidateCfg: candidateConfig,
+    accountId,
+    input,
+  });
+  if (asyncValidationError) {
+    runtime.error(asyncValidationError);
+    runtime.exit(1);
+    return;
+  }
+
+  nextConfig = candidateConfig;
   await plugin.lifecycle?.onAccountConfigChanged?.({
     prevCfg: prevConfig,
     nextCfg: nextConfig,


### PR DESCRIPTION
## Summary

This is **PR 1 of a 3-PR VK stack**.

Follow-up PRs:
- PR 2: `fix(plugin-sdk): forward inbound typing callbacks` <https://github.com/frznfrgg/openclaw/pull/8>
- PR 3: `feat(vk): add VK channel plugin` <https://github.com/frznfrgg/openclaw/pull/9>

Describe the problem and fix in 2–5 bullets:

- Problem: channel setup could validate only raw input fields before config writes, not the fully assembled candidate config that a channel would actually run with.
- Why it matters: VK setup needs to validate the resolved `communityId` and credential source together, then run an async Long Poll probe before writing config.
- What changed: added shared complete/async setup validation hooks, taught the setup wizard to defer writes until the candidate config is validated, and taught `openclaw channels add` to do the same.
- What did NOT change (scope boundary): this PR does not add the VK channel itself and does not change runtime VK routing or outbound behavior.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related PR 2: `fix(plugin-sdk): forward inbound typing callbacks` <https://github.com/frznfrgg/openclaw/pull/8>
- Related PR 3: `feat(vk): add VK channel plugin` <https://github.com/frznfrgg/openclaw/pull/9>
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): the upcoming VK channel needs candidate-config validation before writes because a valid setup depends on the assembled config, not just individual raw flags.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/channels/plugins/setup-wizard.async-validation.test.ts`
- Scenario the test should lock in: the setup wizard builds the candidate config first, then runs complete and async validation before returning a config that could be written.
- Why this is the smallest reliable guardrail: the behavior spans shared setup input collection, candidate-config assembly, and validation timing; a narrower helper-only test would miss the actual contract the wizard exposes.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Channel setup can now reject invalid fully assembled configs before writing them.
- `openclaw channels add` can now reject channel setups that fail complete or async validation before mutating the config file.
- Shared setup input now includes `communityId` and `communityAccessToken`, which VK uses in the next PR.

## Diagram (if applicable)

```text
Before:
[CLI / setup wizard input] -> [basic field validation] -> [write config] -> [discover config is invalid later]

After:
[CLI / setup wizard input] -> [assemble candidate config in memory] -> [complete validation] -> [async validation] -> [write config only if valid]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - The shared setup input surface now carries `communityAccessToken` so channels can validate candidate configs before writes. This does not broaden runtime secret exposure; it only lets channel-owned setup code validate the assembled config before persistence.

## Repro + Verification

### Environment

- OS: Ubuntu Linux
- Runtime/container: local dev worktree and VPS manual verification environment
- Model/provider: N/A (fyi: VPS tests were conducted via OpenAI codex subscription)
- Integration/channel (if any): shared channel setup flow, exercised for VK onboarding
- Relevant config (redacted): candidate `channels.vk` setup with `communityId` plus env-backed or inline community token

### Steps

1. Run `openclaw channels add --channel vk --community-id <id> --use-env` or use the setup wizard with deferred apply enabled.
2. Let the channel setup assemble the candidate config in memory.
3. Run complete validation and async validation before config writes.

### Expected

- If validation passes, setup returns a config that can be written.
- If validation fails, setup exits before writing the invalid config.

### Actual

- The shared setup path now validates the candidate config before write, which unblocks VK setup probing in the next PR.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification run:

```bash
pnpm test src/channels/plugins/setup-wizard.async-validation.test.ts
```

Result:

- `1` file passed
- `2` tests passed

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Focused local test coverage for deferred candidate validation in the shared setup wizard.
  - End-to-end VK onboarding on a VPS later in the stack, which relies on this seam to validate setup before write.
- Edge cases checked:
  - complete validation sees the assembled candidate config
  - async validation failures are surfaced before config write
- What you did **not** verify:
  - I did not manually exercise every non-VK channel against the new complete/async setup hooks.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A

## Risks and Mitigations

- Risk:
  - Shared setup timing changed for channels that opt into deferred validation, so ordering bugs could show up if a channel assumes writes happen before validation.
  - Mitigation:
    - The new behavior is opt-in through the setup contract and is covered by a focused seam test.
- Risk:
  - CLI setup now accepts VK-oriented input fields in the shared command surface.
  - Mitigation:
    - The new fields are narrow and only meaningful to channels that use them; this PR does not change unrelated channel runtime behavior.

## AI Assistance

- [x] AI-assisted
- Testing: focused local test plus later manual VPS verification through the dependent VK stack
- Notes:
  - This PR was prepared with Codex assistance.
  - The implementation and staged validation were reviewed locally before preparing the stack.