### PR TITLE
docs(memory-core): align dreaming output docs with current behavior

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -129,7 +129,7 @@ facts into `MEMORY.md`), and **REM** (reflect and surface themes).
 - Toggle from chat with `/dreaming on|off` (or inspect with `/dreaming status`).
 - Dreaming runs on one managed sweep schedule (`dreaming.frequency`) and executes phases in order: light, REM, deep.
 - Only the deep phase writes durable memory to `MEMORY.md`.
-- Human-readable phase output and diary entries are written to `DREAMS.md` (or existing `dreams.md`), with optional per-phase reports in `memory/dreaming/<phase>/YYYY-MM-DD.md`.
+- Dream Diary entries are written to `DREAMS.md` (or existing `dreams.md`), while human-readable phase output is written to daily memory notes and optional per-phase reports in `memory/dreaming/<phase>/YYYY-MM-DD.md`.
 - Ranking uses weighted signals: recall frequency, retrieval relevance, query diversity, temporal recency, cross-day consolidation, and derived concept richness.
 - Promotion re-reads the live daily note before writing to `MEMORY.md`, so edited or deleted short-term snippets do not get promoted from stale recall-store snapshots.
 - Scheduled and manual `memory promote` runs share the same deep phase defaults unless you pass CLI threshold overrides.

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -20,7 +20,7 @@ Dreaming is **opt-in** and disabled by default.
 Dreaming keeps two kinds of output:
 
 - **Machine state** in `memory/.dreams/` (recall store, phase signals, ingestion checkpoints, locks).
-- **Human-readable output** in `DREAMS.md` (or existing `dreams.md`) and optional phase report files under `memory/dreaming/<phase>/YYYY-MM-DD.md`.
+- **Human-readable output** split across the Dream Diary in `DREAMS.md` (or existing `dreams.md`), inline phase notes in daily memory files when applicable, and optional phase report files under `memory/dreaming/<phase>/YYYY-MM-DD.md`.
 
 Long-term promotion still writes only to `MEMORY.md`.
 
@@ -43,7 +43,7 @@ Light phase ingests recent daily memory signals and recall traces, dedupes them,
 and stages candidate lines.
 
 - Reads from short-term recall state and recent daily memory files.
-- Writes a managed `## Light Sleep` block when storage includes inline output.
+- Writes a managed `## Light Sleep` block into the daily memory file when inline phase output is enabled.
 - Records reinforcement signals for later deep ranking.
 - Never writes to `MEMORY.md`.
 
@@ -55,14 +55,14 @@ Deep phase decides what becomes long-term memory.
 - Requires `minScore`, `minRecallCount`, and `minUniqueQueries` to pass.
 - Rehydrates snippets from live daily files before writing, so stale/deleted snippets are skipped.
 - Appends promoted entries to `MEMORY.md`.
-- Writes a `## Deep Sleep` summary into `DREAMS.md` and optionally writes `memory/dreaming/deep/YYYY-MM-DD.md`.
+- Writes a `# Deep Sleep` report under `memory/dreaming/deep/YYYY-MM-DD.md` when report output is enabled.
 
 ### REM phase
 
 REM phase extracts patterns and reflective signals.
 
 - Builds theme and reflection summaries from recent short-term traces.
-- Writes a managed `## REM Sleep` block when storage includes inline output.
+- Writes a managed `## REM Sleep` block into the daily memory file when inline phase output is enabled.
 - Records REM reinforcement signals used by deep ranking.
 - Never writes to `MEMORY.md`.
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -20,8 +20,8 @@ Your agent has three memory-related files:
   decisions. Loaded at the start of every DM session.
 - **`memory/YYYY-MM-DD.md`** -- daily notes. Running context and observations.
   Today and yesterday's notes are loaded automatically.
-- **`DREAMS.md`** (experimental, optional) -- Dream Diary and dreaming sweep
-  summaries for human review.
+- **`DREAMS.md`** (experimental, optional) -- Dream Diary entries for human
+  review.
 
 These files live in the agent workspace (default `~/.openclaw/workspace`).
 
