### PR TITLE
fix(infra): catch per-provider errors in usage summary to prevent batch crash

### DIFF
--- a/src/infra/provider-usage.load.test.ts
+++ b/src/infra/provider-usage.load.test.ts
@@ -122,6 +122,60 @@ describe("provider-usage.load", () => {
     }
   });
 
+  it("isolates fetch errors so one broken provider does not crash the rest", async () => {
+    const mockFetch = createProviderUsageFetch(async (url) => {
+      if (url.includes("chatgpt.com/backend-api/wham/usage")) {
+        return makeResponse(200, {
+          rate_limit: { primary_window: { used_percent: 30, limit_window_seconds: 10800 } },
+          plan_type: "Plus",
+        });
+      }
+      // Anthropic returns HTTP 200 but with an invalid (non-JSON) body.
+      if (url.includes("api.anthropic.com")) {
+        return new Response("not json", { status: 200 });
+      }
+      return makeResponse(404, "not found");
+    });
+
+    const summary = await loadUsageWithAuth(
+      loadProviderUsageSummary,
+      [
+        { provider: "anthropic", token: "token-a" },
+        { provider: "openai-codex", token: "token-c", accountId: "acc-1" },
+      ],
+      mockFetch,
+    );
+
+    // Codex should still succeed despite Anthropic's invalid response.
+    const codex = summary.providers.find((p) => p.provider === "openai-codex");
+    expect(codex).toBeDefined();
+    expect(codex?.windows[0]?.usedPercent).toBe(30);
+
+    // Anthropic should be reported as a fetch error, not crash the whole batch.
+    const anthropic = summary.providers.find((p) => p.provider === "anthropic");
+    expect(anthropic?.error).toBe("Fetch failed");
+  });
+
+  it("reports aborted provider fetches as timeouts rather than fetch failures", async () => {
+    const mockFetch = createProviderUsageFetch(async (url) => {
+      if (url.includes("api.anthropic.com")) {
+        // Simulate an AbortError from fetchJson's internal AbortController.
+        const err = new DOMException("The operation was aborted", "AbortError");
+        throw err;
+      }
+      return makeResponse(404, "not found");
+    });
+
+    const summary = await loadUsageWithAuth(
+      loadProviderUsageSummary,
+      [{ provider: "anthropic", token: "token-a" }],
+      mockFetch,
+    );
+
+    const anthropic = summary.providers.find((p) => p.provider === "anthropic");
+    expect(anthropic?.error).toBe("Timeout");
+  });
+
   it("throws when fetch is unavailable", async () => {
     const previousFetch = globalThis.fetch;
     vi.stubGlobal("fetch", undefined);

--- a/src/infra/provider-usage.load.test.ts
+++ b/src/infra/provider-usage.load.test.ts
@@ -176,6 +176,26 @@ describe("provider-usage.load", () => {
     expect(anthropic?.error).toBe("Timeout");
   });
 
+  it("reports AbortSignal.timeout() TimeoutError as timeout rather than fetch failure", async () => {
+    const mockFetch = createProviderUsageFetch(async (url) => {
+      if (url.includes("api.anthropic.com")) {
+        // Simulate a TimeoutError thrown by AbortSignal.timeout().
+        const err = new DOMException("The operation timed out", "TimeoutError");
+        throw err;
+      }
+      return makeResponse(404, "not found");
+    });
+
+    const summary = await loadUsageWithAuth(
+      loadProviderUsageSummary,
+      [{ provider: "anthropic", token: "token-a" }],
+      mockFetch,
+    );
+
+    const anthropic = summary.providers.find((p) => p.provider === "anthropic");
+    expect(anthropic?.error).toBe("Timeout");
+  });
+
   it("throws when fetch is unavailable", async () => {
     const previousFetch = globalThis.fetch;
     vi.stubGlobal("fetch", undefined);

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -9,6 +9,7 @@ import {
   fetchMinimaxUsage,
   fetchZaiUsage,
 } from "./provider-usage.fetch.js";
+import { isAbortError } from "./unhandled-rejections.js";
 import {
   DEFAULT_TIMEOUT_MS,
   ignoredErrors,
@@ -206,7 +207,10 @@ export async function loadProviderUsageSummary(
       { ...errorSnapshot, error: "Timeout" },
     ).catch((err: unknown) => ({
       ...errorSnapshot,
-      error: err instanceof Error && err.name === "AbortError" ? "Timeout" : "Fetch failed",
+      error:
+        isAbortError(err) || (err instanceof Error && err.name === "TimeoutError")
+          ? "Timeout"
+          : "Fetch failed",
     }));
   });
 

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -186,8 +186,13 @@ export async function loadProviderUsageSummary(
     return { updatedAt: now, providers: [] };
   }
 
-  const tasks = auths.map((auth) =>
-    withTimeout(
+  const tasks = auths.map((auth) => {
+    const errorSnapshot: ProviderUsageSnapshot = {
+      provider: auth.provider,
+      displayName: PROVIDER_LABELS[auth.provider],
+      windows: [],
+    };
+    return withTimeout(
       fetchProviderUsageSnapshot({
         auth,
         config,
@@ -198,14 +203,12 @@ export async function loadProviderUsageSummary(
         fetchFn,
       }),
       timeoutMs + 1000,
-      {
-        provider: auth.provider,
-        displayName: PROVIDER_LABELS[auth.provider],
-        windows: [],
-        error: "Timeout",
-      },
-    ),
-  );
+      { ...errorSnapshot, error: "Timeout" },
+    ).catch((err: unknown) => ({
+      ...errorSnapshot,
+      error: err instanceof Error && err.name === "AbortError" ? "Timeout" : "Fetch failed",
+    }));
+  });
 
   const snapshots = await Promise.all(tasks);
   const providers = snapshots.filter((entry) => {


### PR DESCRIPTION
## Problem

`loadProviderUsageSummary()` fetches usage data from multiple providers in parallel using `Promise.all`. Each task is wrapped with `withTimeout()`, which handles timeouts via a `Promise.race` fallback — but non-timeout rejections (JSON parse errors, network failures, unexpected response shapes) propagate straight through and reject `Promise.all`.

I ran into this while debugging a setup where one provider was returning `200 OK` with a non-JSON body (HTML error page from a misconfigured proxy). The `.json()` call threw a `SyntaxError`, which crashed the entire usage summary — all providers' data was lost, even the ones that responded correctly.

## Before

One provider returning invalid JSON → `Promise.all` rejects → entire usage summary fails → TUI status bar / `openclaw channels list` shows no usage for any provider.

## After

One provider returning invalid JSON → that provider gets `error: "Fetch failed"` → other providers return their data normally. Abort-style errors (from `fetchJson`'s internal `AbortController`) are still labelled `"Timeout"` to match the existing `withTimeout` fallback behavior.

## Changes

- Added `.catch()` per task in `loadProviderUsageSummary` that converts rejections to error snapshots
- `AbortError` rejections → `"Timeout"` (consistent with `withTimeout` fallback)
- Other rejections → `"Fetch failed"`
- Added two regression tests:
  1. Verifies that a broken provider (HTTP 200 + non-JSON body) doesn't crash other providers
  2. Verifies that `AbortError` rejections are still reported as `"Timeout"`, not `"Fetch failed"`

## Test plan

- [x] New test: broken provider does not crash the batch (RED before fix, GREEN after)
- [x] New test: AbortError still labelled as Timeout
- [x] All 114 existing provider-usage tests pass
- [x] Pre-commit hooks pass (lint, type-check, conflict markers)

AI-assisted (Claude), lightly tested locally. I understand what this code does.