### PR TITLE
fix(docs): remove zh-CN homepage redirect override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Providers/Anthropic: skip `service_tier` injection for OAuth-authenticated stream wrapper requests so Claude OAuth requests stop failing with HTTP 401. (#60356) thanks @openperf.
 - Agents/exec: preserve explicit `host=node` routing under elevated defaults when `tools.exec.host=auto`, and fail loud on invalid elevated cross-host overrides. (#61739) Thanks @obviyus.
+- Docs/i18n: remove the zh-CN homepage redirect override so Mintlify can resolve the localized Chinese homepage without self-redirecting `/zh-CN/index`.
 ## 2026.4.5
 
 ### Breaking

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -125,14 +125,6 @@
       "destination": "/concepts/context"
     },
     {
-      "source": "/zh-CN",
-      "destination": "/zh-CN/index"
-    },
-    {
-      "source": "/zh-CN/",
-      "destination": "/zh-CN/index"
-    },
-    {
       "source": "/compaction",
       "destination": "/concepts/compaction"
     },


### PR DESCRIPTION
## Summary
- remove the zh-CN homepage redirect override from `docs/docs.json`
- let Mintlify resolve the localized Chinese homepage without forcing `/zh-CN` to `/zh-CN/index`
- avoid the current self-redirect on `/zh-CN/index`

## Test plan
- [x] verified `https://docs.openclaw.ai/zh-CN/index` currently returns `308 Location: /zh-CN/index`
- [x] verified localized content pages such as `/zh-CN/providers/anthropic` still resolve normally
- [x] confirmed no equivalent locale-home redirect override exists for other languages in `docs/docs.json`

## Evidence

https://docs.openclaw.ai/zh-CN/index

<img width="2308" height="1822" alt="image" src="https://github.com/user-attachments/assets/23cb58fc-e76f-4e7b-afc1-73cf1ae20a93" />
