### PR TITLE
Lint: enable bundled extension linting incrementally

### DIFF
--- a/.oxlint-extension-allowlist.json
+++ b/.oxlint-extension-allowlist.json
@@ -1,0 +1,3 @@
+{
+  "extensions": ["extensions/matrix", "extensions/qqbot", "extensions/xai"]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -26,7 +26,6 @@
     "assets/",
     "dist/",
     "docs/_layouts/",
-    "extensions/",
     "node_modules/",
     "patches/",
     "pnpm-lock.yaml",

--- a/extensions/anthropic-vertex/index.ts
+++ b/extensions/anthropic-vertex/index.ts
@@ -21,7 +21,7 @@ export default definePluginEntry({
       catalog: {
         order: "simple",
         run: async (ctx) => {
-          const implicit = await resolveImplicitAnthropicVertexProvider({
+          const implicit = resolveImplicitAnthropicVertexProvider({
             env: ctx.env,
           });
           if (!implicit) {

--- a/extensions/brave/src/brave-web-search-provider.ts
+++ b/extensions/brave/src/brave-web-search-provider.ts
@@ -457,7 +457,7 @@ function createBraveToolDefinition(
         return missingBraveKeyPayload();
       }
 
-      const params = args as Record<string, unknown>;
+      const params = args;
       const query = readStringParam(params, "query", { required: true });
       const count =
         readNumberParam(params, "count", { integer: true }) ??

--- a/extensions/duckduckgo/src/ddg-search-provider.test.ts
+++ b/extensions/duckduckgo/src/ddg-search-provider.test.ts
@@ -12,13 +12,11 @@ vi.mock("./ddg-client.js", () => ({
 describe("duckduckgo web search provider", () => {
   let createDuckDuckGoWebSearchProvider: typeof import("./ddg-search-provider.js").createDuckDuckGoWebSearchProvider;
   let ddgClientTesting: typeof import("./ddg-client.js").__testing;
-  let plugin: typeof import("../index.js").default;
 
   beforeAll(async () => {
     ({ createDuckDuckGoWebSearchProvider } = await import("./ddg-search-provider.js"));
     ({ __testing: ddgClientTesting } =
       await vi.importActual<typeof import("./ddg-client.js")>("./ddg-client.js"));
-    ({ default: plugin } = await import("../index.js"));
   });
 
   beforeEach(() => {

--- a/extensions/kimi-coding/index.ts
+++ b/extensions/kimi-coding/index.ts
@@ -28,11 +28,6 @@ function findExplicitProviderConfig(
   return isRecord(match?.[1]) ? match[1] : undefined;
 }
 
-function buildKimiReplayPolicy() {
-  return {
-    preserveSignatures: false,
-  };
-}
 export default definePluginEntry({
   id: PLUGIN_ID,
   name: "Kimi Provider",

--- a/extensions/matrix/index.test.ts
+++ b/extensions/matrix/index.test.ts
@@ -6,9 +6,7 @@ const cliMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./src/cli.js", async () => {
-  const actual = await vi.importActual<typeof import("./src/cli.js")>("./src/cli.js");
   return {
-    ...actual,
     registerMatrixCli: cliMocks.registerMatrixCli,
   };
 });

--- a/extensions/matrix/src/actions.test.ts
+++ b/extensions/matrix/src/actions.test.ts
@@ -59,7 +59,7 @@ describe("matrixMessageActions", () => {
     expect(describeMessageTool).toBeTypeOf("function");
     expect(supportsAction).toBeTypeOf("function");
 
-    const discovery = describeMessageTool!({
+    const discovery = describeMessageTool({
       cfg: createConfiguredMatrixConfig(),
     } as never);
     if (!discovery) {
@@ -76,7 +76,7 @@ describe("matrixMessageActions", () => {
     const describeMessageTool = matrixMessageActions.describeMessageTool;
     const supportsAction = matrixMessageActions.supportsAction ?? (() => false);
 
-    const discovery = describeMessageTool!({
+    const discovery = describeMessageTool({
       cfg: createConfiguredMatrixConfig(),
     } as never);
     if (!discovery) {
@@ -97,7 +97,7 @@ describe("matrixMessageActions", () => {
   });
 
   it("hides gated actions when the default Matrix account disables them", () => {
-    const discovery = matrixMessageActions.describeMessageTool!({
+    const discovery = matrixMessageActions.describeMessageTool({
       cfg: {
         channels: {
           matrix: {
@@ -141,7 +141,7 @@ describe("matrixMessageActions", () => {
   });
 
   it("hides actions until defaultAccount is set for ambiguous multi-account configs", () => {
-    const discovery = matrixMessageActions.describeMessageTool!({
+    const discovery = matrixMessageActions.describeMessageTool({
       cfg: {
         channels: {
           matrix: {

--- a/extensions/matrix/src/channel.directory.test.ts
+++ b/extensions/matrix/src/channel.directory.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createRuntimeEnv } from "../../../test/helpers/plugins/runtime-env.js";
 import type { RuntimeEnv } from "../runtime-api.js";
 import { matrixPlugin } from "./channel.js";

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -7,10 +7,7 @@ import {
 } from "openclaw/plugin-sdk/channel-config-helpers";
 import { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-primitives";
 import { createChatChannelPlugin, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
-import {
-  createPairingPrefixStripper,
-  createTextPairingAdapter,
-} from "openclaw/plugin-sdk/channel-pairing";
+import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import {
   createAllowlistProviderOpenWarningCollector,
   projectAccountConfigWarningCollector,
@@ -58,7 +55,6 @@ import {
   setMatrixThreadBindingIdleTimeoutBySessionKey,
   setMatrixThreadBindingMaxAgeBySessionKey,
 } from "./matrix/thread-bindings-shared.js";
-import { getMatrixRuntime } from "./runtime.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
 import { resolveMatrixOutboundSessionRoute } from "./session-route.js";
 import {
@@ -155,7 +151,7 @@ const matrixConfigAdapter = createScopedChannelConfigAdapter<
   listAccountIds: listMatrixAccountIds,
   resolveAccount: adaptScopedAccountAccessor(resolveMatrixAccount),
   resolveAccessorAccount: ({ cfg, accountId }) =>
-    resolveMatrixAccountConfig({ cfg: cfg as CoreConfig, accountId }),
+    resolveMatrixAccountConfig({ cfg: cfg, accountId }),
   defaultAccountId: resolveDefaultMatrixAccountId,
   clearBaseFields: [
     "name",
@@ -589,9 +585,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
         normalizeAllowEntry: createPairingPrefixStripper(/^matrix:/i),
         notify: async ({ id, message, accountId }) => {
           const { sendMessageMatrix } = await loadMatrixChannelRuntime();
-          await sendMessageMatrix(`user:${id}`, message, {
-            ...(accountId ? { accountId } : {}),
-          });
+          await sendMessageMatrix(`user:${id}`, message, accountId ? { accountId } : {});
         },
       },
     },

--- a/extensions/matrix/src/doctor-contract.ts
+++ b/extensions/matrix/src/doctor-contract.ts
@@ -204,7 +204,7 @@ export function normalizeCompatibilityConfig({
     config: {
       ...cfg,
       channels: {
-        ...(cfg.channels ?? {}),
+        ...cfg.channels,
         matrix: updatedMatrix as NonNullable<OpenClawConfig["channels"]>["matrix"],
       },
     },

--- a/extensions/matrix/src/doctor.ts
+++ b/extensions/matrix/src/doctor.ts
@@ -11,7 +11,6 @@ import {
 } from "openclaw/plugin-sdk/runtime-doctor";
 import {
   hasLegacyFlatAllowPrivateNetworkAlias,
-  isPrivateNetworkOptInEnabled,
   migrateLegacyFlatAllowPrivateNetworkAlias,
 } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -183,7 +182,7 @@ function normalizeMatrixCompatibilityConfig(cfg: OpenClawConfig): ChannelDoctorC
     config: {
       ...cfg,
       channels: {
-        ...(cfg.channels ?? {}),
+        ...cfg.channels,
         matrix: updatedMatrix as NonNullable<OpenClawConfig["channels"]>["matrix"],
       },
     },

--- a/extensions/matrix/src/exec-approvals-handler.ts
+++ b/extensions/matrix/src/exec-approvals-handler.ts
@@ -114,11 +114,10 @@ function buildPendingApprovalContent(params: {
     ask: params.request.request.ask ?? undefined,
     agentId: params.request.request.agentId ?? undefined,
     allowedDecisions,
-    command: resolveExecApprovalCommandDisplay((params.request as ExecApprovalRequest).request)
-      .commandText,
-    cwd: (params.request as ExecApprovalRequest).request.cwd ?? undefined,
-    host: (params.request as ExecApprovalRequest).request.host === "node" ? "node" : "gateway",
-    nodeId: (params.request as ExecApprovalRequest).request.nodeId ?? undefined,
+    command: resolveExecApprovalCommandDisplay(params.request.request).commandText,
+    cwd: params.request.request.cwd ?? undefined,
+    host: params.request.request.host === "node" ? "node" : "gateway",
+    nodeId: params.request.request.nodeId ?? undefined,
     sessionKey: params.request.request.sessionKey ?? undefined,
     expiresAtMs: params.request.expiresAtMs,
     nowMs: params.nowMs,
@@ -149,7 +148,7 @@ function buildResolvedApprovalText(params: {
 }
 
 export class MatrixExecApprovalHandler {
-  private readonly runtime: ExecApprovalChannelRuntime<ApprovalRequest, ApprovalResolved>;
+  private readonly runtime: ExecApprovalChannelRuntime;
   private readonly trackedReactionTargets = new Map<string, ReactionTargetRef>();
   private readonly nowMs: () => number;
   private readonly sendMessage: typeof sendMessageMatrix;

--- a/extensions/matrix/src/matrix/account-config.ts
+++ b/extensions/matrix/src/matrix/account-config.ts
@@ -52,7 +52,7 @@ function mergeMatrixRoomEntries(
     return undefined;
   }
   const merged: MatrixRoomEntries = {
-    ...(inherited ?? {}),
+    ...inherited,
   };
   for (const [key, value] of Object.entries(accountEntries ?? {})) {
     const inheritedValue = merged[key];

--- a/extensions/matrix/src/matrix/actions/messages.test.ts
+++ b/extensions/matrix/src/matrix/actions/messages.test.ts
@@ -65,7 +65,7 @@ function createMessagesClient(params: {
   }));
   const hydrateEvents = vi.fn(
     async (_roomId: string, _events: Array<Record<string, unknown>>) =>
-      (params.hydratedChunk ?? params.chunk) as any,
+      params.hydratedChunk ?? params.chunk,
   );
   const getEvent = vi.fn(async () => params.pollRoot ?? null);
   const getRelations = vi.fn(async () => ({

--- a/extensions/matrix/src/matrix/actions/pins.test.ts
+++ b/extensions/matrix/src/matrix/actions/pins.test.ts
@@ -6,7 +6,7 @@ function createPinsClient(seedPinned: string[], knownBodies: Record<string, stri
   let pinned = [...seedPinned];
   const getRoomStateEvent = vi.fn(async () => ({ pinned: [...pinned] }));
   const sendStateEvent = vi.fn(
-    async (_roomId: string, _type: string, _key: string, payload: any) => {
+    async (_roomId: string, _type: string, _key: string, payload: { pinned: string[] }) => {
       pinned = [...payload.pinned];
     },
   );

--- a/extensions/matrix/src/matrix/actions/reactions.test.ts
+++ b/extensions/matrix/src/matrix/actions/reactions.test.ts
@@ -10,7 +10,7 @@ function createReactionsClient(params: {
   }>;
   userId?: string | null;
 }) {
-  const doRequest = vi.fn(async (_method: string, _path: string, _query: any) => ({
+  const doRequest = vi.fn(async (_method: string, _path: string, _query: unknown) => ({
     chunk: params.chunk.map((item) => ({
       event_id: item.event_id ?? "",
       sender: item.sender ?? "",

--- a/extensions/matrix/src/matrix/client-resolver.test-helpers.ts
+++ b/extensions/matrix/src/matrix/client-resolver.test-helpers.ts
@@ -23,13 +23,20 @@ export const matrixClientResolverMocks: MatrixClientResolverMocks = {
   resolveMatrixAuthContextMock: vi.fn(),
 };
 
-export function createMockMatrixClient(): MatrixClient {
+export type MockMatrixClient = MatrixClient & {
+  prepareForOneOff: Mock<() => Promise<void>>;
+  start: Mock<() => Promise<void>>;
+  stop: Mock<() => void>;
+  stopAndPersist: Mock<() => Promise<void>>;
+};
+
+export function createMockMatrixClient(): MockMatrixClient {
   return {
     prepareForOneOff: vi.fn(async () => undefined),
     start: vi.fn(async () => undefined),
     stop: vi.fn(() => undefined),
     stopAndPersist: vi.fn(async () => undefined),
-  } as unknown as MatrixClient;
+  } as unknown as MockMatrixClient;
 }
 
 export function primeMatrixClientResolverMocks(params?: {

--- a/extensions/matrix/src/matrix/client.test.ts
+++ b/extensions/matrix/src/matrix/client.test.ts
@@ -9,7 +9,7 @@ import type { CoreConfig } from "../types.js";
 function createLookupFn(addresses: Array<{ address: string; family: number }>): LookupFn {
   return vi.fn(async (_hostname: string, options?: unknown) => {
     if (typeof options === "number" || !options || !(options as { all?: boolean }).all) {
-      return addresses[0]!;
+      return addresses[0];
     }
     return addresses;
   }) as unknown as LookupFn;

--- a/extensions/matrix/src/matrix/client/config.ts
+++ b/extensions/matrix/src/matrix/client/config.ts
@@ -47,12 +47,10 @@ let matrixSecretInputDepsPromise: Promise<MatrixSecretInputDeps> | undefined;
 let matrixAuthClientDepsForTest: MatrixAuthClientDeps | undefined;
 
 export function setMatrixAuthClientDepsForTest(
-  deps?:
-    | {
-        MatrixClient: typeof import("../sdk.js").MatrixClient;
-        ensureMatrixSdkLoggingConfigured: typeof import("./logging.js").ensureMatrixSdkLoggingConfigured;
-      }
-    | undefined,
+  deps?: {
+    MatrixClient: typeof import("../sdk.js").MatrixClient;
+    ensureMatrixSdkLoggingConfigured: typeof import("./logging.js").ensureMatrixSdkLoggingConfigured;
+  },
 ): void {
   matrixAuthClientDepsForTest = deps;
 }

--- a/extensions/matrix/src/matrix/client/file-sync-store.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.ts
@@ -272,7 +272,7 @@ export class FileBackedMatrixSyncStore extends MemoryStore {
     const payload: PersistedMatrixSyncStore = {
       version: STORE_VERSION,
       savedSync: this.savedSync ? cloneJson(this.savedSync) : null,
-      cleanShutdown: this.cleanShutdown === true,
+      cleanShutdown: this.cleanShutdown,
       ...(this.savedClientOptions ? { clientOptions: cloneJson(this.savedClientOptions) } : {}),
     };
     try {

--- a/extensions/matrix/src/matrix/client/storage.test.ts
+++ b/extensions/matrix/src/matrix/client/storage.test.ts
@@ -453,7 +453,7 @@ describe("matrix client storage paths", () => {
       accessToken: "secret-token-old",
     });
 
-    const newerCanonicalPaths = seedCanonicalStorageRoot({
+    seedCanonicalStorageRoot({
       stateDir,
       accessToken: "secret-token-new",
       storageMeta: {

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -377,6 +377,7 @@ export async function maybeMigrateLegacyStorage(params: {
       rollbackError
         ? `Failed migrating legacy Matrix client storage: ${String(err)}. Rollback also failed: ${rollbackError}`
         : `Failed migrating legacy Matrix client storage: ${String(err)}`,
+      { cause: err },
     );
   }
   if (moved.length > 0) {

--- a/extensions/matrix/src/matrix/config-update.ts
+++ b/extensions/matrix/src/matrix/config-update.ts
@@ -60,7 +60,7 @@ function applyNullableStringField(
 function applyNullableSecretInputField(
   target: Record<string, unknown>,
   key: "accessToken" | "password",
-  value: MatrixConfig["accessToken"] | MatrixConfig["password"] | null | undefined,
+  value: MatrixConfig["accessToken"] | null | undefined,
   defaults?: NonNullable<CoreConfig["secrets"]>["defaults"],
 ): void {
   if (value === undefined) {
@@ -97,9 +97,7 @@ function cloneMatrixDmConfig(dm: MatrixConfig["dm"]): MatrixConfig["dm"] {
   };
 }
 
-function cloneMatrixRoomMap(
-  rooms: MatrixConfig["groups"] | MatrixConfig["rooms"],
-): MatrixConfig["groups"] | MatrixConfig["rooms"] {
+function cloneMatrixRoomMap(rooms: MatrixConfig["groups"]): MatrixConfig["groups"] {
   if (!rooms) {
     return rooms;
   }
@@ -209,8 +207,9 @@ export function updateMatrixAccountConfig(
     if (patch.dm === null) {
       delete nextAccount.dm;
     } else {
+      const currentDm = nextAccount.dm as MatrixConfig["dm"] | undefined;
       nextAccount.dm = cloneMatrixDmConfig({
-        ...((nextAccount.dm as MatrixConfig["dm"] | undefined) ?? {}),
+        ...currentDm,
         ...patch.dm,
       });
     }

--- a/extensions/matrix/src/matrix/format.ts
+++ b/extensions/matrix/src/matrix/format.ts
@@ -30,7 +30,7 @@ type MatrixMentionCandidate = {
 };
 
 const ESCAPED_MENTION_SENTINEL = "\uE000";
-const MENTION_PATTERN = /@[A-Za-z0-9._=+\-/:\[\]]+/g;
+const MENTION_PATTERN = /@[A-Za-z0-9._=+\-/:[\]]+/g;
 const MATRIX_MENTION_USER_ID_PATTERN =
   /^@[A-Za-z0-9._=+\-/]+:(?:[A-Za-z0-9.-]+|\[[0-9A-Fa-f:.]+\])(?::\d+)?$/;
 const TRIMMABLE_MENTION_SUFFIX = /[),.!?:;\]]/;

--- a/extensions/matrix/src/matrix/monitor/events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/events.test.ts
@@ -495,7 +495,7 @@ describe("registerMatrixMonitorEvents verification routing", () => {
   });
 
   it("posts SAS emoji/decimal details when verification summaries expose them", async () => {
-    const { sendMessage, roomEventListener, listVerifications } = createHarness({
+    const { sendMessage, roomEventListener } = createHarness({
       joinedMembersByRoom: {
         "!dm:example.org": ["@alice:example.org", "@bot:example.org"],
       },
@@ -893,7 +893,7 @@ describe("registerMatrixMonitorEvents verification routing", () => {
 
       await vi.advanceTimersByTimeAsync(500);
       verifications[0] = {
-        ...verifications[0]!,
+        ...verifications[0],
         sas: {
           decimal: [1234, 5678, 9012],
           emoji: [

--- a/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.group-history.test.ts
@@ -23,7 +23,7 @@ import {
   createMatrixRoomMessageEvent,
   createMatrixTextMessageEvent,
 } from "./handler.test-helpers.js";
-import { EventType, type MatrixRawEvent } from "./types.js";
+import type { MatrixRawEvent } from "./types.js";
 
 const DEFAULT_ROOM = "!room:example.org";
 
@@ -313,7 +313,7 @@ describe("matrix group chat history — scenario 1: basic accumulation", () => {
           body: "",
           url: "mxc://example.org/media-a",
         },
-      }) as MatrixRawEvent,
+      }),
     );
     expect(finalizeInboundContext).not.toHaveBeenCalled();
 
@@ -573,12 +573,17 @@ describe("matrix group chat history — scenario 2: race condition safety", () =
     );
 
     expect(finalizeInboundContext).toHaveBeenCalledTimes(2);
-    const firstHistory = (finalizeInboundContext.mock.calls[0]?.[0] as Record<string, unknown>)[
-      "InboundHistory"
-    ] as Array<{ body: string }>;
-    const retryHistory = (finalizeInboundContext.mock.calls[1]?.[0] as Record<string, unknown>)[
-      "InboundHistory"
-    ] as Array<{ body: string }>;
+    const firstCall = finalizeInboundContext.mock.calls[0];
+    const retryCall = finalizeInboundContext.mock.calls[1];
+    if (!firstCall || !retryCall) {
+      throw new Error("expected finalizeInboundContext calls");
+    }
+    const firstHistory = (firstCall[0] as Record<string, unknown>)["InboundHistory"] as Array<{
+      body: string;
+    }>;
+    const retryHistory = (retryCall[0] as Record<string, unknown>)["InboundHistory"] as Array<{
+      body: string;
+    }>;
 
     expect(firstHistory.map((entry) => entry.body)).toEqual(["pending msg"]);
     expect(retryHistory.map((entry) => entry.body)).toEqual(["pending msg"]);

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -195,16 +195,18 @@ export function createMatrixHandlerTestHarness(
     } as never,
     cfg: (options.cfg ?? {}) as never,
     accountId: options.accountId ?? "ops",
-    runtime: (options.runtime ??
+    runtime:
+      options.runtime ??
       ({
         error: () => {},
-      } as RuntimeEnv)) as RuntimeEnv,
-    logger: (options.logger ??
+      } as RuntimeEnv),
+    logger:
+      options.logger ??
       ({
         info: () => {},
         warn: () => {},
         error: () => {},
-      } as RuntimeLogger)) as RuntimeLogger,
+      } as RuntimeLogger),
     logVerboseMessage: options.logVerboseMessage ?? (() => {}),
     allowFrom: options.allowFrom ?? [],
     groupAllowFrom: options.groupAllowFrom ?? [],

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -180,9 +180,12 @@ describe("matrix monitor handler pairing account scope", () => {
       await handler("!room:example.org", makeEvent("$event1"));
       await handler("!room:example.org", makeEvent("$event2"));
       expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
-      expect(String(sendMessageMatrixMock.mock.calls[0]?.[1] ?? "")).toContain(
-        "Pairing request is still pending approval.",
-      );
+      const firstCall = sendMessageMatrixMock.mock.calls[0];
+      const firstBody =
+        firstCall && typeof firstCall[1] === "string"
+          ? firstCall[1]
+          : JSON.stringify(firstCall?.[1]);
+      expect(firstBody).toContain("Pairing request is still pending approval.");
 
       await vi.advanceTimersByTimeAsync(5 * 60_000 + 1);
       await handler("!room:example.org", makeEvent("$event3"));
@@ -489,7 +492,7 @@ describe("matrix monitor handler pairing account scope", () => {
   });
 
   it("drops forged metadata-only mentions before agent routing", async () => {
-    const { handler, recordInboundSession, resolveAgentRoute } = createMatrixHandlerTestHarness({
+    const { handler, recordInboundSession } = createMatrixHandlerTestHarness({
       isDirectMessage: false,
       mentionRegexes: [/@bot/i],
       getMemberDisplayName: async () => "sender",
@@ -1383,7 +1386,7 @@ describe("matrix monitor handler pairing account scope", () => {
         sender: "@user:example.org",
         body: "hello there",
         mentions: { room: true },
-      }) as MatrixRawEvent,
+      }),
     );
 
     expect(enqueueSystemEvent).not.toHaveBeenCalled();

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -95,7 +95,7 @@ vi.mock("../../runtime-api.js", () => {
       extra?: Record<string, unknown>,
     ) => ({
       ...snapshot,
-      ...(extra ?? {}),
+      ...extra,
     }),
     buildSecretInputSchema: () => z.string(),
     chunkTextForOutbound: vi.fn((text: string) => [text]),
@@ -580,10 +580,8 @@ describe("monitorMatrixProvider", () => {
 });
 
 describe("matrix plugin registration", () => {
-  let matrixPlugin: typeof import("../../../index.js").default;
-
   beforeAll(async () => {
-    ({ default: matrixPlugin } = await import("../../../index.js"));
+    await import("../../../index.js");
   });
 
   beforeEach(() => {

--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -65,13 +65,14 @@ describe("matrix approval reactions", () => {
       approvalId: "req-123",
       allowedDecisions: ["allow-once", "allow-always", "deny"],
     });
-    const client = {
-      getEvent: vi.fn().mockResolvedValue({
-        event_id: "$approval-msg",
-        sender: "@bot:example.org",
-        content: { body: "approval prompt" },
-      }),
-    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+    const getEvent = vi.fn().mockResolvedValue({
+      event_id: "$approval-msg",
+      sender: "@bot:example.org",
+      content: { body: "approval prompt" },
+    });
+    const client = { getEvent } as unknown as Parameters<
+      typeof handleInboundMatrixReaction
+    >[0]["client"];
 
     await handleInboundMatrixReaction({
       client,
@@ -214,9 +215,10 @@ describe("matrix approval reactions", () => {
       approvalId: "req-123",
       allowedDecisions: ["allow-once"],
     });
-    const client = {
-      getEvent: vi.fn().mockRejectedValue(new Error("boom")),
-    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+    const getEvent = vi.fn().mockRejectedValue(new Error("boom"));
+    const client = { getEvent } as unknown as Parameters<
+      typeof handleInboundMatrixReaction
+    >[0]["client"];
 
     await handleInboundMatrixReaction({
       client,
@@ -242,7 +244,7 @@ describe("matrix approval reactions", () => {
       logVerboseMessage: vi.fn(),
     });
 
-    expect(client.getEvent).not.toHaveBeenCalled();
+    expect(getEvent).not.toHaveBeenCalled();
     expect(resolveMatrixExecApproval).toHaveBeenCalledWith({
       cfg: buildConfig(),
       approvalId: "req-123",
@@ -263,9 +265,10 @@ describe("matrix approval reactions", () => {
       approvalId: "req-123",
       allowedDecisions: ["deny"],
     });
-    const client = {
-      getEvent: vi.fn(),
-    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+    const getEvent = vi.fn();
+    const client = { getEvent } as unknown as Parameters<
+      typeof handleInboundMatrixReaction
+    >[0]["client"];
 
     await handleInboundMatrixReaction({
       client,
@@ -291,7 +294,7 @@ describe("matrix approval reactions", () => {
       logVerboseMessage: vi.fn(),
     });
 
-    expect(client.getEvent).not.toHaveBeenCalled();
+    expect(getEvent).not.toHaveBeenCalled();
     expect(
       resolveMatrixApprovalReactionTarget({
         roomId: "!ops:example.org",
@@ -309,9 +312,10 @@ describe("matrix approval reactions", () => {
       throw new Error("matrix config missing");
     }
     matrixCfg.reactionNotifications = "off";
-    const client = {
-      getEvent: vi.fn(),
-    } as unknown as Parameters<typeof handleInboundMatrixReaction>[0]["client"];
+    const getEvent = vi.fn();
+    const client = { getEvent } as unknown as Parameters<
+      typeof handleInboundMatrixReaction
+    >[0]["client"];
 
     await handleInboundMatrixReaction({
       client,
@@ -337,7 +341,7 @@ describe("matrix approval reactions", () => {
       logVerboseMessage: vi.fn(),
     });
 
-    expect(client.getEvent).not.toHaveBeenCalled();
+    expect(getEvent).not.toHaveBeenCalled();
     expect(resolveMatrixExecApproval).not.toHaveBeenCalled();
     expect(core.system.enqueueSystemEvent).not.toHaveBeenCalled();
   });

--- a/extensions/matrix/src/matrix/monitor/room-history.ts
+++ b/extensions/matrix/src/matrix/monitor/room-history.ts
@@ -211,7 +211,9 @@ function createRoomHistoryTrackerInternal(
 
     getPendingHistory(agentId, roomId, limit) {
       const queue = roomQueues.get(roomId);
-      if (!queue) return [];
+      if (!queue) {
+        return [];
+      }
       return computePendingHistory(queue, agentId, roomId, limit);
     },
 

--- a/extensions/matrix/src/matrix/monitor/startup-verification.ts
+++ b/extensions/matrix/src/matrix/monitor/startup-verification.ts
@@ -134,8 +134,7 @@ function hasPendingSelfVerification(
   }>,
 ): boolean {
   return verifications.some(
-    (entry) =>
-      entry.isSelfVerification === true && entry.completed !== true && entry.pending !== false,
+    (entry) => entry.isSelfVerification && !entry.completed && entry.pending,
   );
 }
 

--- a/extensions/matrix/src/matrix/monitor/verification-events.ts
+++ b/extensions/matrix/src/matrix/monitor/verification-events.ts
@@ -261,7 +261,7 @@ async function resolveVerificationSummaryForSignal(
   // Fallback for DM flows where transaction IDs do not match room event IDs consistently.
   const activeByUser = list
     .filter((entry) => entry.otherUserId === params.senderId && isActiveVerificationSummary(entry))
-    .sort((a, b) => resolveSummaryRecency(b) - resolveSummaryRecency(a));
+    .toSorted((a, b) => resolveSummaryRecency(b) - resolveSummaryRecency(a));
   const activeInRoom = activeByUser.filter((entry) => {
     const roomId = trimMaybeString(entry.roomId);
     return roomId === params.roomId;

--- a/extensions/matrix/src/matrix/poll-types.ts
+++ b/extensions/matrix/src/matrix/poll-types.ts
@@ -273,7 +273,7 @@ export function buildPollResultsSummary(params: {
     }
   >();
 
-  const orderedRelationEvents = [...params.relationEvents].sort((left, right) => {
+  const orderedRelationEvents = [...params.relationEvents].toSorted((left, right) => {
     const leftTs =
       typeof left.origin_server_ts === "number" && Number.isFinite(left.origin_server_ts)
         ? left.origin_server_ts

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -248,14 +248,22 @@ describe("MatrixClient request hardening", () => {
     await expect(client.downloadContent("mxc://example.org/media")).resolves.toEqual(payload);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const firstUrl = String((fetchMock.mock.calls as unknown[][])[0]?.[0] ?? "");
+    const firstCall = fetchMock.mock.calls[0];
+    const firstInput = firstCall?.[0];
+    const firstUrl =
+      typeof firstInput === "string"
+        ? firstInput
+        : firstInput instanceof URL
+          ? firstInput.toString()
+          : "";
     expect(firstUrl).toContain("/_matrix/client/v1/media/download/example.org/media");
   });
 
   it("falls back to legacy media downloads for older homeservers", async () => {
     const payload = Buffer.from([5, 6, 7, 8]);
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
+      const url =
+        typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
       if (url.includes("/_matrix/client/v1/media/download/")) {
         return new Response(
           JSON.stringify({
@@ -278,8 +286,22 @@ describe("MatrixClient request hardening", () => {
     await expect(client.downloadContent("mxc://example.org/media")).resolves.toEqual(payload);
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    const firstUrl = String((fetchMock.mock.calls as unknown[][])[0]?.[0] ?? "");
-    const secondUrl = String((fetchMock.mock.calls as unknown[][])[1]?.[0] ?? "");
+    const firstCall = fetchMock.mock.calls[0];
+    const secondCall = fetchMock.mock.calls[1];
+    const firstInput = firstCall?.[0];
+    const secondInput = secondCall?.[0];
+    const firstUrl =
+      typeof firstInput === "string"
+        ? firstInput
+        : firstInput instanceof URL
+          ? firstInput.toString()
+          : "";
+    const secondUrl =
+      typeof secondInput === "string"
+        ? secondInput
+        : secondInput instanceof URL
+          ? secondInput.toString()
+          : "";
     expect(firstUrl).toContain("/_matrix/client/v1/media/download/example.org/media");
     expect(secondUrl).toContain("/_matrix/media/v3/download/example.org/media");
   });

--- a/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-bootstrap.test.ts
@@ -450,7 +450,7 @@ describe("MatrixCryptoBootstrapper", () => {
       initiatedByMe: false,
       accept: vi.fn(async () => {}),
     };
-    await listener?.(verificationRequest);
+    await Promise.resolve(listener?.(verificationRequest));
 
     expect(deps.verificationManager.trackVerificationRequest).toHaveBeenCalledWith(
       verificationRequest,
@@ -480,7 +480,7 @@ describe("MatrixCryptoBootstrapper", () => {
       initiatedByMe: false,
       accept: vi.fn(async () => {}),
     };
-    await listener?.(verificationRequest);
+    await Promise.resolve(listener?.(verificationRequest));
 
     expect(verificationRequest.accept).not.toHaveBeenCalled();
   });

--- a/extensions/matrix/src/matrix/sdk/crypto-facade.ts
+++ b/extensions/matrix/src/matrix/sdk/crypto-facade.ts
@@ -22,7 +22,7 @@ export type MatrixCryptoFacade = {
     leftDeviceLists: unknown,
   ) => Promise<void>;
   isRoomEncrypted: (roomId: string) => Promise<boolean>;
-  requestOwnUserVerification: () => Promise<unknown | null>;
+  requestOwnUserVerification: () => Promise<unknown>;
   encryptMedia: (buffer: Buffer) => Promise<{ buffer: Buffer; file: Omit<EncryptedFile, "url"> }>;
   decryptMedia: (
     file: EncryptedFile,
@@ -111,7 +111,7 @@ export function createMatrixCryptoFacade(deps: {
         return false;
       }
     },
-    requestOwnUserVerification: async (): Promise<unknown | null> => {
+    requestOwnUserVerification: async (): Promise<unknown> => {
       const crypto = deps.client.getCrypto() as MatrixVerificationCryptoApi | undefined;
       return await deps.verificationManager.requestOwnUserVerification(crypto);
     },

--- a/extensions/matrix/src/matrix/sdk/event-helpers.ts
+++ b/extensions/matrix/src/matrix/sdk/event-helpers.ts
@@ -11,7 +11,7 @@ export function matrixEventToRaw(event: MatrixEvent): MatrixRawEvent {
     sender: event.getSender() ?? "",
     type: event.getType() ?? "",
     origin_server_ts: event.getTs() ?? 0,
-    content: ((event.getContent?.() ?? {}) as Record<string, unknown>) || {},
+    content: (event.getContent?.() ?? {}) || {},
     unsigned,
   };
   const stateKey = resolveMatrixStateKey(event);

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.test-helpers.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.test-helpers.ts
@@ -8,9 +8,9 @@ export async function clearAllIndexedDbState(): Promise<void> {
         (name) =>
           new Promise<void>((resolve, reject) => {
             const req = indexedDB.deleteDatabase(name);
-            req.onsuccess = () => resolve();
-            req.onerror = () => reject(req.error);
-            req.onblocked = () => resolve();
+            req.addEventListener("success", () => resolve());
+            req.addEventListener("error", () => reject(req.error));
+            req.addEventListener("blocked", () => resolve());
           }),
       ),
   );
@@ -24,26 +24,26 @@ export async function seedDatabase(params: {
 }): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     const req = indexedDB.open(params.name, params.version ?? 1);
-    req.onupgradeneeded = () => {
+    req.addEventListener("upgradeneeded", () => {
       const db = req.result;
       if (!db.objectStoreNames.contains(params.storeName)) {
         db.createObjectStore(params.storeName);
       }
-    };
-    req.onsuccess = () => {
+    });
+    req.addEventListener("success", () => {
       const db = req.result;
       const tx = db.transaction(params.storeName, "readwrite");
       const store = tx.objectStore(params.storeName);
       for (const record of params.records) {
         store.put(record.value, record.key);
       }
-      tx.oncomplete = () => {
+      tx.addEventListener("complete", () => {
         db.close();
         resolve();
-      };
-      tx.onerror = () => reject(tx.error);
-    };
-    req.onerror = () => reject(req.error);
+      });
+      tx.addEventListener("error", () => reject(tx.error));
+    });
+    req.addEventListener("error", () => reject(req.error));
   });
 }
 
@@ -54,7 +54,7 @@ export async function readDatabaseRecords(params: {
 }): Promise<Array<{ key: IDBValidKey; value: unknown }>> {
   return await new Promise((resolve, reject) => {
     const req = indexedDB.open(params.name, params.version ?? 1);
-    req.onsuccess = () => {
+    req.addEventListener("success", () => {
       const db = req.result;
       const tx = db.transaction(params.storeName, "readonly");
       const store = tx.objectStore(params.storeName);
@@ -72,17 +72,17 @@ export async function readDatabaseRecords(params: {
         resolve(keys.map((key, index) => ({ key, value: resolvedValues[index] })));
       };
 
-      keysReq.onsuccess = () => {
+      keysReq.addEventListener("success", () => {
         keys = keysReq.result;
         maybeResolve();
-      };
-      valuesReq.onsuccess = () => {
+      });
+      valuesReq.addEventListener("success", () => {
         values = valuesReq.result;
         maybeResolve();
-      };
-      keysReq.onerror = () => reject(keysReq.error);
-      valuesReq.onerror = () => reject(valuesReq.error);
-    };
-    req.onerror = () => reject(req.error);
+      });
+      keysReq.addEventListener("error", () => reject(keysReq.error));
+      valuesReq.addEventListener("error", () => reject(valuesReq.error));
+    });
+    req.addEventListener("error", () => reject(req.error));
   });
 }

--- a/extensions/matrix/src/matrix/sdk/idb-persistence.ts
+++ b/extensions/matrix/src/matrix/sdk/idb-persistence.ts
@@ -96,8 +96,8 @@ function parseSnapshotPayload(data: string): IdbDatabaseSnapshot[] | null {
 
 function idbReq<T>(req: IDBRequest<T>): Promise<T> {
   return new Promise((resolve, reject) => {
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => reject(req.error);
+    req.addEventListener("success", () => resolve(req.result));
+    req.addEventListener("error", () => reject(req.error));
   });
 }
 
@@ -108,12 +108,16 @@ async function dumpIndexedDatabases(databasePrefix?: string): Promise<IdbDatabas
   const expectedPrefix = databasePrefix ? `${databasePrefix}::` : null;
 
   for (const { name, version } of dbList) {
-    if (!name || !version) continue;
-    if (expectedPrefix && !name.startsWith(expectedPrefix)) continue;
+    if (!name || !version) {
+      continue;
+    }
+    if (expectedPrefix && !name.startsWith(expectedPrefix)) {
+      continue;
+    }
     const db: IDBDatabase = await new Promise((resolve, reject) => {
       const r = idb.open(name, version);
-      r.onsuccess = () => resolve(r.result);
-      r.onerror = () => reject(r.error);
+      r.addEventListener("success", () => resolve(r.result));
+      r.addEventListener("error", () => reject(r.error));
     });
 
     const stores: IdbStoreSnapshot[] = [];
@@ -131,7 +135,7 @@ async function dumpIndexedDatabases(databasePrefix?: string): Promise<IdbDatabas
         const idx = store.index(idxName);
         storeInfo.indexes.push({
           name: idxName,
-          keyPath: idx.keyPath as string | string[],
+          keyPath: idx.keyPath,
           multiEntry: idx.multiEntry,
           unique: idx.unique,
         });
@@ -156,8 +160,12 @@ async function restoreIndexedDatabases(snapshot: IdbDatabaseSnapshot[]): Promise
         const db = r.result;
         for (const storeSnap of dbSnap.stores) {
           const opts: IDBObjectStoreParameters = {};
-          if (storeSnap.keyPath !== null) opts.keyPath = storeSnap.keyPath;
-          if (storeSnap.autoIncrement) opts.autoIncrement = true;
+          if (storeSnap.keyPath !== null) {
+            opts.keyPath = storeSnap.keyPath;
+          }
+          if (storeSnap.autoIncrement) {
+            opts.autoIncrement = true;
+          }
           const store = db.createObjectStore(storeSnap.name, opts);
           for (const idx of storeSnap.indexes) {
             store.createIndex(idx.name, idx.keyPath, {
@@ -171,7 +179,9 @@ async function restoreIndexedDatabases(snapshot: IdbDatabaseSnapshot[]): Promise
         try {
           const db = r.result;
           for (const storeSnap of dbSnap.stores) {
-            if (storeSnap.records.length === 0) continue;
+            if (storeSnap.records.length === 0) {
+              continue;
+            }
             const tx = db.transaction(storeSnap.name, "readwrite");
             const store = tx.objectStore(storeSnap.name);
             for (const rec of storeSnap.records) {
@@ -191,7 +201,7 @@ async function restoreIndexedDatabases(snapshot: IdbDatabaseSnapshot[]): Promise
           reject(err);
         }
       };
-      r.onerror = () => reject(r.error);
+      r.addEventListener("error", () => reject(r.error));
     });
   }
 }
@@ -258,7 +268,9 @@ export async function persistIdbToDisk(params?: {
         return snapshot.length;
       },
     );
-    if (persistedCount === 0) return;
+    if (persistedCount === 0) {
+      return;
+    }
     LogService.debug(
       "IdbPersistence",
       `Persisted ${persistedCount} IndexedDB database(s) to ${snapshotPath}`,

--- a/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
+++ b/extensions/matrix/src/matrix/sdk/recovery-key-store.ts
@@ -144,6 +144,7 @@ export class MatrixRecoveryKeyStore {
     } catch (err) {
       throw new Error(
         `Invalid Matrix recovery key: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
       );
     }
     const keyId =
@@ -247,7 +248,7 @@ export class MatrixRecoveryKeyStore {
 
     const hasDefaultSecretStorageKey = Boolean(status?.defaultKeyId);
     const hasKnownInvalidSecrets = Object.values(status?.secretStorageKeyValidityMap ?? {}).some(
-      (valid) => valid === false,
+      (valid) => !valid,
     );
     let generatedRecoveryKey = false;
     const storedRecovery = this.loadStoredRecoveryKey();

--- a/extensions/matrix/src/matrix/sdk/types.ts
+++ b/extensions/matrix/src/matrix/sdk/types.ts
@@ -200,7 +200,7 @@ export type MatrixCryptoBootstrapApi = {
   }) => Promise<void>;
   createRecoveryKeyFromPassphrase?: (password?: string) => Promise<MatrixGeneratedSecretStorageKey>;
   getSecretStorageStatus?: () => Promise<MatrixSecretStorageStatus>;
-  requestOwnUserVerification: () => Promise<unknown | null>;
+  requestOwnUserVerification: () => Promise<unknown>;
   findVerificationRequestDMInProgress?: (
     roomId: string,
     userId: string,

--- a/extensions/matrix/src/matrix/sdk/verification-manager.ts
+++ b/extensions/matrix/src/matrix/sdk/verification-manager.ts
@@ -82,7 +82,7 @@ export type MatrixVerificationRequestLike = {
 };
 
 export type MatrixVerificationCryptoApi = {
-  requestOwnUserVerification: () => Promise<unknown | null>;
+  requestOwnUserVerification: () => Promise<unknown>;
   findVerificationRequestDMInProgress?: (
     roomId: string,
     userId: string,
@@ -114,6 +114,26 @@ type MatrixVerificationSession = {
   reciprocateQrCallbacks?: MatrixShowQrCodeCallbacks;
 };
 
+type MatrixVerificationPhase = VerificationPhase | -1;
+
+function isVerificationPhase(value: unknown): value is VerificationPhase {
+  return (
+    value === VerificationPhase.Unsent ||
+    value === VerificationPhase.Requested ||
+    value === VerificationPhase.Ready ||
+    value === VerificationPhase.Started ||
+    value === VerificationPhase.Cancelled ||
+    value === VerificationPhase.Done
+  );
+}
+
+function normalizeVerificationPhase(
+  value: unknown,
+  fallback: MatrixVerificationPhase,
+): MatrixVerificationPhase {
+  return isVerificationPhase(value) ? value : fallback;
+}
+
 const MAX_TRACKED_VERIFICATION_SESSIONS = 256;
 const TERMINAL_SESSION_RETENTION_MS = 24 * 60 * 60 * 1000;
 const SAS_AUTO_CONFIRM_DELAY_MS = 30_000;
@@ -137,9 +157,17 @@ export class MatrixVerificationManager {
     }
   }
 
+  private readVerificationPhase(
+    request: MatrixVerificationRequestLike,
+    fallback: MatrixVerificationPhase,
+  ): MatrixVerificationPhase {
+    const phase = this.readRequestValue<unknown>(request, () => request.phase, fallback);
+    return normalizeVerificationPhase(phase, fallback);
+  }
+
   private pruneVerificationSessions(nowMs: number): void {
     for (const [id, session] of this.verificationSessions) {
-      const phase = this.readRequestValue(session.request, () => session.request.phase, -1);
+      const phase = this.readVerificationPhase(session.request, -1);
       const isTerminal = phase === VerificationPhase.Done || phase === VerificationPhase.Cancelled;
       if (isTerminal && nowMs - session.updatedAtMs > TERMINAL_SESSION_RETENTION_MS) {
         this.verificationSessions.delete(id);
@@ -150,7 +178,7 @@ export class MatrixVerificationManager {
       return;
     }
 
-    const sortedByAge = Array.from(this.verificationSessions.entries()).sort(
+    const sortedByAge = Array.from(this.verificationSessions.entries()).toSorted(
       (a, b) => a[1].updatedAtMs - b[1].updatedAtMs,
     );
     const overflow = this.verificationSessions.size - MAX_TRACKED_VERIFICATION_SESSIONS;
@@ -163,22 +191,15 @@ export class MatrixVerificationManager {
   }
 
   private getVerificationPhaseName(phase: number): string {
-    switch (phase) {
-      case VerificationPhase.Unsent:
-        return "unsent";
-      case VerificationPhase.Requested:
-        return "requested";
-      case VerificationPhase.Ready:
-        return "ready";
-      case VerificationPhase.Started:
-        return "started";
-      case VerificationPhase.Cancelled:
-        return "cancelled";
-      case VerificationPhase.Done:
-        return "done";
-      default:
-        return `unknown(${phase})`;
-    }
+    const phaseNames: Record<number, string> = {
+      [VerificationPhase.Unsent]: "unsent",
+      [VerificationPhase.Requested]: "requested",
+      [VerificationPhase.Ready]: "ready",
+      [VerificationPhase.Started]: "started",
+      [VerificationPhase.Cancelled]: "cancelled",
+      [VerificationPhase.Done]: "done",
+    };
+    return phaseNames[phase] ?? `unknown(${phase})`;
   }
 
   private emitVerificationSummary(session: MatrixVerificationSession): void {
@@ -203,7 +224,7 @@ export class MatrixVerificationManager {
 
   private buildVerificationSummary(session: MatrixVerificationSession): MatrixVerificationSummary {
     const request = session.request;
-    const phase = this.readRequestValue(request, () => request.phase, VerificationPhase.Requested);
+    const phase = this.readVerificationPhase(request, VerificationPhase.Requested);
     const accepting = this.readRequestValue(request, () => request.accepting, false);
     const declining = this.readRequestValue(request, () => request.declining, false);
     const pending = this.readRequestValue(request, () => request.pending, false);
@@ -287,7 +308,7 @@ export class MatrixVerificationManager {
       false,
     );
     const initiatedByMe = this.readRequestValue(request, () => request.initiatedByMe, false);
-    const phase = this.readRequestValue(request, () => request.phase, VerificationPhase.Requested);
+    const phase = this.readVerificationPhase(request, VerificationPhase.Requested);
     const accepting = this.readRequestValue(request, () => request.accepting, false);
     const declining = this.readRequestValue(request, () => request.declining, false);
     if (isSelfVerification || initiatedByMe) {
@@ -320,11 +341,7 @@ export class MatrixVerificationManager {
     if (!this.readRequestValue(session.request, () => session.request.isSelfVerification, false)) {
       return;
     }
-    const phase = this.readRequestValue(
-      session.request,
-      () => session.request.phase,
-      VerificationPhase.Requested,
-    );
+    const phase = this.readVerificationPhase(session.request, VerificationPhase.Requested);
     if (phase < VerificationPhase.Ready || phase >= VerificationPhase.Cancelled) {
       return;
     }
@@ -416,11 +433,7 @@ export class MatrixVerificationManager {
     // we send our MAC and finish our side of the SAS flow.
     session.sasAutoConfirmTimer = setTimeout(() => {
       session.sasAutoConfirmTimer = undefined;
-      const phase = this.readRequestValue(
-        session.request,
-        () => session.request.phase,
-        VerificationPhase.Requested,
-      );
+      const phase = this.readVerificationPhase(session.request, VerificationPhase.Requested);
       if (phase >= VerificationPhase.Cancelled) {
         return;
       }
@@ -527,7 +540,7 @@ export class MatrixVerificationManager {
     const summaries = Array.from(this.verificationSessions.values()).map((session) =>
       this.buildVerificationSummary(session),
     );
-    return summaries.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return summaries.toSorted((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   }
 
   async requestVerification(

--- a/extensions/matrix/src/matrix/send.test.ts
+++ b/extensions/matrix/src/matrix/send.test.ts
@@ -425,9 +425,13 @@ describe("sendMessageMatrix mentions", () => {
       body: "hello @alice:example.org",
       "m.mentions": { user_ids: ["@alice:example.org"] },
     });
-    expect(
-      (sendMessage.mock.calls[0]?.[1] as { formatted_body?: string }).formatted_body,
-    ).toContain('href="https://matrix.to/#/%40alice%3Aexample.org"');
+    const firstCall = sendMessage.mock.calls[0];
+    if (!firstCall) {
+      throw new Error("expected sendMessage call");
+    }
+    expect((firstCall[1] as { formatted_body?: string }).formatted_body).toContain(
+      'href="https://matrix.to/#/%40alice%3Aexample.org"',
+    );
   });
 
   it("keeps bare localpart text as plain text", async () => {
@@ -440,9 +444,13 @@ describe("sendMessageMatrix mentions", () => {
     expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
       "m.mentions": {},
     });
-    expect(
-      (sendMessage.mock.calls[0]?.[1] as { formatted_body?: string }).formatted_body,
-    ).not.toContain("matrix.to/#/@alice:example.org");
+    const firstCall = sendMessage.mock.calls[0];
+    if (!firstCall) {
+      throw new Error("expected sendMessage call");
+    }
+    expect((firstCall[1] as { formatted_body?: string }).formatted_body).not.toContain(
+      "matrix.to/#/@alice:example.org",
+    );
   });
 
   it("does not emit mentions for escaped qualified users", async () => {
@@ -455,9 +463,13 @@ describe("sendMessageMatrix mentions", () => {
     expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
       "m.mentions": {},
     });
-    expect(
-      (sendMessage.mock.calls[0]?.[1] as { formatted_body?: string }).formatted_body,
-    ).not.toContain("matrix.to/#/@alice:example.org");
+    const firstCall = sendMessage.mock.calls[0];
+    if (!firstCall) {
+      throw new Error("expected sendMessage call");
+    }
+    expect((firstCall[1] as { formatted_body?: string }).formatted_body).not.toContain(
+      "matrix.to/#/@alice:example.org",
+    );
   });
 
   it("does not emit mentions for escaped room mentions", async () => {
@@ -515,9 +527,11 @@ describe("sendMessageMatrix mentions", () => {
       body: "@room.png",
       "m.mentions": {},
     });
-    expect(
-      (sendMessage.mock.calls[0]?.[1] as { formatted_body?: string }).formatted_body,
-    ).toBeUndefined();
+    const firstCall = sendMessage.mock.calls[0];
+    if (!firstCall) {
+      throw new Error("expected sendMessage call");
+    }
+    expect((firstCall[1] as { formatted_body?: string }).formatted_body).toBeUndefined();
   });
 });
 

--- a/extensions/matrix/src/matrix/send/targets.test.ts
+++ b/extensions/matrix/src/matrix/send/targets.test.ts
@@ -53,6 +53,7 @@ describe("resolveMatrixRoomId", () => {
 
   it("prefers joined rooms marked direct in local member state over plain strict rooms", async () => {
     const userId = "@fallback:example.org";
+    const setAccountData = vi.fn().mockResolvedValue(undefined);
     const client = {
       getAccountData: vi.fn().mockRejectedValue(new Error("nope")),
       getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
@@ -65,13 +66,13 @@ describe("resolveMatrixRoomId", () => {
             ? { is_direct: true }
             : {},
         ),
-      setAccountData: vi.fn().mockResolvedValue(undefined),
+      setAccountData,
     } as unknown as MatrixClient;
 
     const resolved = await resolveMatrixRoomId(client, userId);
 
     expect(resolved).toBe("!explicit:example.org");
-    expect(client.setAccountData).toHaveBeenCalledWith(
+    expect(setAccountData).toHaveBeenCalledWith(
       EventType.Direct,
       expect.objectContaining({ [userId]: ["!explicit:example.org"] }),
     );
@@ -79,6 +80,7 @@ describe("resolveMatrixRoomId", () => {
 
   it("ignores remote member-state direct flags when resolving a direct room", async () => {
     const userId = "@fallback:example.org";
+    const setAccountData = vi.fn().mockResolvedValue(undefined);
     const client = {
       getAccountData: vi.fn().mockRejectedValue(new Error("nope")),
       getUserId: vi.fn().mockResolvedValue("@bot:example.org"),
@@ -91,13 +93,13 @@ describe("resolveMatrixRoomId", () => {
         .mockImplementation(async (roomId: string, _eventType: string, stateKey: string) =>
           roomId === "!remote-marked:example.org" && stateKey === userId ? { is_direct: true } : {},
         ),
-      setAccountData: vi.fn().mockResolvedValue(undefined),
+      setAccountData,
     } as unknown as MatrixClient;
 
     const resolved = await resolveMatrixRoomId(client, userId);
 
     expect(resolved).toBe("!fallback:example.org");
-    expect(client.setAccountData).toHaveBeenCalledWith(
+    expect(setAccountData).toHaveBeenCalledWith(
       EventType.Direct,
       expect.objectContaining({ [userId]: ["!fallback:example.org"] }),
     );

--- a/extensions/matrix/src/matrix/thread-bindings.ts
+++ b/extensions/matrix/src/matrix/thread-bindings.ts
@@ -38,13 +38,6 @@ type StoredMatrixThreadBindingState = {
   bindings: MatrixThreadBindingRecord[];
 };
 
-function normalizeDurationMs(raw: unknown, fallback: number): number {
-  if (typeof raw !== "number" || !Number.isFinite(raw)) {
-    return fallback;
-  }
-  return Math.max(0, Math.floor(raw));
-}
-
 function normalizeText(raw: unknown): string {
   return typeof raw === "string" ? raw.trim() : "";
 }
@@ -122,7 +115,7 @@ function toStoredBindingsState(
 ): StoredMatrixThreadBindingState {
   return {
     version: STORE_VERSION,
-    bindings: [...bindings].sort((a, b) => a.boundAt - b.boundAt),
+    bindings: [...bindings].toSorted((a, b) => a.boundAt - b.boundAt),
   };
 }
 

--- a/extensions/matrix/src/migration-snapshot.test.ts
+++ b/extensions/matrix/src/migration-snapshot.test.ts
@@ -46,9 +46,12 @@ describe("matrix migration snapshots", () => {
 
       expect(result.created).toBe(true);
       expect(result.markerPath).toBe(resolveMatrixMigrationSnapshotMarkerPath(process.env));
-      expect(
-        result.archivePath.startsWith(resolveMatrixMigrationSnapshotOutputDir(process.env)),
-      ).toBe(true);
+      expect(createBackupArchiveMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          output: resolveMatrixMigrationSnapshotOutputDir(process.env),
+          includeWorkspace: false,
+        }),
+      );
       expect(fs.existsSync(result.archivePath)).toBe(true);
       expect(createBackupArchiveMock).toHaveBeenCalledWith({
         output: resolveMatrixMigrationSnapshotOutputDir(process.env),

--- a/extensions/matrix/src/onboarding.test-harness.ts
+++ b/extensions/matrix/src/onboarding.test-harness.ts
@@ -64,7 +64,7 @@ export function createMatrixWizardPrompter(params: {
     fallback: PromptHandler<T | Promise<T>> | undefined,
   ): Promise<T> => {
     if (values && message in values) {
-      return values[message] as T;
+      return values[message];
     }
     if (fallback) {
       return await fallback(message);

--- a/extensions/matrix/src/onboarding.ts
+++ b/extensions/matrix/src/onboarding.ts
@@ -17,11 +17,7 @@ import {
   validateMatrixHomeserverUrl,
 } from "./matrix/client.js";
 import { resolveMatrixEnvAuthReadiness } from "./matrix/client/env-auth.js";
-import {
-  resolveMatrixConfigFieldPath,
-  resolveMatrixConfigPath,
-  updateMatrixAccountConfig,
-} from "./matrix/config-update.js";
+import { resolveMatrixConfigFieldPath, updateMatrixAccountConfig } from "./matrix/config-update.js";
 import { ensureMatrixSdkInstalled, isMatrixSdkAvailable } from "./matrix/deps.js";
 import { resolveMatrixTargets } from "./resolve-targets.js";
 import type { DmPolicy } from "./runtime-api.js";

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -4,7 +4,6 @@ import {
   resolveOutboundSendDep,
   type ChannelOutboundAdapter,
 } from "./runtime-api.js";
-import { getMatrixRuntime } from "./runtime.js";
 
 export const matrixOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",

--- a/extensions/matrix/src/setup-bootstrap.ts
+++ b/extensions/matrix/src/setup-bootstrap.ts
@@ -38,7 +38,7 @@ export async function maybeBootstrapNewEncryptedMatrixAccount(params: {
     const bootstrap = await bootstrapMatrixVerification({ accountId: params.accountId });
     return {
       attempted: true,
-      success: bootstrap.success === true,
+      success: bootstrap.success,
       recoveryKeyCreatedAt: bootstrap.verification.recoveryKeyCreatedAt,
       backupVersion: bootstrap.verification.backupVersion,
       ...(bootstrap.success

--- a/extensions/qqbot/src/api.ts
+++ b/extensions/qqbot/src/api.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 import os from "node:os";
-import { debugLog, debugError } from "./utils/debug-log.js";
+import { debugLog, debugError, formatUnknownError } from "./utils/debug-log.js";
 import { sanitizeFileName } from "./utils/platform.js";
 import { computeFileHash, getCachedFileInfo, setCachedFileInfo } from "./utils/upload-cache.js";
 
@@ -106,6 +106,7 @@ async function doFetchToken(appId: string, clientSecret: string): Promise<string
     debugError(`[qqbot-api:${appId}] <<< Network error:`, err);
     throw new Error(
       `Network error getting access_token: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 
@@ -130,6 +131,7 @@ async function doFetchToken(appId: string, clientSecret: string): Promise<string
     debugError(`[qqbot-api:${appId}] <<< Parse error:`, err);
     throw new Error(
       `Failed to parse access_token response: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 
@@ -225,7 +227,7 @@ export async function apiRequest<T = unknown>(
   if (body) {
     const logBody = { ...body } as Record<string, unknown>;
     if (typeof logBody.file_data === "string") {
-      logBody.file_data = `<base64 ${(logBody.file_data as string).length} chars>`;
+      logBody.file_data = `<base64 ${logBody.file_data.length} chars>`;
     }
     debugLog(`[qqbot-api] >>> Body:`, JSON.stringify(logBody));
   }
@@ -237,10 +239,13 @@ export async function apiRequest<T = unknown>(
     clearTimeout(timeoutId);
     if (err instanceof Error && err.name === "AbortError") {
       debugError(`[qqbot-api] <<< Request timeout after ${timeout}ms`);
-      throw new Error(`Request timeout[${path}]: exceeded ${timeout}ms`);
+      throw new Error(`Request timeout[${path}]: exceeded ${timeout}ms`, { cause: err });
     }
     debugError(`[qqbot-api] <<< Network error:`, err);
-    throw new Error(`Network error [${path}]: ${err instanceof Error ? err.message : String(err)}`);
+    throw new Error(
+      `Network error [${path}]: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
   } finally {
     clearTimeout(timeoutId);
   }
@@ -263,6 +268,7 @@ export async function apiRequest<T = unknown>(
   } catch (err) {
     throw new Error(
       `Failed to parse response[${path}]: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 
@@ -351,7 +357,7 @@ async function sendAndNotify(
     try {
       hook(result.ext_info.ref_idx, meta);
     } catch (err) {
-      debugError(`[qqbot-api:${appId}] onMessageSent hook error: ${err}`);
+      debugError(`[qqbot-api:${appId}] onMessageSent hook error: ${formatUnknownError(err)}`);
     }
   }
   return result;
@@ -431,7 +437,7 @@ export async function sendChannelMessage(
   channelId: string,
   content: string,
   msgId?: string,
-): Promise<{ id: string; timestamp: string }> {
+): Promise<MessageResponse> {
   return apiRequest(accessToken, "POST", `/channels/${channelId}/messages`, {
     content,
     ...(msgId ? { msg_id: msgId } : {}),
@@ -493,7 +499,7 @@ export async function sendProactiveGroupMessage(
   accessToken: string,
   groupOpenid: string,
   content: string,
-): Promise<{ id: string; timestamp: string }> {
+): Promise<MessageResponse> {
   const body = buildProactiveMessageBody(appId, content);
   return apiRequest(accessToken, "POST", `/v2/groups/${groupOpenid}/messages`, body);
 }
@@ -523,7 +529,9 @@ export async function uploadC2CMedia(
   srvSendMsg = false,
   fileName?: string,
 ): Promise<UploadMediaResponse> {
-  if (!url && !fileData) throw new Error("uploadC2CMedia: url or fileData is required");
+  if (!url && !fileData) {
+    throw new Error("uploadC2CMedia: url or fileData is required");
+  }
 
   if (fileData) {
     const contentHash = computeFileHash(fileData);
@@ -534,9 +542,14 @@ export async function uploadC2CMedia(
   }
 
   const body: Record<string, unknown> = { file_type: fileType, srv_send_msg: srvSendMsg };
-  if (url) body.url = url;
-  else if (fileData) body.file_data = fileData;
-  if (fileType === MediaFileType.FILE && fileName) body.file_name = sanitizeFileName(fileName);
+  if (url) {
+    body.url = url;
+  } else if (fileData) {
+    body.file_data = fileData;
+  }
+  if (fileType === MediaFileType.FILE && fileName) {
+    body.file_name = sanitizeFileName(fileName);
+  }
 
   const result = await apiRequestWithRetry<UploadMediaResponse>(
     accessToken,
@@ -569,7 +582,9 @@ export async function uploadGroupMedia(
   srvSendMsg = false,
   fileName?: string,
 ): Promise<UploadMediaResponse> {
-  if (!url && !fileData) throw new Error("uploadGroupMedia: url or fileData is required");
+  if (!url && !fileData) {
+    throw new Error("uploadGroupMedia: url or fileData is required");
+  }
 
   if (fileData) {
     const contentHash = computeFileHash(fileData);
@@ -580,9 +595,14 @@ export async function uploadGroupMedia(
   }
 
   const body: Record<string, unknown> = { file_type: fileType, srv_send_msg: srvSendMsg };
-  if (url) body.url = url;
-  else if (fileData) body.file_data = fileData;
-  if (fileType === MediaFileType.FILE && fileName) body.file_name = sanitizeFileName(fileName);
+  if (url) {
+    body.url = url;
+  } else if (fileData) {
+    body.file_data = fileData;
+  }
+  if (fileType === MediaFileType.FILE && fileName) {
+    body.file_name = sanitizeFileName(fileName);
+  }
 
   const result = await apiRequestWithRetry<UploadMediaResponse>(
     accessToken,
@@ -662,7 +682,9 @@ export async function sendC2CImageMessage(
   const isBase64 = imageUrl.startsWith("data:");
   if (isBase64) {
     const matches = imageUrl.match(/^data:([^;]+);base64,(.+)$/);
-    if (!matches) throw new Error("Invalid Base64 Data URL format");
+    if (!matches) {
+      throw new Error("Invalid Base64 Data URL format");
+    }
     uploadResult = await uploadC2CMedia(
       accessToken,
       openid,
@@ -710,7 +732,9 @@ export async function sendGroupImageMessage(
   const isBase64 = imageUrl.startsWith("data:");
   if (isBase64) {
     const matches = imageUrl.match(/^data:([^;]+);base64,(.+)$/);
-    if (!matches) throw new Error("Invalid Base64 Data URL format");
+    if (!matches) {
+      throw new Error("Invalid Base64 Data URL format");
+    }
     uploadResult = await uploadGroupMedia(
       accessToken,
       groupOpenid,
@@ -932,8 +956,12 @@ export function startBackgroundTokenRefresh(
           await sleep(minRefreshIntervalMs, signal);
         }
       } catch (err) {
-        if (signal.aborted) break;
-        log?.error?.(`[qqbot-api:${appId}] Background token refresh failed: ${err}`);
+        if (signal.aborted) {
+          break;
+        }
+        log?.error?.(
+          `[qqbot-api:${appId}] Background token refresh failed: ${formatUnknownError(err)}`,
+        );
         await sleep(retryDelayMs, signal);
       }
     }
@@ -944,7 +972,9 @@ export function startBackgroundTokenRefresh(
 
   refreshLoop().catch((err) => {
     backgroundRefreshControllers.delete(appId);
-    log?.error?.(`[qqbot-api:${appId}] Background token refresh crashed: ${err}`);
+    log?.error?.(
+      `[qqbot-api:${appId}] Background token refresh crashed: ${formatUnknownError(err)}`,
+    );
   });
 }
 
@@ -968,7 +998,9 @@ export function stopBackgroundTokenRefresh(appId?: string): void {
 }
 
 export function isBackgroundTokenRefreshRunning(appId?: string): boolean {
-  if (appId) return backgroundRefreshControllers.has(appId);
+  if (appId) {
+    return backgroundRefreshControllers.has(appId);
+  }
   return backgroundRefreshControllers.size > 0;
 }
 

--- a/extensions/qqbot/src/command-auth.test.ts
+++ b/extensions/qqbot/src/command-auth.test.ts
@@ -26,7 +26,7 @@ import { qqbotPlugin } from "./channel.js";
 // ---------------------------------------------------------------------------
 
 describe("qqbot: prefix normalization for inbound commandAuthorized", () => {
-  const formatAllowFrom = qqbotPlugin.config!.formatAllowFrom!;
+  const formatAllowFrom = qqbotPlugin.config.formatAllowFrom!;
 
   /** Mirrors the fixed gateway.ts inbound commandAuthorized computation. */
   function resolveInboundCommandAuthorized(rawAllowFrom: string[], senderId: string): boolean {

--- a/extensions/qqbot/src/config.ts
+++ b/extensions/qqbot/src/config.ts
@@ -33,8 +33,13 @@ function normalizeQQBotAccountConfig(account: QQBotAccountConfig | undefined): Q
 }
 
 function normalizeAppId(raw: unknown): string {
-  if (raw === null || raw === undefined) return "";
-  return String(raw).trim();
+  if (typeof raw === "string") {
+    return raw.trim();
+  }
+  if (typeof raw === "number" || typeof raw === "bigint") {
+    return String(raw).trim();
+  }
+  return "";
 }
 
 /** List all configured QQBot account IDs. */
@@ -165,12 +170,13 @@ export function applyQQBotAccountConfig(
   if (accountId === DEFAULT_ACCOUNT_ID) {
     // Default allowFrom to ["*"] when not yet configured.
     const existingConfig = (next.channels?.qqbot as QQBotChannelConfig) || {};
+    const currentQQBot = next.channels?.qqbot as Record<string, unknown> | undefined;
     const allowFrom = existingConfig.allowFrom ?? ["*"];
 
     next.channels = {
       ...next.channels,
       qqbot: {
-        ...((next.channels?.qqbot as Record<string, unknown>) || {}),
+        ...currentQQBot,
         enabled: true,
         allowFrom,
         ...(input.appId ? { appId: input.appId } : {}),
@@ -186,17 +192,18 @@ export function applyQQBotAccountConfig(
     // Default allowFrom to ["*"] when not yet configured.
     const existingAccountConfig =
       (next.channels?.qqbot as QQBotChannelConfig)?.accounts?.[accountId] || {};
+    const currentQQBot = next.channels?.qqbot as Record<string, unknown> | undefined;
     const allowFrom = existingAccountConfig.allowFrom ?? ["*"];
 
     next.channels = {
       ...next.channels,
       qqbot: {
-        ...((next.channels?.qqbot as Record<string, unknown>) || {}),
+        ...currentQQBot,
         enabled: true,
         accounts: {
-          ...((next.channels?.qqbot as QQBotChannelConfig)?.accounts || {}),
+          ...(next.channels?.qqbot as QQBotChannelConfig)?.accounts,
           [accountId]: {
-            ...((next.channels?.qqbot as QQBotChannelConfig)?.accounts?.[accountId] || {}),
+            ...(next.channels?.qqbot as QQBotChannelConfig)?.accounts?.[accountId],
             enabled: true,
             allowFrom,
             ...(input.appId ? { appId: input.appId } : {}),

--- a/extensions/qqbot/src/gateway.ts
+++ b/extensions/qqbot/src/gateway.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import WebSocket from "ws";
+import WebSocket, { type RawData } from "ws";
 import {
   getAccessToken,
   getGatewayUrl,
@@ -43,11 +43,7 @@ import {
 } from "./reply-dispatcher.js";
 import { getQQBotRuntime } from "./runtime.js";
 import { loadSession, saveSession, clearSession } from "./session-store.js";
-import {
-  matchSlashCommand,
-  type SlashCommandContext,
-  type SlashCommandFileResult,
-} from "./slash-commands.js";
+import { matchSlashCommand, type SlashCommandContext } from "./slash-commands.js";
 import type {
   ResolvedQQBotAccount,
   WSPayload,
@@ -57,6 +53,7 @@ import type {
 } from "./types.js";
 import { TypingKeepAlive, TYPING_INPUT_SECOND } from "./typing-keepalive.js";
 import { isGlobalTTSAvailable, resolveTTSConfig } from "./utils/audio-convert.js";
+import { formatUnknownError } from "./utils/debug-log.js";
 import { runDiagnostics } from "./utils/platform.js";
 import { parseFaceTags, parseRefIndices, buildAttachmentSummaries } from "./utils/text-parsing.js";
 
@@ -79,6 +76,19 @@ const RATE_LIMIT_DELAY = 60000;
 const MAX_RECONNECT_ATTEMPTS = 100;
 const MAX_QUICK_DISCONNECT_COUNT = 3;
 const QUICK_DISCONNECT_THRESHOLD = 5000;
+
+function decodeGatewayPayload(data: RawData): string {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString("utf8");
+  }
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  return Buffer.from(data).toString("utf8");
+}
 
 export interface GatewayContext {
   account: ResolvedQQBotAccount;
@@ -115,9 +125,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
   initApiConfig(account.appId, {
     markdownSupport: account.markdownSupport,
   });
-  log?.info(
-    `[qqbot:${account.accountId}] API config: markdownSupport=${account.markdownSupport === true}`,
-  );
+  log?.info(`[qqbot:${account.accountId}] API config: markdownSupport=${account.markdownSupport}`);
 
   // Cache outbound refIdx values from QQ delivery responses for future quoting.
   onMessageSent(account.appId, (refIdx, meta) => {
@@ -170,8 +178,8 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
     log?.info(
       `[qqbot:${account.accountId}] TTS apiKey: ${maskedKey}${ttsCfg.queryParams ? `, queryParams=${JSON.stringify(ttsCfg.queryParams)}` : ""}${ttsCfg.speed !== undefined ? `, speed=${ttsCfg.speed}` : ""}`,
     );
-  } else if (isGlobalTTSAvailable(cfg as OpenClawConfig)) {
-    const globalProvider = (cfg as OpenClawConfig).messages?.tts?.provider ?? "auto";
+  } else if (isGlobalTTSAvailable(cfg)) {
+    const globalProvider = cfg.messages?.tts?.provider ?? "auto";
     log?.info(
       `[qqbot:${account.accountId}] TTS configured (global fallback): provider=${globalProvider}`,
     );
@@ -282,8 +290,8 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
       // path below is retained for forward-compatibility if a future requireAuth:false
       // command returns a SlashCommandFileResult.
       const isFileResult = typeof reply === "object" && reply !== null && "filePath" in reply;
-      const replyText = isFileResult ? (reply as SlashCommandFileResult).text : (reply as string);
-      const replyFile = isFileResult ? (reply as SlashCommandFileResult).filePath : null;
+      const replyText = isFileResult ? reply.text : reply;
+      const replyFile = isFileResult ? reply.filePath : null;
 
       // Send the text portion first.
       if (msg.type === "c2c") {
@@ -325,11 +333,13 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
           await sendDocument(mediaCtx, replyFile);
           log?.info(`[qqbot:${account.accountId}] Slash command file sent: ${replyFile}`);
         } catch (fileErr) {
-          log?.error(`[qqbot:${account.accountId}] Failed to send slash command file: ${fileErr}`);
+          log?.error(
+            `[qqbot:${account.accountId}] Failed to send slash command file: ${formatUnknownError(fileErr)}`,
+          );
         }
       }
     } catch (err) {
-      log?.error(`[qqbot:${account.accountId}] Slash command error: ${err}`);
+      log?.error(`[qqbot:${account.accountId}] Slash command error: ${formatUnknownError(err)}`);
       // Fall back to the normal queue path if the slash command handler fails.
       msgQueue.enqueue(msg);
     }
@@ -387,7 +397,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
     reconnectTimer = setTimeout(() => {
       reconnectTimer = null;
       if (!isAborted) {
-        connect();
+        void connect();
       }
     }, delay);
   };
@@ -462,7 +472,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
         const typing: { keepAlive: TypingKeepAlive | null } = { keepAlive: null };
 
         const inputNotifyPromise: Promise<string | undefined> = (async () => {
-          if (!isC2C) return undefined;
+          if (!isC2C) {
+            return undefined;
+          }
           try {
             let token = await getAccessToken(account.appId, account.clientSecret);
             try {
@@ -512,7 +524,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
               }
             }
           } catch (err) {
-            log?.error(`[qqbot:${account.accountId}] sendC2CInputNotify error: ${err}`);
+            log?.error(
+              `[qqbot:${account.accountId}] sendC2CInputNotify error: ${formatUnknownError(err)}`,
+            );
             return undefined;
           }
         })();
@@ -670,8 +684,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
             : `qqbot:c2c:${event.senderId}`;
 
         const hasTTS =
-          !!resolveTTSConfig(cfg as Record<string, unknown>) ||
-          isGlobalTTSAvailable(cfg as OpenClawConfig);
+          !!resolveTTSConfig(cfg as Record<string, unknown>) || isGlobalTTSAvailable(cfg);
 
         let quotePart = "";
         if (replyToIsQuote) {
@@ -683,7 +696,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
         }
 
         const staticParts: string[] = [`[QQBot] to=${qualifiedTarget}`];
-        if (hasTTS) staticParts.push("voice synthesis enabled");
+        if (hasTTS) {
+          staticParts.push("voice synthesis enabled");
+        }
         const staticInstruction = staticParts.join(" | ");
         systemPrompts.unshift(staticInstruction);
 
@@ -717,7 +732,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
         const rawAllowFrom = account.config?.allowFrom ?? [];
         const normalizedAllowFrom = qqbotPlugin.config?.formatAllowFrom
           ? qqbotPlugin.config.formatAllowFrom({
-              cfg: cfg as OpenClawConfig,
+              cfg: cfg,
               accountId: account.accountId,
               allowFrom: rawAllowFrom,
             })
@@ -875,7 +890,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                     );
                   }
                 } catch (err) {
-                  log?.error(`[qqbot:${account.accountId}] Tool fallback sendMedia failed: ${err}`);
+                  log?.error(
+                    `[qqbot:${account.accountId}] Tool fallback sendMedia failed: ${formatUnknownError(err)}`,
+                  );
                 }
               }
               return;
@@ -960,7 +977,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                           }
                         } catch (err) {
                           log?.error(
-                            `[qqbot:${account.accountId}] Tool media immediate forward failed: ${err}`,
+                            `[qqbot:${account.accountId}] Tool media immediate forward failed: ${formatUnknownError(err)}`,
                           );
                         }
                       }
@@ -995,7 +1012,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                           await sendToolFallback();
                         } catch (sendErr) {
                           log?.error(
-                            `[qqbot:${account.accountId}] Failed to send tool-only fallback: ${sendErr}`,
+                            `[qqbot:${account.accountId}] Failed to send tool-only fallback: ${formatUnknownError(sendErr)}`,
                           );
                         }
                       }
@@ -1069,7 +1086,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                     replyText,
                     recordOutboundActivity,
                   );
-                  if (handled) return;
+                  if (handled) {
+                    return;
+                  }
 
                   await sendPlainReply(
                     payload,
@@ -1088,7 +1107,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                   });
                 },
                 onError: async (err: unknown) => {
-                  log?.error(`[qqbot:${account.accountId}] Dispatch error: ${err}`);
+                  log?.error(
+                    `[qqbot:${account.accountId}] Dispatch error: ${formatUnknownError(err)}`,
+                  );
                   hasResponse = true;
                   if (timeoutId) {
                     clearTimeout(timeoutId);
@@ -1110,7 +1131,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
 
           try {
             await Promise.race([dispatchPromise, timeoutPromise]);
-          } catch (err) {
+          } catch {
             if (timeoutId) {
               clearTimeout(timeoutId);
             }
@@ -1131,7 +1152,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
             }
           }
         } catch (err) {
-          log?.error(`[qqbot:${account.accountId}] Message processing failed: ${err}`);
+          log?.error(
+            `[qqbot:${account.accountId}] Message processing failed: ${formatUnknownError(err)}`,
+          );
         } finally {
           typing.keepAlive?.stop();
         }
@@ -1154,7 +1177,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
 
       ws.on("message", async (data) => {
         try {
-          const rawData = data.toString();
+          const rawData = decodeGatewayPayload(data);
           const payload = JSON.parse(rawData) as WSPayload;
           const { op, d, s, t } = payload;
 
@@ -1208,7 +1231,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
               }
 
               const interval = (d as { heartbeat_interval: number }).heartbeat_interval;
-              if (heartbeatInterval) clearInterval(heartbeatInterval);
+              if (heartbeatInterval) {
+                clearInterval(heartbeatInterval);
+              }
               heartbeatInterval = setInterval(() => {
                 if (ws.readyState === WebSocket.OPEN) {
                   ws.send(JSON.stringify({ op: 1, d: lastSeq }));
@@ -1259,7 +1284,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                   accountId: account.accountId,
                 });
                 const c2cRefs = parseRefIndices(event.message_scene?.ext);
-                trySlashCommandOrEnqueue({
+                void trySlashCommandOrEnqueue({
                   type: "c2c",
                   senderId: event.author.user_openid,
                   content: event.content,
@@ -1272,8 +1297,8 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
               } else if (t === "AT_MESSAGE_CREATE") {
                 const event = d as GuildMessageEvent;
                 // Guild users cannot receive proactive C2C messages — skip known-user recording.
-                const guildRefs = parseRefIndices((event as any).message_scene?.ext);
-                trySlashCommandOrEnqueue({
+                const guildRefs = parseRefIndices(event.message_scene?.ext);
+                void trySlashCommandOrEnqueue({
                   type: "guild",
                   senderId: event.author.id,
                   senderName: event.author.username,
@@ -1289,8 +1314,8 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
               } else if (t === "DIRECT_MESSAGE_CREATE") {
                 const event = d as GuildMessageEvent;
                 // DM author.id is a guild-scoped ID, not a C2C openid — skip known-user recording.
-                const dmRefs = parseRefIndices((event as any).message_scene?.ext);
-                trySlashCommandOrEnqueue({
+                const dmRefs = parseRefIndices(event.message_scene?.ext);
+                void trySlashCommandOrEnqueue({
                   type: "dm",
                   senderId: event.author.id,
                   senderName: event.author.username,
@@ -1311,7 +1336,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                   accountId: account.accountId,
                 });
                 const groupRefs = parseRefIndices(event.message_scene?.ext);
-                trySlashCommandOrEnqueue({
+                void trySlashCommandOrEnqueue({
                   type: "group",
                   senderId: event.author.member_openid,
                   content: event.content,
@@ -1355,7 +1380,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
               break;
           }
         } catch (err) {
-          log?.error(`[qqbot:${account.accountId}] Message parse error: ${err}`);
+          log?.error(
+            `[qqbot:${account.accountId}] Message parse error: ${formatUnknownError(err)}`,
+          );
         }
       });
 
@@ -1454,7 +1481,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
     } catch (err) {
       isConnecting = false;
       const errMsg = String(err);
-      log?.error(`[qqbot:${account.accountId}] Connection failed: ${err}`);
+      log?.error(`[qqbot:${account.accountId}] Connection failed: ${formatUnknownError(err)}`);
 
       // Back off more aggressively after rate-limit failures.
       if (errMsg.includes("Too many requests") || errMsg.includes("100001")) {

--- a/extensions/qqbot/src/inbound-attachments.ts
+++ b/extensions/qqbot/src/inbound-attachments.ts
@@ -1,5 +1,6 @@
 import { transcribeAudio, resolveSTTConfig } from "./stt.js";
 import { convertSilkToWav, isVoiceAttachment, formatDuration } from "./utils/audio-convert.js";
+import { formatUnknownError } from "./utils/debug-log.js";
 import { downloadFile } from "./utils/file-utils.js";
 import { getQQBotMediaDir } from "./utils/platform.js";
 
@@ -53,7 +54,9 @@ export async function processAttachments(
   attachments: RawAttachment[] | undefined,
   ctx: ProcessContext,
 ): Promise<ProcessedAttachments> {
-  if (!attachments?.length) return EMPTY_RESULT;
+  if (!attachments?.length) {
+    return EMPTY_RESULT;
+  }
 
   const { accountId, cfg, log } = ctx;
   const downloadDir = getQQBotMediaDir("downloads");
@@ -176,8 +179,12 @@ export async function processAttachments(
 
   // Phase 3: collect results in the original attachment order.
   for (const result of processResults) {
-    if (result.meta.voiceUrl) voiceAttachmentUrls.push(result.meta.voiceUrl);
-    if (result.meta.asrReferText) voiceAsrReferTexts.push(result.meta.asrReferText);
+    if (result.meta.voiceUrl) {
+      voiceAttachmentUrls.push(result.meta.voiceUrl);
+    }
+    if (result.meta.asrReferText) {
+      voiceAsrReferTexts.push(result.meta.asrReferText);
+    }
 
     if (result.type === "image" && result.localPath) {
       imageUrls.push(result.localPath);
@@ -222,7 +229,9 @@ export async function processAttachments(
 
 /** Format voice transcripts into user-visible text. */
 export function formatVoiceText(transcripts: string[]): string {
-  if (transcripts.length === 0) return "";
+  if (transcripts.length === 0) {
+    return "";
+  }
   return transcripts.length === 1
     ? `[Voice message] ${transcripts[0]}`
     : transcripts.map((t, i) => `[Voice ${i + 1}] ${t}`).join("\n");
@@ -302,7 +311,7 @@ async function processVoiceAttachment(
         audioPath = localPath;
       }
     } catch (convertErr) {
-      log?.error(`${prefix} Voice conversion failed: ${convertErr}`);
+      log?.error(`${prefix} Voice conversion failed: ${formatUnknownError(convertErr)}`);
       if (asrReferText) {
         return {
           localPath,
@@ -324,7 +333,7 @@ async function processVoiceAttachment(
 
   // Run speech-to-text on the prepared audio file.
   try {
-    const transcript = await transcribeAudio(audioPath!, cfg as Record<string, unknown>);
+    const transcript = await transcribeAudio(audioPath, cfg as Record<string, unknown>);
     if (transcript) {
       log?.info(`${prefix} STT transcript: ${transcript.slice(0, 100)}...`);
       return { localPath, type: "voice", transcript, transcriptSource: "stt", meta };
@@ -342,7 +351,7 @@ async function processVoiceAttachment(
       meta,
     };
   } catch (sttErr) {
-    log?.error(`${prefix} STT failed: ${sttErr}`);
+    log?.error(`${prefix} STT failed: ${formatUnknownError(sttErr)}`);
     if (asrReferText) {
       return { localPath, type: "voice", transcript: asrReferText, transcriptSource: "asr", meta };
     }

--- a/extensions/qqbot/src/known-users.ts
+++ b/extensions/qqbot/src/known-users.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { debugLog, debugError } from "./utils/debug-log.js";
+import { debugLog, debugError, formatUnknownError } from "./utils/debug-log.js";
 
 /** Persisted record for a user who has interacted with the bot. */
 export interface KnownUser {
@@ -53,7 +53,7 @@ function loadUsersFromFile(): Map<string, KnownUser> {
       debugLog(`[known-users] Loaded ${usersCache.size} users`);
     }
   } catch (err) {
-    debugError(`[known-users] Failed to load users: ${err}`);
+    debugError(`[known-users] Failed to load users: ${formatUnknownError(err)}`);
     usersCache = new Map();
   }
 
@@ -62,7 +62,9 @@ function loadUsersFromFile(): Map<string, KnownUser> {
 
 /** Schedule a throttled write to disk. */
 function saveUsersToFile(): void {
-  if (!isDirty) return;
+  if (!isDirty) {
+    return;
+  }
 
   if (saveTimer) {
     return;
@@ -76,7 +78,9 @@ function saveUsersToFile(): void {
 
 /** Perform the actual write to disk. */
 function doSaveUsersToFile(): void {
-  if (!usersCache || !isDirty) return;
+  if (!usersCache || !isDirty) {
+    return;
+  }
 
   try {
     ensureDir();
@@ -84,7 +88,7 @@ function doSaveUsersToFile(): void {
     fs.writeFileSync(KNOWN_USERS_FILE, JSON.stringify(users, null, 2), "utf-8");
     isDirty = false;
   } catch (err) {
-    debugError(`[known-users] Failed to save users: ${err}`);
+    debugError(`[known-users] Failed to save users: ${formatUnknownError(err)}`);
   }
 }
 

--- a/extensions/qqbot/src/message-queue.ts
+++ b/extensions/qqbot/src/message-queue.ts
@@ -1,4 +1,5 @@
 import type { QueueSnapshot } from "./slash-commands.js";
+import { formatUnknownError } from "./utils/debug-log.js";
 
 // Message queue limits.
 const MESSAGE_QUEUE_SIZE = 1000;
@@ -67,13 +68,19 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
   let totalEnqueued = 0;
 
   const getMessagePeerId = (msg: QueuedMessage): string => {
-    if (msg.type === "guild") return `guild:${msg.channelId ?? "unknown"}`;
-    if (msg.type === "group") return `group:${msg.groupOpenid ?? "unknown"}`;
+    if (msg.type === "guild") {
+      return `guild:${msg.channelId ?? "unknown"}`;
+    }
+    if (msg.type === "group") {
+      return `group:${msg.groupOpenid ?? "unknown"}`;
+    }
     return `dm:${msg.senderId}`;
   };
 
   const drainUserQueue = async (peerId: string): Promise<void> => {
-    if (activeUsers.has(peerId)) return;
+    if (activeUsers.has(peerId)) {
+      return;
+    }
     if (activeUsers.size >= MAX_CONCURRENT_USERS) {
       log?.info(
         `[qqbot:${accountId}] Max concurrent users (${MAX_CONCURRENT_USERS}) reached, ${peerId} will wait`,
@@ -99,16 +106,20 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
             messagesProcessed++;
           }
         } catch (err) {
-          log?.error(`[qqbot:${accountId}] Message processor error for ${peerId}: ${err}`);
+          log?.error(
+            `[qqbot:${accountId}] Message processor error for ${peerId}: ${formatUnknownError(err)}`,
+          );
         }
       }
     } finally {
       activeUsers.delete(peerId);
       userQueues.delete(peerId);
       for (const [waitingPeerId, waitingQueue] of userQueues) {
-        if (activeUsers.size >= MAX_CONCURRENT_USERS) break;
+        if (activeUsers.size >= MAX_CONCURRENT_USERS) {
+          break;
+        }
         if (waitingQueue.length > 0 && !activeUsers.has(waitingPeerId)) {
-          drainUserQueue(waitingPeerId);
+          void drainUserQueue(waitingPeerId);
         }
       }
     }
@@ -141,7 +152,7 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
       `[qqbot:${accountId}] Message enqueued for ${peerId}, user queue: ${queue.length}, active users: ${activeUsers.size}`,
     );
 
-    drainUserQueue(peerId);
+    void drainUserQueue(peerId);
   };
 
   const startProcessor = (handleMessageFn: (msg: QueuedMessage) => Promise<void>): void => {
@@ -167,7 +178,9 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
 
   const clearUserQueue = (peerId: string): number => {
     const queue = userQueues.get(peerId);
-    if (!queue || queue.length === 0) return 0;
+    if (!queue || queue.length === 0) {
+      return 0;
+    }
     const droppedCount = queue.length;
     queue.length = 0;
     totalEnqueued = Math.max(0, totalEnqueued - droppedCount);
@@ -177,7 +190,7 @@ export function createMessageQueue(ctx: MessageQueueContext): MessageQueue {
   const executeImmediate = (msg: QueuedMessage): void => {
     if (handleMessageFnRef) {
       handleMessageFnRef(msg).catch((err) => {
-        log?.error(`[qqbot:${accountId}] Immediate execution error: ${err}`);
+        log?.error(`[qqbot:${accountId}] Immediate execution error: ${formatUnknownError(err)}`);
       });
     }
   };

--- a/extensions/qqbot/src/outbound-deliver.ts
+++ b/extensions/qqbot/src/outbound-deliver.ts
@@ -25,6 +25,7 @@ import {
 import { getQQBotRuntime } from "./runtime.js";
 import { chunkText, TEXT_CHUNK_LIMIT } from "./text-utils.js";
 import type { ResolvedQQBotAccount } from "./types.js";
+import { formatUnknownError } from "./utils/debug-log.js";
 import { getImageSize, formatQQBotMarkdownImage, hasQQBotImageSize } from "./utils/image-size.js";
 import { normalizeMediaTags } from "./utils/media-tags.js";
 import { normalizePath, isLocalPath as isLocalFilePath } from "./utils/platform.js";
@@ -89,7 +90,7 @@ export async function parseAndSendMediaTags(
 
   const tagCounts = mediaTagMatches.reduce(
     (acc, m) => {
-      const t = m[1]!.toLowerCase();
+      const t = m[1].toLowerCase();
       acc[t] = (acc[t] ?? 0) + 1;
       return acc;
     },
@@ -122,7 +123,7 @@ export async function parseAndSendMediaTags(
       sendQueue.push({ type: "text", content: filterInternalMarkers(textBefore) });
     }
 
-    const tagName = match[1]!.toLowerCase();
+    const tagName = match[1].toLowerCase();
     let mediaPath = decodeMediaPath(match[2]?.trim() ?? "", log, prefix);
 
     if (mediaPath) {
@@ -178,15 +179,21 @@ export async function parseAndSendMediaTags(
       await sendTextChunks(item.content, event, actx, sendWithRetry, consumeQuoteRef);
     } else if (item.type === "image") {
       const result = await sendPhoto(mediaTarget, item.content);
-      if (result.error) log?.error(`${prefix} sendPhoto error: ${result.error}`);
+      if (result.error) {
+        log?.error(`${prefix} sendPhoto error: ${result.error}`);
+      }
     } else if (item.type === "voice") {
       await sendVoiceWithTimeout(mediaTarget, item.content, account, log, prefix);
     } else if (item.type === "video") {
       const result = await sendVideoMsg(mediaTarget, item.content);
-      if (result.error) log?.error(`${prefix} sendVideoMsg error: ${result.error}`);
+      if (result.error) {
+        log?.error(`${prefix} sendVideoMsg error: ${result.error}`);
+      }
     } else if (item.type === "file") {
       const result = await sendDocument(mediaTarget, item.content);
-      if (result.error) log?.error(`${prefix} sendDocument error: ${result.error}`);
+      if (result.error) {
+        log?.error(`${prefix} sendDocument error: ${result.error}`);
+      }
     } else if (item.type === "media") {
       const result = await sendMediaAuto({
         to: actx.qualifiedTarget,
@@ -196,7 +203,9 @@ export async function parseAndSendMediaTags(
         replyToId: event.messageId,
         account,
       });
-      if (result.error) log?.error(`${prefix} sendMedia(auto) error: ${result.error}`);
+      if (result.error) {
+        log?.error(`${prefix} sendMedia(auto) error: ${result.error}`);
+      }
     }
   }
 
@@ -231,7 +240,9 @@ export async function sendPlainReply(
   const localMediaToSend: string[] = [];
 
   const collectImageUrl = (url: string | undefined | null): boolean => {
-    if (!url) return false;
+    if (!url) {
+      return false;
+    }
     const isHttpUrl = url.startsWith("http://") || url.startsWith("https://");
     const isDataUrl = url.startsWith("data:image/");
     if (isHttpUrl || isDataUrl) {
@@ -254,9 +265,13 @@ export async function sendPlainReply(
   };
 
   if (payload.mediaUrls?.length) {
-    for (const url of payload.mediaUrls) collectImageUrl(url);
+    for (const url of payload.mediaUrls) {
+      collectImageUrl(url);
+    }
   }
-  if (payload.mediaUrl) collectImageUrl(payload.mediaUrl);
+  if (payload.mediaUrl) {
+    collectImageUrl(payload.mediaUrl);
+  }
 
   // Extract markdown images.
   const mdImageRegex = /!\[([^\]]*)\]\(([^)]+)\)/gi;
@@ -278,7 +293,7 @@ export async function sendPlainReply(
 
   // Extract bare image URLs.
   const bareUrlRegex =
-    /(?<![(\["'])(https?:\/\/[^\s)"'<>]+\.(?:png|jpg|jpeg|gif|webp)(?:\?[^\s"'<>]*)?)/gi;
+    /(?<![(["'])(https?:\/\/[^\s)"'<>]+\.(?:png|jpg|jpeg|gif|webp)(?:\?[^\s"'<>]*)?)/gi;
   const bareUrlMatches = [...replyText.matchAll(bareUrlRegex)];
   for (const m of bareUrlMatches) {
     const url = m[1];
@@ -288,7 +303,7 @@ export async function sendPlainReply(
     }
   }
 
-  const useMarkdown = account.markdownSupport === true;
+  const useMarkdown = account.markdownSupport;
   log?.info(`${prefix} Markdown mode: ${useMarkdown}, images: ${collectedImageUrls.length}`);
 
   let textWithoutImages = filterInternalMarkers(replyText);
@@ -341,11 +356,13 @@ export async function sendPlainReply(
           replyToId: event.messageId,
           account,
         });
-        if (result.error)
+        if (result.error) {
           log?.error(`${prefix} sendMedia(auto) error for ${mediaPath}: ${result.error}`);
-        else log?.info(`${prefix} Sent local media: ${mediaPath}`);
+        } else {
+          log?.info(`${prefix} Sent local media: ${mediaPath}`);
+        }
       } catch (err) {
-        log?.error(`${prefix} sendMedia(auto) failed for ${mediaPath}: ${err}`);
+        log?.error(`${prefix} sendMedia(auto) failed for ${mediaPath}: ${formatUnknownError(err)}`);
       }
     }
   }
@@ -365,10 +382,13 @@ export async function sendPlainReply(
           replyToId: event.messageId,
           account,
         });
-        if (result.error) log?.error(`${prefix} Tool media forward error: ${result.error}`);
-        else log?.info(`${prefix} Forwarded tool media: ${mediaUrl.slice(0, 80)}...`);
+        if (result.error) {
+          log?.error(`${prefix} Tool media forward error: ${result.error}`);
+        } else {
+          log?.info(`${prefix} Forwarded tool media: ${mediaUrl.slice(0, 80)}...`);
+        }
       } catch (err) {
-        log?.error(`${prefix} Tool media forward failed: ${err}`);
+        log?.error(`${prefix} Tool media forward failed: ${formatUnknownError(err)}`);
       }
     }
     toolMediaUrls.length = 0;
@@ -417,7 +437,7 @@ function decodeMediaPath(raw: string, log: DeliverAccountContext["log"], prefix:
       }
     }
   } catch (decodeErr) {
-    log?.error(`${prefix} Path decode error: ${decodeErr}`);
+    log?.error(`${prefix} Path decode error: ${formatUnknownError(decodeErr)}`);
   }
 
   return mediaPath;
@@ -465,7 +485,7 @@ async function sendTextChunks(
         `${prefix} Sent text chunk (${chunk.length}/${text.length} chars): ${chunk.slice(0, 50)}...`,
       );
     } catch (err) {
-      log?.error(`${prefix} Failed to send text chunk: ${err}`);
+      log?.error(`${prefix} Failed to send text chunk: ${formatUnknownError(err)}`);
     }
   }
 }
@@ -503,9 +523,11 @@ async function sendVoiceWithTimeout(
         }, voiceTimeout),
       ),
     ]);
-    if (result.error) log?.error(`${prefix} sendVoice error: ${result.error}`);
+    if (result.error) {
+      log?.error(`${prefix} sendVoice error: ${result.error}`);
+    }
   } catch (err) {
-    log?.error(`${prefix} sendVoice unexpected error: ${err}`);
+    log?.error(`${prefix} sendVoice unexpected error: ${formatUnknownError(err)}`);
   }
 }
 
@@ -527,8 +549,11 @@ async function sendMarkdownReply(
   const httpImageUrls: string[] = [];
   const base64ImageUrls: string[] = [];
   for (const url of imageUrls) {
-    if (url.startsWith("data:image/")) base64ImageUrls.push(url);
-    else if (url.startsWith("http://") || url.startsWith("https://")) httpImageUrls.push(url);
+    if (url.startsWith("data:image/")) {
+      base64ImageUrls.push(url);
+    } else if (url.startsWith("http://") || url.startsWith("https://")) {
+      httpImageUrls.push(url);
+    }
   }
   log?.info(
     `${prefix} Image classification: httpUrls=${httpImageUrls.length}, base64=${base64ImageUrls.length}`,
@@ -566,7 +591,9 @@ async function sendMarkdownReply(
           `${prefix} Sent Base64 image via Rich Media API (size: ${imageUrl.length} chars)`,
         );
       } catch (imgErr) {
-        log?.error(`${prefix} Failed to send Base64 image via Rich Media API: ${imgErr}`);
+        log?.error(
+          `${prefix} Failed to send Base64 image via Rich Media API: ${formatUnknownError(imgErr)}`,
+        );
       }
     }
   }
@@ -584,7 +611,7 @@ async function sendMarkdownReply(
           `${prefix} Formatted HTTP image: ${size ? `${size.width}x${size.height}` : "default size"} - ${url.slice(0, 60)}...`,
         );
       } catch (err) {
-        log?.info(`${prefix} Failed to get image size, using default: ${err}`);
+        log?.info(`${prefix} Failed to get image size, using default: ${formatUnknownError(err)}`);
         imagesToAppend.push(formatQQBotMarkdownImage(url, null));
       }
     }
@@ -604,7 +631,9 @@ async function sendMarkdownReply(
           `${prefix} Updated image with size: ${size ? `${size.width}x${size.height}` : "default"} - ${imgUrl.slice(0, 60)}...`,
         );
       } catch (err) {
-        log?.info(`${prefix} Failed to get image size for existing md, using default: ${err}`);
+        log?.info(
+          `${prefix} Failed to get image size for existing md, using default: ${formatUnknownError(err)}`,
+        );
         result = result.replace(fullMatch, formatQQBotMarkdownImage(imgUrl, null));
       }
     }
@@ -655,7 +684,7 @@ async function sendMarkdownReply(
           `${prefix} Sent markdown chunk (${chunk.length}/${result.length} chars) with ${httpImageUrls.length} HTTP images (${event.type})`,
         );
       } catch (err) {
-        log?.error(`${prefix} Failed to send markdown message chunk: ${err}`);
+        log?.error(`${prefix} Failed to send markdown message chunk: ${formatUnknownError(err)}`);
       }
     }
   }
@@ -698,8 +727,12 @@ async function sendPlainTextReply(
   };
 
   let result = textWithoutImages;
-  for (const m of mdMatches) result = result.replace(m[0], "").trim();
-  for (const m of bareUrlMatches) result = result.replace(m[0], "").trim();
+  for (const m of mdMatches) {
+    result = result.replace(m[0], "").trim();
+  }
+  for (const m of bareUrlMatches) {
+    result = result.replace(m[0], "").trim();
+  }
 
   // QQ group messages reject some dotted bare URLs, so filter them first.
   if (result && event.type !== "c2c") {
@@ -710,10 +743,13 @@ async function sendPlainTextReply(
     for (const imageUrl of imageUrls) {
       try {
         const imgResult = await sendPhoto(imgMediaTarget, imageUrl);
-        if (imgResult.error) log?.error(`${prefix} Failed to send image: ${imgResult.error}`);
-        else log?.info(`${prefix} Sent image via sendPhoto: ${imageUrl.slice(0, 80)}...`);
+        if (imgResult.error) {
+          log?.error(`${prefix} Failed to send image: ${imgResult.error}`);
+        } else {
+          log?.info(`${prefix} Sent image via sendPhoto: ${imageUrl.slice(0, 80)}...`);
+        }
       } catch (imgErr) {
-        log?.error(`${prefix} Failed to send image: ${imgErr}`);
+        log?.error(`${prefix} Failed to send image: ${formatUnknownError(imgErr)}`);
       }
     }
 
@@ -749,6 +785,6 @@ async function sendPlainTextReply(
       }
     }
   } catch (err) {
-    log?.error(`${prefix} Send failed: ${err}`);
+    log?.error(`${prefix} Send failed: ${formatUnknownError(err)}`);
   }
 }

--- a/extensions/qqbot/src/outbound.ts
+++ b/extensions/qqbot/src/outbound.ts
@@ -23,13 +23,12 @@ import {
   waitForFile,
   shouldTranscodeVoice,
 } from "./utils/audio-convert.js";
-import { debugLog, debugError, debugWarn } from "./utils/debug-log.js";
+import { debugLog, debugError, debugWarn, formatUnknownError } from "./utils/debug-log.js";
 import { downloadFile } from "./utils/file-utils.js";
 import {
   checkFileSize,
   readFileAsync,
   fileExistsAsync,
-  isLargeFile,
   formatFileSize,
 } from "./utils/file-utils.js";
 import { normalizeMediaTags } from "./utils/media-tags.js";
@@ -39,7 +38,6 @@ import {
   normalizePath,
   resolveQQBotLocalMediaPath,
   sanitizeFileName,
-  getQQBotDataDir,
   getQQBotMediaDir,
 } from "./utils/platform.js";
 
@@ -355,7 +353,9 @@ export async function sendPhoto(
         `${prefix} sendPhoto: URL direct upload failed (${msg}), downloading locally and retrying as Base64...`,
       );
       const retryResult = await downloadAndRetrySendPhoto(ctx, mediaPath, prefix);
-      if (retryResult) return retryResult;
+      if (retryResult) {
+        return retryResult;
+      }
     }
 
     debugError(`${prefix} sendPhoto failed: ${msg}`);
@@ -875,7 +875,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
         sendQueue.push({ type: "text", content: textBefore });
       }
 
-      const tagName = match[1]!.toLowerCase();
+      const tagName = match[1].toLowerCase();
 
       let mediaPath = match[2]?.trim() ?? "";
       if (mediaPath.startsWith("MEDIA:")) {
@@ -921,7 +921,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
           }
         }
       } catch (decodeErr) {
-        debugError(`[qqbot] sendText: Path decode error: ${decodeErr}`);
+        debugError(`[qqbot] sendText: Path decode error: ${formatUnknownError(decodeErr)}`);
       }
 
       if (mediaPath) {
@@ -1008,7 +1008,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
                 channel: "qqbot",
                 messageId: result.id,
                 timestamp: result.timestamp,
-                refIdx: (result as any).ext_info?.ref_idx,
+                refIdx: result.ext_info?.ref_idx,
               };
             }
           } else {
@@ -1025,7 +1025,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
                 channel: "qqbot",
                 messageId: result.id,
                 timestamp: result.timestamp,
-                refIdx: (result as any).ext_info?.ref_idx,
+                refIdx: result.ext_info?.ref_idx,
               };
             } else if (target.type === "group") {
               const result = await sendProactiveGroupMessage(
@@ -1038,7 +1038,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
                 channel: "qqbot",
                 messageId: result.id,
                 timestamp: result.timestamp,
-                refIdx: (result as any).ext_info?.ref_idx,
+                refIdx: result.ext_info?.ref_idx,
               };
             } else {
               const result = await sendChannelMessage(accessToken, target.id, item.content);
@@ -1046,7 +1046,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
                 channel: "qqbot",
                 messageId: result.id,
                 timestamp: result.timestamp,
-                refIdx: (result as any).ext_info?.ref_idx,
+                refIdx: result.ext_info?.ref_idx,
               };
             }
           }
@@ -1119,7 +1119,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
           channel: "qqbot",
           messageId: result.id,
           timestamp: result.timestamp,
-          refIdx: (result as any).ext_info?.ref_idx,
+          refIdx: result.ext_info?.ref_idx,
         };
       } else if (target.type === "group") {
         const result = await sendProactiveGroupMessage(account.appId, accessToken, target.id, text);
@@ -1127,7 +1127,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
           channel: "qqbot",
           messageId: result.id,
           timestamp: result.timestamp,
-          refIdx: (result as any).ext_info?.ref_idx,
+          refIdx: result.ext_info?.ref_idx,
         };
       } else {
         const result = await sendChannelMessage(accessToken, target.id, text);
@@ -1135,7 +1135,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
           channel: "qqbot",
           messageId: result.id,
           timestamp: result.timestamp,
-          refIdx: (result as any).ext_info?.ref_idx,
+          refIdx: result.ext_info?.ref_idx,
         };
       }
       return outResult;
@@ -1166,7 +1166,7 @@ export async function sendText(ctx: OutboundContext): Promise<OutboundResult> {
         channel: "qqbot",
         messageId: result.id,
         timestamp: result.timestamp,
-        refIdx: (result as any).ext_info?.ref_idx,
+        refIdx: result.ext_info?.ref_idx,
       };
     }
   } catch (err) {
@@ -1218,7 +1218,7 @@ export async function sendProactiveMessage(
         channel: "qqbot",
         messageId: result.id,
         timestamp: result.timestamp,
-        refIdx: (result as any).ext_info?.ref_idx,
+        refIdx: result.ext_info?.ref_idx,
       };
     } else if (target.type === "group") {
       debugLog(
@@ -1232,7 +1232,7 @@ export async function sendProactiveMessage(
         channel: "qqbot",
         messageId: result.id,
         timestamp: result.timestamp,
-        refIdx: (result as any).ext_info?.ref_idx,
+        refIdx: result.ext_info?.ref_idx,
       };
     } else {
       debugLog(
@@ -1246,7 +1246,7 @@ export async function sendProactiveMessage(
         channel: "qqbot",
         messageId: result.id,
         timestamp: result.timestamp,
-        refIdx: (result as any).ext_info?.ref_idx,
+        refIdx: result.ext_info?.ref_idx,
       };
     }
     return outResult;
@@ -1283,7 +1283,9 @@ export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResu
     const transcodeEnabled = account.config?.audioFormatPolicy?.transcodeEnabled !== false;
     const result = await sendVoice(target, mediaUrl, formats, transcodeEnabled);
     if (!result.error) {
-      if (text?.trim()) await sendTextAfterMedia(target, text);
+      if (text?.trim()) {
+        await sendTextAfterMedia(target, text);
+      }
       return result;
     }
     // Preserve the voice error and fall back to file send.
@@ -1291,7 +1293,9 @@ export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResu
     debugWarn(`[qqbot] sendMedia: sendVoice failed (${voiceError}), falling back to sendDocument`);
     const fallback = await sendDocument(target, mediaUrl);
     if (!fallback.error) {
-      if (text?.trim()) await sendTextAfterMedia(target, text);
+      if (text?.trim()) {
+        await sendTextAfterMedia(target, text);
+      }
       return fallback;
     }
     return { channel: "qqbot", error: `voice: ${voiceError} | fallback file: ${fallback.error}` };
@@ -1299,7 +1303,9 @@ export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResu
 
   if (isVideoFile(mediaUrl, mimeType)) {
     const result = await sendVideoMsg(target, mediaUrl);
-    if (!result.error && text?.trim()) await sendTextAfterMedia(target, text);
+    if (!result.error && text?.trim()) {
+      await sendTextAfterMedia(target, text);
+    }
     return result;
   }
 
@@ -1310,13 +1316,17 @@ export async function sendMedia(ctx: MediaOutboundContext): Promise<OutboundResu
     !isVideoFile(mediaUrl, mimeType)
   ) {
     const result = await sendDocument(target, mediaUrl);
-    if (!result.error && text?.trim()) await sendTextAfterMedia(target, text);
+    if (!result.error && text?.trim()) {
+      await sendTextAfterMedia(target, text);
+    }
     return result;
   }
 
   // Default to image handling. sendPhoto already contains URL fallback logic.
   const result = await sendPhoto(target, mediaUrl);
-  if (!result.error && text?.trim()) await sendTextAfterMedia(target, text);
+  if (!result.error && text?.trim()) {
+    await sendTextAfterMedia(target, text);
+  }
   return result;
 }
 
@@ -1334,20 +1344,22 @@ async function sendTextAfterMedia(ctx: MediaTargetContext, text: string): Promis
       await sendDmMessage(token, ctx.targetId, text, ctx.replyToId);
     }
   } catch (err) {
-    debugError(`[qqbot] sendTextAfterMedia failed: ${err}`);
+    debugError(`[qqbot] sendTextAfterMedia failed: ${formatUnknownError(err)}`);
   }
 }
 
 /** Extract a lowercase extension from a path or URL, ignoring query and hash segments. */
 function getCleanExt(filePath: string): string {
-  const cleanPath = filePath.split("?")[0]!.split("#")[0]!;
+  const cleanPath = filePath.split("?")[0].split("#")[0];
   return path.extname(cleanPath).toLowerCase();
 }
 
 /** Check whether a file is an image using MIME first and extension as fallback. */
 function isImageFile(filePath: string, mimeType?: string): boolean {
   if (mimeType) {
-    if (mimeType.startsWith("image/")) return true;
+    if (mimeType.startsWith("image/")) {
+      return true;
+    }
   }
   const ext = getCleanExt(filePath);
   return [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"].includes(ext);
@@ -1356,7 +1368,9 @@ function isImageFile(filePath: string, mimeType?: string): boolean {
 /** Check whether a file or URL is a video using MIME first and extension as fallback. */
 function isVideoFile(filePath: string, mimeType?: string): boolean {
   if (mimeType) {
-    if (mimeType.startsWith("video/")) return true;
+    if (mimeType.startsWith("video/")) {
+      return true;
+    }
   }
   const ext = getCleanExt(filePath);
   return [".mp4", ".mov", ".avi", ".mkv", ".webm", ".flv", ".wmv"].includes(ext);

--- a/extensions/qqbot/src/proactive.ts
+++ b/extensions/qqbot/src/proactive.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ResolvedQQBotAccount } from "./types.js";
-import { debugLog, debugError } from "./utils/debug-log.js";
+import { debugLog, debugError, formatUnknownError } from "./utils/debug-log.js";
 
 // Re-export known-user types and functions from the canonical module.
 export type { KnownUser } from "./known-users.js";
@@ -54,7 +54,6 @@ import {
   getAccessToken,
   sendProactiveC2CMessage,
   sendProactiveGroupMessage,
-  sendChannelMessage,
   sendC2CImageMessage,
   sendGroupImageMessage,
 } from "./api.js";
@@ -75,7 +74,7 @@ export function listKnownUsers(
 ): ReturnType<typeof listKnownUsersImpl> {
   const type = options?.type;
   return listKnownUsersImpl({
-    type: type === "channel" ? undefined : (type as "c2c" | "group" | undefined),
+    type: type === "channel" ? undefined : type,
     accountId: options?.accountId,
     limit: options?.limit,
     sortBy: options?.sortByLastInteraction !== false ? "lastSeenAt" : undefined,
@@ -134,7 +133,7 @@ export async function sendProactive(
         }
         debugLog(`[qqbot:proactive] Sent image to ${type}:${to}`);
       } catch (err) {
-        debugError(`[qqbot:proactive] Failed to send image: ${err}`);
+        debugError(`[qqbot:proactive] Failed to send image: ${formatUnknownError(err)}`);
       }
     }
 
@@ -148,11 +147,6 @@ export async function sendProactive(
       return {
         success: false,
         error: "Channel proactive messages are not supported. Please use group or c2c.",
-      };
-    } else {
-      return {
-        success: false,
-        error: `Unknown message type: ${type}`,
       };
     }
 
@@ -237,7 +231,7 @@ export async function broadcastMessage(
       {
         to: targetId,
         text,
-        type: user.type as "c2c" | "group",
+        type: user.type,
         accountId: user.accountId,
       },
       cfg,

--- a/extensions/qqbot/src/proactive.ts
+++ b/extensions/qqbot/src/proactive.ts
@@ -137,7 +137,7 @@ export async function sendProactive(
       }
     }
 
-    let result: { id: string; timestamp: number | string };
+    let result: { id: string; timestamp: number | string } | undefined;
 
     if (type === "c2c") {
       result = await sendProactiveC2CMessage(account.appId, accessToken, to, text);
@@ -147,6 +147,13 @@ export async function sendProactive(
       return {
         success: false,
         error: "Channel proactive messages are not supported. Please use group or c2c.",
+      };
+    }
+
+    if (!result) {
+      return {
+        success: false,
+        error: "Unknown message type.",
       };
     }
 

--- a/extensions/qqbot/src/ref-index-store.ts
+++ b/extensions/qqbot/src/ref-index-store.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { debugLog, debugError } from "./utils/debug-log.js";
+import { debugLog, debugError, formatUnknownError } from "./utils/debug-log.js";
 import { getQQBotDataDir } from "./utils/platform.js";
 
 /** Summary stored for one quoted message. */
@@ -41,7 +41,9 @@ let totalLinesOnDisk = 0;
 
 /** Lazily load the JSONL store into memory. */
 function loadFromFile(): Map<string, RefIndexEntry & { _createdAt: number }> {
-  if (cache !== null) return cache;
+  if (cache !== null) {
+    return cache;
+  }
 
   cache = new Map();
   totalLinesOnDisk = 0;
@@ -58,12 +60,16 @@ function loadFromFile(): Map<string, RefIndexEntry & { _createdAt: number }> {
 
     for (const line of lines) {
       const trimmed = line.trim();
-      if (!trimmed) continue;
+      if (!trimmed) {
+        continue;
+      }
       totalLinesOnDisk++;
 
       try {
         const entry = JSON.parse(trimmed) as RefIndexLine;
-        if (!entry.k || !entry.v || !entry.t) continue;
+        if (!entry.k || !entry.v || !entry.t) {
+          continue;
+        }
 
         if (now - entry.t > TTL_MS) {
           expired++;
@@ -85,7 +91,7 @@ function loadFromFile(): Map<string, RefIndexEntry & { _createdAt: number }> {
       compactFile();
     }
   } catch (err) {
-    debugError(`[ref-index-store] Failed to load: ${err}`);
+    debugError(`[ref-index-store] Failed to load: ${formatUnknownError(err)}`);
     cache = new Map();
   }
 
@@ -99,7 +105,7 @@ function appendLine(line: RefIndexLine): void {
     fs.appendFileSync(REF_INDEX_FILE, JSON.stringify(line) + "\n", "utf-8");
     totalLinesOnDisk++;
   } catch (err) {
-    debugError(`[ref-index-store] Failed to append: ${err}`);
+    debugError(`[ref-index-store] Failed to append: ${formatUnknownError(err)}`);
   }
 }
 
@@ -110,12 +116,16 @@ function ensureDir(): void {
 }
 
 function shouldCompact(): boolean {
-  if (!cache) return false;
+  if (!cache) {
+    return false;
+  }
   return totalLinesOnDisk > cache.size * COMPACT_THRESHOLD_RATIO && totalLinesOnDisk > 1000;
 }
 
 function compactFile(): void {
-  if (!cache) return;
+  if (!cache) {
+    return;
+  }
 
   const before = totalLinesOnDisk;
   try {
@@ -144,12 +154,14 @@ function compactFile(): void {
     totalLinesOnDisk = cache.size;
     debugLog(`[ref-index-store] Compacted: ${before} lines → ${totalLinesOnDisk} lines`);
   } catch (err) {
-    debugError(`[ref-index-store] Compact failed: ${err}`);
+    debugError(`[ref-index-store] Compact failed: ${formatUnknownError(err)}`);
   }
 }
 
 function evictIfNeeded(): void {
-  if (!cache || cache.size < MAX_ENTRIES) return;
+  if (!cache || cache.size < MAX_ENTRIES) {
+    return;
+  }
 
   const now = Date.now();
   for (const [key, entry] of cache) {
@@ -159,7 +171,7 @@ function evictIfNeeded(): void {
   }
 
   if (cache.size >= MAX_ENTRIES) {
-    const sorted = [...cache.entries()].sort((a, b) => a[1]._createdAt - b[1]._createdAt);
+    const sorted = [...cache.entries()].toSorted((a, b) => a[1]._createdAt - b[1]._createdAt);
     const toRemove = sorted.slice(0, cache.size - MAX_ENTRIES + 1000);
     for (const [key] of toRemove) {
       cache.delete(key);
@@ -206,7 +218,9 @@ export function setRefIndex(refIdx: string, entry: RefIndexEntry): void {
 export function getRefIndex(refIdx: string): RefIndexEntry | null {
   const store = loadFromFile();
   const entry = store.get(refIdx);
-  if (!entry) return null;
+  if (!entry) {
+    return null;
+  }
 
   if (Date.now() - entry._createdAt > TTL_MS) {
     store.delete(refIdx);

--- a/extensions/qqbot/src/reply-dispatcher.ts
+++ b/extensions/qqbot/src/reply-dispatcher.ts
@@ -27,6 +27,7 @@ import {
   audioFileToSilkBase64,
   formatDuration,
 } from "./utils/audio-convert.js";
+import { formatUnknownError } from "./utils/debug-log.js";
 import { MAX_UPLOAD_SIZE, formatFileSize } from "./utils/file-utils.js";
 import {
   parseQQBotPayload,
@@ -117,7 +118,9 @@ export async function sendErrorToTarget(ctx: ReplyContext, errorText: string): P
   try {
     await sendTextToTarget(ctx, errorText);
   } catch (sendErr) {
-    ctx.log?.error(`[qqbot:${ctx.account.accountId}] Failed to send error message: ${sendErr}`);
+    ctx.log?.error(
+      `[qqbot:${ctx.account.accountId}] Failed to send error message: ${formatUnknownError(sendErr)}`,
+    );
   }
 }
 
@@ -130,17 +133,21 @@ export async function handleStructuredPayload(
   replyText: string,
   recordActivity: () => void,
 ): Promise<boolean> {
-  const { target, account, cfg, log } = ctx;
+  const { account, log } = ctx;
   const payloadResult = parseQQBotPayload(replyText);
 
-  if (!payloadResult.isPayload) return false;
+  if (!payloadResult.isPayload) {
+    return false;
+  }
 
   if (payloadResult.error) {
     log?.error(`[qqbot:${account.accountId}] Payload parse error: ${payloadResult.error}`);
     return true;
   }
 
-  if (!payloadResult.payload) return true;
+  if (!payloadResult.payload) {
+    return true;
+  }
 
   const parsedPayload = payloadResult.payload;
   log?.info(
@@ -157,7 +164,9 @@ export async function handleStructuredPayload(
         `[qqbot:${account.accountId}] Cron reminder confirmation sent, cronMessage: ${cronMessage}`,
       );
     } catch (err) {
-      log?.error(`[qqbot:${account.accountId}] Failed to send cron confirmation: ${err}`);
+      log?.error(
+        `[qqbot:${account.accountId}] Failed to send cron confirmation: ${formatUnknownError(err)}`,
+      );
     }
     recordActivity();
     return true;
@@ -177,15 +186,13 @@ export async function handleStructuredPayload(
     } else if (parsedPayload.mediaType === "file") {
       await handleFilePayload(ctx, parsedPayload);
     } else {
-      log?.error(
-        `[qqbot:${account.accountId}] Unknown media type: ${(parsedPayload as MediaPayload).mediaType}`,
-      );
+      log?.error(`[qqbot:${account.accountId}] Unknown media type in structured payload`);
     }
     recordActivity();
     return true;
   }
 
-  log?.error(`[qqbot:${account.accountId}] Unknown payload type: ${(parsedPayload as any).type}`);
+  log?.error(`[qqbot:${account.accountId}] Unknown payload type: ${parsedPayload.type}`);
   return true;
 }
 
@@ -216,7 +223,12 @@ function isInlineImageDataUrl(p: string): boolean {
 }
 
 function sanitizeForLog(value: string, maxLen = 200): string {
-  return value.replace(/[\r\n\t\0]/g, " ").slice(0, maxLen);
+  return value
+    .replaceAll("\r", " ")
+    .replaceAll("\n", " ")
+    .replaceAll("\t", " ")
+    .replaceAll("\u0000", " ")
+    .slice(0, maxLen);
 }
 
 function describeMediaTargetForLog(pathValue: string, isHttpUrl: boolean): string {
@@ -297,7 +309,9 @@ async function handleImagePayload(ctx: ReplyContext, payload: MediaPayload): Pro
         `[qqbot:${account.accountId}] Converted local image to Base64 (size: ${formatFileSize(fileBuffer.length)})`,
       );
     } catch (readErr) {
-      log?.error(`[qqbot:${account.accountId}] Failed to read local image: ${readErr}`);
+      log?.error(
+        `[qqbot:${account.accountId}] Failed to read local image: ${formatUnknownError(readErr)}`,
+      );
       return;
     }
   }
@@ -348,7 +362,7 @@ async function handleImagePayload(ctx: ReplyContext, payload: MediaPayload): Pro
       await sendTextToTarget(ctx, payload.caption);
     }
   } catch (err) {
-    log?.error(`[qqbot:${account.accountId}] Failed to send image: ${err}`);
+    log?.error(`[qqbot:${account.accountId}] Failed to send image: ${formatUnknownError(err)}`);
   }
 }
 
@@ -432,7 +446,7 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
             account.appId,
             token,
             target.senderId,
-            silkBase64!,
+            silkBase64,
             undefined,
             target.messageId,
             ttsText,
@@ -443,7 +457,7 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
             account.appId,
             token,
             target.groupOpenid,
-            silkBase64!,
+            silkBase64,
             undefined,
             target.messageId,
           );
@@ -464,7 +478,7 @@ async function handleAudioPayload(ctx: ReplyContext, payload: MediaPayload): Pro
     );
     log?.info(`[qqbot:${account.accountId}] Voice message sent`);
   } catch (err) {
-    log?.error(`[qqbot:${account.accountId}] TTS/voice send failed: ${err}`);
+    log?.error(`[qqbot:${account.accountId}] TTS/voice send failed: ${formatUnknownError(err)}`);
   }
 }
 
@@ -560,7 +574,7 @@ async function handleVideoPayload(ctx: ReplyContext, payload: MediaPayload): Pro
       await sendTextToTarget(ctx, payload.caption);
     }
   } catch (err) {
-    log?.error(`[qqbot:${account.accountId}] Video send failed: ${err}`);
+    log?.error(`[qqbot:${account.accountId}] Video send failed: ${formatUnknownError(err)}`);
   }
 }
 
@@ -652,6 +666,6 @@ async function handleFilePayload(ctx: ReplyContext, payload: MediaPayload): Prom
     );
     log?.info(`[qqbot:${account.accountId}] File message sent`);
   } catch (err) {
-    log?.error(`[qqbot:${account.accountId}] File send failed: ${err}`);
+    log?.error(`[qqbot:${account.accountId}] File send failed: ${formatUnknownError(err)}`);
   }
 }

--- a/extensions/qqbot/src/reply-dispatcher.ts
+++ b/extensions/qqbot/src/reply-dispatcher.ts
@@ -192,7 +192,7 @@ export async function handleStructuredPayload(
     return true;
   }
 
-  log?.error(`[qqbot:${account.accountId}] Unknown payload type: ${parsedPayload.type}`);
+  log?.error(`[qqbot:${account.accountId}] Unknown structured payload kind`);
   return true;
 }
 

--- a/extensions/qqbot/src/session-store.ts
+++ b/extensions/qqbot/src/session-store.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { debugLog, debugError } from "./utils/debug-log.js";
+import { debugLog, debugError, formatUnknownError } from "./utils/debug-log.js";
 
 /** Persisted gateway session state. */
 export interface SessionState {
@@ -84,7 +84,9 @@ export function loadSession(accountId: string, expectedAppId?: string): SessionS
     );
     return state;
   } catch (err) {
-    debugError(`[session-store] Failed to load session for ${accountId}: ${err}`);
+    debugError(
+      `[session-store] Failed to load session for ${accountId}: ${formatUnknownError(err)}`,
+    );
     return null;
   }
 }
@@ -152,7 +154,9 @@ function doSaveSession(state: SessionState): void {
       `[session-store] Saved session for ${state.accountId}: sessionId=${state.sessionId}, lastSeq=${state.lastSeq}`,
     );
   } catch (err) {
-    debugError(`[session-store] Failed to save session for ${state.accountId}: ${err}`);
+    debugError(
+      `[session-store] Failed to save session for ${state.accountId}: ${formatUnknownError(err)}`,
+    );
   }
 }
 
@@ -174,7 +178,9 @@ export function clearSession(accountId: string): void {
       debugLog(`[session-store] Cleared session for ${accountId}`);
     }
   } catch (err) {
-    debugError(`[session-store] Failed to clear session for ${accountId}: ${err}`);
+    debugError(
+      `[session-store] Failed to clear session for ${accountId}: ${formatUnknownError(err)}`,
+    );
   }
 }
 

--- a/extensions/qqbot/src/setup-surface.ts
+++ b/extensions/qqbot/src/setup-surface.ts
@@ -28,7 +28,8 @@ function clearQQBotCredentialField(
   field: QQBotEnvCredentialField,
 ): OpenClawConfig {
   const next = { ...cfg };
-  const qqbot = { ...((next.channels?.qqbot as Record<string, unknown>) || {}) };
+  const currentQQBot = next.channels?.qqbot as Record<string, unknown> | undefined;
+  const qqbot = { ...currentQQBot };
 
   const clearField = (entry: Record<string, unknown>) => {
     if (field === "appId") {
@@ -42,7 +43,8 @@ function clearQQBotCredentialField(
   if (accountId === DEFAULT_ACCOUNT_ID) {
     clearField(qqbot);
   } else {
-    const accounts = { ...((qqbot.accounts as Record<string, Record<string, unknown>>) || {}) };
+    const currentAccounts = qqbot.accounts as Record<string, Record<string, unknown>> | undefined;
+    const accounts = { ...currentAccounts };
     if (accounts[accountId]) {
       const entry = { ...accounts[accountId] };
       clearField(entry);

--- a/extensions/qqbot/src/setup.test.ts
+++ b/extensions/qqbot/src/setup.test.ts
@@ -91,8 +91,8 @@ describe("qqbot setup", () => {
     const account = qqbotSetupPlugin.config.resolveAccount?.(cfg, DEFAULT_ACCOUNT_ID);
 
     expect(account?.clientSecret).toBe("");
-    expect(qqbotSetupPlugin.config.isConfigured?.(account!, cfg)).toBe(true);
-    expect(qqbotSetupPlugin.config.describeAccount?.(account!, cfg)?.configured).toBe(true);
+    expect(qqbotSetupPlugin.config.isConfigured?.(account, cfg)).toBe(true);
+    expect(qqbotSetupPlugin.config.describeAccount?.(account, cfg)?.configured).toBe(true);
   });
 
   it("keeps the sibling credential when switching only AppSecret to env mode", async () => {
@@ -105,7 +105,7 @@ describe("qqbot setup", () => {
       },
     } as OpenClawConfig;
 
-    const next = await qqbotSetupWizard.credentials[1]!.applyUseEnv!({
+    const next = await qqbotSetupWizard.credentials[1].applyUseEnv!({
       cfg,
       accountId: DEFAULT_ACCOUNT_ID,
     });

--- a/extensions/qqbot/src/slash-commands.ts
+++ b/extensions/qqbot/src/slash-commands.ts
@@ -244,7 +244,9 @@ function getConfiguredLogFiles(): string[] {
   for (const cli of ["openclaw", "clawdbot", "moltbot"]) {
     try {
       const cfgPath = path.join(homeDir, `.${cli}`, `${cli}.json`);
-      if (!fs.existsSync(cfgPath)) continue;
+      if (!fs.existsSync(cfgPath)) {
+        continue;
+      }
       const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
       const logFile = cfg?.logging?.file;
       if (logFile && typeof logFile === "string") {
@@ -264,13 +266,17 @@ function collectCandidateLogDirs(): string[] {
   const dirs = new Set<string>();
 
   const pushDir = (p?: string) => {
-    if (!p) return;
+    if (!p) {
+      return;
+    }
     const normalized = path.resolve(p);
     dirs.add(normalized);
   };
 
   const pushStateDir = (stateDir?: string) => {
-    if (!stateDir) return;
+    if (!stateDir) {
+      return;
+    }
     pushDir(stateDir);
     pushDir(path.join(stateDir, "logs"));
   };
@@ -280,7 +286,9 @@ function collectCandidateLogDirs(): string[] {
   }
 
   for (const [key, value] of Object.entries(process.env)) {
-    if (!value) continue;
+    if (!value) {
+      continue;
+    }
     if (/STATE_DIR$/i.test(key) && /(OPENCLAW|CLAWDBOT|MOLTBOT)/i.test(key)) {
       pushStateDir(value);
     }
@@ -292,15 +300,23 @@ function collectCandidateLogDirs(): string[] {
   }
 
   const searchRoots = new Set<string>([homeDir, process.cwd(), path.dirname(process.cwd())]);
-  if (process.env.APPDATA) searchRoots.add(process.env.APPDATA);
-  if (process.env.LOCALAPPDATA) searchRoots.add(process.env.LOCALAPPDATA);
+  if (process.env.APPDATA) {
+    searchRoots.add(process.env.APPDATA);
+  }
+  if (process.env.LOCALAPPDATA) {
+    searchRoots.add(process.env.LOCALAPPDATA);
+  }
 
   for (const root of searchRoots) {
     try {
       const entries = fs.readdirSync(root, { withFileTypes: true });
       for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        if (!/(openclaw|clawdbot|moltbot)/i.test(entry.name)) continue;
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        if (!/(openclaw|clawdbot|moltbot)/i.test(entry.name)) {
+          continue;
+        }
         const base = path.join(root, entry.name);
         pushDir(base);
         pushDir(path.join(base, "logs"));
@@ -322,9 +338,15 @@ function collectCandidateLogDirs(): string[] {
   if (isWindows()) {
     // Windows temp locations.
     tmpRoots.add("C:\\tmp");
-    if (process.env.TEMP) tmpRoots.add(process.env.TEMP);
-    if (process.env.TMP) tmpRoots.add(process.env.TMP);
-    if (process.env.LOCALAPPDATA) tmpRoots.add(path.join(process.env.LOCALAPPDATA, "Temp"));
+    if (process.env.TEMP) {
+      tmpRoots.add(process.env.TEMP);
+    }
+    if (process.env.TMP) {
+      tmpRoots.add(process.env.TMP);
+    }
+    if (process.env.LOCALAPPDATA) {
+      tmpRoots.add(path.join(process.env.LOCALAPPDATA, "Temp"));
+    }
   } else {
     tmpRoots.add("/tmp");
   }
@@ -349,10 +371,14 @@ function collectRecentLogFiles(logDirs: string[]): LogCandidate[] {
 
   const pushFile = (filePath: string, sourceDir: string) => {
     const normalized = path.resolve(filePath);
-    if (dedupe.has(normalized)) return;
+    if (dedupe.has(normalized)) {
+      return;
+    }
     try {
       const stat = fs.statSync(normalized);
-      if (!stat.isFile()) return;
+      if (!stat.isFile()) {
+        return;
+      }
       dedupe.add(normalized);
       candidates.push({ filePath: normalized, sourceDir, mtimeMs: stat.mtimeMs });
     } catch {
@@ -375,9 +401,15 @@ function collectRecentLogFiles(logDirs: string[]): LogCandidate[] {
     try {
       const entries = fs.readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
-        if (!entry.isFile()) continue;
-        if (!/\.(log|txt)$/i.test(entry.name)) continue;
-        if (!/(gateway|openclaw|clawdbot|moltbot)/i.test(entry.name)) continue;
+        if (!entry.isFile()) {
+          continue;
+        }
+        if (!/\.(log|txt)$/i.test(entry.name)) {
+          continue;
+        }
+        if (!/(gateway|openclaw|clawdbot|moltbot)/i.test(entry.name)) {
+          continue;
+        }
         pushFile(path.join(dir, entry.name), dir);
       }
     } catch {
@@ -425,7 +457,9 @@ function tailFileLines(
       bytesRead += readSize;
 
       for (let i = 0; i < readSize; i++) {
-        if (buf[i] === 0x0a) newlineCount++;
+        if (buf[i] === 0x0a) {
+          newlineCount++;
+        }
       }
     }
 
@@ -505,7 +539,9 @@ function buildBotLogsResult(): SlashCommandResult {
         lines.push(...tail);
         totalIncluded += tail.length;
         totalOriginal += totalFileLines;
-        if (totalFileLines > MAX_LINES_PER_FILE) truncatedCount++;
+        if (totalFileLines > MAX_LINES_PER_FILE) {
+          truncatedCount++;
+        }
       }
     } catch {
       lines.push(`[Failed to read ${path.basename(logFile.filePath)}]`);
@@ -562,7 +598,9 @@ registerCommand({
  */
 export async function matchSlashCommand(ctx: SlashCommandContext): Promise<SlashCommandResult> {
   const content = ctx.rawContent.trim();
-  if (!content.startsWith("/")) return null;
+  if (!content.startsWith("/")) {
+    return null;
+  }
 
   // Parse the command name and trailing arguments.
   const spaceIdx = content.indexOf(" ");
@@ -570,7 +608,9 @@ export async function matchSlashCommand(ctx: SlashCommandContext): Promise<Slash
   const args = spaceIdx === -1 ? "" : content.slice(spaceIdx + 1).trim();
 
   const cmd = commands.get(cmdName);
-  if (!cmd) return null;
+  if (!cmd) {
+    return null;
+  }
 
   // Gate sensitive commands behind the allowFrom authorization check.
   if (cmd.requireAuth && !ctx.commandAuthorized) {

--- a/extensions/qqbot/src/stt.ts
+++ b/extensions/qqbot/src/stt.ts
@@ -14,30 +14,48 @@ export interface STTConfig {
   model: string;
 }
 
+interface ProviderConfig {
+  baseUrl?: string;
+  apiKey?: string;
+}
+
+interface ChannelSttConfig extends ProviderConfig {
+  enabled?: boolean;
+  provider?: string;
+  model?: string;
+}
+
+interface AudioModelConfig extends ProviderConfig {
+  provider?: string;
+  model?: string;
+}
+
 export function resolveSTTConfig(cfg: Record<string, unknown>): STTConfig | null {
-  const c = cfg as any;
+  const channels = cfg.channels as { qqbot?: { stt?: ChannelSttConfig } } | undefined;
+  const models = cfg.models as { providers?: Record<string, ProviderConfig> } | undefined;
+  const tools = cfg.tools as { media?: { audio?: { models?: AudioModelConfig[] } } } | undefined;
 
   // Prefer plugin-specific STT config.
-  const channelStt = c?.channels?.qqbot?.stt;
+  const channelStt = channels?.qqbot?.stt;
   if (channelStt && channelStt.enabled !== false) {
-    const providerId: string = channelStt?.provider || "openai";
-    const providerCfg = c?.models?.providers?.[providerId];
-    const baseUrl: string | undefined = channelStt?.baseUrl || providerCfg?.baseUrl;
-    const apiKey: string | undefined = channelStt?.apiKey || providerCfg?.apiKey;
-    const model: string = channelStt?.model || "whisper-1";
+    const providerId = channelStt.provider || "openai";
+    const providerCfg = models?.providers?.[providerId];
+    const baseUrl = channelStt.baseUrl || providerCfg?.baseUrl;
+    const apiKey = channelStt.apiKey || providerCfg?.apiKey;
+    const model = channelStt.model || "whisper-1";
     if (baseUrl && apiKey) {
       return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey, model };
     }
   }
 
   // Fall back to framework-level audio model config.
-  const audioModelEntry = c?.tools?.media?.audio?.models?.[0];
+  const audioModelEntry = tools?.media?.audio?.models?.[0];
   if (audioModelEntry) {
-    const providerId: string = audioModelEntry?.provider || "openai";
-    const providerCfg = c?.models?.providers?.[providerId];
-    const baseUrl: string | undefined = audioModelEntry?.baseUrl || providerCfg?.baseUrl;
-    const apiKey: string | undefined = audioModelEntry?.apiKey || providerCfg?.apiKey;
-    const model: string = audioModelEntry?.model || "whisper-1";
+    const providerId = audioModelEntry.provider || "openai";
+    const providerCfg = models?.providers?.[providerId];
+    const baseUrl = audioModelEntry.baseUrl || providerCfg?.baseUrl;
+    const apiKey = audioModelEntry.apiKey || providerCfg?.apiKey;
+    const model = audioModelEntry.model || "whisper-1";
     if (baseUrl && apiKey) {
       return { baseUrl: baseUrl.replace(/\/+$/, ""), apiKey, model };
     }
@@ -51,7 +69,9 @@ export async function transcribeAudio(
   cfg: Record<string, unknown>,
 ): Promise<string | null> {
   const sttCfg = resolveSTTConfig(cfg);
-  if (!sttCfg) return null;
+  if (!sttCfg) {
+    return null;
+  }
 
   const fileBuffer = fs.readFileSync(audioPath);
   const fileName = sanitizeFileName(path.basename(audioPath));

--- a/extensions/qqbot/src/tools/remind.ts
+++ b/extensions/qqbot/src/tools/remind.ts
@@ -96,7 +96,9 @@ function parseRelativeTime(timeStr: string): number | null {
 
 function isCronExpression(timeStr: string): boolean {
   const parts = timeStr.trim().split(/\s+/);
-  if (parts.length < 3 || parts.length > 6) return false;
+  if (parts.length < 3 || parts.length > 6) {
+    return false;
+  }
   // Each cron field must start with a digit, *, or a cron-special character.
   return parts.every((p) => /^[0-9*?/,LW#-]/.test(p));
 }
@@ -165,12 +167,18 @@ function buildCronJob(params: RemindParams) {
 
 function formatDelay(ms: number): string {
   const totalSeconds = Math.round(ms / 1000);
-  if (totalSeconds < 60) return `${totalSeconds}s`;
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
   const totalMinutes = Math.round(ms / 60_000);
-  if (totalMinutes < 60) return `${totalMinutes}m`;
+  if (totalMinutes < 60) {
+    return `${totalMinutes}m`;
+  }
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
-  if (minutes === 0) return `${hours}h`;
+  if (minutes === 0) {
+    return `${hours}h`;
+  }
   return `${hours}h${minutes}m`;
 }
 

--- a/extensions/qqbot/src/types.ts
+++ b/extensions/qqbot/src/types.ts
@@ -112,6 +112,10 @@ export interface GuildMessageEvent {
   guild_id: string;
   content: string;
   timestamp: string;
+  message_scene?: {
+    source: string;
+    ext?: string[];
+  };
   author: {
     id: string;
     username?: string;

--- a/extensions/qqbot/src/typing-keepalive.ts
+++ b/extensions/qqbot/src/typing-keepalive.ts
@@ -1,6 +1,7 @@
 /** Periodically refresh C2C typing state while a response is still in progress. */
 
 import { sendC2CInputNotify } from "./api.js";
+import { formatUnknownError } from "./utils/debug-log.js";
 
 // Refresh every 50s for the QQ API's 60s input-notify window.
 export const TYPING_INTERVAL_MS = 50_000;
@@ -25,7 +26,9 @@ export class TypingKeepAlive {
 
   /** Start periodic keep-alive sends. */
   start(): void {
-    if (this.stopped) return;
+    if (this.stopped) {
+      return;
+    }
     this.timer = setInterval(() => {
       if (this.stopped) {
         this.stop();
@@ -55,7 +58,9 @@ export class TypingKeepAlive {
         const token = await this.getToken();
         await sendC2CInputNotify(token, this.openid, this.msgId, TYPING_INPUT_SECOND);
       } catch {
-        this.log?.debug?.(`${this.logPrefix} Typing keep-alive failed for ${this.openid}: ${err}`);
+        this.log?.debug?.(
+          `${this.logPrefix} Typing keep-alive failed for ${this.openid}: ${formatUnknownError(err)}`,
+        );
       }
     }
   }

--- a/extensions/qqbot/src/update-checker.ts
+++ b/extensions/qqbot/src/update-checker.ts
@@ -44,7 +44,21 @@ let _log:
   | { info: (msg: string) => void; error: (msg: string) => void; debug?: (msg: string) => void }
   | undefined;
 
-function fetchJson(url: string, timeoutMs: number): Promise<any> {
+function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  return Object.values(value as Record<string, unknown>).every(
+    (entry) => typeof entry === "string",
+  );
+}
+
+function fetchJson(url: string, timeoutMs: number): Promise<unknown> {
   return new Promise((resolve, reject) => {
     const req = https.get(
       url,
@@ -80,10 +94,15 @@ async function fetchDistTags(): Promise<Record<string, string>> {
   for (const url of REGISTRIES) {
     try {
       const json = await fetchJson(url, 10_000);
-      const tags = json["dist-tags"];
-      if (tags && typeof tags === "object") return tags;
-    } catch (e: any) {
-      _log?.debug?.(`[qqbot:update-checker] ${url} failed: ${e.message}`);
+      const tags =
+        json && typeof json === "object"
+          ? (json as Record<string, unknown>)["dist-tags"]
+          : undefined;
+      if (isStringRecord(tags)) {
+        return tags;
+      }
+    } catch (e) {
+      _log?.debug?.(`[qqbot:update-checker] ${url} failed: ${formatUnknownError(e)}`);
     }
   }
   throw new Error("all registries failed");
@@ -118,7 +137,9 @@ export function triggerUpdateCheck(log?: {
   error: (msg: string) => void;
   debug?: (msg: string) => void;
 }): void {
-  if (log) _log = log;
+  if (log) {
+    _log = log;
+  }
   // Warm the cache without blocking startup.
   getUpdateInfo()
     .then((info) => {
@@ -136,8 +157,9 @@ export async function getUpdateInfo(): Promise<UpdateInfo> {
   try {
     const tags = await fetchDistTags();
     return buildUpdateInfo(tags);
-  } catch (err: any) {
-    _log?.debug?.(`[qqbot:update-checker] check failed: ${err.message}`);
+  } catch (err) {
+    const message = formatUnknownError(err);
+    _log?.debug?.(`[qqbot:update-checker] check failed: ${message}`);
     return {
       current: CURRENT_VERSION,
       latest: null,
@@ -145,7 +167,7 @@ export async function getUpdateInfo(): Promise<UpdateInfo> {
       alpha: null,
       hasUpdate: false,
       checkedAt: Date.now(),
-      error: err.message,
+      error: message,
     };
   }
 }
@@ -158,7 +180,13 @@ export async function checkVersionExists(version: string): Promise<boolean> {
     try {
       const url = `${baseUrl}/${version}`;
       const json = await fetchJson(url, 10_000);
-      if (json && json.version === version) return true;
+      if (
+        json &&
+        typeof json === "object" &&
+        (json as Record<string, unknown>).version === version
+      ) {
+        return true;
+      }
     } catch {
       // try next registry
     }
@@ -177,12 +205,20 @@ function compareVersions(a: string, b: string): number {
   // Compare the numeric core version first.
   for (let i = 0; i < 3; i++) {
     const diff = (pa.parts[i] || 0) - (pb.parts[i] || 0);
-    if (diff !== 0) return diff;
+    if (diff !== 0) {
+      return diff;
+    }
   }
   // For equal core versions, stable beats prerelease.
-  if (!pa.pre && pb.pre) return 1;
-  if (pa.pre && !pb.pre) return -1;
-  if (!pa.pre && !pb.pre) return 0;
+  if (!pa.pre && pb.pre) {
+    return 1;
+  }
+  if (pa.pre && !pb.pre) {
+    return -1;
+  }
+  if (!pa.pre && !pb.pre) {
+    return 0;
+  }
   // When both are prereleases, compare each prerelease segment in order.
   const aParts = pa.pre!.split(".");
   const bParts = pb.pre!.split(".");
@@ -193,11 +229,17 @@ function compareVersions(a: string, b: string): number {
     const bNum = Number(bP);
     // Compare numerically when both segments are numbers.
     if (!isNaN(aNum) && !isNaN(bNum)) {
-      if (aNum !== bNum) return aNum - bNum;
+      if (aNum !== bNum) {
+        return aNum - bNum;
+      }
     } else {
       // Fall back to lexical comparison for string segments.
-      if (aP < bP) return -1;
-      if (aP > bP) return 1;
+      if (aP < bP) {
+        return -1;
+      }
+      if (aP > bP) {
+        return 1;
+      }
     }
   }
   return 0;

--- a/extensions/qqbot/src/user-messages.ts
+++ b/extensions/qqbot/src/user-messages.ts
@@ -4,3 +4,5 @@
  * The QQ Bot plugin follows the same rule as Feishu: runtime errors are logged
  * but no extra plugin-layer user messages are injected.
  */
+
+export const QQBOT_USER_MESSAGES_DEFINED = true;

--- a/extensions/qqbot/src/utils/audio-convert.ts
+++ b/extensions/qqbot/src/utils/audio-convert.ts
@@ -9,7 +9,9 @@ type SilkWasm = typeof import("silk-wasm");
 let _silkWasmPromise: Promise<SilkWasm | null> | null = null;
 
 function loadSilkWasm(): Promise<SilkWasm | null> {
-  if (_silkWasmPromise) return _silkWasmPromise;
+  if (_silkWasmPromise) {
+    return _silkWasmPromise;
+  }
   _silkWasmPromise = import("silk-wasm").catch((err) => {
     debugWarn(
       `[audio-convert] silk-wasm not available; SILK encode/decode disabled (${err instanceof Error ? err.message : String(err)})`,
@@ -130,7 +132,9 @@ export function formatDuration(durationMs: number): string {
 export function isAudioFile(filePath: string, mimeType?: string): boolean {
   // Prefer MIME when extension data is missing or misleading.
   if (mimeType) {
-    if (mimeType === "voice" || mimeType.startsWith("audio/")) return true;
+    if (mimeType === "voice" || mimeType.startsWith("audio/")) {
+      return true;
+    }
   }
   const ext = path.extname(filePath).toLowerCase();
   return [
@@ -190,23 +194,40 @@ export interface TTSConfig {
   speed?: number;
 }
 
+interface ProviderTTSConfig {
+  baseUrl?: string;
+  apiKey?: string;
+  authStyle?: string;
+  queryParams?: Record<string, string>;
+  speed?: number;
+}
+
+interface TTSBlock extends ProviderTTSConfig {
+  enabled?: boolean;
+  provider?: string;
+  model?: string;
+  voice?: string;
+}
+
 function resolveTTSFromBlock(
-  block: Record<string, any>,
-  providerCfg: Record<string, any> | undefined,
+  block: TTSBlock,
+  providerCfg: ProviderTTSConfig | undefined,
 ): TTSConfig | null {
   const baseUrl: string | undefined = block?.baseUrl || providerCfg?.baseUrl;
   const apiKey: string | undefined = block?.apiKey || providerCfg?.apiKey;
   const model: string = block?.model || "tts-1";
   const voice: string = block?.voice || "alloy";
-  if (!baseUrl || !apiKey) return null;
+  if (!baseUrl || !apiKey) {
+    return null;
+  }
 
   const authStyle =
     (block?.authStyle || providerCfg?.authStyle) === "api-key"
       ? ("api-key" as const)
       : ("bearer" as const);
   const queryParams: Record<string, string> = {
-    ...(providerCfg?.queryParams ?? {}),
-    ...(block?.queryParams ?? {}),
+    ...providerCfg?.queryParams,
+    ...block?.queryParams,
   };
   const speed: number | undefined = block?.speed;
 
@@ -222,25 +243,31 @@ function resolveTTSFromBlock(
 }
 
 export function resolveTTSConfig(cfg: Record<string, unknown>): TTSConfig | null {
-  const c = cfg as any;
+  const channels = cfg.channels as { qqbot?: { tts?: TTSBlock } } | undefined;
+  const messages = cfg.messages as { tts?: Record<string, unknown> } | undefined;
+  const models = cfg.models as { providers?: Record<string, ProviderTTSConfig> } | undefined;
 
   // Prefer plugin-specific TTS config first.
-  const channelTts = c?.channels?.qqbot?.tts;
+  const channelTts = channels?.qqbot?.tts;
   if (channelTts && channelTts.enabled !== false) {
-    const providerId: string = channelTts?.provider || "openai";
-    const providerCfg = c?.models?.providers?.[providerId];
+    const providerId = channelTts.provider || "openai";
+    const providerCfg = models?.providers?.[providerId];
     const result = resolveTTSFromBlock(channelTts, providerCfg);
-    if (result) return result;
+    if (result) {
+      return result;
+    }
   }
 
   // Fall back to framework-level TTS config.
-  const msgTts = c?.messages?.tts;
+  const msgTts = messages?.tts;
   if (msgTts && msgTts.auto !== "off" && msgTts.auto !== "disabled") {
-    const providerId: string = msgTts?.provider || "openai";
-    const providerBlock = msgTts?.[providerId];
-    const providerCfg = c?.models?.providers?.[providerId];
-    const result = resolveTTSFromBlock(providerBlock ?? {}, providerCfg);
-    if (result) return result;
+    const providerId = typeof msgTts.provider === "string" ? msgTts.provider : "openai";
+    const providerBlock = (msgTts[providerId] as TTSBlock | undefined) ?? {};
+    const providerCfg = models?.providers?.[providerId];
+    const result = resolveTTSFromBlock(providerBlock, providerCfg);
+    if (result) {
+      return result;
+    }
   }
 
   return null;
@@ -258,9 +285,13 @@ export function resolveTTSConfig(cfg: Record<string, unknown>): TTSConfig | null
  */
 export function isGlobalTTSAvailable(cfg: OpenClawConfig): boolean {
   const msgTts = cfg.messages?.tts;
-  if (!msgTts) return false;
+  if (!msgTts) {
+    return false;
+  }
   // Framework canonical field takes precedence.
-  if (msgTts.auto) return msgTts.auto !== "off";
+  if (msgTts.auto) {
+    return msgTts.auto !== "off";
+  }
   // Legacy compat: `enabled: true` → "always", absent/false → "off".
   return msgTts.enabled === true;
 }
@@ -427,7 +458,9 @@ export async function textToSilk(
   const { pcmBuffer, sampleRate } = await textToSpeechPCM(text, ttsCfg);
   const { silkBuffer, duration } = await pcmToSilk(pcmBuffer, sampleRate);
 
-  if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir, { recursive: true });
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
   const silkPath = path.join(outputDir, `tts-${Date.now()}.silk`);
   fs.writeFileSync(silkPath, silkBuffer);
 
@@ -446,7 +479,9 @@ export async function audioFileToSilkBase64(
   filePath: string,
   directUploadFormats?: string[],
 ): Promise<string | null> {
-  if (!fs.existsSync(filePath)) return null;
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
 
   const buf = fs.readFileSync(filePath);
   if (buf.length === 0) {
@@ -764,18 +799,30 @@ function normalizeFormats(formats: string[]): string[] {
 
 /** Parse standard PCM WAV as a no-ffmpeg fallback. */
 function parseWavFallback(buf: Buffer): Buffer | null {
-  if (buf.length < 44) return null;
-  if (buf.toString("ascii", 0, 4) !== "RIFF") return null;
-  if (buf.toString("ascii", 8, 12) !== "WAVE") return null;
-  if (buf.toString("ascii", 12, 16) !== "fmt ") return null;
+  if (buf.length < 44) {
+    return null;
+  }
+  if (buf.toString("ascii", 0, 4) !== "RIFF") {
+    return null;
+  }
+  if (buf.toString("ascii", 8, 12) !== "WAVE") {
+    return null;
+  }
+  if (buf.toString("ascii", 12, 16) !== "fmt ") {
+    return null;
+  }
 
   const audioFormat = buf.readUInt16LE(20);
-  if (audioFormat !== 1) return null;
+  if (audioFormat !== 1) {
+    return null;
+  }
 
   const channels = buf.readUInt16LE(22);
   const sampleRate = buf.readUInt32LE(24);
   const bitsPerSample = buf.readUInt16LE(34);
-  if (bitsPerSample !== 16) return null;
+  if (bitsPerSample !== 16) {
+    return null;
+  }
 
   // Find the PCM data chunk.
   let offset = 36;
@@ -795,7 +842,9 @@ function parseWavFallback(buf: Buffer): Buffer | null {
         const outV = new DataView(mono.buffer, mono.byteOffset, mono.byteLength);
         for (let i = 0; i < samplesPerCh; i++) {
           let sum = 0;
-          for (let ch = 0; ch < channels; ch++) sum += inV.getInt16((i * channels + ch) * 2, true);
+          for (let ch = 0; ch < channels; ch++) {
+            sum += inV.getInt16((i * channels + ch) * 2, true);
+          }
           outV.setInt16(i * 2, Math.max(-32768, Math.min(32767, Math.round(sum / channels))), true);
         }
         pcm = mono;

--- a/extensions/qqbot/src/utils/debug-log.ts
+++ b/extensions/qqbot/src/utils/debug-log.ts
@@ -7,6 +7,10 @@
 
 const isDebug = () => !!process.env.QQBOT_DEBUG;
 
+export function formatUnknownError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export function debugLog(...args: unknown[]): void {
   if (isDebug()) {
     console.log(...args);

--- a/extensions/qqbot/src/utils/file-utils.ts
+++ b/extensions/qqbot/src/utils/file-utils.ts
@@ -66,8 +66,12 @@ export function isLargeFile(sizeBytes: number): boolean {
 
 /** Format a byte count into a human-readable size string. */
 export function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  }
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
@@ -111,7 +115,9 @@ export async function downloadFile(
     }
 
     const resp = await fetch(url, { redirect: "follow" });
-    if (!resp.ok || !resp.body) return null;
+    if (!resp.ok || !resp.body) {
+      return null;
+    }
 
     let filename = originalFilename?.trim() || "";
     if (!filename) {

--- a/extensions/qqbot/src/utils/image-size.ts
+++ b/extensions/qqbot/src/utils/image-size.ts
@@ -5,7 +5,7 @@
  */
 
 import { Buffer } from "buffer";
-import { debugLog } from "./debug-log.js";
+import { debugLog, formatUnknownError } from "./debug-log.js";
 
 export interface ImageSize {
   width: number;
@@ -20,7 +20,9 @@ export const DEFAULT_IMAGE_SIZE: ImageSize = { width: 512, height: 512 };
  */
 function parsePngSize(buffer: Buffer): ImageSize | null {
   // PNG signature: 89 50 4E 47 0D 0A 1A 0A
-  if (buffer.length < 24) return null;
+  if (buffer.length < 24) {
+    return null;
+  }
   if (buffer[0] !== 0x89 || buffer[1] !== 0x50 || buffer[2] !== 0x4e || buffer[3] !== 0x47) {
     return null;
   }
@@ -33,7 +35,9 @@ function parsePngSize(buffer: Buffer): ImageSize | null {
 /** Parse image dimensions from JPEG SOF0/SOF2 markers. */
 function parseJpegSize(buffer: Buffer): ImageSize | null {
   // JPEG signature: FF D8 FF
-  if (buffer.length < 4) return null;
+  if (buffer.length < 4) {
+    return null;
+  }
   if (buffer[0] !== 0xff || buffer[1] !== 0xd8) {
     return null;
   }
@@ -70,7 +74,9 @@ function parseJpegSize(buffer: Buffer): ImageSize | null {
 
 /** Parse image dimensions from the GIF header. */
 function parseGifSize(buffer: Buffer): ImageSize | null {
-  if (buffer.length < 10) return null;
+  if (buffer.length < 10) {
+    return null;
+  }
   const signature = buffer.toString("ascii", 0, 6);
   if (signature !== "GIF87a" && signature !== "GIF89a") {
     return null;
@@ -82,7 +88,9 @@ function parseGifSize(buffer: Buffer): ImageSize | null {
 
 /** Parse image dimensions from WebP headers. */
 function parseWebpSize(buffer: Buffer): ImageSize | null {
-  if (buffer.length < 30) return null;
+  if (buffer.length < 30) {
+    return null;
+  }
 
   // Check the RIFF and WEBP signatures.
   const riff = buffer.toString("ascii", 0, 4);
@@ -174,7 +182,7 @@ export async function getImageSizeFromUrl(
 
     return size;
   } catch (err) {
-    debugLog(`[image-size] Error fetching ${url.slice(0, 60)}...: ${err}`);
+    debugLog(`[image-size] Error fetching ${url.slice(0, 60)}...: ${formatUnknownError(err)}`);
     return null;
   }
 }
@@ -198,7 +206,7 @@ export function getImageSizeFromDataUrl(dataUrl: string): ImageSize | null {
 
     return size;
   } catch (err) {
-    debugLog(`[image-size] Error parsing Base64: ${err}`);
+    debugLog(`[image-size] Error parsing Base64: ${formatUnknownError(err)}`);
     return null;
   }
 }

--- a/extensions/qqbot/src/utils/media-tags.ts
+++ b/extensions/qqbot/src/utils/media-tags.ts
@@ -108,7 +108,9 @@ export function normalizeMediaTags(text: string): string {
   let cleaned = text.replace(SELF_CLOSING_TAG_REGEX, (_match, rawTag: string, content: string) => {
     const tag = resolveTagName(rawTag);
     const trimmed = content.trim();
-    if (!trimmed) return _match;
+    if (!trimmed) {
+      return _match;
+    }
     const expanded = expandTilde(trimmed);
     return `<${tag}>${expanded}</${tag}>`;
   });
@@ -124,7 +126,9 @@ export function normalizeMediaTags(text: string): string {
   return cleaned.replace(FUZZY_MEDIA_TAG_REGEX, (_match, rawTag: string, content: string) => {
     const tag = resolveTagName(rawTag);
     const trimmed = content.trim();
-    if (!trimmed) return _match;
+    if (!trimmed) {
+      return _match;
+    }
     const expanded = expandTilde(trimmed);
     return `<${tag}>${expanded}</${tag}>`;
   });

--- a/extensions/qqbot/src/utils/payload.ts
+++ b/extensions/qqbot/src/utils/payload.ts
@@ -125,7 +125,7 @@ export function decodeCronPayload(message: string): {
     if (payload.type !== "cron_reminder") {
       return {
         isCronPayload: true,
-        error: `Expected type cron_reminder but got ${payload.type}`,
+        error: "Expected type cron_reminder",
       };
     }
 

--- a/extensions/qqbot/src/utils/platform.ts
+++ b/extensions/qqbot/src/utils/platform.ts
@@ -17,7 +17,9 @@ export type PlatformType = "darwin" | "linux" | "win32" | "other";
 
 export function getPlatform(): PlatformType {
   const p = process.platform;
-  if (p === "darwin" || p === "linux" || p === "win32") return p;
+  if (p === "darwin" || p === "linux" || p === "win32") {
+    return p;
+  }
   return "other";
 }
 
@@ -38,12 +40,16 @@ export function isWindows(): boolean {
 export function getHomeDir(): string {
   try {
     const home = os.homedir();
-    if (home && fs.existsSync(home)) return home;
+    if (home && fs.existsSync(home)) {
+      return home;
+    }
   } catch {}
 
   // Fall back to environment variables.
   const envHome = process.env.HOME || process.env.USERPROFILE;
-  if (envHome && fs.existsSync(envHome)) return envHome;
+  if (envHome && fs.existsSync(envHome)) {
+    return envHome;
+  }
 
   // Final fallback.
   return os.tmpdir();
@@ -89,8 +95,12 @@ export function getTempDir(): string {
  * Supports `~` and `~/...`. Other forms are returned unchanged.
  */
 export function expandTilde(p: string): string {
-  if (!p) return p;
-  if (p === "~") return getHomeDir();
+  if (!p) {
+    return p;
+  }
+  if (p === "~") {
+    return getHomeDir();
+  }
   if (p.startsWith("~/") || p.startsWith("~\\")) {
     return path.join(getHomeDir(), p.slice(2));
   }
@@ -194,7 +204,9 @@ export function resolveQQBotPayloadLocalFilePath(p: string): string | null {
  * control characters.
  */
 export function sanitizeFileName(name: string): string {
-  if (!name) return name;
+  if (!name) {
+    return name;
+  }
 
   let result = name.trim();
 
@@ -211,7 +223,14 @@ export function sanitizeFileName(name: string): string {
   result = result.normalize("NFC");
 
   // Drop ASCII control characters while keeping printable Unicode content.
-  result = result.replace(/[\x00-\x1F\x7F]/g, "");
+  let sanitized = "";
+  for (const char of result) {
+    const code = char.charCodeAt(0);
+    if (code >= 0x20 && code !== 0x7f) {
+      sanitized += char;
+    }
+  }
+  result = sanitized;
 
   return result;
 }
@@ -222,27 +241,45 @@ export function sanitizeFileName(name: string): string {
  * Return true when the string looks like a local filesystem path rather than a URL.
  */
 export function isLocalPath(p: string): boolean {
-  if (!p) return false;
+  if (!p) {
+    return false;
+  }
   // Local file URI.
-  if (p.startsWith("file://")) return true;
+  if (p.startsWith("file://")) {
+    return true;
+  }
   // Tilde-based Unix path.
-  if (p === "~" || p.startsWith("~/") || p.startsWith("~\\")) return true;
+  if (p === "~" || p.startsWith("~/") || p.startsWith("~\\")) {
+    return true;
+  }
   // Unix absolute path.
-  if (p.startsWith("/")) return true;
+  if (p.startsWith("/")) {
+    return true;
+  }
   // Windows drive-letter path.
-  if (/^[a-zA-Z]:[\\/]/.test(p)) return true;
+  if (/^[a-zA-Z]:[\\/]/.test(p)) {
+    return true;
+  }
   // Windows UNC path.
-  if (p.startsWith("\\\\")) return true;
+  if (p.startsWith("\\\\")) {
+    return true;
+  }
   // POSIX relative path.
-  if (p.startsWith("./") || p.startsWith("../")) return true;
+  if (p.startsWith("./") || p.startsWith("../")) {
+    return true;
+  }
   // Windows relative path.
-  if (p.startsWith(".\\") || p.startsWith("..\\")) return true;
+  if (p.startsWith(".\\") || p.startsWith("..\\")) {
+    return true;
+  }
   return false;
 }
 
 /** Looser local-path heuristic used for markdown-extracted paths. */
 export function looksLikeLocalPath(p: string): boolean {
-  if (isLocalPath(p)) return true;
+  if (isLocalPath(p)) {
+    return true;
+  }
   return /^(?:Users|home|tmp|var|private|[A-Z]:)/i.test(p);
 }
 
@@ -251,8 +288,12 @@ let _ffmpegCheckPromise: Promise<string | null> | null = null;
 
 /** Detect ffmpeg and return an executable path when available. */
 export function detectFfmpeg(): Promise<string | null> {
-  if (_ffmpegPath !== undefined) return Promise.resolve(_ffmpegPath);
-  if (_ffmpegCheckPromise) return _ffmpegCheckPromise;
+  if (_ffmpegPath !== undefined) {
+    return Promise.resolve(_ffmpegPath);
+  }
+  if (_ffmpegCheckPromise) {
+    return _ffmpegCheckPromise;
+  }
 
   _ffmpegCheckPromise = (async () => {
     const envPath = process.env.FFMPEG_PATH;
@@ -326,7 +367,9 @@ let _silkWasmAvailable: boolean | null = null;
 
 /** Check whether silk-wasm can run in the current environment. */
 export async function checkSilkWasmAvailable(): Promise<boolean> {
-  if (_silkWasmAvailable !== null) return _silkWasmAvailable;
+  if (_silkWasmAvailable !== null) {
+    return _silkWasmAvailable;
+  }
 
   try {
     const { isSilk } = await import("silk-wasm");

--- a/extensions/qqbot/src/utils/text-parsing.ts
+++ b/extensions/qqbot/src/utils/text-parsing.ts
@@ -2,7 +2,9 @@ import type { RefAttachmentSummary } from "../ref-index-store.js";
 
 /** Replace QQ face tags with readable text labels. */
 export function parseFaceTags(text: string): string {
-  if (!text) return text;
+  if (!text) {
+    return text;
+  }
 
   return text.replace(/<faceType=\d+,faceId="[^"]*",ext="([^"]*)">/g, (_match, ext: string) => {
     try {
@@ -18,7 +20,9 @@ export function parseFaceTags(text: string): string {
 
 /** Remove internal framework markers before sending text outward. */
 export function filterInternalMarkers(text: string): string {
-  if (!text) return text;
+  if (!text) {
+    return text;
+  }
 
   let result = text.replace(/\[\[[a-z_]+:\s*[^\]]*\]\]/gi, "");
   result = result.replace(/@(?:image|voice|video|file):[a-zA-Z0-9_.-]+/g, "");
@@ -29,7 +33,9 @@ export function filterInternalMarkers(text: string): string {
 
 /** Parse quote-related ref indices from `message_scene.ext`. */
 export function parseRefIndices(ext?: string[]): { refMsgIdx?: string; msgIdx?: string } {
-  if (!ext || ext.length === 0) return {};
+  if (!ext || ext.length === 0) {
+    return {};
+  }
   let refMsgIdx: string | undefined;
   let msgIdx: string | undefined;
   for (const item of ext) {
@@ -52,15 +58,26 @@ export function buildAttachmentSummaries(
   }>,
   localPaths?: Array<string | null>,
 ): RefAttachmentSummary[] | undefined {
-  if (!attachments || attachments.length === 0) return undefined;
+  if (!attachments || attachments.length === 0) {
+    return undefined;
+  }
   return attachments.map((att, idx) => {
     const ct = att.content_type?.toLowerCase() ?? "";
     let type: RefAttachmentSummary["type"] = "unknown";
-    if (ct.startsWith("image/")) type = "image";
-    else if (ct === "voice" || ct.startsWith("audio/") || ct.includes("silk") || ct.includes("amr"))
+    if (ct.startsWith("image/")) {
+      type = "image";
+    } else if (
+      ct === "voice" ||
+      ct.startsWith("audio/") ||
+      ct.includes("silk") ||
+      ct.includes("amr")
+    ) {
       type = "voice";
-    else if (ct.startsWith("video/")) type = "video";
-    else if (ct.startsWith("application/") || ct.startsWith("text/")) type = "file";
+    } else if (ct.startsWith("video/")) {
+      type = "video";
+    } else if (ct.startsWith("application/") || ct.startsWith("text/")) {
+      type = "file";
+    }
     return {
       type,
       filename: att.filename,

--- a/extensions/qqbot/src/utils/upload-cache.ts
+++ b/extensions/qqbot/src/utils/upload-cache.ts
@@ -4,7 +4,6 @@
  */
 
 import * as crypto from "node:crypto";
-import * as fs from "node:fs";
 import { debugLog } from "./debug-log.js";
 
 interface CacheEntry {
@@ -42,7 +41,9 @@ export function getCachedFileInfo(
   const key = buildCacheKey(contentHash, scope, targetId, fileType);
   const entry = cache.get(key);
 
-  if (!entry) return null;
+  if (!entry) {
+    return null;
+  }
 
   if (Date.now() >= entry.expiresAt) {
     cache.delete(key);
@@ -73,7 +74,7 @@ export function setCachedFileInfo(
     if (cache.size >= MAX_CACHE_SIZE) {
       const keys = Array.from(cache.keys());
       for (let i = 0; i < keys.length / 2; i++) {
-        cache.delete(keys[i]!);
+        cache.delete(keys[i]);
       }
     }
   }

--- a/extensions/searxng/src/searxng-search-provider.test.ts
+++ b/extensions/searxng/src/searxng-search-provider.test.ts
@@ -27,10 +27,10 @@ describe("searxng web search provider", () => {
     runSearxngSearch.mockImplementation(async (params: Record<string, unknown>) => params);
   });
 
-  it("registers a setup-visible web search provider", () => {
+  it("registers a setup-visible web search provider", async () => {
     const webSearchProviders: unknown[] = [];
 
-    plugin.register({
+    await plugin.register({
       registerWebSearchProvider(provider: unknown) {
         webSearchProviders.push(provider);
       },

--- a/extensions/xai/code-execution.ts
+++ b/extensions/xai/code-execution.ts
@@ -10,14 +10,6 @@ import {
 } from "./src/code-execution-shared.js";
 import { isXaiToolEnabled, resolveXaiToolApiKey } from "./src/tool-auth-shared.js";
 
-type XaiPluginConfig = NonNullable<
-  NonNullable<OpenClawConfig["plugins"]>["entries"]
->["xai"] extends {
-  config?: infer Config;
-}
-  ? Config
-  : undefined;
-
 type CodeExecutionConfig = {
   enabled?: boolean;
   model?: string;

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -84,8 +84,9 @@ describe("xai provider plugin", () => {
     expect(capturedModelId).toBe("grok-4-fast");
     expect(capturedPayload).toMatchObject({ tool_stream: true });
     expect(capturedPayload).not.toHaveProperty("reasoning");
-    expect(
-      (capturedPayload?.tools as Array<{ function?: Record<string, unknown> }>)[0]?.function,
-    ).not.toHaveProperty("strict");
+    const tools = Array.isArray(capturedPayload?.tools)
+      ? (capturedPayload.tools as Array<{ function?: Record<string, unknown> }>)
+      : [];
+    expect(tools[0]?.function).not.toHaveProperty("strict");
   });
 });

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -200,7 +200,7 @@ export default defineSingleProviderPluginEntry({
         return extraParams;
       }
       return {
-        ...(extraParams ?? {}),
+        ...extraParams,
         tool_stream: true,
       };
     },
@@ -210,7 +210,7 @@ export default defineSingleProviderPluginEntry({
     // private config layout. Callers may receive a real key from the active
     // runtime snapshot or a non-secret SecretRef marker from source config.
     resolveSyntheticAuth: ({ config }) => {
-      const fallbackAuth = resolveFallbackXaiAuth(config as OpenClawConfig | undefined);
+      const fallbackAuth = resolveFallbackXaiAuth(config);
       if (!fallbackAuth) {
         return undefined;
       }

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -243,14 +243,11 @@ export function createXaiWebSearchProvider(): WebSearchProviderPlugin {
             model: resolveXaiWebSearchModel(searchConfig),
             apiKey,
             timeoutSeconds: resolveTimeoutSeconds(
-              (searchConfig?.timeoutSeconds as number | undefined) ?? undefined,
+              searchConfig?.timeoutSeconds,
               DEFAULT_TIMEOUT_SECONDS,
             ),
             inlineCitations: resolveXaiInlineCitations(searchConfig),
-            cacheTtlMs: resolveCacheTtlMs(
-              (searchConfig?.cacheTtlMinutes as number | undefined) ?? undefined,
-              DEFAULT_CACHE_TTL_MINUTES,
-            ),
+            cacheTtlMs: resolveCacheTtlMs(searchConfig?.cacheTtlMinutes, DEFAULT_CACHE_TTL_MINUTES),
           });
         },
       };

--- a/extensions/xai/x-search.ts
+++ b/extensions/xai/x-search.ts
@@ -11,10 +11,7 @@ import {
   writeCache,
 } from "openclaw/plugin-sdk/provider-web-search";
 import { isXaiToolEnabled, resolveXaiToolApiKey } from "./src/tool-auth-shared.js";
-import {
-  resolveEffectiveXSearchConfig,
-  resolveLegacyXSearchConfig,
-} from "./src/x-search-config.js";
+import { resolveEffectiveXSearchConfig } from "./src/x-search-config.js";
 import {
   buildXaiXSearchPayload,
   requestXaiXSearch,
@@ -198,10 +195,9 @@ export function createXSearchTool(options?: {
         enableImageUnderstanding: args.enable_image_understanding === true,
         enableVideoUnderstanding: args.enable_video_understanding === true,
       };
-      const xSearchConfigRecord = xSearchConfig as Record<string, unknown> | undefined;
-      const model = resolveXaiXSearchModel(xSearchConfigRecord);
-      const inlineCitations = resolveXaiXSearchInlineCitations(xSearchConfigRecord);
-      const maxTurns = resolveXaiXSearchMaxTurns(xSearchConfigRecord);
+      const model = resolveXaiXSearchModel(xSearchConfig);
+      const inlineCitations = resolveXaiXSearchInlineCitations(xSearchConfig);
+      const maxTurns = resolveXaiXSearchMaxTurns(xSearchConfig);
       const cacheKey = buildXSearchCacheKey({
         query,
         model,

--- a/scripts/run-oxlint.mjs
+++ b/scripts/run-oxlint.mjs
@@ -1,11 +1,26 @@
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalOxlintPolicy,
 } from "./lib/local-heavy-check-runtime.mjs";
 
-const { args: finalArgs, env } = applyLocalOxlintPolicy(process.argv.slice(2), process.env);
+const EXTENSION_ALLOWLIST_PATH = path.resolve(".oxlint-extension-allowlist.json");
+const FLAGS_WITH_VALUES = new Set([
+  "--config",
+  "-c",
+  "--format",
+  "--ignore-pattern",
+  "--threads",
+  "-t",
+  "--tsconfig",
+  "-p",
+]);
+
+const rawArgs = process.argv.slice(2);
+const allowlistedArgs = applyDefaultExtensionAllowlist(rawArgs);
+const { args: finalArgs, env } = applyLocalOxlintPolicy(allowlistedArgs, process.env);
 
 const oxlintPath = path.resolve("node_modules", ".bin", "oxlint");
 const releaseLock = acquireLocalHeavyCheckLockSync({
@@ -28,4 +43,79 @@ try {
   process.exit(result.status ?? 1);
 } finally {
   releaseLock();
+}
+
+function applyDefaultExtensionAllowlist(args) {
+  if (hasExplicitTargets(args)) {
+    return [...args];
+  }
+
+  const allowlistedExtensions = loadAllowlistedExtensions();
+  if (allowlistedExtensions.size === 0) {
+    return [...args];
+  }
+
+  const nextArgs = [...args];
+  for (const extensionDir of listExtensionDirs()) {
+    if (allowlistedExtensions.has(extensionDir)) {
+      continue;
+    }
+    insertBeforeSeparator(nextArgs, "--ignore-pattern", `${extensionDir}/**`);
+  }
+  return nextArgs;
+}
+
+function hasExplicitTargets(args) {
+  let expectsValue = false;
+  for (const arg of args) {
+    if (expectsValue) {
+      expectsValue = false;
+      continue;
+    }
+
+    if (arg === "--") {
+      continue;
+    }
+
+    const [flag] = arg.split("=", 1);
+    if (arg.startsWith("-")) {
+      if (!arg.includes("=") && FLAGS_WITH_VALUES.has(flag)) {
+        expectsValue = true;
+      }
+      continue;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+function loadAllowlistedExtensions() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(EXTENSION_ALLOWLIST_PATH, "utf8"));
+    const configured = Array.isArray(parsed?.extensions) ? parsed.extensions : [];
+    return new Set(
+      configured
+        .filter((value) => typeof value === "string")
+        .map((value) => value.replaceAll(path.sep, "/")),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+function listExtensionDirs() {
+  const extensionsDir = path.resolve("extensions");
+  return fs
+    .readdirSync(extensionsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.posix.join("extensions", entry.name))
+    .toSorted();
+}
+
+function insertBeforeSeparator(args, ...items) {
+  const separatorIndex = args.indexOf("--");
+  const insertIndex = separatorIndex === -1 ? args.length : separatorIndex;
+  args.splice(insertIndex, 0, ...items);
 }

--- a/tsconfig.oxlint.json
+++ b/tsconfig.oxlint.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*", "ui/**/*", "packages/**/*", "test/**/*"],
-  "exclude": ["node_modules", "dist", "extensions"]
+  "include": ["src/**/*", "ui/**/*", "packages/**/*", "extensions/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: bundled extensions were effectively outside the default oxlint path, so extension boundary work could look clean in CI while `extensions/*` still carried lint debt.
- Why it matters: that made it easy for extension boundary regressions to hide, and it also meant editor warnings and repo lint could disagree in confusing ways.
- What changed: I enabled extension linting, fixed the lint findings in `xai`, `qqbot`, and `matrix`, cleaned a few small one-off extension findings, and then changed the default lint entrypoint to allowlist only the extension directories that are intentionally green today.
- What did NOT change (scope boundary): I did not widen default lint to every currently-green extension yet, and I intentionally left still-dirty extension directories excluded from the default repo lint until we widen the allowlist on purpose.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: default repo lint included `extensions/**/*` in type-aware analysis but did not have a sustainable default policy for partially-clean bundled extensions, so extension lint work either stayed disabled entirely or would fail the repo as soon as all extension directories were included.
- Missing detection / guardrail: we did not have a repo-owned mechanism for saying "default lint should include only the bundled extensions we have intentionally cleaned so far."
- Contributing context (if known): once extension linting was turned on, the first pass surfaced a large backlog across bundled extensions, which made an incremental allowlist approach the safest way to keep default lint useful while we clean the rest one extension at a time.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `scripts/run-oxlint.mjs` via `pnpm lint`, plus the scoped extension tests for `xai`, `qqbot`, and `matrix`
- Scenario the test should lock in: default repo lint should include only the explicitly allowlisted clean bundled extensions, while explicit targeted lint commands like `node scripts/run-oxlint.mjs extensions/feishu` should still lint non-allowlisted extensions on demand.
- Why this is the smallest reliable guardrail: the behavior change is in the repo lint entrypoint and in extension-local fixes, so the smallest trustworthy checks are the default lint command plus scoped extension tests for the cleaned extensions.
- Existing test that already covers this (if any): existing extension test suites covered the `xai`, `qqbot`, and `matrix` behavior that I touched while fixing their lint findings.
- If no new test is added, why not: this PR primarily wires lint scope and removes existing lint debt. I verified the behavior directly with the repo lint entrypoint and scoped extension tests instead of adding a new harness for the lint wrapper in this pass.

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- `pnpm lint` now checks bundled extensions `xai`, `qqbot`, and `matrix` by default.
- `pnpm lint` still skips bundled extension directories that are not intentionally clean yet.
- Explicit extension lint commands still work for any extension, including ones not yet allowlisted.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
pnpm lint -> core/ui/packages/test + bundled extensions effectively not part of the default repo gate

After:
pnpm lint -> core/ui/packages/test + allowlisted clean extensions (xai, qqbot, matrix)
explicit lint path -> any requested extension directory
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 in local dev shell, repo commands run through `npm exec --package=pnpm pnpm ...` because `pnpm` was not on PATH
- Model/provider: N/A
- Integration/channel (if any): bundled extensions `xai`, `qqbot`, `matrix`
- Relevant config (redacted): default local repo config

### Steps

1. Run `npm exec --package=pnpm pnpm lint`.
2. Run `node scripts/run-oxlint.mjs extensions/xai extensions/qqbot extensions/matrix`.
3. Run scoped tests for cleaned extensions.

### Expected

- Default lint passes while checking only the intentionally-clean allowlisted extension directories.
- Explicit extension lint commands still lint any requested extension path.
- Cleaned extensions keep their scoped tests green.

### Actual

- `pnpm lint` passed with the allowlist in place.
- Explicit targeted linting still worked for excluded extensions and still surfaced `feishu` failures when asked directly.
- Scoped extension tests passed for `xai`, `qqbot`, and `matrix`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - I verified `npm exec --package=pnpm pnpm lint` passes with the extension allowlist in place.
  - I verified `node scripts/run-oxlint.mjs extensions/feishu` still lints an excluded extension explicitly and reports its failures instead of silently skipping it.
  - I verified `node scripts/run-oxlint.mjs extensions/matrix` passes.
  - I verified `npm exec --package=pnpm pnpm test extensions/matrix` passes.
  - I verified `npm exec --package=pnpm pnpm test extensions/qqbot` passes.
  - I verified `npm exec --package=pnpm pnpm test extensions/xai/index.test.ts` passes.
- Edge cases checked:
  - default lint with no explicit paths
  - explicit lint of an excluded extension
  - extension-local runtime/test behavior for the cleaned extensions
- What you did **not** verify:
  - I did not widen the allowlist to every currently-green extension yet.
  - I did not fix or re-verify the still-failing extension directories outside `xai`, `qqbot`, and `matrix`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the default lint allowlist could drift from the real set of clean extensions if we forget to widen it after more cleanup work lands.
  - Mitigation: the allowlist is isolated in `.oxlint-extension-allowlist.json`, so widening it is a reviewable one-file change instead of another repo-wide lint config rewrite.
- Risk: extension-local lint fixes could hide a behavior regression in a cleaned extension.
  - Mitigation: I ran scoped tests for `xai`, `qqbot`, and `matrix`, and I intentionally did not add `feishu` to the allowlist because its lifecycle lane still looked unhealthy.
