### PR TITLE
fix(tools): add read action usage hint to message tool description

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -852,6 +852,48 @@ describe("message tool description", () => {
     expect(tool.description).toContain("Current channel (signal) supports: react, send.");
   });
 
+  it("includes read action usage hint when read is a supported action", () => {
+    const slackPlugin = createChannelPlugin({
+      id: "slack",
+      label: "Slack",
+      docsPath: "/channels/slack",
+      blurb: "Slack test plugin.",
+      actions: ["send", "read", "react", "delete", "edit"],
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "slack", source: "test", plugin: slackPlugin }]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "slack",
+    });
+
+    expect(tool.description).toContain('Use action="read" with threadId to fetch prior messages');
+  });
+
+  it("omits read action hint when read is not a supported action", () => {
+    const signalPlugin = createChannelPlugin({
+      id: "signal",
+      label: "Signal",
+      docsPath: "/channels/signal",
+      blurb: "Signal test plugin.",
+      actions: ["send", "react"],
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "signal", source: "test", plugin: signalPlugin }]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "signal",
+    });
+
+    expect(tool.description).not.toContain("read");
+  });
+
   it("does not include 'Other configured channels' when only one channel is configured", () => {
     setActivePluginRegistry(
       createTestRegistry([{ pluginId: "bluebubbles", source: "test", plugin: bluebubblesPlugin }]),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -588,6 +588,11 @@ function buildMessageToolDescription(options?: {
       const actionList = Array.from(allActions).toSorted().join(", ");
       let desc = `${baseDescription} Current channel (${currentChannel}) supports: ${actionList}.`;
 
+      // Add usage hints for non-obvious actions
+      if (allActions.has("read")) {
+        desc += ` Use action="read" with threadId to fetch prior messages in a thread when you need conversation context you don't have.`;
+      }
+
       // Include other configured channels so cron/isolated agents can discover them
       const otherChannels: string[] = [];
       for (const plugin of listChannelPlugins()) {


### PR DESCRIPTION
The message tool description lists supported action names but doesn't explain what `read` does or when to use it. Agents see `read` in the action list but never call `message(action="read", threadId="...")` to recover lost thread context — they tell users they can't access history instead.

Appends a short usage hint to the tool description when `read` is in the channel's supported action set, so the LLM knows it can fetch prior thread messages when it needs context.

**Before:** `... supports: delete, edit, read, react, send.`
**After:** `... supports: delete, edit, read, react, send. Use action="read" with threadId to fetch prior messages in a thread when you need conversation context you don't have.`

Channels that don't support `read` are unaffected.

Fixes #61833