### PR TITLE
perf(cli): add help fast path for built-in and plugin subcommands

### DIFF
--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -30,6 +30,22 @@ const { registerQaCli } = vi.hoisted(() => ({
   }),
 }));
 
+const { registerPairingCli } = vi.hoisted(() => ({
+  registerPairingCli: vi.fn((program: Command) => {
+    program.command("pairing");
+  }),
+}));
+
+const { registerPluginsCli } = vi.hoisted(() => ({
+  registerPluginsCli: vi.fn((program: Command) => {
+    program.command("plugins");
+  }),
+}));
+
+const pluginCliModule = vi.hoisted(() => ({
+  registerPluginCliCommands: vi.fn(),
+}));
+
 const configModule = vi.hoisted(() => ({
   loadConfig: vi.fn(),
   readConfigFileSnapshot: vi.fn(),
@@ -38,7 +54,10 @@ const configModule = vi.hoisted(() => ({
 vi.mock("../acp-cli.js", () => ({ registerAcpCli }));
 vi.mock("../nodes-cli.js", () => ({ registerNodesCli }));
 vi.mock("../qa-cli.js", () => ({ registerQaCli }));
+vi.mock("../pairing-cli.js", () => ({ registerPairingCli }));
+vi.mock("../plugins-cli.js", () => ({ registerPluginsCli }));
 vi.mock("../../config/config.js", () => configModule);
+vi.mock("../../plugins/cli.js", () => pluginCliModule);
 
 describe("registerSubCliCommands", () => {
   const originalArgv = process.argv;
@@ -64,6 +83,9 @@ describe("registerSubCliCommands", () => {
     acpAction.mockClear();
     registerNodesCli.mockClear();
     nodesAction.mockClear();
+    registerPairingCli.mockClear();
+    registerPluginsCli.mockClear();
+    pluginCliModule.registerPluginCliCommands.mockReset();
     configModule.loadConfig.mockReset();
     configModule.readConfigFileSnapshot.mockReset();
   });
@@ -143,5 +165,44 @@ describe("registerSubCliCommands", () => {
     await program.parseAsync(["acp"], { from: "user" });
     expect(registerAcpCli).toHaveBeenCalledTimes(1);
     expect(acpAction).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips plugin CLI bootstrap for pairing help", async () => {
+    process.argv = ["node", "openclaw", "pairing", "--help"];
+    const program = new Command();
+
+    await registerSubCliByName(program, "pairing");
+
+    expect(registerPairingCli).toHaveBeenCalledTimes(1);
+    expect(pluginCliModule.registerPluginCliCommands).not.toHaveBeenCalled();
+    expect(configModule.readConfigFileSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("skips plugin CLI bootstrap for plugins help", async () => {
+    process.argv = ["node", "openclaw", "plugins", "--help"];
+    const program = new Command();
+
+    await registerSubCliByName(program, "plugins");
+
+    expect(registerPluginsCli).toHaveBeenCalledTimes(1);
+    expect(pluginCliModule.registerPluginCliCommands).not.toHaveBeenCalled();
+    expect(configModule.readConfigFileSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("keeps plugin CLI bootstrap for pairing command runs", async () => {
+    const loadedConfig = { plugins: { enabled: true } };
+    process.argv = ["node", "openclaw", "pairing", "list"];
+    configModule.readConfigFileSnapshot.mockResolvedValueOnce({
+      valid: true,
+      config: loadedConfig,
+    });
+    configModule.loadConfig.mockReturnValueOnce(loadedConfig);
+    const program = new Command();
+
+    await registerSubCliByName(program, "pairing");
+
+    expect(configModule.readConfigFileSnapshot).toHaveBeenCalledTimes(1);
+    expect(pluginCliModule.registerPluginCliCommands).toHaveBeenCalledTimes(1);
+    expect(registerPairingCli).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -231,6 +231,11 @@ const entries: SubCliEntry[] = [
     description: "Secure DM pairing (approve inbound requests)",
     hasSubcommands: true,
     register: async (program) => {
+      const mod = await import("../pairing-cli.js");
+      if (hasHelpOrVersion(process.argv)) {
+        mod.registerPairingCli(program);
+        return;
+      }
       // Initialize plugins before registering pairing CLI.
       // The pairing CLI calls listPairingChannels() at registration time,
       // which requires the plugin registry to be populated with channel plugins.
@@ -239,7 +244,6 @@ const entries: SubCliEntry[] = [
       if (config) {
         await registerPluginCliCommands(program, config);
       }
-      const mod = await import("../pairing-cli.js");
       mod.registerPairingCli(program);
     },
   },
@@ -250,6 +254,9 @@ const entries: SubCliEntry[] = [
     register: async (program) => {
       const mod = await import("../plugins-cli.js");
       mod.registerPluginsCli(program);
+      if (hasHelpOrVersion(process.argv)) {
+        return;
+      }
       const { registerPluginCliCommands } = await import("../../plugins/cli.js");
       const config = await loadValidatedConfigForPluginRegistration();
       if (config) {

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -6,6 +6,7 @@ import {
   shouldRegisterPrimarySubcommand,
   shouldSkipPluginCommandRegistration,
   shouldUseRootHelpFastPath,
+  shouldUseSubcommandHelpFastPath,
 } from "./run-main.js";
 
 describe("rewriteUpdateFlagArgv", () => {
@@ -135,6 +136,21 @@ describe("shouldUseRootHelpFastPath", () => {
     expect(shouldUseRootHelpFastPath(["node", "openclaw", "--profile", "work", "-h"])).toBe(true);
     expect(shouldUseRootHelpFastPath(["node", "openclaw", "status", "--help"])).toBe(false);
     expect(shouldUseRootHelpFastPath(["node", "openclaw", "--help", "status"])).toBe(false);
+  });
+});
+
+describe("shouldUseSubcommandHelpFastPath", () => {
+  it("uses the fast path for built-in and plugin subcommand help", () => {
+    expect(shouldUseSubcommandHelpFastPath(["node", "openclaw", "status", "--help"])).toBe(true);
+    expect(shouldUseSubcommandHelpFastPath(["node", "openclaw", "memory", "--help"])).toBe(true);
+  });
+
+  it("does not use the fast path for root help or regular command runs", () => {
+    expect(shouldUseSubcommandHelpFastPath(["node", "openclaw", "--help"])).toBe(false);
+    expect(shouldUseSubcommandHelpFastPath(["node", "openclaw", "status"])).toBe(false);
+    expect(shouldUseSubcommandHelpFastPath(["node", "openclaw", "--profile", "work"])).toBe(
+      false,
+    );
   });
 });
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
-import { CommanderError } from "commander";
+import { Command, CommanderError } from "commander";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { normalizeEnv } from "../infra/env.js";
@@ -86,6 +86,113 @@ export function shouldEnsureCliPath(argv: string[]): boolean {
 
 export function shouldUseRootHelpFastPath(argv: string[]): boolean {
   return isRootHelpInvocation(argv);
+}
+
+export function shouldUseSubcommandHelpFastPath(argv: string[]): boolean {
+  return hasHelpOrVersion(argv) && !isRootHelpInvocation(argv) && Boolean(getPrimaryCommand(argv));
+}
+
+async function createMinimalHelpProgram() {
+  const program = new Command();
+  program.enablePositionalOptions();
+  program.exitOverride((err) => {
+    process.exitCode = typeof err.exitCode === "number" ? err.exitCode : 1;
+    throw err;
+  });
+
+  const [{ createProgramContext }, { configureProgramHelp }, { setProgramContext }] =
+    await Promise.all([
+      import("./program/context.js"),
+      import("./program/help.js"),
+      import("./program/program-context.js"),
+    ]);
+  const ctx = createProgramContext();
+  setProgramContext(program, ctx);
+  configureProgramHelp(program, ctx);
+
+  return { program, ctx };
+}
+
+const HELP_FAST_PATH_PLUGIN_IDS_BY_PRIMARY: Record<string, readonly string[]> = {
+  memory: ["memory-core"],
+};
+
+export async function outputSubcommandHelpFastPath(argv: string[]): Promise<boolean> {
+  const parseArgv = rewriteUpdateFlagArgv(argv);
+  const primary = getPrimaryCommand(parseArgv);
+  if (!primary) {
+    return false;
+  }
+
+  const [{ getCoreCliCommandDescriptors }, { getSubCliEntries }] = await Promise.all([
+    import("./program/core-command-descriptors.js"),
+    import("./program/subcli-descriptors.js"),
+  ]);
+  const builtinCommands = new Set([
+    ...getCoreCliCommandDescriptors().map((entry) => entry.name),
+    ...getSubCliEntries().map((entry) => entry.name),
+  ]);
+  if (!builtinCommands.has(primary)) {
+    return false;
+  }
+
+  const { program, ctx } = await createMinimalHelpProgram();
+  const { registerCoreCliByName } = await import("./program/command-registry.js");
+  await registerCoreCliByName(program, ctx, primary, parseArgv);
+  const { registerSubCliByName } = await import("./program/register.subclis.js");
+  await registerSubCliByName(program, primary);
+
+  try {
+    await program.parseAsync(parseArgv);
+  } catch (error) {
+    if (!(error instanceof CommanderError)) {
+      throw error;
+    }
+    process.exitCode = error.exitCode;
+  }
+  return true;
+}
+
+export async function outputPluginSubcommandHelpFastPath(argv: string[]): Promise<boolean> {
+  const parseArgv = rewriteUpdateFlagArgv(argv);
+  const primary = getPrimaryCommand(parseArgv);
+  if (!primary) {
+    return false;
+  }
+
+  const { program } = await createMinimalHelpProgram();
+  const { loadValidatedConfigForPluginRegistration } = await import("./program/register.subclis.js");
+  const config = await loadValidatedConfigForPluginRegistration();
+  if (!config) {
+    return false;
+  }
+
+  const { registerPluginCliCommands } = await import("../plugins/cli.js");
+  const onlyPluginIds = HELP_FAST_PATH_PLUGIN_IDS_BY_PRIMARY[primary];
+  await registerPluginCliCommands(
+    program,
+    config,
+    undefined,
+    onlyPluginIds ? { onlyPluginIds: [...onlyPluginIds] } : undefined,
+    {
+      helpOnly: true,
+      primary,
+      mode: "eager",
+    },
+  );
+  if (!program.commands.some((command) => command.name() === primary)) {
+    return false;
+  }
+
+  try {
+    await program.parseAsync(parseArgv);
+  } catch (error) {
+    if (!(error instanceof CommanderError)) {
+      throw error;
+    }
+    process.exitCode = error.exitCode;
+  }
+  return true;
 }
 
 export function resolveMissingPluginCommandMessage(
@@ -176,6 +283,15 @@ export async function runCli(argv: string[] = process.argv) {
       return;
     }
 
+    if (shouldUseSubcommandHelpFastPath(normalizedArgv)) {
+      if (await outputSubcommandHelpFastPath(normalizedArgv)) {
+        return;
+      }
+      if (await outputPluginSubcommandHelpFastPath(normalizedArgv)) {
+        return;
+      }
+    }
+
     if (await tryRouteCli(normalizedArgv)) {
       return;
     }
@@ -226,6 +342,7 @@ export async function runCli(argv: string[] = process.argv) {
       const config = await loadValidatedConfigForPluginRegistration();
       if (config) {
         await registerPluginCliCommands(program, config, undefined, undefined, {
+          helpOnly: hasHelpOrVersion(parseArgv),
           mode: "lazy",
           primary,
         });

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -276,6 +276,30 @@ describe("registerPluginCliCommands", () => {
     expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
   });
 
+  it("uses the metadata-only loader for help-only registration", async () => {
+    const program = createProgram();
+
+    await registerPluginCliCommands(
+      program,
+      {} as OpenClawConfig,
+      undefined,
+      { onlyPluginIds: ["memory-core"] },
+      {
+        helpOnly: true,
+        mode: "eager",
+        primary: "memory",
+      },
+    );
+
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["memory-core"],
+      }),
+    );
+    expect(mocks.memoryRegister).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to awaited CLI metadata collection when runtime loading ignored async registration", async () => {
     const asyncRegistrar = vi.fn(async ({ program }: { program: Command }) => {
       const asyncCommand = program.command("async-cli").description("Async CLI");

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -19,7 +19,10 @@ const log = createSubsystemLogger("plugins");
 
 type PluginCliRegistrationMode = "eager" | "lazy";
 
+type PluginCliLoaderOptions = Pick<PluginLoadOptions, "onlyPluginIds" | "pluginSdkResolution">;
+
 type RegisterPluginCliOptions = {
+  helpOnly?: boolean;
   mode?: PluginCliRegistrationMode;
   primary?: string | null;
 };
@@ -83,7 +86,7 @@ function resolvePluginCliLoadContext(cfg?: OpenClawConfig, env?: NodeJS.ProcessE
 async function loadPluginCliMetadataRegistry(
   cfg?: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
-  loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
+  loaderOptions?: PluginCliLoaderOptions,
 ) {
   const context = resolvePluginCliLoadContext(cfg, env);
   return {
@@ -103,7 +106,7 @@ async function loadPluginCliMetadataRegistry(
 async function loadPluginCliCommandRegistry(
   cfg?: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
-  loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
+  loaderOptions?: PluginCliLoaderOptions,
 ) {
   const context = resolvePluginCliLoadContext(cfg, env);
   const runtimeRegistry = loadOpenClawPlugins({
@@ -155,7 +158,7 @@ async function loadPluginCliCommandRegistry(
 export async function getPluginCliCommandDescriptors(
   cfg?: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
-  loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
+  loaderOptions?: PluginCliLoaderOptions,
 ): Promise<OpenClawPluginCliCommandDescriptor[]> {
   try {
     const { registry } = await loadPluginCliMetadataRegistry(cfg, env, loaderOptions);
@@ -180,14 +183,12 @@ export async function registerPluginCliCommands(
   program: Command,
   cfg?: OpenClawConfig,
   env?: NodeJS.ProcessEnv,
-  loaderOptions?: Pick<PluginLoadOptions, "pluginSdkResolution">,
+  loaderOptions?: PluginCliLoaderOptions,
   options?: RegisterPluginCliOptions,
 ) {
-  const { config, workspaceDir, logger, registry } = await loadPluginCliCommandRegistry(
-    cfg,
-    env,
-    loaderOptions,
-  );
+  const loadRegistry =
+    options?.helpOnly === true ? loadPluginCliMetadataRegistry : loadPluginCliCommandRegistry;
+  const { config, workspaceDir, logger, registry } = await loadRegistry(cfg, env, loaderOptions);
   const mode = options?.mode ?? "eager";
   const primary = options?.primary ?? null;
 


### PR DESCRIPTION
# perf(cli): add help fast path for built-in and plugin subcommands

## Problem

`openclaw <subcommand> --help` paths still run through the full CLI bootstrap, including plugin scanning and runtime registration. This makes help output noticeably slow for commands like `memory`, `plugins`, and `pairing`.

## Approach

A three-layer help fast path that short-circuits before the heavy bootstrap:

1. **Root help** (existing) — `openclaw --help` uses precomputed root help text.
2. **Built-in subcommand help** (new) — Detects `--help`/`-h` on a known built-in subcommand, builds a minimal Commander program with only the target command registered, and exits before the normal bootstrap path.
3. **Plugin subcommand help** (new) — For plugin-owned top-level commands (e.g. `memory`), uses metadata-only registration with a command-to-plugin narrowing map. No runtime modules are loaded.

On the normal (non-fast-path) code path, plugin registration now accepts a `helpOnly` flag. When set, it routes through the metadata-only loader instead of the full runtime registry.

## Changes

### CLI entry (`src/cli/run-main.ts`)
- `shouldUseSubcommandHelpFastPath()` — detects subcommand help invocations
- `createMinimalHelpProgram()` — lightweight Commander setup shared by both fast paths
- `outputSubcommandHelpFastPath()` — built-in subcommand help: registers only the target command
- `outputPluginSubcommandHelpFastPath()` — plugin subcommand help: metadata-only with `HELP_FAST_PATH_PLUGIN_IDS_BY_PRIMARY` narrowing
- Dispatch block in `runCli()` tries fast paths before falling through to normal bootstrap
- Normal path passes `helpOnly: true` to plugin registration when `--help`/`-h` is present

### Plugin CLI registration (`src/plugins/cli.ts`)
- New `RegisterPluginCliOptions.helpOnly` — when `true`, uses `loadPluginCliMetadataRegistry` instead of `loadPluginCliCommandRegistry`
- `PluginCliLoaderOptions` now supports `onlyPluginIds` for narrowing plugin search scope
- All loader function signatures updated to accept the unified options type

### Subcommand registration (`src/cli/program/register.subclis.ts`)
- `pairing` register(): early return on `hasHelpOrVersion()`, skips `registerPluginCliCommands`
- `plugins` register(): same pattern — registers `plugins` CLI first, returns early on help

### Memory plugin (`extensions/memory-core/index.ts`)
- Runtime modules (tools, runtime-provider, provider-adapters, dreaming) moved behind `ensureMemoryCoreRuntime()` — a lazy singleton that loads all runtime modules in parallel on first access
- `cli-metadata` registration mode: registers CLI descriptors only, returns immediately
- `full` registration mode: loads runtime via `ensureMemoryCoreRuntime()`, registers tools, memory runtime, dreaming, flush plan
- Top-level imports reduced to `definePluginEntry`, `registerMemoryCli`, flush plan constants, and `buildPromptSection`

### Tests
- `src/cli/run-main.test.ts` — `shouldUseSubcommandHelpFastPath` unit tests
- `src/cli/program/register.subclis.test.ts` — pairing/plugins help skip plugin bootstrap; pairing run keeps plugin bootstrap
- `src/plugins/cli.test.ts` — metadata-only loader with `onlyPluginIds`; `loadOpenClawPlugins` not called on help-only path

## Benchmark

Measured on macOS ARM64 with source-built dist:

| Command | Before | After | Speedup |
|---------|-------:|------:|--------:|
| `openclaw memory --help` | 0.81s | 0.05s | **16×** |
| `openclaw plugins --help` | 0.49s | 0.05s | **10×** |
| `openclaw pairing --help` | 0.31s | 0.04s | **8×** |

## Test Results

```
vitest run — 3 files, 39 tests, all passing
```

## Commit History

- `904056c` perf(cli): add help fast path for built-in and plugin subcommands
- `b984d66` perf(memory-core): lazy-load runtime modules, split cli-metadata from full registration

## Notes

- The `HELP_FAST_PATH_PLUGIN_IDS_BY_PRIMARY` map is intentionally minimal (`memory → memory-core`). New hotspots can be added incrementally without structural changes.
- The mutation gate and Plan Mode (Slice 5-6 from the upstreaming notes) are separate work and not included in this PR.
- `vitest` passes for the three affected test files. Full test suite was not run (no CI access from local clone).
