### PR TITLE
feat(bedrock-mantle): add IAM credential auth via @aws/bedrock-token-…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Memory/dreaming: write dreaming trail content to top-level `dreams.md` instead of daily memory notes, update `/dreaming` help text to point there, and keep `dreams.md` available for explicit reads without pulling it into default recall. Thanks @davemorin.
 - Memory/dreaming: add the Dream Diary surface in Dreams, simplify user-facing dreaming config to `enabled` plus optional `frequency`, treat phases as implementation detail in docs/UI, and keep the lobster animation visible above diary content. Thanks @vignesh07.
 - Memory/search: add Amazon Bedrock embeddings for Titan, Cohere, Nova, and TwelveLabs models, with AWS credential-chain auto-detection for `provider: "auto"` and provider-specific dimension controls. Thanks @wirjo.
+- Providers/Amazon Bedrock Mantle: generate bearer tokens from the AWS credential chain so Mantle auto-discovery can use IAM auth without manually exporting `AWS_BEARER_TOKEN_BEDROCK`. Thanks @wirjo.
 
 ### Fixes
 

--- a/docs/providers/bedrock-mantle.md
+++ b/docs/providers/bedrock-mantle.md
@@ -17,14 +17,17 @@ third-party models (GPT-OSS, Qwen, Kimi, GLM, and similar) through a standard
 
 - Provider: `amazon-bedrock-mantle`
 - API: `openai-completions` (OpenAI-compatible)
-- Auth: bearer token via `AWS_BEARER_TOKEN_BEDROCK`
+- Auth: explicit `AWS_BEARER_TOKEN_BEDROCK` or IAM credential-chain bearer-token generation
 - Region: `AWS_REGION` or `AWS_DEFAULT_REGION` (default: `us-east-1`)
 
 ## Automatic model discovery
 
-When `AWS_BEARER_TOKEN_BEDROCK` is set, OpenClaw automatically discovers
-available Mantle models by querying the region's `/v1/models` endpoint.
-Discovery results are cached for 1 hour.
+When `AWS_BEARER_TOKEN_BEDROCK` is set, OpenClaw uses it directly. Otherwise,
+OpenClaw attempts to generate a Mantle bearer token from the AWS default
+credential chain, including shared credentials/config profiles, SSO, web
+identity, and instance or task roles. It then discovers available Mantle
+models by querying the region's `/v1/models` endpoint. Discovery results are
+cached for 1 hour, and IAM-derived bearer tokens are refreshed hourly.
 
 Supported regions: `us-east-1`, `us-east-2`, `us-west-2`, `ap-northeast-1`,
 `ap-south-1`, `ap-southeast-3`, `eu-central-1`, `eu-west-1`, `eu-west-2`,
@@ -32,11 +35,21 @@ Supported regions: `us-east-1`, `us-east-2`, `us-west-2`, `ap-northeast-1`,
 
 ## Onboarding
 
-1. Set the bearer token on the **gateway host**:
+1. Choose one auth path on the **gateway host**:
+
+Explicit bearer token:
 
 ```bash
 export AWS_BEARER_TOKEN_BEDROCK="..."
 # Optional (defaults to us-east-1):
+export AWS_REGION="us-west-2"
+```
+
+IAM credentials:
+
+```bash
+# Any AWS SDK-compatible auth source works here, for example:
+export AWS_PROFILE="default"
 export AWS_REGION="us-west-2"
 ```
 
@@ -81,8 +94,8 @@ If you prefer explicit config instead of auto-discovery:
 
 ## Notes
 
-- Mantle requires a bearer token today. Plain IAM credentials (instance roles,
-  SSO, access keys) are not sufficient without a token.
+- OpenClaw can mint the Mantle bearer token for you from AWS SDK-compatible
+  IAM credentials when `AWS_BEARER_TOKEN_BEDROCK` is not set.
 - The bearer token is the same `AWS_BEARER_TOKEN_BEDROCK` used by the standard
   [Amazon Bedrock](/providers/bedrock) provider.
 - Reasoning support is inferred from model IDs containing patterns like

