### PR TITLE
Lobster: harden embedded runtime integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ Docs: https://docs.openclaw.ai
 - Docs/IRC: replace public IRC hostname examples with `irc.example.com` and recommend private servers for bot coordination while listing common public networks for intentional use.
 - Memory/dreaming: group nearby daily-note lines into short coherent chunks before staging them for dreaming, so one-off context from recent notes reaches REM/deep with better evidence and less line-level noise.
 - Memory/dreaming: drop generic date/day headings from daily-note chunk prefixes while keeping meaningful section labels, so staged snippets stay cleaner and more reusable. (#61597) Thanks @mbelinky.
+- Plugins/Lobster: run bundled Lobster workflows in process instead of spawning the external CLI, reducing transport overhead and unblocking native runtime integration. (#61523) Thanks @mbelinky.
+- Plugins/Lobster: harden managed resume validation so invalid TaskFlow resume calls fail earlier, and memoize embedded runtime loading per runner while keeping failed loads retryable. (#61566) Thanks @mbelinky.
 
 ### Fixes
 

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -205,6 +205,46 @@ describe("createEmbeddedLobsterRunner", () => {
     });
   });
 
+  it("loads the embedded runtime once per runner", async () => {
+    const runtime = {
+      runToolRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        status: "ok",
+        output: [],
+        requiresApproval: null,
+      }),
+      resumeToolRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        status: "cancelled",
+        output: [],
+        requiresApproval: null,
+      }),
+    };
+    const loadRuntime = vi.fn().mockResolvedValue(runtime);
+
+    const runner = createEmbeddedLobsterRunner({ loadRuntime });
+
+    await runner.run({
+      action: "run",
+      pipeline: "exec --json=true echo hi",
+      cwd: process.cwd(),
+      timeoutMs: 2000,
+      maxStdoutBytes: 4096,
+    });
+    await runner.run({
+      action: "resume",
+      token: "resume-token",
+      approve: false,
+      cwd: process.cwd(),
+      timeoutMs: 2000,
+      maxStdoutBytes: 4096,
+    });
+
+    expect(loadRuntime).toHaveBeenCalledTimes(1);
+  });
+
   it("requires a pipeline for run", async () => {
     const runner = createEmbeddedLobsterRunner({
       loadRuntime: vi.fn().mockResolvedValue({

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
@@ -597,7 +598,19 @@ async function importInstalledLobsterModule<T>(
 function resolveInstalledLobsterRoot() {
   const require = createRequire(import.meta.url);
   const sdkEntry = require.resolve("@clawdbot/lobster");
-  return path.resolve(path.dirname(sdkEntry), "../../..");
+  let currentDir = path.dirname(sdkEntry);
+
+  while (true) {
+    const packageJsonPath = path.join(currentDir, "package.json");
+    if (existsSync(packageJsonPath)) {
+      return currentDir;
+    }
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      throw new Error("Unable to resolve the installed @clawdbot/lobster package root");
+    }
+    currentDir = parentDir;
+  }
 }
 
 async function loadEmbeddedToolRuntimeFromPackage(): Promise<EmbeddedToolRuntime> {
@@ -672,9 +685,19 @@ export function createEmbeddedLobsterRunner(options?: {
   loadRuntime?: LoadEmbeddedToolRuntime;
 }): LobsterRunner {
   const loadRuntime = options?.loadRuntime ?? loadEmbeddedToolRuntimeFromPackage;
+  let runtimePromise: Promise<EmbeddedToolRuntime> | undefined;
+
+  const getRuntime = () => {
+    runtimePromise ??= loadRuntime().catch((error) => {
+      runtimePromise = undefined;
+      throw error;
+    });
+    return runtimePromise;
+  };
+
   return {
     async run(params) {
-      const runtime = await loadRuntime();
+      const runtime = await getRuntime();
       return await withTimeout(params.timeoutMs, async (signal) => {
         const ctx = createEmbeddedToolContext(params, signal);
 

--- a/extensions/lobster/src/lobster-taskflow.test.ts
+++ b/extensions/lobster/src/lobster-taskflow.test.ts
@@ -1,56 +1,17 @@
 import { describe, expect, it, vi } from "vitest";
-import type { OpenClawPluginApi } from "../runtime-api.js";
 import type { LobsterRunner } from "./lobster-runner.js";
 import { resumeManagedLobsterFlow, runManagedLobsterFlow } from "./lobster-taskflow.js";
+import { createFakeTaskFlow } from "./taskflow-test-helpers.js";
 
-type BoundTaskFlow = ReturnType<
-  NonNullable<OpenClawPluginApi["runtime"]>["taskFlow"]["bindSession"]
->;
-
-function createFakeTaskFlow(overrides?: Partial<BoundTaskFlow>) {
-  const baseFlow = {
-    flowId: "flow-1",
-    revision: 1,
-    syncMode: "managed" as const,
-    controllerId: "tests/lobster",
-    ownerKey: "agent:main:main",
-    status: "running" as const,
-    goal: "Run Lobster workflow",
-  };
-
-  const taskFlow: BoundTaskFlow = {
-    sessionKey: "agent:main:main",
-    createManaged: vi.fn().mockReturnValue(baseFlow),
-    get: vi.fn(),
-    list: vi.fn().mockReturnValue([]),
-    findLatest: vi.fn(),
-    resolve: vi.fn(),
-    getTaskSummary: vi.fn(),
-    setWaiting: vi.fn().mockImplementation((input) => ({
-      applied: true,
-      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "waiting" as const },
-    })),
-    resume: vi.fn().mockImplementation((input) => ({
-      applied: true,
-      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "running" as const },
-    })),
-    finish: vi.fn().mockImplementation((input) => ({
-      applied: true,
-      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "completed" as const },
-    })),
-    fail: vi.fn().mockImplementation((input) => ({
-      applied: true,
-      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "failed" as const },
-    })),
-    requestCancel: vi.fn(),
-    cancel: vi.fn(),
-    runTask: vi.fn(),
-    ...overrides,
-  };
-
-  return taskFlow;
+function expectManagedFlowFailure(
+  result: Awaited<ReturnType<typeof runManagedLobsterFlow | typeof resumeManagedLobsterFlow>>,
+) {
+  expect(result.ok).toBe(false);
+  if (result.ok) {
+    throw new Error("Expected managed Lobster flow to fail");
+  }
+  return result;
 }
-
 function createRunner(result: Awaited<ReturnType<LobsterRunner["run"]>>): LobsterRunner {
   return {
     run: vi.fn().mockResolvedValue(result),

--- a/extensions/lobster/src/lobster-tool.test.ts
+++ b/extensions/lobster/src/lobster-tool.test.ts
@@ -1,12 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import { createTestPluginApi } from "../../../test/helpers/plugins/plugin-api.js";
 import type { OpenClawPluginApi, OpenClawPluginToolContext } from "../runtime-api.js";
+import { createFakeTaskFlow } from "./taskflow-test-helpers.js";
 
 let createLobsterTool: typeof import("./lobster-tool.js").createLobsterTool;
-
-type BoundTaskFlow = ReturnType<
-  NonNullable<OpenClawPluginApi["runtime"]>["taskFlow"]["bindSession"]
->;
 
 function fakeApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi {
   return createTestPluginApi({
@@ -30,48 +27,6 @@ function fakeCtx(overrides: Partial<OpenClawPluginToolContext> = {}): OpenClawPl
     messageChannel: undefined,
     agentAccountId: undefined,
     sandboxed: false,
-    ...overrides,
-  };
-}
-
-function createFakeTaskFlow(overrides?: Partial<BoundTaskFlow>): BoundTaskFlow {
-  const baseFlow = {
-    flowId: "flow-1",
-    revision: 1,
-    syncMode: "managed" as const,
-    controllerId: "tests/lobster",
-    ownerKey: "agent:main:main",
-    status: "running" as const,
-    goal: "Run Lobster workflow",
-  };
-
-  return {
-    sessionKey: "agent:main:main",
-    createManaged: vi.fn().mockReturnValue(baseFlow),
-    get: vi.fn(),
-    list: vi.fn().mockReturnValue([]),
-    findLatest: vi.fn(),
-    resolve: vi.fn(),
-    getTaskSummary: vi.fn(),
-    setWaiting: vi.fn().mockImplementation((input) => ({
-      applied: true,
-      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "waiting" as const },
-    })),
-    resume: vi.fn().mockImplementation((input) => ({
-      applied: true,
-      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "running" as const },
-    })),
-    finish: vi.fn().mockImplementation((input) => ({
-      applied: true,
-      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "completed" as const },
-    })),
-    fail: vi.fn().mockImplementation((input) => ({
-      applied: true,
-      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "failed" as const },
-    })),
-    requestCancel: vi.fn(),
-    cancel: vi.fn(),
-    runTask: vi.fn(),
     ...overrides,
   };
 }
@@ -271,6 +226,42 @@ describe("lobster plugin tool", () => {
         flowStateJson: "{bad",
       }),
     ).rejects.toThrow(/flowStateJson must be valid JSON/);
+  });
+
+  it("rejects managed TaskFlow resume mode without a token", async () => {
+    ({ createLobsterTool } = await import("./lobster-tool.js"));
+
+    const tool = createLobsterTool(fakeApi(), {
+      runner: { run: vi.fn() },
+      taskFlow: createFakeTaskFlow(),
+    });
+
+    await expect(
+      tool.execute("call-missing-resume-token", {
+        action: "resume",
+        flowId: "flow-1",
+        flowExpectedRevision: 1,
+        approve: true,
+      }),
+    ).rejects.toThrow(/token required when using managed TaskFlow resume mode/);
+  });
+
+  it("rejects managed TaskFlow resume mode without approve", async () => {
+    ({ createLobsterTool } = await import("./lobster-tool.js"));
+
+    const tool = createLobsterTool(fakeApi(), {
+      runner: { run: vi.fn() },
+      taskFlow: createFakeTaskFlow(),
+    });
+
+    await expect(
+      tool.execute("call-missing-resume-approve", {
+        action: "resume",
+        token: "resume-token",
+        flowId: "flow-1",
+        flowExpectedRevision: 1,
+      }),
+    ).rejects.toThrow(/approve required when using managed TaskFlow resume mode/);
   });
 
   it("requires action", async () => {

--- a/extensions/lobster/src/lobster-tool.ts
+++ b/extensions/lobster/src/lobster-tool.ts
@@ -63,6 +63,16 @@ function readOptionalNumber(value: unknown, fieldName: string): number | undefin
   return value;
 }
 
+function readOptionalBoolean(value: unknown, fieldName: string): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new Error(`${fieldName} must be a boolean`);
+  }
+  return value;
+}
+
 function parseOptionalFlowStateJson(value: unknown): JsonLike | undefined {
   if (value === undefined) {
     return undefined;
@@ -119,6 +129,8 @@ function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResu
   const expectedRevision = readOptionalNumber(params.flowExpectedRevision, "flowExpectedRevision");
   const currentStep = readOptionalTrimmedString(params.flowCurrentStep, "flowCurrentStep");
   const waitingStep = readOptionalTrimmedString(params.flowWaitingStep, "flowWaitingStep");
+  const token = readOptionalTrimmedString(params.token, "token");
+  const approve = readOptionalBoolean(params.approve, "approve");
   const runControllerId = readOptionalTrimmedString(params.flowControllerId, "flowControllerId");
   const runGoal = readOptionalTrimmedString(params.flowGoal, "flowGoal");
   const stateJson = params.flowStateJson;
@@ -140,6 +152,12 @@ function parseResumeFlowParams(params: Record<string, unknown>): ManagedFlowResu
   }
   if (expectedRevision === undefined) {
     throw new Error("flowExpectedRevision required when using managed TaskFlow resume mode");
+  }
+  if (!token) {
+    throw new Error("token required when using managed TaskFlow resume mode");
+  }
+  if (approve === undefined) {
+    throw new Error("approve required when using managed TaskFlow resume mode");
   }
   return {
     flowId,

--- a/extensions/lobster/src/taskflow-test-helpers.ts
+++ b/extensions/lobster/src/taskflow-test-helpers.ts
@@ -1,0 +1,48 @@
+import { vi } from "vitest";
+import type { OpenClawPluginApi } from "../runtime-api.js";
+
+export type BoundTaskFlow = ReturnType<
+  NonNullable<OpenClawPluginApi["runtime"]>["taskFlow"]["bindSession"]
+>;
+
+export function createFakeTaskFlow(overrides?: Partial<BoundTaskFlow>): BoundTaskFlow {
+  const baseFlow = {
+    flowId: "flow-1",
+    revision: 1,
+    syncMode: "managed" as const,
+    controllerId: "tests/lobster",
+    ownerKey: "agent:main:main",
+    status: "running" as const,
+    goal: "Run Lobster workflow",
+  };
+
+  return {
+    sessionKey: "agent:main:main",
+    createManaged: vi.fn().mockReturnValue(baseFlow),
+    get: vi.fn(),
+    list: vi.fn().mockReturnValue([]),
+    findLatest: vi.fn(),
+    resolve: vi.fn(),
+    getTaskSummary: vi.fn(),
+    setWaiting: vi.fn().mockImplementation((input) => ({
+      applied: true,
+      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "waiting" as const },
+    })),
+    resume: vi.fn().mockImplementation((input) => ({
+      applied: true,
+      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "running" as const },
+    })),
+    finish: vi.fn().mockImplementation((input) => ({
+      applied: true,
+      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "completed" as const },
+    })),
+    fail: vi.fn().mockImplementation((input) => ({
+      applied: true,
+      flow: { ...baseFlow, revision: input.expectedRevision + 1, status: "failed" as const },
+    })),
+    requestCancel: vi.fn(),
+    cancel: vi.fn(),
+    runTask: vi.fn(),
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

- Problem: the new in-process Lobster integration still had a few follow-up hardening gaps from Greptile review.
- Why it matters: managed TaskFlow resume mode could accept incomplete resume params, the embedded runtime loader did unnecessary work on every tool call, and the duplicated TaskFlow test mock could drift.
- What changed: managed resume mode now requires `token` and `approve`, the embedded runtime is memoized per runner and resolves the installed Lobster package root without fixed path arithmetic, and the shared TaskFlow test mock now lives in one helper.
- What did NOT change (scope boundary): no changes in `src/tasks/**`, `src/plugins/runtime/**`, or Lobster core itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #61523
- Related #61555
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the first two Lobster PRs landed the main transport and TaskFlow changes, but left a few correctness and maintainability gaps in the plugin seam.
- Missing detection / guardrail: managed resume mode did not have coverage for missing `token` / `approve`, and the embedded runner had no regression test asserting runtime memoization.
- Prior context (`git blame`, prior PR, issue, or refactor if known): this follows up on Greptile review feedback from #61523 and #61555.
- Why this regressed now: the earlier PRs were intentionally kept tight to land the transport and TaskFlow slices first.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/lobster/src/lobster-runner.test.ts`
  - `extensions/lobster/src/lobster-tool.test.ts`
  - `extensions/lobster/src/lobster-taskflow.test.ts`
- Scenario the test should lock in: managed resume mode rejects incomplete resume params, embedded runtime loading is memoized per runner, and TaskFlow tests share one mock helper.
- Why this is the smallest reliable guardrail: the changed behavior is fully inside the Lobster plugin seam.
- Existing test that already covers this (if any): earlier Lobster tests covered the happy paths, but not these follow-up edge cases.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Managed Lobster resume calls now fail fast if `token` or `approve` is missing.
- Repeated Lobster tool invocations on the same runner no longer reload the embedded runtime.

## Diagram (if applicable)

```text
Before:
[lobster tool] -> [validate some flow params] -> [load embedded runtime every call]

After:
[lobster tool] -> [validate complete managed resume params] -> [reuse embedded runtime per runner]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm workspace in a clean worktree
- Model/provider: N/A
- Integration/channel (if any): Lobster bundled plugin
- Relevant config (redacted): default local test config

### Steps

1. Run targeted Lobster Vitest coverage for runner/tool/taskflow.
2. Run Oxlint on the touched Lobster files.
3. Run `pnpm build`.

### Expected

- Lobster hardening changes pass targeted plugin tests and lint.
- Build should stay green unless current `main` already has an unrelated failure.

### Actual

- Targeted Lobster tests passed.
- Oxlint passed.
- `pnpm build` failed in untouched Pi runner code on current `main`:
  - `src/agents/pi-embedded-runner/model.ts(516,11): error TS2304: Cannot find name 'DEFAULT_CONTEXT_TOKENS'.`
  - `src/agents/pi-embedded-runner/model.ts(521,11): error TS2304: Cannot find name 'DEFAULT_CONTEXT_TOKENS'.`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - managed resume rejects missing `token`
  - managed resume rejects missing `approve`
  - embedded runtime loads once per runner
  - shared TaskFlow mock still supports tool/taskflow tests
- Edge cases checked:
  - runtime loader failure still remains retryable because the memoized promise resets on rejection
- What you did **not** verify:
  - no full green build because current `main` fails in untouched Pi runner code

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - Memoizing the embedded runtime could retain a failed load forever.
  - Mitigation:
    - the cached promise is cleared on rejection so later calls can retry.

- Risk:
  - Tightening managed resume validation could reject callers that relied on deferred runner errors.
  - Mitigation:
    - this only affects invalid calls and now fails earlier with clearer error messages.

## AI Assistance

- AI-assisted: yes
- Testing: targeted vitest, oxlint, build attempt
