### PR TITLE
fix(runtime): restore compatibility shims

### DIFF
--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -68,7 +68,7 @@ function resolveModelRequestPolicy(model: Model<Api>) {
 export function buildGuardedModelFetch(model: Model<Api>): typeof fetch {
   const requestConfig = resolveModelRequestPolicy(model);
   const dispatcherPolicy = buildProviderRequestDispatcherPolicy(requestConfig);
-  return async (input, init) => {
+  const guardedFetch = async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? new Request(input, init) : undefined;
     const url =
       request?.url ??
@@ -97,4 +97,7 @@ export function buildGuardedModelFetch(model: Model<Api>): typeof fetch {
     });
     return buildManagedResponse(result.response, result.release);
   };
+  return Object.assign(guardedFetch, {
+    preconnect: (_url: string | URL, _options?: { credentials?: RequestCredentials }) => {},
+  }) as typeof fetch;
 }

--- a/src/agents/skills/skill-contract.ts
+++ b/src/agents/skills/skill-contract.ts
@@ -1,11 +1,20 @@
-import type { Skill as CanonicalSkill, SourceInfo } from "@mariozechner/pi-coding-agent";
+import type { Skill as CanonicalSkill } from "@mariozechner/pi-coding-agent";
 
 export type SourceScope = "user" | "project" | "temporary";
 export type SourceOrigin = "package" | "top-level";
+export type SourceInfo = {
+  path: string;
+  source: string;
+  scope: SourceScope;
+  origin: SourceOrigin;
+  baseDir?: string;
+};
 
 export type Skill = CanonicalSkill & {
   // Preserve legacy source reads while keeping the canonical upstream shape.
   source?: string;
+  // Preserve legacy source metadata reads while keeping the canonical upstream shape.
+  sourceInfo?: SourceInfo;
 };
 
 export function createSyntheticSourceInfo(

--- a/src/auto-reply/reply/commands-subagents-control.runtime.ts
+++ b/src/auto-reply/reply/commands-subagents-control.runtime.ts
@@ -1,6 +1,7 @@
 export {
   killAllControlledSubagentRuns,
   killControlledSubagentRun,
+  listControlledSubagentRuns,
   sendControlledSubagentMessage,
   steerControlledSubagentRun,
 } from "../../agents/subagent-control.js";

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -25,7 +25,7 @@ import {
   truncateLine,
 } from "../../../shared/subagents-format.js";
 import { resolveCommandSurfaceChannel, resolveChannelAccountId } from "../channel-context.js";
-import { extractMessageText } from "../commands-subagents-text.js";
+import { extractMessageText, type ChatMessage } from "../commands-subagents-text.js";
 import type { CommandHandler, CommandHandlerResult } from "../commands-types.js";
 import {
   formatRunLabel,

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -48,6 +48,10 @@ type FetchConfig = NonNullable<OpenClawConfig["tools"]>["web"] extends infer Web
     : undefined
   : undefined;
 
+type LegacyXSearchConfig = Record<string, unknown> & {
+  apiKey?: unknown;
+};
+
 type SecretResolutionResult = {
   value?: string;
   source: WebSearchCredentialResolutionSource | WebFetchCredentialResolutionSource;
@@ -386,8 +390,12 @@ export async function resolveRuntimeWebTools(params: {
     ? params.resolvedConfig.tools
     : undefined;
   const resolvedWeb = isRecord(resolvedTools?.web) ? resolvedTools.web : undefined;
-  const legacyXSearchSource = isRecord(sourceWeb?.x_search) ? sourceWeb.x_search : undefined;
-  const legacyXSearchResolved = isRecord(resolvedWeb?.x_search) ? resolvedWeb.x_search : undefined;
+  const legacyXSearchSource = isRecord(sourceWeb?.x_search)
+    ? (sourceWeb.x_search as LegacyXSearchConfig)
+    : undefined;
+  const legacyXSearchResolved = isRecord(resolvedWeb?.x_search)
+    ? (resolvedWeb.x_search as LegacyXSearchConfig)
+    : undefined;
   if (!sourceWeb && !hasPluginWebToolConfig(params.sourceConfig)) {
     return {
       search: {


### PR DESCRIPTION
## Summary

- Problem: recent runtime/type surface changes dropped a few compatibility shims that downstream runtime paths still read.
- Why it matters: those paths can fail at runtime or lose expected legacy metadata when older callers still depend on the previous shape.
- What changed: restored a no-op `fetch.preconnect` shim on guarded model fetches, preserved legacy `sourceInfo` typing on skills, re-exported `listControlledSubagentRuns`, added the `ChatMessage` type import used by subagent reply helpers, and narrowed legacy `x_search` config reads with an explicit compatibility type.
- What did NOT change (scope boundary): no new provider behavior, secret sources, or command semantics were introduced.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: compatibility reads still expected older runtime shims and metadata fields after adjacent surface tightening.
- Missing detection / guardrail: the affected compatibility paths were not covered by a focused regression test in this change.
- Contributing context (if known): the breakage spans a few small runtime seams, so it shows up as downstream integration failures rather than a single obvious compile-time error.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: targeted coverage around guarded fetch compatibility, skill source metadata compatibility, and subagent control runtime exports.
- Scenario the test should lock in: legacy callers can still read the preserved runtime shim and metadata/export surface without runtime errors.
- Why this is the smallest reliable guardrail: each fix is a narrow compatibility seam that can be locked in without broader end-to-end setup.
- Existing test that already covers this (if any): none confirmed in this PR.
- If no new test is added, why not: this PR was raised from an already-tested local fix and does not add new coverage.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev workspace
- Model/provider: N/A
- Integration/channel (if any): runtime compatibility surfaces only
- Relevant config (redacted): N/A

### Steps

1. Exercise the affected runtime seams that still expect the legacy compatibility surface.
2. Run the already-tested local workflow with this patch applied.
3. Confirm the compatibility path no longer fails.

### Expected

- Legacy compatibility reads continue to work without runtime errors.

### Actual

- Compatibility shims and metadata are restored.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: user reported the patched workflow was already tested and working before PR creation.
- Edge cases checked: I verified the fork branch and upstream PR target only.
- What you did **not** verify: I did not rerun local tests or repro steps in this PR flow.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: compatibility coverage is still implicit rather than locked in with a focused regression test.
  - Mitigation: follow up with narrow seam-level tests if maintainers want the fix hardened further.