### PR TITLE
[codex] Allow memory-core dreaming alongside external memory slot

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -211,6 +211,7 @@ read without importing the plugin runtime.
 ```json
 {
   "contracts": {
+    "memorySlotSidecarSafe": true,
     "speechProviders": ["openai"],
     "realtimeTranscriptionProviders": ["openai"],
     "realtimeVoiceProviders": ["openai"],
@@ -224,19 +225,20 @@ read without importing the plugin runtime.
 }
 ```
 
-Each list is optional:
+Each field is optional:
 
-| Field                            | Type       | What it means                                                  |
-| -------------------------------- | ---------- | -------------------------------------------------------------- |
-| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                          |
-| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.          |
-| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                  |
-| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.             |
-| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                |
-| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                |
-| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                       |
-| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                      |
-| `tools`                          | `string[]` | Agent tool names this plugin owns for bundled contract checks. |
+| Field                            | Type       | What it means                                                                                                                                                       |
+| -------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `memorySlotSidecarSafe`          | `boolean`  | Lets a memory plugin keep non-memory hooks and CLI surfaces active when another plugin owns `plugins.slots.memory`; memory-runtime registrations are still skipped. |
+| `speechProviders`                | `string[]` | Speech provider ids this plugin owns.                                                                                                                               |
+| `realtimeTranscriptionProviders` | `string[]` | Realtime-transcription provider ids this plugin owns.                                                                                                               |
+| `realtimeVoiceProviders`         | `string[]` | Realtime-voice provider ids this plugin owns.                                                                                                                       |
+| `mediaUnderstandingProviders`    | `string[]` | Media-understanding provider ids this plugin owns.                                                                                                                  |
+| `imageGenerationProviders`       | `string[]` | Image-generation provider ids this plugin owns.                                                                                                                     |
+| `videoGenerationProviders`       | `string[]` | Video-generation provider ids this plugin owns.                                                                                                                     |
+| `webFetchProviders`              | `string[]` | Web-fetch provider ids this plugin owns.                                                                                                                            |
+| `webSearchProviders`             | `string[]` | Web-search provider ids this plugin owns.                                                                                                                           |
+| `tools`                          | `string[]` | Agent tool names this plugin owns for bundled contract checks.                                                                                                      |
 
 ## channelConfigs reference
 

--- a/extensions/memory-core/openclaw.plugin.json
+++ b/extensions/memory-core/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "memory-core",
   "kind": "memory",
