### PR TITLE
fix: lazily recreate bound ACP sessions after reset

### DIFF
--- a/src/acp/persistent-bindings.lifecycle.test.ts
+++ b/src/acp/persistent-bindings.lifecycle.test.ts
@@ -85,12 +85,7 @@ describe("resetAcpSessionInPlace", () => {
         clearMeta: false,
       }),
     );
-    expect(managerMocks.initializeSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionKey,
-        agent: "claude",
-        backendId: "acpx",
-      }),
-    );
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+    expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
   });
 });

--- a/src/acp/persistent-bindings.lifecycle.ts
+++ b/src/acp/persistent-bindings.lifecycle.ts
@@ -2,7 +2,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { SessionAcpMeta } from "../config/sessions/types.js";
 import { logVerbose } from "../globals.js";
 import { getAcpSessionManager } from "./control-plane/manager.js";
-import { resolveAcpAgentFromSessionKey } from "./control-plane/manager.utils.js";
 import { resolveConfiguredAcpBindingSpecBySessionKey } from "./persistent-bindings.resolve.js";
 import {
   buildConfiguredAcpSessionKey,
@@ -176,14 +175,6 @@ export async function resetAcpSessionInPlace(params: {
   }
 
   const acpManager = getAcpSessionManager();
-  const agent =
-    normalizeText(meta.agent) ??
-    configuredBinding?.acpAgentId ??
-    configuredBinding?.agentId ??
-    resolveAcpAgentFromSessionKey(sessionKey, "main");
-  const mode = meta.mode === "oneshot" ? "oneshot" : "persistent";
-  const runtimeOptions = { ...meta.runtimeOptions };
-  const cwd = normalizeText(runtimeOptions.cwd ?? meta.cwd);
 
   try {
     await acpManager.closeSession({
@@ -196,25 +187,9 @@ export async function resetAcpSessionInPlace(params: {
       requireAcpSession: false,
     });
 
-    await acpManager.initializeSession({
-      cfg: params.cfg,
-      sessionKey,
-      agent,
-      mode,
-      cwd,
-      backendId: normalizeText(meta.backend) ?? normalizeText(params.cfg.acp?.backend),
-    });
-
-    const runtimeOptionsPatch = Object.fromEntries(
-      Object.entries(runtimeOptions).filter(([, value]) => value !== undefined),
-    ) as SessionAcpMeta["runtimeOptions"];
-    if (runtimeOptionsPatch && Object.keys(runtimeOptionsPatch).length > 0) {
-      await acpManager.updateSessionRuntimeOptions({
-        cfg: params.cfg,
-        sessionKey,
-        patch: runtimeOptionsPatch,
-      });
-    }
+    // Bound ACP /new and /reset should return as soon as the previous
+    // runtime state is discarded. The fresh session can be recreated lazily
+    // on the next turn through the normal binding readiness path.
     return { ok: true };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -1006,7 +1006,7 @@ describe("resetAcpSessionInPlace", () => {
     );
   });
 
-  it("does not clear ACP metadata before reinitialize succeeds", async () => {
+  it("preserves ACP metadata while discarding runtime state for existing sessions", async () => {
     const sessionKey = "agent:claude:acp:binding:discord:default:9373ab192b2317f4";
     sessionMetaMocks.readAcpSessionEntry.mockReturnValue({
       acp: {
@@ -1016,7 +1016,6 @@ describe("resetAcpSessionInPlace", () => {
         runtimeOptions: { cwd: "/home/bob/clawd" },
       },
     });
-    managerMocks.initializeSession.mockRejectedValueOnce(new Error("backend unavailable"));
 
     const result = await persistentBindings.resetAcpSessionInPlace({
       cfg: baseCfg,
@@ -1024,16 +1023,18 @@ describe("resetAcpSessionInPlace", () => {
       reason: "reset",
     });
 
-    expect(result).toEqual({ ok: false, error: "backend unavailable" });
+    expect(result).toEqual({ ok: true });
     expect(managerMocks.closeSession).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionKey,
         clearMeta: false,
       }),
     );
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+    expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
   });
 
-  it("preserves harness agent ids during in-place reset even when not in agents.list", async () => {
+  it("does not eagerly reinitialize harness agent sessions during in-place reset", async () => {
     const cfg = {
       ...baseCfg,
       agents: {
@@ -1056,15 +1057,10 @@ describe("resetAcpSessionInPlace", () => {
     });
 
     expect(result).toEqual({ ok: true });
-    expect(managerMocks.initializeSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionKey,
-        agent: "codex",
-      }),
-    );
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });
 
-  it("preserves configured ACP agent overrides during in-place reset when metadata omits the agent", async () => {
+  it("does not eagerly reinitialize configured ACP agent overrides when metadata omits the agent", async () => {
     const cfg = createCfgWithBindings(
       [
         createDiscordBinding({
@@ -1115,12 +1111,6 @@ describe("resetAcpSessionInPlace", () => {
     });
 
     expect(result).toEqual({ ok: true });
-    expect(managerMocks.initializeSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        sessionKey,
-        agent: "codex",
-        backendId: "acpx",
-      }),
-    );
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
   });
 });

--- a/src/acp/persistent-bindings.test.ts
+++ b/src/acp/persistent-bindings.test.ts
@@ -1034,6 +1034,64 @@ describe("resetAcpSessionInPlace", () => {
     expect(managerMocks.updateSessionRuntimeOptions).not.toHaveBeenCalled();
   });
 
+  it("recreates the bound session on the next ensure after an in-place reset", async () => {
+    const cfg = createCfgWithBindings([
+      createDiscordBinding({
+        agentId: "claude",
+        conversationId: "9373ab192b2317f4",
+        acp: {
+          backend: "acpx",
+        },
+      }),
+    ]);
+    const sessionKey = buildConfiguredAcpSessionKey({
+      channel: "discord",
+      accountId: "default",
+      conversationId: "9373ab192b2317f4",
+      agentId: "claude",
+      mode: "persistent",
+      backend: "acpx",
+    });
+    sessionMetaMocks.readAcpSessionEntry.mockReturnValue({
+      acp: {
+        agent: "claude",
+        mode: "persistent",
+        backend: "acpx",
+      },
+    });
+
+    const resetResult = await persistentBindings.resetAcpSessionInPlace({
+      cfg,
+      sessionKey,
+      reason: "reset",
+    });
+
+    expect(resetResult).toEqual({ ok: true });
+    expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+
+    const spec = persistentBindingsResolveModule.resolveConfiguredAcpBindingSpecBySessionKey({
+      cfg,
+      sessionKey,
+    });
+    expect(spec).toBeTruthy();
+    managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+    const ensured = await persistentBindings.ensureConfiguredAcpBindingSession({
+      cfg,
+      spec: spec!,
+    });
+
+    expect(ensured).toEqual({ ok: true, sessionKey });
+    expect(managerMocks.initializeSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey,
+        agent: "claude",
+        mode: "persistent",
+        backendId: "acpx",
+      }),
+    );
+  });
+
   it("does not eagerly reinitialize harness agent sessions during in-place reset", async () => {
     const cfg = {
       ...baseCfg,


### PR DESCRIPTION
## Summary
- stop eagerly reinitializing existing bound ACP sessions during in-place /new and /reset
- keep the bound metadata, discard the old runtime state, and let the next real turn recreate the session lazily
- update the persistent binding tests to match the lazy reset behavior

## Validation
- `pnpm test src/acp/persistent-bindings.lifecycle.test.ts src/acp/persistent-bindings.test.ts`
- `pnpm test src/auto-reply/reply/session.test.ts -t "preserves selected auth profile overrides across /new and /reset|preserves spawned session ownership metadata across /new and /reset"`

## Notes
- `pnpm build` is currently blocked on unrelated upstream TypeScript errors outside this change, including `extensions/discord/src/proxy-request-client.ts`, `src/agents/tools/message-tool.ts`, and multiple `extensions/xai/*` files.
- `extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts -t "does not bypass configured ACP readiness for Discord /new"` currently hangs in this checkout and did not produce a result.