### PR TITLE
fix: apply Gemini schema cleaning when modelId indicates Gemini behind proxy

### DIFF
--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -19,6 +19,61 @@ describe("normalizeToolParameterSchema", () => {
     expect(normalizeToolParameterSchema(schema)).toEqual(schema);
   });
 
+  it("applies Gemini schema cleaning when modelId contains 'gemini' regardless of provider name", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        action: { const: "run" },
+      },
+    };
+
+    const result = normalizeToolParameterSchema(schema, {
+      modelProvider: "custom-newapi-dditapp-com",
+      modelId: "gemini-3.1-pro-preview",
+    }) as Record<string, unknown>;
+
+    const props = result.properties as Record<string, Record<string, unknown>>;
+    // cleanSchemaForGemini converts `const` to `enum`
+    expect(props.action.const).toBeUndefined();
+    expect(props.action.enum).toEqual(["run"]);
+  });
+
+  it("strips patternProperties for Gemini model behind a proxy provider", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+      patternProperties: {
+        "^x-": { type: "string" },
+      },
+    };
+
+    const result = normalizeToolParameterSchema(schema, {
+      modelProvider: "custom-my-proxy",
+      modelId: "gemini-2.5-pro",
+    }) as Record<string, unknown>;
+
+    expect(result.patternProperties).toBeUndefined();
+  });
+
+  it("does not apply Gemini cleaning for non-Gemini models on custom providers", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        action: { const: "run" },
+      },
+    };
+
+    const result = normalizeToolParameterSchema(schema, {
+      modelProvider: "custom-newapi-dditapp-com",
+      modelId: "gpt-4o",
+    }) as Record<string, unknown>;
+
+    const props = result.properties as Record<string, Record<string, unknown>>;
+    expect(props.action.const).toBe("run");
+  });
+
   it("adds missing top-level type for raw object-ish schemas", () => {
     expect(
       normalizeToolParameterSchema({

--- a/src/agents/pi-tools.schema.ts
+++ b/src/agents/pi-tools.schema.ts
@@ -147,7 +147,8 @@ export function normalizeToolParameterSchema(
   // Normalize once here so callers can always pass `tools` through unchanged.
   const isGeminiProvider =
     options?.modelProvider?.toLowerCase().includes("google") ||
-    options?.modelProvider?.toLowerCase().includes("gemini");
+    options?.modelProvider?.toLowerCase().includes("gemini") ||
+    options?.modelId?.toLowerCase().includes("gemini");
   const isAnthropicProvider = options?.modelProvider?.toLowerCase().includes("anthropic");
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);
 


### PR DESCRIPTION
## Summary
- Fix HTTP 400 errors when using Gemini through OpenAI-compatible proxies (e.g., NewAPI, OneAPI)
- Add `modelId` check to Gemini provider detection in `normalizeToolParameterSchema()`, so `cleanSchemaForGemini()` triggers even when `modelProvider` is a custom proxy name like `"custom-newapi-dditapp-com"`

## Problem
When Gemini is accessed through a proxy with `api: "openai-completions"`, the `modelProvider` is derived from the proxy hostname (e.g., `"custom-newapi-dditapp-com"`) rather than containing `"google"` or `"gemini"`. This caused `cleanSchemaForGemini()` to be skipped, leaving unsupported schema keywords (`patternProperties`, `const`, etc.) in tool definitions, which Gemini rejects with HTTP 400:

```
400 Invalid JSON payload received. Unknown name "patternProperties" at 'tools[0].function_declarations[3]..properties[4].value': Cannot find field.
Invalid JSON payload received. Unknown name "const" at 'tools[0].function_declarations[30]..properties[2].value.any_of[0]': Cannot find field.
```

This particularly affects setups where plugin tools (e.g., feishu_drive, feishu_bitable) have schemas using these keywords.

## Fix
Add a single `||` clause to check `options.modelId` for "gemini" in `normalizeToolParameterSchema()` (line 150 of `pi-tools.schema.ts`). This pattern is already used elsewhere in the codebase (e.g., `provider-replay-helpers.ts`, `transcript-policy.test.ts`).

## Test plan
- [x] New test: Gemini cleaning triggers when `modelId` is `"gemini-3.1-pro-preview"` with custom provider
- [x] New test: `patternProperties` stripped for Gemini model behind proxy
- [x] New test: Non-Gemini models on custom providers are not affected (regression guard)
- [x] All 12 tests in `pi-tools.schema.test.ts` pass
- [ ] Manual: Verify no HTTP 400 when using Gemini through NewAPI proxy with feishu plugin tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)