### PR TITLE
fix(openai-completions): prevent store:false for Google AI endpoints

### DIFF
--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -53,6 +53,8 @@ export function resolveOpenAICompletionsCompatDefaults(
     endpointClass === "cerebras-native" ||
     endpointClass === "chutes-native" ||
     endpointClass === "deepseek-native" ||
+    endpointClass === "google-generative-ai" ||
+    endpointClass === "google-vertex" ||
     endpointClass === "mistral-public" ||
     endpointClass === "opencode-native" ||
     endpointClass === "xai-native" ||


### PR DESCRIPTION
## Summary

The openai-completions streaming transport was sending `store: false` to Google AI endpoints (Gemma, Vertex AI) which don't support this parameter, resulting in 400 errors: `Unknown parameter: store`.

## Root Cause

Google AI endpoints (`generativelanguage.googleapis.com`) were not included in the `isNonStandard` list in `openai-completions-compat.ts`. This meant the `supportsStore` logic could incorrectly evaluate to `true` for these endpoints, causing `store: false` to be included in the request body.

## Fix

Add `google-generative-ai` and `google-vertex` to the `isNonStandard` list, which ensures `supportsStore` evaluates to `false` for these endpoints and `store: false` is not sent.

## Testing

- TypeScript compilation passes
- No existing tests cover this specific scenario (Google AI with openai-completions API)

## Before



## After

`store` parameter is not sent to Google AI endpoints.

Fixes #61826