### PR TITLE
fix: approval card buttons off-screen on mobile

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4275,10 +4275,14 @@ details[open] > .ov-expandable-toggle::after {
 
   .exec-approval-card {
     padding: 16px;
+    max-height: 90dvh;
+    display: flex;
+    flex-direction: column;
   }
 
   .exec-approval-actions {
     flex-direction: column;
+    flex-shrink: 0;
   }
 
   .exec-approval-actions .btn {
@@ -4288,6 +4292,8 @@ details[open] > .ov-expandable-toggle::after {
   .exec-approval-command {
     font-size: 12px;
     padding: 8px 10px;
+    max-height: 40dvh;
+    overflow-y: auto;
   }
 
   .table-head {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -4270,6 +4270,7 @@ details[open] > .ov-expandable-toggle::after {
 
   .exec-approval-overlay {
     padding: 12px;
+    padding-bottom: calc(12px + env(safe-area-inset-bottom, 0px));
   }
 
   .exec-approval-card {


### PR DESCRIPTION
Fixes #61425

## Summary
On small mobile viewports (~375-400px), long shell commands in the approval card push the Approve/Deny buttons off-screen.

## Changes
- Card: `max-height: 90dvh` with flex column layout
- Command preview: `max-height: 40dvh` with overflow-y auto
- Buttons: `flex-shrink: 0` to remain visible
- Safe-area: top and bottom `env()` padding for notched devices