### PR TITLE
fix: stop implicit isolated cron delivery from mirroring to main

### DIFF
--- a/src/cron/isolated-agent.delivery-awareness.test.ts
+++ b/src/cron/isolated-agent.delivery-awareness.test.ts
@@ -104,4 +104,35 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
       expect(peekSystemEvents("global")).toEqual(["global cron digest"]);
     });
   });
+
+  it("does not queue main-session awareness for implicit last-target delivery", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeDefaultAgentSessionStoreEntries({
+        "agent:main:main": {
+          sessionId: "main-session",
+          updatedAt: Date.now(),
+          lastProvider: "telegram",
+          lastChannel: "telegram",
+          lastTo: "123",
+        },
+      });
+      const deps = createCliDeps();
+      mockAgentPayloads([{ text: "implicit cron digest" }]);
+
+      const result = await runAnnounceTurn({
+        home,
+        storePath,
+        sessionKey: "cron:job-1",
+        deps,
+        delivery: {
+          mode: "announce",
+          channel: "last",
+        },
+      });
+
+      expect(result.status).toBe("ok");
+      expect(result.delivered).toBe(true);
+      expect(peekSystemEvents("agent:main:main")).toEqual([]);
+    });
+  });
 });

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -322,6 +322,24 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
+  it("skips main-session awareness for isolated cron jobs with a pinned channel but implicit recipient", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({
+      synthesizedText: "Pinned-channel implicit delivery should stay isolated.",
+      deliveryConfig: { mode: "announce", channel: "telegram" },
+      resolvedDeliveryMode: "implicit",
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryAttempted).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
   it("keeps the cron run successful when awareness queueing throws after delivery", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -113,8 +113,13 @@ function makeBaseParams(overrides: {
   runSessionId?: string;
   sessionTarget?: string;
   deliveryBestEffort?: boolean;
+  deliveryConfig?: { mode: "announce"; channel?: "last" | "telegram"; to?: string };
+  resolvedDeliveryMode?: "explicit" | "implicit";
 }) {
-  const resolvedDelivery = makeResolvedDelivery();
+  const resolvedDelivery = {
+    ...makeResolvedDelivery(),
+    mode: overrides.resolvedDeliveryMode ?? "explicit",
+  } satisfies Extract<DeliveryTargetResolution, { ok: true }>;
   return {
     cfg: {} as never,
     cfgWithAgentDefaults: {} as never,
@@ -125,6 +130,7 @@ function makeBaseParams(overrides: {
       sessionTarget: overrides.sessionTarget ?? "isolated",
       deleteAfterRun: false,
       payload: { kind: "agentTurn", message: "hello" },
+      ...(overrides.deliveryConfig ? { delivery: overrides.deliveryConfig } : {}),
     } as never,
     agentId: "main",
     agentSessionKey: "agent:main",
@@ -278,11 +284,14 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     ).toBe(false);
   });
 
-  it("queues main-session awareness for isolated cron jobs after delivery", async () => {
+  it("queues main-session awareness for isolated cron jobs with explicit delivery targets", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
 
-    const params = makeBaseParams({ synthesizedText: "Morning briefing complete." });
+    const params = makeBaseParams({
+      synthesizedText: "Morning briefing complete.",
+      deliveryConfig: { mode: "announce", channel: "telegram", to: "123456" },
+    });
     const state = await dispatchCronDelivery(params);
 
     expect(state.result).toBeUndefined();
@@ -293,6 +302,24 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       sessionKey: "agent:main:main",
       contextKey: "cron-direct-delivery:v1:run-123:telegram::123456:",
     });
+  });
+
+  it("skips main-session awareness for isolated cron jobs using implicit last-target delivery", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({
+      synthesizedText: "Implicit delivery should stay isolated.",
+      deliveryConfig: { mode: "announce", channel: "last" },
+      resolvedDeliveryMode: "implicit",
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryAttempted).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
   });
 
   it("keeps the cron run successful when awareness queueing throws after delivery", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -234,35 +234,8 @@ function buildDirectCronDeliveryIdempotencyKey(params: {
   return `cron-direct-delivery:v1:${params.runSessionId}:${params.delivery.channel}:${accountId}:${normalizedTo}:${threadId}`;
 }
 
-function hasExplicitCronAwarenessTarget(
-  job: CronJob,
-  delivery: SuccessfulDeliveryTarget,
-): boolean {
-  if (delivery.mode === "explicit") {
-    return true;
-  }
-  const configuredDelivery = job.delivery;
-  if (
-    !configuredDelivery ||
-    configuredDelivery.mode === "none" ||
-    configuredDelivery.mode === "webhook"
-  ) {
-    return false;
-  }
-  const configuredChannel =
-    typeof configuredDelivery.channel === "string"
-      ? configuredDelivery.channel.trim().toLowerCase()
-      : undefined;
-  if (configuredChannel && configuredChannel !== "last") {
-    return true;
-  }
-  if (typeof configuredDelivery.to === "string" && configuredDelivery.to.trim()) {
-    return true;
-  }
-  if (typeof configuredDelivery.accountId === "string" && configuredDelivery.accountId.trim()) {
-    return true;
-  }
-  return configuredDelivery.threadId != null && String(configuredDelivery.threadId).trim() !== "";
+function hasExplicitCronAwarenessTarget(delivery: SuccessfulDeliveryTarget): boolean {
+  return delivery.mode === "explicit";
 }
 
 function shouldQueueCronAwareness(
@@ -276,7 +249,7 @@ function shouldQueueCronAwareness(
   return (
     job.sessionTarget === "isolated" &&
     !deliveryBestEffort &&
-    hasExplicitCronAwarenessTarget(job, delivery)
+    hasExplicitCronAwarenessTarget(delivery)
   );
 }
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -234,10 +234,50 @@ function buildDirectCronDeliveryIdempotencyKey(params: {
   return `cron-direct-delivery:v1:${params.runSessionId}:${params.delivery.channel}:${accountId}:${normalizedTo}:${threadId}`;
 }
 
-function shouldQueueCronAwareness(job: CronJob, deliveryBestEffort: boolean): boolean {
-  // Keep issue #52136 scoped to isolated runs. Session-bound cron jobs keep
-  // their existing behavior, and best-effort sends may only partially deliver.
-  return job.sessionTarget === "isolated" && !deliveryBestEffort;
+function hasExplicitCronAwarenessTarget(
+  job: CronJob,
+  delivery: SuccessfulDeliveryTarget,
+): boolean {
+  if (delivery.mode === "explicit") {
+    return true;
+  }
+  const configuredDelivery = job.delivery;
+  if (
+    !configuredDelivery ||
+    configuredDelivery.mode === "none" ||
+    configuredDelivery.mode === "webhook"
+  ) {
+    return false;
+  }
+  const configuredChannel =
+    typeof configuredDelivery.channel === "string"
+      ? configuredDelivery.channel.trim().toLowerCase()
+      : undefined;
+  if (configuredChannel && configuredChannel !== "last") {
+    return true;
+  }
+  if (typeof configuredDelivery.to === "string" && configuredDelivery.to.trim()) {
+    return true;
+  }
+  if (typeof configuredDelivery.accountId === "string" && configuredDelivery.accountId.trim()) {
+    return true;
+  }
+  return configuredDelivery.threadId != null && String(configuredDelivery.threadId).trim() !== "";
+}
+
+function shouldQueueCronAwareness(
+  job: CronJob,
+  delivery: SuccessfulDeliveryTarget,
+  deliveryBestEffort: boolean,
+): boolean {
+  // Keep issue #52136 scoped to isolated runs with an explicit delivery
+  // target. Default isolated announce delivery should not mirror text back
+  // into the main session, or isolated jobs silently accumulate there.
+  return (
+    job.sessionTarget === "isolated" &&
+    !deliveryBestEffort &&
+    hasExplicitCronAwarenessTarget(job, delivery)
+  );
 }
 
 function resolveCronAwarenessMainSessionKey(params: {
@@ -526,7 +566,7 @@ export async function dispatchCronDelivery(
       // Intentionally leave partial success uncached: replay may duplicate the
       // successful subset, but caching it here would permanently drop the
       // failed payloads by converting the replay into delivered=true.
-      if (delivered && shouldQueueCronAwareness(params.job, params.deliveryBestEffort)) {
+      if (delivered && shouldQueueCronAwareness(params.job, delivery, params.deliveryBestEffort)) {
         await queueCronAwarenessSystemEvent({
           cfg: params.cfgWithAgentDefaults,
           jobId: params.job.id,


### PR DESCRIPTION
Fixes #61426

## Summary
- only queue main-session cron awareness for isolated runs when the delivery target is explicit
- keep default implicit `announce` delivery isolated so it does not accumulate mirrored system events in the main session
- add regression coverage for the implicit `channel: last` path and preserve explicit-target awareness behavior

## Root cause
`dispatchCronDelivery()` queued a main-session awareness system event after every successful isolated delivery. That included the default implicit announce path, so isolated jobs still wrote mirrored text into the main session over time.

## Verification
- targeted Vitest run for `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` passed using a temporary isolated config wrapper because the repo's shared non-isolated runner is broken in this checkout
- `src/cron/isolated-agent.delivery-awareness.test.ts` is included in the patch, but its local run is blocked here by a missing `@modelcontextprotocol/sdk/client/index.js` dependency from the browser extension import path
