### PR TITLE
feat(update): add `openclaw update review` pre-upgrade risk assessment

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -17,6 +17,7 @@ updates happen via the package-manager flow in [Updating](/install/updating).
 
 ```bash
 openclaw update
+openclaw update review
 openclaw update status
 openclaw update wizard
 openclaw update --channel beta
@@ -106,6 +107,35 @@ If pnpm bootstrap still fails, the updater now stops early with a package-manage
 ## `--update` shorthand
 
 `openclaw --update` rewrites to `openclaw update` (useful for shells and launcher scripts).
+
+## `update review`
+
+Run a pre-update risk assessment before deciding whether to upgrade.
+
+```bash
+openclaw update review
+openclaw update review --json
+openclaw update review --timeout 15
+```
+
+Fetches the latest release version from the npm registry and the corresponding
+GitHub release notes, then emits a risk-tiered recommendation card:
+
+- **Risk level** — `🟢 Low` (patch/fixes only), `🟡 Medium` (config or auth changes),
+  `🔴 High` (breaking changes)
+- **Your setup** — notes specific to your local config (e.g. whether you will need
+  to run `openclaw doctor --fix` after upgrading)
+- **What changed** — a preview of the release notes
+- **Recommendation** — `Upgrade now`, `Review before upgrading`, or `Up to date`
+
+`update review` is read-only — it never installs or modifies anything. Run it
+whenever you want to understand the upgrade risk before committing to
+`openclaw update`.
+
+### Options
+
+- `--json` — machine-readable `UpdateReviewResult` JSON
+- `--timeout <seconds>` — timeout for npm registry + GitHub checks (default: 8)
 
 ## See also
 

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -4,6 +4,8 @@ import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 import { inheritOptionFromParent } from "./command-options.js";
 import { formatHelpExamples } from "./help-format.js";
+import { updateReviewCommand } from "./update-cli/review.js";
+import type { UpdateReviewOptions } from "./update-cli/review.js";
 import {
   type UpdateCommandOptions,
   type UpdateStatusOptions,
@@ -13,8 +15,8 @@ import { updateStatusCommand } from "./update-cli/status.js";
 import { updateCommand } from "./update-cli/update-command.js";
 import { updateWizardCommand } from "./update-cli/wizard.js";
 
-export { updateCommand, updateStatusCommand, updateWizardCommand };
-export type { UpdateCommandOptions, UpdateStatusOptions, UpdateWizardOptions };
+export { updateCommand, updateStatusCommand, updateWizardCommand, updateReviewCommand };
+export type { UpdateCommandOptions, UpdateStatusOptions, UpdateWizardOptions, UpdateReviewOptions };
 
 function inheritedUpdateJson(command?: Command): boolean {
   return Boolean(inheritOptionFromParent<boolean>(command, "json"));
@@ -146,6 +148,39 @@ ${theme.muted("Docs:")} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/up
     .action(async (opts, command) => {
       try {
         await updateStatusCommand({
+          json: Boolean(opts.json) || inheritedUpdateJson(command),
+          timeout: inheritedUpdateTimeout(opts, command),
+        });
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  update
+    .command("review")
+    .description(
+      "Pre-update risk assessment — summarises what changed and whether it's safe to upgrade",
+    )
+    .option("--json", "Output result as JSON", false)
+    .option("--timeout <seconds>", "Timeout for registry and GitHub checks in seconds (default: 8)")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw update review", "Show risk assessment for the latest release."],
+          ["openclaw update review --json", "JSON output."],
+        ])}\n\n${theme.heading("Notes:")}\n${theme.muted(
+          "- Fetches the latest release from npm and GitHub release notes",
+        )}\n${theme.muted(
+          "- Detects breaking changes, config migrations, and auth/plugin impacts",
+        )}\n${theme.muted(
+          "- Emits a risk-tiered recommendation before you decide to upgrade",
+        )}\n${theme.muted("- Does not install anything — read-only")}\n`,
+    )
+    .action(async (opts, command) => {
+      try {
+        await updateReviewCommand({
           json: Boolean(opts.json) || inheritedUpdateJson(command),
           timeout: inheritedUpdateTimeout(opts, command),
         });

--- a/src/cli/update-cli/review.test.ts
+++ b/src/cli/update-cli/review.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("../../version.js", () => ({ VERSION: "2026.4.1" }));
+
+vi.mock("../../config/config.js", () => ({
+  readConfigFileSnapshot: vi.fn().mockResolvedValue({
+    path: "/fake/.openclaw/openclaw.json",
+    exists: true,
+    raw: "{}",
+    parsed: {},
+    valid: true,
+    sourceConfig: {},
+    config: {},
+    issues: [],
+  }),
+}));
+
+vi.mock("../../infra/update-channels.js", () => ({
+  normalizeUpdateChannel: vi.fn().mockReturnValue(null),
+  DEFAULT_GIT_CHANNEL: "dev",
+  DEFAULT_PACKAGE_CHANNEL: "stable",
+}));
+
+vi.mock("../../infra/update-check.js", () => ({
+  checkUpdateStatus: vi.fn(),
+  compareSemverStrings: vi.fn(),
+  resolveNpmChannelTag: vi.fn().mockResolvedValue({ tag: "latest", version: null }),
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+    writeJson: vi.fn(),
+  },
+}));
+
+import { normalizeUpdateChannel } from "../../infra/update-channels.js";
+import {
+  checkUpdateStatus,
+  compareSemverStrings,
+  resolveNpmChannelTag,
+} from "../../infra/update-check.js";
+import { defaultRuntime } from "../../runtime.js";
+// Import after mocks
+import { updateReviewCommand } from "./review.js";
+
+const mockCheckUpdateStatus = vi.mocked(checkUpdateStatus);
+const mockCompareSemverStrings = vi.mocked(compareSemverStrings);
+const mockNormalizeUpdateChannel = vi.mocked(normalizeUpdateChannel);
+const mockResolveNpmChannelTag = vi.mocked(resolveNpmChannelTag);
+const mockRuntime = vi.mocked(defaultRuntime);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeUpdateStatus(latestVersion: string | null, gitBehind?: number) {
+  return {
+    root: "/fake",
+    installKind: (gitBehind !== undefined ? "git" : "package") as "git" | "package",
+    packageManager: "npm" as const,
+    registry: { latestVersion },
+    git:
+      gitBehind !== undefined
+        ? { behind: gitBehind, sha: "abc1234", branch: "main", tag: null, dirty: false, ahead: 0, upstream: "origin/main", fetchOk: true }
+        : undefined,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("updateReviewCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Suppress fetch errors in tests
+    vi.stubGlobal("fetch", () => Promise.reject(new Error("network unavailable")));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports up-to-date when no update is available", async () => {
+    mockCheckUpdateStatus.mockResolvedValue(makeUpdateStatus("2026.4.1"));
+    mockCompareSemverStrings.mockReturnValue(0);
+
+    await updateReviewCommand({});
+
+    const logged = mockRuntime.log.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("up to date");
+  });
+
+  it("detects update available and emits recommendation", async () => {
+    mockCheckUpdateStatus.mockResolvedValue(makeUpdateStatus("2026.4.2"));
+    mockCompareSemverStrings.mockReturnValue(-1);
+
+    await updateReviewCommand({});
+
+    const logged = mockRuntime.log.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("2026.4.2");
+    expect(logged).toMatch(/Recommendation|upgrade|review/i);
+  });
+
+  it("emits JSON output when --json is set", async () => {
+    mockCheckUpdateStatus.mockResolvedValue(makeUpdateStatus("2026.4.2"));
+    mockCompareSemverStrings.mockReturnValue(-1);
+
+    await updateReviewCommand({ json: true });
+
+    expect(mockRuntime.writeJson).toHaveBeenCalledOnce();
+    const result = mockRuntime.writeJson.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(result).toMatchObject({
+      installedVersion: "2026.4.1",
+      latestVersion: "2026.4.2",
+      updateAvailable: true,
+    });
+    // riskLevel is null when GitHub notes unavailable (fetch stubbed to reject)
+    expect(result).toHaveProperty("riskLevel");
+    expect(result).toHaveProperty("gitBehind");
+    expect(result).toHaveProperty("recommendation");
+    expect(result).toHaveProperty("localImpact");
+  });
+
+  it("reports registry-unavailable when npm lookup fails (package install)", async () => {
+    // latestVersion=null means the registry call failed
+    mockCheckUpdateStatus.mockResolvedValue(makeUpdateStatus(null));
+    // compareSemverStrings never called when latestVersion is null
+
+    await updateReviewCommand({ json: true });
+
+    expect(mockRuntime.writeJson).toHaveBeenCalledOnce();
+    const result = mockRuntime.writeJson.mock.calls[0]?.[0] as Record<string, unknown>;
+    // Must not claim up-to-date when we simply couldn't check
+    expect(result).toMatchObject({
+      updateAvailable: false,
+      checkUnavailable: true,
+      recommendation: "review",
+    });
+    expect((result.recommendationReason as string)).toContain("Registry unavailable");
+  });
+
+  it("detects git-behind update for git installs (same npm version)", async () => {
+    // latestVersion same as installed, but git checkout is 3 commits behind
+    mockCheckUpdateStatus.mockResolvedValue(makeUpdateStatus("2026.4.1", 3));
+    mockCompareSemverStrings.mockReturnValue(0); // npm is current
+
+    await updateReviewCommand({ json: true });
+
+    expect(mockRuntime.writeJson).toHaveBeenCalledOnce();
+    const result = mockRuntime.writeJson.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(result).toMatchObject({
+      updateAvailable: true,
+      checkUnavailable: false,
+      gitBehind: 3,
+      // Should recommend review, not upgrade — can't score pending commits
+      recommendation: "review",
+    });
+    expect((result.recommendationReason as string)).toContain("3 commits behind");
+  });
+
+  it("recommends review when release notes unavailable (unknown risk)", async () => {
+    mockCheckUpdateStatus.mockResolvedValue(makeUpdateStatus("2026.4.2"));
+    mockCompareSemverStrings.mockReturnValue(-1);
+    // fetch is stubbed to reject, so riskLevel will be null
+
+    await updateReviewCommand({ json: true });
+
+    expect(mockRuntime.writeJson).toHaveBeenCalledOnce();
+    const result = mockRuntime.writeJson.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(result).toMatchObject({
+      riskLevel: null,
+      recommendation: "review",
+    });
+  });
+
+  it("emits up-to-date JSON when no update available", async () => {
+    mockCheckUpdateStatus.mockResolvedValue(makeUpdateStatus("2026.4.1"));
+    mockCompareSemverStrings.mockReturnValue(0);
+
+    await updateReviewCommand({ json: true });
+
+    expect(mockRuntime.writeJson).toHaveBeenCalledOnce();
+    const result = mockRuntime.writeJson.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(result).toMatchObject({
+      updateAvailable: false,
+      checkUnavailable: false,
+      recommendation: "up-to-date",
+      gitBehind: null,
+    });
+  });
+
+  it("defaults git installs to dev channel when no config set", async () => {
+    // No channel in config
+    mockNormalizeUpdateChannel.mockReturnValue(null);
+    // Git install, 0 behind (we'll test via resolveNpmChannelTag being called with dev)
+    mockCheckUpdateStatus.mockResolvedValue(makeUpdateStatus("2026.4.1", 0));
+    mockResolveNpmChannelTag.mockResolvedValue({ tag: "dev", version: "2026.4.2-dev.5" });
+    mockCompareSemverStrings.mockReturnValue(-1);
+
+    await updateReviewCommand({ json: true });
+
+    // Should resolve against dev channel, not stable
+    expect(mockResolveNpmChannelTag).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "dev" }),
+    );
+    const result = mockRuntime.writeJson.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(result).toMatchObject({
+      latestVersion: "2026.4.2-dev.5",
+      updateAvailable: true,
+    });
+  });
+
+  it("uses beta channel version when config specifies beta", async () => {
+    // Config says beta channel
+    mockNormalizeUpdateChannel.mockReturnValue("beta");
+    // resolveNpmChannelTag returns the beta version
+    mockResolveNpmChannelTag.mockResolvedValue({ tag: "beta", version: "2026.5.0-beta.1" });
+    // registry.latestVersion is the stable version (older) — should be ignored
+    mockCheckUpdateStatus.mockResolvedValue(makeUpdateStatus("2026.4.1"));
+    // VERSION (2026.4.1) < beta version (2026.5.0-beta.1)
+    mockCompareSemverStrings.mockReturnValue(-1);
+
+    await updateReviewCommand({ json: true });
+
+    expect(mockResolveNpmChannelTag).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "beta" }),
+    );
+    expect(mockRuntime.writeJson).toHaveBeenCalledOnce();
+    const result = mockRuntime.writeJson.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(result).toMatchObject({
+      latestVersion: "2026.5.0-beta.1",
+      updateAvailable: true,
+    });
+  });
+});

