### PR TITLE
fix(imessage): avoid DM self-chat false positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- iMessage/self-chat: distinguish normal DM outbound rows from true self-chat using `destination_caller_id` plus chat participants, while preserving multi-handle self-chat aliases so outbound DM replies stop looping back as inbound messages. (#61619) Thanks @neeravmakwana.
 - fix(browser): auto-generate browser control auth token for none/trusted-proxy modes [AI]. (#63280) Thanks @pgondhi987.
 - fix(exec): replace TOCTOU check-then-read with atomic pinned-fd open in script preflight [AI]. (#62333) Thanks @pgondhi987.
 - WhatsApp/auto-reply: keep inbound reply, media, and composing sends on the current socket across reconnects, wait through reconnect gaps, and retry timeout-only send failures without dropping the active socket ref. (#62892) Thanks @mcaxtr.

--- a/extensions/imessage/src/monitor.gating.test.ts
+++ b/extensions/imessage/src/monitor.gating.test.ts
@@ -104,6 +104,22 @@ describe("imessage monitor gating + envelope builders", () => {
     ).toBeNull();
   });
 
+  it("parseIMessageNotification preserves destination_caller_id metadata", () => {
+    expect(
+      parseIMessageNotification({
+        message: {
+          id: 1,
+          sender: "+15550001111",
+          destination_caller_id: "+15550002222",
+          is_from_me: true,
+          text: "hello",
+        },
+      }),
+    ).toMatchObject({
+      destination_caller_id: "+15550002222",
+    });
+  });
+
   it("drops group messages without mention by default", () => {
     const decision = resolve({
       message: {

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -170,6 +170,7 @@ export function resolveIMessageInboundDecision(params: {
   const chatId = params.message.chat_id ?? undefined;
   const chatGuid = params.message.chat_guid ?? undefined;
   const chatIdentifier = params.message.chat_identifier ?? undefined;
+  const destinationCallerId = params.message.destination_caller_id ?? undefined;
   const createdAt = params.message.created_at ? Date.parse(params.message.created_at) : undefined;
   const messageText = params.messageText.trim();
   const bodyText = params.bodyText.trim();
@@ -203,14 +204,20 @@ export function resolveIMessageInboundDecision(params: {
     text: bodyText,
     createdAt,
   };
-  // Self-chat detection: in self-chat, sender == chat_identifier (both are the
-  // user's own handle). When is_from_me=true in self-chat, the message could be
-  // either: (a) a real user message typed by the user, or (b) an agent reply
-  // echo reflected back by iMessage. We must distinguish them.
+  const chatIdentifierNormalized =
+    chatIdentifier != null ? normalizeIMessageHandle(chatIdentifier) : undefined;
+  const destinationCallerIdNormalized =
+    destinationCallerId != null ? normalizeIMessageHandle(destinationCallerId) : undefined;
+  // Self-chat detection: older imsg payloads only let us compare sender and
+  // chat_identifier, but current payloads also expose destination_caller_id.
+  // In a normal DM false positive, sender/chat_identifier can both be the peer
+  // handle while destination_caller_id is the local account handle. Treat that
+  // as a normal DM, not self-chat.
   const isSelfChat =
     !isGroup &&
-    chatIdentifier != null &&
-    normalizeIMessageHandle(sender) === normalizeIMessageHandle(chatIdentifier);
+    chatIdentifierNormalized != null &&
+    senderNormalized === chatIdentifierNormalized &&
+    (destinationCallerIdNormalized == null || destinationCallerIdNormalized === senderNormalized);
   // Track whether we already processed the is_from_me=true self-chat path.
   // When true, the selfChatCache.has() check below must be skipped — we just
   // called remember() and would immediately match our own entry.

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -207,13 +207,20 @@ export function resolveIMessageInboundDecision(params: {
   const chatIdentifierNormalized = normalizeIMessageHandle(chatIdentifier ?? "") || undefined;
   const destinationCallerIdNormalized =
     normalizeIMessageHandle(destinationCallerId ?? "") || undefined;
-  // destination_caller_id distinguishes true self-chat from DM rows where imsg
-  // repeats the peer handle in sender/chat_identifier.
+  const chatParticipantHandles = new Set(
+    (params.message.participants ?? [])
+      .map((participant) => normalizeIMessageHandle(participant))
+      .filter((participant): participant is string => participant.length > 0),
+  );
+  const matchesSelfChatDestination =
+    destinationCallerIdNormalized == null ||
+    destinationCallerIdNormalized === senderNormalized ||
+    chatParticipantHandles.has(destinationCallerIdNormalized);
   const isSelfChat =
     !isGroup &&
     chatIdentifierNormalized != null &&
     senderNormalized === chatIdentifierNormalized &&
-    (destinationCallerIdNormalized == null || destinationCallerIdNormalized === senderNormalized);
+    matchesSelfChatDestination;
   // Track whether we already processed the is_from_me=true self-chat path.
   // When true, the selfChatCache.has() check below must be skipped — we just
   // called remember() and would immediately match our own entry.

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -204,15 +204,11 @@ export function resolveIMessageInboundDecision(params: {
     text: bodyText,
     createdAt,
   };
-  const chatIdentifierNormalized =
-    chatIdentifier != null ? normalizeIMessageHandle(chatIdentifier) : undefined;
+  const chatIdentifierNormalized = normalizeIMessageHandle(chatIdentifier ?? "") || undefined;
   const destinationCallerIdNormalized =
-    destinationCallerId != null ? normalizeIMessageHandle(destinationCallerId) : undefined;
-  // Self-chat detection: older imsg payloads only let us compare sender and
-  // chat_identifier, but current payloads also expose destination_caller_id.
-  // In a normal DM false positive, sender/chat_identifier can both be the peer
-  // handle while destination_caller_id is the local account handle. Treat that
-  // as a normal DM, not self-chat.
+    normalizeIMessageHandle(destinationCallerId ?? "") || undefined;
+  // destination_caller_id distinguishes true self-chat from DM rows where imsg
+  // repeats the peer handle in sender/chat_identifier.
   const isSelfChat =
     !isGroup &&
     chatIdentifierNormalized != null &&

--- a/extensions/imessage/src/monitor/parse-notification.ts
+++ b/extensions/imessage/src/monitor/parse-notification.ts
@@ -61,6 +61,7 @@ export function parseIMessageNotification(raw: unknown): IMessagePayload | null 
     !isOptionalString(message.guid) ||
     !isOptionalNumber(message.chat_id) ||
     !isOptionalString(message.sender) ||
+    !isOptionalString(message.destination_caller_id) ||
     !isOptionalBoolean(message.is_from_me) ||
     !isOptionalString(message.text) ||
     !isOptionalStringOrNumber(message.reply_to_id) ||

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -393,6 +393,32 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     expect(decision.kind).toBe("dispatch");
   });
 
+  it("preserves self-chat when destination_caller_id is another local handle", () => {
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 123705,
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
+          destination_caller_id: "me@icloud.com",
+          participants: ["+15551234567", "me@icloud.com"],
+          text: "Hello from my other local handle",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "Hello from my other local handle",
+        bodyText: "Hello from my other local handle",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    expect(decision.kind).toBe("dispatch");
+  });
+
   it("drops agent reply echo in self-chat (is_from_me=true, echo cache text match)", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -344,7 +344,6 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
   });
 
   it("processes real user self-chat message (is_from_me=true, no echo cache match)", () => {
-    // User sends "Hello" to themselves — is_from_me=true, sender==chat_identifier
     const echoCache = createSentMessageCache();
     const selfChatCache = createSelfChatCache();
 
@@ -366,7 +365,31 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       }),
     );
 
-    // Real user message — should be dispatched, not dropped
+    expect(decision.kind).toBe("dispatch");
+  });
+
+  it("treats blank destination_caller_id as missing for real self-chat", () => {
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 123704,
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
+          destination_caller_id: "",
+          text: "Hello this is a test message",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "Hello this is a test message",
+        bodyText: "Hello this is a test message",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
     expect(decision.kind).toBe("dispatch");
   });
 
@@ -576,7 +599,6 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
       }),
     );
 
-    // sender != chat_identifier → not self-chat → dropped as "from me"
     expect(decision).toEqual({ kind: "drop", reason: "from me" });
   });
 

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -354,6 +354,7 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
           id: 123703,
           sender: "+15551234567",
           chat_identifier: "+15551234567",
+          destination_caller_id: "+15551234567",
           text: "Hello this is a test message",
           is_from_me: true,
           is_group: false,
@@ -576,6 +577,36 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     );
 
     // sender != chat_identifier → not self-chat → dropped as "from me"
+    expect(decision).toEqual({ kind: "drop", reason: "from me" });
+  });
+
+  it("uses destination_caller_id to avoid DM self-chat false positives", () => {
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+
+    echoCache.remember("default:imessage:+15551234567", {
+      text: "Clean outbound text",
+      messageId: "p:0/GUID-outbound",
+    });
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 10001,
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
+          destination_caller_id: "+15550001111",
+          text: "�\u0001corrupted stored text",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "�\u0001corrupted stored text",
+        bodyText: "�\u0001corrupted stored text",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
     expect(decision).toEqual({ kind: "drop", reason: "from me" });
   });
 

