### PR TITLE
fix: add "file" param alias to tool display path resolution

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -28,147 +28,69 @@
     "bash": {
       "emoji": "🛠️",
       "title": "Bash",
-      "detailKeys": [
-        "command"
-      ]
+      "detailKeys": ["command"]
     },
     "process": {
       "emoji": "🧰",
       "title": "Process",
-      "detailKeys": [
-        "sessionId"
-      ]
+      "detailKeys": ["sessionId"]
     },
     "read": {
       "emoji": "📖",
       "title": "Read",
-      "detailKeys": [
-        "path"
-      ]
+      "detailKeys": ["path", "file_path", "filePath", "file"]
     },
     "write": {
       "emoji": "✍️",
       "title": "Write",
-      "detailKeys": [
-        "path"
-      ]
+      "detailKeys": ["path", "file_path", "filePath", "file"]
     },
     "edit": {
       "emoji": "📝",
       "title": "Edit",
-      "detailKeys": [
-        "path"
-      ]
+      "detailKeys": ["path", "file_path", "filePath", "file"]
     },
     "attach": {
       "emoji": "📎",
       "title": "Attach",
-      "detailKeys": [
-        "path",
-        "url",
-        "fileName"
-      ]
+      "detailKeys": ["path", "url", "fileName"]
     },
     "browser": {
       "emoji": "🌐",
       "title": "Browser",
       "actions": {
-        "status": {
-          "label": "status"
-        },
-        "start": {
-          "label": "start"
-        },
-        "stop": {
-          "label": "stop"
-        },
-        "tabs": {
-          "label": "tabs"
-        },
-        "open": {
-          "label": "open",
-          "detailKeys": [
-            "targetUrl"
-          ]
-        },
-        "focus": {
-          "label": "focus",
-          "detailKeys": [
-            "targetId"
-          ]
-        },
-        "close": {
-          "label": "close",
-          "detailKeys": [
-            "targetId"
-          ]
-        },
+        "status": { "label": "status" },
+        "start": { "label": "start" },
+        "stop": { "label": "stop" },
+        "tabs": { "label": "tabs" },
+        "open": { "label": "open", "detailKeys": ["targetUrl"] },
+        "focus": { "label": "focus", "detailKeys": ["targetId"] },
+        "close": { "label": "close", "detailKeys": ["targetId"] },
         "snapshot": {
           "label": "snapshot",
-          "detailKeys": [
-            "targetUrl",
-            "targetId",
-            "ref",
-            "element",
-            "format"
-          ]
+          "detailKeys": ["targetUrl", "targetId", "ref", "element", "format"]
         },
         "screenshot": {
           "label": "screenshot",
-          "detailKeys": [
-            "targetUrl",
-            "targetId",
-            "ref",
-            "element"
-          ]
+          "detailKeys": ["targetUrl", "targetId", "ref", "element"]
         },
         "navigate": {
           "label": "navigate",
-          "detailKeys": [
-            "targetUrl",
-            "targetId"
-          ]
+          "detailKeys": ["targetUrl", "targetId"]
         },
-        "console": {
-          "label": "console",
-          "detailKeys": [
-            "level",
-            "targetId"
-          ]
-        },
-        "pdf": {
-          "label": "pdf",
-          "detailKeys": [
-            "targetId"
-          ]
-        },
+        "console": { "label": "console", "detailKeys": ["level", "targetId"] },
+        "pdf": { "label": "pdf", "detailKeys": ["targetId"] },
         "upload": {
           "label": "upload",
-          "detailKeys": [
-            "paths",
-            "ref",
-            "inputRef",
-            "element",
-            "targetId"
-          ]
+          "detailKeys": ["paths", "ref", "inputRef", "element", "targetId"]
         },
         "dialog": {
           "label": "dialog",
-          "detailKeys": [
-            "accept",
-            "promptText",
-            "targetId"
-          ]
+          "detailKeys": ["accept", "promptText", "targetId"]
         },
         "act": {
           "label": "act",
-          "detailKeys": [
-            "request.kind",
-            "request.ref",
-            "request.selector",
-            "request.text",
-            "request.value"
-          ]
+          "detailKeys": ["request.kind", "request.ref", "request.selector", "request.text", "request.value"]
         }
       }
     },
