### PR TITLE
fix(memory-core): honor deep dreaming storage mode

### DIFF
--- a/extensions/memory-core/src/dreaming-markdown.test.ts
+++ b/extensions/memory-core/src/dreaming-markdown.test.ts
@@ -81,13 +81,14 @@ describe("dreaming markdown storage", () => {
       },
     });
 
-    expect(result.inlinePath).toBe(lowercasePath);
+    expect(result.inlinePath).toBeTruthy();
+    expect(await fs.realpath(result.inlinePath!)).toBe(await fs.realpath(lowercasePath));
     const content = await fs.readFile(lowercasePath, "utf-8");
     expect(content).toContain("## REM Sleep");
     expect(content).toContain("- Theme: `glacier` kept surfacing.");
   });
 
-  it("still writes deep reports to the per-phase report directory", async () => {
+  it("writes deep reports to the per-phase report directory without inline output in separate mode", async () => {
     const workspaceDir = await createTempWorkspace();
 
     const reportPath = await writeDeepDreamingReport({
@@ -107,7 +108,29 @@ describe("dreaming markdown storage", () => {
     expect(content).toContain("- Promoted: durable preference");
 
     const dreamsPath = path.join(workspaceDir, "DREAMS.md");
-    const dreamsContent = await fs.readFile(dreamsPath, "utf-8");
+    const dreamsExists = await fs
+      .access(dreamsPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(dreamsExists).toBe(false);
+  });
+
+  it("writes deep reports inline and separately in both mode", async () => {
+    const workspaceDir = await createTempWorkspace();
+
+    const reportPath = await writeDeepDreamingReport({
+      workspaceDir,
+      bodyLines: ["- Promoted: durable preference"],
+      storage: {
+        mode: "both",
+        separateReports: false,
+      },
+      nowMs: Date.parse("2026-04-05T10:00:00Z"),
+      timezone: "UTC",
+    });
+
+    expect(reportPath).toBe(path.join(workspaceDir, "memory", "dreaming", "deep", "2026-04-05.md"));
+    const dreamsContent = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(dreamsContent).toContain("## Deep Sleep");
     expect(dreamsContent).toContain("- Promoted: durable preference");
   });

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -182,10 +182,12 @@ export async function writeDeepDreamingReport(params: {
 }): Promise<string | undefined> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   const body = params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No durable changes.";
-  await writeInlineDeepDreamingBlock({
-    workspaceDir: params.workspaceDir,
-    body,
-  });
+  if (shouldWriteInline(params.storage)) {
+    await writeInlineDeepDreamingBlock({
+      workspaceDir: params.workspaceDir,
+      body,
+    });
+  }
 
   if (!shouldWriteSeparate(params.storage)) {
     return undefined;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: deep dreaming always wrote an inline `## Deep Sleep` block into `DREAMS.md`, even when storage was configured as `mode: "separate"`.
- Why it matters: this made deep-phase output behave differently from light and REM, and violated the configured storage contract.
- What changed: make deep dreaming respect `shouldWriteInline(storage)` before writing inline output, and add regression coverage for `separate` and `both` modes.
- What did NOT change (scope boundary): this does not change promotion logic, ranking thresholds, report contents, or separate report paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `writeDeepDreamingReport()` bypassed the existing inline-output guard and always wrote the deep summary into `DREAMS.md`.
- Missing detection / guardrail: test coverage did not lock in deep-phase behavior for `storage.mode = "separate"` vs `storage.mode = "both"`.
- Contributing context (if known): light and REM already shared the intended storage-mode behavior, but deep had drifted into a special-case write path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming-markdown.test.ts`
- Scenario the test should lock in: deep dreaming should skip inline output in `separate` mode and still write both inline + report output in `both` mode.
- Why this is the smallest reliable guardrail: the bug is local to markdown/report persistence logic and does not require a full dreaming sweep to reproduce.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Deep dreaming now respects `storage.mode = "separate"` and will not create or update inline `DREAMS.md` output in that mode.

## Diagram (if applicable)

```text
Before:
deep report + mode=separate
  -> write report file
  -> also write inline DREAMS.md block

After:
deep report + mode=separate
  -> write report file only

deep report + mode=both
  -> write report file
  -> write inline DREAMS.md block
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Call `writeDeepDreamingReport()` with `storage.mode = "separate"`.
2. Inspect the per-phase report path and the top-level `DREAMS.md`.
3. Repeat with `storage.mode = "both"`.

### Expected

- `separate`: only the per-phase deep report is written.
- `both`: both the per-phase report and inline `DREAMS.md` summary are written.

### Actual

- Before this change, deep dreaming wrote inline `DREAMS.md` output even in `separate` mode.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test extensions/memory-core/src/dreaming-markdown.test.ts` and confirmed deep dreaming behaves correctly in `separate` and `both` modes.
- Edge cases checked: existing lowercase `dreams.md` handling still works; deep reports still write to the dated per-phase report directory.
- What you did **not** verify: I did not run a full end-to-end dreaming sweep through the gateway.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: deployments that accidentally relied on deep summaries always appearing inline in `DREAMS.md` will stop seeing that side effect in `separate` mode.
  - Mitigation: this aligns deep with the existing documented storage contract used by the other dreaming phases, and `both` mode still preserves inline output.
