### PR TITLE
docs: relocalize stale locale links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/TUI: defer terminal chat finalization for per-attempt lifecycle errors so fallback retries keep streaming before the run is marked failed. (#60043) Thanks @jwchmodx.
 - TUI/command messages: strip inbound envelope metadata before rendering command/system messages so async completion notices stop leaking raw wrappers into the operator terminal. (#59985) Thanks @MoerAI.
 - TUI/terminal: restore Kitty keyboard protocol and `modifyOtherKeys` state on TUI exit and fatal CLI crashes so parent shells stop inheriting broken keyboard input after `openclaw tui` exits. (#49130) Thanks @biefan.
+- Docs/i18n: relocalize final localized-page links after translation so generated locale pages stop keeping stale English-root links when targets appear later in the same run. (#61796) thanks @hxy91819.
 
 ## 2026.4.5
 

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -347,7 +347,7 @@ Events are not replayed. On sequence gaps, refresh state (`health`, `system-pres
 | `Gateway start blocked: set gateway.mode=local`                | Config set to remote mode, or local-mode stamp is missing from a damaged config |
 | `unauthorized` during connect                                  | Auth mismatch between client and gateway                                        |
 
-For full diagnosis ladders, use [Gateway Troubleshooting](/gateway/troubleshooting).
+For full symptom-first diagnosis ladders, use [Gateway Troubleshooting](/gateway/troubleshooting).
 
 ## Safety guarantees
 

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -173,7 +173,7 @@ Fallback: SSH tunnel.
 ssh -N -L 18789:127.0.0.1:18789 user@host
 ```
 
-Then connect clients to `ws://127.0.0.1:18789` locally.
+Then connect clients locally to `ws://127.0.0.1:18789`.
 
 <Warning>
 SSH tunnels do not bypass gateway auth. For shared-secret auth, clients still
@@ -347,7 +347,7 @@ Events are not replayed. On sequence gaps, refresh state (`health`, `system-pres
 | `Gateway start blocked: set gateway.mode=local`                | Config set to remote mode, or local-mode stamp is missing from a damaged config |
 | `unauthorized` during connect                                  | Auth mismatch between client and gateway                                        |
 
-For full symptom-first diagnosis ladders, use [Gateway Troubleshooting](/gateway/troubleshooting).
+For full diagnosis ladders, use [Gateway Troubleshooting](/gateway/troubleshooting).
 
 ## Safety guarantees
 

--- a/scripts/docs-i18n/doc_mode.go
+++ b/scripts/docs-i18n/doc_mode.go
@@ -17,7 +17,7 @@ const (
 	bodyTagEnd          = "</body>"
 )
 
-func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, filePath, srcLang, tgtLang string, overwrite bool, routes *routeIndex) (bool, error) {
+func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, filePath, srcLang, tgtLang string, overwrite bool) (bool, error) {
 	absPath, relPath, err := resolveDocsPath(docsRoot, filePath)
 	if err != nil {
 		return false, err
@@ -65,8 +65,6 @@ func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, fil
 	if err := applyFrontmatterTranslations(frontData, markers, translatedFront); err != nil {
 		return false, fmt.Errorf("frontmatter translation failed for %s: %w", relPath, err)
 	}
-	translatedBody = routes.localizeBodyLinks(translatedBody)
-
 	updatedFront, err := encodeFrontMatter(frontData, relPath, content)
 	if err != nil {
 		return false, err

--- a/scripts/docs-i18n/doc_mode.go
+++ b/scripts/docs-i18n/doc_mode.go
@@ -17,7 +17,7 @@ const (
 	bodyTagEnd          = "</body>"
 )
 
-func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, filePath, srcLang, tgtLang string, overwrite bool) (bool, string, error) {
+func processFileDoc(ctx context.Context, translator docsTranslator, docsRoot, filePath, srcLang, tgtLang string, overwrite bool) (bool, string, error) {
 	absPath, relPath, err := resolveDocsPath(docsRoot, filePath)
 	if err != nil {
 		return false, "", err

--- a/scripts/docs-i18n/doc_mode.go
+++ b/scripts/docs-i18n/doc_mode.go
@@ -17,15 +17,15 @@ const (
 	bodyTagEnd          = "</body>"
 )
 
-func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, filePath, srcLang, tgtLang string, overwrite bool) (bool, error) {
+func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, filePath, srcLang, tgtLang string, overwrite bool) (bool, string, error) {
 	absPath, relPath, err := resolveDocsPath(docsRoot, filePath)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	content, err := os.ReadFile(absPath)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 	currentHash := hashBytes(content)
 
@@ -33,10 +33,10 @@ func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, fil
 	if !overwrite {
 		skip, err := shouldSkipDoc(outputPath, currentHash)
 		if err != nil {
-			return false, err
+			return false, "", err
 		}
 		if skip {
-			return true, nil
+			return true, "", nil
 		}
 	}
 
@@ -44,7 +44,7 @@ func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, fil
 	frontData := map[string]any{}
 	if strings.TrimSpace(sourceFront) != "" {
 		if err := yaml.Unmarshal([]byte(sourceFront), &frontData); err != nil {
-			return false, fmt.Errorf("frontmatter parse failed for %s: %w", relPath, err)
+			return false, "", fmt.Errorf("frontmatter parse failed for %s: %w", relPath, err)
 		}
 	}
 	frontTemplate, markers := buildFrontmatterTemplate(frontData)
@@ -52,30 +52,30 @@ func processFileDoc(ctx context.Context, translator *PiTranslator, docsRoot, fil
 
 	translatedDoc, err := translator.TranslateRaw(ctx, taggedInput, srcLang, tgtLang)
 	if err != nil {
-		return false, fmt.Errorf("translate failed (%s): %w", relPath, err)
+		return false, "", fmt.Errorf("translate failed (%s): %w", relPath, err)
 	}
 
 	translatedFront, translatedBody, err := parseTaggedDocument(translatedDoc)
 	if err != nil {
-		return false, fmt.Errorf("tagged output invalid for %s: %w", relPath, err)
+		return false, "", fmt.Errorf("tagged output invalid for %s: %w", relPath, err)
 	}
 	if sourceFront != "" && strings.TrimSpace(translatedFront) == "" {
-		return false, fmt.Errorf("translation removed frontmatter for %s", relPath)
+		return false, "", fmt.Errorf("translation removed frontmatter for %s", relPath)
 	}
 	if err := applyFrontmatterTranslations(frontData, markers, translatedFront); err != nil {
-		return false, fmt.Errorf("frontmatter translation failed for %s: %w", relPath, err)
+		return false, "", fmt.Errorf("frontmatter translation failed for %s: %w", relPath, err)
 	}
 	updatedFront, err := encodeFrontMatter(frontData, relPath, content)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	output := updatedFront + translatedBody
-	return false, os.WriteFile(outputPath, []byte(output), 0o644)
+	return false, outputPath, os.WriteFile(outputPath, []byte(output), 0o644)
 }
 
 func formatTaggedDocument(frontMatter, body string) string {

--- a/scripts/docs-i18n/html_translate.go
+++ b/scripts/docs-i18n/html_translate.go
@@ -19,7 +19,7 @@ type htmlReplacement struct {
 	Value string
 }
 
-func translateHTMLBlocks(ctx context.Context, translator *PiTranslator, body, srcLang, tgtLang string) (string, error) {
+func translateHTMLBlocks(ctx context.Context, translator docsTranslator, body, srcLang, tgtLang string) (string, error) {
 	source := []byte(body)
 	r := text.NewReader(source)
 	md := goldmark.New(
@@ -95,7 +95,7 @@ func sortHTMLReplacements(replacements []htmlReplacement) {
 	})
 }
 
-func translateHTMLBlock(ctx context.Context, translator *PiTranslator, htmlText, srcLang, tgtLang string) (string, error) {
+func translateHTMLBlock(ctx context.Context, translator docsTranslator, htmlText, srcLang, tgtLang string) (string, error) {
 	tokenizer := html.NewTokenizer(strings.NewReader(htmlText))
 	var out strings.Builder
 	skipDepth := 0

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -91,6 +91,7 @@ func main() {
 	start := time.Now()
 	processed := 0
 	skipped := 0
+	var runErr error
 
 	if *parallel < 1 {
 		*parallel = 1
@@ -101,40 +102,43 @@ func main() {
 	case "doc":
 		if *parallel > 1 {
 			proc, skip, err := runDocParallel(context.Background(), ordered, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite, *parallel, glossary, *thinking)
-			if err != nil {
-				fatal(err)
-			}
 			processed += proc
 			skipped += skip
+			if err != nil {
+				runErr = err
+			}
 		} else {
 			proc, skip, err := runDocSequential(context.Background(), ordered, translator, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite)
-			if err != nil {
-				fatal(err)
-			}
 			processed += proc
 			skipped += skip
+			if err != nil {
+				runErr = err
+			}
 		}
 	case "segment":
 		if *parallel > 1 {
 			fatal(fmt.Errorf("parallel processing is only supported in doc mode"))
 		}
 		proc, err := runSegmentSequential(context.Background(), ordered, translator, tm, resolvedDocsRoot, *sourceLang, *targetLang)
-		if err != nil {
-			fatal(err)
-		}
 		processed += proc
+		if err != nil {
+			runErr = err
+		}
 	default:
 		fatal(fmt.Errorf("unknown mode: %s", *mode))
 	}
 
-	if err := tm.Save(); err != nil {
-		fatal(err)
+	if err := tm.Save(); err != nil && runErr == nil {
+		runErr = err
 	}
-	if err := postprocessLocalizedDocs(resolvedDocsRoot, *targetLang); err != nil {
-		fatal(err)
+	if err := postprocessLocalizedDocs(resolvedDocsRoot, *targetLang); err != nil && runErr == nil {
+		runErr = err
 	}
 	elapsed := time.Since(start).Round(time.Millisecond)
 	log.Printf("docs-i18n: completed processed=%d skipped=%d elapsed=%s", processed, skipped, elapsed)
+	if runErr != nil {
+		fatal(runErr)
+	}
 }
 
 func runDocSequential(ctx context.Context, ordered []string, translator *PiTranslator, docsRoot, srcLang, tgtLang string, overwrite bool) (int, int, error) {

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -135,6 +135,9 @@ func main() {
 	if err := tm.Save(); err != nil {
 		fatal(err)
 	}
+	if err := relocalizeExistingDocs(resolvedDocsRoot, *targetLang); err != nil {
+		fatal(err)
+	}
 	elapsed := time.Since(start).Round(time.Millisecond)
 	log.Printf("docs-i18n: completed processed=%d skipped=%d elapsed=%s", processed, skipped, elapsed)
 }

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -58,11 +58,6 @@ func main() {
 		fatal(err)
 	}
 
-	routes, err := loadRouteIndex(resolvedDocsRoot, *targetLang)
-	if err != nil {
-		fatal(err)
-	}
-
 	translator, err := NewPiTranslator(*sourceLang, *targetLang, glossary, *thinking)
 	if err != nil {
 		fatal(err)
@@ -105,14 +100,14 @@ func main() {
 	switch *mode {
 	case "doc":
 		if *parallel > 1 {
-			proc, skip, err := runDocParallel(context.Background(), ordered, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite, *parallel, glossary, *thinking, routes)
+			proc, skip, err := runDocParallel(context.Background(), ordered, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite, *parallel, glossary, *thinking)
 			if err != nil {
 				fatal(err)
 			}
 			processed += proc
 			skipped += skip
 		} else {
-			proc, skip, err := runDocSequential(context.Background(), ordered, translator, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite, routes)
+			proc, skip, err := runDocSequential(context.Background(), ordered, translator, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite)
 			if err != nil {
 				fatal(err)
 			}
@@ -123,7 +118,7 @@ func main() {
 		if *parallel > 1 {
 			fatal(fmt.Errorf("parallel processing is only supported in doc mode"))
 		}
-		proc, err := runSegmentSequential(context.Background(), ordered, translator, tm, resolvedDocsRoot, *sourceLang, *targetLang, routes)
+		proc, err := runSegmentSequential(context.Background(), ordered, translator, tm, resolvedDocsRoot, *sourceLang, *targetLang)
 		if err != nil {
 			fatal(err)
 		}
@@ -135,21 +130,21 @@ func main() {
 	if err := tm.Save(); err != nil {
 		fatal(err)
 	}
-	if err := relocalizeExistingDocs(resolvedDocsRoot, *targetLang); err != nil {
+	if err := postprocessLocalizedDocs(resolvedDocsRoot, *targetLang); err != nil {
 		fatal(err)
 	}
 	elapsed := time.Since(start).Round(time.Millisecond)
 	log.Printf("docs-i18n: completed processed=%d skipped=%d elapsed=%s", processed, skipped, elapsed)
 }
 
-func runDocSequential(ctx context.Context, ordered []string, translator *PiTranslator, docsRoot, srcLang, tgtLang string, overwrite bool, routes *routeIndex) (int, int, error) {
+func runDocSequential(ctx context.Context, ordered []string, translator *PiTranslator, docsRoot, srcLang, tgtLang string, overwrite bool) (int, int, error) {
 	processed := 0
 	skipped := 0
 	for index, file := range ordered {
 		relPath := resolveRelPath(docsRoot, file)
 		log.Printf("docs-i18n: [%d/%d] start %s", index+1, len(ordered), relPath)
 		start := time.Now()
-		skip, err := processFileDoc(ctx, translator, docsRoot, file, srcLang, tgtLang, overwrite, routes)
+		skip, err := processFileDoc(ctx, translator, docsRoot, file, srcLang, tgtLang, overwrite)
 		if err != nil {
 			return processed, skipped, err
 		}
@@ -164,7 +159,7 @@ func runDocSequential(ctx context.Context, ordered []string, translator *PiTrans
 	return processed, skipped, nil
 }
 
-func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tgtLang string, overwrite bool, parallel int, glossary []GlossaryEntry, thinking string, routes *routeIndex) (int, int, error) {
+func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tgtLang string, overwrite bool, parallel int, glossary []GlossaryEntry, thinking string) (int, int, error) {
 	jobs := make(chan docJob)
 	results := make(chan docResult, len(ordered))
 	ctx, cancel := context.WithCancel(ctx)
@@ -187,7 +182,7 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 				}
 				log.Printf("docs-i18n: [w%d %d/%d] start %s", workerID, job.index, len(ordered), job.rel)
 				start := time.Now()
-				skip, err := processFileDoc(ctx, translator, docsRoot, job.path, srcLang, tgtLang, overwrite, routes)
+				skip, err := processFileDoc(ctx, translator, docsRoot, job.path, srcLang, tgtLang, overwrite)
 				results <- docResult{
 					index:    job.index,
 					rel:      job.rel,
@@ -230,13 +225,13 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 	return processed, skipped, nil
 }
 
-func runSegmentSequential(ctx context.Context, ordered []string, translator *PiTranslator, tm *TranslationMemory, docsRoot, srcLang, tgtLang string, routes *routeIndex) (int, error) {
+func runSegmentSequential(ctx context.Context, ordered []string, translator *PiTranslator, tm *TranslationMemory, docsRoot, srcLang, tgtLang string) (int, error) {
 	processed := 0
 	for index, file := range ordered {
 		relPath := resolveRelPath(docsRoot, file)
 		log.Printf("docs-i18n: [%d/%d] start %s", index+1, len(ordered), relPath)
 		start := time.Now()
-		if _, err := processFile(ctx, translator, tm, docsRoot, file, srcLang, tgtLang, routes); err != nil {
+		if _, err := processFile(ctx, translator, tm, docsRoot, file, srcLang, tgtLang); err != nil {
 			return processed, err
 		}
 		processed++

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -211,32 +211,40 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 	}
 
 	go func() {
+		defer close(jobs)
 		for index, file := range ordered {
-			jobs <- docJob{index: index + 1, path: file, rel: resolveRelPath(docsRoot, file)}
+			job := docJob{index: index + 1, path: file, rel: resolveRelPath(docsRoot, file)}
+			select {
+			case <-ctx.Done():
+				return
+			case jobs <- job:
+			}
 		}
-		close(jobs)
+	}()
+
+	go func() {
+		wg.Wait()
+		close(results)
 	}()
 
 	processed := 0
 	skipped := 0
 	outputs := []string{}
-	for i := 0; i < len(ordered); i++ {
-		result := <-results
-		if result.err != nil {
-			wg.Wait()
-			return processed, skipped, outputs, result.err
+	var firstErr error
+	for result := range results {
+		if result.err != nil && firstErr == nil {
+			firstErr = result.err
 		}
 		if result.skipped {
 			skipped++
 			log.Printf("docs-i18n: [w* %d/%d] skipped %s (%s)", result.index, len(ordered), result.rel, result.duration.Round(time.Millisecond))
-		} else {
+		} else if result.err == nil {
 			processed++
 			outputs = append(outputs, result.output)
 			log.Printf("docs-i18n: [w* %d/%d] done %s (%s)", result.index, len(ordered), result.rel, result.duration.Round(time.Millisecond))
 		}
 	}
-	wg.Wait()
-	return processed, skipped, outputs, nil
+	return processed, skipped, outputs, firstErr
 }
 
 func runSegmentSequential(ctx context.Context, ordered []string, translator *PiTranslator, tm *TranslationMemory, docsRoot, srcLang, tgtLang string) (int, []string, error) {

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -20,6 +20,7 @@ type docJob struct {
 type docResult struct {
 	index    int
 	rel      string
+	output   string
 	duration time.Duration
 	skipped  bool
 	err      error
@@ -91,6 +92,7 @@ func main() {
 	start := time.Now()
 	processed := 0
 	skipped := 0
+	localizedFiles := []string{}
 	var runErr error
 
 	if *parallel < 1 {
@@ -101,16 +103,18 @@ func main() {
 	switch *mode {
 	case "doc":
 		if *parallel > 1 {
-			proc, skip, err := runDocParallel(context.Background(), ordered, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite, *parallel, glossary, *thinking)
+			proc, skip, outputs, err := runDocParallel(context.Background(), ordered, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite, *parallel, glossary, *thinking)
 			processed += proc
 			skipped += skip
+			localizedFiles = append(localizedFiles, outputs...)
 			if err != nil {
 				runErr = err
 			}
 		} else {
-			proc, skip, err := runDocSequential(context.Background(), ordered, translator, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite)
+			proc, skip, outputs, err := runDocSequential(context.Background(), ordered, translator, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite)
 			processed += proc
 			skipped += skip
+			localizedFiles = append(localizedFiles, outputs...)
 			if err != nil {
 				runErr = err
 			}
@@ -119,8 +123,9 @@ func main() {
 		if *parallel > 1 {
 			fatal(fmt.Errorf("parallel processing is only supported in doc mode"))
 		}
-		proc, err := runSegmentSequential(context.Background(), ordered, translator, tm, resolvedDocsRoot, *sourceLang, *targetLang)
+		proc, outputs, err := runSegmentSequential(context.Background(), ordered, translator, tm, resolvedDocsRoot, *sourceLang, *targetLang)
 		processed += proc
+		localizedFiles = append(localizedFiles, outputs...)
 		if err != nil {
 			runErr = err
 		}
@@ -131,7 +136,7 @@ func main() {
 	if err := tm.Save(); err != nil && runErr == nil {
 		runErr = err
 	}
-	if err := postprocessLocalizedDocs(resolvedDocsRoot, *targetLang); err != nil && runErr == nil {
+	if err := postprocessLocalizedDocs(resolvedDocsRoot, *targetLang, localizedFiles); err != nil && runErr == nil {
 		runErr = err
 	}
 	elapsed := time.Since(start).Round(time.Millisecond)
@@ -141,29 +146,31 @@ func main() {
 	}
 }
 
-func runDocSequential(ctx context.Context, ordered []string, translator *PiTranslator, docsRoot, srcLang, tgtLang string, overwrite bool) (int, int, error) {
+func runDocSequential(ctx context.Context, ordered []string, translator *PiTranslator, docsRoot, srcLang, tgtLang string, overwrite bool) (int, int, []string, error) {
 	processed := 0
 	skipped := 0
+	outputs := []string{}
 	for index, file := range ordered {
 		relPath := resolveRelPath(docsRoot, file)
 		log.Printf("docs-i18n: [%d/%d] start %s", index+1, len(ordered), relPath)
 		start := time.Now()
-		skip, err := processFileDoc(ctx, translator, docsRoot, file, srcLang, tgtLang, overwrite)
+		skip, outputPath, err := processFileDoc(ctx, translator, docsRoot, file, srcLang, tgtLang, overwrite)
 		if err != nil {
-			return processed, skipped, err
+			return processed, skipped, outputs, err
 		}
 		if skip {
 			skipped++
 			log.Printf("docs-i18n: [%d/%d] skipped %s (%s)", index+1, len(ordered), relPath, time.Since(start).Round(time.Millisecond))
 		} else {
 			processed++
+			outputs = append(outputs, outputPath)
 			log.Printf("docs-i18n: [%d/%d] done %s (%s)", index+1, len(ordered), relPath, time.Since(start).Round(time.Millisecond))
 		}
 	}
-	return processed, skipped, nil
+	return processed, skipped, outputs, nil
 }
 
-func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tgtLang string, overwrite bool, parallel int, glossary []GlossaryEntry, thinking string) (int, int, error) {
+func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tgtLang string, overwrite bool, parallel int, glossary []GlossaryEntry, thinking string) (int, int, []string, error) {
 	jobs := make(chan docJob)
 	results := make(chan docResult, len(ordered))
 	ctx, cancel := context.WithCancel(ctx)
@@ -186,10 +193,11 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 				}
 				log.Printf("docs-i18n: [w%d %d/%d] start %s", workerID, job.index, len(ordered), job.rel)
 				start := time.Now()
-				skip, err := processFileDoc(ctx, translator, docsRoot, job.path, srcLang, tgtLang, overwrite)
+				skip, outputPath, err := processFileDoc(ctx, translator, docsRoot, job.path, srcLang, tgtLang, overwrite)
 				results <- docResult{
 					index:    job.index,
 					rel:      job.rel,
+					output:   outputPath,
 					duration: time.Since(start),
 					skipped:  skip,
 					err:      err,
@@ -211,37 +219,42 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 
 	processed := 0
 	skipped := 0
+	outputs := []string{}
 	for i := 0; i < len(ordered); i++ {
 		result := <-results
 		if result.err != nil {
 			wg.Wait()
-			return processed, skipped, result.err
+			return processed, skipped, outputs, result.err
 		}
 		if result.skipped {
 			skipped++
 			log.Printf("docs-i18n: [w* %d/%d] skipped %s (%s)", result.index, len(ordered), result.rel, result.duration.Round(time.Millisecond))
 		} else {
 			processed++
+			outputs = append(outputs, result.output)
 			log.Printf("docs-i18n: [w* %d/%d] done %s (%s)", result.index, len(ordered), result.rel, result.duration.Round(time.Millisecond))
 		}
 	}
 	wg.Wait()
-	return processed, skipped, nil
+	return processed, skipped, outputs, nil
 }
 
-func runSegmentSequential(ctx context.Context, ordered []string, translator *PiTranslator, tm *TranslationMemory, docsRoot, srcLang, tgtLang string) (int, error) {
+func runSegmentSequential(ctx context.Context, ordered []string, translator *PiTranslator, tm *TranslationMemory, docsRoot, srcLang, tgtLang string) (int, []string, error) {
 	processed := 0
+	outputs := []string{}
 	for index, file := range ordered {
 		relPath := resolveRelPath(docsRoot, file)
 		log.Printf("docs-i18n: [%d/%d] start %s", index+1, len(ordered), relPath)
 		start := time.Now()
-		if _, err := processFile(ctx, translator, tm, docsRoot, file, srcLang, tgtLang); err != nil {
-			return processed, err
+		_, outputPath, err := processFile(ctx, translator, tm, docsRoot, file, srcLang, tgtLang)
+		if err != nil {
+			return processed, outputs, err
 		}
 		processed++
+		outputs = append(outputs, outputPath)
 		log.Printf("docs-i18n: [%d/%d] done %s (%s)", index+1, len(ordered), relPath, time.Since(start).Round(time.Millisecond))
 	}
-	return processed, nil
+	return processed, outputs, nil
 }
 
 func resolveRelPath(docsRoot, file string) string {

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -26,6 +26,18 @@ type docResult struct {
 	err      error
 }
 
+type runConfig struct {
+	targetLang string
+	sourceLang string
+	docsRoot   string
+	tmPath     string
+	mode       string
+	thinking   string
+	overwrite  bool
+	maxFiles   int
+	parallel   int
+}
+
 func main() {
 	var (
 		targetLang = flag.String("lang", "zh-CN", "target language (e.g., zh-CN)")
@@ -44,48 +56,70 @@ func main() {
 		fatal(fmt.Errorf("no doc files provided"))
 	}
 
-	resolvedDocsRoot, err := filepath.Abs(*docsRoot)
-	if err != nil {
+	if err := runDocsI18N(context.Background(), runConfig{
+		targetLang: *targetLang,
+		sourceLang: *sourceLang,
+		docsRoot:   *docsRoot,
+		tmPath:     *tmPath,
+		mode:       *mode,
+		thinking:   *thinking,
+		overwrite:  *overwrite,
+		maxFiles:   *maxFiles,
+		parallel:   *parallel,
+	}, files, func(srcLang, tgtLang string, glossary []GlossaryEntry, thinking string) (docsTranslator, error) {
+		return NewPiTranslator(srcLang, tgtLang, glossary, thinking)
+	}); err != nil {
 		fatal(err)
 	}
+}
 
-	if *tmPath == "" {
-		*tmPath = filepath.Join(resolvedDocsRoot, ".i18n", fmt.Sprintf("%s.tm.jsonl", *targetLang))
+func runDocsI18N(ctx context.Context, cfg runConfig, files []string, newTranslator docsTranslatorFactory) error {
+	if len(files) == 0 {
+		return fmt.Errorf("no doc files provided")
 	}
 
-	glossaryPath := filepath.Join(resolvedDocsRoot, ".i18n", fmt.Sprintf("glossary.%s.json", *targetLang))
+	resolvedDocsRoot, err := filepath.Abs(cfg.docsRoot)
+	if err != nil {
+		return err
+	}
+
+	tmPath := cfg.tmPath
+	if tmPath == "" {
+		tmPath = filepath.Join(resolvedDocsRoot, ".i18n", fmt.Sprintf("%s.tm.jsonl", cfg.targetLang))
+	}
+
+	glossaryPath := filepath.Join(resolvedDocsRoot, ".i18n", fmt.Sprintf("glossary.%s.json", cfg.targetLang))
 	glossary, err := LoadGlossary(glossaryPath)
 	if err != nil {
-		fatal(err)
+		return err
 	}
 
-	translator, err := NewPiTranslator(*sourceLang, *targetLang, glossary, *thinking)
+	tm, err := LoadTranslationMemory(tmPath)
 	if err != nil {
-		fatal(err)
-	}
-	defer translator.Close()
-
-	tm, err := LoadTranslationMemory(*tmPath)
-	if err != nil {
-		fatal(err)
+		return err
 	}
 
 	ordered, err := orderFiles(resolvedDocsRoot, files)
 	if err != nil {
-		fatal(err)
+		return err
 	}
 	totalFiles := len(ordered)
 	preSkipped := 0
-	if *mode == "doc" && !*overwrite {
-		filtered, skipped, err := filterDocQueue(resolvedDocsRoot, *targetLang, ordered)
+	if cfg.mode == "doc" && !cfg.overwrite {
+		filtered, skipped, err := filterDocQueue(resolvedDocsRoot, cfg.targetLang, ordered)
 		if err != nil {
-			fatal(err)
+			return err
 		}
 		ordered = filtered
 		preSkipped = skipped
 	}
-	if *maxFiles > 0 && *maxFiles < len(ordered) {
-		ordered = ordered[:*maxFiles]
+	if cfg.maxFiles > 0 && cfg.maxFiles < len(ordered) {
+		ordered = ordered[:cfg.maxFiles]
+	}
+
+	parallel := cfg.parallel
+	if parallel < 1 {
+		parallel = 1
 	}
 
 	log.SetFlags(log.LstdFlags)
@@ -95,15 +129,11 @@ func main() {
 	localizedFiles := []string{}
 	var runErr error
 
-	if *parallel < 1 {
-		*parallel = 1
-	}
-
-	log.Printf("docs-i18n: mode=%s total=%d pending=%d pre_skipped=%d overwrite=%t thinking=%s parallel=%d", *mode, totalFiles, len(ordered), preSkipped, *overwrite, *thinking, *parallel)
-	switch *mode {
+	log.Printf("docs-i18n: mode=%s total=%d pending=%d pre_skipped=%d overwrite=%t thinking=%s parallel=%d", cfg.mode, totalFiles, len(ordered), preSkipped, cfg.overwrite, cfg.thinking, parallel)
+	switch cfg.mode {
 	case "doc":
-		if *parallel > 1 {
-			proc, skip, outputs, err := runDocParallel(context.Background(), ordered, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite, *parallel, glossary, *thinking)
+		if parallel > 1 {
+			proc, skip, outputs, err := runDocParallel(ctx, ordered, resolvedDocsRoot, cfg.sourceLang, cfg.targetLang, cfg.overwrite, parallel, glossary, cfg.thinking, newTranslator)
 			processed += proc
 			skipped += skip
 			localizedFiles = append(localizedFiles, outputs...)
@@ -111,7 +141,12 @@ func main() {
 				runErr = err
 			}
 		} else {
-			proc, skip, outputs, err := runDocSequential(context.Background(), ordered, translator, resolvedDocsRoot, *sourceLang, *targetLang, *overwrite)
+			translator, err := newTranslator(cfg.sourceLang, cfg.targetLang, glossary, cfg.thinking)
+			if err != nil {
+				return err
+			}
+			defer translator.Close()
+			proc, skip, outputs, err := runDocSequential(ctx, ordered, translator, resolvedDocsRoot, cfg.sourceLang, cfg.targetLang, cfg.overwrite)
 			processed += proc
 			skipped += skip
 			localizedFiles = append(localizedFiles, outputs...)
@@ -120,33 +155,36 @@ func main() {
 			}
 		}
 	case "segment":
-		if *parallel > 1 {
-			fatal(fmt.Errorf("parallel processing is only supported in doc mode"))
+		if parallel > 1 {
+			return fmt.Errorf("parallel processing is only supported in doc mode")
 		}
-		proc, outputs, err := runSegmentSequential(context.Background(), ordered, translator, tm, resolvedDocsRoot, *sourceLang, *targetLang)
+		translator, err := newTranslator(cfg.sourceLang, cfg.targetLang, glossary, cfg.thinking)
+		if err != nil {
+			return err
+		}
+		defer translator.Close()
+		proc, outputs, err := runSegmentSequential(ctx, ordered, translator, tm, resolvedDocsRoot, cfg.sourceLang, cfg.targetLang)
 		processed += proc
 		localizedFiles = append(localizedFiles, outputs...)
 		if err != nil {
 			runErr = err
 		}
 	default:
-		fatal(fmt.Errorf("unknown mode: %s", *mode))
+		return fmt.Errorf("unknown mode: %s", cfg.mode)
 	}
 
 	if err := tm.Save(); err != nil && runErr == nil {
 		runErr = err
 	}
-	if err := postprocessLocalizedDocs(resolvedDocsRoot, *targetLang, localizedFiles); err != nil && runErr == nil {
+	if err := postprocessLocalizedDocs(resolvedDocsRoot, cfg.targetLang, localizedFiles); err != nil && runErr == nil {
 		runErr = err
 	}
 	elapsed := time.Since(start).Round(time.Millisecond)
 	log.Printf("docs-i18n: completed processed=%d skipped=%d elapsed=%s", processed, skipped, elapsed)
-	if runErr != nil {
-		fatal(runErr)
-	}
+	return runErr
 }
 
-func runDocSequential(ctx context.Context, ordered []string, translator *PiTranslator, docsRoot, srcLang, tgtLang string, overwrite bool) (int, int, []string, error) {
+func runDocSequential(ctx context.Context, ordered []string, translator docsTranslator, docsRoot, srcLang, tgtLang string, overwrite bool) (int, int, []string, error) {
 	processed := 0
 	skipped := 0
 	outputs := []string{}
@@ -170,7 +208,7 @@ func runDocSequential(ctx context.Context, ordered []string, translator *PiTrans
 	return processed, skipped, outputs, nil
 }
 
-func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tgtLang string, overwrite bool, parallel int, glossary []GlossaryEntry, thinking string) (int, int, []string, error) {
+func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tgtLang string, overwrite bool, parallel int, glossary []GlossaryEntry, thinking string, newTranslator docsTranslatorFactory) (int, int, []string, error) {
 	jobs := make(chan docJob)
 	results := make(chan docResult, len(ordered))
 	ctx, cancel := context.WithCancel(ctx)
@@ -181,7 +219,7 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 		wg.Add(1)
 		go func(workerID int) {
 			defer wg.Done()
-			translator, err := NewPiTranslator(srcLang, tgtLang, glossary, thinking)
+			translator, err := newTranslator(srcLang, tgtLang, glossary, thinking)
 			if err != nil {
 				results <- docResult{err: err}
 				return
@@ -247,7 +285,7 @@ func runDocParallel(ctx context.Context, ordered []string, docsRoot, srcLang, tg
 	return processed, skipped, outputs, firstErr
 }
 
-func runSegmentSequential(ctx context.Context, ordered []string, translator *PiTranslator, tm *TranslationMemory, docsRoot, srcLang, tgtLang string) (int, []string, error) {
+func runSegmentSequential(ctx context.Context, ordered []string, translator docsTranslator, tm *TranslationMemory, docsRoot, srcLang, tgtLang string) (int, []string, error) {
 	processed := 0
 	outputs := []string{}
 	for index, file := range ordered {

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -38,12 +38,12 @@ func TestRunDocsI18NRewritesFinalLocalizedPageLinks(t *testing.T) {
 		"",
 		"See [Troubleshooting](/gateway/troubleshooting).",
 		"",
-		"See [Alibaba](/providers/alibaba).",
+		"See [Example provider](/providers/example-provider).",
 	))
 	writeFile(t, filepath.Join(docsRoot, "gateway", "troubleshooting.md"), "# Troubleshooting\n")
-	writeFile(t, filepath.Join(docsRoot, "providers", "alibaba.md"), "# Alibaba\n")
+	writeFile(t, filepath.Join(docsRoot, "providers", "example-provider.md"), "# Example provider\n")
 	writeFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "troubleshooting.md"), "# 故障排除\n")
-	writeFile(t, filepath.Join(docsRoot, "zh-CN", "providers", "alibaba.md"), "# 阿里巴巴\n")
+	writeFile(t, filepath.Join(docsRoot, "zh-CN", "providers", "example-provider.md"), "# 示例 provider\n")
 
 	// This is the higher-level regression for the bug fixed in this PR:
 	// if the pipeline stops wiring postprocess through the main flow, the final
@@ -66,7 +66,7 @@ func TestRunDocsI18NRewritesFinalLocalizedPageLinks(t *testing.T) {
 	got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "index.md"))
 	expected := []string{
 		"参见 [Troubleshooting](/zh-CN/gateway/troubleshooting).",
-		"参见 [Alibaba](/zh-CN/providers/alibaba).",
+		"参见 [Example provider](/zh-CN/providers/example-provider).",
 	}
 	for _, want := range expected {
 		if !containsLine(got, want) {

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -14,6 +14,8 @@ func (fakeDocsTranslator) Translate(_ context.Context, text, _, _ string) (strin
 }
 
 func (fakeDocsTranslator) TranslateRaw(_ context.Context, text, _, _ string) (string, error) {
+	// Keep the fake translator deterministic so this test exercises the
+	// docs-i18n pipeline wiring and final link relocalization, not model output.
 	replaced := strings.NewReplacer(
 		"Gateway", "网关",
 		"See ", "参见 ",
@@ -43,6 +45,9 @@ func TestRunDocsI18NRewritesFinalLocalizedPageLinks(t *testing.T) {
 	writeFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "troubleshooting.md"), "# 故障排除\n")
 	writeFile(t, filepath.Join(docsRoot, "zh-CN", "providers", "alibaba.md"), "# 阿里巴巴\n")
 
+	// This is the higher-level regression for the bug fixed in this PR:
+	// if the pipeline stops wiring postprocess through the main flow, the final
+	// localized output page will keep stale English-root links and this test fails.
 	err := runDocsI18N(context.Background(), runConfig{
 		targetLang: "zh-CN",
 		sourceLang: "en",

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeDocsTranslator struct{}
+
+func (fakeDocsTranslator) Translate(_ context.Context, text, _, _ string) (string, error) {
+	return text, nil
+}
+
+func (fakeDocsTranslator) TranslateRaw(_ context.Context, text, _, _ string) (string, error) {
+	replaced := strings.NewReplacer(
+		"Gateway", "网关",
+		"See ", "参见 ",
+	).Replace(text)
+	return replaced, nil
+}
+
+func (fakeDocsTranslator) Close() {}
+
+func TestRunDocsI18NRewritesFinalLocalizedPageLinks(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, ".i18n", "glossary.zh-CN.json"), "[]")
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	writeFile(t, filepath.Join(docsRoot, "gateway", "index.md"), stringsJoin(
+		"---",
+		"title: Gateway",
+		"---",
+		"",
+		"See [Troubleshooting](/gateway/troubleshooting).",
+		"",
+		"See [Alibaba](/providers/alibaba).",
+	))
+	writeFile(t, filepath.Join(docsRoot, "gateway", "troubleshooting.md"), "# Troubleshooting\n")
+	writeFile(t, filepath.Join(docsRoot, "providers", "alibaba.md"), "# Alibaba\n")
+	writeFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "troubleshooting.md"), "# 故障排除\n")
+	writeFile(t, filepath.Join(docsRoot, "zh-CN", "providers", "alibaba.md"), "# 阿里巴巴\n")
+
+	err := runDocsI18N(context.Background(), runConfig{
+		targetLang: "zh-CN",
+		sourceLang: "en",
+		docsRoot:   docsRoot,
+		mode:       "doc",
+		thinking:   "high",
+		overwrite:  true,
+		parallel:   1,
+	}, []string{filepath.Join(docsRoot, "gateway", "index.md")}, func(_, _ string, _ []GlossaryEntry, _ string) (docsTranslator, error) {
+		return fakeDocsTranslator{}, nil
+	})
+	if err != nil {
+		t.Fatalf("runDocsI18N failed: %v", err)
+	}
+
+	got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "index.md"))
+	expected := []string{
+		"参见 [Troubleshooting](/zh-CN/gateway/troubleshooting).",
+		"参见 [Alibaba](/zh-CN/providers/alibaba).",
+	}
+	for _, want := range expected {
+		if !containsLine(got, want) {
+			t.Fatalf("expected final localized page link %q in output:\n%s", want, got)
+		}
+	}
+}

--- a/scripts/docs-i18n/process.go
+++ b/scripts/docs-i18n/process.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func processFile(ctx context.Context, translator *PiTranslator, tm *TranslationMemory, docsRoot, filePath, srcLang, tgtLang string, routes *routeIndex) (bool, error) {
+func processFile(ctx context.Context, translator *PiTranslator, tm *TranslationMemory, docsRoot, filePath, srcLang, tgtLang string) (bool, error) {
 	absPath, relPath, err := resolveDocsPath(docsRoot, filePath)
 	if err != nil {
 		return false, err
@@ -74,7 +74,6 @@ func processFile(ctx context.Context, translator *PiTranslator, tm *TranslationM
 	}
 
 	translatedBody := applyTranslations(body, segments)
-	translatedBody = routes.localizeBodyLinks(translatedBody)
 	updatedFront, err := encodeFrontMatter(frontData, relPath, content)
 	if err != nil {
 		return false, err

--- a/scripts/docs-i18n/process.go
+++ b/scripts/docs-i18n/process.go
@@ -11,37 +11,37 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func processFile(ctx context.Context, translator *PiTranslator, tm *TranslationMemory, docsRoot, filePath, srcLang, tgtLang string) (bool, error) {
+func processFile(ctx context.Context, translator *PiTranslator, tm *TranslationMemory, docsRoot, filePath, srcLang, tgtLang string) (bool, string, error) {
 	absPath, relPath, err := resolveDocsPath(docsRoot, filePath)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	content, err := os.ReadFile(absPath)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	frontMatter, body := splitFrontMatter(string(content))
 	frontData := map[string]any{}
 	if frontMatter != "" {
 		if err := yaml.Unmarshal([]byte(frontMatter), &frontData); err != nil {
-			return false, fmt.Errorf("frontmatter parse failed for %s: %w", relPath, err)
+			return false, "", fmt.Errorf("frontmatter parse failed for %s: %w", relPath, err)
 		}
 	}
 
 	if err := translateFrontMatter(ctx, translator, tm, frontData, relPath, srcLang, tgtLang); err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	body, err = translateHTMLBlocks(ctx, translator, body, srcLang, tgtLang)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	segments, err := extractSegments(body, relPath)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	namespace := cacheNamespace()
@@ -54,7 +54,7 @@ func processFile(ctx context.Context, translator *PiTranslator, tm *TranslationM
 		}
 		translated, err := translator.Translate(ctx, seg.Text, srcLang, tgtLang)
 		if err != nil {
-			return false, fmt.Errorf("translate failed (%s): %w", relPath, err)
+			return false, "", fmt.Errorf("translate failed (%s): %w", relPath, err)
 		}
 		seg.Translated = translated
 		entry := TMEntry{
@@ -76,16 +76,16 @@ func processFile(ctx context.Context, translator *PiTranslator, tm *TranslationM
 	translatedBody := applyTranslations(body, segments)
 	updatedFront, err := encodeFrontMatter(frontData, relPath, content)
 	if err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	outputPath := filepath.Join(docsRoot, tgtLang, relPath)
 	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
-		return false, err
+		return false, "", err
 	}
 
 	output := updatedFront + translatedBody
-	return false, os.WriteFile(outputPath, []byte(output), 0o644)
+	return false, outputPath, os.WriteFile(outputPath, []byte(output), 0o644)
 }
 
 func splitFrontMatter(content string) (string, string) {

--- a/scripts/docs-i18n/process.go
+++ b/scripts/docs-i18n/process.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func processFile(ctx context.Context, translator *PiTranslator, tm *TranslationMemory, docsRoot, filePath, srcLang, tgtLang string) (bool, string, error) {
+func processFile(ctx context.Context, translator docsTranslator, tm *TranslationMemory, docsRoot, filePath, srcLang, tgtLang string) (bool, string, error) {
 	absPath, relPath, err := resolveDocsPath(docsRoot, filePath)
 	if err != nil {
 		return false, "", err
@@ -133,7 +133,7 @@ func encodeFrontMatter(frontData map[string]any, relPath string, source []byte) 
 	return fmt.Sprintf("---\n%s---\n\n", string(encoded)), nil
 }
 
-func translateFrontMatter(ctx context.Context, translator *PiTranslator, tm *TranslationMemory, data map[string]any, relPath, srcLang, tgtLang string) error {
+func translateFrontMatter(ctx context.Context, translator docsTranslator, tm *TranslationMemory, data map[string]any, relPath, srcLang, tgtLang string) error {
 	if len(data) == 0 {
 		return nil
 	}
@@ -170,7 +170,7 @@ func translateFrontMatter(ctx context.Context, translator *PiTranslator, tm *Tra
 	return nil
 }
 
-func translateSnippet(ctx context.Context, translator *PiTranslator, tm *TranslationMemory, segmentID, textValue, srcLang, tgtLang string) (string, error) {
+func translateSnippet(ctx context.Context, translator docsTranslator, tm *TranslationMemory, segmentID, textValue, srcLang, tgtLang string) (string, error) {
 	if strings.TrimSpace(textValue) == "" {
 		return textValue, nil
 	}

--- a/scripts/docs-i18n/relocalize.go
+++ b/scripts/docs-i18n/relocalize.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func relocalizeExistingDocs(docsRoot, targetLang string) error {
+	if targetLang == "" || targetLang == "en" {
+		return nil
+	}
+
+	routes, err := loadRouteIndex(docsRoot, targetLang)
+	if err != nil {
+		return err
+	}
+
+	localeRoot := filepath.Join(docsRoot, targetLang)
+	if _, err := os.Stat(localeRoot); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	return filepath.WalkDir(localeRoot, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() || !isMarkdownFile(path) {
+			return nil
+		}
+
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		frontMatter, body := splitFrontMatter(string(content))
+		rewrittenBody := routes.localizeBodyLinks(body)
+		if rewrittenBody == body {
+			return nil
+		}
+
+		output := rewrittenBody
+		if frontMatter != "" {
+			output = "---\n" + frontMatter + "---\n\n" + rewrittenBody
+		}
+
+		return os.WriteFile(path, []byte(output), 0o644)
+	})
+}

--- a/scripts/docs-i18n/relocalize.go
+++ b/scripts/docs-i18n/relocalize.go
@@ -44,7 +44,7 @@ func postprocessLocalizedDocs(docsRoot, targetLang string) error {
 
 		output := rewrittenBody
 		if frontMatter != "" {
-			output = "---\n" + frontMatter + "---\n\n" + rewrittenBody
+			output = "---\n" + frontMatter + "\n---\n\n" + rewrittenBody
 		}
 
 		return os.WriteFile(path, []byte(output), 0o644)

--- a/scripts/docs-i18n/relocalize.go
+++ b/scripts/docs-i18n/relocalize.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 )
 
-func relocalizeExistingDocs(docsRoot, targetLang string) error {
+func postprocessLocalizedDocs(docsRoot, targetLang string) error {
 	if targetLang == "" || targetLang == "en" {
 		return nil
 	}

--- a/scripts/docs-i18n/relocalize.go
+++ b/scripts/docs-i18n/relocalize.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"os"
-	"path/filepath"
 )
 
-func postprocessLocalizedDocs(docsRoot, targetLang string) error {
-	if targetLang == "" || targetLang == "en" {
+func postprocessLocalizedDocs(docsRoot, targetLang string, localizedFiles []string) error {
+	if targetLang == "" || targetLang == "en" || len(localizedFiles) == 0 {
 		return nil
 	}
 
@@ -15,22 +14,7 @@ func postprocessLocalizedDocs(docsRoot, targetLang string) error {
 		return err
 	}
 
-	localeRoot := filepath.Join(docsRoot, targetLang)
-	if _, err := os.Stat(localeRoot); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	return filepath.WalkDir(localeRoot, func(path string, entry os.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() || !isMarkdownFile(path) {
-			return nil
-		}
-
+	for _, path := range localizedFiles {
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return err
@@ -47,6 +31,10 @@ func postprocessLocalizedDocs(docsRoot, targetLang string) error {
 			output = "---\n" + frontMatter + "\n---\n\n" + rewrittenBody
 		}
 
-		return os.WriteFile(path, []byte(output), 0o644)
-	})
+		if err := os.WriteFile(path, []byte(output), 0o644); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/scripts/docs-i18n/relocalize.go
+++ b/scripts/docs-i18n/relocalize.go
@@ -23,7 +23,7 @@ func postprocessLocalizedDocs(docsRoot, targetLang string, localizedFiles []stri
 		frontMatter, body := splitFrontMatter(string(content))
 		rewrittenBody := routes.localizeBodyLinks(body)
 		if rewrittenBody == body {
-			return nil
+			continue
 		}
 
 		output := rewrittenBody

--- a/scripts/docs-i18n/relocalize_test.go
+++ b/scripts/docs-i18n/relocalize_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRelocalizeExistingDocsFixesStaleLinksAfterLaterPagesExist(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	writeFile(t, filepath.Join(docsRoot, "gateway", "index.md"), "# Gateway\n")
+	writeFile(t, filepath.Join(docsRoot, "gateway", "troubleshooting.md"), "# Troubleshooting\n")
+	writeFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "index.md"), stringsJoin(
+		"---",
+		"title: 网关",
+		"x-i18n:",
+		"  source_hash: test",
+		"---",
+		"",
+		"See [Troubleshooting](/gateway/troubleshooting).",
+	))
+	writeFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "troubleshooting.md"), stringsJoin(
+		"---",
+		"title: 故障排除",
+		"x-i18n:",
+		"  source_hash: test",
+		"---",
+		"",
+		"# 故障排除",
+	))
+
+	if err := relocalizeExistingDocs(docsRoot, "zh-CN"); err != nil {
+		t.Fatalf("relocalizeExistingDocs failed: %v", err)
+	}
+
+	got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "index.md"))
+	want := "See [Troubleshooting](/zh-CN/gateway/troubleshooting)."
+	if !containsLine(got, want) {
+		t.Fatalf("expected rewritten localized link %q in output:\n%s", want, got)
+	}
+}
+
+func stringsJoin(lines ...string) string {
+	result := ""
+	for i, line := range lines {
+		if i > 0 {
+			result += "\n"
+		}
+		result += line
+	}
+	return result
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read failed for %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func containsLine(text, want string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		if line == want {
+			return true
+		}
+	}
+	return false
+}

--- a/scripts/docs-i18n/relocalize_test.go
+++ b/scripts/docs-i18n/relocalize_test.go
@@ -38,6 +38,9 @@ func TestPostprocessLocalizedDocsFixesStaleLinksAfterLaterPagesExist(t *testing.
 	}
 
 	got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "index.md"))
+	if !strings.Contains(got, "---\ntitle: 网关\nx-i18n:\n  source_hash: test\n---\n\n") {
+		t.Fatalf("front matter corrupted after rewrite:\n%s", got)
+	}
 	want := "See [Troubleshooting](/zh-CN/gateway/troubleshooting)."
 	if !containsLine(got, want) {
 		t.Fatalf("expected rewritten localized link %q in output:\n%s", want, got)

--- a/scripts/docs-i18n/relocalize_test.go
+++ b/scripts/docs-i18n/relocalize_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestRelocalizeExistingDocsFixesStaleLinksAfterLaterPagesExist(t *testing.T) {
+func TestPostprocessLocalizedDocsFixesStaleLinksAfterLaterPagesExist(t *testing.T) {
 	t.Parallel()
 
 	docsRoot := t.TempDir()
@@ -33,8 +33,8 @@ func TestRelocalizeExistingDocsFixesStaleLinksAfterLaterPagesExist(t *testing.T)
 		"# 故障排除",
 	))
 
-	if err := relocalizeExistingDocs(docsRoot, "zh-CN"); err != nil {
-		t.Fatalf("relocalizeExistingDocs failed: %v", err)
+	if err := postprocessLocalizedDocs(docsRoot, "zh-CN"); err != nil {
+		t.Fatalf("postprocessLocalizedDocs failed: %v", err)
 	}
 
 	got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "index.md"))

--- a/scripts/docs-i18n/relocalize_test.go
+++ b/scripts/docs-i18n/relocalize_test.go
@@ -33,7 +33,10 @@ func TestPostprocessLocalizedDocsFixesStaleLinksAfterLaterPagesExist(t *testing.
 		"# 故障排除",
 	))
 
-	if err := postprocessLocalizedDocs(docsRoot, "zh-CN"); err != nil {
+	if err := postprocessLocalizedDocs(docsRoot, "zh-CN", []string{
+		filepath.Join(docsRoot, "zh-CN", "gateway", "index.md"),
+		filepath.Join(docsRoot, "zh-CN", "gateway", "troubleshooting.md"),
+	}); err != nil {
 		t.Fatalf("postprocessLocalizedDocs failed: %v", err)
 	}
 
@@ -44,6 +47,48 @@ func TestPostprocessLocalizedDocsFixesStaleLinksAfterLaterPagesExist(t *testing.
 	want := "See [Troubleshooting](/zh-CN/gateway/troubleshooting)."
 	if !containsLine(got, want) {
 		t.Fatalf("expected rewritten localized link %q in output:\n%s", want, got)
+	}
+}
+
+func TestPostprocessLocalizedDocsOnlyTouchesScopedFiles(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	writeFile(t, filepath.Join(docsRoot, "gateway", "troubleshooting.md"), "# Troubleshooting\n")
+	writeFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "troubleshooting.md"), "# 故障排除\n")
+
+	scopedPath := filepath.Join(docsRoot, "zh-CN", "gateway", "index.md")
+	unscopedPath := filepath.Join(docsRoot, "zh-CN", "help", "index.md")
+
+	writeFile(t, scopedPath, stringsJoin(
+		"---",
+		"title: 网关",
+		"---",
+		"",
+		"See [Troubleshooting](/gateway/troubleshooting).",
+	))
+	writeFile(t, unscopedPath, stringsJoin(
+		"---",
+		"title: 帮助",
+		"---",
+		"",
+		"See [Troubleshooting](/gateway/troubleshooting).",
+	))
+
+	beforeUnscoped := mustReadFile(t, unscopedPath)
+	if err := postprocessLocalizedDocs(docsRoot, "zh-CN", []string{scopedPath}); err != nil {
+		t.Fatalf("postprocessLocalizedDocs failed: %v", err)
+	}
+
+	gotScoped := mustReadFile(t, scopedPath)
+	if !containsLine(gotScoped, "See [Troubleshooting](/zh-CN/gateway/troubleshooting).") {
+		t.Fatalf("expected scoped file rewrite, got:\n%s", gotScoped)
+	}
+
+	afterUnscoped := mustReadFile(t, unscopedPath)
+	if afterUnscoped != beforeUnscoped {
+		t.Fatalf("expected unscoped file to remain unchanged\nbefore:\n%s\nafter:\n%s", beforeUnscoped, afterUnscoped)
 	}
 }
 

--- a/scripts/docs-i18n/relocalize_test.go
+++ b/scripts/docs-i18n/relocalize_test.go
@@ -50,6 +50,68 @@ func TestPostprocessLocalizedDocsFixesStaleLinksAfterLaterPagesExist(t *testing.
 	}
 }
 
+func TestPostprocessLocalizedDocsRewritesPublishedPageLinksForEachLocale(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		lang       string
+		title      string
+		wantPrefix string
+	}{
+		{name: "zh-CN", lang: "zh-CN", title: "网关", wantPrefix: "/zh-CN"},
+		{name: "ja-JP", lang: "ja-JP", title: "ゲートウェイ", wantPrefix: "/ja-JP"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			docsRoot := t.TempDir()
+			writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+			writeFile(t, filepath.Join(docsRoot, "gateway", "index.md"), "# Gateway\n")
+			writeFile(t, filepath.Join(docsRoot, "gateway", "troubleshooting.md"), "# Troubleshooting\n")
+			writeFile(t, filepath.Join(docsRoot, "providers", "alibaba.md"), "# Alibaba\n")
+			writeFile(t, filepath.Join(docsRoot, tt.lang, "gateway", "troubleshooting.md"), "# Localized troubleshooting\n")
+			writeFile(t, filepath.Join(docsRoot, tt.lang, "providers", "alibaba.md"), "# Localized Alibaba\n")
+
+			pagePath := filepath.Join(docsRoot, tt.lang, "gateway", "index.md")
+			writeFile(t, pagePath, stringsJoin(
+				"---",
+				"title: "+tt.title,
+				"x-i18n:",
+				"  source_hash: test",
+				"---",
+				"",
+				"See [Troubleshooting](/gateway/troubleshooting).",
+				"",
+				"See [Alibaba](/providers/alibaba).",
+				"",
+				`<Card href="/gateway/troubleshooting" title="Troubleshooting" />`,
+				`<Card href="`+tt.wantPrefix+`/providers/alibaba" title="Alibaba" />`,
+			))
+
+			if err := postprocessLocalizedDocs(docsRoot, tt.lang, []string{pagePath}); err != nil {
+				t.Fatalf("postprocessLocalizedDocs failed: %v", err)
+			}
+
+			got := mustReadFile(t, pagePath)
+			expectedLinks := []string{
+				"See [Troubleshooting](" + tt.wantPrefix + "/gateway/troubleshooting).",
+				"See [Alibaba](" + tt.wantPrefix + "/providers/alibaba).",
+				`<Card href="` + tt.wantPrefix + `/gateway/troubleshooting" title="Troubleshooting" />`,
+				`<Card href="` + tt.wantPrefix + `/providers/alibaba" title="Alibaba" />`,
+			}
+			for _, want := range expectedLinks {
+				if !containsLine(got, want) {
+					t.Fatalf("expected rewritten link %q in output:\n%s", want, got)
+				}
+			}
+		})
+	}
+}
+
 func TestPostprocessLocalizedDocsOnlyTouchesScopedFiles(t *testing.T) {
 	t.Parallel()
 

--- a/scripts/docs-i18n/relocalize_test.go
+++ b/scripts/docs-i18n/relocalize_test.go
@@ -92,6 +92,42 @@ func TestPostprocessLocalizedDocsOnlyTouchesScopedFiles(t *testing.T) {
 	}
 }
 
+func TestPostprocessLocalizedDocsContinuesAfterUnchangedFile(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	writeFile(t, filepath.Join(docsRoot, "gateway", "troubleshooting.md"), "# Troubleshooting\n")
+	writeFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "troubleshooting.md"), "# 故障排除\n")
+
+	unchangedPath := filepath.Join(docsRoot, "zh-CN", "gateway", "already-localized.md")
+	needsRewritePath := filepath.Join(docsRoot, "zh-CN", "gateway", "index.md")
+
+	writeFile(t, unchangedPath, stringsJoin(
+		"---",
+		"title: 已本地化",
+		"---",
+		"",
+		"See [Troubleshooting](/zh-CN/gateway/troubleshooting).",
+	))
+	writeFile(t, needsRewritePath, stringsJoin(
+		"---",
+		"title: 网关",
+		"---",
+		"",
+		"See [Troubleshooting](/gateway/troubleshooting).",
+	))
+
+	if err := postprocessLocalizedDocs(docsRoot, "zh-CN", []string{unchangedPath, needsRewritePath}); err != nil {
+		t.Fatalf("postprocessLocalizedDocs failed: %v", err)
+	}
+
+	got := mustReadFile(t, needsRewritePath)
+	if !containsLine(got, "See [Troubleshooting](/zh-CN/gateway/troubleshooting).") {
+		t.Fatalf("expected later file rewrite after unchanged file, got:\n%s", got)
+	}
+}
+
 func stringsJoin(lines ...string) string {
 	result := ""
 	for i, line := range lines {

--- a/scripts/docs-i18n/relocalize_test.go
+++ b/scripts/docs-i18n/relocalize_test.go
@@ -72,9 +72,9 @@ func TestPostprocessLocalizedDocsRewritesPublishedPageLinksForEachLocale(t *test
 			writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
 			writeFile(t, filepath.Join(docsRoot, "gateway", "index.md"), "# Gateway\n")
 			writeFile(t, filepath.Join(docsRoot, "gateway", "troubleshooting.md"), "# Troubleshooting\n")
-			writeFile(t, filepath.Join(docsRoot, "providers", "alibaba.md"), "# Alibaba\n")
+			writeFile(t, filepath.Join(docsRoot, "providers", "example-provider.md"), "# Example provider\n")
 			writeFile(t, filepath.Join(docsRoot, tt.lang, "gateway", "troubleshooting.md"), "# Localized troubleshooting\n")
-			writeFile(t, filepath.Join(docsRoot, tt.lang, "providers", "alibaba.md"), "# Localized Alibaba\n")
+			writeFile(t, filepath.Join(docsRoot, tt.lang, "providers", "example-provider.md"), "# Localized example provider\n")
 
 			pagePath := filepath.Join(docsRoot, tt.lang, "gateway", "index.md")
 			writeFile(t, pagePath, stringsJoin(
@@ -86,10 +86,10 @@ func TestPostprocessLocalizedDocsRewritesPublishedPageLinksForEachLocale(t *test
 				"",
 				"See [Troubleshooting](/gateway/troubleshooting).",
 				"",
-				"See [Alibaba](/providers/alibaba).",
+				"See [Example provider](/providers/example-provider).",
 				"",
 				`<Card href="/gateway/troubleshooting" title="Troubleshooting" />`,
-				`<Card href="`+tt.wantPrefix+`/providers/alibaba" title="Alibaba" />`,
+				`<Card href="`+tt.wantPrefix+`/providers/example-provider" title="Example provider" />`,
 			))
 
 			if err := postprocessLocalizedDocs(docsRoot, tt.lang, []string{pagePath}); err != nil {
@@ -99,9 +99,9 @@ func TestPostprocessLocalizedDocsRewritesPublishedPageLinksForEachLocale(t *test
 			got := mustReadFile(t, pagePath)
 			expectedLinks := []string{
 				"See [Troubleshooting](" + tt.wantPrefix + "/gateway/troubleshooting).",
-				"See [Alibaba](" + tt.wantPrefix + "/providers/alibaba).",
+				"See [Example provider](" + tt.wantPrefix + "/providers/example-provider).",
 				`<Card href="` + tt.wantPrefix + `/gateway/troubleshooting" title="Troubleshooting" />`,
-				`<Card href="` + tt.wantPrefix + `/providers/alibaba" title="Alibaba" />`,
+				`<Card href="` + tt.wantPrefix + `/providers/example-provider" title="Example provider" />`,
 			}
 			for _, want := range expectedLinks {
 				if !containsLine(got, want) {

--- a/scripts/docs-i18n/translator.go
+++ b/scripts/docs-i18n/translator.go
@@ -22,6 +22,14 @@ type PiTranslator struct {
 	client *docsPiClient
 }
 
+type docsTranslator interface {
+	Translate(context.Context, string, string, string) (string, error)
+	TranslateRaw(context.Context, string, string, string) (string, error)
+	Close()
+}
+
+type docsTranslatorFactory func(string, string, []GlossaryEntry, string) (docsTranslator, error)
+
 func NewPiTranslator(srcLang, tgtLang string, glossary []GlossaryEntry, thinking string) (*PiTranslator, error) {
 	client, err := startDocsPiClient(context.Background(), docsPiClientOptions{
 		SystemPrompt: translationPrompt(srcLang, tgtLang, glossary),


### PR DESCRIPTION
## Summary
- switch docs i18n to a single locale-link postprocess stage instead of localizing links both during per-page translation and again afterward
- scope postprocessing to only the localized files successfully emitted in the current run
- add regression tests covering stale index-page links and scoped postprocess behavior
- add a pipeline-level regression test that runs the docs-i18n main flow with a fake translator and asserts the final localized page links are corrected
- touch the gateway runbook copy so zh-CN and ja-JP regenerate and pick up the fixed localized links

## Verification trigger
- the tiny wording-only change in `docs/gateway/index.md` is intentional
- it forces the `/gateway` locale pages back through the publish/translation pipeline so we can verify the stale locale-link fix actually propagates in `openclaw/docs`
- this keeps the validation tied to the real generated locale flow instead of relying only on local fixtures

## Test plan
- `go test ./...` in `scripts/docs-i18n`

## Root cause
- the existing pipeline previously localized links while translating each individual page
- files are processed in path-sorted order (`scripts/docs-i18n/order.go`), so index pages like `gateway/index.md` can be translated before locale child pages such as `gateway/troubleshooting.md` exist
- link localization only prefixes a route when the localized target page already exists in `localizedRoutes` (`scripts/docs-i18n/localized_links.go`)
- doc-mode skip logic only compares the English source hash (`scripts/docs-i18n/doc_mode.go`), so once a page is written with stale English links it will usually be skipped on later runs unless the English source changes

## Design
Current design before this PR:

```mermaid
flowchart TD
    A[Collect changed English docs] --> B[Sort files by relative path]
    B --> C[Translate one page]
    C --> D[Try to localize links immediately]
    D --> E{Does localized target page already exist?}
    E -- yes --> F[Write locale-prefixed link]
    E -- no --> G[Keep English root-relative link]
    F --> H[Write localized page]
    G --> H
    H --> I[Future runs compare only source_hash]
    I --> J[Page usually skipped unless English source changes]
```

Redesigned flow in this PR:

```mermaid
flowchart TD
    A[Collect changed English docs] --> B[Sort files by relative path]
    B --> C[Translate one page]
    C --> D[Write localized page without link rewriting]
    D --> E{Page write succeeded?}
    E -- yes --> F[Add output path to successful file set]
    E -- no --> G[Return run error]
    F --> H[Repeat for remaining pages]
    G --> I[Stop translation loop]
    H --> J[Save translation memory]
    I --> J
    J --> K[Build route index from full locale tree]
    K --> L[Postprocess only files in successful file set]
    L --> M[Rewrite links using final localized route set]
    M --> N[Exit success or return original run error]

    classDef highlight fill:#ffe8a3,stroke:#b7791f,stroke-width:2px,color:#111;
    classDef success fill:#d9f99d,stroke:#4d7c0f,stroke-width:2px,color:#111;
    class F,L,M highlight;
    class E success;
```

## What changed in the design
- removed duplicate link-localization logic from the translation path
- made localization order-independent by rewriting links only after the target locale tree exists
- kept `localized_links.go` as the single place that decides whether a route should gain a locale prefix
- scoped postprocessing to the files successfully emitted in the current run, so failed runs do not rewrite unrelated localized docs
- preserved partial-run correctness by still postprocessing files that were successfully written before a later failure

## Context
- fixes stale localized links like `/zh-CN/gateway` and `/ja-JP/gateway` pointing some body links at English routes even when localized target pages exist
- also explains why pages like `/zh-CN/providers` could already look correct: those links were localized successfully because their target locale pages already existed when that page was translated


