### PR TITLE
fix: preserve thinking blocks for Claude Opus 4.5+/Sonnet 4.5+ to fix prompt cache [AI-assisted]

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -262,6 +262,32 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.validateAnthropicTurns).toBe(true);
   });
 
+  it("preserves thinking blocks for newer Claude models in unowned Anthropic transport fallback", () => {
+    // Opus 4.6 via custom proxy: should NOT drop thinking blocks
+    const opus46 = resolveTranscriptPolicy({
+      provider: "custom-anthropic-proxy",
+      modelId: "claude-opus-4-6",
+      modelApi: "anthropic-messages",
+    });
+    expect(opus46.dropThinkingBlocks).toBe(false);
+
+    // Sonnet 4.5 via custom proxy: should NOT drop
+    const sonnet45 = resolveTranscriptPolicy({
+      provider: "custom-anthropic-proxy",
+      modelId: "claude-sonnet-4-5-20250929",
+      modelApi: "anthropic-messages",
+    });
+    expect(sonnet45.dropThinkingBlocks).toBe(false);
+
+    // Legacy Sonnet 3.7 via custom proxy: SHOULD drop
+    const sonnet37 = resolveTranscriptPolicy({
+      provider: "custom-anthropic-proxy",
+      modelId: "claude-3-7-sonnet-20250219",
+      modelApi: "anthropic-messages",
+    });
+    expect(sonnet37.dropThinkingBlocks).toBe(true);
+  });
+
   it("preserves transport defaults when a runtime plugin has not adopted replay hooks", () => {
     const policy = resolveTranscriptPolicy({
       provider: "vllm",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -47,6 +47,35 @@ function isAnthropicApi(modelApi?: string | null): boolean {
 }
 
 /**
+ * Returns true for Claude models that preserve thinking blocks in context
+ * natively (Opus 4.5+, Sonnet 4.5+, Haiku 4.5+). For these models, dropping
+ * thinking blocks from prior turns breaks prompt cache prefix matching.
+ *
+ * See: https://platform.claude.com/docs/en/build-with-claude/extended-thinking#differences-in-thinking-across-model-versions
+ */
+function shouldPreserveThinkingBlocksForModel(modelId: string): boolean {
+  if (!modelId.includes("claude")) return false;
+
+  if (
+    modelId.includes("opus-4") ||
+    modelId.includes("sonnet-4-5") ||
+    modelId.includes("sonnet-4-6") ||
+    modelId.includes("sonnet-4.5") ||
+    modelId.includes("sonnet-4.6") ||
+    modelId.includes("haiku-4")
+  ) {
+    return true;
+  }
+
+  // Future-proofing: claude-5-x, claude-6-x etc.
+  if (/claude-[5-9]/.test(modelId) || /claude-\d{2,}/.test(modelId)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
  * Provides a narrow replay-policy fallback for providers that do not have an
  * owning runtime plugin.
  *
@@ -93,7 +122,7 @@ function buildUnownedProviderTransportReplayFallback(params: {
           },
         }
       : {}),
-    ...(isAnthropic && modelId.includes("claude") ? { dropThinkingBlocks: true } : {}),
+    ...(isAnthropic && modelId.includes("claude") ? { dropThinkingBlocks: !shouldPreserveThinkingBlocksForModel(modelId) } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { applyAssistantFirstOrderingFix: true } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { validateGeminiTurns: true } : {}),
     ...(isAnthropic || isStrictOpenAiCompatible ? { validateAnthropicTurns: true } : {}),

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -47,7 +47,6 @@ function isAnthropicApi(modelApi?: string | null): boolean {
   return modelApi === "anthropic-messages" || modelApi === "bedrock-converse-stream";
 }
 
-
 /**
  * Provides a narrow replay-policy fallback for providers that do not have an
  * owning runtime plugin.
@@ -95,7 +94,9 @@ function buildUnownedProviderTransportReplayFallback(params: {
           },
         }
       : {}),
-    ...(isAnthropic && modelId.includes("claude") ? { dropThinkingBlocks: !shouldPreserveThinkingBlocks(modelId) } : {}),
+    ...(isAnthropic && modelId.includes("claude")
+      ? { dropThinkingBlocks: !shouldPreserveThinkingBlocks(modelId) }
+      : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { applyAssistantFirstOrderingFix: true } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { validateGeminiTurns: true } : {}),
     ...(isAnthropic || isStrictOpenAiCompatible ? { validateAnthropicTurns: true } : {}),

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { shouldPreserveThinkingBlocks } from "../plugins/provider-replay-helpers.js";
 import { resolveProviderRuntimePlugin } from "../plugins/provider-runtime.js";
 import type { ProviderReplayPolicy, ProviderRuntimeModel } from "../plugins/types.js";
 import { normalizeProviderId } from "./model-selection.js";
@@ -46,34 +47,6 @@ function isAnthropicApi(modelApi?: string | null): boolean {
   return modelApi === "anthropic-messages" || modelApi === "bedrock-converse-stream";
 }
 
-/**
- * Returns true for Claude models that preserve thinking blocks in context
- * natively (Opus 4.5+, Sonnet 4.5+, Haiku 4.5+). For these models, dropping
- * thinking blocks from prior turns breaks prompt cache prefix matching.
- *
- * See: https://platform.claude.com/docs/en/build-with-claude/extended-thinking#differences-in-thinking-across-model-versions
- */
-function shouldPreserveThinkingBlocksForModel(modelId: string): boolean {
-  if (!modelId.includes("claude")) return false;
-
-  if (
-    modelId.includes("opus-4") ||
-    modelId.includes("sonnet-4-5") ||
-    modelId.includes("sonnet-4-6") ||
-    modelId.includes("sonnet-4.5") ||
-    modelId.includes("sonnet-4.6") ||
-    modelId.includes("haiku-4")
-  ) {
-    return true;
-  }
-
-  // Future-proofing: claude-5-x, claude-6-x etc.
-  if (/claude-[5-9]/.test(modelId) || /claude-\d{2,}/.test(modelId)) {
-    return true;
-  }
-
-  return false;
-}
 
 /**
  * Provides a narrow replay-policy fallback for providers that do not have an
@@ -122,7 +95,7 @@ function buildUnownedProviderTransportReplayFallback(params: {
           },
         }
       : {}),
-    ...(isAnthropic && modelId.includes("claude") ? { dropThinkingBlocks: !shouldPreserveThinkingBlocksForModel(modelId) } : {}),
+    ...(isAnthropic && modelId.includes("claude") ? { dropThinkingBlocks: !shouldPreserveThinkingBlocks(modelId) } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { applyAssistantFirstOrderingFix: true } : {}),
     ...(isGoogle || isStrictOpenAiCompatible ? { validateGeminiTurns: true } : {}),
     ...(isAnthropic || isStrictOpenAiCompatible ? { validateAnthropicTurns: true } : {}),

--- a/src/plugin-sdk/provider-model-shared.test.ts
+++ b/src/plugin-sdk/provider-model-shared.test.ts
@@ -28,8 +28,9 @@ describe("buildProviderReplayFamilyHooks", () => {
         },
         match: {
           validateAnthropicTurns: true,
-          dropThinkingBlocks: true,
+          // Sonnet 4.6 preserves thinking blocks (no dropThinkingBlocks)
         },
+        absent: ["dropThinkingBlocks"],
         hasSanitizeReplayHistory: false,
         reasoningMode: undefined,
       },
@@ -78,8 +79,9 @@ describe("buildProviderReplayFamilyHooks", () => {
         },
         match: {
           validateAnthropicTurns: true,
-          dropThinkingBlocks: true,
+          // Sonnet 4.6 preserves thinking blocks even with flag set
         },
+        absent: ["dropThinkingBlocks"],
         hasSanitizeReplayHistory: false,
         reasoningMode: undefined,
       },
@@ -95,7 +97,13 @@ describe("buildProviderReplayFamilyHooks", () => {
           : { family: testCase.family },
       );
 
-      expect(hooks.buildReplayPolicy?.(testCase.ctx as never)).toMatchObject(testCase.match);
+      const policy = hooks.buildReplayPolicy?.(testCase.ctx as never);
+      expect(policy).toMatchObject(testCase.match);
+      if ((testCase as { absent?: string[] }).absent) {
+        for (const key of (testCase as { absent: string[] }).absent) {
+          expect(policy).not.toHaveProperty(key);
+        }
+      }
       expect(Boolean(hooks.sanitizeReplayHistory)).toBe(testCase.hasSanitizeReplayHistory);
       expect(hooks.resolveReasoningOutputMode?.(testCase.ctx as never)).toBe(
         testCase.reasoningMode,

--- a/src/plugins/provider-replay-helpers.test.ts
+++ b/src/plugins/provider-replay-helpers.test.ts
@@ -33,19 +33,51 @@ describe("provider replay helpers", () => {
   });
 
   it("derives claude-only anthropic replay policy from the model id", () => {
+    // Sonnet 4.6 preserves thinking blocks (no drop)
     expect(buildAnthropicReplayPolicyForModel("claude-sonnet-4-6")).toMatchObject({
       sanitizeToolCallIds: true,
       toolCallIdMode: "strict",
-      dropThinkingBlocks: true,
       validateAnthropicTurns: true,
+    });
+    expect(buildAnthropicReplayPolicyForModel("claude-sonnet-4-6")).not.toHaveProperty(
+      "dropThinkingBlocks",
+    );
+    // Legacy models still drop thinking blocks
+    expect(buildAnthropicReplayPolicyForModel("claude-3-7-sonnet-20250219")).toMatchObject({
+      dropThinkingBlocks: true,
     });
     expect(buildAnthropicReplayPolicyForModel("amazon.nova-pro-v1")).not.toHaveProperty(
       "dropThinkingBlocks",
     );
   });
 
+  it("preserves thinking blocks for Claude Opus 4.5+ and Sonnet 4.5+ models", () => {
+    // These models should NOT drop thinking blocks
+    for (const modelId of [
+      "claude-opus-4-5-20251101",
+      "claude-opus-4-6",
+      "claude-sonnet-4-5-20250929",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5-20251001",
+    ]) {
+      const policy = buildAnthropicReplayPolicyForModel(modelId);
+      expect(policy).not.toHaveProperty("dropThinkingBlocks");
+    }
+
+    // These legacy models SHOULD drop thinking blocks
+    for (const modelId of [
+      "claude-3-7-sonnet-20250219",
+      "claude-3-5-sonnet-20240620",
+    ]) {
+      const policy = buildAnthropicReplayPolicyForModel(modelId);
+      expect(policy).toMatchObject({ dropThinkingBlocks: true });
+    }
+  });
+
   it("builds native Anthropic replay policy with selective tool-call id preservation", () => {
-    expect(buildNativeAnthropicReplayPolicyForModel("claude-sonnet-4-6")).toMatchObject({
+    // Sonnet 4.6 preserves thinking blocks
+    const policy46 = buildNativeAnthropicReplayPolicyForModel("claude-sonnet-4-6");
+    expect(policy46).toMatchObject({
       sanitizeMode: "full",
       sanitizeToolCallIds: true,
       toolCallIdMode: "strict",
@@ -54,17 +86,37 @@ describe("provider replay helpers", () => {
       repairToolUseResultPairing: true,
       validateAnthropicTurns: true,
       allowSyntheticToolResults: true,
+    });
+    expect(policy46).not.toHaveProperty("dropThinkingBlocks");
+
+    // Legacy model drops thinking blocks
+    expect(buildNativeAnthropicReplayPolicyForModel("claude-3-7-sonnet-20250219")).toMatchObject({
       dropThinkingBlocks: true,
     });
   });
 
   it("builds hybrid anthropic or openai replay policy", () => {
+    // Sonnet 4.6 preserves thinking blocks even when flag is set
+    const sonnet46Policy = buildHybridAnthropicOrOpenAIReplayPolicy(
+      {
+        provider: "minimax",
+        modelApi: "anthropic-messages",
+        modelId: "claude-sonnet-4-6",
+      } as never,
+      { anthropicModelDropThinkingBlocks: true },
+    );
+    expect(sonnet46Policy).toMatchObject({
+      validateAnthropicTurns: true,
+    });
+    expect(sonnet46Policy).not.toHaveProperty("dropThinkingBlocks");
+
+    // Legacy model still drops
     expect(
       buildHybridAnthropicOrOpenAIReplayPolicy(
         {
           provider: "minimax",
           modelApi: "anthropic-messages",
-          modelId: "claude-sonnet-4-6",
+          modelId: "claude-3-7-sonnet-20250219",
         } as never,
         { anthropicModelDropThinkingBlocks: true },
       ),

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -72,7 +72,9 @@ export function buildStrictAnthropicReplayPolicy(
  */
 export function shouldPreserveThinkingBlocks(modelId?: string): boolean {
   const id = (modelId ?? "").toLowerCase();
-  if (!id.includes("claude")) return false;
+  if (!id.includes("claude")) {
+    return false;
+  }
 
   // Models that preserve thinking blocks natively (Claude 4.5+):
   // - claude-opus-4-x (opus-4-5, opus-4-6, ...)
@@ -81,11 +83,7 @@ export function shouldPreserveThinkingBlocks(modelId?: string): boolean {
   // - claude-haiku-4-x (haiku-4-5, ...)
   // Models that require dropping thinking blocks:
   // - claude-3-7-sonnet, claude-3-5-sonnet, and earlier
-  if (
-    id.includes("opus-4") ||
-    id.includes("sonnet-4") ||
-    id.includes("haiku-4")
-  ) {
+  if (id.includes("opus-4") || id.includes("sonnet-4") || id.includes("haiku-4")) {
     return true;
   }
 

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -63,15 +63,53 @@ export function buildStrictAnthropicReplayPolicy(
   };
 }
 
+/**
+ * Returns true for Claude models that preserve thinking blocks in context
+ * natively (Opus 4.5+, Sonnet 4.5+, Haiku 4.5+). For these models, dropping
+ * thinking blocks from prior turns breaks prompt cache prefix matching.
+ *
+ * See: https://platform.claude.com/docs/en/build-with-claude/extended-thinking#differences-in-thinking-across-model-versions
+ */
+function shouldPreserveThinkingBlocks(modelId?: string): boolean {
+  const id = (modelId ?? "").toLowerCase();
+  if (!id.includes("claude")) return false;
+
+  // Models that preserve thinking blocks natively:
+  // - claude-opus-4-5, claude-opus-4-6 (and any future opus-4.x+)
+  // - claude-sonnet-4-5, claude-sonnet-4-6 (and any future sonnet-4.x+)
+  // - claude-haiku-4-5 (and any future haiku-4.x+)
+  // Models that require dropping thinking blocks:
+  // - claude-3-7-sonnet, claude-3-5-sonnet, and earlier
+  if (
+    id.includes("opus-4") ||
+    id.includes("sonnet-4-5") ||
+    id.includes("sonnet-4-6") ||
+    id.includes("sonnet-4.5") ||
+    id.includes("sonnet-4.6") ||
+    id.includes("haiku-4")
+  ) {
+    return true;
+  }
+
+  // Future-proofing: claude-5-x, claude-6-x etc. should also preserve
+  if (/claude-[5-9]/.test(id) || /claude-\d{2,}/.test(id)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function buildAnthropicReplayPolicyForModel(modelId?: string): ProviderReplayPolicy {
+  const isClaude = (modelId?.toLowerCase() ?? "").includes("claude");
   return buildStrictAnthropicReplayPolicy({
-    dropThinkingBlocks: (modelId?.toLowerCase() ?? "").includes("claude"),
+    dropThinkingBlocks: isClaude && !shouldPreserveThinkingBlocks(modelId),
   });
 }
 
 export function buildNativeAnthropicReplayPolicyForModel(modelId?: string): ProviderReplayPolicy {
+  const isClaude = (modelId?.toLowerCase() ?? "").includes("claude");
   return buildStrictAnthropicReplayPolicy({
-    dropThinkingBlocks: (modelId?.toLowerCase() ?? "").includes("claude"),
+    dropThinkingBlocks: isClaude && !shouldPreserveThinkingBlocks(modelId),
     sanitizeToolCallIds: true,
     preserveNativeAnthropicToolUseIds: true,
   });
@@ -82,10 +120,12 @@ export function buildHybridAnthropicOrOpenAIReplayPolicy(
   options: { anthropicModelDropThinkingBlocks?: boolean } = {},
 ): ProviderReplayPolicy | undefined {
   if (ctx.modelApi === "anthropic-messages" || ctx.modelApi === "bedrock-converse-stream") {
+    const isClaude = (ctx.modelId?.toLowerCase() ?? "").includes("claude");
     return buildStrictAnthropicReplayPolicy({
       dropThinkingBlocks:
         options.anthropicModelDropThinkingBlocks &&
-        (ctx.modelId?.toLowerCase() ?? "").includes("claude"),
+        isClaude &&
+        !shouldPreserveThinkingBlocks(ctx.modelId),
     });
   }
 

--- a/src/plugins/provider-replay-helpers.ts
+++ b/src/plugins/provider-replay-helpers.ts
@@ -70,22 +70,20 @@ export function buildStrictAnthropicReplayPolicy(
  *
  * See: https://platform.claude.com/docs/en/build-with-claude/extended-thinking#differences-in-thinking-across-model-versions
  */
-function shouldPreserveThinkingBlocks(modelId?: string): boolean {
+export function shouldPreserveThinkingBlocks(modelId?: string): boolean {
   const id = (modelId ?? "").toLowerCase();
   if (!id.includes("claude")) return false;
 
-  // Models that preserve thinking blocks natively:
-  // - claude-opus-4-5, claude-opus-4-6 (and any future opus-4.x+)
-  // - claude-sonnet-4-5, claude-sonnet-4-6 (and any future sonnet-4.x+)
-  // - claude-haiku-4-5 (and any future haiku-4.x+)
+  // Models that preserve thinking blocks natively (Claude 4.5+):
+  // - claude-opus-4-x (opus-4-5, opus-4-6, ...)
+  // - claude-sonnet-4-x (sonnet-4-5, sonnet-4-6, ...)
+  //   Note: "sonnet-4" is safe — legacy "claude-3-5-sonnet" does not contain "sonnet-4"
+  // - claude-haiku-4-x (haiku-4-5, ...)
   // Models that require dropping thinking blocks:
   // - claude-3-7-sonnet, claude-3-5-sonnet, and earlier
   if (
     id.includes("opus-4") ||
-    id.includes("sonnet-4-5") ||
-    id.includes("sonnet-4-6") ||
-    id.includes("sonnet-4.5") ||
-    id.includes("sonnet-4.6") ||
+    id.includes("sonnet-4") ||
     id.includes("haiku-4")
   ) {
     return true;


### PR DESCRIPTION
## Summary

Fixes #61793

Claude Opus 4.5+ and Sonnet 4.5+ preserve thinking blocks in model context by default ([docs](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#differences-in-thinking-across-model-versions)). The current code unconditionally drops thinking blocks from prior assistant turns for all Claude models, which was correct for Sonnet 3.7 but **breaks prompt caching** on newer models.

## Problem

When thinking blocks are dropped between turns, the token sequence changes, breaking Anthropic's prefix-based cache matching. Combined with the [20-block lookback window](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), accumulated drops can cause complete cache misses (`cacheRead = 0`).

This was introduced in #44843 (2026-03-13) which extended `dropThinkingBlockModelHints: ["claude"]` from only `github-copilot` to also `anthropic` and `amazon-bedrock`. The original fix was for GitHub Copilot's proxy limitations, but was incorrectly generalized to native Anthropic API where newer models natively support thinking block preservation.

## Changes

- **`src/plugins/provider-replay-helpers.ts`**: Added exported `shouldPreserveThinkingBlocks()` that returns `true` for Opus 4.5+, Sonnet 4+, Haiku 4+, and future models. Updated `buildAnthropicReplayPolicyForModel`, `buildNativeAnthropicReplayPolicyForModel`, and `buildHybridAnthropicOrOpenAIReplayPolicy` to use it.
- **`src/agents/transcript-policy.ts`**: Imports `shouldPreserveThinkingBlocks` from provider-replay-helpers (no duplication) for the unowned-provider fallback path.
- **Tests**: Updated and added tests across 3 test files for all affected functions, covering both legacy (drop) and modern (preserve) models.

## Model Version Behavior

| Model | dropThinkingBlocks |
|-------|-------------------|
| claude-3-7-sonnet | ✅ true (drop) |
| claude-3-5-sonnet | ✅ true (drop) |
| claude-opus-4-5 | ❌ false (preserve) |
| claude-opus-4-6 | ❌ false (preserve) |
| claude-sonnet-4-x | ❌ false (preserve) |
| claude-haiku-4-x | ❌ false (preserve) |
| claude-5-x+ (future) | ❌ false (preserve) |

## Testing

All verification gates passed locally (macOS, Node 22, pnpm):

- **`pnpm build`**: Passed (no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings)
- **`pnpm check`**: Passed (0 warnings, 0 errors — includes tsgo, oxlint, format, and policy checks)
- **`pnpm test`** (scoped to 3 changed test files): **36 tests passed, 0 failures**
- Tested manually on live Opus 4.6 session — observed cache miss pattern before fix matches documented behavior

## Deployment Verification

Successfully deployed and running on a personal VPS (OpenClaw 2026.4.6) with the fix applied. Gateway is operating normally with Claude Opus 4.6 + thinking: high.

### Pre-fix cache data (68 turns, OpenClaw 2026.4.5)

| Turn | input | cacheRead | Δread | cacheWrite | output | thinking | tool | note |
|-----:|------:|----------:|------:|-----------:|-------:|:--------:|:----:|------|
| 0 | 3 | 0 | 0 | 33,721 | 293 | ✅ | 🔧 |  |
| 1 | 1 | 33,721 | +33,721 | 33,929 | 272 | ✅ |  |  |
| 2 | 3 | 33,721 | 0 | 32,979 | 81 | ✅ |  | ⚠️ flat after thinking |
| 3 | 3 | 33,721 | 0 | 33,241 | 142 | ✅ |  | ⚠️ flat after thinking |
| 4 | 3 | 33,721 | 0 | 33,701 | 847 | ✅ |  | ⚠️ flat after thinking |
| 5 | 3 | 33,721 | 0 | 34,788 | 37 |  | 🔧 | ⚠️ flat after thinking |
| 6 | 1 | 33,721 | 0 | 34,438 | 364 | ✅ |  |  |
| 7 | 3 | 68,159 | +34,438 | 737 | 788 | ✅ | 🔧 |  |
| 17 | 1 | 85,293 | +159 | 1,672 | 308 |  |  | ✅ (no thinking) |
| 18 | 3 | 86,965 | +1,672 | 658 | 1,325 | ✅ |  | ✅ |
| 19 | 3 | 87,623 | +658 | 1,693 | 34 |  |  | ✅ |
| 20 | 3 | 87,623 | 0 | 1,102 | 178 | ✅ |  | ⚠️ flat after thinking |
| 21 | 3 | 88,725 | +1,102 | 551 | 507 | ✅ |  |  |
| 22 | 3 | 88,725 | 0 | 1,351 | 676 | ✅ |  | ⚠️ flat after thinking |
| 23 | 3 | 88,725 | 0 | 2,061 | 3,276 | ✅ |  | ⚠️ flat after thinking |
| 24 | 3 | 88,725 | 0 | 5,324 | 1,494 | ✅ |  | ⚠️ flat after thinking |
| 25 | 3 | 88,725 | 0 | 4,270 | 1,612 | ✅ |  | ⚠️ flat after thinking |
| 26 | 3 | 88,725 | 0 | 5,027 | 503 | ✅ |  | ⚠️ flat after thinking |
| 27 | 3 | 88,725 | 0 | 4,621 | 721 | ✅ |  | ⚠️ flat after thinking |
| 28 | 3 | 88,725 | 0 | 5,475 | 1,359 | ✅ |  | ⚠️ flat after thinking |
| 29 | 3 | 88,725 | 0 | 6,845 | 665 | ✅ |  | ⚠️ flat after thinking |
| 30 | 3 | 88,725 | 0 | 6,903 | 28 |  |  | ⚠️ flat after thinking |

**Pre-fix summary:** 332,551 tokens of wasted cacheWrite across 68 turns. 10-turn plateau at 88,725 (Δread=0) during consecutive thinking turns.

### Post-fix cache data (14 turns, OpenClaw 2026.4.6)

| Turn | input | cacheRead | Δread | cacheWrite | output | thinking | tool | cr(N) = cr(N-1)+cw(N-1)? |
|-----:|------:|----------:|------:|-----------:|-------:|:--------:|:----:|:-----------------------:|
| 75 | 3 | 0 | 0 | 152,888 | 37 |  | 🔧 | — (cold start after upgrade) |
| 76 | 1 | 152,888 | +152,888 | 231 | 707 | ✅ |  | ✅ exact |
| 77 | 3 | 153,119 | +231 | 1,043 | 297 | ✅ |  | ✅ exact |
| 78 | 3 | 154,162 | +1,043 | 651 | 348 | ✅ |  | ✅ exact |
| 79 | 3 | 154,813 | +651 | 722 | 745 | ✅ |  | ✅ exact |
| 80 | 3 | 155,535 | +722 | 1,123 | 854 |  | 🔧 | ✅ exact |
| 81 | 1 | 156,658 | +1,123 | 1,357 | 348 |  |  | ✅ exact |
| 82 | 3 | 158,015 | +1,357 | 720 | 431 | ✅ |  | ✅ exact |
| 83 | 3 | 158,735 | +720 | 801 | 98 |  | 🔧 | ✅ exact |
| 84 | 1 | 159,536 | +801 | 4,176 | 191 |  |  | ✅ exact |
| 85 | 3 | 163,712 | +4,176 | 581 | 292 | ✅ |  | ✅ exact |
| 86 | 3 | 164,293 | +581 | 634 | 1,394 |  | 🔧 | ✅ exact |
| 87 | 1 | 164,927 | +634 | 2,158 | 72 |  |  | ✅ exact |
| 88 | 3 | 167,085 | +2,158 | 410 | 1,457 |  | 🔧 | ✅ exact |

**Post-fix summary:**
- **13/13 turns** show exact `cacheRead(N) = cacheRead(N-1) + cacheWrite(N-1)`
- **0 wasted cache writes** — every write is read next turn
- Thinking turns (✅) now grow cache normally instead of causing Δread=0 plateaus

| Metric | Pre-fix (68 turns) | Post-fix (14 turns) |
|--------|-------------------|-------------------|
| Thinking turns with Δread=0 | 14 | **0** |
| Wasted cacheWrite | 332,551 tokens | **0 tokens** |
| Exact cr(N)=cr(N-1)+cw(N-1) | rare | **13/13** |

## AI Disclosure

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing (untested / lightly tested / fully tested)
- [x] Confirm you understand what the code does
- [x] Resolve or reply to bot review conversations after you address them

- **AI-assisted**: PR authored with Claude Opus 4.6 via OpenClaw, reviewed by GPT-5.4 subagent and Greptile bot
- **Testing level**: Fully tested — `pnpm build`, `pnpm check`, and scoped `pnpm test` all pass; manual verification on live session
- **Understanding**: Fully understood — root cause traced from observed cache metrics through OpenClaw source to Anthropic API docs