### PR TITLE
fix(moonshot): normalize boolean tool schemas to prevent API 400

### DIFF
--- a/extensions/moonshot/index.test.ts
+++ b/extensions/moonshot/index.test.ts
@@ -23,6 +23,52 @@ describe("moonshot provider plugin", () => {
     });
   });
 
+  it("normalizes boolean tool schemas for Moonshot API", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const [tool] =
+      provider.normalizeToolSchemas?.({
+        provider: "moonshot",
+        tools: [
+          {
+            name: "test_tool",
+            description: "A tool with boolean params",
+            parameters: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+                enabled: { type: "boolean", description: "Toggle feature" },
+                optional: {
+                  anyOf: [{ type: "boolean" }, { type: "null" }],
+                },
+              },
+            },
+          },
+        ],
+      } as never) ?? [];
+
+    const props = (tool?.parameters as Record<string, unknown>)?.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(props.query).toEqual({ type: "string" });
+    expect(props.enabled).toEqual({
+      type: "string",
+      enum: ["true", "false"],
+      description: "Toggle feature",
+    });
+    expect(props.optional).toEqual({
+      anyOf: [{ type: "string", enum: ["true", "false"] }, { type: "null" }],
+    });
+
+    expect(
+      provider.inspectToolSchemas?.({
+        provider: "moonshot",
+        tools: [tool],
+      } as never),
+    ).toEqual([]);
+  });
+
   it("wires moonshot-thinking stream hooks", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     let capturedPayload: Record<string, unknown> | undefined;

--- a/extensions/moonshot/index.ts
+++ b/extensions/moonshot/index.ts
@@ -10,6 +10,7 @@ import {
 } from "./onboard.js";
 import { buildMoonshotProvider } from "./provider-catalog.js";
 import { createKimiWebSearchProvider } from "./src/kimi-web-search-provider.js";
+import { inspectMoonshotToolSchemas, normalizeMoonshotToolSchemas } from "./tool-schema-compat.js";
 
 const PROVIDER_ID = "moonshot";
 const OPENAI_COMPATIBLE_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
@@ -62,6 +63,8 @@ export default defineSingleProviderPluginEntry({
       applyMoonshotNativeStreamingUsageCompat(providerConfig),
     ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
     ...MOONSHOT_THINKING_STREAM_HOOKS,
+    normalizeToolSchemas: normalizeMoonshotToolSchemas,
+    inspectToolSchemas: inspectMoonshotToolSchemas,
   },
   register(api) {
     api.registerMediaUnderstandingProvider(moonshotMediaUnderstandingProvider);

--- a/extensions/moonshot/tool-schema-compat.test.ts
+++ b/extensions/moonshot/tool-schema-compat.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./tool-schema-compat.js";
+
+const { cleanSchemaForMoonshot, findBooleanSchemaViolations } = __testing;
+
+describe("cleanSchemaForMoonshot", () => {
+  it("converts plain boolean type to string enum", () => {
+    expect(cleanSchemaForMoonshot({ type: "boolean" })).toEqual({
+      type: "string",
+      enum: ["true", "false"],
+    });
+  });
+
+  it("preserves description when converting boolean", () => {
+    expect(cleanSchemaForMoonshot({ type: "boolean", description: "Enable feature" })).toEqual({
+      type: "string",
+      enum: ["true", "false"],
+      description: "Enable feature",
+    });
+  });
+
+  it("converts boolean variant inside anyOf (TypeBox Optional pattern)", () => {
+    const schema = {
+      anyOf: [{ type: "boolean" }, { type: "null" }],
+    };
+    expect(cleanSchemaForMoonshot(schema)).toEqual({
+      anyOf: [{ type: "string", enum: ["true", "false"] }, { type: "null" }],
+    });
+  });
+
+  it("converts boolean variant inside anyOf with description", () => {
+    const schema = {
+      anyOf: [{ type: "boolean", description: "Toggle" }, { type: "null" }],
+      description: "Optional toggle",
+    };
+    expect(cleanSchemaForMoonshot(schema)).toEqual({
+      anyOf: [{ type: "string", enum: ["true", "false"], description: "Toggle" }, { type: "null" }],
+      description: "Optional toggle",
+    });
+  });
+
+  it("recursively converts boolean in nested object properties", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        enabled: { type: "boolean" },
+        nested: {
+          type: "object",
+          properties: {
+            debug: { type: "boolean", description: "Debug mode" },
+          },
+        },
+      },
+    };
+    const result = cleanSchemaForMoonshot(schema) as Record<string, unknown>;
+    const props = result.properties as Record<string, Record<string, unknown>>;
+
+    expect(props.name).toEqual({ type: "string" });
+    expect(props.enabled).toEqual({ type: "string", enum: ["true", "false"] });
+
+    const nestedProps = props.nested.properties as Record<string, Record<string, unknown>>;
+    expect(nestedProps.debug).toEqual({
+      type: "string",
+      enum: ["true", "false"],
+      description: "Debug mode",
+    });
+  });
+
+  it("converts boolean in array items", () => {
+    const schema = {
+      type: "array",
+      items: { type: "boolean" },
+    };
+    expect(cleanSchemaForMoonshot(schema)).toEqual({
+      type: "array",
+      items: { type: "string", enum: ["true", "false"] },
+    });
+  });
+
+  it("converts boolean inside oneOf and allOf", () => {
+    expect(cleanSchemaForMoonshot({ oneOf: [{ type: "boolean" }, { type: "string" }] })).toEqual({
+      oneOf: [{ type: "string", enum: ["true", "false"] }, { type: "string" }],
+    });
+    expect(cleanSchemaForMoonshot({ allOf: [{ type: "boolean" }] })).toEqual({
+      allOf: [{ type: "string", enum: ["true", "false"] }],
+    });
+  });
+
+  it("converts boolean inside tuple-style items array", () => {
+    const schema = {
+      type: "array",
+      items: [{ type: "boolean" }, { type: "string" }],
+    };
+    expect(cleanSchemaForMoonshot(schema)).toEqual({
+      type: "array",
+      items: [{ type: "string", enum: ["true", "false"] }, { type: "string" }],
+    });
+  });
+
+  it("leaves non-boolean schemas unchanged", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Name" },
+        count: { type: "number", minimum: 1 },
+      },
+      required: ["name"],
+    };
+    expect(cleanSchemaForMoonshot(schema)).toEqual(schema);
+  });
+
+  it("passes through primitives and nulls", () => {
+    expect(cleanSchemaForMoonshot(null)).toBeNull();
+    expect(cleanSchemaForMoonshot(undefined)).toBeUndefined();
+    expect(cleanSchemaForMoonshot("string")).toBe("string");
+    expect(cleanSchemaForMoonshot(42)).toBe(42);
+  });
+});
+
+describe("findBooleanSchemaViolations", () => {
+  it("reports plain boolean type", () => {
+    const violations = findBooleanSchemaViolations({ type: "boolean" }, "tool.parameters");
+    expect(violations).toEqual(["tool.parameters.type=boolean"]);
+  });
+
+  it("reports boolean inside anyOf", () => {
+    const violations = findBooleanSchemaViolations(
+      { anyOf: [{ type: "boolean" }, { type: "null" }] },
+      "tool.parameters",
+    );
+    expect(violations).toEqual(["tool.parameters.anyOf[0].type=boolean"]);
+  });
+
+  it("reports boolean in nested properties", () => {
+    const violations = findBooleanSchemaViolations(
+      {
+        type: "object",
+        properties: {
+          enabled: { type: "boolean" },
+        },
+      },
+      "tool.parameters",
+    );
+    expect(violations).toEqual(["tool.parameters.properties.enabled.type=boolean"]);
+  });
+
+  it("returns empty for non-boolean schemas", () => {
+    const violations = findBooleanSchemaViolations(
+      {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+        },
+      },
+      "tool.parameters",
+    );
+    expect(violations).toEqual([]);
+  });
+});

