### PR TITLE
fix(agents): OpenAI WS stream — gate buffered text delta on valid phase value, not just outputItemPhaseById key existence

### DIFF
--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -1059,7 +1059,7 @@ export function createOpenAIWebSocketStreamFn(
                 const key = getOutputTextKey(event.item_id, event.content_index);
                 const nextText = `${outputTextByPart.get(key) ?? ""}${event.delta}`;
                 outputTextByPart.set(key, nextText);
-                if (outputItemPhaseById.has(event.item_id)) {
+                if (outputItemPhaseById.get(event.item_id) !== undefined) {
                   emitBufferedTextDelta({
                     itemId: event.item_id,
                     contentIndex: event.content_index,
@@ -1073,7 +1073,7 @@ export function createOpenAIWebSocketStreamFn(
                 if (event.text && event.text !== outputTextByPart.get(key)) {
                   outputTextByPart.set(key, event.text);
                 }
-                if (outputItemPhaseById.has(event.item_id)) {
+                if (outputItemPhaseById.get(event.item_id) !== undefined) {
                   emitBufferedTextDelta({
                     itemId: event.item_id,
                     contentIndex: event.content_index,


### PR DESCRIPTION
## What this fixes (plain English)
The WebSocket streaming code was supposed to hold back text until it knew the phase (commentary vs. visible), but a subtle bug meant it released text as soon as the item was registered — even if the phase was still unknown. This caused internal commentary to leak into user-visible output.

## Technical details
**Root cause:** `outputItemPhaseById.has(event.item_id)` returns `true` even when the stored value is `undefined` (set by an `output_item.added` event before phase metadata arrives). This defeats the buffering protection entirely.

**Fix:** Changed both emission gates (`.delta` and `.done` handlers) from `.has(id)` to `.get(id) !== undefined` so text stays buffered until a valid phase value arrives.

**Files changed:**
- `src/agents/openai-ws-stream.ts` — 2-line gate fix (`.has()` -> `.get() !== undefined`)

## Related
- Fixes #61477
- Parent fix: #59643
- Companion PRs: #61529, #61463, #61478

## Test plan
- [x] 92/92 existing tests pass
- [x] 2-line change, minimal blast radius
- [x] No scope creep — single file, single fix