### PR TITLE
fix(browser): retry remote CDP websocket readiness before failing

### DIFF
--- a/extensions/browser/src/browser/server-context.availability.ts
+++ b/extensions/browser/src/browser/server-context.availability.ts
@@ -236,6 +236,9 @@ export function createProfileAvailability({
           return;
         }
       }
+      if (remoteCdp && (await isReachable(PROFILE_ATTACH_RETRY_TIMEOUT_MS))) {
+        return;
+      }
       throw new BrowserProfileUnavailableError(
         remoteCdp
           ? `Remote CDP websocket for profile "${profile.name}" is not reachable.`

--- a/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -3,7 +3,6 @@ import "./server-context.chrome-test-harness.js";
 import {
   PROFILE_ATTACH_RETRY_TIMEOUT_MS,
   PROFILE_HTTP_REACHABILITY_TIMEOUT_MS,
-  PROFILE_WS_REACHABILITY_MAX_TIMEOUT_MS,
 } from "./cdp-timeouts.js";
 import * as chromeModule from "./chrome.js";
 import { createBrowserRouteContext } from "./server-context.js";
@@ -104,6 +103,8 @@ describe("browser server-context ensureBrowserAvailable", () => {
     };
     const ctx = createBrowserRouteContext({ getState: () => state });
     const profile = ctx.forProfile("openclaw");
+    const expectedRemoteHttpTimeoutMs = state.resolved.remoteCdpTimeoutMs;
+    const expectedRemoteWsTimeoutMs = state.resolved.remoteCdpHandshakeTimeoutMs;
 
     isChromeReachable.mockResolvedValueOnce(true);
     isChromeCdpReady.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
@@ -115,8 +116,8 @@ describe("browser server-context ensureBrowserAvailable", () => {
     expect(isChromeCdpReady).toHaveBeenNthCalledWith(
       1,
       "ws://browserless:3001",
-      PROFILE_WS_REACHABILITY_MAX_TIMEOUT_MS,
-      3000,
+      expectedRemoteHttpTimeoutMs,
+      expectedRemoteWsTimeoutMs,
       {
         allowPrivateNetwork: true,
       },
@@ -124,8 +125,8 @@ describe("browser server-context ensureBrowserAvailable", () => {
     expect(isChromeCdpReady).toHaveBeenNthCalledWith(
       2,
       "ws://browserless:3001",
-      PROFILE_ATTACH_RETRY_TIMEOUT_MS,
-      3000,
+      expectedRemoteHttpTimeoutMs,
+      expectedRemoteWsTimeoutMs,
       {
         allowPrivateNetwork: true,
       },

--- a/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
+++ b/extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts
@@ -3,6 +3,7 @@ import "./server-context.chrome-test-harness.js";
 import {
   PROFILE_ATTACH_RETRY_TIMEOUT_MS,
   PROFILE_HTTP_REACHABILITY_TIMEOUT_MS,
+  PROFILE_WS_REACHABILITY_MAX_TIMEOUT_MS,
 } from "./cdp-timeouts.js";
 import * as chromeModule from "./chrome.js";
 import { createBrowserRouteContext } from "./server-context.js";
@@ -83,6 +84,48 @@ describe("browser server-context ensureBrowserAvailable", () => {
       2,
       "http://127.0.0.1:18800",
       PROFILE_ATTACH_RETRY_TIMEOUT_MS,
+      {
+        allowPrivateNetwork: true,
+      },
+    );
+    expect(launchOpenClawChrome).not.toHaveBeenCalled();
+    expect(stopOpenClawChrome).not.toHaveBeenCalled();
+  });
+
+  it("retries remote CDP websocket reachability once before failing", async () => {
+    const { launchOpenClawChrome, stopOpenClawChrome, isChromeCdpReady } =
+      setupEnsureBrowserAvailableHarness();
+    const isChromeReachable = vi.mocked(chromeModule.isChromeReachable);
+
+    const state = makeBrowserServerState();
+    state.resolved.profiles.openclaw = {
+      cdpUrl: "ws://browserless:3001",
+      color: "#00AA00",
+    };
+    const ctx = createBrowserRouteContext({ getState: () => state });
+    const profile = ctx.forProfile("openclaw");
+
+    isChromeReachable.mockResolvedValueOnce(true);
+    isChromeCdpReady.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await expect(profile.ensureBrowserAvailable()).resolves.toBeUndefined();
+
+    expect(isChromeReachable).toHaveBeenCalledTimes(1);
+    expect(isChromeCdpReady).toHaveBeenCalledTimes(2);
+    expect(isChromeCdpReady).toHaveBeenNthCalledWith(
+      1,
+      "ws://browserless:3001",
+      PROFILE_WS_REACHABILITY_MAX_TIMEOUT_MS,
+      3000,
+      {
+        allowPrivateNetwork: true,
+      },
+    );
+    expect(isChromeCdpReady).toHaveBeenNthCalledWith(
+      2,
+      "ws://browserless:3001",
+      PROFILE_ATTACH_RETRY_TIMEOUT_MS,
+      3000,
       {
         allowPrivateNetwork: true,
       },


### PR DESCRIPTION
## Summary
- Fixes #57397
- For remote CDP profiles (for example browserless), `ensureBrowserAvailable` could fail immediately after HTTP is reachable but before the CDP websocket command channel is fully ready.
- Add one extra remote websocket readiness retry using the existing attach retry window before surfacing `Remote CDP websocket ... is not reachable`.

## Root cause
`extensions/browser/src/browser/server-context.availability.ts` checked:
1. `isHttpReachable()`
2. `isReachable()` once

For remote CDP endpoints, this can race during warm-up: `/json/version` is already reachable, while the websocket command channel (`Browser.getVersion`) still initializes for a short period.

## Changes
- `extensions/browser/src/browser/server-context.availability.ts`
  - In the `attachOnly || remoteCdp` branch when HTTP is reachable but WS is not, add one extra `isReachable(PROFILE_ATTACH_RETRY_TIMEOUT_MS)` probe for remote profiles before throwing.

- `extensions/browser/src/browser/server-context.ensure-browser-available.waits-for-cdp-ready.test.ts`
  - Add regression test:
    - `retries remote CDP websocket reachability once before failing`
  - Verifies remote profile flow performs two websocket readiness probes and succeeds when the second probe becomes ready.

## Verification notes
- `pnpm exec oxfmt` on changed files: ✅
- LSP diagnostics on changed files: ✅ clean
- In this Windows shell, repo vitest invocation hung after runner startup in this session (no case execution output), so I verified by static diagnostics + targeted regression test assertions in-code and kept the change minimal/surgical.