### PR TITLE
fix(browser): re-check interaction-driven navigations

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.interactions.batch.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.batch.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-let page: { evaluate: ReturnType<typeof vi.fn> } | null = null;
+let page: {
+  evaluate: ReturnType<typeof vi.fn>;
+  url: ReturnType<typeof vi.fn>;
+} | null = null;
 
 const getPageForTargetId = vi.fn(async () => {
   if (!page) {
@@ -9,6 +12,7 @@ const getPageForTargetId = vi.fn(async () => {
   return page;
 });
 const ensurePageState = vi.fn(() => {});
+const assertPageNavigationCompletedSafely = vi.fn(async () => {});
 const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
 const refLocator = vi.fn(() => {
   throw new Error("test: refLocator should not be called");
@@ -19,6 +23,7 @@ const closePageViaPlaywright = vi.fn(async () => {});
 const resizeViewportViaPlaywright = vi.fn(async () => {});
 
 vi.mock("./pw-session.js", () => ({
+  assertPageNavigationCompletedSafely,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
@@ -38,6 +43,7 @@ describe("batchViaPlaywright", () => {
     vi.clearAllMocks();
     page = {
       evaluate: vi.fn(async () => "ok"),
+      url: vi.fn(() => "about:blank"),
     };
   });
 

--- a/extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-let page: { evaluate: ReturnType<typeof vi.fn> } | null = null;
+let page: { evaluate: ReturnType<typeof vi.fn>; url: ReturnType<typeof vi.fn> } | null = null;
 let locator: { evaluate: ReturnType<typeof vi.fn> } | null = null;
 
 const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
@@ -11,6 +11,7 @@ const getPageForTargetId = vi.fn(async () => {
   return page;
 });
 const ensurePageState = vi.fn(() => {});
+const assertPageNavigationCompletedSafely = vi.fn(async () => {});
 const restoreRoleRefsForTarget = vi.fn(() => {});
 const refLocator = vi.fn(() => {
   if (!locator) {
@@ -21,6 +22,7 @@ const refLocator = vi.fn(() => {
 
 vi.mock("./pw-session.js", () => {
   return {
+    assertPageNavigationCompletedSafely,
     ensurePageState,
     forceDisconnectPlaywrightForTarget,
     getPageForTargetId,
@@ -64,6 +66,7 @@ describe("evaluateViaPlaywright (abort)", () => {
         }
         return pendingPromise;
       }),
+      url: vi.fn(() => "https://example.com/current"),
     };
     locator = {
       evaluate: vi.fn(() => {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -193,6 +193,27 @@ describe("pw-tools-core interaction navigation guard", () => {
     expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).not.toHaveBeenCalled();
   });
 
+  it("does not run the navigation guard when only the URL hash changes (same-document navigation)", async () => {
+    const click = vi.fn(async () => {});
+    const page = {
+      url: vi
+        .fn()
+        .mockReturnValueOnce("https://example.com/page")
+        .mockReturnValue("https://example.com/page#section"),
+    };
+    setPwToolsCoreCurrentRefLocator({ click });
+    setPwToolsCoreCurrentPage(page);
+
+    await mod.clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      ref: "1",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).not.toHaveBeenCalled();
+  });
+
   it("does not run the post-evaluate navigation guard when the url is unchanged", async () => {
     const page = {
       evaluate: vi.fn(async () => "ok"),

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -10,6 +10,59 @@ installPwToolsCoreTestHooks();
 const mod = await import("./pw-tools-core.js");
 
 describe("pw-tools-core interaction navigation guard", () => {
+  it("runs the post-click navigation guard when navigation starts shortly after the click resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      const listeners = new Set<() => void>();
+      let currentUrl = "http://127.0.0.1:9222/json/version";
+      const click = vi.fn(async () => {
+        setTimeout(() => {
+          currentUrl = "http://127.0.0.1:9222/json/list";
+          for (const listener of listeners) {
+            listener();
+          }
+        }, 0);
+      });
+      const page = {
+        on: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.add(listener);
+          }
+        }),
+        off: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.delete(listener);
+          }
+        }),
+        url: vi.fn(() => currentUrl),
+      };
+      setPwToolsCoreCurrentRefLocator({ click });
+      setPwToolsCoreCurrentPage(page);
+
+      const task = mod.clickViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        ref: "1",
+        ssrfPolicy: { allowPrivateNetwork: false },
+      });
+
+      await vi.runAllTimersAsync();
+      await task;
+
+      expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
+        {
+          cdpUrl: "http://127.0.0.1:18792",
+          page,
+          response: null,
+          ssrfPolicy: { allowPrivateNetwork: false },
+          targetId: "T1",
+        },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("runs the post-click navigation guard with the resolved SSRF policy", async () => {
     const click = vi.fn(async () => {});
     const page = {
@@ -125,5 +178,64 @@ describe("pw-tools-core interaction navigation guard", () => {
       ssrfPolicy: { allowPrivateNetwork: false },
       targetId: "T1",
     });
+  });
+
+  it("runs the post-evaluate navigation guard when evaluate rejects after triggering navigation", async () => {
+    vi.useFakeTimers();
+    try {
+      const listeners = new Set<() => void>();
+      let currentUrl = "http://127.0.0.1:9222/json/version";
+      const page = {
+        evaluate: vi.fn(async () => {
+          setTimeout(() => {
+            currentUrl = "http://127.0.0.1:9222/json/list";
+            for (const listener of listeners) {
+              listener();
+            }
+          }, 0);
+          throw new Error("evaluate failed after scheduling navigation");
+        }),
+        on: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.add(listener);
+          }
+        }),
+        off: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.delete(listener);
+          }
+        }),
+        url: vi.fn(() => currentUrl),
+      };
+      setPwToolsCoreCurrentPage(page);
+
+      const blocked = new Error("blocked interaction navigation");
+      getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely.mockRejectedValueOnce(
+        blocked,
+      );
+
+      const task = mod.evaluateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        fn: "() => location.href = 'http://127.0.0.1:9222/json/list'",
+        ssrfPolicy: { allowPrivateNetwork: false },
+      });
+      const expectation = expect(task).rejects.toThrow("blocked interaction navigation");
+
+      await vi.runAllTimersAsync();
+      await expectation;
+
+      expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
+        {
+          cdpUrl: "http://127.0.0.1:18792",
+          page,
+          response: null,
+          ssrfPolicy: { allowPrivateNetwork: false },
+          targetId: "T1",
+        },
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getPwToolsCoreSessionMocks,
+  installPwToolsCoreTestHooks,
+  setPwToolsCoreCurrentPage,
+  setPwToolsCoreCurrentRefLocator,
+} from "./pw-tools-core.test-harness.js";
+
+installPwToolsCoreTestHooks();
+const mod = await import("./pw-tools-core.js");
+
+describe("pw-tools-core interaction navigation guard", () => {
+  it("runs the post-click navigation guard with the resolved SSRF policy", async () => {
+    const click = vi.fn(async () => {});
+    const page = { url: vi.fn(() => "http://127.0.0.1:9222/json/version") };
+    setPwToolsCoreCurrentRefLocator({ click });
+    setPwToolsCoreCurrentPage(page);
+
+    const blocked = new Error("blocked interaction navigation");
+    getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely.mockRejectedValueOnce(blocked);
+
+    await expect(
+      mod.clickViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        ref: "1",
+        ssrfPolicy: { allowPrivateNetwork: false },
+      }),
+    ).rejects.toThrow("blocked interaction navigation");
+
+    expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page,
+      response: null,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      targetId: "T1",
+    });
+  });
+
+  it("runs the post-evaluate navigation guard after page evaluation", async () => {
+    const page = {
+      evaluate: vi.fn(async () => "ok"),
+      url: vi.fn(() => "http://127.0.0.1:9222/json/version"),
+    };
+    setPwToolsCoreCurrentPage(page);
+
+    const result = await mod.evaluateViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      fn: "() => location.href = 'http://127.0.0.1:9222/json/version'",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(result).toBe("ok");
+    expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page,
+      response: null,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      targetId: "T1",
+    });
+  });
+
+  it("propagates the SSRF policy through batch interaction actions", async () => {
+    const click = vi.fn(async () => {});
+    const page = { url: vi.fn(() => "about:blank") };
+    setPwToolsCoreCurrentRefLocator({ click });
+    setPwToolsCoreCurrentPage(page);
+
+    await mod.batchViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      ssrfPolicy: { allowPrivateNetwork: false },
+      actions: [{ kind: "click", ref: "1" }],
+    });
+
+    expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page,
+      response: null,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      targetId: "T1",
+    });
+  });
+});

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -118,6 +118,59 @@ describe("pw-tools-core interaction navigation guard", () => {
     }
   });
 
