### PR TITLE
fix: suppress commentary history leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Docs: https://docs.openclaw.ai
 - Agents/history: keep truly legacy unsigned replay text unphased when mixed with phased OpenAI WS assistant blocks, while still inheriting message phase for id-only replay signatures. (#61529) Thanks @100yenadmin.
 - Discord/thread titles: stop forcing a hardcoded temperature for generated auto-thread names so Codex-backed thread title generation works on `openai-codex/*` models again. (#59525)
 - Providers/OpenAI: keep WebSocket text buffered until a real assistant phase arrives, even when text deltas land before a phaseless `output_item.added` announcement. (#61954) Thanks @100yenadmin.
+- Agents/history: keep history-based reply reads and subagent completion summaries on `final_answer` text only so internal commentary stops leaking into user-visible follow-up replies. (#61747) Thanks @afurm.
 
 ## 2026.4.5
 

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -73,6 +73,63 @@ describe("readLatestAssistantReply", () => {
     expect(result.text).toBe("new output");
     expect(result.fingerprint).toContain('"timestamp":42');
   });
+
+  it("reads only final_answer text from phased assistant history", async () => {
+    callGatewayMock.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Need fix line quoting properly.",
+              textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+            },
+            {
+              type: "text",
+              text: "Fixed the quoting issue.",
+              textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await readLatestAssistantReply({ sessionKey: "agent:main:child" });
+
+    expect(result).toBe("Fixed the quoting issue.");
+  });
+
+  it("preserves spaces across split final_answer history blocks", async () => {
+    callGatewayMock.mockResolvedValue({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Need fix line quoting properly.",
+              textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+            },
+            {
+              type: "text",
+              text: "Hi ",
+              textSignature: JSON.stringify({ v: 1, id: "final_1", phase: "final_answer" }),
+            },
+            {
+              type: "text",
+              text: "there",
+              textSignature: JSON.stringify({ v: 1, id: "final_2", phase: "final_answer" }),
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await readLatestAssistantReply({ sessionKey: "agent:main:child" });
+
+    expect(result).toBe("Hi there");
+  });
 });
 
 describe("waitForAgentRun", () => {

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -117,17 +117,7 @@ function extractSubagentOutputText(message: unknown): string {
   const role = (message as { role?: unknown }).role;
   const content = (message as { content?: unknown }).content;
   if (role === "assistant") {
-    const assistantText = extractAssistantText(message);
-    if (assistantText) {
-      return assistantText;
-    }
-    if (typeof content === "string") {
-      return sanitizeTextContent(content);
-    }
-    if (Array.isArray(content)) {
-      return extractInlineTextContent(content);
-    }
-    return "";
+    return extractAssistantText(message) ?? "";
   }
   if (role === "toolResult" || role === "tool") {
     return extractToolResultText((message as ToolResultMessage).content);

--- a/src/agents/tools/assistant-phase-text.test.ts
+++ b/src/agents/tools/assistant-phase-text.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { extractAssistantText as extractChatHistoryAssistantText } from "./chat-history-text.js";
+import { extractAssistantText as extractSessionAssistantText } from "./session-message-text.js";
+
+describe("phase-aware assistant text helpers", () => {
+  it("fails soft for malformed inputs", () => {
+    for (const message of [null, 42, "broken history entry"]) {
+      expect(extractChatHistoryAssistantText(message)).toBeUndefined();
+      expect(extractSessionAssistantText(message)).toBeUndefined();
+    }
+  });
+
+  it("prefers final_answer text over commentary in chat history helpers", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need fix line quoting properly.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "Fixed the quoting issue.",
+          textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractChatHistoryAssistantText(message)).toBe("Fixed the quoting issue.");
+  });
+
+  it("does not fall back to commentary when an explicit final_answer is empty", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need simpler use cat overwrite full file.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "   ",
+          textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractChatHistoryAssistantText(message)).toBeUndefined();
+  });
+
+  it("preserves spaces across split final_answer blocks in chat history helpers", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need verify healthy.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "Hi ",
+          textSignature: JSON.stringify({ v: 1, id: "final_1", phase: "final_answer" }),
+        },
+        {
+          type: "text",
+          text: "<think>secret</think>there",
+          textSignature: JSON.stringify({ v: 1, id: "final_2", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractChatHistoryAssistantText(message)).toBe("Hi there");
+  });
+
+  it("prefers final_answer text over commentary in session message helpers", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need verify healthy.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "Health check completed successfully.",
+          textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractSessionAssistantText(message)).toBe("Health check completed successfully.");
+  });
+
+  it("preserves spaces across split final_answer blocks in session message helpers", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Need verify healthy.",
+          textSignature: JSON.stringify({ v: 1, id: "commentary", phase: "commentary" }),
+        },
+        {
+          type: "text",
+          text: "Hi ",
+          textSignature: JSON.stringify({ v: 1, id: "final_1", phase: "final_answer" }),
+        },
+        {
+          type: "text",
+          text: "<think>secret</think>there",
+          textSignature: JSON.stringify({ v: 1, id: "final_2", phase: "final_answer" }),
+        },
+      ],
+    };
+
+    expect(extractSessionAssistantText(message)).toBe("Hi there");
+  });
+});

