### PR TITLE
refactor: share plugin update install args

### DIFF
--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -180,6 +180,7 @@ Hook guard semantics to keep in mind:
 - `before_tool_call`: `{ requireApproval: true }` pauses agent execution and prompts the user for approval via the exec approval overlay, Telegram buttons, Discord interactions, or the `/approve` command on any channel.
 - `before_install`: `{ block: true }` is terminal and stops lower-priority handlers.
 - `before_install`: `{ block: false }` is treated as no decision.
+- `tool_result_persist`: must stay synchronous because it runs in the transcript persistence path; return an updated tool result payload or `undefined` to keep the original.
 - `message_sending`: `{ cancel: true }` is terminal and stops lower-priority handlers.
 - `message_sending`: `{ cancel: false }` is treated as no decision.
 

--- a/extensions/qa-lab/src/qa-gateway-config.test.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.test.ts
@@ -12,7 +12,7 @@ describe("buildQaGatewayConfig", () => {
       workspaceDir: "/tmp/qa-workspace",
     });
 
-    expect(cfg.agents?.defaults?.model?.primary).toBe("mock-openai/gpt-5.4");
+    expect(cfg.agents?.defaults?.model).toBe("mock-openai/gpt-5.4");
     expect(cfg.models?.providers?.["mock-openai"]?.baseUrl).toBe("http://127.0.0.1:44080/v1");
     expect(cfg.plugins?.allow).toEqual(["memory-core", "qa-channel"]);
     expect(cfg.plugins?.entries?.["memory-core"]).toEqual({ enabled: true });
@@ -32,8 +32,8 @@ describe("buildQaGatewayConfig", () => {
       alternateModel: "openai/gpt-5.4",
     });
 
