### PR TITLE
fix(gateway): load TTS speech plugin owners at startup (#61412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/TTS: load bundled plugins that own `messages.tts` speech providers during gateway startup so MiniMax and other extension-registered TTS backends register in the active plugin registry (fixes `no_provider_registered` when text models work but TTS does not). (#61412)
 - Security: preserve restrictive plugin-only tool allowlists, require owner access for `/allowlist add` and `/allowlist remove`, fail closed when `before_tool_call` hooks crash, block browser SSRF redirect bypasses earlier, and keep non-interactive auth-choice inference scoped to bundled and already-trusted plugins. (#58476, #59836, #59822, #58771, #59120) Thanks @eleqtrizit and @pgondhi987.
 - Providers/OpenAI: make GPT-5 and Codex runs act sooner with lower-verbosity defaults, visible progress during tool work, and a one-shot retry when a turn only narrates the plan instead of taking action.
 - Providers/OpenAI and reply delivery: preserve native `reasoning.effort: "none"` and strict schemas where supported, add GPT-5.4 assistant `phase` metadata across replay and the Gateway `/v1/responses` layer, and keep commentary buffered until `final_answer` so web chat, session previews, embedded replies, and Telegram partials stop leaking planning text. Fixes #59150, #59643, #61282.

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -12,7 +12,10 @@ vi.mock("./manifest-registry.js", () => ({
   loadPluginManifestRegistry,
 }));
 
-import { resolveGatewayStartupPluginIds } from "./channel-plugin-ids.js";
+import {
+  resolveGatewayStartupPluginIds,
+  resolveGatewayTtsSpeechPluginIds,
+} from "./channel-plugin-ids.js";
 
 function createManifestRegistryFixture() {
   return {
@@ -235,5 +238,78 @@ describe("resolveGatewayStartupPluginIds", () => {
       activationSourceConfig: rawConfig,
       expected: ["demo-channel", "browser"],
     });
+  });
+
+  it("includes plugins that own configured TTS speech providers", () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        ...createManifestRegistryFixture().plugins,
+        {
+          id: "minimax",
+          channels: [],
+          origin: "bundled",
+          enabledByDefault: true,
+          providers: ["minimax"],
+          contracts: { speechProviders: ["minimax"] },
+        },
+      ],
+      diagnostics: [],
+    });
+    expectStartupPluginIds({
+      config: {
+        ...createStartupConfig({}),
+        messages: { tts: { provider: "minimax" } },
+      } as OpenClawConfig,
+      expected: ["demo-channel", "browser", "minimax"],
+    });
+  });
+
+  it("includes TTS speech plugin owners from messages.tts.providers keys", () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        ...createManifestRegistryFixture().plugins,
+        {
+          id: "minimax",
+          channels: [],
+          origin: "bundled",
+          enabledByDefault: true,
+          providers: ["minimax"],
+          contracts: { speechProviders: ["minimax"] },
+        },
+      ],
+      diagnostics: [],
+    });
+    expectStartupPluginIds({
+      config: {
+        ...createStartupConfig({}),
+        messages: { tts: { providers: { minimax: { apiKey: "test" } } } },
+      } as OpenClawConfig,
+      expected: ["demo-channel", "browser", "minimax"],
+    });
+  });
+
+  it("resolveGatewayTtsSpeechPluginIds returns owning plugin ids for configured speech providers", () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        ...createManifestRegistryFixture().plugins,
+        {
+          id: "minimax",
+          channels: [],
+          origin: "bundled",
+          providers: ["minimax"],
+          contracts: { speechProviders: ["minimax"] },
+        },
+      ],
+      diagnostics: [],
+    });
+    expect(
+      resolveGatewayTtsSpeechPluginIds({
+        config: {
+          messages: { tts: { provider: "minimax" } },
+        } as OpenClawConfig,
+        workspaceDir: "/tmp",
+        env: process.env,
+      }),
+    ).toEqual(["minimax"]);
   });
 });

