### PR TITLE
Make gateway connect handshake timeout configurable and honor it in callGateway

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2327,7 +2327,9 @@ Notes:
         allowAgents: ["research"],
         model: "minimax/MiniMax-M2.7",
         maxConcurrent: 8,
+        startupWaitTimeoutMs: 60000,
         runTimeoutSeconds: 900,
+        completionAnnounceTimeoutMs: 90000,
         archiveAfterMinutes: 60,
       },
     },
@@ -2337,7 +2339,10 @@ Notes:
 
 - `model`: default model for spawned sub-agents. If omitted, sub-agents inherit the caller's model.
 - `allowAgents`: default allowlist of target agent ids for `sessions_spawn` when the requester agent does not set its own `subagents.allowAgents` (`["*"]` = any; default: same agent only).
+- `startupWaitTimeoutMs`: requester-side patience in milliseconds for sub-agent startup/setup RPCs before the child is considered launched. Default: `60000`. This affects early spawn bookkeeping and the primary startup RPC; it does not change child runtime abort behavior.
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
+- `completionAnnounceTimeoutMs`: preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls. Default: `90000`.
+- `announceTimeoutMs`: backward-compatible alias for `completionAnnounceTimeoutMs`. If both are set, `completionAnnounceTimeoutMs` wins.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 
 ---

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2831,6 +2831,8 @@ See [Plugins](/tools/plugin).
 
 ## Gateway
 