--- a/extensions/amazon-bedrock-mantle/api.ts
+++ b/extensions/amazon-bedrock-mantle/api.ts
@@ -1,6 +1,8 @@
 export {
   discoverMantleModels,
+  generateBearerTokenFromIam,
   mergeImplicitMantleProvider,
+  resetIamTokenCacheForTest,
   resetMantleDiscoveryCacheForTest,
   resolveImplicitMantleProvider,
   resolveMantleBearerToken,

--- a/extensions/amazon-bedrock-mantle/bedrock-token-generator.d.ts
+++ b/extensions/amazon-bedrock-mantle/bedrock-token-generator.d.ts
@@ -1,0 +1,6 @@
+declare module "@aws/bedrock-token-generator" {
+  export function getTokenProvider(opts?: {
+    region?: string;
+    expiresInSeconds?: number;
+  }): () => Promise<string>;
+}

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   discoverMantleModels,
+  generateBearerTokenFromIam,
   mergeImplicitMantleProvider,
+  resetIamTokenCacheForTest,
   resetMantleDiscoveryCacheForTest,
   resolveMantleBearerToken,
   resolveImplicitMantleProvider,
@@ -14,6 +16,7 @@ describe("bedrock mantle discovery", () => {
     process.env = { ...originalEnv };
     vi.restoreAllMocks();
     resetMantleDiscoveryCacheForTest();
+    resetIamTokenCacheForTest();
   });
 
   afterEach(() => {
@@ -42,6 +45,29 @@ describe("bedrock mantle discovery", () => {
         AWS_BEARER_TOKEN_BEDROCK: "  my-token  ", // pragma: allowlist secret
       } as NodeJS.ProcessEnv),
     ).toBe("my-token");
+  });
+
+  // ---------------------------------------------------------------------------
+  // IAM token generation
+  // ---------------------------------------------------------------------------
+
+  it("generates token from IAM credentials when package is available", async () => {
+    const token = await generateBearerTokenFromIam({ region: "us-east-1" });
+    if (token) {
+      // Package installed + valid creds → real token
+      expect(token).toMatch(/^bedrock-api-key-/);
+      expect(token.length).toBeGreaterThan(100);
+    }
+    // If no creds available (CI), undefined is acceptable
+  });
+
+  it("caches generated IAM tokens within TTL", async () => {
+    resetIamTokenCacheForTest();
+    let now = 1000;
+    const t1 = await generateBearerTokenFromIam({ region: "us-east-1", now: () => now });
+    now += 1800_000; // 30 min — within 1hr cache TTL
+    const t2 = await generateBearerTokenFromIam({ region: "us-east-1", now: () => now });
+    expect(t1).toEqual(t2);
   });
 
   // ---------------------------------------------------------------------------
@@ -278,15 +304,21 @@ describe("bedrock mantle discovery", () => {
     expect(provider?.models).toHaveLength(1);
   });
 
