### PR TITLE
fix(slack): restore replyToMode regression from extension migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/Windows: load plugin entrypoints through `file://` import specifiers on Windows without breaking plugin SDK alias resolution, fixing `ERR_UNSUPPORTED_ESM_URL_SCHEME` for absolute plugin paths. (#61832) Thanks @Zeesejo.
 - Discord/forwarding: recover forwarded referenced message text and attachments when Discord omits snapshot payloads, so forwarded-message relays keep the original content. (#61670) Thanks @artwalker.
 - Plugins/install: preserve plugin-schema defaults during fresh-install raw config validation so bundled plugin installs stop failing when required fields rely on schema defaults. (#61856) Thanks @SuperMarioYL.
+- Slack/threading: keep legacy thread stickiness for real replies when older callers omit `isThreadReply`, while still honoring `replyToMode` for Slack's auto-created top-level `thread_ts`. (#61835) Thanks @kaonash.
 - Docs/i18n: remove the zh-CN homepage redirect override so Mintlify can resolve the localized Chinese homepage without self-redirecting `/zh-CN/index`.
 - Agents/heartbeat: stop truncating live session transcripts after no-op heartbeat acks, move heartbeat cleanup to prompt assembly and compaction, and keep post-filter context-engine ingestion aligned with the real session baseline. (#60998) Thanks @nxmxbbd.
 - macOS/gateway version: strip trailing commit metadata from CLI version output before semver parsing so the Mac app recognizes installed gateway versions like `OpenClaw 2026.4.2 (d74a122)` again. (#61111) Thanks @oliviareid-svg.

--- a/extensions/slack/src/monitor.test.ts
+++ b/extensions/slack/src/monitor.test.ts
@@ -68,6 +68,7 @@ describe("resolveSlackThreadTs", () => {
             incomingThreadTs: threadTs,
             messageTs,
             hasReplied,
+            isThreadReply: true,
           }),
         ).toBe(threadTs);
       }

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -6,6 +6,7 @@ vi.mock("../send.js", () => ({
 }));
 
 let deliverReplies: typeof import("./replies.js").deliverReplies;
+let resolveSlackThreadTs: typeof import("./replies.js").resolveSlackThreadTs;
 import { deliverSlackSlashReplies } from "./replies.js";
 
 function baseParams(overrides?: Record<string, unknown>) {
@@ -22,7 +23,7 @@ function baseParams(overrides?: Record<string, unknown>) {
 
 describe("deliverReplies identity passthrough", () => {
   beforeAll(async () => {
-    ({ deliverReplies } = await import("./replies.js"));
+    ({ deliverReplies, resolveSlackThreadTs } = await import("./replies.js"));
   });
 
   beforeEach(() => {
@@ -162,6 +163,51 @@ describe("deliverReplies identity passthrough", () => {
         }),
       ),
     ).rejects.toThrow(/Slack blocks cannot exceed 50 items/i);
+  });
+});
+
+describe("resolveSlackThreadTs fallback classification", () => {
+  const threadTs = "1234567890.123456";
+  const messageTs = "9999999999.999999";
+
+  it("keeps legacy thread-stickiness for genuine replies when callers omit isThreadReply", () => {
+    expect(
+      resolveSlackThreadTs({
+        replyToMode: "off",
+        incomingThreadTs: threadTs,
+        messageTs,
+        hasReplied: false,
+      }),
+    ).toBe(threadTs);
+  });
+
+  it("respects replyToMode for auto-created top-level thread_ts when callers omit isThreadReply", () => {
+    expect(
+      resolveSlackThreadTs({
+        replyToMode: "off",
+        incomingThreadTs: messageTs,
+        messageTs,
+        hasReplied: false,
+      }),
+    ).toBeUndefined();
+
+    expect(
+      resolveSlackThreadTs({
+        replyToMode: "first",
+        incomingThreadTs: messageTs,
+        messageTs,
+        hasReplied: false,
+      }),
+    ).toBe(messageTs);
+
+    expect(
+      resolveSlackThreadTs({
+        replyToMode: "batched",
+        incomingThreadTs: messageTs,
+        messageTs,
+        hasReplied: true,
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -140,7 +140,6 @@ function createSlackReplyReferencePlanner(params: {
 }) {
   // Only force threading for genuine user thread replies. Slack auto-populates
   // thread_ts on top-level messages; respect the configured replyToMode there.
-  // See: openclaw/openclaw#23839
   const effectiveMode = params.isThreadReply ? "all" : params.replyToMode;
   return createReplyReferencePlanner({
     replyToMode: effectiveMode,

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -138,9 +138,13 @@ function createSlackReplyReferencePlanner(params: {
   hasReplied?: boolean;
   isThreadReply?: boolean;
 }) {
-  // Only force threading for genuine user thread replies. Slack auto-populates
-  // thread_ts on top-level messages; respect the configured replyToMode there.
-  const effectiveMode = params.isThreadReply ? "all" : params.replyToMode;
+  // Older/internal callers may not pass explicit thread classification. Keep
+  // genuine thread replies sticky, but do not let Slack's auto-populated
+  // top-level thread_ts override the configured replyToMode.
+  const effectiveIsThreadReply =
+    params.isThreadReply ??
+    Boolean(params.incomingThreadTs && params.incomingThreadTs !== params.messageTs);
+  const effectiveMode = effectiveIsThreadReply ? "all" : params.replyToMode;
   return createReplyReferencePlanner({
     replyToMode: effectiveMode,
     existingId: params.incomingThreadTs,

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -138,12 +138,10 @@ function createSlackReplyReferencePlanner(params: {
   hasReplied?: boolean;
   isThreadReply?: boolean;
 }) {
-  // Keep backward-compatible behavior: when a thread id is present and caller
-  // does not provide explicit classification, stay in thread. Callers that can
-  // distinguish Slack's auto-populated top-level thread_ts should pass
-  // `isThreadReply: false` to preserve replyToMode behavior.
-  const effectiveIsThreadReply = params.isThreadReply ?? Boolean(params.incomingThreadTs);
-  const effectiveMode = effectiveIsThreadReply ? "all" : params.replyToMode;
+  // Only force threading for genuine user thread replies. Slack auto-populates
+  // thread_ts on top-level messages; respect the configured replyToMode there.
+  // See: openclaw/openclaw#23839
+  const effectiveMode = params.isThreadReply ? "all" : params.replyToMode;
   return createReplyReferencePlanner({
     replyToMode: effectiveMode,
     existingId: params.incomingThreadTs,


### PR DESCRIPTION
## Summary

- Removes backward-compatibility fallback in `createSlackReplyReferencePlanner` that overrode `isThreadReply` with `Boolean(incomingThreadTs)`, causing `replyToMode` to be ignored when Slack auto-populates `thread_ts` on top-level messages.
- Restores the behavior from #23839 (commit `71c2c59c6c`) which was regressed during the Slack extension migration.
- Updates `monitor.test.ts` to pass `isThreadReply: true` for genuine-thread test scenarios instead of relying on the removed fallback.

## How the regression happened

1. **`71c2c59c6c`** (#23839, Feb 22) — Fixed `replyToMode` being ignored when Slack auto-populates `thread_ts` on top-level messages. The fix was simple:
   ```typescript
   const effectiveMode = params.isThreadReply ? "all" : params.replyToMode;
   ```

2. **`f8171ffcdc`** (#23796, Feb 22, same day) — An unrelated PR ("Config UI: tag filters and complete schema help/labels coverage") added a fallback for `isThreadReply` in `resolveSlackThreadTs` to unblock tests. This didn't directly conflict with #23839, but introduced a pattern of falling back to `incomingThreadTs` when `isThreadReply` was not provided.

3. **`8746362f5e`** (#45621, Mar 14) — Slack code was migrated to `extensions/slack/`. During the migration, a backward-compatibility fallback was added inside `createSlackReplyReferencePlanner` itself:
   ```typescript
   const effectiveIsThreadReply = params.isThreadReply ?? Boolean(params.incomingThreadTs);
   ```
   This was likely intended as a safety measure for callers that might not pass `isThreadReply`, but it effectively reverted the #23839 fix — any message with `incomingThreadTs` (including Slack's auto-populated top-level `thread_ts`) would be forced into threading regardless of the configured `replyToMode`.

**Root cause**: #23839 and #23796 merged on the same day without conflicting, and the fallback pattern from #23796 carried forward into the extension migration, where it was generalized into the planner function itself, negating the original fix.

## Problem

Since Slack auto-populates `thread_ts` on top-level messages in some cases (e.g. Agents & AI Apps feature), the fallback incorrectly forced `effectiveMode = "all"` even when the caller explicitly passed `isThreadReply: false`. This made the configured `replyToMode` setting be ignored.

All current callers (`dispatch.ts`) already pass `isThreadReply` explicitly, so the fallback is unnecessary.

## Fix

```typescript
// Before (regressed)
const effectiveIsThreadReply = params.isThreadReply ?? Boolean(params.incomingThreadTs);
const effectiveMode = effectiveIsThreadReply ? "all" : params.replyToMode;

// After (restored)
const effectiveMode = params.isThreadReply ? "all" : params.replyToMode;
```

## Test plan

- [x] `pnpm test extensions/slack/src/monitor/replies.test.ts` — 7/7 passed
- [x] `pnpm test extensions/slack/src/monitor.test.ts` — all passed (updated genuine-thread test to pass `isThreadReply: true`)
- [x] `pnpm test extensions/slack/src/threading.test.ts extensions/slack/src/monitor.tool-result.test.ts` — 55/55 passed
- [ ] Manual: configure `replyToMode: "off"` or `"first"`, send top-level channel message with auto-created `thread_ts` → bot should respect configured mode
- [ ] Manual: send genuine thread reply → bot should still reply in thread regardless of `replyToMode`

Fixes regression of #23839.
Related: #5470, #16080

🤖 Generated with [Claude Code](https://claude.com/claude-code)