@@ -176,136 +98,31 @@
       "emoji": "🖼️",
       "title": "Canvas",
       "actions": {
-        "present": {
-          "label": "present",
-          "detailKeys": [
-            "target",
-            "node",
-            "nodeId"
-          ]
-        },
-        "hide": {
-          "label": "hide",
-          "detailKeys": [
-            "node",
-            "nodeId"
-          ]
-        },
-        "navigate": {
-          "label": "navigate",
-          "detailKeys": [
-            "url",
-            "node",
-            "nodeId"
-          ]
-        },
-        "eval": {
-          "label": "eval",
-          "detailKeys": [
-            "javaScript",
-            "node",
-            "nodeId"
-          ]
-        },
-        "snapshot": {
-          "label": "snapshot",
-          "detailKeys": [
-            "format",
-            "node",
-            "nodeId"
-          ]
-        },
-        "a2ui_push": {
-          "label": "A2UI push",
-          "detailKeys": [
-            "jsonlPath",
-            "node",
-            "nodeId"
-          ]
-        },
-        "a2ui_reset": {
-          "label": "A2UI reset",
-          "detailKeys": [
-            "node",
-            "nodeId"
-          ]
-        }
+        "present": { "label": "present", "detailKeys": ["target", "node", "nodeId"] },
+        "hide": { "label": "hide", "detailKeys": ["node", "nodeId"] },
+        "navigate": { "label": "navigate", "detailKeys": ["url", "node", "nodeId"] },
+        "eval": { "label": "eval", "detailKeys": ["javaScript", "node", "nodeId"] },
+        "snapshot": { "label": "snapshot", "detailKeys": ["format", "node", "nodeId"] },
+        "a2ui_push": { "label": "A2UI push", "detailKeys": ["jsonlPath", "node", "nodeId"] },
+        "a2ui_reset": { "label": "A2UI reset", "detailKeys": ["node", "nodeId"] }
       }
     },
     "nodes": {
       "emoji": "📱",
       "title": "Nodes",
       "actions": {
-        "status": {
-          "label": "status"
-        },
-        "describe": {
-          "label": "describe",
-          "detailKeys": [
-            "node",
-            "nodeId"
-          ]
-        },
-        "pending": {
-          "label": "pending"
-        },
-        "approve": {
-          "label": "approve",
-          "detailKeys": [
-            "requestId"
-          ]
-        },
-        "reject": {
-          "label": "reject",
-          "detailKeys": [
-            "requestId"
-          ]
-        },
-        "notify": {
-          "label": "notify",
-          "detailKeys": [
-            "node",
-            "nodeId",
-            "title",
-            "body"
-          ]
-        },
-        "camera_snap": {
-          "label": "camera snap",
-          "detailKeys": [
-            "node",
-            "nodeId",
-            "facing",
-            "deviceId"
-          ]
-        },
-        "camera_list": {
-          "label": "camera list",
-          "detailKeys": [
-            "node",
-            "nodeId"
-          ]
-        },
-        "camera_clip": {
-          "label": "camera clip",
-          "detailKeys": [
-            "node",
-            "nodeId",
-            "facing",
-            "duration",
-            "durationMs"
-          ]
-        },
+        "status": { "label": "status" },
+        "describe": { "label": "describe", "detailKeys": ["node", "nodeId"] },
+        "pending": { "label": "pending" },
+        "approve": { "label": "approve", "detailKeys": ["requestId"] },
+        "reject": { "label": "reject", "detailKeys": ["requestId"] },
+        "notify": { "label": "notify", "detailKeys": ["node", "nodeId", "title", "body"] },
+        "camera_snap": { "label": "camera snap", "detailKeys": ["node", "nodeId", "facing", "deviceId"] },
+        "camera_list": { "label": "camera list", "detailKeys": ["node", "nodeId"] },
+        "camera_clip": { "label": "camera clip", "detailKeys": ["node", "nodeId", "facing", "duration", "durationMs"] },
         "screen_record": {
           "label": "screen record",
-          "detailKeys": [
-            "node",
-            "nodeId",
-            "duration",
-            "durationMs",
-            "fps",
-            "screenIndex"
-          ]
+          "detailKeys": ["node", "nodeId", "duration", "durationMs", "fps", "screenIndex"]
         }
       }
     },
@@ -313,798 +130,68 @@
       "emoji": "⏰",
       "title": "Cron",
       "actions": {
-        "status": {
-          "label": "status"
-        },
-        "list": {
-          "label": "list"
-        },
+        "status": { "label": "status" },
+        "list": { "label": "list" },
         "add": {
           "label": "add",
-          "detailKeys": [
-            "job.name",
-            "job.id",
-            "job.schedule",
-            "job.cron"
-          ]
+          "detailKeys": ["job.name", "job.id", "job.schedule", "job.cron"]
         },
-        "update": {
-          "label": "update",
-          "detailKeys": [
-            "id"
-          ]
-        },
-        "remove": {
-          "label": "remove",
-          "detailKeys": [
-            "id"
-          ]
-        },
-        "run": {
-          "label": "run",
-          "detailKeys": [
-            "id"
-          ]
-        },
-        "runs": {
-          "label": "runs",
-          "detailKeys": [
-            "id"
-          ]
-        },
-        "wake": {
-          "label": "wake",
-          "detailKeys": [
-            "text",
-            "mode"
-          ]
-        }
+        "update": { "label": "update", "detailKeys": ["id"] },
+        "remove": { "label": "remove", "detailKeys": ["id"] },
+        "run": { "label": "run", "detailKeys": ["id"] },
+        "runs": { "label": "runs", "detailKeys": ["id"] },
+        "wake": { "label": "wake", "detailKeys": ["text", "mode"] }
       }