--- a/src/cli/update-cli/review.ts
+++ b/src/cli/update-cli/review.ts
@@ -1,0 +1,449 @@
+/**
+ * `openclaw update review` — pre-update risk assessment.
+ *
+ * Fetches the latest release from the npm registry, summarises what changed
+ * relative to the installed version, and emits a risk-tiered recommendation
+ * card with any local-config implications before the user decides whether to
+ * run `openclaw update`.
+ */
+
+import { readConfigFileSnapshot } from "../../config/config.js";
+import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
+import {
+  DEFAULT_GIT_CHANNEL,
+  DEFAULT_PACKAGE_CHANNEL,
+  normalizeUpdateChannel,
+  type UpdateChannel,
+} from "../../infra/update-channels.js";
+import {
+  checkUpdateStatus,
+  compareSemverStrings,
+  resolveNpmChannelTag,
+} from "../../infra/update-check.js";
+import { defaultRuntime } from "../../runtime.js";
+import { getTerminalTableWidth, renderTable } from "../../terminal/table.js";
+import { theme } from "../../terminal/theme.js";
+import { VERSION } from "../../version.js";
+import { formatCliCommand } from "../command-format.js";
+import { parseTimeoutMsOrExit, resolveUpdateRoot } from "./shared.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type UpdateReviewOptions = {
+  json?: boolean;
+  timeout?: string;
+};
+
+export type RiskLevel = "low" | "medium" | "high";
+
+export type LocalImpact = {
+  /** True when the release notes mention a `Breaking` section. */
+  hasBreakingChanges: boolean;
+  /** True when the release notes mention config-key removals. */
+  hasConfigMigration: boolean;
+  /** True when the release notes mention auth/OAuth/token changes. */
+  hasAuthChanges: boolean;
+  /** True when the release notes mention plugin-related changes. */
+  hasPluginChanges: boolean;
+  /** Human-readable lines describing what to watch for. */
+  notes: string[];
+};
+
+export type UpdateReviewResult = {
+  installedVersion: string;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+  /** Commits behind upstream for git installs; null for package installs. */
+  gitBehind: number | null;
+  /**
+   * True when the registry was unreachable and there is no git signal.
+   * The command cannot determine whether an update exists.
+   */
+  checkUnavailable: boolean;
+  /** null when release notes could not be fetched (rate limit / network). */
+  riskLevel: RiskLevel | null;
+  releaseBody: string | null;
+  changelogPreview: string | null;
+  localImpact: LocalImpact;
+  recommendation: "upgrade" | "review" | "up-to-date";
+  recommendationReason: string;
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const BREAKING_PATTERN = /###\s*breaking/i;
+const CONFIG_PATTERN = /config.*remov|remov.*config.*key|doctor.*--fix|legacy.*config/i;
+const AUTH_PATTERN = /\b(oauth|api[._-]?key|token|auth(?:entication|orization)?)\b/i;
+const PLUGIN_PATTERN = /plugin/i;
+
+/**
+ * Derive risk level from release body heuristics.
+ * Returns null when the body is unavailable — callers treat null as "unknown"
+ * so a missing changelog never silently downgrades the risk estimate.
+ */
+function assessRisk(body: string | null): RiskLevel | null {
+  if (!body) {
+    return null;
+  }
+  if (BREAKING_PATTERN.test(body)) {
+    return "high";
+  }
+  if (CONFIG_PATTERN.test(body) || AUTH_PATTERN.test(body)) {
+    return "medium";
+  }
+  return "low";
+}
+
+/** Extract local-impact notes from release body. */
+function extractLocalImpact(body: string | null, configSnapshot: ConfigFileSnapshot): LocalImpact {
+  if (!body) {
+    return {
+      hasBreakingChanges: false,
+      hasConfigMigration: false,
+      hasAuthChanges: false,
+      hasPluginChanges: false,
+      notes: [],
+    };
+  }
+
+  const hasBreakingChanges = BREAKING_PATTERN.test(body);
+  const hasConfigMigration = CONFIG_PATTERN.test(body);
+  const hasAuthChanges = AUTH_PATTERN.test(body);
+  const hasPluginChanges = PLUGIN_PATTERN.test(body);
+
+  const notes: string[] = [];
+
+  if (hasBreakingChanges) {
+    notes.push("Breaking changes detected — review the changelog before upgrading.");
+  }
+  if (hasConfigMigration) {
+    notes.push(
+      "Config key changes detected — run `openclaw doctor --fix` after upgrading to apply migrations.",
+    );
+  }
+  if (hasAuthChanges && configSnapshot.valid) {
+    notes.push(
+      "Auth/OAuth changes detected — verify your provider profiles are still valid after upgrading.",
+    );
+  }
+  if (hasPluginChanges) {
+    notes.push("Plugin changes detected — plugins will be synced automatically during upgrade.");
+  }
+
+  if (notes.length === 0) {
+    notes.push("No local-config action required.");
+  }
+
+  return {
+    hasBreakingChanges,
+    hasConfigMigration,
+    hasAuthChanges,
+    hasPluginChanges,
+    notes,
+  };
+}
+
+/** Map risk level to a coloured badge string. */
+function formatRiskBadge(risk: RiskLevel): string {
+  switch (risk) {
+    case "low":
+      return theme.success("🟢 Low");
+    case "medium":
+      return theme.warn("🟡 Medium");
+    case "high":
+      return theme.error("🔴 High");
+  }
+}
+
+/** Fetch GitHub release body for a given version tag. */
+async function fetchReleaseBody(version: string, timeoutMs: number): Promise<string | null> {
+  const tag = `v${version}`;
+  const url = `https://api.github.com/repos/openclaw/openclaw/releases/tags/${tag}`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: "application/vnd.github.v3+json" },
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    if (!res.ok) {
+      return null;
+    }
+    const data = (await res.json()) as { body?: string | null };
+    return data.body ?? null;
+  } catch {
+    clearTimeout(timer);
+    return null;
+  }
+}
+
+/** Truncate a long release body to a readable preview. */
+function summariseBody(body: string | null, maxLines = 20): string | null {
+  if (!body) {
+    return null;
+  }
+  const lines = body
+    .split("\n")
+    .map((l) => l.trimEnd())
+    .filter((l) => l.length > 0);
+  if (lines.length <= maxLines) {
+    return lines.join("\n");
+  }
+  return lines.slice(0, maxLines).join("\n") + `\n  … (${lines.length - maxLines} more lines)`;
+}
+
+// ── Command ──────────────────────────────────────────────────────────────────
+
+export async function updateReviewCommand(opts: UpdateReviewOptions): Promise<void> {
+  const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
+  if (timeoutMs === null) {
+    return;
+  }
+
+  const root = await resolveUpdateRoot();
+  const [updateStatus, configSnapshot] = await Promise.all([
+    checkUpdateStatus({
+      root,
+      timeoutMs: timeoutMs ?? 8000,
+      fetchGit: true,
+      includeRegistry: true,
+    }),
+    readConfigFileSnapshot(),
+  ]);
+
+  // Resolve the effective update channel so beta/dev users get the right target version.
+  const configChannel: UpdateChannel | null = configSnapshot.valid
+    ? normalizeUpdateChannel(configSnapshot.config?.update?.channel)
+    : null;
+  const defaultChannel: UpdateChannel =
+    updateStatus.installKind === "git" ? DEFAULT_GIT_CHANNEL : DEFAULT_PACKAGE_CHANNEL;
+  const effectiveChannel: UpdateChannel = configChannel ?? defaultChannel;
+
+  // For stable channel, use the registry result we already have.
+  // For beta/dev, resolve the channel-specific dist-tag version.
+  let targetVersion: string | null;
+  let resolvedTag: string = "latest";
+  if (effectiveChannel === "stable") {
+    targetVersion = updateStatus.registry?.latestVersion ?? null;
+  } else {
+    const resolved = await resolveNpmChannelTag({
+      channel: effectiveChannel,
+      timeoutMs: timeoutMs ?? 8000,
+    });
+    targetVersion = resolved.version;
+    resolvedTag = resolved.tag;
+  }
+
+  const cmp = targetVersion ? compareSemverStrings(VERSION, targetVersion) : null;
+
+  // Three distinct registry states — null means we couldn't check, not that we're current.
+  const registryCheckState: "update-available" | "up-to-date" | "unavailable" =
+    targetVersion == null
+      ? "unavailable"
+      : cmp != null && cmp < 0
+        ? "update-available"
+        : "up-to-date";
+
+  // For git installs, check whether the local checkout is behind upstream.
+  const gitBehind =
+    updateStatus.installKind === "git" &&
+    typeof updateStatus.git?.behind === "number" &&
+    updateStatus.git.behind > 0
+      ? updateStatus.git.behind
+      : null;
+
+  // If git fetch itself failed, we can't trust the behind count — treat as unknown.
+  const gitFetchFailed =
+    updateStatus.installKind === "git" && updateStatus.git?.fetchOk === false;
+
+  // Detect downgrade scenario: installed version is *ahead* of the channel target.
+  const isDowngrade = cmp != null && cmp > 0;
+
+  // Registry truly unavailable (or git fetch failed) with no other signal.
+  const checkUnavailable =
+    (registryCheckState === "unavailable" && gitBehind === null && !gitFetchFailed) ||
+    (gitFetchFailed && registryCheckState !== "update-available");
+
+  const updateAvailable =
+    registryCheckState === "update-available" || gitBehind !== null || isDowngrade;
+
+  // Only fetch release notes when there is a *newer* npm version to score.
+  // For git-behind-only cases the installed npm version's notes are stale/irrelevant.
+  const releaseBody =
+    registryCheckState === "update-available" && targetVersion
+      ? await fetchReleaseBody(targetVersion, timeoutMs ?? 8000)
+      : null;
+
+  const riskLevel = assessRisk(releaseBody);
+  const localImpact = extractLocalImpact(releaseBody, configSnapshot);
+
+  // Recommendation logic
+  let recommendation: UpdateReviewResult["recommendation"];
+  let recommendationReason: string;
+
+  if (checkUnavailable) {
+    recommendation = "review";
+    recommendationReason =
+      "Registry unavailable — couldn't determine if an update exists. Check your connection.";
+  } else if (isDowngrade) {
+    recommendation = "review";
+    recommendationReason =
+      `Installed version (${VERSION}) is ahead of the ${resolvedTag} target (${targetVersion}) — this would be a downgrade.`;
+  } else if (!updateAvailable) {
+    recommendation = "up-to-date";
+    recommendationReason = "You are on the latest version.";
+  } else if (gitFetchFailed) {
+    recommendation = "review";
+    recommendationReason =
+      "Git fetch failed — couldn't determine upstream status. Check your connection and retry.";
+  } else if (gitBehind !== null && registryCheckState !== "update-available") {
+    // Git checkout is behind upstream but npm version is current — can't score the pending commits.
+    recommendation = "review";
+    recommendationReason =
+      `Git checkout is ${gitBehind} commit${gitBehind === 1 ? "" : "s"} behind upstream — run \`openclaw update\` to see what changed.`;
+  } else if (riskLevel === null) {
+    // Update available but release notes couldn't be fetched — don't assume safe.
+    recommendation = "review";
+    recommendationReason =
+      "Release notes unavailable — inspect the changelog manually before upgrading.";
+  } else if (riskLevel === "high") {
+    recommendation = "review";
+    recommendationReason = "Breaking changes present — read the changelog before upgrading.";
+  } else if (riskLevel === "medium") {
+    recommendation = "upgrade";
+    recommendationReason =
+      "Config or auth changes detected — run `openclaw doctor --fix` after upgrading.";
+  } else {
+    recommendation = "upgrade";
+    recommendationReason = "Low-risk update — safe to upgrade now.";
+  }
+
+  const changelogPreview = summariseBody(releaseBody);
+
+  const result: UpdateReviewResult = {
+    installedVersion: VERSION,
+    latestVersion: targetVersion,
+    updateAvailable,
+    checkUnavailable,
+    gitBehind,
+    riskLevel,
+    releaseBody,
+    changelogPreview,
+    localImpact,
+    recommendation,
+    recommendationReason,
+  };
+
+  if (opts.json) {
+    defaultRuntime.writeJson(result);
+    return;
+  }
+
+  // ── Human-readable output ──────────────────────────────────────────────────
+
+  defaultRuntime.log(theme.heading("OpenClaw update review"));
+  defaultRuntime.log("");
+
+  const tableWidth = getTerminalTableWidth();
+
+  // Build the Update cell.
+  let updateValue: string;
+  if (checkUnavailable) {
+    updateValue = theme.warn("unknown (check failed)");
+  } else if (isDowngrade) {
+    updateValue = theme.warn("downgrade");
+  } else if (!updateAvailable) {
+    updateValue = theme.success("up to date");
+  } else if (gitFetchFailed) {
+    updateValue = theme.warn("unknown (git fetch failed)");
+  } else if (gitBehind !== null && registryCheckState !== "update-available") {
+    updateValue = theme.warn(`git behind ${gitBehind}`);
+  } else if (gitBehind !== null) {
+    updateValue = theme.warn(`available · git behind ${gitBehind}`);
+  } else {
+    updateValue = theme.warn("available");
+  }
+
+  // Risk is only meaningful when we scored actual release notes.
+  let riskValue: string;
+  if (checkUnavailable || gitFetchFailed || (gitBehind !== null && registryCheckState !== "update-available")) {
+    riskValue = theme.warn("unknown");
+  } else if (!updateAvailable) {
+    riskValue = theme.success("none");
+  } else if (riskLevel !== null) {
+    riskValue = formatRiskBadge(riskLevel);
+  } else {
+    riskValue = theme.warn("unknown");
+  }
+
+  const channelSuffix = resolvedTag !== "latest" ? ` (${resolvedTag})` : "";
+
+  const rows = [
+    { Item: "Installed", Value: VERSION },
+    { Item: "Latest", Value: (targetVersion ?? theme.muted("unknown")) + channelSuffix },
+    { Item: "Update", Value: updateValue },
+    { Item: "Risk", Value: riskValue },
+  ];
+
+  defaultRuntime.log(
+    renderTable({
+      width: tableWidth,
+      columns: [
+        { key: "Item", header: "Item", minWidth: 10 },
+        { key: "Value", header: "Value", minWidth: 20, flex: true },
+      ],
+      rows,
+    }).trimEnd(),
+  );
+  defaultRuntime.log("");
+
+  if (!updateAvailable && !checkUnavailable && !isDowngrade) {
+    return;
+  }
+
+  defaultRuntime.log(theme.heading("Your setup"));
+  defaultRuntime.log("");
+  for (const note of localImpact.notes) {
+    defaultRuntime.log(`- ${note}`);
+  }
+  defaultRuntime.log("");
+
+  if (changelogPreview) {
+    defaultRuntime.log(theme.heading("What changed"));
+    defaultRuntime.log("");
+    for (const line of changelogPreview.split("\n")) {
+      defaultRuntime.log(theme.muted(line));
+    }
+    defaultRuntime.log("");
+  } else {
+    defaultRuntime.log(
+      theme.muted("Release notes unavailable (GitHub rate limit or network error)."),
+    );
+    defaultRuntime.log("");
+  }
+
+  const recIcon =
+    recommendation === "upgrade"
+      ? theme.success("✅")
+      : recommendation === "review"
+        ? theme.warn("⚠️ ")
+        : theme.success("✓");
+
+  const recLabel =
+    recommendation === "upgrade"
+      ? "Upgrade now"
+      : recommendation === "review"
+        ? "Review before upgrading"
+        : "Up to date";
+
+  defaultRuntime.log(theme.heading("Recommendation:"));
+  defaultRuntime.log(`  ${recIcon} ${recLabel}`);
+  defaultRuntime.log(`  ${theme.muted(recommendationReason)}`);
+  defaultRuntime.log("");
+
+  if (recommendation !== "up-to-date") {
+    defaultRuntime.log(`  ${theme.muted("To upgrade:")} ${formatCliCommand("openclaw update")}`);
+    defaultRuntime.log("");
+  }
+}


