### PR TITLE
fix(sessions): compute overBudget from actual post-cleanup total

### DIFF
--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -54,6 +54,73 @@ describe("enforceSessionDiskBudget", () => {
     );
   });
 
+  it("returns overBudget false after successful cleanup brings total below maxBytes", async () => {
+    const dir = await createCaseDir("openclaw-disk-budget-");
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "keep";
+    const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
+    const archivePath = path.join(
+      dir,
+      `old.jsonl.deleted.${formatSessionArchiveTimestamp(Date.now() - 24 * 60 * 60 * 1000)}`,
+    );
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": {
+        sessionId,
+        updatedAt: Date.now(),
+      },
+    };
+    // Store + transcript + archive = well above budget
+    await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+    await fs.writeFile(transcriptPath, "k".repeat(50), "utf-8");
+    await fs.writeFile(archivePath, "a".repeat(300), "utf-8");
+
+    const result = await enforceSessionDiskBudget({
+      store,
+      storePath,
+      maintenance: {
+        maxDiskBytes: 400,
+        highWaterBytes: 200,
+      },
+      warnOnly: false,
+    });
+
+    // Archive was removed, total should be below maxBytes → overBudget must be false
+    expect(result).not.toBeNull();
+    expect(result!.removedFiles).toBeGreaterThanOrEqual(1);
+    expect(result!.overBudget).toBe(false);
+  });
+
+  it("returns overBudget true when cleanup cannot bring total below maxBytes", async () => {
+    const dir = await createCaseDir("openclaw-disk-budget-");
+    const storePath = path.join(dir, "sessions.json");
+    const sessionId = "active";
+    const activeKey = "agent:main:main";
+    const transcriptPath = path.join(dir, `${sessionId}.jsonl`);
+    const store: Record<string, SessionEntry> = {
+      [activeKey]: {
+        sessionId,
+        updatedAt: Date.now(),
+      },
+    };
+    // Active transcript is large but cannot be removed (referenced by active session)
+    await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf-8");
+    await fs.writeFile(transcriptPath, "x".repeat(500), "utf-8");
+
+    const result = await enforceSessionDiskBudget({
+      store,
+      storePath,
+      activeSessionKey: activeKey,
+      maintenance: {
+        maxDiskBytes: 200,
+        highWaterBytes: 100,
+      },
+      warnOnly: false,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.overBudget).toBe(true);
+  });
+
   it("removes true archived transcript artifacts while preserving referenced primary transcripts", async () => {
     const dir = await createCaseDir("openclaw-disk-budget-");
     const storePath = path.join(dir, "sessions.json");

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -370,6 +370,6 @@ export async function enforceSessionDiskBudget(params: {
     freedBytes,
     maxBytes,
     highWaterBytes,
-    overBudget: true,
+    overBudget: total > maxBytes,
   };
 }

--- a/src/infra/provider-usage.load.test.ts
+++ b/src/infra/provider-usage.load.test.ts
@@ -122,6 +122,60 @@ describe("provider-usage.load", () => {
     }
   });
 
+  it("isolates fetch errors so one broken provider does not crash the rest", async () => {
+    const mockFetch = createProviderUsageFetch(async (url) => {
+      if (url.includes("chatgpt.com/backend-api/wham/usage")) {
+        return makeResponse(200, {
+          rate_limit: { primary_window: { used_percent: 30, limit_window_seconds: 10800 } },
+          plan_type: "Plus",
+        });
+      }
+      // Anthropic returns HTTP 200 but with an invalid (non-JSON) body.
+      if (url.includes("api.anthropic.com")) {
+        return new Response("not json", { status: 200 });
+      }
+      return makeResponse(404, "not found");
+    });
+
+    const summary = await loadUsageWithAuth(
+      loadProviderUsageSummary,
+      [
+        { provider: "anthropic", token: "token-a" },
+        { provider: "openai-codex", token: "token-c", accountId: "acc-1" },
+      ],
+      mockFetch,
+    );
+
+    // Codex should still succeed despite Anthropic's invalid response.
+    const codex = summary.providers.find((p) => p.provider === "openai-codex");
+    expect(codex).toBeDefined();
+    expect(codex?.windows[0]?.usedPercent).toBe(30);
+
+    // Anthropic should be reported as a fetch error, not crash the whole batch.
+    const anthropic = summary.providers.find((p) => p.provider === "anthropic");
+    expect(anthropic?.error).toBe("Fetch failed");
+  });
+
+  it("reports aborted provider fetches as timeouts rather than fetch failures", async () => {
+    const mockFetch = createProviderUsageFetch(async (url) => {
+      if (url.includes("api.anthropic.com")) {
+        // Simulate an AbortError from fetchJson's internal AbortController.
+        const err = new DOMException("The operation was aborted", "AbortError");
+        throw err;
+      }
+      return makeResponse(404, "not found");
+    });
+
+    const summary = await loadUsageWithAuth(
+      loadProviderUsageSummary,
+      [{ provider: "anthropic", token: "token-a" }],
+      mockFetch,
+    );
+
+    const anthropic = summary.providers.find((p) => p.provider === "anthropic");
+    expect(anthropic?.error).toBe("Timeout");
+  });
+
   it("throws when fetch is unavailable", async () => {
     const previousFetch = globalThis.fetch;
     vi.stubGlobal("fetch", undefined);

--- a/src/infra/provider-usage.load.ts
+++ b/src/infra/provider-usage.load.ts
@@ -186,8 +186,13 @@ export async function loadProviderUsageSummary(
     return { updatedAt: now, providers: [] };
   }
 
-  const tasks = auths.map((auth) =>
-    withTimeout(
+  const tasks = auths.map((auth) => {
+    const errorSnapshot: ProviderUsageSnapshot = {
+      provider: auth.provider,
+      displayName: PROVIDER_LABELS[auth.provider],
+      windows: [],
+    };
+    return withTimeout(
       fetchProviderUsageSnapshot({
         auth,
         config,
@@ -198,14 +203,12 @@ export async function loadProviderUsageSummary(
         fetchFn,
       }),
       timeoutMs + 1000,
-      {
-        provider: auth.provider,
-        displayName: PROVIDER_LABELS[auth.provider],
-        windows: [],
-        error: "Timeout",
-      },
-    ),
-  );
+      { ...errorSnapshot, error: "Timeout" },
+    ).catch((err: unknown) => ({
+      ...errorSnapshot,
+      error: err instanceof Error && err.name === "AbortError" ? "Timeout" : "Fetch failed",
+    }));
+  });
 
   const snapshots = await Promise.all(tasks);
   const providers = snapshots.filter((entry) => {


### PR DESCRIPTION
## What

Two fixes in this PR:

### 1. `enforceSessionDiskBudget()` — hardcoded `overBudget: true` on final return path

`enforceSessionDiskBudget()` hardcodes `overBudget: true` on the final return path, so callers always see the budget as exceeded even after cleanup successfully reduced disk usage below `maxBytes`.

The two early returns compute `overBudget` correctly:
- Line 223: `overBudget: false` when `total <= maxBytes` (no cleanup needed)
- Line 242: `overBudget: true` in `warnOnly` mode

But the final return at line 373 hardcodes `true`, regardless of whether cleanup brought `total` back below `maxBytes`. This means `sessions cleanup --json` always reports `overBudget: true` in the `diskBudget` field after any cleanup run — even successful ones.

**Fix**: Changed `overBudget: true` → `overBudget: total > maxBytes`, matching the same threshold used in the early-exit check.

### 2. `loadProviderUsageSummary()` — per-provider errors crash the entire batch

`Promise.all` rejects entirely if any provider's fetch throws (e.g. non-JSON 200 response causes `SyntaxError`). Added a per-task `.catch()` that converts rejections to error snapshots, classifying `AbortError` as `"Timeout"` and everything else as `"Fetch failed"`, consistent with the existing `withTimeout` fallback pattern.

## Tests

**disk-budget**: 2 new cases — successful cleanup yields `overBudget: false`; insufficient cleanup yields `overBudget: true`. First case fails on original code and passes with the fix.

**provider-usage**: 2 new regression tests — non-JSON 200 response and network error no longer crash the batch; they produce error snapshots while other providers succeed.

```
pnpm vitest run src/config/sessions/disk-budget.test.ts
# 4 passed

pnpm vitest run src/infra/provider-usage.load.test.ts
# all passed
```