### PR TITLE
feat: agent env.scope isolation for collaborator security

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -410,7 +410,7 @@ export function resolveAgentEnvVars(
 
   // Agent-specific vars always override
   for (const [key, value] of Object.entries(agentVars)) {
-    if (value) base[key] = value;
+    if (value !== undefined && value !== null) base[key] = value;
   }
 
   return base;

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -384,7 +384,7 @@ export function resolveAgentEnvVars(
   const agentEnv = agentCfg?.env;
   const scope = agentEnv?.scope ?? "all";
 
-  const globalVars = collectConfigEnvVars(cfg);
+  const globalVars = collectConfigRuntimeEnvVars(cfg);
   const agentVars = agentEnv?.vars ?? {};
 
   let base: Record<string, string>;

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
+import { collectConfigEnvVars } from "../config/env-vars.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
@@ -50,6 +51,7 @@ type ResolvedAgentConfig = {
   subagents?: AgentEntry["subagents"];
   sandbox?: AgentEntry["sandbox"];
   tools?: AgentEntry["tools"];
+  env?: AgentEntry["env"];
 };
 
 let defaultAgentWarned = false;
@@ -157,6 +159,7 @@ export function resolveAgentConfig(
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,
     sandbox: entry.sandbox,
     tools: entry.tools,
+    env: entry.env,
   };
 }
 
@@ -360,4 +363,55 @@ export function resolveAgentDir(
   }
   const root = resolveStateDir(env);
   return path.join(root, "agents", id, "agent");
+}
+
+/**
+ * Resolve environment variables scoped to a specific agent.
+ *
+ * Scope modes:
+ * - "all" (default): agent inherits all global env vars + its own vars
+ * - "own": agent gets only its own vars + allowlisted global keys
+ * - "none": agent gets only its own vars, zero global inheritance
+ *
+ * Agent-specific vars (agent.env.vars) always take highest priority.
+ */
+export function resolveAgentEnvVars(
+  cfg: OpenClawConfig,
+  agentId: string,
+): Record<string, string> {
+  const id = normalizeAgentId(agentId);
+  const agentCfg = resolveAgentConfig(cfg, id);
+  const agentEnv = agentCfg?.env;
+  const scope = agentEnv?.scope ?? "all";
+
+  const globalVars = collectConfigEnvVars(cfg);
+  const agentVars = agentEnv?.vars ?? {};
+
+  let base: Record<string, string>;
+
+  switch (scope) {
+    case "all":
+      base = { ...globalVars };
+      break;
+    case "own": {
+      base = {};
+      const allow = new Set(agentEnv?.allow ?? []);
+      for (const key of allow) {
+        if (key in globalVars) base[key] = globalVars[key];
+      }
+      break;
+    }
+    case "none":
+      base = {};
+      break;
+    default:
+      base = { ...globalVars };
+  }
+
+  // Agent-specific vars always override
+  for (const [key, value] of Object.entries(agentVars)) {
+    if (value) base[key] = value;
+  }
+
+  return base;
 }

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
-import { collectConfigEnvVars } from "../config/env-vars.js";
+import { collectConfigRuntimeEnvVars } from "../config/env-vars.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -31,6 +31,13 @@ export type ExecToolDefaults = {
   notifyOnExit?: boolean;
   notifyOnExitEmptySuccess?: boolean;
   cwd?: string;