--- a/extensions/imessage/src/monitor/types.ts
+++ b/extensions/imessage/src/monitor/types.ts
@@ -12,6 +12,7 @@ export type IMessagePayload = {
   guid?: string | null;
   chat_id?: number | null;
   sender?: string | null;
+  destination_caller_id?: string | null;
   is_from_me?: boolean | null;
   text?: string | null;
   reply_to_id?: number | string | null;


### PR DESCRIPTION
## Summary

- Problem: iMessage DM outbound rows can be misclassified as self-chat when `imsg` reports the peer handle in both `sender` and `chat_identifier`.
- Why it matters: that sends normal DMs down the self-chat echo path, so a cache miss can leak the bot's own outbound reply back into inbound handling and start a loop.
- What changed: the iMessage monitor now uses `destination_caller_id` when available to distinguish true self-chat from DM false positives, and it preserves that metadata in the parsed payload.
- What did NOT change (scope boundary): no echo-cache redesign, no config changes, and no behavior change for older payloads that do not include `destination_caller_id`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61543
- Related #59845
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveIMessageInboundDecision()` treated `sender === chat_identifier` as sufficient proof of self-chat, but current `imsg` payloads can use the peer handle for both fields in a normal DM outbound row.
- Missing detection / guardrail: the monitor ignored `destination_caller_id`, which is the field that differentiates a real self-chat from this DM false positive.
- Contributing context (if known): the earlier self-chat fixes addressed reflected duplicate rows, but they still depended on the older heuristic for identifying self-chat in the first place.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/imessage/src/monitor/self-chat-dedupe.test.ts`, `extensions/imessage/src/monitor.gating.test.ts`
- Scenario the test should lock in: `is_from_me=true` DM rows with `sender===chat_identifier` but a different `destination_caller_id` must still take the normal `from me` drop path, while real self-chat still dispatches.
- Why this is the smallest reliable guardrail: the bug lives entirely inside inbound payload parsing and the inbound-decision branch, so focused tests on those two seams cover the real regression surface.
- Existing test that already covers this (if any): the existing self-chat tests covered the legacy heuristic and true self-chat behavior, but not the DM false-positive shape.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- OpenClaw no longer treats normal iMessage DM outbound rows as self-chat when `imsg` provides a different `destination_caller_id`.
- That keeps those rows on the normal `from me` drop path and avoids self-echo loops caused by cache misses.

## Diagram (if applicable)

```text
Before:
[normal DM outbound row]
  -> sender == chat_identifier
  -> misclassified as self-chat
  -> echo cache miss
  -> dispatched as inbound

After:
[normal DM outbound row]
  -> destination_caller_id != sender
  -> classified as normal DM
  -> dropped as from me
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.3 / Darwin 25.3.0
- Runtime/container: Node.js via repo scripts
- Model/provider: N/A
- Integration/channel: iMessage via `imsg`
- Relevant config (redacted): standard iMessage channel config; no config changes required

### Steps

1. Receive a normal iMessage DM where `imsg` reports an outbound row with the peer handle in both `sender` and `chat_identifier`.
2. Let OpenClaw process the `is_from_me=true` row.
3. Observe whether it takes the self-chat path or the normal `from me` drop path.

### Expected

- The row is recognized as a normal DM outbound event and dropped as `from me`.
- Real self-chat rows still use the self-chat path.

### Actual

- Before this change, the row could be misclassified as self-chat and leak through on an echo-cache miss.
- After this change, the same shape drops as `from me` when `destination_caller_id` points at a different local handle.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran a direct `node --import tsx` repro against `resolveIMessageInboundDecision()` for the reported DM false-positive payload shape and for the true self-chat shape; the DM case now drops as `from me` and the true self-chat case still dispatches.
- Edge cases checked: parser now preserves `destination_caller_id`; current fallback behavior remains unchanged when that field is absent.
- What you did **not** verify: the heavier Vitest lanes (`pnpm test`, `pnpm test:extension imessage`, and a focused Vitest invocation) stalled after Vitest startup in this environment, so I did not get a completed test summary from those commands.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: older `imsg` payloads that omit `destination_caller_id` still rely on the legacy heuristic.
  - Mitigation: the new logic is additive and only tightens classification when the stronger signal is present, so older payload behavior is preserved rather than reinterpreted.

- Risk: this assumes `destination_caller_id` is the local sending identity for the normal DM false-positive shape.
  - Mitigation: the new regression test locks in the exact reported payload shape, and the change is scoped to `is_from_me` self-chat classification only.

## AI Disclosure

This PR was prepared with AI assistance and reviewed before submission.

Made with [Cursor](https://cursor.com)