### PR TITLE
fix(agents): accept read path aliases in start diagnostics

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -81,6 +81,38 @@ describe("handleToolExecutionStart read path checks", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("does not warn when read tool uses filePath alias", async () => {
+    const { ctx, warn, onBlockReplyFlush } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-file-path",
+      args: { filePath: "/tmp/example.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when read tool uses file alias", async () => {
+    const { ctx, warn, onBlockReplyFlush } = createTestContext();
+
+    const evt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "read",
+      toolCallId: "tool-file",
+      args: { file: "/tmp/example.txt" },
+    };
+
+    await handleToolExecutionStart(ctx, evt);
+
+    expect(onBlockReplyFlush).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("warns when read tool has neither path nor file_path", async () => {
     const { ctx, warn } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -78,6 +78,23 @@ function buildToolItemId(toolCallId: string): string {
   return `tool:${toolCallId}`;
 }
 
+function resolveReadToolPathArg(args: unknown): string {
+  const record = args && typeof args === "object" ? (args as Record<string, unknown>) : null;
+  if (!record) {
+    return "";
+  }
+  for (const candidate of [record.path, record.file_path, record.filePath, record.file]) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const trimmed = candidate.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return "";
+}
+
 function buildToolItemTitle(toolName: string, meta?: string): string {
   return meta ? `${toolName} ${meta}` : toolName;
 }
@@ -539,14 +556,7 @@ export function handleToolExecutionStart(
     toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: startedAt, args });
 
     if (toolName === "read") {
-      const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};
-      const filePathValue =
-        typeof record.path === "string"
-          ? record.path
-          : typeof record.file_path === "string"
-            ? record.file_path
-            : "";
-      const filePath = filePathValue.trim();
+      const filePath = resolveReadToolPathArg(args);
       if (!filePath) {
         const argsPreview = typeof args === "string" ? args.slice(0, 200) : undefined;
         ctx.log.warn(


### PR DESCRIPTION
## Summary
- align the read tool start diagnostic with the path aliases the runtime already accepts
- treat `filePath` and `file` as valid read-path inputs alongside `path` and `file_path`
- add focused regression coverage for both aliases

Closes #61904

## Verification
- `pnpm test -- src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
- `pnpm exec oxfmt --check src/agents/pi-embedded-subscribe.handlers.tools.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts`