+  /**
+   * Pre-resolved agent-scoped env vars. When set, these replace the global
+   * process.env as the base environment for command execution (non-sandbox).
+   * This enables per-agent env isolation so external collaborator agents
+   * don't inherit the owner's API keys.
+   */
+  agentEnvVars?: Record<string, string>;
 };
 
 export type ExecElevatedDefaults = {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1387,7 +1387,22 @@ export function createExecTool(
       }
       rejectExecApprovalShellCommand(params.command);
 
-      const inheritedBaseEnv = coerceEnv(process.env);
+      // When agentEnvVars is set, use it as the base instead of process.env
+      // to enforce per-agent env isolation (external collaborators won't
+      // inherit owner's global API keys).
+      const inheritedBaseEnv = defaults?.agentEnvVars
+        ? {
+            ...defaults.agentEnvVars,
+            ...coerceEnv({
+              PATH: process.env.PATH,
+              HOME: process.env.HOME,
+              SHELL: process.env.SHELL,
+              USER: process.env.USER,
+              LANG: process.env.LANG,
+              TERM: process.env.TERM,
+            }),
+          }
+        : coerceEnv(process.env);
       const hostEnvResult =
         host === "sandbox"
           ? null

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -465,10 +465,7 @@ export function createOpenClawCodingTools(options?: {
   const agentEnvVars =
     agentId && options?.config
       ? (() => {
-          const agentEnvCfg = options.config?.agents?.list?.find(
-            (a) => a?.id?.toLowerCase() === agentId.toLowerCase(),
-          )?.env;
-          // Only build scoped env when agent explicitly opts into isolation
+          const agentEnvCfg = resolveAgentConfig(options.config, agentId)?.env;
           if (agentEnvCfg?.scope && agentEnvCfg.scope !== "all") {
             return resolveAgentEnvVars(options.config, agentId);
           }

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -7,7 +7,7 @@ import { logWarn } from "../logger.js";
 import { getPluginToolMeta } from "../plugins/tools.js";
 import { isSubagentSessionKey } from "../routing/session-key.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentEnvVars } from "./agent-scope.js";
 import { createApplyPatchTool } from "./apply-patch.js";
 import {
   createExecTool,
@@ -460,6 +460,21 @@ export function createOpenClawCodingTools(options?: {
     }
     return [tool];
   });
+  // Resolve agent-scoped env vars (returns undefined for scope="all" agents,
+  // letting them inherit process.env as before).
+  const agentEnvVars =
+    agentId && options?.config
+      ? (() => {
+          const agentEnvCfg = options.config?.agents?.list?.find(
+            (a) => a?.id?.toLowerCase() === agentId.toLowerCase(),
+          )?.env;
+          // Only build scoped env when agent explicitly opts into isolation
+          if (agentEnvCfg?.scope && agentEnvCfg.scope !== "all") {
+            return resolveAgentEnvVars(options.config, agentId);
+          }
+          return undefined;
+        })()
+      : undefined;
   const { cleanupMs: cleanupMsOverride, ...execDefaults } = options?.exec ?? {};
   const execTool = createExecTool({
     ...execDefaults,
@@ -474,6 +489,7 @@ export function createOpenClawCodingTools(options?: {
     safeBinTrustedDirs: options?.exec?.safeBinTrustedDirs ?? execConfig.safeBinTrustedDirs,
     safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
     agentId,
+    agentEnvVars,
     cwd: workspaceRoot,
     allowBackground,
     scopeKey,

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -97,6 +97,23 @@ export type AgentConfig = {
   tools?: AgentToolsConfig;
   /** Optional runtime descriptor for this agent. */
   runtime?: AgentRuntimeConfig;
+  /**
+   * Per-agent environment variable scoping.
+   * Controls which global env vars this agent can access.
+   */
+  env?: {
+    /**
+     * Scope mode:
+     * - "all": inherit all global env vars (default for owner agents)
+     * - "own": only use vars explicitly listed in this agent's `vars` + `allow`
+     * - "none": no global env vars at all, only agent-specific `vars`
+     */
+    scope?: "all" | "own" | "none";
+    /** Agent-specific env vars (always included regardless of scope). */
+    vars?: Record<string, string>;
+    /** Allowlist of global env var keys this agent may access (when scope="own"). */
+    allow?: string[];
+  };
 };
 
 export type AgentsConfig = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -812,6 +812,14 @@ export const AgentEntrySchema = z
     params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,
+    env: z
+      .object({
+        scope: z.union([z.literal("all"), z.literal("own"), z.literal("none")]).optional(),
+        vars: z.record(z.string(), z.string()).optional(),
+        allow: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- Add per-agent env var scoping (all/own/none) to AgentConfig
- Add resolveAgentEnvVars() to agent-scope.ts
- Integrate agentEnvVars into exec tool creation chain
- Add Zod schema validation for env field

Enables external collaborator agents to run with zero global env inheritance (scope=none), internal agents with allowlisted keys only (scope=own), and owner agents unchanged (scope=all).

## Files changed (6)
- src/config/types.agents.ts
- src/config/zod-schema.agent-runtime.ts
- src/agents/agent-scope.ts
- src/agents/bash-tools.exec-types.ts
- src/agents/bash-tools.exec.ts
- src/agents/pi-tools.ts

Rebased on latest upstream (c109a7623b). Replaces #61696 which had merge conflicts.

## Test plan
- [x] tsc --noEmit: 0 errors in changed files
- [x] gitleaks: no leaks
- [x] Backward compatible (scope=all is default, no behavior change for existing agents)