### PR TITLE
fix(gateway): abort HTTP agent runs on client disconnect

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -882,4 +883,107 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       await server.close({ reason: "openai token auth owner test done" });
     }
   });
+
+  it("aborts agent command when streaming client disconnects", { timeout: 15_000 }, async () => {
+    let serverAbortSignal: AbortSignal | undefined;
+
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(
+      (opts: unknown) =>
+        new Promise<undefined>((resolve) => {
+          const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+          serverAbortSignal = signal;
+          if (signal?.aborted) {
+            resolve(undefined);
+            return;
+          }
+          signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+        }),
+    );
+
+    const clientReq = http.request({
+      hostname: "127.0.0.1",
+      port: enabledPort,
+      path: "/v1/chat/completions",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-openclaw-scopes": "operator.write",
+      },
+    });
+    clientReq.on("error", () => {});
+    clientReq.end(
+      JSON.stringify({
+        stream: true,
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    });
+
+    clientReq.destroy();
+
+    await vi.waitFor(
+      () => {
+        expect(serverAbortSignal?.aborted).toBe(true);
+      },
+      { timeout: 5_000, interval: 50 },
+    );
+  });
+
+  it(
+    "aborts agent command when non-streaming client disconnects",
+    { timeout: 15_000 },
+    async () => {
+      let serverAbortSignal: AbortSignal | undefined;
+
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce(
+        (opts: unknown) =>
+          new Promise<undefined>((resolve) => {
+            const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+            serverAbortSignal = signal;
+            if (signal?.aborted) {
+              resolve(undefined);
+              return;
+            }
+            signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+          }),
+      );
+
+      const clientReq = http.request({
+        hostname: "127.0.0.1",
+        port: enabledPort,
+        path: "/v1/chat/completions",
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openclaw-scopes": "operator.write",
+        },
+      });
+      clientReq.on("error", () => {});
+      clientReq.end(
+        JSON.stringify({
+          model: "openclaw",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(agentCommand).toHaveBeenCalledTimes(1);
+      });
+
+      clientReq.destroy();
+
+      await vi.waitFor(
+        () => {
+          expect(serverAbortSignal?.aborted).toBe(true);
+        },
+        { timeout: 5_000, interval: 50 },
+      );
+    },
+  );
 });

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -506,12 +506,29 @@ export async function handleOpenAiHttpRequest(
     senderIsOwner,
   });
 
