### PR TITLE
Web tools/MrScraper: add bundled MrScraper web-fetch and scraping plugin

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -325,6 +325,10 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/tavily/**"
+"extensions: mrscraper":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/mrscraper/**"
 "extensions: talk-voice":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Docs: https://docs.openclaw.ai
 - Docs/i18n: remove the zh-CN homepage redirect override so Mintlify can resolve the localized Chinese homepage without self-redirecting `/zh-CN/index`.
 - Agents/heartbeat: stop truncating live session transcripts after no-op heartbeat acks, move heartbeat cleanup to prompt assembly and compaction, and keep post-filter context-engine ingestion aligned with the real session baseline. (#60998) Thanks @nxmxbbd.
 
+### Changes
+
+- Web tools/MrScraper: add a bundled `mrscraper` plugin with `web_fetch` provider fallback via the unblocker plus explicit `mrscraper_fetch_html` and `mrscraper_scrape` tools, using plugin-owned config under `plugins.entries.mrscraper.config.*`.
+
 ## 2026.4.5
 
 ### Breaking

--- a/extensions/mrscraper/index.ts
+++ b/extensions/mrscraper/index.ts
@@ -1,0 +1,15 @@
+import { definePluginEntry, type AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import { createMrScraperWebFetchProvider } from "./src/mrscraper-fetch-provider.js";
+import { createMrScraperFetchHtmlTool } from "./src/mrscraper-fetch-tool.js";
+import { createMrScraperScrapeTool } from "./src/mrscraper-scrape-tool.js";
+
+export default definePluginEntry({
+  id: "mrscraper",
+  name: "MrScraper Plugin",
+  description: "Bundled MrScraper unblocker and AI scraping plugin",
+  register(api) {
+    api.registerWebFetchProvider(createMrScraperWebFetchProvider());
+    api.registerTool(createMrScraperFetchHtmlTool(api) as AnyAgentTool);
+    api.registerTool(createMrScraperScrapeTool(api) as AnyAgentTool);
+  },
+});

--- a/extensions/mrscraper/openclaw.plugin.json
+++ b/extensions/mrscraper/openclaw.plugin.json
@@ -1,0 +1,69 @@
+{
+  "id": "mrscraper",
+  "skills": ["./skills"],
+  "providerAuthEnvVars": {
+    "mrscraper": ["MRSCRAPER_API_TOKEN"]
+  },
+  "uiHints": {
+    "apiToken": {
+      "label": "MrScraper API Token",
+      "help": "MrScraper API token for unblocker and scraper APIs (fallback: MRSCRAPER_API_TOKEN env var).",
+      "sensitive": true,
+      "placeholder": "mrs_..."
+    },
+    "webFetch.baseUrl": {
+      "label": "MrScraper Unblocker Base URL",
+      "help": "MrScraper unblocker base URL override."
+    },
+    "platform.baseUrl": {
+      "label": "MrScraper Platform Base URL",
+      "help": "MrScraper platform API base URL override."
+    }
+  },
+  "contracts": {
+    "webFetchProviders": ["mrscraper"],
+    "tools": ["mrscraper_fetch_html", "mrscraper_scrape"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiToken": {
+        "type": ["string", "object"]
+      },
+      "webFetch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "baseUrl": {
+            "type": "string"
+          },
+          "timeoutSeconds": {
+            "type": "number"
+          },
+          "geoCode": {
+            "type": "string"
+          },
+          "blockResources": {
+            "type": "boolean"
+          }
+        }
+      },
+      "platform": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "baseUrl": {
+            "type": "string"
+          },
+          "timeoutSeconds": {
+            "type": "number"
+          },
+          "proxyCountry": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/mrscraper/package.json
+++ b/extensions/mrscraper/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/mrscraper-plugin",
+  "version": "2026.4.5",
+  "private": true,
+  "description": "OpenClaw MrScraper plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/mrscraper/skills/mrscraper/SKILL.md
+++ b/extensions/mrscraper/skills/mrscraper/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: mrscraper
+description: MrScraper unblocker and AI scraping tools for blocked pages and structured extraction.
+metadata:
+  { "openclaw": { "emoji": "🕸️", "requires": { "config": ["plugins.entries.mrscraper.enabled"] } } }
+---
+
+# MrScraper Tools
+
+## When to use which tool
+
+| Need                              | Tool                   | When                                                                |
+| --------------------------------- | ---------------------- | ------------------------------------------------------------------- |
+| Blocked or JS-heavy page fetch    | `web_fetch`            | MrScraper can power `web_fetch` when selected as the fetch provider |
+| Rendered HTML plus extracted text | `mrscraper_fetch_html` | Need unblocker controls like `geoCode` or `blockResources`          |
+| AI-powered structured extraction  | `mrscraper_scrape`     | Need schema-free extraction from plain-language instructions        |
+
+## web_fetch
+
+When `mrscraper` is the selected `web_fetch` provider, OpenClaw routes normal
+`web_fetch` calls through MrScraper's unblocker.
+
+| Parameter     | Description                 |
+| ------------- | --------------------------- |
+| `url`         | HTTP or HTTPS URL to fetch  |
+| `extractMode` | `markdown` or `text`        |
+| `maxChars`    | Maximum returned characters |
+
+## mrscraper_fetch_html
+
+Use this when you need unblocker-specific controls or want both rendered HTML
+and extracted text back in one tool result.
+
+| Parameter        | Description                                     |
+| ---------------- | ----------------------------------------------- |
+| `url`            | HTTP or HTTPS URL to fetch                      |
+| `extractMode`    | `markdown` or `text`                            |
+| `maxChars`       | Maximum returned characters                     |
+| `timeoutSeconds` | Request timeout                                 |
+| `geoCode`        | Optional country routing code like `US` or `SG` |
+| `blockResources` | Block images/fonts/resources for faster loads   |
+
+## mrscraper_scrape
+
+Use this when you want MrScraper to create an AI scraper run from natural-language
+instructions.
+
+| Parameter         | Description                                    |
+| ----------------- | ---------------------------------------------- | --- | --- |
+| `url`             | Target page or site                            |
+| `message`         | What to extract                                |
+| `agent`           | `general`, `listing`, or `map`                 |
+| `proxyCountry`    | Optional ISO country code                      |
+| `maxDepth`        | `map` agent only                               |
+| `maxPages`        | `map` agent only                               |
+| `limit`           | `map` agent only                               |
+| `includePatterns` | `map` agent only; regex patterns joined with ` |     | `   |
+| `excludePatterns` | `map` agent only; regex patterns joined with ` |     | `   |
+
+## Tips
+
+- Start with `web_fetch` or `mrscraper_fetch_html` when you mainly need page contents.
+- Use `mrscraper_scrape` when you need structured extracted data instead of raw page text.
+- Prefer the `map` agent only when the task really needs multi-page crawling.

--- a/extensions/mrscraper/src/config.ts
+++ b/extensions/mrscraper/src/config.ts
@@ -1,0 +1,162 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  normalizeResolvedSecretInputString,
+  normalizeSecretInput,
+} from "openclaw/plugin-sdk/secret-input";
+
+export const DEFAULT_MRSCRAPER_UNBLOCKER_BASE_URL = "https://api.mrscraper.com";
+export const DEFAULT_MRSCRAPER_PLATFORM_BASE_URL = "https://api.app.mrscraper.com";
+export const DEFAULT_MRSCRAPER_FETCH_TIMEOUT_SECONDS = 60;
+export const DEFAULT_MRSCRAPER_SCRAPE_TIMEOUT_SECONDS = 120;
+
+type PluginEntryConfig =
+  | {
+      apiToken?: unknown;
+      webFetch?: {
+        baseUrl?: string;
+        timeoutSeconds?: number;
+        geoCode?: string;
+        blockResources?: boolean;
+      };
+      platform?: {
+        baseUrl?: string;
+        timeoutSeconds?: number;
+        proxyCountry?: string;
+      };
+    }
+  | undefined;
+
+type LegacyFetchConfig =
+  | {
+      mrscraper?: {
+        apiToken?: unknown;
+      };
+    }
+  | undefined;
+
+function resolvePluginConfig(cfg?: OpenClawConfig): PluginEntryConfig {
+  const pluginConfig = cfg?.plugins?.entries?.mrscraper?.config;
+  if (pluginConfig && typeof pluginConfig === "object" && !Array.isArray(pluginConfig)) {
+    return pluginConfig as PluginEntryConfig;
+  }
+  return undefined;
+}
+
+function resolveLegacyFetchConfig(cfg?: OpenClawConfig): LegacyFetchConfig {
+  const fetch = cfg?.tools?.web?.fetch;
+  if (fetch && typeof fetch === "object" && !Array.isArray(fetch)) {
+    return fetch as LegacyFetchConfig;
+  }
+  return undefined;
+}
+
+function normalizeConfiguredSecret(value: unknown, path: string): string | undefined {
+  return normalizeSecretInput(
+    normalizeResolvedSecretInputString({
+      value,
+      path,
+    }),
+  );
+}
+
+export function resolveMrScraperApiToken(cfg?: OpenClawConfig): string | undefined {
+  const pluginConfig = resolvePluginConfig(cfg);
+  const legacyFetch = resolveLegacyFetchConfig(cfg);
+  return (
+    normalizeConfiguredSecret(
+      pluginConfig?.apiToken,
+      "plugins.entries.mrscraper.config.apiToken",
+    ) ||
+    normalizeConfiguredSecret(
+      legacyFetch?.mrscraper?.apiToken,
+      "tools.web.fetch.mrscraper.apiToken",
+    ) ||
+    normalizeSecretInput(process.env.MRSCRAPER_API_TOKEN) ||
+    undefined
+  );
+}
+
+export function resolveMrScraperWebFetchConfig(cfg?: OpenClawConfig) {
+  return resolvePluginConfig(cfg)?.webFetch;
+}
+
+export function resolveMrScraperPlatformConfig(cfg?: OpenClawConfig) {
+  return resolvePluginConfig(cfg)?.platform;
+}
+
+export function resolveMrScraperUnblockerBaseUrl(cfg?: OpenClawConfig): string {
+  const configured =
+    (typeof resolveMrScraperWebFetchConfig(cfg)?.baseUrl === "string"
+      ? resolveMrScraperWebFetchConfig(cfg)?.baseUrl?.trim()
+      : "") || "";
+  return configured || DEFAULT_MRSCRAPER_UNBLOCKER_BASE_URL;
+}
+
+export function resolveMrScraperPlatformBaseUrl(cfg?: OpenClawConfig): string {
+  const configured =
+    (typeof resolveMrScraperPlatformConfig(cfg)?.baseUrl === "string"
+      ? resolveMrScraperPlatformConfig(cfg)?.baseUrl?.trim()
+      : "") || "";
+  return configured || DEFAULT_MRSCRAPER_PLATFORM_BASE_URL;
+}
+
+export function resolveMrScraperFetchTimeoutSeconds(
+  cfg?: OpenClawConfig,
+  override?: number,
+): number {
+  if (typeof override === "number" && Number.isFinite(override) && override > 0) {
+    return Math.floor(override);
+  }
+  const configured = resolveMrScraperWebFetchConfig(cfg)?.timeoutSeconds;
+  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return DEFAULT_MRSCRAPER_FETCH_TIMEOUT_SECONDS;
+}
+
+export function resolveMrScraperScrapeTimeoutSeconds(
+  cfg?: OpenClawConfig,
+  override?: number,
+): number {
+  if (typeof override === "number" && Number.isFinite(override) && override > 0) {
+    return Math.floor(override);
+  }
+  const configured = resolveMrScraperPlatformConfig(cfg)?.timeoutSeconds;
+  if (typeof configured === "number" && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  return DEFAULT_MRSCRAPER_SCRAPE_TIMEOUT_SECONDS;
+}
+
+export function resolveMrScraperGeoCode(
+  cfg?: OpenClawConfig,
+  override?: string,
+): string | undefined {
+  const candidate =
+    (typeof override === "string" ? override.trim() : "") ||
+    (typeof resolveMrScraperWebFetchConfig(cfg)?.geoCode === "string"
+      ? resolveMrScraperWebFetchConfig(cfg)?.geoCode?.trim()
+      : "") ||
+    "";
+  return candidate || undefined;
+}
+
+export function resolveMrScraperBlockResources(cfg?: OpenClawConfig, override?: boolean): boolean {
+  if (typeof override === "boolean") {
+    return override;
+  }
+  return resolveMrScraperWebFetchConfig(cfg)?.blockResources === true;
+}
+
+export function resolveMrScraperProxyCountry(
+  cfg?: OpenClawConfig,
+  override?: string,
+): string | undefined {
+  const candidate =
+    (typeof override === "string" ? override.trim() : "") ||
+    (typeof resolveMrScraperPlatformConfig(cfg)?.proxyCountry === "string"
+      ? resolveMrScraperPlatformConfig(cfg)?.proxyCountry?.trim()
+      : "") ||
+    "";
+  return candidate || undefined;
+}

--- a/extensions/mrscraper/src/mrscraper-client.ts
+++ b/extensions/mrscraper/src/mrscraper-client.ts
@@ -1,0 +1,316 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import {
+  readResponseText,
+  resolveTimeoutSeconds,
+  withStrictWebToolsEndpoint,
+  wrapExternalContent,
+  wrapWebContent,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { normalizeSecretInput } from "openclaw/plugin-sdk/secret-input";
+import {
+  resolveMrScraperApiToken,
+  resolveMrScraperBlockResources,
+  resolveMrScraperFetchTimeoutSeconds,
+  resolveMrScraperGeoCode,
+  resolveMrScraperPlatformBaseUrl,
+  resolveMrScraperProxyCountry,
+  resolveMrScraperScrapeTimeoutSeconds,
+  resolveMrScraperUnblockerBaseUrl,
+} from "./config.js";
+
+const ALLOWED_UNBLOCKER_HOSTS = new Set(["api.mrscraper.com"]);
+const ALLOWED_PLATFORM_HOSTS = new Set(["api.app.mrscraper.com", "sync.scraper.mrscraper.com"]);
+const DEFAULT_FETCH_MAX_CHARS = 50_000;
+
+export type MrScraperFetchHtmlParams = {
+  cfg?: OpenClawConfig;
+  url: string;
+  extractMode: "markdown" | "text";
+  maxChars?: number;
+  timeoutSeconds?: number;
+  geoCode?: string;
+  blockResources?: boolean;
+};
+
+export type MrScraperCreateAiScraperParams = {
+  cfg?: OpenClawConfig;
+  url: string;
+  message: string;
+  agent?: "general" | "listing" | "map";
+  proxyCountry?: string;
+  maxDepth?: number;
+  maxPages?: number;
+  limit?: number;
+  includePatterns?: string;
+  excludePatterns?: string;
+  timeoutSeconds?: number;
+};
+
+function resolveEndpoint(params: {
+  baseUrl: string;
+  defaultBaseUrl: string;
+  pathname?: string;
+  allowedHosts: Set<string>;
+  product: string;
+}): string {
+  const candidate = params.baseUrl.trim() || params.defaultBaseUrl;
+  let url: URL;
+  try {
+    url = new URL(candidate);
+  } catch {
+    url = new URL(params.defaultBaseUrl);
+  }
+  if (url.protocol !== "https:") {
+    throw new Error(`${params.product} baseUrl must use https.`);
+  }
+  if (!params.allowedHosts.has(url.hostname)) {
+    throw new Error(`${params.product} baseUrl host is not allowed: ${url.hostname}`);
+  }
+  url.username = "";
+  url.password = "";
+  url.search = "";
+  url.hash = "";
+  if (params.pathname) {
+    url.pathname = params.pathname;
+  }
+  return url.toString();
+}
+
+async function throwHttpError(response: Response, label: string): Promise<never> {
+  let detail =
+    typeof response.statusText === "string" && response.statusText.trim()
+      ? response.statusText.trim()
+      : "request failed";
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      const payload = (await response.json()) as Record<string, unknown>;
+      detail =
+        typeof payload.message === "string"
+          ? payload.message
+          : typeof payload.error === "string"
+            ? payload.error
+            : detail;
+    } catch {
+      // Ignore and fall back to text body parsing below.
+    }
+  } else {
+    const errorBody = await readResponseText(response, { maxBytes: 64_000 });
+    if (errorBody.text) {
+      detail = errorBody.text;
+    }
+  }
+
+  throw new Error(
+    `${label} API error (${response.status}): ${wrapWebContent(detail, "web_fetch")}`,
+  );
+}
+
+function extractTitle(html: string): string | undefined {
+  const match = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  return decodeHtmlEntities(match[1]).trim() || undefined;
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'");
+}
+
+function htmlToPlainText(html: string): string {
+  return decodeHtmlEntities(
+    html
+      .replace(/<script[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style[\s\S]*?<\/style>/gi, " ")
+      .replace(/<noscript[\s\S]*?<\/noscript>/gi, " ")
+      .replace(/<\/(p|div|section|article|main|header|footer|aside|li|tr|h[1-6])>/gi, "\n")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\r/g, "")
+      .replace(/[ \t]+\n/g, "\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .replace(/[ \t]{2,}/g, " ")
+      .trim(),
+  );
+}
+
+function normalizeMaxChars(maxChars?: number): number {
+  if (typeof maxChars === "number" && Number.isFinite(maxChars) && maxChars > 0) {
+    return Math.floor(maxChars);
+  }
+  return DEFAULT_FETCH_MAX_CHARS;
+}
+
+function truncate(value: string, maxChars: number): { text: string; truncated: boolean } {
+  if (value.length <= maxChars) {
+    return { text: value, truncated: false };
+  }
+  return {
+    text: value.slice(0, Math.max(0, maxChars - 1)).trimEnd(),
+    truncated: true,
+  };
+}
+
+export async function runMrScraperFetchHtml(
+  params: MrScraperFetchHtmlParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = resolveMrScraperApiToken(params.cfg);
+  if (!apiToken) {
+    throw new Error(
+      "web_fetch (mrscraper) needs a MrScraper API token. Set MRSCRAPER_API_TOKEN in the Gateway environment, or configure plugins.entries.mrscraper.config.apiToken.",
+    );
+  }
+
+  const baseUrl = resolveEndpoint({
+    baseUrl: resolveMrScraperUnblockerBaseUrl(params.cfg),
+    defaultBaseUrl: "https://api.mrscraper.com",
+    allowedHosts: ALLOWED_UNBLOCKER_HOSTS,
+    product: "MrScraper unblocker",
+  });
+  const timeoutSeconds = resolveTimeoutSeconds(
+    params.timeoutSeconds,
+    resolveMrScraperFetchTimeoutSeconds(params.cfg),
+  );
+  const url = new URL(baseUrl);
+  url.searchParams.set("token", normalizeSecretInput(apiToken));
+  url.searchParams.set("url", params.url);
+  url.searchParams.set("timeout", String(timeoutSeconds));
+  const geoCode = resolveMrScraperGeoCode(params.cfg, params.geoCode);
+  if (geoCode) {
+    url.searchParams.set("geoCode", geoCode);
+  }
+  if (resolveMrScraperBlockResources(params.cfg, params.blockResources)) {
+    url.searchParams.set("blockResources", "true");
+  }
+
+  const start = Date.now();
+  const html = await withStrictWebToolsEndpoint(
+    {
+      url: url.toString(),
+      timeoutSeconds,
+    },
+    async ({ response }) => {
+      if (!response.ok) {
+        await throwHttpError(response, "MrScraper unblocker");
+      }
+      return await response.text();
+    },
+  );
+
+  const title = extractTitle(html);
+  const plainText = htmlToPlainText(html);
+  const maxChars = normalizeMaxChars(params.maxChars);
+  const htmlResult = truncate(html, maxChars);
+  const textResult = truncate(plainText, maxChars);
+  const requestedText = params.extractMode === "text" ? textResult.text : htmlResult.text;
+  const requestedTruncated =
+    params.extractMode === "text" ? textResult.truncated : htmlResult.truncated;
+
+  return {
+    url: params.url,
+    title,
+    status: 200,
+    contentType: "text/html",
+    extractor: "mrscraper",
+    tookMs: Date.now() - start,
+    truncated: requestedTruncated,
+    warning:
+      params.extractMode === "markdown"
+        ? "MrScraper returns rendered HTML for unblocker requests; markdown mode returns the rendered HTML payload."
+        : undefined,
+    text:
+      params.extractMode === "text"
+        ? requestedText
+        : wrapExternalContent(requestedText, { source: "web_fetch", includeWarning: false }),
+    html: wrapExternalContent(htmlResult.text, { source: "web_fetch", includeWarning: false }),
+    renderedText: wrapExternalContent(textResult.text, {
+      source: "web_fetch",
+      includeWarning: false,
+    }),
+  };
+}
+
+export async function runMrScraperCreateAiScraper(
+  params: MrScraperCreateAiScraperParams,
+): Promise<Record<string, unknown>> {
+  const apiToken = resolveMrScraperApiToken(params.cfg);
+  if (!apiToken) {
+    throw new Error(
+      "mrscraper_scrape needs a MrScraper API token. Set MRSCRAPER_API_TOKEN in the Gateway environment, or configure plugins.entries.mrscraper.config.apiToken.",
+    );
+  }
+
+  const endpoint = resolveEndpoint({
+    baseUrl: resolveMrScraperPlatformBaseUrl(params.cfg),
+    defaultBaseUrl: "https://api.app.mrscraper.com",
+    pathname: "/api/v1/scrapers-ai",
+    allowedHosts: ALLOWED_PLATFORM_HOSTS,
+    product: "MrScraper platform",
+  });
+  const timeoutSeconds = resolveTimeoutSeconds(
+    params.timeoutSeconds,
+    resolveMrScraperScrapeTimeoutSeconds(params.cfg),
+  );
+
+  const body: Record<string, unknown> = {
+    url: params.url,
+    message: params.message,
+    agent: params.agent ?? "general",
+  };
+  const proxyCountry = resolveMrScraperProxyCountry(params.cfg, params.proxyCountry);
+  if (proxyCountry) {
+    body.proxyCountry = proxyCountry;
+  }
+  if (params.agent === "map") {
+    if (typeof params.maxDepth === "number") body.maxDepth = Math.floor(params.maxDepth);
+    if (typeof params.maxPages === "number") body.maxPages = Math.floor(params.maxPages);
+    if (typeof params.limit === "number") body.limit = Math.floor(params.limit);
+    if (params.includePatterns) body.includePatterns = params.includePatterns;
+    if (params.excludePatterns) body.excludePatterns = params.excludePatterns;
+  }
+
+  const start = Date.now();
+  const payload = await withStrictWebToolsEndpoint(
+    {
+      url: endpoint,
+      timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          "x-api-token": normalizeSecretInput(apiToken),
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async ({ response }) => {
+      if (!response.ok) {
+        await throwHttpError(response, "MrScraper AI scraper");
+      }
+      return (await response.json()) as Record<string, unknown>;
+    },
+  );
+
+  return {
+    provider: "mrscraper",
+    operation: "create_ai_scraper",
+    tookMs: Date.now() - start,
+    ...payload,
+  };
+}
+
+export const __testing = {
+  decodeHtmlEntities,
+  extractTitle,
+  htmlToPlainText,
+  resolveEndpoint,
+};

--- a/extensions/mrscraper/src/mrscraper-fetch-provider.ts
+++ b/extensions/mrscraper/src/mrscraper-fetch-provider.ts
@@ -1,0 +1,112 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { WebFetchProviderPlugin } from "openclaw/plugin-sdk/provider-web-fetch";
+import { enablePluginInConfig } from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperFetchHtml } from "./mrscraper-client.js";
+
+const MrScraperWebFetchSchema = Type.Object(
+  {
+    url: Type.String({ description: "HTTP or HTTPS URL to fetch through MrScraper." }),
+    extractMode: Type.Optional(
+      Type.Unsafe<"markdown" | "text">({
+        type: "string",
+        enum: ["markdown", "text"],
+        description: 'Output format: "markdown" or "text". Default: markdown.',
+      }),
+    ),
+    maxChars: Type.Optional(
+      Type.Number({
+        description: "Maximum characters to return.",
+        minimum: 100,
+      }),
+    ),
+    timeoutSeconds: Type.Optional(
+      Type.Number({
+        description: "Timeout in seconds for the unblocker request.",
+        minimum: 1,
+      }),
+    ),
+    geoCode: Type.Optional(
+      Type.String({
+        description: "Optional country code for routed unblocker traffic, for example SG or US.",
+      }),
+    ),
+    blockResources: Type.Optional(
+      Type.Boolean({
+        description: "Block images, fonts, and similar resources to speed up fetches.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+function readConfiguredCredential(config?: OpenClawConfig): unknown {
+  return (config?.plugins?.entries?.mrscraper?.config as { apiToken?: unknown } | undefined)
+    ?.apiToken;
+}
+
+export function createMrScraperWebFetchProvider(): WebFetchProviderPlugin {
+  return {
+    id: "mrscraper",
+    label: "MrScraper",
+    hint: "Fetch blocked pages with a stealth browser and IP rotation.",
+    envVars: ["MRSCRAPER_API_TOKEN"],
+    placeholder: "mrs_...",
+    signupUrl: "https://mrscraper.com/",
+    docsUrl: "https://mrscraper.com/",
+    autoDetectOrder: 60,
+    credentialPath: "plugins.entries.mrscraper.config.apiToken",
+    inactiveSecretPaths: ["plugins.entries.mrscraper.config.apiToken"],
+    getCredentialValue: (fetchConfig) => {
+      if (!fetchConfig || typeof fetchConfig !== "object") {
+        return undefined;
+      }
+      const scoped = (fetchConfig as { mrscraper?: { apiToken?: unknown } }).mrscraper;
+      return scoped?.apiToken;
+    },
+    setCredentialValue: (fetchConfigTarget, value) => {
+      const current =
+        fetchConfigTarget.mrscraper &&
+        typeof fetchConfigTarget.mrscraper === "object" &&
+        !Array.isArray(fetchConfigTarget.mrscraper)
+          ? (fetchConfigTarget.mrscraper as Record<string, unknown>)
+          : {};
+      current.apiToken = value;
+      fetchConfigTarget.mrscraper = current;
+    },
+    getConfiguredCredentialValue: (config) => readConfiguredCredential(config),
+    setConfiguredCredentialValue: (configTarget, value) => {
+      const plugins = (configTarget.plugins ??= {});
+      const entries = (plugins.entries ??= {});
+      const entry = (entries.mrscraper ??= {});
+      const pluginConfig =
+        entry.config && typeof entry.config === "object" && !Array.isArray(entry.config)
+          ? (entry.config as Record<string, unknown>)
+          : ((entry.config = {}), entry.config as Record<string, unknown>);
+      pluginConfig.apiToken = value;
+    },
+    applySelectionConfig: (config) => enablePluginInConfig(config, "mrscraper").config,
+    createTool: ({ config }) => ({
+      description:
+        "Fetch a page through MrScraper's unblocker. Helpful for JS-heavy or bot-protected pages.",
+      parameters: MrScraperWebFetchSchema,
+      execute: async (args) =>
+        await runMrScraperFetchHtml({
+          cfg: config,
+          url: typeof args.url === "string" ? args.url : "",
+          extractMode: args.extractMode === "text" ? "text" : "markdown",
+          maxChars:
+            typeof args.maxChars === "number" && Number.isFinite(args.maxChars)
+              ? Math.floor(args.maxChars)
+              : undefined,
+          timeoutSeconds:
+            typeof args.timeoutSeconds === "number" && Number.isFinite(args.timeoutSeconds)
+              ? Math.floor(args.timeoutSeconds)
+              : undefined,
+          geoCode: typeof args.geoCode === "string" ? args.geoCode : undefined,
+          blockResources:
+            typeof args.blockResources === "boolean" ? args.blockResources : undefined,
+        }),
+    }),
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-fetch-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-fetch-tool.ts
@@ -1,0 +1,76 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperFetchHtml } from "./mrscraper-client.js";
+
+const MrScraperFetchHtmlSchema = Type.Object(
+  {
+    url: Type.String({ description: "HTTP or HTTPS URL to fetch through MrScraper." }),
+    extractMode: Type.Optional(
+      Type.Unsafe<"markdown" | "text">({
+        type: "string",
+        enum: ["markdown", "text"],
+        description: 'Output format: "markdown" or "text". Default: markdown.',
+      }),
+    ),
+    maxChars: Type.Optional(
+      Type.Number({
+        description: "Maximum characters to return.",
+        minimum: 100,
+      }),
+    ),
+    timeoutSeconds: Type.Optional(
+      Type.Number({
+        description: "Timeout in seconds for the unblocker request.",
+        minimum: 1,
+      }),
+    ),
+    geoCode: Type.Optional(
+      Type.String({
+        description: "Optional country code for routed unblocker traffic, for example SG or US.",
+      }),
+    ),
+    blockResources: Type.Optional(
+      Type.Boolean({
+        description: "Block images, fonts, and similar resources to speed up fetches.",
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperFetchHtmlTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_fetch_html",
+    label: "MrScraper Fetch HTML",
+    description:
+      "Open a page through MrScraper's unblocker and return the rendered HTML plus extracted text.",
+    parameters: MrScraperFetchHtmlSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const url = readStringParam(rawParams, "url", { required: true });
+      const extractMode =
+        readStringParam(rawParams, "extractMode") === "text" ? "text" : "markdown";
+      const maxChars = readNumberParam(rawParams, "maxChars", { integer: true });
+      const timeoutSeconds = readNumberParam(rawParams, "timeoutSeconds", { integer: true });
+      const geoCode = readStringParam(rawParams, "geoCode");
+      const blockResources =
+        typeof rawParams.blockResources === "boolean" ? rawParams.blockResources : undefined;
+
+      return jsonResult(
+        await runMrScraperFetchHtml({
+          cfg: api.config,
+          url,
+          extractMode,
+          maxChars,
+          timeoutSeconds,
+          geoCode,
+          blockResources,
+        }),
+      );
+    },
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-scrape-tool.ts
+++ b/extensions/mrscraper/src/mrscraper-scrape-tool.ts
@@ -1,0 +1,102 @@
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-runtime";
+import {
+  jsonResult,
+  readNumberParam,
+  readStringParam,
+} from "openclaw/plugin-sdk/provider-web-fetch";
+import { runMrScraperCreateAiScraper } from "./mrscraper-client.js";
+
+const MrScraperScrapeSchema = Type.Object(
+  {
+    url: Type.String({ description: "Target URL to scrape." }),
+    message: Type.String({ description: "Plain-language extraction instructions." }),
+    agent: Type.Optional(
+      Type.Unsafe<"general" | "listing" | "map">({
+        type: "string",
+        enum: ["general", "listing", "map"],
+        description: 'MrScraper agent type: "general", "listing", or "map".',
+      }),
+    ),
+    proxyCountry: Type.Optional(
+      Type.String({ description: "Optional ISO country code for proxy routing." }),
+    ),
+    maxDepth: Type.Optional(
+      Type.Number({
+        description: "Map-agent only: maximum crawl depth.",
+        minimum: 0,
+      }),
+    ),
+    maxPages: Type.Optional(
+      Type.Number({
+        description: "Map-agent only: maximum pages to crawl.",
+        minimum: 1,
+      }),
+    ),
+    limit: Type.Optional(
+      Type.Number({
+        description: "Map-agent only: maximum extracted records.",
+        minimum: 1,
+      }),
+    ),
+    includePatterns: Type.Optional(
+      Type.String({
+        description: "Map-agent only: regex URL include patterns separated with ||.",
+      }),
+    ),
+    excludePatterns: Type.Optional(
+      Type.String({
+        description: "Map-agent only: regex URL exclude patterns separated with ||.",
+      }),
+    ),
+    timeoutSeconds: Type.Optional(
+      Type.Number({
+        description: "HTTP timeout in seconds for the API request.",
+        minimum: 1,
+      }),
+    ),
+  },
+  { additionalProperties: false },
+);
+
+export function createMrScraperScrapeTool(api: OpenClawPluginApi) {
+  return {
+    name: "mrscraper_scrape",
+    label: "MrScraper Scrape",
+    description:
+      "Create a MrScraper AI scraper run from plain-language instructions and return the platform response.",
+    parameters: MrScraperScrapeSchema,
+    execute: async (_toolCallId: string, rawParams: Record<string, unknown>) => {
+      const url = readStringParam(rawParams, "url", { required: true });
+      const message = readStringParam(rawParams, "message", { required: true });
+      const agentRaw = readStringParam(rawParams, "agent");
+      const agent =
+        agentRaw === "listing" || agentRaw === "map" || agentRaw === "general"
+          ? agentRaw
+          : undefined;
+      const proxyCountry = readStringParam(rawParams, "proxyCountry");
+      const includePatterns = readStringParam(rawParams, "includePatterns");
+      const excludePatterns = readStringParam(rawParams, "excludePatterns");
+      const maxDepth = readNumberParam(rawParams, "maxDepth", { integer: true });
+      const maxPages = readNumberParam(rawParams, "maxPages", { integer: true });
+      const limit = readNumberParam(rawParams, "limit", { integer: true });
+      const timeoutSeconds = readNumberParam(rawParams, "timeoutSeconds", { integer: true });
+
+      return jsonResult(
+        await runMrScraperCreateAiScraper({
+          cfg: api.config,
+          url,
+          message,
+          agent,
+          proxyCountry,
+          maxDepth,
+          maxPages,
+          limit,
+          includePatterns,
+          excludePatterns,
+          timeoutSeconds,
+        }),
+      );
+    },
+  };
+}

--- a/extensions/mrscraper/src/mrscraper-tools.test.ts
+++ b/extensions/mrscraper/src/mrscraper-tools.test.ts
@@ -1,0 +1,241 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MRSCRAPER_FETCH_TIMEOUT_SECONDS,
+  DEFAULT_MRSCRAPER_PLATFORM_BASE_URL,
+  DEFAULT_MRSCRAPER_SCRAPE_TIMEOUT_SECONDS,
+  DEFAULT_MRSCRAPER_UNBLOCKER_BASE_URL,
+  resolveMrScraperApiToken,
+  resolveMrScraperBlockResources,
+  resolveMrScraperFetchTimeoutSeconds,
+  resolveMrScraperPlatformBaseUrl,
+  resolveMrScraperProxyCountry,
+  resolveMrScraperScrapeTimeoutSeconds,
+  resolveMrScraperUnblockerBaseUrl,
+} from "./config.js";
+
+const { runMrScraperFetchHtml, runMrScraperCreateAiScraper } = vi.hoisted(() => ({
+  runMrScraperFetchHtml: vi.fn(async (params: Record<string, unknown>) => params),
+  runMrScraperCreateAiScraper: vi.fn(async (params: Record<string, unknown>) => params),
+}));
+
+vi.mock("./mrscraper-client.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("./mrscraper-client.js")>("./mrscraper-client.js");
+  return {
+    ...actual,
+    runMrScraperFetchHtml,
+    runMrScraperCreateAiScraper,
+  };
+});
+
+describe("mrscraper tools", () => {
+  let createMrScraperWebFetchProvider: typeof import("./mrscraper-fetch-provider.js").createMrScraperWebFetchProvider;
+  let createMrScraperFetchHtmlTool: typeof import("./mrscraper-fetch-tool.js").createMrScraperFetchHtmlTool;
+  let createMrScraperScrapeTool: typeof import("./mrscraper-scrape-tool.js").createMrScraperScrapeTool;
+  let mrscraperClientTesting: typeof import("./mrscraper-client.js").__testing;
+
+  beforeAll(async () => {
+    ({ createMrScraperWebFetchProvider } = await import("./mrscraper-fetch-provider.js"));
+    ({ createMrScraperFetchHtmlTool } = await import("./mrscraper-fetch-tool.js"));
+    ({ createMrScraperScrapeTool } = await import("./mrscraper-scrape-tool.js"));
+    ({ __testing: mrscraperClientTesting } =
+      await vi.importActual<typeof import("./mrscraper-client.js")>("./mrscraper-client.js"));
+  });
+
+  beforeEach(() => {
+    runMrScraperFetchHtml.mockReset();
+    runMrScraperFetchHtml.mockImplementation(async (params: Record<string, unknown>) => params);
+    runMrScraperCreateAiScraper.mockReset();
+    runMrScraperCreateAiScraper.mockImplementation(
+      async (params: Record<string, unknown>) => params,
+    );
+    vi.unstubAllEnvs();
+  });
+
+  it("exposes fetch-provider metadata and enables the plugin", () => {
+    const provider = createMrScraperWebFetchProvider();
+    if (!provider.applySelectionConfig) {
+      throw new Error("Expected applySelectionConfig to be defined");
+    }
+    const applied = provider.applySelectionConfig({});
+
+    expect(provider.id).toBe("mrscraper");
+    expect(provider.credentialPath).toBe("plugins.entries.mrscraper.config.apiToken");
+    expect(applied.plugins?.entries?.mrscraper?.enabled).toBe(true);
+  });
+
+  it("maps web_fetch provider args into MrScraper unblocker params", async () => {
+    const provider = createMrScraperWebFetchProvider();
+    const tool = provider.createTool({
+      config: { test: true },
+    } as never);
+    if (!tool) {
+      throw new Error("Expected tool definition");
+    }
+
+    await tool.execute({
+      url: "https://example.com",
+      extractMode: "text",
+      maxChars: 1234,
+      timeoutSeconds: 30,
+      geoCode: "SG",
+      blockResources: true,
+    });
+
+    expect(runMrScraperFetchHtml).toHaveBeenCalledWith({
+      cfg: { test: true },
+      url: "https://example.com",
+      extractMode: "text",
+      maxChars: 1234,
+      timeoutSeconds: 30,
+      geoCode: "SG",
+      blockResources: true,
+    });
+  });
+
+  it("normalizes explicit fetch-tool parameters", async () => {
+    const tool = createMrScraperFetchHtmlTool({
+      config: { env: "test" },
+    } as never);
+
+    const result = await tool.execute("call-1", {
+      url: "https://example.com",
+      extractMode: "markdown",
+      maxChars: 1500,
+      timeoutSeconds: 45,
+      geoCode: "US",
+      blockResources: false,
+    });
+
+    expect(runMrScraperFetchHtml).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      url: "https://example.com",
+      extractMode: "markdown",
+      maxChars: 1500,
+      timeoutSeconds: 45,
+      geoCode: "US",
+      blockResources: false,
+    });
+    expect(result.details).toMatchObject({
+      cfg: { env: "test" },
+      url: "https://example.com",
+    });
+  });
+
+  it("normalizes explicit AI scrape parameters", async () => {
+    const tool = createMrScraperScrapeTool({
+      config: { env: "test" },
+    } as never);
+
+    const result = await tool.execute("call-2", {
+      url: "https://example.com/catalog",
+      message: "Extract names and prices",
+      agent: "map",
+      proxyCountry: "US",
+      maxDepth: 2,
+      maxPages: 10,
+      limit: 50,
+      includePatterns: ".*/products/.*",
+      excludePatterns: ".*/cart/.*",
+      timeoutSeconds: 90,
+    });
+
+    expect(runMrScraperCreateAiScraper).toHaveBeenCalledWith({
+      cfg: { env: "test" },
+      url: "https://example.com/catalog",
+      message: "Extract names and prices",
+      agent: "map",
+      proxyCountry: "US",
+      maxDepth: 2,
+      maxPages: 10,
+      limit: 50,
+      includePatterns: ".*/products/.*",
+      excludePatterns: ".*/cart/.*",
+      timeoutSeconds: 90,
+    });
+    expect(result.details).toMatchObject({
+      cfg: { env: "test" },
+      agent: "map",
+    });
+  });
+
+  it("prefers plugin config over env defaults and falls back cleanly", () => {
+    vi.stubEnv("MRSCRAPER_API_TOKEN", "env-token");
+
+    const cfg = {
+      plugins: {
+        entries: {
+          mrscraper: {
+            config: {
+              apiToken: "plugin-token",
+              webFetch: {
+                baseUrl: "https://api.mrscraper.com",
+                timeoutSeconds: 75,
+                geoCode: "GB",
+                blockResources: true,
+              },
+              platform: {
+                baseUrl: "https://api.app.mrscraper.com",
+                timeoutSeconds: 150,
+                proxyCountry: "SG",
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveMrScraperApiToken(cfg)).toBe("plugin-token");
+    expect(resolveMrScraperUnblockerBaseUrl(cfg)).toBe("https://api.mrscraper.com");
+    expect(resolveMrScraperPlatformBaseUrl(cfg)).toBe("https://api.app.mrscraper.com");
+    expect(resolveMrScraperFetchTimeoutSeconds(cfg)).toBe(75);
+    expect(resolveMrScraperScrapeTimeoutSeconds(cfg)).toBe(150);
+    expect(resolveMrScraperProxyCountry(cfg)).toBe("SG");
+    expect(resolveMrScraperBlockResources(cfg)).toBe(true);
+  });
+
+  it("uses default config values when plugin config is missing", () => {
+    vi.stubEnv("MRSCRAPER_API_TOKEN", "env-token");
+
+    expect(resolveMrScraperApiToken()).toBe("env-token");
+    expect(resolveMrScraperUnblockerBaseUrl()).toBe(DEFAULT_MRSCRAPER_UNBLOCKER_BASE_URL);
+    expect(resolveMrScraperPlatformBaseUrl()).toBe(DEFAULT_MRSCRAPER_PLATFORM_BASE_URL);
+    expect(resolveMrScraperFetchTimeoutSeconds()).toBe(DEFAULT_MRSCRAPER_FETCH_TIMEOUT_SECONDS);
+    expect(resolveMrScraperScrapeTimeoutSeconds()).toBe(DEFAULT_MRSCRAPER_SCRAPE_TIMEOUT_SECONDS);
+    expect(resolveMrScraperBlockResources()).toBe(false);
+  });
+
+  it("extracts useful text from rendered html", () => {
+    expect(
+      mrscraperClientTesting.htmlToPlainText(
+        "<html><head><title>Example</title></head><body><main><h1>Hello</h1><p>World</p></main></body></html>",
+      ),
+    ).toContain("Hello");
+    expect(
+      mrscraperClientTesting.extractTitle(
+        "<html><head><title>Example &amp; Test</title></head><body></body></html>",
+      ),
+    ).toBe("Example & Test");
+  });
+
+  it("keeps endpoint host allowlists strict", () => {
+    expect(
+      mrscraperClientTesting.resolveEndpoint({
+        baseUrl: "https://api.mrscraper.com",
+        defaultBaseUrl: "https://api.mrscraper.com",
+        allowedHosts: new Set(["api.mrscraper.com"]),
+        product: "MrScraper unblocker",
+      }),
+    ).toBe("https://api.mrscraper.com/");
+
+    expect(() =>
+      mrscraperClientTesting.resolveEndpoint({
+        baseUrl: "https://evil.example.com",
+        defaultBaseUrl: "https://api.mrscraper.com",
+        allowedHosts: new Set(["api.mrscraper.com"]),
+        product: "MrScraper unblocker",
+      }),
+    ).toThrow("MrScraper unblocker baseUrl host is not allowed");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -550,6 +550,8 @@ importers:
 
   extensions/moonshot: {}
 
+  extensions/mrscraper: {}
+
   extensions/msteams:
     dependencies:
       '@microsoft/teams.api':

--- a/src/plugins/contracts/plugin-registration.mrscraper.contract.test.ts
+++ b/src/plugins/contracts/plugin-registration.mrscraper.contract.test.ts
@@ -1,0 +1,4 @@
+import { pluginRegistrationContractCases } from "../../../test/helpers/plugins/plugin-registration-contract-cases.js";
+import { describePluginRegistrationContract } from "../../../test/helpers/plugins/plugin-registration-contract.js";
+
+describePluginRegistrationContract(pluginRegistrationContractCases.mrscraper);

--- a/test/helpers/plugins/plugin-registration-contract-cases.ts
+++ b/test/helpers/plugins/plugin-registration-contract-cases.ts
@@ -68,6 +68,11 @@ export const pluginRegistrationContractCases = {
     speechProviderIds: ["microsoft"],
     requireSpeechVoices: true,
   },
+  mrscraper: {
+    pluginId: "mrscraper",
+    webFetchProviderIds: ["mrscraper"],
+    toolNames: ["mrscraper_fetch_html", "mrscraper_scrape"],
+  },
   minimax: {
     pluginId: "minimax",
     providerIds: ["minimax", "minimax-portal"],


### PR DESCRIPTION

## Summary

- Problem: OpenClaw did not have a bundled MrScraper integration, so users could not use MrScraper through the bundled plugin system or select it as a managed plugin-owned web tool provider.
- Why it matters: MrScraper can improve blocked-page fetching and AI-powered extraction without requiring users to maintain a custom third-party plugin.
- What changed: Added a bundled `extensions/mrscraper` plugin with a `web_fetch` provider, explicit `mrscraper_fetch_html` and `mrscraper_scrape` tools, plugin-owned config under `plugins.entries.mrscraper.config.*`, plugin skill metadata, tests, changelog entry, and labeler wiring.
- What did NOT change (scope boundary): This PR does not add MrScraper as a `web_search` provider because the current MrScraper API surface used here does not expose a native search-query endpoint that matches OpenClaw’s managed `web_search` contract.

## Change Type (select all)

- [x] Feature
- [x] Docs
- [x] API / contracts

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Auth / tokens
- [x] Integrations
- [x] API / contracts
- [x] UI / DX

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/mrscraper/src/mrscraper-tools.test.ts`
  - `src/plugins/contracts/plugin-registration.mrscraper.contract.test.ts`
  - `src/plugins/contracts/web-fetch-provider.contract.test.ts`
- Scenario the test should lock in: bundled plugin registration, plugin enablement/config wiring, fetch-provider argument mapping, API token/config fallback behavior, and strict endpoint host validation.
- Why this is the smallest reliable guardrail: the change is a bundled plugin plus contract wiring, so targeted plugin tests plus contract coverage verify behavior without needing unrelated full-suite churn.
- Existing test that already covers this (if any): shared web-fetch provider contract coverage applies once the plugin is registered.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Users can enable the bundled `mrscraper` plugin and use it for managed `web_fetch`.
- Users get explicit `mrscraper_fetch_html` and `mrscraper_scrape` tools.
- Users can configure MrScraper through `plugins.entries.mrscraper.config.*` or `MRSCRAPER_API_TOKEN`.

## Diagram (if applicable)

```text
Before:
[user enables bundled plugins] -> [no MrScraper integration available]

After:
[user enables mrscraper] -> [plugin registers web_fetch + tools] -> [blocked-page fetch or AI scrape available]
```

## Security Impact (required)

- New permissions/capabilities? `Yes`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `Yes`
- Command/tool execution surface changed? `Yes`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  - Adds new bundled networked tool surfaces to `api.mrscraper.com` and `api.app.mrscraper.com`.
  - API token handling is plugin-owned and uses the existing secret-input/config patterns plus env fallback.
  - Endpoint resolution is restricted to an explicit HTTPS host allowlist to avoid arbitrary base-URL SSRF expansion.
  - No new local command execution is added; the new tool surface is HTTP-only.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `plugins.entries.mrscraper.config.apiToken`, optional `webFetch` / `platform` config

### Steps

1. Add the bundled `mrscraper` plugin files and contract wiring.
2. Run targeted plugin and contract tests.
3. Confirm provider metadata, config wiring, and tool argument mapping pass.

### Expected

- Bundled plugin registers cleanly.
- `mrscraper` is available as a web-fetch provider.
- Explicit MrScraper tools execute through the plugin-owned runtime surfaces.
- Targeted tests pass.

### Actual

- Targeted tests passed.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios:
  - Added bundled plugin registration and manifest wiring.
  - Verified `web_fetch` provider metadata and plugin enablement.
  - Verified explicit tool argument mapping for fetch and scrape tools.
  - Verified config/env token fallback and strict endpoint allowlists.
- Edge cases checked:
  - Missing tool nullability in test setup.
  - Invalid endpoint host rejection.
  - Plugin-config-over-env precedence.
- What you did **not** verify:
  - Live MrScraper API calls against real credentials.
  - Broader repo gates like `pnpm check` or `pnpm build`.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes`
- Migration needed? `No`
- If yes, exact upgrade steps:
  - N/A

## Risks and Mitigations

- Risk: reviewers may expect MrScraper to appear under managed `web_search`.
  - Mitigation: PR summary explicitly scopes this to `web_fetch` plus explicit tools because the current API surface does not provide a native OpenClaw-style search provider contract.
- Risk: vendor endpoint overrides could widen network reach.
  - Mitigation: runtime endpoint resolution is restricted to explicit allowed HTTPS hosts.
- Risk: live API response shapes may differ from documented examples.
  - Mitigation: this PR keeps the surface narrow, uses targeted mapping tests, and avoids claiming unsupported search-provider behavior.