### PR TITLE
fix(memory): surface warning when sqlite-vec unavailable during index

### DIFF
--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -856,13 +856,14 @@ export async function runMemoryIndex(opts: MemoryCommandOptions) {
           if (qmdIndexSummary) {
             defaultRuntime.log(qmdIndexSummary);
           }
-          // HELM-0251: surface warning if vec0/chunks_vec was not updated
           const postIndexStatus = manager.status();
           const vectorEnabled = postIndexStatus.vector?.enabled ?? false;
           const vectorAvailable = postIndexStatus.vector?.available;
           const vectorLoadErr = postIndexStatus.vector?.loadError;
           if (vectorEnabled && vectorAvailable === false) {
             const errDetail = vectorLoadErr ? `: ${vectorLoadErr}` : "";
+            // Indexing still persisted chunks/FTS state; keep the command successful but
+            // emit a stderr warning so operators and scripts can detect degraded recall.
             defaultRuntime.error(
               `Memory index WARNING (${agentId}): chunks_vec not updated — sqlite-vec unavailable${errDetail}. Vector recall degraded.`,
             );

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -856,7 +856,19 @@ export async function runMemoryIndex(opts: MemoryCommandOptions) {
           if (qmdIndexSummary) {
             defaultRuntime.log(qmdIndexSummary);
           }
-          defaultRuntime.log(`Memory index updated (${agentId}).`);
+          // HELM-0251: surface warning if vec0/chunks_vec was not updated
+          const postIndexStatus = manager.status();
+          const vectorEnabled = postIndexStatus.vector?.enabled ?? false;
+          const vectorAvailable = postIndexStatus.vector?.available;
+          const vectorLoadErr = postIndexStatus.vector?.loadError;
+          if (vectorEnabled && vectorAvailable === false) {
+            const errDetail = vectorLoadErr ? `: ${vectorLoadErr}` : "";
+            defaultRuntime.error(
+              `Memory index WARNING (${agentId}): chunks_vec not updated — sqlite-vec unavailable${errDetail}. Vector recall degraded.`,
+            );
+          } else {
+            defaultRuntime.log(`Memory index updated (${agentId}).`);
+          }
         } catch (err) {
           const message = formatErrorMessage(err);
           defaultRuntime.error(`Memory index failed (${agentId}): ${message}`);

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -529,6 +529,33 @@ describe("memory cli", () => {
     expect(log).toHaveBeenCalledWith("Memory index updated (main).");
   });
 
+  it("warns on stderr when index completes without sqlite-vec embeddings", async () => {
+    const close = vi.fn(async () => {});
+    const sync = vi.fn(async () => {});
+    mockManager({
+      sync,
+      status: () =>
+        makeMemoryStatus({
+          vector: {
+            enabled: true,
+            available: false,
+            loadError: "load failed",
+          },
+        }),
+      close,
+    });
+
+    const error = spyRuntimeErrors(defaultRuntime);
+    await runMemoryCli(["index"]);
+
+    expectCliSync(sync);
+    expect(error).toHaveBeenCalledWith(
+      "Memory index WARNING (main): chunks_vec not updated — sqlite-vec unavailable: load failed. Vector recall degraded.",
+    );
+    expect(close).toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it("logs qmd index file path and size after index", async () => {
     const close = vi.fn(async () => {});
     const sync = vi.fn(async () => {});

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -655,6 +655,13 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
       }
     }
+    // HELM-0251: warn if chunks were written but chunks_vec was not updated
+    if (this.vector.enabled && !vectorReady && chunks.length > 0) {
+      const errDetail = this.vector.loadError ? `: ${this.vector.loadError}` : "";
+      log.warn(
+        `HELM-0251: chunks written for ${entry.path} without vector embeddings — chunks_vec not updated (sqlite-vec unavailable${errDetail}). Vector recall degraded for this file.`,
+      );
+    }
     this.upsertFileRecord(entry, source);
   }
 

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -655,11 +655,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
       }
     }
-    // HELM-0251: warn if chunks were written but chunks_vec was not updated
     if (this.vector.enabled && !vectorReady && chunks.length > 0) {
       const errDetail = this.vector.loadError ? `: ${this.vector.loadError}` : "";
       log.warn(
-        `HELM-0251: chunks written for ${entry.path} without vector embeddings — chunks_vec not updated (sqlite-vec unavailable${errDetail}). Vector recall degraded for this file.`,
+        `chunks written for ${entry.path} without vector embeddings — chunks_vec not updated (sqlite-vec unavailable${errDetail}). Vector recall degraded for this file.`,
       );
     }
     this.upsertFileRecord(entry, source);


### PR DESCRIPTION
## Problem

When `sqlite-vec` extension is not loaded (`vec0` module unavailable), the memory index command silently reports success:
```
Memory index updated (hull).
```
...even though `chunks_vec` was **not** updated and vector recall is degraded.

This silent failure makes it impossible for agents or operators to know when the vector index is stale.

## Fix

Gate the success message on `vector.available` status. When `vector.enabled=true` and `vector.available=false`, emit an error-level warning instead:
```
Memory index WARNING (hull): chunks_vec not updated — sqlite-vec unavailable: <reason>. Vector recall degraded.
```

Also adds a per-file warning in `writeChunks` when chunks are written without vector embeddings.

## Files changed
- `extensions/memory-core/src/cli.runtime.ts` — gate success message on vector availability
- `extensions/memory-core/src/memory/manager-embedding-ops.ts` — per-file warning when chunks written without embeddings

## Testing
- CI passes (0 TS errors, 0 lint warnings)
- Tested locally with sqlite-vec unavailable: warning emitted correctly
- Tested with sqlite-vec available: normal success message unchanged

Closes: internal HELM-0251 / HELM-0252