### PR TITLE
Fix: exclude runtimeSubagentMode from plugin loader cache key (Resolves #61756)

### DIFF
--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./memory-state.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 import { setActivePluginRegistry } from "./runtime.js";
+import type { CreatePluginRuntimeOptions } from "./runtime/index.js";
 
 afterEach(() => {
   resetPluginLoaderTestStateForTest();
@@ -39,7 +40,7 @@ describe("getCompatibleActivePluginRegistry", () => {
       },
     };
     const { cacheKey } = __testing.resolvePluginLoadCacheContext(loadOptions);
-    setActivePluginRegistry(registry, cacheKey);
+    setActivePluginRegistry(registry, cacheKey, "gateway-bindable");
 
     expect(__testing.getCompatibleActivePluginRegistry(loadOptions)).toBe(registry);
     expect(
@@ -58,6 +59,38 @@ describe("getCompatibleActivePluginRegistry", () => {
       __testing.getCompatibleActivePluginRegistry({
         ...loadOptions,
         runtimeOptions: undefined,
+      }),
+    ).toBe(registry);
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...loadOptions,
+        runtimeOptions: {
+          subagent: {} as CreatePluginRuntimeOptions["subagent"],
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not treat a default-mode active registry as compatible with gateway binding", () => {
+    const registry = createEmptyPluginRegistry();
+    const loadOptions = {
+      config: {
+        plugins: {
+          allow: ["demo"],
+          load: { paths: ["/tmp/demo.js"] },
+        },
+      },
+      workspaceDir: "/tmp/workspace-a",
+    };
+    const { cacheKey } = __testing.resolvePluginLoadCacheContext(loadOptions);
+    setActivePluginRegistry(registry, cacheKey, "default");
+
+    expect(
+      __testing.getCompatibleActivePluginRegistry({
+        ...loadOptions,
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
       }),
     ).toBeUndefined();
   });

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -43,6 +43,7 @@ import {
   listImportedRuntimePluginIds,
   setActivePluginRegistry,
 } from "./runtime.js";
+import type { PluginSdkResolutionPreference } from "./sdk-alias.js";
 let cachedBundledTelegramDir = "";
 let cachedBundledMemoryDir = "";
 const BUNDLED_TELEGRAM_PLUGIN_BODY = `module.exports = {
@@ -1779,41 +1780,47 @@ module.exports = { id: "throws-after-import", register() {} };`,
           loadVariant: () =>
             loadOpenClawPlugins({
               ...options,
-              pluginSdkResolution: "workspace" as const,
+              pluginSdkResolution: "workspace" as PluginSdkResolutionPreference,
+            }),
+        };
+      },
+    },
+    {
+      name: "does not reuse cached registries across gateway subagent binding modes",
+      setup: () => {
+        useNoBundledPlugins();
+        const plugin = writePlugin({
+          id: "cache-gateway-shared",
+          filename: "cache-gateway-shared.cjs",
+          body: `module.exports = { id: "cache-gateway-shared", register() {} };`,
+        });
+
+        const options = {
+          workspaceDir: plugin.dir,
+          config: {
+            plugins: {
+              allow: ["cache-gateway-shared"],
+              load: {
+                paths: [plugin.file],
+              },
+            },
+          },
+        };
+
+        return {
+          loadFirst: () => loadOpenClawPlugins(options),
+          loadVariant: () =>
+            loadOpenClawPlugins({
+              ...options,
+              runtimeOptions: {
+                allowGatewaySubagentBinding: true,
+              },
             }),
         };
       },
     },
   ])("$name", ({ setup }) => {
     expectCacheMissThenHit(setup());
-  });
-
-  it("reuses cached registry across gateway subagent binding modes", () => {
-    useNoBundledPlugins();
-    const plugin = writePlugin({
-      id: "cache-gateway-shared",
-      filename: "cache-gateway-shared.cjs",
-      body: `module.exports = { id: "cache-gateway-shared", register() {} };`,
-    });
-
-    const options = {
-      workspaceDir: plugin.dir,
-      config: {
-        plugins: {
-          allow: ["cache-gateway-shared"],
-          load: {
-            paths: [plugin.file],
-          },
-        },
-      },
-    };
-
-    const first = loadOpenClawPlugins(options);
-    const second = loadOpenClawPlugins({
-      ...options,
-      runtimeOptions: { allowGatewaySubagentBinding: true },
-    });
-    expect(second).toBe(first);
   });
 
   it("evicts least recently used registries when the loader cache exceeds its cap", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1753,20 +1753,20 @@ module.exports = { id: "throws-after-import", register() {} };`,
       },
     },
     {
-      name: "does not reuse cached registries across gateway subagent binding modes",
+      name: "does not reuse cached registries across different plugin SDK resolution preferences",
       setup: () => {
         useNoBundledPlugins();
         const plugin = writePlugin({
-          id: "cache-gateway-bindable",
-          filename: "cache-gateway-bindable.cjs",
-          body: `module.exports = { id: "cache-gateway-bindable", register() {} };`,
+          id: "cache-sdk-resolution",
+          filename: "cache-sdk-resolution.cjs",
+          body: `module.exports = { id: "cache-sdk-resolution", register() {} };`,
         });
 
         const options = {
           workspaceDir: plugin.dir,
           config: {
             plugins: {
-              allow: ["cache-gateway-bindable"],
+              allow: ["cache-sdk-resolution"],
               load: {
                 paths: [plugin.file],
               },
@@ -1779,15 +1779,41 @@ module.exports = { id: "throws-after-import", register() {} };`,
           loadVariant: () =>
             loadOpenClawPlugins({
               ...options,
-              runtimeOptions: {
-                allowGatewaySubagentBinding: true,
-              },
+              pluginSdkResolution: "workspace" as const,
             }),
         };
       },
     },
   ])("$name", ({ setup }) => {
     expectCacheMissThenHit(setup());
+  });
+
+  it("reuses cached registry across gateway subagent binding modes", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "cache-gateway-shared",
+      filename: "cache-gateway-shared.cjs",
+      body: `module.exports = { id: "cache-gateway-shared", register() {} };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          allow: ["cache-gateway-shared"],
+          load: {
+            paths: [plugin.file],
+          },
+        },
+      },
+    };
+
+    const first = loadOpenClawPlugins(options);
+    const second = loadOpenClawPlugins({
+      ...options,
+      runtimeOptions: { allowGatewaySubagentBinding: true },
+    });
+    expect(second).toBe(first);
   });
 
   it("evicts least recently used registries when the loader cache exceeds its cap", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -49,6 +49,7 @@ import { resolvePluginCacheInputs } from "./roots.js";
 import {
   getActivePluginRegistry,
   getActivePluginRegistryKey,
+  getActivePluginRuntimeSubagentMode,
   recordImportedPluginId,
   setActivePluginRegistry,
 } from "./runtime.js";
@@ -285,6 +286,7 @@ function buildCacheKey(params: {
   includeSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
   loadModules?: boolean;
+  runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
   pluginSdkResolution?: PluginSdkResolutionPreference;
   coreGatewayMethodNames?: string[];
 }): string {
@@ -314,13 +316,14 @@ function buildCacheKey(params: {
   const startupChannelMode =
     params.preferSetupRuntimeForChannelPlugins === true ? "prefer-setup" : "full";
   const moduleLoadMode = params.loadModules === false ? "manifest-only" : "load-modules";
+  const runtimeSubagentMode = params.runtimeSubagentMode ?? "default";
   const gatewayMethodsKey = JSON.stringify(params.coreGatewayMethodNames ?? []);
   return `${roots.workspace ?? ""}::${roots.global ?? ""}::${roots.stock ?? ""}::${JSON.stringify({
     ...params.plugins,
     installs,
     loadPaths,
     activationMetadataKey: params.activationMetadataKey ?? "",
-  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${moduleLoadMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
+  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${moduleLoadMode}::${runtimeSubagentMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
 }
 
 function normalizeScopedPluginIds(ids?: string[]): string[] | undefined {
@@ -419,6 +422,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   const onlyPluginIds = normalizeScopedPluginIds(options.onlyPluginIds);
   const includeSetupOnlyChannelPlugins = options.includeSetupOnlyChannelPlugins === true;
   const preferSetupRuntimeForChannelPlugins = options.preferSetupRuntimeForChannelPlugins === true;
+  const runtimeSubagentMode = resolveRuntimeSubagentMode(options.runtimeOptions);
   const coreGatewayMethodNames = Object.keys(options.coreGatewayHandlers ?? {}).toSorted();
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
@@ -433,6 +437,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
     loadModules: options.loadModules,
+    runtimeSubagentMode,
     pluginSdkResolution: options.pluginSdkResolution,
     coreGatewayMethodNames,
   });
@@ -448,7 +453,7 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     preferSetupRuntimeForChannelPlugins,
     shouldActivate: options.activate !== false,
     shouldLoadModules: options.loadModules !== false,
-    runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
+    runtimeSubagentMode,
     cacheKey,
   };
 }
@@ -467,9 +472,26 @@ function getCompatibleActivePluginRegistry(
   if (!activeCacheKey) {
     return undefined;
   }
-  return resolvePluginLoadCacheContext(options).cacheKey === activeCacheKey
-    ? activeRegistry
-    : undefined;
+  const loadContext = resolvePluginLoadCacheContext(options);
+  if (loadContext.cacheKey === activeCacheKey) {
+    return activeRegistry;
+  }
+  if (
+    loadContext.runtimeSubagentMode === "default" &&
+    getActivePluginRuntimeSubagentMode() === "gateway-bindable"
+  ) {
+    const gatewayBindableCacheKey = resolvePluginLoadCacheContext({
+      ...options,
+      runtimeOptions: {
+        ...options.runtimeOptions,
+        allowGatewaySubagentBinding: true,
+      },
+    }).cacheKey;
+    if (gatewayBindableCacheKey === activeCacheKey) {
+      return activeRegistry;
+    }
+  }
+  return undefined;
 }
 
 export function resolveRuntimePluginRegistry(

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -285,7 +285,6 @@ function buildCacheKey(params: {
   includeSetupOnlyChannelPlugins?: boolean;
   preferSetupRuntimeForChannelPlugins?: boolean;
   loadModules?: boolean;
-  runtimeSubagentMode?: "default" | "explicit" | "gateway-bindable";
   pluginSdkResolution?: PluginSdkResolutionPreference;
   coreGatewayMethodNames?: string[];
 }): string {
@@ -321,7 +320,7 @@ function buildCacheKey(params: {
     installs,
     loadPaths,
     activationMetadataKey: params.activationMetadataKey ?? "",
-  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${moduleLoadMode}::${params.runtimeSubagentMode ?? "default"}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
+  })}::${scopeKey}::${setupOnlyKey}::${startupChannelMode}::${moduleLoadMode}::${params.pluginSdkResolution ?? "auto"}::${gatewayMethodsKey}`;
 }
 
 function normalizeScopedPluginIds(ids?: string[]): string[] | undefined {
@@ -434,7 +433,6 @@ function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     includeSetupOnlyChannelPlugins,
     preferSetupRuntimeForChannelPlugins,
     loadModules: options.loadModules,
-    runtimeSubagentMode: resolveRuntimeSubagentMode(options.runtimeOptions),
     pluginSdkResolution: options.pluginSdkResolution,
     coreGatewayMethodNames,
   });


### PR DESCRIPTION
Fixes #61756.

The plugin loader cache key included `runtimeSubagentMode`, which is derived from `allowGatewaySubagentBinding`. Different call sites in the message processing pipeline pass different values for this flag (some with `allowGatewaySubagentBinding: true`, some without), producing distinct cache keys and triggering redundant `register()` calls — 40+ in 24 seconds after startup as reported.

`runtimeSubagentMode` does not affect which plugins are loaded or how they are configured. It is only metadata stored alongside the active registry state (via `setActivePluginRegistry`). Removing it from the cache key lets all call sites share the same cached registry regardless of their binding mode, while the active state's `runtimeSubagentMode` is still correctly updated on each activation.

**Changes:**
- Remove `runtimeSubagentMode` from `buildCacheKey()` parameters and cache key string in `src/plugins/loader.ts`
- Update test: replace the old "does not reuse cached registries across gateway subagent binding modes" test case with a cache-miss test for `pluginSdkResolution` (which is still a valid cache key dimension)
- Add new test verifying that registries ARE reused across gateway subagent binding modes

**Testing:**
- `pnpm check` passes
- `pnpm build` passes (no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings)
- All 138 loader tests pass
- Plugin tools optional tests pass (15/15)

AI-assisted (Claude). Fully tested. I understand the changes.