### PR TITLE
fix(ollama): resolve per-provider baseUrl in createStreamFn

### DIFF
--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -19,6 +19,9 @@ const promptAndConfigureOllamaMock = vi.hoisted(() =>
 );
 const ensureOllamaModelPulledMock = vi.hoisted(() => vi.fn(async () => {}));
 const buildOllamaProviderMock = vi.hoisted(() => vi.fn());
+const createConfiguredOllamaStreamFnMock = vi.hoisted(() =>
+  vi.fn((_params: { model: unknown; providerBaseUrl?: string }) => ({}) as never),
+);
 
 vi.mock("./api.js", () => ({
   promptAndConfigureOllama: promptAndConfigureOllamaMock,
@@ -27,10 +30,19 @@ vi.mock("./api.js", () => ({
   buildOllamaProvider: buildOllamaProviderMock,
 }));
 
+vi.mock("./src/stream.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./src/stream.js")>();
+  return {
+    ...actual,
+    createConfiguredOllamaStreamFn: createConfiguredOllamaStreamFnMock,
+  };
+});
+
 beforeEach(() => {
   promptAndConfigureOllamaMock.mockClear();
   ensureOllamaModelPulledMock.mockClear();
   buildOllamaProviderMock.mockReset();
+  createConfiguredOllamaStreamFnMock.mockClear();
 });
 
 function registerProvider() {
@@ -205,6 +217,60 @@ describe("ollama plugin", () => {
         modelId: "qwen3.5:9b",
       } as never),
     ).toBeUndefined();
+  });
+
+  it("routes createStreamFn to the correct provider baseUrl for ollama2", () => {
+    const provider = registerProvider();
+    const config = {
+      models: {
+        providers: {
+          ollama: {
+            api: "ollama",
+            baseUrl: "http://127.0.0.1:11434",
+            models: [],
+          },
+          ollama2: {
+            api: "ollama",
+            baseUrl: "http://127.0.0.1:11435",
+            models: [],
+          },
+        },
+      },
+    };
+    const model = { id: "llama3.2", provider: "ollama2", baseUrl: undefined };
+
+    provider.createStreamFn?.({ config, model, provider: "ollama2" } as never);
+
+    expect(createConfiguredOllamaStreamFnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ providerBaseUrl: "http://127.0.0.1:11435" }),
+    );
+  });
+
+  it("uses ollama provider baseUrl when provider is ollama (backward compat)", () => {
+    const provider = registerProvider();
+    const config = {
+      models: {
+        providers: {
+          ollama: {
+            api: "ollama",
+            baseUrl: "http://127.0.0.1:11434",
+            models: [],
+          },
+          ollama2: {
+            api: "ollama",
+            baseUrl: "http://127.0.0.1:11435",
+            models: [],
+          },
+        },
+      },
+    };
+    const model = { id: "llama3.2", provider: "ollama", baseUrl: undefined };
+
+    provider.createStreamFn?.({ config, model, provider: "ollama" } as never);
+
+    expect(createConfiguredOllamaStreamFnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ providerBaseUrl: "http://127.0.0.1:11434" }),
+    );
   });
 
   it("wraps native Ollama payloads with top-level think=false when thinking is off", () => {

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -23,6 +23,7 @@ import { resolveOllamaApiBase } from "./src/provider-models.js";
 import {
   createConfiguredOllamaCompatStreamWrapper,
   createConfiguredOllamaStreamFn,
+  resolveConfiguredOllamaProviderConfig,
 } from "./src/stream.js";
 import { createOllamaWebSearchProvider } from "./src/web-search-provider.js";
 
@@ -183,10 +184,11 @@ export default definePluginEntry({
         }
         await ensureOllamaModelPulled({ config, model, prompter });
       },
-      createStreamFn: ({ config, model }) => {
+      createStreamFn: ({ config, model, provider }) => {
         return createConfiguredOllamaStreamFn({
           model,
-          providerBaseUrl: config?.models?.providers?.ollama?.baseUrl,
+          providerBaseUrl: resolveConfiguredOllamaProviderConfig({ config, providerId: provider })
+            ?.baseUrl,
         });
       },
       ...OPENAI_COMPATIBLE_REPLAY_HOOKS,

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -50,7 +50,7 @@ export function resolveOllamaBaseUrlForRun(params: {
   return OLLAMA_NATIVE_BASE_URL;
 }
 
-function resolveConfiguredOllamaProviderConfig(params: {
+export function resolveConfiguredOllamaProviderConfig(params: {
   config?: OpenClawConfig;
   providerId?: string;
 }) {


### PR DESCRIPTION
## Summary

- When multiple Ollama providers are configured (e.g. `ollama` and `ollama2`), `createStreamFn` hardcoded `config.models.providers.ollama.baseUrl` — ignoring the active provider's actual `baseUrl`.
- Changed `createStreamFn` to use the `provider` parameter from `ProviderCreateStreamFnContext` and resolve the correct config via `resolveConfiguredOllamaProviderConfig`.
- Exported `resolveConfiguredOllamaProviderConfig` from `extensions/ollama/src/stream.ts` (was already implemented but unexported).

## Test plan

- [x] Added test: `createStreamFn resolves baseUrl from the active provider id when multiple Ollama providers are configured`
- [x] Verified backward compatibility — single-provider setups continue to work unchanged

Closes #61678