### PR TITLE
fix(plugins): prevent reentrant stack overflow in resolveProviderPluginsForHooks during plugin loading

### DIFF
--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1280,4 +1280,52 @@ describe("provider-runtime", () => {
       }),
     );
   });
+
+  it("does not stack-overflow when resolvePluginProviders reentrantly triggers provider hook resolution", () => {
+    // Regression test for #61922 / #61938: when loadOpenClawPlugins (called
+    // via resolvePluginProviders) reentrantly triggers
+    // normalizeProviderConfigWithPlugin during plugin module loading, the
+    // reentrancy guard must return an empty list instead of recursing.
+    let callDepth = 0;
+    resolvePluginProvidersMock.mockImplementation(() => {
+      callDepth++;
+      if (callDepth === 1) {
+        // Simulate the reentrant call that happens when a plugin's
+        // register() or top-level module code triggers provider config
+        // normalization, which calls resolveProviderPluginsForHooks again.
+        const reentrantResult = normalizeProviderConfigWithPlugin({
+          provider: "reentrant-provider",
+          context: {
+            provider: "reentrant-provider",
+            providerConfig: {
+              baseUrl: "https://example.com",
+              api: "openai-completions",
+              models: [],
+            },
+          },
+        });
+        // The reentrant call should safely return undefined (no plugin
+        // matched) instead of blowing the stack.
+        expect(reentrantResult).toBeUndefined();
+      }
+      return [];
+    });
+
+    // The outer call should complete without throwing RangeError.
+    const result = normalizeProviderConfigWithPlugin({
+      provider: "demo",
+      context: {
+        provider: "demo",
+        providerConfig: { baseUrl: "https://example.com", api: "openai-completions", models: [] },
+      },
+    });
+
+    expect(result).toBeUndefined();
+    // resolvePluginProviders should have been called exactly twice:
+    // once for the outer resolveProviderRuntimePlugin lookup, and once
+    // for the outer resolveProviderPluginsForHooks fallback.  The
+    // reentrant calls inside callDepth===1 are short-circuited by the
+    // guard and never reach resolvePluginProviders.
+    expect(callDepth).toBe(2);
+  });
 });

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -116,6 +116,15 @@ function buildHookProviderCacheKey(params: {
   return `${roots.workspace ?? ""}::${roots.global}::${roots.stock ?? ""}::${JSON.stringify(params.config ?? null)}::${JSON.stringify(params.onlyPluginIds ?? [])}::${JSON.stringify(params.providerRefs ?? [])}`;
 }
 
+// Reentrancy guard: prevents infinite recursion when plugin loading triggers
+// provider config normalization which in turn triggers another plugin load.
+// The cycle is: validateConfigObject → materializeRuntimeConfig → applyModelDefaults
+// → normalizeProviderSpecificConfig → normalizeProviderConfigWithPlugin
+// → resolveProviderPluginsForHooks → resolvePluginProviders
+// → resolveRuntimePluginRegistry → loadOpenClawPlugins → (plugin register/import)
+// → normalizeProviderConfigWithPlugin → ... (infinite recursion).
+let resolvingProviderPluginsForHooks = false;
+
 export function clearProviderRuntimeHookCache(): void {
   cachedHookProvidersWithoutConfig = new WeakMap<
     NodeJS.ProcessEnv,
@@ -129,6 +138,7 @@ export function clearProviderRuntimeHookCache(): void {
 
 export function resetProviderRuntimeHookCacheForTest(): void {
   clearProviderRuntimeHookCache();
+  resolvingProviderPluginsForHooks = false;
 }
 
 function resolveProviderPluginsForHooks(params: {
@@ -155,17 +165,31 @@ function resolveProviderPluginsForHooks(params: {
   if (cached) {
     return cached;
   }
-  const resolved = resolvePluginProviders({
-    ...params,
-    workspaceDir,
-    env,
-    activate: false,
-    cache: false,
-    bundledProviderAllowlistCompat: true,
-    bundledProviderVitestCompat: true,
-  });
-  cacheBucket.set(cacheKey, resolved);
-  return resolved;
+  // Reentrancy bailout: if we are already inside a provider-plugin
+  // resolution call (e.g. a plugin's register() or top-level module code
+  // triggered another normalizeProviderConfigWithPlugin), return an empty
+  // list to break the recursive cycle.  This check intentionally sits
+  // *after* the cache lookup so that already-cached provider keys are
+  // still served correctly during reentrant resolution.
+  if (resolvingProviderPluginsForHooks) {
+    return [];
+  }
+  resolvingProviderPluginsForHooks = true;
+  try {
+    const resolved = resolvePluginProviders({
+      ...params,
+      workspaceDir,
+      env,
+      activate: false,
+      cache: false,
+      bundledProviderAllowlistCompat: true,
+      bundledProviderVitestCompat: true,
+    });
+    cacheBucket.set(cacheKey, resolved);
+    return resolved;
+  } finally {
+    resolvingProviderPluginsForHooks = false;
+  }
 }
 
 function resolveProviderPluginsForCatalogHooks(params: {


### PR DESCRIPTION
### Summary

- **Problem**: The `openclaw` dashboard crashes with `RangeError: Maximum call stack size exceeded` during startup or when certain plugins trigger repeated loads. The stack trace points to a deep synchronous recursion involving `normalizeProviderConfigWithPlugin` and `loadOpenClawPlugins`.
- **Root Cause**: The recursion is caused by a **reentrant cycle** during plugin loading. When `validateConfigObject` applies model defaults via `materializeRuntimeConfig`, it calls `normalizeProviderSpecificConfig` for each provider. This triggers `normalizeProviderConfigWithPlugin`, which calls `resolveProviderPluginsForHooks`. If the cache is empty and there is no active registry, it calls `loadOpenClawPlugins` with `activate: false` and `cache: false`. During the module evaluation of these plugins (via `jiti`), top-level code or `register()` callbacks can indirectly trigger another config read or provider normalization, re-entering `resolveProviderPluginsForHooks` before the first load finishes. Because `cache: false` prevents caching the intermediate registry, this forms an infinite synchronous loop until the stack overflows.
- **Fix**: Added a reentrancy guard (`resolvingProviderPluginsForHooks`) in `resolveProviderPluginsForHooks`. If the function is called while already resolving plugins, it safely returns an empty array to break the cycle. This check intentionally sits **after** the cache lookup so that already-cached provider keys are still served correctly during reentrant resolution. The outer call will then complete normally and populate the cache, allowing subsequent lookups to succeed without recursing.
- **What changed**:
  - `src/plugins/provider-runtime.ts`: Added `resolvingProviderPluginsForHooks` boolean flag and wrapped the `resolvePluginProviders` call in a `try/finally` block to manage the guard state.
  - `src/plugins/provider-runtime.test.ts`: Added a strict regression test that mocks a reentrant call to `normalizeProviderConfigWithPlugin` during plugin resolution to ensure the guard breaks the cycle and prevents `RangeError`.
- **What did NOT change (scope boundary)**: The core plugin loading logic (`loadOpenClawPlugins`), config validation (`validateConfigObject`), and registry caching mechanisms remain unchanged. The fix is strictly scoped to the provider hook resolution path where the recursion occurs.
- **Note on other stack overflow issues**: This PR specifically fixes the **synchronous reentrant cycle** described above. It does **not** address stack overflows caused by deep AJV schema compilation (e.g., when loading plugins with massive `oneOf` branches like `google` or `minimax`), which is a separate issue related to AST generation depth.

### Related Issues
Fixes #61922

