### PR TITLE
docs: quote plan title frontmatter

### DIFF
--- a/docs/plans/2026-04-05-002-refactor-real-plugin-sdk-workspace-plan.md
+++ b/docs/plans/2026-04-05-002-refactor-real-plugin-sdk-workspace-plan.md
@@ -1,5 +1,5 @@
 ---
-title: refactor: Make plugin-sdk a real workspace package incrementally
+title: "refactor: Make plugin-sdk a real workspace package incrementally"
 type: refactor
 status: active
 date: 2026-04-05


### PR DESCRIPTION
## Summary
- quote the plan title in `docs/plans/2026-04-05-002-refactor-real-plugin-sdk-workspace-plan.md`
- restore valid YAML frontmatter so docs-i18n can parse the file during publish-repo locale refreshes

## Root cause
- the title value contained a second `:` but was not quoted
- docs-i18n doc mode parses frontmatter before translation
- the invalid YAML caused `Translate zh-CN` and `Translate uk` in `openclaw/docs` to fail while processing this plan doc

## Test plan
- parsed the frontmatter with the repo `yaml` package via `node`
- `pnpm check:docs`
