### PR TITLE
Align tool-result truncation more closely with PI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ Docs: https://docs.openclaw.ai
 - macOS/gateway version: strip trailing commit metadata from CLI version output before semver parsing so the Mac app recognizes installed gateway versions like `OpenClaw 2026.4.2 (d74a122)` again. (#61111) Thanks @oliviareid-svg.
 - Memory/dreaming: strip managed Light Sleep and REM blocks before daily-note ingestion so dreaming summaries stop re-ingesting their own staged output into new candidates. (#61720) Thanks @MonkeyLeeT.
 - Plugins/Windows: disable native Jiti loading for setup and doctor contract registries on Windows so onboarding and config-doctor plugin probes stop crashing with `ERR_UNSUPPORTED_ESM_URL_SCHEME`. (#61836, #61853)
+- Agents/context overflow: combine oversized and aggregate tool-result recovery in one repair pass, and restore a total-context overflow backstop during tool loops so recoverable sessions retry instead of failing early. (#61651) Thanks @Takhoffman.
 
 ## 2026.4.5
-
 ### Breaking
 
 - Config: remove legacy public config aliases such as `talk.voiceId` / `talk.apiKey`, `agents.*.sandbox.perSession`, `browser.ssrfPolicy.allowPrivateNetwork`, `hooks.internal.handlers`, and channel/group/room `allow` toggles in favor of the canonical public paths and `enabled`, while keeping load-time compatibility and `openclaw doctor --fix` migration support for existing configs. (#60726) Thanks @vincentkoc.

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -112,8 +112,8 @@ export function queueOverflowAttemptWithOversizedToolOutput(
       promptError: overflowError,
       messagesSnapshot: [
         {
-          role: "assistant",
-          content: "big tool output",
+          role: "toolResult",
+          content: [{ type: "text", text: "x".repeat(80_000) }],
         } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
       ],
     }),

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -69,6 +69,19 @@ export const mockedPrepareProviderRuntimeAuth = vi.fn(async () => undefined);
 export const mockedRunEmbeddedAttempt =
   vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
 export const mockedRunContextEngineMaintenance = vi.fn(async () => undefined);
+export const mockedSessionLikelyHasOversizedToolResults = vi.fn(() => false);
+type MockTruncateOversizedToolResultsResult = {
+  truncated: boolean;
+  truncatedCount: number;
+  reason?: string;
+};
+export const mockedTruncateOversizedToolResultsInSession = vi.fn<
+  () => Promise<MockTruncateOversizedToolResultsResult>
+>(async () => ({
+  truncated: false,
+  truncatedCount: 0,
+  reason: "no oversized tool results",
+}));
 
 type MockFailoverErrorDescription = {
   message: string;
@@ -203,6 +216,14 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedRunEmbeddedAttempt.mockReset();
   mockedRunContextEngineMaintenance.mockReset();
   mockedRunContextEngineMaintenance.mockResolvedValue(undefined);
+  mockedSessionLikelyHasOversizedToolResults.mockReset();
+  mockedSessionLikelyHasOversizedToolResults.mockReturnValue(false);
+  mockedTruncateOversizedToolResultsInSession.mockReset();
+  mockedTruncateOversizedToolResultsInSession.mockResolvedValue({
+    truncated: false,
+    truncatedCount: 0,
+    reason: "no oversized tool results",
+  });
 
   mockedCoerceToFailoverError.mockReset();
   mockedCoerceToFailoverError.mockReturnValue(null);
@@ -373,6 +394,11 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("./run/attempt.js", () => ({
     runEmbeddedAttempt: mockedRunEmbeddedAttempt,
+  }));
+
+  vi.doMock("./tool-result-truncation.js", () => ({
+    sessionLikelyHasOversizedToolResults: mockedSessionLikelyHasOversizedToolResults,
+    truncateOversizedToolResultsInSession: mockedTruncateOversizedToolResultsInSession,
   }));
 
   vi.doMock("./context-engine-maintenance.js", () => ({

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -69,14 +69,6 @@ export const mockedPrepareProviderRuntimeAuth = vi.fn(async () => undefined);
 export const mockedRunEmbeddedAttempt =
   vi.fn<(params: unknown) => Promise<EmbeddedRunAttemptResult>>();
 export const mockedRunContextEngineMaintenance = vi.fn(async () => undefined);
-export const mockedSessionLikelyHasOversizedToolResults = vi.fn(() => false);
-export const mockedTruncateOversizedToolResultsInSession = vi.fn<
-  () => Promise<MockTruncateOversizedToolResultsResult>
->(async () => ({
-  truncated: false,
-  truncatedCount: 0,
-  reason: "no oversized tool results",
-}));
 
 type MockFailoverErrorDescription = {
   message: string;
@@ -91,12 +83,6 @@ type MockCoerceToFailoverError = (
 ) => unknown;
 type MockDescribeFailoverError = (err: unknown) => MockFailoverErrorDescription;
 type MockResolveFailoverStatus = (reason: string) => number | undefined;
-type MockTruncateOversizedToolResultsResult = {
-  truncated: boolean;
-  truncatedCount: number;
-  reason?: string;
-};
-
 export class MockedFailoverError extends Error {
   constructor(message: string) {
     super(message);
@@ -217,14 +203,6 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   mockedRunEmbeddedAttempt.mockReset();
   mockedRunContextEngineMaintenance.mockReset();
   mockedRunContextEngineMaintenance.mockResolvedValue(undefined);
-  mockedSessionLikelyHasOversizedToolResults.mockReset();
-  mockedSessionLikelyHasOversizedToolResults.mockReturnValue(false);
-  mockedTruncateOversizedToolResultsInSession.mockReset();
-  mockedTruncateOversizedToolResultsInSession.mockResolvedValue({
-    truncated: false,
-    truncatedCount: 0,
-    reason: "no oversized tool results",
-  });
 
   mockedCoerceToFailoverError.mockReset();
   mockedCoerceToFailoverError.mockReturnValue(null);
@@ -473,11 +451,6 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("./run/payloads.js", () => ({
     buildEmbeddedRunPayloads: vi.fn(() => []),
-  }));
-
-  vi.doMock("./tool-result-truncation.js", () => ({
-    truncateOversizedToolResultsInSession: mockedTruncateOversizedToolResultsInSession,
-    sessionLikelyHasOversizedToolResults: mockedSessionLikelyHasOversizedToolResults,
   }));
 
   vi.doMock("./compact.js", () => ({

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -4,6 +4,7 @@ import {
   makeCompactionSuccess,
   makeOverflowError,
   mockOverflowRetrySuccess,
+  queueOverflowAttemptWithOversizedToolOutput,
 } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
@@ -13,6 +14,8 @@ import {
   mockedIsLikelyContextOverflowError,
   mockedLog,
   mockedRunEmbeddedAttempt,
+  mockedSessionLikelyHasOversizedToolResults,
+  mockedTruncateOversizedToolResultsInSession,
   overflowBaseRunParams as baseParams,
 } from "./run.overflow-compaction.harness.js";
 
@@ -26,6 +29,8 @@ describe("overflow compaction in run loop", () => {
   beforeEach(() => {
     mockedRunEmbeddedAttempt.mockReset();
     mockedCompactDirect.mockReset();
+    mockedSessionLikelyHasOversizedToolResults.mockReset();
+    mockedTruncateOversizedToolResultsInSession.mockReset();
     mockedContextEngine.info.ownsCompaction = false;
     mockedLog.debug.mockReset();
     mockedLog.info.mockReset();
@@ -56,6 +61,12 @@ describe("overflow compaction in run loop", () => {
       ok: false,
       compacted: false,
       reason: "nothing to compact",
+    });
+    mockedSessionLikelyHasOversizedToolResults.mockReturnValue(false);
+    mockedTruncateOversizedToolResultsInSession.mockResolvedValue({
+      truncated: false,
+      truncatedCount: 0,
+      reason: "no oversized tool results",
     });
   });
 
@@ -127,6 +138,37 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error?.kind).toBe("context_overflow");
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("auto-compaction failed"));
+  });
+
+  it("falls back to tool-result truncation and retries when oversized results are detected", async () => {
+    queueOverflowAttemptWithOversizedToolOutput(mockedRunEmbeddedAttempt, makeOverflowError());
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "nothing to compact",
+    });
+    mockedSessionLikelyHasOversizedToolResults.mockReturnValue(true);
+    mockedTruncateOversizedToolResultsInSession.mockResolvedValueOnce({
+      truncated: true,
+      truncatedCount: 1,
+    });
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedSessionLikelyHasOversizedToolResults).toHaveBeenCalledWith(
+      expect.objectContaining({ contextWindowTokens: 200000 }),
+    );
+    expect(mockedTruncateOversizedToolResultsInSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionFile: "/tmp/session.json" }),
+    );
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedLog.info).toHaveBeenCalledWith(
+      expect.stringContaining("Truncated 1 tool result(s)"),
+    );
+    expect(result.meta.error).toBeUndefined();
   });
 
   it("retries compaction up to 3 times before giving up", async () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   makeAttemptResult,
   makeCompactionSuccess,
@@ -10,9 +10,11 @@ import {
   loadRunOverflowCompactionHarness,
   mockedContextEngine,
   mockedCompactDirect,
+  mockedEvaluateContextWindowGuard,
   mockedIsCompactionFailureError,
   mockedIsLikelyContextOverflowError,
   mockedLog,
+  mockedResolveContextWindowInfo,
   mockedRunEmbeddedAttempt,
   mockedSessionLikelyHasOversizedToolResults,
   mockedTruncateOversizedToolResultsInSession,
@@ -168,6 +170,86 @@ describe("overflow compaction in run loop", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(mockedLog.info).toHaveBeenCalledWith(
       expect.stringContaining("Truncated 1 tool result(s)"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("falls back to tool-result truncation and retries when real aggregate tool-result detection trips", async () => {
+    const { sessionLikelyHasOversizedToolResults } = await vi.importActual<
+      typeof import("./tool-result-truncation.js")
+    >("./tool-result-truncation.js");
+    mockedResolveContextWindowInfo.mockReturnValue({
+      tokens: 10_000,
+      source: "model",
+    });
+    mockedEvaluateContextWindowGuard.mockReturnValue({
+      shouldWarn: false,
+      shouldBlock: false,
+      tokens: 10_000,
+      source: "model",
+    });
+
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: makeOverflowError(),
+          messagesSnapshot: [
+            {
+              role: "user",
+              content: "u".repeat(20_000),
+            } as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+            {
+              role: "toolResult",
+              toolCallId: "call_a",
+              toolName: "read",
+              content: [{ type: "text", text: "a".repeat(10_000) }],
+              isError: false,
+            } as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+            {
+              role: "toolResult",
+              toolCallId: "call_b",
+              toolName: "read",
+              content: [{ type: "text", text: "b".repeat(10_000) }],
+              isError: false,
+            } as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+            {
+              role: "toolResult",
+              toolCallId: "call_c",
+              toolName: "read",
+              content: [{ type: "text", text: "c".repeat(10_000) }],
+              isError: false,
+            } as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "nothing to compact",
+    });
+    mockedSessionLikelyHasOversizedToolResults.mockImplementation(
+      ((params: Parameters<typeof sessionLikelyHasOversizedToolResults>[0]) =>
+        sessionLikelyHasOversizedToolResults(params)) as never,
+    );
+    mockedTruncateOversizedToolResultsInSession.mockResolvedValueOnce({
+      truncated: true,
+      truncatedCount: 2,
+    });
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedSessionLikelyHasOversizedToolResults).toHaveBeenCalledWith(
+      expect.objectContaining({ contextWindowTokens: 10_000 }),
+    );
+    expect(mockedTruncateOversizedToolResultsInSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionFile: "/tmp/session.json" }),
+    );
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedLog.info).toHaveBeenCalledWith(
+      expect.stringContaining("Truncated 2 tool result(s)"),
     );
     expect(result.meta.error).toBeUndefined();
   });

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -18,6 +18,7 @@ import {
   mockedTruncateOversizedToolResultsInSession,
   overflowBaseRunParams as baseParams,
 } from "./run.overflow-compaction.harness.js";
+import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
 
@@ -278,7 +279,9 @@ describe("overflow compaction in run loop", () => {
     expect(mockedTruncateOversizedToolResultsInSession).not.toHaveBeenCalled();
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(mockedLog.warn).toHaveBeenCalledWith(
-      expect.stringContaining("context overflow detected (attempt 1/3); attempting auto-compaction"),
+      expect.stringContaining(
+        "context overflow detected (attempt 1/3); attempting auto-compaction",
+      ),
     );
     expect(result.meta.error).toBeUndefined();
   });

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -171,6 +171,68 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error).toBeUndefined();
   });
 
+  it("retries without hitting compaction when attempt-level preflight truncation already handled the overflow", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: null,
+          preflightRecovery: {
+            route: "truncate_tool_results_only",
+            handled: true,
+            truncatedCount: 2,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(mockedTruncateOversizedToolResultsInSession).not.toHaveBeenCalled();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedLog.info).toHaveBeenCalledWith(
+      expect.stringContaining("early recovery route=truncate_tool_results_only"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("runs post-compaction tool-result truncation before retry for mixed precheck routes", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: makeOverflowError(
+            "Context overflow: prompt too large for the model (precheck).",
+          ),
+          preflightRecovery: { route: "compact_then_truncate" },
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted session",
+        firstKeptEntryId: "entry-5",
+        tokensBefore: 150000,
+      }),
+    );
+    mockedTruncateOversizedToolResultsInSession.mockResolvedValueOnce({
+      truncated: true,
+      truncatedCount: 2,
+    });
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedTruncateOversizedToolResultsInSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionFile: "/tmp/session.json" }),
+    );
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedLog.info).toHaveBeenCalledWith(
+      expect.stringContaining("post-compaction tool-result truncation succeeded"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
   it("retries compaction up to 3 times before giving up", async () => {
     const overflowError = makeOverflowError();
 

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -1,26 +1,20 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   makeAttemptResult,
   makeCompactionSuccess,
   makeOverflowError,
   mockOverflowRetrySuccess,
-  queueOverflowAttemptWithOversizedToolOutput,
 } from "./run.overflow-compaction.fixture.js";
 import {
   loadRunOverflowCompactionHarness,
   mockedContextEngine,
   mockedCompactDirect,
-  mockedEvaluateContextWindowGuard,
   mockedIsCompactionFailureError,
   mockedIsLikelyContextOverflowError,
   mockedLog,
-  mockedResolveContextWindowInfo,
   mockedRunEmbeddedAttempt,
-  mockedSessionLikelyHasOversizedToolResults,
-  mockedTruncateOversizedToolResultsInSession,
   overflowBaseRunParams as baseParams,
 } from "./run.overflow-compaction.harness.js";
-import type { EmbeddedRunAttemptResult } from "./run/types.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
 
@@ -32,8 +26,6 @@ describe("overflow compaction in run loop", () => {
   beforeEach(() => {
     mockedRunEmbeddedAttempt.mockReset();
     mockedCompactDirect.mockReset();
-    mockedSessionLikelyHasOversizedToolResults.mockReset();
-    mockedTruncateOversizedToolResultsInSession.mockReset();
     mockedContextEngine.info.ownsCompaction = false;
     mockedLog.debug.mockReset();
     mockedLog.info.mockReset();
@@ -64,12 +56,6 @@ describe("overflow compaction in run loop", () => {
       ok: false,
       compacted: false,
       reason: "nothing to compact",
-    });
-    mockedSessionLikelyHasOversizedToolResults.mockReturnValue(false);
-    mockedTruncateOversizedToolResultsInSession.mockResolvedValue({
-      truncated: false,
-      truncatedCount: 0,
-      reason: "no oversized tool results",
     });
   });
 
@@ -141,117 +127,6 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error?.kind).toBe("context_overflow");
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("auto-compaction failed"));
-  });
-
-  it("falls back to tool-result truncation and retries when oversized results are detected", async () => {
-    queueOverflowAttemptWithOversizedToolOutput(mockedRunEmbeddedAttempt, makeOverflowError());
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
-
-    mockedCompactDirect.mockResolvedValueOnce({
-      ok: false,
-      compacted: false,
-      reason: "nothing to compact",
-    });
-    mockedSessionLikelyHasOversizedToolResults.mockReturnValue(true);
-    mockedTruncateOversizedToolResultsInSession.mockResolvedValueOnce({
-      truncated: true,
-      truncatedCount: 1,
-    });
-
-    const result = await runEmbeddedPiAgent(baseParams);
-
-    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
-    expect(mockedSessionLikelyHasOversizedToolResults).toHaveBeenCalledWith(
-      expect.objectContaining({ contextWindowTokens: 200000 }),
-    );
-    expect(mockedTruncateOversizedToolResultsInSession).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionFile: "/tmp/session.json" }),
-    );
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    expect(mockedLog.info).toHaveBeenCalledWith(
-      expect.stringContaining("Truncated 1 tool result(s)"),
-    );
-    expect(result.meta.error).toBeUndefined();
-  });
-
-  it("falls back to tool-result truncation and retries when real aggregate tool-result detection trips", async () => {
-    const { sessionLikelyHasOversizedToolResults } = await vi.importActual<
-      typeof import("./tool-result-truncation.js")
-    >("./tool-result-truncation.js");
-    mockedResolveContextWindowInfo.mockReturnValue({
-      tokens: 10_000,
-      source: "model",
-    });
-    mockedEvaluateContextWindowGuard.mockReturnValue({
-      shouldWarn: false,
-      shouldBlock: false,
-      tokens: 10_000,
-      source: "model",
-    });
-
-    mockedRunEmbeddedAttempt
-      .mockResolvedValueOnce(
-        makeAttemptResult({
-          promptError: makeOverflowError(),
-          messagesSnapshot: [
-            {
-              role: "user",
-              content: "u".repeat(20_000),
-            } as EmbeddedRunAttemptResult["messagesSnapshot"][number],
-            {
-              role: "toolResult",
-              toolCallId: "call_a",
-              toolName: "read",
-              content: [{ type: "text", text: "a".repeat(10_000) }],
-              isError: false,
-            } as EmbeddedRunAttemptResult["messagesSnapshot"][number],
-            {
-              role: "toolResult",
-              toolCallId: "call_b",
-              toolName: "read",
-              content: [{ type: "text", text: "b".repeat(10_000) }],
-              isError: false,
-            } as EmbeddedRunAttemptResult["messagesSnapshot"][number],
-            {
-              role: "toolResult",
-              toolCallId: "call_c",
-              toolName: "read",
-              content: [{ type: "text", text: "c".repeat(10_000) }],
-              isError: false,
-            } as EmbeddedRunAttemptResult["messagesSnapshot"][number],
-          ],
-        }),
-      )
-      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
-
-    mockedCompactDirect.mockResolvedValueOnce({
-      ok: false,
-      compacted: false,
-      reason: "nothing to compact",
-    });
-    mockedSessionLikelyHasOversizedToolResults.mockImplementation(
-      ((params: Parameters<typeof sessionLikelyHasOversizedToolResults>[0]) =>
-        sessionLikelyHasOversizedToolResults(params)) as never,
-    );
-    mockedTruncateOversizedToolResultsInSession.mockResolvedValueOnce({
-      truncated: true,
-      truncatedCount: 2,
-    });
-
-    const result = await runEmbeddedPiAgent(baseParams);
-
-    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
-    expect(mockedSessionLikelyHasOversizedToolResults).toHaveBeenCalledWith(
-      expect.objectContaining({ contextWindowTokens: 10_000 }),
-    );
-    expect(mockedTruncateOversizedToolResultsInSession).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionFile: "/tmp/session.json" }),
-    );
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
-    expect(mockedLog.info).toHaveBeenCalledWith(
-      expect.stringContaining("Truncated 2 tool result(s)"),
-    );
-    expect(result.meta.error).toBeUndefined();
   });
 
   it("retries compaction up to 3 times before giving up", async () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -171,6 +171,62 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error).toBeUndefined();
   });
 