+  it("deduplicates delayed navigation guards across repeated successful interactions", async () => {
+    vi.useFakeTimers();
+    try {
+      const listeners = new Set<() => void>();
+      let currentUrl = "http://127.0.0.1:9222/json/version";
+      const click = vi.fn(async () => {});
+      const page = {
+        on: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.add(listener);
+          }
+        }),
+        off: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.delete(listener);
+          }
+        }),
+        url: vi.fn(() => currentUrl),
+      };
+      setPwToolsCoreCurrentRefLocator({ click });
+      setPwToolsCoreCurrentPage(page);
+
+      await mod.clickViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        ref: "1",
+        ssrfPolicy: { allowPrivateNetwork: false },
+      });
+      expect(listeners.size).toBe(1);
+
+      await mod.clickViaPlaywright({
+        cdpUrl: "http://127.0.0.1:18792",
+        targetId: "T1",
+        ref: "1",
+        ssrfPolicy: { allowPrivateNetwork: false },
+      });
+      expect(listeners.size).toBe(1);
+
+      currentUrl = "http://127.0.0.1:9222/json/list";
+      for (const listener of Array.from(listeners)) {
+        listener();
+      }
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(
+        getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely,
+      ).toHaveBeenCalledTimes(1);
+      expect(listeners.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("runs the post-click navigation guard with the resolved SSRF policy", async () => {
     const click = vi.fn(async () => {});
     const page = {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -12,7 +12,12 @@ const mod = await import("./pw-tools-core.js");
 describe("pw-tools-core interaction navigation guard", () => {
   it("runs the post-click navigation guard with the resolved SSRF policy", async () => {
     const click = vi.fn(async () => {});
-    const page = { url: vi.fn(() => "http://127.0.0.1:9222/json/version") };
+    const page = {
+      url: vi
+        .fn()
+        .mockReturnValueOnce("http://127.0.0.1:9222/json/version")
+        .mockReturnValue("http://127.0.0.1:9222/json/list"),
+    };
     setPwToolsCoreCurrentRefLocator({ click });
     setPwToolsCoreCurrentPage(page);
 
@@ -40,7 +45,10 @@ describe("pw-tools-core interaction navigation guard", () => {
   it("runs the post-evaluate navigation guard after page evaluation", async () => {
     const page = {
       evaluate: vi.fn(async () => "ok"),
-      url: vi.fn(() => "http://127.0.0.1:9222/json/version"),
+      url: vi
+        .fn()
+        .mockReturnValueOnce("http://127.0.0.1:9222/json/version")
+        .mockReturnValue("http://127.0.0.1:9222/json/list"),
     };
     setPwToolsCoreCurrentPage(page);
 
@@ -61,9 +69,45 @@ describe("pw-tools-core interaction navigation guard", () => {
     });
   });
 
+  it("does not run the post-click navigation guard when the url is unchanged", async () => {
+    const click = vi.fn(async () => {});
+    const page = { url: vi.fn(() => "http://127.0.0.1:9222/json/version") };
+    setPwToolsCoreCurrentRefLocator({ click });
+    setPwToolsCoreCurrentPage(page);
+
+    await mod.clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      ref: "1",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).not.toHaveBeenCalled();
+  });
+
+  it("does not run the post-evaluate navigation guard when the url is unchanged", async () => {
+    const page = {
+      evaluate: vi.fn(async () => "ok"),
+      url: vi.fn(() => "http://127.0.0.1:9222/json/version"),
+    };
+    setPwToolsCoreCurrentPage(page);
+
+    const result = await mod.evaluateViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "T1",
+      fn: "() => 1",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(result).toBe("ok");
+    expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).not.toHaveBeenCalled();
+  });
+
   it("propagates the SSRF policy through batch interaction actions", async () => {
     const click = vi.fn(async () => {});
-    const page = { url: vi.fn(() => "about:blank") };
+    const page = {
+      url: vi.fn().mockReturnValueOnce("about:blank").mockReturnValue("https://example.com/after"),
+    };
     setPwToolsCoreCurrentRefLocator({ click });
     setPwToolsCoreCurrentPage(page);
 

--- a/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts
@@ -10,6 +10,52 @@ installPwToolsCoreTestHooks();
 const mod = await import("./pw-tools-core.js");
 
 describe("pw-tools-core interaction navigation guard", () => {
+  it("does not wait for the grace window after a successful non-navigating click", async () => {
+    vi.useFakeTimers();
+    try {
+      const listeners = new Set<() => void>();
+      const click = vi.fn(async () => {});
+      const page = {
+        on: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.add(listener);
+          }
+        }),
+        off: vi.fn((event: string, listener: () => void) => {
+          if (event === "framenavigated") {
+            listeners.delete(listener);
+          }
+        }),
+        url: vi.fn(() => "http://127.0.0.1:9222/json/version"),
+      };
+      setPwToolsCoreCurrentRefLocator({ click });
+      setPwToolsCoreCurrentPage(page);
+
+      const completion = vi.fn();
+      const task = mod
+        .clickViaPlaywright({
+          cdpUrl: "http://127.0.0.1:18792",
+          targetId: "T1",
+          ref: "1",
+          ssrfPolicy: { allowPrivateNetwork: false },
+        })
+        .then(completion);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(completion).toHaveBeenCalledTimes(1);
+      expect(listeners.size).toBe(1);
+      expect(
+        getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely,
+      ).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(250);
+      expect(listeners.size).toBe(0);
+      await task;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("runs the post-click navigation guard when navigation starts shortly after the click resolves", async () => {
     vi.useFakeTimers();
     try {
@@ -21,7 +67,7 @@ describe("pw-tools-core interaction navigation guard", () => {
           for (const listener of listeners) {
             listener();
           }
-        }, 0);
+        }, 10);
       });
       const page = {
         on: vi.fn((event: string, listener: () => void) => {
@@ -39,14 +85,23 @@ describe("pw-tools-core interaction navigation guard", () => {
       setPwToolsCoreCurrentRefLocator({ click });
       setPwToolsCoreCurrentPage(page);
 
-      const task = mod.clickViaPlaywright({
-        cdpUrl: "http://127.0.0.1:18792",
-        targetId: "T1",
-        ref: "1",
-        ssrfPolicy: { allowPrivateNetwork: false },
-      });
+      const completion = vi.fn();
+      const task = mod
+        .clickViaPlaywright({
+          cdpUrl: "http://127.0.0.1:18792",
+          targetId: "T1",
+          ref: "1",
+          ssrfPolicy: { allowPrivateNetwork: false },
+        })
+        .then(completion);
 
-      await vi.runAllTimersAsync();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(completion).toHaveBeenCalledTimes(1);
+      expect(
+        getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely,
+      ).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(10);
       await task;
 
       expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledWith(

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -1,3 +1,4 @@
+import type { Frame, Page } from "playwright";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import type { BrowserActRequest, BrowserFormField } from "./client-actions-core.js";
 import { DEFAULT_FILL_FIELD_TYPE } from "./form-fields.js";
@@ -26,6 +27,12 @@ type TargetOpts = {
 const MAX_CLICK_DELAY_MS = 5_000;
 const MAX_WAIT_TIME_MS = 30_000;
 const MAX_BATCH_ACTIONS = 100;
+const INTERACTION_NAVIGATION_GRACE_MS = 250;
+
+type NavigationObservablePage = Pick<Page, "url"> & {
+  on?: (event: "framenavigated", listener: (frame: Frame) => void) => unknown;
+  off?: (event: "framenavigated", listener: (frame: Frame) => void) => unknown;
+};
 
 function resolveBoundedDelayMs(value: number | undefined, label: string, maxMs: number): number {
   const normalized = Math.floor(value ?? 0);
@@ -51,6 +58,73 @@ function resolveInteractionTimeoutMs(timeoutMs?: number): number {
 
 function didPageUrlChange(page: { url(): string }, previousUrl: string): boolean {
   return page.url() !== previousUrl;
+}
+
+function observeDelayedInteractionNavigation(
+  page: NavigationObservablePage,
+  previousUrl: string,
+): Promise<boolean> {
+  if (didPageUrlChange(page, previousUrl)) {
+    return Promise.resolve(true);
+  }
+  if (typeof page.on !== "function" || typeof page.off !== "function") {
+    return Promise.resolve(false);
+  }
+  const addFrameNavigatedListener = page.on;
+  const removeFrameNavigatedListener = page.off;
+
+  return new Promise<boolean>((resolve) => {
+    const onFrameNavigated = (_frame: Frame) => {
+      if (!didPageUrlChange(page, previousUrl)) {
+        return;
+      }
+      cleanup();
+      resolve(true);
+    };
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve(didPageUrlChange(page, previousUrl));
+    }, INTERACTION_NAVIGATION_GRACE_MS);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      removeFrameNavigatedListener("framenavigated", onFrameNavigated);
+    };
+
+    addFrameNavigatedListener("framenavigated", onFrameNavigated);
+  });
+}
+
+async function assertInteractionNavigationCompletedSafely<T>(opts: {
+  action: () => Promise<T>;
+  cdpUrl: string;
+  page: Page;
+  previousUrl: string;
+  ssrfPolicy?: SsrFPolicy;
+  targetId?: string;
+}): Promise<T> {
+  const navigationObserved = observeDelayedInteractionNavigation(opts.page, opts.previousUrl);
+  let result: T | undefined;
+  let actionError: unknown = null;
+  try {
+    result = await opts.action();
+  } catch (err) {
+    actionError = err;
+  }
+
+  if (await navigationObserved) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
+
+  if (actionError) {
+    throw actionError;
+  }
+  return result as T;
 }
 
 async function awaitEvalWithAbort<T>(
@@ -104,33 +178,33 @@ export async function clickViaPlaywright(opts: {
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
   const previousUrl = page.url();
   try {
-    const delayMs = resolveBoundedDelayMs(opts.delayMs, "click delayMs", MAX_CLICK_DELAY_MS);
-    if (delayMs > 0) {
-      await locator.hover({ timeout });
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
-    if (opts.doubleClick) {
-      await locator.dblclick({
-        timeout,
-        button: opts.button,
-        modifiers: opts.modifiers,
-      });
-    } else {
-      await locator.click({
-        timeout,
-        button: opts.button,
-        modifiers: opts.modifiers,
-      });
-    }
-    if (didPageUrlChange(page, previousUrl)) {
-      await assertPageNavigationCompletedSafely({
-        cdpUrl: opts.cdpUrl,
-        page,
-        response: null,
-        ssrfPolicy: opts.ssrfPolicy,
-        targetId: opts.targetId,
-      });
-    }
+    await assertInteractionNavigationCompletedSafely({
+      action: async () => {
+        const delayMs = resolveBoundedDelayMs(opts.delayMs, "click delayMs", MAX_CLICK_DELAY_MS);
+        if (delayMs > 0) {
+          await locator.hover({ timeout });
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+        if (opts.doubleClick) {
+          await locator.dblclick({
+            timeout,
+            button: opts.button,
+            modifiers: opts.modifiers,
+          });
+          return;
+        }
+        await locator.click({
+          timeout,
+          button: opts.button,
+          modifiers: opts.modifiers,
+        });
+      },
+      cdpUrl: opts.cdpUrl,
+      page,
+      previousUrl,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }
@@ -397,16 +471,14 @@ export async function evaluateViaPlaywright(opts: {
         fnBody: fnText,
         timeoutMs: evaluateTimeout,
       });
-      const result = await awaitEvalWithAbort(evalPromise, abortPromise);
-      if (didPageUrlChange(page, previousUrl)) {
-        await assertPageNavigationCompletedSafely({
-          cdpUrl: opts.cdpUrl,
-          page,
-          response: null,
-          ssrfPolicy: opts.ssrfPolicy,
-          targetId: opts.targetId,
-        });
-      }
+      const result = await assertInteractionNavigationCompletedSafely({
+        action: () => awaitEvalWithAbort(evalPromise, abortPromise),
+        cdpUrl: opts.cdpUrl,
+        page,
+        previousUrl,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+      });
       return result;
     }
 
@@ -438,16 +510,14 @@ export async function evaluateViaPlaywright(opts: {
       fnBody: fnText,
       timeoutMs: evaluateTimeout,
     });
-    const result = await awaitEvalWithAbort(evalPromise, abortPromise);
-    if (didPageUrlChange(page, previousUrl)) {
-      await assertPageNavigationCompletedSafely({
-        cdpUrl: opts.cdpUrl,
-        page,
-        response: null,
-        ssrfPolicy: opts.ssrfPolicy,
-        targetId: opts.targetId,
-      });
-    }
+    const result = await assertInteractionNavigationCompletedSafely({
+      action: () => awaitEvalWithAbort(evalPromise, abortPromise),
+      cdpUrl: opts.cdpUrl,
+      page,
+      previousUrl,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
     return result;
   } finally {
     if (signal && abortListener) {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -56,15 +56,37 @@ function resolveInteractionTimeoutMs(timeoutMs?: number): number {
   return Math.max(500, Math.min(60_000, Math.floor(timeoutMs ?? 8000)));
 }
 
-function didPageUrlChange(page: { url(): string }, previousUrl: string): boolean {
-  return page.url() !== previousUrl;
+// Returns true only when the URL change indicates a cross-document navigation
+// (i.e., a real network fetch occurred). Same-document hash-only mutations —
+// anchor clicks and history.pushState/replaceState that change only the
+// fragment — do not cause a network request and must not trigger SSRF checks.
+function didCrossDocumentUrlChange(page: { url(): string }, previousUrl: string): boolean {
+  const currentUrl = page.url();
+  if (currentUrl === previousUrl) {
+    return false;
+  }
+  try {
+    const prev = new URL(previousUrl);
+    const curr = new URL(currentUrl);
+    if (
+      prev.origin === curr.origin &&
+      prev.pathname === curr.pathname &&
+      prev.search === curr.search
+    ) {
+      // Only the fragment changed — same-document navigation, no fetch.
+      return false;
+    }
+  } catch {
+    // Non-parseable URL; fall through to string comparison.
+  }
+  return true;
 }
 
 function observeDelayedInteractionNavigation(
   page: NavigationObservablePage,
   previousUrl: string,
 ): Promise<boolean> {
-  if (didPageUrlChange(page, previousUrl)) {
+  if (didCrossDocumentUrlChange(page, previousUrl)) {
     return Promise.resolve(true);
   }
   if (typeof page.on !== "function" || typeof page.off !== "function") {
@@ -73,7 +95,7 @@ function observeDelayedInteractionNavigation(
 
   return new Promise<boolean>((resolve) => {
     const onFrameNavigated = (_frame: Frame) => {
-      if (!didPageUrlChange(page, previousUrl)) {
+      if (!didCrossDocumentUrlChange(page, previousUrl)) {
         return;
       }
       cleanup();
@@ -81,7 +103,7 @@ function observeDelayedInteractionNavigation(
     };
     const timeout = setTimeout(() => {
       cleanup();
-      resolve(didPageUrlChange(page, previousUrl));
+      resolve(didCrossDocumentUrlChange(page, previousUrl));
     }, INTERACTION_NAVIGATION_GRACE_MS);
     const cleanup = () => {
       clearTimeout(timeout);
@@ -104,7 +126,7 @@ function scheduleDelayedInteractionNavigationGuard(opts: {
   targetId?: string;
 }): void {
   const page = opts.page as unknown as NavigationObservablePage;
-  if (didPageUrlChange(page, opts.previousUrl)) {
+  if (didCrossDocumentUrlChange(page, opts.previousUrl)) {
     void assertPageNavigationCompletedSafely({
       cdpUrl: opts.cdpUrl,
       page: opts.page,
@@ -119,7 +141,7 @@ function scheduleDelayedInteractionNavigationGuard(opts: {
   }
 
   const onFrameNavigated = (_frame: Frame) => {
-    if (!didPageUrlChange(page, opts.previousUrl)) {
+    if (!didCrossDocumentUrlChange(page, opts.previousUrl)) {
       return;
     }
     cleanup();
@@ -157,7 +179,7 @@ async function assertInteractionNavigationCompletedSafely<T>(opts: {
   const navPage = opts.page as unknown as NavigationObservablePage;
   let navigatedDuringAction = false;
   const onFrameNavigated = (_frame: Frame) => {
-    if (didPageUrlChange(opts.page, opts.previousUrl)) {
+    if (didCrossDocumentUrlChange(opts.page, opts.previousUrl)) {
       navigatedDuringAction = true;
     }
   };
@@ -177,7 +199,8 @@ async function assertInteractionNavigationCompletedSafely<T>(opts: {
     }
   }
 
-  const navigationObserved = navigatedDuringAction || didPageUrlChange(opts.page, opts.previousUrl);
+  const navigationObserved =
+    navigatedDuringAction || didCrossDocumentUrlChange(opts.page, opts.previousUrl);
 
   if (navigationObserved) {
     await assertPageNavigationCompletedSafely({

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -1,4 +1,4 @@
-import type { Frame, Page } from "playwright";
+import type { Frame, Page } from "playwright-core";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import type { BrowserActRequest, BrowserFormField } from "./client-actions-core.js";
 import { DEFAULT_FILL_FIELD_TYPE } from "./form-fields.js";

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -1,7 +1,9 @@
+import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import type { BrowserActRequest, BrowserFormField } from "./client-actions-core.js";
 import { DEFAULT_FILL_FIELD_TYPE } from "./form-fields.js";
 import { DEFAULT_UPLOAD_DIR, resolveStrictExistingPathsWithinRoot } from "./paths.js";
 import {
+  assertPageNavigationCompletedSafely,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
@@ -80,6 +82,7 @@ export async function highlightViaPlaywright(opts: {
 export async function clickViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  ssrfPolicy?: SsrFPolicy;
   ref?: string;
   selector?: string;
   doubleClick?: boolean;
@@ -114,6 +117,13 @@ export async function clickViaPlaywright(opts: {
         modifiers: opts.modifiers,
       });
     }
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }
@@ -289,6 +299,7 @@ export async function fillFormViaPlaywright(opts: {
 export async function evaluateViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  ssrfPolicy?: SsrFPolicy;
   fn: string;
   ref?: string;
   timeoutMs?: number;
@@ -378,7 +389,15 @@ export async function evaluateViaPlaywright(opts: {
         fnBody: fnText,
         timeoutMs: evaluateTimeout,
       });
-      return await awaitEvalWithAbort(evalPromise, abortPromise);
+      const result = await awaitEvalWithAbort(evalPromise, abortPromise);
+      await assertPageNavigationCompletedSafely({
+        cdpUrl: opts.cdpUrl,
+        page,
+        response: null,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+      });
+      return result;
     }
 
     // eslint-disable-next-line @typescript-eslint/no-implied-eval -- required for browser-context eval
@@ -408,7 +427,15 @@ export async function evaluateViaPlaywright(opts: {
       fnBody: fnText,
       timeoutMs: evaluateTimeout,
     });
-    return await awaitEvalWithAbort(evalPromise, abortPromise);
+    const result = await awaitEvalWithAbort(evalPromise, abortPromise);
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+    return result;
   } finally {
     if (signal && abortListener) {
       signal.removeEventListener("abort", abortListener);
@@ -711,6 +738,7 @@ async function executeSingleAction(
   action: BrowserActRequest,
   cdpUrl: string,
   targetId?: string,
+  ssrfPolicy?: SsrFPolicy,
   evaluateEnabled?: boolean,
   depth = 0,
 ): Promise<void> {
@@ -723,6 +751,7 @@ async function executeSingleAction(
       await clickViaPlaywright({
         cdpUrl,
         targetId: effectiveTargetId,
+        ssrfPolicy,
         ref: action.ref,
         selector: action.selector,
         doubleClick: action.doubleClick,
@@ -833,6 +862,7 @@ async function executeSingleAction(
       await evaluateViaPlaywright({
         cdpUrl,
         targetId: effectiveTargetId,
+        ssrfPolicy,
         fn: action.fn,
         ref: action.ref,
         timeoutMs: action.timeoutMs,
@@ -848,6 +878,7 @@ async function executeSingleAction(
       await batchViaPlaywright({
         cdpUrl,
         targetId: effectiveTargetId,
+        ssrfPolicy,
         actions: action.actions,
         stopOnError: action.stopOnError,
         evaluateEnabled,
@@ -862,6 +893,7 @@ async function executeSingleAction(
 export async function batchViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  ssrfPolicy?: SsrFPolicy;
   actions: BrowserActRequest[];
   stopOnError?: boolean;
   evaluateEnabled?: boolean;
@@ -877,7 +909,14 @@ export async function batchViaPlaywright(opts: {
   const results: Array<{ ok: boolean; error?: string }> = [];
   for (const action of opts.actions) {
     try {
-      await executeSingleAction(action, opts.cdpUrl, opts.targetId, opts.evaluateEnabled, depth);
+      await executeSingleAction(
+        action,
+        opts.cdpUrl,
+        opts.targetId,
+        opts.ssrfPolicy,
+        opts.evaluateEnabled,
+        depth,
+      );
       results.push({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -34,6 +34,8 @@ type NavigationObservablePage = Pick<Page, "url"> & {
   off?: (event: "framenavigated", listener: (frame: Frame) => void) => unknown;
 };
 
+const pendingInteractionNavigationGuardCleanup = new WeakMap<Page, () => void>();
+
 function resolveBoundedDelayMs(value: number | undefined, label: string, maxMs: number): number {
   const normalized = Math.floor(value ?? 0);
   if (!Number.isFinite(normalized) || normalized < 0) {
@@ -140,6 +142,8 @@ function scheduleDelayedInteractionNavigationGuard(opts: {
     return;
   }
 
+  pendingInteractionNavigationGuardCleanup.get(opts.page)?.();
+
   const onFrameNavigated = (_frame: Frame) => {
     if (!didCrossDocumentUrlChange(page, opts.previousUrl)) {
       return;
@@ -159,8 +163,12 @@ function scheduleDelayedInteractionNavigationGuard(opts: {
   const cleanup = () => {
     clearTimeout(timeout);
     page.off!("framenavigated", onFrameNavigated);
+    if (pendingInteractionNavigationGuardCleanup.get(opts.page) === cleanup) {
+      pendingInteractionNavigationGuardCleanup.delete(opts.page);
+    }
   };
 
+  pendingInteractionNavigationGuardCleanup.set(opts.page, cleanup);
   page.on("framenavigated", onFrameNavigated);
 }
 

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -96,6 +96,52 @@ function observeDelayedInteractionNavigation(
   });
 }
 
+function scheduleDelayedInteractionNavigationGuard(opts: {
+  cdpUrl: string;
+  page: Page;
+  previousUrl: string;
+  ssrfPolicy?: SsrFPolicy;
+  targetId?: string;
+}): void {
+  const page = opts.page as unknown as NavigationObservablePage;
+  if (didPageUrlChange(page, opts.previousUrl)) {
+    void assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    }).catch(() => {});
+    return;
+  }
+  if (typeof page.on !== "function" || typeof page.off !== "function") {
+    return;
+  }
+
+  const onFrameNavigated = (_frame: Frame) => {
+    if (!didPageUrlChange(page, opts.previousUrl)) {
+      return;
+    }
+    cleanup();
+    void assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    }).catch(() => {});
+  };
+  const timeout = setTimeout(() => {
+    cleanup();
+  }, INTERACTION_NAVIGATION_GRACE_MS);
+  const cleanup = () => {
+    clearTimeout(timeout);
+    page.off!("framenavigated", onFrameNavigated);
+  };
+
+  page.on("framenavigated", onFrameNavigated);
+}
+
 async function assertInteractionNavigationCompletedSafely<T>(opts: {
   action: () => Promise<T>;
   cdpUrl: string;
@@ -131,17 +177,40 @@ async function assertInteractionNavigationCompletedSafely<T>(opts: {
     }
   }
 
-  // Phase 2: after the action completes, apply a brief grace window so navigations
-  // that are delayed slightly past action resolution are still caught.
-  const navigationObserved =
-    navigatedDuringAction ||
-    (await observeDelayedInteractionNavigation(opts.page, opts.previousUrl));
+  const navigationObserved = navigatedDuringAction || didPageUrlChange(opts.page, opts.previousUrl);
 
   if (navigationObserved) {
     await assertPageNavigationCompletedSafely({
       cdpUrl: opts.cdpUrl,
       page: opts.page,
       response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  } else if (actionError) {
+    // Preserve the action-error path semantics: if a rejected click/evaluate still
+    // triggers a delayed navigation, the SSRF block must win over the original
+    // action error instead of surfacing a stale interaction failure.
+    const delayedNavigationObserved = await observeDelayedInteractionNavigation(
+      opts.page,
+      opts.previousUrl,
+    );
+    if (delayedNavigationObserved) {
+      await assertPageNavigationCompletedSafely({
+        cdpUrl: opts.cdpUrl,
+        page: opts.page,
+        response: null,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+      });
+    }
+  } else {
+    // Successful non-navigating interactions should not wait out the grace window,
+    // but we still keep a short-lived listener alive to quarantine late SSRF hops.
+    scheduleDelayedInteractionNavigationGuard({
+      cdpUrl: opts.cdpUrl,
+      page: opts.page,
+      previousUrl: opts.previousUrl,
       ssrfPolicy: opts.ssrfPolicy,
       targetId: opts.targetId,
     });

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -70,8 +70,6 @@ function observeDelayedInteractionNavigation(
   if (typeof page.on !== "function" || typeof page.off !== "function") {
     return Promise.resolve(false);
   }
-  const addFrameNavigatedListener = page.on;
-  const removeFrameNavigatedListener = page.off;
 
   return new Promise<boolean>((resolve) => {
     const onFrameNavigated = (_frame: Frame) => {
@@ -87,10 +85,14 @@ function observeDelayedInteractionNavigation(
     }, INTERACTION_NAVIGATION_GRACE_MS);
     const cleanup = () => {
       clearTimeout(timeout);
-      removeFrameNavigatedListener("framenavigated", onFrameNavigated);
+      // Call off directly on page (not via a cached reference) to preserve
+      // Playwright's EventEmitter `this` binding.
+      page.off!("framenavigated", onFrameNavigated);
     };
 
-    addFrameNavigatedListener("framenavigated", onFrameNavigated);
+    // Call on directly on page (not via a cached reference) to preserve
+    // Playwright's EventEmitter `this` binding.
+    page.on!("framenavigated", onFrameNavigated);
   });
 }
 
@@ -102,16 +104,40 @@ async function assertInteractionNavigationCompletedSafely<T>(opts: {
   ssrfPolicy?: SsrFPolicy;
   targetId?: string;
 }): Promise<T> {
-  const navigationObserved = observeDelayedInteractionNavigation(opts.page, opts.previousUrl);
+  // Phase 1: keep a framenavigated listener alive for the entire duration of the
+  // action so navigations triggered mid-click or mid-evaluate are not missed.
+  // Using a fixed pre-action timer would expire before the action finishes for
+  // slow interactions, silently bypassing the SSRF guard.
+  const navPage = opts.page as unknown as NavigationObservablePage;
+  let navigatedDuringAction = false;
+  const onFrameNavigated = (_frame: Frame) => {
+    if (didPageUrlChange(opts.page, opts.previousUrl)) {
+      navigatedDuringAction = true;
+    }
+  };
+  if (typeof navPage.on === "function") {
+    navPage.on("framenavigated", onFrameNavigated);
+  }
+
   let result: T | undefined;
   let actionError: unknown = null;
   try {
     result = await opts.action();
   } catch (err) {
     actionError = err;
+  } finally {
+    if (typeof navPage.off === "function") {
+      navPage.off("framenavigated", onFrameNavigated);
+    }
   }
 
-  if (await navigationObserved) {
+  // Phase 2: after the action completes, apply a brief grace window so navigations
+  // that are delayed slightly past action resolution are still caught.
+  const navigationObserved =
+    navigatedDuringAction ||
+    (await observeDelayedInteractionNavigation(opts.page, opts.previousUrl));
+
+  if (navigationObserved) {
     await assertPageNavigationCompletedSafely({
       cdpUrl: opts.cdpUrl,
       page: opts.page,

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -49,6 +49,10 @@ function resolveInteractionTimeoutMs(timeoutMs?: number): number {
   return Math.max(500, Math.min(60_000, Math.floor(timeoutMs ?? 8000)));
 }
 
+function didPageUrlChange(page: { url(): string }, previousUrl: string): boolean {
+  return page.url() !== previousUrl;
+}
+
 async function awaitEvalWithAbort<T>(
   evalPromise: Promise<T>,
   abortPromise?: Promise<never>,
@@ -98,6 +102,7 @@ export async function clickViaPlaywright(opts: {
     ? refLocator(page, requireRef(resolved.ref))
     : page.locator(resolved.selector!);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+  const previousUrl = page.url();
   try {
     const delayMs = resolveBoundedDelayMs(opts.delayMs, "click delayMs", MAX_CLICK_DELAY_MS);
     if (delayMs > 0) {
@@ -117,13 +122,15 @@ export async function clickViaPlaywright(opts: {
         modifiers: opts.modifiers,
       });
     }
-    await assertPageNavigationCompletedSafely({
-      cdpUrl: opts.cdpUrl,
-      page,
-      response: null,
-      ssrfPolicy: opts.ssrfPolicy,
-      targetId: opts.targetId,
-    });
+    if (didPageUrlChange(page, previousUrl)) {
+      await assertPageNavigationCompletedSafely({
+        cdpUrl: opts.cdpUrl,
+        page,
+        response: null,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+      });
+    }
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }
@@ -361,6 +368,7 @@ export async function evaluateViaPlaywright(opts: {
   try {
     if (opts.ref) {
       const locator = refLocator(page, opts.ref);
+      const previousUrl = page.url();
       // eslint-disable-next-line @typescript-eslint/no-implied-eval -- required for browser-context eval
       const elementEvaluator = new Function(
         "el",
@@ -390,16 +398,19 @@ export async function evaluateViaPlaywright(opts: {
         timeoutMs: evaluateTimeout,
       });
       const result = await awaitEvalWithAbort(evalPromise, abortPromise);
-      await assertPageNavigationCompletedSafely({
-        cdpUrl: opts.cdpUrl,
-        page,
-        response: null,
-        ssrfPolicy: opts.ssrfPolicy,
-        targetId: opts.targetId,
-      });
+      if (didPageUrlChange(page, previousUrl)) {
+        await assertPageNavigationCompletedSafely({
+          cdpUrl: opts.cdpUrl,
+          page,
+          response: null,
+          ssrfPolicy: opts.ssrfPolicy,
+          targetId: opts.targetId,
+        });
+      }
       return result;
     }
 
+    const previousUrl = page.url();
     // eslint-disable-next-line @typescript-eslint/no-implied-eval -- required for browser-context eval
     const browserEvaluator = new Function(
       "args",
@@ -428,13 +439,15 @@ export async function evaluateViaPlaywright(opts: {
       timeoutMs: evaluateTimeout,
     });
     const result = await awaitEvalWithAbort(evalPromise, abortPromise);
-    await assertPageNavigationCompletedSafely({
-      cdpUrl: opts.cdpUrl,
-      page,
-      response: null,
-      ssrfPolicy: opts.ssrfPolicy,
-      targetId: opts.targetId,
-    });
+    if (didPageUrlChange(page, previousUrl)) {
+      await assertPageNavigationCompletedSafely({
+        cdpUrl: opts.cdpUrl,
+        page,
+        response: null,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+      });
+    }
     return result;
   } finally {
     if (signal && abortListener) {

--- a/extensions/browser/src/browser/routes/agent.act.hooks.ts
+++ b/extensions/browser/src/browser/routes/agent.act.hooks.ts
@@ -100,6 +100,7 @@ export function registerBrowserAgentActHookRoutes(
             await pw.clickViaPlaywright({
               cdpUrl,
               targetId: tab.targetId,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
               ref,
             });
           }

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -537,6 +537,7 @@ export function registerBrowserAgentActRoutes(
             const clickRequest: Parameters<typeof pw.clickViaPlaywright>[0] = {
               cdpUrl,
               targetId: tab.targetId,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
               doubleClick,
             };
             if (ref) {
@@ -1042,6 +1043,7 @@ export function registerBrowserAgentActRoutes(
             const evalRequest: Parameters<typeof pw.evaluateViaPlaywright>[0] = {
               cdpUrl,
               targetId: tab.targetId,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
               fn,
               ref,
               signal: req.signal,
@@ -1101,6 +1103,7 @@ export function registerBrowserAgentActRoutes(
             const result = await pw.batchViaPlaywright({
               cdpUrl,
               targetId: tab.targetId,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
               actions,
               stopOnError,
               evaluateEnabled,


### PR DESCRIPTION
## Summary
- re-check browser tab safety after navigation-capable interaction actions
- carry the resolved browser SSRF policy through click, evaluate, and batch interaction flows

## Changes
- run `assertPageNavigationCompletedSafely(...)` after Playwright `click` and `evaluate` calls so interaction-driven main-frame navigations are quarantined when they land on blocked URLs
- thread `ssrfPolicy` through `act` route handling, hook-triggered clicks, and batched browser actions so interaction paths use the same policy as guarded navigation paths
- add regression coverage for click, evaluate, and batch interaction flows, and update the batch test mock to match the guarded session contract

## Validation
- Ran `corepack pnpm test extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts extensions/browser/src/browser/pw-tools-core.interactions.batch.test.ts extensions/browser/src/browser/pw-tools-core.clamps-timeoutms-scrollintoview.test.ts`
- Ran `corepack pnpm tsgo` and observed unrelated pre-existing repo-wide type errors outside the touched browser files
- Attempted local agentic review with `claude -p "/review"`, but the tool requested an existing PR context/number before it would proceed

## Notes
- An earlier closed branch explored the same follow-up action-gating direction; this PR reapplies the scoped interaction-path portion against current `main`
- Residual gap: repo-wide `tsgo` is currently red on unrelated files, so validation here is scoped to the touched browser interaction surface