@@ -98,8 +98,8 @@ It is designed to keep long-term memory high signal:
   for a full dreaming sweep.
 - **Thresholded**: promotions must pass score, recall frequency, and query
   diversity gates.
-- **Reviewable**: phase summaries and diary entries are written to `DREAMS.md`
-  for human review.
+- **Reviewable**: Dream Diary entries are written to `DREAMS.md`, and phase
+  output can be inspected in daily memory notes and dated dreaming reports.
 
 For phase behavior, scoring signals, and Dream Diary details, see
 [Dreaming (experimental)](/concepts/dreaming).

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -501,5 +501,5 @@ For conceptual behavior and slash commands, see [Dreaming](/concepts/dreaming).
 Notes:
 
 - Dreaming writes machine state to `memory/.dreams/`.
-- Dreaming writes human-readable narrative output to `DREAMS.md` (or existing `dreams.md`).
+- Dreaming writes Dream Diary narrative output to `DREAMS.md` (or existing `dreams.md`) and keeps phase output in daily memory notes and optional per-phase reports.
 - The light/deep/REM phase policy and thresholds are internal behavior, not user-facing config.

--- a/extensions/memory-core/src/dreaming-command.ts
+++ b/extensions/memory-core/src/dreaming-command.ts
@@ -47,7 +47,7 @@ function formatPhaseGuide(): string {
   return [
     "- implementation detail: each sweep runs light -> REM -> deep.",
     "- deep is the only stage that writes durable entries to MEMORY.md.",
-    "- DREAMS.md is for human-readable dreaming summaries and diary entries.",
+    "- DREAMS.md is for Dream Diary entries; phase output lives in daily memory notes or per-phase reports.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: dreaming docs and `/dreaming` help text still described human-readable phase output as living in `DREAMS.md`, but the current implementation now splits Dream Diary output from phase output.
- Why it matters: readers and operators can look in the wrong file, especially after the recent move of inline phase blocks into daily memory notes.
- What changed: align the docs and command help text with current behavior by documenting `DREAMS.md` as the Dream Diary surface and daily notes / dated phase reports as the phase-output surfaces.
- What did NOT change (scope boundary): this PR does not change dreaming behavior, storage policy, phase ordering, or promotion logic.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] API / contracts
- [ ] Integrations
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #61679
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the implementation changed faster than the docs and command help text, so references to `DREAMS.md` remained after phase output moved to daily memory notes and dated reports.
- Missing detection / guardrail: there was no follow-through update for the user-facing docs/help text when the dreaming markdown output paths changed.
- Contributing context (if known): recent dreaming work split the Dream Diary surface from phase summaries, but the published conceptual docs still described the older layout.

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

- Docs and `/dreaming` help now describe `DREAMS.md` as the Dream Diary surface.
- Docs now describe phase output as living in daily memory notes and optional per-phase reports.

## Diagram (if applicable)

```text
Before:
Dream Diary + phase summaries -> DREAMS.md

After:
Dream Diary -> DREAMS.md
light/REM inline phase notes -> memory/YYYY-MM-DD.md
per-phase reports -> memory/dreaming/<phase>/YYYY-MM-DD.md
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Read the current dreaming docs and `/dreaming help` guidance.
2. Compare the documented output locations with the current `dreaming-markdown` implementation.
3. Update the docs and help text to match the current output paths.

### Expected

- User-facing docs and command help point to the same file layout the code actually writes.

### Actual

- Before this change, docs and help text still implied that phase summaries lived in `DREAMS.md`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm test extensions/memory-core/src/dreaming-command.test.ts` after updating the help text.
- Edge cases checked: docs consistently distinguish Dream Diary output from phase output across the concept page, memory overview, CLI page, config reference, and `/dreaming` command help.
- What you did **not** verify: I did not run a full docs site build or a full end-to-end dreaming sweep.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: readers may notice the docs no longer describe all human-readable dreaming output as a single `DREAMS.md` surface.
  - Mitigation: that is the current implementation, and the updated wording reduces operator confusion instead of changing runtime behavior.
