### PR TITLE
fix(zai): default to GLM-5.1 instead of GLM-5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,9 +101,9 @@ Docs: https://docs.openclaw.ai
 - Daemon/systemd: keep sudo systemctl calls scoped to the invoking user when machine-scoped systemctl fails, while still avoiding machine fallback for permission-denied user bus errors. (#62337) Thanks @Aftabbs.
 - Docs/i18n: relocalize final localized-page links after translation and remove the zh-CN homepage redirect override so localized Mintlify pages resolve to the correct language roots again. (#61796) Thanks @hxy91819.
 - Agents/exec: keep timed-out shell-backgrounded commands on the failed path and point long-running jobs to exec background/yield sessions so process polling is only suggested for registered sessions.
-
 - Agents/model resolution: let explicit `openai-codex/gpt-5.4` selection prefer provider runtime metadata when it reports a larger context window, keeping configured Codex runs aligned with the live provider limits. (#62694) Thanks @ruclaw7.
 - Agents/model resolution: keep explicit-model runtime comparisons on the configured workspace plugin registry, so workspace-installed providers do not silently fall back to stale explicit metadata during runtime model lookup.
+- Providers/Z.AI: default onboarding and endpoint detection to GLM-5.1 instead of GLM-5. (#61998) Thanks @serg0x.
 
 ## 2026.4.5
 

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -115,7 +115,7 @@ Interactive onboarding behavior with reference mode:
 
 Non-interactive Z.AI endpoint choices:
 
-Note: `--auth-choice zai-api-key` now auto-detects the best Z.AI endpoint for your key (prefers the general API with `zai/glm-5`).
+Note: `--auth-choice zai-api-key` now auto-detects the best Z.AI endpoint for your key (prefers the general API with `zai/glm-5.1`).
 If you specifically want the GLM Coding Plan endpoints, pick `zai-coding-global` or `zai-coding-cn`.
 
 ```bash

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -371,7 +371,7 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
 
 - Provider: `zai`
 - Auth: `ZAI_API_KEY`
-- Example model: `zai/glm-5`
+- Example model: `zai/glm-5.1`
 - CLI: `openclaw onboard --auth-choice zai-api-key`
   - Aliases: `z.ai/*` and `z-ai/*` normalize to `zai/*`
   - `zai-api-key` auto-detects the matching Z.AI endpoint; `zai-coding-global`, `zai-coding-cn`, `zai-global`, and `zai-cn` force a specific surface

--- a/docs/providers/glm.md
+++ b/docs/providers/glm.md
@@ -35,7 +35,7 @@ openclaw onboard --auth-choice zai-cn
 ```json5
 {
   env: { ZAI_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "zai/glm-5" } } },
+  agents: { defaults: { model: { primary: "zai/glm-5.1" } } },
 }
 ```
 
@@ -64,5 +64,5 @@ OpenClaw currently seeds the bundled `zai` provider with these GLM refs:
 ## Notes
 
 - GLM versions and availability can change; check Z.AI's docs for the latest.
-- Default bundled model ref is `zai/glm-5`.
+- Default bundled model ref is `zai/glm-5.1`.
 - For provider details, see [/providers/zai](/providers/zai).

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -36,7 +36,7 @@ openclaw onboard --auth-choice zai-cn
 ```json5
 {
   env: { ZAI_API_KEY: "sk-..." },
-  agents: { defaults: { model: { primary: "zai/glm-5" } } },
+  agents: { defaults: { model: { primary: "zai/glm-5.1" } } },
 }
 ```
 
@@ -65,7 +65,7 @@ OpenClaw currently seeds the bundled `zai` provider with:
 ## Notes
 
 - GLM models are available as `zai/<model>` (example: `zai/glm-5`).
-- Default bundled model ref: `zai/glm-5`
+- Default bundled model ref: `zai/glm-5.1`
 - Unknown `glm-5*` ids still forward-resolve on the bundled provider path by
   synthesizing provider-owned metadata from the `glm-4.7` template when the id
   matches the current GLM-5 family shape.

--- a/extensions/zai/model-definitions.ts
+++ b/extensions/zai/model-definitions.ts
@@ -4,7 +4,7 @@ export const ZAI_CODING_GLOBAL_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 export const ZAI_CODING_CN_BASE_URL = "https://open.bigmodel.cn/api/coding/paas/v4";
 export const ZAI_GLOBAL_BASE_URL = "https://api.z.ai/api/paas/v4";
 export const ZAI_CN_BASE_URL = "https://open.bigmodel.cn/api/paas/v4";
-export const ZAI_DEFAULT_MODEL_ID = "glm-5";
+export const ZAI_DEFAULT_MODEL_ID = "glm-5.1";
 export const ZAI_DEFAULT_MODEL_REF = `zai/${ZAI_DEFAULT_MODEL_ID}`;
 
 type ZaiCatalogEntry = {

--- a/src/commands/onboard-non-interactive.provider-auth.test.ts
+++ b/src/commands/onboard-non-interactive.provider-auth.test.ts
@@ -106,7 +106,7 @@ vi.mock("./onboard-non-interactive/local/auth-choice.plugin-providers.js", async
   const ZAI_FALLBACKS = {
     "zai-api-key": {
       baseUrl: ZAI_GLOBAL_BASE_URL,
-      modelId: "glm-5",
+      modelId: "glm-5.1",
     },
     "zai-coding-cn": {
       baseUrl: ZAI_CODING_CN_BASE_URL,
@@ -114,7 +114,7 @@ vi.mock("./onboard-non-interactive/local/auth-choice.plugin-providers.js", async
     },
     "zai-coding-global": {
       baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
-      modelId: "glm-5",
+      modelId: "glm-5.1",
     },
   } as const;
 
@@ -1064,7 +1064,7 @@ describe("onboard (non-interactive): provider auth", () => {
   it("stores Z.AI API key after probing the global endpoint", async () => {
     await withZaiProbeFetch(
       {
-        [`${ZAI_GLOBAL_BASE_URL}/chat/completions::glm-5`]: 200,
+        [`${ZAI_GLOBAL_BASE_URL}/chat/completions::glm-5.1`]: 200,
       },
       async (fetchMock) =>
         await withOnboardEnv("openclaw-onboard-zai-", async (env) => {
@@ -1078,7 +1078,7 @@ describe("onboard (non-interactive): provider auth", () => {
           expectZaiProbeCalls(fetchMock, [
             {
               url: `${ZAI_GLOBAL_BASE_URL}/chat/completions`,
-              modelId: "glm-5",
+              modelId: "glm-5.1",
             },
           ]);
           await expectApiKeyProfile({
@@ -1093,7 +1093,7 @@ describe("onboard (non-interactive): provider auth", () => {
   it("supports Z.AI CN coding endpoint auth choice", async () => {
     await withZaiProbeFetch(
       {
-        [`${ZAI_CODING_CN_BASE_URL}/chat/completions::glm-5`]: 404,
+        [`${ZAI_CODING_CN_BASE_URL}/chat/completions::glm-5.1`]: 404,
         [`${ZAI_CODING_CN_BASE_URL}/chat/completions::glm-4.7`]: 200,
       },
       async (fetchMock) =>
@@ -1108,7 +1108,7 @@ describe("onboard (non-interactive): provider auth", () => {
           expectZaiProbeCalls(fetchMock, [
             {
               url: `${ZAI_CODING_CN_BASE_URL}/chat/completions`,
-              modelId: "glm-5",
+              modelId: "glm-5.1",
             },
             {
               url: `${ZAI_CODING_CN_BASE_URL}/chat/completions`,
@@ -1127,7 +1127,7 @@ describe("onboard (non-interactive): provider auth", () => {
   it("supports Z.AI Coding Plan global endpoint detection", async () => {
     await withZaiProbeFetch(
       {
-        [`${ZAI_CODING_GLOBAL_BASE_URL}/chat/completions::glm-5`]: 200,
+        [`${ZAI_CODING_GLOBAL_BASE_URL}/chat/completions::glm-5.1`]: 200,
       },
       async (fetchMock) =>
         await withOnboardEnv("openclaw-onboard-zai-coding-global-", async (env) => {
@@ -1141,7 +1141,7 @@ describe("onboard (non-interactive): provider auth", () => {
           expectZaiProbeCalls(fetchMock, [
             {
               url: `${ZAI_CODING_GLOBAL_BASE_URL}/chat/completions`,
-              modelId: "glm-5",
+              modelId: "glm-5.1",
             },
           ]);
           await expectApiKeyProfile({

--- a/src/commands/zai-endpoint-detect.test.ts
+++ b/src/commands/zai-endpoint-detect.test.ts
@@ -27,34 +27,34 @@ describe("detectZaiEndpoint", () => {
     }> = [
       {
         responses: {
-          "https://api.z.ai/api/paas/v4/chat/completions::glm-5": { status: 200 },
+          "https://api.z.ai/api/paas/v4/chat/completions::glm-5.1": { status: 200 },
         },
-        expected: { endpoint: "global", modelId: "glm-5" },
+        expected: { endpoint: "global", modelId: "glm-5.1" },
       },
       {
         responses: {
-          "https://api.z.ai/api/paas/v4/chat/completions::glm-5": {
+          "https://api.z.ai/api/paas/v4/chat/completions::glm-5.1": {
             status: 404,
             body: { error: { message: "not found" } },
           },
-          "https://open.bigmodel.cn/api/paas/v4/chat/completions::glm-5": { status: 200 },
+          "https://open.bigmodel.cn/api/paas/v4/chat/completions::glm-5.1": { status: 200 },
         },
-        expected: { endpoint: "cn", modelId: "glm-5" },
+        expected: { endpoint: "cn", modelId: "glm-5.1" },
       },
       {
         responses: {
-          "https://api.z.ai/api/paas/v4/chat/completions::glm-5": { status: 404 },
-          "https://open.bigmodel.cn/api/paas/v4/chat/completions::glm-5": { status: 404 },
-          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5": { status: 200 },
+          "https://api.z.ai/api/paas/v4/chat/completions::glm-5.1": { status: 404 },
+          "https://open.bigmodel.cn/api/paas/v4/chat/completions::glm-5.1": { status: 404 },
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.1": { status: 200 },
         },
-        expected: { endpoint: "coding-global", modelId: "glm-5" },
+        expected: { endpoint: "coding-global", modelId: "glm-5.1" },
       },
       {
         endpoint: "coding-global",
         responses: {
-          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5": {
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.1": {
             status: 404,
-            body: { error: { message: "glm-5 unavailable" } },
+            body: { error: { message: "glm-5.1 unavailable" } },
           },
           "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-4.7": { status: 200 },
         },
@@ -63,16 +63,18 @@ describe("detectZaiEndpoint", () => {
       {
         endpoint: "coding-cn",
         responses: {
-          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5": { status: 200 },
+          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.1": {
+            status: 200,
+          },
         },
-        expected: { endpoint: "coding-cn", modelId: "glm-5" },
+        expected: { endpoint: "coding-cn", modelId: "glm-5.1" },
       },
       {
         endpoint: "coding-cn",
         responses: {
-          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5": {
+          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.1": {
             status: 404,
-            body: { error: { message: "glm-5 unavailable" } },
+            body: { error: { message: "glm-5.1 unavailable" } },
           },
           "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-4.7": { status: 200 },
         },
@@ -80,11 +82,13 @@ describe("detectZaiEndpoint", () => {
       },
       {
         responses: {
-          "https://api.z.ai/api/paas/v4/chat/completions::glm-5": { status: 401 },
-          "https://open.bigmodel.cn/api/paas/v4/chat/completions::glm-5": { status: 401 },
-          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5": { status: 401 },
+          "https://api.z.ai/api/paas/v4/chat/completions::glm-5.1": { status: 401 },
+          "https://open.bigmodel.cn/api/paas/v4/chat/completions::glm-5.1": { status: 401 },
+          "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-5.1": { status: 401 },
           "https://api.z.ai/api/coding/paas/v4/chat/completions::glm-4.7": { status: 401 },
-          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5": { status: 401 },
+          "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-5.1": {
+            status: 401,
+          },
           "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions::glm-4.7": { status: 401 },
         },
         expected: null,

--- a/src/plugins/provider-zai-endpoint.ts
+++ b/src/plugins/provider-zai-endpoint.ts
@@ -102,28 +102,28 @@ export async function detectZaiEndpoint(params: {
       {
         endpoint: "global" as const,
         baseUrl: ZAI_GLOBAL_BASE_URL,
-        modelId: "glm-5",
-        note: "Verified GLM-5 on global endpoint.",
+        modelId: "glm-5.1",
+        note: "Verified GLM-5.1 on global endpoint.",
       },
       {
         endpoint: "cn" as const,
         baseUrl: ZAI_CN_BASE_URL,
-        modelId: "glm-5",
-        note: "Verified GLM-5 on cn endpoint.",
+        modelId: "glm-5.1",
+        note: "Verified GLM-5.1 on cn endpoint.",
       },
     ];
-    const codingGlm5 = [
+    const codingGlm51 = [
       {
         endpoint: "coding-global" as const,
         baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
-        modelId: "glm-5",
-        note: "Verified GLM-5 on coding-global endpoint.",
+        modelId: "glm-5.1",
+        note: "Verified GLM-5.1 on coding-global endpoint.",
       },
       {
         endpoint: "coding-cn" as const,
         baseUrl: ZAI_CODING_CN_BASE_URL,
-        modelId: "glm-5",
-        note: "Verified GLM-5 on coding-cn endpoint.",
+        modelId: "glm-5.1",
+        note: "Verified GLM-5.1 on coding-cn endpoint.",
       },
     ];
     const codingFallback = [
@@ -131,13 +131,13 @@ export async function detectZaiEndpoint(params: {
         endpoint: "coding-global" as const,
         baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
         modelId: "glm-4.7",
-        note: "Coding Plan endpoint verified, but this key/plan does not expose GLM-5 there. Defaulting to GLM-4.7.",
+        note: "Coding Plan endpoint verified, but this key/plan does not expose GLM-5.1 there. Defaulting to GLM-4.7.",
       },
       {
         endpoint: "coding-cn" as const,
         baseUrl: ZAI_CODING_CN_BASE_URL,
         modelId: "glm-4.7",
-        note: "Coding Plan CN endpoint verified, but this key/plan does not expose GLM-5 there. Defaulting to GLM-4.7.",
+        note: "Coding Plan CN endpoint verified, but this key/plan does not expose GLM-5.1 there. Defaulting to GLM-4.7.",
       },
     ];
 
@@ -148,16 +148,16 @@ export async function detectZaiEndpoint(params: {
         return general.filter((candidate) => candidate.endpoint === "cn");
       case "coding-global":
         return [
-          ...codingGlm5.filter((candidate) => candidate.endpoint === "coding-global"),
+          ...codingGlm51.filter((candidate) => candidate.endpoint === "coding-global"),
           ...codingFallback.filter((candidate) => candidate.endpoint === "coding-global"),
         ];
       case "coding-cn":
         return [
-          ...codingGlm5.filter((candidate) => candidate.endpoint === "coding-cn"),
+          ...codingGlm51.filter((candidate) => candidate.endpoint === "coding-cn"),
           ...codingFallback.filter((candidate) => candidate.endpoint === "coding-cn"),
         ];
       default:
-        return [...general, ...codingGlm5, ...codingFallback];
+        return [...general, ...codingGlm51, ...codingFallback];
     }
   })();
 


### PR DESCRIPTION
## Summary

- Update `ZAI_DEFAULT_MODEL_ID` constant from `glm-5` to `glm-5.1`
- Update default model references in provider and model docs

## Context

GLM-5.1 is the latest stable model available via the Z.AI Coding Plan. Currently, `openclaw onboard --auth-choice zai-coding-global` defaults to GLM-5, requiring users to manually configure GLM-5.1 as described in the Z.AI docs: https://docs.z.ai/devpack/tool/openclaw

GLM-5.1 is already in the bundled model catalog (`extensions/zai/model-definitions.ts`), so no catalog changes are needed — only the default constant and documentation references.

## Changes

- `extensions/zai/model-definitions.ts`: `ZAI_DEFAULT_MODEL_ID` → `glm-5.1`
- `docs/providers/zai.md`: update config snippet and default model ref
- `docs/providers/glm.md`: update config snippet and default model ref
- `docs/concepts/model-providers.md`: update example model

## What was not changed

- `extensions/zai/index.ts`: `startsWith("glm-5")` prefix matching already covers both `glm-5` and `glm-5.1`
- Bundled model catalog: `glm-5.1` entry already exists
- CHANGELOG.md: historical entries left as-is

## Test plan

- [x] `glm-5.1` model definition exists in the catalog
- [x] `onboard.ts` uses `getZaiDefaultModelId()` which reads from the updated constant
- [x] Prefix matching in `index.ts` (`startsWith('glm-5')`) covers both versions
- [x] Diff limited to 4 expected files, 6 line changes
- [x] `pnpm test:extension zai` passes locally

## AI-assisted PR 🤖

- [x] This PR was authored with AI assistance (Cursor + Claude)
- [x] Lightly tested — scoped to a single constant change and doc updates; CI `extension-fast (zai)` passed
- [x] I understand what the code does
- [ ] `codex review --base origin/main` run locally (no Codex access)
- [x] Bot review conversations will be resolved by author