### PR TITLE
fix(command-queue): crash on SIGUSR1 restart after upgrade from pre-4.5

### DIFF
--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -378,6 +378,42 @@ describe("command queue", () => {
     await expect(enqueueCommand(async () => "ok")).resolves.toBe("ok");
   });
 
+  it("migrates legacy queue state missing activeTaskWaiters without crashing", async () => {
+    // Simulate a SIGUSR1 in-process restart where the globalThis singleton was
+    // created by an older code version (e.g. v2026.4.2) that did not include
+    // the `activeTaskWaiters` field.  The schema migration in getQueueState()
+    // must patch the missing field so resetAllLanes() and
+    // notifyActiveTaskWaiters() do not throw.
+    const key = Symbol.for("openclaw.commandQueueState");
+    const globalStore = globalThis as Record<PropertyKey, unknown>;
+    const original = globalStore[key];
+
+    try {
+      // Plant a legacy-shaped state object (no activeTaskWaiters).
+      globalStore[key] = {
+        gatewayDraining: false,
+        lanes: new Map(),
+        nextTaskId: 1,
+      };
+
+      // resetAllLanes calls notifyActiveTaskWaiters → Array.from(state.activeTaskWaiters).
+      // Without the migration this would throw:
+      //   TypeError: undefined is not iterable
+      expect(() => resetAllLanes()).not.toThrow();
+
+      // waitForActiveTasks also accesses activeTaskWaiters.
+      await expect(waitForActiveTasks(0)).resolves.toEqual({ drained: true });
+    } finally {
+      // Restore original state so subsequent tests are not affected.
+      if (original !== undefined) {
+        globalStore[key] = original;
+      } else {
+        delete globalStore[key];
+      }
+      resetCommandQueueStateForTest();
+    }
+  });
+
   it("shares lane state across distinct module instances", async () => {
     const commandQueueA = await importFreshModule<typeof import("./command-queue.js")>(
       import.meta.url,

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -64,12 +64,22 @@ function isExpectedNonErrorLaneFailure(err: unknown): boolean {
 const COMMAND_QUEUE_STATE_KEY = Symbol.for("openclaw.commandQueueState");
 
 function getQueueState() {
-  return resolveGlobalSingleton(COMMAND_QUEUE_STATE_KEY, () => ({
+  const state = resolveGlobalSingleton(COMMAND_QUEUE_STATE_KEY, () => ({
     gatewayDraining: false,
     lanes: new Map<string, LaneState>(),
     activeTaskWaiters: new Set<ActiveTaskWaiter>(),
     nextTaskId: 1,
   }));
+  // Schema migration: the singleton may have been created by an older code
+  // version (e.g. v2026.4.2) that did not include `activeTaskWaiters`.  After
+  // a SIGUSR1 in-process restart the new code inherits the stale object via
+  // `resolveGlobalSingleton` because the Symbol key already exists on
+  // globalThis.  Patch the missing field so all downstream consumers see a
+  // valid Set instead of `undefined`.
+  if (!state.activeTaskWaiters) {
+    state.activeTaskWaiters = new Set<ActiveTaskWaiter>();
+  }
+  return state;
 }
 
 function normalizeLane(lane: string): string {


### PR DESCRIPTION

### Summary

- **Problem**: After upgrading from v2026.4.2 to v2026.4.5 and triggering a SIGUSR1 in-process restart, the gateway enters a crash loop with `TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))` at `notifyActiveTaskWaiters()` in `src/process/command-queue.ts:134`. The crash fires every ~3 minutes as systemd repeatedly restarts the process, causing all Discord/Telegram message delivery to fail silently.

- **Root Cause**: In v2026.4.5, `getQueueState()` (line 66) was extended to include a new `activeTaskWaiters: new Set<ActiveTaskWaiter>()` field in the singleton state object, and `waitForActiveTasks()` was rewritten from a polling-based approach to an event-driven design using this Set. However, `resolveGlobalSingleton()` (`src/shared/global-singleton.ts:4`) returns the **existing** object from `globalThis` when the Symbol key is already present — it never calls the factory function to create a fresh object. When a SIGUSR1 in-process restart occurs after an npm upgrade from v2026.4.2 (whose singleton lacks `activeTaskWaiters`) to v2026.4.5, the new code inherits the stale v2026.4.2 state object. `queueState.activeTaskWaiters` resolves to `undefined`, and `Array.from(undefined)` in `notifyActiveTaskWaiters()` throws the TypeError. This is called from `resetAllLanes()` (line 343), which is invoked by `createRestartIterationHook()` in `src/cli/gateway-cli/run-loop.ts:239` on every SIGUSR1 restart iteration.

- **Fix**: Add a schema migration step in `getQueueState()` that checks whether `activeTaskWaiters` exists on the returned singleton and patches it with `new Set<ActiveTaskWaiter>()` if missing. This is a targeted migration at the data source — the single function through which all command-queue code accesses the global state — rather than defensive null-checks scattered across every consumer. The migration runs only once per stale singleton (subsequent calls see the patched field), has zero cost on fresh installs, and follows the same pattern that would be needed for any future schema additions to the singleton.

- **What changed**:
  - `src/process/command-queue.ts`: `getQueueState()` now assigns the singleton to a local variable, checks for the missing `activeTaskWaiters` field, and patches it before returning. (+10 lines, including explanatory comment)
  - `src/process/command-queue.test.ts`: Added one new test case `"migrates legacy queue state missing activeTaskWaiters without crashing"` that plants a v2026.4.2-shaped state object on `globalThis`, then verifies `resetAllLanes()` and `waitForActiveTasks()` both succeed without throwing. (+36 lines)

- **What did NOT change (scope boundary)**:
  - `resolveGlobalSingleton()` itself is not modified — the migration is scoped to the consumer, avoiding any global behavioral change to the singleton utility.
  - `resetAllLanes()`, `notifyActiveTaskWaiters()`, `resolveActiveTaskWaiter()`, `waitForActiveTasks()`, and all other command-queue functions are untouched — the fix is entirely in the data initialization path.
  - `src/cli/gateway-cli/run-loop.ts` (the SIGUSR1 restart coordinator) is not modified.
  - No changes to any other subsystem, channel, or plugin code.

### Reproduction

1. Install openclaw v2026.4.2 and start the gateway (`openclaw start`)
2. Upgrade to v2026.4.5 via `npm i -g openclaw@latest` (do **not** restart the process manually)
3. Send SIGUSR1 to the gateway process (`kill -USR1 $(pgrep -f openclaw)`) or wait for the auto-update sentinel to trigger it
4. Observe the crash in logs:
   ```
   Unhandled promise rejection: TypeError: undefined is not iterable
       at Function.from (<anonymous>)
       at notifyActiveTaskWaiters (command-queue-Cssp02gj.js:88:29)
   ```
5. systemd restarts the process, but the same crash repeats because the stale globalThis singleton persists across the in-process restart

### Risk / Mitigation

- **Risk**: The migration check (`if (!state.activeTaskWaiters)`) runs on every `getQueueState()` call. Since `getQueueState()` is called frequently (on every enqueue, drain, and reset), there is a theoretical micro-overhead from the truthiness check.
- **Mitigation**: The check is a single property truthiness test on a local variable — negligible compared to the async task scheduling work that follows. The test suite (19/19 passing) covers the migration path, normal operation, cross-module shared state, SIGUSR1 reset, drain behavior, and timeout semantics. No existing tests were modified; the new test is additive and isolated via `try/finally` cleanup.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Process / Command Queue
- [x] Tests

### Linked Issue/PR

Fixes #61905
