### PR TITLE
fix(agents): gate WS text delta on valid phase value — prevent commentary leak from phaseless output_item.added

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -2026,6 +2026,95 @@ describe("createOpenAIWebSocketStreamFn", () => {
     ]);
   });
 
+  it("buffers text when output_item.added arrives without phase metadata", async () => {
+    const streamFn = createOpenAIWebSocketStreamFn("sk-test", "sess-phaseless-gate");
+    const stream = streamFn(
+      modelStub as Parameters<typeof streamFn>[0],
+      contextStub as Parameters<typeof streamFn>[1],
+    );
+
+    const events: Array<{
+      type?: string;
+      delta?: string;
+      partial?: { phase?: string; content?: unknown[] };
+    }> = [];
+    const done = (async () => {
+      for await (const ev of await resolveStream(stream)) {
+        events.push(ev as (typeof events)[number]);
+      }
+    })();
+
+    await new Promise((r) => setImmediate(r));
+    const manager = MockManager.lastInstance!;
+
+    // output_item.added WITHOUT phase — simulates phaseless announcement
+    manager.simulateEvent({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        type: "message",
+        id: "item_phaseless",
+        role: "assistant",
+        content: [],
+      },
+    });
+
+    // Text delta arrives while phase is still unknown
+    manager.simulateEvent({
+      type: "response.output_text.delta",
+      item_id: "item_phaseless",
+      output_index: 0,
+      content_index: 0,
+      delta: "Leaked?",
+    });
+
+    // Yield to let any would-be emissions propagate
+    await new Promise((r) => setImmediate(r));
+    const prematureDeltas = events.filter((e) => e.type === "text_delta");
+    expect(prematureDeltas).toHaveLength(0);
+
+    // output_item.done delivers the actual phase — should flush buffered text
+    manager.simulateEvent({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        type: "message",
+        id: "item_phaseless",
+        role: "assistant",
+        phase: "commentary",
+        content: [{ type: "output_text", text: "Leaked?" }],
+      },
+    });
+
+    manager.simulateEvent({
+      type: "response.completed",
+      response: {
+        id: "resp_phaseless_gate",
+        object: "response",
+        created_at: Date.now(),
+        status: "completed",
+        model: "gpt-5.2",
+        output: [
+          {
+            type: "message",
+            id: "item_phaseless",
+            role: "assistant",
+            phase: "commentary",
+            content: [{ type: "output_text", text: "Leaked?" }],
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+      },
+    });
+
+    await done;
+
+    const deltas = events.filter((e) => e.type === "text_delta");
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]).toMatchObject({ delta: "Leaked?" });
+    expect(deltas[0]?.partial?.phase).toBe("commentary");
+  });
+
   it("falls back to HTTP when WebSocket connect fails (session pre-broken via flag)", async () => {
     // Set the class-level flag BEFORE calling streamFn so the new instance
     // fails on connect().  We patch the static default via MockManager directly.

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -1059,7 +1059,7 @@ export function createOpenAIWebSocketStreamFn(
                 const key = getOutputTextKey(event.item_id, event.content_index);
                 const nextText = `${outputTextByPart.get(key) ?? ""}${event.delta}`;
                 outputTextByPart.set(key, nextText);
-                if (outputItemPhaseById.has(event.item_id)) {
+                if (outputItemPhaseById.get(event.item_id) !== undefined) {
                   emitBufferedTextDelta({
                     itemId: event.item_id,
                     contentIndex: event.content_index,
@@ -1073,7 +1073,7 @@ export function createOpenAIWebSocketStreamFn(
                 if (event.text && event.text !== outputTextByPart.get(key)) {
                   outputTextByPart.set(key, event.text);
                 }
-                if (outputItemPhaseById.has(event.item_id)) {
+                if (outputItemPhaseById.get(event.item_id) !== undefined) {
                   emitBufferedTextDelta({
                     itemId: event.item_id,
                     contentIndex: event.content_index,


### PR DESCRIPTION
Fixes #61477.

Recreated from #61528 with narrower scope and dedicated regression test (as requested by @steipete).

## What this fixes (plain English)
When OpenAI streams a response, it first announces each output item (`output_item.added`) then streams text deltas. If the announcement arrives without phase metadata (e.g., phase is determined later), our buffering gate incorrectly let text through because it checked "does the map have a key?" rather than "does the key have a valid value?" This caused internal commentary to appear as visible user text.

## Technical details
**Root cause:** `outputItemPhaseById.set(id, undefined)` on phaseless `output_item.added`, then `.has(id)` returns `true` for both `response.output_text.delta` and `response.output_text.done` handlers.

**Fix:** Change `.has(event.item_id)` → `.get(event.item_id) !== undefined` on both emission gates (2 lines).

**Regression test:** Sends phaseless `output_item.added` → text delta → asserts no emission → `output_item.done` with phase → asserts correct emission.

## Files changed
- `src/agents/openai-ws-stream.ts` — 2-line gate fix
- `src/agents/openai-ws-stream.test.ts` — regression test for phaseless scenario

## Related
- Parent fix: #59643
- Companion PRs: #61529 (phase inheritance), #61463 (phase extraction)
- Tracks: #61814 (output_item flush-without-phase)
- Initiative: #25592

## Test plan
- [x] Phaseless output_item.added does not flush text
- [x] Text buffered until valid phase arrives via output_item.done
- [x] Existing 92 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)