### PR TITLE
fix(agents): suppress commentary leaks in history-based replies

### DIFF
--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -73,6 +73,32 @@ describe("readLatestAssistantReply", () => {
     expect(result.text).toBe("new output");
     expect(result.fingerprint).toContain('"timestamp":42');
   });
+
+  it("reads only final_answer text from phased assistant history", async () => {
+    callGatewayMock.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Need fix line quoting properly.",
+              textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+            },
+            {
+              type: "text",
+              text: "Fixed the quoting issue.",
+              textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await readLatestAssistantReply({ sessionKey: "agent:main:child" });
+
+    expect(result).toBe("Fixed the quoting issue.");
+  });
 });
 
 describe("waitForAgentRun", () => {

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -99,6 +99,37 @@ describe("readLatestAssistantReply", () => {
 
     expect(result).toBe("Fixed the quoting issue.");
   });
+
+  it("preserves spaces across split final_answer history blocks", async () => {
+    callGatewayMock.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Need fix line quoting properly.",
+              textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+            },
+            {
+              type: "text",
+              text: "Hi ",
+              textSignature: JSON.stringify({ v: 1, id: "final_1", phase: "final_answer" }),
+            },
+            {
+              type: "text",
+              text: "there",
+              textSignature: JSON.stringify({ v: 1, id: "final_2", phase: "final_answer" }),
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await readLatestAssistantReply({ sessionKey: "agent:main:child" });
+
+    expect(result).toBe("Hi there");
+  });
 });
 
 describe("waitForAgentRun", () => {

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -117,17 +117,7 @@ function extractSubagentOutputText(message: unknown): string {
   const role = (message as { role?: unknown }).role;
   const content = (message as { content?: unknown }).content;
   if (role === "assistant") {
-    const assistantText = extractAssistantText(message);
-    if (assistantText) {
-      return assistantText;
-    }
-    if (typeof content === "string") {
-      return sanitizeTextContent(content);
-    }
-    if (Array.isArray(content)) {
-      return extractInlineTextContent(content);
-    }
-    return "";
+    return extractAssistantText(message) ?? "";
   }
   if (role === "toolResult" || role === "tool") {
     return extractToolResultText((message as ToolResultMessage).content);

--- a/src/agents/tools/assistant-phase-text.test.ts
+++ b/src/agents/tools/assistant-phase-text.test.ts
@@ -3,6 +3,13 @@ import { extractAssistantText as extractChatHistoryAssistantText } from "./chat-
 import { extractAssistantText as extractSessionAssistantText } from "./session-message-text.js";
 
 describe("phase-aware assistant text helpers", () => {
+  it("fails soft for malformed inputs", () => {
+    for (const message of [null, 42, "broken history entry"]) {
+      expect(extractChatHistoryAssistantText(message)).toBeUndefined();
+      expect(extractSessionAssistantText(message)).toBeUndefined();
+    }
+  });
+
   it("prefers final_answer text over commentary in chat history helpers", () => {
     const message = {
       role: "assistant",

--- a/src/agents/tools/assistant-phase-text.test.ts
+++ b/src/agents/tools/assistant-phase-text.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { extractAssistantText as extractChatHistoryAssistantText } from "./chat-history-text.js";
+import { extractAssistantText as extractSessionAssistantText } from "./session-message-text.js";
+
+describe("phase-aware assistant text helpers", () => {
+  it("prefers final_answer text over commentary in chat history helpers", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need fix line quoting properly.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "Fixed the quoting issue.",
+          textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractChatHistoryAssistantText(message)).toBe("Fixed the quoting issue.");
+  });
+
+  it("does not fall back to commentary when an explicit final_answer is empty", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need simpler use cat overwrite full file.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "   ",
+          textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractChatHistoryAssistantText(message)).toBeUndefined();
+  });
+
+  it("prefers final_answer text over commentary in session message helpers", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need verify healthy.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "Health check completed successfully.",
+          textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractSessionAssistantText(message)).toBe("Health check completed successfully.");
+  });
+});

--- a/src/agents/tools/assistant-phase-text.test.ts
+++ b/src/agents/tools/assistant-phase-text.test.ts
@@ -43,6 +43,31 @@ describe("phase-aware assistant text helpers", () => {
     expect(extractChatHistoryAssistantText(message)).toBeUndefined();
   });
 
+  it("preserves spaces across split final_answer blocks in chat history helpers", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need verify healthy.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "Hi ",
+          textSignature: JSON.stringify({ v: 1, id: "final_1", phase: "final_answer" }),
+        },
+        {
+          type: "text",
+          text: "<think>secret</think>there",
+          textSignature: JSON.stringify({ v: 1, id: "final_2", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractChatHistoryAssistantText(message)).toBe("Hi there");
+  });
+
   it("prefers final_answer text over commentary in session message helpers", () => {
     const message = {
       role: "assistant",
@@ -61,5 +86,30 @@ describe("phase-aware assistant text helpers", () => {
     };
 
     expect(extractSessionAssistantText(message)).toBe("Health check completed successfully.");
+  });
+
+  it("preserves spaces across split final_answer blocks in session message helpers", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need verify healthy.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "Hi ",
+          textSignature: JSON.stringify({ v: 1, id: "final_1", phase: "final_answer" }),
+        },
+        {
+          type: "text",
+          text: "<think>secret</think>there",
+          textSignature: JSON.stringify({ v: 1, id: "final_2", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractSessionAssistantText(message)).toBe("Hi there");
   });
 });

--- a/src/agents/tools/chat-history-text.ts
+++ b/src/agents/tools/chat-history-text.ts
@@ -31,6 +31,10 @@ export function sanitizeTextContent(text: string): string {
 }
 
 export function extractAssistantText(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+
   const joined =
     extractAssistantTextForPhase(message, {
       phase: "final_answer",

--- a/src/agents/tools/chat-history-text.ts
+++ b/src/agents/tools/chat-history-text.ts
@@ -1,4 +1,9 @@
 import { extractTextFromChatContent } from "../../shared/chat-content.js";
+import {
+  normalizeAssistantPhase,
+  parseAssistantTextSignature,
+  type AssistantPhase,
+} from "../../shared/chat-message-content.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
   stripDowngradedToolCallText,
@@ -30,23 +35,80 @@ export function sanitizeTextContent(text: string): string {
   );
 }
 
-export function extractAssistantText(message: unknown): string | undefined {
+function extractAssistantTextForPhase(
+  message: unknown,
+  phase?: AssistantPhase,
+): string | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
   }
   if ((message as { role?: unknown }).role !== "assistant") {
     return undefined;
   }
-  const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
+  const entry = message as { text?: unknown; content?: unknown; phase?: unknown };
+  const messagePhase = normalizeAssistantPhase(entry.phase);
+  const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
+    if (phase) {
+      return resolvedPhase === phase;
+    }
+    return resolvedPhase === undefined;
+  };
+  const normalizeVisibleText = (text: string) => {
+    const normalized = sanitizeTextContent(text).trim();
+    return normalized || undefined;
+  };
+
+  if (typeof entry.text === "string") {
+    return shouldIncludeContent(messagePhase) ? normalizeVisibleText(entry.text) : undefined;
+  }
+
+  if (typeof entry.content === "string") {
+    return shouldIncludeContent(messagePhase) ? normalizeVisibleText(entry.content) : undefined;
+  }
+
+  if (!Array.isArray(entry.content)) {
     return undefined;
   }
+
+  const hasExplicitPhasedTextBlocks = entry.content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const record = block as { type?: unknown; textSignature?: unknown };
+    if (record.type !== "text") {
+      return false;
+    }
+    return Boolean(parseAssistantTextSignature(record.textSignature)?.phase);
+  });
+
   const joined =
-    extractTextFromChatContent(content, {
-      sanitizeText: sanitizeTextContent,
-      joinWith: "",
-      normalizeText: (text) => text.trim(),
-    }) ?? "";
+    extractTextFromChatContent(
+      entry.content.filter((block) => {
+        if (!block || typeof block !== "object") {
+          return false;
+        }
+        const record = block as { type?: unknown; textSignature?: unknown };
+        if (record.type !== "text") {
+          return false;
+        }
+        const signature = parseAssistantTextSignature(record.textSignature);
+        const resolvedPhase =
+          signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
+        return shouldIncludeContent(resolvedPhase);
+      }),
+      {
+        sanitizeText: sanitizeTextContent,
+        joinWith: "",
+        normalizeText: (text) => text.trim(),
+      },
+    ) ?? "";
+
+  return joined || undefined;
+}
+
+export function extractAssistantText(message: unknown): string | undefined {
+  const joined =
+    extractAssistantTextForPhase(message, "final_answer") ?? extractAssistantTextForPhase(message);
   const stopReason = (message as { stopReason?: unknown }).stopReason;
   // Gate on stopReason only — a non-error response with a stale/background errorMessage
   // should not have its content rewritten with error templates (#13935).

--- a/src/agents/tools/chat-history-text.ts
+++ b/src/agents/tools/chat-history-text.ts
@@ -1,9 +1,4 @@
-import { extractTextFromChatContent } from "../../shared/chat-content.js";
-import {
-  normalizeAssistantPhase,
-  parseAssistantTextSignature,
-  type AssistantPhase,
-} from "../../shared/chat-message-content.js";
+import { extractAssistantTextForPhase } from "../../shared/chat-message-content.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
   stripDowngradedToolCallText,
@@ -35,80 +30,17 @@ export function sanitizeTextContent(text: string): string {
   );
 }
 
-function extractAssistantTextForPhase(
-  message: unknown,
-  phase?: AssistantPhase,
-): string | undefined {
-  if (!message || typeof message !== "object") {
-    return undefined;
-  }
-  if ((message as { role?: unknown }).role !== "assistant") {
-    return undefined;
-  }
-  const entry = message as { text?: unknown; content?: unknown; phase?: unknown };
-  const messagePhase = normalizeAssistantPhase(entry.phase);
-  const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
-    if (phase) {
-      return resolvedPhase === phase;
-    }
-    return resolvedPhase === undefined;
-  };
-  const normalizeVisibleText = (text: string) => {
-    const normalized = sanitizeTextContent(text).trim();
-    return normalized || undefined;
-  };
-
-  if (typeof entry.text === "string") {
-    return shouldIncludeContent(messagePhase) ? normalizeVisibleText(entry.text) : undefined;
-  }
-
-  if (typeof entry.content === "string") {
-    return shouldIncludeContent(messagePhase) ? normalizeVisibleText(entry.content) : undefined;
-  }
-
-  if (!Array.isArray(entry.content)) {
-    return undefined;
-  }
-
-  const hasExplicitPhasedTextBlocks = entry.content.some((block) => {
-    if (!block || typeof block !== "object") {
-      return false;
-    }
-    const record = block as { type?: unknown; textSignature?: unknown };
-    if (record.type !== "text") {
-      return false;
-    }
-    return Boolean(parseAssistantTextSignature(record.textSignature)?.phase);
-  });
-
-  const joined =
-    extractTextFromChatContent(
-      entry.content.filter((block) => {
-        if (!block || typeof block !== "object") {
-          return false;
-        }
-        const record = block as { type?: unknown; textSignature?: unknown };
-        if (record.type !== "text") {
-          return false;
-        }
-        const signature = parseAssistantTextSignature(record.textSignature);
-        const resolvedPhase =
-          signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
-        return shouldIncludeContent(resolvedPhase);
-      }),
-      {
-        sanitizeText: sanitizeTextContent,
-        joinWith: "",
-        normalizeText: (text) => text.trim(),
-      },
-    ) ?? "";
-
-  return joined || undefined;
-}
-
 export function extractAssistantText(message: unknown): string | undefined {
   const joined =
-    extractAssistantTextForPhase(message, "final_answer") ?? extractAssistantTextForPhase(message);
+    extractAssistantTextForPhase(message, {
+      phase: "final_answer",
+      sanitizeText: sanitizeTextContent,
+      joinWith: "",
+    }) ??
+    extractAssistantTextForPhase(message, {
+      sanitizeText: sanitizeTextContent,
+      joinWith: "",
+    });
   const stopReason = (message as { stopReason?: unknown }).stopReason;
   // Gate on stopReason only — a non-error response with a stale/background errorMessage
   // should not have its content rewritten with error templates (#13935).

--- a/src/agents/tools/session-message-text.ts
+++ b/src/agents/tools/session-message-text.ts
@@ -1,4 +1,9 @@
 import { extractTextFromChatContent } from "../../shared/chat-content.js";
+import {
+  normalizeAssistantPhase,
+  parseAssistantTextSignature,
+  type AssistantPhase,
+} from "../../shared/chat-message-content.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
   stripDowngradedToolCallText,
@@ -26,23 +31,80 @@ export function sanitizeTextContent(text: string): string {
   );
 }
 
