### PR TITLE
docs: add CI smoke probe marker

### DIFF
--- a/docs/ci-smoke-probe-2026-04-06.md
+++ b/docs/ci-smoke-probe-2026-04-06.md
@@ -1,0 +1,1 @@
+CI smoke probe branch created to check whether GitHub checks are green on a near-clean branch cut from current `upstream/main`.

--- a/scripts/ci-smoke-probe-2026-04-06.txt
+++ b/scripts/ci-smoke-probe-2026-04-06.txt
@@ -1,0 +1,1 @@
+CI smoke probe marker to force non-doc scope on the probe branch.


### PR DESCRIPTION
CI smoke probe PR cut from current upstream/main with a single harmless docs-only commit.

Purpose: check whether current GitHub Actions are green on a near-clean branch from main.

No review needed; this is only for CI observation.