### PR TITLE
fix(gateway): resolve catastrophic backtracking in interpreter heuristics regex

### DIFF
--- a/src/agents/bash-tools.exec.script-preflight.test.ts
+++ b/src/agents/bash-tools.exec.script-preflight.test.ts
@@ -2,7 +2,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
-import { createExecTool } from "./bash-tools.exec.js";
+import { __testing, createExecTool } from "./bash-tools.exec.js";
+
+const { analyzeInterpreterHeuristicsFromUnquoted } = __testing;
 
 const isWin = process.platform === "win32";
 
@@ -720,6 +722,48 @@ describeNonWin("exec script preflight", () => {
       expect(text).toContain("bad.py");
       expect(text).not.toMatch(/exec preflight:/);
     });
+  });
+});
+
+describe("analyzeInterpreterHeuristicsFromUnquoted regex safety", () => {
+  it("does not catastrophically backtrack on repeated env-var assignments without a trailing interpreter keyword", () => {
+    // Regression test for #61881 — the original `.*` in the env-prefix group
+    // caused exponential backtracking when the input contained many
+    // `VAR=value` pairs followed by a non-interpreter word.
+    const parts: string[] = [];
+    for (let i = 0; i < 30; i++) {
+      parts.push(`VAR${i}=val${i}`);
+    }
+    const payload = parts.join(" ") + " endofline";
+
+    const start = Date.now();
+    const result = analyzeInterpreterHeuristicsFromUnquoted(payload);
+    const elapsed = Date.now() - start;
+
+    expect(result.hasPython).toBe(false);
+    expect(result.hasNode).toBe(false);
+    // With the fix the call completes in <5 ms; the old regex would hang for
+    // minutes.  Use a generous 2 000 ms ceiling so the test is not flaky on
+    // slow CI runners while still catching exponential blowup.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  it("still detects python after env-var prefixes", () => {
+    const result = analyzeInterpreterHeuristicsFromUnquoted("A=1 B=2 python script.py");
+    expect(result.hasPython).toBe(true);
+    expect(result.hasNode).toBe(false);
+  });
+
+  it("still detects node after env-var prefixes", () => {
+    const result = analyzeInterpreterHeuristicsFromUnquoted("NODE_ENV=production node server.js");
+    expect(result.hasPython).toBe(false);
+    expect(result.hasNode).toBe(true);
+  });
+
+  it("returns false for commands without interpreter keywords", () => {
+    const result = analyzeInterpreterHeuristicsFromUnquoted("ls -la /tmp");
+    expect(result.hasPython).toBe(false);
+    expect(result.hasNode).toBe(false);
   });
 });
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -418,11 +418,11 @@ function analyzeInterpreterHeuristicsFromUnquoted(raw: string): {
   hasScriptHint: boolean;
 } {
   const hasPython =
-    /(?:^|\s|(?<!\\)[|&;()])(?:[A-Za-z_][A-Za-z0-9_]*=.*\s+)*python(?:3(?:\.\d+)?)?(?=$|[\s|&;()<>\n\r`$])/i.test(
+    /(?:^|\s|(?<!\\)[|&;()])(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*python(?:3(?:\.\d+)?)?(?=$|[\s|&;()<>\n\r`$])/i.test(
       raw,
     );
   const hasNode =
-    /(?:^|\s|(?<!\\)[|&;()])(?:[A-Za-z_][A-Za-z0-9_]*=.*\s+)*node(?=$|[\s|&;()<>\n\r`$])/i.test(
+    /(?:^|\s|(?<!\\)[|&;()])(?:[A-Za-z_][A-Za-z0-9_]*=\S*\s+)*node(?=$|[\s|&;()<>\n\r`$])/i.test(
       raw,
     );
   const hasProcessSubstitution = /(?<!\\)<\(|(?<!\\)>\(/u.test(raw);
@@ -1656,3 +1656,7 @@ export function createExecTool(
 }
 
 export const execTool = createExecTool();
+
+export const __testing = {
+  analyzeInterpreterHeuristicsFromUnquoted,
+};


### PR DESCRIPTION
### Summary

- **Problem**: The gateway process hangs permanently at 100% CPU when parsing specific shell commands containing multiple environment variable assignments followed by non-interpreter keywords. This causes a complete denial of service for all users on the affected gateway. The issue originates in `src/agents/bash-tools.exec.ts` lines 420-427.
- **Root Cause**: The regular expressions used in `analyzeInterpreterHeuristicsFromUnquoted` for detecting Python and Node (`/(?:[A-Za-z_][A-Za-z0-9_]*=.*\s+)*python/i`) suffer from catastrophic backtracking. The inner group contains `.*` (which greedily matches any character, including spaces) followed by `\s+` (which matches spaces). This creates overlapping match conditions for whitespace characters. When the input contains multiple `VAR=value` assignments but fails to match the trailing `python` or `node` keyword, the regex engine attempts $O(2^N)$ permutations to split the whitespace between `.*` and `\s+`, leading to an infinite loop.
- **Fix**: Replaced the greedy `.*` with `\S*` (match non-whitespace characters) in both the Python and Node detection regexes. This is a root-cause fix, not a defensive patch. By ensuring that the value part of the environment variable assignment only matches non-whitespace characters, we completely eliminate the matching ambiguity between the value and the trailing `\s+`. This reduces the time complexity from $O(2^N)$ to $O(N)$. It is also semantically more accurate, as unquoted shell variable assignments cannot contain spaces.
- **What changed**:
  - `src/agents/bash-tools.exec.ts`: Replaced `.*` with `\S*` in `hasPython` and `hasNode` regexes. Exported `analyzeInterpreterHeuristicsFromUnquoted` via `__testing` for unit tests.
  - `src/agents/bash-tools.exec.script-preflight.test.ts`: Added comprehensive regression tests for the ReDoS vulnerability and functional correctness tests for the modified regexes.
- **What did NOT change (scope boundary)**: No changes were made to the overall preflight logic, command execution flow, or other regexes in the file. The fix is strictly isolated to the two specific regexes causing the ReDoS.

### Reproduction

1. Extract the `analyzeInterpreterHeuristicsFromUnquoted` function.
2. Pass the following payload: `VAR0=val0 VAR1=val1 VAR2=val2 VAR3=val3 VAR4=val4 VAR5=val5 VAR6=val6 VAR7=val7 VAR8=val8 VAR9=val9 VAR10=val10 VAR11=val11 VAR12=val12 VAR13=val13 VAR14=val14 VAR15=val15 VAR16=val16 VAR17=val17 VAR18=val18 VAR19=val19 VAR20=val20 VAR21=val21 VAR22=val22 VAR23=val23 VAR24=val24 VAR25=val25 VAR26=val26 VAR27=val27 VAR28=val28 VAR29=val29 endofline`
3. Observe the process hanging indefinitely at 100% CPU.
4. Apply the fix and observe the function returning `false` in < 5ms.

### Risk / Mitigation

- **Risk**: The modified regex might fail to detect legitimate interpreter invocations if the environment variable assignment contains spaces.
- **Mitigation**: In unquoted shell syntax, environment variable assignments like `VAR=hello world python` are parsed as `VAR=hello` followed by the command `world`, not `python`. If quotes are used (`VAR="hello world" python`), the `extractUnquotedShellText` function strips the quoted parts before passing the string to the regex. Therefore, `\S*` is semantically correct for the unquoted text. We have added functional tests in `bash-tools.exec.script-preflight.test.ts` to verify that legitimate `python` and `node` invocations are still correctly detected.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway

### Linked Issue/PR

Fixes #61881