-export function extractAssistantText(message: unknown): string | undefined {
+function extractAssistantTextForPhase(
+  message: unknown,
+  phase?: AssistantPhase,
+): string | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
   }
   if ((message as { role?: unknown }).role !== "assistant") {
     return undefined;
   }
-  const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
+  const entry = message as { text?: unknown; content?: unknown; phase?: unknown };
+  const messagePhase = normalizeAssistantPhase(entry.phase);
+  const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
+    if (phase) {
+      return resolvedPhase === phase;
+    }
+    return resolvedPhase === undefined;
+  };
+  const normalizeVisibleText = (text: string) => {
+    const normalized = sanitizeTextContent(text).trim();
+    return normalized || undefined;
+  };
+
+  if (typeof entry.text === "string") {
+    return shouldIncludeContent(messagePhase) ? normalizeVisibleText(entry.text) : undefined;
+  }
+
+  if (typeof entry.content === "string") {
+    return shouldIncludeContent(messagePhase) ? normalizeVisibleText(entry.content) : undefined;
+  }
+
+  if (!Array.isArray(entry.content)) {
     return undefined;
   }
+
+  const hasExplicitPhasedTextBlocks = entry.content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const record = block as { type?: unknown; textSignature?: unknown };
+    if (record.type !== "text") {
+      return false;
+    }
+    return Boolean(parseAssistantTextSignature(record.textSignature)?.phase);
+  });
+
   const joined =