+  "contracts": {
+    "memorySlotSidecarSafe": true
+  },
   "uiHints": {
     "dreaming.frequency": {
       "label": "Dreaming Frequency",

--- a/src/plugins/config-policy.ts
+++ b/src/plugins/config-policy.ts
@@ -247,27 +247,34 @@ export function resolveMemorySlotDecision(params: {
   kind?: PluginKind | PluginKind[];
   slot: string | null | undefined;
   selectedId: string | null;
-}): { enabled: boolean; reason?: string; selected?: boolean } {
+  explicitlyEnabled?: boolean;
+  sidecarSafe?: boolean;
+}): { enabled: boolean; reason?: string; selected?: boolean; sidecar?: boolean } {
   if (!hasKind(params.kind, "memory")) {
     return { enabled: true };
   }
   // A dual-kind plugin (e.g. ["memory", "context-engine"]) that lost the
   // memory slot must stay enabled so its other slot role can still load.
   const isMultiKind = Array.isArray(params.kind) && params.kind.length > 1;
+  const sidecarAllowed =
+    isMultiKind ||
+    (params.slot !== null && params.explicitlyEnabled === true && params.sidecarSafe);
   if (params.slot === null) {
-    return isMultiKind ? { enabled: true } : { enabled: false, reason: "memory slot disabled" };
+    return sidecarAllowed
+      ? { enabled: true, sidecar: true }
+      : { enabled: false, reason: "memory slot disabled" };
   }
   if (typeof params.slot === "string") {
     if (params.slot === params.id) {
       return { enabled: true, selected: true };
     }
-    return isMultiKind
-      ? { enabled: true }
+    return sidecarAllowed
+      ? { enabled: true, sidecar: true }
       : { enabled: false, reason: `memory slot set to "${params.slot}"` };
   }
   if (params.selectedId && params.selectedId !== params.id) {
-    return isMultiKind
-      ? { enabled: true }
+    return sidecarAllowed
+      ? { enabled: true, sidecar: true }
       : { enabled: false, reason: `memory slot already filled by "${params.selectedId}"` };
   }
   return { enabled: true, selected: true };

--- a/src/plugins/config-state.test.ts
+++ b/src/plugins/config-state.test.ts
@@ -547,6 +547,7 @@ describe("resolveMemorySlotDecision", () => {
     });
     expect(result.enabled).toBe(true);
     expect(result.selected).toBeUndefined();
+    expect(result.sidecar).toBe(true);
   });
 
   it("selects a dual-kind plugin when it owns the memory slot", () => {
@@ -568,6 +569,7 @@ describe("resolveMemorySlotDecision", () => {
       selectedId: null,
     });
     expect(result.enabled).toBe(true);
+    expect(result.sidecar).toBe(true);
   });
 
   it("disables a memory-only plugin when memory slot is null", () => {
@@ -576,6 +578,44 @@ describe("resolveMemorySlotDecision", () => {
       kind: "memory",
       slot: null,
       selectedId: null,
+    });
+    expect(result.enabled).toBe(false);
+  });
+
+  it("keeps an explicitly enabled sidecar-safe memory plugin enabled when slot points elsewhere", () => {
+    const result = resolveMemorySlotDecision({
+      id: "memory-sidecar",
+      kind: "memory",
+      slot: "new-memory",
+      selectedId: null,
+      explicitlyEnabled: true,
+      sidecarSafe: true,
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.selected).toBeUndefined();
+    expect(result.sidecar).toBe(true);
+  });
+
+  it("still disables a non-sidecar-safe memory plugin when explicitly enabled but slot points elsewhere", () => {
+    const result = resolveMemorySlotDecision({
+      id: "old-memory",
+      kind: "memory",
+      slot: "new-memory",
+      selectedId: null,
+      explicitlyEnabled: true,
+      sidecarSafe: false,
+    });
+    expect(result.enabled).toBe(false);
+  });
+
+  it("still disables a sidecar-safe memory plugin when memory slot is none", () => {
+    const result = resolveMemorySlotDecision({
+      id: "memory-sidecar",
+      kind: "memory",
+      slot: null,
+      selectedId: null,
+      explicitlyEnabled: true,
+      sidecarSafe: true,
     });
     expect(result.enabled).toBe(false);
   });

--- a/src/plugins/config-state.ts
+++ b/src/plugins/config-state.ts
@@ -422,27 +422,34 @@ export function resolveMemorySlotDecision(params: {
   kind?: string | string[];
   slot: string | null | undefined;
   selectedId: string | null;
-}): { enabled: boolean; reason?: string; selected?: boolean } {
+  explicitlyEnabled?: boolean;
+  sidecarSafe?: boolean;
+}): { enabled: boolean; reason?: string; selected?: boolean; sidecar?: boolean } {
   if (!hasKind(params.kind as PluginKind | PluginKind[] | undefined, "memory")) {
     return { enabled: true };
   }
   // A dual-kind plugin (e.g. ["memory", "context-engine"]) that lost the
   // memory slot must stay enabled so its other slot role can still load.
   const isMultiKind = Array.isArray(params.kind) && params.kind.length > 1;
+  const sidecarAllowed =
+    isMultiKind ||
+    (params.slot !== null && params.explicitlyEnabled === true && params.sidecarSafe);
   if (params.slot === null) {
-    return isMultiKind ? { enabled: true } : { enabled: false, reason: "memory slot disabled" };
+    return sidecarAllowed
+      ? { enabled: true, sidecar: true }
+      : { enabled: false, reason: "memory slot disabled" };
   }
   if (typeof params.slot === "string") {
     if (params.slot === params.id) {
       return { enabled: true, selected: true };
     }
-    return isMultiKind
-      ? { enabled: true }
+    return sidecarAllowed
+      ? { enabled: true, sidecar: true }
       : { enabled: false, reason: `memory slot set to "${params.slot}"` };
   }
   if (params.selectedId && params.selectedId !== params.id) {
-    return isMultiKind
-      ? { enabled: true }
+    return sidecarAllowed
+      ? { enabled: true, sidecar: true }
       : { enabled: false, reason: `memory slot already filled by "${params.selectedId}"` };
   }
   return { enabled: true, selected: true };

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2948,6 +2948,104 @@ module.exports = {
         },
       },
       {
+        label: "loads sidecar-safe bundled memory plugins without memory runtime ownership",
+        loadRegistry: () => {
+          const bundledDir = makeTempDir();
+          const memoryADir = path.join(bundledDir, "memory-a");
+          const memoryBDir = path.join(bundledDir, "memory-b");
+          mkdirSafe(memoryADir);
+          mkdirSafe(memoryBDir);
+          writePlugin({
+            id: "memory-a",
+            dir: memoryADir,
+            filename: "index.cjs",
+            body: `
+module.exports = {
+  id: "memory-a",
+  kind: "memory",
+  register(api) {
+    api.registerHook("gateway:startup", () => {}, { name: "memory-a-startup" });
+    api.registerMemoryRuntime({
+      async getMemorySearchManager() {
+        return { manager: null, error: "missing" };
+      },
+      resolveMemoryBackendConfig() {
+        return { backend: "builtin" };
+      },
+    });
+  },
+};`,
+          });
+          writePlugin({
+            id: "memory-b",
+            dir: memoryBDir,
+            filename: "index.cjs",
+            body: memoryPluginBody("memory-b"),
+          });
+          fs.writeFileSync(
+            path.join(memoryADir, "openclaw.plugin.json"),
+            JSON.stringify(
+              {
+                id: "memory-a",
+                kind: "memory",
+                configSchema: EMPTY_PLUGIN_SCHEMA,
+                contracts: { memorySlotSidecarSafe: true },
+              },
+              null,
+              2,
+            ),
+            "utf-8",
+          );
+          fs.writeFileSync(
+            path.join(memoryBDir, "openclaw.plugin.json"),
+            JSON.stringify(
+              {
+                id: "memory-b",
+                kind: "memory",
+                configSchema: EMPTY_PLUGIN_SCHEMA,
+              },
+              null,
+              2,
+            ),
+            "utf-8",
+          );
+          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+          return loadOpenClawPlugins({
+            cache: false,
+            config: {
+              plugins: {
+                allow: ["memory-a", "memory-b"],
+                slots: { memory: "memory-b" },
+                entries: {
+                  "memory-a": { enabled: true },
+                  "memory-b": { enabled: true },
+                },
+              },
+            },
+          });
+        },
+        assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
+          const a = registry.plugins.find((entry) => entry.id === "memory-a");
+          const b = registry.plugins.find((entry) => entry.id === "memory-b");
+          expect(a?.status).toBe("loaded");
+          expect(a?.memorySlotSelected).toBeUndefined();
+          expect(a?.memorySlotSidecar).toBe(true);
+          expect(a?.hookNames).toContain("memory-a-startup");
+          expect(
+            registry.diagnostics.some(
+              (diag) =>
+                diag.pluginId === "memory-a" &&
+                String(diag.message).includes(
+                  "memory plugin not selected for memory slot; skipping memory runtime registration",
+                ),
+            ),
+          ).toBe(true);
+          expect(b?.status).toBe("loaded");
+          expect(b?.memorySlotSelected).toBe(true);
+        },
+      },
+      {
         label: "disables memory plugins when slot is none",
         loadRegistry: () => {
           process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1397,6 +1397,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         kind: manifestRecord.kind,
         slot: memorySlot,
         selectedId: selectedMemoryPluginId,
+        explicitlyEnabled: record.explicitlyEnabled,
+        sidecarSafe: manifestRecord.contracts?.memorySlotSidecarSafe === true,
       });
       if (!earlyMemoryDecision.enabled) {
         record.enabled = false;
@@ -1420,6 +1422,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         kind: record.kind,
         slot: memorySlot,
         selectedId: selectedMemoryPluginId,
+        explicitlyEnabled: record.explicitlyEnabled,
+        sidecarSafe: record.contracts?.memorySlotSidecarSafe === true,
       });
 
       if (!memoryDecision.enabled) {
@@ -1436,6 +1440,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         selectedMemoryPluginId = record.id;
         memorySlotMatched = true;
         record.memorySlotSelected = true;
+      } else if (memoryDecision.sidecar && hasKind(record.kind, "memory")) {
+        record.memorySlotSidecar = true;
       }
     }
 