+  // Abort the embedded agent run when the HTTP client disconnects.
+  // Without this, cancelled requests leave Ollama NUM_PARALLEL slots occupied
+  // for up to agents.defaults.timeoutSeconds (48h by default).
+  const httpAbortController = new AbortController();
+
   if (!stream) {
+    let responseSent = false;
+    res.on("close", () => {
+      if (!responseSent) {
+        logWarn(`openai-compat: client disconnected, aborting agent run runId=${runId}`);
+        httpAbortController.abort(new Error("client_disconnect"));
+      }
+    });
     try {
-      const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
+      const result = await agentCommandFromIngress(
+        { ...commandInput, abortSignal: httpAbortController.signal },
+        defaultRuntime,
+        deps,
+      );
 
       const content = resolveAgentResponseText(result);
 
+      responseSent = true;
       sendJson(res, 200, {
         id: runId,
         object: "chat.completion",
@@ -528,6 +545,7 @@ export async function handleOpenAiHttpRequest(
       });
     } catch (err) {
       logWarn(`openai-compat: chat completion failed: ${String(err)}`);
+      responseSent = true;
       sendJson(res, 500, {
         error: { message: "internal error", type: "api_error" },
       });
@@ -581,14 +599,22 @@ export async function handleOpenAiHttpRequest(
     }
   });
 
-  req.on("close", () => {
+  res.on("close", () => {
+    if (!closed) {
+      logWarn(`openai-compat: client disconnected, aborting streaming run runId=${runId}`);
+    }
     closed = true;
     unsubscribe();
+    httpAbortController.abort(new Error("client_disconnect"));
   });
 
   void (async () => {
     try {
-      const result = await agentCommandFromIngress(commandInput, defaultRuntime, deps);
+      const result = await agentCommandFromIngress(
+        { ...commandInput, abortSignal: httpAbortController.signal },
+        defaultRuntime,
+        deps,
+      );
 
       if (closed) {
         return;

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -1169,4 +1170,107 @@ describe("OpenResponses HTTP API (e2e)", () => {
       await capServer.close({ reason: "responses url cap hardening test done" });
     }
   });
+
+  it("aborts agent command when streaming client disconnects", { timeout: 15_000 }, async () => {
+    let serverAbortSignal: AbortSignal | undefined;
+
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce(
+      (opts: unknown) =>
+        new Promise<undefined>((resolve) => {
+          const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+          serverAbortSignal = signal;
+          if (signal?.aborted) {
+            resolve(undefined);
+            return;
+          }
+          signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+        }),
+    );
+
+    const clientReq = http.request({
+      hostname: "127.0.0.1",
+      port: enabledPort,
+      path: "/v1/responses",
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-openclaw-scopes": "operator.write",
+      },
+    });
+    clientReq.on("error", () => {});
+    clientReq.end(
+      JSON.stringify({
+        stream: true,
+        model: "openclaw",
+        input: "hi",
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(agentCommand).toHaveBeenCalledTimes(1);
+    });
+
+    clientReq.destroy();
+
+    await vi.waitFor(
+      () => {
+        expect(serverAbortSignal?.aborted).toBe(true);
+      },
+      { timeout: 5_000, interval: 50 },
+    );
+  });
+
+  it(
+    "aborts agent command when non-streaming client disconnects",
+    { timeout: 15_000 },
+    async () => {
+      let serverAbortSignal: AbortSignal | undefined;
+
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce(
+        (opts: unknown) =>
+          new Promise<undefined>((resolve) => {
+            const signal = (opts as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+            serverAbortSignal = signal;
+            if (signal?.aborted) {
+              resolve(undefined);
+              return;
+            }
+            signal?.addEventListener("abort", () => resolve(undefined), { once: true });
+          }),
+      );
+
+      const clientReq = http.request({
+        hostname: "127.0.0.1",
+        port: enabledPort,
+        path: "/v1/responses",
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-openclaw-scopes": "operator.write",
+        },
+      });
+      clientReq.on("error", () => {});
+      clientReq.end(
+        JSON.stringify({
+          model: "openclaw",
+          input: "hi",
+        }),
+      );
+
+      await vi.waitFor(() => {
+        expect(agentCommand).toHaveBeenCalledTimes(1);
+      });
+
+      clientReq.destroy();
+
+      await vi.waitFor(
+        () => {
+          expect(serverAbortSignal?.aborted).toBe(true);
+        },
+        { timeout: 5_000, interval: 50 },
+      );
+    },
+  );
 });

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -407,6 +407,7 @@ async function runResponsesAgentCommand(params: {
   messageChannel: string;
   senderIsOwner: boolean;
   deps: ReturnType<typeof createDefaultDeps>;
+  abortSignal?: AbortSignal;
 }) {
   return agentCommandFromIngress(
     {
@@ -423,6 +424,7 @@ async function runResponsesAgentCommand(params: {
       bestEffortDeliver: false,
       senderIsOwner: params.senderIsOwner,
       allowModelOverride: true,
+      abortSignal: params.abortSignal,
     },
     defaultRuntime,
     params.deps,
@@ -680,7 +682,19 @@ export async function handleOpenResponsesHttpRequest(
       ? { maxTokens: payload.max_output_tokens }
       : undefined;
 
+  // Abort the embedded agent run when the HTTP client disconnects.
+  // Without this, cancelled requests leave Ollama NUM_PARALLEL slots occupied
+  // for up to agents.defaults.timeoutSeconds (48h by default).
+  const httpAbortController = new AbortController();
+
   if (!stream) {
+    let responseSent = false;
+    res.on("close", () => {
+      if (!responseSent) {
+        logWarn(`openresponses: client disconnected, aborting non-streaming run runId=${responseId}`);
+        httpAbortController.abort(new Error("client_disconnect"));
+      }
+    });
     try {
       const result = await runResponsesAgentCommand({
         message: prompt.message,
@@ -694,6 +708,7 @@ export async function handleOpenResponsesHttpRequest(
         messageChannel,
         senderIsOwner,
         deps,
+        abortSignal: httpAbortController.signal,
       });
 
       const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
@@ -742,6 +757,7 @@ export async function handleOpenResponsesHttpRequest(
           usage,
         });
         rememberResponseSession();
+        responseSent = true;
         sendJson(res, 200, response);
         return true;
       }
@@ -770,6 +786,7 @@ export async function handleOpenResponsesHttpRequest(
       });
 
       rememberResponseSession();
+      responseSent = true;
       sendJson(res, 200, response);
     } catch (err) {
       logWarn(`openresponses: non-stream response failed: ${String(err)}`);
@@ -781,6 +798,7 @@ export async function handleOpenResponsesHttpRequest(
         error: { code: "api_error", message: "internal error" },
       });
       rememberResponseSession();
+      responseSent = true;
       sendJson(res, 500, response);
     }
     return true;
@@ -940,9 +958,13 @@ export async function handleOpenResponsesHttpRequest(
     }
   });
 
-  req.on("close", () => {
+  res.on("close", () => {
+    if (!closed) {
+      logWarn(`openresponses: client disconnected, aborting streaming run runId=${responseId}`);
+    }
     closed = true;
     unsubscribe();
+    httpAbortController.abort(new Error("client_disconnect"));
   });
 
   void (async () => {
@@ -959,6 +981,7 @@ export async function handleOpenResponsesHttpRequest(
         messageChannel,
         senderIsOwner,
         deps,
+        abortSignal: httpAbortController.signal,
       });
 
       finalUsage = extractUsageFromResult(result);


### PR DESCRIPTION
When an HTTP client disconnects mid-request on `/v1/responses` or `/v1/chat/completions`, the embedded agent run previously continued until its full timeout (up to `agents.defaults.timeoutSeconds` -- 48h by default), holding resources (e.g. Ollama `NUM_PARALLEL` slots).

## Summary

- **Problem:** HTTP client disconnect does not cancel the in-flight agent run on `/v1/responses` or `/v1/chat/completions`
- **Why it matters:** Disconnected requests hold LLM backend slots (e.g. Ollama `NUM_PARALLEL`) for up to 48h, starving other requests
- **What changed:** Wired `AbortController` + `res.on("close")` into both endpoints (streaming and non-streaming paths), passing `abortSignal` through `agentCommandFromIngress` -> `acpManager.runTurn`
- **What did NOT change (scope boundary):** No changes to the agent runtime, ACP manager, WebSocket handlers, or any other endpoint. The `AbortSignal` infrastructure was already in place; this PR only wires it into the two HTTP endpoints that were missing it

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts

## Linked Issue/PR

- Related #54388
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The `/v1/chat/completions` and `/v1/responses` HTTP handlers were implemented without `AbortController` integration. The `abortSignal` parameter on `AgentCommandOpts` existed but was never wired in from these HTTP code paths.
- Missing detection / guardrail: No tests verified that client disconnection propagated an abort signal to the agent command layer for HTTP endpoints.
- Contributing context (if known): The WebSocket chat handler (`server-methods/chat.ts`) was implemented with proper abort support from the start; the HTTP endpoints were added later without this consideration.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `src/gateway/openai-http.test.ts`, `src/gateway/openresponses-http.test.ts`
- Scenario the test should lock in: When an HTTP client disconnects mid-request (both streaming and non-streaming), the `abortSignal` passed to `agentCommandFromIngress` must transition to aborted state.
- Why this is the smallest reliable guardrail: The tests mock the agent command to observe the abort signal directly, using `http.request` + `req.destroy()` to simulate client disconnection.
- Existing test that already covers this (if any): None for HTTP; WebSocket abort tests exist elsewhere.
- If no new test is added, why not: 4 new tests added.

## User-visible / Behavior Changes

When an HTTP client disconnects from `/v1/chat/completions` or `/v1/responses` (streaming or non-streaming), the backend now cancels the in-flight agent run instead of letting it continue to timeout. This frees resources faster.

## Diagram (if applicable)

```text
Before:
[client disconnect] -> [agent run continues to timeout] -> [slot freed after 48h]

After:
[client disconnect] -> [res.on("close")] -> [AbortController.abort()] -> [slot freed in ~1s]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Docker linux/amd64)
- Runtime/container: Node 22 / OpenClaw 2026.4.4
- Model/provider: Ollama (qwen3.5-128k) with `NUM_PARALLEL=1`
- Integration/channel (if any): HTTP gateway endpoints
- Relevant config (redacted): default local config

### Steps

1. Start gateway with HTTP endpoints enabled
2. Send a streaming request to `/v1/responses`
3. Disconnect the client before the response completes

### Expected

- The agent command receives an aborted signal and stops processing

### Actual

- Before fix: agent command continues running to completion
- After fix: matches expected

## Evidence

- [x] Trace/log snippets

```
[openresponses] client disconnected, aborting agent run runId=resp_6cd0b051-...
[agent] run resp_6cd0b051-... ended with stopReason=toolUse
```

Local test results:
- `pnpm test -- src/gateway/openai-http.test.ts` (7/7 passed)
- `pnpm test -- src/gateway/openresponses-http.test.ts` (16/16 passed)

## Human Verification (required)

- Verified scenarios: streaming disconnect on `/v1/responses` with Ollama (`NUM_PARALLEL=1`) -- agent run terminated within 1 second of client disconnect
- Edge cases checked: `res.on("close")` vs `req.on("close")` -- verified that `req.on("close")` does NOT fire reliably after body consumption; switched to `res.on("close")`
- What you did **not** verify: full `pnpm test` suite; live integration with cloud LLM providers

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: `res.on("close")` fires after a successful response is fully sent, calling `abort()` on a completed operation.
  - Mitigation: Aborting an already-completed `AbortController` is a no-op. The `!closed` guard in streaming paths prevents spurious log noise.
