### PR TITLE
enhance Makefile with standard build, test, and quality targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,87 @@
-.PHONY: build
+.PHONY: help clean clean-dist build rebuild deps test test-fast test-coverage \
+       lint check format format-fix typecheck ui dev version \
+       test-contracts test-extensions test-channels
 
-build:
+# Default target
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# ── Dependencies ──────────────────────────────────────────
+
+deps: node_modules ## Install dependencies
+
+node_modules: pnpm-lock.yaml
+	pnpm install
+	@touch node_modules
+
+# ── Build ─────────────────────────────────────────────────
+
+build: deps ## Build everything (main + UI)
 	pnpm build
+	pnpm ui:build
+
+ui: deps ## Build the Control UI only
+	pnpm ui:build
+
+# ── Clean ─────────────────────────────────────────────────
+
+clean: ## Remove dist, dist-runtime, and node_modules
+	rm -rf dist dist-runtime node_modules
+
+clean-dist: ## Remove build output only (keep node_modules)
+	rm -rf dist dist-runtime
+
+rebuild: clean-dist build ## Clean build output then rebuild everything
+
+# ── Quality gates ─────────────────────────────────────────
+# See AGENTS.md "Build, Test, and Development Commands" for
+# the full gate definitions (local dev gate, landing gate, CI gate).
+
+check: deps ## Local dev gate: lint + format + type-check
+	pnpm check
+
+typecheck: deps ## TypeScript type-check only
+	pnpm tsgo
+
+lint: deps ## Lint only (oxlint)
+	pnpm lint
+
+format: deps ## Check formatting (oxfmt --check)
+	pnpm format
+
+format-fix: deps ## Fix formatting (oxfmt --write)
+	pnpm format:fix
+
+# ── Tests ─────────────────────────────────────────────────
+
+test: deps ## Run full test suite (vitest)
+	pnpm test
+
+test-fast: deps ## Run fast test subset
+	pnpm test:fast
+
+test-coverage: deps ## Run tests with coverage
+	pnpm test:coverage
+
+test-contracts: deps ## Run contract tests (plugins + channels)
+	pnpm test:contracts
+
+test-extensions: deps ## Run extension test suite
+	pnpm test:extensions
+
+test-channels: deps ## Run channel tests
+	pnpm test:channels
+
+# ── Development ───────────────────────────────────────────
+
+dev: deps ## Run gateway in foreground (dev mode)
+	pnpm dev
+
+version: ## Print current version
+	@node -e "console.log(require('./package.json').version)" 2>/dev/null || \
+		git describe --tags HEAD 2>/dev/null || echo "unknown"
+
+# ── Compound targets ──────────────────────────────────────
+
+landing-gate: check test build ## Full landing gate (check + test + build)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help clean clean-dist build rebuild deps test test-fast test-coverage \
        lint check format format-fix typecheck ui dev version \
-       test-contracts test-extensions test-channels
+       test-contracts test-extensions test-channels landing-gate
 
 # Default target
 help: ## Show available targets
@@ -48,7 +48,7 @@ lint: deps ## Lint only (oxlint)
 	pnpm lint
 
 format: deps ## Check formatting (oxfmt --check)
-	pnpm format
+	pnpm format:check
 
 format-fix: deps ## Fix formatting (oxfmt --write)
 	pnpm format:fix

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,9 @@ clean: ## Remove dist, dist-runtime, and node_modules
 clean-dist: ## Remove build output only (keep node_modules)
 	rm -rf dist dist-runtime
 
-rebuild: clean-dist build ## Clean build output then rebuild everything
+rebuild: ## Clean build output then rebuild everything
+	$(MAKE) clean-dist
+	$(MAKE) build
 
 # ── Quality gates ─────────────────────────────────────────
 # See AGENTS.md "Build, Test, and Development Commands" for
@@ -75,8 +77,8 @@ test-channels: deps ## Run channel tests
 
 # ── Development ───────────────────────────────────────────
 
-dev: deps ## Run gateway in foreground (dev mode)
-	pnpm dev
+dev: deps ## Run gateway watch in foreground (dev mode)
+	pnpm gateway:watch:raw
 
 version: ## Print current version
 	@node -e "console.log(require('./package.json').version)" 2>/dev/null || \
@@ -84,4 +86,7 @@ version: ## Print current version
 
 # ── Compound targets ──────────────────────────────────────
 