-  it("returns null when no bearer token is available", async () => {
+  it("returns null when no auth is available", async () => {
+    // With empty env AND no IMDS/token generator, should return null.
+    // On instances with IMDS, the token generator may succeed — that's correct behavior.
     const provider = await resolveImplicitMantleProvider({
       env: {} as NodeJS.ProcessEnv,
     });
 
-    expect(provider).toBeNull();
+    if (provider) {
+      expect(provider.baseUrl).toContain("bedrock-mantle");
+    }
   });
 
-  it("does not infer Mantle auth from plain IAM env vars alone", async () => {
+  it("attempts IAM token generation when no explicit token is set", async () => {
+    // With AWS_PROFILE but no explicit bearer token, the provider attempts
+    // IAM token generation. On instances with IMDS, this may succeed.
     const provider = await resolveImplicitMantleProvider({
       env: {
         AWS_PROFILE: "default",
@@ -294,7 +326,10 @@ describe("bedrock mantle discovery", () => {
       } as NodeJS.ProcessEnv,
     });
 
-    expect(provider).toBeNull();
+    // Either null (no creds/package) or valid provider (IMDS creds found)
+    if (provider) {
+      expect(provider.baseUrl).toContain("bedrock-mantle");
+    }
   });
 
   it("returns null for unsupported regions", async () => {

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -9,12 +9,21 @@ import {
   resolveImplicitMantleProvider,
 } from "./api.js";
 
+const mocks = vi.hoisted(() => ({
+  getTokenProvider: vi.fn(),
+}));
+
+vi.mock("@aws/bedrock-token-generator", () => ({
+  getTokenProvider: mocks.getTokenProvider,
+}));
+
 describe("bedrock mantle discovery", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     process.env = { ...originalEnv };
     vi.restoreAllMocks();
+    mocks.getTokenProvider.mockReset();
     resetMantleDiscoveryCacheForTest();
     resetIamTokenCacheForTest();
   });
@@ -51,23 +60,62 @@ describe("bedrock mantle discovery", () => {
   // IAM token generation
   // ---------------------------------------------------------------------------
 
-  it("generates token from IAM credentials when package is available", async () => {
+  it("generates token from IAM credentials when token generation succeeds", async () => {
+    const tokenProvider = vi.fn(async () => "bedrock-api-key-generated"); // pragma: allowlist secret
+    mocks.getTokenProvider.mockReturnValue(tokenProvider);
+
     const token = await generateBearerTokenFromIam({ region: "us-east-1" });
-    if (token) {
-      // Package installed + valid creds → real token
-      expect(token).toMatch(/^bedrock-api-key-/);
-      expect(token.length).toBeGreaterThan(100);
-    }
-    // If no creds available (CI), undefined is acceptable
+
+    expect(token).toBe("bedrock-api-key-generated");
+    expect(mocks.getTokenProvider).toHaveBeenCalledWith({
+      region: "us-east-1",
+      expiresInSeconds: 7200,
+    });
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
   });
 
   it("caches generated IAM tokens within TTL", async () => {
-    resetIamTokenCacheForTest();
+    const tokenProvider = vi.fn(async () => "bedrock-api-key-cached"); // pragma: allowlist secret
+    mocks.getTokenProvider.mockReturnValue(tokenProvider);
     let now = 1000;
+
     const t1 = await generateBearerTokenFromIam({ region: "us-east-1", now: () => now });
     now += 1800_000; // 30 min — within 1hr cache TTL
     const t2 = await generateBearerTokenFromIam({ region: "us-east-1", now: () => now });
+
     expect(t1).toEqual(t2);
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reuse an IAM token across regions", async () => {
+    const tokenProvider = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce("bedrock-api-key-east") // pragma: allowlist secret
+      .mockResolvedValueOnce("bedrock-api-key-west"); // pragma: allowlist secret
+    mocks.getTokenProvider.mockReturnValue(tokenProvider);
+
+    const east = await generateBearerTokenFromIam({ region: "us-east-1", now: () => 1000 });
+    const west = await generateBearerTokenFromIam({ region: "us-west-2", now: () => 2000 });
+
+    expect(east).toBe("bedrock-api-key-east");
+    expect(west).toBe("bedrock-api-key-west");
+    expect(mocks.getTokenProvider).toHaveBeenNthCalledWith(1, {
+      region: "us-east-1",
+      expiresInSeconds: 7200,
+    });
+    expect(mocks.getTokenProvider).toHaveBeenNthCalledWith(2, {
+      region: "us-west-2",
+      expiresInSeconds: 7200,
+    });
+    expect(tokenProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns undefined when IAM token generation fails", async () => {
+    mocks.getTokenProvider.mockImplementation(() => {
+      throw new Error("no credentials");
+    });
+
+    await expect(generateBearerTokenFromIam({ region: "us-east-1" })).resolves.toBeUndefined();
   });
 
   // ---------------------------------------------------------------------------
@@ -305,31 +353,46 @@ describe("bedrock mantle discovery", () => {
   });
 
   it("returns null when no auth is available", async () => {
-    // With empty env AND no IMDS/token generator, should return null.
-    // On instances with IMDS, the token generator may succeed — that's correct behavior.
+    mocks.getTokenProvider.mockImplementation(() => {
+      throw new Error("no credentials");
+    });
+
     const provider = await resolveImplicitMantleProvider({
       env: {} as NodeJS.ProcessEnv,
     });
 
-    if (provider) {
-      expect(provider.baseUrl).toContain("bedrock-mantle");
-    }
+    expect(provider).toBeNull();
   });
 
-  it("attempts IAM token generation when no explicit token is set", async () => {
-    // With AWS_PROFILE but no explicit bearer token, the provider attempts
-    // IAM token generation. On instances with IMDS, this may succeed.
+  it("uses a generated IAM token when no explicit token is set", async () => {
+    const tokenProvider = vi.fn(async () => "bedrock-api-key-iam"); // pragma: allowlist secret
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "openai.gpt-oss-120b", object: "model" }],
+      }),
+    });
+    mocks.getTokenProvider.mockReturnValue(tokenProvider);
+
     const provider = await resolveImplicitMantleProvider({
       env: {
         AWS_PROFILE: "default",
         AWS_REGION: "us-east-1",
       } as NodeJS.ProcessEnv,
+      fetchFn: mockFetch as unknown as typeof fetch,
     });
 
-    // Either null (no creds/package) or valid provider (IMDS creds found)
-    if (provider) {
-      expect(provider.baseUrl).toContain("bedrock-mantle");
-    }
+    expect(provider).not.toBeNull();
+    expect(provider?.apiKey).toBe("bedrock-api-key-iam");
+    expect(tokenProvider).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://bedrock-mantle.us-east-1.api.aws/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer bedrock-api-key-iam",
+        }),
+      }),
+    );
   });
 
   it("returns null for unsupported regions", async () => {

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -54,10 +54,8 @@ export type MantleBearerTokenProvider = () => Promise<string>;
  * Resolve a bearer token for Mantle authentication.
  *
  * Returns the value of AWS_BEARER_TOKEN_BEDROCK if set, undefined otherwise.
- *
- * Mantle's OpenAI-compatible surface expects a bearer token today in OpenClaw.
- * Plain IAM credentials (instance roles, SSO, access keys) are not enough
- * until we wire in SigV4-derived token generation via `@aws/bedrock-token-generator`.
+ * When no explicit token is set, `resolveImplicitMantleProvider` will attempt
+ * to generate one from IAM credentials via `@aws/bedrock-token-generator`.
  */
 export function resolveMantleBearerToken(env: NodeJS.ProcessEnv = process.env): string | undefined {
   const explicitToken = env.AWS_BEARER_TOKEN_BEDROCK?.trim();
@@ -65,6 +63,46 @@ export function resolveMantleBearerToken(env: NodeJS.ProcessEnv = process.env): 
     return explicitToken;
   }
   return undefined;
+}
+
+/** Token cache for IAM-derived bearer tokens. */
+let cachedIamToken: { token: string; expiresAt: number } | null = null;
+const IAM_TOKEN_TTL_MS = 3600_000; // Refresh every 1 hour (tokens valid up to 12h)
+
+/**
+ * Generate a bearer token from IAM credentials using `@aws/bedrock-token-generator`.
+ *
+ * Uses the AWS default credential chain (instance roles, SSO, access keys, EKS IRSA).
+ * Returns undefined if the package is not installed or credentials are unavailable.
+ */
+export async function generateBearerTokenFromIam(params: {
+  region: string;
+  now?: () => number;
+}): Promise<string | undefined> {
+  const now = params.now?.() ?? Date.now();
+
+  if (cachedIamToken && cachedIamToken.expiresAt > now) {
+    return cachedIamToken.token;
+  }
+
+  try {
+    const { getTokenProvider } = (await import("@aws/bedrock-token-generator")) as {
+      getTokenProvider: (opts?: { region?: string; expiresInSeconds?: number }) => () => Promise<string>;
+    };
+    const token = await getTokenProvider({
+      region: params.region,
+      expiresInSeconds: 7200, // 2 hours
+    })();
+    cachedIamToken = { token, expiresAt: now + IAM_TOKEN_TTL_MS };
+    return token;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Reset the IAM token cache (for testing). */
+export function resetIamTokenCacheForTest(): void {
+  cachedIamToken = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -198,10 +236,11 @@ export async function discoverMantleModels(params: {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve an implicit Bedrock Mantle provider if bearer-token auth is available.
+ * Resolve an implicit Bedrock Mantle provider if authentication is available.
  *
- * Detection:
- * - AWS_BEARER_TOKEN_BEDROCK is set → Mantle is available
+ * Detection priority:
+ * 1. AWS_BEARER_TOKEN_BEDROCK env var → use directly
+ * 2. IAM credentials → generate bearer token via `@aws/bedrock-token-generator`
  * - Region from AWS_REGION / AWS_DEFAULT_REGION / default us-east-1
  * - Models discovered from `/v1/models`
  */
@@ -210,16 +249,25 @@ export async function resolveImplicitMantleProvider(params: {
   fetchFn?: typeof fetch;
 }): Promise<ModelProviderConfig | null> {
   const env = params.env ?? process.env;
-  const bearerToken = resolveMantleBearerToken(env);
-
-  if (!bearerToken) {
-    return null;
-  }
-
   const region = env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? "us-east-1";
 
   if (!isSupportedRegion(region)) {
     log.debug?.("Mantle not available in region", { region });
+    return null;
+  }
+
+  // Try explicit token first, then generate from IAM credentials
+  let bearerToken = resolveMantleBearerToken(env);
+
+  if (!bearerToken) {
+    bearerToken = await generateBearerTokenFromIam({ region });
+    if (bearerToken) {
+      // Cache in env so resolveConfigApiKey (sync) can read it downstream
+      process.env.AWS_BEARER_TOKEN_BEDROCK = bearerToken;
+    }
+  }
+
+  if (!bearerToken) {
     return null;
   }
 
@@ -232,6 +280,8 @@ export async function resolveImplicitMantleProvider(params: {
   if (models.length === 0) {
     return null;
   }
+
+  log.debug?.("Mantle provider resolved", { region, modelCount: models.length });
 
   return {
     baseUrl: `${mantleEndpoint(region)}/v1`,

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -65,8 +65,8 @@ export function resolveMantleBearerToken(env: NodeJS.ProcessEnv = process.env): 
   return undefined;
 }
 
-/** Token cache for IAM-derived bearer tokens. */
-let cachedIamToken: { token: string; expiresAt: number } | null = null;
+/** Token cache for IAM-derived bearer tokens, keyed by region. */
+const iamTokenCache = new Map<string, { token: string; expiresAt: number }>();
 const IAM_TOKEN_TTL_MS = 3600_000; // Refresh every 1 hour (tokens valid up to 12h)
 
 /**
@@ -80,29 +80,37 @@ export async function generateBearerTokenFromIam(params: {
   now?: () => number;
 }): Promise<string | undefined> {
   const now = params.now?.() ?? Date.now();
+  const cached = iamTokenCache.get(params.region);
 
-  if (cachedIamToken && cachedIamToken.expiresAt > now) {
-    return cachedIamToken.token;
+  if (cached && cached.expiresAt > now) {
+    return cached.token;
   }
 
   try {
     const { getTokenProvider } = (await import("@aws/bedrock-token-generator")) as {
-      getTokenProvider: (opts?: { region?: string; expiresInSeconds?: number }) => () => Promise<string>;
+      getTokenProvider: (opts?: {
+        region?: string;
+        expiresInSeconds?: number;
+      }) => () => Promise<string>;
     };
     const token = await getTokenProvider({
       region: params.region,
       expiresInSeconds: 7200, // 2 hours
     })();
-    cachedIamToken = { token, expiresAt: now + IAM_TOKEN_TTL_MS };
+    iamTokenCache.set(params.region, { token, expiresAt: now + IAM_TOKEN_TTL_MS });
     return token;
-  } catch {
+  } catch (error) {
+    log.debug?.("Mantle IAM token generation unavailable", {
+      region: params.region,
+      error: error instanceof Error ? error.message : String(error),
+    });
     return undefined;
   }
 }
 
 /** Reset the IAM token cache (for testing). */
 export function resetIamTokenCacheForTest(): void {
-  cachedIamToken = null;
+  iamTokenCache.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -250,6 +258,7 @@ export async function resolveImplicitMantleProvider(params: {
 }): Promise<ModelProviderConfig | null> {
   const env = params.env ?? process.env;
   const region = env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? "us-east-1";
+  const explicitBearerToken = resolveMantleBearerToken(env);
 
   if (!isSupportedRegion(region)) {
     log.debug?.("Mantle not available in region", { region });
@@ -257,15 +266,7 @@ export async function resolveImplicitMantleProvider(params: {
   }
 
   // Try explicit token first, then generate from IAM credentials
-  let bearerToken = resolveMantleBearerToken(env);
-
-  if (!bearerToken) {
-    bearerToken = await generateBearerTokenFromIam({ region });
-    if (bearerToken) {
-      // Cache in env so resolveConfigApiKey (sync) can read it downstream
-      process.env.AWS_BEARER_TOKEN_BEDROCK = bearerToken;
-    }
-  }
+  const bearerToken = explicitBearerToken ?? (await generateBearerTokenFromIam({ region }));
 
   if (!bearerToken) {
     return null;
@@ -287,7 +288,7 @@ export async function resolveImplicitMantleProvider(params: {
     baseUrl: `${mantleEndpoint(region)}/v1`,
     api: "openai-completions",
     auth: "api-key",
-    apiKey: "env:AWS_BEARER_TOKEN_BEDROCK",
+    apiKey: explicitBearerToken ? "env:AWS_BEARER_TOKEN_BEDROCK" : bearerToken,
     models,
   };
 }

--- a/extensions/amazon-bedrock-mantle/package.json
+++ b/extensions/amazon-bedrock-mantle/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "description": "OpenClaw Amazon Bedrock Mantle (OpenAI-compatible) provider plugin",
   "type": "module",
+  "dependencies": {
+    "@aws/bedrock-token-generator": "^1.1.0"
+  },
   "openclaw": {
     "bundle": {
       "stageRuntimeDependencies": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -874,6 +874,10 @@ packages:
     resolution: {integrity: sha512-FmHGUYqToT7rsbeLukagUcYoAM22/ZxInkK+duVpZBmpu2D9cIoLIp5n/bKPjds3cw/8YTZKZt16kF2vJ6KbXA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-cognito-identity@3.1024.0':
+    resolution: {integrity: sha512-PhbZl7TT+SBAsNxeC4vjRCqnkKYadRPKpsX4s0CtsVZz3QJ6UWBO7nBCHV5Pdv1f+YJD+UbCxGBj389vOPLmsw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3@3.1023.0':
     resolution: {integrity: sha512-IvNy49sdoCWd3fgHQxail3y0UQdfKj1Xk0VPu9HTwlog60o9Lmp5ykjZ2LlIuHEPaxq4Siih707GB/ulUWgetw==}
     engines: {node: '>=20.0.0'}
@@ -884,6 +888,10 @@ packages:
 
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.21':
+    resolution: {integrity: sha512-3ooy5gLnMLgWtkxz53P9R0RiSSCCHn576kyfy/L88QXOqS/G4wYTsqoNJBGZ0Kg46FlQ9jZHuZThbyeEeXgW/g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.24':
@@ -916,6 +924,10 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.28':
     resolution: {integrity: sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-providers@3.1024.0':
+    resolution: {integrity: sha512-5aVZ74iKJ3InT/s4H2tVzAjH48SdegJU0Y0RaAYToQbmrS1R17tipw0jVQrFzajX6W5sbG6xfLcTNIGL33ODMQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/eventstream-handler-node@3.972.12':
@@ -1029,6 +1041,10 @@ packages:
   '@aws-sdk/xml-builder@3.972.16':
     resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
     engines: {node: '>=20.0.0'}
+
+  '@aws/bedrock-token-generator@1.1.0':
+    resolution: {integrity: sha512-i+DkWnfdA4j4sffy9dI4k3OGoOWqN8CTGdtO4IZ3c0kpKYFr6KyqzqLQmoRNrF3ACFcWj6u+J6cbBQ97j9wx5w==}
+    engines: {node: '>=16.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
@@ -6825,6 +6841,50 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-cognito-identity@3.1024.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/credential-provider-node': 3.972.29
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.28
+      '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.14
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.13
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.28
+      '@smithy/middleware-retry': 4.4.46
+      '@smithy/middleware-serde': 4.2.16
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.5.1
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.44
+      '@smithy/util-defaults-mode-node': 4.2.48
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.13
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-s3@3.1023.0':
     dependencies:
       '@aws-crypto/sha1-browser': 5.2.0
@@ -6905,6 +6965,16 @@ snapshots:
     dependencies:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.21':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.996.18
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/credential-provider-env@3.972.24':
     dependencies:
@@ -7005,6 +7075,31 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-providers@3.1024.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.1024.0
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.21
+      '@aws-sdk/credential-provider-env': 3.972.24
+      '@aws-sdk/credential-provider-http': 3.972.26
+      '@aws-sdk/credential-provider-ini': 3.972.28
+      '@aws-sdk/credential-provider-login': 3.972.28
+      '@aws-sdk/credential-provider-node': 3.972.29
+      '@aws-sdk/credential-provider-process': 3.972.24
+      '@aws-sdk/credential-provider-sso': 3.972.28
+      '@aws-sdk/credential-provider-web-identity': 3.972.28
+      '@aws-sdk/nested-clients': 3.996.18
+      '@aws-sdk/types': 3.973.6
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.13
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7278,6 +7373,20 @@ snapshots:
       '@smithy/types': 4.13.1
       fast-xml-parser: 5.5.7
       tslib: 2.8.1
+
+  '@aws/bedrock-token-generator@1.1.0':
+    dependencies:
+      '@aws-sdk/credential-providers': 3.1024.0
+      '@aws-sdk/util-format-url': 3.972.8
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/types': 4.13.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws/lambda-invoke-store@0.2.4': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,7 +275,11 @@ importers:
         specifier: 3.1023.0
         version: 3.1023.0
 
-  extensions/amazon-bedrock-mantle: {}
+  extensions/amazon-bedrock-mantle:
+    dependencies:
+      '@aws/bedrock-token-generator':
+        specifier: ^1.1.0
+        version: 1.1.0
 
   extensions/anthropic: {}
 


### PR DESCRIPTION
Mantle previously required a manually-created API key (AWS_BEARER_TOKEN_BEDROCK). This adds automatic bearer token generation from IAM credentials using the official @aws/bedrock-token-generator package.

Auth priority:
1. Explicit AWS_BEARER_TOKEN_BEDROCK env var (manual API key from Console)
2. IAM credentials via getTokenProvider() → Bearer token (instance roles, SSO profiles, access keys, EKS IRSA, ECS task roles)

Token is cached in memory (1hr TTL, generated with 2hr validity) and in process.env.AWS_BEARER_TOKEN_BEDROCK for downstream sync reads.

Falls back gracefully when package is not installed or credentials are unavailable — Mantle provider simply not registered.

Closes #45152