### PR TITLE
fix(memory): register ollama builtin embedding adapter

### DIFF
--- a/extensions/memory-core/src/memory/provider-adapters.test.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.test.ts
@@ -39,7 +39,7 @@ describe("registerBuiltInMemoryEmbeddingProviders", () => {
       },
     });
 
-    expect(ids).toEqual(["local", "openai", "gemini", "voyage", "mistral"]);
+    expect(ids).toEqual(["local", "openai", "gemini", "voyage", "mistral", "ollama"]);
     expect(mocks.listRegisteredMemoryEmbeddingProviderAdapters).toHaveBeenCalledTimes(1);
     expect(mocks.listMemoryEmbeddingProviders).not.toHaveBeenCalled();
   });
@@ -57,7 +57,7 @@ describe("registerBuiltInMemoryEmbeddingProviders", () => {
       },
     });
 
-    expect(ids).toEqual(["openai", "voyage", "mistral"]);
+    expect(ids).toEqual(["openai", "voyage", "mistral", "ollama"]);
     expect(mocks.listMemoryEmbeddingProviders).not.toHaveBeenCalled();
   });
 });

--- a/extensions/memory-core/src/memory/provider-adapters.ts
+++ b/extensions/memory-core/src/memory/provider-adapters.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_GEMINI_EMBEDDING_MODEL,
   DEFAULT_LOCAL_MODEL,
   DEFAULT_MISTRAL_EMBEDDING_MODEL,
+  DEFAULT_OLLAMA_EMBEDDING_MODEL,
   DEFAULT_OPENAI_EMBEDDING_MODEL,
   DEFAULT_VOYAGE_EMBEDDING_MODEL,
   OPENAI_BATCH_ENDPOINT,
@@ -10,6 +11,7 @@ import {
   createGeminiEmbeddingProvider,
   createLocalEmbeddingProvider,
   createMistralEmbeddingProvider,
+  createOllamaEmbeddingProvider,
   createOpenAiEmbeddingProvider,
   createVoyageEmbeddingProvider,
   hasNonTextEmbeddingParts,
@@ -287,6 +289,33 @@ const mistralAdapter: MemoryEmbeddingProviderAdapter = {
   },
 };
 
+const ollamaAdapter: MemoryEmbeddingProviderAdapter = {
+  id: "ollama",
+  defaultModel: DEFAULT_OLLAMA_EMBEDDING_MODEL,
+  transport: "remote",
+  allowExplicitWhenConfiguredAuto: true,
+  shouldContinueAutoSelection: isMissingApiKeyError,
+  create: async (options) => {
+    const { provider, client } = await createOllamaEmbeddingProvider({
+      ...options,
+      provider: "ollama",
+      fallback: "none",
+    });
+    return {
+      provider,
+      runtime: {
+        id: "ollama",
+        cacheKeyData: {
+          provider: "ollama",
+          baseUrl: client.baseUrl,
+          model: client.model,
+          headers: sanitizeHeaders(client.headers, ["authorization"]),
+        },
+      },
+    };
+  },
+};
+
 const localAdapter: MemoryEmbeddingProviderAdapter = {
   id: "local",
   defaultModel: DEFAULT_LOCAL_MODEL,
@@ -319,6 +348,7 @@ export const builtinMemoryEmbeddingProviderAdapters = [
   geminiAdapter,
   voyageAdapter,
   mistralAdapter,
+  ollamaAdapter,
 ] as const;
 
 const builtinMemoryEmbeddingProviderAdapterById = new Map(


### PR DESCRIPTION
## Summary
- register the builtin `ollama` memory embedding adapter in memory-core
- reuse the existing host-engine Ollama provider/runtime instead of throwing `Unknown memory embedding provider: ollama`
- add focused coverage that locks the builtin registration list to include `ollama`

## Verification
- `pnpm exec vitest run extensions/memory-core/src/memory/provider-adapters.test.ts`
- `pnpm exec oxfmt --check extensions/memory-core/src/memory/provider-adapters.ts extensions/memory-core/src/memory/provider-adapters.test.ts`

Closes #61919
