### PR TITLE
fix(windows): wrap plugin loader paths with pathToFileURL to fix ERR_UNSUPPORTED_ESM_URL_SCHEME

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { createJiti } from "jiti";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import { isChannelConfigured } from "../config/channel-configured.js";
@@ -167,6 +168,22 @@ export function clearPluginLoaderCache(): void {
 }
 
 const defaultLogger = () => createSubsystemLogger("plugins");
+
+/**
+ * On Windows, the Node.js ESM loader requires absolute paths to be expressed
+ * as file:// URLs (e.g. file:///C:/Users/...). Raw drive-letter paths like
+ * C:\... are rejected with ERR_UNSUPPORTED_ESM_URL_SCHEME because the loader
+ * mistakes the drive letter for an unknown URL scheme.
+ *
+ * This helper converts an absolute path to a file:// URL string on Windows
+ * and leaves it unchanged on POSIX systems where raw paths are accepted.
+ */
+function toSafeImportPath(absolutePath: string): string {
+  if (process.platform === "win32" && /^[a-zA-Z]:[\\/]/.test(absolutePath)) {
+    return pathToFileURL(absolutePath).href;
+  }
+  return absolutePath;
+}
 
 function createPluginJitiLoader(options: Pick<PluginLoadOptions, "pluginSdkResolution">) {
   const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
@@ -1040,7 +1057,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     if (!runtimeModulePath) {
       throw new Error("Unable to resolve plugin runtime module");
     }
-    const runtimeModule = getJiti(runtimeModulePath)(runtimeModulePath) as {
+    const safeRuntimePath = toSafeImportPath(runtimeModulePath);
+    const runtimeModule = getJiti(safeRuntimePath)(safeRuntimePath) as {
       createPluginRuntime?: (options?: CreatePluginRuntimeOptions) => PluginRuntime;
     };
     if (typeof runtimeModule.createPluginRuntime !== "function") {
@@ -1448,12 +1466,16 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     const safeSource = opened.path;
     fs.closeSync(opened.fd);
 
+    // On Windows, Node.js ESM requires file:// URLs for absolute paths.
+    // toSafeImportPath converts C:\... -> file:///C:/... on win32 only.
+    const safeImportSource = toSafeImportPath(safeSource);
+
     let mod: OpenClawPluginModule | null = null;
     try {
       // Track the plugin as imported once module evaluation begins. Top-level
       // code may have already executed even if evaluation later throws.
       recordImportedPluginId(record.id);
-      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
+      mod = getJiti(safeImportSource)(safeImportSource) as OpenClawPluginModule;
     } catch (err) {
       recordPluginError({
         logger,
@@ -1899,9 +1921,12 @@ export async function loadOpenClawPluginCliRegistry(
     const safeSource = opened.path;
     fs.closeSync(opened.fd);
 
+    // On Windows, Node.js ESM requires file:// URLs for absolute paths.
+    const safeImportSource = toSafeImportPath(safeSource);
+
     let mod: OpenClawPluginModule | null = null;
     try {
-      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
+      mod = getJiti(safeImportSource)(safeImportSource) as OpenClawPluginModule;
     } catch (err) {
       recordPluginError({
         logger,


### PR DESCRIPTION
## Problem

On Windows, the Node.js ESM loader rejects raw absolute paths like `C:\Users\...` with:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data,
and node are supported by the default ESM loader. On Windows, absolute paths
must be valid file:// URLs. Received protocol 'c:'
```

The plugin loader in `src/plugins/loader.ts` passed raw Windows paths directly to `getJiti()(path)` in **three call sites**, causing `openclaw onboard`, interactive setup, and the Control UI to crash on Windows immediately after a provider/model is selected.

This was independently reported in at least three separate issues today alone:
- Closes #61795
- Closes #61810  
- Closes #61792

## Root Cause

The `getJiti(safeSource)(safeSource)` and `getJiti(runtimeModulePath)(runtimeModulePath)` calls receive a bare Windows absolute path (e.g. `C:\Users\...\extensions\openclaw-web-search`) which the ESM loader misinterprets as an unknown URL scheme `c:`.

## Fix

Adds a `toSafeImportPath()` helper that converts Windows absolute paths to `file://` URLs using Node's built-in `pathToFileURL()` from `node:url`. The conversion is **only applied on `win32`** — POSIX paths are returned unchanged, so Linux/macOS behaviour is completely unaffected.

```ts
// Before
mod = getJiti(safeSource)(safeSource);

// After  
const safeImportSource = toSafeImportPath(safeSource); // file:///C:/... on Windows
mod = getJiti(safeImportSource)(safeImportSource);
```

All three affected call sites in `loadOpenClawPlugins` (plugin module load), `loadOpenClawPluginCliRegistry` (CLI metadata load), and `resolveCreatePluginRuntime` (runtime module load) are patched.

## Testing

- POSIX: no change in path handling (`process.platform !== 'win32'` branch is a no-op)
- Windows: `C:\...` paths are converted to `file:///C:/...` before being passed to jiti/ESM loader

Workaround until merged: use WSL2 on Windows (raw Linux paths avoid the issue).