### PR TITLE
docs: require i18n postprocess before skip

### DIFF
--- a/scripts/docs-i18n/doc_mode.go
+++ b/scripts/docs-i18n/doc_mode.go
@@ -31,7 +31,7 @@ func processFileDoc(ctx context.Context, translator docsTranslator, docsRoot, fi
 
 	outputPath := filepath.Join(docsRoot, tgtLang, relPath)
 	if !overwrite {
-		skip, err := shouldSkipDoc(outputPath, currentHash)
+		skip, err := shouldSkipDoc(outputPath, currentHash, tgtLang)
 		if err != nil {
 			return false, "", err
 		}
@@ -223,7 +223,7 @@ func setReadWhenValue(existing any, index int, value string) []any {
 	return readWhen
 }
 
-func shouldSkipDoc(outputPath string, sourceHash string) (bool, error) {
+func shouldSkipDoc(outputPath string, sourceHash string, targetLang string) (bool, error) {
 	data, err := os.ReadFile(outputPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -242,6 +242,9 @@ func shouldSkipDoc(outputPath string, sourceHash string) (bool, error) {
 	storedHash := extractSourceHash(frontData)
 	if storedHash == "" {
 		return false, nil
+	}
+	if strings.EqualFold(strings.TrimSpace(targetLang), "en") {
+		return strings.EqualFold(storedHash, sourceHash), nil
 	}
 	postprocessVersion := extractPostprocessVersion(frontData)
 	if !strings.EqualFold(postprocessVersion, localizedLinkPostprocessVersion) {

--- a/scripts/docs-i18n/doc_mode.go
+++ b/scripts/docs-i18n/doc_mode.go
@@ -243,11 +243,15 @@ func shouldSkipDoc(outputPath string, sourceHash string) (bool, error) {
 	if storedHash == "" {
 		return false, nil
 	}
+	postprocessVersion := extractPostprocessVersion(frontData)
+	if !strings.EqualFold(postprocessVersion, localizedLinkPostprocessVersion) {
+		return false, nil
+	}
 	return strings.EqualFold(storedHash, sourceHash), nil
 }
 
 func extractSourceHash(frontData map[string]any) string {
-	xi, ok := frontData["x-i18n"].(map[string]any)
+	xi, ok := extractXI18N(frontData)
 	if !ok {
 		return ""
 	}
@@ -256,6 +260,26 @@ func extractSourceHash(frontData map[string]any) string {
 		return ""
 	}
 	return strings.TrimSpace(value)
+}
+
+func extractPostprocessVersion(frontData map[string]any) string {
+	xi, ok := extractXI18N(frontData)
+	if !ok {
+		return ""
+	}
+	value, ok := xi["postprocess_version"].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(value)
+}
+
+func extractXI18N(frontData map[string]any) (map[string]any, bool) {
+	xi, ok := frontData["x-i18n"].(map[string]any)
+	if ok {
+		return xi, true
+	}
+	return nil, false
 }
 
 func resolveDocsPath(docsRoot, filePath string) (string, string, error) {

--- a/scripts/docs-i18n/main.go
+++ b/scripts/docs-i18n/main.go
@@ -325,7 +325,7 @@ func filterDocQueue(docsRoot, targetLang string, ordered []string) ([]string, in
 		}
 		sourceHash := hashBytes(content)
 		outputPath := filepath.Join(docsRoot, targetLang, relPath)
-		skip, err := shouldSkipDoc(outputPath, sourceHash)
+		skip, err := shouldSkipDoc(outputPath, sourceHash, targetLang)
 		if err != nil {
 			return nil, skipped, err
 		}

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -91,8 +91,6 @@ func TestRunDocsI18NOnlyBecomesSkippableAfterPostprocessSucceeds(t *testing.T) {
 		"See [Troubleshooting](/gateway/troubleshooting).",
 	))
 	writeFile(t, filepath.Join(docsRoot, "gateway", "troubleshooting.md"), "# Troubleshooting\n")
-	outputPath := filepath.Join(docsRoot, "zh-CN", "gateway", "index.md")
-
 	skip, outputPath, err := processFileDoc(context.Background(), fakeDocsTranslator{}, docsRoot, sourcePath, "en", "zh-CN", true)
 	if err != nil {
 		t.Fatalf("processFileDoc failed: %v", err)
@@ -105,7 +103,7 @@ func TestRunDocsI18NOnlyBecomesSkippableAfterPostprocessSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read source failed: %v", err)
 	}
-	canSkip, err := shouldSkipDoc(outputPath, hashBytes(sourceBytes))
+	canSkip, err := shouldSkipDoc(outputPath, hashBytes(sourceBytes), "zh-CN")
 	if err != nil {
 		t.Fatalf("shouldSkipDoc before postprocess failed: %v", err)
 	}
@@ -117,11 +115,44 @@ func TestRunDocsI18NOnlyBecomesSkippableAfterPostprocessSucceeds(t *testing.T) {
 		t.Fatalf("postprocessLocalizedDocs failed: %v", err)
 	}
 
-	canSkip, err = shouldSkipDoc(outputPath, hashBytes(sourceBytes))
+	canSkip, err = shouldSkipDoc(outputPath, hashBytes(sourceBytes), "zh-CN")
 	if err != nil {
 		t.Fatalf("shouldSkipDoc after postprocess failed: %v", err)
 	}
 	if !canSkip {
 		t.Fatalf("expected postprocessed output to become skippable:\n%s", mustReadFile(t, outputPath))
+	}
+}
+
+func TestShouldSkipDocKeepsEnglishTargetsHashOnly(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	sourcePath := filepath.Join(docsRoot, "gateway", "index.md")
+	writeFile(t, sourcePath, stringsJoin(
+		"---",
+		"title: Gateway",
+		"---",
+		"",
+		"See [Troubleshooting](/gateway/troubleshooting).",
+	))
+	outputPath := filepath.Join(docsRoot, "en", "gateway", "index.md")
+	writeFile(t, outputPath, stringsJoin(
+		"---",
+		"title: Gateway",
+		"x-i18n:",
+		"  source_hash: "+hashBytes([]byte(mustReadFile(t, sourcePath))),
+		"  postprocess_version: pending",
+		"---",
+		"",
+		"See [Troubleshooting](/gateway/troubleshooting).",
+	))
+
+	canSkip, err := shouldSkipDoc(outputPath, hashBytes([]byte(mustReadFile(t, sourcePath))), "en")
+	if err != nil {
+		t.Fatalf("shouldSkipDoc for English target failed: %v", err)
+	}
+	if !canSkip {
+		t.Fatal("expected English target to remain skippable with matching source hash")
 	}
 }

--- a/scripts/docs-i18n/main_test.go
+++ b/scripts/docs-i18n/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -72,5 +73,55 @@ func TestRunDocsI18NRewritesFinalLocalizedPageLinks(t *testing.T) {
 		if !containsLine(got, want) {
 			t.Fatalf("expected final localized page link %q in output:\n%s", want, got)
 		}
+	}
+}
+
+func TestRunDocsI18NOnlyBecomesSkippableAfterPostprocessSucceeds(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	writeFile(t, filepath.Join(docsRoot, ".i18n", "glossary.zh-CN.json"), "[]")
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	sourcePath := filepath.Join(docsRoot, "gateway", "index.md")
+	writeFile(t, sourcePath, stringsJoin(
+		"---",
+		"title: Gateway",
+		"---",
+		"",
+		"See [Troubleshooting](/gateway/troubleshooting).",
+	))
+	writeFile(t, filepath.Join(docsRoot, "gateway", "troubleshooting.md"), "# Troubleshooting\n")
+	outputPath := filepath.Join(docsRoot, "zh-CN", "gateway", "index.md")
+
+	skip, outputPath, err := processFileDoc(context.Background(), fakeDocsTranslator{}, docsRoot, sourcePath, "en", "zh-CN", true)
+	if err != nil {
+		t.Fatalf("processFileDoc failed: %v", err)
+	}
+	if skip {
+		t.Fatal("processFileDoc unexpectedly skipped translation")
+	}
+
+	sourceBytes, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source failed: %v", err)
+	}
+	canSkip, err := shouldSkipDoc(outputPath, hashBytes(sourceBytes))
+	if err != nil {
+		t.Fatalf("shouldSkipDoc before postprocess failed: %v", err)
+	}
+	if canSkip {
+		t.Fatal("expected pending postprocess output to remain non-skippable")
+	}
+
+	if err := postprocessLocalizedDocs(docsRoot, "zh-CN", []string{outputPath}); err != nil {
+		t.Fatalf("postprocessLocalizedDocs failed: %v", err)
+	}
+
+	canSkip, err = shouldSkipDoc(outputPath, hashBytes(sourceBytes))
+	if err != nil {
+		t.Fatalf("shouldSkipDoc after postprocess failed: %v", err)
+	}
+	if !canSkip {
+		t.Fatalf("expected postprocessed output to become skippable:\n%s", mustReadFile(t, outputPath))
 	}
 }

--- a/scripts/docs-i18n/process.go
+++ b/scripts/docs-i18n/process.go
@@ -11,6 +11,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	localizedLinkPostprocessPending = "pending"
+	localizedLinkPostprocessVersion = "locale-links-v1"
+)
+
 func processFile(ctx context.Context, translator docsTranslator, tm *TranslationMemory, docsRoot, filePath, srcLang, tgtLang string) (bool, string, error) {
 	absPath, relPath, err := resolveDocsPath(docsRoot, filePath)
 	if err != nil {
@@ -119,12 +124,13 @@ func encodeFrontMatter(frontData map[string]any, relPath string, source []byte) 
 		frontData = map[string]any{}
 	}
 	frontData["x-i18n"] = map[string]any{
-		"source_path":  relPath,
-		"source_hash":  hashBytes(source),
-		"provider":     docsPiProvider(),
-		"model":        docsPiModel(),
-		"workflow":     workflowVersion,
-		"generated_at": time.Now().UTC().Format(time.RFC3339),
+		"source_path":         relPath,
+		"source_hash":         hashBytes(source),
+		"provider":            docsPiProvider(),
+		"model":               docsPiModel(),
+		"workflow":            workflowVersion,
+		"generated_at":        time.Now().UTC().Format(time.RFC3339),
+		"postprocess_version": localizedLinkPostprocessPending,
 	}
 	encoded, err := yaml.Marshal(frontData)
 	if err != nil {

--- a/scripts/docs-i18n/relocalize.go
+++ b/scripts/docs-i18n/relocalize.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 )
 
 func postprocessLocalizedDocs(docsRoot, targetLang string, localizedFiles []string) error {
@@ -22,13 +23,14 @@ func postprocessLocalizedDocs(docsRoot, targetLang string, localizedFiles []stri
 
 		frontMatter, body := splitFrontMatter(string(content))
 		rewrittenBody := routes.localizeBodyLinks(body)
-		if rewrittenBody == body {
+		updatedFrontMatter := setPostprocessVersion(frontMatter, localizedLinkPostprocessVersion)
+		if rewrittenBody == body && updatedFrontMatter == frontMatter {
 			continue
 		}
 
 		output := rewrittenBody
-		if frontMatter != "" {
-			output = "---\n" + frontMatter + "\n---\n\n" + rewrittenBody
+		if updatedFrontMatter != "" {
+			output = "---\n" + updatedFrontMatter + "\n---\n\n" + rewrittenBody
 		}
 
 		if err := os.WriteFile(path, []byte(output), 0o644); err != nil {
@@ -37,4 +39,56 @@ func postprocessLocalizedDocs(docsRoot, targetLang string, localizedFiles []stri
 	}
 
 	return nil
+}
+
+func setPostprocessVersion(frontMatter, version string) string {
+	if strings.TrimSpace(frontMatter) == "" {
+		return frontMatter
+	}
+
+	lines := strings.Split(frontMatter, "\n")
+	inXI18N := false
+	xi18nLine := -1
+	insertAt := -1
+	childIndent := "  "
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "x-i18n:" {
+			inXI18N = true
+			xi18nLine = i
+			insertAt = len(lines)
+			continue
+		}
+		if !inXI18N {
+			continue
+		}
+		if trimmed == "" {
+			continue
+		}
+		indent := leadingWhitespace(line)
+		if len(indent) <= len(leadingWhitespace(lines[xi18nLine])) {
+			insertAt = i
+			break
+		}
+		childIndent = indent
+		if strings.HasPrefix(trimmed, "postprocess_version:") {
+			lines[i] = indent + "postprocess_version: " + version
+			return strings.Join(lines, "\n")
+		}
+	}
+
+	if xi18nLine == -1 {
+		return frontMatter
+	}
+	if insertAt == -1 {
+		insertAt = len(lines)
+	}
+
+	lines = append(lines[:insertAt], append([]string{childIndent + "postprocess_version: " + version}, lines[insertAt:]...)...)
+	return strings.Join(lines, "\n")
+}
+
+func leadingWhitespace(text string) string {
+	return text[:len(text)-len(strings.TrimLeft(text, " \t"))]
 }

--- a/scripts/docs-i18n/relocalize_test.go
+++ b/scripts/docs-i18n/relocalize_test.go
@@ -41,7 +41,7 @@ func TestPostprocessLocalizedDocsFixesStaleLinksAfterLaterPagesExist(t *testing.
 	}
 
 	got := mustReadFile(t, filepath.Join(docsRoot, "zh-CN", "gateway", "index.md"))
-	if !strings.Contains(got, "---\ntitle: 网关\nx-i18n:\n  source_hash: test\n---\n\n") {
+	if !strings.Contains(got, "---\ntitle: 网关\nx-i18n:\n  source_hash: test\n  postprocess_version: "+localizedLinkPostprocessVersion+"\n---\n\n") {
 		t.Fatalf("front matter corrupted after rewrite:\n%s", got)
 	}
 	want := "See [Troubleshooting](/zh-CN/gateway/troubleshooting)."
@@ -187,6 +187,36 @@ func TestPostprocessLocalizedDocsContinuesAfterUnchangedFile(t *testing.T) {
 	got := mustReadFile(t, needsRewritePath)
 	if !containsLine(got, "See [Troubleshooting](/zh-CN/gateway/troubleshooting).") {
 		t.Fatalf("expected later file rewrite after unchanged file, got:\n%s", got)
+	}
+}
+
+func TestPostprocessLocalizedDocsFinalizesPostprocessVersionWithoutBodyRewrite(t *testing.T) {
+	t.Parallel()
+
+	docsRoot := t.TempDir()
+	path := filepath.Join(docsRoot, "zh-CN", "gateway", "index.md")
+	writeFile(t, filepath.Join(docsRoot, "docs.json"), `{"redirects":[]}`)
+	writeFile(t, path, stringsJoin(
+		"---",
+		"title: 网关",
+		"x-i18n:",
+		"  source_hash: test",
+		"  postprocess_version: "+localizedLinkPostprocessPending,
+		"---",
+		"",
+		"See [Troubleshooting](/zh-CN/gateway/troubleshooting).",
+	))
+
+	if err := postprocessLocalizedDocs(docsRoot, "zh-CN", []string{path}); err != nil {
+		t.Fatalf("postprocessLocalizedDocs failed: %v", err)
+	}
+
+	got := mustReadFile(t, path)
+	if !strings.Contains(got, "  postprocess_version: "+localizedLinkPostprocessVersion) {
+		t.Fatalf("expected postprocess version marker to be finalized:\n%s", got)
+	}
+	if !containsLine(got, "See [Troubleshooting](/zh-CN/gateway/troubleshooting).") {
+		t.Fatalf("expected localized link to remain unchanged, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- require docs-i18n postprocess completion before localized outputs become skippable
- mark newly written localized docs as `postprocess_version: pending` and finalize them only after locale-link postprocess succeeds
- add regression coverage for the sticky-failure path where stale English links could otherwise survive retries

## Root cause
- docs-i18n writes translated localized files before `postprocessLocalizedDocs(...)` runs
- those files already carried a fresh `x-i18n.source_hash`, so a later postprocess failure could leave stale English-root links on disk
- on retry with `--overwrite=false`, `shouldSkipDoc(...)` only looked at `source_hash`, so the broken file could be skipped indefinitely unless the English source changed

## Fix
- `encodeFrontMatter(...)` now writes `x-i18n.postprocess_version: pending`
- `postprocessLocalizedDocs(...)` upgrades that marker to the current postprocess version only after it rewrites or finalizes the file
- `shouldSkipDoc(...)` now requires both a matching `source_hash` and the current postprocess version before it skips a localized file

## Test plan
- `go test ./...` in `scripts/docs-i18n`
