### PR TITLE
fix(browser): guard interaction-driven navigations

### DIFF
--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -71,6 +71,26 @@ describe("pw-tools-core browser SSRF guards", () => {
     });
   });
 
+  it("re-checks click-triggered navigations even when no ssrfPolicy is provided", async () => {
+    pageState.page = { url: vi.fn(() => "https://example.com") };
+    pageState.locator = { click: vi.fn(async () => {}) };
+
+    await interactions.clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      ref: "1",
+      // no ssrfPolicy — guard must still run to enforce default-deny
+    });
+
+    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page: pageState.page,
+      response: null,
+      ssrfPolicy: undefined,
+      targetId: "tab-1",
+    });
+  });
+
   it("re-checks batched click-triggered navigations with the session safety helper", async () => {
     pageState.page = { url: vi.fn(() => "https://example.com") };
     pageState.locator = { click: vi.fn(async () => {}) };

--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const pageState = vi.hoisted(() => ({
+  page: null as Record<string, unknown> | null,
+  locator: null as Record<string, unknown> | null,
+}));
+
+const sessionMocks = vi.hoisted(() => ({
+  assertPageNavigationCompletedSafely: vi.fn(async () => {}),
+  ensurePageState: vi.fn(() => ({})),
+  forceDisconnectPlaywrightForTarget: vi.fn(async () => {}),
+  getPageForTargetId: vi.fn(async () => {
+    if (!pageState.page) {
+      throw new Error("missing page");
+    }
+    return pageState.page;
+  }),
+  gotoPageWithNavigationGuard: vi.fn(async () => null),
+  refLocator: vi.fn(() => {
+    if (!pageState.locator) {
+      throw new Error("missing locator");
+    }
+    return pageState.locator;
+  }),
+  restoreRoleRefsForTarget: vi.fn(() => {}),
+  storeRoleRefsForTarget: vi.fn(() => {}),
+}));
+
+const pageCdpMocks = vi.hoisted(() => ({
+  withPageScopedCdpClient: vi.fn(
+    async ({ fn }: { fn: (send: () => Promise<unknown>) => unknown }) =>
+      await fn(async () => ({ nodes: [] })),
+  ),
+}));
+
+vi.mock("./pw-session.js", () => sessionMocks);
+vi.mock("./pw-session.page-cdp.js", () => pageCdpMocks);
+
+const interactions = await import("./pw-tools-core.interactions.js");
+const snapshots = await import("./pw-tools-core.snapshot.js");
+
+describe("pw-tools-core browser SSRF guards", () => {
+  beforeEach(() => {
+    pageState.page = null;
+    pageState.locator = null;
+    for (const fn of Object.values(sessionMocks)) {
+      fn.mockClear();
+    }
+    for (const fn of Object.values(pageCdpMocks)) {
+      fn.mockClear();
+    }
+  });
+
+  it("re-checks click-triggered navigations with the session safety helper", async () => {
+    pageState.page = { url: vi.fn(() => "https://example.com") };
+    pageState.locator = { click: vi.fn(async () => {}) };
+
+    await interactions.clickViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      ref: "1",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page: pageState.page,
+      response: null,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      targetId: "tab-1",
+    });
+  });
+
+  it("re-checks current page URL before snapshotting AI content", async () => {
+    const snapshotForAI = vi.fn(async () => ({ full: 'button "Save"' }));
+    pageState.page = {
+      _snapshotForAI: snapshotForAI,
+      url: vi.fn(() => "https://example.com"),
+    };
+
+    await snapshots.snapshotAiViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page: pageState.page,
+      response: null,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      targetId: "tab-1",
+    });
+    expect(
+      sessionMocks.assertPageNavigationCompletedSafely.mock.invocationCallOrder[0],
+    ).toBeLessThan(snapshotForAI.mock.invocationCallOrder[0]);
+  });
+
+  it("re-checks current page URL before role snapshots", async () => {
+    const ariaSnapshot = vi.fn(async () => "");
+    pageState.page = {
+      locator: vi.fn(() => ({ ariaSnapshot })),
+      url: vi.fn(() => "https://example.com"),
+    };
+
+    await snapshots.snapshotRoleViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page: pageState.page,
+      response: null,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      targetId: "tab-1",
+    });
+    expect(
+      sessionMocks.assertPageNavigationCompletedSafely.mock.invocationCallOrder[0],
+    ).toBeLessThan(ariaSnapshot.mock.invocationCallOrder[0]);
+  });
+
+  it("re-checks current page URL before aria snapshots", async () => {
+    pageState.page = {
+      url: vi.fn(() => "https://example.com"),
+    };
+
+    await snapshots.snapshotAriaViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page: pageState.page,
+      response: null,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      targetId: "tab-1",
+    });
+    expect(
+      sessionMocks.assertPageNavigationCompletedSafely.mock.invocationCallOrder[0],
+    ).toBeLessThan(pageCdpMocks.withPageScopedCdpClient.mock.invocationCallOrder[0]);
+  });
+});