-    },
-    "update_plan": {
-      "emoji": "🗺️",
-      "title": "Update Plan",
-      "detailKeys": [
-        "explanation",
-        "plan.0.step"
-      ]
     },
     "gateway": {
       "emoji": "🔌",
       "title": "Gateway",
       "actions": {
-        "restart": {
-          "label": "restart",
-          "detailKeys": [
-            "reason",
-            "delayMs"
-          ]
-        }
+        "restart": { "label": "restart", "detailKeys": ["reason", "delayMs"] }
       }
     },
     "whatsapp_login": {
       "emoji": "🟢",
       "title": "WhatsApp Login",
       "actions": {
-        "start": {
-          "label": "start"
-        },
-        "wait": {
-          "label": "wait"
-        }
+        "start": { "label": "start" },
+        "wait": { "label": "wait" }
       }
     },
     "discord": {
       "emoji": "💬",
       "title": "Discord",
       "actions": {
-        "react": {
-          "label": "react",
-          "detailKeys": [
-            "channelId",
-            "messageId",
-            "emoji"
-          ]
-        },
-        "reactions": {
-          "label": "reactions",
-          "detailKeys": [
-            "channelId",
-            "messageId"
-          ]
-        },
-        "sticker": {
-          "label": "sticker",
-          "detailKeys": [
-            "to",
-            "stickerIds"
-          ]
-        },
-        "poll": {
-          "label": "poll",
-          "detailKeys": [
-            "question",
-            "to"
-          ]
-        },
-        "permissions": {
-          "label": "permissions",
-          "detailKeys": [
-            "channelId"
-          ]
-        },
-        "readMessages": {
-          "label": "read messages",
-          "detailKeys": [
-            "channelId",
-            "limit"
-          ]
-        },
-        "sendMessage": {
-          "label": "send",
-          "detailKeys": [
-            "to",
-            "content"
-          ]
-        },
-        "editMessage": {
-          "label": "edit",
-          "detailKeys": [
-            "channelId",
-            "messageId"
-          ]
-        },
-        "deleteMessage": {
-          "label": "delete",
-          "detailKeys": [
-            "channelId",
-            "messageId"
-          ]
-        },
-        "threadCreate": {
-          "label": "thread create",
-          "detailKeys": [
-            "channelId",
-            "name"
-          ]
-        },
-        "threadList": {
-          "label": "thread list",
-          "detailKeys": [
-            "guildId",
-            "channelId"
-          ]
-        },
-        "threadReply": {
-          "label": "thread reply",
-          "detailKeys": [
-            "channelId",
-            "content"
-          ]
-        },
-        "pinMessage": {
-          "label": "pin",
-          "detailKeys": [
-            "channelId",
-            "messageId"
-          ]
-        },
-        "unpinMessage": {
-          "label": "unpin",
-          "detailKeys": [
-            "channelId",
-            "messageId"
-          ]
-        },
-        "listPins": {
-          "label": "list pins",
-          "detailKeys": [
-            "channelId"
-          ]
-        },
-        "searchMessages": {
-          "label": "search",
-          "detailKeys": [
-            "guildId",
-            "content"
-          ]
-        },
-        "memberInfo": {
-          "label": "member",
-          "detailKeys": [
-            "guildId",
-            "userId"
-          ]
-        },
-        "roleInfo": {
-          "label": "roles",
-          "detailKeys": [
-            "guildId"
-          ]
-        },
-        "emojiList": {
-          "label": "emoji list",
-          "detailKeys": [
-            "guildId"
-          ]
-        },
-        "roleAdd": {
-          "label": "role add",
-          "detailKeys": [
-            "guildId",
-            "userId",
-            "roleId"
-          ]
-        },
-        "roleRemove": {
-          "label": "role remove",
-          "detailKeys": [
-            "guildId",
-            "userId",
-            "roleId"
-          ]
-        },
-        "channelInfo": {
-          "label": "channel",
-          "detailKeys": [
-            "channelId"
-          ]
-        },
-        "channelList": {
-          "label": "channels",
-          "detailKeys": [
-            "guildId"
-          ]
-        },
-        "voiceStatus": {
-          "label": "voice",
-          "detailKeys": [
-            "guildId",
-            "userId"
-          ]
-        },
-        "eventList": {
-          "label": "events",
-          "detailKeys": [
-            "guildId"
-          ]
-        },
-        "eventCreate": {
-          "label": "event create",
-          "detailKeys": [
-            "guildId",
-            "name"
-          ]
-        },
-        "timeout": {
-          "label": "timeout",
-          "detailKeys": [
-            "guildId",
-            "userId"
-          ]
-        },
-        "kick": {
-          "label": "kick",
-          "detailKeys": [
-            "guildId",
-            "userId"
-          ]
-        },
-        "ban": {
-          "label": "ban",
-          "detailKeys": [
-            "guildId",
-            "userId"
-          ]
-        }
+        "react": { "label": "react", "detailKeys": ["channelId", "messageId", "emoji"] },
+        "reactions": { "label": "reactions", "detailKeys": ["channelId", "messageId"] },
+        "sticker": { "label": "sticker", "detailKeys": ["to", "stickerIds"] },
+        "poll": { "label": "poll", "detailKeys": ["question", "to"] },
+        "permissions": { "label": "permissions", "detailKeys": ["channelId"] },
+        "readMessages": { "label": "read messages", "detailKeys": ["channelId", "limit"] },
+        "sendMessage": { "label": "send", "detailKeys": ["to", "content"] },
+        "editMessage": { "label": "edit", "detailKeys": ["channelId", "messageId"] },
+        "deleteMessage": { "label": "delete", "detailKeys": ["channelId", "messageId"] },
+        "threadCreate": { "label": "thread create", "detailKeys": ["channelId", "name"] },
+        "threadList": { "label": "thread list", "detailKeys": ["guildId", "channelId"] },
+        "threadReply": { "label": "thread reply", "detailKeys": ["channelId", "content"] },
+        "pinMessage": { "label": "pin", "detailKeys": ["channelId", "messageId"] },
+        "unpinMessage": { "label": "unpin", "detailKeys": ["channelId", "messageId"] },
+        "listPins": { "label": "list pins", "detailKeys": ["channelId"] },
+        "searchMessages": { "label": "search", "detailKeys": ["guildId", "content"] },
+        "memberInfo": { "label": "member", "detailKeys": ["guildId", "userId"] },
+        "roleInfo": { "label": "roles", "detailKeys": ["guildId"] },
+        "emojiList": { "label": "emoji list", "detailKeys": ["guildId"] },
+        "roleAdd": { "label": "role add", "detailKeys": ["guildId", "userId", "roleId"] },
+        "roleRemove": { "label": "role remove", "detailKeys": ["guildId", "userId", "roleId"] },
+        "channelInfo": { "label": "channel", "detailKeys": ["channelId"] },
+        "channelList": { "label": "channels", "detailKeys": ["guildId"] },
+        "voiceStatus": { "label": "voice", "detailKeys": ["guildId", "userId"] },
+        "eventList": { "label": "events", "detailKeys": ["guildId"] },
+        "eventCreate": { "label": "event create", "detailKeys": ["guildId", "name"] },
+        "timeout": { "label": "timeout", "detailKeys": ["guildId", "userId"] },
+        "kick": { "label": "kick", "detailKeys": ["guildId", "userId"] },
+        "ban": { "label": "ban", "detailKeys": ["guildId", "userId"] }
       }
-    },
-    "exec": {
-      "emoji": "🛠️",
-      "title": "Exec",
-      "detailKeys": [
-        "command"
-      ]
-    },
-    "tool_call": {
-      "emoji": "🧰",
-      "title": "Tool Call",
-      "detailKeys": []
-    },
-    "tool_call_update": {
-      "emoji": "🧰",
-      "title": "Tool Call",
-      "detailKeys": []
-    },
-    "session_status": {
-      "emoji": "📊",
-      "title": "Session Status",
-      "detailKeys": [
-        "sessionKey",
-        "model"
-      ]
-    },
-    "sessions_list": {
-      "emoji": "🗂️",
-      "title": "Sessions",
-      "detailKeys": [
-        "kinds",
-        "limit",
-        "activeMinutes",
-        "messageLimit"
-      ]
-    },
-    "sessions_send": {
-      "emoji": "📨",
-      "title": "Session Send",
-      "detailKeys": [
-        "label",
-        "sessionKey",
-        "agentId",
-        "timeoutSeconds"
-      ]
-    },
-    "sessions_history": {
-      "emoji": "🧾",
-      "title": "Session History",
-      "detailKeys": [
-        "sessionKey",
-        "limit",
-        "includeTools"
-      ]
-    },
-    "sessions_spawn": {
-      "emoji": "🧑‍🔧",
-      "title": "Sub-agent",
-      "detailKeys": [
-        "label",
-        "task",
-        "agentId",
-        "model",
-        "thinking",
-        "runTimeoutSeconds",
-        "cleanup"
-      ]
-    },
-    "subagents": {
-      "emoji": "🤖",
-      "title": "Subagents",
-      "actions": {
-        "list": {
-          "label": "list",
-          "detailKeys": [
-            "recentMinutes"
-          ]
-        },
-        "kill": {
-          "label": "kill",
-          "detailKeys": [
-            "target"
-          ]
-        },
-        "steer": {
-          "label": "steer",
-          "detailKeys": [
-            "target"
-          ]
-        }
-      }
-    },
-    "agents_list": {
-      "emoji": "🧭",
-      "title": "Agents",
-      "detailKeys": []
-    },
-    "memory_search": {
-      "emoji": "🧠",
-      "title": "Memory Search",
-      "detailKeys": [
-        "query"
-      ]
-    },
-    "memory_get": {
-      "emoji": "📓",
-      "title": "Memory Get",
-      "detailKeys": [
-        "path",
-        "from",
-        "lines"
-      ]
-    },
-    "web_search": {
-      "emoji": "🔎",
-      "title": "Web Search",
-      "detailKeys": [
-        "query",
-        "count"
-      ]
-    },
-    "web_fetch": {
-      "emoji": "📄",
-      "title": "Web Fetch",
-      "detailKeys": [
-        "url",
-        "extractMode",
-        "maxChars"
-      ]
-    },
-    "code_execution": {
-      "emoji": "🧮",
-      "title": "Code Execution",
-      "detailKeys": [
-        "task"
-      ]
-    },
-    "message": {
-      "emoji": "✉️",
-      "title": "Message",
-      "actions": {
-        "send": {
-          "label": "send",
-          "detailKeys": [
-            "provider",
-            "to",
-            "media",
-            "replyTo",
-            "threadId"
-          ]
-        },
-        "poll": {
-          "label": "poll",
-          "detailKeys": [
-            "provider",
-            "to",
-            "pollQuestion"
-          ]
-        },
-        "react": {
-          "label": "react",
-          "detailKeys": [
-            "provider",
-            "to",
-            "messageId",
-            "emoji",
-            "remove"
-          ]
-        },
-        "reactions": {
-          "label": "reactions",
-          "detailKeys": [
-            "provider",
-            "to",
-            "messageId",
-            "limit"
-          ]
-        },
-        "read": {
-          "label": "read",
-          "detailKeys": [
-            "provider",
-            "to",
-            "limit"
-          ]
-        },
-        "edit": {
-          "label": "edit",
-          "detailKeys": [
-            "provider",
-            "to",
-            "messageId"
-          ]
-        },
-        "delete": {
-          "label": "delete",
-          "detailKeys": [
-            "provider",
-            "to",
-            "messageId"
-          ]
-        },
-        "pin": {
-          "label": "pin",
-          "detailKeys": [
-            "provider",
-            "to",
-            "messageId"
-          ]
-        },
-        "unpin": {
-          "label": "unpin",
-          "detailKeys": [
-            "provider",
-            "to",
-            "messageId"
-          ]
-        },
-        "list-pins": {
-          "label": "list pins",
-          "detailKeys": [
-            "provider",
-            "to"
-          ]
-        },
-        "permissions": {
-          "label": "permissions",
-          "detailKeys": [
-            "provider",
-            "channelId",
-            "to"
-          ]
-        },
-        "thread-create": {
-          "label": "thread create",
-          "detailKeys": [
-            "provider",
-            "channelId",
-            "threadName"
-          ]
-        },
-        "thread-list": {
-          "label": "thread list",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "channelId"
-          ]
-        },
-        "thread-reply": {
-          "label": "thread reply",
-          "detailKeys": [
-            "provider",
-            "channelId",
-            "messageId"
-          ]
-        },
-        "search": {
-          "label": "search",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "query"
-          ]
-        },
-        "sticker": {
-          "label": "sticker",
-          "detailKeys": [
-            "provider",
-            "to",
-            "stickerId"
-          ]
-        },
-        "member-info": {
-          "label": "member",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "userId"
-          ]
-        },
-        "role-info": {
-          "label": "roles",
-          "detailKeys": [
-            "provider",
-            "guildId"
-          ]
-        },
-        "emoji-list": {
-          "label": "emoji list",
-          "detailKeys": [
-            "provider",
-            "guildId"
-          ]
-        },
-        "emoji-upload": {
-          "label": "emoji upload",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "emojiName"
-          ]
-        },
-        "sticker-upload": {
-          "label": "sticker upload",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "stickerName"
-          ]
-        },
-        "role-add": {
-          "label": "role add",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "userId",
-            "roleId"
-          ]
-        },
-        "role-remove": {
-          "label": "role remove",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "userId",
-            "roleId"
-          ]
-        },
-        "channel-info": {
-          "label": "channel",
-          "detailKeys": [
-            "provider",
-            "channelId"
-          ]
-        },
-        "channel-list": {
-          "label": "channels",
-          "detailKeys": [
-            "provider",
-            "guildId"
-          ]
-        },
-        "voice-status": {
-          "label": "voice",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "userId"
-          ]
-        },
-        "event-list": {
-          "label": "events",
-          "detailKeys": [
-            "provider",
-            "guildId"
-          ]
-        },
-        "event-create": {
-          "label": "event create",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "eventName"
-          ]
-        },
-        "timeout": {
-          "label": "timeout",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "userId"
-          ]
-        },
-        "kick": {
-          "label": "kick",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "userId"
-          ]
-        },
-        "ban": {
-          "label": "ban",
-          "detailKeys": [
-            "provider",
-            "guildId",
-            "userId"
-          ]
-        }
-      }
-    },
-    "apply_patch": {
-      "emoji": "🩹",
-      "title": "Apply Patch",
-      "detailKeys": []
-    },
-    "image": {
-      "emoji": "🖼️",
-      "title": "Image",
-      "detailKeys": [
-        "path",
-        "paths",
-        "url",
-        "urls",
-        "prompt",
-        "model"
-      ]
-    },
-    "image_generate": {
-      "emoji": "🎨",
-      "title": "Image Generation",
-      "actions": {
-        "generate": {
-          "label": "generate",
-          "detailKeys": [
-            "prompt",
-            "model",
-            "count",
-            "resolution",
-            "aspectRatio"
-          ]
-        },
-        "list": {
-          "label": "list",
-          "detailKeys": [
-            "provider",
-            "model"
-          ]
-        }
-      }
-    },
-    "music_generate": {
-      "emoji": "🎵",
-      "title": "Music Generation",
-      "actions": {
-        "generate": {
-          "label": "generate",
-          "detailKeys": [
-            "prompt",
-            "model",
-            "durationSeconds",
-            "format",
-            "instrumental"
-          ]
-        },
-        "list": {
-          "label": "list",
-          "detailKeys": [
-            "provider",
-            "model"
-          ]
-        }
-      }
-    },
-    "video_generate": {
-      "emoji": "🎬",
-      "title": "Video Generation",
-      "actions": {
-        "generate": {
-          "label": "generate",
-          "detailKeys": [
-            "prompt",
-            "model",
-            "durationSeconds",
-            "resolution",
-            "aspectRatio",
-            "audio",
-            "watermark"
-          ]
-        },
-        "list": {
-          "label": "list",
-          "detailKeys": [
-            "provider",
-            "model"
-          ]
-        }
-      }
-    },
-    "pdf": {
-      "emoji": "📑",
-      "title": "PDF",
-      "detailKeys": [
-        "path",
-        "paths",
-        "url",
-        "urls",
-        "prompt",
-        "pageRange",
-        "model"
-      ]
-    },
-    "sessions_yield": {
-      "emoji": "⏸️",
-      "title": "Yield",
-      "detailKeys": [
-        "message"
-      ]
-    },
-    "tts": {
-      "emoji": "🔊",
-      "title": "TTS",
-      "detailKeys": [
-        "text",
-        "channel"
-      ]
     }
   }
 }

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,23 +1,5 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
-import type {
-  AgentApprovalEventData,
-  AgentCommandOutputEventData,
-  AgentItemEventData,
-  AgentPatchSummaryEventData,
-} from "../infra/agent-events.js";
-import {
-  emitAgentApprovalEvent,
-  emitAgentCommandOutputEvent,
-  emitAgentEvent,
-  emitAgentItemEvent,
-  emitAgentPatchSummaryEvent,
-} from "../infra/agent-events.js";
-import {
-  buildExecApprovalPendingReplyPayload,
-  buildExecApprovalUnavailableReplyPayload,
-} from "../infra/exec-approval-reply.js";
-import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
-import { splitMediaFromOutput } from "../media/parse.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { normalizeOptionalLowercaseString, readStringValue } from "../shared/string-coerce.js";
@@ -30,33 +12,20 @@ import type {
   ToolCallSummary,
   ToolHandlerContext,
 } from "./pi-embedded-subscribe.handlers.types.js";