### PR DESCRIPTION
## What this adds

`openclaw update review` — a read-only pre-upgrade risk assessment subcommand.

Run it before `openclaw update` to understand what changed and whether it is safe to upgrade right now.

```
openclaw update review
openclaw update review --json
openclaw update review --timeout 15
```

### Sample output (update available)

```
OpenClaw update review

 Item       Value
 ───────── ──────────────
 Installed  2026.4.1
 Latest     2026.4.5
 Update     available
 Risk       🔴 High

Your setup

- Breaking changes detected — review the changelog before upgrading.
- Config key changes detected — run `openclaw doctor --fix` after upgrading.

What changed

  ### Breaking
  - Config: remove legacy public config aliases …
  …

Recommendation:
  ⚠️  Review before upgrading
  Breaking changes present — read the changelog before upgrading.

  To upgrade: openclaw update
```

## How it works

1. Checks npm registry for `latestVersion` vs `VERSION`
2. If update available: fetches GitHub release body via `api.github.com/repos/openclaw/openclaw/releases/tags/vX.Y.Z`
3. Runs lightweight heuristics on the release body:
   - `### Breaking` → risk = **high**
   - config-key removals / `doctor --fix` / legacy-config mentions → risk = **medium**
   - auth/OAuth/token mentions → risk = **medium**
   - anything else → risk = **low**
4. Extracts local-impact notes scoped to the user's setup
5. Renders a table + notes + changelog preview + tiered recommendation
6. `--json` emits a typed `UpdateReviewResult` for scripting / morning-brief scripts

Read-only — never installs or modifies anything.

## Files changed

| File | Change |
|------|--------|
| `src/cli/update-cli/review.ts` | New — implementation |
| `src/cli/update-cli/review.test.ts` | New — 5 vitest tests |
| `src/cli/update-cli.ts` | Wire `review` subcommand, export types |
| `docs/cli/update.md` | Document `update review` |

## Validation

- `tsc --noEmit` — clean
- `vitest run src/cli/update-cli/review.test.ts` — 5/5 pass

## Notes

- Uses `parseTimeoutMsOrExit` from `shared.ts` (same as `status`)
- Uses `renderTable` + `getTerminalTableWidth` — matches house style from `status.ts`
- GitHub fetch is best-effort: degrades gracefully on rate-limit or network error
- `--json` output shape is stable and typed (`UpdateReviewResult`)