--- a/extensions/moonshot/tool-schema-compat.ts
+++ b/extensions/moonshot/tool-schema-compat.ts
@@ -1,0 +1,139 @@
+// Moonshot API rejects `{"type": "boolean"}` in tool parameter schemas with
+// HTTP 400 "invalid scalar type [object boolean]". This module converts boolean
+// schemas to `{"type": "string", "enum": ["true", "false"]}` so the API
+// accepts them. The LLM still returns native JSON booleans in practice, so
+// tool execute functions are unaffected.
+
+import type {
+  AnyAgentTool,
+  ProviderNormalizeToolSchemasContext,
+  ProviderToolSchemaDiagnostic,
+} from "openclaw/plugin-sdk/plugin-entry";
+
+function isBooleanSchema(schema: Record<string, unknown>): boolean {
+  return schema.type === "boolean";
+}
+
+function convertBooleanNode(schema: Record<string, unknown>): Record<string, unknown> {
+  const converted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key === "type") {
+      converted.type = "string";
+      continue;
+    }
+    converted[key] = value;
+  }
+  converted.enum = ["true", "false"];
+  return converted;
+}
+
+function cleanSchemaForMoonshot(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+  if (Array.isArray(schema)) {
+    return schema.map(cleanSchemaForMoonshot);
+  }
+
+  const obj = schema as Record<string, unknown>;
+
+  if (isBooleanSchema(obj)) {
+    return convertBooleanNode(obj);
+  }
+
+  const cleaned: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === "properties" && value && typeof value === "object" && !Array.isArray(value)) {
+      cleaned[key] = Object.fromEntries(
+        Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+          k,
+          cleanSchemaForMoonshot(v),
+        ]),
+      );
+    } else if (key === "items" && value && typeof value === "object") {
+      cleaned[key] = Array.isArray(value)
+        ? value.map(cleanSchemaForMoonshot)
+        : cleanSchemaForMoonshot(value);
+    } else if ((key === "anyOf" || key === "oneOf" || key === "allOf") && Array.isArray(value)) {
+      cleaned[key] = value.map(cleanSchemaForMoonshot);
+    } else {
+      cleaned[key] = value;
+    }
+  }
+
+  return cleaned;
+}
+
+function findBooleanSchemaViolations(schema: unknown, path: string): string[] {
+  if (!schema || typeof schema !== "object") {
+    return [];
+  }
+  if (Array.isArray(schema)) {
+    return schema.flatMap((item, index) => findBooleanSchemaViolations(item, `${path}[${index}]`));
+  }
+  const record = schema as Record<string, unknown>;
+  const violations: string[] = [];
+
+  if (isBooleanSchema(record)) {
+    violations.push(`${path}.type=boolean`);
+  }
+
+  const properties =
+    record.properties && typeof record.properties === "object" && !Array.isArray(record.properties)
+      ? (record.properties as Record<string, unknown>)
+      : undefined;
+  if (properties) {
+    for (const [key, value] of Object.entries(properties)) {
+      violations.push(...findBooleanSchemaViolations(value, `${path}.properties.${key}`));
+    }
+  }
+
+  for (const compKey of ["anyOf", "oneOf", "allOf"] as const) {
+    const arr = record[compKey];
+    if (Array.isArray(arr)) {
+      violations.push(
+        ...arr.flatMap((variant, i) =>
+          findBooleanSchemaViolations(variant, `${path}.${compKey}[${i}]`),
+        ),
+      );
+    }
+  }
+
+  if (record.items && typeof record.items === "object") {
+    violations.push(...findBooleanSchemaViolations(record.items, `${path}.items`));
+  }
+
+  return violations;
+}
+
+export function normalizeMoonshotToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): AnyAgentTool[] {
+  return ctx.tools.map((tool) => {
+    if (!tool.parameters || typeof tool.parameters !== "object") {
+      return tool;
+    }
+    return {
+      ...tool,
+      parameters: cleanSchemaForMoonshot(tool.parameters as Record<string, unknown>),
+    };
+  });
+}
+
+export function inspectMoonshotToolSchemas(
+  ctx: ProviderNormalizeToolSchemasContext,
+): ProviderToolSchemaDiagnostic[] {
+  return ctx.tools.flatMap((tool, toolIndex) => {
+    const violations = findBooleanSchemaViolations(tool.parameters, `${tool.name}.parameters`);
+    if (violations.length === 0) {
+      return [];
+    }
+    return [{ toolName: tool.name, toolIndex, violations }];
+  });
+}
+
+export const __testing = {
+  cleanSchemaForMoonshot,
+  findBooleanSchemaViolations,
+} as const;


