### PR TITLE
feat(routing): Intent-based message classification and routing

### DIFF
--- a/src/routing/intent-classifier.test.ts
+++ b/src/routing/intent-classifier.test.ts
@@ -1,0 +1,504 @@
+import { describe, it, expect } from "vitest";
+import { classifyIntent, evaluateMatcher, DEFAULT_INTENT_RULES } from "./intent-classifier.js";
+import type { IntentRule, IntentMatcher } from "./intent-classifier.js";
+
+// ---------------------------------------------------------------------------
+// evaluateMatcher — unit tests for individual matcher types
+// ---------------------------------------------------------------------------
+
+describe("evaluateMatcher", () => {
+  describe("regex matcher", () => {
+    it("matches a simple pattern", () => {
+      const m: IntentMatcher = { type: "regex", pattern: "\\bhello\\b", flags: "i" };
+      expect(evaluateMatcher(m, "Hello world")).toBe(true);
+    });
+
+    it("rejects when pattern does not match", () => {
+      const m: IntentMatcher = { type: "regex", pattern: "\\bxyz\\b", flags: "i" };
+      expect(evaluateMatcher(m, "Hello world")).toBe(false);
+    });
+
+    it("returns false for missing pattern", () => {
+      const m: IntentMatcher = { type: "regex" };
+      expect(evaluateMatcher(m, "anything")).toBe(false);
+    });
+
+    it("returns false for invalid regex (does not throw)", () => {
+      const m: IntentMatcher = { type: "regex", pattern: "[invalid" };
+      expect(evaluateMatcher(m, "test")).toBe(false);
+    });
+
+    it("respects flags (multiline)", () => {
+      const m: IntentMatcher = { type: "regex", pattern: "^\\d+\\.", flags: "m" };
+      expect(evaluateMatcher(m, "intro\n1. item")).toBe(true);
+      expect(evaluateMatcher(m, "no numbers here")).toBe(false);
+    });
+  });
+
+  describe("keyword matcher", () => {
+    it("matches case-insensitively", () => {
+      const m: IntentMatcher = { type: "keyword", keywords: ["hello"] };
+      expect(evaluateMatcher(m, "HELLO WORLD")).toBe(true);
+    });
+
+    it("matches any keyword (OR logic)", () => {
+      const m: IntentMatcher = { type: "keyword", keywords: ["foo", "bar", "baz"] };
+      expect(evaluateMatcher(m, "contains bar inside")).toBe(true);
+    });
+
+    it("rejects when no keywords match", () => {
+      const m: IntentMatcher = { type: "keyword", keywords: ["xyz"] };
+      expect(evaluateMatcher(m, "nothing here")).toBe(false);
+    });
+
+    it("returns false for empty keywords array", () => {
+      const m: IntentMatcher = { type: "keyword", keywords: [] };
+      expect(evaluateMatcher(m, "anything")).toBe(false);
+    });
+
+    it("returns false for missing keywords", () => {
+      const m: IntentMatcher = { type: "keyword" };
+      expect(evaluateMatcher(m, "anything")).toBe(false);
+    });
+  });
+
+  describe("length matcher", () => {
+    it("passes when length is within range", () => {
+      const m: IntentMatcher = { type: "length", minLength: 5, maxLength: 10 };
+      expect(evaluateMatcher(m, "1234567")).toBe(true);
+    });
+
+    it("fails when message is too short", () => {
+      const m: IntentMatcher = { type: "length", minLength: 10 };
+      expect(evaluateMatcher(m, "short")).toBe(false);
+    });
+
+    it("fails when message is too long", () => {
+      const m: IntentMatcher = { type: "length", maxLength: 5 };
+      expect(evaluateMatcher(m, "this is too long")).toBe(false);
+    });
+
+    it("maxLength boundary: exactly at limit passes", () => {
+      const m: IntentMatcher = { type: "length", maxLength: 5 };
+      expect(evaluateMatcher(m, "12345")).toBe(true);
+    });
+
+    it("maxLength boundary: one over limit fails", () => {
+      const m: IntentMatcher = { type: "length", maxLength: 5 };
+      expect(evaluateMatcher(m, "123456")).toBe(false);
+    });
+
+    it("passes with no constraints", () => {
+      const m: IntentMatcher = { type: "length" };
+      expect(evaluateMatcher(m, "anything at all")).toBe(true);
+    });
+  });
+
+  describe("negation matcher", () => {
+    it("inverts a passing matcher", () => {
+      const m: IntentMatcher = {
+        type: "negation",
+        inner: { type: "keyword", keywords: ["hello"] },
+      };
+      expect(evaluateMatcher(m, "hello world")).toBe(false);
+    });
+
+    it("inverts a failing matcher", () => {
+      const m: IntentMatcher = {
+        type: "negation",
+        inner: { type: "keyword", keywords: ["xyz"] },
+      };
+      expect(evaluateMatcher(m, "hello world")).toBe(true);
+    });
+
+    it("returns true when inner is missing", () => {
+      const m: IntentMatcher = { type: "negation" };
+      expect(evaluateMatcher(m, "anything")).toBe(true);
+    });
+  });
+
+  describe("unknown matcher type", () => {
+    it("returns false for unknown type", () => {
+      const m = { type: "unknown" } as unknown as IntentMatcher;
+      expect(evaluateMatcher(m, "test")).toBe(false);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyIntent — default rules: simple messages
+// ---------------------------------------------------------------------------
+
+describe("classifyIntent (default rules)", () => {
+  describe("classifies simple messages correctly", () => {
+    const simpleCases = [
+      "Say hello",
+      "What is 2 + 2?",
+      "Explain monads in one paragraph",
+      "Translate this to French: Good morning",
+      "List 3 blockchain security vulnerabilities",
+      "Write a haiku about TypeScript",
+      "Summarize this article",
+      "Fix the typo in the README",
+      "What does this error mean?",
+    ];
+
+    for (const msg of simpleCases) {
+      it(`"${msg}" → simple`, () => {
+        const result = classifyIntent(msg);
+        expect(result.category).toBe("simple");
+      });
+    }
+  });
+
+  describe("classifies simple Chinese messages correctly", () => {
+    const simpleCases = [
+      "你好",
+      "今天天气怎么样",
+      "解释一下什么是 TypeScript",
+      "翻译成英文：早上好",
+    ];
+
+    for (const msg of simpleCases) {
+      it(`"${msg}" → simple`, () => {
+        const result = classifyIntent(msg);
+        expect(result.category).toBe("simple");
+      });
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Complex messages
+  // -----------------------------------------------------------------------
+
+  describe("classifies complex messages correctly", () => {
+    it('"first...then" sequencing', () => {
+      const result = classifyIntent("First design the API schema, then implement the endpoints");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:first-then");
+    });
+
+    it("numbered list", () => {
+      const result = classifyIntent("1. Design the schema\n2. Implement the API\n3. Write tests");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:numbered-list");
+    });
+
+    it("step N pattern", () => {
+      const result = classifyIntent("Step 1: set up the project. Step 2: write the code.");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:step-n");
+    });
+
+    it("phase N pattern", () => {
+      const result = classifyIntent("Phase 1 is planning, phase 2 is execution");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:phase-n");
+    });
+
+    it("stage N pattern", () => {
+      const result = classifyIntent("Stage 1 research, stage 2 implementation");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:stage-n");
+    });
+
+    it("collaboration language", () => {
+      const result = classifyIntent("Collaborate on building a REST API with tests");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:collaborate");
+    });
+
+    it("coordination language", () => {
+      const result = classifyIntent("Coordinate the team to build and deploy the service");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:coordinate");
+    });
+
+    it("review each other", () => {
+      const result = classifyIntent("Write code and review each other's pull requests");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:review-each-other");
+    });
+
+    it("work together", () => {
+      const result = classifyIntent("Work together to build the frontend and backend");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:work-together");
+    });
+
+    it("parallel execution", () => {
+      const result = classifyIntent("Run the linter and tests in parallel");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:in-parallel");
+    });
+
+    it("concurrently", () => {
+      const result = classifyIntent("Execute both tasks concurrently");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:concurrently");
+    });
+
+    it("at the same time", () => {
+      const result = classifyIntent("Build and test at the same time");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:same-time");
+    });
+
+    it("multiple deliverables", () => {
+      const result = classifyIntent(
+        "Build the REST API endpoints and then write comprehensive integration tests for each one",
+      );
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:multi-deliverable");
+    });
+
+    it("Chinese multi-step keywords", () => {
+      const result = classifyIntent("首先设计数据库，然后实现 API");
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:zh-sequence");
+    });
+
+    it("very long message (>500 chars)", () => {
+      const longMsg = "Please analyze " + "a".repeat(500);
+      const result = classifyIntent(longMsg);
+      expect(result.category).toBe("complex");
+      expect(result.matchedRule).toBe("complex:long-message");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Edge cases — common words that should NOT trigger complexity
+  // -----------------------------------------------------------------------
+
+  describe("does not false-positive on common words", () => {
+    it('"and" alone is not complex', () => {
+      const result = classifyIntent("Pros and cons of TypeScript");
+      expect(result.category).toBe("simple");
+    });
+
+    it('"then" alone is not complex', () => {
+      const result = classifyIntent("What happened then?");
+      expect(result.category).toBe("simple");
+    });
+
+    it('"summarize" is not complex', () => {
+      const result = classifyIntent("Summarize the article about AI safety");
+      expect(result.category).toBe("simple");
+    });
+
+    it('"analyze" is not complex', () => {
+      const result = classifyIntent("Analyze this error log");
+      expect(result.category).toBe("simple");
+    });
+
+    it('"aggregate" is not complex', () => {
+      const result = classifyIntent("Aggregate the results");
+      expect(result.category).toBe("simple");
+    });
+
+    it('"coordinate" as a noun is complex (matches substring)', () => {
+      // This is an acceptable trade-off: the word "coordinate" strongly
+      // implies coordination, even in noun form.
+      const result = classifyIntent("Use coordinate geometry to solve the problem");
+      expect(result.category).toBe("complex");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Length boundary tests
+  // -----------------------------------------------------------------------
+
+  describe("length boundaries", () => {
+    it("empty string → simple", () => {
+      expect(classifyIntent("").category).toBe("simple");
+    });
+
+    it("exactly 200 chars → simple", () => {
+      expect(classifyIntent("x".repeat(200)).category).toBe("simple");
+    });
+
+    it("201 chars → default (too long for simple, too short for complex:long)", () => {
+      expect(classifyIntent("x".repeat(201)).category).toBe("default");
+    });
+
+    it("500 chars → complex (long message)", () => {
+      expect(classifyIntent("x".repeat(500)).category).toBe("complex");
+    });
+
+    it("201-499 chars without patterns → default", () => {
+      expect(classifyIntent("x".repeat(300)).category).toBe("default");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Confidence levels
+  // -----------------------------------------------------------------------
+
+  describe("confidence levels", () => {
+    it("regex match → high confidence", () => {
+      const result = classifyIntent("First do A, then do B");
+      expect(result.confidence).toBe("high");
+    });
+
+    it("keyword match → medium confidence", () => {
+      const result = classifyIntent("首先做这个");
+      expect(result.confidence).toBe("medium");
+    });
+
+    it("length-only match → low confidence", () => {
+      const result = classifyIntent("short");
+      expect(result.confidence).toBe("low");
+    });
+
+    it("default fallthrough → low confidence", () => {
+      const result = classifyIntent("x".repeat(300));
+      expect(result.confidence).toBe("low");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyIntent — custom rules
+// ---------------------------------------------------------------------------
+
+describe("classifyIntent (custom rules)", () => {
+  it("respects custom rules over defaults", () => {
+    const rules: IntentRule[] = [
+      {
+        id: "custom:greeting",
+        category: "greeting",
+        priority: 1,
+        matchers: [{ type: "keyword", keywords: ["hello", "hi", "hey"] }],
+      },
+    ];
+
+    const result = classifyIntent("Hello there!", rules);
+    expect(result.category).toBe("greeting");
+    expect(result.matchedRule).toBe("custom:greeting");
+  });
+
+  it("evaluates rules in priority order", () => {
+    const rules: IntentRule[] = [
+      {
+        id: "low-priority",
+        category: "catch-all",
+        priority: 100,
+        matchers: [{ type: "length", maxLength: 999 }],
+      },
+      {
+        id: "high-priority",
+        category: "specific",
+        priority: 1,
+        matchers: [{ type: "keyword", keywords: ["test"] }],
+      },
+    ];
+
+    const result = classifyIntent("run the test", rules);
+    expect(result.category).toBe("specific");
+    expect(result.matchedRule).toBe("high-priority");
+  });
+
+  it("returns default when no custom rules match", () => {
+    const rules: IntentRule[] = [
+      {
+        id: "nope",
+        category: "nope",
+        priority: 1,
+        matchers: [{ type: "keyword", keywords: ["xyzzy"] }],
+      },
+    ];
+
+    const result = classifyIntent("nothing matches", rules);
+    expect(result.category).toBe("default");
+    expect(result.matchedRule).toBeNull();
+  });
+
+  it("AND logic: all matchers must pass", () => {
+    const rules: IntentRule[] = [
+      {
+        id: "strict",
+        category: "strict",
+        priority: 1,
+        matchers: [
+          { type: "keyword", keywords: ["deploy"] },
+          { type: "length", minLength: 20 },
+        ],
+      },
+    ];
+
+    // Has keyword but too short
+    expect(classifyIntent("deploy it", rules).category).toBe("default");
+
+    // Long enough and has keyword
+    expect(classifyIntent("please deploy the application now", rules).category).toBe("strict");
+  });
+
+  it("empty matchers array is skipped", () => {
+    const rules: IntentRule[] = [
+      { id: "empty", category: "empty", priority: 1, matchers: [] },
+      { id: "fallback", category: "fallback", priority: 2, matchers: [{ type: "length" }] },
+    ];
+
+    const result = classifyIntent("anything", rules);
+    expect(result.category).toBe("fallback");
+  });
+
+  it("handles equal priorities (stable sort — first defined wins)", () => {
+    const rules: IntentRule[] = [
+      {
+        id: "first",
+        category: "first",
+        priority: 10,
+        matchers: [{ type: "length", maxLength: 999 }],
+      },
+      {
+        id: "second",
+        category: "second",
+        priority: 10,
+        matchers: [{ type: "length", maxLength: 999 }],
+      },
+    ];
+
+    const result = classifyIntent("test", rules);
+    expect(result.category).toBe("first");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_INTENT_RULES structure validation
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_INTENT_RULES", () => {
+  it("has at least 15 rules", () => {
+    expect(DEFAULT_INTENT_RULES.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it("all rules have unique IDs", () => {
+    const ids = DEFAULT_INTENT_RULES.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("all rules have non-empty matchers", () => {
+    for (const rule of DEFAULT_INTENT_RULES) {
+      expect(rule.matchers.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("complex rules have priority 10-15", () => {
+    const complexRules = DEFAULT_INTENT_RULES.filter((r) => r.category === "complex");
+    for (const rule of complexRules) {
+      expect(rule.priority).toBeGreaterThanOrEqual(10);
+      expect(rule.priority).toBeLessThanOrEqual(15);
+    }
+  });
+
+  it("simple rules have higher priority number than complex", () => {
+    const complexMax = Math.max(
+      ...DEFAULT_INTENT_RULES.filter((r) => r.category === "complex").map((r) => r.priority),
+    );
+    const simpleMin = Math.min(
+      ...DEFAULT_INTENT_RULES.filter((r) => r.category === "simple").map((r) => r.priority),
+    );
+    expect(simpleMin).toBeGreaterThan(complexMax);
+  });
+});

--- a/src/routing/intent-classifier.ts
+++ b/src/routing/intent-classifier.ts
@@ -1,0 +1,350 @@
+/**
+ * @fileoverview Intent classification engine for OpenClaw message routing.
+ *
+ * Classifies incoming messages by complexity using local heuristics — no LLM
+ * calls, no network requests, no side effects. The classifier evaluates a
+ * configurable rule chain where each rule has a category, priority, and a set
+ * of matchers. Rules are evaluated in priority order (lowest number first);
+ * the first rule whose matchers ALL pass wins.
+ *
+ * Users can supply custom rules via config or rely on the built-in defaults
+ * that distinguish "simple" (single-action) from "complex" (multi-step /
+ * coordination) messages.
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Extensible string literal — users can define arbitrary categories. */
+export type IntentCategory = string;
+
+/**
+ * A single classification rule. All {@link matchers} must pass (AND logic)
+ * for the rule to match. Use separate rules for OR logic.
+ */
+export interface IntentRule {
+  /** Human-readable identifier for debugging / observability. */
+  readonly id: string;
+  /** The intent category this rule classifies into. */
+  readonly category: IntentCategory;
+  /** Evaluation order — lower numbers are checked first. */
+  readonly priority: number;
+  /** Every matcher must pass for this rule to match. */
+  readonly matchers: IntentMatcher[];
+}
+
+/**
+ * A composable matching primitive. Matchers are evaluated against the raw
+ * message text.
+ *
+ * - `regex`    — Tests message against a RegExp built from `pattern` + `flags`.
+ * - `keyword`  — Passes if ANY keyword appears in the message (case-insensitive).
+ * - `length`   — Passes if message length is within `minLength`..`maxLength`.
+ * - `negation` — Inverts the result of `inner`.
+ */
+export interface IntentMatcher {
+  readonly type: "regex" | "keyword" | "length" | "negation";
+  /** RegExp source string (for `regex` type). */
+  readonly pattern?: string;
+  /** RegExp flags, e.g. `"i"` for case-insensitive (for `regex` type). */
+  readonly flags?: string;
+  /** Keyword list — any match passes (for `keyword` type). */
+  readonly keywords?: string[];
+  /** Minimum message length in characters (for `length` type). */
+  readonly minLength?: number;
+  /** Maximum message length in characters (for `length` type). */
+  readonly maxLength?: number;
+  /** Inner matcher whose result is inverted (for `negation` type). */
+  readonly inner?: IntentMatcher;
+}
+
+/** The result of classifying a message. */
+export interface IntentClassification {
+  /** The matched category, or `"default"` if no rule matched. */
+  readonly category: IntentCategory;
+  /**
+   * Confidence level derived from matcher specificity:
+   *  - `high`   — matched a specific regex pattern
+   *  - `medium` — matched via keyword or composite rule
+   *  - `low`    — matched via length-only rule or default fallthrough
+   */
+  readonly confidence: "high" | "medium" | "low";
+  /** The `id` of the matched rule, or `null` for default fallthrough. */
+  readonly matchedRule: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Matcher evaluation
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a single matcher against a message.
+ *
+ * @returns `true` if the matcher condition is satisfied.
+ */
+export function evaluateMatcher(matcher: IntentMatcher, message: string): boolean {
+  switch (matcher.type) {
+    case "regex": {
+      if (!matcher.pattern) {
+        return false;
+      }
+      try {
+        const re = new RegExp(matcher.pattern, matcher.flags ?? "");
+        return re.test(message);
+      } catch {
+        // Invalid regex pattern — treat as non-match rather than crashing.
+        return false;
+      }
+    }
+
+    case "keyword": {
+      if (!matcher.keywords || matcher.keywords.length === 0) {
+        return false;
+      }
+      const lower = message.toLowerCase();
+      return matcher.keywords.some((kw) => lower.includes(kw.toLowerCase()));
+    }
+
+    case "length": {
+      const len = message.length;
+      if (matcher.minLength !== undefined && len < matcher.minLength) {
+        return false;
+      }
+      if (matcher.maxLength !== undefined && len > matcher.maxLength) {
+        return false;
+      }
+      return true;
+    }
+
+    case "negation": {
+      if (!matcher.inner) {
+        return true;
+      }
+      return !evaluateMatcher(matcher.inner, message);
+    }
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Derive a confidence level from the matchers that contributed to a match.
+ *
+ * - Any regex matcher → `high`
+ * - Any keyword matcher (no regex) → `medium`
+ * - Length-only or negation-only → `low`
+ */
+function deriveConfidence(matchers: IntentMatcher[]): "high" | "medium" | "low" {
+  let hasRegex = false;
+  let hasKeyword = false;
+
+  for (const m of matchers) {
+    if (m.type === "regex") {
+      hasRegex = true;
+    }
+    if (m.type === "keyword") {
+      hasKeyword = true;
+    }
+  }
+
+  if (hasRegex) {
+    return "high";
+  }
+  if (hasKeyword) {
+    return "medium";
+  }
+  return "low";
+}
+
+// ---------------------------------------------------------------------------
+// Classifier
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a message against an ordered list of intent rules.
+ *
+ * Rules are sorted by `priority` (ascending) and evaluated sequentially. The
+ * first rule whose matchers ALL pass determines the classification. If no rule
+ * matches, the result is `{ category: 'default', confidence: 'low' }`.
+ *
+ * @param message - The raw user message text.
+ * @param rules   - Intent rules to evaluate. Defaults to {@link DEFAULT_INTENT_RULES}.
+ */
+export function classifyIntent(
+  message: string,
+  rules: readonly IntentRule[] = DEFAULT_INTENT_RULES,
+): IntentClassification {
+  // Sort by priority (stable — preserves insertion order for equal priorities).
+  const sorted = [...rules].toSorted((a, b) => a.priority - b.priority);
+
+  for (const rule of sorted) {
+    if (rule.matchers.length === 0) {
+      continue;
+    }
+
+    const allMatch = rule.matchers.every((m) => evaluateMatcher(m, message));
+    if (allMatch) {
+      return {
+        category: rule.category,
+        confidence: deriveConfidence(rule.matchers),
+        matchedRule: rule.id,
+      };
+    }
+  }
+
+  return { category: "default", confidence: "low", matchedRule: null };
+}
+
+// ---------------------------------------------------------------------------
+// Default rules
+// ---------------------------------------------------------------------------
+
+/**
+ * Built-in complexity detection rules.
+ *
+ * Ported from the `isSimpleGoal()` heuristics in open-multi-agent, extended
+ * with multilingual support and structured as composable matcher rules.
+ *
+ * The "complex" rules use OR-per-rule design: each regex pattern is a
+ * separate rule (all at priority 10) so that ANY pattern matching is enough
+ * to classify a message as complex.
+ */
+export const DEFAULT_INTENT_RULES: IntentRule[] = [
+  // -----------------------------------------------------------------------
+  // Complex: sequencing patterns
+  // -----------------------------------------------------------------------
+  {
+    id: "complex:first-then",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bfirst\\b.{3,60}\\bthen\\b", flags: "i" }],
+  },
+  {
+    id: "complex:step-n",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bstep\\s*\\d", flags: "i" }],
+  },
+  {
+    id: "complex:phase-n",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bphase\\s*\\d", flags: "i" }],
+  },
+  {
+    id: "complex:stage-n",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bstage\\s*\\d", flags: "i" }],
+  },
+  {
+    id: "complex:numbered-list",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "^\\s*\\d+[.)]", flags: "m" }],
+  },
+
+  // -----------------------------------------------------------------------
+  // Complex: coordination language
+  // -----------------------------------------------------------------------
+  {
+    id: "complex:collaborate",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bcollaborat", flags: "i" }],
+  },
+  {
+    id: "complex:coordinate",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bcoordinat", flags: "i" }],
+  },
+  {
+    id: "complex:review-each-other",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\breview\\s+each\\s+other", flags: "i" }],
+  },
+  {
+    id: "complex:work-together",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bwork\\s+together\\b", flags: "i" }],
+  },
+
+  // -----------------------------------------------------------------------
+  // Complex: parallel execution
+  // -----------------------------------------------------------------------
+  {
+    id: "complex:in-parallel",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bin\\s+parallel\\b", flags: "i" }],
+  },
+  {
+    id: "complex:concurrently",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bconcurrently\\b", flags: "i" }],
+  },
+  {
+    id: "complex:same-time",
+    category: "complex",
+    priority: 10,
+    matchers: [{ type: "regex", pattern: "\\bat\\s+the\\s+same\\s+time\\b", flags: "i" }],
+  },
+
+  // -----------------------------------------------------------------------
+  // Complex: multiple deliverables joined by connectives
+  // -----------------------------------------------------------------------
+  {
+    id: "complex:multi-deliverable",
+    category: "complex",
+    priority: 10,
+    matchers: [
+      {
+        type: "regex",
+        pattern:
+          "\\b(?:build|create|implement|design|write|develop)\\b.{5,80}\\b(?:and|then)\\b.{5,80}\\b(?:build|create|implement|design|write|develop|test|review|deploy)\\b",
+        flags: "i",
+      },
+    ],
+  },
+
+  // -----------------------------------------------------------------------
+  // Complex: Chinese multi-step markers
+  // -----------------------------------------------------------------------
+  {
+    id: "complex:zh-sequence",
+    category: "complex",
+    priority: 10,
+    matchers: [
+      {
+        type: "keyword",
+        keywords: ["第一步", "第二步", "第三步", "首先", "然后", "最后", "分步", "步骤"],
+      },
+    ],
+  },
+
+  // -----------------------------------------------------------------------
+  // Complex: very long messages (>500 chars)
+  // -----------------------------------------------------------------------
+  {
+    id: "complex:long-message",
+    category: "complex",
+    priority: 15,
+    matchers: [{ type: "length", minLength: 500 }],
+  },
+
+  // -----------------------------------------------------------------------
+  // Simple: short messages with no complexity signals
+  // -----------------------------------------------------------------------
+  {
+    id: "simple:short",
+    category: "simple",
+    priority: 20,
+    matchers: [{ type: "length", maxLength: 200 }],
+  },
+];

--- a/src/routing/intent-router.test.ts
+++ b/src/routing/intent-router.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest";
+import { resolveIntentRoute, resolveAgentRouteWithIntent } from "./intent-router.js";
+import type { ResolvedAgentRoute, IntentRoutingConfig } from "./intent-router.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function baseRoute(overrides?: Partial<ResolvedAgentRoute>): ResolvedAgentRoute {
+  return {
+    agentId: "default-agent",
+    channel: "telegram",
+    accountId: "user-123",
+    sessionKey: "agent:default-agent:telegram:user-123:direct:abc:main",
+    mainSessionKey: "agent:default-agent:main",
+    lastRoutePolicy: "main",
+    matchedBy: "binding.channel",
+    ...overrides,
+  };
+}
+
+function config(overrides?: Partial<IntentRoutingConfig>): IntentRoutingConfig {
+  return {
+    enabled: true,
+    routes: {
+      complex: {
+        agentId: "orchestrator",
+        executionMode: "acp",
+        acpBackend: "claude-code",
+      },
+      simple: {
+        modelOverride: "claude-3-5-haiku-20241022",
+      },
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// resolveIntentRoute
+// ---------------------------------------------------------------------------
+
+describe("resolveIntentRoute", () => {
+  describe("disabled config", () => {
+    it("returns base route unchanged when disabled", () => {
+      const base = baseRoute();
+      const result = resolveIntentRoute(base, "anything", config({ enabled: false }));
+      expect(result).toEqual(base);
+    });
+
+    it("returns base route when routes map is empty", () => {
+      const base = baseRoute();
+      const result = resolveIntentRoute(base, "anything", config({ routes: {} }));
+      expect(result).toEqual(base);
+    });
+  });
+
+  describe("simple message routing", () => {
+    it("applies model override for simple messages", () => {
+      const base = baseRoute();
+      const result = resolveIntentRoute(base, "Say hello", config());
+
+      expect(result.modelOverride).toBe("claude-3-5-haiku-20241022");
+      expect(result.matchedBy).toBe("intent:simple");
+      expect(result.agentId).toBe("default-agent"); // unchanged
+      expect(result.intentClassification?.category).toBe("simple");
+    });
+  });
+
+  describe("complex message routing", () => {
+    it("overrides agent and execution mode for complex messages", () => {
+      const base = baseRoute();
+      const result = resolveIntentRoute(
+        base,
+        "First design the schema, then implement the API endpoints",
+        config(),
+      );
+
+      expect(result.agentId).toBe("orchestrator");
+      expect(result.executionMode).toBe("acp");
+      expect(result.acpBackend).toBe("claude-code");
+      expect(result.matchedBy).toBe("intent:complex");
+      expect(result.intentClassification?.category).toBe("complex");
+      expect(result.intentClassification?.matchedRule).toBe("complex:first-then");
+    });
+  });
+
+  describe("default category (no match)", () => {
+    it("returns base route for messages that match no pattern", () => {
+      const base = baseRoute();
+      // 201-499 chars with no complexity patterns falls through to default
+      const result = resolveIntentRoute(base, "x".repeat(300), config());
+
+      expect(result).toEqual(base);
+    });
+  });
+
+  describe("category without configured route", () => {
+    it("falls back to base route when category has no route entry", () => {
+      const base = baseRoute();
+      const cfg = config({
+        routes: {
+          // Only "complex" is configured, not "simple"
+          complex: { agentId: "orchestrator" },
+        },
+      });
+
+      const result = resolveIntentRoute(base, "Say hello", cfg);
+      // "simple" matches but has no route → fall through
+      expect(result).toEqual(base);
+    });
+  });
+
+  describe("partial overrides", () => {
+    it("keeps base agentId when target has no agentId", () => {
+      const base = baseRoute({ agentId: "original" });
+      const cfg = config({
+        routes: {
+          simple: { modelOverride: "fast-model" },
+        },
+      });
+
+      const result = resolveIntentRoute(base, "Hello", cfg);
+      expect(result.agentId).toBe("original");
+      expect(result.modelOverride).toBe("fast-model");
+    });
+
+    it("keeps base fields that are not overridden", () => {
+      const base = baseRoute();
+      const result = resolveIntentRoute(base, "Say hello", config());
+
+      expect(result.channel).toBe(base.channel);
+      expect(result.accountId).toBe(base.accountId);
+      expect(result.sessionKey).toBe(base.sessionKey);
+      expect(result.mainSessionKey).toBe(base.mainSessionKey);
+      expect(result.lastRoutePolicy).toBe(base.lastRoutePolicy);
+    });
+  });
+
+  describe("matchedBy field", () => {
+    it("sets matchedBy to intent:simple for simple messages", () => {
+      const result = resolveIntentRoute(baseRoute(), "Hello", config());
+      expect(result.matchedBy).toBe("intent:simple");
+    });
+
+    it("sets matchedBy to intent:complex for complex messages", () => {
+      const result = resolveIntentRoute(baseRoute(), "Step 1: plan. Step 2: execute.", config());
+      expect(result.matchedBy).toBe("intent:complex");
+    });
+
+    it("preserves original matchedBy when no intent match", () => {
+      const base = baseRoute({ matchedBy: "binding.peer" });
+      const result = resolveIntentRoute(base, "x".repeat(300), config());
+      expect(result.matchedBy).toBe("binding.peer");
+    });
+  });
+
+  describe("intentClassification in result", () => {
+    it("includes classification for matched intents", () => {
+      const result = resolveIntentRoute(baseRoute(), "Collaborate on the project", config());
+      expect(result.intentClassification).toBeDefined();
+      expect(result.intentClassification?.category).toBe("complex");
+      expect(result.intentClassification?.confidence).toBe("high");
+    });
+
+    it("has no classification for unmatched intents", () => {
+      const result = resolveIntentRoute(baseRoute(), "x".repeat(300), config());
+      expect(result.intentClassification).toBeUndefined();
+    });
+  });
+
+  describe("custom rules", () => {
+    it("uses custom rules when provided in config", () => {
+      const cfg: IntentRoutingConfig = {
+        enabled: true,
+        rules: [
+          {
+            id: "custom:code",
+            category: "code",
+            priority: 1,
+            matchers: [{ type: "keyword", keywords: ["code", "implement", "function"] }],
+          },
+        ],
+        routes: {
+          code: { agentId: "coder-agent", modelOverride: "claude-opus" },
+        },
+      };
+
+      const result = resolveIntentRoute(baseRoute(), "Write a function", cfg);
+      expect(result.agentId).toBe("coder-agent");
+      expect(result.modelOverride).toBe("claude-opus");
+      expect(result.matchedBy).toBe("intent:code");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAgentRouteWithIntent — convenience wrapper
+// ---------------------------------------------------------------------------
+
+describe("resolveAgentRouteWithIntent", () => {
+  it("passes through when no intent config provided", () => {
+    const base = baseRoute();
+    const result = resolveAgentRouteWithIntent(base, "anything");
+    expect(result).toEqual(base);
+  });
+
+  it("passes through when intent config is undefined", () => {
+    const base = baseRoute();
+    const result = resolveAgentRouteWithIntent(base, "anything", undefined);
+    expect(result).toEqual(base);
+  });
+
+  it("passes through when disabled", () => {
+    const base = baseRoute();
+    const result = resolveAgentRouteWithIntent(base, "anything", config({ enabled: false }));
+    expect(result).toEqual(base);
+  });
+
+  it("applies intent routing when enabled", () => {
+    const base = baseRoute();
+    const result = resolveAgentRouteWithIntent(base, "Say hello", config());
+    expect(result.matchedBy).toBe("intent:simple");
+    expect(result.modelOverride).toBe("claude-3-5-haiku-20241022");
+  });
+
+  it("applies complex routing through the wrapper", () => {
+    const base = baseRoute();
+    const result = resolveAgentRouteWithIntent(
+      base,
+      "First design, then implement the whole thing",
+      config(),
+    );
+    expect(result.agentId).toBe("orchestrator");
+    expect(result.executionMode).toBe("acp");
+  });
+});

--- a/src/routing/intent-router.ts
+++ b/src/routing/intent-router.ts
@@ -1,0 +1,150 @@
+/**
+ * @fileoverview Intent-to-route mapping layer for OpenClaw.
+ *
+ * Takes an {@link IntentClassification} (from the classifier) and a
+ * binding-resolved base route, then applies intent-based overrides such as
+ * switching to a different agent, execution mode, or model.
+ *
+ * This module is designed to sit between `resolveAgentRoute()` (existing
+ * binding-based dispatch) and `agentCommand()` (execution entry point),
+ * providing a non-breaking extension layer.
+ */
+
+import { classifyIntent, DEFAULT_INTENT_RULES } from "./intent-classifier.js";
+import type { IntentRule, IntentClassification } from "./intent-classifier.js";
+import type { ResolvedAgentRoute as BaseResolvedAgentRoute } from "./resolve-route.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Extends the binding-resolved {@link BaseResolvedAgentRoute} with additional
+ * fields for intent-based routing overrides.
+ *
+ * The `matchedBy` field is widened to `string` so that intent categories
+ * (e.g., `"intent:complex"`) can be represented alongside the existing
+ * binding-based literals.
+ */
+export type ResolvedAgentRoute = Omit<BaseResolvedAgentRoute, "matchedBy"> & {
+  /** How the route was determined — binding literal or `intent:<category>`. */
+  readonly matchedBy: BaseResolvedAgentRoute["matchedBy"] | `intent:${string}`;
+  // --- Intent routing extensions ---
+  /** Override execution mode: `'standard'` (default) or `'acp'`. */
+  readonly executionMode?: "standard" | "acp";
+  /** ACP backend identifier when `executionMode` is `'acp'`. */
+  readonly acpBackend?: string;
+  /** Override the agent's default model. */
+  readonly modelOverride?: string;
+  /** The intent classification that produced this route (for observability). */
+  readonly intentClassification?: IntentClassification;
+};
+
+/** What to do when a classified intent has no matching route entry. */
+export type IntentFallback = "binding" | "default-agent";
+
+/** Per-category routing target overrides. */
+export interface IntentRouteTarget {
+  /** Override agent ID. If omitted, keeps the binding-resolved agent. */
+  readonly agentId?: string;
+  /** Switch execution mode. Defaults to `'standard'`. */
+  readonly executionMode?: "standard" | "acp";
+  /** ACP backend identifier (e.g., `"claude-code"`, `"codex"`). */
+  readonly acpBackend?: string;
+  /** Override the model used for this intent (e.g., `"claude-3-5-haiku"`). */
+  readonly modelOverride?: string;
+}
+
+/** Top-level intent routing configuration (lives in OpenClaw's config.json5). */
+export interface IntentRoutingConfig {
+  /** Master switch. When `false`, intent routing is entirely skipped. */
+  readonly enabled: boolean;
+  /**
+   * Custom classification rules. When provided, these REPLACE the default
+   * rules entirely (to allow full user control). Omit to use
+   * {@link DEFAULT_INTENT_RULES}.
+   */
+  readonly rules?: IntentRule[];
+  /**
+   * Maps intent categories to routing targets. Categories not listed here
+   * fall through to the binding-based route.
+   */
+  readonly routes: Readonly<Record<string, IntentRouteTarget>>;
+  /** Behavior when no route matches. Defaults to `'binding'`. */
+  readonly fallback?: IntentFallback;
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a final agent route by applying intent-based overrides to a
+ * binding-resolved base route.
+ *
+ * @param baseRoute - The route produced by `resolveAgentRoute()`.
+ * @param message   - The raw user message text (used for classification).
+ * @param config    - Intent routing configuration.
+ * @returns An augmented route with intent overrides applied, or the original
+ *          `baseRoute` if intent routing is disabled or no rule matches.
+ */
+export function resolveIntentRoute(
+  baseRoute: ResolvedAgentRoute,
+  message: string,
+  config: IntentRoutingConfig,
+): ResolvedAgentRoute {
+  // Short-circuit: disabled or no routes configured.
+  if (!config.enabled || !config.routes || Object.keys(config.routes).length === 0) {
+    return baseRoute;
+  }
+
+  // Classify the message.
+  const rules = config.rules ?? DEFAULT_INTENT_RULES;
+  const classification = classifyIntent(message, rules);
+
+  // Default category means no rule matched — use fallback behavior.
+  if (classification.category === "default") {
+    return baseRoute;
+  }
+
+  // Look up the classified category in the routes map.
+  const target = config.routes[classification.category];
+  if (!target) {
+    // Category classified but no route configured for it — fall through.
+    return baseRoute;
+  }
+
+  // Apply overrides to produce the final route.
+  return {
+    ...baseRoute,
+    agentId: target.agentId ?? baseRoute.agentId,
+    matchedBy: `intent:${classification.category}`,
+    executionMode: target.executionMode ?? baseRoute.executionMode,
+    acpBackend: target.acpBackend ?? baseRoute.acpBackend,
+    modelOverride: target.modelOverride ?? baseRoute.modelOverride,
+    intentClassification: classification,
+  };
+}
+
+/**
+ * Convenience wrapper that combines binding-based routing with intent routing.
+ *
+ * In the OpenClaw codebase, this function would call `resolveAgentRoute()`
+ * internally. Here we accept the base route as a parameter to keep the
+ * module self-contained.
+ *
+ * @param baseRoute     - Pre-computed binding-based route.
+ * @param message       - Raw user message text.
+ * @param intentConfig  - Intent routing config (may be `undefined` if not configured).
+ * @returns The final resolved route.
+ */
+export function resolveAgentRouteWithIntent(
+  baseRoute: ResolvedAgentRoute,
+  message: string,
+  intentConfig?: IntentRoutingConfig,
+): ResolvedAgentRoute {
+  if (!intentConfig || !intentConfig.enabled) {
+    return baseRoute;
+  }
+  return resolveIntentRoute(baseRoute, message, intentConfig);
+}


### PR DESCRIPTION
## Summary

- Add local-heuristic intent classification engine (`intent-classifier.ts`) that classifies messages by complexity using composable matchers (regex, keyword, length, negation) — zero LLM calls, zero network requests, zero side effects
- Add intent-to-route mapping layer (`intent-router.ts`) that applies per-category overrides (agentId, executionMode, acpBackend, modelOverride) to the binding-resolved base route
- 93 unit tests (74 classifier + 19 router) covering all matcher types, default rules, edge cases, custom rules, multilingual support

### Architecture

```
Message arrives
  → resolveAgentRoute(context)                    // existing (unchanged)
  → resolveIntentRoute(baseRoute, message, cfg)   // NEW opt-in layer
     → classifyIntent(message, rules)             // pure, sync, no LLM
     → look up category in routes map
     → apply overrides
  → agentCommand() uses final route
```

### Default Rules (16 total)

| Category | Priority | Patterns |
|----------|----------|----------|
| `complex` | 10 | `first...then`, `step N`, `phase N`, `stage N`, numbered lists, `collaborate`, `coordinate`, `review each other`, `work together`, `in parallel`, `concurrently`, `at the same time`, multi-verb+connective, Chinese multi-step markers |
| `complex` | 15 | Messages > 500 chars |
| `simple` | 20 | Messages <= 200 chars |

### Config Example (`config.json5`)

```json5
{
  intentRouting: {
    enabled: true,
    routes: {
      complex: { agentId: "orchestrator", executionMode: "acp", acpBackend: "claude-code" },
      simple: { modelOverride: "claude-3-5-haiku-20241022" }
    }
  }
}
```

### Integration Points (not included in this PR)

This PR adds the self-contained classification and routing logic. To wire it into the main flow, these changes are needed in follow-up:

1. `src/agents/agent-command.ts` — call `resolveAgentRouteWithIntent()` wrapper
2. `src/config/types.agents.ts` — add `IntentRoutingConfig` to config schema
3. `src/config/validation.ts` — add Zod schemas for intent config

### Background

Rewrite of [agent-commander](https://github.com/EchoOfZion/agent-commander), which had critical issues: `execSync` command injection, Chinese-only keywords, fake parallelism, LLM call per classification, zero tests. This rewrite addresses all of those.

## Test plan

- [x] `npx vitest run` — 93 tests pass (74 classifier + 19 router)
- [x] `tsgo` — no type errors in new files (pre-existing extension errors only)
- [ ] CI pipeline validation
- [ ] Manual: verify simple messages get `intent:simple`, complex get `intent:complex`
- [ ] Manual: verify disabled config produces zero behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)