### PR TITLE
fix(reply): await block streaming delivery on same-channel dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- Slack/media: preserve bearer auth across same-origin `files.slack.com` redirects while still stripping it on cross-origin Slack CDN hops, so `url_private_download` image attachments load again. (#62960) Thanks @vincentkoc.
+
 ## 2026.4.8
 
 ### Fixes

--- a/apps/android/app/build.gradle.kts
+++ b/apps/android/app/build.gradle.kts
@@ -65,8 +65,8 @@ android {
         applicationId = "ai.openclaw.app"
         minSdk = 31
         targetSdk = 36
-        versionCode = 2026040801
-        versionName = "2026.4.8"
+        versionCode = 2026040901
+        versionName = "2026.4.9"
         ndk {
             // Support all major ABIs — native libs are tiny (~47 KB per ABI)
             abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")

--- a/apps/ios/Config/Version.xcconfig
+++ b/apps/ios/Config/Version.xcconfig
@@ -1,8 +1,8 @@
 // Shared iOS version defaults.
 // Generated overrides live in build/Version.xcconfig (git-ignored).
 
-OPENCLAW_GATEWAY_VERSION = 2026.4.8
-OPENCLAW_MARKETING_VERSION = 2026.4.8
-OPENCLAW_BUILD_VERSION = 2026040801
+OPENCLAW_GATEWAY_VERSION = 2026.4.9
+OPENCLAW_MARKETING_VERSION = 2026.4.9
+OPENCLAW_BUILD_VERSION = 2026040901
 
 #include? "../build/Version.xcconfig"

--- a/apps/macos/Sources/OpenClaw/Resources/Info.plist
+++ b/apps/macos/Sources/OpenClaw/Resources/Info.plist
@@ -15,9 +15,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2026.4.8</string>
+    <string>2026.4.9</string>
     <key>CFBundleVersion</key>
-    <string>2026040801</string>
+    <string>2026040901</string>
     <key>CFBundleIconFile</key>
     <string>OpenClaw</string>
     <key>CFBundleURLTypes</key>

--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/acpx",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw ACP runtime backend",
   "type": "module",
   "dependencies": {

--- a/extensions/alibaba/package.json
+++ b/extensions/alibaba/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/alibaba-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Alibaba Model Studio video provider plugin",
   "type": "module",

--- a/extensions/amazon-bedrock-mantle/package.json
+++ b/extensions/amazon-bedrock-mantle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-mantle-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Amazon Bedrock Mantle (OpenAI-compatible) provider plugin",
   "type": "module",

--- a/extensions/amazon-bedrock/package.json
+++ b/extensions/amazon-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Amazon Bedrock provider plugin",
   "type": "module",

--- a/extensions/anthropic-vertex/package.json
+++ b/extensions/anthropic-vertex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-vertex-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Anthropic Vertex provider plugin",
   "type": "module",

--- a/extensions/anthropic/package.json
+++ b/extensions/anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/anthropic-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Anthropic provider plugin",
   "type": "module",

--- a/extensions/arcee/package.json
+++ b/extensions/arcee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/arcee-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Arcee provider plugin",
   "type": "module",

--- a/extensions/bluebubbles/package.json
+++ b/extensions/bluebubbles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/bluebubbles",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw BlueBubbles channel plugin",
   "type": "module",
   "devDependencies": {
@@ -8,7 +8,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -40,13 +40,13 @@
     "install": {
       "npmSpec": "@openclaw/bluebubbles",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/brave/package.json
+++ b/extensions/brave/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/brave-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Brave plugin",
   "type": "module",

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/browser-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw browser tool plugin",
   "type": "module",

--- a/extensions/byteplus/package.json
+++ b/extensions/byteplus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/byteplus-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw BytePlus provider plugin",
   "type": "module",

--- a/extensions/chutes/package.json
+++ b/extensions/chutes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/chutes-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Chutes.ai provider plugin",
   "type": "module",

--- a/extensions/cloudflare-ai-gateway/package.json
+++ b/extensions/cloudflare-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/cloudflare-ai-gateway-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Cloudflare AI Gateway provider plugin",
   "type": "module",

--- a/extensions/comfy/package.json
+++ b/extensions/comfy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/comfy-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw ComfyUI provider plugin",
   "type": "module",

--- a/extensions/copilot-proxy/package.json
+++ b/extensions/copilot-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/copilot-proxy",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Copilot Proxy provider plugin",
   "type": "module",

--- a/extensions/deepgram/package.json
+++ b/extensions/deepgram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepgram-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Deepgram media-understanding provider",
   "type": "module",

--- a/extensions/deepseek/package.json
+++ b/extensions/deepseek/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/deepseek-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw DeepSeek provider plugin",
   "type": "module",

--- a/extensions/diagnostics-otel/package.json
+++ b/extensions/diagnostics-otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diagnostics-otel",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw diagnostics OpenTelemetry exporter",
   "type": "module",
   "dependencies": {
@@ -24,10 +24,10 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/diffs/package.json
+++ b/extensions/diffs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/diffs",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw diff viewer plugin",
   "type": "module",

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/discord",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Discord channel plugin",
   "type": "module",
   "dependencies": {
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -49,13 +49,13 @@
     "install": {
       "npmSpec": "@openclaw/discord",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "bundle": {
       "stageRuntimeDependencies": true

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -38,7 +38,7 @@ const deliverDiscordReply = deliveryMocks.deliverDiscordReply;
 const createDiscordDraftStream = deliveryMocks.createDiscordDraftStream;
 type DispatchInboundParams = {
   dispatcher: {
-    sendBlockReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
+    sendBlockReply: (payload: ReplyPayload) => false | Promise<void>;
     sendFinalReply: (payload: ReplyPayload) => boolean | Promise<boolean>;
   };
   replyOptions?: {
@@ -125,7 +125,7 @@ vi.spyOn(replyRuntimeModule, "createReplyDispatcherWithTyping").mockImplementati
     sendToolResult: vi.fn(() => true),
     sendBlockReply: vi.fn((payload: unknown) => {
       void opts.deliver(payload as never, { kind: "block" });
-      return true;
+      return Promise.resolve();
     }),
     sendFinalReply: vi.fn((payload: unknown) => {
       void opts.deliver(payload as never, { kind: "final" });

--- a/extensions/duckduckgo/package.json
+++ b/extensions/duckduckgo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/duckduckgo-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw DuckDuckGo plugin",
   "type": "module",

--- a/extensions/elevenlabs/package.json
+++ b/extensions/elevenlabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/elevenlabs-speech",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw ElevenLabs speech plugin",
   "type": "module",

--- a/extensions/exa/package.json
+++ b/extensions/exa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/exa-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Exa plugin",
   "type": "module",

--- a/extensions/fal/package.json
+++ b/extensions/fal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fal-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw fal provider plugin",
   "type": "module",

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/feishu",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Feishu/Lark channel plugin (community maintained by @m1heng)",
   "type": "module",
   "dependencies": {
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -40,13 +40,13 @@
     "install": {
       "npmSpec": "@openclaw/feishu",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "bundle": {
       "stageRuntimeDependencies": true

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1173,7 +1173,7 @@ export async function handleFeishuMessage(params: {
           delete (agentCtx as Record<string, unknown>).CommandAuthorized;
           const noopDispatcher = {
             sendToolResult: () => false,
-            sendBlockReply: () => false,
+            sendBlockReply: () => false as const,
             sendFinalReply: () => false,
             waitForIdle: async () => {},
             getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),

--- a/extensions/firecrawl/package.json
+++ b/extensions/firecrawl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/firecrawl-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Firecrawl plugin",
   "type": "module",

--- a/extensions/fireworks/package.json
+++ b/extensions/fireworks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/fireworks-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Fireworks provider plugin",
   "type": "module",

--- a/extensions/github-copilot/package.json
+++ b/extensions/github-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/github-copilot-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw GitHub Copilot provider plugin",
   "type": "module",

--- a/extensions/google/package.json
+++ b/extensions/google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/google-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Google plugin",
   "type": "module",

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/googlechat",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Google Chat channel plugin",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -43,7 +43,7 @@
     "install": {
       "npmSpec": "@openclaw/googlechat",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     }
   }
 }

--- a/extensions/groq/package.json
+++ b/extensions/groq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/groq-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Groq media-understanding provider",
   "type": "module",

--- a/extensions/huggingface/package.json
+++ b/extensions/huggingface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/huggingface-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Hugging Face provider plugin",
   "type": "module",

--- a/extensions/image-generation-core/package.json
+++ b/extensions/image-generation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/image-generation-core",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw image generation runtime package",
   "type": "module",

--- a/extensions/imessage/package.json
+++ b/extensions/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/imessage",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw iMessage channel plugin",
   "type": "module",

--- a/extensions/irc/package.json
+++ b/extensions/irc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/irc",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw IRC channel plugin",
   "type": "module",
   "devDependencies": {
@@ -11,7 +11,7 @@
       "./index.ts"
     ],
     "install": {
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "setupEntry": "./setup-entry.ts",
     "channel": {

--- a/extensions/kilocode/package.json
+++ b/extensions/kilocode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kilocode-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Kilo Gateway provider plugin",
   "type": "module",

--- a/extensions/kimi-coding/package.json
+++ b/extensions/kimi-coding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/kimi-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Kimi provider plugin",
   "type": "module",

--- a/extensions/line/package.json
+++ b/extensions/line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/line",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw LINE channel plugin",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -36,7 +36,7 @@
     "install": {
       "npmSpec": "@openclaw/line",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     }
   }
 }

--- a/extensions/litellm/package.json
+++ b/extensions/litellm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/litellm-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw LiteLLM provider plugin",
   "type": "module",

--- a/extensions/llm-task/package.json
+++ b/extensions/llm-task/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/llm-task",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw JSON-only LLM task plugin",
   "type": "module",

--- a/extensions/lobster/package.json
+++ b/extensions/lobster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/lobster",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "Lobster workflow tool plugin (typed pipelines + resumable approvals)",
   "type": "module",
   "dependencies": {
@@ -15,10 +15,10 @@
       "./index.ts"
     ],
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/matrix/package.json
+++ b/extensions/matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/matrix",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Matrix channel plugin",
   "type": "module",
   "dependencies": {
@@ -16,7 +16,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -45,7 +45,7 @@
     "install": {
       "npmSpec": "@openclaw/matrix",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8",
+      "minHostVersion": ">=2026.4.9",
       "allowInvalidConfigRecovery": true
     },
     "releaseChecks": {

--- a/extensions/mattermost/package.json
+++ b/extensions/mattermost/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mattermost",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Mattermost channel plugin",
   "type": "module",
   "dependencies": {
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -36,7 +36,7 @@
     "install": {
       "npmSpec": "@openclaw/mattermost",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     }
   }
 }

--- a/extensions/media-understanding-core/package.json
+++ b/extensions/media-understanding-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/media-understanding-core",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw media understanding runtime package",
   "type": "module",

--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -20,6 +20,7 @@ describe("buildPromptSection", () => {
     expect(result[0]).toBe("## Memory Recall");
     expect(result[1]).toContain("run memory_search");
     expect(result[1]).toContain("then use memory_get");
+    expect(result[1]).toContain("indexed session transcripts");
     expect(result).toContain(
       "Citations: include Source: <path#line> when it helps the user verify memory snippets.",
     );
@@ -30,6 +31,7 @@ describe("buildPromptSection", () => {
     const result = buildPromptSection({ availableTools: new Set(["memory_search"]) });
     expect(result[0]).toBe("## Memory Recall");
     expect(result[1]).toContain("run memory_search");
+    expect(result[1]).toContain("indexed session transcripts");
     expect(result[1]).not.toContain("then use memory_get");
   });
 

--- a/extensions/memory-core/package.json
+++ b/extensions/memory-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-core",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw core memory search plugin",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/memory-core/src/prompt-section.ts
+++ b/extensions/memory-core/src/prompt-section.ts
@@ -14,10 +14,10 @@ export const buildPromptSection: MemoryPromptSectionBuilder = ({
   let toolGuidance: string;
   if (hasMemorySearch && hasMemoryGet) {
     toolGuidance =
-      "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.";
+      "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md + indexed session transcripts; then use memory_get to pull only the needed lines. If low confidence after search, say you checked.";
   } else if (hasMemorySearch) {
     toolGuidance =
-      "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md and answer from the matching results. If low confidence after search, say you checked.";
+      "Before answering anything about prior work, decisions, dates, people, preferences, or todos: run memory_search on MEMORY.md + memory/*.md + indexed session transcripts and answer from the matching results. If low confidence after search, say you checked.";
   } else {
     toolGuidance =
       "Before answering anything about prior work, decisions, dates, people, preferences, or todos that already point to a specific memory file or note: run memory_get to pull only the needed lines. If low confidence after reading them, say you checked.";

--- a/extensions/memory-lancedb/package.json
+++ b/extensions/memory-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-lancedb",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw LanceDB-backed long-term memory plugin with auto-recall/capture",
   "type": "module",
   "dependencies": {
@@ -18,13 +18,13 @@
     "install": {
       "npmSpec": "@openclaw/memory-lancedb",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/memory-wiki/package.json
+++ b/extensions/memory-wiki/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/memory-wiki",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw persistent wiki plugin",
   "type": "module",
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {

--- a/extensions/microsoft-foundry/package.json
+++ b/extensions/microsoft-foundry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-foundry",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Microsoft Foundry provider plugin",
   "type": "module",

--- a/extensions/microsoft/package.json
+++ b/extensions/microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/microsoft-speech",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Microsoft speech plugin",
   "type": "module",

--- a/extensions/minimax/package.json
+++ b/extensions/minimax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/minimax-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw MiniMax provider and OAuth plugin",
   "type": "module",

--- a/extensions/mistral/package.json
+++ b/extensions/mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/mistral-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Mistral provider plugin",
   "type": "module",

--- a/extensions/moonshot/package.json
+++ b/extensions/moonshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/moonshot-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Moonshot provider plugin",
   "type": "module",

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/msteams",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Microsoft Teams channel plugin",
   "type": "module",
   "dependencies": {
@@ -13,7 +13,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -40,13 +40,13 @@
     "install": {
       "npmSpec": "@openclaw/msteams",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/nextcloud-talk/package.json
+++ b/extensions/nextcloud-talk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nextcloud-talk",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Nextcloud Talk channel plugin",
   "type": "module",
   "devDependencies": {
@@ -8,7 +8,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -37,13 +37,13 @@
     "install": {
       "npmSpec": "@openclaw/nextcloud-talk",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/nostr/package.json
+++ b/extensions/nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nostr",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Nostr channel plugin for NIP-04 encrypted DMs",
   "type": "module",
   "dependencies": {
@@ -11,7 +11,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -36,13 +36,13 @@
     "install": {
       "npmSpec": "@openclaw/nostr",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/nvidia/package.json
+++ b/extensions/nvidia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/nvidia-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw NVIDIA provider plugin",
   "type": "module",

--- a/extensions/ollama/package.json
+++ b/extensions/ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/ollama-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Ollama provider plugin",
   "type": "module",

--- a/extensions/open-prose/package.json
+++ b/extensions/open-prose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/open-prose",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenProse VM skill pack plugin (slash command + telemetry).",
   "type": "module",

--- a/extensions/openai/package.json
+++ b/extensions/openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openai-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw OpenAI provider plugins",
   "type": "module",

--- a/extensions/opencode-go/package.json
+++ b/extensions/opencode-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-go-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw OpenCode Go provider plugin",
   "type": "module",

--- a/extensions/opencode/package.json
+++ b/extensions/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/opencode-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw OpenCode Zen provider plugin",
   "type": "module",

--- a/extensions/openrouter/package.json
+++ b/extensions/openrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openrouter-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw OpenRouter provider plugin",
   "type": "module",

--- a/extensions/openshell/package.json
+++ b/extensions/openshell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/openshell-sandbox",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw OpenShell sandbox backend",
   "type": "module",

--- a/extensions/perplexity/package.json
+++ b/extensions/perplexity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/perplexity-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Perplexity plugin",
   "type": "module",

--- a/extensions/qa-channel/package.json
+++ b/extensions/qa-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-channel",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw QA synthetic channel plugin",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -40,7 +40,7 @@
     "install": {
       "npmSpec": "@openclaw/qa-channel",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     }
   }
 }

--- a/extensions/qa-lab/package.json
+++ b/extensions/qa-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qa-lab",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw QA lab plugin with private debugger UI and scenario runner",
   "type": "module",
@@ -9,7 +9,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -23,10 +23,10 @@
     "install": {
       "npmSpec": "@openclaw/qa-lab",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     }
   }
 }

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -21,6 +21,8 @@ function createParams(baseEnv?: NodeJS.ProcessEnv) {
     xdgConfigHome: "/tmp/openclaw-qa/xdg-config",
     xdgDataHome: "/tmp/openclaw-qa/xdg-data",
     xdgCacheHome: "/tmp/openclaw-qa/xdg-cache",
+    bundledPluginsDir: "/tmp/openclaw-qa/bundled-plugins",
+    compatibilityHostVersion: "2026.4.8",
     baseEnv,
   };
 }
@@ -35,6 +37,8 @@ describe("buildQaRuntimeEnv", () => {
     expect(env.OPENCLAW_TEST_FAST).toBe("1");
     expect(env.OPENCLAW_QA_ALLOW_LOCAL_IMAGE_PROVIDER).toBe("1");
     expect(env.OPENCLAW_ALLOW_SLOW_REPLY_TESTS).toBe("1");
+    expect(env.OPENCLAW_BUNDLED_PLUGINS_DIR).toBe("/tmp/openclaw-qa/bundled-plugins");
+    expect(env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBe("2026.4.8");
   });
 
   it("maps live frontier key aliases into provider env vars", () => {
@@ -128,5 +132,119 @@ describe("resolveQaControlUiRoot", () => {
 
     expect(resolveQaControlUiRoot({ repoRoot })).toBeUndefined();
     expect(resolveQaControlUiRoot({ repoRoot, controlUiEnabled: false })).toBeUndefined();
+  });
+});
+
+describe("qa bundled plugin dir", () => {
+  it("prefers the built bundled plugin tree when present", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-bundled-root-"));
+    cleanups.push(async () => {
+      await rm(repoRoot, { recursive: true, force: true });
+    });
+    await mkdir(path.join(repoRoot, "dist", "extensions", "qa-channel"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(repoRoot, "dist", "extensions", "qa-channel", "package.json"),
+      "{}",
+      "utf8",
+    );
+    await mkdir(path.join(repoRoot, "dist-runtime", "extensions", "qa-channel"), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(repoRoot, "dist-runtime", "extensions", "qa-channel", "package.json"),
+      "{}",
+      "utf8",
+    );
+    await mkdir(path.join(repoRoot, "extensions", "qa-channel"), { recursive: true });
+
+    expect(__testing.resolveQaBundledPluginsSourceRoot(repoRoot)).toBe(
+      path.join(repoRoot, "dist", "extensions"),
+    );
+  });
+
+  it("creates a scoped bundled plugin tree for the allowed plugins only", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-bundled-scope-"));
+    cleanups.push(async () => {
+      await rm(repoRoot, { recursive: true, force: true });
+    });
+    await mkdir(path.join(repoRoot, "dist", "extensions", "qa-channel"), { recursive: true });
+    await mkdir(path.join(repoRoot, "dist", "extensions", "memory-core"), { recursive: true });
+    await mkdir(path.join(repoRoot, "dist", "extensions", "unused-plugin"), { recursive: true });
+    await writeFile(path.join(repoRoot, "dist", "shared-chunk-abc123.js"), "export {};\n", "utf8");
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), "qa-bundled-target-"));
+    cleanups.push(async () => {
+      await rm(tempRoot, { recursive: true, force: true });
+    });
+
+    const { bundledPluginsDir, stagedRoot } = await __testing.createQaBundledPluginsDir({
+      repoRoot,
+      tempRoot,
+      allowedPluginIds: ["qa-channel", "memory-core"],
+    });
+
+    expect((await readdir(bundledPluginsDir)).toSorted()).toEqual(["memory-core", "qa-channel"]);
+    expect(bundledPluginsDir).toBe(
+      path.join(
+        repoRoot,
+        ".artifacts",
+        "qa-runtime",
+        path.basename(tempRoot),
+        "dist",
+        "extensions",
+      ),
+    );
+    expect(stagedRoot).toBe(
+      path.join(repoRoot, ".artifacts", "qa-runtime", path.basename(tempRoot)),
+    );
+    expect((await lstat(path.join(bundledPluginsDir, "qa-channel"))).isDirectory()).toBe(true);
+    expect((await lstat(path.join(bundledPluginsDir, "memory-core"))).isDirectory()).toBe(true);
+    await expect(
+      lstat(
+        path.join(
+          repoRoot,
+          ".artifacts",
+          "qa-runtime",
+          path.basename(tempRoot),
+          "dist",
+          "shared-chunk-abc123.js",
+        ),
+      ),
+    ).resolves.toBeTruthy();
+  });
+
+  it("raises the QA runtime host version to the highest allowed plugin floor", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-runtime-version-"));
+    cleanups.push(async () => {
+      await rm(repoRoot, { recursive: true, force: true });
+    });
+    await writeFile(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({ version: "2026.4.7-1" }),
+      "utf8",
+    );
+    const bundledRoot = path.join(repoRoot, "extensions");
+    await mkdir(path.join(bundledRoot, "qa-channel"), { recursive: true });
+    await writeFile(
+      path.join(bundledRoot, "qa-channel", "package.json"),
+      JSON.stringify({ openclaw: { install: { minHostVersion: ">=2026.4.8" } } }),
+      "utf8",
+    );
+
+    await mkdir(path.join(bundledRoot, "memory-core"), { recursive: true });
+    await writeFile(
+      path.join(bundledRoot, "memory-core", "package.json"),
+      JSON.stringify({ openclaw: { install: { minHostVersion: ">=2026.4.7" } } }),
+      "utf8",
+    );
+
+    await expect(
+      __testing.resolveQaRuntimeHostVersion({
+        repoRoot,
+        bundledPluginsSourceRoot: bundledRoot,
+        allowedPluginIds: ["memory-core", "qa-channel"],
+      }),
+    ).resolves.toBe("2026.4.8");
   });
 });

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
+import { createWriteStream, existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
@@ -95,6 +95,8 @@ export function buildQaRuntimeEnv(params: {
   xdgConfigHome: string;
   xdgDataHome: string;
   xdgCacheHome: string;
+  bundledPluginsDir?: string;
+  compatibilityHostVersion?: string;
   providerMode?: "mock-openai" | "live-frontier";
   baseEnv?: NodeJS.ProcessEnv;
 }) {
@@ -118,6 +120,10 @@ export function buildQaRuntimeEnv(params: {
     XDG_CONFIG_HOME: params.xdgConfigHome,
     XDG_DATA_HOME: params.xdgDataHome,
     XDG_CACHE_HOME: params.xdgCacheHome,
+    ...(params.bundledPluginsDir ? { OPENCLAW_BUNDLED_PLUGINS_DIR: params.bundledPluginsDir } : {}),
+    ...(params.compatibilityHostVersion
+      ? { OPENCLAW_COMPATIBILITY_HOST_VERSION: params.compatibilityHostVersion }
+      : {}),
   };
   return normalizeQaProviderModeEnv(env, params.providerMode);
 }
@@ -136,7 +142,145 @@ function isRetryableGatewayCallError(details: string): boolean {
 export const __testing = {
   buildQaRuntimeEnv,
   isRetryableGatewayCallError,
+  resolveQaBundledPluginsSourceRoot,
+  resolveQaRuntimeHostVersion,
+  createQaBundledPluginsDir,
 };
+
+function resolveQaBundledPluginsSourceRoot(repoRoot: string) {
+  const candidates = [
+    path.join(repoRoot, "dist", "extensions"),
+    path.join(repoRoot, "dist-runtime", "extensions"),
+    path.join(repoRoot, "extensions"),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  throw new Error("failed to resolve qa bundled plugins source root");
+}
+
+function parseStableSemverFloor(value: string | undefined) {
+  if (!value) {
+    return null;
+  }
+  const match = value.trim().match(/(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    return null;
+  }
+  return {
+    major: Number.parseInt(match[1] ?? "", 10),
+    minor: Number.parseInt(match[2] ?? "", 10),
+    patch: Number.parseInt(match[3] ?? "", 10),
+    label: `${match[1]}.${match[2]}.${match[3]}`,
+  };
+}
+
+function compareSemverFloors(
+  left: ReturnType<typeof parseStableSemverFloor>,
+  right: ReturnType<typeof parseStableSemverFloor>,
+) {
+  if (!left && !right) {
+    return 0;
+  }
+  if (!left) {
+    return -1;
+  }
+  if (!right) {
+    return 1;
+  }
+  if (left.major !== right.major) {
+    return left.major - right.major;
+  }
+  if (left.minor !== right.minor) {
+    return left.minor - right.minor;
+  }
+  return left.patch - right.patch;
+}
+
+async function resolveQaRuntimeHostVersion(params: {
+  repoRoot: string;
+  bundledPluginsSourceRoot: string;
+  allowedPluginIds: readonly string[];
+}) {
+  const rootPackageRaw = await fs.readFile(path.join(params.repoRoot, "package.json"), "utf8");
+  const rootPackage = JSON.parse(rootPackageRaw) as { version?: string };
+  let selected = parseStableSemverFloor(rootPackage.version);
+
+  for (const pluginId of params.allowedPluginIds) {
+    const packagePath = path.join(params.bundledPluginsSourceRoot, pluginId, "package.json");
+    if (!existsSync(packagePath)) {
+      continue;
+    }
+    const packageRaw = await fs.readFile(packagePath, "utf8");
+    const packageJson = JSON.parse(packageRaw) as {
+      openclaw?: {
+        install?: {
+          minHostVersion?: string;
+        };
+      };
+    };
+    const candidate = parseStableSemverFloor(packageJson.openclaw?.install?.minHostVersion);
+    if (compareSemverFloors(candidate, selected) > 0) {
+      selected = candidate;
+    }
+  }
+
+  return selected?.label;
+}
+
+async function createQaBundledPluginsDir(params: {
+  repoRoot: string;
+  tempRoot: string;
+  allowedPluginIds: readonly string[];
+}) {
+  const sourceRoot = resolveQaBundledPluginsSourceRoot(params.repoRoot);
+  const sourceTreeRoot = path.dirname(sourceRoot);
+  if (
+    sourceTreeRoot === path.join(params.repoRoot, "dist") ||
+    sourceTreeRoot === path.join(params.repoRoot, "dist-runtime")
+  ) {
+    const stagedRoot = path.join(
+      params.repoRoot,
+      ".artifacts",
+      "qa-runtime",
+      path.basename(params.tempRoot),
+    );
+    await fs.rm(stagedRoot, { recursive: true, force: true });
+    await fs.mkdir(stagedRoot, { recursive: true });
+    const stagedTreeRoot = path.join(stagedRoot, path.basename(sourceTreeRoot));
+    await fs.cp(sourceTreeRoot, stagedTreeRoot, { recursive: true });
+    const stagedExtensionsDir = path.join(stagedTreeRoot, "extensions");
+    for (const entry of await fs.readdir(stagedExtensionsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || params.allowedPluginIds.includes(entry.name)) {
+        continue;
+      }
+      await fs.rm(path.join(stagedExtensionsDir, entry.name), { recursive: true, force: true });
+    }
+    return {
+      bundledPluginsDir: stagedExtensionsDir,
+      stagedRoot,
+    };
+  }
+
+  const bundledPluginsDir = path.join(params.tempRoot, "bundled-plugins");
+  await fs.mkdir(bundledPluginsDir, { recursive: true });
+  for (const pluginId of params.allowedPluginIds) {
+    const sourceDir = path.join(sourceRoot, pluginId);
+    if (!existsSync(sourceDir)) {
+      throw new Error(`qa bundled plugin not found: ${pluginId} (${sourceDir})`);
+    }
+    // Plugin discovery walks real directories; copying avoids symlink-only
+    // trees being skipped by Dirent-based scans in the child runtime.
+    await fs.cp(sourceDir, path.join(bundledPluginsDir, pluginId), { recursive: true });
+  }
+  return {
+    bundledPluginsDir,
+    stagedRoot: null,
+  };
+}
+
 async function waitForGatewayReady(params: {
   baseUrl: string;
   logs: () => string;
@@ -242,9 +386,28 @@ export async function startQaGatewayChild(params: {
     controlUiEnabled: params.controlUiEnabled,
   });
   await fs.writeFile(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+  const allowedPluginIds = (cfg.plugins?.allow ?? []).filter(
+    (pluginId): pluginId is string => typeof pluginId === "string" && pluginId.length > 0,
+  );
+  const bundledPluginsSourceRoot = resolveQaBundledPluginsSourceRoot(params.repoRoot);
+  const { bundledPluginsDir, stagedRoot: stagedBundledPluginsRoot } =
+    await createQaBundledPluginsDir({
+      repoRoot: params.repoRoot,
+      tempRoot,
+      allowedPluginIds,
+    });
+  const runtimeHostVersion = await resolveQaRuntimeHostVersion({
+    repoRoot: params.repoRoot,
+    bundledPluginsSourceRoot,
+    allowedPluginIds,
+  });
 
   const stdout: Buffer[] = [];
   const stderr: Buffer[] = [];
+  const stdoutLogPath = path.join(tempRoot, "gateway.stdout.log");
+  const stderrLogPath = path.join(tempRoot, "gateway.stderr.log");
+  const stdoutLog = createWriteStream(stdoutLogPath, { flags: "a" });
+  const stderrLog = createWriteStream(stderrLogPath, { flags: "a" });
   const env = buildQaRuntimeEnv({
     configPath,
     gatewayToken,
@@ -253,6 +416,8 @@ export async function startQaGatewayChild(params: {
     xdgConfigHome,
     xdgDataHome,
     xdgCacheHome,
+    bundledPluginsDir,
+    compatibilityHostVersion: runtimeHostVersion,
     providerMode: params.providerMode,
   });
 
@@ -274,8 +439,16 @@ export async function startQaGatewayChild(params: {
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
-  child.stdout.on("data", (chunk) => stdout.push(Buffer.from(chunk)));
-  child.stderr.on("data", (chunk) => stderr.push(Buffer.from(chunk)));
+  child.stdout.on("data", (chunk) => {
+    const buffer = Buffer.from(chunk);
+    stdout.push(buffer);
+    stdoutLog.write(buffer);
+  });
+  child.stderr.on("data", (chunk) => {
+    const buffer = Buffer.from(chunk);
+    stderr.push(buffer);
+    stderrLog.write(buffer);
+  });
 
   const baseUrl = `http://127.0.0.1:${gatewayPort}`;
   const wsUrl = `ws://127.0.0.1:${gatewayPort}`;
@@ -318,7 +491,12 @@ export async function startQaGatewayChild(params: {
       throw lastRpcError ?? new Error("qa gateway rpc client failed to start");
     }
   } catch (error) {
+    stdoutLog.end();
+    stderrLog.end();
     child.kill("SIGTERM");
+    if (!keepTemp && stagedBundledPluginsRoot) {
+      await fs.rm(stagedBundledPluginsRoot, { recursive: true, force: true }).catch(() => {});
+    }
     throw error;
   }
 
@@ -370,6 +548,8 @@ export async function startQaGatewayChild(params: {
     },
     async stop(opts?: { keepTemp?: boolean }) {
       await rpcClient.stop().catch(() => {});
+      stdoutLog.end();
+      stderrLog.end();
       if (!child.killed) {
         child.kill("SIGTERM");
         await Promise.race([
@@ -383,6 +563,9 @@ export async function startQaGatewayChild(params: {
       }
       if (!(opts?.keepTemp ?? keepTemp)) {
         await fs.rm(tempRoot, { recursive: true, force: true });
+        if (stagedBundledPluginsRoot) {
+          await fs.rm(stagedBundledPluginsRoot, { recursive: true, force: true });
+        }
       }
     },
   };

--- a/extensions/qa-lab/src/qa-gateway-config.ts
+++ b/extensions/qa-lab/src/qa-gateway-config.ts
@@ -8,28 +8,6 @@ import {
   type QaProviderMode,
 } from "./model-selection.js";
 
-const DISABLED_BUNDLED_CHANNELS = Object.freeze({
-  bluebubbles: { enabled: false },
-  discord: { enabled: false },
-  feishu: { enabled: false },
-  googlechat: { enabled: false },
-  imessage: { enabled: false },
-  irc: { enabled: false },
-  line: { enabled: false },
-  mattermost: { enabled: false },
-  matrix: { enabled: false },
-  msteams: { enabled: false },
-  qqbot: { enabled: false },
-  signal: { enabled: false },
-  slack: { enabled: false },
-  "synology-chat": { enabled: false },
-  telegram: { enabled: false },
-  tlon: { enabled: false },
-  whatsapp: { enabled: false },
-  zalo: { enabled: false },
-  zalouser: { enabled: false },
-} satisfies Record<string, { enabled: false }>);
-
 export const DEFAULT_QA_CONTROL_UI_ALLOWED_ORIGINS = Object.freeze([
   "http://127.0.0.1:18789",
   "http://localhost:18789",
@@ -273,7 +251,6 @@ export function buildQaGatewayConfig(params: {
       },
     },
     channels: {
-      ...DISABLED_BUNDLED_CHANNELS,
       "qa-channel": {
         enabled: true,
         baseUrl: params.qaBusBaseUrl,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -65,8 +65,11 @@ type QaSuiteEnvironment = {
 
 const _QA_IMAGE_UNDERSTANDING_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAAAklEQVR4AewaftIAAAK4SURBVO3BAQEAMAwCIG//znsQgXfJBZjUALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsl9wFmNQAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwP4TIF+7ciPkoAAAAASUVORK5CYII=";
-const QA_IMAGE_UNDERSTANDING_LARGE_PNG_BASE64 =
+const _QA_IMAGE_UNDERSTANDING_LARGE_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAACuklEQVR4Ae3BAQEAMAwCIG//znsQgXfJBZjUALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsBpjVALMaYFYDzGqAWQ0wqwFmNcCsl9wFmNQAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwGmNUAsxpgVgPMaoBZDTCrAWY1wKwP4TIF+2YE/z8AAAAASUVORK5CYII=";
+
+const QA_IMAGE_UNDERSTANDING_VALID_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAALklEQVR4nO3OoQEAAAyDsP7/9HYGJgJNdtuVDQAAAAAAACAHxH8AAAAAAACAHvBX0fhq85dN7QAAAABJRU5ErkJggg==";
 
 type QaSkillStatusEntry = {
   name?: string;
@@ -170,12 +173,14 @@ async function waitForOutboundMessage(
   state: QaBusState,
   predicate: (message: QaBusMessage) => boolean,
   timeoutMs = 15_000,
+  options?: { sinceIndex?: number },
 ) {
   return await waitForCondition(
     () =>
       state
         .getSnapshot()
         .messages.filter((message) => message.direction === "outbound")
+        .slice(options?.sinceIndex ?? 0)
         .find(predicate),
     timeoutMs,
   );
@@ -1131,9 +1136,19 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
             name: "stores the canary fact",
             run: async () => {
               const config = readScenarioExecutionConfig<{
+                resetDurableMemory?: boolean;
                 rememberPrompt?: string;
+                rememberAckAny?: string[];
                 recallPrompt?: string;
+                recallExpectedAny?: string[];
               }>("memory-recall");
+              if (config.resetDurableMemory) {
+                const today = formatMemoryDreamingDay(Date.now());
+                await fs.rm(path.join(env.gateway.workspaceDir, "MEMORY.md"), { force: true });
+                await fs.rm(path.join(env.gateway.workspaceDir, "memory", `${today}.md`), {
+                  force: true,
+                });
+              }
               await reset();
               await runAgentPrompt(env, {
                 sessionKey: "agent:qa:memory",
@@ -1141,9 +1156,16 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
                   config.rememberPrompt ??
                   "Please remember this fact for later: the QA canary code is ALPHA-7.",
               });
+              const rememberAckAny = (config.rememberAckAny ?? ["remembered alpha-7"]).map(
+                (needle) => needle.toLowerCase(),
+              );
               const outbound = await waitForOutboundMessage(
                 state,
-                (candidate) => candidate.conversation.id === "qa-operator",
+                (candidate) =>
+                  candidate.conversation.id === "qa-operator" &&
+                  rememberAckAny.some((needle) =>
+                    normalizeLowercaseStringOrEmpty(candidate.text).includes(needle),
+                  ),
               );
               return outbound.text;
             },
@@ -1152,8 +1174,11 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
             name: "recalls the same fact later",
             run: async () => {
               const config = readScenarioExecutionConfig<{
+                resetDurableMemory?: boolean;
                 rememberPrompt?: string;
+                rememberAckAny?: string[];
                 recallPrompt?: string;
+                recallExpectedAny?: string[];
               }>("memory-recall");
               await runAgentPrompt(env, {
                 sessionKey: "agent:qa:memory",
@@ -1161,6 +1186,9 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
                   config.recallPrompt ??
                   "What was the QA canary code I asked you to remember earlier?",
               });
+              const recallExpectedAny = (config.recallExpectedAny ?? ["alpha-7"]).map((needle) =>
+                needle.toLowerCase(),
+              );
               const outbound = await waitForCondition(
                 () =>
                   state
@@ -1169,7 +1197,9 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
                       (candidate) =>
                         candidate.direction === "outbound" &&
                         candidate.conversation.id === "qa-operator" &&
-                        candidate.text.includes("ALPHA-7"),
+                        recallExpectedAny.some((needle) =>
+                          normalizeLowercaseStringOrEmpty(candidate.text).includes(needle),
+                        ),
                     )
                     .at(-1),
                 20_000,
@@ -2049,6 +2079,15 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
           {
             name: "prefers the newer transcript-backed fact over the stale durable note",
             run: async () => {
+              const config = readScenarioExecutionConfig<{
+                staleFact?: string;
+                currentFact?: string;
+                transcriptQuestion?: string;
+                transcriptAnswer?: string;
+                prompt?: string;
+              }>("session-memory-ranking");
+              const staleFact = config.staleFact ?? "ORBIT-9";
+              const currentFact = config.currentFact ?? "ORBIT-10";
               const original = await readConfigSnapshot(env);
               const originalMemorySearch =
                 original.config.agents &&
@@ -2090,7 +2129,11 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
               await waitForQaChannelReady(env, 60_000);
               try {
                 const memoryPath = path.join(env.gateway.workspaceDir, "MEMORY.md");
-                await fs.writeFile(memoryPath, "Project Nebula stale codename: ORBIT-9.\n", "utf8");
+                await fs.writeFile(
+                  memoryPath,
+                  `Project Nebula stale codename: ${staleFact}.\n`,
+                  "utf8",
+                );
                 const staleAt = new Date("2020-01-01T00:00:00.000Z");
                 await fs.utimes(memoryPath, staleAt, staleAt);
                 const transcriptsDir = resolveSessionTranscriptsDirForAgent(
@@ -2117,7 +2160,9 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
                         content: [
                           {
                             type: "text",
-                            text: "What is the current Project Nebula codename?",
+                            text:
+                              config.transcriptQuestion ??
+                              "What is the current Project Nebula codename?",
                           },
                         ],
                       },
@@ -2130,7 +2175,9 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
                         content: [
                           {
                             type: "text",
-                            text: "The current Project Nebula codename is ORBIT-10.",
+                            text:
+                              config.transcriptAnswer ??
+                              `The current Project Nebula codename is ${currentFact}.`,
                           },
                         ],
                       },
@@ -2140,26 +2187,27 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
                 );
                 await forceMemoryIndex({
                   env,
-                  query: "current Project Nebula codename ORBIT-10",
-                  expectedNeedle: "ORBIT-10",
+                  query: `current Project Nebula codename ${currentFact}`,
+                  expectedNeedle: currentFact,
                 });
                 await reset();
                 await runAgentPrompt(env, {
                   sessionKey: "agent:qa:session-memory-ranking",
                   message:
-                    "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.",
+                    config.prompt ??
+                    `Session memory ranking check: what is the current Project Nebula codename? Use memory tools first. If durable notes conflict with newer indexed session transcripts, prefer the newer current fact.`,
                   timeoutMs: liveTurnTimeoutMs(env, 45_000),
                 });
                 const outbound = await waitForOutboundMessage(
                   state,
                   (candidate) =>
                     candidate.conversation.id === "qa-operator" &&
-                    candidate.text.includes("ORBIT-10"),
+                    candidate.text.includes(currentFact),
                   liveTurnTimeoutMs(env, 45_000),
                 );
                 const lower = normalizeLowercaseStringOrEmpty(outbound.text);
                 const staleLeak =
-                  outbound.text.includes("ORBIT-9") &&
+                  outbound.text.includes(staleFact) &&
                   !lower.includes("stale") &&
                   !lower.includes("older") &&
                   !lower.includes("previous");
@@ -2380,18 +2428,23 @@ function buildScenarioMap(env: QaSuiteEnvironment) {
               const config = readScenarioExecutionConfig<{
                 prompt?: string;
                 expectedContains?: string;
+                skillName?: string;
+                skillBody?: string;
               }>("skill-visibility-invocation");
+              const skillName = config.skillName ?? "qa-visible-skill";
               await writeWorkspaceSkill({
                 env,
-                name: "qa-visible-skill",
-                body: `---
+                name: skillName,
+                body:
+                  config.skillBody ??
+                  `---
 name: qa-visible-skill
 description: Visible QA skill marker
 ---
 When the user asks for the visible skill marker exactly, reply with exactly: VISIBLE-SKILL-OK`,
               });
               const skills = await readSkillStatus(env);
-              const visible = findSkill(skills, "qa-visible-skill");
+              const visible = findSkill(skills, skillName);
               if (!visible?.eligible || visible.disabled || visible.blockedByAllowlist) {
                 throw new Error(`skill not visible/eligible: ${JSON.stringify(visible)}`);
               }
@@ -2635,16 +2688,24 @@ When the user asks for the hot install marker exactly, reply with exactly: HOT-I
           {
             name: "describes an attached image in one short sentence",
             run: async () => {
+              const config = readScenarioExecutionConfig<{
+                prompt?: string;
+                requiredColorGroups?: string[][];
+              }>("image-understanding-attachment");
               await reset();
+              const outboundStartIndex = state
+                .getSnapshot()
+                .messages.filter((message) => message.direction === "outbound").length;
               await runAgentPrompt(env, {
                 sessionKey: "agent:qa:image-understanding",
                 message:
+                  config.prompt ??
                   "Image understanding check: describe the top and bottom colors in the attached image in one short sentence.",
                 attachments: [
                   {
                     mimeType: "image/png",
                     fileName: "red-top-blue-bottom.png",
-                    content: QA_IMAGE_UNDERSTANDING_LARGE_PNG_BASE64,
+                    content: QA_IMAGE_UNDERSTANDING_VALID_PNG_BASE64,
                   },
                 ],
                 timeoutMs: liveTurnTimeoutMs(env, 45_000),
@@ -2653,9 +2714,17 @@ When the user asks for the hot install marker exactly, reply with exactly: HOT-I
                 state,
                 (candidate) => candidate.conversation.id === "qa-operator",
                 liveTurnTimeoutMs(env, 45_000),
+                { sinceIndex: outboundStartIndex },
               );
               const lower = normalizeLowercaseStringOrEmpty(outbound.text);
-              if (!lower.includes("red") || !lower.includes("blue")) {
+              const requiredColorGroups = config.requiredColorGroups ?? [
+                ["red", "scarlet", "crimson"],
+                ["blue", "azure", "teal", "cyan", "aqua"],
+              ];
+              const missingColorGroup = requiredColorGroups.find(
+                (group) => !group.some((candidate) => lower.includes(candidate)),
+              );
+              if (missingColorGroup) {
                 throw new Error(`missing expected colors in image description: ${outbound.text}`);
               }
               if (env.mock) {
@@ -2835,6 +2904,11 @@ When the user asks for the hot disable marker exactly, reply with exactly: HOT-P
           {
             name: "restores image_generate after restart and uses it in the same session",
             run: async () => {
+              const config = readScenarioExecutionConfig<{
+                setupPrompt?: string;
+                imagePrompt?: string;
+                imagePromptSnippet?: string;
+              }>("config-restart-capability-flip");
               await ensureImageGenerationConfigured(env);
               const original = await readConfigSnapshot(env);
               const originalTools =
@@ -2868,6 +2942,7 @@ When the user asks for the hot disable marker exactly, reply with exactly: HOT-P
                 await runAgentPrompt(env, {
                   sessionKey,
                   message:
+                    config.setupPrompt ??
                     "Capability flip setup: acknowledge this setup so restart wake-up has a route.",
                   timeoutMs: liveTurnTimeoutMs(env, 30_000),
                 });
@@ -2907,12 +2982,13 @@ When the user asks for the hot disable marker exactly, reply with exactly: HOT-P
                 await runAgentPrompt(env, {
                   sessionKey,
                   message:
+                    config.imagePrompt ??
                     "Capability flip image check: generate a QA lighthouse image now and keep the media path in the reply.",
                   timeoutMs: liveTurnTimeoutMs(env, 45_000),
                 });
                 const mediaPath = await resolveGeneratedImagePath({
                   env,
-                  promptSnippet: "Capability flip image check",
+                  promptSnippet: config.imagePromptSnippet ?? "Capability flip image check",
                   startedAtMs: imageStartedAtMs,
                   timeoutMs: liveTurnTimeoutMs(env, 45_000),
                 });

--- a/extensions/qianfan/package.json
+++ b/extensions/qianfan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qianfan-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Qianfan provider plugin",
   "type": "module",

--- a/extensions/qqbot/package.json
+++ b/extensions/qqbot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qqbot",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": false,
   "description": "OpenClaw QQ Bot channel plugin",
   "type": "module",
@@ -15,7 +15,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -41,13 +41,13 @@
       "npmSpec": "@openclaw/qqbot",
       "localPath": "extensions/qqbot",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "bundle": {
       "stageRuntimeDependencies": true

--- a/extensions/qwen/package.json
+++ b/extensions/qwen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/qwen-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Qwen Cloud provider plugin",
   "type": "module",

--- a/extensions/runway/package.json
+++ b/extensions/runway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/runway-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Runway video provider plugin",
   "type": "module",

--- a/extensions/searxng/package.json
+++ b/extensions/searxng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/searxng-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw SearXNG plugin",
   "type": "module",

--- a/extensions/sglang/package.json
+++ b/extensions/sglang/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/sglang-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw SGLang provider plugin",
   "type": "module",

--- a/extensions/signal/package.json
+++ b/extensions/signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/signal",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Signal channel plugin",
   "type": "module",

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/slack",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Slack channel plugin",
   "type": "module",

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -22,6 +22,11 @@ const createSavedMedia = (filePath: string, contentType: string): SavedMedia => 
   contentType,
 });
 
+function getRequestHeader(callIndex: number, headerName: string): string | null {
+  const init = mockFetch.mock.calls[callIndex]?.[1];
+  return new Headers(init?.headers).get(headerName);
+}
+
 describe("fetchWithSlackAuth", () => {
   beforeEach(() => {
     // Create a new mock for each test
@@ -65,7 +70,7 @@ describe("fetchWithSlackAuth", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("follows redirects without Authorization header", async () => {
+  it("strips Authorization header on cross-origin redirects", async () => {
     // First call: redirect response from Slack
     const redirectResponse = new Response(null, {
       status: 302,
@@ -99,8 +104,7 @@ describe("fetchWithSlackAuth", () => {
     );
   });
 
-  it("handles relative redirect URLs", async () => {
-    // Redirect with relative URL
+  it("preserves Authorization header on same-origin redirects", async () => {
     const redirectResponse = new Response(null, {
       status: 302,
       headers: { location: "/files/redirect-target" },
@@ -115,8 +119,8 @@ describe("fetchWithSlackAuth", () => {
 
     await fetchWithSlackAuth("https://files.slack.com/original.jpg", "xoxb-test-token");
 
-    // Second call should resolve the relative URL against the original
     expect(mockFetch).toHaveBeenNthCalledWith(2, "https://files.slack.com/files/redirect-target", {
+      headers: { Authorization: "Bearer xoxb-test-token" },
       redirect: "follow",
     });
   });
@@ -210,6 +214,74 @@ describe("resolveSlackMedia", () => {
       "https://files.slack.com/download.jpg",
       expect.anything(),
     );
+  });
+
+  it("preserves Authorization on same-origin redirects for private downloads", async () => {
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
+      createSavedMedia("/tmp/test.jpg", "image/jpeg"),
+    );
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: "/files/redirect-target" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("image data"), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      );
+
+    const result = await resolveSlackMedia({
+      files: [{ url_private_download: "https://files.slack.com/download.jpg", name: "test.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).not.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://files.slack.com/download.jpg");
+    expect(mockFetch.mock.calls[1]?.[0]).toBe("https://files.slack.com/files/redirect-target");
+    expect(getRequestHeader(0, "Authorization")).toBe("Bearer xoxb-test-token");
+    expect(getRequestHeader(1, "Authorization")).toBe("Bearer xoxb-test-token");
+  });
+
+  it("strips Authorization on cross-origin redirects for private downloads", async () => {
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
+      createSavedMedia("/tmp/test.jpg", "image/jpeg"),
+    );
+
+    mockFetch
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: "https://downloads.slack-edge.com/presigned-url?sig=abc123" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(Buffer.from("image data"), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        }),
+      );
+
+    const result = await resolveSlackMedia({
+      files: [{ url_private_download: "https://files.slack.com/download.jpg", name: "test.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).not.toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://files.slack.com/download.jpg");
+    expect(mockFetch.mock.calls[1]?.[0]).toBe(
+      "https://downloads.slack-edge.com/presigned-url?sig=abc123",
+    );
+    expect(getRequestHeader(0, "Authorization")).toBe("Bearer xoxb-test-token");
+    expect(getRequestHeader(1, "Authorization")).toBeNull();
   });
 
   it("returns null when download fails", async () => {
@@ -481,9 +553,7 @@ describe("resolveSlackMedia", () => {
     }) as typeof fetch;
     const runtimeFetchSpy = vi
       .spyOn(ssrf, "fetchWithRuntimeDispatcher")
-      .mockImplementation(async (_input: RequestInfo | URL, init?: RequestInit) => {
-        expect(init).toMatchObject({ redirect: "manual" });
-        expect(init && "dispatcher" in init).toBe(true);
+      .mockImplementation(async () => {
         return new Response(Buffer.from("image data"), {
           status: 200,
           headers: { "content-type": "image/jpeg" },
@@ -498,6 +568,13 @@ describe("resolveSlackMedia", () => {
 
     expect(result).not.toBeNull();
     expect(runtimeFetchSpy).toHaveBeenCalled();
+    expect(runtimeFetchSpy.mock.calls[0]?.[1]).toMatchObject({ redirect: "manual" });
+    expect(
+      runtimeFetchSpy.mock.calls[0]?.[1] && "dispatcher" in runtimeFetchSpy.mock.calls[0][1],
+    ).toBe(true);
+    expect(new Headers(runtimeFetchSpy.mock.calls[0]?.[1]?.headers).get("Authorization")).toBe(
+      "Bearer xoxb-test-token",
+    );
   });
 });
 

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -43,6 +43,26 @@ function assertSlackFileUrl(rawUrl: string): URL {
   return parsed;
 }
 
+function createSlackAuthHeaders(token: string): HeadersInit {
+  return { Authorization: `Bearer ${token}` };
+}
+
+function createSlackMediaRequest(
+  url: string,
+  token: string,
+): {
+  url: string;
+  requestInit: RequestInit;
+} {
+  const parsed = assertSlackFileUrl(url);
+  return {
+    url: parsed.href,
+    // Let the shared guarded-fetch redirect logic preserve auth on same-origin
+    // Slack hops and strip it once the redirect crosses origins.
+    requestInit: { headers: createSlackAuthHeaders(token) },
+  };
+}
+
 function isMockedFetch(fetchImpl: typeof fetch | undefined): boolean {
   if (typeof fetchImpl !== "function") {
     return false;
@@ -50,68 +70,53 @@ function isMockedFetch(fetchImpl: typeof fetch | undefined): boolean {
   return typeof (fetchImpl as typeof fetch & { mock?: unknown }).mock === "object";
 }
 
-function createSlackMediaFetch(token: string): FetchLike {
-  let includeAuth = true;
+function createSlackMediaFetch(): FetchLike {
   return async (input, init) => {
     const url = resolveRequestUrl(input);
     if (!url) {
       throw new Error("Unsupported fetch input: expected string, URL, or Request");
     }
-    const { headers: initHeaders, redirect: _redirect, ...rest } = init ?? {};
-    const headers = new Headers(initHeaders);
+    const parsed = assertSlackFileUrl(url);
     const fetchImpl =
       "dispatcher" in (init ?? {}) && !isMockedFetch(globalThis.fetch)
         ? fetchWithRuntimeDispatcher
         : globalThis.fetch;
-
-    if (includeAuth) {
-      includeAuth = false;
-      const parsed = assertSlackFileUrl(url);
-      headers.set("Authorization", `Bearer ${token}`);
-      return fetchImpl(parsed.href, { ...rest, headers, redirect: "manual" });
-    }
-
-    headers.delete("Authorization");
-    return fetchImpl(url, { ...rest, headers, redirect: "manual" });
+    return fetchImpl(parsed.href, { ...init, redirect: "manual" });
   };
 }
 
 /**
- * Fetches a URL with Authorization header, handling cross-origin redirects.
- * Node.js fetch strips Authorization headers on cross-origin redirects for security.
- * Slack's file URLs redirect to CDN domains with pre-signed URLs that don't need the
- * Authorization header, so we handle the initial auth request manually.
+ * Fetches a URL with Authorization header while keeping same-origin redirects
+ * authenticated and dropping auth once the redirect crosses origins.
  */
 export async function fetchWithSlackAuth(url: string, token: string): Promise<Response> {
   const parsed = assertSlackFileUrl(url);
+  const authHeaders = createSlackAuthHeaders(token);
 
-  // Initial request with auth and manual redirect handling
   const initialRes = await fetch(parsed.href, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: authHeaders,
     redirect: "manual",
   });
 
-  // If not a redirect, return the response directly
   if (initialRes.status < 300 || initialRes.status >= 400) {
     return initialRes;
   }
 
-  // Handle redirect - the redirected URL should be pre-signed and not need auth
   const redirectUrl = initialRes.headers.get("location");
   if (!redirectUrl) {
     return initialRes;
   }
 
-  // Resolve relative URLs against the original
   const resolvedUrl = new URL(redirectUrl, parsed.href);
-
-  // Only follow safe protocols (we do NOT include Authorization on redirects).
   if (resolvedUrl.protocol !== "https:") {
     return initialRes;
   }
-
-  // Follow the redirect without the Authorization header
-  // (Slack's CDN URLs are pre-signed and don't need it)
+  if (resolvedUrl.origin === parsed.origin) {
+    return fetch(resolvedUrl.toString(), {
+      headers: authHeaders,
+      redirect: "follow",
+    });
+  }
   return fetch(resolvedUrl.toString(), { redirect: "follow" });
 }
 
@@ -223,13 +228,12 @@ export async function resolveSlackMedia(params: {
         return null;
       }
       try {
-        // Note: fetchRemoteMedia calls fetchImpl(url) with the URL string today and
-        // handles size limits internally. Provide a fetcher that uses auth once, then lets
-        // the redirect chain continue without credentials.
-        const fetchImpl = createSlackMediaFetch(params.token);
+        const { url: slackUrl, requestInit } = createSlackMediaRequest(url, params.token);
+        const fetchImpl = createSlackMediaFetch();
         const fetched = await fetchRemoteMedia({
-          url,
+          url: slackUrl,
           fetchImpl,
+          requestInit,
           filePathHint: file.name,
           maxBytes: params.maxBytes,
           ssrfPolicy: SLACK_MEDIA_SSRF_POLICY,
@@ -307,10 +311,12 @@ export async function resolveSlackAttachmentContent(params: {
     const imageUrl = resolveForwardedAttachmentImageUrl(att);
     if (imageUrl) {
       try {
-        const fetchImpl = createSlackMediaFetch(params.token);
+        const { url: slackUrl, requestInit } = createSlackMediaRequest(imageUrl, params.token);
+        const fetchImpl = createSlackMediaFetch();
         const fetched = await fetchRemoteMedia({
-          url: imageUrl,
+          url: slackUrl,
           fetchImpl,
+          requestInit,
           maxBytes: params.maxBytes,
           ssrfPolicy: SLACK_MEDIA_SSRF_POLICY,
         });

--- a/extensions/speech-core/package.json
+++ b/extensions/speech-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/speech-core",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw speech runtime package",
   "type": "module",

--- a/extensions/stepfun/package.json
+++ b/extensions/stepfun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/stepfun-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw StepFun provider plugin",
   "type": "module",

--- a/extensions/synology-chat/package.json
+++ b/extensions/synology-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synology-chat",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "Synology Chat channel plugin for OpenClaw",
   "type": "module",
   "devDependencies": {
@@ -23,7 +23,7 @@
     "install": {
       "npmSpec": "@openclaw/synology-chat",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     }
   }
 }

--- a/extensions/synthetic/package.json
+++ b/extensions/synthetic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/synthetic-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Synthetic provider plugin",
   "type": "module",

--- a/extensions/tavily/package.json
+++ b/extensions/tavily/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tavily-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Tavily plugin",
   "type": "module",

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/telegram",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Telegram channel plugin",
   "type": "module",

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/tlon",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Tlon/Urbit channel plugin",
   "type": "module",
   "dependencies": {
@@ -14,7 +14,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -39,7 +39,7 @@
     "install": {
       "npmSpec": "@openclaw/tlon",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     }
   }
 }

--- a/extensions/together/package.json
+++ b/extensions/together/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/together-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Together provider plugin",
   "type": "module",

--- a/extensions/twitch/package.json
+++ b/extensions/twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/twitch",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Twitch channel plugin",
   "type": "module",
   "dependencies": {
@@ -16,7 +16,7 @@
       "./index.ts"
     ],
     "install": {
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "channel": {
       "id": "twitch",

--- a/extensions/venice/package.json
+++ b/extensions/venice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/venice-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Venice provider plugin",
   "type": "module",

--- a/extensions/vercel-ai-gateway/package.json
+++ b/extensions/vercel-ai-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vercel-ai-gateway-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Vercel AI Gateway provider plugin",
   "type": "module",

--- a/extensions/video-generation-core/package.json
+++ b/extensions/video-generation-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/video-generation-core",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw video generation runtime package",
   "type": "module",

--- a/extensions/vllm/package.json
+++ b/extensions/vllm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vllm-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw vLLM provider plugin",
   "type": "module",

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/voice-call",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw voice-call plugin",
   "type": "module",
   "dependencies": {
@@ -13,7 +13,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -25,13 +25,13 @@
       "./index.ts"
     ],
     "install": {
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/volcengine/package.json
+++ b/extensions/volcengine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/volcengine-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Volcengine provider plugin",
   "type": "module",

--- a/extensions/vydra/package.json
+++ b/extensions/vydra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/vydra-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Vydra media provider plugin",
   "type": "module",

--- a/extensions/webhooks/package.json
+++ b/extensions/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/webhooks",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw webhook bridge plugin",
   "type": "module",

--- a/extensions/whatsapp/package.json
+++ b/extensions/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/whatsapp",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw WhatsApp channel plugin",
   "type": "module",
   "dependencies": {
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -41,13 +41,13 @@
     "install": {
       "npmSpec": "@openclaw/whatsapp",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/xai/package.json
+++ b/extensions/xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xai-plugin",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw xAI plugin",
   "type": "module",

--- a/extensions/xiaomi/package.json
+++ b/extensions/xiaomi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/xiaomi-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Xiaomi provider plugin",
   "type": "module",

--- a/extensions/zai/package.json
+++ b/extensions/zai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zai-provider",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "private": true,
   "description": "OpenClaw Z.AI provider plugin",
   "type": "module",

--- a/extensions/zalo/package.json
+++ b/extensions/zalo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalo",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Zalo channel plugin",
   "type": "module",
   "dependencies": {
@@ -11,7 +11,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -39,13 +39,13 @@
     "install": {
       "npmSpec": "@openclaw/zalo",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/extensions/zalouser/package.json
+++ b/extensions/zalouser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/zalouser",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "OpenClaw Zalo Personal Account plugin via native zca-js integration",
   "type": "module",
   "dependencies": {
@@ -12,7 +12,7 @@
     "openclaw": "workspace:*"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.4.8"
+    "openclaw": ">=2026.4.9"
   },
   "peerDependenciesMeta": {
     "openclaw": {
@@ -40,13 +40,13 @@
     "install": {
       "npmSpec": "@openclaw/zalouser",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.8"
+      "minHostVersion": ">=2026.4.9"
     },
     "compat": {
-      "pluginApi": ">=2026.4.8"
+      "pluginApi": ">=2026.4.9"
     },
     "build": {
-      "openclawVersion": "2026.4.8"
+      "openclawVersion": "2026.4.9"
     },
     "release": {
       "publishToClawHub": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw",
-  "version": "2026.4.8",
+  "version": "2026.4.9",
   "description": "Multi-channel AI gateway with extensible messaging integrations",
   "keywords": [],
   "homepage": "https://github.com/openclaw/openclaw#readme",

--- a/qa/scenarios/approval-turn-tool-followthrough.md
+++ b/qa/scenarios/approval-turn-tool-followthrough.md
@@ -27,4 +27,9 @@ execution:
       - qa
       - mission
       - testing
+      - repo
+      - worked
+      - failed
+      - blocked
+      - chat flows
 ```

--- a/qa/scenarios/config-restart-capability-flip.md
+++ b/qa/scenarios/config-restart-capability-flip.md
@@ -22,4 +22,8 @@ execution:
   kind: custom
   handler: config-restart-capability-flip
   summary: Verify a restart-triggering config change flips capability inventory and the same session successfully uses the newly restored tool after wake-up.
+  config:
+    setupPrompt: "Capability flip setup: acknowledge this setup so restart wake-up has a route."
+    imagePrompt: "Capability flip image check: generate a QA lighthouse image in this turn right now. Do not acknowledge first, do not promise future work, and do not stop before using image_generate. Final reply must include the MEDIA path."
+    imagePromptSnippet: "Capability flip image check"
 ```

--- a/qa/scenarios/image-understanding-attachment.md
+++ b/qa/scenarios/image-understanding-attachment.md
@@ -20,4 +20,9 @@ execution:
   kind: custom
   handler: image-understanding-attachment
   summary: Verify an attached image reaches the agent model and the agent can describe what it sees.
+  config:
+    prompt: "Image understanding check: describe the top and bottom colors in the attached image in one short sentence."
+    requiredColorGroups:
+      - [red, scarlet, crimson]
+      - [blue, azure, teal, cyan, aqua]
 ```

--- a/qa/scenarios/memory-recall.md
+++ b/qa/scenarios/memory-recall.md
@@ -18,6 +18,11 @@ execution:
   handler: memory-recall
   summary: Verify the agent can store a fact, switch topics, then recall the fact accurately later.
   config:
-    rememberPrompt: "Please remember this fact for later: the QA canary code is ALPHA-7."
-    recallPrompt: "What was the QA canary code I asked you to remember earlier?"
+    resetDurableMemory: true
+    rememberPrompt: "Please remember this fact for later: the QA canary code is ALPHA-7. Use your normal memory mechanism, avoid manual repo cleanup, and reply exactly `Remembered ALPHA-7.` once stored."
+    rememberAckAny:
+      - remembered alpha-7
+    recallPrompt: "What was the QA canary code I asked you to remember earlier? Reply with the code only, plus at most one short sentence."
+    recallExpectedAny:
+      - alpha-7
 ```

--- a/qa/scenarios/session-memory-ranking.md
+++ b/qa/scenarios/session-memory-ranking.md
@@ -20,4 +20,10 @@ execution:
   kind: custom
   handler: session-memory-ranking
   summary: Verify session-transcript memory can outrank stale durable notes and drive the final answer toward the newer fact.
+  config:
+    staleFact: ORBIT-9
+    currentFact: ORBIT-10
+    transcriptQuestion: "What is the current Project Nebula codename?"
+    transcriptAnswer: "The current Project Nebula codename is ORBIT-10."
+    prompt: "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first. If durable notes conflict with newer indexed session transcripts, prefer the newer current fact."
 ```

--- a/qa/scenarios/skill-visibility-invocation.md
+++ b/qa/scenarios/skill-visibility-invocation.md
@@ -20,6 +20,13 @@ execution:
   handler: skill-visibility-invocation
   summary: Verify a workspace skill becomes visible in skills.status and influences the next agent turn.
   config:
-    prompt: "Visible skill marker: give me the visible skill marker exactly."
+    skillName: qa-visible-skill
+    skillBody: |-
+      ---
+      name: qa-visible-skill
+      description: Visible QA skill marker
+      ---
+      When the user asks for the visible skill marker exactly, or explicitly asks you to use qa-visible-skill, reply with exactly: VISIBLE-SKILL-OK
+    prompt: "Use qa-visible-skill now. Reply exactly with the visible skill marker and nothing else."
     expectedContains: "VISIBLE-SKILL-OK"
 ```

--- a/scripts/docker/install-sh-e2e/run.sh
+++ b/scripts/docker/install-sh-e2e/run.sh
@@ -452,15 +452,11 @@ run_profile() {
   if [[ "$agent_model_provider" == "openai" ]]; then
     agent_model="$(set_agent_model "$profile" \
       "openai/gpt-5.4" \
-      "openai/gpt-4.1-mini" \
-      "openai/gpt-4.1" \
       "openai/gpt-4o-mini" \
       "openai/gpt-4o")"
     image_model="$(set_image_model "$profile" \
-      "openai/gpt-4.1" \
       "openai/gpt-4o-mini" \
-      "openai/gpt-4o" \
-      "openai/gpt-4.1-mini")"
+      "openai/gpt-4o")"
   else
     agent_model="$(set_agent_model "$profile" \
       "anthropic/claude-opus-4-6" \

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -45,7 +45,7 @@ const {
 function createDispatcher(record: string[]): ReplyDispatcher {
   return {
     sendToolResult: () => true,
-    sendBlockReply: () => Promise.resolve(),
+    sendBlockReply: () => Promise.resolve(true),
     sendFinalReply: () => true,
     getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
     getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
@@ -63,7 +63,7 @@ describe("withReplyDispatcher", () => {
     const order: string[] = [];
     const dispatcher = {
       sendToolResult: () => true,
-      sendBlockReply: () => Promise.resolve(),
+      sendBlockReply: () => Promise.resolve(true),
       sendFinalReply: () => {
         order.push("sendFinalReply");
         return true;
@@ -137,7 +137,7 @@ describe("withReplyDispatcher", () => {
     const order: string[] = [];
     const dispatcher = {
       sendToolResult: () => true,
-      sendBlockReply: () => Promise.resolve(),
+      sendBlockReply: () => Promise.resolve(true),
       sendFinalReply: () => {
         order.push("sendFinalReply");
         return true;

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -45,7 +45,7 @@ const {
 function createDispatcher(record: string[]): ReplyDispatcher {
   return {
     sendToolResult: () => true,
-    sendBlockReply: () => true,
+    sendBlockReply: () => Promise.resolve(),
     sendFinalReply: () => true,
     getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
     getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
@@ -131,6 +131,35 @@ describe("withReplyDispatcher", () => {
 
     expect(onSettled).toHaveBeenCalledTimes(1);
     expect(order).toEqual(["run", "markComplete", "waitForIdle", "onSettled"]);
+  });
+
+  it("dispatchInboundMessage owns dispatcher lifecycle", async () => {
+    const order: string[] = [];
+    const dispatcher = {
+      sendToolResult: () => true,
+      sendBlockReply: () => Promise.resolve(),
+      sendFinalReply: () => {
+        order.push("sendFinalReply");
+        return true;
+      },
+      getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      markComplete: () => {
+        order.push("markComplete");
+      },
+      waitForIdle: async () => {
+        order.push("waitForIdle");
+      },
+    } satisfies ReplyDispatcher;
+
+    await dispatchInboundMessage({
+      ctx: buildTestCtx(),
+      cfg: {} as OpenClawConfig,
+      dispatcher,
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    expect(order).toEqual(["sendFinalReply", "markComplete", "waitForIdle"]);
   });
 
   it("dispatchInboundMessageWithBufferedDispatcher cleans up typing after a resolver starts it", async () => {

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -63,7 +63,7 @@ describe("withReplyDispatcher", () => {
     const order: string[] = [];
     const dispatcher = {
       sendToolResult: () => true,
-      sendBlockReply: () => true,
+      sendBlockReply: () => Promise.resolve(),
       sendFinalReply: () => {
         order.push("sendFinalReply");
         return true;

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -66,7 +66,7 @@ vi.mock("../../infra/outbound/message-action-runner.js", () => ({
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => Promise.resolve()),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
@@ -239,7 +239,7 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
   it("tracks failed visible telegram block delivery separately", async () => {
     const dispatcher: ReplyDispatcher = {
       sendToolResult: vi.fn(() => true),
-      sendBlockReply: vi.fn(() => false),
+      sendBlockReply: vi.fn((): false => false),
       sendFinalReply: vi.fn(() => true),
       waitForIdle: vi.fn(async () => {}),
       getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -66,7 +66,7 @@ vi.mock("../../infra/outbound/message-action-runner.js", () => ({
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve(true)),
+    sendBlockReply: vi.fn(() => Promise.resolve(true as const)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -66,7 +66,7 @@ vi.mock("../../infra/outbound/message-action-runner.js", () => ({
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve()),
+    sendBlockReply: vi.fn(() => Promise.resolve(true)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -353,12 +353,15 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       text: ttsPayload.text,
       routed: false,
     });
-    const delivered =
+    // sendBlockReply returns false | Promise<void>; coerce to boolean for
+    // the uniform delivered/failed tracking below.
+    const deliveredRaw =
       kind === "tool"
         ? params.dispatcher.sendToolResult(ttsPayload)
         : kind === "block"
           ? params.dispatcher.sendBlockReply(ttsPayload)
           : params.dispatcher.sendFinalReply(ttsPayload);
+    const delivered = Boolean(deliveredRaw);
     if (kind === "final" && delivered) {
       state.deliveredFinalReply = true;
     }

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -91,7 +91,7 @@ function createDispatcher(): {
   const counts = { tool: 0, block: 0, final: 0 };
   const dispatcher: ReplyDispatcher = {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve(true)),
+    sendBlockReply: vi.fn(() => Promise.resolve(true as const)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => counts),

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -91,7 +91,7 @@ function createDispatcher(): {
   const counts = { tool: 0, block: 0, final: 0 };
   const dispatcher: ReplyDispatcher = {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => Promise.resolve()),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => counts),

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -91,7 +91,7 @@ function createDispatcher(): {
   const counts = { tool: 0, block: 0, final: 0 };
   const dispatcher: ReplyDispatcher = {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve()),
+    sendBlockReply: vi.fn(() => Promise.resolve(true)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => counts),

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -281,7 +281,7 @@ let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tr
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve()),
+    sendBlockReply: vi.fn(() => Promise.resolve(true)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -281,7 +281,7 @@ let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tr
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve(true)),
+    sendBlockReply: vi.fn(() => Promise.resolve(true as const)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -281,7 +281,7 @@ let tryDispatchAcpReplyHook: typeof import("../../plugin-sdk/acp-runtime.js").tr
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => Promise.resolve()),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -278,7 +278,7 @@ let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => Promise.resolve()),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -278,7 +278,7 @@ let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve()),
+    sendBlockReply: vi.fn(() => Promise.resolve(true)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.reply-dispatch.test.ts
@@ -278,7 +278,7 @@ let resetInboundDedupe: typeof import("./inbound-dedupe.js").resetInboundDedupe;
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve(true)),
+    sendBlockReply: vi.fn(() => Promise.resolve(true as const)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -366,7 +366,7 @@ beforeAll(async () => {
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve(true)),
+    sendBlockReply: vi.fn(() => Promise.resolve(true as const)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -366,7 +366,7 @@ beforeAll(async () => {
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => true),
+    sendBlockReply: vi.fn(() => Promise.resolve()),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -366,7 +366,7 @@ beforeAll(async () => {
 function createDispatcher(): ReplyDispatcher {
   return {
     sendToolResult: vi.fn(() => true),
-    sendBlockReply: vi.fn(() => Promise.resolve()),
+    sendBlockReply: vi.fn(() => Promise.resolve(true)),
     sendFinalReply: vi.fn(() => true),
     waitForIdle: vi.fn(async () => {}),
     getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -917,7 +917,9 @@ export async function dispatchReplyFromConfig(params: {
             if (shouldRouteToOriginating) {
               await sendPayloadAsync(ttsPayload, context?.abortSignal, false);
             } else {
-              dispatcher.sendBlockReply(ttsPayload);
+              // Await delivery so block text reaches the user before tool
+              // execution continues on the same channel (#32868).
+              await dispatcher.sendBlockReply(ttsPayload);
             }
           };
           return run();

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -77,7 +77,19 @@ type ReplyDispatcherWithTypingResult = {
 
 export type ReplyDispatcher = {
   sendToolResult: (payload: ReplyPayload) => boolean;
-  sendBlockReply: (payload: ReplyPayload) => boolean;
+  /**
+   * Enqueue a block reply for delivery.
+   *
+   * Returns `false` when the payload is dropped (empty/silent).
+   * Otherwise returns a `Promise<void>` that resolves when the queued delivery
+   * (and all preceding deliveries) complete.  Callers on the same-channel path
+   * should `await` this to guarantee the block text reaches the user before
+   * tool execution continues.
+   *
+   * Because a fulfilled `Promise` is truthy, existing boolean-style checks
+   * (`if (delivered)`) remain correct without changes.
+   */
+  sendBlockReply: (payload: ReplyPayload) => false | Promise<void>;
   sendFinalReply: (payload: ReplyPayload) => boolean;
   waitForIdle: () => Promise<void>;
   getQueuedCounts: () => Record<ReplyDispatchKind, number>;
@@ -217,7 +229,13 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
 
   return {
     sendToolResult: (payload) => enqueue("tool", payload),
-    sendBlockReply: (payload) => enqueue("block", payload),
+    sendBlockReply: (payload) => {
+      if (!enqueue("block", payload)) {
+        return false;
+      }
+      // Return the delivery chain so same-channel callers can await delivery.
+      return sendChain;
+    },
     sendFinalReply: (payload) => enqueue("final", payload),
     waitForIdle: () => sendChain,
     getQueuedCounts: () => ({ ...queuedCounts }),

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -95,7 +95,7 @@ export type ReplyDispatcher = {
    * Because a fulfilled `Promise` is truthy, existing boolean-style checks
    * (`if (delivered)`) remain correct without changes.
    */
-  sendBlockReply: (payload: ReplyPayload) => false | Promise<void>;
+  sendBlockReply: (payload: ReplyPayload) => false | Promise<true>;
   sendFinalReply: (payload: ReplyPayload) => boolean;
   waitForIdle: () => Promise<void>;
   getQueuedCounts: () => Record<ReplyDispatchKind, number>;
@@ -240,7 +240,8 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         return false;
       }
       // Return the delivery chain so same-channel callers can await delivery.
-      return sendChain;
+      // Resolve to true to preserve backward compatibility for await-and-branch patterns.
+      return sendChain.then(() => true);
     },
     sendFinalReply: (payload) => enqueue("final", payload),
     waitForIdle: () => sendChain,

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -24,6 +24,12 @@ type ReplyDispatchDeliverer = (
 
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
+/**
+ * Hard ceiling for human-delay so that custom configs with unbounded minMs/maxMs
+ * cannot exceed the block-reply pipeline timeout (default 15 s).  10 s leaves a
+ * comfortable 5 s budget for transport delivery within a single pipeline tick.
+ */
+const MAX_HUMAN_DELAY_MS = 10_000;
 
 /** Generate a random delay within the configured range. */
 function getHumanDelay(config: HumanDelayConfig | undefined): number {
@@ -36,9 +42,9 @@ function getHumanDelay(config: HumanDelayConfig | undefined): number {
   const max =
     mode === "custom" ? (config?.maxMs ?? DEFAULT_HUMAN_DELAY_MAX_MS) : DEFAULT_HUMAN_DELAY_MAX_MS;
   if (max <= min) {
-    return min;
+    return Math.min(min, MAX_HUMAN_DELAY_MS);
   }
-  return min + generateSecureInt(max - min + 1);
+  return Math.min(min + generateSecureInt(max - min + 1), MAX_HUMAN_DELAY_MS);
 }
 
 export type ReplyDispatcherOptions = {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -105,6 +105,39 @@ describe("createReplyDispatcher", () => {
     expect(onIdle).toHaveBeenCalledTimes(1);
   });
 
+  it("sendBlockReply returns false for dropped payloads and a Promise for accepted ones", async () => {
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    // Dropped payload returns false (empty text, no media).
+    expect(dispatcher.sendBlockReply({ text: "" })).toBe(false);
+    expect(dispatcher.sendBlockReply({ text: SILENT_REPLY_TOKEN })).toBe(false);
+
+    // Accepted payload returns a Promise that resolves after delivery.
+    const result = dispatcher.sendBlockReply({ text: "hello" });
+    expect(result).not.toBe(false);
+    expect(result).toBeInstanceOf(Promise);
+    await result;
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaiting sendBlockReply guarantees delivery completes before continuation", async () => {
+    const order: string[] = [];
+    const deliver = vi.fn(async () => {
+      await Promise.resolve();
+      order.push("delivered");
+    });
+    const dispatcher = createReplyDispatcher({ deliver });
+
+    const promise = dispatcher.sendBlockReply({ text: "block" });
+    expect(promise).not.toBe(false);
+    await promise;
+    order.push("continued");
+
+    // "delivered" must come before "continued" because we awaited the promise.
+    expect(order).toEqual(["delivered", "continued"]);
+  });
+
   it("delays block replies after the first when humanDelay is natural", async () => {
     vi.useFakeTimers();
     const deliver = vi.fn().mockResolvedValue(undefined);

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1021,7 +1021,7 @@ describe("update-cli", () => {
       makeOkUpdateResult({
         mode: "git",
         root: path.join(tempDir, "..", "openclaw"),
-        after: { version: "2026.4.8" },
+        after: { version: "2026.4.9" },
       }),
     );
     serviceLoaded.mockResolvedValue(true);

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -26904,6 +26904,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       tags: ["advanced", "url-secret"],
     },
   },
-  version: "2026.4.8",
+  version: "2026.4.9",
   generatedAt: "2026-03-22T21:17:33.302Z",
 };

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -694,7 +694,10 @@ describe("gateway server chat", () => {
         const [params] = args as [
           {
             dispatcher: {
-              sendBlockReply: (payload: { text: string; btw: { question: string } }) => boolean;
+              sendBlockReply: (payload: {
+                text: string;
+                btw: { question: string };
+              }) => false | Promise<void>;
               markComplete: () => void;
               waitForIdle: () => Promise<void>;
               getQueuedCounts: () => { final: number; block: number; tool: number };

--- a/src/plugin-sdk/acp-runtime.test.ts
+++ b/src/plugin-sdk/acp-runtime.test.ts
@@ -37,7 +37,7 @@ const ctx = {
   cfg: {},
   dispatcher: {
     sendToolResult: () => false,
-    sendBlockReply: () => false,
+    sendBlockReply: () => false as const,
     sendFinalReply: () => false,
     waitForIdle: async () => {},
     getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),

--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -86,6 +86,53 @@ describe("loadBundledEntryExportSync", () => {
     }
   });
 
+  it("loads packaged telegram setup sidecars from dist-facing api modules", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
+    tempDirs.push(tempRoot);
+
+    const pluginRoot = path.join(tempRoot, "dist", "extensions", "telegram");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+
+    const importerPath = path.join(pluginRoot, "setup-entry.js");
+    const setupApiPath = path.join(pluginRoot, "setup-plugin-api.js");
+    const secretsApiPath = path.join(pluginRoot, "secret-contract-api.js");
+
+    fs.writeFileSync(importerPath, "export default {};\n", "utf8");
+    fs.writeFileSync(
+      setupApiPath,
+      'export const telegramSetupPlugin = { id: "telegram" };\n',
+      "utf8",
+    );
+    fs.writeFileSync(
+      secretsApiPath,
+      [
+        "export const collectRuntimeConfigAssignments = () => [];",
+        "export const secretTargetRegistryEntries = [];",
+        'export const channelSecrets = { TELEGRAM_TOKEN: { env: "TELEGRAM_TOKEN" } };',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    expect(
+      loadBundledEntryExportSync<{ id: string }>(pathToFileURL(importerPath).href, {
+        specifier: "./setup-plugin-api.js",
+        exportName: "telegramSetupPlugin",
+      }),
+    ).toEqual({ id: "telegram" });
+
+    expect(
+      loadBundledEntryExportSync<Record<string, unknown>>(pathToFileURL(importerPath).href, {
+        specifier: "./secret-contract-api.js",
+        exportName: "channelSecrets",
+      }),
+    ).toEqual({
+      TELEGRAM_TOKEN: {
+        env: "TELEGRAM_TOKEN",
+      },
+    });
+  });
+
   it("can disable source-tree fallback for dist bundled entry checks", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
     tempDirs.push(tempRoot);

--- a/src/plugins/stage-bundled-plugin-runtime-deps.test.ts
+++ b/src/plugins/stage-bundled-plugin-runtime-deps.test.ts
@@ -48,7 +48,7 @@ describe("stageBundledPluginRuntimeDeps", () => {
       JSON.stringify(
         {
           name: "@openclaw/feishu",
-          version: "2026.4.8",
+          version: "2026.4.9",
           dependencies: {
             "@larksuiteoapi/node-sdk": "^1.60.0",
           },
@@ -120,7 +120,7 @@ describe("stageBundledPluginRuntimeDeps", () => {
       JSON.stringify(
         {
           name: "@openclaw/amazon-bedrock-provider",
-          version: "2026.4.8",
+          version: "2026.4.9",
           dependencies: {
             "@aws-sdk/client-bedrock": "3.1024.0",
           },

--- a/src/plugins/wired-hooks-reply-dispatch.test.ts
+++ b/src/plugins/wired-hooks-reply-dispatch.test.ts
@@ -15,7 +15,7 @@ const replyDispatchCtx = {
   cfg: {},
   dispatcher: {
     sendToolResult: () => false,
-    sendBlockReply: () => false,
+    sendBlockReply: () => false as const,
     sendFinalReply: () => false,
     waitForIdle: async () => {},
     getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),

--- a/src/secrets/runtime-web-tools.test.ts
+++ b/src/secrets/runtime-web-tools.test.ts
@@ -822,6 +822,53 @@ describe("runtime web tools resolution", () => {
     expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
   });
 
+  it("uses exact plugin-id hints for configured bundled provider entries without manifest owner lookup", async () => {
+    const { metadata } = await runRuntimeWebTools({
+      config: asConfig({
+        tools: {
+          web: {
+            search: {
+              enabled: true,
+              provider: "brave",
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            brave: {
+              enabled: true,
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "default", id: "BRAVE_PROVIDER_REF" },
+                },
+              },
+            },
+            google: {
+              enabled: true,
+              config: {
+                webSearch: {
+                  apiKey: { source: "env", provider: "default", id: "GOOGLE_PROVIDER_REF" },
+                },
+              },
+            },
+          },
+        },
+      }),
+      env: {
+        BRAVE_PROVIDER_REF: "brave-provider-key",
+        GOOGLE_PROVIDER_REF: "google-provider-key",
+      },
+    });
+
+    expect(metadata.search.selectedProvider).toBe("brave");
+    expect(resolveBundledExplicitWebSearchProvidersFromPublicArtifactsMock).toHaveBeenCalledWith({
+      onlyPluginIds: ["brave"],
+    });
+    expect(resolveManifestContractOwnerPluginIdMock).not.toHaveBeenCalled();
+    expect(resolveBundledWebSearchProvidersFromPublicArtifactsMock).not.toHaveBeenCalled();
+    expect(resolvePluginWebSearchProvidersMock).not.toHaveBeenCalled();
+  });
+
   it("limits legacy top-level web search apiKey auto-detect to compatibility owners", async () => {
     const { metadata } = await runRuntimeWebTools({
       config: asConfig({

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -107,6 +107,19 @@ function inferSingleBundledPluginScopedWebToolConfigOwner(
   return matches[0];
 }
 
+function inferExactBundledPluginScopedWebToolConfigOwner(params: {
+  config: OpenClawConfig;
+  key: "webSearch" | "webFetch";
+  pluginId: string;
+}): string | undefined {
+  const entry = params.config.plugins?.entries?.[params.pluginId];
+  if (!isRecord(entry) || entry.enabled === false) {
+    return undefined;
+  }
+  const pluginConfig = isRecord(entry.config) ? entry.config : undefined;
+  return isRecord(pluginConfig?.[params.key]) ? params.pluginId : undefined;
+}
+
 function hasCustomWebSearchPluginRisk(config: OpenClawConfig): boolean {
   const plugins = config.plugins;
   if (!plugins) {
@@ -459,6 +472,11 @@ export async function resolveRuntimeWebTools(params: {
     ? params.resolvedConfig.tools
     : undefined;
   const resolvedWeb = isRecord(resolvedTools?.web) ? resolvedTools.web : undefined;
+  let hasCustomWebSearchRisk: boolean | undefined;
+  const getHasCustomWebSearchRisk = (): boolean => {
+    hasCustomWebSearchRisk ??= hasCustomWebSearchPluginRisk(params.sourceConfig);
+    return hasCustomWebSearchRisk;
+  };
   const legacyXSearchSource = isRecord(sourceWeb?.x_search) ? sourceWeb.x_search : undefined;
   const legacyXSearchResolved = isRecord(resolvedWeb?.x_search) ? resolvedWeb.x_search : undefined;
 
@@ -501,7 +519,6 @@ export async function resolveRuntimeWebTools(params: {
   }
   const search = isRecord(sourceWeb?.search) ? sourceWeb.search : undefined;
   const fetch = isRecord(sourceWeb?.fetch) ? (sourceWeb.fetch as FetchConfig) : undefined;
-  const hasCustomWebSearchRisk = hasCustomWebSearchPluginRisk(params.sourceConfig);
   if (!search && !fetch && !hasPluginWebSearchConfig && !hasPluginWebFetchConfig) {
     return {
       search: {
@@ -517,8 +534,15 @@ export async function resolveRuntimeWebTools(params: {
   }
   const rawProvider = normalizeLowercaseStringOrEmpty(search?.provider);
   const configuredBundledWebSearchPluginIdHint =
-    rawProvider && hasPluginWebSearchConfig && !hasCustomWebSearchRisk
-      ? inferSingleBundledPluginScopedWebToolConfigOwner(params.sourceConfig, "webSearch")
+    rawProvider && hasPluginWebSearchConfig
+      ? (inferExactBundledPluginScopedWebToolConfigOwner({
+          config: params.sourceConfig,
+          key: "webSearch",
+          pluginId: rawProvider,
+        }) ??
+        (!getHasCustomWebSearchRisk()
+          ? inferSingleBundledPluginScopedWebToolConfigOwner(params.sourceConfig, "webSearch")
+          : undefined))
       : undefined;
   const searchMetadata: RuntimeWebSearchMetadata = {
     providerSource: "none",
@@ -557,10 +581,10 @@ export async function resolveRuntimeWebTools(params: {
           onlyPluginIds:
             configuredBundledPluginId === undefined &&
             searchCompatibilityOnlyPluginIds.length > 0 &&
-            !hasCustomWebSearchRisk
+            !getHasCustomWebSearchRisk()
               ? searchCompatibilityOnlyPluginIds
               : undefined,
-          hasCustomWebSearchPluginRisk: hasCustomWebSearchRisk,
+          hasCustomWebSearchPluginRisk: getHasCustomWebSearchRisk(),
         }),
       sortProviders: sortWebSearchProvidersForAutoDetect,
       readConfiguredCredential: ({ provider, config, toolConfig }) =>

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -501,6 +501,7 @@ export async function resolveRuntimeWebTools(params: {
   }
   const search = isRecord(sourceWeb?.search) ? sourceWeb.search : undefined;
   const fetch = isRecord(sourceWeb?.fetch) ? (sourceWeb.fetch as FetchConfig) : undefined;
+  const hasCustomWebSearchRisk = hasCustomWebSearchPluginRisk(params.sourceConfig);
   if (!search && !fetch && !hasPluginWebSearchConfig && !hasPluginWebFetchConfig) {
     return {
       search: {
@@ -516,7 +517,7 @@ export async function resolveRuntimeWebTools(params: {
   }
   const rawProvider = normalizeLowercaseStringOrEmpty(search?.provider);
   const configuredBundledWebSearchPluginIdHint =
-    rawProvider && hasPluginWebSearchConfig && !hasCustomWebSearchPluginRisk(params.sourceConfig)
+    rawProvider && hasPluginWebSearchConfig && !hasCustomWebSearchRisk
       ? inferSingleBundledPluginScopedWebToolConfigOwner(params.sourceConfig, "webSearch")
       : undefined;
   const searchMetadata: RuntimeWebSearchMetadata = {
@@ -556,10 +557,10 @@ export async function resolveRuntimeWebTools(params: {
           onlyPluginIds:
             configuredBundledPluginId === undefined &&
             searchCompatibilityOnlyPluginIds.length > 0 &&
-            !hasCustomWebSearchPluginRisk(params.sourceConfig)
+            !hasCustomWebSearchRisk
               ? searchCompatibilityOnlyPluginIds
               : undefined,
-          hasCustomWebSearchPluginRisk: hasCustomWebSearchPluginRisk(params.sourceConfig),
+          hasCustomWebSearchPluginRisk: hasCustomWebSearchRisk,
         }),
       sortProviders: sortWebSearchProvidersForAutoDetect,
       readConfiguredCredential: ({ provider, config, toolConfig }) =>

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -161,6 +161,17 @@ describe("version resolution", () => {
     ).toBe("2026.3.99");
   });
 
+  it("prefers explicit compatibility host overrides over runtime and stale env versions", () => {
+    expect(
+      resolveCompatibilityHostVersion({
+        OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.4.8",
+        OPENCLAW_VERSION: "2026.3.99",
+        OPENCLAW_SERVICE_VERSION: "2026.3.98",
+        npm_package_version: "2026.3.97",
+      }),
+    ).toBe("2026.4.8");
+  });
+
   it("normalizes runtime version candidate for fallback handling", () => {
     expect(resolveUsableRuntimeVersion(undefined)).toBeUndefined();
     expect(resolveUsableRuntimeVersion("")).toBeUndefined();

--- a/src/version.ts
+++ b/src/version.ts
@@ -139,6 +139,10 @@ export function resolveCompatibilityHostVersion(
   env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
   fallback = RUNTIME_SERVICE_VERSION_FALLBACK,
 ): string {
+  const explicitCompatibilityVersion = firstNonEmpty(env.OPENCLAW_COMPATIBILITY_HOST_VERSION);
+  if (explicitCompatibilityVersion) {
+    return explicitCompatibilityVersion;
+  }
   return resolveVersionFromRuntimeSources({
     env,
     runtimeVersion: resolveUsableRuntimeVersion(VERSION),

--- a/test/plugin-npm-release.test.ts
+++ b/test/plugin-npm-release.test.ts
@@ -133,7 +133,7 @@ describe("collectPublishablePluginPackages", () => {
     mkdirSync(join(repoDir, "extensions", "demo-plugin"), { recursive: true });
     writeJsonFile(join(repoDir, "extensions", "demo-plugin", "package.json"), {
       name: "@openclaw/demo-plugin",
-      version: "2026.4.8",
+      version: "2026.4.9",
       openclaw: {
         extensions: ["./index.ts"],
         install: {
@@ -150,7 +150,7 @@ describe("collectPublishablePluginPackages", () => {
         extensionId: "demo-plugin",
         packageDir: "extensions/demo-plugin",
         packageName: "@openclaw/demo-plugin",
-        version: "2026.4.8",
+        version: "2026.4.9",
         channel: "stable",
         publishTag: "latest",
         installNpmSpec: "@openclaw/demo-plugin",


### PR DESCRIPTION
## Summary

Fixes #32868 --- block streaming replies on same-channel dispatch are not awaited, allowing tool execution to continue before the block text reaches the user.

### Problem

`sendBlockReply` returned a plain `boolean`, and the `onBlockReply` callback in `dispatch-from-config.ts` fire-and-forgot the dispatcher call on the same-channel path. This meant tool results could be delivered before the preceding block text, causing out-of-order messages on channels like WhatsApp, Telegram, and web chat.

The `shouldRouteToOriginating` (cross-channel) path already awaited delivery correctly via `sendPayloadAsync`.

### Changes

1. **`reply-dispatcher.ts`**: `sendBlockReply` now returns `false | Promise<void>` instead of `boolean`. It returns `false` when the payload is dropped (empty/silent), or the internal `sendChain` promise when the delivery is enqueued. Since a fulfilled `Promise` is truthy, existing boolean-style checks (`if (delivered)`) remain correct without changes.

2. **`dispatch-from-config.ts`**: The same-channel `onBlockReply` path now `await`s `dispatcher.sendBlockReply(ttsPayload)`, matching the cross-channel path that already awaited delivery.

3. **`dispatch-acp-delivery.ts`**: Coerce `sendBlockReply` result to `boolean` via `Boolean()` for the uniform delivered/failed tracking.

4. **Test updates**: All test mocks updated to match the new return type (`Promise.resolve()` for accepted, `false` for dropped). Two new tests verify return semantics and delivery ordering guarantees.

### Backward Compatibility

- `sendBlockReply` previously returned `true` on success; it now returns `Promise.resolve()` which is also truthy. All existing `if (delivered)` checks work unchanged.
- The `false` return for dropped payloads is identical.
- The only behavioral change is that same-channel block delivery is now awaited, which is the intended fix.