### PR TITLE
fix(command-queue): guard against missing activeTaskWaiters on stale singleton

### DIFF
--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -378,6 +378,55 @@ describe("command queue", () => {
     await expect(enqueueCommand(async () => "ok")).resolves.toBe("ok");
   });
 
+  it("notifyActiveTaskWaiters survives stale singleton without activeTaskWaiters (pre-restart state)", async () => {
+    // Simulate a state object created by an older module version that predates
+    // the activeTaskWaiters field. resolveGlobalSingleton returns it as-is on
+    // an in-process restart, causing Array.from(undefined) to crash.
+    const STATE_KEY = Symbol.for("openclaw.commandQueueState");
+    const globalStore = globalThis as Record<PropertyKey, unknown>;
+    const staleState = {
+      gatewayDraining: false,
+      lanes: new Map(),
+      // activeTaskWaiters intentionally omitted to simulate older code
+      nextTaskId: 1,
+    };
+    globalStore[STATE_KEY] = staleState;
+
+    try {
+      // Any of these should not throw even though activeTaskWaiters is missing
+      expect(() => resetAllLanes()).not.toThrow();
+      expect(() => resetCommandQueueStateForTest()).not.toThrow();
+      // After getQueueState() patches it, normal operation resumes
+      await expect(enqueueCommand(async () => "ok")).resolves.toBe("ok");
+    } finally {
+      resetCommandQueueStateForTest();
+    }
+  });
+
+  it("notifyActiveTaskWaiters handles concurrent task completion with multiple waiters", async () => {
+    const lane = `concurrent-notify-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 3);
+
+    const deferreds = [createDeferred(), createDeferred(), createDeferred()];
+
+    const tasks = deferreds.map((d) =>
+      enqueueCommandInLane(lane, async () => {
+        await d.promise;
+      }),
+    );
+
+    // Wait for all three concurrent tasks
+    const drainPromise = waitForActiveTasks(5000);
+    expect(getActiveTaskCount()).toBeGreaterThanOrEqual(3);
+
+    // Release all tasks concurrently — multiple notifyActiveTaskWaiters calls
+    // fire in the same microtask batch; the waiter must only be resolved once.
+    deferreds.forEach((d) => d.resolve());
+    const { drained } = await drainPromise;
+    expect(drained).toBe(true);
+    await Promise.all(tasks);
+  });
+
   it("shares lane state across distinct module instances", async () => {
     const commandQueueA = await importFreshModule<typeof import("./command-queue.js")>(
       import.meta.url,

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -64,12 +64,19 @@ function isExpectedNonErrorLaneFailure(err: unknown): boolean {
 const COMMAND_QUEUE_STATE_KEY = Symbol.for("openclaw.commandQueueState");
 
 function getQueueState() {
-  return resolveGlobalSingleton(COMMAND_QUEUE_STATE_KEY, () => ({
+  const state = resolveGlobalSingleton(COMMAND_QUEUE_STATE_KEY, () => ({
     gatewayDraining: false,
     lanes: new Map<string, LaneState>(),
     activeTaskWaiters: new Set<ActiveTaskWaiter>(),
     nextTaskId: 1,
   }));
+  // Guard: state objects created by older module versions (e.g. before an
+  // in-process SIGUSR1 restart) may predate the activeTaskWaiters field.
+  // Initialize it here rather than crashing in notifyActiveTaskWaiters.
+  if (!state.activeTaskWaiters) {
+    state.activeTaskWaiters = new Set<ActiveTaskWaiter>();
+  }
+  return state;
 }
 
 function normalizeLane(lane: string): string {
@@ -131,7 +138,7 @@ function resolveActiveTaskWaiter(waiter: ActiveTaskWaiter, result: { drained: bo
 
 function notifyActiveTaskWaiters(): void {
   const queueState = getQueueState();
-  for (const waiter of Array.from(queueState.activeTaskWaiters)) {
+  for (const waiter of Array.from(queueState.activeTaskWaiters ?? [])) {
     if (waiter.activeTaskIds.size === 0 || !hasPendingActiveTasks(waiter.activeTaskIds)) {
       resolveActiveTaskWaiter(waiter, { drained: true });
     }
@@ -304,7 +311,7 @@ export function resetCommandQueueStateForTest(): void {
   const queueState = getQueueState();
   queueState.gatewayDraining = false;
   queueState.lanes.clear();
-  for (const waiter of Array.from(queueState.activeTaskWaiters)) {
+  for (const waiter of Array.from(queueState.activeTaskWaiters ?? [])) {
     resolveActiveTaskWaiter(waiter, { drained: true });
   }
   queueState.nextTaskId = 1;


### PR DESCRIPTION
## Summary

- After an in-process restart (SIGUSR1), `resolveGlobalSingleton` returns the state object from the previous module version which may predate the `activeTaskWaiters` field. This caused `Array.from(undefined)` to throw `TypeError` in `notifyActiveTaskWaiters`.
- Added a guard in `getQueueState()` to initialize `activeTaskWaiters` as a new `Set` if missing from the stale singleton.
- Added `?? []` fallback in `notifyActiveTaskWaiters` and `resetCommandQueueStateForTest` as belt-and-suspenders protection.

## Test plan

- [x] Added test: `notifyActiveTaskWaiters survives stale singleton without activeTaskWaiters (pre-restart state)`
- [x] Added test: `notifyActiveTaskWaiters handles concurrent task completion with multiple waiters`
- [x] All existing command-queue tests continue to pass

Closes #61731