### PR TITLE
fix(discord): recover forwarded referenced message content

### DIFF
--- a/extensions/discord/src/monitor/message-utils.test.ts
+++ b/extensions/discord/src/monitor/message-utils.test.ts
@@ -1,5 +1,5 @@
 import { ChannelType, type Client, type Message } from "@buape/carbon";
-import { StickerFormatType } from "discord-api-types/v10";
+import { MessageReferenceType, StickerFormatType } from "discord-api-types/v10";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const fetchRemoteMedia = vi.fn();
@@ -126,6 +126,35 @@ function asForwardedSnapshotMessage(params: {
         },
       ],
     },
+  });
+}
+
+function asReferencedForwardMessage(params: {
+  content?: string;
+  embeds?: Array<{ title?: string; description?: string }>;
+  attachments?: Array<Record<string, unknown>>;
+  messageReferenceType?: MessageReferenceType;
+}) {
+  return asMessage({
+    content: "",
+    messageReference: {
+      type: params.messageReferenceType ?? MessageReferenceType.Forward,
+      message_id: "m0",
+      channel_id: "c1",
+    },
+    referencedMessage: asMessage({
+      id: "m0",
+      channelId: "c1",
+      content: params.content ?? "",
+      attachments: params.attachments ?? [],
+      embeds: params.embeds ?? [],
+      stickers: [],
+      author: {
+        id: "u2",
+        username: "Bob",
+        discriminator: "0",
+      },
+    }),
   });
 }
 