--- a/src/agents/tools/chat-history-text.ts
+++ b/src/agents/tools/chat-history-text.ts
@@ -1,7 +1,6 @@
-import { extractTextFromChatContent } from "../../shared/chat-content.js";
+import { extractAssistantTextForPhase } from "../../shared/chat-message-content.js";
 import { sanitizeAssistantVisibleTextWithProfile } from "../../shared/text/assistant-visible-text.js";
 import { sanitizeUserFacingText } from "../pi-embedded-helpers.js";
-import { extractAssistantVisibleText } from "../pi-embedded-utils.js";
 
 export function stripToolMessages(messages: unknown[]): unknown[] {
   return messages.filter((msg) => {
@@ -39,7 +38,6 @@ export function hasAssistantPhaseMetadata(message: unknown): boolean {
       typeof (block as { textSignature?: unknown }).textSignature === "string",
   );
 }
-
 export function extractAssistantText(message: unknown): string | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
@@ -47,30 +45,20 @@ export function extractAssistantText(message: unknown): string | undefined {
   if ((message as { role?: unknown }).role !== "assistant") {
     return undefined;
   }
-  if (hasAssistantPhaseMetadata(message)) {
-    const visibleText = extractAssistantVisibleText(
-      message as Parameters<typeof extractAssistantVisibleText>[0],
-    );
-    return visibleText?.trim() ? visibleText : undefined;
-  }
-  const content = (message as { content?: unknown }).content;
-  const joined = Array.isArray(content)
-    ? (extractTextFromChatContent(content, {
-        sanitizeText: sanitizeTextContent,
-        joinWith: "",
-        normalizeText: (text) => text.trim(),
-      }) ?? "")
-    : sanitizeTextContent(
-        extractAssistantVisibleText(message as Parameters<typeof extractAssistantVisibleText>[0]) ??
-          "",
-      );
-  if (!joined.trim()) {
-    return undefined;
-  }
+  const joined =
+    extractAssistantTextForPhase(message, {
+      phase: "final_answer",
+      sanitizeText: sanitizeTextContent,
+      joinWith: "",
+    }) ??
+    extractAssistantTextForPhase(message, {
+      sanitizeText: sanitizeTextContent,
+      joinWith: "",
+    });
   const stopReason = (message as { stopReason?: unknown }).stopReason;
   // Gate on stopReason only — a non-error response with a stale/background errorMessage
   // should not have its content rewritten with error templates (#13935).
   const errorContext = stopReason === "error";
 
-  return sanitizeUserFacingText(joined, { errorContext });
+  return joined ? sanitizeUserFacingText(joined, { errorContext }) : undefined;
 }

--- a/src/auto-reply/reply/commands-subagents-control.runtime.ts
+++ b/src/auto-reply/reply/commands-subagents-control.runtime.ts
@@ -1,7 +1,7 @@
 export {
+  listControlledSubagentRuns,
   killAllControlledSubagentRuns,
   killControlledSubagentRun,
-  listControlledSubagentRuns,
   sendControlledSubagentMessage,
   steerControlledSubagentRun,
 } from "../../agents/subagent-control.js";

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -258,6 +258,7 @@ export class GatewayClient {
         }
         return undefined;
       };
+      };
     }
     const ws = new WebSocket(url, wsOptions as ClientOptions);
     this.ws = ws;

--- a/src/plugins/hooks.sync-only.test.ts
+++ b/src/plugins/hooks.sync-only.test.ts
@@ -16,9 +16,11 @@ function createLogger(): HookRunnerLogger & {
   warn: ReturnType<typeof vi.fn>;
   error: ReturnType<typeof vi.fn>;
 } {
+  const warn = vi.fn<(message: string) => void>();
+  const error = vi.fn<(message: string) => void>();
   return {
-    warn: vi.fn(),
-    error: vi.fn(),
+    warn,
+    error,
   };
 }
 

--- a/src/shared/chat-message-content.test.ts
+++ b/src/shared/chat-message-content.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  extractAssistantTextForPhase,
   extractAssistantVisibleText,
   extractFirstTextBlock,
   resolveAssistantMessagePhase,