-import { isPromiseLike } from "./pi-embedded-subscribe.promise.js";
 import {
-  extractToolResultMediaArtifact,
-  extractMessagingToolSend,
   extractToolErrorMessage,
+  extractToolResultMediaPaths,
   extractToolResultText,
-  filterToolResultMediaUrls,
+  extractMessagingToolSend,
   isToolResultError,
-  isToolResultTimedOut,
   sanitizeToolResult,
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
-import { consumeAdjustedParamsForToolCall } from "./pi-tools.before-tool-call.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 
-type ToolStartRecord = {
-  startTime: number;
-  args: unknown;
-};
-
-/** Track tool execution start data for after_tool_call hook. */
-const toolStartData = new Map<string, ToolStartRecord>();
-
-function buildToolStartKey(runId: string, toolCallId: string): string {
-  return `${runId}:${toolCallId}`;
-}
+/** Track tool execution start times and args for after_tool_call hook */
+const toolStartData = new Map<string, { startTime: number; args: unknown }>();
 
 function isCronAddAction(args: unknown): boolean {
   if (!args || typeof args !== "object") {
@@ -73,110 +42,6 @@ function buildToolCallSummary(toolName: string, args: unknown, meta?: string): T
     mutatingAction: mutation.mutatingAction,
     actionFingerprint: mutation.actionFingerprint,
   };
-}
-
-function buildToolItemId(toolCallId: string): string {
-  return `tool:${toolCallId}`;
-}
-
-function buildToolItemTitle(toolName: string, meta?: string): string {
-  return meta ? `${toolName} ${meta}` : toolName;
-}
-
-function isExecToolName(toolName: string): boolean {
-  return toolName === "exec" || toolName === "bash";
-}
-
-function isPatchToolName(toolName: string): boolean {
-  return toolName === "apply_patch";
-}
-
-function buildCommandItemId(toolCallId: string): string {
-  return `command:${toolCallId}`;
-}
-
-function buildPatchItemId(toolCallId: string): string {
-  return `patch:${toolCallId}`;
-}
-
-function buildCommandItemTitle(toolName: string, meta?: string): string {
-  return meta ? `command ${meta}` : `${toolName} command`;
-}
-
-function buildPatchItemTitle(meta?: string): string {
-  return meta ? `patch ${meta}` : "apply patch";
-}
-
-function emitTrackedItemEvent(ctx: ToolHandlerContext, itemData: AgentItemEventData): void {
-  if (itemData.phase === "start") {
-    ctx.state.itemActiveIds.add(itemData.itemId);
-    ctx.state.itemStartedCount += 1;
-  } else if (itemData.phase === "end") {
-    ctx.state.itemActiveIds.delete(itemData.itemId);
-    ctx.state.itemCompletedCount += 1;
-  }
-  emitAgentItemEvent({
-    runId: ctx.params.runId,
-    ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
-    data: itemData,
-  });
-  void ctx.params.onAgentEvent?.({
-    stream: "item",
-    data: itemData,
-  });
-}
-
-function readToolResultDetailsRecord(result: unknown): Record<string, unknown> | undefined {
-  if (!result || typeof result !== "object") {
-    return undefined;
-  }
-  const details = (result as { details?: unknown }).details;
-  return details && typeof details === "object" && !Array.isArray(details)
-    ? (details as Record<string, unknown>)
-    : undefined;
-}
-
-function readExecToolDetails(result: unknown): ExecToolDetails | null {
-  const details = readToolResultDetailsRecord(result);
-  if (!details || typeof details.status !== "string") {
-    return null;
-  }
-  return details as ExecToolDetails;
-}
-
-function readApplyPatchSummary(result: unknown): ApplyPatchSummary | null {
-  const details = readToolResultDetailsRecord(result);
-  const summary =
-    details?.summary && typeof details.summary === "object" && !Array.isArray(details.summary)
-      ? (details.summary as Record<string, unknown>)
-      : null;
-  if (!summary) {
-    return null;
-  }
-  const added = Array.isArray(summary.added)
-    ? summary.added.filter((entry): entry is string => typeof entry === "string")
-    : [];
-  const modified = Array.isArray(summary.modified)
-    ? summary.modified.filter((entry): entry is string => typeof entry === "string")
-    : [];
-  const deleted = Array.isArray(summary.deleted)
-    ? summary.deleted.filter((entry): entry is string => typeof entry === "string")
-    : [];
-  return { added, modified, deleted };
-}
-
-function buildPatchSummaryText(summary: ApplyPatchSummary): string {
-  const parts: string[] = [];
-  if (summary.added.length > 0) {
-    parts.push(`${summary.added.length} added`);
-  }
-  if (summary.modified.length > 0) {
-    parts.push(`${summary.modified.length} modified`);
-  }
-  if (summary.deleted.length > 0) {
-    parts.push(`${summary.deleted.length} deleted`);
-  }
-  return parts.length > 0 ? parts.join(", ") : "no file changes recorded";
 }
 
 function extendExecMeta(toolName: string, args: unknown, meta?: string): string | undefined {
@@ -546,7 +411,11 @@ export function handleToolExecutionStart(
           ? record.path
           : typeof record.file_path === "string"
             ? record.file_path
-            : "";
+            : typeof record.filePath === "string"
+              ? record.filePath
+              : typeof record.file === "string"
+                ? record.file
+                : "";
       const filePath = filePathValue.trim();
       if (!filePath) {
         const argsPreview = readStringValue(args)?.slice(0, 200);
@@ -650,92 +519,6 @@ export function handleToolExecutionStart(
     }
   };
 
-  // Flush pending block replies to preserve message boundaries before tool execution.
-  const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer();
-  if (isPromiseLike<void>(flushBlockReplyBufferResult)) {
-    return flushBlockReplyBufferResult.then(() => continueAfterBlockReplyFlush());
-  }
-  return continueAfterBlockReplyFlush();
-}
-
-export function handleToolExecutionUpdate(
-  ctx: ToolHandlerContext,
-  evt: AgentEvent & {
-    toolName: string;
-    toolCallId: string;
-    partialResult?: unknown;
-  },
-) {
-  const toolName = normalizeToolName(String(evt.toolName));
-  const toolCallId = String(evt.toolCallId);
-  const partial = evt.partialResult;
-  const sanitized = sanitizeToolResult(partial);
-  emitAgentEvent({
-    runId: ctx.params.runId,
-    stream: "tool",
-    data: {
-      phase: "update",
-      name: toolName,
-      toolCallId,
-      partialResult: sanitized,
-    },
-  });
-  const itemData: AgentItemEventData = {
-    itemId: buildToolItemId(toolCallId),
-    phase: "update",
-    kind: "tool",
-    title: buildToolItemTitle(toolName, ctx.state.toolMetaById.get(toolCallId)?.meta),
-    status: "running",
-    name: toolName,
-    meta: ctx.state.toolMetaById.get(toolCallId)?.meta,
-    toolCallId,
-  };
-  emitTrackedItemEvent(ctx, itemData);
-  void ctx.params.onAgentEvent?.({
-    stream: "tool",
-    data: {
-      phase: "update",
-      name: toolName,
-      toolCallId,
-    },
-  });
-  if (isExecToolName(toolName)) {
-    const output = extractToolResultText(sanitized);
-    const commandData: AgentItemEventData = {
-      itemId: buildCommandItemId(toolCallId),
-      phase: "update",
-      kind: "command",
-      title: buildCommandItemTitle(toolName, ctx.state.toolMetaById.get(toolCallId)?.meta),
-      status: "running",
-      name: toolName,
-      meta: ctx.state.toolMetaById.get(toolCallId)?.meta,
-      toolCallId,
-      ...(output ? { progressText: output } : {}),
-    };
-    emitTrackedItemEvent(ctx, commandData);
-    if (output) {
-      const outputData: AgentCommandOutputEventData = {
-        itemId: commandData.itemId,
-        phase: "delta",
-        title: commandData.title,
-        toolCallId,
-        name: toolName,
-        output,
-        status: "running",
-      };
-      emitAgentCommandOutputEvent({
-        runId: ctx.params.runId,
-        ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
-        data: outputData,
-      });
-      void ctx.params.onAgentEvent?.({
-        stream: "command_output",
-        data: outputData,
-      });
-    }
-  }
-}
-
 export async function handleToolExecutionEnd(
   ctx: ToolHandlerContext,
   evt: AgentEvent & {
@@ -747,14 +530,12 @@ export async function handleToolExecutionEnd(
 ) {
   const toolName = normalizeToolName(String(evt.toolName));
   const toolCallId = String(evt.toolCallId);
-  const runId = ctx.params.runId;
   const isError = Boolean(evt.isError);
   const result = evt.result;
   const isToolError = isError || isToolResultError(result);
   const sanitizedResult = sanitizeToolResult(result);
-  const toolStartKey = buildToolStartKey(runId, toolCallId);
-  const startData = toolStartData.get(toolStartKey);
-  toolStartData.delete(toolStartKey);
+  const startData = toolStartData.get(toolCallId);
+  toolStartData.delete(toolCallId);
   const callSummary = ctx.state.toolMetaById.get(toolCallId);
   const meta = callSummary?.meta;
   ctx.state.toolMetas.push({ toolName, meta });
@@ -766,7 +547,6 @@ export async function handleToolExecutionEnd(
       toolName,
       meta,
       error: errorMessage,
-      timedOut: isToolResultTimedOut(sanitizedResult) || undefined,
       mutatingAction: callSummary?.mutatingAction,
       actionFingerprint: callSummary?.actionFingerprint,
     };
@@ -812,11 +592,6 @@ export async function handleToolExecutionEnd(
     startData?.args && typeof startData.args === "object"
       ? (startData.args as Record<string, unknown>)
       : {};
-  const adjustedArgs = consumeAdjustedParamsForToolCall(toolCallId, runId);
-  const afterToolCallArgs =
-    adjustedArgs && typeof adjustedArgs === "object"
-      ? (adjustedArgs as Record<string, unknown>)
-      : startArgs;
   const isMessagingSend =
     pendingMediaUrls.length > 0 ||
     (isMessagingTool(toolName) && isMessagingToolSendAction(toolName, startArgs));
@@ -848,24 +623,6 @@ export async function handleToolExecutionEnd(
       result: sanitizedResult,
     },
   });
-  const endedAt = Date.now();
-  const itemId = buildToolItemId(toolCallId);
-  const itemData: AgentItemEventData = {
-    itemId,
-    phase: "end",
-    kind: "tool",
-    title: buildToolItemTitle(toolName, meta),
-    status: isToolError ? "failed" : "completed",
-    name: toolName,
-    meta,
-    toolCallId,
-    startedAt: startData?.startTime,
-    endedAt,
-    ...(isToolError && extractToolErrorMessage(sanitizedResult)
-      ? { error: extractToolErrorMessage(sanitizedResult) }
-      : {}),
-  };
-  emitTrackedItemEvent(ctx, itemData);
   void ctx.params.onAgentEvent?.({
     stream: "tool",
     data: {
@@ -877,201 +634,39 @@ export async function handleToolExecutionEnd(
     },
   });
 
-  if (isExecToolName(toolName)) {
-    const execDetails = readExecToolDetails(result);
-    const commandItemId = buildCommandItemId(toolCallId);
-    if (
-      execDetails?.status === "approval-pending" ||
-      execDetails?.status === "approval-unavailable"
-    ) {
-      const approvalStatus = execDetails.status === "approval-pending" ? "pending" : "unavailable";
-      const approvalData: AgentApprovalEventData = {
-        phase: "requested",
-        kind: "exec",
-        status: approvalStatus,
-        title:
-          approvalStatus === "pending"
-            ? "Command approval requested"
-            : "Command approval unavailable",
-        itemId: commandItemId,
-        toolCallId,
-        ...(execDetails.status === "approval-pending"
-          ? {
-              approvalId: execDetails.approvalId,
-              approvalSlug: execDetails.approvalSlug,
-            }
-          : {}),
-        command: execDetails.command,
-        host: execDetails.host,
-        ...(execDetails.status === "approval-unavailable" ? { reason: execDetails.reason } : {}),
-        message: execDetails.warningText,
-      };
-      emitAgentApprovalEvent({
-        runId: ctx.params.runId,
-        ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
-        data: approvalData,
-      });
-      void ctx.params.onAgentEvent?.({
-        stream: "approval",
-        data: approvalData,
-      });
-      emitTrackedItemEvent(ctx, {
-        itemId: commandItemId,
-        phase: "end",
-        kind: "command",
-        title: buildCommandItemTitle(toolName, meta),
-        status: "blocked",
-        name: toolName,
-        meta,
-        toolCallId,
-        startedAt: startData?.startTime,
-        endedAt,
-        ...(execDetails.status === "approval-pending"
-          ? {
-              approvalId: execDetails.approvalId,
-              approvalSlug: execDetails.approvalSlug,
-              summary: "Awaiting approval before command can run.",
-            }
-          : {
-              summary: "Command is blocked because no interactive approval route is available.",
-            }),
-      });
-    } else {
-      const output =
-        execDetails && "aggregated" in execDetails
-          ? execDetails.aggregated
-          : extractToolResultText(sanitizedResult);
-      const commandStatus =
-        execDetails?.status === "failed" || isToolError ? "failed" : "completed";
-      emitTrackedItemEvent(ctx, {
-        itemId: commandItemId,
-        phase: "end",
-        kind: "command",
-        title: buildCommandItemTitle(toolName, meta),
-        status: commandStatus,
-        name: toolName,
-        meta,
-        toolCallId,
-        startedAt: startData?.startTime,
-        endedAt,
-        ...(output ? { summary: output } : {}),
-        ...(isToolError && extractToolErrorMessage(sanitizedResult)
-          ? { error: extractToolErrorMessage(sanitizedResult) }
-          : {}),
-      });
-      const outputData: AgentCommandOutputEventData = {
-        itemId: commandItemId,
-        phase: "end",
-        title: buildCommandItemTitle(toolName, meta),
-        toolCallId,
-        name: toolName,
-        ...(output ? { output } : {}),
-        status: commandStatus,
-        ...(execDetails && "exitCode" in execDetails ? { exitCode: execDetails.exitCode } : {}),
-        ...(execDetails && "durationMs" in execDetails
-          ? { durationMs: execDetails.durationMs }
-          : {}),
-        ...(execDetails && "cwd" in execDetails && typeof execDetails.cwd === "string"
-          ? { cwd: execDetails.cwd }
-          : {}),
-      };
-      emitAgentCommandOutputEvent({
-        runId: ctx.params.runId,
-        ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
-        data: outputData,
-      });
-      void ctx.params.onAgentEvent?.({
-        stream: "command_output",
-        data: outputData,
-      });
-
-      if (typeof output === "string") {
-        const parsedApprovalResult = parseExecApprovalResultText(output);
-        if (parsedApprovalResult.kind === "denied") {
-          const approvalData: AgentApprovalEventData = {
-            phase: "resolved",
-            kind: "exec",
-            status: parsedApprovalResult.metadata.toLowerCase().includes("approval-request-failed")
-              ? "failed"
-              : "denied",
-            title: "Command approval resolved",
-            itemId: commandItemId,
-            toolCallId,
-            message: parsedApprovalResult.body || parsedApprovalResult.raw,
-          };
-          emitAgentApprovalEvent({
-            runId: ctx.params.runId,
-            ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
-            data: approvalData,
-          });
-          void ctx.params.onAgentEvent?.({
-            stream: "approval",
-            data: approvalData,
-          });
-        }
-      }
-    }
-  }
-
-  if (isPatchToolName(toolName)) {
-    const patchSummary = readApplyPatchSummary(result);
-    const patchItemId = buildPatchItemId(toolCallId);
-    const summaryText = patchSummary ? buildPatchSummaryText(patchSummary) : undefined;
-    emitTrackedItemEvent(ctx, {
-      itemId: patchItemId,
-      phase: "end",
-      kind: "patch",
-      title: buildPatchItemTitle(meta),
-      status: isToolError ? "failed" : "completed",
-      name: toolName,
-      meta,
-      toolCallId,
-      startedAt: startData?.startTime,
-      endedAt,
-      ...(summaryText ? { summary: summaryText } : {}),
-      ...(isToolError && extractToolErrorMessage(sanitizedResult)
-        ? { error: extractToolErrorMessage(sanitizedResult) }
-        : {}),
-    });
-    if (patchSummary) {
-      const patchData: AgentPatchSummaryEventData = {
-        itemId: patchItemId,
-        phase: "end",
-        title: buildPatchItemTitle(meta),
-        toolCallId,
-        name: toolName,
-        added: patchSummary.added,
-        modified: patchSummary.modified,
-        deleted: patchSummary.deleted,
-        summary: summaryText ?? buildPatchSummaryText(patchSummary),
-      };
-      emitAgentPatchSummaryEvent({
-        runId: ctx.params.runId,
-        ...(ctx.params.sessionKey ? { sessionKey: ctx.params.sessionKey } : {}),
-        data: patchData,
-      });
-      void ctx.params.onAgentEvent?.({
-        stream: "patch",
-        data: patchData,
-      });
-    }
-  }
-
   ctx.log.debug(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
 
-  await emitToolResultOutput({ ctx, toolName, meta, isToolError, result, sanitizedResult });
+  if (ctx.params.onToolResult && ctx.shouldEmitToolOutput()) {
+    const outputText = extractToolResultText(sanitizedResult);
+    if (outputText) {
+      ctx.emitToolOutput(toolName, meta, outputText);
+    }
+  }
+
+  // Deliver media from tool results when the verbose emitToolOutput path is off.
+  // When shouldEmitToolOutput() is true, emitToolOutput already delivers media
+  // via parseReplyDirectives (MEDIA: text extraction), so skip to avoid duplicates.
+  if (ctx.params.onToolResult && !isToolError && !ctx.shouldEmitToolOutput()) {
+    const mediaPaths = extractToolResultMediaPaths(result);
+    if (mediaPaths.length > 0) {
+      try {
+        void ctx.params.onToolResult({ mediaUrls: mediaPaths });
+      } catch {
+        // ignore delivery failures
+      }
+    }
+  }
 
   // Run after_tool_call plugin hook (fire-and-forget)
   const hookRunnerAfter = ctx.hookRunner ?? getGlobalHookRunner();
   if (hookRunnerAfter?.hasHooks("after_tool_call")) {
     const durationMs = startData?.startTime != null ? Date.now() - startData.startTime : undefined;
+    const toolArgs = startData?.args;
     const hookEvent: PluginHookAfterToolCallEvent = {
       toolName,
-      params: afterToolCallArgs,
-      runId,
-      toolCallId,
+      params: (toolArgs && typeof toolArgs === "object" ? toolArgs : {}) as Record<string, unknown>,
       result: sanitizedResult,
       error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
       durationMs,
@@ -1089,4 +684,5 @@ export async function handleToolExecutionEnd(
         ctx.log.warn(`after_tool_call hook failed: tool=${toolName} error=${String(err)}`);
       });
   }
+}
 }

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -176,7 +176,7 @@ export function resolvePathArg(args: unknown): string | undefined {
   if (!record) {
     return undefined;
   }
-  for (const candidate of [record.path, record.file_path, record.filePath]) {
+  for (const candidate of [record.path, record.file_path, record.filePath, record.file]) {
     if (typeof candidate !== "string") {
       continue;
     }


### PR DESCRIPTION
Fixes #54882

## Problem
When the model calls `Read`, `Write`, or `Edit` using the `file` parameter alias, the verbose tool summary shows only the bare emoji + label without the file path.

## Fix
Update tool display path resolution to recognize the `file` alias alongside `path`.