### PR TITLE
fix(matrix): compact loose list HTML for consistent Element rendering

### DIFF
--- a/extensions/matrix/src/matrix/format.test.ts
+++ b/extensions/matrix/src/matrix/format.test.ts
@@ -50,6 +50,55 @@ describe("markdownToMatrixHtml", () => {
     expect(html).toContain("<br");
   });
 
+  it("compacts loose ordered lists without paragraph tags", () => {
+    const html = markdownToMatrixHtml("1. first\n\n2. second\n\n3. third");
+    expect(html).toContain("<ol>");
+    expect(html).toContain("<li>");
+    expect(html).not.toContain("<p>");
+  });
+
+  it("compacts loose unordered lists without paragraph tags", () => {
+    const html = markdownToMatrixHtml("- one\n\n- two\n\n- three");
+    expect(html).toContain("<ul>");
+    expect(html).not.toContain("<p>");
+  });
+
+  it("keeps tight lists unchanged", () => {
+    const html = markdownToMatrixHtml("- one\n- two");
+    expect(html).toContain("<ul>");
+    expect(html).not.toContain("<p>");
+  });
+
+  it("preserves inline formatting in loose lists", () => {
+    const html = markdownToMatrixHtml("1. **bold**\n\n2. _italic_");
+    expect(html).toContain("<strong>bold</strong>");
+    expect(html).toContain("<em>italic</em>");
+    expect(html).not.toContain("<p>");
+  });
+
+  it("does not strip paragraph tags outside lists", () => {
+    const html = markdownToMatrixHtml("Hello\n\nWorld");
+    expect(html).toContain("<p>Hello</p>");
+    expect(html).toContain("<p>World</p>");
+  });
+
+  it("compacts nested sublists without paragraph tags", () => {
+    const html = markdownToMatrixHtml("1. parent\n\n   - child\n\n2. other");
+    expect(html).toContain("<ol>");
+    expect(html).toContain("<ul>");
+    expect(html).not.toContain("<p>");
+  });
+
+  it("compacts loose lists with mentions via renderMarkdownToMatrixHtmlWithMentions", async () => {
+    const result = await renderMarkdownToMatrixHtmlWithMentions({
+      markdown: "1. hello @alice:example.org\n\n2. bye",
+      client: createMentionClient(),
+    });
+    expect(result.html).not.toContain("<p>");
+    expect(result.html).toContain('href="https://matrix.to/#/%40alice%3Aexample.org"');
+    expect(result.mentions).toEqual({ user_ids: ["@alice:example.org"] });
+  });
+
   it("renders qualified Matrix user mentions as matrix.to links and m.mentions metadata", async () => {
     const result = await renderMarkdownToMatrixHtmlWithMentions({
       markdown: "hello @alice:example.org",

--- a/extensions/matrix/src/matrix/format.test.ts
+++ b/extensions/matrix/src/matrix/format.test.ts
@@ -99,6 +99,13 @@ describe("markdownToMatrixHtml", () => {
     expect(result.mentions).toEqual({ user_ids: ["@alice:example.org"] });
   });
 
+  it("preserves paragraph wrappers for multi-paragraph list items", () => {
+    const html = markdownToMatrixHtml("1. First sentence.\n\n   Second sentence in the same item.");
+    expect(html).toContain("<li>");
+    expect(html).toContain("<p>First sentence.</p>");
+    expect(html).toContain("<p>Second sentence in the same item.</p>");
+  });
+
   it("renders qualified Matrix user mentions as matrix.to links and m.mentions metadata", async () => {
     const result = await renderMarkdownToMatrixHtmlWithMentions({
       markdown: "hello @alice:example.org",

--- a/extensions/matrix/src/matrix/format.ts
+++ b/extensions/matrix/src/matrix/format.ts
@@ -309,20 +309,51 @@ function mutateInlineTokensWithMentions(params: {
   return { children: nextChildren, roomMentioned };
 }
 
-// Compact loose lists by hiding paragraph tokens inside list items,
+// Compact loose lists by hiding a list item's single wrapper paragraph,
 // mirroring what markdown-it already does for tight lists. Without this
 // Element renders <p> margins inside <li>, splitting numbers from content.
+//
+// Keep multi-paragraph items visible so separate paragraphs do not collapse
+// together inside the same list item.
 function compactLooseListTokens(tokens: MarkdownToken[]): void {
-  let insideListItem = 0;
-  for (const token of tokens) {
+  const listItemStack: Array<{
+    level: number;
+    immediateParagraphOpenIndexes: number[];
+    immediateParagraphCloseIndexes: number[];
+  }> = [];
+
+  for (const [index, token] of tokens.entries()) {
     if (token.type === "list_item_open") {
-      insideListItem++;
-    } else if (token.type === "list_item_close") {
-      insideListItem--;
-    } else if (insideListItem > 0) {
-      if (token.type === "paragraph_open" || token.type === "paragraph_close") {
-        token.hidden = true;
+      listItemStack.push({
+        level: token.level,
+        immediateParagraphOpenIndexes: [],
+        immediateParagraphCloseIndexes: [],
+      });
+      continue;
+    }
+
+    if (token.type === "list_item_close") {
+      const item = listItemStack.pop();
+      if (
+        item &&
+        item.immediateParagraphOpenIndexes.length === 1 &&
+        item.immediateParagraphCloseIndexes.length === 1
+      ) {
+        tokens[item.immediateParagraphOpenIndexes[0]].hidden = true;
+        tokens[item.immediateParagraphCloseIndexes[0]].hidden = true;
       }
+      continue;
+    }
+
+    const currentItem = listItemStack.at(-1);
+    if (!currentItem || token.level !== currentItem.level + 1) {
+      continue;
+    }
+
+    if (token.type === "paragraph_open") {
+      currentItem.immediateParagraphOpenIndexes.push(index);
+    } else if (token.type === "paragraph_close") {
+      currentItem.immediateParagraphCloseIndexes.push(index);
     }
   }
 }

--- a/extensions/matrix/src/matrix/format.ts
+++ b/extensions/matrix/src/matrix/format.ts
@@ -309,9 +309,28 @@ function mutateInlineTokensWithMentions(params: {
   return { children: nextChildren, roomMentioned };
 }
 
+// Compact loose lists by hiding paragraph tokens inside list items,
+// mirroring what markdown-it already does for tight lists. Without this
+// Element renders <p> margins inside <li>, splitting numbers from content.
+function compactLooseListTokens(tokens: MarkdownToken[]): void {
+  let insideListItem = 0;
+  for (const token of tokens) {
+    if (token.type === "list_item_open") {
+      insideListItem++;
+    } else if (token.type === "list_item_close") {
+      insideListItem--;
+    } else if (insideListItem > 0) {
+      if (token.type === "paragraph_open" || token.type === "paragraph_close") {
+        token.hidden = true;
+      }
+    }
+  }
+}
+
 export function markdownToMatrixHtml(markdown: string): string {
-  const rendered = md.render(markdown ?? "");
-  return rendered.trimEnd();
+  const tokens = md.parse(markdown ?? "", {});
+  compactLooseListTokens(tokens);
+  return md.renderer.render(tokens, md.options, {}).trimEnd();
 }
 
 async function resolveMarkdownMentionState(params: {
@@ -366,6 +385,7 @@ export async function renderMarkdownToMatrixHtmlWithMentions(params: {
   client: MatrixClient;
 }): Promise<{ html?: string; mentions: MatrixMentions }> {
   const state = await resolveMarkdownMentionState(params);
+  compactLooseListTokens(state.tokens);
   const html = md.renderer.render(state.tokens, md.options, {}).trimEnd();
   return {
     html: html || undefined,


### PR DESCRIPTION
## Summary

When LLMs output numbered/bulleted lists with blank lines between items (loose lists per CommonMark), `markdown-it` renders them as `<li><p>...</p></li>`. Element Web applies `<p>` margins inside `<li>`, causing list numbers to appear on their own line with content below — visually broken.

This fix sets `hidden=true` on `paragraph_open`/`paragraph_close` tokens inside list items before rendering, mirroring what markdown-it already does for tight lists internally. The fix applies to both rendering paths (`markdownToMatrixHtml` and `renderMarkdownToMatrixHtmlWithMentions`), so all send paths benefit automatically (normal sends, media captions, draft streaming edits).

## Change Type

Bug fix

## Scope

Integrations (Matrix channel plugin)

## Linked Issue

Closes #60997

## Root Cause

markdown-it produces `<li><p>...</p></li>` for loose lists (blank lines between items) per the CommonMark spec. Element Web renders the `<p>` inside `<li>` with default paragraph margins, pushing list markers onto their own line. Other channels (Telegram, Slack, Discord) are unaffected because they use the shared IR system that outputs plain-text list markers.

## Regression Test Plan

- [x] Loose ordered list renders without `<p>` tags
- [x] Loose unordered list renders without `<p>` tags
- [x] Tight lists remain unchanged (no regression)
- [x] Inline formatting preserved in loose lists
- [x] Non-list paragraphs unaffected
- [x] Nested sublists compact correctly
- [x] Mention links preserved in loose lists

## User-visible / Behavior Changes

Numbered and bulleted lists in Matrix messages now render compactly in Element, FluffyChat, and other Matrix clients — list numbers/bullets appear inline with their content instead of on separate lines.

## Security Impact

- Does this change touch authentication or authorization? No
- Does it modify input validation or sanitization? No
- Does it change how secrets, tokens, or credentials are handled? No
- Does it alter network request handling, URL construction, or redirect behavior? No
- Could it affect other users, channels, or sessions? No

## Evidence

All 34 tests pass (27 existing + 7 new):
```
Test Files  1 passed (1)
     Tests  34 passed (34)
  Duration  620ms
```

## Human Verification

Verified the `token.hidden` mechanism matches what markdown-it uses internally for tight lists. Tested with markdown-it directly: loose list tokens have `hidden=false` on paragraph tokens, tight lists have `hidden=true` — our fix applies the same treatment.

## Compatibility / Migration

No config changes needed. The fix is backwards-compatible — tight lists are unaffected, and non-list content is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Thanks @gucasbrg for filing the issue and suggesting the fix direction.