### PR TITLE
fix: prevent full re-render on every keystroke in webchat input

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -81,6 +81,11 @@ export async function handleAbortChat(host: ChatHost) {
     return;
   }
   host.chatMessage = "";
+  // chatMessage is intentionally non-reactive (@state removed) to avoid full
+  // re-renders on every keystroke.  Explicitly request an update so the
+  // textarea reflects the cleared draft — abortChatRun may not mutate any
+  // other reactive property, leaving the DOM stale.
+  (host as unknown as OpenClawApp).requestUpdate();
   await abortChatRun(host as unknown as OpenClawApp);
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -145,6 +145,7 @@ async function sendChatMessageNow(
   const ok = Boolean(runId);
   if (!ok && opts?.previousDraft != null) {
     host.chatMessage = opts.previousDraft;
+    (host as unknown as OpenClawApp).requestUpdate();
   }
   if (!ok && opts?.previousAttachments) {
     host.chatAttachments = opts.previousAttachments;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -159,7 +159,9 @@ export class OpenClawApp extends LitElement {
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;
   @state() chatSending = false;
-  @state() chatMessage = "";
+  // Not @state — draft changes must not trigger full re-render on every keystroke.
+  // Textarea value is managed by the browser natively; Lit syncs it on other state changes.
+  chatMessage = "";
   @state() chatMessages: unknown[] = [];
   @state() chatToolMessages: unknown[] = [];
   @state() chatStreamSegments: Array<{ text: string; ts: number }> = [];

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1107,6 +1107,9 @@ export function renderChat(props: ChatProps) {
         if (prev !== null) {
           e.preventDefault();
           props.onDraftChange(prev);
+          // chatMessage is non-reactive; explicitly refresh so the
+          // textarea reflects the recalled history entry.
+          requestUpdate();
         }
         return;
       }
@@ -1114,6 +1117,9 @@ export function renderChat(props: ChatProps) {
         const next = inputHistory.down();
         e.preventDefault();
         props.onDraftChange(next ?? "");
+        // chatMessage is non-reactive; explicitly refresh so the
+        // textarea reflects the recalled history entry.
+        requestUpdate();
         return;
       }
     }


### PR DESCRIPTION
Fixes #54911

## Summary
- Remove `@state()` from `chatMessage` in `app.ts` to prevent Lit from triggering a full component re-render on every keystroke
- Restore draft clears and keyboard history recalls with explicit `requestUpdate()` calls
- 4 commits, minimal changes to `app.ts`, `app-chat.ts`, and `chat.ts`