+- `gateway.connectChallengeTimeoutMs`: WebSocket pre-auth/connect handshake timeout in milliseconds. Default: `10000`. Raise this when local control-plane stalls can delay connect challenge completion enough to trip a handshake-timeout before the session is connected.
+
 ```json5
 {
   gateway: {

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2329,7 +2329,7 @@ Notes:
         maxConcurrent: 8,
         startupWaitTimeoutMs: 60000,
         runTimeoutSeconds: 900,
-        completionAnnounceTimeoutMs: 90000,
+        completionAnnounceTimeoutMs: 120000,
         archiveAfterMinutes: 60,
       },
     },
@@ -2341,7 +2341,7 @@ Notes:
 - `allowAgents`: default allowlist of target agent ids for `sessions_spawn` when the requester agent does not set its own `subagents.allowAgents` (`["*"]` = any; default: same agent only).
 - `startupWaitTimeoutMs`: requester-side patience in milliseconds for sub-agent startup/setup RPCs before the child is considered launched. Default: `60000`. This affects early spawn bookkeeping and the primary startup RPC; it does not change child runtime abort behavior.
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
-- `completionAnnounceTimeoutMs`: preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls. Default: `90000`.
+- `completionAnnounceTimeoutMs`: preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls. Default: `120000`.
 - `announceTimeoutMs`: backward-compatible alias for `completionAnnounceTimeoutMs`. If both are set, `completionAnnounceTimeoutMs` wins.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -83,7 +83,9 @@ Use `sessions_spawn`:
 - Then runs an announce step and posts the announce reply to the requester chat channel
 - Default model: inherits the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.list[].subagents.model`); an explicit `sessions_spawn.model` still wins.
 - Default thinking: inherits the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.list[].subagents.thinking`); an explicit `sessions_spawn.thinking` still wins.
+- Default startup patience: sub-agent startup/setup RPCs use `agents.defaults.subagents.startupWaitTimeoutMs` when set; otherwise they fall back to `60000` ms. This is requester-side wait budget only.
 - Default run timeout: if `sessions_spawn.runTimeoutSeconds` is omitted, OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout).
+- Default completion announce timeout: completion delivery uses `agents.defaults.subagents.completionAnnounceTimeoutMs` when set, otherwise falls back to the legacy alias `agents.defaults.subagents.announceTimeoutMs`, then to `90000` ms.
 
 Tool params:
 
@@ -149,7 +151,9 @@ Auto-archive:
 - Archive uses `sessions.delete` and renames the transcript to `*.deleted.<timestamp>` (same folder).
 - `cleanup: "delete"` archives immediately after announce (still keeps the transcript via rename).
 - Auto-archive is best-effort; pending timers are lost if the gateway restarts.
+- `startupWaitTimeoutMs` does **not** stop a child that eventually starts; it only controls how long the requester waits for startup/setup RPCs before surfacing a timeout.
 - `runTimeoutSeconds` does **not** auto-archive; it only stops the run. The session remains until auto-archive.
+- `completionAnnounceTimeoutMs` only affects final completion announce delivery. It does not change startup wait or child runtime limits.
 - Auto-archive applies equally to depth-1 and depth-2 sessions.
 - Browser cleanup is separate from archive cleanup: tracked browser tabs/processes are best-effort closed when the run finishes, even if the transcript/session record is kept.
 
@@ -167,7 +171,10 @@ By default, sub-agents cannot spawn their own sub-agents (`maxSpawnDepth: 1`). Y
         maxSpawnDepth: 2, // allow sub-agents to spawn children (default: 1)
         maxChildrenPerAgent: 5, // max active children per agent session (default: 5)
         maxConcurrent: 8, // global concurrency lane cap (default: 8)
-        runTimeoutSeconds: 900, // default timeout for sessions_spawn when omitted (0 = no timeout)
+        startupWaitTimeoutMs: 60000, // requester wait budget for startup/setup RPCs before launch
+        runTimeoutSeconds: 900, // child runtime timeout when sessions_spawn omits it (0 = no timeout)
+        completionAnnounceTimeoutMs: 90000, // preferred completion announce delivery timeout
+        announceTimeoutMs: 90000, // legacy alias for completionAnnounceTimeoutMs
       },
     },
   },

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-startup-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-startup-timeout.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "./test-helpers/fast-core-tools.js";
 import {
   getCallGatewayMock,
@@ -49,6 +49,12 @@ function findSessionsDeleteCall(
 
 describe("sessions_spawn subagent startup wait timeout", () => {
   beforeEach(() => {
+    resetSessionsSpawnConfigOverride();
+    resetSubagentRegistryForTests();
+    getCallGatewayMock().mockClear();
+  });
+
+  afterEach(() => {
     resetSessionsSpawnConfigOverride();
     resetSubagentRegistryForTests();
     getCallGatewayMock().mockClear();

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-startup-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-startup-timeout.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import "./test-helpers/fast-core-tools.js";
+import {
+  getCallGatewayMock,
+  getSessionsSpawnTool,
+  resetSessionsSpawnConfigOverride,
+  setSessionsSpawnConfigOverride,
+  setupSessionsSpawnGatewayMock,
+  type GatewayRequest,
+} from "./openclaw-tools.subagents.sessions-spawn.test-harness.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+const MAIN_SESSION_KEY = "agent:test:main";
+
+function configureDefaults(subagents: Record<string, unknown>) {
+  setSessionsSpawnConfigOverride({
+    session: { mainKey: "main", scope: "per-sender" },
+    agents: { defaults: { subagents } },
+  });
+}
+
+function findSubagentStartupCall(
+  calls: Array<GatewayRequest>,
+): (GatewayRequest & { timeoutMs?: number }) | undefined {
+  return calls.find((entry) => {
+    if (entry.method !== "agent") {
+      return false;
+    }
+    const params = entry.params as { lane?: string } | undefined;
+    return params?.lane === "subagent";
+  }) as (GatewayRequest & { timeoutMs?: number }) | undefined;
+}
+
+function findSessionsPatchCall(
+  calls: Array<GatewayRequest>,
+): (GatewayRequest & { timeoutMs?: number }) | undefined {
+  return calls.find((entry) => entry.method === "sessions.patch") as
+    | (GatewayRequest & { timeoutMs?: number })
+    | undefined;
+}
+
+function findSessionsDeleteCall(
+  calls: Array<GatewayRequest>,
+): (GatewayRequest & { timeoutMs?: number }) | undefined {
+  return calls.find((entry) => entry.method === "sessions.delete") as
+    | (GatewayRequest & { timeoutMs?: number })
+    | undefined;
+}
+
+describe("sessions_spawn subagent startup wait timeout", () => {
+  beforeEach(() => {
+    resetSessionsSpawnConfigOverride();
+    resetSubagentRegistryForTests();
+    getCallGatewayMock().mockClear();
+  });
+
+  it("falls back to 60s startup wait patience when config key is absent", async () => {
+    configureDefaults({ maxConcurrent: 8 });
+    const gateway = setupSessionsSpawnGatewayMock({});
+    const tool = await getSessionsSpawnTool({ agentSessionKey: MAIN_SESSION_KEY });
+
+    const result = await tool.execute("call-startup-timeout-default", { task: "hello" });
+
+    expect(result.details).toMatchObject({ status: "accepted" });
+    expect(findSubagentStartupCall(gateway.calls)?.timeoutMs).toBe(60_000);
+  });
+
+  it("honors configured startupWaitTimeoutMs for pre-launch setup and the primary startup RPC", async () => {
+    configureDefaults({ maxConcurrent: 8, startupWaitTimeoutMs: 45_000 });
+    const gateway = setupSessionsSpawnGatewayMock({});
+    const tool = await getSessionsSpawnTool({ agentSessionKey: MAIN_SESSION_KEY });
+
+    const result = await tool.execute("call-startup-timeout-configured", { task: "hello" });
+
+    expect(result.details).toMatchObject({ status: "accepted" });
+    expect(findSessionsPatchCall(gateway.calls)?.timeoutMs).toBe(45_000);
+    expect(findSubagentStartupCall(gateway.calls)?.timeoutMs).toBe(45_000);
+  });
+
+  it("keeps cleanup-path waits on their short budget when startup fails", async () => {
+    configureDefaults({ maxConcurrent: 8, startupWaitTimeoutMs: 45_000 });
+    const calls: Array<GatewayRequest> = [];
+    getCallGatewayMock().mockImplementation(async (request: GatewayRequest) => {
+      calls.push(request);
+      if (request.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (request.method === "agent") {
+        throw new Error("spawn startup failed");
+      }
+      if (request.method === "sessions.delete") {
+        return { ok: true };
+      }
+      return {};
+    });
+    const tool = await getSessionsSpawnTool({ agentSessionKey: MAIN_SESSION_KEY });
+
+    const result = await tool.execute("call-startup-timeout-cleanup", { task: "hello" });
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "spawn startup failed",
+    });
+    expect(findSubagentStartupCall(calls)?.timeoutMs).toBe(45_000);
+    expect(findSessionsDeleteCall(calls)?.timeoutMs).toBe(10_000);
+  });
+});

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -65,7 +65,12 @@ function resolveDirectAnnounceTransientRetryDelaysMs() {
 }
 
 export function resolveSubagentAnnounceTimeoutMs(cfg: ReturnType<typeof loadConfig>): number {
-  const configured = cfg.agents?.defaults?.subagents?.announceTimeoutMs;
+  const subagents = cfg.agents?.defaults?.subagents;
+  const configured =
+    typeof subagents?.completionAnnounceTimeoutMs === "number" &&
+    Number.isFinite(subagents.completionAnnounceTimeoutMs)
+      ? subagents.completionAnnounceTimeoutMs
+      : subagents?.announceTimeoutMs;
   if (typeof configured !== "number" || !Number.isFinite(configured)) {
     return DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS;
   }

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -122,13 +122,15 @@ vi.mock("./subagent-announce-delivery.js", () => ({
             }),
       },
     });
+    const subagents = configOverride.agents?.defaults?.subagents;
+    const configuredTimeoutMs =
+      typeof subagents?.completionAnnounceTimeoutMs === "number" &&
+      Number.isFinite(subagents.completionAnnounceTimeoutMs)
+        ? subagents.completionAnnounceTimeoutMs
+        : subagents?.announceTimeoutMs;
     const timeoutMs =
-      typeof configOverride.agents?.defaults?.subagents?.announceTimeoutMs === "number" &&
-      Number.isFinite(configOverride.agents.defaults.subagents.announceTimeoutMs)
-        ? Math.min(
-            Math.max(1, Math.floor(configOverride.agents.defaults.subagents.announceTimeoutMs)),
-            2_147_000_000,
-          )
+      typeof configuredTimeoutMs === "number" && Number.isFinite(configuredTimeoutMs)
+        ? Math.min(Math.max(1, Math.floor(configuredTimeoutMs)), 2_147_000_000)
         : 120_000;
     const retryDelaysMs =
       process.env.OPENCLAW_TEST_FAST === "1" ? [8, 16, 32] : [5_000, 10_000, 20_000];
@@ -160,7 +162,12 @@ vi.mock("./subagent-announce-delivery.js", () => ({
   resolveSubagentCompletionOrigin: async (params: { requesterOrigin?: unknown }) =>
     params.requesterOrigin,
   resolveSubagentAnnounceTimeoutMs: (cfg: typeof configOverride) => {
-    const configured = cfg.agents?.defaults?.subagents?.announceTimeoutMs;
+    const subagents = cfg.agents?.defaults?.subagents;
+    const configured =
+      typeof subagents?.completionAnnounceTimeoutMs === "number" &&
+      Number.isFinite(subagents.completionAnnounceTimeoutMs)
+        ? subagents.completionAnnounceTimeoutMs
+        : subagents?.announceTimeoutMs;
     if (typeof configured !== "number" || !Number.isFinite(configured)) {
       return 120_000;
     }
@@ -212,13 +219,21 @@ const baseAnnounceFlowParams = {
   outcome: { status: "ok" as const },
 } satisfies Omit<AnnounceFlowParams, "childRunId">;
 
-function setConfiguredAnnounceTimeout(timeoutMs: number): void {
+function setConfiguredAnnounceTimeout(params: {
+  announceTimeoutMs?: number;
+  completionAnnounceTimeoutMs?: number;
+}): void {
   configOverride = {
     session: defaultSessionConfig,
     agents: {
       defaults: {
         subagents: {
-          announceTimeoutMs: timeoutMs,
+          ...(typeof params.announceTimeoutMs === "number"
+            ? { announceTimeoutMs: params.announceTimeoutMs }
+            : {}),
+          ...(typeof params.completionAnnounceTimeoutMs === "number"
+            ? { completionAnnounceTimeoutMs: params.completionAnnounceTimeoutMs }
+            : {}),
         },
       },
     },
@@ -288,7 +303,7 @@ describe("subagent announce timeout config", () => {
   });
 
   it("honors configured announce timeout for direct announce agent call", async () => {
-    setConfiguredAnnounceTimeout(120_000);
+    setConfiguredAnnounceTimeout({ announceTimeoutMs: 120_000 });
     await runAnnounceFlowForTest("run-config-timeout-agent");
 
     const directAgentCall = findGatewayCall(
@@ -298,7 +313,7 @@ describe("subagent announce timeout config", () => {
   });
 
   it("honors configured announce timeout for completion direct agent call", async () => {
-    setConfiguredAnnounceTimeout(120_000);
+    setConfiguredAnnounceTimeout({ announceTimeoutMs: 120_000 });
     await runAnnounceFlowForTest("run-config-timeout-send", {
       requesterOrigin: {
         channel: "discord",
@@ -311,6 +326,29 @@ describe("subagent announce timeout config", () => {
       (call) => call.method === "agent" && call.expectFinal === true,
     );
     expect(completionDirectAgentCall?.timeoutMs).toBe(120_000);
+  });
+
+  it("uses completionAnnounceTimeoutMs when only the new key is configured", async () => {
+    setConfiguredAnnounceTimeout({ completionAnnounceTimeoutMs: 95_000 });
+    await runAnnounceFlowForTest("run-config-completion-timeout-only");
+
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    expect(directAgentCall?.timeoutMs).toBe(95_000);
+  });
+
+  it("prefers completionAnnounceTimeoutMs over announceTimeoutMs when both are set", async () => {
+    setConfiguredAnnounceTimeout({
+      announceTimeoutMs: 80_000,
+      completionAnnounceTimeoutMs: 105_000,
+    });
+    await runAnnounceFlowForTest("run-config-completion-timeout-precedence");
+
+    const directAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    expect(directAgentCall?.timeoutMs).toBe(105_000);
   });
 
   it("retries gateway timeout for externally delivered completion announces before giving up", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -59,6 +59,17 @@ export type SpawnSubagentSandboxMode = (typeof SUBAGENT_SPAWN_SANDBOX_MODES)[num
 
 export { decodeStrictBase64 };
 
+const DEFAULT_SUBAGENT_STARTUP_TIMEOUT_MS = 60_000;
+const SUBAGENT_MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
+
+export function resolveSubagentStartupWaitTimeoutMs(cfg: ReturnType<typeof loadConfig>): number {
+  const configured = cfg.agents?.defaults?.subagents?.startupWaitTimeoutMs;
+  if (typeof configured !== "number" || !Number.isFinite(configured)) {
+    return DEFAULT_SUBAGENT_STARTUP_TIMEOUT_MS;
+  }
+  return Math.min(Math.max(1, Math.floor(configured)), SUBAGENT_MAX_SAFE_TIMEOUT_MS);
+}
+
 type SubagentSpawnDeps = {
   callGateway: typeof callGateway;
   getGlobalHookRunner: () => SubagentLifecycleHookRunner | null;
@@ -399,6 +410,7 @@ export async function spawnSubagentDirect(
     cfg,
     runTimeoutSeconds: params.runTimeoutSeconds,
   });
+  const startupWaitTimeoutMs = resolveSubagentStartupWaitTimeoutMs(cfg);
   let modelApplied = false;
   let threadBindingReady = false;
   const { mainKey, alias } = resolveMainSessionAlias(cfg);
@@ -729,7 +741,7 @@ export async function spawnSubagentDirect(
           : {}),
         ...publicSpawnedMetadata,
       },
-      timeoutMs: 10_000,
+      timeoutMs: startupWaitTimeoutMs,
     });
     const runId = readGatewayRunId(response);
     if (runId) {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -98,7 +98,6 @@ export type SpawnSubagentParams = {
   lightContext?: boolean;
   cleanup?: "delete" | "keep";
   sandbox?: SpawnSubagentSandboxMode;
-  lightContext?: boolean;
   expectsCompletionMessage?: boolean;
   attachments?: Array<{
     name: string;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -84,6 +84,7 @@ export type SpawnSubagentParams = {
   runTimeoutSeconds?: number;
   thread?: boolean;
   mode?: SpawnSubagentMode;
+  lightContext?: boolean;
   cleanup?: "delete" | "keep";
   sandbox?: SpawnSubagentSandboxMode;
   lightContext?: boolean;

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -518,7 +518,7 @@ export async function spawnSubagentDirect(
       await callSubagentGateway({
         method: "sessions.patch",
         params: { key: childSessionKey, ...patch },
-        timeoutMs: 10_000,
+        timeoutMs: startupWaitTimeoutMs,
       });
       return undefined;
     } catch (err) {

--- a/src/config/gateway-connect-challenge-timeout.test.ts
+++ b/src/config/gateway-connect-challenge-timeout.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { validateConfigObject } from "./validation.js";
+
+describe("gateway.connectChallengeTimeoutMs", () => {
+  it("accepts values above the old 10-second handshake cap", () => {
+    const result = validateConfigObject({
+      gateway: {
+        connectChallengeTimeoutMs: 20_000,
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/config/gateway-connect-challenge-timeout.test.ts
+++ b/src/config/gateway-connect-challenge-timeout.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { validateConfigObject } from "./validation.js";
 
 describe("gateway.connectChallengeTimeoutMs", () => {
@@ -10,5 +9,15 @@ describe("gateway.connectChallengeTimeoutMs", () => {
       },
     });
     expect(result.ok).toBe(true);
+  });
+
+  it("rejects values above the runtime max", () => {
+    const result = validateConfigObject({
+      gateway: {
+        connectChallengeTimeoutMs: 300_001,
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.issues.join("\n")).toContain("connectChallengeTimeoutMs");
   });
 });

--- a/src/config/gateway-connect-challenge-timeout.test.ts
+++ b/src/config/gateway-connect-challenge-timeout.test.ts
@@ -18,6 +18,9 @@ describe("gateway.connectChallengeTimeoutMs", () => {
       },
     });
     expect(result.ok).toBe(false);
-    expect(result.issues.join("\n")).toContain("connectChallengeTimeoutMs");
+    if (result.ok) {
+      throw new Error("Expected config validation to fail");
+    }
+    expect(JSON.stringify(result.issues)).toContain("connectChallengeTimeoutMs");
   });
 });

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4833,27 +4833,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   thinking: {
                     type: "string",
                   },
-                  startupWaitTimeoutMs: {
-                    description:
-                      "Requester-side wait budget in milliseconds for the primary sub-agent startup RPC (default: 60000).",
-                    type: "integer",
-                    exclusiveMinimum: 0,
-                    maximum: 9007199254740991,
-                  },
                   runTimeoutSeconds: {
                     type: "integer",
                     minimum: 0,
                     maximum: 9007199254740991,
                   },
-                  completionAnnounceTimeoutMs: {
-                    description:
-                      "Preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls (default: 90000).",
-                    type: "integer",
-                    exclusiveMinimum: 0,
-                    maximum: 9007199254740991,
-                  },
                   announceTimeoutMs: {
-                    description: "Backward-compatible alias for completionAnnounceTimeoutMs.",
                     type: "integer",
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
@@ -20803,7 +20788,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
           connectChallengeTimeoutMs: {
             type: "integer",
             minimum: 1,
-            maximum: 9007199254740991,
+            maximum: 300000,
             description:
               "WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.",
           },

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4833,12 +4833,27 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   thinking: {
                     type: "string",
                   },
+                  startupWaitTimeoutMs: {
+                    description:
+                      "Requester-side wait budget in milliseconds for the primary sub-agent startup RPC (default: 60000).",
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
                   runTimeoutSeconds: {
                     type: "integer",
                     minimum: 0,
                     maximum: 9007199254740991,
                   },
+                  completionAnnounceTimeoutMs: {
+                    description:
+                      "Preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls (default: 90000).",
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
                   announceTimeoutMs: {
+                    description: "Backward-compatible alias for completionAnnounceTimeoutMs.",
                     type: "integer",
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
@@ -20784,6 +20799,13 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             title: "Gateway Channel Max Restarts Per Hour",
             description:
               "Maximum number of health-monitor-initiated channel restarts allowed within a rolling one-hour window. Once hit, further restarts are skipped until the window expires. Default: 10.",
+          },
+          connectChallengeTimeoutMs: {
+            type: "integer",
+            minimum: 1,
+            maximum: 9007199254740991,
+            description:
+              "WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.",
           },
           tailscale: {
             type: "object",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4838,6 +4838,16 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     minimum: 0,
                     maximum: 9007199254740991,
                   },
+                  startupWaitTimeoutMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  completionAnnounceTimeoutMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
                   announceTimeoutMs: {
                     type: "integer",
                     exclusiveMinimum: 0,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -327,7 +327,11 @@ export type AgentDefaultsConfig = {
     thinking?: string;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
     runTimeoutSeconds?: number;
-    /** Gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
+    /** Gateway timeout in ms for sub-agent startup/setup RPCs before launch is considered failed (default: 60000). */
+    startupWaitTimeoutMs?: number;
+    /** Preferred gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
+    completionAnnounceTimeoutMs?: number;
+    /** Legacy alias for completionAnnounceTimeoutMs. */
     announceTimeoutMs?: number;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
     requireAgentId?: boolean;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -329,7 +329,7 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent startup/setup RPCs before launch is considered failed (default: 60000). */
     startupWaitTimeoutMs?: number;
-    /** Preferred gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
+    /** Preferred gateway timeout in ms for sub-agent announce delivery calls (default: 120000). */
     completionAnnounceTimeoutMs?: number;
     /** Legacy alias for completionAnnounceTimeoutMs. */
     announceTimeoutMs?: number;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -406,6 +406,8 @@ export type GatewayConfig = {
   http?: GatewayHttpConfig;
   push?: GatewayPushConfig;
   nodes?: GatewayNodesConfig;
+  /** WebSocket pre-auth/connect handshake timeout in milliseconds (default: 10000). */
+  connectChallengeTimeoutMs?: number;
   /**
    * IPs of trusted reverse proxies (e.g. Traefik, nginx). When a connection
    * arrives from one of these IPs, the Gateway trusts `x-forwarded-for`

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -31,6 +31,37 @@ describe("agent defaults schema", () => {
     ).not.toThrow();
   });
 
+  it("accepts positive subagent startupWaitTimeoutMs", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        subagents: {
+          startupWaitTimeoutMs: 60_000,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects invalid subagent startupWaitTimeoutMs", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        subagents: {
+          startupWaitTimeoutMs: 0,
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("accepts both completionAnnounceTimeoutMs and announceTimeoutMs during the alias window", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        subagents: {
+          completionAnnounceTimeoutMs: 90_000,
+          announceTimeoutMs: 45_000,
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("accepts contextInjection: always", () => {
     const result = AgentDefaultsSchema.parse({ contextInjection: "always" })!;
     expect(result.contextInjection).toBe("always");

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -213,6 +213,8 @@ export const AgentDefaultsSchema = z
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
+        startupWaitTimeoutMs: z.number().int().positive().optional(),
+        completionAnnounceTimeoutMs: z.number().int().positive().optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
         requireAgentId: z.boolean().optional(),
       })

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -738,7 +738,15 @@ export const OpenClawSchema = z
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
         channelMaxRestartsPerHour: z.number().int().min(1).optional(),
-connectChallengeTimeoutMs: z.number().int().min(1).describe("WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.").optional(),
+        connectChallengeTimeoutMs: z
+          .number()
+          .int()
+          .min(1)
+          .max(300_000)
+          .describe(
+            "WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.",
+          )
+          .optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -738,6 +738,7 @@ export const OpenClawSchema = z
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
         channelMaxRestartsPerHour: z.number().int().min(1).optional(),
+connectChallengeTimeoutMs: z.number().int().min(1).describe("WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.").optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -810,6 +810,32 @@ describe("callGateway error details", () => {
     expect(String(err)).toContain("gateway timeout after 25000ms");
   });
 
+  it("preserves the 10s default outer timeout when handshake timeout is configured lower", async () => {
+    vi.useFakeTimers();
+    startMode = "silent";
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback", connectChallengeTimeoutMs: 250 },
+    });
+    setGatewayNetworkDefaults();
+
+    const promise = callGateway({ method: "health" }).catch((caught) => caught);
+
+    await vi.advanceTimersByTimeAsync(9_999);
+    await Promise.resolve();
+
+    let settled = false;
+    void promise.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    const err = await promise;
+    expect(err).toBeInstanceOf(Error);
+    expect(String(err)).toContain("gateway timeout after 10000ms");
+  });
+
   it("does not inject wrapper timeout defaults into expectFinal requests", async () => {
     setLocalLoopbackGatewayConfig();
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -784,6 +784,32 @@ describe("callGateway error details", () => {
     expect(lastClientOptions?.connectChallengeTimeoutMs).toBe(25_000);
   });
 
+  it("uses configured connect handshake budget as the default outer timeout floor", async () => {
+    vi.useFakeTimers();
+    startMode = "silent";
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback", connectChallengeTimeoutMs: 25_000 },
+    });
+    setGatewayNetworkDefaults();
+
+    const promise = callGateway({ method: "health" }).catch((caught) => caught);
+
+    await vi.advanceTimersByTimeAsync(10_001);
+    await Promise.resolve();
+
+    let settled = false;
+    void promise.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    const err = await promise;
+    expect(err).toBeInstanceOf(Error);
+    expect(String(err)).toContain("gateway timeout after 25000ms");
+  });
+
   it("does not inject wrapper timeout defaults into expectFinal requests", async () => {
     setLocalLoopbackGatewayConfig();
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -27,6 +27,7 @@ let lastClientOptions: {
   token?: string;
   password?: string;
   tlsFingerprint?: string;
+  connectChallengeTimeoutMs?: number;
   scopes?: string[];
   deviceIdentity?: unknown;
   onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
@@ -58,6 +59,7 @@ vi.mock("./client.js", () => ({
       url?: string;
       token?: string;
       password?: string;
+      connectChallengeTimeoutMs?: number;
       scopes?: string[];
       onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
       onClose?: (code: number, reason: string) => void;
@@ -95,6 +97,7 @@ class StubGatewayClient {
     url?: string;
     token?: string;
     password?: string;
+    connectChallengeTimeoutMs?: number;
     scopes?: string[];
     onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
     onClose?: (code: number, reason: string) => void;
@@ -760,13 +763,25 @@ describe("callGateway error details", () => {
     expect(errMessage).toContain("gateway closed (1006");
   });
 
-  it("forwards caller timeout to client requests", async () => {
+  it("forwards caller timeout to client requests and connect handshake budget", async () => {
     setLocalLoopbackGatewayConfig();
 
     await callGateway({ method: "health", timeoutMs: 45_000 });
 
+    expect(lastClientOptions?.connectChallengeTimeoutMs).toBe(45_000);
     expect(lastRequestOptions?.method).toBe("health");
     expect(lastRequestOptions?.opts?.timeoutMs).toBe(45_000);
+  });
+
+  it("falls back to configured connect handshake budget when caller timeout is absent", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback", connectChallengeTimeoutMs: 25_000 },
+    });
+    setGatewayNetworkDefaults();
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.connectChallengeTimeoutMs).toBe(25_000);
   });
 
   it("does not inject wrapper timeout defaults into expectFinal requests", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -40,6 +40,7 @@ import {
   type GatewayRemoteCredentialPrecedence,
 } from "./credentials.js";
 import { canSkipGatewayConfigLoad } from "./explicit-connection-policy.js";
+import { getPreauthHandshakeTimeoutMsFromEnv } from "./handshake-timeouts.js";
 import {
   CLI_DEFAULT_OPERATOR_SCOPES,
   resolveLeastPrivilegeOperatorScopesForMethod,
@@ -278,12 +279,17 @@ type ResolvedGatewayCallContext = {
   remotePasswordFallback?: GatewayRemoteCredentialFallback;
 };
 
-function resolveGatewayCallTimeout(timeoutValue: unknown): {
+function resolveGatewayCallTimeout(
+  timeoutValue: unknown,
+  defaultTimeoutMs = 10_000,
+): {
   timeoutMs: number;
   safeTimerTimeoutMs: number;
 } {
   const timeoutMs =
-    typeof timeoutValue === "number" && Number.isFinite(timeoutValue) ? timeoutValue : 10_000;
+    typeof timeoutValue === "number" && Number.isFinite(timeoutValue)
+      ? timeoutValue
+      : defaultTimeoutMs;
   const safeTimerTimeoutMs = Math.max(1, Math.min(Math.floor(timeoutMs), 2_147_483_647));
   return { timeoutMs, safeTimerTimeoutMs };
 }
@@ -809,8 +815,15 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   opts: CallGatewayBaseOptions,
   scopes: OperatorScope[],
 ): Promise<T> {
-  const { timeoutMs, safeTimerTimeoutMs } = resolveGatewayCallTimeout(opts.timeoutMs);
   const context = resolveGatewayCallContext(opts);
+  const configuredConnectChallengeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv(
+    process.env,
+    context.config.gateway?.connectChallengeTimeoutMs,
+  );
+  const { timeoutMs, safeTimerTimeoutMs } = resolveGatewayCallTimeout(
+    opts.timeoutMs,
+    configuredConnectChallengeTimeoutMs,
+  );
   const resolvedCredentials = await resolveGatewayCredentials(context);
   ensureExplicitGatewayAuth({
     urlOverride: context.urlOverride,
@@ -830,7 +843,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   const connectChallengeTimeoutMs =
     typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
       ? timeoutMs
-      : context.config.gateway?.connectChallengeTimeoutMs;
+      : configuredConnectChallengeTimeoutMs;
   const url = connectionDetails.url;
   const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
   const { token, password } = resolvedCredentials;

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -822,7 +822,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   );
   const { timeoutMs, safeTimerTimeoutMs } = resolveGatewayCallTimeout(
     opts.timeoutMs,
-    configuredConnectChallengeTimeoutMs,
+    Math.max(10_000, configuredConnectChallengeTimeoutMs),
   );
   const resolvedCredentials = await resolveGatewayCredentials(context);
   ensureExplicitGatewayAuth({

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -711,12 +711,22 @@ async function executeGatewayRequestWithScopes<T>(params: {
   token?: string;
   password?: string;
   tlsFingerprint?: string;
+  connectChallengeTimeoutMs?: number;
   timeoutMs: number;
   safeTimerTimeoutMs: number;
   connectionDetails: GatewayConnectionDetails;
 }): Promise<T> {
-  const { opts, scopes, url, token, password, tlsFingerprint, timeoutMs, safeTimerTimeoutMs } =
-    params;
+  const {
+    opts,
+    scopes,
+    url,
+    token,
+    password,
+    tlsFingerprint,
+    connectChallengeTimeoutMs,
+    timeoutMs,
+    safeTimerTimeoutMs,
+  } = params;
   // Yield to the event loop before starting the WebSocket connection.
   // On Windows with large dist bundles, heavy synchronous module loading
   // can starve the event loop, preventing timely processing of the
@@ -743,6 +753,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       token,
       password,
       tlsFingerprint,
+      connectChallengeTimeoutMs,
       instanceId: opts.instanceId ?? randomUUID(),
       clientName: opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
       clientDisplayName: opts.clientDisplayName,
@@ -816,6 +827,10 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     urlSource: context.urlOverrideSource,
     ...(opts.configPath ? { configPath: opts.configPath } : {}),
   });
+  const connectChallengeTimeoutMs =
+    typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
+      ? timeoutMs
+      : context.config.gateway?.connectChallengeTimeoutMs;
   const url = connectionDetails.url;
   const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
   const { token, password } = resolvedCredentials;
@@ -826,6 +841,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     token,
     password,
     tlsFingerprint,
+    connectChallengeTimeoutMs,
     timeoutMs,
     safeTimerTimeoutMs,
     connectionDetails,

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -27,7 +27,6 @@ import {
 import { VERSION } from "../version.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
 import { resolveConnectChallengeTimeoutMs } from "./handshake-timeouts.js";
-import { loadConfig } from "../config/validation.js";
 import { isLoopbackHost, isSecureWebSocketUrl } from "./net.js";
 import {
   ConnectErrorDetailCodes,

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -27,6 +27,7 @@ import {
 import { VERSION } from "../version.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
 import { resolveConnectChallengeTimeoutMs } from "./handshake-timeouts.js";
+import { loadConfig } from "../config/validation.js";
 import { isLoopbackHost, isSecureWebSocketUrl } from "./net.js";
 import {
   ConnectErrorDetailCodes,

--- a/src/gateway/handshake-timeouts.configured.test.ts
+++ b/src/gateway/handshake-timeouts.configured.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_CONNECT_CHALLENGE_TIMEOUT_MS,
+  getPreauthHandshakeTimeoutMsFromEnv,
+} from "./handshake-timeouts.js";
+
+describe("getPreauthHandshakeTimeoutMsFromEnv", () => {
+  it("falls back to configured gateway timeout when env overrides are absent", () => {
+    expect(getPreauthHandshakeTimeoutMsFromEnv({}, 45_000)).toBe(45_000);
+  });
+
+  it("prefers env overrides over the configured gateway timeout", () => {
+    expect(
+      getPreauthHandshakeTimeoutMsFromEnv({ OPENCLAW_HANDSHAKE_TIMEOUT_MS: "75" }, 45_000),
+    ).toBe(75);
+  });
+
+  it("clamps configured gateway timeout into the safe range", () => {
+    expect(getPreauthHandshakeTimeoutMsFromEnv({}, 999_999_999)).toBe(
+      MAX_CONNECT_CHALLENGE_TIMEOUT_MS,
+    );
+  });
+});

--- a/src/gateway/handshake-timeouts.test.ts
+++ b/src/gateway/handshake-timeouts.test.ts
@@ -17,7 +17,7 @@ describe("gateway handshake timeouts", () => {
   test("clamps connect challenge timeouts into the supported range", () => {
     expect(clampConnectChallengeTimeoutMs(0)).toBe(MIN_CONNECT_CHALLENGE_TIMEOUT_MS);
     expect(clampConnectChallengeTimeoutMs(2_000)).toBe(2_000);
-    expect(clampConnectChallengeTimeoutMs(20_000)).toBe(MAX_CONNECT_CHALLENGE_TIMEOUT_MS);
+    expect(clampConnectChallengeTimeoutMs(500_000)).toBe(MAX_CONNECT_CHALLENGE_TIMEOUT_MS);
   });
 
   test("prefers OPENCLAW_HANDSHAKE_TIMEOUT_MS and falls back on the test-only env", () => {

--- a/src/gateway/handshake-timeouts.ts
+++ b/src/gateway/handshake-timeouts.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 10_000;
 export const MIN_CONNECT_CHALLENGE_TIMEOUT_MS = 250;
-export const MAX_CONNECT_CHALLENGE_TIMEOUT_MS = DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
+export const MAX_CONNECT_CHALLENGE_TIMEOUT_MS = 300_000;
 
 export function clampConnectChallengeTimeoutMs(timeoutMs: number): number {
   return Math.max(
@@ -33,7 +33,7 @@ export function resolveConnectChallengeTimeoutMs(timeoutMs?: number | null): num
   return DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
 }
 
-export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = process.env): number {
+export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = process.env, configuredMs?: unknown): number {
   const configuredTimeout =
     env.OPENCLAW_HANDSHAKE_TIMEOUT_MS || (env.VITEST && env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
   if (configuredTimeout) {

--- a/src/gateway/handshake-timeouts.ts
+++ b/src/gateway/handshake-timeouts.ts
@@ -33,7 +33,10 @@ export function resolveConnectChallengeTimeoutMs(timeoutMs?: number | null): num
   return DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
 }
 
-export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = process.env, configuredMs?: unknown): number {
+export function getPreauthHandshakeTimeoutMsFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredMs?: unknown,
+): number {
   const configuredTimeout =
     env.OPENCLAW_HANDSHAKE_TIMEOUT_MS || (env.VITEST && env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
   if (configuredTimeout) {
@@ -42,5 +45,7 @@ export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = pro
       return parsed;
     }
   }
-  return DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
+  return resolveConnectChallengeTimeoutMs(
+    typeof configuredMs === "number" && Number.isFinite(configuredMs) ? configuredMs : undefined,
+  );
 }

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { WebSocket, WebSocketServer } from "ws";
+import { loadConfig } from "../../config/config.js";
 import { resolveCanvasHostUrl } from "../../infra/canvas-host-url.js";
 import { removeRemoteNodeInfo } from "../../infra/skills-remote.js";
 import { upsertPresence } from "../../infra/system-presence.js";
@@ -10,7 +11,6 @@ import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { getPreauthHandshakeTimeoutMsFromEnv } from "../handshake-timeouts.js";
-import { loadConfig } from "../../config/validation.js";
 import { isLoopbackAddress } from "../net.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
@@ -298,7 +298,10 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       close();
     });
 
-    const handshakeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv(process.env, loadConfig().gateway?.connectChallengeTimeoutMs);
+    const handshakeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv(
+      process.env,
+      loadConfig().gateway?.connectChallengeTimeoutMs,
+    );
     const handshakeTimer = setTimeout(() => {
       if (!client) {
         handshakeState = "failed";

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -10,6 +10,7 @@ import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { getPreauthHandshakeTimeoutMsFromEnv } from "../handshake-timeouts.js";
+import { loadConfig } from "../../config/validation.js";
 import { isLoopbackAddress } from "../net.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
@@ -297,7 +298,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       close();
     });
 
-    const handshakeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv();
+    const handshakeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv(process.env, loadConfig().gateway?.connectChallengeTimeoutMs);
     const handshakeTimer = setTimeout(() => {
       if (!client) {
         handshakeState = "failed";


### PR DESCRIPTION
# Timeout handshake config + callGateway propagation

## Proposed title
Make gateway connect handshake timeout configurable and honor it in callGateway

## Severity / operator impact

**Critical for low-performance and latency-sensitive systems.**

On slower hosts or installations with intermittent loopback/control-plane latency, this bug can make the gateway behave as if handshake/connect budgets are shorter than configured, producing misleading timeout or closure failures in ordinary operations such as subagent startup and session-control calls.

## Problem
Subagent startup and other gateway-backed operations could fail with misleading timeout/closure symptoms under live conditions even when the gateway was still technically reachable. The investigation showed that the effective connect/pre-auth handshake budget was not consistently controlled across the server and caller paths.

In practice this meant:
- live latency spikes on the loopback gateway path could push handshake/connect time beyond the old default envelope
- some calls still behaved as if they were on a shorter hidden connect budget even when higher-level timeouts were larger
- failure diagnosis was made harder by some failure paths whose broad exception handling and error-collapsing behavior reduced more specific causes into generic timeout or closure symptoms

## Root cause / diagnosis
This PR captures the clean, durable core of the timeout investigation:

1. the gateway needed an operator-facing config surface for the connect/pre-auth handshake timeout
2. the client/caller path also needed to honor that effective timeout instead of silently retaining the default connect budget

Without both parts, the installation could still behave as if the handshake path were capped near the default even when broader wait budgets were configured elsewhere.

## Changes
This PR contains two commits as one coherent fix line:

- `a465ffe864` — make gateway connect handshake timeout configurable
  - adds `gateway.connectChallengeTimeoutMs`
  - wires configured timeout into the gateway server handshake path
  - documents and tests the new config surface

- `06a1bdbf8f` — honor gateway handshake timeout in `callGateway`
  - propagates the effective timeout into `GatewayClient`
  - makes the handshake-timeout helper actually fall back to configured timeout when env overrides are absent
  - adds focused tests for configured-timeout behavior

Together these changes make the handshake/connect timeout:
- configurable on the gateway side
- actually honored on the caller/client side

## Why this PR is intentionally narrow
This investigation also produced other commits around launch accounting, startup propagation, callback visibility, and bootstrap/materialization behavior.

Those changes were useful during diagnosis, but they are not included in this first PR because they are either:
- broader in scope,
- mixed with adjacent lifecycle changes,
- or part of later exploratory/superseded fix attempts.

This PR intentionally keeps the first upstreamable slice focused on the cleanest durable timeout line.

## Validation
Validation already performed on the original investigation checkout for the same committed changes:
- targeted handshake/config tests for `gateway.connectChallengeTimeoutMs`
- targeted handshake-timeout helper tests
- targeted `callGateway` connect-handshake-budget assertions

Additional note for branch prep:
- when these commits were replayed onto a fresh branch from updated `origin/main`, one conflict appeared in `src/gateway/call.ts`
- the conflict was resolved by keeping both behaviors:
  - the upstream `setImmediate` yield before opening the WebSocket connection
  - and the local `connectChallengeTimeoutMs` propagation from `06a1bdbf8f`

## Remaining caveats
This PR is intentionally **narrow**, not comprehensive.

Reason:
- later live investigation on `crayfish` still found additional installed-runtime/control-plane issues beyond this core source fix line
- so this PR is best presented as a foundational upstream timeout fix, not as the complete explanation for every observed live failure in that installation

In other words:
- this PR captures a real, durable fix line
- but additional live/runtime-specific work may still be needed outside the scope of this first PR