@@ -53,6 +54,29 @@ describe("shared/chat-message-content", () => {
 });
 
 describe("extractAssistantVisibleText", () => {
+  it("preserves boundary spacing when joining adjacent final_answer text blocks", () => {
+    expect(
+      extractAssistantTextForPhase(
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "Hi ",
+              textSignature: JSON.stringify({ v: 1, id: "msg_final_1", phase: "final_answer" }),
+            },
+            {
+              type: "text",
+              text: "there",
+              textSignature: JSON.stringify({ v: 1, id: "msg_final_2", phase: "final_answer" }),
+            },
+          ],
+        },
+        { phase: "final_answer", joinWith: "" },
+      ),
+    ).toBe("Hi there");
+  });
+
   it("prefers final_answer text over commentary text", () => {
     expect(
       extractAssistantVisibleText({
@@ -82,6 +106,22 @@ describe("extractAssistantVisibleText", () => {
             type: "text",
             text: "thinking like caveman",
             textSignature: JSON.stringify({ v: 1, id: "msg_commentary", phase: "commentary" }),
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not fall back to unphased legacy text when final_answer is empty", () => {
+    expect(
+      extractAssistantVisibleText({
+        role: "assistant",
+        content: [
+          { type: "text", text: "Legacy answer" },
+          {
+            type: "text",
+            text: "   ",
+            textSignature: JSON.stringify({ v: 1, id: "msg_final", phase: "final_answer" }),
           },
         ],
       }),

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -88,30 +88,46 @@ export function resolveAssistantMessagePhase(message: unknown): AssistantPhase |
   return explicitPhases.size === 1 ? [...explicitPhases][0] : undefined;
 }
 
-function extractAssistantTextForPhase(
+export function extractAssistantTextForPhase(
   message: unknown,
-  phase?: AssistantPhase,
+  options?: {
+    phase?: AssistantPhase;
+    sanitizeText?: (text: string) => string;
+    joinWith?: string;
+  },
 ): string | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
   }
   const entry = message as { text?: unknown; content?: unknown; phase?: unknown };
   const messagePhase = normalizeAssistantPhase(entry.phase);
+  const phase = options?.phase;
   const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
     if (phase) {
       return resolvedPhase === phase;
     }
     return resolvedPhase === undefined;
   };
+  const sanitizeText = options?.sanitizeText;
+  const joinWith = options?.joinWith ?? "\n";
+  const sanitizeBlockText = (text: string) => (sanitizeText ? sanitizeText(text) : text);
+  const normalizeJoinedText = (text: string) => {
+    const normalized = text.trim();
+    return normalized || undefined;
+  };
 
   if (typeof entry.text === "string") {
-    const normalized = entry.text.trim();
-    return shouldIncludeContent(messagePhase) && normalized ? normalized : undefined;
+    if (!shouldIncludeContent(messagePhase)) {
+      return undefined;
+    }
+    return normalizeJoinedText(sanitizeBlockText(entry.text));
   }
 
   if (typeof entry.content === "string") {
-    const normalized = entry.content.trim();
-    return shouldIncludeContent(messagePhase) && normalized ? normalized : undefined;
+    if (!shouldIncludeContent(messagePhase)) {
+      return undefined;
+    }
+    return normalizeJoinedText(sanitizeBlockText(entry.content));
   }
 
   if (!Array.isArray(entry.content)) {
@@ -129,6 +145,12 @@ function extractAssistantTextForPhase(
     return Boolean(parseAssistantTextSignature(record.textSignature)?.phase);
   });
 
+  // Once explicit phased blocks exist, unphased extraction should not revive
+  // legacy text from the same message.
+  if (!phase && hasExplicitPhasedTextBlocks) {
+    return undefined;
+  }
+
   const parts = entry.content
     .map((block) => {
       if (!block || typeof block !== "object") {
@@ -144,19 +166,19 @@ function extractAssistantTextForPhase(
       if (!shouldIncludeContent(resolvedPhase)) {
         return null;
       }
-      const normalized = record.text.trim();
-      return normalized || null;
+      const sanitized = sanitizeBlockText(record.text);
+      return sanitized.trim() ? sanitized : null;
     })
     .filter((value): value is string => typeof value === "string");
 
   if (parts.length === 0) {
     return undefined;
   }
-  return parts.join("\n");
+  return normalizeJoinedText(parts.join(joinWith));
 }
 
 export function extractAssistantVisibleText(message: unknown): string | undefined {
-  const finalAnswerText = extractAssistantTextForPhase(message, "final_answer");
+  const finalAnswerText = extractAssistantTextForPhase(message, { phase: "final_answer" });
   if (finalAnswerText) {
     return finalAnswerText;
   }


### PR DESCRIPTION
Supersedes #61747 after the original fork branch was closed during rebase fallout.

What changed:
- keep history reply reads and subagent summaries on `final_answer` only
- add regression coverage for helper + run-wait path
- carry the changelog thanks for @afurm
- include tiny latest-main type drift repairs needed to keep `pnpm check` green while landing

Local verification:
- `pnpm test src/shared/chat-message-content.test.ts src/agents/tools/assistant-phase-text.test.ts src/agents/run-wait.test.ts`
- `pnpm check`
- `pnpm build`

Note: full `pnpm test` on current main remains noisy/red outside this patch surface.