### PR TITLE
fix(tools): add read action hint scoped to threadId-based channels only

### DIFF
--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -102,8 +102,9 @@ Name lookup:
 - `read`
   - Channels: Discord/Slack/Matrix
   - Required: `--target`
-  - Optional: `--limit`, `--before`, `--after`
+  - Optional: `--limit`, `--before`, `--after`, `--thread-id`
   - Discord only: `--around`
+  - Fetches messages from a channel or thread. Use `--thread-id` to read historical messages in a Slack or Discord thread (e.g. a thread timestamp like `1234567890.123456`). Use `--limit` to control how many messages to fetch (default varies by channel). Use `--before` or `--after` with a message ID or timestamp to paginate. This is useful when the agent needs context from earlier in a thread that may have been lost due to context pruning or a session reset.
 
 - `edit`
   - Channels: Discord/Slack/Matrix
@@ -217,6 +218,20 @@ openclaw message send --channel discord \
 ```
 
 See [Discord components](/channels/discord#interactive-components) for the full schema.
+
+Read messages from a Slack thread:
+
+```
+openclaw message read --channel slack \
+  --target C123 --thread-id 1234567890.123456 --limit 20
+```
+
+Read messages from a Discord thread:
+
+```
+openclaw message read --channel discord \
+  --target channel:123 --thread-id 456789 --limit 20
+```
 
 Send a shared interactive payload:
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1,5 +1,5 @@
 import { Type, type TSchema } from "@sinclair/typebox";
-import { listChannelPlugins } from "../../channels/plugins/index.js";
+import { getChannelPlugin, listChannelPlugins } from "../../channels/plugins/index.js";
 import {
   channelSupportsMessageCapability,
   channelSupportsMessageCapabilityForChannel,
@@ -552,6 +552,29 @@ function resolveAgentAccountId(value?: string): string | undefined {
   return normalizeAccountId(trimmed);
 }
 
+/**
+ * Returns true if the given channel uses threadId for the read action,
+ * false if it uses messageId (or has no read support).
+ * This is used to decide whether to add threadId-based hint in the tool description.
+ */
+function channelUsesThreadIdForRead(channel: string): boolean {
+  const plugin = getChannelPlugin(channel);
+  if (!plugin) {
+    return false;
+  }
+  const aliases = plugin.actions?.messageActionTargetAliases?.read?.aliases;
+  // If aliases include threadId, the channel uses threadId for read
+  if (aliases?.includes("threadId")) {
+    return true;
+  }
+  // If aliases include messageId, the channel uses messageId for read (e.g. Feishu)
+  if (aliases?.includes("messageId")) {
+    return false;
+  }
+  // Default: assume threadId-based if no aliases defined (e.g. Slack)
+  return true;
+}
+
 function buildMessageToolDescription(options?: {
   config?: OpenClawConfig;
   currentChannel?: string;
@@ -587,6 +610,10 @@ function buildMessageToolDescription(options?: {
       const allActions = new Set(["send", ...channelActions]);
       const actionList = Array.from(allActions).toSorted().join(", ");
       let desc = `${baseDescription} Current channel (${currentChannel}) supports: ${actionList}.`;
+      if (allActions.has("read") && channelUsesThreadIdForRead(currentChannel)) {
+        desc +=
+          " Use `read` with `threadId` to fetch prior messages in a thread when you need context you don't have.";
+      }
 
       // Include other configured channels so cron/isolated agents can discover them
       const otherChannels: string[] = [];
@@ -620,6 +647,8 @@ function buildMessageToolDescription(options?: {
   }
 
   // Fallback to generic description with all configured actions
+  // Note: we don't add threadId hint here because we don't know which channel will be used.
+  // Some channels (like Feishu) use messageId for read, not threadId.
   if (resolvedOptions.config) {
     const actions = listChannelMessageActions(resolvedOptions.config);
     if (actions.length > 0) {


### PR DESCRIPTION
## Summary

The message tool description was adding a threadId-based hint for the `read` action for ALL channels, but some channels (like Feishu) use `messageId` for read, not `threadId`. This fix scopes the hint to only channels that use `threadId` for read (like Slack).

## Changes

1. Added `channelUsesThreadIdForRead(channel)` helper function that checks the channel plugin's `messageActionTargetAliases` to determine if the channel uses `threadId` or `messageId` for the read action.
2. Only add the threadId hint when `channelUsesThreadIdForRead` returns true.
3. Removed the hint from the generic fallback description since we don't know which channel will be used there.

## Before

The hint was added for all channels supporting read, including Feishu which incorrectly requires `messageId` for read.

## After

The hint is only added when the current channel uses `threadId` for read (e.g., Slack). Channels like Feishu that use `messageId` are unaffected.

Fixes #61833