@@ -1561,6 +1567,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         kind: record.kind,
         slot: memorySlot,
         selectedId: selectedMemoryPluginId,
+        explicitlyEnabled: record.explicitlyEnabled,
+        sidecarSafe: record.contracts?.memorySlotSidecarSafe === true,
       });
 
       if (!memoryDecision.enabled) {
@@ -1576,6 +1584,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       if (memoryDecision.selected && hasKind(record.kind, "memory")) {
         selectedMemoryPluginId = record.id;
         record.memorySlotSelected = true;
+      } else if (memoryDecision.sidecar && hasKind(record.kind, "memory")) {
+        record.memorySlotSidecar = true;
       }
     }
 
@@ -1980,6 +1990,8 @@ export async function loadOpenClawPluginCliRegistry(
       kind: record.kind,
       slot: memorySlot,
       selectedId: selectedMemoryPluginId,
+      explicitlyEnabled: record.explicitlyEnabled,
+      sidecarSafe: record.contracts?.memorySlotSidecarSafe === true,
     });
     if (!memoryDecision.enabled) {
       record.enabled = false;
@@ -1993,6 +2005,8 @@ export async function loadOpenClawPluginCliRegistry(
     if (memoryDecision.selected && hasKind(record.kind, "memory")) {
       selectedMemoryPluginId = record.id;
       record.memorySlotSelected = true;
+    } else if (memoryDecision.sidecar && hasKind(record.kind, "memory")) {
+      record.memorySlotSidecar = true;
     }
 
     if (typeof register !== "function") {

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -110,6 +110,12 @@ export type PluginManifest = {
 };
 
 export type PluginManifestContracts = {
+  /**
+   * Allows a memory plugin to keep non-memory surfaces active even when another
+   * plugin owns `plugins.slots.memory`. Memory-runtime registrations remain
+   * gated to the selected slot owner.
+   */
+  memorySlotSidecarSafe?: boolean;
   memoryEmbeddingProviders?: string[];
   speechProviders?: string[];
   realtimeTranscriptionProviders?: string[];
@@ -192,6 +198,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
     return undefined;
   }
 
+  const memorySlotSidecarSafe = value.memorySlotSidecarSafe === true;
   const memoryEmbeddingProviders = normalizeStringList(value.memoryEmbeddingProviders);
   const speechProviders = normalizeStringList(value.speechProviders);
   const realtimeTranscriptionProviders = normalizeStringList(value.realtimeTranscriptionProviders);
@@ -204,6 +211,7 @@ function normalizeManifestContracts(value: unknown): PluginManifestContracts | u
   const webSearchProviders = normalizeStringList(value.webSearchProviders);
   const tools = normalizeStringList(value.tools);
   const contracts = {
+    ...(memorySlotSidecarSafe ? { memorySlotSidecarSafe: true } : {}),
     ...(memoryEmbeddingProviders.length > 0 ? { memoryEmbeddingProviders } : {}),
     ...(speechProviders.length > 0 ? { speechProviders } : {}),
     ...(realtimeTranscriptionProviders.length > 0 ? { realtimeTranscriptionProviders } : {}),

--- a/src/plugins/registry.dual-kind-memory-gate.test.ts
+++ b/src/plugins/registry.dual-kind-memory-gate.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  createPluginRegistryFixture,
-  registerTestPlugin,
-  registerVirtualTestPlugin,
-} from "./contracts/testkit.js";
+import { createPluginRegistryFixture, registerTestPlugin } from "./contracts/testkit.js";
 import { clearMemoryEmbeddingProviders } from "./memory-embedding-providers.js";
 import { _resetMemoryPluginState, getMemoryRuntime } from "./memory-state.js";
 import { createPluginRecord } from "./status.test-helpers.js";
@@ -28,12 +24,15 @@ describe("dual-kind memory registration gate", () => {
   it("blocks memory runtime registration for dual-kind plugins not selected for memory slot", () => {
     const { config, registry } = createPluginRegistryFixture();
 
-    registerVirtualTestPlugin({
+    registerTestPlugin({
       registry,
       config,
-      id: "dual-plugin",
-      name: "Dual Plugin",
-      kind: ["memory", "context-engine"],
+      record: createPluginRecord({
+        id: "dual-plugin",
+        name: "Dual Plugin",
+        kind: ["memory", "context-engine"],
+        memorySlotSidecar: true,
+      }),
       register(api) {
         api.registerMemoryRuntime(createStubMemoryRuntime());
       },
@@ -45,7 +44,7 @@ describe("dual-kind memory registration gate", () => {
         expect.objectContaining({
           pluginId: "dual-plugin",
           level: "warn",
-          message: expect.stringContaining("dual-kind plugin not selected for memory slot"),
+          message: expect.stringContaining("memory plugin not selected for memory slot"),
         }),
       ]),
     );
@@ -79,17 +78,48 @@ describe("dual-kind memory registration gate", () => {
   it("allows memory runtime registration for single-kind memory plugins without memorySlotSelected", () => {
     const { config, registry } = createPluginRegistryFixture();
 
-    registerVirtualTestPlugin({
+    registerTestPlugin({
       registry,
       config,
-      id: "memory-only",
-      name: "Memory Only",
-      kind: "memory",
+      record: createPluginRecord({
+        id: "memory-only",
+        name: "Memory Only",
+        kind: "memory",
+      }),
       register(api) {
         api.registerMemoryRuntime(createStubMemoryRuntime());
       },
     });
 
     expect(getMemoryRuntime()).toBeDefined();
+  });
+
+  it("blocks memory runtime registration for sidecar memory plugins that do not own the slot", () => {
+    const { config, registry } = createPluginRegistryFixture();
+
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({
+        id: "memory-sidecar",
+        name: "Memory Sidecar",
+        kind: "memory",
+        memorySlotSidecar: true,
+      }),
+      register(api) {
+        api.registerMemoryRuntime(createStubMemoryRuntime());
+      },
+    });
+
+    expect(getMemoryRuntime()).toBeUndefined();
+    expect(registry.registry.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          pluginId: "memory-sidecar",
+          level: "warn",
+          message: expect.stringContaining("memory plugin not selected for memory slot"),
+        }),
+      ]),
+    );
   });
 });

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -284,6 +284,7 @@ export type PluginRecord = {
   configJsonSchema?: Record<string, unknown>;
   contracts?: PluginManifestContracts;
   memorySlotSelected?: boolean;
+  memorySlotSidecar?: boolean;
 };
 
 export type PluginRegistry = {
@@ -317,6 +318,10 @@ export type PluginRegistry = {
   conversationBindingResolvedHandlers: PluginConversationBindingResolvedHandlerRegistration[];
   diagnostics: PluginDiagnostic[];
 };
+
+function isMemorySlotSidecar(record: PluginRecord): boolean {
+  return hasKind(record.kind, "memory") && record.memorySlotSidecar === true;
+}
 
 export type PluginRegistryParams = {
   logger: PluginLogger;
@@ -1305,17 +1310,13 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                if (
-                  Array.isArray(record.kind) &&
-                  record.kind.length > 1 &&
-                  !record.memorySlotSelected
-                ) {
+                if (isMemorySlotSidecar(record)) {
                   pushDiagnostic({
                     level: "warn",
                     pluginId: record.id,
                     source: record.source,
                     message:
-                      "dual-kind plugin not selected for memory slot; skipping memory prompt section registration",
+                      "memory plugin not selected for memory slot; skipping memory prompt section registration",
                   });
                   return;
                 }
@@ -1337,17 +1338,13 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                if (
-                  Array.isArray(record.kind) &&
-                  record.kind.length > 1 &&
-                  !record.memorySlotSelected
-                ) {
+                if (isMemorySlotSidecar(record)) {
                   pushDiagnostic({
                     level: "warn",
                     pluginId: record.id,
                     source: record.source,
                     message:
-                      "dual-kind plugin not selected for memory slot; skipping memory flush plan registration",
+                      "memory plugin not selected for memory slot; skipping memory flush plan registration",
                   });
                   return;
                 }
@@ -1363,17 +1360,13 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
                   });
                   return;
                 }
-                if (
-                  Array.isArray(record.kind) &&
-                  record.kind.length > 1 &&
-                  !record.memorySlotSelected
-                ) {
+                if (isMemorySlotSidecar(record)) {
                   pushDiagnostic({
                     level: "warn",
                     pluginId: record.id,
                     source: record.source,
                     message:
-                      "dual-kind plugin not selected for memory slot; skipping memory runtime registration",
+                      "memory plugin not selected for memory slot; skipping memory runtime registration",
                   });
                   return;
                 }
@@ -1381,17 +1374,13 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               },
               registerMemoryEmbeddingProvider: (adapter) => {
                 if (hasKind(record.kind, "memory")) {
-                  if (
-                    Array.isArray(record.kind) &&
-                    record.kind.length > 1 &&
-                    !record.memorySlotSelected
-                  ) {
+                  if (isMemorySlotSidecar(record)) {
                     pushDiagnostic({
                       level: "warn",
                       pluginId: record.id,
                       source: record.source,
                       message:
-                        "dual-kind plugin not selected for memory slot; skipping memory embedding provider registration",
+                        "memory plugin not selected for memory slot; skipping memory embedding provider registration",
                     });
                     return;
                   }


### PR DESCRIPTION
## Summary

This change allows `memory-core` to keep its dreaming hooks active even when another memory plugin owns `plugins.slots.memory`.

## What changed

- add an opt-in manifest contract, `contracts.memorySlotSidecarSafe`, for memory plugins that are safe to load as sidecars
- teach plugin slot resolution, loader state, and registry gating to keep those sidecar-safe memory plugins active while still skipping memory-runtime ownership unless they own the slot
- mark `memory-core` as sidecar-safe so dreaming can run alongside `memory-lancedb-pro` and similar external memory-slot plugins
- add coverage for slot decisions, registry gating, and bundled-loader behavior
- document the new manifest contract

## Root cause

Dreaming lives in `memory-core`, but `memory-core` was fully gated off whenever another `kind: "memory"` plugin owned `plugins.slots.memory`.
That meant configurations such as `plugins.slots.memory = "memory-lancedb-pro"` could still produce memory files, but `memory-core`'s dreaming startup hook and trigger path never loaded.

## Impact

Users can keep an external memory-slot plugin active and still enable `memory-core` dreaming, as long as `memory-core` itself is explicitly enabled/allowed in config.

## Validation

- `pnpm test src/plugins/config-state.test.ts src/plugins/registry.dual-kind-memory-gate.test.ts src/plugins/loader.test.ts`
- `pnpm build`
- attempted commit-hook `pnpm check`, but current `origin/main` hits unrelated `tsgo` failures in untouched extensions (`msteams`, `qqbot`, `signal`, `synology-chat`, `tlon`)