--- a/src/plugins/channel-plugin-ids.ts
+++ b/src/plugins/channel-plugin-ids.ts
@@ -8,6 +8,55 @@ import {
 import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
 import { hasKind } from "./slots.js";
 
+function normalizeSpeechProviderIdForTts(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().toLowerCase();
+  return trimmed ? trimmed : undefined;
+}
+
+/** Bundled plugin ids that must load at gateway startup so TTS speech providers register (see issue #61412). */
+export function resolveGatewayTtsSpeechPluginIds(params: {
+  config: OpenClawConfig;
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+}): string[] {
+  const tts = params.config.messages?.tts;
+  if (!tts) {
+    return [];
+  }
+  const requested = new Set<string>();
+  const primary = normalizeSpeechProviderIdForTts(tts.provider);
+  if (primary) {
+    requested.add(primary);
+  }
+  for (const key of Object.keys(tts.providers ?? {})) {
+    const normalized = normalizeSpeechProviderIdForTts(key);
+    if (normalized) {
+      requested.add(normalized);
+    }
+  }
+  if (requested.size === 0) {
+    return [];
+  }
+  const manifest = loadPluginManifestRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  const owners = new Set<string>();
+  for (const speechProviderId of requested) {
+    const normalized = speechProviderId.trim().toLowerCase();
+    const pluginId = manifest.plugins.find((plugin) =>
+      (plugin.contracts?.speechProviders ?? []).some(
+        (candidate) => candidate.trim().toLowerCase() === normalized,
+      ),
+    )?.id;
+    if (pluginId) {
+      owners.add(pluginId);
+    }
+  }
+  return [...owners].toSorted((left, right) => left.localeCompare(right));
+}
+
 function hasRuntimeContractSurface(plugin: PluginManifestRecord): boolean {
   return Boolean(
     plugin.providers.length > 0 ||
@@ -95,7 +144,7 @@ export function resolveGatewayStartupPluginIds(params: {
   const activationSource = createPluginActivationSource({
     config: params.activationSourceConfig ?? params.config,
   });
-  return loadPluginManifestRegistry({
+  const baseIds = loadPluginManifestRegistry({
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
@@ -124,4 +173,22 @@ export function resolveGatewayStartupPluginIds(params: {
       return activationState.source === "explicit" || activationState.source === "default";
     })
     .map((plugin) => plugin.id);
+
+  const ttsSpeechPluginIds = resolveGatewayTtsSpeechPluginIds({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  if (ttsSpeechPluginIds.length === 0) {
+    return baseIds;
+  }
+  const seen = new Set(baseIds);
+  const merged = [...baseIds];
+  for (const id of ttsSpeechPluginIds) {
+    if (!seen.has(id)) {
+      merged.push(id);
+      seen.add(id);
+    }
+  }
+  return merged;
 }


### PR DESCRIPTION
## Summary

- **Problem:** Gateway startup uses a minimal plugin set (channels + startup sidecars). Provider extensions such as MiniMax register TTS via `registerSpeechProvider`, but were not in that set, so `getSpeechProvider` could return nothing and TTS failed with `no_provider_registered` while text models still worked.
- **Why it matters:** Users configuring `messages.tts` for MiniMax (or other extension-owned speech backends) expect `/tts` and auto-TTS to resolve the same provider as the CLI/catalog.
- **What changed:** `resolveGatewayStartupPluginIds` unions plugin ids that own the speech providers referenced by `messages.tts.provider` and `messages.tts.providers` (via manifest `contracts.speechProviders`). New helper `resolveGatewayTtsSpeechPluginIds` encapsulates the lookup.
- **What did NOT change:** Channel/sidecar selection rules, plugin activation semantics, and TTS runtime behavior beyond ensuring the owning plugin loads when TTS config references it.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #61412
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** Gateway startup intentionally omitted provider-only plugins; speech registration happens in those plugins` `register()` hooks, so the active registry never received their `SpeechProviderPlugin` entries.
- **Missing detection / guardrail:** Startup scope did not consider `messages.tts` speech provider ownership.
- **Contributing context:** Model inference can load providers on demand; TTS reads the active plugin registry.

## Regression Test Plan

- [x] Unit test
- **Target test or file:** `src/plugins/channel-plugin-ids.test.ts`
- **Scenario:** Config with `messages.tts` referencing a speech provider declared on a manifest plugin adds that plugin id to gateway startup ids.

## User-visible / Behavior Changes

- Gateway loads the bundled plugin that owns the configured TTS speech provider when `messages.tts` names that provider, so TTS can register and run (e.g. MiniMax).

## Diagram

N/A

## Security Impact

- **New permissions/capabilities?** No — only aligns gateway startup plugin load with already-configured `messages.tts` speech provider ids.


Made with [Cursor](https://cursor.com)