### PR TITLE
fix(failover): classify Anthropic 'out of extra usage' as billing

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -127,6 +127,10 @@ describe("isBillingErrorMessage", () => {
         "Insufficient USD or Diem balance to complete request. Visit https://venice.ai/settings/api to add credits.",
         "This model requires more credits to use",
         "This endpoint require more credits",
+        // Anthropic "out of extra usage" HTTP 400 error (#61743)
+        "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+        '{"type":"error","error":{"type":"invalid_request_error","message":"You\'re out of extra usage. Add more at claude.ai/settings/usage and keep going."}}',
+        "out of usage",
       ],
       expected: true,
     },
@@ -867,6 +871,17 @@ describe("classifyFailoverReason", () => {
     ).toBe("billing");
     // OpenRouter "requires more credits" billing text
     expect(classifyFailoverReason("This model requires more credits to use")).toBe("billing");
+    // Anthropic "out of extra usage" HTTP 400 error (#61743)
+    expect(
+      classifyFailoverReason(
+        "You're out of extra usage. Add more at claude.ai/settings/usage and keep going.",
+      ),
+    ).toBe("billing");
+    expect(
+      classifyFailoverReason(
+        '400 {"type":"error","error":{"type":"invalid_request_error","message":"You\'re out of extra usage. Add more at claude.ai/settings/usage and keep going."}}',
+      ),
+    ).toBe("billing");
   });
 
   it("classifies internal and compatibility error messages", () => {

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -120,6 +120,8 @@ const ERROR_PATTERNS = {
     "insufficient balance",
     "insufficient usd or diem balance",
     /requires?\s+more\s+credits/i,
+    // Anthropic "out of extra usage" error (HTTP 400, invalid_request_error)
+    /out of (?:extra )?usage/i,
   ],
   authPermanent: HIGH_CONFIDENCE_AUTH_PERMANENT_PATTERNS,
   auth: [...AMBIGUOUS_AUTH_ERROR_PATTERNS, ...COMMON_AUTH_ERROR_PATTERNS],


### PR DESCRIPTION
## Summary

Anthropic returns HTTP 400 with `invalid_request_error` type when an account has exceeded its usage limit:

```json
{"type":"error","error":{"type":"invalid_request_error","message":"You're out of extra usage. Add more at claude.ai/settings/usage and keep going."}}
```

This was being misclassified as a format error (30-second cooldown) instead of a billing error (5h backoff), causing unnecessary retry churn.

## Changes

- Add `/out of (?:extra )?usage/i` pattern to the billing error matchers
- Add test cases for the Anthropic error message and JSON payload

## Testing

- Added test cases to `pi-embedded-helpers.isbillingerrormessage.test.ts`
- All existing tests pass

Fixes #61743