### PR TITLE
fix: prevent duplicate block reply delivery for text_end channels

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -513,6 +513,131 @@ describe("handleMessageEnd", () => {
     expect(finalizeAssistantTexts).not.toHaveBeenCalled();
   });
 
+  it("does not duplicate block reply for text_end channels when text was already delivered", () => {
+    const onBlockReply = vi.fn();
+    const emitBlockReply = vi.fn();
+    // In real usage, the directive accumulator returns null for empty/consumed
+    // input. The non-empty call shouldn't happen for text_end channels (that's
+    // the safety send we're guarding against).
+    const consumeReplyDirectives = vi.fn((text: string) => (text ? { text } : null));
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onBlockReply,
+      },
+      state: {
+        deterministicApprovalPromptSent: false,
+        messagingToolSentTexts: [],
+        messagingToolSentTextsNormalized: [],
+        includeReasoning: false,
+        streamReasoning: false,
+        emittedAssistantUpdate: true,
+        lastStreamedAssistantCleaned: "Hello world",
+        assistantTexts: [],
+        assistantTextBaseline: 0,
+        blockReplyBreak: "text_end",
+        // Simulate text_end already delivered this text through emitBlockChunk
+        lastBlockReplyText: "Hello world",
+        lastReasoningSent: undefined,
+        reasoningStreamOpen: false,
+        deltaBuffer: "",
+        blockBuffer: "",
+        blockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+      },
+      log: { debug: vi.fn() },
+      noteLastAssistant: vi.fn(),
+      recordAssistantUsage: vi.fn(),
+      stripBlockTags: (text: string) => text,
+      finalizeAssistantTexts: vi.fn(),
+      emitBlockReply,
+      consumeReplyDirectives,
+      emitReasoningStream: vi.fn(),
+      flushBlockReplyBuffer: vi.fn(),
+      blockChunker: null,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+        usage: { input: 10, output: 5, total: 15 },
+      },
+    } as never);
+
+    // The block reply should NOT fire again since text_end already delivered it.
+    // consumeReplyDirectives is called once with "" (the final flush for
+    // text_end channels) but returns null, so emitBlockReply is never called.
+    expect(emitBlockReply).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate block reply for text_end channels even when stripping differs", () => {
+    const onBlockReply = vi.fn();
+    const emitBlockReply = vi.fn();
+    // Same pattern: directive accumulator returns null for empty final flush
+    const consumeReplyDirectives = vi.fn((text: string) => (text ? { text } : null));
+    const ctx = {
+      params: {
+        runId: "run-1",
+        session: { id: "session-1" },
+        onBlockReply,
+      },
+      state: {
+        deterministicApprovalPromptSent: false,
+        messagingToolSentTexts: [],
+        messagingToolSentTextsNormalized: [],
+        includeReasoning: false,
+        streamReasoning: false,
+        emittedAssistantUpdate: true,
+        lastStreamedAssistantCleaned: "Hello world",
+        assistantTexts: [],
+        assistantTextBaseline: 0,
+        blockReplyBreak: "text_end",
+        // text_end delivered via emitBlockChunk which uses different stripping
+        lastBlockReplyText: "Hello world.",
+        lastReasoningSent: undefined,
+        reasoningStreamOpen: false,
+        deltaBuffer: "",
+        blockBuffer: "",
+        blockState: {
+          thinking: false,
+          final: false,
+          inlineCode: createInlineCodeState(),
+        },
+      },
+      log: { debug: vi.fn() },
+      noteLastAssistant: vi.fn(),
+      recordAssistantUsage: vi.fn(),
+      stripBlockTags: (text: string) => text,
+      finalizeAssistantTexts: vi.fn(),
+      emitBlockReply,
+      consumeReplyDirectives,
+      emitReasoningStream: vi.fn(),
+      flushBlockReplyBuffer: vi.fn(),
+      blockChunker: null,
+    } as unknown as EmbeddedPiSubscribeContext;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        // The raw text differs slightly from lastBlockReplyText due to stripping
+        content: [{ type: "text", text: "Hello world" }],
+        usage: { input: 10, output: 5, total: 15 },
+      },
+    } as never);
+
+    // Even though text !== lastBlockReplyText (different stripping), the safety
+    // send should NOT fire for text_end channels. The only consumeReplyDirectives
+    // call is the final empty flush which returns null.
+    expect(emitBlockReply).not.toHaveBeenCalled();
+  });
+
   it("emits a replacement final assistant event when final_answer appears only at message_end", () => {
     const onAgentEvent = vi.fn();
     const ctx = {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -602,20 +602,33 @@ export function handleMessageEnd(
       ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
       ctx.blockChunker.reset();
     } else if (text !== ctx.state.lastBlockReplyText) {
-      // Check for duplicates before emitting (same logic as emitBlockChunk).
-      const normalizedText = normalizeTextForComparison(text);
-      if (
-        isMessagingToolDuplicateNormalized(
-          normalizedText,
-          ctx.state.messagingToolSentTextsNormalized,
-        )
-      ) {
+      // Guard: for text_end channels, if text_end already delivered content
+      // (lastBlockReplyText is set), skip this safety send. The text comparison
+      // here uses a different stripping pipeline (stripBlockTags with reset state)
+      // than emitBlockChunk (stripBlockTags with running blockState +
+      // stripDowngradedToolCallText), which can false-positive. When text_end
+      // didn't deliver (e.g. commentary suppressed, provider skipped text_end),
+      // lastBlockReplyText is still null and message_end must deliver.
+      if (ctx.state.blockReplyBreak === "text_end" && ctx.state.lastBlockReplyText != null) {
         ctx.log.debug(
-          `Skipping message_end block reply - already sent via messaging tool: ${text.slice(0, 50)}...`,
+          `Skipping message_end safety send for text_end channel - content already delivered via text_end`,
         );
       } else {
-        ctx.state.lastBlockReplyText = text;
-        emitSplitResultAsBlockReply(ctx.consumeReplyDirectives(text, { final: true }));
+        // Check for duplicates before emitting (same logic as emitBlockChunk).
+        const normalizedText = normalizeTextForComparison(text);
+        if (
+          isMessagingToolDuplicateNormalized(
+            normalizedText,
+            ctx.state.messagingToolSentTextsNormalized,
+          )
+        ) {
+          ctx.log.debug(
+            `Skipping message_end block reply - already sent via messaging tool: ${text.slice(0, 50)}...`,
+          );
+        } else {
+          ctx.state.lastBlockReplyText = text;
+          emitSplitResultAsBlockReply(ctx.consumeReplyDirectives(text, { final: true }));
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

Messages are being sent twice on channels using `blockReplyBreak: "text_end"` (e.g. BlueBubbles). Three recent commits introduced this regression:

- 7bef5a7466 (Apr 2) — Added a new condition in `handleMessageEnd` that sends a block reply whenever `text !== lastBlockReplyText`
- 98ce1c2902 (Apr 5) — Removed `shouldDeferTextEndBlockReply` guard
- 318111286f (Apr 5) — Further simplified phase logic

## Root Cause

With `blockReplyBreak: "text_end"`, content is delivered once at `text_end` through the block chunker/coalescer pipeline (`emitBlockChunk` → `stripBlockTags` with running `blockState` + `stripDowngradedToolCallText`), which sets `lastBlockReplyText`.

Then at `message_end`, `handleMessageEnd` computes a fresh `text` via `stripBlockTags(rawVisibleText, { thinking: false, final: false })` — a different stripping pipeline with reset state. Because the two pipelines can produce slightly different results, the safety check `text !== lastBlockReplyText` false-positives and the message gets sent again.

## Fix

Added a guard in the `handleMessageEnd` safety-send path: when `blockReplyBreak === "text_end"` and `lastBlockReplyText` is already set (meaning `text_end` successfully delivered content), skip the safety send entirely. This is the correct behavior because:

- If `text_end` already delivered, there's nothing new to send at `message_end`
- If `text_end` didn't deliver (e.g. commentary was suppressed, or the provider skipped `text_end`), `lastBlockReplyText` is still `undefined` and `message_end` correctly delivers the content

This preserves the commentary/final-answer phase separation that the original commits intended to fix.

## Testing

- Added 2 new unit tests in `pi-embedded-subscribe.handlers.messages.test.ts`:
  - Verifies no duplicate when `lastBlockReplyText` matches (text_end already delivered)
  - Verifies no duplicate even when stripping pipelines produce different results
- All 105 existing tests across 20 `pi-embedded-subscribe` test files pass
- Commentary phase suppression tests continue to pass
- Late `text_end` dedup tests continue to pass
- `message_end` delivery for message_end channels unaffected