-landing-gate: check test build ## Full landing gate (check + test + build)
+landing-gate: ## Full landing gate (check + test + build)
+	$(MAKE) check
+	$(MAKE) test
+	$(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,87 @@
+.PHONY: help clean clean-dist build rebuild deps test test-fast test-coverage \
+       lint check format format-fix typecheck ui dev version \
+       test-contracts test-extensions test-channels
+
+# Default target
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+# ── Dependencies ──────────────────────────────────────────
+
+deps: node_modules ## Install dependencies
+
+node_modules: pnpm-lock.yaml
+	pnpm install
+	@touch node_modules
+
+# ── Build ─────────────────────────────────────────────────
+
+build: deps ## Build everything (main + UI)
+	pnpm build
+	pnpm ui:build
+
+ui: deps ## Build the Control UI only
+	pnpm ui:build
+
+# ── Clean ─────────────────────────────────────────────────
+
+clean: ## Remove dist, dist-runtime, and node_modules
+	rm -rf dist dist-runtime node_modules
+
+clean-dist: ## Remove build output only (keep node_modules)
+	rm -rf dist dist-runtime
+
+rebuild: clean-dist build ## Clean build output then rebuild everything
+
+# ── Quality gates ─────────────────────────────────────────
+# See AGENTS.md "Build, Test, and Development Commands" for
+# the full gate definitions (local dev gate, landing gate, CI gate).
+
+check: deps ## Local dev gate: lint + format + type-check
+	pnpm check
+
+typecheck: deps ## TypeScript type-check only
+	pnpm tsgo
+
+lint: deps ## Lint only (oxlint)
+	pnpm lint
+
+format: deps ## Check formatting (oxfmt --check)
+	pnpm format
+
+format-fix: deps ## Fix formatting (oxfmt --write)
+	pnpm format:fix
+
+# ── Tests ─────────────────────────────────────────────────
+
+test: deps ## Run full test suite (vitest)
+	pnpm test
+
+test-fast: deps ## Run fast test subset
+	pnpm test:fast
+
+test-coverage: deps ## Run tests with coverage
+	pnpm test:coverage
+
+test-contracts: deps ## Run contract tests (plugins + channels)
+	pnpm test:contracts
+
+test-extensions: deps ## Run extension test suite
+	pnpm test:extensions
+
+test-channels: deps ## Run channel tests
+	pnpm test:channels
+
+# ── Development ───────────────────────────────────────────
+
+dev: deps ## Run gateway in foreground (dev mode)
+	pnpm dev
+
+version: ## Print current version
+	@node -e "console.log(require('./package.json').version)" 2>/dev/null || \
+		git describe --tags HEAD 2>/dev/null || echo "unknown"
+
+# ── Compound targets ──────────────────────────────────────
+
+landing-gate: check test build ## Full landing gate (check + test + build)


### PR DESCRIPTION
## Summary

- Replace the minimal single-target Makefile with a full developer workflow
- `make help` (default) lists all targets with descriptions
- Dependency tracking: `make deps` auto-runs `pnpm install` when lockfile changes
- Build: `make build` (main + UI), `make ui`, `make rebuild`, `make clean-dist`
- Quality gates: `make check`, `make lint`, `make format`, `make typecheck`
- Tests: `make test`, `make test-fast`, `make test-coverage`, plus scoped `test-contracts`, `test-extensions`, `test-channels`
- Compound: `make landing-gate` runs the full check + test + build sequence
- Development: `make dev`, `make version`

All targets delegate to existing pnpm scripts — the Makefile is a convenience layer for contributors who prefer `make`.

## Test plan

- [x] `make help` prints all targets with descriptions
- [x] `make version` prints current version
- [x] `make build` completes successfully (tested on v2026.4.5)
- [ ] Verify `make check` passes on clean main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Real behavior proof

- **Behavior addressed**: The Makefile review feedback is addressed on the rebased PR head: `rebuild` and `landing-gate` now run ordered phases through sequential recipes, `dev` delegates to the documented foreground gateway watcher, and the branch no longer has a merge conflict with current `main`.
- **Real environment tested**: Local OpenClaw checkout on macOS, branch `makefile-enhance`, rebased onto `origin/main` at `a13468320c63573917c185db278f3d4e13389a78`; PR head `4ce7262306b17af5b99422475cfe16d9ea9f6ddb`.
- **Exact steps or command run after the patch**: `make -n rebuild`; `make -n -j8 rebuild`; `make -n landing-gate`; `make -n -j8 landing-gate`; `make -n dev`; `make help`; `make version`; `git diff --check origin/main..HEAD`.
- **Evidence after fix**: Terminal output from the rebased PR head:

```text
$ make -n -j8 rebuild
/Library/Developer/CommandLineTools/usr/bin/make clean-dist
rm -rf dist dist-runtime
/Library/Developer/CommandLineTools/usr/bin/make build
pnpm install
touch node_modules
pnpm build
pnpm ui:build

$ make -n -j8 landing-gate
/Library/Developer/CommandLineTools/usr/bin/make check
pnpm install
touch node_modules
pnpm check
/Library/Developer/CommandLineTools/usr/bin/make test
pnpm install
touch node_modules
pnpm test
/Library/Developer/CommandLineTools/usr/bin/make build
pnpm install
touch node_modules
pnpm build
pnpm ui:build

$ make -n dev
pnpm install
touch node_modules
pnpm gateway:watch:raw

$ make version
2026.5.19

$ git diff --check origin/main..HEAD
(no output)
```

- **Observed result after fix**: The `-j8` dry runs still show `rebuild` executing clean before build and `landing-gate` executing check, then test, then build. `make dev` now resolves to `pnpm gateway:watch:raw`, matching the documented foreground gateway watch command. `make help` lists `landing-gate`, `rebuild`, and the updated `dev` description, and `git diff --check origin/main..HEAD` produced no whitespace errors.
- **What was not tested**: Full execution of `make landing-gate`; this proof uses dry-run command output for the Makefile sequencing behavior requested in review.

