### PR TITLE
fix(ssrf): disable HTTP/2 for pinned dispatchers (undici 8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Docs: https://docs.openclaw.ai
 - Memory/dreaming: strip managed Light Sleep and REM blocks before daily-note ingestion so dreaming summaries stop re-ingesting their own staged output into new candidates. (#61720) Thanks @MonkeyLeeT.
 - Docs/i18n: relocalize final localized-page links after translation so generated locale pages stop keeping stale English-root links when targets appear later in the same run. (#61796) thanks @hxy91819.
 - Docs/i18n: remove the zh-CN homepage redirect override so Mintlify can resolve the localized Chinese homepage without self-redirecting `/zh-CN/index`.
-
+- Tools/web_fetch and web_search: fix `TypeError: fetch failed` caused by undici 8.0 enabling HTTP/2 by default; pinned SSRF-guard dispatchers now explicitly set `allowH2: false` to restore HTTP/1.1 behavior and keep the custom DNS-pinning lookup compatible. (#61738, #61777) Thanks @zozo123.
 ## 2026.4.5
 
 ### Breaking

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -770,9 +770,12 @@ describe("discord component interactions", () => {
     const acknowledge = vi.fn().mockResolvedValue(undefined);
     const reply = vi.fn().mockResolvedValue(undefined);
     const update = vi.fn().mockResolvedValue(undefined);
-    const baseInteraction = createComponentButtonInteraction().interaction;
+    const baseInteraction = createComponentButtonInteraction().interaction as unknown as Record<
+      string,
+      unknown
+    >;
     const interaction = {
-      ...(baseInteraction as object),
+      ...baseInteraction,
       acknowledge,
       reply,
       update,
@@ -822,9 +825,12 @@ describe("discord component interactions", () => {
     const button = createDiscordComponentButton(createComponentContext());
     const acknowledge = vi.fn().mockResolvedValue(undefined);
     const followUp = vi.fn().mockResolvedValue(undefined);
-    const baseInteraction = createComponentButtonInteraction().interaction;
+    const baseInteraction = createComponentButtonInteraction().interaction as unknown as Record<
+      string,
+      unknown
+    >;
     const interaction = {
-      ...(baseInteraction as object),
+      ...baseInteraction,
       acknowledge,
       followUp,
     } as unknown as ButtonInteraction;

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -783,8 +783,6 @@ describe("exec approvals", () => {
     const result = await tool.execute("call-gw-followup", {
       command: "echo ok",
       workdir: process.cwd(),
-      gatewayUrl: undefined,
-      gatewayToken: undefined,
     });
 
     expect(result.details.status).toBe("approval-pending");
@@ -826,8 +824,6 @@ describe("exec approvals", () => {
     const result = await tool.execute("call-gw-followup-discord", {
       command: "echo ok",
       workdir: process.cwd(),
-      gatewayUrl: undefined,
-      gatewayToken: undefined,
     });
 
     expect(result.details.status).toBe("approval-pending");
@@ -889,8 +885,6 @@ describe("exec approvals", () => {
     const result = await tool.execute("call-gw-followup-discord-delayed", {
       command: "node -e \"require('node:fs').writeFileSync('marker.txt','ok')\"",
       workdir: tempDir,
-      gatewayUrl: undefined,
-      gatewayToken: undefined,
     });
 
     expect(result.details.status).toBe("approval-pending");
@@ -965,8 +959,6 @@ describe("exec approvals", () => {
     const result = await tool.execute("call-gw-followup-webchat", {
       command: "node -e \"require('node:fs').writeFileSync('marker.txt','ok')\"",
       workdir: tempDir,
-      gatewayUrl: undefined,
-      gatewayToken: undefined,
     });
 
     expect(result.details.status).toBe("approval-pending");
@@ -1021,8 +1013,6 @@ describe("exec approvals", () => {
     const result = await tool.execute("call-gw-followup-deny", {
       command: "echo ok",
       workdir: process.cwd(),
-      gatewayUrl: undefined,
-      gatewayToken: undefined,
     });
 
     expect(result.details.status).toBe("approval-pending");

--- a/src/agents/bash-tools.exec.background-abort.test.ts
+++ b/src/agents/bash-tools.exec.background-abort.test.ts
@@ -18,6 +18,8 @@ let getFinishedSession: typeof import("./bash-process-registry.js").getFinishedS
 let getSession: typeof import("./bash-process-registry.js").getSession;
 let resetProcessRegistryForTests: typeof import("./bash-process-registry.js").resetProcessRegistryForTests;
 
+type ExecToolExecuteParams = Parameters<ReturnType<typeof createExecTool>["execute"]>[1];
+
 const createTestExecTool = (
   defaults?: Parameters<typeof createExecTool>[0],
 ): ReturnType<typeof createExecTool> => createExecTool({ ...TEST_EXEC_DEFAULTS, ...defaults });
@@ -61,7 +63,7 @@ function cleanupRunningSession(sessionId: string) {
 
 async function expectBackgroundSessionSurvivesAbort(params: {
   tool: ReturnType<typeof createExecTool>;
-  executeParams: Record<string, unknown>;
+  executeParams: ExecToolExecuteParams;
 }) {
   const abortController = new AbortController();
   const result = await params.tool.execute(
@@ -97,7 +99,7 @@ async function expectBackgroundSessionSurvivesAbort(params: {
 
 async function expectBackgroundSessionTimesOut(params: {
   tool: ReturnType<typeof createExecTool>;
-  executeParams: Record<string, unknown>;
+  executeParams: ExecToolExecuteParams;
   signal?: AbortSignal;
   abortAfterStart?: boolean;
 }) {

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -31,11 +31,12 @@ async function pollSession(
   sessionId: string,
   timeout?: number | string,
 ) {
-  return processTool.execute(callId, {
+  const args = {
     action: "poll",
     sessionId,
     ...(timeout === undefined ? {} : { timeout }),
-  });
+  } as unknown as Parameters<ReturnType<typeof createProcessTool>["execute"]>[1];
+  return processTool.execute(callId, args);
 }
 
 function retryMs(result: Awaited<ReturnType<ReturnType<typeof createProcessTool>["execute"]>>) {

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -24,6 +24,7 @@ vi.mock("../plugins/provider-runtime.js", () => ({
   },
   formatProviderAuthProfileApiKeyWithPlugin: async () => undefined,
   refreshProviderOAuthCredentialWithPlugin: async () => null,
+  resolveExternalAuthProfilesWithPlugins: () => [],
   resolveProviderSyntheticAuthWithPlugin: (params: {
     provider: string;
     context: { providerConfig?: { api?: string; baseUrl?: string; models?: unknown[] } };

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -22,6 +22,7 @@ import {
 
 vi.mock("../plugins/provider-runtime.js", () => ({
   buildProviderMissingAuthMessageWithPlugin: () => undefined,
+  resolveExternalAuthProfilesWithPlugins: () => [],
   shouldDeferProviderSyntheticProfileAuthWithPlugin: (params: {
     provider: string;
     context: { resolvedApiKey?: string };

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -134,6 +134,10 @@ describe("model-selection", () => {
   });
 
   describe("isCliProvider", () => {
+    it("returns true for setup-registered cli backends", () => {
+      expect(isCliProvider("claude-cli", {} as OpenClawConfig)).toBe(true);
+    });
+
     it("returns false for provider ids", () => {
       expect(isCliProvider("example-cli", {} as OpenClawConfig)).toBe(false);
     });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -7,6 +7,7 @@ import {
 } from "../config/model-input.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveRuntimeCliBackends } from "../plugins/cli-backends.runtime.js";
+import { resolvePluginSetupCliBackend } from "../plugins/setup-registry.js";
 import { sanitizeForLog, stripAnsi } from "../terminal/ansi.js";
 import {
   resolveAgentConfig,
@@ -91,6 +92,9 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
   const normalized = normalizeProviderId(provider);
   const cliBackends = resolveRuntimeCliBackends();
   if (cliBackends.some((backend) => normalizeProviderId(backend.id) === normalized)) {
+    return true;
+  }
+  if (resolvePluginSetupCliBackend({ backend: normalized })) {
     return true;
   }
   const backends = cfg?.agents?.defaults?.cliBackends ?? {};

--- a/src/agents/pi-embedded-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -104,7 +104,7 @@ describe("resolveModel forward-compat errors and overrides", () => {
     expectResolvedForwardCompatFallbackResult({
       result: resolveModelForTest("google-antigravity", "claude-opus-4-6-thinking", "/tmp/agent"),
       expectedModel: {
-        api: "google-generative-ai",
+        api: "google-gemini-cli",
         baseUrl: "https://cloudcode-pa.googleapis.com",
         id: "claude-opus-4-6-thinking",
         provider: "google-antigravity",

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -155,6 +155,8 @@ vi.mock("@mariozechner/pi-coding-agent", () => {
     AuthStorage,
     createAgentSession: (...args: unknown[]) => hoisted.createAgentSessionMock(...args),
     DefaultResourceLoader,
+    estimateTokens: () => 0,
+    generateSummary: async () => "",
     ModelRegistry,
     SessionManager: {
       open: (...args: unknown[]) => hoisted.sessionManagerOpenMock(...args),
@@ -264,6 +266,8 @@ vi.mock("../../session-write-lock.js", () => ({
 }));
 
 vi.mock("../tool-result-context-guard.js", () => ({
+  formatContextLimitTruncationNotice: (truncatedChars: number) =>
+    `[... ${Math.max(1, Math.floor(truncatedChars))} more characters truncated]`,
   installToolResultContextGuard: (...args: unknown[]) =>
     (hoisted.installToolResultContextGuardMock as (...args: unknown[]) => unknown)(...args),
 }));

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -475,7 +475,7 @@ describe("provider request config", () => {
     });
 
     expect(resolved.baseUrl).toBe("https://api.openai.com/v1");
-    expect(resolved.allowPrivateNetwork).toBe(true);
+    expect(resolved.allowPrivateNetwork).toBe(false);
     expect(resolved.policy.endpointClass).toBe("openai-public");
     expect(resolved.capabilities.allowsResponsesStore).toBe(true);
     expect(resolved.headers).toMatchObject({

--- a/src/agents/tools/music-generate-tool.actions.ts
+++ b/src/agents/tools/music-generate-tool.actions.ts
@@ -87,7 +87,8 @@ export function createMusicGenerateStatusActionResult(
   return createMediaGenerateStatusActionResult({
     sessionKey,
     inactiveText: "No active music generation task is currently running for this session.",
-    findActiveTask: findActiveMusicGenerationTaskForSession,
+    findActiveTask: (activeSessionKey) =>
+      findActiveMusicGenerationTaskForSession(activeSessionKey) ?? undefined,
     buildStatusText: buildMusicGenerationTaskStatusText,
     buildStatusDetails: buildMusicGenerationTaskStatusDetails,
   });
@@ -98,7 +99,8 @@ export function createMusicGenerateDuplicateGuardResult(
 ): MusicGenerateActionResult | null {
   return createMediaGenerateDuplicateGuardResult({
     sessionKey,
-    findActiveTask: findActiveMusicGenerationTaskForSession,
+    findActiveTask: (activeSessionKey) =>
+      findActiveMusicGenerationTaskForSession(activeSessionKey) ?? undefined,
     buildStatusText: buildMusicGenerationTaskStatusText,
     buildStatusDetails: buildMusicGenerationTaskStatusDetails,
   });

--- a/src/agents/tools/video-generate-tool.actions.ts
+++ b/src/agents/tools/video-generate-tool.actions.ts
@@ -91,7 +91,8 @@ export function createVideoGenerateStatusActionResult(
   return createMediaGenerateStatusActionResult({
     sessionKey,
     inactiveText: "No active video generation task is currently running for this session.",
-    findActiveTask: findActiveVideoGenerationTaskForSession,
+    findActiveTask: (activeSessionKey) =>
+      findActiveVideoGenerationTaskForSession(activeSessionKey) ?? undefined,
     buildStatusText: buildVideoGenerationTaskStatusText,
     buildStatusDetails: buildVideoGenerationTaskStatusDetails,
   });
@@ -102,7 +103,8 @@ export function createVideoGenerateDuplicateGuardResult(
 ): VideoGenerateActionResult | null {
   return createMediaGenerateDuplicateGuardResult({
     sessionKey,
-    findActiveTask: findActiveVideoGenerationTaskForSession,
+    findActiveTask: (activeSessionKey) =>
+      findActiveVideoGenerationTaskForSession(activeSessionKey) ?? undefined,
     buildStatusText: buildVideoGenerationTaskStatusText,
     buildStatusDetails: buildVideoGenerationTaskStatusDetails,
   });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -248,15 +248,15 @@ export class GatewayClient {
         );
         const expected = normalizeFingerprint(this.opts.tlsFingerprint ?? "");
         if (!expected) {
-          return false;
+          return undefined;
         }
         if (!fingerprint) {
-          return false;
+          return new Error("Missing server TLS fingerprint");
         }
         if (fingerprint !== expected) {
-          return false;
+          return new Error("Server TLS fingerprint mismatch");
         }
-        return true;
+        return undefined;
       };
       };
     }

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -258,7 +258,6 @@ export class GatewayClient {
         }
         return undefined;
       };
-      };
     }
     const ws = new WebSocket(url, wsOptions as ClientOptions);
     this.ws = ws;

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { hasInterSessionUserProvenance } from "../../../sessions/input-provenance.js";
 
 function extractTextMessageContent(content: unknown): string | undefined {

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -448,6 +448,7 @@ describe("fetchWithSsrFGuard hardening", () => {
 
     expect(proxyAgentCtor).toHaveBeenCalledWith({
       uri: "http://proxy.example:7890",
+      allowH2: false,
       requestTls: {
         servername: "public.example",
       },

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -105,11 +105,17 @@ describe("fetchWithSsrFGuard hardening", () => {
     expectEnvProxy: boolean;
   }): Promise<void> {
     vi.stubEnv("HTTP_PROXY", "http://127.0.0.1:7890");
+    (globalThis as Record<string, unknown>)[TEST_UNDICI_RUNTIME_DEPS_KEY] = {
+      Agent: agentCtor,
+      EnvHttpProxyAgent: envHttpProxyAgentCtor,
+      ProxyAgent: proxyAgentCtor,
+      fetch: vi.fn(async () => okResponse()),
+    };
     const lookupFn = createPublicLookup();
     const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
       const requestInit = init as RequestInit & { dispatcher?: unknown };
       if (params.expectEnvProxy) {
-        expect(getDispatcherClassName(requestInit.dispatcher)).toBe("EnvHttpProxyAgent");
+        expect(requestInit.dispatcher).toBeDefined();
       } else {
         expect(requestInit.dispatcher).toBeDefined();
         expect(getDispatcherClassName(requestInit.dispatcher)).not.toBe("EnvHttpProxyAgent");
@@ -125,6 +131,12 @@ describe("fetchWithSsrFGuard hardening", () => {
     });
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
+    if (params.expectEnvProxy) {
+      expect(envHttpProxyAgentCtor).toHaveBeenCalledTimes(1);
+      expect(envHttpProxyAgentCtor).toHaveBeenCalledWith({
+        allowH2: false,
+      });
+    }
     await result.release();
   }
 

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -17,7 +17,11 @@ import {
   SsrFBlockedError,
   type SsrFPolicy,
 } from "./ssrf.js";
-import { loadUndiciRuntimeDeps } from "./undici-runtime.js";
+import {
+  createHttp1Agent,
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
+} from "./undici-runtime.js";
 
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
@@ -104,32 +108,27 @@ function createPolicyDispatcherWithoutPinnedDns(
   if (!dispatcherPolicy) {
     return null;
   }
-  const { Agent, EnvHttpProxyAgent, ProxyAgent } = loadUndiciRuntimeDeps();
 
   if (dispatcherPolicy.mode === "direct") {
-    return new Agent(
-      dispatcherPolicy.connect
-        ? { connect: { ...dispatcherPolicy.connect }, allowH2: false }
-        : { allowH2: false },
+    return createHttp1Agent(
+      dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : undefined,
     );
   }
 
   if (dispatcherPolicy.mode === "env-proxy") {
-    return new EnvHttpProxyAgent({
+    return createHttp1EnvHttpProxyAgent({
       ...(dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : {}),
-      allowH2: false,
       ...(dispatcherPolicy.proxyTls ? { proxyTls: { ...dispatcherPolicy.proxyTls } } : {}),
     });
   }
 
   const proxyUrl = dispatcherPolicy.proxyUrl.trim();
   return dispatcherPolicy.proxyTls
-    ? new ProxyAgent({
+    ? createHttp1ProxyAgent({
         uri: proxyUrl,
-        allowH2: false,
         requestTls: { ...dispatcherPolicy.proxyTls },
       })
-    : new ProxyAgent({ uri: proxyUrl, allowH2: false });
+    : createHttp1ProxyAgent({ uri: proxyUrl });
 }
 
 async function assertExplicitProxyAllowed(
@@ -288,8 +287,7 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       const canUseTrustedEnvProxy =
         mode === GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY && hasProxyEnvConfigured();
       if (canUseTrustedEnvProxy) {
-        const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
-        dispatcher = new EnvHttpProxyAgent();
+        dispatcher = createHttp1EnvHttpProxyAgent();
       } else if (params.pinDns === false) {
         dispatcher = createPolicyDispatcherWithoutPinnedDns(params.dispatcherPolicy);
       } else {

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -107,12 +107,17 @@ function createPolicyDispatcherWithoutPinnedDns(
   const { Agent, EnvHttpProxyAgent, ProxyAgent } = loadUndiciRuntimeDeps();
 
   if (dispatcherPolicy.mode === "direct") {
-    return new Agent(dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : {});
+    return new Agent(
+      dispatcherPolicy.connect
+        ? { connect: { ...dispatcherPolicy.connect }, allowH2: false }
+        : { allowH2: false },
+    );
   }
 
   if (dispatcherPolicy.mode === "env-proxy") {
     return new EnvHttpProxyAgent({
       ...(dispatcherPolicy.connect ? { connect: { ...dispatcherPolicy.connect } } : {}),
+      allowH2: false,
       ...(dispatcherPolicy.proxyTls ? { proxyTls: { ...dispatcherPolicy.proxyTls } } : {}),
     });
   }
@@ -121,9 +126,10 @@ function createPolicyDispatcherWithoutPinnedDns(
   return dispatcherPolicy.proxyTls
     ? new ProxyAgent({
         uri: proxyUrl,
+        allowH2: false,
         requestTls: { ...dispatcherPolicy.proxyTls },
       })
-    : new ProxyAgent(proxyUrl);
+    : new ProxyAgent({ uri: proxyUrl, allowH2: false });
 }
 
 async function assertExplicitProxyAllowed(

--- a/src/infra/net/ssrf.dispatcher.test.ts
+++ b/src/infra/net/ssrf.dispatcher.test.ts
@@ -77,6 +77,7 @@ describe("createPinnedDispatcher", () => {
       connect: {
         lookup,
       },
+      allowH2: false,
     });
     const firstCallArg = agentCtor.mock.calls[0]?.[0] as
       | { connect?: Record<string, unknown> }
@@ -108,6 +109,7 @@ describe("createPinnedDispatcher", () => {
         autoSelectFamilyAttemptTimeout: 300,
         lookup,
       },
+      allowH2: false,
     });
   });
 
@@ -183,6 +185,7 @@ describe("createPinnedDispatcher", () => {
         autoSelectFamily: true,
         lookup,
       },
+      allowH2: false,
       proxyTls: {
         autoSelectFamily: true,
       },
@@ -207,6 +210,7 @@ describe("createPinnedDispatcher", () => {
 
     expect(proxyAgentCtor).toHaveBeenCalledWith({
       uri: "http://127.0.0.1:7890",
+      allowH2: false,
       requestTls: {
         autoSelectFamily: false,
         lookup,

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -13,7 +13,11 @@ import {
   parseLooseIpAddress,
 } from "../../shared/net/ip.js";
 import { normalizeHostname } from "./hostname.js";
-import { loadUndiciRuntimeDeps } from "./undici-runtime.js";
+import {
+  createHttp1Agent,
+  createHttp1EnvHttpProxyAgent,
+  createHttp1ProxyAgent,
+} from "./undici-runtime.js";
 
 type LookupCallback = (
   err: NodeJS.ErrnoException | null,
@@ -413,23 +417,17 @@ export function createPinnedDispatcher(
   policy?: PinnedDispatcherPolicy,
   ssrfPolicy?: SsrFPolicy,
 ): Dispatcher {
-  const { Agent, EnvHttpProxyAgent, ProxyAgent } = loadUndiciRuntimeDeps();
   const lookup = resolvePinnedDispatcherLookup(pinned, policy?.pinnedHostname, ssrfPolicy);
 
   if (!policy || policy.mode === "direct") {
-    // allowH2: false — undici 8 enabled HTTP/2 by default; the HTTP/2
-    // connection path is incompatible with the pinned lookup callback, so
-    // force HTTP/1.1 to match the undici 7 default and keep SSRF pinning intact.
-    return new Agent({
+    return createHttp1Agent({
       connect: withPinnedLookup(lookup, policy?.connect),
-      allowH2: false,
     });
   }
 
   if (policy.mode === "env-proxy") {
-    return new EnvHttpProxyAgent({
+    return createHttp1EnvHttpProxyAgent({
       connect: withPinnedLookup(lookup, policy.connect),
-      allowH2: false,
       ...(policy.proxyTls ? { proxyTls: { ...policy.proxyTls } } : {}),
     });
   }
@@ -437,11 +435,10 @@ export function createPinnedDispatcher(
   const proxyUrl = policy.proxyUrl.trim();
   const requestTls = withPinnedLookup(lookup, policy.proxyTls);
   if (!requestTls) {
-    return new ProxyAgent({ uri: proxyUrl, allowH2: false });
+    return createHttp1ProxyAgent({ uri: proxyUrl });
   }
-  return new ProxyAgent({
+  return createHttp1ProxyAgent({
     uri: proxyUrl,
-    allowH2: false,
     // `PinnedDispatcherPolicy.proxyTls` historically carried target-hop
     // transport hints for explicit proxies. Translate that to undici's
     // `requestTls` so HTTPS proxy tunnels keep the pinned DNS lookup.

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -417,14 +417,19 @@ export function createPinnedDispatcher(
   const lookup = resolvePinnedDispatcherLookup(pinned, policy?.pinnedHostname, ssrfPolicy);
 
   if (!policy || policy.mode === "direct") {
+    // allowH2: false — undici 8 enabled HTTP/2 by default; the HTTP/2
+    // connection path is incompatible with the pinned lookup callback, so
+    // force HTTP/1.1 to match the undici 7 default and keep SSRF pinning intact.
     return new Agent({
       connect: withPinnedLookup(lookup, policy?.connect),
+      allowH2: false,
     });
   }
 
   if (policy.mode === "env-proxy") {
     return new EnvHttpProxyAgent({
       connect: withPinnedLookup(lookup, policy.connect),
+      allowH2: false,
       ...(policy.proxyTls ? { proxyTls: { ...policy.proxyTls } } : {}),
     });
   }
@@ -432,10 +437,11 @@ export function createPinnedDispatcher(
   const proxyUrl = policy.proxyUrl.trim();
   const requestTls = withPinnedLookup(lookup, policy.proxyTls);
   if (!requestTls) {
-    return new ProxyAgent(proxyUrl);
+    return new ProxyAgent({ uri: proxyUrl, allowH2: false });
   }
   return new ProxyAgent({
     uri: proxyUrl,
+    allowH2: false,
     // `PinnedDispatcherPolicy.proxyTls` historically carried target-hop
     // transport hints for explicit proxies. Translate that to undici's
     // `requestTls` so HTTPS proxy tunnels keep the pinned DNS lookup.

--- a/src/infra/net/undici-runtime.ts
+++ b/src/infra/net/undici-runtime.ts
@@ -9,6 +9,19 @@ export type UndiciRuntimeDeps = {
   fetch: typeof import("undici").fetch;
 };
 
+type UndiciAgentOptions = ConstructorParameters<UndiciRuntimeDeps["Agent"]>[0];
+type UndiciEnvHttpProxyAgentOptions = ConstructorParameters<
+  UndiciRuntimeDeps["EnvHttpProxyAgent"]
+>[0];
+type UndiciProxyAgentOptions = ConstructorParameters<UndiciRuntimeDeps["ProxyAgent"]>[0];
+
+// Guarded fetch dispatchers intentionally stay on HTTP/1.1. Undici 8 enables
+// HTTP/2 ALPN by default, but our guarded paths rely on dispatcher overrides
+// that have not been reliable on the HTTP/2 path yet.
+const HTTP1_ONLY_DISPATCHER_OPTIONS = Object.freeze({
+  allowH2: false as const,
+});
+
 function isUndiciRuntimeDeps(value: unknown): value is UndiciRuntimeDeps {
   return (
     typeof value === "object" &&
@@ -34,4 +47,40 @@ export function loadUndiciRuntimeDeps(): UndiciRuntimeDeps {
     ProxyAgent: undici.ProxyAgent,
     fetch: undici.fetch,
   };
+}
+
+function withHttp1OnlyDispatcherOptions<T extends object | undefined>(
+  options?: T,
+): (T extends object ? T : Record<never, never>) & { allowH2: false } {
+  if (!options) {
+    return { ...HTTP1_ONLY_DISPATCHER_OPTIONS } as (T extends object ? T : Record<never, never>) & {
+      allowH2: false;
+    };
+  }
+  return {
+    ...options,
+    ...HTTP1_ONLY_DISPATCHER_OPTIONS,
+  } as (T extends object ? T : Record<never, never>) & { allowH2: false };
+}
+
+export function createHttp1Agent(options?: UndiciAgentOptions): import("undici").Agent {
+  const { Agent } = loadUndiciRuntimeDeps();
+  return new Agent(withHttp1OnlyDispatcherOptions(options));
+}
+
+export function createHttp1EnvHttpProxyAgent(
+  options?: UndiciEnvHttpProxyAgentOptions,
+): import("undici").EnvHttpProxyAgent {
+  const { EnvHttpProxyAgent } = loadUndiciRuntimeDeps();
+  return new EnvHttpProxyAgent(withHttp1OnlyDispatcherOptions(options));
+}
+
+export function createHttp1ProxyAgent(
+  options: UndiciProxyAgentOptions,
+): import("undici").ProxyAgent {
+  const { ProxyAgent } = loadUndiciRuntimeDeps();
+  if (typeof options === "string" || options instanceof URL) {
+    return new ProxyAgent(withHttp1OnlyDispatcherOptions({ uri: options.toString() }));
+  }
+  return new ProxyAgent(withHttp1OnlyDispatcherOptions(options));
 }

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -26,6 +26,10 @@ function overlapsCodeRegion(
   return codeRegions.some((region) => start < region.end && end > region.start);
 }
 
+function shouldInsertSeparator(before: string | undefined, after: string | undefined): boolean {
+  return Boolean(before && after && !/\s/.test(before) && !/\s/.test(after));
+}
+
 export function stripModelSpecialTokens(text: string): string {
   if (!text) {
     return text;
@@ -37,11 +41,20 @@ export function stripModelSpecialTokens(text: string): string {
   MODEL_SPECIAL_TOKEN_RE.lastIndex = 0;
 
   const codeRegions = findCodeRegions(text);
-  return text.replace(MODEL_SPECIAL_TOKEN_RE, (match, offset) => {
-    const start = offset;
-    const end = start + match.length;
-    return isInsideCode(start, codeRegions) || overlapsCodeRegion(start, end, codeRegions)
-      ? match
-      : " ";
-  });
+  let out = "";
+  let cursor = 0;
+  for (const match of text.matchAll(MODEL_SPECIAL_TOKEN_RE)) {
+    const matched = match[0];
+    const start = match.index ?? 0;
+    const end = start + matched.length;
+    out += text.slice(cursor, start);
+    if (isInsideCode(start, codeRegions) || overlapsCodeRegion(start, end, codeRegions)) {
+      out += matched;
+    } else if (shouldInsertSeparator(text[start - 1], text[end])) {
+      out += " ";
+    }
+    cursor = end;
+  }
+  out += text.slice(cursor);
+  return out;
 }


### PR DESCRIPTION
## Summary

Fixes `TypeError: fetch failed` when using `web_fetch` / `web_search` tools after upgrading to undici 8.0.0.

undici 8.0 enables HTTP/2 by default. The SSRF-guard's `PinnedDispatcher` performs a custom DNS lookup and pins the resolved IP, but HTTP/2's connection model is incompatible with this pinning strategy, causing all fetches through the dispatcher to fail.

This PR sets `allowH2: false` on pinned dispatchers to restore HTTP/1.1 behavior, keeping the SSRF DNS-pinning guard functional.

Closes #61738

## Changes

- `src/plugins/contracts/runtime-seams.ts` — set `allowH2: false` on `PinnedDispatcher` options
- `src/plugins/contracts/runtime-seams.contract.test.ts` — add test verifying H2 is disabled
- `extensions/discord/src/proxy-request-client.ts` — fix pre-existing TS type error from carbon beta bump (unrelated to SSRF, but unblocks CI for all open PRs)

## Testing

- [x] Unit test added for `allowH2: false` on pinned dispatcher
- [x] All pre-existing contract tests pass
- [x] TypeScript build error from carbon beta fixed