### PR TITLE
fix(gateway): resolve mattermost plugin entry path escaping plugin root

### DIFF
--- a/extensions/mattermost/channel-plugin-api.ts
+++ b/extensions/mattermost/channel-plugin-api.ts
@@ -1,0 +1,3 @@
+// Keep bundled channel entry imports narrow so bootstrap/discovery paths do
+// not drag the broad Mattermost API barrel into lightweight plugin loads.
+export { mattermostPlugin } from "./src/channel.js";

--- a/extensions/mattermost/index.ts
+++ b/extensions/mattermost/index.ts
@@ -18,7 +18,7 @@ export default defineBundledChannelEntry({
   description: "Mattermost channel plugin",
   importMetaUrl: import.meta.url,
   plugin: {
-    specifier: "./src/channel.js",
+    specifier: "./channel-plugin-api.js",
     exportName: "mattermostPlugin",
   },
   runtime: {

--- a/extensions/mattermost/setup-entry.ts
+++ b/extensions/mattermost/setup-entry.ts
@@ -3,7 +3,7 @@ import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entr
 export default defineBundledChannelSetupEntry({
   importMetaUrl: import.meta.url,
   plugin: {
-    specifier: "./src/channel.js",
+    specifier: "./channel-plugin-api.js",
     exportName: "mattermostPlugin",
   },
 });

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -253,6 +253,31 @@ describe("bundled channel entry shape guards", () => {
     expect(reentered).toBe(true);
   });
 
+  it("keeps bundled channel entry specifiers off src subdirectories", () => {
+    const offenders: string[] = [];
+
+    for (const extensionDir of bundledPluginRoots) {
+      for (const relativePath of ["index.ts", "channel-entry.ts", "setup-entry.ts"]) {
+        const filePath = path.join(extensionDir, relativePath);
+        if (!fs.existsSync(filePath)) {
+          continue;
+        }
+        const source = fs.readFileSync(filePath, "utf8");
+        const usesEntryHelpers =
+          source.includes("defineBundledChannelEntry") ||
+          source.includes("defineBundledChannelSetupEntry");
+        if (!usesEntryHelpers) {
+          continue;
+        }
+        if (/specifier:\s*["']\.\/src\//u.test(source)) {
+          offenders.push(path.relative(process.cwd(), filePath));
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
   it("keeps private src runtime barrels from forwarding to parent runtime barrels that export local plugins", () => {
     const offenders: string[] = [];
 


### PR DESCRIPTION
### Summary

- **Problem**: After upgrading to 2026.4.5, the gateway fails to start with a fatal error: `plugin entry path escapes plugin root: ./src/channel.js`. This affects the Mattermost plugin and crashes `openclaw doctor --fix` as well.
- **Root Cause**: The Mattermost plugin's `index.ts` and `setup-entry.ts` defined their `specifier` directly as `"./src/channel.js"`. While this works in the source tree, during the `tsdown` build process, `src/channel.ts` is not treated as a top-level build entry and is tree-shaken into the bundles. Consequently, in the `dist` output, `dist/extensions/mattermost/src/channel.js` does not exist. When `resolveBundledEntryModulePath` attempts to validate this path via `openBoundaryFileSync`, it fails with `ENOENT`, which incorrectly triggers the misleading "escapes plugin root" error message.
- **Fix**: Created a `channel-plugin-api.ts` barrel file for the Mattermost plugin that re-exports from `./src/channel.js`, and updated the specifiers in `index.ts` and `setup-entry.ts` to point to `"./channel-plugin-api.js"`. This aligns Mattermost with the pattern used by all other channel plugins (e.g., Telegram, IRC, Discord). The barrel file is correctly built as a top-level entry by `tsdown`, ensuring it exists in the `dist` output. Additionally, added a shape guard test to prevent future regressions where specifiers directly reference `src/` subdirectories.
- **What changed**: 
  - Added `extensions/mattermost/channel-plugin-api.ts`
  - Modified `extensions/mattermost/index.ts`
  - Modified `extensions/mattermost/setup-entry.ts`
  - Modified `src/channels/plugins/bundled.shape-guard.test.ts`
- **What did NOT change (scope boundary)**: No changes were made to the core plugin SDK boundary validation logic (`channel-entry-contract.ts` or `boundary-file-read.ts`), ensuring zero risk of weakening security boundaries for other plugins.

### Reproduction

1. Install OpenClaw from source or npm (version 2026.4.5).
2. Configure the Mattermost plugin in `~/.openclaw/openclaw.json`.
3. Run `openclaw gateway` or `openclaw doctor --fix`.
4. Observe the fatal crash: `Error: plugin entry path escapes plugin root: ./src/channel.js`.

### Risk / Mitigation

- **Risk**: The fix modifies the entry point resolution for the Mattermost plugin. If the barrel file is not built correctly, the plugin might fail to load.
- **Mitigation**: The fix exactly mirrors the proven pattern used by all other bundled channel plugins. A new shape guard test (`keeps bundled channel entry specifiers off src subdirectories`) has been added to statically verify that no bundled plugin specifier directly references the `src/` directory, preventing this class of bugs entirely.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Plugins (Mattermost)
- [x] Tests

### Linked Issue/PR

Fixes #61682