### PR TITLE
Agents: skip redundant partial compaction summarization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,7 @@ Docs: https://docs.openclaw.ai
 - Plugins: suppress trust-warning noise during non-activating snapshot and CLI metadata loads. (#61427) Thanks @gumadeiras.
 - Agents/video generation: accept `agents.defaults.videoGenerationModel` in strict config validation and `openclaw config set/get`, so gateways using `video_generate` no longer fail to boot after enabling a video model.
 - Matrix/streaming: add a quiet preview mode for streamed Matrix replies, keep legacy `partial` preview-first behavior, and finalize quiet media captions correctly so previews stop notifying early without dropping final text semantics. (#61450) Thanks @gumadeiras.
+- Agents/compaction: skip redundant partial summarization when no messages were oversized, so the same transcript is not summarized twice after a full summarization failure. Fixes #61465. (#61603) Thanks @neeravmakwana.
 - Gateway/shutdown: bound websocket-server shutdown even when no tracked clients remain, so gateway restarts stop hanging until the watchdog kills the process. (#61565) Thanks @mbelinky.
 - Control UI/multilingual: localize the remaining shared channel, instances, nodes, and gateway-confirmation strings so the dashboard stops mixing translated UI with hardcoded English labels. Thanks @vincentkoc.
 - Discord/media: raise the default inbound and outbound media cap to `100MB` so Discord matches Telegram more closely and larger attachments stop failing on the old low default.

--- a/src/agents/compaction.summarize-fallback.test.ts
+++ b/src/agents/compaction.summarize-fallback.test.ts
@@ -1,0 +1,103 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { UserMessage } from "@mariozechner/pi-ai";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const piCodingAgentMocks = vi.hoisted(() => ({
+  generateSummary: vi.fn(),
+  estimateTokens: vi.fn((_message: unknown) => 100),
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>(
+    "@mariozechner/pi-coding-agent",
+  );
+  return {
+    ...actual,
+    generateSummary: piCodingAgentMocks.generateSummary,
+    estimateTokens: piCodingAgentMocks.estimateTokens,
+  };
+});
+
+const { summarizeWithFallback } = await import("./compaction.js");
+
+const testModel = {
+  id: "test",
+  name: "test",
+  contextWindow: 200_000,
+  contextTokens: 200_000,
+  maxTokens: 8192,
+} as unknown as NonNullable<ExtensionContext["model"]>;
+
+describe("summarizeWithFallback", () => {
+  beforeEach(() => {
+    piCodingAgentMocks.generateSummary.mockReset();
+    piCodingAgentMocks.generateSummary.mockRejectedValue(
+      new Error("Summarization failed: fetch failed"),
+    );
+    piCodingAgentMocks.estimateTokens.mockReset();
+    piCodingAgentMocks.estimateTokens.mockImplementation(() => 100);
+  });
+
+  it("does not duplicate summarization when no messages were oversized", async () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: "hello",
+        timestamp: 1,
+      } satisfies UserMessage,
+    ];
+
+    const result = await summarizeWithFallback({
+      messages,
+      model: testModel,
+      apiKey: "test-key", // pragma: allowlist secret
+      signal: new AbortController().signal,
+      reserveTokens: 1000,
+      maxChunkTokens: 50_000,
+      contextWindow: 200_000,
+    });
+
+    expect(result).toContain("Context contained 1 messages");
+    expect(result).toContain("0 oversized");
+    // Full path: retryAsync attempts (3) for a single chunk; partial path must not run.
+    expect(piCodingAgentMocks.generateSummary).toHaveBeenCalledTimes(3);
+  });
+
+  it("still attempts partial summarization when oversized messages were excluded", async () => {
+    piCodingAgentMocks.estimateTokens.mockImplementation((message: unknown) => {
+      const content =
+        typeof (message as { content?: unknown }).content === "string"
+          ? (message as { content: string }).content
+          : "";
+      return content.length > 10_000 ? 500_000 : 100;
+    });
+
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: "small",
+        timestamp: 1,
+      } satisfies UserMessage,
+      {
+        role: "user",
+        content: "x".repeat(500_000),
+        timestamp: 2,
+      } satisfies UserMessage,
+    ];
+
+    const result = await summarizeWithFallback({
+      messages,
+      model: testModel,
+      apiKey: "test-key", // pragma: allowlist secret
+      signal: new AbortController().signal,
+      reserveTokens: 1000,
+      maxChunkTokens: 50_000,
+      contextWindow: 200_000,
+    });
+
+    expect(result).toContain("2 messages (1 oversized)");
+    // Full attempt (3 retries) plus distinct partial transcript (3 retries).
+    expect(piCodingAgentMocks.generateSummary.mock.calls.length).toBe(6);
+  });
+});

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -420,7 +420,9 @@ export async function summarizeWithFallback(params: {
     }
   }
 
-  if (smallMessages.length > 0) {
+  // When nothing was oversized, `smallMessages` is the same transcript as the full attempt.
+  // Re-summarizing it would duplicate the same failing API work (and duplicate warn logs).
+  if (smallMessages.length > 0 && smallMessages.length !== messages.length) {
     try {
       const partialSummary = await summarizeChunks({
         ...params,

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -398,7 +398,7 @@ export async function summarizeWithFallback(params: {
     return await summarizeChunks(params);
   } catch (fullError) {
     log.warn(
-      `Full summarization failed, trying partial: ${
+      `Full summarization failed: ${
         fullError instanceof Error ? fullError.message : String(fullError)
       }`,
     );


### PR DESCRIPTION
## Summary

- **Problem:** When full summarization failed and no messages were marked oversized, `summarizeWithFallback` still ran a "partial" pass over the **same** transcript, duplicating failing API work (including retries) and the second warning log.
- **Why it matters:** Under transport failures (for example `fetch failed`), this doubled load and log noise and worsened responsiveness during compaction.
- **What changed:** Only run the partial summarization path when `smallMessages` is a **strict subset** of the original messages (i.e. at least one oversized message was excluded).
- **What did NOT change:** When oversized messages exist, partial summarization still runs on the smaller set; staged summarization and other compaction behavior are unchanged.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #61465
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Fallback logic treated "partial" as always distinct from "full", but when nothing was oversized the two inputs were identical.
- **Missing detection / guardrail:** No check that partial would use a different message set than the failed full attempt.
- **Contributing context (if known):** N/A

## Regression Test Plan (if applicable)

- **Coverage level:** Unit test
- **Target test or file:** `src/agents/compaction.summarize-fallback.test.ts`
- **Scenario the test should lock in:** When all messages are non-oversized and summarization fails, `generateSummary` is invoked only for the full path retries (3), not again for a duplicate partial pass. When one message is oversized, full and partial paths each run (6 total mock calls).
- **Why this is the smallest reliable guardrail:** Asserts call counts without coupling to provider error strings.

## User-visible / Behavior Changes

- Fewer redundant summarization attempts and one fewer warning line when full summarization fails and there are no oversized messages to drop. Final text fallback behavior is unchanged.

## Diagram (if applicable)

N/A

## Security Impact (required)

- **New permissions/capabilities?** No

## Testing

- `pnpm test` on `src/agents/compaction.test.ts`, `compaction.retry.test.ts`, `compaction.tool-result-details.test.ts`, `compaction.summarize-fallback.test.ts`
- `oxlint` on touched TypeScript files
