### PR TITLE
fix(infra): set restrictive directory permissions for sensitive state files

### DIFF
--- a/src/infra/device-auth-store.ts
+++ b/src/infra/device-auth-store.ts
@@ -35,7 +35,7 @@ function readStore(filePath: string): DeviceAuthStore | null {
 }
 
 function writeStore(filePath: string, store: DeviceAuthStore): void {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
   fs.writeFileSync(filePath, `${JSON.stringify(store, null, 2)}\n`, { mode: 0o600 });
   try {
     fs.chmodSync(filePath, 0o600);

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -22,7 +22,7 @@ function resolveDefaultIdentityPath(): string {
 }
 
 function ensureDir(filePath: string) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
 }
 
 const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -234,7 +234,7 @@ function mergeLegacyAgent(
 
 function ensureDir(filePath: string) {
   const dir = path.dirname(filePath);
-  fs.mkdirSync(dir, { recursive: true });
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
 }
 
 // Coerce legacy/corrupted allowlists into `ExecAllowlistEntry[]` before we spread

--- a/src/infra/gateway-lock.ts
+++ b/src/infra/gateway-lock.ts
@@ -264,7 +264,7 @@ export async function acquireGatewayLock(
   const sleep =
     opts.sleep ?? (async (ms: number) => await new Promise((resolve) => setTimeout(resolve, ms)));
   const { lockPath, configPath } = resolveGatewayLockPath(env, opts.lockDir);
-  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  await fs.mkdir(path.dirname(lockPath), { recursive: true, mode: 0o700 });
 
   const startedAt = now();
   let lastPayload: LockPayload | null = null;

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -67,7 +67,7 @@ export async function writeRestartSentinel(
   env: NodeJS.ProcessEnv = process.env,
 ) {
   const filePath = resolveRestartSentinelPath(env);
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
   const data: RestartSentinel = { version: 1, payload };
   await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
   return filePath;


### PR DESCRIPTION
## Problem

Several infrastructure modules create directories for security-sensitive data without specifying restrictive permissions. The files themselves are often written with `mode: 0o600`, but the parent directories inherit the process umask (commonly `0o755`), which allows other local users to traverse into directories containing private keys, authentication tokens, and approval policies.

## Fix

Add `mode: 0o700` to `mkdir` calls in five modules that store sensitive state:

- **`device-identity.ts`** — Ed25519 device private key
- **`device-auth-store.ts`** — device authentication tokens
- **`exec-approvals.ts`** — execution approval allowlists
- **`gateway-lock.ts`** — gateway lock files with process metadata
- **`restart-sentinel.ts`** — restart instruction payloads

This aligns with the convention already established in `json-file.ts` (`JSON_DIR_MODE = 0o700`) and `delivery-queue-storage.ts` (`mode: 0o700`).

## Impact

On multi-user systems, this prevents local users from listing or traversing into directories that hold private keys and auth tokens. No functional change on single-user systems since the files already have `0o600` permissions — this adds defense in depth at the directory level.