### PR TITLE
fix(Gateway): strip tool_call and tool_result XML blocks from assistant visible text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ Docs: https://docs.openclaw.ai
 - Agents/context overflow: combine oversized and aggregate tool-result recovery in one repair pass, and restore a total-context overflow backstop during tool loops so recoverable sessions retry instead of failing early. (#61651) Thanks @Takhoffman.
 - Gateway/containers: auto-bind to `0.0.0.0` during container startup for Docker and Podman compatibility, while keeping host-side status and doctor checks on the hardened loopback default when `gateway.bind` is unset. (#61818) Thanks @openperf.
 - TUI/status: route `/status` through the shared session-status command and move the old gateway-wide diagnostic summary to `/gateway-status` (`/gwstatus`). Thanks @vincentkoc.
+- Agents/history: use one shared assistant-visible sanitizer across embedded delivery and chat-history extraction so leaked `<tool_call>` and `<tool_result>` XML blocks stay hidden from user-facing replies. (#61729) Thanks @openperf.
 
 ## 2026.4.5
+
 ### Breaking
 
 - Config: remove legacy public config aliases such as `talk.voiceId` / `talk.apiKey`, `agents.*.sandbox.perSession`, `browser.ssrfPolicy.allowPrivateNetwork`, `hooks.internal.handlers`, and channel/group/room `allow` toggles in favor of the canonical public paths and `enabled`, while keeping load-time compatibility and `openclaw doctor --fix` migration support for existing configs. (#60726) Thanks @vincentkoc.

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -437,6 +437,116 @@ File contents here`,
     expect(result).toBe("Here's what I found:\nDone checking.");
   });
 
+  it("strips raw <tool_call> XML blocks from assistant text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Let me check.\n\n<tool_call> {"name": "read", "arguments": {"file_path": "test.md"}} </tool_call> Done.',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toBe("Let me check.\n\n Done.");
+  });
+
+  it("strips raw <tool_result> XML blocks from assistant text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Prefix\n<tool_result> {"output": "file contents"} </tool_result>\nSuffix',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toBe("Prefix\n\nSuffix");
+  });
+
+  it("strips dangling <tool_call> XML content to end-of-string", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Let me run.\n<tool_call>\n{"name": "find", "arguments": {}}\n',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toBe("Let me run.");
+  });
+
+  it("strips mixed <tool_call> and <tool_result> XML blocks from assistant text", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: [
+            "I will read the file.",
+            '<tool_call>{"name":"read","arguments":{"path":"/tmp/x"}}</tool_call>',
+            '<tool_result>{"output":"hello world"}</tool_result>',
+            "The file contains: hello world",
+          ].join("\n"),
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    expect(extractAssistantText(msg)).toBe(
+      "I will read the file.\n\n\nThe file contains: hello world",
+    );
+  });
+
+  it("strips <tool_result> closed with mismatched </tool_call> tag and preserves trailing text", () => {
+    // Issue #61688: gateway sometimes emits <tool_result>...</tool_call>
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Prefix\n<tool_result> {"output": "data"} </tool_call>\nSuffix',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    // The mismatched closing tag should still exit the block, stripping the
+    // tool XML while preserving legitimate trailing prose.
+    expect(result).not.toContain("<tool_result>");
+    expect(result).not.toContain("output");
+    expect(result).toContain("Prefix");
+    expect(result).toContain("Suffix");
+  });
+
+  it("does not let </tool_result> close a <tool_call> block (prevents payload leak)", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: 'Prefix\n<tool_call>{"name":"x"}</tool_result>LEAK</tool_call>\nSuffix',
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    // </tool_result> must NOT exit a <tool_call> block; the block should
+    // continue until the matching </tool_call>, preventing payload leaks.
+    expect(result).not.toContain("LEAK");
+    expect(result).not.toContain("<tool_call>");
+    expect(result).toContain("Prefix");
+    expect(result).toContain("Suffix");
+  });
+
   it("strips reasoning/thinking tag variants", () => {
     const cases = [
       {

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -6,6 +6,7 @@ import {
   parseAssistantTextSignature,
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
+import { stripToolCallXmlTags } from "../shared/text/assistant-visible-text.js";
 import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 import { sanitizeUserFacingText } from "./pi-embedded-helpers.js";
 import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
@@ -240,7 +241,9 @@ export function stripThinkingTagsFromText(text: string): string {
 
 function sanitizeAssistantText(text: string): string {
   return stripThinkingTagsFromText(
-    stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
+    stripToolCallXmlTags(
+      stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
+    ),
   ).trim();
 }
 

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -6,228 +6,19 @@ import {
   parseAssistantTextSignature,
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
-import { stripToolCallXmlTags } from "../shared/text/assistant-visible-text.js";
+import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 import { sanitizeUserFacingText } from "./pi-embedded-helpers.js";
 import { formatToolDetail, resolveToolDisplay } from "./tool-display.js";
 
+export {
+  stripDowngradedToolCallText,
+  stripMinimaxToolCallXml,
+} from "../shared/text/assistant-visible-text.js";
+export { stripModelSpecialTokens } from "../shared/text/model-special-tokens.js";
+
 export function isAssistantMessage(msg: AgentMessage | undefined): msg is AssistantMessage {
   return msg?.role === "assistant";
-}
-
-/**
- * Strip malformed Minimax tool invocations that leak into text content.
- * Minimax sometimes embeds tool calls as XML in text blocks instead of
- * proper structured tool calls. This removes:
- * - <invoke name="...">...</invoke> blocks
- * - </minimax:tool_call> closing tags
- */
-export function stripMinimaxToolCallXml(text: string): string {
-  if (!text) {
-    return text;
-  }
-  if (!/minimax:tool_call/i.test(text)) {
-    return text;
-  }
-
-  // Remove <invoke ...>...</invoke> blocks (non-greedy to handle multiple).
-  let cleaned = text.replace(/<invoke\b[^>]*>[\s\S]*?<\/invoke>/gi, "");
-
-  // Remove stray minimax tool tags.
-  cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
-
-  return cleaned;
-}
-
-/**
- * Strip model control tokens leaked into assistant text output.
- *
- * Models like GLM-5 and DeepSeek sometimes emit internal delimiter tokens
- * (e.g. `<|assistant|>`, `<|tool_call_result_begin|>`, `<｜begin▁of▁sentence｜>`)
- * in their responses. These use the universal `<|...|>` convention (ASCII or
- * full-width pipe variants) and should never reach end users.
- *
- * This is a provider bug — no upstream fix tracked yet.
- * Remove this function when upstream providers stop leaking tokens.
- * @see https://github.com/openclaw/openclaw/issues/40020
- */
-// Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
-const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
-
-export function stripModelSpecialTokens(text: string): string {
-  if (!text) {
-    return text;
-  }
-  if (!MODEL_SPECIAL_TOKEN_RE.test(text)) {
-    return text;
-  }
-  MODEL_SPECIAL_TOKEN_RE.lastIndex = 0;
-  return text.replace(MODEL_SPECIAL_TOKEN_RE, " ").replace(/  +/g, " ").trim();
-}
-
-/**
- * Strip downgraded tool call text representations that leak into text content.
- * When replaying history to Gemini, tool calls without `thought_signature` are
- * downgraded to text blocks like `[Tool Call: name (ID: ...)]`. These should
- * not be shown to users.
- */
-export function stripDowngradedToolCallText(text: string): string {
-  if (!text) {
-    return text;
-  }
-  if (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text)) {
-    return text;
-  }
-
-  const consumeJsonish = (
-    input: string,
-    start: number,
-    options?: { allowLeadingNewlines?: boolean },
-  ): number | null => {
-    const { allowLeadingNewlines = false } = options ?? {};
-    let index = start;
-    while (index < input.length) {
-      const ch = input[index];
-      if (ch === " " || ch === "\t") {
-        index += 1;
-        continue;
-      }
-      if (allowLeadingNewlines && (ch === "\n" || ch === "\r")) {
-        index += 1;
-        continue;
-      }
-      break;
-    }
-    if (index >= input.length) {
-      return null;
-    }
-
-    const startChar = input[index];
-    if (startChar === "{" || startChar === "[") {
-      let depth = 0;
-      let inString = false;
-      let escape = false;
-      for (let i = index; i < input.length; i += 1) {
-        const ch = input[i];
-        if (inString) {
-          if (escape) {
-            escape = false;
-          } else if (ch === "\\") {
-            escape = true;
-          } else if (ch === '"') {
-            inString = false;
-          }
-          continue;
-        }
-        if (ch === '"') {
-          inString = true;
-          continue;
-        }
-        if (ch === "{" || ch === "[") {
-          depth += 1;
-          continue;
-        }
-        if (ch === "}" || ch === "]") {
-          depth -= 1;
-          if (depth === 0) {
-            return i + 1;
-          }
-        }
-      }
-      return null;
-    }
-
-    if (startChar === '"') {
-      let escape = false;
-      for (let i = index + 1; i < input.length; i += 1) {
-        const ch = input[i];
-        if (escape) {
-          escape = false;
-          continue;
-        }
-        if (ch === "\\") {
-          escape = true;
-          continue;
-        }
-        if (ch === '"') {
-          return i + 1;
-        }
-      }
-      return null;
-    }
-
-    let end = index;
-    while (end < input.length && input[end] !== "\n" && input[end] !== "\r") {
-      end += 1;
-    }
-    return end;
-  };
-
-  const stripToolCalls = (input: string): string => {
-    const markerRe = /\[Tool Call:[^\]]*\]/gi;
-    let result = "";
-    let cursor = 0;
-    for (const match of input.matchAll(markerRe)) {
-      const start = match.index ?? 0;
-      if (start < cursor) {
-        continue;
-      }
-      result += input.slice(cursor, start);
-      let index = start + match[0].length;
-      while (index < input.length && (input[index] === " " || input[index] === "\t")) {
-        index += 1;
-      }
-      if (input[index] === "\r") {
-        index += 1;
-        if (input[index] === "\n") {
-          index += 1;
-        }
-      } else if (input[index] === "\n") {
-        index += 1;
-      }
-      while (index < input.length && (input[index] === " " || input[index] === "\t")) {
-        index += 1;
-      }
-      if (input.slice(index, index + 9).toLowerCase() === "arguments") {
-        index += 9;
-        if (input[index] === ":") {
-          index += 1;
-        }
-        if (input[index] === " ") {
-          index += 1;
-        }
-        const end = consumeJsonish(input, index, { allowLeadingNewlines: true });
-        if (end !== null) {
-          index = end;
-        }
-      }
-      if (
-        (input[index] === "\n" || input[index] === "\r") &&
-        (result.endsWith("\n") || result.endsWith("\r") || result.length === 0)
-      ) {
-        if (input[index] === "\r") {
-          index += 1;
-        }
-        if (input[index] === "\n") {
-          index += 1;
-        }
-      }
-      cursor = index;
-    }
-    result += input.slice(cursor);
-    return result;
-  };
-
-  // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
-  let cleaned = stripToolCalls(text);
-
-  // Remove [Tool Result for ID ...] blocks and their content.
-  cleaned = cleaned.replace(/\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi, "");
-
-  // Remove [Historical context: ...] markers (self-contained within brackets).
-  cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, "");
-
-  return cleaned.trim();
 }
 
 /**
@@ -240,11 +31,7 @@ export function stripThinkingTagsFromText(text: string): string {
 }
 
 function sanitizeAssistantText(text: string): string {
-  return stripThinkingTagsFromText(
-    stripToolCallXmlTags(
-      stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
-    ),
-  ).trim();
+  return sanitizeAssistantVisibleText(text);
 }
 
 function finalizeAssistantExtraction(msg: AssistantMessage, extracted: string): string {

--- a/src/agents/tools/chat-history-text.ts
+++ b/src/agents/tools/chat-history-text.ts
@@ -1,12 +1,7 @@
 import { extractTextFromChatContent } from "../../shared/chat-content.js";
+import { sanitizeAssistantVisibleTextWithOptions } from "../../shared/text/assistant-visible-text.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
-import {
-  extractAssistantVisibleText,
-  stripDowngradedToolCallText,
-  stripMinimaxToolCallXml,
-  stripModelSpecialTokens,
-  stripThinkingTagsFromText,
-} from "../pi-embedded-utils.js";
+import { extractAssistantVisibleText } from "../pi-embedded-utils.js";
 
 export function stripToolMessages(messages: unknown[]): unknown[] {
   return messages.filter((msg) => {
@@ -23,12 +18,7 @@ export function stripToolMessages(messages: unknown[]): unknown[] {
  * This ensures user-facing text doesn't leak internal tool representations.
  */
 export function sanitizeTextContent(text: string): string {
-  if (!text) {
-    return text;
-  }
-  return stripThinkingTagsFromText(
-    stripDowngradedToolCallText(stripModelSpecialTokens(stripMinimaxToolCallXml(text))),
-  );
+  return sanitizeAssistantVisibleTextWithOptions(text, { trim: "none" });
 }
 
 export function hasAssistantPhaseMetadata(message: unknown): boolean {

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -156,6 +156,13 @@ describe("sanitizeTextContent", () => {
     expect(result).not.toContain("Tool Call");
   });
 
+  it("strips tool_result XML via the shared assistant-visible sanitizer", () => {
+    const input = 'Prefix\n<tool_result>{"output":"hidden"}</tool_result>\nSuffix';
+    const result = sanitizeTextContent(input).trim();
+    expect(result).toBe("Prefix\n\nSuffix");
+    expect(result).not.toContain("tool_result");
+  });
+
   it("strips thinking tags", () => {
     const input = "Before <think>secret</think> after";
     const result = sanitizeTextContent(input).trim();

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -116,6 +116,31 @@ describe("stripAssistantInternalScaffolding", () => {
       );
     });
 
+    it("strips closed <tool_result> blocks", () => {
+      expectVisibleText(
+        'Prefix\n<tool_result> {"output": "file contents"} </tool_result>\nSuffix',
+        "Prefix\n\nSuffix",
+      );
+    });
+
+    it("strips dangling <tool_result> content to end-of-string", () => {
+      expectVisibleText('Result:\n<tool_result>\n{"output": "data"}\n', "Result:\n");
+    });
+
+    it("strips <tool_result> closed with mismatched </tool_call> and preserves trailing text", () => {
+      expectVisibleText(
+        'Prefix\n<tool_result> {"output": "data"} </tool_call>\nSuffix',
+        "Prefix\n\nSuffix",
+      );
+    });
+
+    it("does not let </tool_result> close a <tool_call> block", () => {
+      expectVisibleText(
+        'Prefix\n<tool_call>{"name":"x"}</tool_result>LEAK</tool_call>\nSuffix',
+        "Prefix\n\nSuffix",
+      );
+    });
+
     it("hides dangling <tool_call> content to end-of-string", () => {
       expectVisibleText(
         'Let me run.\n<tool_call>\n{"name": "find", "arguments": {}}\n',

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { stripAssistantInternalScaffolding } from "./assistant-visible-text.js";
+import {
+  sanitizeAssistantVisibleText,
+  stripAssistantInternalScaffolding,
+} from "./assistant-visible-text.js";
 import { stripModelSpecialTokens } from "./model-special-tokens.js";
 
 describe("stripAssistantInternalScaffolding", () => {
@@ -391,5 +394,31 @@ describe("stripAssistantInternalScaffolding", () => {
       expect(stripModelSpecialTokens("prefix <|assistant|>")).toBe("prefix  ");
       expect(stripModelSpecialTokens("<|assistant|>short")).toBe(" short");
     });
+  });
+});
+
+describe("sanitizeAssistantVisibleText", () => {
+  it("strips minimax, tool XML, downgraded tool markers, and think tags in one pass", () => {
+    const input = [
+      '<invoke name="read">payload</invoke></minimax:tool_call>',
+      '<tool_result>{"output":"hidden"}</tool_result>',
+      "[Tool Call: read (ID: toolu_1)]",
+      'Arguments: {"path":"/tmp/x"}',
+      "<think>secret</think>",
+      "Visible answer",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("strips relevant-memories blocks on the canonical user-visible path", () => {
+    const input = [
+      "<relevant-memories>",
+      "internal note",
+      "</relevant-memories>",
+      "Visible answer",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
   });
 });

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -10,8 +10,14 @@ const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
  * This stateful pass hides content from an opening tag through the matching
  * closing tag, or to end-of-string if the stream was truncated mid-tag.
  */
-const TOOL_CALL_QUICK_RE = /<\s*\/?\s*(?:tool_call|function_calls?|tool_calls)\b/i;
-const TOOL_CALL_TAG_NAMES = new Set(["tool_call", "function_call", "function_calls", "tool_calls"]);
+const TOOL_CALL_QUICK_RE = /<\s*\/?\s*(?:tool_call|tool_result|function_calls?|tool_calls)\b/i;
+const TOOL_CALL_TAG_NAMES = new Set([
+  "tool_call",
+  "tool_result",
+  "function_call",
+  "function_calls",
+  "tool_calls",
+]);
 const TOOL_CALL_JSON_PAYLOAD_START_RE =
   /^(?:\s+[A-Za-z_:][-A-Za-z0-9_:.]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))*\s*(?:\r?\n\s*)?[[{]/;
 
@@ -151,7 +157,7 @@ function parseToolCallTagAt(text: string, start: number): ParsedToolCallTag | nu
   };
 }
 
-function stripToolCallXmlTags(text: string): string {
+export function stripToolCallXmlTags(text: string): string {
   if (!text || !TOOL_CALL_QUICK_RE.test(text)) {
     return text;
   }
@@ -224,7 +230,8 @@ function stripToolCallXmlTags(text: string): string {
       }
     } else if (
       tag.isClose &&
-      tag.tagName === toolCallBlockTagName &&
+      (tag.tagName === toolCallBlockTagName ||
+        (toolCallBlockTagName === "tool_result" && tag.tagName === "tool_call")) &&
       !endsInsideQuotedString(text, toolCallContentStart, idx)
     ) {
       inToolCallBlock = false;

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -249,6 +249,186 @@ export function stripToolCallXmlTags(text: string): string {
   return result;
 }
 
+/**
+ * Strip malformed Minimax tool invocations that leak into text content.
+ * Minimax sometimes embeds tool calls as XML in text blocks instead of
+ * proper structured tool calls.
+ */
+export function stripMinimaxToolCallXml(text: string): string {
+  if (!text || !/minimax:tool_call/i.test(text)) {
+    return text;
+  }
+
+  // Remove <invoke ...>...</invoke> blocks (non-greedy to handle multiple).
+  let cleaned = text.replace(/<invoke\b[^>]*>[\s\S]*?<\/invoke>/gi, "");
+
+  // Remove stray minimax tool tags.
+  cleaned = cleaned.replace(/<\/?minimax:tool_call>/gi, "");
+
+  return cleaned;
+}
+
+/**
+ * Strip downgraded tool call text representations that leak into user-visible
+ * text content when replaying history across providers.
+ */
+export function stripDowngradedToolCallText(text: string): string {
+  if (!text) {
+    return text;
+  }
+  if (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text)) {
+    return text;
+  }
+
+  const consumeJsonish = (
+    input: string,
+    start: number,
+    options?: { allowLeadingNewlines?: boolean },
+  ): number | null => {
+    const { allowLeadingNewlines = false } = options ?? {};
+    let index = start;
+    while (index < input.length) {
+      const ch = input[index];
+      if (ch === " " || ch === "\t") {
+        index += 1;
+        continue;
+      }
+      if (allowLeadingNewlines && (ch === "\n" || ch === "\r")) {
+        index += 1;
+        continue;
+      }
+      break;
+    }
+    if (index >= input.length) {
+      return null;
+    }
+
+    const startChar = input[index];
+    if (startChar === "{" || startChar === "[") {
+      let depth = 0;
+      let inString = false;
+      let escape = false;
+      for (let idx = index; idx < input.length; idx += 1) {
+        const ch = input[idx];
+        if (inString) {
+          if (escape) {
+            escape = false;
+          } else if (ch === "\\") {
+            escape = true;
+          } else if (ch === '"') {
+            inString = false;
+          }
+          continue;
+        }
+        if (ch === '"') {
+          inString = true;
+          continue;
+        }
+        if (ch === "{" || ch === "[") {
+          depth += 1;
+        } else if (ch === "}" || ch === "]") {
+          depth -= 1;
+          if (depth === 0) {
+            return idx + 1;
+          }
+        }
+      }
+      return null;
+    }
+
+    if (startChar === '"') {
+      let escape = false;
+      for (let idx = index + 1; idx < input.length; idx += 1) {
+        const ch = input[idx];
+        if (escape) {
+          escape = false;
+          continue;
+        }
+        if (ch === "\\") {
+          escape = true;
+          continue;
+        }
+        if (ch === '"') {
+          return idx + 1;
+        }
+      }
+      return null;
+    }
+
+    let end = index;
+    while (end < input.length && input[end] !== "\n" && input[end] !== "\r") {
+      end += 1;
+    }
+    return end;
+  };
+
+  const stripToolCalls = (input: string): string => {
+    const toolCallRe = /\[Tool Call:[^\]]*\]/gi;
+    let result = "";
+    let cursor = 0;
+    for (const match of input.matchAll(toolCallRe)) {
+      const start = match.index ?? 0;
+      if (start < cursor) {
+        continue;
+      }
+      result += input.slice(cursor, start);
+      let index = start + match[0].length;
+      while (index < input.length && (input[index] === " " || input[index] === "\t")) {
+        index += 1;
+      }
+      if (input[index] === "\r") {
+        index += 1;
+        if (input[index] === "\n") {
+          index += 1;
+        }
+      } else if (input[index] === "\n") {
+        index += 1;
+      }
+      while (index < input.length && (input[index] === " " || input[index] === "\t")) {
+        index += 1;
+      }
+      if (input.slice(index, index + 9).toLowerCase() === "arguments") {
+        index += 9;
+        if (input[index] === ":") {
+          index += 1;
+        }
+        if (input[index] === " ") {
+          index += 1;
+        }
+        const end = consumeJsonish(input, index, { allowLeadingNewlines: true });
+        if (end !== null) {
+          index = end;
+        }
+      }
+      if (
+        (input[index] === "\n" || input[index] === "\r") &&
+        (result.endsWith("\n") || result.endsWith("\r") || result.length === 0)
+      ) {
+        if (input[index] === "\r") {
+          index += 1;
+        }
+        if (input[index] === "\n") {
+          index += 1;
+        }
+      }
+      cursor = index;
+    }
+    result += input.slice(cursor);
+    return result;
+  };
+
+  // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
+  let cleaned = stripToolCalls(text);
+
+  // Remove [Tool Result for ID ...] blocks and their content.
+  cleaned = cleaned.replace(/\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi, "");
+
+  // Remove [Historical context: ...] markers (self-contained within brackets).
+  cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, "");
+
+  return cleaned.trim();
+}
+
 function stripRelevantMemoriesTags(text: string): string {
   if (!text || !MEMORY_TAG_QUICK_RE.test(text)) {
     return text;
@@ -292,4 +472,33 @@ export function stripAssistantInternalScaffolding(text: string): string {
   const withoutToolCalls = stripToolCallXmlTags(withoutMemories);
   const withoutSpecialTokens = stripModelSpecialTokens(withoutToolCalls);
   return withoutSpecialTokens.trimStart();
+}
+
+/**
+ * Canonical user-visible assistant text sanitizer for delivery and history
+ * extraction paths. Keeps prose, removes internal scaffolding.
+ */
+export function sanitizeAssistantVisibleText(text: string): string {
+  return sanitizeAssistantVisibleTextWithOptions(text, { trim: "both" });
+}
+
+export function sanitizeAssistantVisibleTextWithOptions(
+  text: string,
+  options?: { trim?: "none" | "both" },
+): string {
+  if (!text) {
+    return text;
+  }
+  const trimMode = options?.trim ?? "both";
+
+  const withoutMinimaxToolXml = stripMinimaxToolCallXml(text);
+  const withoutSpecialTokens = stripModelSpecialTokens(withoutMinimaxToolXml);
+  const withoutMemories = stripRelevantMemoriesTags(withoutSpecialTokens);
+  const withoutToolCallXml = stripToolCallXmlTags(withoutMemories);
+  const withoutDowngradedToolText = stripDowngradedToolCallText(withoutToolCallXml);
+  const sanitized = stripReasoningTagsFromText(withoutDowngradedToolText, {
+    mode: "strict",
+    trim: trimMode,
+  });
+  return trimMode === "both" ? sanitized.trim() : sanitized;
 }


### PR DESCRIPTION
### Summary

- **Problem**: In Discord and other gateway-managed channels, raw `<tool_call>` and `<tool_result>` XML blocks leak into the assistant's visible messages even when `verboseDefault: "off"` is set. This occurs because the gateway layer sometimes emits tool results wrapped in XML (e.g., `<tool_result>...</tool_result>` or even mismatched `<tool_result>...</tool_call>`), and the core message delivery pipeline fails to strip these tags.
- **Root Cause**: There are two separate sanitization pipelines in the codebase. PR #60619 added `stripToolCallXmlTags()` to `stripAssistantInternalScaffolding()` in `assistant-visible-text.ts`, but this function is only exported for the plugin SDK and is **never called** in the main message delivery path. The actual delivery pipeline uses `sanitizeAssistantText()` in `pi-embedded-utils.ts`, which strips `<think>` tags, downgraded `[Tool Call: ...]` text, and Minimax XML, but completely misses standard `<tool_call>` and `<tool_result>` XML tags. Furthermore, the `TOOL_CALL_TAG_NAMES` set did not include `tool_result`, meaning even if the function was called, `<tool_result>` blocks would still leak.
- **Fix**: 
  1. Exported `stripToolCallXmlTags` from `assistant-visible-text.ts` and integrated it into the core `sanitizeAssistantText()` pipeline in `pi-embedded-utils.ts`.
  2. Added `tool_result` to `TOOL_CALL_TAG_NAMES` and `TOOL_CALL_QUICK_RE` so that tool result XML blocks are properly identified and stripped.
  This ensures that all assistant text is properly sanitized of tool XML before being chunked and delivered to any channel, fixing the root cause of the leak.
- **What changed**:
  - `src/shared/text/assistant-visible-text.ts`: Added `tool_result` to tag names and regex; exported `stripToolCallXmlTags`.
  - `src/agents/pi-embedded-utils.ts`: Imported and called `stripToolCallXmlTags` inside `sanitizeAssistantText()`.
  - `src/shared/text/assistant-visible-text.test.ts`: Added tests for `<tool_result>` stripping.
  - `src/agents/pi-embedded-utils.test.ts`: Added regression tests for `<tool_call>` and `<tool_result>` stripping in `extractAssistantText`.
- **What did NOT change (scope boundary)**: The logic for determining *when* to emit tool results (the verbose flag logic) remains unchanged. We are strictly fixing the text sanitization pipeline to ensure XML scaffolding never reaches the user-facing text buffer. The `stripAssistantInternalScaffolding` behavior for plugins remains functionally identical (just with added `tool_result` support).

### Reproduction

1. Set `agents.defaults.verboseDefault: "off"` in `openclaw.json`.
2. Use `/verbose off` in a Discord channel.
3. Send a message that triggers a tool call (e.g., "Read the file test.txt").
4. Observe that the assistant's reply no longer contains raw `<tool_call>` or `<tool_result>` XML blocks inline.

### Risk / Mitigation

- **Risk**: Stripping `<tool_result>` or `<tool_call>` might accidentally remove legitimate user-facing text if the assistant is trying to teach the user about these XML tags.
- **Mitigation**: The `stripToolCallXmlTags` function is already stateful and carefully designed to preserve literal XML-style examples in prose (e.g., when wrapped in backticks or when used as lone mentions). We added comprehensive unit tests in `pi-embedded-utils.test.ts` to ensure both the stripping of raw blocks and the preservation of legitimate text work as expected.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Agents

### Linked Issue/PR

Fixes #61688