### PR TITLE
fix(gateway-status): use local TLS probe targets with fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - TUI/terminal: restore Kitty keyboard protocol and `modifyOtherKeys` state on TUI exit and fatal CLI crashes so parent shells stop inheriting broken keyboard input after `openclaw tui` exits. (#49130) Thanks @biefan.
 - Docs/i18n: relocalize final localized-page links after translation so generated locale pages stop keeping stale English-root links when targets appear later in the same run. (#61796) thanks @hxy91819.
 - iOS/Watch exec approvals: keep Apple Watch review and approval recovery working while the iPhone is locked or backgrounded, including background-safe reconnects, persisted pending approvals, notification cleanup, and APNs-backed watch refresh recovery. (#61757) Thanks @ngutman.
+- Gateway/status: probe local TLS gateways over `wss://`, forward the local cert fingerprint for self-signed loopback probes, and warn when the local TLS runtime cannot load the configured cert. (#61935) Thanks @ThanhNguyxn07.
 
 ## 2026.4.5
 

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -38,6 +38,11 @@ const mocks = vi.hoisted(() => {
       stderr: [],
       stop: sshStop,
     })),
+    loadGatewayTlsRuntime: vi.fn(async () => ({
+      enabled: true,
+      required: true,
+      fingerprintSha256: "sha256:local-fingerprint",
+    })),
     probeGateway: vi.fn(async (opts: { url: string }): Promise<GatewayProbeResult> => {
       const { url } = opts;
       if (url.includes("127.0.0.1")) {
@@ -125,6 +130,7 @@ const {
   sshStop,
   resolveSshConfig,
   startSshPortForward,
+  loadGatewayTlsRuntime,
   probeGateway,
 } = mocks;
 
@@ -158,6 +164,10 @@ vi.mock("../infra/ssh-tunnel.js", async () => {
 
 vi.mock("../infra/ssh-config.js", () => ({
   resolveSshConfig: mocks.resolveSshConfig,
+}));
+
+vi.mock("../infra/tls/gateway.js", () => ({
+  loadGatewayTlsRuntime: mocks.loadGatewayTlsRuntime,
 }));
 
 vi.mock("../gateway/probe.js", () => ({
@@ -628,6 +638,30 @@ describe("gateway-status command", () => {
     const parsed = JSON.parse(runtimeLogs.join("\n")) as Record<string, unknown>;
     const targets = parsed.targets as Array<Record<string, unknown>>;
     expect(targets.some((t) => t.kind === "sshTunnel")).toBe(true);
+  });
+
+  it("uses local TLS target strategy and fingerprint for local loopback probes", async () => {
+    const { runtime } = createRuntimeCapture();
+    probeGateway.mockClear();
+    loadGatewayTlsRuntime.mockClear();
+    readBestEffortConfig.mockResolvedValueOnce({
+      gateway: {
+        mode: "local",
+        tls: { enabled: true },
+        auth: { mode: "token", token: "ltok" },
+      },
+    } as never);
+
+    await runGatewayStatus(runtime, { timeout: "15000", json: true });
+
+    expect(loadGatewayTlsRuntime).toHaveBeenCalledTimes(1);
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://127.0.0.1:18789",
+        tlsFingerprint: "sha256:local-fingerprint",
+        timeoutMs: 15_000,
+      }),
+    );
   });
 
   it("passes the full caller timeout through to local loopback probes", async () => {

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -664,6 +664,45 @@ describe("gateway-status command", () => {
     );
   });
 
+  it("warns when local TLS is enabled but the certificate fingerprint cannot be loaded", async () => {
+    const { runtime, runtimeLogs } = createRuntimeCapture();
+    probeGateway.mockClear();
+    loadGatewayTlsRuntime.mockResolvedValueOnce({
+      enabled: false,
+      required: true,
+      error: "gateway tls: cert/key missing",
+    });
+    readBestEffortConfig.mockResolvedValueOnce({
+      gateway: {
+        mode: "local",
+        tls: { enabled: true },
+        auth: { mode: "token", token: "ltok" },
+      },
+    } as never);
+
+    await runGatewayStatus(runtime, { timeout: "15000", json: true });
+
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://127.0.0.1:18789",
+        tlsFingerprint: undefined,
+      }),
+    );
+
+    const parsed = JSON.parse(runtimeLogs.join("\n")) as {
+      warnings?: Array<{ code?: string; message?: string; targetIds?: string[] }>;
+    };
+    expect(parsed.warnings).toContainEqual(
+      expect.objectContaining({
+        code: "local_tls_runtime_unavailable",
+        targetIds: ["localLoopback"],
+      }),
+    );
+    expect(
+      parsed.warnings?.find((warning) => warning.code === "local_tls_runtime_unavailable")?.message,
+    ).toContain("gateway tls: cert/key missing");
+  });
+
   it("passes the full caller timeout through to local loopback probes", async () => {
     const { runtime } = createRuntimeCapture();
     probeGateway.mockClear();

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -122,6 +122,10 @@ export async function gatewayStatusCommand(
     sshTarget: probePass.sshTarget,
     sshTunnelStarted: probePass.sshTunnelStarted,
     sshTunnelError: probePass.sshTunnelError,
+    localTlsLoadError:
+      localTlsRuntime && !localTlsRuntime.enabled && localTlsRuntime.required
+        ? (localTlsRuntime.error ?? "gateway tls is enabled but local TLS runtime could not load")
+        : null,
   });
   const primary = pickPrimaryProbedTarget(probePass.probed);
 

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -20,6 +20,7 @@ import { runGatewayStatusProbePass } from "./gateway-status/probe-run.js";
 
 let sshConfigModulePromise: Promise<typeof import("../infra/ssh-config.js")> | undefined;
 let sshTunnelModulePromise: Promise<typeof import("../infra/ssh-tunnel.js")> | undefined;
+let gatewayTlsModulePromise: Promise<typeof import("../infra/tls/gateway.js")> | undefined;
 
 function loadSshConfigModule() {
   sshConfigModulePromise ??= import("../infra/ssh-config.js");
@@ -29,6 +30,11 @@ function loadSshConfigModule() {
 function loadSshTunnelModule() {
   sshTunnelModulePromise ??= import("../infra/ssh-tunnel.js");
   return sshTunnelModulePromise;
+}
+
+function loadGatewayTlsModule() {
+  gatewayTlsModulePromise ??= import("../infra/tls/gateway.js");
+  return gatewayTlsModulePromise;
 }
 
 export async function gatewayStatusCommand(
@@ -80,6 +86,13 @@ export async function gatewayStatusCommand(
     }
   }
 
+  const localTlsRuntime =
+    cfg.gateway?.tls?.enabled === true
+      ? await loadGatewayTlsModule().then(({ loadGatewayTlsRuntime }) =>
+          loadGatewayTlsRuntime(cfg.gateway?.tls),
+        )
+      : undefined;
+
   const probePass = await withProgress(
     {
       label: "Inspecting gateways…",
@@ -98,6 +111,9 @@ export async function gatewayStatusCommand(
         sshTarget,
         sshIdentity,
         loadSshTunnelModule,
+        localTlsFingerprint: localTlsRuntime?.enabled
+          ? localTlsRuntime.fingerprintSha256
+          : undefined,
       }),
   );
 

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { withEnvAsync } from "../../test-utils/env.js";
 import {
+  buildNetworkHints,
   extractConfigSummary,
   isProbeReachable,
   isScopeLimitedProbeFailure,
   renderProbeSummaryLine,
-  resolveProbeBudgetMs,
   resolveAuthForTarget,
+  resolveProbeBudgetMs,
+  resolveTargets,
 } from "./helpers.js";
 
 describe("extractConfigSummary", () => {
@@ -274,6 +276,28 @@ describe("probe reachability classification", () => {
     expect(renderProbeSummaryLine(probe, false)).toContain("RPC: failed");
   });
 });
+describe("gateway-status local target scheme", () => {
+  it("uses wss for local loopback targets and network hints when gateway TLS is enabled", () => {
+    const cfg = {
+      gateway: {
+        mode: "local",
+        tls: { enabled: true },
+      },
+    };
+
+    const targets = resolveTargets(cfg as never);
+    expect(targets).toContainEqual(
+      expect.objectContaining({
+        id: "localLoopback",
+        url: "wss://127.0.0.1:18789",
+      }),
+    );
+
+    const hints = buildNetworkHints(cfg as never);
+    expect(hints.localLoopbackUrl).toBe("wss://127.0.0.1:18789");
+  });
+});
+
 describe("resolveProbeBudgetMs", () => {
   it("lets active local loopback probes use the full caller budget", () => {
     expect(

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -106,10 +106,11 @@ export function resolveTargets(cfg: OpenClawConfig, explicitUrl?: string): Gatew
   }
 
   const port = resolveGatewayPort(cfg);
+  const localScheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
   add({
     id: "localLoopback",
     kind: "localLoopback",
-    url: `ws://127.0.0.1:${port}`,
+    url: `${localScheme}://127.0.0.1:${port}`,
     active: cfg.gateway?.mode !== "remote",
   });
 
@@ -243,9 +244,10 @@ export function extractConfigSummary(snapshotUnknown: unknown): GatewayConfigSum
 export function buildNetworkHints(cfg: OpenClawConfig) {
   const { tailnetIPv4 } = inspectBestEffortPrimaryTailnetIPv4();
   const port = resolveGatewayPort(cfg);
+  const localScheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
   return {
-    localLoopbackUrl: `ws://127.0.0.1:${port}`,
-    localTailnetUrl: tailnetIPv4 ? `ws://${tailnetIPv4}:${port}` : null,
+    localLoopbackUrl: `${localScheme}://127.0.0.1:${port}`,
+    localTailnetUrl: tailnetIPv4 ? `${localScheme}://${tailnetIPv4}:${port}` : null,
     tailnetIPv4: tailnetIPv4 ?? null,
   };
 }

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -32,6 +32,7 @@ export function buildGatewayStatusWarnings(params: {
   sshTarget: string | null;
   sshTunnelStarted: boolean;
   sshTunnelError: string | null;
+  localTlsLoadError?: string | null;
 }): GatewayStatusWarning[] {
   const reachable = params.probed.filter((entry) => isProbeReachable(entry.probe));
   const degradedScopeLimited = params.probed.filter((entry) =>
@@ -44,6 +45,13 @@ export function buildGatewayStatusWarnings(params: {
       message: params.sshTunnelError
         ? `SSH tunnel failed: ${String(params.sshTunnelError)}`
         : "SSH tunnel failed to start; falling back to direct probes.",
+    });
+  }
+  if (params.localTlsLoadError) {
+    warnings.push({
+      code: "local_tls_runtime_unavailable",
+      message: `Local gateway TLS is enabled but OpenClaw could not load the local certificate fingerprint: ${params.localTlsLoadError}`,
+      targetIds: ["localLoopback"],
     });
   }
   if (reachable.length > 1) {

--- a/src/commands/gateway-status/probe-run.ts
+++ b/src/commands/gateway-status/probe-run.ts
@@ -37,6 +37,7 @@ export async function runGatewayStatusProbePass(params: {
   sshTarget: string | null;
   sshIdentity: string | null;
   loadSshTunnelModule: () => Promise<typeof import("../../infra/ssh-tunnel.js")>;
+  localTlsFingerprint?: string;
 }): Promise<{
   discovery: GatewayBonjourBeacon[];
   probed: GatewayStatusProbedTarget[];
@@ -124,6 +125,10 @@ export async function runGatewayStatusProbePass(params: {
             token: authResolution.token,
             password: authResolution.password,
           },
+          tlsFingerprint:
+            target.kind === "localLoopback" && target.url.startsWith("wss://")
+              ? params.localTlsFingerprint
+              : undefined,
           timeoutMs: resolveProbeBudgetMs(params.overallTimeoutMs, target),
         });
         return {


### PR DESCRIPTION
## Summary
- Fixes #61767
- Make `gateway status` / `gateway probe` TLS-aware for local targets.
- Prevent false "gateway unreachable" on healthy local TLS gateways by using the correct local target scheme and TLS fingerprint.

## Root cause
`gateway-status` always constructed local targets as `ws://127.0.0.1:<port>`, even when `gateway.tls.enabled=true`.
It also did not pass local TLS fingerprint to the probe client, so even a corrected `wss://` target could fail for self-signed local cert setups.

## Changes
- `src/commands/gateway-status/helpers.ts`
  - `resolveTargets`: local loopback target now uses `wss://` when `gateway.tls.enabled`.
  - `buildNetworkHints`: local loopback/tailnet URLs now use TLS-aware scheme.

- `src/commands/gateway-status.ts`
  - Loads local gateway TLS runtime when local TLS is enabled.
  - Passes local TLS fingerprint into probe pass for local loopback probes.

- `src/commands/gateway-status/probe-run.ts`
  - Adds optional `localTlsFingerprint` input.
  - For `localLoopback` + `wss://` targets, forwards `tlsFingerprint` to `probeGateway`.

- Tests
  - `src/commands/gateway-status/helpers.test.ts`
    - New test verifies TLS-enabled local targets/hints use `wss://`.
  - `src/commands/gateway-status.test.ts`
    - New command-level test verifies local TLS loopback probe uses `wss://127.0.0.1:<port>` and forwards local TLS fingerprint.

## Verification
- `pnpm test -- src/commands/gateway-status.test.ts --reporter=verbose`
- `pnpm test -- src/commands/gateway-status/helpers.test.ts --reporter=verbose`
- `pnpm test -- src/commands/gateway-status.test.ts -t "uses local TLS target strategy and fingerprint for local loopback probes" --reporter=verbose`
- `pnpm exec oxfmt ...` on changed files
- LSP diagnostics clean on all changed files