### PR TITLE
memory: trim generic daily chunk headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/exec approvals: clarify unavailable-approval replies so Matrix no longer claims chat approvals are unsupported when native exec approvals are merely unconfigured. (#61424) Thanks @gumadeiras.
 - Docs/IRC: replace public IRC hostname examples with `irc.example.com` and recommend private servers for bot coordination while listing common public networks for intentional use.
 - Memory/dreaming: group nearby daily-note lines into short coherent chunks before staging them for dreaming, so one-off context from recent notes reaches REM/deep with better evidence and less line-level noise.
-- Memory/dreaming: drop generic date/day headings from daily-note chunk prefixes while keeping meaningful section labels, so staged snippets stay cleaner and more reusable.
+- Memory/dreaming: drop generic date/day headings from daily-note chunk prefixes while keeping meaningful section labels, so staged snippets stay cleaner and more reusable. (#61597)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/exec approvals: clarify unavailable-approval replies so Matrix no longer claims chat approvals are unsupported when native exec approvals are merely unconfigured. (#61424) Thanks @gumadeiras.
 - Docs/IRC: replace public IRC hostname examples with `irc.example.com` and recommend private servers for bot coordination while listing common public networks for intentional use.
 - Memory/dreaming: group nearby daily-note lines into short coherent chunks before staging them for dreaming, so one-off context from recent notes reaches REM/deep with better evidence and less line-level noise.
+- Memory/dreaming: drop generic date/day headings from daily-note chunk prefixes while keeping meaningful section labels, so staged snippets stay cleaner and more reusable.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/exec approvals: clarify unavailable-approval replies so Matrix no longer claims chat approvals are unsupported when native exec approvals are merely unconfigured. (#61424) Thanks @gumadeiras.
 - Docs/IRC: replace public IRC hostname examples with `irc.example.com` and recommend private servers for bot coordination while listing common public networks for intentional use.
 - Memory/dreaming: group nearby daily-note lines into short coherent chunks before staging them for dreaming, so one-off context from recent notes reaches REM/deep with better evidence and less line-level noise.
-- Memory/dreaming: drop generic date/day headings from daily-note chunk prefixes while keeping meaningful section labels, so staged snippets stay cleaner and more reusable. (#61597)
+- Memory/dreaming: drop generic date/day headings from daily-note chunk prefixes while keeping meaningful section labels, so staged snippets stay cleaner and more reusable. (#61597) Thanks @mbelinky.
 
 ### Fixes
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -247,6 +247,73 @@ describe("memory-core dreaming phases", () => {
     expect(after[0]?.snippet).toContain("messages short and low-pressure");
   });
 
+  it("drops generic day headings but keeps meaningful section labels", async () => {
+    const workspaceDir = await createTempWorkspace();
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-05.md"),
+      [
+        "# Friday, April 5, 2026",
+        "",
+        "## Morning",
+        "- Reviewed travel timing and calendar placement.",
+        "",
+        "## Emma Rees",
+        "- She prefers direct plans over open-ended maybes.",
+        "- Better to offer one concrete time window.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { beforeAgentReply } = createHarness(
+      {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 2,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    await beforeAgentReply(
+      { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+      { trigger: "heartbeat", workspaceDir },
+    );
+
+    const after = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-05T10:05:00.000Z"),
+    });
+    expect(after).toHaveLength(2);
+    expect(after.map((candidate) => candidate.snippet)).toEqual(
+      expect.arrayContaining([
+        "Reviewed travel timing and calendar placement.",
+        expect.stringContaining("Emma Rees:"),
+      ]),
+    );
+    for (const candidate of after) {
+      expect(candidate.snippet).not.toContain("Friday, April 5, 2026:");
+      expect(candidate.snippet).not.toContain("Morning:");
+    }
+  });
+
   it("splits noisy daily notes into a few coherent chunks instead of one line per item", async () => {
     const workspaceDir = await createTempWorkspace();
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -84,6 +84,8 @@ const DAILY_INGESTION_SCORE = 0.62;
 const DAILY_INGESTION_MAX_SNIPPET_CHARS = 280;
 const DAILY_INGESTION_MIN_SNIPPET_CHARS = 8;
 const DAILY_INGESTION_MAX_CHUNK_LINES = 4;
+const GENERIC_DAY_HEADING_RE =
+  /^(?:(?:mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|sun|sunday)(?:,\s+)?)?(?:(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4}[/-]\d{2}[/-]\d{2})$/i;
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -339,10 +341,25 @@ function normalizeDailyHeading(line: string): string | null {
     return null;
   }
   const heading = match[1] ? normalizeDailyListMarker(match[1]) : "";
-  if (!heading || DAILY_MEMORY_FILENAME_RE.test(heading)) {
+  if (!heading || DAILY_MEMORY_FILENAME_RE.test(heading) || isGenericDailyHeading(heading)) {
     return null;
   }
   return heading.slice(0, DAILY_INGESTION_MAX_SNIPPET_CHARS).replace(/\s+/g, " ");
+}
+
+function isGenericDailyHeading(heading: string): boolean {
+  const normalized = heading.trim().replace(/\s+/g, " ");
+  if (!normalized) {
+    return true;
+  }
+  const lower = normalized.toLowerCase();
+  if (lower === "today" || lower === "yesterday" || lower === "tomorrow") {
+    return true;
+  }
+  if (lower === "morning" || lower === "afternoon" || lower === "evening" || lower === "night") {
+    return true;
+  }
+  return GENERIC_DAY_HEADING_RE.test(normalized);
 }
 
 function normalizeDailySnippet(line: string): string | null {
@@ -363,6 +380,17 @@ type DailySnippetChunk = {
   snippet: string;
 };
 
+function buildDailyChunkSnippet(
+  heading: string | null,
+  chunkLines: string[],
+  chunkKind: "list" | "paragraph" | null,
+): string {
+  const joiner = chunkKind === "list" ? "; " : " ";
+  const body = chunkLines.join(joiner).trim();
+  const prefixed = heading ? `${heading}: ${body}` : body;
+  return prefixed.slice(0, DAILY_INGESTION_MAX_SNIPPET_CHARS).replace(/\s+/g, " ").trim();
+}
+
 function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetChunk[] {
   const chunks: DailySnippetChunk[] = [];
   let activeHeading: string | null = null;
@@ -379,13 +407,7 @@ function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetCh
       return;
     }
 
-    const joiner = chunkKind === "list" ? "; " : " ";
-    const body = chunkLines.join(joiner).trim();
-    const prefixed = activeHeading ? `${activeHeading}: ${body}` : body;
-    const snippet = prefixed
-      .slice(0, DAILY_INGESTION_MAX_SNIPPET_CHARS)
-      .replace(/\s+/g, " ")
-      .trim();
+    const snippet = buildDailyChunkSnippet(activeHeading, chunkLines, chunkKind);
     if (snippet.length >= DAILY_INGESTION_MIN_SNIPPET_CHARS) {
       chunks.push({
         startLine: chunkStartLine,
@@ -427,9 +449,7 @@ function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetCh
 
     const nextKind = /^([-*+]\s+|\d+\.\s+)/.test(trimmed) ? "list" : "paragraph";
     const nextChunkLines = chunkLines.length === 0 ? [snippet] : [...chunkLines, snippet];
-    const nextJoiner = nextKind === "list" ? "; " : " ";
-    const candidateBody = nextChunkLines.join(nextJoiner).trim();
-    const candidateSnippet = activeHeading ? `${activeHeading}: ${candidateBody}` : candidateBody;
+    const candidateSnippet = buildDailyChunkSnippet(activeHeading, nextChunkLines, nextKind);
     const shouldSplit =
       chunkLines.length > 0 &&
       (chunkKind !== nextKind ||


### PR DESCRIPTION
## Summary\n- drop generic day/date headings from daily dreaming chunk prefixes\n- keep meaningful section labels like person/topic headings\n- add focused regression coverage for heading cleanup\n\n## Testing\n- ./node_modules/.bin/vitest run --maxWorkers=1 extensions/memory-core/src/dreaming-phases.test.ts