@@ -287,6 +316,38 @@ describe("resolveForwardedMediaList", () => {
 
     expect(result).toEqual([]);
     expect(fetchRemoteMedia).not.toHaveBeenCalled();
+  });
+
+  it("downloads forwarded referenced attachments when snapshots are absent", async () => {
+    const attachment = {
+      id: "att-ref-1",
+      url: "https://cdn.discordapp.com/attachments/1/ref-image.png",
+      filename: "ref-image.png",
+      content_type: "image/png",
+    };
+    fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("image"),
+      contentType: "image/png",
+    });
+    saveMediaBuffer.mockResolvedValueOnce({
+      path: "/tmp/ref-image.png",
+      contentType: "image/png",
+    });
+
+    const result = await resolveForwardedMediaList(
+      asReferencedForwardMessage({
+        attachments: [attachment],
+      }),
+      512,
+    );
+
+    expectSinglePngDownload({
+      result,
+      expectedUrl: attachment.url,
+      filePathHint: attachment.filename,
+      expectedPath: "/tmp/ref-image.png",
+      placeholder: "<media:image>",
+    });
   });
 
   it("skips snapshots without attachments", async () => {
@@ -767,6 +828,30 @@ describe("resolveDiscordMessageText", () => {
 
     expect(text).toContain("[Forwarded message from @Bob]");
     expect(text).toContain("forwarded hello");
+  });
+
+  it("falls back to referenced forward message text when snapshots are absent", () => {
+    const text = resolveDiscordMessageText(
+      asReferencedForwardMessage({
+        content: "forwarded from referenced message",
+      }),
+      { includeForwarded: true },
+    );
+
+    expect(text).toContain("[Forwarded message from @Bob]");
+    expect(text).toContain("forwarded from referenced message");
+  });
+
+  it("does not treat ordinary replies as forwarded context", () => {
+    const text = resolveDiscordMessageText(
+      asReferencedForwardMessage({
+        content: "quoted reply content",
+        messageReferenceType: MessageReferenceType.Default,
+      }),
+      { includeForwarded: true },
+    );
+
+    expect(text).toBe("");
   });
 
   it("resolves user mentions in content", () => {

--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -1,5 +1,10 @@
 import type { ChannelType, Client, Message } from "@buape/carbon";
-import { StickerFormatType, type APIAttachment, type APIStickerItem } from "discord-api-types/v10";
+import {
+  MessageReferenceType,
+  StickerFormatType,
+  type APIAttachment,
+  type APIStickerItem,
+} from "discord-api-types/v10";
 import { fetchRemoteMedia, type FetchLike } from "openclaw/plugin-sdk/media-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
 import { buildMediaPayload } from "openclaw/plugin-sdk/reply-payload";
@@ -253,35 +258,61 @@ export async function resolveForwardedMediaList(
   options?: DiscordMediaResolveOptions,
 ): Promise<DiscordMediaInfo[]> {
   const snapshots = resolveDiscordMessageSnapshots(message);
-  if (snapshots.length === 0) {
-    return [];
-  }
   const out: DiscordMediaInfo[] = [];
   const resolvedSsrFPolicy = resolveDiscordMediaSsrFPolicy(options?.ssrfPolicy);
-  for (const snapshot of snapshots) {
-    await appendResolvedMediaFromAttachments({
-      attachments: snapshot.message?.attachments,
-      maxBytes,
-      out,
-      errorPrefix: "discord: failed to download forwarded attachment",
-      fetchImpl: options?.fetchImpl,
-      ssrfPolicy: resolvedSsrFPolicy,
-      readIdleTimeoutMs: options?.readIdleTimeoutMs,
-      totalTimeoutMs: options?.totalTimeoutMs,
-      abortSignal: options?.abortSignal,
-    });
-    await appendResolvedMediaFromStickers({
-      stickers: snapshot.message ? resolveDiscordSnapshotStickers(snapshot.message) : [],
-      maxBytes,
-      out,
-      errorPrefix: "discord: failed to download forwarded sticker",
-      fetchImpl: options?.fetchImpl,
-      ssrfPolicy: resolvedSsrFPolicy,
-      readIdleTimeoutMs: options?.readIdleTimeoutMs,
-      totalTimeoutMs: options?.totalTimeoutMs,
-      abortSignal: options?.abortSignal,
-    });
+  if (snapshots.length > 0) {
+    for (const snapshot of snapshots) {
+      await appendResolvedMediaFromAttachments({
+        attachments: snapshot.message?.attachments,
+        maxBytes,
+        out,
+        errorPrefix: "discord: failed to download forwarded attachment",
+        fetchImpl: options?.fetchImpl,
+        ssrfPolicy: resolvedSsrFPolicy,
+        readIdleTimeoutMs: options?.readIdleTimeoutMs,
+        totalTimeoutMs: options?.totalTimeoutMs,
+        abortSignal: options?.abortSignal,
+      });
+      await appendResolvedMediaFromStickers({
+        stickers: snapshot.message ? resolveDiscordSnapshotStickers(snapshot.message) : [],
+        maxBytes,
+        out,
+        errorPrefix: "discord: failed to download forwarded sticker",
+        fetchImpl: options?.fetchImpl,
+        ssrfPolicy: resolvedSsrFPolicy,
+        readIdleTimeoutMs: options?.readIdleTimeoutMs,
+        totalTimeoutMs: options?.totalTimeoutMs,
+        abortSignal: options?.abortSignal,
+      });
+    }
+    return out;
   }
+  const referencedForward = resolveDiscordReferencedForwardMessage(message);
+  if (!referencedForward) {
+    return out;
+  }
+  await appendResolvedMediaFromAttachments({
+    attachments: referencedForward.attachments,
+    maxBytes,
+    out,
+    errorPrefix: "discord: failed to download forwarded attachment",
+    fetchImpl: options?.fetchImpl,
+    ssrfPolicy: resolvedSsrFPolicy,
+    readIdleTimeoutMs: options?.readIdleTimeoutMs,
+    totalTimeoutMs: options?.totalTimeoutMs,
+    abortSignal: options?.abortSignal,
+  });
+  await appendResolvedMediaFromStickers({
+    stickers: resolveDiscordMessageStickers(referencedForward),
+    maxBytes,
+    out,
+    errorPrefix: "discord: failed to download forwarded sticker",
+    fetchImpl: options?.fetchImpl,
+    ssrfPolicy: resolvedSsrFPolicy,
+    readIdleTimeoutMs: options?.readIdleTimeoutMs,
+    totalTimeoutMs: options?.totalTimeoutMs,
+    abortSignal: options?.abortSignal,
+  });
   return out;
 }
 
@@ -635,35 +666,23 @@ function resolveDiscordMentions(text: string, message: Message): string {
 }
 
 function resolveDiscordForwardedMessagesText(message: Message): string {
-  return resolveDiscordForwardedMessagesTextFromSnapshots(resolveDiscordMessageSnapshots(message));
-}
-
-function resolveDiscordMessageSnapshots(message: Message): DiscordMessageSnapshot[] {
-  const rawData = (message as { rawData?: { message_snapshots?: unknown } }).rawData;
-  return normalizeDiscordMessageSnapshots(
-    rawData?.message_snapshots ??
-      (message as { message_snapshots?: unknown }).message_snapshots ??
-      (message as { messageSnapshots?: unknown }).messageSnapshots,
-  );
-}
-
-function normalizeDiscordMessageSnapshots(snapshots: unknown): DiscordMessageSnapshot[] {
-  if (!Array.isArray(snapshots)) {
-    return [];
+  const snapshots = resolveDiscordMessageSnapshots(message);
+  if (snapshots.length > 0) {
+    return resolveDiscordForwardedMessagesTextFromSnapshots(snapshots);
   }
-  return snapshots.filter(
-    (entry): entry is DiscordMessageSnapshot => Boolean(entry) && typeof entry === "object",
-  );
-}
-
-export function resolveDiscordForwardedMessagesTextFromSnapshots(snapshots: unknown): string {
-  const forwardedBlocks = normalizeDiscordMessageSnapshots(snapshots)
-    .map((snapshot) => buildDiscordForwardedMessageBlock(snapshot.message))
-    .filter((entry): entry is string => Boolean(entry));
-  if (forwardedBlocks.length === 0) {
+  const referencedForward = resolveDiscordReferencedForwardMessage(message);
+  if (!referencedForward) {
     return "";
   }
-  return forwardedBlocks.join("\n\n");
+  const referencedText = resolveDiscordMessageText(referencedForward, {
+    includeForwarded: true,
+  });
+  if (!referencedText) {
+    return "";
+  }
+  const authorLabel = formatDiscordSnapshotAuthor(referencedForward.author);
+  const heading = authorLabel ? `[Forwarded message from ${authorLabel}]` : "[Forwarded message]";
+  return `${heading}\n${referencedText}`;
 }
 
 function buildDiscordForwardedMessageBlock(
@@ -679,6 +698,12 @@ function buildDiscordForwardedMessageBlock(
   const authorLabel = formatDiscordSnapshotAuthor(snapshotMessage.author);
   const heading = authorLabel ? `[Forwarded message from ${authorLabel}]` : "[Forwarded message]";
   return `${heading}\n${text}`;
+}
+
+function resolveDiscordReferencedForwardMessage(message: Message): Message | null {
+  return message.messageReference?.type === MessageReferenceType.Forward
+    ? message.referencedMessage
+    : null;
 }
 
 function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): string {

--- a/extensions/discord/src/monitor/message-utils.ts
+++ b/extensions/discord/src/monitor/message-utils.ts
@@ -674,15 +674,41 @@ function resolveDiscordForwardedMessagesText(message: Message): string {
   if (!referencedForward) {
     return "";
   }
-  const referencedText = resolveDiscordMessageText(referencedForward, {
-    includeForwarded: true,
-  });
+  const referencedText = resolveDiscordMessageText(referencedForward);
   if (!referencedText) {
     return "";
   }
   const authorLabel = formatDiscordSnapshotAuthor(referencedForward.author);
   const heading = authorLabel ? `[Forwarded message from ${authorLabel}]` : "[Forwarded message]";
   return `${heading}\n${referencedText}`;
+}
+
+function resolveDiscordMessageSnapshots(message: Message): DiscordMessageSnapshot[] {
+  const rawData = (message as { rawData?: { message_snapshots?: unknown } }).rawData;
+  return normalizeDiscordMessageSnapshots(
+    rawData?.message_snapshots ??
+      (message as { message_snapshots?: unknown }).message_snapshots ??
+      (message as { messageSnapshots?: unknown }).messageSnapshots,
+  );
+}
+
+function normalizeDiscordMessageSnapshots(snapshots: unknown): DiscordMessageSnapshot[] {
+  if (!Array.isArray(snapshots)) {
+    return [];
+  }
+  return snapshots.filter(
+    (entry): entry is DiscordMessageSnapshot => Boolean(entry) && typeof entry === "object",
+  );
+}
+
+export function resolveDiscordForwardedMessagesTextFromSnapshots(snapshots: unknown): string {
+  const forwardedBlocks = normalizeDiscordMessageSnapshots(snapshots)
+    .map((snapshot) => buildDiscordForwardedMessageBlock(snapshot.message))
+    .filter((entry): entry is string => Boolean(entry));
+  if (forwardedBlocks.length === 0) {
+    return "";
+  }
+  return forwardedBlocks.join("\n\n");
 }
 
 function buildDiscordForwardedMessageBlock(


### PR DESCRIPTION
## Summary

- Problem: Discord forwarded messages could reach the agent with only `Conversation info` metadata when Discord populated `referenced_message` but did not include `message_snapshots`.
- Why it matters: forwarded handoff content becomes invisible to the agent, which breaks Discord-based multi-agent coordination and forces users to copy-paste instead of using Forward.
- What changed: the Discord inbound message path now falls back to `messageReference.type === Forward` + `referencedMessage` when snapshots are absent, for both forwarded text and forwarded attachments.
- What did NOT change (scope boundary): this PR does not change ordinary reply handling, thread-starter resolution beyond existing behavior, or non-Discord channels.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61664
- Related #60139
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `extensions/discord/src/monitor/message-utils.ts` only treated `message_snapshots` as forwarded-message content. When Discord delivered a forward via `message_reference.type = Forward` plus `referenced_message`, OpenClaw kept the reply metadata but dropped the forwarded body and attachments from the main inbound content path.
- Missing detection / guardrail: there was no regression test for forwarded messages that carry content only in `referencedMessage`.
- Prior context (`git blame`, prior PR, issue, or refactor if known): #60139 fixed a related Discord forwarded-message gap for thread starter resolution, but explicitly stayed out of `message-utils.ts` and regular inbound processing.
- Why this regressed now: this appears to be an unsupported Discord forward representation rather than a recent regression introduced by this PR.
- If unknown, what was ruled out: the issue is not limited to `message_snapshots`; local code inspection confirmed the regular inbound path already handled snapshots but had no `referencedMessage` fallback.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/monitor/message-utils.test.ts`
- Scenario the test should lock in: forwarded Discord messages with `messageReference.type === Forward` and no snapshots still surface referenced text and referenced attachments to the agent, while ordinary replies do not get treated as forwarded context.
- Why this is the smallest reliable guardrail: the bug is isolated to the Discord message text/media normalization helpers, so unit tests on that seam directly cover the dropped-content path without requiring a live Discord runtime.
- Existing test that already covers this (if any): existing tests already covered snapshot-based forwarded content only.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord forwarded messages now preserve forwarded body text and forwarded attachments in the inbound agent context even when Discord sends them via `referenced_message` instead of `message_snapshots`.

## Diagram (if applicable)

```text
Before:
[Discord forward] -> referenced_message only -> metadata reaches agent -> forwarded content missing

After:
[Discord forward] -> referenced_message only -> fallback extracts body/media -> agent sees forwarded content
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu 24.04.3
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): N/A

### Steps

1. Create a Discord message object whose forward content is available only via `messageReference.type === Forward` and `referencedMessage`, with no `message_snapshots`.
2. Run the Discord inbound message normalization helpers.
3. Confirm the agent-facing text/media include the forwarded content, and that ordinary replies still do not get treated as forwarded context.

### Expected

- Forwarded referenced text is included in the inbound content.
- Forwarded referenced attachments are preserved in forwarded media resolution.
- Non-forward replies remain unchanged.

### Actual

- Matches expected with the patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test -- extensions/discord/src/monitor/message-utils.test.ts`; confirmed new tests pass for referenced forwarded text, referenced forwarded attachments, and ordinary reply non-regression. Ran `pnpm build` successfully in the main workspace before preparing the clean PR branch.
- Edge cases checked: snapshot-based forwarded messages still work; ordinary replies with `messageReference.type === Default` are not treated as forwarded context; forwarded attachments still resolve when snapshots are absent.
- What you did **not** verify: end-to-end with a live Discord forwarded message event against a running OpenClaw instance.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Discord could send message references for ordinary replies and forwarded messages through the same fields in some future shape change.
  - Mitigation: the fallback is gated specifically on `messageReference.type === Forward`, and there is a regression test asserting ordinary replies stay unchanged.
- Risk: snapshot-based forwarded handling could regress while adding the fallback path.
  - Mitigation: existing snapshot tests still pass, and the fallback only runs when snapshots are absent.

## AI-Assisted

- [x] AI-assisted (Codex)
- [x] Fully tested locally for the touched surface
- [x] Understand what the code does