### PR TITLE
fix(telegram): bound startup request timeouts

### DIFF
--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -36,6 +36,7 @@ import { apiThrottler, Bot, sequentialize, type ApiClientOptions } from "./bot.r
 import { buildTelegramGroupPeerId, resolveTelegramStreamMode } from "./bot/helpers.js";
 import { resolveTelegramTransport, type TelegramTransport } from "./fetch.js";
 import { tagTelegramNetworkError } from "./network-errors.js";
+import { resolveTelegramRequestTimeoutMs } from "./request-timeouts.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
@@ -80,8 +81,6 @@ const DEFAULT_TELEGRAM_BOT_RUNTIME: TelegramBotRuntime = {
   sequentialize,
   apiThrottler,
 };
-
-const TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS = 45_000;
 
 let telegramBotRuntimeForTest: TelegramBotRuntime | undefined;
 
@@ -200,8 +199,7 @@ export function createTelegramBot(opts: TelegramBotOptions): TelegramBotInstance
         }
       };
       const method = extractTelegramApiMethod(input);
-      const requestTimeoutMs =
-        method === "getupdates" ? TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS : undefined;
+      const requestTimeoutMs = resolveTelegramRequestTimeoutMs(method);
       let requestTimeout: ReturnType<typeof setTimeout> | undefined;
       let onRequestAbort: (() => void) | undefined;
       const requestSignal = init?.signal;

--- a/extensions/telegram/src/request-timeouts.test.ts
+++ b/extensions/telegram/src/request-timeouts.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolveTelegramRequestTimeoutMs } from "./request-timeouts.js";
+
+describe("resolveTelegramRequestTimeoutMs", () => {
+  it("bounds Telegram startup control-plane methods", () => {
+    expect(resolveTelegramRequestTimeoutMs("deletewebhook")).toBe(15_000);
+    expect(resolveTelegramRequestTimeoutMs("getme")).toBe(15_000);
+    expect(resolveTelegramRequestTimeoutMs("setwebhook")).toBe(15_000);
+  });
+
+  it("keeps the longer polling timeout for getUpdates", () => {
+    expect(resolveTelegramRequestTimeoutMs("getupdates")).toBe(45_000);
+  });
+
+  it("does not assign hard timeouts to unrelated Telegram methods", () => {
+    expect(resolveTelegramRequestTimeoutMs("sendmessage")).toBeUndefined();
+    expect(resolveTelegramRequestTimeoutMs(null)).toBeUndefined();
+  });
+});

--- a/extensions/telegram/src/request-timeouts.ts
+++ b/extensions/telegram/src/request-timeouts.ts
@@ -1,0 +1,15 @@
+const TELEGRAM_REQUEST_TIMEOUTS_MS = {
+  // Bound startup/control-plane calls so the gateway cannot report Telegram as
+  // healthy while provider startup is still hung on Bot API setup.
+  deletewebhook: 15_000,
+  getme: 15_000,
+  getupdates: 45_000,
+  setwebhook: 15_000,
+} as const;
+
+export function resolveTelegramRequestTimeoutMs(method: string | null): number | undefined {
+  if (!method) {
+    return undefined;
+  }
+  return TELEGRAM_REQUEST_TIMEOUTS_MS[method as keyof typeof TELEGRAM_REQUEST_TIMEOUTS_MS];
+}


### PR DESCRIPTION
## Summary

- Problem: Telegram could report healthy/running while provider startup was still hung before inbound polling or webhook setup actually finished.
- Why it matters: inbound Telegram updates could silently never start even though health checks still passed.
- What changed: centralized Telegram Bot API request timeout resolution and added bounded startup/control-plane timeouts for `getMe`, `setWebhook`, and `deleteWebhook` while keeping the longer `getUpdates` timeout.
- What did NOT change (scope boundary): no routing/session behavior changes, no config changes, and no changes to Telegram retry policy beyond letting existing retry handling recover from startup stalls.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61570
- Related #61570
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: only `getUpdates` had a hard request timeout; Telegram startup/control-plane calls could block indefinitely before polling or webhook setup completed.
- Missing detection / guardrail: there was no startup-path timeout guard for `deleteWebhook`, `getMe`, or `setWebhook`, even though gateway runtime state is set to running before the provider fully hands off to a healthy steady state.
- Contributing context (if known): health probing uses `getMe` separately from the runtime startup path, so health could still look OK while startup was stuck on a different Bot API request.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/request-timeouts.test.ts`
- Scenario the test should lock in: startup/control-plane Telegram methods (`deleteWebhook`, `getMe`, `setWebhook`) stay bounded while `getUpdates` keeps the longer polling timeout.
- Why this is the smallest reliable guardrail: the wrapper already had timeout behavior coverage for `getUpdates`; this adds direct coverage for the newly bounded startup methods without expanding the Telegram runtime surface.
- Existing test that already covers this (if any): `extensions/telegram/src/monitor.test.ts` already covers retry/restart behavior once startup cleanup errors are surfaced.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram startup now fails/retries instead of hanging indefinitely when Telegram Bot API startup calls stall before inbound polling or webhook setup becomes active.

## Diagram (if applicable)

```text
Before:
[gateway starts Telegram] -> [startup control-plane call hangs] -> [channel looks healthy/running] -> [no inbound updates]

After:
[gateway starts Telegram] -> [startup control-plane call hits timeout] -> [existing retry/error path runs] -> [startup recovers or surfaces failure]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (darwin 25.3.0)
- Runtime/container: local repo workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram bot token configured; startup in polling or webhook mode

### Steps

1. Start Telegram with valid bot credentials.
2. Let a startup-path Bot API call (`deleteWebhook`, `getMe`, or `setWebhook`) stall.
3. Observe that inbound startup never reaches a healthy steady state even though health probing can still succeed independently.

### Expected

- Telegram startup should not hang indefinitely on startup-path Bot API calls.
- A stalled startup call should time out and fall into the existing retry/error path.

### Actual

- Startup-path Bot API calls could previously hang forever, leaving Telegram apparently healthy/running while inbound startup never completed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm build`; `pnpm check`; `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/telegram/src/request-timeouts.test.ts extensions/telegram/src/monitor.test.ts`
- Edge cases checked: startup-only timeout coverage for `deleteWebhook`, `getMe`, `setWebhook`; preserved longer `getUpdates` timeout; unrelated Telegram methods remain unbounded by this helper.
- What you did **not** verify: live Telegram bot startup against a real account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: startup timeouts could be too aggressive on unusually slow Telegram control-plane requests.
  - Mitigation: only startup/control-plane methods are bounded to 15s, `getUpdates` keeps its longer polling timeout, and existing recoverable retry handling remains in place.

## AI Assistance

- [x] AI-assisted
- Testing level: `pnpm build`, `pnpm check`, and targeted Telegram regression tests above.
- I reviewed the change end-to-end and understand the code paths touched.

Made with [Cursor](https://cursor.com)