-    extractTextFromChatContent(content, {
-      sanitizeText: sanitizeTextContent,
-      joinWith: "",
-      normalizeText: (text) => text.trim(),
-    }) ?? "";
+    extractTextFromChatContent(
+      entry.content.filter((block) => {
+        if (!block || typeof block !== "object") {
+          return false;
+        }
+        const record = block as { type?: unknown; textSignature?: unknown };
+        if (record.type !== "text") {
+          return false;
+        }
+        const signature = parseAssistantTextSignature(record.textSignature);
+        const resolvedPhase =
+          signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
+        return shouldIncludeContent(resolvedPhase);
+      }),
+      {
+        sanitizeText: sanitizeTextContent,
+        joinWith: "",
+        normalizeText: (text) => text.trim(),
+      },
+    ) ?? "";
+
+  return joined || undefined;
+}
+
+export function extractAssistantText(message: unknown): string | undefined {
+  const joined =
+    extractAssistantTextForPhase(message, "final_answer") ?? extractAssistantTextForPhase(message);
   const stopReason = (message as { stopReason?: unknown }).stopReason;
   const errorContext = stopReason === "error";
 

--- a/src/agents/tools/session-message-text.ts
+++ b/src/agents/tools/session-message-text.ts
@@ -27,6 +27,10 @@ export function sanitizeTextContent(text: string): string {
 }
 
 export function extractAssistantText(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+
   const joined =
     extractAssistantTextForPhase(message, {
       phase: "final_answer",

--- a/src/agents/tools/session-message-text.ts
+++ b/src/agents/tools/session-message-text.ts
@@ -1,9 +1,4 @@
-import { extractTextFromChatContent } from "../../shared/chat-content.js";
-import {
-  normalizeAssistantPhase,
-  parseAssistantTextSignature,
-  type AssistantPhase,
-} from "../../shared/chat-message-content.js";
+import { extractAssistantTextForPhase } from "../../shared/chat-message-content.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
 import {
   stripDowngradedToolCallText,
@@ -31,80 +26,17 @@ export function sanitizeTextContent(text: string): string {
   );
 }
 
-function extractAssistantTextForPhase(
-  message: unknown,
-  phase?: AssistantPhase,
-): string | undefined {
-  if (!message || typeof message !== "object") {
-    return undefined;
-  }
-  if ((message as { role?: unknown }).role !== "assistant") {
-    return undefined;
-  }
-  const entry = message as { text?: unknown; content?: unknown; phase?: unknown };
-  const messagePhase = normalizeAssistantPhase(entry.phase);
-  const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
-    if (phase) {
-      return resolvedPhase === phase;
-    }
-    return resolvedPhase === undefined;
-  };
-  const normalizeVisibleText = (text: string) => {
-    const normalized = sanitizeTextContent(text).trim();
-    return normalized || undefined;
-  };
-
-  if (typeof entry.text === "string") {
-    return shouldIncludeContent(messagePhase) ? normalizeVisibleText(entry.text) : undefined;
-  }
-
-  if (typeof entry.content === "string") {
-    return shouldIncludeContent(messagePhase) ? normalizeVisibleText(entry.content) : undefined;
-  }
-
-  if (!Array.isArray(entry.content)) {
-    return undefined;
-  }
-
-  const hasExplicitPhasedTextBlocks = entry.content.some((block) => {
-    if (!block || typeof block !== "object") {
-      return false;
-    }
-    const record = block as { type?: unknown; textSignature?: unknown };
-    if (record.type !== "text") {
-      return false;
-    }
-    return Boolean(parseAssistantTextSignature(record.textSignature)?.phase);
-  });
-
-  const joined =
-    extractTextFromChatContent(
-      entry.content.filter((block) => {
-        if (!block || typeof block !== "object") {
-          return false;
-        }
-        const record = block as { type?: unknown; textSignature?: unknown };
-        if (record.type !== "text") {
-          return false;
-        }
-        const signature = parseAssistantTextSignature(record.textSignature);
-        const resolvedPhase =
-          signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
-        return shouldIncludeContent(resolvedPhase);
-      }),
-      {
-        sanitizeText: sanitizeTextContent,
-        joinWith: "",
-        normalizeText: (text) => text.trim(),
-      },
-    ) ?? "";
-
-  return joined || undefined;
-}
-
 export function extractAssistantText(message: unknown): string | undefined {
   const joined =
-    extractAssistantTextForPhase(message, "final_answer") ?? extractAssistantTextForPhase(message);
+    extractAssistantTextForPhase(message, {
+      phase: "final_answer",
+      sanitizeText: sanitizeTextContent,
+      joinWith: "",
+    }) ??
+    extractAssistantTextForPhase(message, {
+      sanitizeText: sanitizeTextContent,
+      joinWith: "",
+    });
   const stopReason = (message as { stopReason?: unknown }).stopReason;
   const errorContext = stopReason === "error";
 

--- a/src/auto-reply/reply/commands-subagents-control.runtime.ts
+++ b/src/auto-reply/reply/commands-subagents-control.runtime.ts
@@ -1,4 +1,5 @@
 export {
+  listControlledSubagentRuns,
   killAllControlledSubagentRuns,
   killControlledSubagentRun,
   listControlledSubagentRuns,

--- a/src/auto-reply/reply/commands-subagents-control.runtime.ts
+++ b/src/auto-reply/reply/commands-subagents-control.runtime.ts
@@ -2,7 +2,6 @@ export {
   listControlledSubagentRuns,
   killAllControlledSubagentRuns,
   killControlledSubagentRun,
-  listControlledSubagentRuns,
   sendControlledSubagentMessage,
   steerControlledSubagentRun,
 } from "../../agents/subagent-control.js";

--- a/src/shared/chat-message-content.test.ts
+++ b/src/shared/chat-message-content.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  extractAssistantTextForPhase,
   extractAssistantVisibleText,
   extractFirstTextBlock,
   resolveAssistantMessagePhase,
@@ -53,6 +54,29 @@ describe("shared/chat-message-content", () => {
 });
 
 describe("extractAssistantVisibleText", () => {
+  it("preserves boundary spacing when joining adjacent final_answer text blocks", () => {
+    expect(
+      extractAssistantTextForPhase(
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Hi ",
+              textSignature: JSON.stringify({ v: 1, id: "msg_final_1", phase: "final_answer" }),
+            },
+            {
+              type: "text",
+              text: "there",
+              textSignature: JSON.stringify({ v: 1, id: "msg_final_2", phase: "final_answer" }),
+            },
+          ],
+        },
+        { phase: "final_answer", joinWith: "" },
+      ),
+    ).toBe("Hi there");
+  });
+
   it("prefers final_answer text over commentary text", () => {
     expect(
       extractAssistantVisibleText({

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -88,30 +88,39 @@ export function resolveAssistantMessagePhase(message: unknown): AssistantPhase |
   return explicitPhases.size === 1 ? [...explicitPhases][0] : undefined;
 }
 
-function extractAssistantTextForPhase(
+export function extractAssistantTextForPhase(
   message: unknown,
-  phase?: AssistantPhase,
+  options?: {
+    phase?: AssistantPhase;
+    sanitizeText?: (text: string) => string;
+    joinWith?: string;
+  },
 ): string | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
   }
   const entry = message as { text?: unknown; content?: unknown; phase?: unknown };
   const messagePhase = normalizeAssistantPhase(entry.phase);
+  const phase = options?.phase;
   const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
     if (phase) {
       return resolvedPhase === phase;
     }
     return resolvedPhase === undefined;
   };
+  const sanitizeText = options?.sanitizeText;
+  const joinWith = options?.joinWith ?? "\n";
+  const normalizeText = (text: string) => {
+    const normalized = (sanitizeText ? sanitizeText(text) : text).trim();
+    return normalized || undefined;
+  };
 
   if (typeof entry.text === "string") {
-    const normalized = entry.text.trim();
-    return shouldIncludeContent(messagePhase) && normalized ? normalized : undefined;
+    return shouldIncludeContent(messagePhase) ? normalizeText(entry.text) : undefined;
   }
 
   if (typeof entry.content === "string") {
-    const normalized = entry.content.trim();
-    return shouldIncludeContent(messagePhase) && normalized ? normalized : undefined;
+    return shouldIncludeContent(messagePhase) ? normalizeText(entry.content) : undefined;
   }
 
   if (!Array.isArray(entry.content)) {
@@ -144,19 +153,18 @@ function extractAssistantTextForPhase(
       if (!shouldIncludeContent(resolvedPhase)) {
         return null;
       }
-      const normalized = record.text.trim();
-      return normalized || null;
+      return normalizeText(record.text) ?? null;
     })
     .filter((value): value is string => typeof value === "string");
 
   if (parts.length === 0) {
     return undefined;
   }
-  return parts.join("\n");
+  return parts.join(joinWith);
 }
 
 export function extractAssistantVisibleText(message: unknown): string | undefined {
-  const finalAnswerText = extractAssistantTextForPhase(message, "final_answer");
+  const finalAnswerText = extractAssistantTextForPhase(message, { phase: "final_answer" });
   if (finalAnswerText) {
     return finalAnswerText;
   }

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -110,17 +110,24 @@ export function extractAssistantTextForPhase(
   };
   const sanitizeText = options?.sanitizeText;
   const joinWith = options?.joinWith ?? "\n";
-  const normalizeText = (text: string) => {
-    const normalized = (sanitizeText ? sanitizeText(text) : text).trim();
+  const sanitizeBlockText = (text: string) => (sanitizeText ? sanitizeText(text) : text);
+  const normalizeJoinedText = (text: string) => {
+    const normalized = text.trim();
     return normalized || undefined;
   };
 
   if (typeof entry.text === "string") {
-    return shouldIncludeContent(messagePhase) ? normalizeText(entry.text) : undefined;
+    if (!shouldIncludeContent(messagePhase)) {
+      return undefined;
+    }
+    return normalizeJoinedText(sanitizeBlockText(entry.text));
   }
 
   if (typeof entry.content === "string") {
-    return shouldIncludeContent(messagePhase) ? normalizeText(entry.content) : undefined;
+    if (!shouldIncludeContent(messagePhase)) {
+      return undefined;
+    }
+    return normalizeJoinedText(sanitizeBlockText(entry.content));
   }
 
   if (!Array.isArray(entry.content)) {
@@ -153,14 +160,15 @@ export function extractAssistantTextForPhase(
       if (!shouldIncludeContent(resolvedPhase)) {
         return null;
       }
-      return normalizeText(record.text) ?? null;
+      const sanitized = sanitizeBlockText(record.text);
+      return sanitized.trim() ? sanitized : null;
     })
     .filter((value): value is string => typeof value === "string");
 
   if (parts.length === 0) {
     return undefined;
   }
-  return parts.join(joinWith);
+  return normalizeJoinedText(parts.join(joinWith));
 }
 
 export function extractAssistantVisibleText(message: unknown): string | undefined {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: history-based assistant reply readers could still leak `commentary` text even after `chat.history` became phase-aware, because older helper extractors re-flattened mixed-phase assistant messages downstream.
- Why it matters: user-facing follow-up paths such as wait/read flows and subagent completion summaries could surface internal planning text like `Need fix...` instead of only the intended final answer.
- What changed: made the shared assistant-text helpers phase-aware, preferring `final_answer` over `commentary`, and removed the raw assistant-content fallback in subagent output summarization that could reintroduce suppressed commentary.
- What did NOT change (scope boundary): this does not change provider streaming semantics, tool-call behavior, transcript storage format, or the existing upstream `chat.history` sanitization rules.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61734
- Related #59643
- Related #61282
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `chat.history` already returned phase-aware assistant messages, but `src/agents/tools/chat-history-text.ts` and `src/agents/tools/session-message-text.ts` still extracted assistant text phase-blindly, so downstream consumers could rejoin `commentary` with `final_answer` or fall back to commentary-only content.
- Missing detection / guardrail: there was no targeted regression coverage for mixed-phase assistant messages flowing through the history-based reply helpers used by `run-wait` and subagent announce paths.
- Contributing context (if known): earlier fixes in this bug family hardened embedded delivery and history sanitization, but these helper seams remained phase-blind.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/tools/assistant-phase-text.test.ts`
  - `src/agents/run-wait.test.ts`
- Scenario the test should lock in:
  - helper extraction prefers `final_answer` over `commentary`
  - explicit phased `final_answer` that sanitizes empty does not fall back to commentary
  - `readLatestAssistantReply()` returns only the final-answer text from mixed-phase history
- Why this is the smallest reliable guardrail: the bug lives in shared extraction helpers, so direct helper coverage plus one downstream history-reader seam test catches the regression without needing a full end-to-end provider/channel run.
- Existing test that already covers this (if any): upstream phase-aware history sanitization tests existed, but they did not cover these downstream helper re-extraction paths.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- History-based reply reads now suppress commentary planning text when a `final_answer` block exists.
- Subagent completion output no longer falls back to raw assistant content that can reintroduce suppressed commentary.
- No config or default behavior changes outside the mixed-phase assistant-message case.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[mixed commentary + final_answer assistant message]
  -> [phase-aware chat.history]
  -> [phase-blind helper re-extracts text]
  -> [commentary leaks into reply/subagent output]

After:
[mixed commentary + final_answer assistant message]
  -> [phase-aware chat.history]
  -> [phase-aware helper prefers final_answer]
  -> [user sees only final answer]