-    expect(cfg.agents?.defaults?.model?.primary).toBe("openai/gpt-5.4");
-    expect(cfg.agents?.list?.[0]?.model?.primary).toBe("openai/gpt-5.4");
+    expect(cfg.agents?.defaults?.model).toBe("openai/gpt-5.4");
+    expect(cfg.agents?.list?.[0]?.model).toBe("openai/gpt-5.4");
     expect(cfg.models).toBeUndefined();
     expect(cfg.plugins?.allow).toEqual(["memory-core", "openai", "qa-channel"]);
     expect(cfg.plugins?.entries?.openai).toEqual({ enabled: true });

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -48,6 +48,7 @@ export function buildQaGatewayConfig(params: {
   const alternateModel =
     params.alternateModel ??
     (providerMode === "live-openai" ? "openai/gpt-5.4" : "mock-openai/gpt-5.4-alt");
+  const mockProviderBaseUrl = params.providerBaseUrl ?? "http://127.0.0.1:44080/v1";
   const liveModelParams =
     providerMode === "live-openai"
       ? {
@@ -91,9 +92,7 @@ export function buildQaGatewayConfig(params: {
     agents: {
       defaults: {
         workspace: params.workspaceDir,
-        model: {
-          primary: primaryModel,
-        },
+        model: primaryModel,
         models: {
           [primaryModel]: {
             params: liveModelParams,
@@ -111,9 +110,7 @@ export function buildQaGatewayConfig(params: {
         {
           id: "qa",
           default: true,
-          model: {
-            primary: primaryModel,
-          },
+          model: primaryModel,
           identity: {
             name: "C-3PO QA",
             theme: "Flustered Protocol Droid",
@@ -132,7 +129,7 @@ export function buildQaGatewayConfig(params: {
             mode: "replace",
             providers: {
               "mock-openai": {
-                baseUrl: params.providerBaseUrl,
+                baseUrl: mockProviderBaseUrl,
                 apiKey: "test",
                 api: "openai-responses",
                 models: [

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -147,6 +147,7 @@ describe("createVideoGenerateTool", () => {
       provider: "qwen",
       model: "wan2.6-t2v",
       attempts: [],
+      ignoredOverrides: [],
       videos: [
         {
           buffer: Buffer.from("video-bytes"),

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -316,12 +316,15 @@ vi.mock("../infra/clawhub.js", () => ({
 
 const { registerPluginsCli } = await import("./plugins-cli.js");
 
-export { registerPluginsCli };
+export function createPluginsProgram() {
+  const program = new Command();
+  registerPluginsCli(program);
+  return program;
+}
 
 export function runPluginsCommand(argv: string[]) {
-  const program = new Command();
+  const program = createPluginsProgram();
   program.exitOverride();
-  registerPluginsCli(program);
   return program.parseAsync(argv, { from: "user" });
 }
 

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -1,9 +1,8 @@
-import { Command } from "commander";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  createPluginsProgram,
   loadConfig,
-  registerPluginsCli,
   resetPluginsCliTestState,
   runPluginsCommand,
   runtimeErrors,
@@ -38,8 +37,7 @@ describe("plugins cli update", () => {
   });
 
   it("shows the dangerous unsafe install override in update help", () => {
-    const program = new Command();
-    registerPluginsCli(program);
+    const program = createPluginsProgram();
 
     const pluginsCommand = program.commands.find((command) => command.name() === "plugins");
     const updateCommand = pluginsCommand?.commands.find((command) => command.name() === "update");

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -631,6 +631,79 @@ describe("updateNpmInstalledPlugins", () => {
       }),
     );
   });
+
+  it("forwards dangerous force unsafe install to ClawHub plugin updates", async () => {
+    installPluginFromClawHubMock.mockResolvedValue({
+      ok: true,
+      pluginId: "demo",
+      targetDir: "/tmp/demo",
+      version: "1.2.4",
+      clawhub: {
+        source: "clawhub",
+        clawhubUrl: "https://clawhub.ai",
+        clawhubPackage: "demo",
+        clawhubFamily: "code-plugin",
+        clawhubChannel: "official",
+        integrity: "sha256-next",
+        resolvedAt: "2026-03-22T00:00:00.000Z",
+      },
+    });
+
+    await updateNpmInstalledPlugins({
+      config: createClawHubInstallConfig({
+        pluginId: "demo",
+        installPath: "/tmp/demo",
+        clawhubUrl: "https://clawhub.ai",
+        clawhubPackage: "demo",
+        clawhubFamily: "code-plugin",
+        clawhubChannel: "official",
+      }),
+      pluginIds: ["demo"],
+      dangerouslyForceUnsafeInstall: true,
+    });
+
+    expect(installPluginFromClawHubMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "clawhub:demo",
+        dangerouslyForceUnsafeInstall: true,
+        expectedPluginId: "demo",
+      }),
+    );
+  });
+
+  it("forwards dangerous force unsafe install to marketplace plugin updates", async () => {
+    installPluginFromMarketplaceMock.mockResolvedValue({
+      ok: true,
+      pluginId: "claude-bundle",
+      targetDir: "/tmp/claude-bundle",
+      version: "1.3.0",
+      extensions: ["index.ts"],
+      marketplaceName: "Vincent's Claude Plugins",
+      marketplaceSource: "vincentkoc/claude-marketplace",
+      marketplacePlugin: "claude-bundle",
+    });
+
+    await updateNpmInstalledPlugins({
+      config: createMarketplaceInstallConfig({
+        pluginId: "claude-bundle",
+        installPath: "/tmp/claude-bundle",
+        marketplaceName: "Vincent's Claude Plugins",
+        marketplaceSource: "vincentkoc/claude-marketplace",
+        marketplacePlugin: "claude-bundle",
+      }),
+      pluginIds: ["claude-bundle"],
+      dangerouslyForceUnsafeInstall: true,
+    });
+
+    expect(installPluginFromMarketplaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        marketplace: "vincentkoc/claude-marketplace",
+        plugin: "claude-bundle",
+        dangerouslyForceUnsafeInstall: true,
+        expectedPluginId: "claude-bundle",
+      }),
+    );
+  });
 });
 
 describe("syncPluginsForUpdateChannel", () => {

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -269,6 +269,55 @@ export async function updateNpmInstalledPlugins(params: {
   let next = params.config;
   let changed = false;
 
+  const buildSharedInstallFields = (pluginId: string) => ({
+    mode: "update" as const,
+    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
+    expectedPluginId: pluginId,
+    logger,
+  });
+
+  const buildNpmInstallParams = (input: {
+    pluginId: string;
+    spec: string;
+    expectedIntegrity?: string;
+    dryRun: boolean;
+  }) => ({
+    ...buildSharedInstallFields(input.pluginId),
+    spec: input.spec,
+    ...(input.dryRun ? { dryRun: true } : {}),
+    expectedIntegrity: input.expectedIntegrity,
+    onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
+      pluginId: input.pluginId,
+      dryRun: input.dryRun,
+      logger,
+      onIntegrityDrift: params.onIntegrityDrift,
+    }),
+  });
+
+  const buildClawHubInstallParams = (input: {
+    pluginId: string;
+    spec: string;
+    baseUrl?: string;
+    dryRun: boolean;
+  }) => ({
+    ...buildSharedInstallFields(input.pluginId),
+    spec: input.spec,
+    baseUrl: input.baseUrl,
+    ...(input.dryRun ? { dryRun: true } : {}),
+  });
+
+  const buildMarketplaceInstallParams = (input: {
+    pluginId: string;
+    marketplace: string;
+    plugin: string;
+    dryRun: boolean;
+  }) => ({
+    ...buildSharedInstallFields(input.pluginId),
+    marketplace: input.marketplace,
+    plugin: input.plugin,
+    ...(input.dryRun ? { dryRun: true } : {}),
+  });
+
   for (const pluginId of targets) {
     if (params.skipIds?.has(pluginId)) {
       outcomes.push({
@@ -300,6 +349,7 @@ export async function updateNpmInstalledPlugins(params: {
 
     const effectiveSpec =
       record.source === "npm" ? (params.specOverrides?.[pluginId] ?? record.spec) : record.spec;
+    const clawhubSpec = effectiveSpec ?? `clawhub:${record.clawhubPackage ?? ""}`;
     const expectedIntegrity =
       record.source === "npm" && effectiveSpec === record.spec
         ? expectedIntegrityForUpdate(record.spec, record.integrity)
@@ -356,40 +406,31 @@ export async function updateNpmInstalledPlugins(params: {
       try {
         probe =
           record.source === "npm"
-            ? await installPluginFromNpmSpec({
-                spec: effectiveSpec!,
-                mode: "update",
-                dryRun: true,
-                dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-                expectedPluginId: pluginId,
-                expectedIntegrity,
-                onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
+            ? await installPluginFromNpmSpec(
+                buildNpmInstallParams({
                   pluginId,
+                  spec: effectiveSpec!,
+                  expectedIntegrity,
                   dryRun: true,
-                  logger,
-                  onIntegrityDrift: params.onIntegrityDrift,
                 }),
-                logger,
-              })
+              )
             : record.source === "clawhub"
-              ? await installPluginFromClawHub({
-                  spec: effectiveSpec ?? `clawhub:${record.clawhubPackage!}`,
-                  baseUrl: record.clawhubUrl,
-                  mode: "update",
-                  dryRun: true,
-                  dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-                  expectedPluginId: pluginId,
-                  logger,
-                })
-              : await installPluginFromMarketplace({
-                  marketplace: record.marketplaceSource!,
-                  plugin: record.marketplacePlugin!,
-                  mode: "update",
-                  dryRun: true,
-                  dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-                  expectedPluginId: pluginId,
-                  logger,
-                });
+              ? await installPluginFromClawHub(
+                  buildClawHubInstallParams({
+                    pluginId,
+                    spec: clawhubSpec,
+                    baseUrl: record.clawhubUrl,
+                    dryRun: true,
+                  }),
+                )
+              : await installPluginFromMarketplace(
+                  buildMarketplaceInstallParams({
+                    pluginId,
+                    marketplace: record.marketplaceSource!,
+                    plugin: record.marketplacePlugin!,
+                    dryRun: true,
+                  }),
+                );
       } catch (err) {
         outcomes.push({
           pluginId,
@@ -413,7 +454,7 @@ export async function updateNpmInstalledPlugins(params: {
               : record.source === "clawhub"
                 ? formatClawHubInstallFailure({
                     pluginId,
-                    spec: effectiveSpec ?? `clawhub:${record.clawhubPackage!}`,
+                    spec: clawhubSpec,
                     phase: "check",
                     error: probe.error,
                   })
@@ -457,37 +498,31 @@ export async function updateNpmInstalledPlugins(params: {
     try {
       result =
         record.source === "npm"
-          ? await installPluginFromNpmSpec({
-              spec: effectiveSpec!,
-              mode: "update",
-              dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-              expectedPluginId: pluginId,
-              expectedIntegrity,
-              onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
+          ? await installPluginFromNpmSpec(
+              buildNpmInstallParams({
                 pluginId,
+                spec: effectiveSpec!,
+                expectedIntegrity,
                 dryRun: false,
-                logger,
-                onIntegrityDrift: params.onIntegrityDrift,
               }),
-              logger,
-            })
+            )
           : record.source === "clawhub"
-            ? await installPluginFromClawHub({
-                spec: effectiveSpec ?? `clawhub:${record.clawhubPackage!}`,
-                baseUrl: record.clawhubUrl,
-                mode: "update",
-                dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-                expectedPluginId: pluginId,
-                logger,
-              })
-            : await installPluginFromMarketplace({
-                marketplace: record.marketplaceSource!,
-                plugin: record.marketplacePlugin!,
-                mode: "update",
-                dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-                expectedPluginId: pluginId,
-                logger,
-              });
+            ? await installPluginFromClawHub(
+                buildClawHubInstallParams({
+                  pluginId,
+                  spec: clawhubSpec,
+                  baseUrl: record.clawhubUrl,
+                  dryRun: false,
+                }),
+              )
+            : await installPluginFromMarketplace(
+                buildMarketplaceInstallParams({
+                  pluginId,
+                  marketplace: record.marketplaceSource!,
+                  plugin: record.marketplacePlugin!,
+                  dryRun: false,
+                }),
+              );
     } catch (err) {
       outcomes.push({
         pluginId,
@@ -511,7 +546,7 @@ export async function updateNpmInstalledPlugins(params: {
             : record.source === "clawhub"
               ? formatClawHubInstallFailure({
                   pluginId,
-                  spec: effectiveSpec ?? `clawhub:${record.clawhubPackage!}`,
+                  spec: clawhubSpec,
                   phase: "update",
                   error: result.error,
                 })
@@ -549,7 +584,7 @@ export async function updateNpmInstalledPlugins(params: {
       next = recordPluginInstall(next, {
         pluginId: resolvedPluginId,
         source: "clawhub",
-        spec: effectiveSpec ?? record.spec ?? `clawhub:${record.clawhubPackage!}`,
+        spec: effectiveSpec ?? record.spec ?? clawhubSpec,
         installPath: result.targetDir,
         version: nextVersion,
         integrity: clawhubResult.clawhub.integrity,


### PR DESCRIPTION
## Summary
- extract shared plugin update installer arg builders
- reuse the same helper path for npm, ClawHub, and marketplace update probes/installs
- add coverage for dangerous unsafe install forwarding on ClawHub and marketplace updates
- small CLI test-helper cleanup and hook docs note

## Verification
- `pnpm test src/plugins/update.test.ts src/cli/plugins-cli.update.test.ts --testTimeout=10000 --hookTimeout=10000`

## Notes
- `pnpm tsgo` is currently red on latest `main` in unrelated files (`extensions/qa-lab/*`, `src/agents/tools/video-generate-tool.test.ts`), so I did not use it as the gate for this salvage PR.
- supersedes the salvageable subset of #60437