+  it("retries after fallback truncation for a mixed oversized-plus-aggregate tool tail", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: makeOverflowError(),
+          messagesSnapshot: [
+            {
+              role: "toolResult",
+              content: [{ type: "text", text: "x".repeat(80_000) }],
+            } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+            {
+              role: "toolResult",
+              content: [{ type: "text", text: "alpha beta gamma delta ".repeat(800) }],
+            } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+            {
+              role: "toolResult",
+              content: [{ type: "text", text: "alpha beta gamma delta ".repeat(800) }],
+            } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedCompactDirect.mockResolvedValueOnce({
+      ok: false,
+      compacted: false,
+      reason: "nothing to compact",
+    });
+    mockedSessionLikelyHasOversizedToolResults.mockReturnValue(true);
+    mockedTruncateOversizedToolResultsInSession.mockResolvedValueOnce({
+      truncated: true,
+      truncatedCount: 2,
+    });
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedSessionLikelyHasOversizedToolResults).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: "toolResult" }),
+          expect.objectContaining({ role: "toolResult" }),
+          expect.objectContaining({ role: "toolResult" }),
+        ]),
+      }),
+    );
+    expect(mockedTruncateOversizedToolResultsInSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionFile: "/tmp/session.json" }),
+    );
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedLog.info).toHaveBeenCalledWith(
+      expect.stringContaining("Truncated 2 tool result(s)"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
   it("retries without hitting compaction when attempt-level preflight truncation already handled the overflow", async () => {
     mockedRunEmbeddedAttempt
       .mockResolvedValueOnce(
@@ -192,6 +248,37 @@ describe("overflow compaction in run loop", () => {
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(mockedLog.info).toHaveBeenCalledWith(
       expect.stringContaining("early recovery route=truncate_tool_results_only"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("falls back to compaction when early truncate-only recovery does not help", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: makeOverflowError(
+            "Context overflow: prompt too large for the model (precheck).",
+          ),
+          preflightRecovery: { route: "compact_only" },
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted after failed early truncation",
+        firstKeptEntryId: "entry-7",
+        tokensBefore: 155000,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledTimes(1);
+    expect(mockedTruncateOversizedToolResultsInSession).not.toHaveBeenCalled();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedLog.warn).toHaveBeenCalledWith(
+      expect.stringContaining("context overflow detected (attempt 1/3); attempting auto-compaction"),
     );
     expect(result.meta.error).toBeUndefined();
   });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -64,10 +64,6 @@ import { runContextEngineMaintenance } from "./context-engine-maintenance.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModelAsync } from "./model.js";
-import {
-  sessionLikelyHasOversizedToolResults,
-  truncateOversizedToolResultsInSession,
-} from "./tool-result-truncation.js";
 import { handleAssistantFailover } from "./run/assistant-failover.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
 import { createEmbeddedRunAuthController } from "./run/auth-controller.js";
@@ -95,6 +91,10 @@ import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import { resolveEffectiveRuntimeModel, resolveHookModelSelection } from "./run/setup.js";
+import {
+  sessionLikelyHasOversizedToolResults,
+  truncateOversizedToolResultsInSession,
+} from "./tool-result-truncation.js";
 import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
 import { describeUnknownError } from "./utils.js";
@@ -616,6 +616,7 @@ export async function runEmbeddedPiAgent(
           const {
             aborted,
             promptError,
+            preflightRecovery,
             timedOut,
             timedOutDuringCompaction,
             sessionIdUsed,
@@ -663,6 +664,13 @@ export async function runEmbeddedPiAgent(
             !attempt.lastToolError &&
             attempt.toolMetas.length === 0 &&
             attempt.assistantTexts.length === 0;
+          if (preflightRecovery?.handled) {
+            log.info(
+              `[context-overflow-precheck] early recovery route=${preflightRecovery.route} ` +
+                `completed for ${provider}/${modelId}; retrying prompt`,
+            );
+            continue;
+          }
           const requestedSelection = shouldSwitchToLiveModel({
             cfg: params.config,
             sessionKey: params.sessionKey,
@@ -919,6 +927,25 @@ export async function runEmbeddedPiAgent(
               }
               await runOwnsCompactionAfterHook("overflow recovery", compactResult);
               if (compactResult.compacted) {
+                if (preflightRecovery?.route === "compact_then_truncate") {
+                  const truncResult = await truncateOversizedToolResultsInSession({
+                    sessionFile: params.sessionFile,
+                    contextWindowTokens: ctxInfo.tokens,
+                    sessionId: params.sessionId,
+                    sessionKey: params.sessionKey,
+                  });
+                  if (truncResult.truncated) {
+                    log.info(
+                      `[context-overflow-precheck] post-compaction tool-result truncation succeeded for ` +
+                        `${provider}/${modelId}; truncated ${truncResult.truncatedCount} tool result(s)`,
+                    );
+                  } else {
+                    log.warn(
+                      `[context-overflow-precheck] post-compaction tool-result truncation did not help for ` +
+                        `${provider}/${modelId}: ${truncResult.reason ?? "unknown"}`,
+                    );
+                  }
+                }
                 autoCompactionCount += 1;
                 log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
                 continue;
@@ -960,7 +987,8 @@ export async function runEmbeddedPiAgent(
               }
             }
             if (
-              (isCompactionFailure || overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS) &&
+              (isCompactionFailure ||
+                overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS) &&
               log.isEnabled("debug")
             ) {
               log.debug(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -91,10 +91,6 @@ import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import { handleRetryLimitExhaustion } from "./run/retry-limit.js";
 import { resolveEffectiveRuntimeModel, resolveHookModelSelection } from "./run/setup.js";
-import {
-  sessionLikelyHasOversizedToolResults,
-  truncateOversizedToolResultsInSession,
-} from "./tool-result-truncation.js";
 import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
 import { describeUnknownError } from "./utils.js";
@@ -320,7 +316,6 @@ export async function runEmbeddedPiAgent(
       const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
       const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
       let overflowCompactionAttempts = 0;
-      let toolResultTruncationAttempted = false;
       let bootstrapPromptWarningSignaturesSeen =
         params.bootstrapPromptWarningSignaturesSeen ??
         (params.bootstrapPromptWarningSignature ? [params.bootstrapPromptWarningSignature] : []);
@@ -927,60 +922,8 @@ export async function runEmbeddedPiAgent(
                 `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
               );
             }
-            // Fallback: try truncating oversized tool results in the session.
-            // This handles the case where a single tool result exceeds the
-            // context window and compaction cannot reduce it further.
-            if (!toolResultTruncationAttempted) {
-              const contextWindowTokens = ctxInfo.tokens;
-              const hasOversized = attempt.messagesSnapshot
-                ? sessionLikelyHasOversizedToolResults({
-                    messages: attempt.messagesSnapshot,
-                    contextWindowTokens,
-                  })
-                : false;
-
-              if (hasOversized) {
-                if (log.isEnabled("debug")) {
-                  log.debug(
-                    `[compaction-diag] decision diagId=${overflowDiagId} branch=truncate_tool_results ` +
-                      `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=${hasOversized} ` +
-                      `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
-                  );
-                }
-                toolResultTruncationAttempted = true;
-                log.warn(
-                  `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
-                    `(contextWindow=${contextWindowTokens} tokens)`,
-                );
-                const truncResult = await truncateOversizedToolResultsInSession({
-                  sessionFile: params.sessionFile,
-                  contextWindowTokens,
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                });
-                if (truncResult.truncated) {
-                  log.info(
-                    `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
-                  );
-                  // Do NOT reset overflowCompactionAttempts here — the global cap must remain
-                  // enforced across all iterations to prevent unbounded compaction cycles (OC-65).
-                  continue;
-                }
-                log.warn(
-                  `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
-                );
-              } else if (log.isEnabled("debug")) {
-                log.debug(
-                  `[compaction-diag] decision diagId=${overflowDiagId} branch=give_up ` +
-                    `isCompactionFailure=${isCompactionFailure} hasOversizedToolResults=${hasOversized} ` +
-                    `attempt=${overflowCompactionAttempts} maxAttempts=${MAX_OVERFLOW_COMPACTION_ATTEMPTS}`,
-                );
-              }
-            }
             if (
-              (isCompactionFailure ||
-                overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS ||
-                toolResultTruncationAttempted) &&
+              (isCompactionFailure || overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS) &&
               log.isEnabled("debug")
             ) {
               log.debug(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -64,6 +64,10 @@ import { runContextEngineMaintenance } from "./context-engine-maintenance.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModelAsync } from "./model.js";
+import {
+  sessionLikelyHasOversizedToolResults,
+  truncateOversizedToolResultsInSession,
+} from "./tool-result-truncation.js";
 import { handleAssistantFailover } from "./run/assistant-failover.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
 import { createEmbeddedRunAuthController } from "./run/auth-controller.js";
@@ -316,6 +320,7 @@ export async function runEmbeddedPiAgent(
       const MAX_OVERFLOW_COMPACTION_ATTEMPTS = 3;
       const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
       let overflowCompactionAttempts = 0;
+      let toolResultTruncationAttempted = false;
       let bootstrapPromptWarningSignaturesSeen =
         params.bootstrapPromptWarningSignaturesSeen ??
         (params.bootstrapPromptWarningSignature ? [params.bootstrapPromptWarningSignature] : []);
@@ -921,6 +926,38 @@ export async function runEmbeddedPiAgent(
               log.warn(
                 `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
               );
+            }
+            if (!toolResultTruncationAttempted) {
+              const contextWindowTokens = ctxInfo.tokens;
+              const hasOversized = attempt.messagesSnapshot
+                ? sessionLikelyHasOversizedToolResults({
+                    messages: attempt.messagesSnapshot,
+                    contextWindowTokens,
+                  })
+                : false;
+
+              if (hasOversized) {
+                toolResultTruncationAttempted = true;
+                log.warn(
+                  `[context-overflow-recovery] Attempting tool result truncation for ${provider}/${modelId} ` +
+                    `(contextWindow=${contextWindowTokens} tokens)`,
+                );
+                const truncResult = await truncateOversizedToolResultsInSession({
+                  sessionFile: params.sessionFile,
+                  contextWindowTokens,
+                  sessionId: params.sessionId,
+                  sessionKey: params.sessionKey,
+                });
+                if (truncResult.truncated) {
+                  log.info(
+                    `[context-overflow-recovery] Truncated ${truncResult.truncatedCount} tool result(s); retrying prompt`,
+                  );
+                  continue;
+                }
+                log.warn(
+                  `[context-overflow-recovery] Tool result truncation did not help: ${truncResult.reason ?? "unknown"}`,
+                );
+              }
             }
             if (
               (isCompactionFailure || overflowCompactionAttempts >= MAX_OVERFLOW_COMPACTION_ATTEMPTS) &&

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1769,17 +1769,18 @@ export async function runEmbeddedAttempt(
           }
 
           const reserveTokens = settingsManager.getCompactionReserveTokens();
+          const contextTokenBudget = params.contextTokenBudget ?? DEFAULT_CONTEXT_TOKENS;
           const preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
             messages: activeSession.messages,
             systemPrompt: systemPromptText,
             prompt: effectivePrompt,
-            contextTokenBudget: params.contextTokenBudget,
+            contextTokenBudget,
             reserveTokens,
           });
           if (preemptiveCompaction.route === "truncate_tool_results_only") {
             const truncationResult = truncateOversizedToolResultsInSessionManager({
               sessionManager,
-              contextWindowTokens: params.contextTokenBudget,
+              contextWindowTokens: contextTokenBudget,
               sessionFile: params.sessionFile,
               sessionId: params.sessionId,
               sessionKey: params.sessionKey,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -121,6 +121,10 @@ import {
 import { resolveCacheRetention } from "../prompt-cache-retention.js";
 import { sanitizeSessionHistory, validateReplayTurns } from "../replay-history.js";
 import {
+  PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  shouldPreemptivelyCompactBeforePrompt,
+} from "./preemptive-compaction.js";
+import {
   clearActiveEmbeddedRun,
   type EmbeddedPiQueueHandle,
   setActiveEmbeddedRun,
@@ -1521,7 +1525,7 @@ export async function runEmbeddedAttempt(
       const hookAgentId = sessionAgentId;
 
       let promptError: unknown = null;
-      let promptErrorSource: "prompt" | "compaction" | null = null;
+      let promptErrorSource: "prompt" | "compaction" | "precheck" | null = null;
       let prePromptMessageCount = activeSession.messages.length;
       try {
         const promptStartedAt = Date.now();
@@ -1759,6 +1763,27 @@ export async function runEmbeddedAttempt(
               .catch((err) => {
                 log.warn(`llm_input hook failed: ${String(err)}`);
               });
+          }
+
+          const reserveTokens = settingsManager.getCompactionReserveTokens();
+          const preemptiveCompaction = shouldPreemptivelyCompactBeforePrompt({
+            messages: activeSession.messages,
+            systemPrompt: systemPromptText,
+            prompt: effectivePrompt,
+            contextTokenBudget: params.contextTokenBudget,
+            reserveTokens,
+          });
+          if (preemptiveCompaction.shouldCompact) {
+            promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+            promptErrorSource = "precheck";
+            log.warn(
+              `[context-overflow-precheck] sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                `provider=${params.provider}/${params.modelId} ` +
+                `estimatedPromptTokens=${preemptiveCompaction.estimatedPromptTokens} ` +
+                `promptBudgetBeforeReserve=${preemptiveCompaction.promptBudgetBeforeReserve} ` +
+                `reserveTokens=${reserveTokens} sessionFile=${params.sessionFile}`,
+            );
+            return;
           }
 
           const btwSnapshotMessages = activeSession.messages.slice(-MAX_BTW_SNAPSHOT_MESSAGES);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -121,10 +121,6 @@ import {
 import { resolveCacheRetention } from "../prompt-cache-retention.js";
 import { sanitizeSessionHistory, validateReplayTurns } from "../replay-history.js";
 import {
-  PREEMPTIVE_OVERFLOW_ERROR_TEXT,
-  shouldPreemptivelyCompactBeforePrompt,
-} from "./preemptive-compaction.js";
-import {
   clearActiveEmbeddedRun,
   type EmbeddedPiQueueHandle,
   setActiveEmbeddedRun,
@@ -149,6 +145,7 @@ import {
 import { dropThinkingBlocks } from "../thinking.js";
 import { collectAllowedToolNames } from "../tool-name-allowlist.js";
 import { installToolResultContextGuard } from "../tool-result-context-guard.js";
+import { truncateOversizedToolResultsInSessionManager } from "../tool-result-truncation.js";
 import {
   logProviderToolSchemaDiagnostics,
   normalizeProviderToolSchemas,
@@ -210,6 +207,10 @@ import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { buildAttemptReplayMetadata } from "./incomplete-turn.js";
 import { resolveLlmIdleTimeoutMs, streamWithIdleTimeout } from "./llm-idle-timeout.js";
+import {
+  PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  shouldPreemptivelyCompactBeforePrompt,
+} from "./preemptive-compaction.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
 
 export {
@@ -1525,8 +1526,10 @@ export async function runEmbeddedAttempt(
       const hookAgentId = sessionAgentId;
 
       let promptError: unknown = null;
+      let preflightRecovery: EmbeddedRunAttemptResult["preflightRecovery"];
       let promptErrorSource: "prompt" | "compaction" | "precheck" | null = null;
       let prePromptMessageCount = activeSession.messages.length;
+      let skipPromptSubmission = false;
       try {
         const promptStartedAt = Date.now();
 
@@ -1773,32 +1776,81 @@ export async function runEmbeddedAttempt(
             contextTokenBudget: params.contextTokenBudget,
             reserveTokens,
           });
+          if (preemptiveCompaction.route === "truncate_tool_results_only") {
+            const truncationResult = truncateOversizedToolResultsInSessionManager({
+              sessionManager,
+              contextWindowTokens: params.contextTokenBudget,
+              sessionFile: params.sessionFile,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            });
+            if (truncationResult.truncated) {
+              preflightRecovery = {
+                route: "truncate_tool_results_only",
+                handled: true,
+                truncatedCount: truncationResult.truncatedCount,
+              };
+              log.info(
+                `[context-overflow-precheck] early tool-result truncation succeeded for ` +
+                  `${params.provider}/${params.modelId} route=${preemptiveCompaction.route} ` +
+                  `truncatedCount=${truncationResult.truncatedCount} ` +
+                  `estimatedPromptTokens=${preemptiveCompaction.estimatedPromptTokens} ` +
+                  `promptBudgetBeforeReserve=${preemptiveCompaction.promptBudgetBeforeReserve} ` +
+                  `overflowTokens=${preemptiveCompaction.overflowTokens} ` +
+                  `toolResultReducibleChars=${preemptiveCompaction.toolResultReducibleChars} ` +
+                  `sessionFile=${params.sessionFile}`,
+              );
+              skipPromptSubmission = true;
+            }
+            if (!skipPromptSubmission) {
+              log.warn(
+                `[context-overflow-precheck] early tool-result truncation did not help for ` +
+                  `${params.provider}/${params.modelId}; falling back to compaction ` +
+                  `reason=${truncationResult.reason ?? "unknown"} sessionFile=${params.sessionFile}`,
+              );
+              preflightRecovery = { route: "compact_only" };
+              promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
+              promptErrorSource = "precheck";
+              skipPromptSubmission = true;
+            }
+          }
           if (preemptiveCompaction.shouldCompact) {
+            preflightRecovery =
+              preemptiveCompaction.route === "compact_then_truncate"
+                ? { route: "compact_then_truncate" }
+                : { route: "compact_only" };
             promptError = new Error(PREEMPTIVE_OVERFLOW_ERROR_TEXT);
             promptErrorSource = "precheck";
             log.warn(
               `[context-overflow-precheck] sessionKey=${params.sessionKey ?? params.sessionId} ` +
                 `provider=${params.provider}/${params.modelId} ` +
+                `route=${preemptiveCompaction.route} ` +
                 `estimatedPromptTokens=${preemptiveCompaction.estimatedPromptTokens} ` +
                 `promptBudgetBeforeReserve=${preemptiveCompaction.promptBudgetBeforeReserve} ` +
+                `overflowTokens=${preemptiveCompaction.overflowTokens} ` +
+                `toolResultReducibleChars=${preemptiveCompaction.toolResultReducibleChars} ` +
                 `reserveTokens=${reserveTokens} sessionFile=${params.sessionFile}`,
             );
-            return;
+            skipPromptSubmission = true;
           }
 
-          const btwSnapshotMessages = activeSession.messages.slice(-MAX_BTW_SNAPSHOT_MESSAGES);
-          updateActiveEmbeddedRunSnapshot(params.sessionId, {
-            transcriptLeafId,
-            messages: btwSnapshotMessages,
-            inFlightPrompt: effectivePrompt,
-          });
+          if (!skipPromptSubmission) {
+            const btwSnapshotMessages = activeSession.messages.slice(-MAX_BTW_SNAPSHOT_MESSAGES);
+            updateActiveEmbeddedRunSnapshot(params.sessionId, {
+              transcriptLeafId,
+              messages: btwSnapshotMessages,
+              inFlightPrompt: effectivePrompt,
+            });
 
-          // Only pass images option if there are actually images to pass
-          // This avoids potential issues with models that don't expect the images parameter
-          if (imageResult.images.length > 0) {
-            await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
-          } else {
-            await abortable(activeSession.prompt(effectivePrompt));
+            // Only pass images option if there are actually images to pass
+            // This avoids potential issues with models that don't expect the images parameter
+            if (imageResult.images.length > 0) {
+              await abortable(
+                activeSession.prompt(effectivePrompt, { images: imageResult.images }),
+              );
+            } else {
+              await abortable(activeSession.prompt(effectivePrompt));
+            }
           }
         } catch (err) {
           // Yield-triggered abort is intentional — treat as clean stop, not error.
@@ -2160,6 +2212,7 @@ export async function runEmbeddedAttempt(
         timedOut,
         timedOutDuringCompaction,
         promptError,
+        preflightRecovery,
         sessionIdUsed,
         bootstrapPromptWarningSignaturesSeen: bootstrapPromptWarning.warningSignaturesSeen,
         bootstrapPromptWarningSignature: bootstrapPromptWarning.signature,

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -126,25 +126,11 @@ describe("preemptive-compaction", () => {
       makeToolResultMessage(medium),
     ];
     const reserveTokens = 500;
-    const baseContextTokenBudget = 3_500;
-    const estimatedPromptTokens = estimatePrePromptTokens({
-      messages,
-      systemPrompt: verboseSystem,
-      prompt: verbosePrompt,
-    });
-    const toolResultPotential = estimateToolResultReductionPotential({
-      messages,
-      contextWindowTokens: baseContextTokenBudget,
-    });
-    const desiredOverflowTokens = Math.ceil((toolResultPotential.maxReducibleChars + 4_096) / 4);
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages,
       systemPrompt: verboseSystem,
       prompt: verbosePrompt,
-      contextTokenBudget: Math.max(
-        baseContextTokenBudget,
-        estimatedPromptTokens - desiredOverflowTokens + reserveTokens,
-      ),
+      contextTokenBudget: 12_000,
       reserveTokens,
     });
 

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
   estimatePrePromptTokens,
@@ -43,6 +44,7 @@ describe("preemptive-compaction", () => {
     });
 
     expect(result.shouldCompact).toBe(true);
+    expect(result.route).toBe("compact_only");
     expect(result.estimatedPromptTokens).toBeGreaterThan(result.promptBudgetBeforeReserve);
   });
 
@@ -56,6 +58,85 @@ describe("preemptive-compaction", () => {
     });
 
     expect(result.shouldCompact).toBe(false);
+    expect(result.route).toBe("fits");
     expect(result.estimatedPromptTokens).toBeLessThan(result.promptBudgetBeforeReserve);
+  });
+
+  it("routes to direct tool-result truncation when recent tool tails can clearly absorb the overflow", () => {
+    const medium = "alpha beta gamma delta epsilon ".repeat(2200);
+    const messages = [
+      { role: "assistant", content: "short history" },
+      {
+        role: "toolResult",
+        content: [
+          { type: "text", text: medium },
+          { type: "text", text: medium },
+          { type: "text", text: medium },
+          { type: "text", text: medium },
+        ],
+      } as never,
+    ];
+    const reserveTokens = 2_000;
+    const contextTokenBudget = 26_000;
+    const estimatedPromptTokens = estimatePrePromptTokens({
+      messages,
+      systemPrompt: "sys",
+      prompt: "hello",
+    });
+    const desiredOverflowTokens = 200;
+    const adjustedContextTokenBudget =
+      estimatedPromptTokens - desiredOverflowTokens + reserveTokens;
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: Math.max(contextTokenBudget, adjustedContextTokenBudget),
+      reserveTokens,
+    });
+
+    expect(result.route).toBe("truncate_tool_results_only");
+    expect(result.shouldCompact).toBe(false);
+    expect(result.overflowTokens).toBeGreaterThan(0);
+    expect(result.toolResultReducibleChars).toBeGreaterThan(0);
+  });
+
+  it("routes to compact then truncate when recent tool tails help but cannot fully cover the overflow", () => {
+    const medium = "alpha beta gamma delta epsilon ".repeat(220);
+    const longHistory = "old discussion with substantial retained context and decisions ".repeat(
+      5000,
+    );
+    const messages = [
+      { role: "assistant", content: longHistory },
+      { role: "toolResult", content: [{ type: "text", text: medium }] } as never,
+      { role: "toolResult", content: [{ type: "text", text: medium }] } as never,
+      { role: "toolResult", content: [{ type: "text", text: medium }] } as never,
+    ];
+    const reserveTokens = 500;
+    const baseContextTokenBudget = 3_500;
+    const estimatedPromptTokens = estimatePrePromptTokens({
+      messages,
+      systemPrompt: verboseSystem,
+      prompt: verbosePrompt,
+    });
+    const toolResultPotential = estimateToolResultReductionPotential({
+      messages: messages as never,
+      contextWindowTokens: baseContextTokenBudget,
+    });
+    const desiredOverflowTokens = Math.ceil((toolResultPotential.maxReducibleChars + 4_096) / 4);
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: verboseSystem,
+      prompt: verbosePrompt,
+      contextTokenBudget: Math.max(
+        baseContextTokenBudget,
+        estimatedPromptTokens - desiredOverflowTokens + reserveTokens,
+      ),
+      reserveTokens,
+    });
+
+    expect(result.route).toBe("compact_then_truncate");
+    expect(result.shouldCompact).toBe(true);
+    expect(result.overflowTokens).toBeGreaterThan(0);
+    expect(result.toolResultReducibleChars).toBeGreaterThan(0);
   });
 });

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -1,3 +1,4 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it } from "vitest";
 import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
 import {
@@ -5,6 +6,27 @@ import {
   estimatePrePromptTokens,
   shouldPreemptivelyCompactBeforePrompt,
 } from "./preemptive-compaction.js";
+
+let timestamp = 1;
+
+function makeAssistantHistory(text: string): AgentMessage {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp: timestamp++,
+  } as AgentMessage;
+}
+
+function makeToolResultMessage(...texts: string[]): AgentMessage {
+  return {
+    role: "toolResult",
+    toolCallId: `call_${timestamp}`,
+    toolName: "read",
+    content: texts.map((text) => ({ type: "text", text })),
+    isError: false,
+    timestamp: timestamp++,
+  } as AgentMessage;
+}
 
 describe("preemptive-compaction", () => {
   const verboseHistory =
@@ -21,12 +43,12 @@ describe("preemptive-compaction", () => {
 
   it("raises the estimate as prompt-side content grows", () => {
     const smaller = estimatePrePromptTokens({
-      messages: [{ role: "assistant", content: verboseHistory }],
+      messages: [makeAssistantHistory(verboseHistory)],
       systemPrompt: "sys",
       prompt: "hello",
     });
     const larger = estimatePrePromptTokens({
-      messages: [{ role: "assistant", content: verboseHistory }],
+      messages: [makeAssistantHistory(verboseHistory)],
       systemPrompt: verboseSystem,
       prompt: verbosePrompt,
     });
@@ -36,7 +58,7 @@ describe("preemptive-compaction", () => {
 
   it("requests preemptive compaction when the reserve-based prompt budget would be exceeded", () => {
     const result = shouldPreemptivelyCompactBeforePrompt({
-      messages: [{ role: "assistant", content: verboseHistory }],
+      messages: [makeAssistantHistory(verboseHistory)],
       systemPrompt: verboseSystem,
       prompt: verbosePrompt,
       contextTokenBudget: 500,
@@ -50,7 +72,7 @@ describe("preemptive-compaction", () => {
 
   it("does not request preemptive compaction when the reserve-based prompt budget still fits", () => {
     const result = shouldPreemptivelyCompactBeforePrompt({
-      messages: [{ role: "assistant", content: "short history" }],
+      messages: [makeAssistantHistory("short history")],
       systemPrompt: "sys",
       prompt: "hello",
       contextTokenBudget: 10_000,
@@ -64,17 +86,9 @@ describe("preemptive-compaction", () => {
 
   it("routes to direct tool-result truncation when recent tool tails can clearly absorb the overflow", () => {
     const medium = "alpha beta gamma delta epsilon ".repeat(2200);
-    const messages = [
-      { role: "assistant", content: "short history" },
-      {
-        role: "toolResult",
-        content: [
-          { type: "text", text: medium },
-          { type: "text", text: medium },
-          { type: "text", text: medium },
-          { type: "text", text: medium },
-        ],
-      } as never,
+    const messages: AgentMessage[] = [
+      makeAssistantHistory("short history"),
+      makeToolResultMessage(medium, medium, medium, medium),
     ];
     const reserveTokens = 2_000;
     const contextTokenBudget = 26_000;
@@ -106,10 +120,10 @@ describe("preemptive-compaction", () => {
       5000,
     );
     const messages = [
-      { role: "assistant", content: longHistory },
-      { role: "toolResult", content: [{ type: "text", text: medium }] } as never,
-      { role: "toolResult", content: [{ type: "text", text: medium }] } as never,
-      { role: "toolResult", content: [{ type: "text", text: medium }] } as never,
+      makeAssistantHistory(longHistory),
+      makeToolResultMessage(medium),
+      makeToolResultMessage(medium),
+      makeToolResultMessage(medium),
     ];
     const reserveTokens = 500;
     const baseContextTokenBudget = 3_500;
@@ -119,7 +133,7 @@ describe("preemptive-compaction", () => {
       prompt: verbosePrompt,
     });
     const toolResultPotential = estimateToolResultReductionPotential({
-      messages: messages as never,
+      messages,
       contextWindowTokens: baseContextTokenBudget,
     });
     const desiredOverflowTokens = Math.ceil((toolResultPotential.maxReducibleChars + 4_096) / 4);
@@ -138,5 +152,41 @@ describe("preemptive-compaction", () => {
     expect(result.shouldCompact).toBe(true);
     expect(result.overflowTokens).toBeGreaterThan(0);
     expect(result.toolResultReducibleChars).toBeGreaterThan(0);
+  });
+
+  it("treats mixed oversized-plus-aggregate tool tails as cumulative recovery potential", () => {
+    const oversized = "x".repeat(45_000);
+    const medium = "alpha beta gamma delta epsilon ".repeat(500);
+    const messages: AgentMessage[] = [
+      makeAssistantHistory("short history"),
+      makeToolResultMessage(oversized),
+      makeToolResultMessage(medium),
+      makeToolResultMessage(medium),
+    ];
+    const reserveTokens = 2_000;
+    const estimatedPromptTokens = estimatePrePromptTokens({
+      messages,
+      systemPrompt: "sys",
+      prompt: "hello",
+    });
+    const potential = estimateToolResultReductionPotential({
+      messages,
+      contextWindowTokens: 128_000,
+    });
+    const desiredOverflowTokens = 2_000;
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages,
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: estimatedPromptTokens - desiredOverflowTokens + reserveTokens,
+      reserveTokens,
+    });
+
+    expect(potential.oversizedReducibleChars).toBeGreaterThan(0);
+    expect(potential.aggregateReducibleChars).toBeGreaterThan(0);
+    expect(potential.oversizedReducibleChars).toBeLessThan(desiredOverflowTokens * 4);
+    expect(potential.maxReducibleChars).toBeGreaterThan(desiredOverflowTokens * 4);
+    expect(result.route).toBe("truncate_tool_results_only");
+    expect(result.shouldCompact).toBe(false);
   });
 });

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  PREEMPTIVE_OVERFLOW_ERROR_TEXT,
+  estimatePrePromptTokens,
+  shouldPreemptivelyCompactBeforePrompt,
+} from "./preemptive-compaction.js";
+
+describe("preemptive-compaction", () => {
+  const verboseHistory =
+    "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu ".repeat(40);
+  const verboseSystem =
+    "system guidance with multiple distinct words to avoid tokenizer overcompression ".repeat(25);
+  const verbosePrompt =
+    "user request with distinct content asking for a detailed answer and more context ".repeat(25);
+
+  it("exports a context-overflow-compatible precheck error text", () => {
+    expect(PREEMPTIVE_OVERFLOW_ERROR_TEXT).toContain("Context overflow:");
+    expect(PREEMPTIVE_OVERFLOW_ERROR_TEXT).toContain("(precheck)");
+  });
+
+  it("raises the estimate as prompt-side content grows", () => {
+    const smaller = estimatePrePromptTokens({
+      messages: [{ role: "assistant", content: verboseHistory }],
+      systemPrompt: "sys",
+      prompt: "hello",
+    });
+    const larger = estimatePrePromptTokens({
+      messages: [{ role: "assistant", content: verboseHistory }],
+      systemPrompt: verboseSystem,
+      prompt: verbosePrompt,
+    });
+
+    expect(larger).toBeGreaterThan(smaller);
+  });
+
+  it("requests preemptive compaction when the reserve-based prompt budget would be exceeded", () => {
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [{ role: "assistant", content: verboseHistory }],
+      systemPrompt: verboseSystem,
+      prompt: verbosePrompt,
+      contextTokenBudget: 500,
+      reserveTokens: 50,
+    });
+
+    expect(result.shouldCompact).toBe(true);
+    expect(result.estimatedPromptTokens).toBeGreaterThan(result.promptBudgetBeforeReserve);
+  });
+
+  it("does not request preemptive compaction when the reserve-based prompt budget still fits", () => {
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [{ role: "assistant", content: "short history" }],
+      systemPrompt: "sys",
+      prompt: "hello",
+      contextTokenBudget: 10_000,
+      reserveTokens: 1_000,
+    });
+
+    expect(result.shouldCompact).toBe(false);
+    expect(result.estimatedPromptTokens).toBeLessThan(result.promptBudgetBeforeReserve);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -1,9 +1,19 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { estimateTokens } from "@mariozechner/pi-coding-agent";
 import { SAFETY_MARGIN, estimateMessagesTokens } from "../../compaction.js";
+import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
 
 export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
   "Context overflow: prompt too large for the model (precheck).";
+
+const ESTIMATED_CHARS_PER_TOKEN = 4;
+const TRUNCATION_ROUTE_BUFFER_TOKENS = 512;
+
+export type PreemptiveCompactionRoute =
+  | "fits"
+  | "compact_only"
+  | "truncate_tool_results_only"
+  | "compact_then_truncate";
 
 export function estimatePrePromptTokens(params: {
   messages: AgentMessage[];
@@ -30,18 +40,47 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   contextTokenBudget: number;
   reserveTokens: number;
 }): {
+  route: PreemptiveCompactionRoute;
   shouldCompact: boolean;
   estimatedPromptTokens: number;
   promptBudgetBeforeReserve: number;
+  overflowTokens: number;
+  toolResultReducibleChars: number;
 } {
   const estimatedPromptTokens = estimatePrePromptTokens(params);
   const promptBudgetBeforeReserve = Math.max(
     1,
     Math.floor(params.contextTokenBudget) - Math.max(0, Math.floor(params.reserveTokens)),
   );
+  const overflowTokens = Math.max(0, estimatedPromptTokens - promptBudgetBeforeReserve);
+  const toolResultPotential = estimateToolResultReductionPotential({
+    messages: params.messages,
+    contextWindowTokens: params.contextTokenBudget,
+  });
+  const overflowChars = overflowTokens * ESTIMATED_CHARS_PER_TOKEN;
+  const truncationBufferChars = TRUNCATION_ROUTE_BUFFER_TOKENS * ESTIMATED_CHARS_PER_TOKEN;
+  const truncateOnlyThresholdChars = Math.max(
+    overflowChars + truncationBufferChars,
+    Math.ceil(overflowChars * 1.5),
+  );
+  const toolResultReducibleChars = toolResultPotential.maxReducibleChars;
+
+  let route: PreemptiveCompactionRoute = "fits";
+  if (overflowTokens > 0) {
+    if (toolResultReducibleChars <= 0) {
+      route = "compact_only";
+    } else if (toolResultReducibleChars >= truncateOnlyThresholdChars) {
+      route = "truncate_tool_results_only";
+    } else {
+      route = "compact_then_truncate";
+    }
+  }
   return {
-    shouldCompact: estimatedPromptTokens > promptBudgetBeforeReserve,
+    route,
+    shouldCompact: route === "compact_only" || route === "compact_then_truncate",
     estimatedPromptTokens,
     promptBudgetBeforeReserve,
+    overflowTokens,
+    toolResultReducibleChars,
   };
 }

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -23,9 +23,13 @@ export function estimatePrePromptTokens(params: {
   const { messages, systemPrompt, prompt } = params;
   const syntheticMessages: AgentMessage[] = [];
   if (typeof systemPrompt === "string" && systemPrompt.trim().length > 0) {
-    syntheticMessages.push({ role: "system", content: systemPrompt } as AgentMessage);
+    syntheticMessages.push({
+      role: "system",
+      content: systemPrompt,
+      timestamp: 0,
+    } as unknown as AgentMessage);
   }
-  syntheticMessages.push({ role: "user", content: prompt } as AgentMessage);
+  syntheticMessages.push({ role: "user", content: prompt, timestamp: 0 } as AgentMessage);
 
   const estimated =
     estimateMessagesTokens(messages) +

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -1,0 +1,47 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { estimateTokens } from "@mariozechner/pi-coding-agent";
+import { SAFETY_MARGIN, estimateMessagesTokens } from "../../compaction.js";
+
+export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
+  "Context overflow: prompt too large for the model (precheck).";
+
+export function estimatePrePromptTokens(params: {
+  messages: AgentMessage[];
+  systemPrompt?: string;
+  prompt: string;
+}): number {
+  const { messages, systemPrompt, prompt } = params;
+  const syntheticMessages: AgentMessage[] = [];
+  if (typeof systemPrompt === "string" && systemPrompt.trim().length > 0) {
+    syntheticMessages.push({ role: "system", content: systemPrompt } as AgentMessage);
+  }
+  syntheticMessages.push({ role: "user", content: prompt } as AgentMessage);
+
+  const estimated =
+    estimateMessagesTokens(messages) +
+    syntheticMessages.reduce((sum, message) => sum + estimateTokens(message), 0);
+  return Math.max(0, Math.ceil(estimated * SAFETY_MARGIN));
+}
+
+export function shouldPreemptivelyCompactBeforePrompt(params: {
+  messages: AgentMessage[];
+  systemPrompt?: string;
+  prompt: string;
+  contextTokenBudget: number;
+  reserveTokens: number;
+}): {
+  shouldCompact: boolean;
+  estimatedPromptTokens: number;
+  promptBudgetBeforeReserve: number;
+} {
+  const estimatedPromptTokens = estimatePrePromptTokens(params);
+  const promptBudgetBeforeReserve = Math.max(
+    1,
+    Math.floor(params.contextTokenBudget) - Math.max(0, Math.floor(params.reserveTokens)),
+  );
+  return {
+    shouldCompact: estimatedPromptTokens > promptBudgetBeforeReserve,
+    estimatedPromptTokens,
+    promptBudgetBeforeReserve,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -9,6 +9,7 @@ import type { MessagingToolSend } from "../../pi-embedded-messaging.js";
 import type { ToolErrorSummary } from "../../tool-error-summary.js";
 import type { NormalizedUsage } from "../../usage.js";
 import type { RunEmbeddedPiAgentParams } from "./params.js";
+import type { PreemptiveCompactionRoute } from "./preemptive-compaction.js";
 
 type EmbeddedRunAttemptBase = Omit<
   RunEmbeddedPiAgentParams,
@@ -41,6 +42,16 @@ export type EmbeddedRunAttemptResult = {
   /** True if the timeout occurred while compaction was in progress or pending. */
   timedOutDuringCompaction: boolean;
   promptError: unknown;
+  preflightRecovery?:
+    | {
+        route: Exclude<PreemptiveCompactionRoute, "fits">;
+        handled: true;
+        truncatedCount?: number;
+      }
+    | {
+        route: Exclude<PreemptiveCompactionRoute, "fits">;
+        handled?: false;
+      };
   sessionIdUsed: string;
   bootstrapPromptWarningSignaturesSeen?: string[];
   bootstrapPromptWarningSignature?: string;

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -5,6 +5,7 @@ import {
   CONTEXT_LIMIT_TRUNCATION_NOTICE,
   formatContextLimitTruncationNotice,
   installToolResultContextGuard,
+  PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
 } from "./tool-result-context-guard.js";
 
 function makeUser(text: string): AgentMessage {
@@ -118,7 +119,7 @@ describe("installToolResultContextGuard", () => {
 
   it("does not preemptively overflow large non-tool context that is still under the high-water mark", async () => {
     const agent = makeGuardableAgent();
-    const contextForNextCall = [makeUser("u".repeat(50_000))];
+    const contextForNextCall = [makeUser("u".repeat(3_200))];
 
     const transformed = await applyGuardToContext(agent, contextForNextCall);
 
@@ -180,19 +181,20 @@ describe("installToolResultContextGuard", () => {
     expect((contextForNextCall[0] as { details?: unknown }).details).toBeDefined();
   });
 
-  it("does not preemptively overflow when total context remains large after one-time truncation", async () => {
+  it("throws a preemptive overflow when total context still exceeds the high-water mark", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [
       makeUser("u".repeat(50_000)),
-      makeToolResult("call_ok", "x".repeat(500)),
+      makeToolResult("call_big", "x".repeat(5_000)),
     ];
 
-    const transformed = await applyGuardToContext(agent, contextForNextCall);
-
-    expect(transformed).toBe(contextForNextCall);
+    await expect(applyGuardToContext(agent, contextForNextCall)).rejects.toThrow(
+      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
+    );
+    expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(5_000));
   });
 
-  it("does not rewrite older tool results under aggregate pressure", async () => {
+  it("throws instead of rewriting older tool results under aggregate pressure", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [
       makeUser("u".repeat(50_000)),
@@ -201,15 +203,15 @@ describe("installToolResultContextGuard", () => {
       makeToolResult("call_3", "c".repeat(500)),
     ];
 
-    const transformed = await applyGuardToContext(agent, contextForNextCall);
-
-    expect(transformed).toBe(contextForNextCall);
+    await expect(applyGuardToContext(agent, contextForNextCall)).rejects.toThrow(
+      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
+    );
     expect(getToolResultText(contextForNextCall[1])).toBe("a".repeat(500));
     expect(getToolResultText(contextForNextCall[2])).toBe("b".repeat(500));
     expect(getToolResultText(contextForNextCall[3])).toBe("c".repeat(500));
   });
 
-  it("does not special-case the latest read result under aggregate pressure", async () => {
+  it("does not special-case the latest read result before throwing under aggregate pressure", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [
       makeUser("u".repeat(50_000)),
@@ -217,9 +219,9 @@ describe("installToolResultContextGuard", () => {
       makeReadToolResult("call_new", "y".repeat(500)),
     ];
 
-    const transformed = await applyGuardToContext(agent, contextForNextCall);
-
-    expect(transformed).toBe(contextForNextCall);
+    await expect(applyGuardToContext(agent, contextForNextCall)).rejects.toThrow(
+      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
+    );
     expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(400));
     expect(getToolResultText(contextForNextCall[2])).toBe("y".repeat(500));
   });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
   CONTEXT_LIMIT_TRUNCATION_NOTICE,
-  PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
   formatContextLimitTruncationNotice,
   installToolResultContextGuard,
 } from "./tool-result-context-guard.js";
@@ -119,7 +118,7 @@ describe("installToolResultContextGuard", () => {
 
   it("does not preemptively overflow large non-tool context that is still under the high-water mark", async () => {
     const agent = makeGuardableAgent();
-    const contextForNextCall = [makeUser("u".repeat(3_200))];
+    const contextForNextCall = [makeUser("u".repeat(50_000))];
 
     const transformed = await applyGuardToContext(agent, contextForNextCall);
 
@@ -181,50 +180,46 @@ describe("installToolResultContextGuard", () => {
     expect((contextForNextCall[0] as { details?: unknown }).details).toBeDefined();
   });
 
-  it("throws overflow when total context exceeds the budget after one-time truncation", async () => {
+  it("does not preemptively overflow when total context remains large after one-time truncation", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [
-      makeUser("u".repeat(2_800)),
+      makeUser("u".repeat(50_000)),
       makeToolResult("call_ok", "x".repeat(500)),
     ];
 
-    await expect(applyGuardToContext(agent, contextForNextCall)).rejects.toThrow(
-      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
-    );
+    const transformed = await applyGuardToContext(agent, contextForNextCall);
 
-    expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(500));
+    expect(transformed).toBe(contextForNextCall);
   });
 
-  it("throws overflow instead of historically rewriting older tool results", async () => {
+  it("does not rewrite older tool results under aggregate pressure", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [
-      makeUser("u".repeat(2_200)),
+      makeUser("u".repeat(50_000)),
       makeToolResult("call_1", "a".repeat(500)),
       makeToolResult("call_2", "b".repeat(500)),
       makeToolResult("call_3", "c".repeat(500)),
     ];
 
-    await expect(applyGuardToContext(agent, contextForNextCall)).rejects.toThrow(
-      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
-    );
+    const transformed = await applyGuardToContext(agent, contextForNextCall);
 
+    expect(transformed).toBe(contextForNextCall);
     expect(getToolResultText(contextForNextCall[1])).toBe("a".repeat(500));
     expect(getToolResultText(contextForNextCall[2])).toBe("b".repeat(500));
     expect(getToolResultText(contextForNextCall[3])).toBe("c".repeat(500));
   });
 
-  it("throws overflow instead of special-casing the latest read result", async () => {
+  it("does not special-case the latest read result under aggregate pressure", async () => {
     const agent = makeGuardableAgent();
     const contextForNextCall = [
-      makeUser("u".repeat(2_900)),
+      makeUser("u".repeat(50_000)),
       makeToolResult("call_old", "x".repeat(400)),
       makeReadToolResult("call_new", "y".repeat(500)),
     ];
 
-    await expect(applyGuardToContext(agent, contextForNextCall)).rejects.toThrow(
-      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
-    );
+    const transformed = await applyGuardToContext(agent, contextForNextCall);
 
+    expect(transformed).toBe(contextForNextCall);
     expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(400));
     expect(getToolResultText(contextForNextCall[2])).toBe("y".repeat(500));
   });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -4,8 +4,7 @@ import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
 import {
   CONTEXT_LIMIT_TRUNCATION_NOTICE,
   PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
-  PREEMPTIVE_TOOL_RESULT_COMPACTION_NOTICE,
-  PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER,
+  formatContextLimitTruncationNotice,
   installToolResultContextGuard,
 } from "./tool-result-context-guard.js";
 
@@ -61,6 +60,9 @@ function makeToolResultWithDetails(id: string, text: string, detailText: string)
 
 function getToolResultText(msg: AgentMessage): string {
   const content = (msg as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return content;
+  }
   if (!Array.isArray(content)) {
     return "";
   }
@@ -79,342 +81,164 @@ function makeGuardableAgent(
   return { transformContext };
 }
 
-function makeTwoToolResultOverflowContext(): AgentMessage[] {
-  return [
-    makeUser("u".repeat(2_000)),
-    makeToolResult("call_old", "x".repeat(1_000)),
-    makeToolResult("call_new", "y".repeat(1_000)),
-  ];
-}
-
 async function applyGuardToContext(
   agent: { transformContext?: (messages: AgentMessage[], signal: AbortSignal) => unknown },
   contextForNextCall: AgentMessage[],
+  contextWindowTokens = 1_000,
 ) {
   installToolResultContextGuard({
     agent,
-    contextWindowTokens: 1_000,
+    contextWindowTokens,
   });
   return await agent.transformContext?.(contextForNextCall, new AbortController().signal);
 }
 
-function expectReadableCompaction(text: string, prefix: string) {
-  expect(text.includes(PREEMPTIVE_TOOL_RESULT_COMPACTION_NOTICE)).toBe(true);
-  expect(text).toContain(prefix.repeat(64));
-  expect(text).not.toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
-  expect(text).not.toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
+function expectPiStyleTruncation(text: string): void {
+  expect(text).toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
+  expect(text).toMatch(/\[\.\.\. \d+ more characters truncated\]$/);
+  expect(text).not.toContain("[compacted: tool output removed to free context]");
+  expect(text).not.toContain("[compacted: tool output trimmed to free context]");
+  expect(text).not.toContain("[truncated: output exceeded context limit]");
 }
 
-function expectReadableToolSlice(text: string, prefix: string) {
-  expect(text).toContain(prefix.repeat(64));
-  expect(text).not.toBe(PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
-  expect(
-    text.includes(PREEMPTIVE_TOOL_RESULT_COMPACTION_NOTICE) ||
-      text.includes(CONTEXT_LIMIT_TRUNCATION_NOTICE),
-  ).toBe(true);
-}
-
-function expectCompactedOrPlaceholder(text: string, prefix: string) {
-  if (text === PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER) {
-    return;
-  }
-  expectReadableCompaction(text, prefix);
-}
+describe("formatContextLimitTruncationNotice", () => {
+  it("formats pi-style truncation wording with a count", () => {
+    expect(formatContextLimitTruncationNotice(123)).toBe("[... 123 more characters truncated]");
+  });
+});
 
 describe("installToolResultContextGuard", () => {
-  it("returns a cloned guarded context so original tool output stays visible", async () => {
+  it("passes through unchanged context when under the per-tool and total budget", async () => {
     const agent = makeGuardableAgent();
-    const contextForNextCall = makeTwoToolResultOverflowContext();
+    const contextForNextCall = [makeUser("hello"), makeToolResult("call_ok", "small output")];
+
     const transformed = await applyGuardToContext(agent, contextForNextCall);
 
-    expect(transformed).not.toBe(contextForNextCall);
-    const transformedMessages = transformed as AgentMessage[];
-    expectReadableCompaction(getToolResultText(transformedMessages[1]), "x");
-    expectReadableCompaction(getToolResultText(transformedMessages[2]), "y");
-    expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(1_000));
-    expect(getToolResultText(contextForNextCall[2])).toBe("y".repeat(1_000));
+    expect(transformed).toBe(contextForNextCall);
   });
 
-  it("keeps at least one readable older slice before falling back to a placeholder", async () => {
+  it("does not preemptively overflow large non-tool context that is still under the high-water mark", async () => {
     const agent = makeGuardableAgent();
+    const contextForNextCall = [makeUser("u".repeat(3_200))];
 
-    installToolResultContextGuard({
-      agent,
-      contextWindowTokens: 1_000,
-    });
+    const transformed = await applyGuardToContext(agent, contextForNextCall);
 
-    const contextForNextCall = [
-      makeUser("u".repeat(2_200)),
-      makeToolResult("call_1", "a".repeat(800)),
-      makeToolResult("call_2", "b".repeat(800)),
-      makeToolResult("call_3", "c".repeat(800)),
-    ];
-
-    const transformed = (await agent.transformContext?.(
-      contextForNextCall,
-      new AbortController().signal,
-    )) as AgentMessage[];
-
-    const first = getToolResultText(transformed[1]);
-    const second = getToolResultText(transformed[2]);
-    const third = getToolResultText(transformed[3]);
-
-    expectReadableCompaction(first, "a");
-    expectReadableCompaction(third, "c");
-    expect(
-      second === "b".repeat(800) || second === PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER,
-    ).toBe(true);
+    expect(transformed).toBe(contextForNextCall);
   });
 
-  it("keeps the newest large tool result visible when an older one can absorb overflow", async () => {
+  it("returns a cloned guarded context so original oversized tool output stays visible", async () => {
     const agent = makeGuardableAgent();
-
-    installToolResultContextGuard({
-      agent,
-      contextWindowTokens: 100_000,
-    });
-
-    const contextForNextCall: AgentMessage[] = [makeUser("stress")];
-    let transformed: AgentMessage[] | undefined;
-    for (let i = 1; i <= 4; i++) {
-      contextForNextCall.push(makeToolResult(`call_${i}`, String(i).repeat(95_000)));
-      transformed = (await agent.transformContext?.(
-        contextForNextCall,
-        new AbortController().signal,
-      )) as AgentMessage[];
-    }
-
-    const toolResultTexts = (transformed ?? [])
-      .filter((msg) => msg.role === "toolResult")
-      .map((msg) => getToolResultText(msg as AgentMessage));
-
-    expect(toolResultTexts[0]).toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
-    expectReadableCompaction(toolResultTexts[1] ?? "", "2");
-    expectReadableCompaction(toolResultTexts[2] ?? "", "3");
-    expectReadableToolSlice(toolResultTexts[3] ?? "", "4");
-  });
-
-  it("truncates an individually oversized tool result with a context-limit notice", async () => {
-    const agent = makeGuardableAgent();
-
-    installToolResultContextGuard({
-      agent,
-      contextWindowTokens: 1_000,
-    });
-
     const contextForNextCall = [makeToolResult("call_big", "z".repeat(5_000))];
 
-    const transformed = (await agent.transformContext?.(
-      contextForNextCall,
-      new AbortController().signal,
-    )) as AgentMessage[];
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
 
+    expect(transformed).not.toBe(contextForNextCall);
     const newResultText = getToolResultText(transformed[0]);
     expect(newResultText.length).toBeLessThan(5_000);
-    expect(newResultText).toContain(CONTEXT_LIMIT_TRUNCATION_NOTICE);
-  });
-
-  it("falls back to compacting the newest tool result when older ones are insufficient", async () => {
-    const agent = makeGuardableAgent();
-
-    installToolResultContextGuard({
-      agent,
-      contextWindowTokens: 1_000,
-    });
-
-    const contextForNextCall = [
-      makeUser("u".repeat(2_600)),
-      makeToolResult("call_old", "x".repeat(700)),
-      makeToolResult("call_new", "y".repeat(1_000)),
-    ];
-
-    const transformed = (await agent.transformContext?.(
-      contextForNextCall,
-      new AbortController().signal,
-    )) as AgentMessage[];
-    expectCompactedOrPlaceholder(getToolResultText(transformed[1]), "x");
-    expectCompactedOrPlaceholder(getToolResultText(transformed[2]), "y");
+    expectPiStyleTruncation(newResultText);
+    expect(getToolResultText(contextForNextCall[0])).toBe("z".repeat(5_000));
   });
 
   it("wraps an existing transformContext and guards the transformed output", async () => {
-    const agent = makeGuardableAgent((messages) => {
-      return messages.map((msg) =>
+    const agent = makeGuardableAgent((messages) =>
+      messages.map((msg) =>
         castAgentMessage({
           ...(msg as unknown as Record<string, unknown>),
         }),
-      );
-    });
-    const contextForNextCall = makeTwoToolResultOverflowContext();
-    const transformed = await applyGuardToContext(agent, contextForNextCall);
+      ),
+    );
+    const contextForNextCall = [makeToolResult("call_big", "x".repeat(5_000))];
+
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
 
     expect(transformed).not.toBe(contextForNextCall);
-    const transformedMessages = transformed as AgentMessage[];
-    const oldResultText = getToolResultText(transformedMessages[1]);
-    expectReadableCompaction(oldResultText, "x");
+    expectPiStyleTruncation(getToolResultText(transformed[0]));
   });
 
-  it("handles legacy role=tool string outputs when enforcing context budget", async () => {
+  it("handles legacy role=tool string outputs with pi-style truncation wording", async () => {
     const agent = makeGuardableAgent();
+    const contextForNextCall = [makeLegacyToolResult("call_big", "y".repeat(5_000))];
 
-    installToolResultContextGuard({
-      agent,
-      contextWindowTokens: 1_000,
-    });
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
+    const newResultText = getToolResultText(transformed[0]);
 
+    expect(typeof (transformed[0] as { content?: unknown }).content).toBe("string");
+    expectPiStyleTruncation(newResultText);
+  });
+
+  it("drops oversized tool-result details when truncating once", async () => {
+    const agent = makeGuardableAgent();
     const contextForNextCall = [
-      makeUser("u".repeat(2_000)),
-      makeLegacyToolResult("call_old", "x".repeat(1_000)),
-      makeLegacyToolResult("call_new", "y".repeat(1_000)),
+      makeToolResultWithDetails("call_big", "x".repeat(900), "d".repeat(8_000)),
     ];
 
-    const transformed = (await agent.transformContext?.(
-      contextForNextCall,
-      new AbortController().signal,
-    )) as AgentMessage[];
+    const transformed = (await applyGuardToContext(agent, contextForNextCall)) as AgentMessage[];
+    const result = transformed[0] as { details?: unknown };
+    const newResultText = getToolResultText(transformed[0]);
 
-    const oldResultText = (transformed[1] as { content?: unknown }).content;
-    const newResultText = (transformed[2] as { content?: unknown }).content;
-
-    expect(typeof oldResultText).toBe("string");
-    expect(typeof newResultText).toBe("string");
-    expect(oldResultText).toContain(PREEMPTIVE_TOOL_RESULT_COMPACTION_NOTICE);
-    expect(newResultText).toContain(PREEMPTIVE_TOOL_RESULT_COMPACTION_NOTICE);
+    expectPiStyleTruncation(newResultText);
+    expect(result.details).toBeUndefined();
+    expect((contextForNextCall[0] as { details?: unknown }).details).toBeDefined();
   });
 
-  it("drops oversized read-tool details payloads when compacting tool results", async () => {
+  it("throws overflow when total context exceeds the budget after one-time truncation", async () => {
     const agent = makeGuardableAgent();
-
-    installToolResultContextGuard({
-      agent,
-      contextWindowTokens: 1_000,
-    });
-
     const contextForNextCall = [
-      makeUser("u".repeat(1_600)),
-      makeToolResultWithDetails("call_old", "x".repeat(900), "d".repeat(8_000)),
-      makeToolResultWithDetails("call_new", "y".repeat(900), "d".repeat(8_000)),
+      makeUser("u".repeat(2_800)),
+      makeToolResult("call_ok", "x".repeat(500)),
     ];
 
-    const transformed = (await agent.transformContext?.(
-      contextForNextCall,
-      new AbortController().signal,
-    )) as AgentMessage[];
+    await expect(applyGuardToContext(agent, contextForNextCall)).rejects.toThrow(
+      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
+    );
 
-    const oldResult = transformed[1] as {
-      details?: unknown;
-    };
-    const newResult = transformed[2] as {
-      details?: unknown;
-    };
-    const oldResultText = getToolResultText(transformed[1]);
-    const newResultText = getToolResultText(transformed[2]);
-
-    expectReadableToolSlice(oldResultText, "x");
-    expectReadableToolSlice(newResultText, "y");
-    expect(oldResult.details).toBeUndefined();
-    expect(newResult.details).toBeUndefined();
+    expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(500));
   });
 
-  it("throws overflow instead of compacting the latest read result during aggregate compaction", async () => {
+  it("throws overflow instead of historically rewriting older tool results", async () => {
     const agent = makeGuardableAgent();
-
-    installToolResultContextGuard({
-      agent,
-      contextWindowTokens: 1_000,
-    });
-
     const contextForNextCall = [
-      makeUser("u".repeat(2_600)),
-      makeToolResult("call_old", "x".repeat(300)),
+      makeUser("u".repeat(2_200)),
+      makeToolResult("call_1", "a".repeat(500)),
+      makeToolResult("call_2", "b".repeat(500)),
+      makeToolResult("call_3", "c".repeat(500)),
+    ];
+
+    await expect(applyGuardToContext(agent, contextForNextCall)).rejects.toThrow(
+      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
+    );
+
+    expect(getToolResultText(contextForNextCall[1])).toBe("a".repeat(500));
+    expect(getToolResultText(contextForNextCall[2])).toBe("b".repeat(500));
+    expect(getToolResultText(contextForNextCall[3])).toBe("c".repeat(500));
+  });
+
+  it("throws overflow instead of special-casing the latest read result", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [
+      makeUser("u".repeat(2_900)),
+      makeToolResult("call_old", "x".repeat(400)),
       makeReadToolResult("call_new", "y".repeat(500)),
     ];
 
-    await expect(
-      agent.transformContext?.(contextForNextCall, new AbortController().signal),
-    ).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+    await expect(applyGuardToContext(agent, contextForNextCall)).rejects.toThrow(
+      PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE,
+    );
 
-    expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(300));
+    expect(getToolResultText(contextForNextCall[1])).toBe("x".repeat(400));
     expect(getToolResultText(contextForNextCall[2])).toBe("y".repeat(500));
   });
 
-  it("keeps the latest read result when older outputs absorb the aggregate overflow", async () => {
+  it("supports model-window-specific truncation for large but otherwise valid tool results", async () => {
     const agent = makeGuardableAgent();
+    const contextForNextCall = [makeToolResult("call_big", "q".repeat(95_000))];
 
-    installToolResultContextGuard({
+    const transformed = (await applyGuardToContext(
       agent,
-      contextWindowTokens: 1_000,
-    });
-
-    const contextForNextCall = [
-      makeUser("u".repeat(1_400)),
-      makeToolResult("call_old_1", "a".repeat(350)),
-      makeToolResult("call_old_2", "b".repeat(350)),
-      makeReadToolResult("call_new", "c".repeat(500)),
-    ];
-
-    const transformed = (await agent.transformContext?.(
       contextForNextCall,
-      new AbortController().signal,
+      100_000,
     )) as AgentMessage[];
 
-    expect(getToolResultText(transformed[3])).toBe("c".repeat(500));
-  });
-
-  it("throws preemptive context overflow when context exceeds 90% after tool-result compaction", async () => {
-    const agent = makeGuardableAgent();
-
-    installToolResultContextGuard({
-      agent,
-      // contextBudgetChars = 1000 * 4 * 0.75 = 3000
-      // preemptiveOverflowChars = 1000 * 4 * 0.9 = 3600
-      contextWindowTokens: 1_000,
-    });
-
-    // Large user message (non-compactable) pushes context past 90% threshold.
-    const contextForNextCall = [makeUser("u".repeat(3_700)), makeToolResult("call_1", "small")];
-
-    await expect(
-      agent.transformContext?.(contextForNextCall, new AbortController().signal),
-    ).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
-  });
-
-  it("does not throw when context is under 90% after tool-result compaction", async () => {
-    const agent = makeGuardableAgent();
-
-    installToolResultContextGuard({
-      agent,
-      contextWindowTokens: 1_000,
-    });
-
-    // Context well under the 3600-char preemptive threshold.
-    const contextForNextCall = [makeUser("u".repeat(1_000)), makeToolResult("call_1", "small")];
-
-    await expect(
-      agent.transformContext?.(contextForNextCall, new AbortController().signal),
-    ).resolves.not.toThrow();
-  });
-
-  it("compacts tool results before checking the preemptive overflow threshold", async () => {
-    const agent = makeGuardableAgent();
-
-    installToolResultContextGuard({
-      agent,
-      contextWindowTokens: 1_000,
-    });
-
-    // Large user message + large tool result. The guard should compact the tool
-    // result first, then check the overflow threshold. Even after compaction the
-    // user content alone pushes past 90%, so the overflow error fires.
-    const contextForNextCall = [
-      makeUser("u".repeat(3_700)),
-      makeToolResult("call_old", "x".repeat(2_000)),
-    ];
-
-    const guarded = agent.transformContext?.(contextForNextCall, new AbortController().signal);
-    await expect(guarded).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
-
-    // Tool result should have been compacted before the overflow check.
-    const toolResultText = getToolResultText(contextForNextCall[1]);
-    expect(toolResultText).toBe("x".repeat(2_000));
+    expectPiStyleTruncation(getToolResultText(transformed[0]));
   });
 });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -10,33 +10,18 @@ import {
   invalidateMessageCharsCacheEntry,
   isToolResultMessage,
 } from "./tool-result-char-estimator.js";
-import { truncateToolResultText } from "./tool-result-truncation.js";
 
 // Keep a conservative input budget to absorb tokenizer variance and provider framing overhead.
 const CONTEXT_INPUT_HEADROOM_RATIO = 0.75;
 const SINGLE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
-// High-water mark: if context exceeds this ratio after tool-result compaction,
-// trigger full session compaction via the existing overflow recovery cascade.
 const PREEMPTIVE_OVERFLOW_RATIO = 0.9;
 
-export const CONTEXT_LIMIT_TRUNCATION_NOTICE = "[truncated: output exceeded context limit]";
-const CONTEXT_LIMIT_TRUNCATION_SUFFIX = `\n${CONTEXT_LIMIT_TRUNCATION_NOTICE}`;
-
-export const PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER =
-  "[compacted: tool output removed to free context]";
-export const PREEMPTIVE_TOOL_RESULT_COMPACTION_NOTICE =
-  "[compacted: tool output trimmed to free context]";
+export const CONTEXT_LIMIT_TRUNCATION_NOTICE = "more characters truncated";
 
 export const PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE =
   "Preemptive context overflow: estimated context size exceeds safe threshold during tool loop";
-
-const PREEMPTIVE_TOOL_RESULT_COMPACTION_SUFFIX = `\n${PREEMPTIVE_TOOL_RESULT_COMPACTION_NOTICE}`;
-const MIN_COMPACTED_TOOL_RESULT_TEXT_CHARS = 96;
 const TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO =
   CHARS_PER_TOKEN_ESTIMATE / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
-const MIN_COMPACTED_TOOL_RESULT_ESTIMATE_CHARS = Math.ceil(
-  MIN_COMPACTED_TOOL_RESULT_TEXT_CHARS * TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO,
-);
 
 type GuardableTransformContext = (
   messages: AgentMessage[],
@@ -49,19 +34,8 @@ type GuardableAgentRecord = {
   transformContext?: GuardableTransformContext;
 };
 
-function getToolResultName(msg: AgentMessage): string | undefined {
-  const toolName = (msg as { toolName?: unknown }).toolName;
-  if (typeof toolName === "string" && toolName.trim().length > 0) {
-    return toolName;
-  }
-  const legacyToolName = (msg as { tool_name?: unknown }).tool_name;
-  return typeof legacyToolName === "string" && legacyToolName.trim().length > 0
-    ? legacyToolName
-    : undefined;
-}
-
-function isReadToolResultMessage(msg: AgentMessage): boolean {
-  return isToolResultMessage(msg) && getToolResultName(msg) === "read";
+export function formatContextLimitTruncationNotice(truncatedChars: number): string {
+  return `[... ${Math.max(1, Math.floor(truncatedChars))} ${CONTEXT_LIMIT_TRUNCATION_NOTICE}]`;
 }
 
 function truncateTextToBudget(text: string, maxChars: number): string {
@@ -70,21 +44,25 @@ function truncateTextToBudget(text: string, maxChars: number): string {
   }
 
   if (maxChars <= 0) {
-    return CONTEXT_LIMIT_TRUNCATION_NOTICE;
+    return formatContextLimitTruncationNotice(text.length);
   }
 
-  const bodyBudget = Math.max(0, maxChars - CONTEXT_LIMIT_TRUNCATION_SUFFIX.length);
-  if (bodyBudget <= 0) {
-    return CONTEXT_LIMIT_TRUNCATION_NOTICE;
+  let bodyBudget = maxChars;
+  for (let i = 0; i < 4; i += 1) {
+    const estimatedSuffix = formatContextLimitTruncationNotice(
+      Math.max(1, text.length - bodyBudget),
+    );
+    bodyBudget = Math.max(0, maxChars - estimatedSuffix.length);
   }
 
   let cutPoint = bodyBudget;
-  const newline = text.lastIndexOf("\n", bodyBudget);
+  const newline = text.lastIndexOf("\n", cutPoint);
   if (newline > bodyBudget * 0.7) {
     cutPoint = newline;
   }
 
-  return text.slice(0, cutPoint) + CONTEXT_LIMIT_TRUNCATION_SUFFIX;
+  const omittedChars = text.length - cutPoint;
+  return text.slice(0, cutPoint) + formatContextLimitTruncationNotice(omittedChars);
 }
 
 function replaceToolResultText(msg: AgentMessage, text: string): AgentMessage {
@@ -104,89 +82,6 @@ function estimateBudgetToTextBudget(maxChars: number): number {
   return Math.max(0, Math.floor(maxChars / TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO));
 }
 
-function compactToolResultToEstimateBudget(
-  msg: AgentMessage,
-  maxChars: number,
-  cache: MessageCharEstimateCache,
-): AgentMessage {
-  if (!isToolResultMessage(msg)) {
-    return msg;
-  }
-
-  const estimatedChars = estimateMessageCharsCached(msg, cache);
-  if (estimatedChars <= maxChars) {
-    return msg;
-  }
-
-  const rawText = getToolResultText(msg);
-  if (!rawText) {
-    return replaceToolResultText(msg, PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
-  }
-
-  const textBudget = estimateBudgetToTextBudget(maxChars);
-  if (textBudget <= PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER.length) {
-    return replaceToolResultText(msg, PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
-  }
-
-  const maxCompactedTextChars = Math.max(MIN_COMPACTED_TOOL_RESULT_TEXT_CHARS, textBudget);
-  if (maxCompactedTextChars <= PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER.length) {
-    return replaceToolResultText(msg, PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
-  }
-
-  const minKeepChars = Math.max(
-    96,
-    Math.min(
-      MIN_COMPACTED_TOOL_RESULT_TEXT_CHARS,
-      maxCompactedTextChars - PREEMPTIVE_TOOL_RESULT_COMPACTION_SUFFIX.length - 1,
-    ),
-  );
-
-  const compactedText = truncateToolResultText(rawText, maxCompactedTextChars, {
-    suffix: PREEMPTIVE_TOOL_RESULT_COMPACTION_SUFFIX,
-    minKeepChars,
-  });
-
-  return replaceToolResultText(msg, compactedText);
-}
-
-function compactToPlaceholderInPlace(params: {
-  messages: AgentMessage[];
-  charsNeeded: number;
-  cache: MessageCharEstimateCache;
-}): number {
-  const { messages, charsNeeded, cache } = params;
-  if (charsNeeded <= 0) {
-    return 0;
-  }
-
-  let reduced = 0;
-  for (const i of resolveToolResultCompactionOrder(messages)) {
-    const msg = messages[i];
-    if (!isToolResultMessage(msg)) {
-      continue;
-    }
-
-    const before = estimateMessageCharsCached(msg, cache);
-    if (before <= PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER.length) {
-      continue;
-    }
-
-    const compacted = replaceToolResultText(msg, PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
-    applyMessageMutationInPlace(msg, compacted, cache);
-    const after = estimateMessageCharsCached(msg, cache);
-    if (after >= before) {
-      continue;
-    }
-
-    reduced += before - after;
-    if (reduced >= charsNeeded) {
-      break;
-    }
-  }
-
-  return reduced;
-}
-
 function truncateToolResultToChars(
   msg: AgentMessage,
   maxChars: number,
@@ -203,12 +98,16 @@ function truncateToolResultToChars(
 
   const rawText = getToolResultText(msg);
   if (!rawText) {
-    return replaceToolResultText(msg, CONTEXT_LIMIT_TRUNCATION_NOTICE);
+    const omittedChars = Math.max(
+      1,
+      estimateBudgetToTextBudget(Math.max(estimatedChars - maxChars, 1)),
+    );
+    return replaceToolResultText(msg, formatContextLimitTruncationNotice(omittedChars));
   }
 
   const textBudget = estimateBudgetToTextBudget(maxChars);
   if (textBudget <= 0) {
-    return replaceToolResultText(msg, CONTEXT_LIMIT_TRUNCATION_NOTICE);
+    return replaceToolResultText(msg, formatContextLimitTruncationNotice(rawText.length));
   }
 
   if (rawText.length <= textBudget) {
@@ -219,163 +118,27 @@ function truncateToolResultToChars(
   return replaceToolResultText(msg, truncatedText);
 }
 
-function compactExistingToolResultsInPlace(params: {
-  messages: AgentMessage[];
-  charsNeeded: number;
-  cache: MessageCharEstimateCache;
-}): number {
-  const { messages, charsNeeded, cache } = params;
-  if (charsNeeded <= 0) {
-    return 0;
-  }
-
-  let reduced = 0;
-  // Keep the most recent tool result visible as long as older tool outputs can
-  // absorb the overflow. Among older tool results, compact newest-first so we
-  // still preserve as much of the cached prefix as possible.
-  for (const i of resolveToolResultCompactionOrder(messages)) {
-    const msg = messages[i];
-    if (!isToolResultMessage(msg)) {
-      continue;
-    }
-
-    const before = estimateMessageCharsCached(msg, cache);
-    if (before <= PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER.length) {
-      continue;
-    }
-
-    const targetAfter = Math.max(
-      MIN_COMPACTED_TOOL_RESULT_ESTIMATE_CHARS,
-      before - (charsNeeded - reduced),
-    );
-
-    let compacted = compactToolResultToEstimateBudget(msg, targetAfter, cache);
-    let after = estimateMessageCharsCached(compacted, cache);
-    if (after >= before) {
-      compacted = replaceToolResultText(msg, PREEMPTIVE_TOOL_RESULT_COMPACTION_PLACEHOLDER);
-      after = estimateMessageCharsCached(compacted, cache);
-    }
-
-    applyMessageMutationInPlace(msg, compacted, cache);
-    if (after >= before) {
-      continue;
-    }
-
-    reduced += before - after;
-    if (reduced >= charsNeeded) {
-      break;
-    }
-  }
-
-  if (reduced < charsNeeded) {
-    reduced += compactToPlaceholderInPlace({
-      messages,
-      charsNeeded: charsNeeded - reduced,
-      cache,
-    });
-  }
-
-  return reduced;
-}
-
-function resolveToolResultCompactionOrder(messages: AgentMessage[]): number[] {
-  const toolResultIndexes: number[] = [];
-  for (let i = 0; i < messages.length; i += 1) {
-    if (isToolResultMessage(messages[i])) {
-      toolResultIndexes.push(i);
-    }
-  }
-  if (toolResultIndexes.length <= 1) {
-    return toolResultIndexes;
-  }
-  const newestIndex = toolResultIndexes[toolResultIndexes.length - 1];
-  const olderIndexes = toolResultIndexes.slice(0, -1).toReversed();
-  return [...olderIndexes, newestIndex];
-}
-
-function getNewestToolResultIndex(messages: AgentMessage[]): number | undefined {
-  for (let i = messages.length - 1; i >= 0; i -= 1) {
-    if (isToolResultMessage(messages[i])) {
-      return i;
-    }
-  }
-  return undefined;
-}
-
-function shouldPreferOverflowForLatestRead(params: {
-  messages: AgentMessage[];
-  contextBudgetChars: number;
-  maxSingleToolResultChars: number;
-}): boolean {
-  const newestToolResultIndex = getNewestToolResultIndex(params.messages);
-  if (newestToolResultIndex === undefined) {
-    return false;
-  }
-  const newestToolResult = params.messages[newestToolResultIndex];
-  if (!isReadToolResultMessage(newestToolResult)) {
-    return false;
-  }
-
-  const initialCache = createMessageCharEstimateCache();
-  if (
-    estimateMessageCharsCached(newestToolResult, initialCache) > params.maxSingleToolResultChars
-  ) {
-    return false;
-  }
-
-  const simulatedMessages = cloneMessagesForGuard(params.messages);
-  const estimateCache = createMessageCharEstimateCache();
-  for (const message of simulatedMessages) {
-    if (!isToolResultMessage(message)) {
-      continue;
-    }
-    const truncated = truncateToolResultToChars(
-      message,
-      params.maxSingleToolResultChars,
-      estimateCache,
-    );
-    applyMessageMutationInPlace(message, truncated, estimateCache);
-  }
-
-  const currentChars = estimateContextChars(simulatedMessages, estimateCache);
-  if (currentChars <= params.contextBudgetChars) {
-    return false;
-  }
-
-  const newestToolResultAfterPerToolLimit = simulatedMessages[newestToolResultIndex];
-  const newestToolResultTextBefore = getToolResultText(newestToolResultAfterPerToolLimit);
-  compactExistingToolResultsInPlace({
-    messages: simulatedMessages,
-    charsNeeded: currentChars - params.contextBudgetChars,
-    cache: estimateCache,
-  });
-  return getToolResultText(simulatedMessages[newestToolResultIndex]) !== newestToolResultTextBefore;
-}
-
 function cloneMessagesForGuard(messages: AgentMessage[]): AgentMessage[] {
   return messages.map(
     (msg) => ({ ...(msg as unknown as Record<string, unknown>) }) as unknown as AgentMessage,
   );
 }
 
-function contextNeedsToolResultCompaction(params: {
+function toolResultsNeedTruncation(params: {
   messages: AgentMessage[];
-  contextBudgetChars: number;
   maxSingleToolResultChars: number;
 }): boolean {
-  const { messages, contextBudgetChars, maxSingleToolResultChars } = params;
+  const { messages, maxSingleToolResultChars } = params;
   const estimateCache = createMessageCharEstimateCache();
-  let sawToolResult = false;
   for (const message of messages) {
     if (!isToolResultMessage(message)) {
       continue;
     }
-    sawToolResult = true;
     if (estimateMessageCharsCached(message, estimateCache) > maxSingleToolResultChars) {
       return true;
     }
   }
-  return sawToolResult && estimateContextChars(messages, estimateCache) > contextBudgetChars;
+  return false;
 }
 
 function applyMessageMutationInPlace(
@@ -400,15 +163,13 @@ function applyMessageMutationInPlace(
   }
 }
 
-function enforceToolResultContextBudgetInPlace(params: {
+function enforceToolResultLimitInPlace(params: {
   messages: AgentMessage[];
-  contextBudgetChars: number;
   maxSingleToolResultChars: number;
 }): void {
-  const { messages, contextBudgetChars, maxSingleToolResultChars } = params;
+  const { messages, maxSingleToolResultChars } = params;
   const estimateCache = createMessageCharEstimateCache();
 
-  // Ensure each tool result has an upper bound before considering total context usage.
   for (const message of messages) {
     if (!isToolResultMessage(message)) {
       continue;
@@ -416,19 +177,6 @@ function enforceToolResultContextBudgetInPlace(params: {
     const truncated = truncateToolResultToChars(message, maxSingleToolResultChars, estimateCache);
     applyMessageMutationInPlace(message, truncated, estimateCache);
   }
-
-  let currentChars = estimateContextChars(messages, estimateCache);
-  if (currentChars <= contextBudgetChars) {
-    return;
-  }
-
-  // Prefer compacting older tool outputs before sacrificing the newest one;
-  // stop once the context is back under budget.
-  compactExistingToolResultsInPlace({
-    messages,
-    charsNeeded: currentChars - contextBudgetChars,
-    cache: estimateCache,
-  });
 }
 
 export function installToolResultContextGuard(params: {
@@ -440,15 +188,15 @@ export function installToolResultContextGuard(params: {
     1_024,
     Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * CONTEXT_INPUT_HEADROOM_RATIO),
   );
+  const preemptiveOverflowChars = Math.max(
+    contextBudgetChars,
+    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
+  );
   const maxSingleToolResultChars = Math.max(
     1_024,
     Math.floor(
       contextWindowTokens * TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE * SINGLE_TOOL_RESULT_CONTEXT_SHARE,
     ),
-  );
-  const preemptiveOverflowChars = Math.max(
-    contextBudgetChars,
-    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
   );
 
   // Agent.transformContext is private in pi-coding-agent, so access it via a
@@ -462,32 +210,19 @@ export function installToolResultContextGuard(params: {
       : messages;
 
     const sourceMessages = Array.isArray(transformed) ? transformed : messages;
-    if (
-      shouldPreferOverflowForLatestRead({
-        messages: sourceMessages,
-        contextBudgetChars,
-        maxSingleToolResultChars,
-      })
-    ) {
-      throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
-    }
-    const contextMessages = contextNeedsToolResultCompaction({
+    const contextMessages = toolResultsNeedTruncation({
       messages: sourceMessages,
-      contextBudgetChars,
       maxSingleToolResultChars,
     })
       ? cloneMessagesForGuard(sourceMessages)
       : sourceMessages;
-    enforceToolResultContextBudgetInPlace({
-      messages: contextMessages,
-      contextBudgetChars,
-      maxSingleToolResultChars,
-    });
+    if (contextMessages !== sourceMessages) {
+      enforceToolResultLimitInPlace({
+        messages: contextMessages,
+        maxSingleToolResultChars,
+      });
+    }
 
-    // After tool-result compaction, check if context still exceeds the high-water mark.
-    // If it does, non-tool-result content dominates and only full LLM-based session
-    // compaction can reduce context size. Throwing a context overflow error triggers
-    // the existing overflow recovery cascade in run.ts.
     const postEnforcementChars = estimateContextChars(
       contextMessages,
       createMessageCharEstimateCache(),

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,8 +1,10 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import {
+  CHARS_PER_TOKEN_ESTIMATE,
   TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
   type MessageCharEstimateCache,
   createMessageCharEstimateCache,
+  estimateContextChars,
   estimateMessageCharsCached,
   getToolResultText,
   invalidateMessageCharsCacheEntry,
@@ -10,10 +12,12 @@ import {
 } from "./tool-result-char-estimator.js";
 
 const SINGLE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
+const PREEMPTIVE_OVERFLOW_RATIO = 0.9;
 
 export const CONTEXT_LIMIT_TRUNCATION_NOTICE = "more characters truncated";
-const TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO =
-  4 / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
+export const PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE =
+  "Context overflow: estimated context size exceeds safe threshold during tool loop.";
+const TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO = 4 / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
 
 type GuardableTransformContext = (
   messages: AgentMessage[],
@@ -133,6 +137,14 @@ function toolResultsNeedTruncation(params: {
   return false;
 }
 
+function exceedsPreemptiveOverflowThreshold(params: {
+  messages: AgentMessage[];
+  maxContextChars: number;
+}): boolean {
+  const estimateCache = createMessageCharEstimateCache();
+  return estimateContextChars(params.messages, estimateCache) > params.maxContextChars;
+}
+
 function applyMessageMutationInPlace(
   target: AgentMessage,
   source: AgentMessage,
@@ -176,6 +188,10 @@ export function installToolResultContextGuard(params: {
   contextWindowTokens: number;
 }): () => void {
   const contextWindowTokens = Math.max(1, Math.floor(params.contextWindowTokens));
+  const maxContextChars = Math.max(
+    1_024,
+    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
+  );
   const maxSingleToolResultChars = Math.max(
     1_024,
     Math.floor(
@@ -205,6 +221,14 @@ export function installToolResultContextGuard(params: {
         messages: contextMessages,
         maxSingleToolResultChars,
       });
+    }
+    if (
+      exceedsPreemptiveOverflowThreshold({
+        messages: contextMessages,
+        maxContextChars,
+      })
+    ) {
+      throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
     }
 
     return contextMessages;

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,27 +1,19 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import {
-  CHARS_PER_TOKEN_ESTIMATE,
   TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
   type MessageCharEstimateCache,
   createMessageCharEstimateCache,
-  estimateContextChars,
   estimateMessageCharsCached,
   getToolResultText,
   invalidateMessageCharsCacheEntry,
   isToolResultMessage,
 } from "./tool-result-char-estimator.js";
 
-// Keep a conservative input budget to absorb tokenizer variance and provider framing overhead.
-const CONTEXT_INPUT_HEADROOM_RATIO = 0.75;
 const SINGLE_TOOL_RESULT_CONTEXT_SHARE = 0.5;
-const PREEMPTIVE_OVERFLOW_RATIO = 0.9;
 
 export const CONTEXT_LIMIT_TRUNCATION_NOTICE = "more characters truncated";
-
-export const PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE =
-  "Preemptive context overflow: estimated context size exceeds safe threshold during tool loop";
 const TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO =
-  CHARS_PER_TOKEN_ESTIMATE / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
+  4 / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
 
 type GuardableTransformContext = (
   messages: AgentMessage[],
@@ -184,14 +176,6 @@ export function installToolResultContextGuard(params: {
   contextWindowTokens: number;
 }): () => void {
   const contextWindowTokens = Math.max(1, Math.floor(params.contextWindowTokens));
-  const contextBudgetChars = Math.max(
-    1_024,
-    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * CONTEXT_INPUT_HEADROOM_RATIO),
-  );
-  const preemptiveOverflowChars = Math.max(
-    contextBudgetChars,
-    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
-  );
   const maxSingleToolResultChars = Math.max(
     1_024,
     Math.floor(
@@ -221,14 +205,6 @@ export function installToolResultContextGuard(params: {
         messages: contextMessages,
         maxSingleToolResultChars,
       });
-    }
-
-    const postEnforcementChars = estimateContextChars(
-      contextMessages,
-      createMessageCharEstimateCache(),
-    );
-    if (postEnforcementChars > preemptiveOverflowChars) {
-      throw new Error(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
     }
 
     return contextMessages;

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -1,6 +1,10 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 
 let truncateToolResultText: typeof import("./tool-result-truncation.js").truncateToolResultText;
@@ -8,9 +12,12 @@ let truncateToolResultMessage: typeof import("./tool-result-truncation.js").trun
 let calculateMaxToolResultChars: typeof import("./tool-result-truncation.js").calculateMaxToolResultChars;
 let getToolResultTextLength: typeof import("./tool-result-truncation.js").getToolResultTextLength;
 let truncateOversizedToolResultsInMessages: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInMessages;
+let truncateOversizedToolResultsInSession: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInSession;
 let isOversizedToolResult: typeof import("./tool-result-truncation.js").isOversizedToolResult;
+let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncation.js").sessionLikelyHasOversizedToolResults;
 let DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 let HARD_MAX_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").HARD_MAX_TOOL_RESULT_CHARS;
+let tmpDir: string | undefined;
 
 async function loadFreshToolResultTruncationModuleForTest() {
   ({
@@ -19,7 +26,9 @@ async function loadFreshToolResultTruncationModuleForTest() {
     calculateMaxToolResultChars,
     getToolResultTextLength,
     truncateOversizedToolResultsInMessages,
+    truncateOversizedToolResultsInSession,
     isOversizedToolResult,
+    sessionLikelyHasOversizedToolResults,
     DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     HARD_MAX_TOOL_RESULT_CHARS,
   } = await import("./tool-result-truncation.js"));
@@ -31,6 +40,13 @@ const nextTimestamp = () => testTimestamp++;
 beforeEach(async () => {
   testTimestamp = 1;
   await loadFreshToolResultTruncationModuleForTest();
+});
+
+afterEach(async () => {
+  if (tmpDir) {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    tmpDir = undefined;
+  }
 });
 
 function makeToolResult(text: string, toolCallId = "call_1"): ToolResultMessage {
@@ -67,6 +83,11 @@ function getFirstToolResultText(message: AgentMessage | ToolResultMessage): stri
   }
   const firstBlock = message.content[0];
   return firstBlock && "text" in firstBlock ? firstBlock.text : "";
+}
+
+async function createTmpDir(): Promise<string> {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tool-result-truncation-test-"));
+  return tmpDir;
 }
 
 describe("truncateToolResultText", () => {
@@ -203,6 +224,27 @@ describe("isOversizedToolResult", () => {
   });
 });
 
+describe("sessionLikelyHasOversizedToolResults", () => {
+  it("returns true for individually oversized tool results", () => {
+    const messages: AgentMessage[] = [makeToolResult("x".repeat(500_000))];
+    expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 128_000 })).toBe(
+      true,
+    );
+  });
+
+  it("returns true for aggregate medium tool results that exceed the shared budget", () => {
+    const medium = "alpha beta gamma delta epsilon ".repeat(600);
+    const messages: AgentMessage[] = [
+      makeToolResult(medium, "call_1"),
+      makeToolResult(medium, "call_2"),
+      makeToolResult(medium, "call_3"),
+    ];
+    expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 128_000 })).toBe(
+      true,
+    );
+  });
+});
+
 describe("truncateOversizedToolResultsInMessages", () => {
   it("returns unchanged messages when nothing is oversized", () => {
     const messages = [
@@ -265,6 +307,64 @@ describe("truncateOversizedToolResultsInMessages", () => {
       const text = getFirstToolResultText(msg);
       expect(text.length).toBeLessThan(500_000);
     }
+  });
+});
+
+describe("truncateOversizedToolResultsInSession", () => {
+  it("readably truncates aggregate medium tool results in a session file", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("hello"));
+    sm.appendMessage(makeAssistantMessage("calling tools"));
+    const medium = "alpha beta gamma delta epsilon ".repeat(600);
+    sm.appendMessage(makeToolResult(medium, "call_1"));
+    sm.appendMessage(makeToolResult(medium, "call_2"));
+    sm.appendMessage(makeToolResult(medium, "call_3"));
+    const sessionFile = sm.getSessionFile()!;
+
+    const beforeBranch = SessionManager.open(sessionFile).getBranch();
+    const beforeLengths = beforeBranch
+      .filter((entry) => entry.type === "message")
+      .map((entry) =>
+        entry.type === "message" && entry.message.role === "toolResult"
+          ? getToolResultTextLength(entry.message)
+          : 0,
+      )
+      .filter((length) => length > 0);
+
+    const result = await truncateOversizedToolResultsInSession({
+      sessionFile,
+      contextWindowTokens: 128_000,
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.truncatedCount).toBeGreaterThan(0);
+
+    const afterBranch = SessionManager.open(sessionFile).getBranch();
+    const afterToolResults = afterBranch.filter(
+      (entry) => entry.type === "message" && entry.message.role === "toolResult",
+    );
+    const afterLengths = afterToolResults.map((entry) =>
+      entry.type === "message" ? getToolResultTextLength(entry.message) : 0,
+    );
+
+    expect(afterLengths.reduce((sum, value) => sum + value, 0)).toBeLessThan(
+      beforeLengths.reduce((sum, value) => sum + value, 0),
+    );
+    expect(
+      afterToolResults.some((entry) =>
+        entry.type === "message"
+          ? getFirstToolResultText(entry.message).includes("truncated")
+          : false,
+      ),
+    ).toBe(true);
+    expect(
+      afterToolResults.some((entry) =>
+        entry.type === "message"
+          ? getFirstToolResultText(entry.message).includes("[compacted:")
+          : false,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -2,8 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 
@@ -15,6 +15,7 @@ let truncateOversizedToolResultsInMessages: typeof import("./tool-result-truncat
 let truncateOversizedToolResultsInSession: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInSession;
 let isOversizedToolResult: typeof import("./tool-result-truncation.js").isOversizedToolResult;
 let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncation.js").sessionLikelyHasOversizedToolResults;
+let estimateToolResultReductionPotential: typeof import("./tool-result-truncation.js").estimateToolResultReductionPotential;
 let DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 let HARD_MAX_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").HARD_MAX_TOOL_RESULT_CHARS;
 let tmpDir: string | undefined;
@@ -29,6 +30,7 @@ async function loadFreshToolResultTruncationModuleForTest() {
     truncateOversizedToolResultsInSession,
     isOversizedToolResult,
     sessionLikelyHasOversizedToolResults,
+    estimateToolResultReductionPotential,
     DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     HARD_MAX_TOOL_RESULT_CHARS,
   } = await import("./tool-result-truncation.js"));
@@ -242,6 +244,58 @@ describe("sessionLikelyHasOversizedToolResults", () => {
     expect(sessionLikelyHasOversizedToolResults({ messages, contextWindowTokens: 128_000 })).toBe(
       true,
     );
+  });
+});
+
+describe("estimateToolResultReductionPotential", () => {
+  it("reports no reducible budget when tool results are already small", () => {
+    const messages: AgentMessage[] = [makeToolResult("small result")];
+
+    const estimate = estimateToolResultReductionPotential({
+      messages,
+      contextWindowTokens: 128_000,
+    });
+
+    expect(estimate.toolResultCount).toBe(1);
+    expect(estimate.maxReducibleChars).toBe(0);
+  });
+
+  it("estimates reducible chars for aggregate medium tool-result tails", () => {
+    const medium = "alpha beta gamma delta epsilon ".repeat(600);
+    const messages: AgentMessage[] = [
+      makeToolResult(medium, "call_1"),
+      makeToolResult(medium, "call_2"),
+      makeToolResult(medium, "call_3"),
+    ];
+
+    const estimate = estimateToolResultReductionPotential({
+      messages,
+      contextWindowTokens: 128_000,
+    });
+
+    expect(estimate.toolResultCount).toBe(3);
+    expect(estimate.oversizedCount).toBe(0);
+    expect(estimate.aggregateReducibleChars).toBeGreaterThan(0);
+    expect(estimate.maxReducibleChars).toBe(estimate.aggregateReducibleChars);
+  });
+
+  it("does not count aggregate savings on top of oversized savings in a single pass", () => {
+    const oversized = "x".repeat(500_000);
+    const medium = "alpha beta gamma delta epsilon ".repeat(800);
+    const messages: AgentMessage[] = [
+      makeToolResult(oversized, "call_1"),
+      makeToolResult(medium, "call_2"),
+      makeToolResult(medium, "call_3"),
+    ];
+
+    const estimate = estimateToolResultReductionPotential({
+      messages,
+      contextWindowTokens: 128_000,
+    });
+
+    expect(estimate.oversizedCount).toBeGreaterThan(0);
+    expect(estimate.oversizedReducibleChars).toBeGreaterThan(0);
+    expect(estimate.maxReducibleChars).toBe(estimate.oversizedReducibleChars);
   });
 });
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -424,6 +424,46 @@ describe("truncateOversizedToolResultsInSession", () => {
     ).toBe(false);
   });
 
+  it("prefers truncating newer aggregate tool-result entries before older larger ones", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("hello"));
+    sm.appendMessage(makeAssistantMessage("calling tools"));
+    const olderLarge = "older-large ".repeat(2_000);
+    const newerEnough = "newer-enough ".repeat(1_400);
+    sm.appendMessage(makeToolResult(olderLarge, "call_1"));
+    sm.appendMessage(makeToolResult(newerEnough, "call_2"));
+    const sessionFile = sm.getSessionFile()!;
+
+    const beforeBranch = SessionManager.open(sessionFile).getBranch();
+    const beforeToolResults = beforeBranch.filter(
+      (entry) => entry.type === "message" && entry.message.role === "toolResult",
+    );
+    const beforeTexts = beforeToolResults.map((entry) =>
+      entry.type === "message" ? getFirstToolResultText(entry.message) : "",
+    );
+
+    const result = await truncateOversizedToolResultsInSession({
+      sessionFile,
+      contextWindowTokens: 128_000,
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.truncatedCount).toBe(1);
+
+    const afterBranch = SessionManager.open(sessionFile).getBranch();
+    const afterToolResults = afterBranch.filter(
+      (entry) => entry.type === "message" && entry.message.role === "toolResult",
+    );
+    const afterTexts = afterToolResults.map((entry) =>
+      entry.type === "message" ? getFirstToolResultText(entry.message) : "",
+    );
+
+    expect(afterTexts[0]).toBe(beforeTexts[0]);
+    expect(afterTexts[1]).not.toBe(beforeTexts[1]);
+    expect(afterTexts[1]).toContain("truncated");
+  });
+
   it("allows persisted-session recovery truncation to shrink below the old 2k floor", async () => {
     const dir = await createTmpDir();
     const sm = SessionManager.create(dir, dir);

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -388,7 +388,7 @@ describe("truncateOversizedToolResultsInSession", () => {
 
     const result = await truncateOversizedToolResultsInSession({
       sessionFile,
-      contextWindowTokens: 128_000,
+      contextWindowTokens: 100,
     });
 
     expect(result.truncated).toBe(true);
@@ -419,6 +419,33 @@ describe("truncateOversizedToolResultsInSession", () => {
           : false,
       ),
     ).toBe(false);
+  });
+
+  it("allows persisted-session recovery truncation to shrink below the old 2k floor", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("hello"));
+    sm.appendMessage(makeAssistantMessage("calling tools"));
+    sm.appendMessage(makeToolResult("x".repeat(500_000), "call_1"));
+    const sessionFile = sm.getSessionFile()!;
+
+    const result = await truncateOversizedToolResultsInSession({
+      sessionFile,
+      contextWindowTokens: 100,
+    });
+
+    expect(result.truncated).toBe(true);
+    const afterBranch = SessionManager.open(sessionFile).getBranch();
+    const toolResult = afterBranch.find(
+      (entry) => entry.type === "message" && entry.message.role === "toolResult",
+    );
+    expect(toolResult?.type).toBe("message");
+    if (!toolResult || toolResult.type !== "message") {
+      throw new Error("expected truncated tool result");
+    }
+    const text = getFirstToolResultText(toolResult.message);
+    expect(text.length).toBeLessThan(2_000);
+    expect(text).toContain("truncated");
   });
 });
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -490,51 +490,36 @@ describe("truncateOversizedToolResultsInSession", () => {
     expect(text.length).toBeLessThan(2_000);
     expect(text).toContain("truncated");
   });
-
-  it("applies aggregate recovery after oversized truncation for mixed tool-result tails", async () => {
+  it("combines oversized and aggregate recovery truncation in the same session rewrite", async () => {
     const dir = await createTmpDir();
     const sm = SessionManager.create(dir, dir);
     sm.appendMessage(makeUserMessage("hello"));
     sm.appendMessage(makeAssistantMessage("calling tools"));
-    const oversized = "x".repeat(500_000);
+    sm.appendMessage(makeToolResult("x".repeat(500_000), "call_1"));
     const medium = "alpha beta gamma delta epsilon ".repeat(800);
-    sm.appendMessage(makeToolResult(oversized, "call_1"));
     sm.appendMessage(makeToolResult(medium, "call_2"));
     sm.appendMessage(makeToolResult(medium, "call_3"));
     const sessionFile = sm.getSessionFile()!;
 
-    const beforeBranch = SessionManager.open(sessionFile).getBranch();
-    const beforeToolResults = beforeBranch.filter(
-      (entry) => entry.type === "message" && entry.message.role === "toolResult",
-    );
-    const beforeLengths = beforeToolResults.map((entry) =>
-      entry.type === "message" ? getToolResultTextLength(entry.message) : 0,
-    );
-
     const result = await truncateOversizedToolResultsInSession({
       sessionFile,
-      contextWindowTokens: 128_000,
+      contextWindowTokens: 100,
     });
 
     expect(result.truncated).toBe(true);
-    expect(result.truncatedCount).toBeGreaterThan(1);
+    expect(result.truncatedCount).toBe(3);
 
     const afterBranch = SessionManager.open(sessionFile).getBranch();
-    const afterToolResults = afterBranch.filter(
+    const toolResults = afterBranch.filter(
       (entry) => entry.type === "message" && entry.message.role === "toolResult",
     );
-    const afterLengths = afterToolResults.map((entry) =>
-      entry.type === "message" ? getToolResultTextLength(entry.message) : 0,
+    const toolTexts = toolResults.map((entry) =>
+      entry.type === "message" ? getFirstToolResultText(entry.message) : "",
     );
 
-    expect(afterLengths[0]).toBeLessThan(beforeLengths[0] ?? Infinity);
-    expect(
-      (afterLengths[1] ?? Infinity) < (beforeLengths[1] ?? Infinity) ||
-        (afterLengths[2] ?? Infinity) < (beforeLengths[2] ?? Infinity),
-    ).toBe(true);
-    expect(afterLengths.reduce((sum, value) => sum + value, 0)).toBeLessThan(
-      beforeLengths.reduce((sum, value) => sum + value, 0),
-    );
+    expect(toolTexts[0]).toContain("truncated");
+    expect(toolTexts[1]).toContain("truncated");
+    expect(toolTexts[2].length).toBeGreaterThan(0);
   });
 });
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -1,51 +1,25 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  buildSessionWriteLockModuleMock,
-  resetModulesWithSessionWriteLockDoMock,
-} from "../../test-utils/session-write-lock-module-mock.js";
+import { beforeEach, describe, expect, it } from "vitest";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
-
-const acquireSessionWriteLockReleaseMock = vi.hoisted(() => vi.fn(async () => {}));
-const acquireSessionWriteLockMock = vi.hoisted(() =>
-  vi.fn(async (_params?: unknown) => ({ release: acquireSessionWriteLockReleaseMock })),
-);
-
-vi.mock("../session-write-lock.js", () =>
-  buildSessionWriteLockModuleMock(
-    () => vi.importActual<typeof import("../session-write-lock.js")>("../session-write-lock.js"),
-    (params) => acquireSessionWriteLockMock(params),
-  ),
-);
 
 let truncateToolResultText: typeof import("./tool-result-truncation.js").truncateToolResultText;
 let truncateToolResultMessage: typeof import("./tool-result-truncation.js").truncateToolResultMessage;
 let calculateMaxToolResultChars: typeof import("./tool-result-truncation.js").calculateMaxToolResultChars;
 let getToolResultTextLength: typeof import("./tool-result-truncation.js").getToolResultTextLength;
 let truncateOversizedToolResultsInMessages: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInMessages;
-let truncateOversizedToolResultsInSession: typeof import("./tool-result-truncation.js").truncateOversizedToolResultsInSession;
 let isOversizedToolResult: typeof import("./tool-result-truncation.js").isOversizedToolResult;
-let sessionLikelyHasOversizedToolResults: typeof import("./tool-result-truncation.js").sessionLikelyHasOversizedToolResults;
 let DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
 let HARD_MAX_TOOL_RESULT_CHARS: typeof import("./tool-result-truncation.js").HARD_MAX_TOOL_RESULT_CHARS;
-let onSessionTranscriptUpdate: typeof import("../../sessions/transcript-events.js").onSessionTranscriptUpdate;
 
 async function loadFreshToolResultTruncationModuleForTest() {
-  resetModulesWithSessionWriteLockDoMock("../session-write-lock.js", (params) =>
-    acquireSessionWriteLockMock(params),
-  );
-  ({ onSessionTranscriptUpdate } = await import("../../sessions/transcript-events.js"));
   ({
     truncateToolResultText,
     truncateToolResultMessage,
     calculateMaxToolResultChars,
     getToolResultTextLength,
     truncateOversizedToolResultsInMessages,
-    truncateOversizedToolResultsInSession,
     isOversizedToolResult,
-    sessionLikelyHasOversizedToolResults,
     DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
     HARD_MAX_TOOL_RESULT_CHARS,
   } = await import("./tool-result-truncation.js"));
@@ -56,8 +30,6 @@ const nextTimestamp = () => testTimestamp++;
 
 beforeEach(async () => {
   testTimestamp = 1;
-  acquireSessionWriteLockMock.mockClear();
-  acquireSessionWriteLockReleaseMock.mockClear();
   await loadFreshToolResultTruncationModuleForTest();
 });
 
@@ -293,206 +265,6 @@ describe("truncateOversizedToolResultsInMessages", () => {
       const text = getFirstToolResultText(msg);
       expect(text.length).toBeLessThan(500_000);
     }
-  });
-});
-
-describe("truncateOversizedToolResultsInSession", () => {
-  it("acquires the session write lock before rewriting oversized tool results", async () => {
-    const sessionFile = "/tmp/tool-result-truncation-session.jsonl";
-    const sessionManager = SessionManager.inMemory();
-    sessionManager.appendMessage(makeUserMessage("hello"));
-    sessionManager.appendMessage(makeAssistantMessage("reading file"));
-    sessionManager.appendMessage(makeToolResult("x".repeat(500_000)));
-
-    const openSpy = vi
-      .spyOn(SessionManager, "open")
-      .mockReturnValue(sessionManager as unknown as ReturnType<typeof SessionManager.open>);
-    const listener = vi.fn();
-    const cleanup = onSessionTranscriptUpdate(listener);
-
-    try {
-      const result = await truncateOversizedToolResultsInSession({
-        sessionFile,
-        contextWindowTokens: 128_000,
-        sessionKey: "agent:main:test",
-      });
-
-      expect(result.truncated).toBe(true);
-      expect(result.truncatedCount).toBe(1);
-      expect(acquireSessionWriteLockMock).toHaveBeenCalledWith({ sessionFile });
-      expect(acquireSessionWriteLockReleaseMock).toHaveBeenCalledTimes(1);
-      expect(listener).toHaveBeenCalledWith({ sessionFile });
-
-      const branch = sessionManager.getBranch();
-      const rewrittenToolResult = branch.find(
-        (entry) => entry.type === "message" && entry.message.role === "toolResult",
-      );
-      expect(rewrittenToolResult?.type).toBe("message");
-      if (
-        rewrittenToolResult?.type !== "message" ||
-        rewrittenToolResult.message.role !== "toolResult"
-      ) {
-        throw new Error("expected rewritten tool result");
-      }
-      const rewrittenText = getFirstToolResultText(rewrittenToolResult.message);
-      expect(rewrittenText.length).toBeLessThan(500_000);
-      expect(rewrittenText).toContain("truncated");
-    } finally {
-      cleanup();
-      openSpy.mockRestore();
-    }
-  });
-
-  it("rewrites aggregate medium tool results when their combined size still overflows the session", async () => {
-    const sessionFile = "/tmp/tool-result-truncation-aggregate-session.jsonl";
-    const sessionManager = SessionManager.inMemory();
-    sessionManager.appendMessage(makeUserMessage("u".repeat(20_000)));
-    sessionManager.appendMessage(makeAssistantMessage("reading files"));
-    sessionManager.appendMessage(makeToolResult("a".repeat(10_000)));
-    sessionManager.appendMessage(makeToolResult("b".repeat(10_000)));
-    sessionManager.appendMessage(makeToolResult("c".repeat(10_000)));
-
-    const openSpy = vi
-      .spyOn(SessionManager, "open")
-      .mockReturnValue(sessionManager as unknown as ReturnType<typeof SessionManager.open>);
-
-    try {
-      const result = await truncateOversizedToolResultsInSession({
-        sessionFile,
-        contextWindowTokens: 10_000,
-        sessionKey: "agent:main:aggregate-test",
-      });
-
-      expect(result.truncated).toBe(true);
-      expect(result.truncatedCount).toBeGreaterThan(0);
-
-      const branch = sessionManager.getBranch();
-      const toolTexts = branch
-        .filter((entry) => entry.type === "message" && entry.message.role === "toolResult")
-        .map((entry) =>
-          entry.type === "message" && entry.message.role === "toolResult"
-            ? getFirstToolResultText(entry.message)
-            : "",
-        );
-      expect(toolTexts.some((text) => text.includes("truncated"))).toBe(true);
-      expect(toolTexts.some((text) => text.length < 10_000)).toBe(true);
-    } finally {
-      openSpy.mockRestore();
-    }
-  });
-
-  it("lets a retry pass the real guard after aggregate session rewrite", async () => {
-    const { PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE, installToolResultContextGuard } =
-      await import("./tool-result-context-guard.js");
-    const sessionFile = "/tmp/tool-result-truncation-seam-session.jsonl";
-    const contextWindowTokens = 10_000;
-    const originalMessages = [
-      makeUserMessage("u".repeat(20_000)),
-      makeAssistantMessage("reading files"),
-      makeToolResult("a".repeat(10_000), "call_a"),
-      makeToolResult("b".repeat(10_000), "call_b"),
-      makeToolResult("c".repeat(10_000), "call_c"),
-    ];
-    const guardAgent = {};
-    installToolResultContextGuard({ agent: guardAgent, contextWindowTokens });
-
-    await expect(
-      (
-        guardAgent as {
-          transformContext?: (messages: AgentMessage[], signal: AbortSignal) => unknown;
-        }
-      ).transformContext?.(originalMessages, new AbortController().signal),
-    ).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
-
-    expect(
-      sessionLikelyHasOversizedToolResults({
-        messages: originalMessages,
-        contextWindowTokens,
-      }),
-    ).toBe(true);
-
-    const sessionManager = SessionManager.inMemory();
-    for (const message of originalMessages) {
-      sessionManager.appendMessage(message);
-    }
-    const openSpy = vi
-      .spyOn(SessionManager, "open")
-      .mockReturnValue(sessionManager as unknown as ReturnType<typeof SessionManager.open>);
-
-    try {
-      const rewriteResult = await truncateOversizedToolResultsInSession({
-        sessionFile,
-        contextWindowTokens,
-        sessionKey: "agent:main:seam-test",
-      });
-
-      expect(rewriteResult.truncated).toBe(true);
-      expect(rewriteResult.truncatedCount).toBeGreaterThan(0);
-
-      const rewrittenMessages = sessionManager
-        .getBranch()
-        .filter((entry) => entry.type === "message")
-        .map((entry) => (entry.type === "message" ? entry.message : null))
-        .filter((message): message is AgentMessage => message !== null);
-
-      const retryAgent = {};
-      installToolResultContextGuard({ agent: retryAgent, contextWindowTokens });
-      await expect(
-        (
-          retryAgent as {
-            transformContext?: (messages: AgentMessage[], signal: AbortSignal) => unknown;
-          }
-        ).transformContext?.(rewrittenMessages, new AbortController().signal),
-      ).resolves.toBeDefined();
-    } finally {
-      openSpy.mockRestore();
-    }
-  });
-});
-
-describe("sessionLikelyHasOversizedToolResults", () => {
-  it("returns false when no tool results are oversized", () => {
-    const messages = [makeUserMessage("hello"), makeToolResult("small result")];
-    expect(
-      sessionLikelyHasOversizedToolResults({
-        messages,
-        contextWindowTokens: 200_000,
-      }),
-    ).toBe(false);
-  });
-
-  it("returns true when a tool result is oversized", () => {
-    const messages = [makeUserMessage("hello"), makeToolResult("x".repeat(500_000))];
-    expect(
-      sessionLikelyHasOversizedToolResults({
-        messages,
-        contextWindowTokens: 128_000,
-      }),
-    ).toBe(true);
-  });
-
-  it("returns true when several medium tool results exceed the aggregate overflow budget", () => {
-    const messages = [
-      makeUserMessage("u".repeat(20_000)),
-      makeToolResult("a".repeat(10_000)),
-      makeToolResult("b".repeat(10_000)),
-      makeToolResult("c".repeat(10_000)),
-    ];
-    expect(
-      sessionLikelyHasOversizedToolResults({
-        messages,
-        contextWindowTokens: 10_000,
-      }),
-    ).toBe(true);
-  });
-
-  it("returns false for empty messages", () => {
-    expect(
-      sessionLikelyHasOversizedToolResults({
-        messages: [],
-        contextWindowTokens: 200_000,
-      }),
-    ).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -279,7 +279,7 @@ describe("estimateToolResultReductionPotential", () => {
     expect(estimate.maxReducibleChars).toBe(estimate.aggregateReducibleChars);
   });
 
-  it("does not count aggregate savings on top of oversized savings in a single pass", () => {
+  it("counts aggregate savings on top of oversized savings in a single pass", () => {
     const oversized = "x".repeat(500_000);
     const medium = "alpha beta gamma delta epsilon ".repeat(800);
     const messages: AgentMessage[] = [
@@ -295,7 +295,10 @@ describe("estimateToolResultReductionPotential", () => {
 
     expect(estimate.oversizedCount).toBeGreaterThan(0);
     expect(estimate.oversizedReducibleChars).toBeGreaterThan(0);
-    expect(estimate.maxReducibleChars).toBe(estimate.oversizedReducibleChars);
+    expect(estimate.aggregateReducibleChars).toBeGreaterThan(0);
+    expect(estimate.maxReducibleChars).toBe(
+      estimate.oversizedReducibleChars + estimate.aggregateReducibleChars,
+    );
   });
 });
 
@@ -446,6 +449,52 @@ describe("truncateOversizedToolResultsInSession", () => {
     const text = getFirstToolResultText(toolResult.message);
     expect(text.length).toBeLessThan(2_000);
     expect(text).toContain("truncated");
+  });
+
+  it("applies aggregate recovery after oversized truncation for mixed tool-result tails", async () => {
+    const dir = await createTmpDir();
+    const sm = SessionManager.create(dir, dir);
+    sm.appendMessage(makeUserMessage("hello"));
+    sm.appendMessage(makeAssistantMessage("calling tools"));
+    const oversized = "x".repeat(500_000);
+    const medium = "alpha beta gamma delta epsilon ".repeat(800);
+    sm.appendMessage(makeToolResult(oversized, "call_1"));
+    sm.appendMessage(makeToolResult(medium, "call_2"));
+    sm.appendMessage(makeToolResult(medium, "call_3"));
+    const sessionFile = sm.getSessionFile()!;
+
+    const beforeBranch = SessionManager.open(sessionFile).getBranch();
+    const beforeToolResults = beforeBranch.filter(
+      (entry) => entry.type === "message" && entry.message.role === "toolResult",
+    );
+    const beforeLengths = beforeToolResults.map((entry) =>
+      entry.type === "message" ? getToolResultTextLength(entry.message) : 0,
+    );
+
+    const result = await truncateOversizedToolResultsInSession({
+      sessionFile,
+      contextWindowTokens: 128_000,
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.truncatedCount).toBeGreaterThan(1);
+
+    const afterBranch = SessionManager.open(sessionFile).getBranch();
+    const afterToolResults = afterBranch.filter(
+      (entry) => entry.type === "message" && entry.message.role === "toolResult",
+    );
+    const afterLengths = afterToolResults.map((entry) =>
+      entry.type === "message" ? getToolResultTextLength(entry.message) : 0,
+    );
+
+    expect(afterLengths[0]).toBeLessThan(beforeLengths[0] ?? Infinity);
+    expect(
+      (afterLengths[1] ?? Infinity) < (beforeLengths[1] ?? Infinity) ||
+        (afterLengths[2] ?? Infinity) < (beforeLengths[2] ?? Infinity),
+    ).toBe(true);
+    expect(afterLengths.reduce((sum, value) => sum + value, 0)).toBeLessThan(
+      beforeLengths.reduce((sum, value) => sum + value, 0),
+    );
   });
 });
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.test.ts
@@ -342,6 +342,112 @@ describe("truncateOversizedToolResultsInSession", () => {
       openSpy.mockRestore();
     }
   });
+
+  it("rewrites aggregate medium tool results when their combined size still overflows the session", async () => {
+    const sessionFile = "/tmp/tool-result-truncation-aggregate-session.jsonl";
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage(makeUserMessage("u".repeat(20_000)));
+    sessionManager.appendMessage(makeAssistantMessage("reading files"));
+    sessionManager.appendMessage(makeToolResult("a".repeat(10_000)));
+    sessionManager.appendMessage(makeToolResult("b".repeat(10_000)));
+    sessionManager.appendMessage(makeToolResult("c".repeat(10_000)));
+
+    const openSpy = vi
+      .spyOn(SessionManager, "open")
+      .mockReturnValue(sessionManager as unknown as ReturnType<typeof SessionManager.open>);
+
+    try {
+      const result = await truncateOversizedToolResultsInSession({
+        sessionFile,
+        contextWindowTokens: 10_000,
+        sessionKey: "agent:main:aggregate-test",
+      });
+
+      expect(result.truncated).toBe(true);
+      expect(result.truncatedCount).toBeGreaterThan(0);
+
+      const branch = sessionManager.getBranch();
+      const toolTexts = branch
+        .filter((entry) => entry.type === "message" && entry.message.role === "toolResult")
+        .map((entry) =>
+          entry.type === "message" && entry.message.role === "toolResult"
+            ? getFirstToolResultText(entry.message)
+            : "",
+        );
+      expect(toolTexts.some((text) => text.includes("truncated"))).toBe(true);
+      expect(toolTexts.some((text) => text.length < 10_000)).toBe(true);
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  it("lets a retry pass the real guard after aggregate session rewrite", async () => {
+    const { PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE, installToolResultContextGuard } =
+      await import("./tool-result-context-guard.js");
+    const sessionFile = "/tmp/tool-result-truncation-seam-session.jsonl";
+    const contextWindowTokens = 10_000;
+    const originalMessages = [
+      makeUserMessage("u".repeat(20_000)),
+      makeAssistantMessage("reading files"),
+      makeToolResult("a".repeat(10_000), "call_a"),
+      makeToolResult("b".repeat(10_000), "call_b"),
+      makeToolResult("c".repeat(10_000), "call_c"),
+    ];
+    const guardAgent = {};
+    installToolResultContextGuard({ agent: guardAgent, contextWindowTokens });
+
+    await expect(
+      (
+        guardAgent as {
+          transformContext?: (messages: AgentMessage[], signal: AbortSignal) => unknown;
+        }
+      ).transformContext?.(originalMessages, new AbortController().signal),
+    ).rejects.toThrow(PREEMPTIVE_CONTEXT_OVERFLOW_MESSAGE);
+
+    expect(
+      sessionLikelyHasOversizedToolResults({
+        messages: originalMessages,
+        contextWindowTokens,
+      }),
+    ).toBe(true);
+
+    const sessionManager = SessionManager.inMemory();
+    for (const message of originalMessages) {
+      sessionManager.appendMessage(message);
+    }
+    const openSpy = vi
+      .spyOn(SessionManager, "open")
+      .mockReturnValue(sessionManager as unknown as ReturnType<typeof SessionManager.open>);
+
+    try {
+      const rewriteResult = await truncateOversizedToolResultsInSession({
+        sessionFile,
+        contextWindowTokens,
+        sessionKey: "agent:main:seam-test",
+      });
+
+      expect(rewriteResult.truncated).toBe(true);
+      expect(rewriteResult.truncatedCount).toBeGreaterThan(0);
+
+      const rewrittenMessages = sessionManager
+        .getBranch()
+        .filter((entry) => entry.type === "message")
+        .map((entry) => (entry.type === "message" ? entry.message : null))
+        .filter((message): message is AgentMessage => message !== null);
+
+      const retryAgent = {};
+      installToolResultContextGuard({ agent: retryAgent, contextWindowTokens });
+      await expect(
+        (
+          retryAgent as {
+            transformContext?: (messages: AgentMessage[], signal: AbortSignal) => unknown;
+          }
+        ).transformContext?.(rewrittenMessages, new AbortController().signal),
+      ).resolves.toBeDefined();
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
 });
 
 describe("sessionLikelyHasOversizedToolResults", () => {
@@ -361,6 +467,21 @@ describe("sessionLikelyHasOversizedToolResults", () => {
       sessionLikelyHasOversizedToolResults({
         messages,
         contextWindowTokens: 128_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when several medium tool results exceed the aggregate overflow budget", () => {
+    const messages = [
+      makeUserMessage("u".repeat(20_000)),
+      makeToolResult("a".repeat(10_000)),
+      makeToolResult("b".repeat(10_000)),
+      makeToolResult("c".repeat(10_000)),
+    ];
+    expect(
+      sessionLikelyHasOversizedToolResults({
+        messages,
+        contextWindowTokens: 10_000,
       }),
     ).toBe(true);
   });

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -1,16 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { TextContent } from "@mariozechner/pi-ai";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
-import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
-import { acquireSessionWriteLock } from "../session-write-lock.js";
-import { log } from "./logger.js";
-import {
-  CHARS_PER_TOKEN_ESTIMATE,
-  TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
-  createMessageCharEstimateCache,
-  estimateContextChars,
-} from "./tool-result-char-estimator.js";
-import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
 
 /**
  * Maximum share of the context window a single tool result should occupy.
@@ -18,11 +7,6 @@ import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.j
  * consume more than 30% of the context window even without other messages.
  */
 const MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3;
-const CONTEXT_INPUT_HEADROOM_RATIO = 0.75;
-const PREEMPTIVE_OVERFLOW_RATIO = 0.9;
-const TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO =
-  CHARS_PER_TOKEN_ESTIMATE / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
-const AGGREGATE_TRUNCATION_MIN_KEEP_CHARS = 256;
 
 /**
  * Default hard cap for a single live tool result text block.
@@ -57,56 +41,6 @@ type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
   minKeepChars?: number;
 };
-
-type ToolResultRewriteCandidate = {
-  entryId: string;
-  entryIndex: number;
-  message: AgentMessage;
-  textLength: number;
-};
-
-function calculateContextBudgetChars(contextWindowTokens: number): number {
-  return Math.max(
-    1_024,
-    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * CONTEXT_INPUT_HEADROOM_RATIO),
-  );
-}
-
-function calculatePreemptiveOverflowChars(contextWindowTokens: number): number {
-  return Math.max(
-    calculateContextBudgetChars(contextWindowTokens),
-    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
-  );
-}
-
-function estimateToolResultCharsFromTextLength(textLength: number): number {
-  return Math.ceil(textLength * TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO);
-}
-
-function collectToolResultRewriteCandidates(branch: ReturnType<SessionManager["getBranch"]>): {
-  candidates: ToolResultRewriteCandidate[];
-  messages: AgentMessage[];
-} {
-  const candidates: ToolResultRewriteCandidate[] = [];
-  const messages: AgentMessage[] = [];
-  for (let i = 0; i < branch.length; i++) {
-    const entry = branch[i];
-    if (entry.type !== "message") {
-      continue;
-    }
-    messages.push(entry.message);
-    if ((entry.message as { role?: string }).role !== "toolResult") {
-      continue;
-    }
-    candidates.push({
-      entryId: entry.id,
-      entryIndex: i,
-      message: entry.message,
-      textLength: getToolResultTextLength(entry.message),
-    });
-  }
-  return { candidates, messages };
-}
 
 /**
  * Marker inserted between head and tail when using head+tail truncation.
@@ -283,142 +217,6 @@ export function truncateToolResultMessage(
 }
 
 /**
- * Find oversized tool result entries in a session and truncate them.
- *
- * This operates on the session file by:
- * 1. Opening the session manager
- * 2. Walking the current branch to find oversized tool results
- * 3. Branching from before the first oversized tool result
- * 4. Re-appending all entries from that point with truncated tool results
- *
- * @returns Object indicating whether any truncation was performed
- */
-export async function truncateOversizedToolResultsInSession(params: {
-  sessionFile: string;
-  contextWindowTokens: number;
-  sessionId?: string;
-  sessionKey?: string;
-}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
-  const { sessionFile, contextWindowTokens } = params;
-  const maxChars = calculateMaxToolResultChars(contextWindowTokens);
-  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
-
-  try {
-    sessionLock = await acquireSessionWriteLock({ sessionFile });
-    const sessionManager = SessionManager.open(sessionFile);
-    const branch = sessionManager.getBranch();
-
-    if (branch.length === 0) {
-      return { truncated: false, truncatedCount: 0, reason: "empty session" };
-    }
-
-    const { candidates, messages } = collectToolResultRewriteCandidates(branch);
-    const oversizedCandidates = candidates.filter((candidate) => candidate.textLength > maxChars);
-    for (const candidate of oversizedCandidates) {
-      log.info(
-        `[tool-result-truncation] Found oversized tool result: ` +
-          `entry=${candidate.entryId} chars=${candidate.textLength} maxChars=${maxChars} ` +
-          `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-      );
-    }
-
-    const currentContextChars = estimateContextChars(messages, createMessageCharEstimateCache());
-    const overflowThresholdChars = calculatePreemptiveOverflowChars(contextWindowTokens);
-    const aggregateCharsNeeded = Math.max(0, currentContextChars - overflowThresholdChars);
-
-    if (oversizedCandidates.length === 0 && aggregateCharsNeeded <= 0) {
-      return { truncated: false, truncatedCount: 0, reason: "no tool result truncation needed" };
-    }
-
-    let remainingAggregateCharsNeeded = aggregateCharsNeeded;
-    const candidatesByRecency = [...candidates].toSorted((a, b) => b.entryIndex - a.entryIndex);
-    const replacements = candidatesByRecency.flatMap((candidate) => {
-      const aggregateEligible =
-        remainingAggregateCharsNeeded > 0 &&
-        candidate.textLength > AGGREGATE_TRUNCATION_MIN_KEEP_CHARS;
-      const targetChars =
-        candidate.textLength > maxChars
-          ? maxChars
-          : aggregateEligible
-            ? Math.max(
-                AGGREGATE_TRUNCATION_MIN_KEEP_CHARS,
-                candidate.textLength -
-                  Math.ceil(remainingAggregateCharsNeeded / TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO),
-              )
-            : candidate.textLength;
-
-      if (targetChars >= candidate.textLength) {
-        return [];
-      }
-
-      const minKeepChars =
-        candidate.textLength > maxChars ? undefined : AGGREGATE_TRUNCATION_MIN_KEEP_CHARS;
-      const message = truncateToolResultMessage(
-        candidate.message,
-        targetChars,
-        minKeepChars === undefined ? {} : { minKeepChars },
-      );
-      const newLength = getToolResultTextLength(message);
-      if (newLength >= candidate.textLength) {
-        return [];
-      }
-
-      const reducedEstimateChars = estimateToolResultCharsFromTextLength(
-        candidate.textLength - newLength,
-      );
-      remainingAggregateCharsNeeded = Math.max(
-        0,
-        remainingAggregateCharsNeeded - reducedEstimateChars,
-      );
-
-      log.info(
-        `[tool-result-truncation] Truncated tool result: ` +
-          `originalEntry=${candidate.entryId} newChars=${newLength} ` +
-          `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-      );
-      return [{ entryId: candidate.entryId, message }];
-    });
-
-    if (replacements.length === 0) {
-      return {
-        truncated: false,
-        truncatedCount: 0,
-        reason:
-          oversizedCandidates.length > 0
-            ? "oversized tool results could not be reduced"
-            : "aggregate tool result overflow could not be reduced",
-      };
-    }
-
-    const rewriteResult = rewriteTranscriptEntriesInSessionManager({
-      sessionManager,
-      replacements,
-    });
-    if (rewriteResult.changed) {
-      emitSessionTranscriptUpdate(sessionFile);
-    }
-
-    log.info(
-      `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
-        `(contextWindow=${contextWindowTokens} maxChars=${maxChars}) ` +
-        `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-    );
-
-    return {
-      truncated: rewriteResult.changed,
-      truncatedCount: rewriteResult.rewrittenEntries,
-      reason: rewriteResult.reason,
-    };
-  } catch (err) {
-    const errMsg = err instanceof Error ? err.message : String(err);
-    log.warn(`[tool-result-truncation] Failed to truncate: ${errMsg}`);
-    return { truncated: false, truncatedCount: 0, reason: errMsg };
-  } finally {
-    await sessionLock?.release();
-  }
-}
-
-/**
  * Truncate oversized tool results in an array of messages (in-memory).
  * Returns a new array with truncated messages.
  *
@@ -456,34 +254,4 @@ export function isOversizedToolResult(msg: AgentMessage, contextWindowTokens: nu
   }
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
   return getToolResultTextLength(msg) > maxChars;
-}
-
-/**
- * Estimate whether the session likely has oversized tool results that caused
- * a context overflow. Used as a heuristic to decide whether to attempt
- * tool result truncation before giving up.
- */
-export function sessionLikelyHasOversizedToolResults(params: {
-  messages: AgentMessage[];
-  contextWindowTokens: number;
-}): boolean {
-  const { messages, contextWindowTokens } = params;
-  const maxChars = calculateMaxToolResultChars(contextWindowTokens);
-  const contextBudgetChars = calculatePreemptiveOverflowChars(contextWindowTokens);
-  let sawToolResult = false;
-  let aggregateToolResultChars = 0;
-
-  for (const msg of messages) {
-    if ((msg as { role?: string }).role !== "toolResult") {
-      continue;
-    }
-    sawToolResult = true;
-    const textLength = getToolResultTextLength(msg);
-    aggregateToolResultChars += estimateToolResultCharsFromTextLength(textLength);
-    if (textLength > maxChars) {
-      return true;
-    }
-  }
-
-  return sawToolResult && aggregateToolResultChars > contextBudgetChars;
 }

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -1,5 +1,10 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { TextContent } from "@mariozechner/pi-ai";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { acquireSessionWriteLock } from "../session-write-lock.js";
+import { log } from "./logger.js";
+import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
 
 /**
  * Maximum share of the context window a single tool result should occupy.
@@ -245,6 +250,80 @@ export function truncateOversizedToolResultsInMessages(
   return { messages: result, truncatedCount };
 }
 
+export async function truncateOversizedToolResultsInSession(params: {
+  sessionFile: string;
+  contextWindowTokens: number;
+  sessionId?: string;
+  sessionKey?: string;
+}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
+  const { sessionFile, contextWindowTokens } = params;
+  const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+
+  try {
+    sessionLock = await acquireSessionWriteLock({ sessionFile });
+    const sessionManager = SessionManager.open(sessionFile);
+    const branch = sessionManager.getBranch();
+
+    if (branch.length === 0) {
+      return { truncated: false, truncatedCount: 0, reason: "empty session" };
+    }
+
+    const oversizedIndices: number[] = [];
+    for (let i = 0; i < branch.length; i += 1) {
+      const entry = branch[i];
+      if (entry.type !== "message") {
+        continue;
+      }
+      const msg = entry.message;
+      if ((msg as { role?: string }).role !== "toolResult") {
+        continue;
+      }
+      if (getToolResultTextLength(msg) > maxChars) {
+        oversizedIndices.push(i);
+      }
+    }
+
+    if (oversizedIndices.length === 0) {
+      return { truncated: false, truncatedCount: 0, reason: "no oversized tool results" };
+    }
+
+    const replacements = oversizedIndices.flatMap((index) => {
+      const entry = branch[index];
+      if (!entry || entry.type !== "message") {
+        return [];
+      }
+      return [{ entryId: entry.id, message: truncateToolResultMessage(entry.message, maxChars) }];
+    });
+
+    const rewriteResult = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements,
+    });
+    if (rewriteResult.changed) {
+      emitSessionTranscriptUpdate(sessionFile);
+    }
+
+    log.info(
+      `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
+        `(contextWindow=${contextWindowTokens} maxChars=${maxChars}) ` +
+        `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
+    );
+
+    return {
+      truncated: rewriteResult.changed,
+      truncatedCount: rewriteResult.rewrittenEntries,
+      reason: rewriteResult.reason,
+    };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.warn(`[tool-result-truncation] Failed to truncate: ${errMsg}`);
+    return { truncated: false, truncatedCount: 0, reason: errMsg };
+  } finally {
+    await sessionLock?.release();
+  }
+}
+
 /**
  * Check if a tool result message exceeds the size limit for a given context window.
  */
@@ -254,4 +333,23 @@ export function isOversizedToolResult(msg: AgentMessage, contextWindowTokens: nu
   }
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
   return getToolResultTextLength(msg) > maxChars;
+}
+
+export function sessionLikelyHasOversizedToolResults(params: {
+  messages: AgentMessage[];
+  contextWindowTokens: number;
+}): boolean {
+  const { messages, contextWindowTokens } = params;
+  const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+
+  for (const msg of messages) {
+    if ((msg as { role?: string }).role !== "toolResult") {
+      continue;
+    }
+    if (getToolResultTextLength(msg) > maxChars) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -4,6 +4,12 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { acquireSessionWriteLock } from "../session-write-lock.js";
 import { log } from "./logger.js";
+import {
+  CHARS_PER_TOKEN_ESTIMATE,
+  TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE,
+  createMessageCharEstimateCache,
+  estimateContextChars,
+} from "./tool-result-char-estimator.js";
 import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
 
 /**
@@ -12,6 +18,11 @@ import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.j
  * consume more than 30% of the context window even without other messages.
  */
 const MAX_TOOL_RESULT_CONTEXT_SHARE = 0.3;
+const CONTEXT_INPUT_HEADROOM_RATIO = 0.75;
+const PREEMPTIVE_OVERFLOW_RATIO = 0.9;
+const TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO =
+  CHARS_PER_TOKEN_ESTIMATE / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE;
+const AGGREGATE_TRUNCATION_MIN_KEEP_CHARS = 256;
 
 /**
  * Default hard cap for a single live tool result text block.
@@ -43,9 +54,59 @@ const TRUNCATION_SUFFIX =
   "offset/limit parameters to read smaller chunks.]";
 
 type ToolResultTruncationOptions = {
-  suffix?: string;
+  suffix?: string | ((truncatedChars: number) => string);
   minKeepChars?: number;
 };
+
+type ToolResultRewriteCandidate = {
+  entryId: string;
+  entryIndex: number;
+  message: AgentMessage;
+  textLength: number;
+};
+
+function calculateContextBudgetChars(contextWindowTokens: number): number {
+  return Math.max(
+    1_024,
+    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * CONTEXT_INPUT_HEADROOM_RATIO),
+  );
+}
+
+function calculatePreemptiveOverflowChars(contextWindowTokens: number): number {
+  return Math.max(
+    calculateContextBudgetChars(contextWindowTokens),
+    Math.floor(contextWindowTokens * CHARS_PER_TOKEN_ESTIMATE * PREEMPTIVE_OVERFLOW_RATIO),
+  );
+}
+
+function estimateToolResultCharsFromTextLength(textLength: number): number {
+  return Math.ceil(textLength * TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO);
+}
+
+function collectToolResultRewriteCandidates(branch: ReturnType<SessionManager["getBranch"]>): {
+  candidates: ToolResultRewriteCandidate[];
+  messages: AgentMessage[];
+} {
+  const candidates: ToolResultRewriteCandidate[] = [];
+  const messages: AgentMessage[] = [];
+  for (let i = 0; i < branch.length; i++) {
+    const entry = branch[i];
+    if (entry.type !== "message") {
+      continue;
+    }
+    messages.push(entry.message);
+    if ((entry.message as { role?: string }).role !== "toolResult") {
+      continue;
+    }
+    candidates.push({
+      entryId: entry.id,
+      entryIndex: i,
+      message: entry.message,
+      textLength: getToolResultTextLength(entry.message),
+    });
+  }
+  return { candidates, messages };
+}
 
 /**
  * Marker inserted between head and tail when using head+tail truncation.
@@ -82,12 +143,16 @@ export function truncateToolResultText(
   maxChars: number,
   options: ToolResultTruncationOptions = {},
 ): string {
-  const suffix = options.suffix ?? TRUNCATION_SUFFIX;
+  const suffixFactory: (truncatedChars: number) => string =
+    typeof options.suffix === "function"
+      ? options.suffix
+      : () => (options.suffix ?? TRUNCATION_SUFFIX);
   const minKeepChars = options.minKeepChars ?? MIN_KEEP_CHARS;
   if (text.length <= maxChars) {
     return text;
   }
-  const budget = Math.max(minKeepChars, maxChars - suffix.length);
+  const defaultSuffix = suffixFactory(Math.max(1, text.length - maxChars));
+  const budget = Math.max(minKeepChars, maxChars - defaultSuffix.length);
 
   // If tail looks important, split budget between head and tail
   if (hasImportantTail(text) && budget > minKeepChars * 2) {
@@ -108,7 +173,9 @@ export function truncateToolResultText(
         tailStart = tailNewline + 1;
       }
 
-      return text.slice(0, headCut) + MIDDLE_OMISSION_MARKER + text.slice(tailStart) + suffix;
+      const keptText = text.slice(0, headCut) + MIDDLE_OMISSION_MARKER + text.slice(tailStart);
+      const suffix = suffixFactory(Math.max(1, text.length - keptText.length));
+      return keptText + suffix;
     }
   }
 
@@ -118,7 +185,9 @@ export function truncateToolResultText(
   if (lastNewline > budget * 0.8) {
     cutPoint = lastNewline;
   }
-  return text.slice(0, cutPoint) + suffix;
+  const keptText = text.slice(0, cutPoint);
+  const suffix = suffixFactory(Math.max(1, text.length - keptText.length));
+  return keptText + suffix;
 }
 
 /**
@@ -167,7 +236,10 @@ export function truncateToolResultMessage(
   maxChars: number,
   options: ToolResultTruncationOptions = {},
 ): AgentMessage {
-  const suffix = options.suffix ?? TRUNCATION_SUFFIX;
+  const suffixFactory: (truncatedChars: number) => string =
+    typeof options.suffix === "function"
+      ? options.suffix
+      : () => (options.suffix ?? TRUNCATION_SUFFIX);
   const minKeepChars = options.minKeepChars ?? MIN_KEEP_CHARS;
   const content = (msg as { content?: unknown }).content;
   if (!Array.isArray(content)) {
@@ -191,10 +263,19 @@ export function truncateToolResultMessage(
     }
     // Proportional budget for this block
     const blockShare = textBlock.text.length / totalTextChars;
-    const blockBudget = Math.max(minKeepChars + suffix.length, Math.floor(maxChars * blockShare));
+    const defaultSuffix = suffixFactory(
+      Math.max(1, textBlock.text.length - Math.floor(maxChars * blockShare)),
+    );
+    const blockBudget = Math.max(
+      minKeepChars + defaultSuffix.length,
+      Math.floor(maxChars * blockShare),
+    );
     return {
       ...textBlock,
-      text: truncateToolResultText(textBlock.text, blockBudget, { suffix, minKeepChars }),
+      text: truncateToolResultText(textBlock.text, blockBudget, {
+        suffix: suffixFactory,
+        minKeepChars,
+      }),
     };
   });
 
@@ -231,46 +312,83 @@ export async function truncateOversizedToolResultsInSession(params: {
       return { truncated: false, truncatedCount: 0, reason: "empty session" };
     }
 
-    // Find oversized tool result entries and their indices in the branch
-    const oversizedIndices: number[] = [];
-    for (let i = 0; i < branch.length; i++) {
-      const entry = branch[i];
-      if (entry.type !== "message") {
-        continue;
-      }
-      const msg = entry.message;
-      if ((msg as { role?: string }).role !== "toolResult") {
-        continue;
-      }
-      const textLength = getToolResultTextLength(msg);
-      if (textLength > maxChars) {
-        oversizedIndices.push(i);
-        log.info(
-          `[tool-result-truncation] Found oversized tool result: ` +
-            `entry=${entry.id} chars=${textLength} maxChars=${maxChars} ` +
-            `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-        );
-      }
-    }
-
-    if (oversizedIndices.length === 0) {
-      return { truncated: false, truncatedCount: 0, reason: "no oversized tool results" };
-    }
-
-    const replacements = oversizedIndices.flatMap((index) => {
-      const entry = branch[index];
-      if (!entry || entry.type !== "message") {
-        return [];
-      }
-      const message = truncateToolResultMessage(entry.message, maxChars);
-      const newLength = getToolResultTextLength(message);
+    const { candidates, messages } = collectToolResultRewriteCandidates(branch);
+    const oversizedCandidates = candidates.filter((candidate) => candidate.textLength > maxChars);
+    for (const candidate of oversizedCandidates) {
       log.info(
-        `[tool-result-truncation] Truncated tool result: ` +
-          `originalEntry=${entry.id} newChars=${newLength} ` +
+        `[tool-result-truncation] Found oversized tool result: ` +
+          `entry=${candidate.entryId} chars=${candidate.textLength} maxChars=${maxChars} ` +
           `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
       );
-      return [{ entryId: entry.id, message }];
+    }
+
+    const currentContextChars = estimateContextChars(messages, createMessageCharEstimateCache());
+    const overflowThresholdChars = calculatePreemptiveOverflowChars(contextWindowTokens);
+    const aggregateCharsNeeded = Math.max(0, currentContextChars - overflowThresholdChars);
+
+    if (oversizedCandidates.length === 0 && aggregateCharsNeeded <= 0) {
+      return { truncated: false, truncatedCount: 0, reason: "no tool result truncation needed" };
+    }
+
+    let remainingAggregateCharsNeeded = aggregateCharsNeeded;
+    const candidatesByRecency = [...candidates].toSorted((a, b) => b.entryIndex - a.entryIndex);
+    const replacements = candidatesByRecency.flatMap((candidate) => {
+      const aggregateEligible =
+        remainingAggregateCharsNeeded > 0 &&
+        candidate.textLength > AGGREGATE_TRUNCATION_MIN_KEEP_CHARS;
+      const targetChars =
+        candidate.textLength > maxChars
+          ? maxChars
+          : aggregateEligible
+            ? Math.max(
+                AGGREGATE_TRUNCATION_MIN_KEEP_CHARS,
+                candidate.textLength -
+                  Math.ceil(remainingAggregateCharsNeeded / TOOL_RESULT_ESTIMATE_TO_TEXT_RATIO),
+              )
+            : candidate.textLength;
+
+      if (targetChars >= candidate.textLength) {
+        return [];
+      }
+
+      const minKeepChars =
+        candidate.textLength > maxChars ? undefined : AGGREGATE_TRUNCATION_MIN_KEEP_CHARS;
+      const message = truncateToolResultMessage(
+        candidate.message,
+        targetChars,
+        minKeepChars === undefined ? {} : { minKeepChars },
+      );
+      const newLength = getToolResultTextLength(message);
+      if (newLength >= candidate.textLength) {
+        return [];
+      }
+
+      const reducedEstimateChars = estimateToolResultCharsFromTextLength(
+        candidate.textLength - newLength,
+      );
+      remainingAggregateCharsNeeded = Math.max(
+        0,
+        remainingAggregateCharsNeeded - reducedEstimateChars,
+      );
+
+      log.info(
+        `[tool-result-truncation] Truncated tool result: ` +
+          `originalEntry=${candidate.entryId} newChars=${newLength} ` +
+          `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
+      );
+      return [{ entryId: candidate.entryId, message }];
     });
+
+    if (replacements.length === 0) {
+      return {
+        truncated: false,
+        truncatedCount: 0,
+        reason:
+          oversizedCandidates.length > 0
+            ? "oversized tool results could not be reduced"
+            : "aggregate tool result overflow could not be reduced",
+      };
+    }
 
     const rewriteResult = rewriteTranscriptEntriesInSessionManager({
       sessionManager,
@@ -351,16 +469,21 @@ export function sessionLikelyHasOversizedToolResults(params: {
 }): boolean {
   const { messages, contextWindowTokens } = params;
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+  const contextBudgetChars = calculatePreemptiveOverflowChars(contextWindowTokens);
+  let sawToolResult = false;
+  let aggregateToolResultChars = 0;
 
   for (const msg of messages) {
     if ((msg as { role?: string }).role !== "toolResult") {
       continue;
     }
+    sawToolResult = true;
     const textLength = getToolResultTextLength(msg);
+    aggregateToolResultChars += estimateToolResultCharsFromTextLength(textLength);
     if (textLength > maxChars) {
       return true;
     }
   }
 
-  return false;
+  return sawToolResult && aggregateToolResultChars > contextBudgetChars;
 }

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -3,8 +3,8 @@ import type { TextContent } from "@mariozechner/pi-ai";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { acquireSessionWriteLock } from "../session-write-lock.js";
-import { formatContextLimitTruncationNotice } from "./tool-result-context-guard.js";
 import { log } from "./logger.js";
+import { formatContextLimitTruncationNotice } from "./tool-result-context-guard.js";
 import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
 
 /**
@@ -42,7 +42,7 @@ type ToolResultTruncationOptions = {
 
 const DEFAULT_SUFFIX = (truncatedChars: number) =>
   formatContextLimitTruncationNotice(truncatedChars);
-const MIN_TRUNCATED_TEXT_CHARS = MIN_KEEP_CHARS + DEFAULT_SUFFIX(1).length;
+export const MIN_TRUNCATED_TEXT_CHARS = MIN_KEEP_CHARS + DEFAULT_SUFFIX(1).length;
 
 /**
  * Marker inserted between head and tail when using head+tail truncation.
@@ -82,7 +82,7 @@ export function truncateToolResultText(
   const suffixFactory: (truncatedChars: number) => string =
     typeof options.suffix === "function"
       ? options.suffix
-      : () => (options.suffix ?? DEFAULT_SUFFIX(1));
+      : () => options.suffix ?? DEFAULT_SUFFIX(1);
   const minKeepChars = options.minKeepChars ?? MIN_KEEP_CHARS;
   if (text.length <= maxChars) {
     return text;
@@ -175,7 +175,7 @@ export function truncateToolResultMessage(
   const suffixFactory: (truncatedChars: number) => string =
     typeof options.suffix === "function"
       ? options.suffix
-      : () => (options.suffix ?? DEFAULT_SUFFIX(1));
+      : () => options.suffix ?? DEFAULT_SUFFIX(1);
   const minKeepChars = options.minKeepChars ?? MIN_KEEP_CHARS;
   const content = (msg as { content?: unknown }).content;
   if (!Array.isArray(content)) {
@@ -251,6 +251,17 @@ function calculateAggregateToolResultChars(contextWindowTokens: number): number 
   return Math.max(calculateMaxToolResultChars(contextWindowTokens), MIN_TRUNCATED_TEXT_CHARS);
 }
 
+export type ToolResultReductionPotential = {
+  maxChars: number;
+  aggregateBudgetChars: number;
+  toolResultCount: number;
+  totalToolResultChars: number;
+  oversizedCount: number;
+  oversizedReducibleChars: number;
+  aggregateReducibleChars: number;
+  maxReducibleChars: number;
+};
+
 function buildAggregateToolResultReplacements(params: {
   branch: Array<{ id: string; type: string; message?: AgentMessage }>;
   aggregateBudgetChars: number;
@@ -258,7 +269,9 @@ function buildAggregateToolResultReplacements(params: {
   const candidates = params.branch
     .map((entry, index) => ({ entry, index }))
     .filter(
-      (item): item is {
+      (
+        item,
+      ): item is {
         entry: { id: string; type: string; message: AgentMessage };
         index: number;
       } =>
@@ -313,94 +326,131 @@ function buildAggregateToolResultReplacements(params: {
   return replacements;
 }
 
-export async function truncateOversizedToolResultsInSession(params: {
-  sessionFile: string;
+export function estimateToolResultReductionPotential(params: {
+  messages: AgentMessage[];
   contextWindowTokens: number;
-  sessionId?: string;
-  sessionKey?: string;
-}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
-  const { sessionFile, contextWindowTokens } = params;
+}): ToolResultReductionPotential {
+  const { messages, contextWindowTokens } = params;
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
   const aggregateBudgetChars = calculateAggregateToolResultChars(contextWindowTokens);
-  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
 
-  try {
-    sessionLock = await acquireSessionWriteLock({ sessionFile });
-    const sessionManager = SessionManager.open(sessionFile);
-    const branch = sessionManager.getBranch();
+  let toolResultCount = 0;
+  let totalToolResultChars = 0;
+  let oversizedCount = 0;
+  let oversizedReducibleChars = 0;
+  const individuallyTrimmedMessages = messages.slice();
 
-    if (branch.length === 0) {
-      return { truncated: false, truncatedCount: 0, reason: "empty session" };
+  for (let index = 0; index < messages.length; index += 1) {
+    const msg = messages[index];
+    if ((msg as { role?: string }).role !== "toolResult") {
+      continue;
     }
-
-    const oversizedIndices: number[] = [];
-    for (let i = 0; i < branch.length; i += 1) {
-      const entry = branch[i];
-      if (entry.type !== "message") {
-        continue;
-      }
-      const msg = entry.message;
-      if ((msg as { role?: string }).role !== "toolResult") {
-        continue;
-      }
-      if (getToolResultTextLength(msg) > maxChars) {
-        oversizedIndices.push(i);
-      }
+    const textLength = getToolResultTextLength(msg);
+    if (textLength <= 0) {
+      continue;
     }
+    toolResultCount += 1;
+    totalToolResultChars += textLength;
+    if (textLength <= maxChars) {
+      continue;
+    }
+    oversizedCount += 1;
+    const truncatedMessage = truncateToolResultMessage(msg, maxChars);
+    individuallyTrimmedMessages[index] = truncatedMessage;
+    oversizedReducibleChars += Math.max(0, textLength - getToolResultTextLength(truncatedMessage));
+  }
 
-    if (oversizedIndices.length === 0) {
-      const replacements = buildAggregateToolResultReplacements({
-        branch: branch as Array<{ id: string; type: string; message?: AgentMessage }>,
-        aggregateBudgetChars,
-      });
-      if (replacements.length === 0) {
-        return {
-          truncated: false,
-          truncatedCount: 0,
-          reason: "no oversized or aggregate tool results",
-        };
-      }
+  const aggregateReplacements = buildAggregateToolResultReplacements({
+    branch: individuallyTrimmedMessages.map((message, index) => ({
+      id: `message-${index}`,
+      type: "message",
+      message,
+    })),
+    aggregateBudgetChars,
+  });
+  const individuallyTrimmedBranch = individuallyTrimmedMessages.map((message, index) => ({
+    id: `message-${index}`,
+    type: "message",
+    message,
+  }));
+  const aggregateReducibleChars = aggregateReplacements.reduce((sum, replacement) => {
+    const match = individuallyTrimmedBranch.find((entry) => entry.id === replacement.entryId);
+    const originalLength =
+      match && match.message
+        ? getToolResultTextLength(match.message)
+        : getToolResultTextLength(replacement.message);
+    const newLength = getToolResultTextLength(replacement.message);
+    return sum + Math.max(0, originalLength - newLength);
+  }, 0);
+  const maxReducibleChars = oversizedCount > 0 ? oversizedReducibleChars : aggregateReducibleChars;
 
-      const rewriteResult = rewriteTranscriptEntriesInSessionManager({
-        sessionManager,
-        replacements,
-      });
-      if (rewriteResult.changed) {
-        emitSessionTranscriptUpdate(sessionFile);
-      }
+  return {
+    maxChars,
+    aggregateBudgetChars,
+    toolResultCount,
+    totalToolResultChars,
+    oversizedCount,
+    oversizedReducibleChars,
+    aggregateReducibleChars,
+    maxReducibleChars,
+  };
+}
 
-      log.info(
-        `[tool-result-truncation] Aggregate-truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
-          `(contextWindow=${contextWindowTokens} aggregateBudgetChars=${aggregateBudgetChars}) ` +
-          `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-      );
+function truncateOversizedToolResultsInExistingSessionManager(params: {
+  sessionManager: SessionManager;
+  contextWindowTokens: number;
+  sessionFile?: string;
+  sessionId?: string;
+  sessionKey?: string;
+}): { truncated: boolean; truncatedCount: number; reason?: string } {
+  const { sessionManager, contextWindowTokens } = params;
+  const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+  const aggregateBudgetChars = calculateAggregateToolResultChars(contextWindowTokens);
+  const branch = sessionManager.getBranch();
 
+  if (branch.length === 0) {
+    return { truncated: false, truncatedCount: 0, reason: "empty session" };
+  }
+
+  const oversizedIndices: number[] = [];
+  for (let i = 0; i < branch.length; i += 1) {
+    const entry = branch[i];
+    if (entry.type !== "message") {
+      continue;
+    }
+    const msg = entry.message;
+    if ((msg as { role?: string }).role !== "toolResult") {
+      continue;
+    }
+    if (getToolResultTextLength(msg) > maxChars) {
+      oversizedIndices.push(i);
+    }
+  }
+
+  if (oversizedIndices.length === 0) {
+    const replacements = buildAggregateToolResultReplacements({
+      branch: branch as Array<{ id: string; type: string; message?: AgentMessage }>,
+      aggregateBudgetChars,
+    });
+    if (replacements.length === 0) {
       return {
-        truncated: rewriteResult.changed,
-        truncatedCount: rewriteResult.rewrittenEntries,
-        reason: rewriteResult.reason,
+        truncated: false,
+        truncatedCount: 0,
+        reason: "no oversized or aggregate tool results",
       };
     }
-
-    const replacements = oversizedIndices.flatMap((index) => {
-      const entry = branch[index];
-      if (!entry || entry.type !== "message") {
-        return [];
-      }
-      return [{ entryId: entry.id, message: truncateToolResultMessage(entry.message, maxChars) }];
-    });
 
     const rewriteResult = rewriteTranscriptEntriesInSessionManager({
       sessionManager,
       replacements,
     });
-    if (rewriteResult.changed) {
-      emitSessionTranscriptUpdate(sessionFile);
+    if (rewriteResult.changed && params.sessionFile) {
+      emitSessionTranscriptUpdate(params.sessionFile);
     }
 
     log.info(
-      `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
-        `(contextWindow=${contextWindowTokens} maxChars=${maxChars}) ` +
+      `[tool-result-truncation] Aggregate-truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
+        `(contextWindow=${contextWindowTokens} aggregateBudgetChars=${aggregateBudgetChars}) ` +
         `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
     );
 
@@ -409,6 +459,72 @@ export async function truncateOversizedToolResultsInSession(params: {
       truncatedCount: rewriteResult.rewrittenEntries,
       reason: rewriteResult.reason,
     };
+  }
+
+  const replacements = oversizedIndices.flatMap((index) => {
+    const entry = branch[index];
+    if (!entry || entry.type !== "message") {
+      return [];
+    }
+    return [{ entryId: entry.id, message: truncateToolResultMessage(entry.message, maxChars) }];
+  });
+
+  const rewriteResult = rewriteTranscriptEntriesInSessionManager({
+    sessionManager,
+    replacements,
+  });
+  if (rewriteResult.changed && params.sessionFile) {
+    emitSessionTranscriptUpdate(params.sessionFile);
+  }
+
+  log.info(
+    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
+      `(contextWindow=${contextWindowTokens} maxChars=${maxChars}) ` +
+      `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
+  );
+
+  return {
+    truncated: rewriteResult.changed,
+    truncatedCount: rewriteResult.rewrittenEntries,
+    reason: rewriteResult.reason,
+  };
+}
+
+export function truncateOversizedToolResultsInSessionManager(params: {
+  sessionManager: SessionManager;
+  contextWindowTokens: number;
+  sessionFile?: string;
+  sessionId?: string;
+  sessionKey?: string;
+}): { truncated: boolean; truncatedCount: number; reason?: string } {
+  try {
+    return truncateOversizedToolResultsInExistingSessionManager(params);
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    log.warn(`[tool-result-truncation] Failed to truncate: ${errMsg}`);
+    return { truncated: false, truncatedCount: 0, reason: errMsg };
+  }
+}
+
+export async function truncateOversizedToolResultsInSession(params: {
+  sessionFile: string;
+  contextWindowTokens: number;
+  sessionId?: string;
+  sessionKey?: string;
+}): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
+  const { sessionFile, contextWindowTokens } = params;
+  let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
+
+  try {
+    sessionLock = await acquireSessionWriteLock({ sessionFile });
+    const sessionManager = SessionManager.open(sessionFile);
+    return truncateOversizedToolResultsInExistingSessionManager({
+      sessionManager,
+      contextWindowTokens,
+      sessionFile,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : String(err);
     log.warn(`[tool-result-truncation] Failed to truncate: ${errMsg}`);
@@ -433,25 +549,6 @@ export function sessionLikelyHasOversizedToolResults(params: {
   messages: AgentMessage[];
   contextWindowTokens: number;
 }): boolean {
-  const { messages, contextWindowTokens } = params;
-  const maxChars = calculateMaxToolResultChars(contextWindowTokens);
-  const aggregateBudgetChars = calculateAggregateToolResultChars(contextWindowTokens);
-  let totalToolResultChars = 0;
-  let toolResultCount = 0;
-
-  for (const msg of messages) {
-    if ((msg as { role?: string }).role !== "toolResult") {
-      continue;
-    }
-    const textLength = getToolResultTextLength(msg);
-    if (textLength > maxChars) {
-      return true;
-    }
-    totalToolResultChars += textLength;
-    if (textLength > 0) {
-      toolResultCount += 1;
-    }
-  }
-
-  return toolResultCount >= 2 && totalToolResultChars > aggregateBudgetChars;
+  const estimate = estimateToolResultReductionPotential(params);
+  return estimate.oversizedCount > 0 || estimate.aggregateReducibleChars > 0;
 }

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -34,6 +34,7 @@ export const HARD_MAX_TOOL_RESULT_CHARS = DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
  * what was in the content.
  */
 const MIN_KEEP_CHARS = 2_000;
+const RECOVERY_MIN_KEEP_CHARS = 0;
 
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
@@ -43,6 +44,7 @@ type ToolResultTruncationOptions = {
 const DEFAULT_SUFFIX = (truncatedChars: number) =>
   formatContextLimitTruncationNotice(truncatedChars);
 export const MIN_TRUNCATED_TEXT_CHARS = MIN_KEEP_CHARS + DEFAULT_SUFFIX(1).length;
+const RECOVERY_MIN_TRUNCATED_TEXT_CHARS = RECOVERY_MIN_KEEP_CHARS + DEFAULT_SUFFIX(1).length;
 
 /**
  * Marker inserted between head and tail when using head+tail truncation.
@@ -247,8 +249,11 @@ export function truncateOversizedToolResultsInMessages(
   return { messages: result, truncatedCount };
 }
 
-function calculateAggregateToolResultChars(contextWindowTokens: number): number {
-  return Math.max(calculateMaxToolResultChars(contextWindowTokens), MIN_TRUNCATED_TEXT_CHARS);
+function calculateRecoveryAggregateToolResultChars(contextWindowTokens: number): number {
+  return Math.max(
+    calculateMaxToolResultChars(contextWindowTokens),
+    RECOVERY_MIN_TRUNCATED_TEXT_CHARS,
+  );
 }
 
 export type ToolResultReductionPotential = {
@@ -265,7 +270,10 @@ export type ToolResultReductionPotential = {
 function buildAggregateToolResultReplacements(params: {
   branch: Array<{ id: string; type: string; message?: AgentMessage }>;
   aggregateBudgetChars: number;
+  minKeepChars?: number;
 }): Array<{ entryId: string; message: AgentMessage }> {
+  const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
+  const minTruncatedTextChars = minKeepChars + DEFAULT_SUFFIX(1).length;
   const candidates = params.branch
     .map((entry, index) => ({ entry, index }))
     .filter(
@@ -302,17 +310,16 @@ function buildAggregateToolResultReplacements(params: {
     if (remainingReduction <= 0) {
       break;
     }
-    const reducibleChars = Math.max(0, candidate.textLength - MIN_TRUNCATED_TEXT_CHARS);
+    const reducibleChars = Math.max(0, candidate.textLength - minTruncatedTextChars);
     if (reducibleChars <= 0) {
       continue;
     }
 
     const requestedReduction = Math.min(reducibleChars, remainingReduction);
-    const targetChars = Math.max(
-      MIN_TRUNCATED_TEXT_CHARS,
-      candidate.textLength - requestedReduction,
-    );
-    const truncatedMessage = truncateToolResultMessage(candidate.message, targetChars);
+    const targetChars = Math.max(minTruncatedTextChars, candidate.textLength - requestedReduction);
+    const truncatedMessage = truncateToolResultMessage(candidate.message, targetChars, {
+      minKeepChars,
+    });
     const newLength = getToolResultTextLength(truncatedMessage);
     const actualReduction = Math.max(0, candidate.textLength - newLength);
     if (actualReduction <= 0) {
@@ -332,7 +339,7 @@ export function estimateToolResultReductionPotential(params: {
 }): ToolResultReductionPotential {
   const { messages, contextWindowTokens } = params;
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
-  const aggregateBudgetChars = calculateAggregateToolResultChars(contextWindowTokens);
+  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(contextWindowTokens);
 
   let toolResultCount = 0;
   let totalToolResultChars = 0;
@@ -355,7 +362,9 @@ export function estimateToolResultReductionPotential(params: {
       continue;
     }
     oversizedCount += 1;
-    const truncatedMessage = truncateToolResultMessage(msg, maxChars);
+    const truncatedMessage = truncateToolResultMessage(msg, maxChars, {
+      minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+    });
     individuallyTrimmedMessages[index] = truncatedMessage;
     oversizedReducibleChars += Math.max(0, textLength - getToolResultTextLength(truncatedMessage));
   }
@@ -367,6 +376,7 @@ export function estimateToolResultReductionPotential(params: {
       message,
     })),
     aggregateBudgetChars,
+    minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
   const individuallyTrimmedBranch = individuallyTrimmedMessages.map((message, index) => ({
     id: `message-${index}`,
@@ -405,7 +415,7 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
 }): { truncated: boolean; truncatedCount: number; reason?: string } {
   const { sessionManager, contextWindowTokens } = params;
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
-  const aggregateBudgetChars = calculateAggregateToolResultChars(contextWindowTokens);
+  const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(contextWindowTokens);
   const branch = sessionManager.getBranch();
 
   if (branch.length === 0) {
@@ -431,6 +441,7 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
     const replacements = buildAggregateToolResultReplacements({
       branch: branch as Array<{ id: string; type: string; message?: AgentMessage }>,
       aggregateBudgetChars,
+      minKeepChars: RECOVERY_MIN_KEEP_CHARS,
     });
     if (replacements.length === 0) {
       return {
@@ -466,7 +477,14 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
     if (!entry || entry.type !== "message") {
       return [];
     }
-    return [{ entryId: entry.id, message: truncateToolResultMessage(entry.message, maxChars) }];
+    return [
+      {
+        entryId: entry.id,
+        message: truncateToolResultMessage(entry.message, maxChars, {
+          minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+        }),
+      },
+    ];
   });
 
   const rewriteResult = rewriteTranscriptEntriesInSessionManager({

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -333,6 +333,30 @@ function buildAggregateToolResultReplacements(params: {
   return replacements;
 }
 
+function applyToolResultReplacementsToBranch(params: {
+  branch: Array<{ id: string; type: string; message?: AgentMessage }>;
+  replacements: Array<{ entryId: string; message: AgentMessage }>;
+}): Array<{ id: string; type: string; message?: AgentMessage }> {
+  if (params.replacements.length === 0) {
+    return params.branch;
+  }
+
+  const replacementsById = new Map(
+    params.replacements.map((replacement) => [replacement.entryId, replacement.message]),
+  );
+
+  return params.branch.map((entry) => {
+    if (entry.type !== "message") {
+      return entry;
+    }
+    const replacement = replacementsById.get(entry.id);
+    if (!replacement) {
+      return entry;
+    }
+    return { ...entry, message: replacement };
+  });
+}
+
 export function estimateToolResultReductionPotential(params: {
   messages: AgentMessage[];
   contextWindowTokens: number;
@@ -392,7 +416,7 @@ export function estimateToolResultReductionPotential(params: {
     const newLength = getToolResultTextLength(replacement.message);
     return sum + Math.max(0, originalLength - newLength);
   }, 0);
-  const maxReducibleChars = oversizedCount > 0 ? oversizedReducibleChars : aggregateReducibleChars;
+  const maxReducibleChars = oversizedReducibleChars + aggregateReducibleChars;
 
   return {
     maxChars,
@@ -437,42 +461,7 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
     }
   }
 
-  if (oversizedIndices.length === 0) {
-    const replacements = buildAggregateToolResultReplacements({
-      branch: branch as Array<{ id: string; type: string; message?: AgentMessage }>,
-      aggregateBudgetChars,
-      minKeepChars: RECOVERY_MIN_KEEP_CHARS,
-    });
-    if (replacements.length === 0) {
-      return {
-        truncated: false,
-        truncatedCount: 0,
-        reason: "no oversized or aggregate tool results",
-      };
-    }
-
-    const rewriteResult = rewriteTranscriptEntriesInSessionManager({
-      sessionManager,
-      replacements,
-    });
-    if (rewriteResult.changed && params.sessionFile) {
-      emitSessionTranscriptUpdate(params.sessionFile);
-    }
-
-    log.info(
-      `[tool-result-truncation] Aggregate-truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
-        `(contextWindow=${contextWindowTokens} aggregateBudgetChars=${aggregateBudgetChars}) ` +
-        `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
-    );
-
-    return {
-      truncated: rewriteResult.changed,
-      truncatedCount: rewriteResult.rewrittenEntries,
-      reason: rewriteResult.reason,
-    };
-  }
-
-  const replacements = oversizedIndices.flatMap((index) => {
+  const oversizedReplacements = oversizedIndices.flatMap((index) => {
     const entry = branch[index];
     if (!entry || entry.type !== "message") {
       return [];
@@ -487,17 +476,48 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
     ];
   });
 
+  const oversizedTrimmedBranch = applyToolResultReplacementsToBranch({
+    branch: branch as Array<{ id: string; type: string; message?: AgentMessage }>,
+    replacements: oversizedReplacements,
+  });
+  const aggregateReplacements = buildAggregateToolResultReplacements({
+    branch: oversizedTrimmedBranch,
+    aggregateBudgetChars,
+    minKeepChars: RECOVERY_MIN_KEEP_CHARS,
+  });
+  const replacements = [...oversizedReplacements];
+  const replacementIndexById = new Map(replacements.map((replacement) => [replacement.entryId, replacement]));
+  for (const replacement of aggregateReplacements) {
+    replacementIndexById.set(replacement.entryId, replacement);
+  }
+  const mergedReplacements = Array.from(replacementIndexById.values());
+
+  if (mergedReplacements.length === 0) {
+    return {
+      truncated: false,
+      truncatedCount: 0,
+      reason: "no oversized or aggregate tool results",
+    };
+  }
+
   const rewriteResult = rewriteTranscriptEntriesInSessionManager({
     sessionManager,
-    replacements,
+    replacements: mergedReplacements,
   });
   if (rewriteResult.changed && params.sessionFile) {
     emitSessionTranscriptUpdate(params.sessionFile);
   }
 
+  const truncatedKinds = [
+    oversizedReplacements.length > 0 ? "oversized" : "",
+    aggregateReplacements.length > 0 ? "aggregate" : "",
+  ]
+    .filter(Boolean)
+    .join("+");
+
   log.info(
-    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
-      `(contextWindow=${contextWindowTokens} maxChars=${maxChars}) ` +
+    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} ${truncatedKinds || "tool"} tool result(s) in session ` +
+      `(contextWindow=${contextWindowTokens} maxChars=${maxChars} aggregateBudgetChars=${aggregateBudgetChars}) ` +
       `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
   );
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -46,6 +46,18 @@ const DEFAULT_SUFFIX = (truncatedChars: number) =>
 export const MIN_TRUNCATED_TEXT_CHARS = MIN_KEEP_CHARS + DEFAULT_SUFFIX(1).length;
 const RECOVERY_MIN_TRUNCATED_TEXT_CHARS = RECOVERY_MIN_KEEP_CHARS + DEFAULT_SUFFIX(1).length;
 
+function resolveSuffixFactory(
+  suffix: ToolResultTruncationOptions["suffix"],
+): (truncatedChars: number) => string {
+  if (typeof suffix === "function") {
+    return suffix;
+  }
+  if (typeof suffix === "string") {
+    return () => suffix;
+  }
+  return DEFAULT_SUFFIX;
+}
+
 /**
  * Marker inserted between head and tail when using head+tail truncation.
  */
@@ -81,10 +93,7 @@ export function truncateToolResultText(
   maxChars: number,
   options: ToolResultTruncationOptions = {},
 ): string {
-  const suffixFactory: (truncatedChars: number) => string =
-    typeof options.suffix === "function"
-      ? options.suffix
-      : () => options.suffix ?? DEFAULT_SUFFIX(1);
+  const suffixFactory = resolveSuffixFactory(options.suffix);
   const minKeepChars = options.minKeepChars ?? MIN_KEEP_CHARS;
   if (text.length <= maxChars) {
     return text;
@@ -174,10 +183,7 @@ export function truncateToolResultMessage(
   maxChars: number,
   options: ToolResultTruncationOptions = {},
 ): AgentMessage {
-  const suffixFactory: (truncatedChars: number) => string =
-    typeof options.suffix === "function"
-      ? options.suffix
-      : () => options.suffix ?? DEFAULT_SUFFIX(1);
+  const suffixFactory = resolveSuffixFactory(options.suffix);
   const minKeepChars = options.minKeepChars ?? MIN_KEEP_CHARS;
   const content = (msg as { content?: unknown }).content;
   if (!Array.isArray(content)) {
@@ -267,11 +273,22 @@ export type ToolResultReductionPotential = {
   maxReducibleChars: number;
 };
 
+type ToolResultBranchEntry = {
+  id: string;
+  type: string;
+  message?: AgentMessage;
+};
+
+type ToolResultReplacement = {
+  entryId: string;
+  message: AgentMessage;
+};
+
 function buildAggregateToolResultReplacements(params: {
-  branch: Array<{ id: string; type: string; message?: AgentMessage }>;
+  branch: ToolResultBranchEntry[];
   aggregateBudgetChars: number;
   minKeepChars?: number;
-}): Array<{ entryId: string; message: AgentMessage }> {
+}): ToolResultReplacement[] {
   const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
   const minTruncatedTextChars = minKeepChars + DEFAULT_SUFFIX(1).length;
   const candidates = params.branch
@@ -339,30 +356,126 @@ function buildAggregateToolResultReplacements(params: {
   return replacements;
 }
 
-function applyToolResultReplacementsToBranch(params: {
-  branch: Array<{ id: string; type: string; message?: AgentMessage }>;
-  replacements: Array<{ entryId: string; message: AgentMessage }>;
-}): Array<{ id: string; type: string; message?: AgentMessage }> {
-  if (params.replacements.length === 0) {
-    return params.branch;
+function buildOversizedToolResultReplacements(params: {
+  branch: ToolResultBranchEntry[];
+  maxChars: number;
+  minKeepChars?: number;
+}): ToolResultReplacement[] {
+  const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
+  const replacements: ToolResultReplacement[] = [];
+
+  for (const entry of params.branch) {
+    if (entry.type !== "message" || !entry.message) {
+      continue;
+    }
+    const msg = entry.message;
+    if ((msg as { role?: string }).role !== "toolResult") {
+      continue;
+    }
+    if (getToolResultTextLength(msg) <= params.maxChars) {
+      continue;
+    }
+    replacements.push({
+      entryId: entry.id,
+      message: truncateToolResultMessage(msg, params.maxChars, {
+        minKeepChars,
+      }),
+    });
   }
 
-  const replacementsById = new Map(
-    params.replacements.map((replacement) => [replacement.entryId, replacement.message]),
-  );
+  return replacements;
+}
 
-  return params.branch.map((entry) => {
-    if (entry.type !== "message") {
-      return entry;
+function calculateReplacementReduction(
+  branch: ToolResultBranchEntry[],
+  replacements: ToolResultReplacement[],
+): number {
+  if (replacements.length === 0) {
+    return 0;
+  }
+  const branchById = new Map(branch.map((entry) => [entry.id, entry]));
+  let reduction = 0;
+
+  for (const replacement of replacements) {
+    const entry = branchById.get(replacement.entryId);
+    if (!entry?.message) {
+      continue;
     }
+    reduction += Math.max(
+      0,
+      getToolResultTextLength(entry.message) - getToolResultTextLength(replacement.message),
+    );
+  }
+
+  return reduction;
+}
+
+function applyToolResultReplacementsToBranch(
+  branch: ToolResultBranchEntry[],
+  replacements: ToolResultReplacement[],
+): ToolResultBranchEntry[] {
+  if (replacements.length === 0) {
+    return branch;
+  }
+  const replacementsById = new Map(
+    replacements.map((replacement) => [replacement.entryId, replacement]),
+  );
+  return branch.map((entry) => {
     const replacement = replacementsById.get(entry.id);
-    if (!replacement) {
+    if (!replacement || entry.type !== "message") {
       return entry;
     }
-    return { ...entry, message: replacement };
+    return {
+      ...entry,
+      message: replacement.message,
+    };
   });
 }
 
+function buildToolResultReplacementPlan(params: {
+  branch: ToolResultBranchEntry[];
+  maxChars: number;
+  aggregateBudgetChars: number;
+  minKeepChars?: number;
+}): {
+  replacements: ToolResultReplacement[];
+  oversizedReplacementCount: number;
+  aggregateReplacementCount: number;
+  oversizedReducibleChars: number;
+  aggregateReducibleChars: number;
+} {
+  const minKeepChars = params.minKeepChars ?? MIN_KEEP_CHARS;
+  const oversizedReplacements = buildOversizedToolResultReplacements({
+    branch: params.branch,
+    maxChars: params.maxChars,
+    minKeepChars,
+  });
+  const oversizedReducibleChars = calculateReplacementReduction(
+    params.branch,
+    oversizedReplacements,
+  );
+  const oversizedTrimmedBranch = applyToolResultReplacementsToBranch(
+    params.branch,
+    oversizedReplacements,
+  );
+  const aggregateReplacements = buildAggregateToolResultReplacements({
+    branch: oversizedTrimmedBranch,
+    aggregateBudgetChars: params.aggregateBudgetChars,
+    minKeepChars,
+  });
+  const aggregateReducibleChars = calculateReplacementReduction(
+    oversizedTrimmedBranch,
+    aggregateReplacements,
+  );
+
+  return {
+    replacements: [...oversizedReplacements, ...aggregateReplacements],
+    oversizedReplacementCount: oversizedReplacements.length,
+    aggregateReplacementCount: aggregateReplacements.length,
+    oversizedReducibleChars,
+    aggregateReducibleChars,
+  };
+}
 export function estimateToolResultReductionPotential(params: {
   messages: AgentMessage[];
   contextWindowTokens: number;
@@ -370,15 +483,15 @@ export function estimateToolResultReductionPotential(params: {
   const { messages, contextWindowTokens } = params;
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
   const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(contextWindowTokens);
+  const branch = messages.map((message, index) => ({
+    id: `message-${index}`,
+    type: "message",
+    message,
+  }));
 
   let toolResultCount = 0;
   let totalToolResultChars = 0;
-  let oversizedCount = 0;
-  let oversizedReducibleChars = 0;
-  const individuallyTrimmedMessages = messages.slice();
-
-  for (let index = 0; index < messages.length; index += 1) {
-    const msg = messages[index];
+  for (const msg of messages) {
     if ((msg as { role?: string }).role !== "toolResult") {
       continue;
     }
@@ -388,50 +501,23 @@ export function estimateToolResultReductionPotential(params: {
     }
     toolResultCount += 1;
     totalToolResultChars += textLength;
-    if (textLength <= maxChars) {
-      continue;
-    }
-    oversizedCount += 1;
-    const truncatedMessage = truncateToolResultMessage(msg, maxChars, {
-      minKeepChars: RECOVERY_MIN_KEEP_CHARS,
-    });
-    individuallyTrimmedMessages[index] = truncatedMessage;
-    oversizedReducibleChars += Math.max(0, textLength - getToolResultTextLength(truncatedMessage));
   }
-
-  const aggregateReplacements = buildAggregateToolResultReplacements({
-    branch: individuallyTrimmedMessages.map((message, index) => ({
-      id: `message-${index}`,
-      type: "message",
-      message,
-    })),
+  const plan = buildToolResultReplacementPlan({
+    branch,
+    maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
-  const individuallyTrimmedBranch = individuallyTrimmedMessages.map((message, index) => ({
-    id: `message-${index}`,
-    type: "message",
-    message,
-  }));
-  const aggregateReducibleChars = aggregateReplacements.reduce((sum, replacement) => {
-    const match = individuallyTrimmedBranch.find((entry) => entry.id === replacement.entryId);
-    const originalLength =
-      match && match.message
-        ? getToolResultTextLength(match.message)
-        : getToolResultTextLength(replacement.message);
-    const newLength = getToolResultTextLength(replacement.message);
-    return sum + Math.max(0, originalLength - newLength);
-  }, 0);
-  const maxReducibleChars = oversizedReducibleChars + aggregateReducibleChars;
+  const maxReducibleChars = plan.oversizedReducibleChars + plan.aggregateReducibleChars;
 
   return {
     maxChars,
     aggregateBudgetChars,
     toolResultCount,
     totalToolResultChars,
-    oversizedCount,
-    oversizedReducibleChars,
-    aggregateReducibleChars,
+    oversizedCount: plan.oversizedReplacementCount,
+    oversizedReducibleChars: plan.oversizedReducibleChars,
+    aggregateReducibleChars: plan.aggregateReducibleChars,
     maxReducibleChars,
   };
 }
@@ -446,84 +532,37 @@ function truncateOversizedToolResultsInExistingSessionManager(params: {
   const { sessionManager, contextWindowTokens } = params;
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
   const aggregateBudgetChars = calculateRecoveryAggregateToolResultChars(contextWindowTokens);
-  const branch = sessionManager.getBranch();
+  const branch = sessionManager.getBranch() as ToolResultBranchEntry[];
 
   if (branch.length === 0) {
     return { truncated: false, truncatedCount: 0, reason: "empty session" };
   }
 
-  const oversizedIndices: number[] = [];
-  for (let i = 0; i < branch.length; i += 1) {
-    const entry = branch[i];
-    if (entry.type !== "message") {
-      continue;
-    }
-    const msg = entry.message;
-    if ((msg as { role?: string }).role !== "toolResult") {
-      continue;
-    }
-    if (getToolResultTextLength(msg) > maxChars) {
-      oversizedIndices.push(i);
-    }
-  }
-
-  const oversizedReplacements = oversizedIndices.flatMap((index) => {
-    const entry = branch[index];
-    if (!entry || entry.type !== "message") {
-      return [];
-    }
-    return [
-      {
-        entryId: entry.id,
-        message: truncateToolResultMessage(entry.message, maxChars, {
-          minKeepChars: RECOVERY_MIN_KEEP_CHARS,
-        }),
-      },
-    ];
-  });
-
-  const oversizedTrimmedBranch = applyToolResultReplacementsToBranch({
-    branch: branch as Array<{ id: string; type: string; message?: AgentMessage }>,
-    replacements: oversizedReplacements,
-  });
-  const aggregateReplacements = buildAggregateToolResultReplacements({
-    branch: oversizedTrimmedBranch,
+  const plan = buildToolResultReplacementPlan({
+    branch,
+    maxChars,
     aggregateBudgetChars,
     minKeepChars: RECOVERY_MIN_KEEP_CHARS,
   });
-  const replacements = [...oversizedReplacements];
-  const replacementIndexById = new Map(replacements.map((replacement) => [replacement.entryId, replacement]));
-  for (const replacement of aggregateReplacements) {
-    replacementIndexById.set(replacement.entryId, replacement);
-  }
-  const mergedReplacements = Array.from(replacementIndexById.values());
-
-  if (mergedReplacements.length === 0) {
+  if (plan.replacements.length === 0) {
     return {
       truncated: false,
       truncatedCount: 0,
       reason: "no oversized or aggregate tool results",
     };
   }
-
   const rewriteResult = rewriteTranscriptEntriesInSessionManager({
     sessionManager,
-    replacements: mergedReplacements,
+    replacements: plan.replacements,
   });
   if (rewriteResult.changed && params.sessionFile) {
     emitSessionTranscriptUpdate(params.sessionFile);
   }
 
-  const truncatedKinds = [
-    oversizedReplacements.length > 0 ? "oversized" : "",
-    aggregateReplacements.length > 0 ? "aggregate" : "",
-  ]
-    .filter(Boolean)
-    .join("+");
-
   log.info(
-    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} ${truncatedKinds || "tool"} tool result(s) in session ` +
-      `(contextWindow=${contextWindowTokens} maxChars=${maxChars} aggregateBudgetChars=${aggregateBudgetChars}) ` +
+    `[tool-result-truncation] Truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
+      `(contextWindow=${contextWindowTokens} maxChars=${maxChars} aggregateBudgetChars=${aggregateBudgetChars} ` +
+      `oversized=${plan.oversizedReplacementCount} aggregate=${plan.aggregateReplacementCount}) ` +
       `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
   );
 

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -3,6 +3,7 @@ import type { TextContent } from "@mariozechner/pi-ai";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import { acquireSessionWriteLock } from "../session-write-lock.js";
+import { formatContextLimitTruncationNotice } from "./tool-result-context-guard.js";
 import { log } from "./logger.js";
 import { rewriteTranscriptEntriesInSessionManager } from "./transcript-rewrite.js";
 
@@ -34,19 +35,14 @@ export const HARD_MAX_TOOL_RESULT_CHARS = DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS;
  */
 const MIN_KEEP_CHARS = 2_000;
 
-/**
- * Suffix appended to truncated tool results.
- */
-const TRUNCATION_SUFFIX =
-  "\n\n⚠️ [Content truncated — original was too large for the model's context window. " +
-  "The content above is a partial view. If you need more, request specific sections or use " +
-  "offset/limit parameters to read smaller chunks.]";
-const MIN_TRUNCATED_TEXT_CHARS = MIN_KEEP_CHARS + TRUNCATION_SUFFIX.length;
-
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
   minKeepChars?: number;
 };
+
+const DEFAULT_SUFFIX = (truncatedChars: number) =>
+  formatContextLimitTruncationNotice(truncatedChars);
+const MIN_TRUNCATED_TEXT_CHARS = MIN_KEEP_CHARS + DEFAULT_SUFFIX(1).length;
 
 /**
  * Marker inserted between head and tail when using head+tail truncation.
@@ -86,7 +82,7 @@ export function truncateToolResultText(
   const suffixFactory: (truncatedChars: number) => string =
     typeof options.suffix === "function"
       ? options.suffix
-      : () => (options.suffix ?? TRUNCATION_SUFFIX);
+      : () => (options.suffix ?? DEFAULT_SUFFIX(1));
   const minKeepChars = options.minKeepChars ?? MIN_KEEP_CHARS;
   if (text.length <= maxChars) {
     return text;
@@ -179,7 +175,7 @@ export function truncateToolResultMessage(
   const suffixFactory: (truncatedChars: number) => string =
     typeof options.suffix === "function"
       ? options.suffix
-      : () => (options.suffix ?? TRUNCATION_SUFFIX);
+      : () => (options.suffix ?? DEFAULT_SUFFIX(1));
   const minKeepChars = options.minKeepChars ?? MIN_KEEP_CHARS;
   const content = (msg as { content?: unknown }).content;
   if (!Array.isArray(content)) {

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -41,6 +41,7 @@ const TRUNCATION_SUFFIX =
   "\n\n⚠️ [Content truncated — original was too large for the model's context window. " +
   "The content above is a partial view. If you need more, request specific sections or use " +
   "offset/limit parameters to read smaller chunks.]";
+const MIN_TRUNCATED_TEXT_CHARS = MIN_KEEP_CHARS + TRUNCATION_SUFFIX.length;
 
 type ToolResultTruncationOptions = {
   suffix?: string | ((truncatedChars: number) => string);
@@ -250,6 +251,72 @@ export function truncateOversizedToolResultsInMessages(
   return { messages: result, truncatedCount };
 }
 
+function calculateAggregateToolResultChars(contextWindowTokens: number): number {
+  return Math.max(calculateMaxToolResultChars(contextWindowTokens), MIN_TRUNCATED_TEXT_CHARS);
+}
+
+function buildAggregateToolResultReplacements(params: {
+  branch: Array<{ id: string; type: string; message?: AgentMessage }>;
+  aggregateBudgetChars: number;
+}): Array<{ entryId: string; message: AgentMessage }> {
+  const candidates = params.branch
+    .map((entry, index) => ({ entry, index }))
+    .filter(
+      (item): item is {
+        entry: { id: string; type: string; message: AgentMessage };
+        index: number;
+      } =>
+        item.entry.type === "message" &&
+        Boolean(item.entry.message) &&
+        (item.entry.message as { role?: string }).role === "toolResult",
+    )
+    .map((item) => ({
+      entryId: item.entry.id,
+      message: item.entry.message,
+      textLength: getToolResultTextLength(item.entry.message),
+    }))
+    .filter((item) => item.textLength > 0);
+
+  if (candidates.length < 2) {
+    return [];
+  }
+
+  const totalChars = candidates.reduce((sum, item) => sum + item.textLength, 0);
+  if (totalChars <= params.aggregateBudgetChars) {
+    return [];
+  }
+
+  let remainingReduction = totalChars - params.aggregateBudgetChars;
+  const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
+
+  for (const candidate of candidates.toSorted((a, b) => b.textLength - a.textLength)) {
+    if (remainingReduction <= 0) {
+      break;
+    }
+    const reducibleChars = Math.max(0, candidate.textLength - MIN_TRUNCATED_TEXT_CHARS);
+    if (reducibleChars <= 0) {
+      continue;
+    }
+
+    const requestedReduction = Math.min(reducibleChars, remainingReduction);
+    const targetChars = Math.max(
+      MIN_TRUNCATED_TEXT_CHARS,
+      candidate.textLength - requestedReduction,
+    );
+    const truncatedMessage = truncateToolResultMessage(candidate.message, targetChars);
+    const newLength = getToolResultTextLength(truncatedMessage);
+    const actualReduction = Math.max(0, candidate.textLength - newLength);
+    if (actualReduction <= 0) {
+      continue;
+    }
+
+    replacements.push({ entryId: candidate.entryId, message: truncatedMessage });
+    remainingReduction -= actualReduction;
+  }
+
+  return replacements;
+}
+
 export async function truncateOversizedToolResultsInSession(params: {
   sessionFile: string;
   contextWindowTokens: number;
@@ -258,6 +325,7 @@ export async function truncateOversizedToolResultsInSession(params: {
 }): Promise<{ truncated: boolean; truncatedCount: number; reason?: string }> {
   const { sessionFile, contextWindowTokens } = params;
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+  const aggregateBudgetChars = calculateAggregateToolResultChars(contextWindowTokens);
   let sessionLock: Awaited<ReturnType<typeof acquireSessionWriteLock>> | undefined;
 
   try {
@@ -285,7 +353,37 @@ export async function truncateOversizedToolResultsInSession(params: {
     }
 
     if (oversizedIndices.length === 0) {
-      return { truncated: false, truncatedCount: 0, reason: "no oversized tool results" };
+      const replacements = buildAggregateToolResultReplacements({
+        branch: branch as Array<{ id: string; type: string; message?: AgentMessage }>,
+        aggregateBudgetChars,
+      });
+      if (replacements.length === 0) {
+        return {
+          truncated: false,
+          truncatedCount: 0,
+          reason: "no oversized or aggregate tool results",
+        };
+      }
+
+      const rewriteResult = rewriteTranscriptEntriesInSessionManager({
+        sessionManager,
+        replacements,
+      });
+      if (rewriteResult.changed) {
+        emitSessionTranscriptUpdate(sessionFile);
+      }
+
+      log.info(
+        `[tool-result-truncation] Aggregate-truncated ${rewriteResult.rewrittenEntries} tool result(s) in session ` +
+          `(contextWindow=${contextWindowTokens} aggregateBudgetChars=${aggregateBudgetChars}) ` +
+          `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
+      );
+
+      return {
+        truncated: rewriteResult.changed,
+        truncatedCount: rewriteResult.rewrittenEntries,
+        reason: rewriteResult.reason,
+      };
     }
 
     const replacements = oversizedIndices.flatMap((index) => {
@@ -341,15 +439,23 @@ export function sessionLikelyHasOversizedToolResults(params: {
 }): boolean {
   const { messages, contextWindowTokens } = params;
   const maxChars = calculateMaxToolResultChars(contextWindowTokens);
+  const aggregateBudgetChars = calculateAggregateToolResultChars(contextWindowTokens);
+  let totalToolResultChars = 0;
+  let toolResultCount = 0;
 
   for (const msg of messages) {
     if ((msg as { role?: string }).role !== "toolResult") {
       continue;
     }
-    if (getToolResultTextLength(msg) > maxChars) {
+    const textLength = getToolResultTextLength(msg);
+    if (textLength > maxChars) {
       return true;
+    }
+    totalToolResultChars += textLength;
+    if (textLength > 0) {
+      toolResultCount += 1;
     }
   }
 
-  return false;
+  return toolResultCount >= 2 && totalToolResultChars > aggregateBudgetChars;
 }

--- a/src/agents/pi-embedded-runner/tool-result-truncation.ts
+++ b/src/agents/pi-embedded-runner/tool-result-truncation.ts
@@ -288,6 +288,7 @@ function buildAggregateToolResultReplacements(params: {
         (item.entry.message as { role?: string }).role === "toolResult",
     )
     .map((item) => ({
+      index: item.index,
       entryId: item.entry.id,
       message: item.entry.message,
       textLength: getToolResultTextLength(item.entry.message),
@@ -306,7 +307,12 @@ function buildAggregateToolResultReplacements(params: {
   let remainingReduction = totalChars - params.aggregateBudgetChars;
   const replacements: Array<{ entryId: string; message: AgentMessage }> = [];
 
-  for (const candidate of candidates.toSorted((a, b) => b.textLength - a.textLength)) {
+  for (const candidate of candidates.toSorted((a, b) => {
+    if (a.index !== b.index) {
+      return b.index - a.index;
+    }
+    return b.textLength - a.textLength;
+  })) {
     if (remainingReduction <= 0) {
       break;
     }

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -158,6 +158,17 @@ describe("installSessionToolResultGuard", () => {
     expectPersistedRoles(sm, ["assistant", "toolResult"]);
   });
 
+  it("applies pi-style count-based truncation wording when persisting oversized tool results", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    appendToolResultText(sm, "x".repeat(80_000));
+
+    const text = getToolResultText(getPersistedMessages(sm));
+    expect(text).toContain("more characters truncated");
+    expect(text).toMatch(/\[\.\.\. \d+ more characters truncated\]$/);
+  });
+
   it("backfills blank toolResult names from pending tool calls", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -5,6 +5,7 @@ import type {
   PluginHookBeforeMessageWriteResult,
 } from "../plugins/types.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { formatContextLimitTruncationNotice } from "./pi-embedded-runner/tool-result-context-guard.js";
 import {
   DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
   truncateToolResultMessage,
@@ -12,10 +13,6 @@ import {
 import { createPendingToolCallState } from "./session-tool-result-state.js";
 import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
-
-const GUARD_TRUNCATION_SUFFIX =
-  "\n\n⚠️ [Content truncated during persistence — original exceeded size limit. " +
-  "Use offset/limit parameters or request specific sections for large content.]";
 const RAW_APPEND_MESSAGE = Symbol("openclaw.session.rawAppendMessage");
 
 type SessionManagerWithRawAppend = SessionManager & {
@@ -32,7 +29,7 @@ function capToolResultSize(msg: AgentMessage): AgentMessage {
     return msg;
   }
   return truncateToolResultMessage(msg, DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS, {
-    suffix: GUARD_TRUNCATION_SUFFIX,
+    suffix: (truncatedChars) => formatContextLimitTruncationNotice(truncatedChars),
     minKeepChars: 2_000,
   });
 }

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -102,7 +102,7 @@ export function buildSubagentSystemPrompt(params: {
     "3. **Don't initiate** - No heartbeats, no proactive actions, no side quests",
     "4. **Be ephemeral** - You may be terminated after task completion. That's fine.",
     "5. **Trust push-based completion** - Descendant results are auto-announced back to you; do not busy-poll for status.",
-    "6. **Recover from truncated tool output** - If you see a notice like `[..., N more characters truncated]`, assume prior output was reduced. Re-read only what you need using smaller chunks (`read` with offset/limit, or targeted `rg`/`head`/`tail`) instead of full-file `cat`.",
+    "6. **Recover from truncated tool output** - If you see a notice like `[... N more characters truncated]`, assume prior output was reduced. Re-read only what you need using smaller chunks (`read` with offset/limit, or targeted `rg`/`head`/`tail`) instead of full-file `cat`.",
     "",
     "## Output Format",
     "When complete, your final response should include:",

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -102,7 +102,7 @@ export function buildSubagentSystemPrompt(params: {
     "3. **Don't initiate** - No heartbeats, no proactive actions, no side quests",
     "4. **Be ephemeral** - You may be terminated after task completion. That's fine.",
     "5. **Trust push-based completion** - Descendant results are auto-announced back to you; do not busy-poll for status.",
-    "6. **Recover from compacted/truncated tool output** - If you see `[compacted: tool output removed to free context]` or `[truncated: output exceeded context limit]`, assume prior output was reduced. Re-read only what you need using smaller chunks (`read` with offset/limit, or targeted `rg`/`head`/`tail`) instead of full-file `cat`.",
+    "6. **Recover from truncated tool output** - If you see a notice like `[..., N more characters truncated]`, assume prior output was reduced. Re-read only what you need using smaller chunks (`read` with offset/limit, or targeted `rg`/`head`/`tail`) instead of full-file `cat`.",
     "",
     "## Output Format",
     "When complete, your final response should include:",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -993,7 +993,7 @@ describe("buildSubagentSystemPrompt", () => {
     expect(prompt).toContain("Avoid polling loops");
     expect(prompt).toContain("spawned by the main agent");
     expect(prompt).toContain("reported to the main agent");
-    expect(prompt).toContain("[..., N more characters truncated]");
+    expect(prompt).toContain("[... N more characters truncated]");
     expect(prompt).toContain("offset/limit");
     expect(prompt).toContain("instead of full-file `cat`");
   });

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -993,8 +993,7 @@ describe("buildSubagentSystemPrompt", () => {
     expect(prompt).toContain("Avoid polling loops");
     expect(prompt).toContain("spawned by the main agent");
     expect(prompt).toContain("reported to the main agent");
-    expect(prompt).toContain("[compacted: tool output removed to free context]");
-    expect(prompt).toContain("[truncated: output exceeded context limit]");
+    expect(prompt).toContain("[..., N more characters truncated]");
     expect(prompt).toContain("offset/limit");
     expect(prompt).toContain("instead of full-file `cat`");
   });


### PR DESCRIPTION
## Summary
- align OpenClaw’s tool-result handling more closely with PI’s model: truncate tool results once, preserve stored history, and stop rewriting older tool results in live context
- switch live and persisted truncation wording to PI-style `[... N more characters truncated]`
- restore a reserve-based precheck before provider submission and make it cause-aware: when the prompt estimate is too large, choose the cheapest local recovery path first
- keep a readable persisted-session repair fallback after compaction failure, including aggregate medium tool-result tails, without collapsing tool results to placeholder-only markers
- keep a central ingress backstop for tool results because OpenClaw still needs uniform protection across tools and integration surfaces

## Original behavior: OpenClaw before this PR
```text
Tool executes
  |
  v
Raw tool result is stored in session/history
  |
  v
Next model call starts
  |
  v
transformContext guard runs
  |
  +--> If one tool result is too large:
  |       truncate that result for live context
  |
  +--> If total context is still too large:
  |       rewrite older tool results in-place
  |       trim them again under aggregate pressure
  |       and sometimes replace them with compaction markers
  |
  +--> If that still is not enough:
          trigger overflow / session compaction
          compact older history
          retry prompt
```

## PI behavior (For reference)
```text
Tool executes
  |
  v
Tool applies its own output limit
  |
  v
Bounded tool result is stored in session/history
  |
  v
Next model call starts
  |
  v
Build prompt from session history
  |
  +--> If prompt estimate fits within contextWindow - reserveTokens:
  |       send prompt unchanged
  |
  +--> If prompt estimate exceeds contextWindow - reserveTokens:
          compact older history into a summary
          keep recent messages and tool results together
          rebuild prompt from compacted history
          retry prompt
```

## New behavior: OpenClaw after this PR
```text
Tool executes
  |
  v
Central guard applies one-time truncation if needed
  (so every tool result has one uniform ingress cap before it reaches history)
  |
  v
Bounded tool result is stored in session/history
  |
  v
Next model call starts
  |
  v
Build prompt from session history
  |
  v
Reserve-based precheck estimates assembled prompt
against contextTokenBudget - reserveTokens
  |
  +--> If estimate fits:
  |       send prompt unchanged
  |
  +--> If estimate exceeds budget:
          classify likely pressure source
          |
          +--> compact_only:
          |       trigger existing session compaction early
          |       compact older history
          |       rebuild prompt from compacted session
          |       retry
          |
          +--> truncate_tool_results_only:
          |       readably truncate persisted recent tool-result tails
          |       skip provider call for this attempt
          |       retry with updated session history
          |
          +--> compact_then_truncate:
                  trigger existing session compaction early
                  compact older history
                  then readably truncate persisted recent tool-result tails
                  rebuild prompt from updated session history
                  retry
  |
  v
If a later provider attempt still reports overflow:
existing overflow handling remains the final fallback path
  |
  +--> try explicit overflow compaction
  +--> if still needed, try readable persisted-session tool-result truncation
  +--> otherwise return context overflow error
```

## Aggregate tool-result fallback
Aggregate overflow means no single tool result is above the per-result limit, but the recent tool-result tail is still too large as a group.

Example:
- tool result A is 18k chars
- tool result B is 17k chars
- tool result C is 16k chars
- each one is individually valid, so the single-result guard leaves them alone
- if that recent tail still explains the overflow, the new precheck can truncate it early without hitting the provider
- if the estimate is mixed, OpenClaw compacts older history first and then truncates the recent tool-result tail before retry
- if a later provider attempt still overflows, the existing overflow path remains as the final safety net

Important behavior:
- this is readable truncation, not placeholder replacement
- each rewritten tool result keeps real content plus the truncation suffix
- mixed tails are handled in one persisted-session rewrite pass: if one tool result is individually oversized and the remaining medium tail is still over budget, OpenClaw truncates the oversized entry first and then still applies aggregate trimming to the remaining medium tail
- the old live `[compacted: ...]` style behavior is not reintroduced
- normal one-time truncation still keeps a readable floor, but persisted-session recovery truncation can now shrink all the way down to suffix-only when needed

## How this differs from PI
- PI mostly relies on tool-local output limits, while OpenClaw still keeps a central ingress backstop for tool results
- the precheck is now PI-like in shape, but it still plugs into OpenClaw’s existing context engine and overflow handling rather than replacing that stack wholesale
- OpenClaw also keeps a readable persisted-session repair fallback after compaction failure; PI does not appear to have an equivalent session rewrite path
- this PR removes the OpenClaw-only live historical rewriting path while keeping recovery paths readable and bounded

## Why not switch fully to PI in this PR
- replacing OpenClaw’s full overflow/compaction behavior with PI’s exact implementation would still be a much larger behavioral change than this PR’s truncation and precheck cleanup
- that would touch more runtime boundaries at once and make it harder to isolate regressions if context handling changes in production
- this PR takes the lower-risk step: remove the custom live rewrite layer we do not want, restore a PI-like reserve-based precheck, add cause-aware local routing, keep the central ingress safety backstop, and preserve a readable session repair fallback where OpenClaw still needs one

## Verification
- `pnpm exec vitest run src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts src/agents/pi-embedded-runner/tool-result-truncation.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts --config vitest.config.ts --reporter verbose`
- `pnpm exec oxlint src/agents/pi-embedded-runner/run/preemptive-compaction.ts src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts src/agents/pi-embedded-runner/tool-result-truncation.ts src/agents/pi-embedded-runner/tool-result-truncation.test.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/types.ts src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`

## Notes
- the normal commit hook previously hit unrelated pre-existing repo type errors in `src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts` and `src/cli/update-cli/update-command.ts`; this PR’s code changes were validated with the focused commands above

