### PR TITLE
fix(agents): classify OpenRouter no-endpoints 404s

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -595,6 +595,15 @@ describe("classifyFailoverReasonFromHttpStatus", () => {
     ).toBe("overloaded");
   });
 
+  it("treats OpenRouter 404 no-endpoints responses as model_not_found", () => {
+    expect(
+      classifyFailoverReasonFromHttpStatus(
+        404,
+        "404 No endpoints found for deepseek/deepseek-r1:free.",
+      ),
+    ).toBe("model_not_found");
+  });
+
   it("treats generic HTTP 410 responses as retryable timeouts", () => {
     expect(classifyFailoverReasonFromHttpStatus(410)).toBe("timeout");
     expect(classifyFailoverReasonFromHttpStatus(410, "")).toBe("timeout");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -564,6 +564,9 @@ function classifyFailoverClassificationFromHttpStatus(
   if (status === 408) {
     return toReasonClassification("timeout");
   }
+  if (status === 404) {
+    return messageReason === "model_not_found" ? messageClassification : null;
+  }
   if (status === 410) {
     // HTTP 410 is only a true session-expiry signal when the payload says the
     // remote session/conversation is gone. Generic 410/no-body responses from
@@ -1205,6 +1208,7 @@ export function isModelNotFoundErrorMessage(raw: string): boolean {
     lower.includes("unknown model") ||
     lower.includes("model not found") ||
     lower.includes("model_not_found") ||
+    lower.includes("no endpoints found") ||
     lower.includes("not_found_error") ||
     (lower.includes("does not exist") && lower.includes("model")) ||
     (lower.includes("invalid model") && !lower.includes("invalid model reference"))


### PR DESCRIPTION
## Summary
- classify OpenRouter "No endpoints found" 404 responses as `model_not_found`
- treat 404s as `model_not_found` only when the message classification already indicates a missing model / endpoint
- add a focused regression test for the OpenRouter no-endpoints response shape

## Why
OpenRouter can return HTTP 404 with an error like `No endpoints found for deepseek/deepseek-r1:free.` when a free model has no available upstream endpoints. Today that response is not classified as `model_not_found`, so the failover path can stop too early instead of treating it like a missing model.

## Verification
- `pnpm exec vitest run src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts --testNamePattern "OpenRouter 404 no-endpoints"`
- `pnpm exec oxfmt --check src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`

## Notes
I also tried the full `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` file locally, but it currently trips the shared `loadConfig` unhandled rejection / timeout that is not introduced by this change.

Related #61411
