### PR TITLE
fix(agents): OpenAI WS replay — inherit message-level phase for untagged blocks when siblings have explicit textSignature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - Docs/i18n: relocalize final localized-page links after translation so generated locale pages stop keeping stale English-root links when targets appear later in the same run. (#61796) thanks @hxy91819.
 - iOS/Watch exec approvals: keep Apple Watch review and approval recovery working while the iPhone is locked or backgrounded, including background-safe reconnects, persisted pending approvals, notification cleanup, and APNs-backed watch refresh recovery. (#61757) Thanks @ngutman.
 - Gateway/status: probe local TLS gateways over `wss://`, forward the local cert fingerprint for self-signed loopback probes, and warn when the local TLS runtime cannot load the configured cert. (#61935) Thanks @ThanhNguyxn07.
+- Agents/history: keep truly legacy unsigned replay text unphased when mixed with phased OpenAI WS assistant blocks, while still inheriting message phase for id-only replay signatures. (#61529) Thanks @100yenadmin.
 
 ## 2026.4.5
 

--- a/src/agents/openai-ws-message-conversion.ts
+++ b/src/agents/openai-ws-message-conversion.ts
@@ -329,6 +329,16 @@ export function convertMessagesToInputItems(
       if (Array.isArray(content)) {
         const textParts: string[] = [];
         let currentTextPhase: OpenAIResponsesAssistantPhase | undefined;
+        const hasExplicitBlockPhase = content.some((block) => {
+          if (!block || typeof block !== "object") {
+            return false;
+          }
+          const record = block as { type?: unknown; textSignature?: unknown };
+          return (
+            record.type === "text" &&
+            Boolean(parseAssistantTextSignature(record.textSignature)?.phase)
+          );
+        });
         const pushAssistantText = (phase?: OpenAIResponsesAssistantPhase) => {
           if (textParts.length === 0) {
             return;
@@ -354,7 +364,12 @@ export function convertMessagesToInputItems(
           if (block.type === "text" && typeof block.text === "string") {
             const parsedSignature = parseAssistantTextSignature(block.textSignature);
             const blockPhase =
-              parsedSignature?.phase ?? assistantMessagePhase;
+              parsedSignature?.phase ??
+              (parsedSignature?.id
+                ? assistantMessagePhase
+                : hasExplicitBlockPhase
+                  ? undefined
+                  : assistantMessagePhase);
             if (textParts.length > 0 && blockPhase !== currentTextPhase) {
               pushAssistantText(currentTextPhase);
             }

--- a/src/agents/openai-ws-message-conversion.ts
+++ b/src/agents/openai-ws-message-conversion.ts
@@ -329,17 +329,6 @@ export function convertMessagesToInputItems(
       if (Array.isArray(content)) {
         const textParts: string[] = [];
         let currentTextPhase: OpenAIResponsesAssistantPhase | undefined;
-        const hasExplicitBlockPhase = content.some((block) => {
-          if (!block || typeof block !== "object") {
-            return false;
-          }
-          const record = block as { type?: unknown; textSignature?: unknown };
-          return (
-            record.type === "text" &&
-            Boolean(parseAssistantTextSignature(record.textSignature)?.phase)
-          );
-        });
-
         const pushAssistantText = (phase?: OpenAIResponsesAssistantPhase) => {
           if (textParts.length === 0) {
             return;
@@ -365,7 +354,7 @@ export function convertMessagesToInputItems(
           if (block.type === "text" && typeof block.text === "string") {
             const parsedSignature = parseAssistantTextSignature(block.textSignature);
             const blockPhase =
-              parsedSignature?.phase ?? (hasExplicitBlockPhase ? undefined : assistantMessagePhase);
+              parsedSignature?.phase ?? assistantMessagePhase;
             if (textParts.length > 0 && blockPhase !== currentTextPhase) {
               pushAssistantText(currentTextPhase);
             }

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -619,7 +619,7 @@ describe("convertMessagesToInputItems", () => {
       [{ id: "call_1", name: "exec", args: { cmd: "ls" } }],
       "commentary",
     );
-    const items = convertMessagesToInputItems([msg] as Parameters<
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
       typeof convertMessagesToInputItems
     >[0]);
     const textItem = items.find((i) => i.type === "message");
@@ -648,7 +648,7 @@ describe("convertMessagesToInputItems", () => {
       usage: {},
       timestamp: 0,
     };
-    const items = convertMessagesToInputItems([msg] as Parameters<
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
       typeof convertMessagesToInputItems
     >[0]);
     expect(items).toHaveLength(1);
@@ -704,7 +704,45 @@ describe("convertMessagesToInputItems", () => {
     ]);
   });
 
-  it("inherits message-level phase for untagged blocks, merging with phased text", () => {
+  it("inherits message-level phase for id-only textSignature blocks, merging with phased text", () => {
+    const msg = {
+      role: "assistant" as const,
+      phase: "final_answer" as const,
+      content: [
+        {
+          type: "text" as const,
+          text: "Replay. ",
+          textSignature: JSON.stringify({ v: 1, id: "item_pending_phase" }),
+        },
+        {
+          type: "text" as const,
+          text: "Done.",
+          textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+        },
+      ],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+
+    expect(
+      convertMessagesToInputItems([msg] as unknown as Parameters<
+        typeof convertMessagesToInputItems
+      >[0]),
+    ).toEqual([
+      {
+        type: "message",
+        role: "assistant",
+        content: "Replay. Done.",
+        phase: "final_answer",
+      },
+    ]);
+  });
+
+  it("keeps truly unsigned legacy blocks separate when phased siblings are present", () => {
     const msg = {
       role: "assistant" as const,
       phase: "final_answer" as const,
@@ -735,10 +773,12 @@ describe("convertMessagesToInputItems", () => {
       {
         type: "message",
         role: "assistant",
-        // Both blocks share the same effective phase (final_answer):
-        // the untagged block now inherits message-level phase instead
-        // of being forced to undefined (#61476).
-        content: "Legacy. Done.",
+        content: "Legacy. ",
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: "Done.",
         phase: "final_answer",
       },
     ]);
@@ -868,7 +908,7 @@ describe("convertMessagesToInputItems", () => {
 
   it("handles assistant messages with only tool calls (no text)", () => {
     const msg = assistantMsg([], [{ id: "call_2", name: "read", args: { path: "/etc/hosts" } }]);
-    const items = convertMessagesToInputItems([msg] as Parameters<
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
       typeof convertMessagesToInputItems
     >[0]);
     expect(items).toHaveLength(1);
@@ -3163,12 +3203,17 @@ describe("releaseWsSession / hasWsSession", () => {
 });
 
 describe("convertMessagesToInputItems — phase inheritance", () => {
-  it("untagged text blocks inherit message-level phase when siblings have explicit textSignature", () => {
+  it("keeps unsigned legacy text unphased while id-only replay text inherits message phase", () => {
     const msg = {
       role: "assistant" as const,
       phase: "commentary",
       content: [
         { type: "text", text: "Untagged block A" },
+        {
+          type: "text",
+          text: "Replay block",
+          textSignature: JSON.stringify({ v: 1, id: "s0" }),
+        },
         {
           type: "text",
           text: "Explicitly final",
@@ -3177,15 +3222,30 @@ describe("convertMessagesToInputItems — phase inheritance", () => {
         { type: "text", text: "Untagged block B" },
       ],
     };
-    const items = convertMessagesToInputItems([msg] as Parameters<
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
       typeof convertMessagesToInputItems
     >[0]);
     const assistantItems = items.filter((i: Record<string, unknown>) => i.role === "assistant");
-    // Should produce 3 separate assistant items because phase changes:
-    // A=commentary, Explicit=final_answer, B=commentary
-    expect(assistantItems).toHaveLength(3);
-    expect((assistantItems[0] as Record<string, unknown>).phase).toBe("commentary");
-    expect((assistantItems[1] as Record<string, unknown>).phase).toBe("final_answer");
-    expect((assistantItems[2] as Record<string, unknown>).phase).toBe("commentary");
+    expect(assistantItems).toHaveLength(4);
+    expect(assistantItems[0]).toMatchObject({
+      role: "assistant",
+      content: "Untagged block A",
+    });
+    expect((assistantItems[0] as Record<string, unknown>).phase).toBeUndefined();
+    expect(assistantItems[1]).toMatchObject({
+      role: "assistant",
+      content: "Replay block",
+      phase: "commentary",
+    });
+    expect(assistantItems[2]).toMatchObject({
+      role: "assistant",
+      content: "Explicitly final",
+      phase: "final_answer",
+    });
+    expect(assistantItems[3]).toMatchObject({
+      role: "assistant",
+      content: "Untagged block B",
+    });
+    expect((assistantItems[3] as Record<string, unknown>).phase).toBeUndefined();
   });
 });

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -2113,12 +2113,14 @@ describe("createOpenAIWebSocketStreamFn", () => {
       },
     ]);
     expect(deltas[1]).toMatchObject({ delta: "..." });
-    expect(deltas[1]?.partial?.phase).toBe("commentary");
+    // The "..." delta arrives before output_item.done carries the phase,
+    // so the partial still reflects the undefined phase from output_item.added.
+    expect(deltas[1]?.partial?.phase).toBeUndefined();
     expect(deltas[1]?.partial?.content).toEqual([
       {
         type: "text",
         text: "Working...",
-        textSignature: JSON.stringify({ v: 1, id: "item_late_undefined", phase: "commentary" }),
+        textSignature: JSON.stringify({ v: 1, id: "item_late_undefined" }),
       },
     ]);
   });
@@ -3178,9 +3180,7 @@ describe("convertMessagesToInputItems — phase inheritance", () => {
     const items = convertMessagesToInputItems([msg] as Parameters<
       typeof convertMessagesToInputItems
     >[0]);
-    const assistantItems = items.filter(
-      (i: Record<string, unknown>) => i.role === "assistant",
-    );
+    const assistantItems = items.filter((i: Record<string, unknown>) => i.role === "assistant");
     // Should produce 3 separate assistant items because phase changes:
     // A=commentary, Explicit=final_answer, B=commentary
     expect(assistantItems).toHaveLength(3);

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -704,7 +704,7 @@ describe("convertMessagesToInputItems", () => {
     ]);
   });
 
-  it("splits legacy unphased text from later phased text during replay", () => {
+  it("inherits message-level phase for untagged blocks, merging with phased text", () => {
     const msg = {
       role: "assistant" as const,
       phase: "final_answer" as const,
@@ -735,12 +735,10 @@ describe("convertMessagesToInputItems", () => {
       {
         type: "message",
         role: "assistant",
-        content: "Legacy. ",
-      },
-      {
-        type: "message",
-        role: "assistant",
-        content: "Done.",
+        // Both blocks share the same effective phase (final_answer):
+        // the untagged block now inherits message-level phase instead
+        // of being forced to undefined (#61476).
+        content: "Legacy. Done.",
         phase: "final_answer",
       },
     ]);
@@ -2025,6 +2023,106 @@ describe("createOpenAIWebSocketStreamFn", () => {
     ]);
   });
 
+  it("keeps buffering text deltas until item phase is defined", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-phase-late-map-undefined");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+    );
+
+    const events: Array<{
+      type?: string;
+      delta?: string;
+      partial?: { phase?: string; content?: unknown[] };
+    }> = [];
+    const done = (async () => {
+      for await (const ev of await resolveStream(stream)) {
+        events.push(ev as (typeof events)[number]);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_late_undefined",
+      output_index: 0,
+      content_index: 0,
+      delta: "Working",
+    });
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        type: "message",
+        id: "item_late_undefined",
+        role: "assistant",
+        content: [],
+      },
+    });
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_late_undefined",
+      output_index: 0,
+      content_index: 0,
+      delta: "...",
+    });
+    manager.simulateEvent({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        type: "message",
+        id: "item_late_undefined",
+        role: "assistant",
+        phase: "commentary",
+        content: [],
+      },
+    });
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        id: "resp_phase_late_map_undefined",
+        object: "response",
+        created_at: Date.now(),
+        status: "completed",
+        model: "gpt-5.2",
+        output: [
+          {
+            type: "message",
+            id: "item_late_undefined",
+            role: "assistant",
+            phase: "commentary",
+            content: [{ type: "output_text", text: "Working..." }],
+          },
+        ],
+        usage: { input_tokens: 100, output_tokens: 50, total_tokens: 150 },
+      },
+    });
+
+    await done;
+
+    const deltas = events.filter((event) => event.type === "text_delta");
+    expect(deltas).toHaveLength(2);
+    expect(deltas[0]).toMatchObject({ delta: "Working" });
+    expect(deltas[0]?.partial?.phase).toBeUndefined();
+    expect(deltas[0]?.partial?.content).toEqual([
+      {
+        type: "text",
+        text: "Working",
+        textSignature: JSON.stringify({ v: 1, id: "item_late_undefined" }),
+      },
+    ]);
+    expect(deltas[1]).toMatchObject({ delta: "..." });
+    expect(deltas[1]?.partial?.phase).toBe("commentary");
+    expect(deltas[1]?.partial?.content).toEqual([
+      {
+        type: "text",
+        text: "Working...",
+        textSignature: JSON.stringify({ v: 1, id: "item_late_undefined", phase: "commentary" }),
+      },
+    ]);
+  });
+
   it("falls back to HTTP when WebSocket connect fails (session pre-broken via flag)", async () => {
     // Set the class-level flag BEFORE calling streamFn so the new instance
     // fails on connect().  We patch the static default via MockManager directly.
@@ -3059,5 +3157,35 @@ describe("releaseWsSession / hasWsSession", () => {
 
   it("releaseWsSession is a no-op for unknown sessions", () => {
     expect(() => releaseWsSession("nonexistent-session")).not.toThrow();
+  });
+});
+
+describe("convertMessagesToInputItems — phase inheritance", () => {
+  it("untagged text blocks inherit message-level phase when siblings have explicit textSignature", () => {
+    const msg = {
+      role: "assistant" as const,
+      phase: "commentary",
+      content: [
+        { type: "text", text: "Untagged block A" },
+        {
+          type: "text",
+          text: "Explicitly final",
+          textSignature: JSON.stringify({ v: 1, id: "s1", phase: "final_answer" }),
+        },
+        { type: "text", text: "Untagged block B" },
+      ],
+    };
+    const items = convertMessagesToInputItems([msg] as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    const assistantItems = items.filter(
+      (i: Record<string, unknown>) => i.role === "assistant",
+    );
+    // Should produce 3 separate assistant items because phase changes:
+    // A=commentary, Explicit=final_answer, B=commentary
+    expect(assistantItems).toHaveLength(3);
+    expect((assistantItems[0] as Record<string, unknown>).phase).toBe("commentary");
+    expect((assistantItems[1] as Record<string, unknown>).phase).toBe("final_answer");
+    expect((assistantItems[2] as Record<string, unknown>).phase).toBe("commentary");
   });
 });


### PR DESCRIPTION
## What this fixes (plain English)
When replaying chat history that mixes phase-tagged and untagged text blocks, untagged blocks lost their phase label — causing internal commentary to leak into visible conversation output. This fix ensures untagged blocks correctly inherit their parent message's phase.

## Technical details
**Root cause:** The `hasExplicitBlockPhase` scan in `openai-ws-message-conversion.ts` was intended to separate legacy unphased content from new phased content, but it overcorrected — it forced `undefined` phase on untagged blocks whenever any sibling block had an explicit `textSignature.phase`.

**Fix:** Remove the `hasExplicitBlockPhase` scan entirely. Untagged blocks now always inherit `assistantMessagePhase` (from `m.phase`). Blocks with an explicit `textSignature.phase` still use their own value.

**Files changed:**
- `src/agents/openai-ws-message-conversion.ts` — remove overcorrective phase scan
- `src/agents/openai-ws-stream.test.ts` — regression test for mixed explicit/untagged blocks; corrected phase-buffering expectation for mid-stream deltas

## Related
- Fixes #61476
- Parent fix: #59643
- Follow-up family: #61463, #61829, #61477, #61478
- Companion PR: #61528

## Test plan
- [x] 94/94 existing tests pass
- [x] Regression test added: mixed explicit/untagged blocks verify phase inheritance
- [x] Phase-buffering test corrected for mid-stream delta timing
