### PR TITLE
fix: forward message:received hook notices

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2407,6 +2407,45 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
   });
 
+  it("waits for internal message:received notices before resolving the dispatch", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      SessionKey: "agent:main:main",
+      CommandBody: "/help",
+    });
+    let markHookStarted: (() => void) | undefined;
+    const hookStarted = new Promise<void>((resolve) => {
+      markHookStarted = resolve;
+    });
+    let releaseHook: (() => void) | undefined;
+    const hookReleased = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    internalHookMocks.triggerInternalHook.mockImplementationOnce(async (eventUnknown: unknown) => {
+      const event = eventUnknown as { messages: string[] };
+      event.messages.push("  hook notice  ");
+      markHookStarted?.();
+      await hookReleased;
+    });
+    const replyResolver = vi.fn(async () => ({ text: "hi" }) satisfies ReplyPayload);
+
+    const pendingDispatch = dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    await hookStarted;
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+
+    releaseHook?.();
+    await pendingDispatch;
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith({ text: "  hook notice  " });
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+  });
+
   it("skips internal message:received hook when session key is unavailable", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2385,6 +2385,28 @@ describe("dispatchReplyFromConfig", () => {
     expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
+  it("forwards internal message:received hook messages as additive notices", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      SessionKey: "agent:main:main",
+      CommandBody: "/help",
+    });
+    internalHookMocks.triggerInternalHook.mockImplementationOnce(async (eventUnknown: unknown) => {
+      const event = eventUnknown as { messages: string[] };
+      event.messages.push("hook notice", "   ");
+    });
+
+    const replyResolver = async () => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith({ text: "hook notice" });
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+  });
+
   it("skips internal message:received hook when session key is unavailable", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -490,18 +490,21 @@ export async function dispatchReplyFromConfig(params: {
       ...toInternalMessageReceivedContext(hookContext),
       timestamp,
     });
-    fireAndForgetHook(
-      (async () => {
-        await triggerInternalHook(internalHookEvent);
-        for (const message of internalHookEvent.messages) {
-          if (typeof message !== "string" || !message.trim()) {
-            continue;
-          }
-          await sendBindingNotice({ text: message }, "additive");
+    try {
+      await triggerInternalHook(internalHookEvent);
+      for (const message of internalHookEvent.messages) {
+        const trimmedMessage = typeof message === "string" ? message.trim() : "";
+        if (!trimmedMessage) {
+          continue;
         }
-      })(),
-      "dispatch-from-config: message_received internal hook failed",
-    );
+        // Preserve intentional hook formatting; trim only guards blank notices.
+        await sendBindingNotice({ text: message }, "additive");
+      }
+    } catch (err) {
+      logVerbose(
+        `dispatch-from-config: message_received internal hook failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   markProcessing();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -486,13 +486,20 @@ export async function dispatchReplyFromConfig(params: {
 
   // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
   if (sessionKey) {
+    const internalHookEvent = createInternalHookEvent("message", "received", sessionKey, {
+      ...toInternalMessageReceivedContext(hookContext),
+      timestamp,
+    });
     fireAndForgetHook(
-      triggerInternalHook(
-        createInternalHookEvent("message", "received", sessionKey, {
-          ...toInternalMessageReceivedContext(hookContext),
-          timestamp,
-        }),
-      ),
+      (async () => {
+        await triggerInternalHook(internalHookEvent);
+        for (const message of internalHookEvent.messages) {
+          if (typeof message !== "string" || !message.trim()) {
+            continue;
+          }
+          await sendBindingNotice({ text: message }, "additive");
+        }
+      })(),
       "dispatch-from-config: message_received internal hook failed",
     );
   }


### PR DESCRIPTION
Fixes #61432

## Summary
- run `message:received` internal hooks inside the existing async dispatch wrapper
- forward any non-empty `event.messages` entries through the same additive notice path used for binding notices
- add a regression test covering `event.messages.push()` on `message:received`

## Root cause
`dispatchReplyFromConfig()` created and triggered the internal hook event, but never consumed `event.messages` afterward, so pushes were silently dropped.

## Verification
- targeted Vitest run against `src/auto-reply/reply/dispatch-from-config.test.ts` passed using a temporary isolated config wrapper because the repo's shared non-isolated runner is broken in this checkout
