### PR TITLE
fix(build): restore main build

### DIFF
--- a/src/auto-reply/reply/commands-subagents-control.runtime.ts
+++ b/src/auto-reply/reply/commands-subagents-control.runtime.ts
@@ -1,6 +1,7 @@
 export {
   killAllControlledSubagentRuns,
   killControlledSubagentRun,
+  listControlledSubagentRuns,
   sendControlledSubagentMessage,
   steerControlledSubagentRun,
 } from "../../agents/subagent-control.js";

--- a/src/auto-reply/reply/commands-subagents/shared.ts
+++ b/src/auto-reply/reply/commands-subagents/shared.ts
@@ -25,7 +25,7 @@ import {
   truncateLine,
 } from "../../../shared/subagents-format.js";
 import { resolveCommandSurfaceChannel, resolveChannelAccountId } from "../channel-context.js";
-import { extractMessageText } from "../commands-subagents-text.js";
+import { extractMessageText, type ChatMessage } from "../commands-subagents-text.js";
 import type { CommandHandler, CommandHandlerResult } from "../commands-types.js";
 import {
   formatRunLabel,

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -386,8 +386,12 @@ export async function resolveRuntimeWebTools(params: {
     ? params.resolvedConfig.tools
     : undefined;
   const resolvedWeb = isRecord(resolvedTools?.web) ? resolvedTools.web : undefined;
-  const legacyXSearchSource = isRecord(sourceWeb?.x_search) ? sourceWeb.x_search : undefined;
-  const legacyXSearchResolved = isRecord(resolvedWeb?.x_search) ? resolvedWeb.x_search : undefined;
+  const legacyXSearchSource = isRecord(sourceWeb?.x_search)
+    ? (sourceWeb.x_search as Record<string, unknown>)
+    : undefined;
+  const legacyXSearchResolved = isRecord(resolvedWeb?.x_search)
+    ? (resolvedWeb.x_search as Record<string, unknown>)
+    : undefined;
   if (!sourceWeb && !hasPluginWebToolConfig(params.sourceConfig)) {
     return {
       search: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `pnpm build` on current `main` failed during TypeScript declaration generation.
- Why it matters: this blocked packaging and made the branch fail the required build gate.
- What changed: restored the missing `listControlledSubagentRuns` runtime re-export, imported `ChatMessage` where it is used, and widened legacy `tools.web.x_search` access to safe record reads/writes.
- What did NOT change (scope boundary): no behavior changes outside these compile-time fixes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: a subagents control refactor stopped re-exporting `listControlledSubagentRuns`, `ChatMessage` was re-exported but not imported into local type scope, and legacy `x_search.apiKey` access no longer matched the narrowed config type.
- Missing detection / guardrail: the broken state was not caught before merging even though the full `pnpm build` gate catches it.
- Contributing context (if known): compile drift across adjacent refactors in subagents and runtime web tool config handling.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `pnpm build`, `src/secrets/runtime-web-tools.test.ts`, `src/auto-reply/reply/commands-subagents-shared.test.ts`, `src/auto-reply/reply/commands-subagents-routing.test.ts`
- Scenario the test should lock in: subagents command modules and runtime web tools compile and load cleanly under the production build path.
- Why this is the smallest reliable guardrail: the failure surfaced during build-time type generation, and the targeted tests cover the touched modules directly.
- Existing test that already covers this (if any): the targeted tests above plus the full build gate.
- If no new test is added, why not: no behavior change was needed; restoring the existing build/test path was sufficient.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 / pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Check out latest `main`.
2. Run `pnpm build`.
3. Observe TypeScript declaration build errors in subagents/runtime web tools.

### Expected

- `pnpm build` passes.

### Actual

- `pnpm build` failed before this fix.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm build`; ran `pnpm test src/secrets/runtime-web-tools.test.ts src/auto-reply/reply/commands-subagents-shared.test.ts src/auto-reply/reply/commands-subagents-routing.test.ts`.
- Edge cases checked: legacy `x_search` auth path still compiles; subagents shared helpers still typecheck with local `ChatMessage` usage.
- What you did **not** verify: broader full-suite `pnpm test`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the `x_search` compatibility path could accidentally diverge from current config expectations.
  - Mitigation: kept the fix limited to record-safe access for the legacy branch and verified with the existing runtime web tools test file.