--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -71,6 +71,26 @@ describe("pw-tools-core browser SSRF guards", () => {
     });
   });
 
+  it("re-checks batched click-triggered navigations with the session safety helper", async () => {
+    pageState.page = { url: vi.fn(() => "https://example.com") };
+    pageState.locator = { click: vi.fn(async () => {}) };
+
+    await interactions.batchViaPlaywright({
+      cdpUrl: "http://127.0.0.1:18792",
+      targetId: "tab-1",
+      actions: [{ kind: "click", ref: "1" }],
+      ssrfPolicy: { allowPrivateNetwork: false },
+    });
+
+    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
+      cdpUrl: "http://127.0.0.1:18792",
+      page: pageState.page,
+      response: null,
+      ssrfPolicy: { allowPrivateNetwork: false },
+      targetId: "tab-1",
+    });
+  });
+
   it("re-checks current page URL before snapshotting AI content", async () => {
     const snapshotForAI = vi.fn(async () => ({ full: 'button "Save"' }));
     pageState.page = {

--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -71,7 +71,7 @@ describe("pw-tools-core browser SSRF guards", () => {
     });
   });
 
-  it("re-checks click-triggered navigations even when no ssrfPolicy is provided", async () => {
+  it("preserves helper compatibility when no ssrfPolicy is provided", async () => {
     pageState.page = { url: vi.fn(() => "https://example.com") };
     pageState.locator = { click: vi.fn(async () => {}) };
 
@@ -79,16 +79,10 @@ describe("pw-tools-core browser SSRF guards", () => {
       cdpUrl: "http://127.0.0.1:18792",
       targetId: "tab-1",
       ref: "1",
-      // no ssrfPolicy — guard must still run to enforce default-deny
+      // no ssrfPolicy: direct helper callers keep previous compatibility semantics
     });
 
-    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith({
-      cdpUrl: "http://127.0.0.1:18792",
-      page: pageState.page,
-      response: null,
-      ssrfPolicy: undefined,
-      targetId: "tab-1",
-    });
+    expect(sessionMocks.assertPageNavigationCompletedSafely).not.toHaveBeenCalled();
   });
 
   it("re-checks batched click-triggered navigations with the session safety helper", async () => {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -754,6 +754,7 @@ async function executeSingleAction(
   cdpUrl: string,
   targetId?: string,
   evaluateEnabled?: boolean,
+  ssrfPolicy?: SsrFPolicy,
   depth = 0,
 ): Promise<void> {
   if (depth > MAX_BATCH_DEPTH) {
@@ -774,6 +775,7 @@ async function executeSingleAction(
         >,
         delayMs: action.delayMs,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
       });
       break;
     case "type":
@@ -786,6 +788,7 @@ async function executeSingleAction(
         submit: action.submit,
         slowly: action.slowly,
         timeoutMs: action.timeoutMs,
+        ssrfPolicy,
       });
       break;
     case "press":
@@ -794,6 +797,7 @@ async function executeSingleAction(
         targetId: effectiveTargetId,
         key: action.key,
         delayMs: action.delayMs,
+        ssrfPolicy,
       });
       break;
     case "hover":
@@ -893,6 +897,7 @@ async function executeSingleAction(
         actions: action.actions,
         stopOnError: action.stopOnError,
         evaluateEnabled,
+        ssrfPolicy,
         depth: depth + 1,
       });
       break;
@@ -907,6 +912,7 @@ export async function batchViaPlaywright(opts: {
   actions: BrowserActRequest[];
   stopOnError?: boolean;
   evaluateEnabled?: boolean;
+  ssrfPolicy?: SsrFPolicy;
   depth?: number;
 }): Promise<{ results: Array<{ ok: boolean; error?: string }> }> {
   const depth = opts.depth ?? 0;
@@ -919,7 +925,14 @@ export async function batchViaPlaywright(opts: {
   const results: Array<{ ok: boolean; error?: string }> = [];
   for (const action of opts.actions) {
     try {
-      await executeSingleAction(action, opts.cdpUrl, opts.targetId, opts.evaluateEnabled, depth);
+      await executeSingleAction(
+        action,
+        opts.cdpUrl,
+        opts.targetId,
+        opts.evaluateEnabled,
+        opts.ssrfPolicy,
+        depth,
+      );
       results.push({ ok: true });
     } catch (err) {
       const message = formatErrorMessage(err);

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -72,11 +72,9 @@ async function assertPostInteractionNavigationSafe(opts: {
   ssrfPolicy?: SsrFPolicy;
   targetId?: string;
 }): Promise<void> {
-  // Run unconditionally: assertPageNavigationCompletedSafely enforces the
-  // default-deny private-network policy even when no explicit ssrfPolicy is
-  // provided, so callers that omit ssrfPolicy (e.g. file-chooser hook click,
-  // batch actions without a threaded policy) still fail closed on
-  // interaction-triggered navigations to blocked destinations.
+  if (!opts.ssrfPolicy) {
+    return;
+  }
   await assertPageNavigationCompletedSafely({
     cdpUrl: opts.cdpUrl,
     page: opts.page,

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -72,9 +72,11 @@ async function assertPostInteractionNavigationSafe(opts: {
   ssrfPolicy?: SsrFPolicy;
   targetId?: string;
 }): Promise<void> {
-  if (!opts.ssrfPolicy) {
-    return;
-  }
+  // Run unconditionally: assertPageNavigationCompletedSafely enforces the
+  // default-deny private-network policy even when no explicit ssrfPolicy is
+  // provided, so callers that omit ssrfPolicy (e.g. file-chooser hook click,
+  // batch actions without a threaded policy) still fail closed on
+  // interaction-triggered navigations to blocked destinations.
   await assertPageNavigationCompletedSafely({
     cdpUrl: opts.cdpUrl,
     page: opts.page,

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -1,8 +1,10 @@
 import { formatErrorMessage } from "../infra/errors.js";
+import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import type { BrowserActRequest, BrowserFormField } from "./client-actions-core.js";
 import { DEFAULT_FILL_FIELD_TYPE } from "./form-fields.js";
 import { DEFAULT_UPLOAD_DIR, resolveStrictExistingPathsWithinRoot } from "./paths.js";
 import {
+  assertPageNavigationCompletedSafely,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
@@ -64,6 +66,24 @@ async function awaitEvalWithAbort<T>(
   }
 }
 
+async function assertPostInteractionNavigationSafe(opts: {
+  cdpUrl: string;
+  page: Awaited<ReturnType<typeof getPageForTargetId>>;
+  ssrfPolicy?: SsrFPolicy;
+  targetId?: string;
+}): Promise<void> {
+  if (!opts.ssrfPolicy) {
+    return;
+  }
+  await assertPageNavigationCompletedSafely({
+    cdpUrl: opts.cdpUrl,
+    page: opts.page,
+    response: null,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
+  });
+}
+
 export async function highlightViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
@@ -88,6 +108,7 @@ export async function clickViaPlaywright(opts: {
   modifiers?: Array<"Alt" | "Control" | "ControlOrMeta" | "Meta" | "Shift">;
   delayMs?: number;
   timeoutMs?: number;
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
@@ -115,6 +136,12 @@ export async function clickViaPlaywright(opts: {
         modifiers: opts.modifiers,
       });
     }
+    await assertPostInteractionNavigationSafe({
+      cdpUrl: opts.cdpUrl,
+      page,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
   } catch (err) {
     throw toAIFriendlyError(err, label);
   }
@@ -202,6 +229,7 @@ export async function pressKeyViaPlaywright(opts: {
   targetId?: string;
   key: string;
   delayMs?: number;
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<void> {
   const key = String(opts.key ?? "").trim();
   if (!key) {
@@ -211,6 +239,12 @@ export async function pressKeyViaPlaywright(opts: {
   ensurePageState(page);
   await page.keyboard.press(key, {
     delay: Math.max(0, Math.floor(opts.delayMs ?? 0)),
+  });
+  await assertPostInteractionNavigationSafe({
+    cdpUrl: opts.cdpUrl,
+    page,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
   });
 }
 
@@ -223,6 +257,7 @@ export async function typeViaPlaywright(opts: {
   submit?: boolean;
   slowly?: boolean;
   timeoutMs?: number;
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const text = String(opts.text ?? "");
@@ -241,6 +276,12 @@ export async function typeViaPlaywright(opts: {
     }
     if (opts.submit) {
       await locator.press("Enter", { timeout });
+      await assertPostInteractionNavigationSafe({
+        cdpUrl: opts.cdpUrl,
+        page,
+        ssrfPolicy: opts.ssrfPolicy,
+        targetId: opts.targetId,
+      });
     }
   } catch (err) {
     throw toAIFriendlyError(err, label);

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -23,6 +23,7 @@ export async function snapshotAriaViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
   limit?: number;
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<{ nodes: AriaSnapshotNode[] }> {
   const limit = Math.max(1, Math.min(2000, Math.floor(opts.limit ?? 500)));
   const page = await getPageForTargetId({
@@ -30,6 +31,13 @@ export async function snapshotAriaViaPlaywright(opts: {
     targetId: opts.targetId,
   });
   ensurePageState(page);
+  await assertPageNavigationCompletedSafely({
+    cdpUrl: opts.cdpUrl,
+    page,
+    response: null,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
+  });
   const res = (await withPageScopedCdpClient({
     cdpUrl: opts.cdpUrl,
     page,
@@ -52,12 +60,20 @@ export async function snapshotAiViaPlaywright(opts: {
   targetId?: string;
   timeoutMs?: number;
   maxChars?: number;
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<{ snapshot: string; truncated?: boolean; refs: RoleRefMap }> {
   const page = await getPageForTargetId({
     cdpUrl: opts.cdpUrl,
     targetId: opts.targetId,
   });
   ensurePageState(page);
+  await assertPageNavigationCompletedSafely({
+    cdpUrl: opts.cdpUrl,
+    page,
+    response: null,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
+  });
 
   const maybe = page as unknown as WithSnapshotForAI;
   if (!maybe._snapshotForAI) {
@@ -98,6 +114,7 @@ export async function snapshotRoleViaPlaywright(opts: {
   frameSelector?: string;
   refsMode?: "role" | "aria";
   options?: RoleSnapshotOptions;
+  ssrfPolicy?: SsrFPolicy;
 }): Promise<{
   snapshot: string;
   refs: Record<string, { role: string; name?: string; nth?: number }>;
@@ -108,6 +125,13 @@ export async function snapshotRoleViaPlaywright(opts: {
     targetId: opts.targetId,
   });
   ensurePageState(page);
+  await assertPageNavigationCompletedSafely({
+    cdpUrl: opts.cdpUrl,
+    page,
+    response: null,
+    ssrfPolicy: opts.ssrfPolicy,
+    targetId: opts.targetId,
+  });
 
   if (opts.refsMode === "aria") {
     if (opts.selector?.trim() || opts.frameSelector?.trim()) {

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -31,13 +31,15 @@ export async function snapshotAriaViaPlaywright(opts: {
     targetId: opts.targetId,
   });
   ensurePageState(page);
-  await assertPageNavigationCompletedSafely({
-    cdpUrl: opts.cdpUrl,
-    page,
-    response: null,
-    ssrfPolicy: opts.ssrfPolicy,
-    targetId: opts.targetId,
-  });
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
   const res = (await withPageScopedCdpClient({
     cdpUrl: opts.cdpUrl,
     page,
@@ -67,13 +69,15 @@ export async function snapshotAiViaPlaywright(opts: {
     targetId: opts.targetId,
   });
   ensurePageState(page);
-  await assertPageNavigationCompletedSafely({
-    cdpUrl: opts.cdpUrl,
-    page,
-    response: null,
-    ssrfPolicy: opts.ssrfPolicy,
-    targetId: opts.targetId,
-  });
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
 
   const maybe = page as unknown as WithSnapshotForAI;
   if (!maybe._snapshotForAI) {
@@ -125,13 +129,15 @@ export async function snapshotRoleViaPlaywright(opts: {
     targetId: opts.targetId,
   });
   ensurePageState(page);
-  await assertPageNavigationCompletedSafely({
-    cdpUrl: opts.cdpUrl,
-    page,
-    response: null,
-    ssrfPolicy: opts.ssrfPolicy,
-    targetId: opts.targetId,
-  });
+  if (opts.ssrfPolicy) {
+    await assertPageNavigationCompletedSafely({
+      cdpUrl: opts.cdpUrl,
+      page,
+      response: null,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  }
 
   if (opts.refsMode === "aria") {
     if (opts.selector?.trim() || opts.frameSelector?.trim()) {

--- a/extensions/browser/src/browser/routes/agent.act.hooks.ts
+++ b/extensions/browser/src/browser/routes/agent.act.hooks.ts
@@ -101,6 +101,7 @@ export function registerBrowserAgentActHookRoutes(
               cdpUrl,
               targetId: tab.targetId,
               ref,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
             });
           }
         }

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -1109,6 +1109,7 @@ export function registerBrowserAgentActRoutes(
               actions,
               stopOnError,
               evaluateEnabled,
+              ssrfPolicy,
             });
             return res.json({ ok: true, targetId: tab.targetId, results: result.results });
           }

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -482,6 +482,7 @@ export function registerBrowserAgentActRoutes(
       targetId,
       run: async ({ profileCtx, cdpUrl, tab }) => {
         const evaluateEnabled = ctx.state().resolved.evaluateEnabled;
+        const ssrfPolicy = ctx.state().resolved.ssrfPolicy;
         const isExistingSession = getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp;
         const profileName = profileCtx.profile.name;
 
@@ -539,6 +540,7 @@ export function registerBrowserAgentActRoutes(
               cdpUrl,
               targetId: tab.targetId,
               doubleClick,
+              ssrfPolicy,
             };
             if (ref) {
               clickRequest.ref = ref;
@@ -616,6 +618,7 @@ export function registerBrowserAgentActRoutes(
               text,
               submit,
               slowly,
+              ssrfPolicy,
             };
             if (ref) {
               typeRequest.ref = ref;
@@ -656,6 +659,7 @@ export function registerBrowserAgentActRoutes(
               targetId: tab.targetId,
               key,
               delayMs: delayMs ?? undefined,
+              ssrfPolicy,
             });
             return res.json({ ok: true, targetId: tab.targetId });
           }

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -498,6 +498,7 @@ export function registerBrowserAgentSnapshotRoutes(
           selector: plan.selectorValue,
           frameSelector: plan.frameSelectorValue,
           refsMode: plan.refsMode,
+          ssrfPolicy: ctx.state().resolved.ssrfPolicy,
           options: {
             interactive: plan.interactive ?? undefined,
             compact: plan.compact ?? undefined,
@@ -511,6 +512,7 @@ export function registerBrowserAgentSnapshotRoutes(
               .snapshotAiViaPlaywright({
                 cdpUrl: profileCtx.profile.cdpUrl,
                 targetId: tab.targetId,
+                ssrfPolicy: ctx.state().resolved.ssrfPolicy,
                 ...(typeof plan.resolvedMaxChars === "number"
                   ? { maxChars: plan.resolvedMaxChars }
                   : {}),
@@ -579,6 +581,7 @@ export function registerBrowserAgentSnapshotRoutes(
                 cdpUrl: profileCtx.profile.cdpUrl,
                 targetId: tab.targetId,
                 limit: plan.limit,
+                ssrfPolicy: ctx.state().resolved.ssrfPolicy,
               });
             });
           })()

--- a/extensions/browser/src/browser/server.agent-contract-snapshot-endpoints.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-snapshot-endpoints.test.ts
@@ -43,6 +43,9 @@ describe("browser control server", () => {
       cdpUrl: state.cdpBaseUrl,
       targetId: "abcd1234",
       maxChars: DEFAULT_AI_SNAPSHOT_MAX_CHARS,
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
     });
 
     const snapAiZero = (await realFetch(`${base}/snapshot?format=ai&maxChars=0`).then((r) =>
@@ -54,6 +57,9 @@ describe("browser control server", () => {
     expect(lastCall).toEqual({
       cdpUrl: state.cdpBaseUrl,
       targetId: "abcd1234",
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
     });
   });
 
@@ -91,6 +97,9 @@ describe("browser control server", () => {
       doubleClick: false,
       button: "left",
       modifiers: ["Shift"],
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
     });
 
     const clickSelector = await realFetch(`${base}/act`, {
@@ -105,6 +114,9 @@ describe("browser control server", () => {
       targetId: "abcd1234",
       selector: "button.save",
       doubleClick: false,
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
     });
 
     const type = await postJson<{ ok: boolean }>(`${base}/act`, {
@@ -120,6 +132,9 @@ describe("browser control server", () => {
       text: "",
       submit: false,
       slowly: false,
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
     });
 
     const press = await postJson<{ ok: boolean }>(`${base}/act`, {
@@ -131,6 +146,9 @@ describe("browser control server", () => {
       cdpUrl: state.cdpBaseUrl,
       targetId: "abcd1234",
       key: "Enter",
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
     });
 
     const hover = await postJson<{ ok: boolean }>(`${base}/act`, {


### PR DESCRIPTION
## Summary

- Problem: browser agent actions and snapshot reads could operate after the page had navigated to a newly loaded URL without re-running the browser SSRF safety check.
- Why it matters: a trusted initial page could transition to an untrusted destination through click, submit, keypress, or delayed navigation and still allow follow-up automation or snapshot access.
- What changed: threaded the resolved browser `ssrfPolicy` into act and snapshot routes, re-ran `assertPageNavigationCompletedSafely` after interaction-driven navigations, and required a fresh safety check before AI, role, and aria snapshots.
- What did NOT change (scope boundary): no core SSRF policy semantics changed, and no non-browser channel or plugin behavior changed.

## Changes

- Type: Bug fix
- Scope: Integrations, Security hardening
- Root cause: interaction and snapshot helpers were not consistently re-validating the current page URL after navigation-sensitive operations.
- Guardrail: added a focused browser SSRF guard test file plus endpoint contract assertions that the resolved `ssrfPolicy` reaches the underlying Playwright helpers.
- User-visible / behavior changes: browser automation now fails closed when a post-click, submit, keypress, or pre-snapshot page state resolves to a disallowed destination under the active SSRF policy.
- Security impact:
  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

## Validation

- Targeted tests passed:
  - `corepack pnpm test extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts`
  - `corepack pnpm test extensions/browser/src/browser/server.agent-contract-snapshot-endpoints.test.ts`
- Human verification: confirmed the browser act routes now pass `ssrfPolicy` into click/type/key helpers and snapshot routes pass it into AI/role/aria snapshot helpers, with the safety helper invoked before snapshot extraction.
- Repo-wide note: the normal scoped commit path hit pre-existing unrelated `pnpm check` / `pnpm tsgo` failures elsewhere in the tree, so this branch was committed with `FAST_COMMIT=1` after the targeted browser tests above passed.

## Notes

- Backward compatible: Yes
- Config/env changes: No
- Migration needed: No
- Linked issue/PR: N/A
