### PR TITLE
fix(gateway): drop late exec/PTY output after run settlement to prevent crash

### DIFF
--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -255,4 +255,39 @@ describe("process supervisor", () => {
     expect(streamed).toBe("streamed");
     expect(exit.stdout).toBe("");
   });
+
+  it("does not forward late stdout/stderr after the run has settled", async () => {
+    const adapter = createStubChildAdapter();
+    createChildAdapterMock.mockResolvedValue(adapter);
+
+    const supervisor = createProcessSupervisor();
+    const chunks: string[] = [];
+    const run = await spawnChild(supervisor, {
+      sessionId: "s-late",
+      argv: createWriteStdoutArgv("early"),
+      timeoutMs: 1_000,
+      stdinMode: "pipe-closed",
+      captureOutput: false,
+      onStdout: (chunk) => {
+        chunks.push(`out:${chunk}`);
+      },
+      onStderr: (chunk) => {
+        chunks.push(`err:${chunk}`);
+      },
+    });
+
+    adapter.emitStdout("early");
+    adapter.settle(0);
+
+    const exit = await run.wait();
+    expect(exit.reason).toBe("exit");
+
+    // Simulate late output arriving after the run has settled.
+    // Before the fix, these would be forwarded to onStdout/onStderr
+    // and could crash the gateway when the agent run is no longer active.
+    adapter.emitStdout("late-stdout");
+    adapter.emitStderr("late-stderr");
+
+    expect(chunks).toEqual(["out:early"]);
+  });
 });

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -173,6 +173,9 @@ export function createProcessSupervisor(): ProcessSupervisor {
       }
 
       adapter.onStdout((chunk) => {
+        if (settled) {
+          return;
+        }
         if (captureOutput) {
           stdout += chunk;
         }
@@ -180,6 +183,9 @@ export function createProcessSupervisor(): ProcessSupervisor {
         touchOutput();
       });
       adapter.onStderr((chunk) => {
+        if (settled) {
+          return;
+        }
         if (captureOutput) {
           stderr += chunk;
         }


### PR DESCRIPTION
### Summary

- **Problem**: After updating to 2026.4.5, the gateway crashes with `Unhandled promise rejection: Error: Agent listener invoked outside active run` during exec/PTY flows. This occurs when late stdout/stderr data arrives from a process after the agent run has already ended. The crash originates in `Agent.processEvents` (pi-agent-core/src/agent.ts:533:10) via `emitUpdate` and `onUpdate`.
- **Root Cause**: In `src/process/supervisor/supervisor.ts`, the `adapter.onStdout` and `adapter.onStderr` listeners forward chunks to `input.onStdout?.(chunk)` and `input.onStderr?.(chunk)` unconditionally. The listener teardown (`adapter.dispose()`) only happens inside the `waitPromise` path after `adapter.wait()` resolves. Between the time a process starts exiting (or is cancelled) and `adapter.wait()` settles, any late stdout/stderr data emitted by the adapter is still forwarded upstream. This reaches `emitUpdate()` which passes it to the agent's `onUpdate` handler, crashing the gateway if the agent run is no longer active.
- **Fix**: Added a `if (settled) { return; }` guard inside the `adapter.onStdout` and `adapter.onStderr` listeners in `supervisor.ts`. This ensures that once the supervisor marks the run as settled (which happens immediately upon exit or cancellation), no further output chunks are forwarded to the upstream callbacks. This prevents the late-output race condition without affecting normal streaming behavior.
- **What changed**:
  - `src/process/supervisor/supervisor.ts`: Added `settled` guards to `adapter.onStdout` and `adapter.onStderr` callbacks.
  - `src/process/supervisor/supervisor.test.ts`: Added a regression test `does not forward late stdout/stderr after the run has settled` to verify the fix.
- **What did NOT change (scope boundary)**: The core process lifecycle, adapter implementations, and PTY handling logic remain unchanged. The fix only drops late output chunks at the supervisor boundary after settlement, ensuring no side effects on active runs or other subsystems.

### Reproduction

1. Start an agent run that executes a background shell command or PTY process.
2. Cancel the agent run or let it finish while the process is still flushing output.
3. Observe the gateway crash with `Agent listener invoked outside active run` as late output reaches the agent loop.
4. With this fix, the late output is safely dropped at the supervisor layer, and the gateway remains stable.

### Risk / Mitigation

- **Risk**: Dropping output chunks could theoretically lead to missing logs if a process flushes important data right at exit.
- **Mitigation**: The `settled` flag is only set to `true` after `adapter.wait()` resolves (meaning the process has fully exited and all streams are closed) or when an error/cancellation forces an immediate teardown. In the latter case, the run is already considered dead by the system, so dropping subsequent output is the correct and safe behavior. A new unit test explicitly verifies this logic.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] Gateway
- [x] Process Supervisor

### Linked Issue/PR

Fixes #61912
Fixes #61917