### PR TITLE
fix(exec): clarify preflight obfuscation guidance

### DIFF
--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -140,4 +140,20 @@ describe("exec approval reply helpers", () => {
       ).toContain(testCase.expected);
     }
   });
+
+  it("uses preflight guidance instead of approval guidance for obfuscation warnings", () => {
+    const payload = buildExecApprovalUnavailableReplyPayload({
+      warningText: "⚠️ Obfuscated command detected: Command too long; potential obfuscation",
+      reason: "initiating-platform-disabled",
+      channelLabel: "Discord",
+    });
+
+    expect(payload.text).toContain(
+      "Exec preflight blocked this command before any approval flow was started.",
+    );
+    expect(payload.text).toContain("`tools.exec.maxCommandChars`");
+    expect(payload.text).toContain("`tools.exec.obfuscationCheck: false`");
+    expect(payload.text).not.toContain("chat exec approvals are not enabled");
+    expect(payload.text).not.toContain("Approve it from the Web UI or terminal UI");
+  });
 });

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -37,6 +37,17 @@ export function getExecApprovalApproverDmNoticeText(): string {
   return "Approval required. I sent the allowed approvers DMs.";
 }
 
+function isExecPreflightObfuscationWarning(text: string | undefined): boolean {
+  const normalized = text?.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return (
+    normalized.includes("obfuscated command detected") ||
+    normalized.includes("potential obfuscation")
+  );
+}
+
 function buildFence(text: string, language?: string): string {
   let fence = "```";
   while (text.includes(fence)) {
@@ -134,6 +145,16 @@ export function buildExecApprovalUnavailableReplyPayload(
   const warningText = params.warningText?.trim();
   if (warningText) {
     lines.push(warningText);
+  }
+
+  if (isExecPreflightObfuscationWarning(warningText)) {
+    lines.push("Exec preflight blocked this command before any approval flow was started.");
+    lines.push(
+      "If this command is expected, raise `tools.exec.maxCommandChars` or disable the heuristic with `tools.exec.obfuscationCheck: false`, then retry.",
+    );
+    return {
+      text: lines.join("\n\n"),
+    };
   }
 
   if (params.sentApproverDms) {


### PR DESCRIPTION
## Summary
- detect exec preflight obfuscation warnings before falling back to approval-unavailable guidance
- explain that the command was blocked by exec preflight, not by the approvals subsystem
- point users at \\	ools.exec.maxCommandChars\\ and \\	ools.exec.obfuscationCheck: false\\
- add focused reply helper coverage for the obfuscation warning path

Closes #61600

## Verification
- \\pnpm exec oxfmt --check src/infra/exec-approval-reply.ts src/infra/exec-approval-reply.test.ts\\
- direct runtime assertion for \\uildExecApprovalUnavailableReplyPayload(...)\\ on the obfuscation warning path