### PR DESCRIPTION
## Summary

- Moonshot API rejects tool parameter schemas containing `{"type": "boolean"}` with HTTP 400 `"invalid scalar type [object boolean]"`
- Adds a provider-local `normalizeToolSchemas` hook that converts boolean schemas to `{"type": "string", "enum": ["true", "false"]}` before sending to the API
- The LLM still returns native JSON booleans in tool call arguments regardless of schema type, so tool execute functions are unaffected

Follows the established Gemini normalizer pattern (`normalizeGeminiToolSchemas`), keeping the implementation local to `extensions/moonshot/` per architecture boundary rules.

Closes #61320

## Changes

| File | Change |
|------|--------|
| `extensions/moonshot/tool-schema-compat.ts` | New — recursive boolean-to-string-enum schema normalizer + diagnostic inspector |
| `extensions/moonshot/index.ts` | Register `normalizeToolSchemas` and `inspectToolSchemas` hooks on the provider |
| `extensions/moonshot/tool-schema-compat.test.ts` | 14 unit tests covering all edge cases (plain boolean, anyOf/oneOf/allOf, nested properties, array items, tuple items, passthrough) |
| `extensions/moonshot/index.test.ts` | Integration test verifying hook wiring through plugin registration |

## Test plan

- [x] `pnpm test extensions/moonshot` — 17/17 tests pass
- [x] TypeScript check — no type errors in changed files
- [x] Formatting — oxfmt clean
- [ ] Verify with real Moonshot API key that boolean-param tools (cron, message, sessions) no longer return 400