### PR TITLE
fix(memory-core): ignore managed dreaming blocks during daily ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Docs/i18n: remove the zh-CN homepage redirect override so Mintlify can resolve the localized Chinese homepage without self-redirecting `/zh-CN/index`.
 - Agents/heartbeat: stop truncating live session transcripts after no-op heartbeat acks, move heartbeat cleanup to prompt assembly and compaction, and keep post-filter context-engine ingestion aligned with the real session baseline. (#60998) Thanks @nxmxbbd.
 - macOS/gateway version: strip trailing commit metadata from CLI version output before semver parsing so the Mac app recognizes installed gateway versions like `OpenClaw 2026.4.2 (d74a122)` again. (#61111) Thanks @oliviareid-svg.
+- Memory/dreaming: strip managed Light Sleep and REM blocks before daily-note ingestion so dreaming summaries stop re-ingesting their own staged output into new candidates. (#61720) Thanks @MonkeyLeeT.
 
 ## 2026.4.5
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -11,6 +11,8 @@ import {
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
 const { createTempWorkspace } = createMemoryCoreTestHarness();
+const DREAMING_TEST_BASE_TIME = new Date("2026-04-05T10:00:00.000Z");
+const DREAMING_TEST_DAY = "2026-04-05";
 
 function createHarness(config: OpenClawConfig, workspaceDir?: string) {
   let beforeAgentReply:
@@ -55,31 +57,41 @@ function createHarness(config: OpenClawConfig, workspaceDir?: string) {
   return { beforeAgentReply, logger };
 }
 
+function setDreamingTestTime(offsetMinutes = 0) {
+  vi.setSystemTime(new Date(DREAMING_TEST_BASE_TIME.getTime() + offsetMinutes * 60_000));
+}
+
 describe("memory-core dreaming phases", () => {
   it("does not re-ingest managed light dreaming blocks from daily notes", async () => {
+    vi.useFakeTimers();
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
-    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-    await fs.writeFile(
-      path.join(workspaceDir, "memory", "2026-04-05.md"),
-      ["# 2026-04-05", "", "- Move backups to S3 Glacier.", "- Keep retention at 365 days."].join(
-        "\n",
-      ),
-      "utf-8",
-    );
+    try {
+      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+        [
+          `# ${DREAMING_TEST_DAY}`,
+          "",
+          "- Move backups to S3 Glacier.",
+          "- Keep retention at 365 days.",
+        ].join("\n"),
+        "utf-8",
+      );
 
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 2,
+      const { beforeAgentReply } = createHarness(
+        {
+          plugins: {
+            entries: {
+              "memory-core": {
+                config: {
+                  dreaming: {
+                    enabled: true,
+                    phases: {
+                      light: {
+                        enabled: true,
+                        limit: 20,
+                        lookbackDays: 2,
+                      },
                     },
                   },
                 },
@@ -87,13 +99,163 @@ describe("memory-core dreaming phases", () => {
             },
           },
         },
-      },
-      workspaceDir,
-    );
+        workspaceDir,
+      );
 
-    const candidateCounts: number[] = [];
-    const candidateSnippets: string[][] = [];
-    for (let run = 0; run < 3; run += 1) {
+      const candidateCounts: number[] = [];
+      const candidateSnippets: string[][] = [];
+      for (let run = 0; run < 3; run += 1) {
+        setDreamingTestTime(run + 1);
+        await beforeAgentReply(
+          { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+          { trigger: "heartbeat", workspaceDir },
+        );
+
+        const candidates = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+          nowMs: Date.parse(`2026-04-05T10:0${run + 1}:00.000Z`),
+        });
+        candidateCounts.push(candidates.length);
+        candidateSnippets.push(candidates.map((candidate) => candidate.snippet));
+      }
+
+      expect(candidateCounts).toEqual([1, 1, 1]);
+      expect(candidateSnippets).toEqual([
+        ["Move backups to S3 Glacier.; Keep retention at 365 days."],
+        ["Move backups to S3 Glacier.; Keep retention at 365 days."],
+        ["Move backups to S3 Glacier.; Keep retention at 365 days."],
+      ]);
+
+      const dailyContent = await fs.readFile(
+        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+        "utf-8",
+      );
+      expect(dailyContent).toContain("## Light Sleep");
+      expect(dailyContent.match(/^- Candidate:/gm)).toHaveLength(1);
+      expect(dailyContent).not.toContain("Light Sleep: Candidate:");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not re-ingest managed light dreaming blocks from CRLF daily notes", async () => {
+    vi.useFakeTimers();
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    try {
+      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+        [
+          `# ${DREAMING_TEST_DAY}`,
+          "",
+          "- Move backups to S3 Glacier.",
+          "- Keep retention at 365 days.",
+        ].join("\r\n"),
+        "utf-8",
+      );
+
+      const { beforeAgentReply } = createHarness(
+        {
+          plugins: {
+            entries: {
+              "memory-core": {
+                config: {
+                  dreaming: {
+                    enabled: true,
+                    phases: {
+                      light: {
+                        enabled: true,
+                        limit: 20,
+                        lookbackDays: 2,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        workspaceDir,
+      );
+
+      for (let run = 0; run < 2; run += 1) {
+        setDreamingTestTime(run + 1);
+        await beforeAgentReply(
+          { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+          { trigger: "heartbeat", workspaceDir },
+        );
+      }
+
+      const candidates = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-04-05T10:02:00.000Z"),
+      });
+      expect(candidates.map((candidate) => candidate.snippet)).toEqual([
+        "Move backups to S3 Glacier.; Keep retention at 365 days.",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops stripping a malformed managed block at the next section boundary", async () => {
+    vi.useFakeTimers();
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    try {
+      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+        [
+          `# ${DREAMING_TEST_DAY}`,
+          "",
+          "- Move backups to S3 Glacier.",
+          "",
+          "## Light Sleep",
+          "<!-- openclaw:dreaming:light:start -->",
+          "- Candidate: Old staged summary.",
+          "",
+          "## Ops",
+          "- Rotate access keys.",
+          "",
+          "## Light Sleep",
+          "<!-- openclaw:dreaming:light:start -->",
+          "- Candidate: Fresh staged summary.",
+          "<!-- openclaw:dreaming:light:end -->",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const { beforeAgentReply } = createHarness(
+        {
+          plugins: {
+            entries: {
+              "memory-core": {
+                config: {
+                  dreaming: {
+                    enabled: true,
+                    phases: {
+                      light: {
+                        enabled: true,
+                        limit: 20,
+                        lookbackDays: 2,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        workspaceDir,
+      );
+
+      setDreamingTestTime(1);
       await beforeAgentReply(
         { cleanedBody: "__openclaw_memory_core_light_sleep__" },
         { trigger: "heartbeat", workspaceDir },
@@ -104,139 +266,14 @@ describe("memory-core dreaming phases", () => {
         minScore: 0,
         minRecallCount: 0,
         minUniqueQueries: 0,
-        nowMs: Date.parse(`2026-04-05T10:0${run + 1}:00.000Z`),
+        nowMs: Date.parse("2026-04-05T10:01:00.000Z"),
       });
-      candidateCounts.push(candidates.length);
-      candidateSnippets.push(candidates.map((candidate) => candidate.snippet));
-    }
-
-    expect(candidateCounts).toEqual([1, 1, 1]);
-    expect(candidateSnippets).toEqual([
-      ["Move backups to S3 Glacier.; Keep retention at 365 days."],
-      ["Move backups to S3 Glacier.; Keep retention at 365 days."],
-      ["Move backups to S3 Glacier.; Keep retention at 365 days."],
-    ]);
-
-    const dailyContent = await fs.readFile(
-      path.join(workspaceDir, "memory", "2026-04-05.md"),
-      "utf-8",
-    );
-    expect(dailyContent).toContain("## Light Sleep");
-    expect(dailyContent.match(/^- Candidate:/gm)).toHaveLength(1);
-    expect(dailyContent).not.toContain("Light Sleep: Candidate:");
-  });
-
-  it("does not re-ingest managed light dreaming blocks from CRLF daily notes", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
-    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-    await fs.writeFile(
-      path.join(workspaceDir, "memory", "2026-04-05.md"),
-      ["# 2026-04-05", "", "- Move backups to S3 Glacier.", "- Keep retention at 365 days."].join(
-        "\r\n",
-      ),
-      "utf-8",
-    );
-
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 2,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
-
-    for (let run = 0; run < 2; run += 1) {
-      await beforeAgentReply(
-        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
-        { trigger: "heartbeat", workspaceDir },
+      expect(candidates.map((candidate) => candidate.snippet)).toContain(
+        "Ops: Rotate access keys.",
       );
+    } finally {
+      vi.useRealTimers();
     }
-
-    const candidates = await rankShortTermPromotionCandidates({
-      workspaceDir,
-      minScore: 0,
-      minRecallCount: 0,
-      minUniqueQueries: 0,
-      nowMs: Date.parse("2026-04-05T10:02:00.000Z"),
-    });
-    expect(candidates.map((candidate) => candidate.snippet)).toEqual([
-      "Move backups to S3 Glacier.; Keep retention at 365 days.",
-    ]);
-  });
-
-  it("does not swallow later notes when a managed dreaming block is incomplete", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
-    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-    await fs.writeFile(
-      path.join(workspaceDir, "memory", "2026-04-05.md"),
-      [
-        "# 2026-04-05",
-        "",
-        "- Move backups to S3 Glacier.",
-        "",
-        "## Light Sleep",
-        "<!-- openclaw:dreaming:light:start -->",
-        "- Candidate: Old staged summary.",
-        "",
-        "## Ops",
-        "- Rotate access keys.",
-      ].join("\n"),
-      "utf-8",
-    );
-
-    const { beforeAgentReply } = createHarness(
-      {
-        plugins: {
-          entries: {
-            "memory-core": {
-              config: {
-                dreaming: {
-                  enabled: true,
-                  phases: {
-                    light: {
-                      enabled: true,
-                      limit: 20,
-                      lookbackDays: 2,
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-      workspaceDir,
-    );
-
-    await beforeAgentReply(
-      { cleanedBody: "__openclaw_memory_core_light_sleep__" },
-      { trigger: "heartbeat", workspaceDir },
-    );
-
-    const candidates = await rankShortTermPromotionCandidates({
-      workspaceDir,
-      minScore: 0,
-      minRecallCount: 0,
-      minUniqueQueries: 0,
-      nowMs: Date.parse("2026-04-05T10:01:00.000Z"),
-    });
-    expect(candidates.map((candidate) => candidate.snippet)).toContain("Ops: Rotate access keys.");
   });
 
   it("checkpoints daily ingestion and skips unchanged daily files", async () => {

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -126,6 +126,119 @@ describe("memory-core dreaming phases", () => {
     expect(dailyContent).not.toContain("Light Sleep: Candidate:");
   });
 
+  it("does not re-ingest managed light dreaming blocks from CRLF daily notes", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-05.md"),
+      ["# 2026-04-05", "", "- Move backups to S3 Glacier.", "- Keep retention at 365 days."].join(
+        "\r\n",
+      ),
+      "utf-8",
+    );
+
+    const { beforeAgentReply } = createHarness(
+      {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 2,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    for (let run = 0; run < 2; run += 1) {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    }
+
+    const candidates = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-05T10:02:00.000Z"),
+    });
+    expect(candidates.map((candidate) => candidate.snippet)).toEqual([
+      "Move backups to S3 Glacier.; Keep retention at 365 days.",
+    ]);
+  });
+
+  it("does not swallow later notes when a managed dreaming block is incomplete", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-05.md"),
+      [
+        "# 2026-04-05",
+        "",
+        "- Move backups to S3 Glacier.",
+        "",
+        "## Light Sleep",
+        "<!-- openclaw:dreaming:light:start -->",
+        "- Candidate: Old staged summary.",
+        "",
+        "## Ops",
+        "- Rotate access keys.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const { beforeAgentReply } = createHarness(
+      {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 2,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    await beforeAgentReply(
+      { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+      { trigger: "heartbeat", workspaceDir },
+    );
+
+    const candidates = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-05T10:01:00.000Z"),
+    });
+    expect(candidates.map((candidate) => candidate.snippet)).toContain("Ops: Rotate access keys.");
+  });
+
   it("checkpoints daily ingestion and skips unchanged daily files", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -56,6 +56,76 @@ function createHarness(config: OpenClawConfig, workspaceDir?: string) {
 }
 
 describe("memory-core dreaming phases", () => {
+  it("does not re-ingest managed light dreaming blocks from daily notes", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-05.md"),
+      ["# 2026-04-05", "", "- Move backups to S3 Glacier.", "- Keep retention at 365 days."].join(
+        "\n",
+      ),
+      "utf-8",
+    );
+
+    const { beforeAgentReply } = createHarness(
+      {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 2,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    const candidateCounts: number[] = [];
+    const candidateSnippets: string[][] = [];
+    for (let run = 0; run < 3; run += 1) {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+
+      const candidates = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse(`2026-04-05T10:0${run + 1}:00.000Z`),
+      });
+      candidateCounts.push(candidates.length);
+      candidateSnippets.push(candidates.map((candidate) => candidate.snippet));
+    }
+
+    expect(candidateCounts).toEqual([1, 1, 1]);
+    expect(candidateSnippets).toEqual([
+      ["Move backups to S3 Glacier.; Keep retention at 365 days."],
+      ["Move backups to S3 Glacier.; Keep retention at 365 days."],
+      ["Move backups to S3 Glacier.; Keep retention at 365 days."],
+    ]);
+
+    const dailyContent = await fs.readFile(
+      path.join(workspaceDir, "memory", "2026-04-05.md"),
+      "utf-8",
+    );
+    expect(dailyContent).toContain("## Light Sleep");
+    expect(dailyContent.match(/^- Candidate:/gm)).toHaveLength(1);
+    expect(dailyContent).not.toContain("Light Sleep: Candidate:");
+  });
+
   it("checkpoints daily ingestion and skips unchanged daily files", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -90,15 +90,11 @@ async function withDreamingTestClock(run: () => Promise<void>) {
   }
 }
 
-async function writeDailyNote(
-  workspaceDir: string,
-  lines: string[],
-  newline = "\n",
-): Promise<void> {
+async function writeDailyNote(workspaceDir: string, lines: string[]): Promise<void> {
   await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
   await fs.writeFile(
     path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
-    lines.join(newline),
+    lines.join("\n"),
     "utf-8",
   );
 }
@@ -166,31 +162,6 @@ describe("memory-core dreaming phases", () => {
       expect(dailyContent).toContain("## Light Sleep");
       expect(dailyContent.match(/^- Candidate:/gm)).toHaveLength(1);
       expect(dailyContent).not.toContain("Light Sleep: Candidate:");
-    });
-  });
-
-  it("does not re-ingest managed light dreaming blocks from CRLF daily notes", async () => {
-    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
-    await withDreamingTestClock(async () => {
-      await writeDailyNote(
-        workspaceDir,
-        [
-          `# ${DREAMING_TEST_DAY}`,
-          "",
-          "- Move backups to S3 Glacier.",
-          "- Keep retention at 365 days.",
-        ],
-        "\r\n",
-      );
-
-      const { beforeAgentReply } = createLightDreamingHarness(workspaceDir);
-      for (let run = 0; run < 2; run += 1) {
-        await triggerLightDreaming(beforeAgentReply, workspaceDir, run + 1);
-      }
-
-      expect(await readCandidateSnippets(workspaceDir, "2026-04-05T10:02:00.000Z")).toEqual([
-        "Move backups to S3 Glacier.; Keep retention at 365 days.",
-      ]);
     });
   });
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -13,6 +13,26 @@ import { createMemoryCoreTestHarness } from "./test-helpers.js";
 const { createTempWorkspace } = createMemoryCoreTestHarness();
 const DREAMING_TEST_BASE_TIME = new Date("2026-04-05T10:00:00.000Z");
 const DREAMING_TEST_DAY = "2026-04-05";
+const LIGHT_DREAMING_TEST_CONFIG: OpenClawConfig = {
+  plugins: {
+    entries: {
+      "memory-core": {
+        config: {
+          dreaming: {
+            enabled: true,
+            phases: {
+              light: {
+                enabled: true,
+                limit: 20,
+                lookbackDays: 2,
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
 
 function createHarness(config: OpenClawConfig, workspaceDir?: string) {
   let beforeAgentReply:
@@ -61,65 +81,75 @@ function setDreamingTestTime(offsetMinutes = 0) {
   vi.setSystemTime(new Date(DREAMING_TEST_BASE_TIME.getTime() + offsetMinutes * 60_000));
 }
 
+async function withDreamingTestClock(run: () => Promise<void>) {
+  vi.useFakeTimers();
+  try {
+    await run();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+async function writeDailyNote(
+  workspaceDir: string,
+  lines: string[],
+  newline = "\n",
+): Promise<void> {
+  await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+  await fs.writeFile(
+    path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+    lines.join(newline),
+    "utf-8",
+  );
+}
+
+function createLightDreamingHarness(workspaceDir: string) {
+  return createHarness(LIGHT_DREAMING_TEST_CONFIG, workspaceDir);
+}
+
+async function triggerLightDreaming(
+  beforeAgentReply: NonNullable<ReturnType<typeof createHarness>["beforeAgentReply"]>,
+  workspaceDir: string,
+  offsetMinutes: number,
+): Promise<void> {
+  setDreamingTestTime(offsetMinutes);
+  await beforeAgentReply(
+    { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+    { trigger: "heartbeat", workspaceDir },
+  );
+}
+
+async function readCandidateSnippets(workspaceDir: string, nowIso: string): Promise<string[]> {
+  const candidates = await rankShortTermPromotionCandidates({
+    workspaceDir,
+    minScore: 0,
+    minRecallCount: 0,
+    minUniqueQueries: 0,
+    nowMs: Date.parse(nowIso),
+  });
+  return candidates.map((candidate) => candidate.snippet);
+}
+
 describe("memory-core dreaming phases", () => {
   it("does not re-ingest managed light dreaming blocks from daily notes", async () => {
-    vi.useFakeTimers();
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
-    try {
-      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-      await fs.writeFile(
-        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
-        [
-          `# ${DREAMING_TEST_DAY}`,
-          "",
-          "- Move backups to S3 Glacier.",
-          "- Keep retention at 365 days.",
-        ].join("\n"),
-        "utf-8",
-      );
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "- Move backups to S3 Glacier.",
+        "- Keep retention at 365 days.",
+      ]);
 
-      const { beforeAgentReply } = createHarness(
-        {
-          plugins: {
-            entries: {
-              "memory-core": {
-                config: {
-                  dreaming: {
-                    enabled: true,
-                    phases: {
-                      light: {
-                        enabled: true,
-                        limit: 20,
-                        lookbackDays: 2,
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        workspaceDir,
-      );
-
+      const { beforeAgentReply } = createLightDreamingHarness(workspaceDir);
       const candidateCounts: number[] = [];
       const candidateSnippets: string[][] = [];
       for (let run = 0; run < 3; run += 1) {
-        setDreamingTestTime(run + 1);
-        await beforeAgentReply(
-          { cleanedBody: "__openclaw_memory_core_light_sleep__" },
-          { trigger: "heartbeat", workspaceDir },
+        await triggerLightDreaming(beforeAgentReply, workspaceDir, run + 1);
+        candidateSnippets.push(
+          await readCandidateSnippets(workspaceDir, `2026-04-05T10:0${run + 1}:00.000Z`),
         );
-
-        const candidates = await rankShortTermPromotionCandidates({
-          workspaceDir,
-          minScore: 0,
-          minRecallCount: 0,
-          minUniqueQueries: 0,
-          nowMs: Date.parse(`2026-04-05T10:0${run + 1}:00.000Z`),
-        });
-        candidateCounts.push(candidates.length);
-        candidateSnippets.push(candidates.map((candidate) => candidate.snippet));
+        candidateCounts.push(candidateSnippets.at(-1)?.length ?? 0);
       }
 
       expect(candidateCounts).toEqual([1, 1, 1]);
@@ -136,144 +166,62 @@ describe("memory-core dreaming phases", () => {
       expect(dailyContent).toContain("## Light Sleep");
       expect(dailyContent.match(/^- Candidate:/gm)).toHaveLength(1);
       expect(dailyContent).not.toContain("Light Sleep: Candidate:");
-    } finally {
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("does not re-ingest managed light dreaming blocks from CRLF daily notes", async () => {
-    vi.useFakeTimers();
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
-    try {
-      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-      await fs.writeFile(
-        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(
+        workspaceDir,
         [
           `# ${DREAMING_TEST_DAY}`,
           "",
           "- Move backups to S3 Glacier.",
           "- Keep retention at 365 days.",
-        ].join("\r\n"),
-        "utf-8",
+        ],
+        "\r\n",
       );
 
-      const { beforeAgentReply } = createHarness(
-        {
-          plugins: {
-            entries: {
-              "memory-core": {
-                config: {
-                  dreaming: {
-                    enabled: true,
-                    phases: {
-                      light: {
-                        enabled: true,
-                        limit: 20,
-                        lookbackDays: 2,
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        workspaceDir,
-      );
-
+      const { beforeAgentReply } = createLightDreamingHarness(workspaceDir);
       for (let run = 0; run < 2; run += 1) {
-        setDreamingTestTime(run + 1);
-        await beforeAgentReply(
-          { cleanedBody: "__openclaw_memory_core_light_sleep__" },
-          { trigger: "heartbeat", workspaceDir },
-        );
+        await triggerLightDreaming(beforeAgentReply, workspaceDir, run + 1);
       }
 
-      const candidates = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-04-05T10:02:00.000Z"),
-      });
-      expect(candidates.map((candidate) => candidate.snippet)).toEqual([
+      expect(await readCandidateSnippets(workspaceDir, "2026-04-05T10:02:00.000Z")).toEqual([
         "Move backups to S3 Glacier.; Keep retention at 365 days.",
       ]);
-    } finally {
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("stops stripping a malformed managed block at the next section boundary", async () => {
-    vi.useFakeTimers();
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
-    try {
-      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
-      await fs.writeFile(
-        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
-        [
-          `# ${DREAMING_TEST_DAY}`,
-          "",
-          "- Move backups to S3 Glacier.",
-          "",
-          "## Light Sleep",
-          "<!-- openclaw:dreaming:light:start -->",
-          "- Candidate: Old staged summary.",
-          "",
-          "## Ops",
-          "- Rotate access keys.",
-          "",
-          "## Light Sleep",
-          "<!-- openclaw:dreaming:light:start -->",
-          "- Candidate: Fresh staged summary.",
-          "<!-- openclaw:dreaming:light:end -->",
-        ].join("\n"),
-        "utf-8",
-      );
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "- Move backups to S3 Glacier.",
+        "",
+        "## Light Sleep",
+        "<!-- openclaw:dreaming:light:start -->",
+        "- Candidate: Old staged summary.",
+        "",
+        "## Ops",
+        "- Rotate access keys.",
+        "",
+        "## Light Sleep",
+        "<!-- openclaw:dreaming:light:start -->",
+        "- Candidate: Fresh staged summary.",
+        "<!-- openclaw:dreaming:light:end -->",
+      ]);
 
-      const { beforeAgentReply } = createHarness(
-        {
-          plugins: {
-            entries: {
-              "memory-core": {
-                config: {
-                  dreaming: {
-                    enabled: true,
-                    phases: {
-                      light: {
-                        enabled: true,
-                        limit: 20,
-                        lookbackDays: 2,
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-        workspaceDir,
-      );
+      const { beforeAgentReply } = createLightDreamingHarness(workspaceDir);
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 1);
 
-      setDreamingTestTime(1);
-      await beforeAgentReply(
-        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
-        { trigger: "heartbeat", workspaceDir },
-      );
-
-      const candidates = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        nowMs: Date.parse("2026-04-05T10:01:00.000Z"),
-      });
-      expect(candidates.map((candidate) => candidate.snippet)).toContain(
+      expect(await readCandidateSnippets(workspaceDir, "2026-04-05T10:01:00.000Z")).toContain(
         "Ops: Rotate access keys.",
       );
-    } finally {
-      vi.useRealTimers();
-    }
+    });
   });
 
   it("checkpoints daily ingestion and skips unchanged daily files", async () => {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -86,6 +86,18 @@ const DAILY_INGESTION_MIN_SNIPPET_CHARS = 8;
 const DAILY_INGESTION_MAX_CHUNK_LINES = 4;
 const GENERIC_DAY_HEADING_RE =
   /^(?:(?:mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|sun|sunday)(?:,\s+)?)?(?:(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4}[/-]\d{2}[/-]\d{2})$/i;
+const MANAGED_DAILY_DREAMING_BLOCKS = [
+  {
+    heading: "## Light Sleep",
+    startMarker: "<!-- openclaw:dreaming:light:start -->",
+    endMarker: "<!-- openclaw:dreaming:light:end -->",
+  },
+  {
+    heading: "## REM Sleep",
+    startMarker: "<!-- openclaw:dreaming:rem:start -->",
+    endMarker: "<!-- openclaw:dreaming:rem:end -->",
+  },
+] as const;
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -107,6 +119,10 @@ function formatErrorMessage(err: unknown): string {
     return err.message;
   }
   return String(err);
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function buildCronDescription(params: {
@@ -476,6 +492,23 @@ function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetCh
   return chunks.slice(0, limit);
 }
 
+function blankNonNewlineCharacters(value: string): string {
+  return value.replace(/[^\n]/g, "");
+}
+
+function stripManagedDailyDreamingBlocks(raw: string): string {
+  let sanitized = raw;
+  for (const block of MANAGED_DAILY_DREAMING_BLOCKS) {
+    const pattern = new RegExp(
+      `${escapeRegex(block.heading)}\\n${escapeRegex(block.startMarker)}[\\s\\S]*?${escapeRegex(block.endMarker)}(?:\\n|$)?`,
+      "g",
+    );
+    // Preserve line numbers so evidence coordinates remain stable for later notes.
+    sanitized = sanitized.replace(pattern, (match) => blankNonNewlineCharacters(match));
+  }
+  return sanitized;
+}
+
 function entryWithinLookback(entry: ShortTermRecallEntry, cutoffMs: number): boolean {
   const byDay = (entry.recallDays ?? []).some((day) => isDayWithinLookback(day, cutoffMs));
   if (byDay) {
@@ -640,7 +673,7 @@ async function collectDailyIngestionBatches(params: {
     if (!raw) {
       continue;
     }
-    const lines = raw.split(/\r?\n/);
+    const lines = stripManagedDailyDreamingBlocks(raw).split(/\r?\n/);
     const chunks = buildDailySnippetChunks(lines, perFileCap);
     const results: MemorySearchResult[] = [];
     for (const chunk of chunks) {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -525,11 +525,9 @@ function stripManagedDailyDreamingLines(lines: string[]): string[] {
       continue;
     }
 
-    const headingIndex = findManagedDailyDreamingHeadingIndex(sanitized, index, block.heading);
-    if (headingIndex !== null) {
-      sanitized[headingIndex] = "";
-    }
-    for (let cursor = index; cursor <= endIndex; cursor += 1) {
+    const headingIndex = findManagedDailyDreamingHeadingIndex(lines, index, block.heading);
+    const startIndex = headingIndex ?? index;
+    for (let cursor = startIndex; cursor <= endIndex; cursor += 1) {
       sanitized[cursor] = "";
     }
     index = endIndex;

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -503,10 +503,17 @@ function findManagedDailyDreamingHeadingIndex(
   return null;
 }
 
+function isManagedDailyDreamingBoundary(
+  line: string,
+  blockByStartMarker: ReadonlyMap<string, (typeof MANAGED_DAILY_DREAMING_BLOCKS)[number]>,
+): boolean {
+  const trimmed = line.trim();
+  return /^#{1,6}\s+/.test(trimmed) || blockByStartMarker.has(trimmed);
+}
+
 function stripManagedDailyDreamingLines(lines: string[]): string[] {
-  const blockByStartMarker = new Map(
-    MANAGED_DAILY_DREAMING_BLOCKS.map((block) => [block.startMarker, block]),
-  );
+  const blockByStartMarker: ReadonlyMap<string, (typeof MANAGED_DAILY_DREAMING_BLOCKS)[number]> =
+    new Map(MANAGED_DAILY_DREAMING_BLOCKS.map((block) => [block.startMarker, block]));
   const sanitized = [...lines];
   for (let index = 0; index < sanitized.length; index += 1) {
     const block = blockByStartMarker.get(sanitized[index]?.trim() ?? "");
@@ -514,23 +521,29 @@ function stripManagedDailyDreamingLines(lines: string[]): string[] {
       continue;
     }
 
-    let endIndex = -1;
+    let stripUntilIndex = -1;
     for (let cursor = index + 1; cursor < sanitized.length; cursor += 1) {
-      if ((sanitized[cursor]?.trim() ?? "") === block.endMarker) {
-        endIndex = cursor;
+      const line = sanitized[cursor];
+      const trimmed = line?.trim() ?? "";
+      if (trimmed === block.endMarker) {
+        stripUntilIndex = cursor;
+        break;
+      }
+      if (line && isManagedDailyDreamingBoundary(line, blockByStartMarker)) {
+        stripUntilIndex = cursor - 1;
         break;
       }
     }
-    if (endIndex === -1) {
+    if (stripUntilIndex < index) {
       continue;
     }
 
     const headingIndex = findManagedDailyDreamingHeadingIndex(lines, index, block.heading);
     const startIndex = headingIndex ?? index;
-    for (let cursor = startIndex; cursor <= endIndex; cursor += 1) {
+    for (let cursor = startIndex; cursor <= stripUntilIndex; cursor += 1) {
       sanitized[cursor] = "";
     }
-    index = endIndex;
+    index = stripUntilIndex;
   }
 
   return sanitized;

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -121,10 +121,6 @@ function formatErrorMessage(err: unknown): string {
   return String(err);
 }
 
-function escapeRegex(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function buildCronDescription(params: {
   tag: string;
   phase: "light" | "rem";
@@ -492,20 +488,53 @@ function buildDailySnippetChunks(lines: string[], limit: number): DailySnippetCh
   return chunks.slice(0, limit);
 }
 
-function blankNonNewlineCharacters(value: string): string {
-  return value.replace(/[^\n]/g, "");
+function findManagedDailyDreamingHeadingIndex(
+  lines: string[],
+  startIndex: number,
+  heading: string,
+): number | null {
+  for (let index = startIndex - 1; index >= 0; index -= 1) {
+    const trimmed = lines[index]?.trim() ?? "";
+    if (!trimmed) {
+      continue;
+    }
+    return trimmed === heading ? index : null;
+  }
+  return null;
 }
 
-function stripManagedDailyDreamingBlocks(raw: string): string {
-  let sanitized = raw;
-  for (const block of MANAGED_DAILY_DREAMING_BLOCKS) {
-    const pattern = new RegExp(
-      `${escapeRegex(block.heading)}\\n${escapeRegex(block.startMarker)}[\\s\\S]*?${escapeRegex(block.endMarker)}(?:\\n|$)?`,
-      "g",
-    );
-    // Preserve line numbers so evidence coordinates remain stable for later notes.
-    sanitized = sanitized.replace(pattern, (match) => blankNonNewlineCharacters(match));
+function stripManagedDailyDreamingLines(lines: string[]): string[] {
+  const blockByStartMarker = new Map(
+    MANAGED_DAILY_DREAMING_BLOCKS.map((block) => [block.startMarker, block]),
+  );
+  const sanitized = [...lines];
+  for (let index = 0; index < sanitized.length; index += 1) {
+    const block = blockByStartMarker.get(sanitized[index]?.trim() ?? "");
+    if (!block) {
+      continue;
+    }
+
+    let endIndex = -1;
+    for (let cursor = index + 1; cursor < sanitized.length; cursor += 1) {
+      if ((sanitized[cursor]?.trim() ?? "") === block.endMarker) {
+        endIndex = cursor;
+        break;
+      }
+    }
+    if (endIndex === -1) {
+      continue;
+    }
+
+    const headingIndex = findManagedDailyDreamingHeadingIndex(sanitized, index, block.heading);
+    if (headingIndex !== null) {
+      sanitized[headingIndex] = "";
+    }
+    for (let cursor = index; cursor <= endIndex; cursor += 1) {
+      sanitized[cursor] = "";
+    }
+    index = endIndex;
   }
+
   return sanitized;
 }
 
@@ -673,7 +702,7 @@ async function collectDailyIngestionBatches(params: {
     if (!raw) {
       continue;
     }
-    const lines = stripManagedDailyDreamingBlocks(raw).split(/\r?\n/);
+    const lines = stripManagedDailyDreamingLines(raw.split(/\r?\n/));
     const chunks = buildDailySnippetChunks(lines, perFileCap);
     const results: MemorySearchResult[] = [];
     for (const chunk of chunks) {


### PR DESCRIPTION
## Summary
- prevent daily dreaming ingestion from re-reading managed `## Light Sleep` and `## REM Sleep` blocks out of `memory/YYYY-MM-DD.md`
- preserve line numbers while stripping those managed blocks so later evidence coordinates stay stable
- add a regression test that repeats Light Dreaming three times and locks in a flat candidate set instead of recursive growth

## Why
Light/REM phase output can be written inline into the same dated daily note that `ingestDailyMemorySignals()` re-scans on the next run. That let Dreaming ingest its own generated `Candidate:` / `status:` lines and recursively bloat both the recall candidates and the managed block itself.

## Root Cause
`collectDailyIngestionBatches()` chunked raw daily note contents without excluding managed Dreaming sections, while `writeDailyDreamingPhaseBlock()` writes those sections back into `memory/YYYY-MM-DD.md` in inline mode.

## Fix
Before chunking a dated daily note for ingestion, blank out the managed Light/REM Dreaming blocks identified by their heading + marker pairs. The replacement preserves newline structure so subsequent line references in the same note do not drift.

## Validation
- `pnpm test extensions/memory-core/src/dreaming-phases.test.ts`
- `pnpm test extensions/memory-core/src/dreaming-markdown.test.ts`
- `pnpm exec oxlint extensions/memory-core/src/dreaming-phases.ts extensions/memory-core/src/dreaming-phases.test.ts`

## Notes
- I first tried the repo commit hook, but `pnpm check` currently fails on untouched `origin/main` TypeScript errors under `src/auto-reply/reply/*`, so I used the repo's fast-commit path after running the focused Dreaming checks above.
