### PR TITLE
test: fix current-main prep blockers

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -200,6 +200,7 @@ vi.mock("../utils/message-channel.js", () => ({
 const resolveEffectiveModelFallbacksMock = vi.fn().mockReturnValue(undefined);
 vi.mock("./agent-scope.js", () => ({
   listAgentIds: () => ["default"],
+  resolveAgentConfig: () => undefined,
   resolveAgentDir: () => "/tmp/agent",
   resolveEffectiveModelFallbacks: resolveEffectiveModelFallbacksMock,
   resolveSessionAgentId: () => "default",

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -236,7 +236,7 @@ describe("registerPreActionHooks", () => {
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({
       runtime: runtimeMock,
-      commandPath: ["agent"],
+      commandPath: ["agent", "hi"],
     });
     expect(ensurePluginRegistryLoadedMock).toHaveBeenCalledWith({ scope: "all" });
   });


### PR DESCRIPTION
## Summary

- Problem: current `main` has stale test expectations/mocks that fail maintainer prep while validating `#61566`.
- Why it matters: these test-only failures are unrelated to the Lobster hardening PR but block the normal `review-pr -> prepare-pr -> merge-pr` flow on `mb-server`.
- What changed: update the local-agent preaction expectation and add the missing `resolveAgentConfig` export to the live-model-switch test mock.
- What did NOT change (scope boundary): no production runtime behavior changed; this PR is only the minimum test correction needed to unblock PR validation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #61566
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: current tests drifted behind current runtime/module seams on `main`.
- Missing detection / guardrail: the affected tests still asserted older command-path/mock shapes after adjacent runtime changes landed.
- Contributing context (if known): both failures reproduced while preparing `#61566` on `mb-server`, and the live-model-switch failure reproduces directly on clean latest `origin/main`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
- Target test or file:
  - `src/cli/program/preaction.test.ts`
  - `src/agents/agent-command.live-model-switch.test.ts`
- Scenario the test should lock in:
  - local agent preaction uses the actual parsed command path from argv
  - live-model-switch tests mock the full `agent-scope` surface needed by `exec-defaults.ts`
- Why this is the smallest reliable guardrail: both failures were already in existing targeted tests; only stale expectations/mocks needed correction.
- Existing test that already covers this (if any): the two updated files above.
- If no new test is added, why not: the existing failing tests are the guardrails.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout and `mb-server` maintainer clone
- Model/provider: N/A
- Integration/channel (if any): CLI + agents test lanes
- Relevant config (redacted): default test config

### Steps

1. Reproduce prep on `#61566` and observe unrelated test failures on current `main`.
2. Reproduce the affected tests directly on latest `origin/main`.
3. Apply the stale test fixes and rerun the targeted tests.

### Expected

- The targeted blocker tests pass and prep can move past these unrelated failures.

### Actual

- Verified locally for both updated test files.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm exec vitest run --config vitest.config.ts src/cli/program/preaction.test.ts -t "loads plugins for local agent runs"`
  - `pnpm exec vitest run --config vitest.config.ts src/agents/agent-command.live-model-switch.test.ts`
- Edge cases checked: confirmed the live-model-switch failure reproduced first on clean latest `origin/main`, not because of the Lobster PR.
- What you did **not** verify: no full-suite rerun is complete yet; this PR only fixes the current known prep blockers.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - This is still a test-only PR, which is normally not accepted for known `main` failures.
  - Mitigation:
    - the scope is intentionally minimal and directly required to unblock validation of `#61566`; no production behavior changes are included.
