### PR TITLE
fix(macos): rewrite wildcard A2UI host to loopback

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -7,6 +7,7 @@ actor MacNodeRuntime {
     private let cameraCapture = CameraCaptureService()
     private let makeMainActorServices: () async -> any MacNodeRuntimeMainActorServices
     private let browserProxyRequest: @Sendable (String?) async throws -> String
+    private let canvasHostUrlProvider: @Sendable () async -> String?
     private var cachedMainActorServices: (any MacNodeRuntimeMainActorServices)?
     private var mainSessionKey: String = "main"
     private var eventSender: (@Sendable (String, String?) async -> Void)?
@@ -17,10 +18,14 @@ actor MacNodeRuntime {
         },
         browserProxyRequest: @escaping @Sendable (String?) async throws -> String = { paramsJSON in
             try await MacNodeBrowserProxy.shared.request(paramsJSON: paramsJSON)
+        },
+        canvasHostUrlProvider: @escaping @Sendable () async -> String? = {
+            await GatewayConnection.shared.canvasHostUrl()
         })
     {
         self.makeMainActorServices = makeMainActorServices
         self.browserProxyRequest = browserProxyRequest
+        self.canvasHostUrlProvider = canvasHostUrlProvider
     }
 
     func updateMainSessionKey(_ sessionKey: String) {
@@ -427,11 +432,28 @@ actor MacNodeRuntime {
     }
 
     private func resolveA2UIHostUrl() async -> String? {
-        guard let raw = await GatewayConnection.shared.canvasHostUrl() else { return nil }
+        guard let raw = await self.canvasHostUrlProvider() else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, let baseUrl = URL(string: trimmed) else { return nil }
-        return baseUrl.appendingPathComponent("__openclaw__/a2ui/").absoluteString + "?platform=macos"
+        let normalizedBaseUrl = Self.normalizeCanvasHostForClient(baseUrl)
+        return normalizedBaseUrl.appendingPathComponent("__openclaw__/a2ui/").absoluteString + "?platform=macos"
     }
+
+    private static func normalizeCanvasHostForClient(_ url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+        let host = components.host?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+        guard host == "0.0.0.0" || host == "::" else { return url }
+        components.host = "127.0.0.1"
+        return components.url ?? url
+    }
+
+    #if DEBUG
+    func _test_resolveA2UIHostUrl() async -> String? {
+        await self.resolveA2UIHostUrl()
+    }
+    #endif
 
     private func isA2UIReady(poll: Bool = false) async -> Bool {
         let deadline = poll ? Date().addingTimeInterval(6.0) : Date()

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -12,6 +12,22 @@ struct MacNodeRuntimeTests {
         #expect(response.ok == false)
     }
 
+    @Test func `resolve a2ui host URL uses injected canvas host provider`() async {
+        let runtime = MacNodeRuntime(canvasHostUrlProvider: {
+            "http://127.0.0.1:18789/__openclaw__/cap/node-token"
+        })
+        let resolved = await runtime._test_resolveA2UIHostUrl()
+        #expect(resolved == "http://127.0.0.1:18789/__openclaw__/cap/node-token/__openclaw__/a2ui/?platform=macos")
+    }
+
+    @Test func `resolve a2ui host URL rewrites wildcard host to loopback`() async {
+        let runtime = MacNodeRuntime(canvasHostUrlProvider: {
+            "http://0.0.0.0:18789/__openclaw__/cap/node-token"
+        })
+        let resolved = await runtime._test_resolveA2UIHostUrl()
+        #expect(resolved == "http://127.0.0.1:18789/__openclaw__/cap/node-token/__openclaw__/a2ui/?platform=macos")
+    }
+
     @Test func `handle invoke rejects empty system run`() async throws {
         let runtime = MacNodeRuntime()
         let params = OpenClawSystemRunParams(command: [])


### PR DESCRIPTION
## Summary
- Fixes macOS node A2UI URL resolution by rewriting wildcard canvas hosts (`0.0.0.0` / `::`) to loopback before appending the A2UI path.
- Keeps the change minimal and isolated to macOS node runtime URL handling, so existing non-wildcard host behavior is unchanged.
- Adds targeted macOS runtime tests covering both injected scoped host URLs and wildcard-host rewrite behavior.

## Root Cause
The gateway can advertise `canvasHostUrl` with a wildcard bind host when running LAN bind mode. macOS node runtime consumed that value directly, producing an A2UI navigation URL that is not dialable from the client (`0.0.0.0` / `::`), leading to `A2UI_HOST_UNAVAILABLE` even though the gateway canvas host was mounted.

## Verification
- Added focused unit tests in `apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift` for URL resolution + wildcard rewrite.
- `pnpm check` was executed; it currently fails due to pre-existing unrelated TypeScript errors across extension packages (no new failures tied to this macOS change).
- Local Swift test execution could not be run in this Windows environment (`swift` toolchain not installed).

Fixes #59022