### PR TITLE
fix: this is a real approval boundary bypass that tur (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 - Agents/session keys: backfill `sessionKey` from `sessionId` in the embedded PI runner when callers omit it, so hooks, LCM, and compaction receive a valid key; also normalize whitespace-only session keys to `undefined` before downstream consumers see them. (#60555) Thanks @100yenadmin.
 - Plugins/provider hooks: stop recursive provider snapshot loads from overflowing the stack during plugin initialization, while still preserving cached nested provider-hook results. (#61922, #61938, #61946, #61951)
 - Discord/voice: re-arm DAVE receive passthrough without suppressing decrypt-failure rejoin recovery, and clear capture state before finalize teardown so rapid speaker restarts keep their next utterance. (#41536) Thanks @wit-oc.
+- Agents/exec: keep `strictInlineEval` commands blocked after approval timeouts on both gateway and node exec hosts, so timeout fallback no longer turns timed-out inline interpreter prompts into automatic execution.
 
 ## 2026.4.5
 

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -3,6 +3,13 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const createAndRegisterDefaultExecApprovalRequestMock = vi.hoisted(() => vi.fn());
 const buildExecApprovalPendingToolResultMock = vi.hoisted(() => vi.fn());
 const buildExecApprovalFollowupTargetMock = vi.hoisted(() => vi.fn(() => null));
+const createExecApprovalDecisionStateMock = vi.hoisted(() =>
+  vi.fn(() => ({
+    baseDecision: { timedOut: false },
+    approvedByAsk: false,
+    deniedReason: "approval-required",
+  })),
+);
 const evaluateShellAllowlistMock = vi.hoisted(() =>
   vi.fn(() => ({
     allowlistMatches: [],
@@ -20,6 +27,7 @@ const buildEnforcedShellCommandMock = vi.hoisted(() =>
   })),
 );
 const recordAllowlistMatchesUseMock = vi.hoisted(() => vi.fn());
+const resolveApprovalDecisionOrUndefinedMock = vi.hoisted(() => vi.fn(async () => undefined));
 const resolveExecHostApprovalContextMock = vi.hoisted(() =>
   vi.fn(() => ({
     approvals: { allowlist: [], file: { version: 1, agents: {} } },
@@ -28,6 +36,12 @@ const resolveExecHostApprovalContextMock = vi.hoisted(() =>
     askFallback: "deny",
   })),
 );
+const runExecProcessMock = vi.hoisted(() => vi.fn());
+const sendExecApprovalFollowupResultMock = vi.hoisted(() => vi.fn(async () => undefined));
+const enforceStrictInlineEvalApprovalBoundaryMock = vi.hoisted(() =>
+  vi.fn((value: { approvedByAsk: boolean; deniedReason: string | null }) => value),
+);
+const detectInterpreterInlineEvalArgvMock = vi.hoisted(() => vi.fn(() => null));
 
 vi.mock("../infra/exec-approvals.js", () => ({
   evaluateShellAllowlist: evaluateShellAllowlistMock,
@@ -55,14 +69,11 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   buildHeadlessExecApprovalDeniedMessage: vi.fn(() => "denied"),
   buildExecApprovalFollowupTarget: buildExecApprovalFollowupTargetMock,
   buildExecApprovalPendingToolResult: buildExecApprovalPendingToolResultMock,
-  createExecApprovalDecisionState: vi.fn(() => ({
-    baseDecision: { timedOut: false },
-    approvedByAsk: false,
-    deniedReason: "approval-required",
-  })),
+  createExecApprovalDecisionState: createExecApprovalDecisionStateMock,
   createAndRegisterDefaultExecApprovalRequest: createAndRegisterDefaultExecApprovalRequestMock,
-  resolveApprovalDecisionOrUndefined: vi.fn(async () => undefined),
-  sendExecApprovalFollowupResult: vi.fn(async () => undefined),
+  enforceStrictInlineEvalApprovalBoundary: enforceStrictInlineEvalApprovalBoundaryMock,
+  resolveApprovalDecisionOrUndefined: resolveApprovalDecisionOrUndefinedMock,
+  sendExecApprovalFollowupResult: sendExecApprovalFollowupResultMock,
   shouldResolveExecApprovalUnavailableInline: vi.fn(() => false),
 }));
 
@@ -70,7 +81,7 @@ vi.mock("./bash-tools.exec-runtime.js", () => ({
   DEFAULT_NOTIFY_TAIL_CHARS: 1000,
   createApprovalSlug: vi.fn(() => "slug"),
   normalizeNotifyOutput: vi.fn((value) => value),
-  runExecProcess: vi.fn(),
+  runExecProcess: runExecProcessMock,
 }));
 
 vi.mock("./bash-process-registry.js", () => ({
@@ -80,7 +91,7 @@ vi.mock("./bash-process-registry.js", () => ({
 
 vi.mock("../infra/exec-inline-eval.js", () => ({
   describeInterpreterInlineEval: vi.fn(() => "python -c"),
-  detectInterpreterInlineEvalArgv: vi.fn(() => null),
+  detectInterpreterInlineEvalArgv: detectInterpreterInlineEvalArgvMock,
 }));
 
 let processGatewayAllowlist: typeof import("./bash-tools.exec-host-gateway.js").processGatewayAllowlist;
@@ -94,6 +105,12 @@ describe("processGatewayAllowlist", () => {
     buildExecApprovalPendingToolResultMock.mockReset();
     buildExecApprovalFollowupTargetMock.mockReset();
     buildExecApprovalFollowupTargetMock.mockReturnValue(null);
+    createExecApprovalDecisionStateMock.mockReset();
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: false },
+      approvedByAsk: false,
+      deniedReason: "approval-required",
+    });
     evaluateShellAllowlistMock.mockReset();
     evaluateShellAllowlistMock.mockReturnValue({
       allowlistMatches: [],
@@ -110,6 +127,8 @@ describe("processGatewayAllowlist", () => {
       reason: "segment execution plan unavailable",
     });
     recordAllowlistMatchesUseMock.mockReset();
+    resolveApprovalDecisionOrUndefinedMock.mockReset();
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue(undefined);
     resolveExecHostApprovalContextMock.mockReset();
     resolveExecHostApprovalContextMock.mockReturnValue({
       approvals: { allowlist: [], file: { version: 1, agents: {} } },
@@ -117,6 +136,14 @@ describe("processGatewayAllowlist", () => {
       hostAsk: "off",
       askFallback: "deny",
     });
+    runExecProcessMock.mockReset();
+    sendExecApprovalFollowupResultMock.mockReset();
+    enforceStrictInlineEvalApprovalBoundaryMock.mockReset();
+    enforceStrictInlineEvalApprovalBoundaryMock.mockImplementation(
+      (value: { approvedByAsk: boolean; deniedReason: string | null }) => value,
+    );
+    detectInterpreterInlineEvalArgvMock.mockReset();
+    detectInterpreterInlineEvalArgvMock.mockReturnValue(null);
     buildExecApprovalPendingToolResultMock.mockReturnValue({
       details: { status: "approval-pending" },
       content: [],
@@ -241,5 +268,97 @@ describe("processGatewayAllowlist", () => {
         sessionKey: "agent:main:telegram:direct:123",
       }),
     );
+  });
+
+  it("denies timed-out inline-eval requests instead of auto-running them", async () => {
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "always",
+      askFallback: "full",
+    });
+    detectInterpreterInlineEvalArgvMock.mockReturnValue({ kind: "python-c" });
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue(null);
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: true },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    enforceStrictInlineEvalApprovalBoundaryMock.mockReturnValue({
+      approvedByAsk: false,
+      deniedReason: "approval-timeout",
+    });
+
+    const result = await processGatewayAllowlist({
+      command: "python3 -c 'print(1)'",
+      workdir: process.cwd(),
+      env: process.env as Record<string, string>,
+      pty: false,
+      defaultTimeoutSec: 30,
+      security: "full",
+      ask: "always",
+      safeBins: new Set(),
+      safeBinProfiles: {},
+      strictInlineEval: true,
+      warnings: [],
+      approvalRunningNoticeMs: 0,
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+        null,
+        "Exec denied (gateway id=req-1, approval-timeout): python3 -c 'print(1)'",
+      );
+    });
+    expect(runExecProcessMock).not.toHaveBeenCalled();
+  });
+
+  it("denies allowlist timeout fallback for strict inline-eval commands", async () => {
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "allowlist",
+      hostAsk: "always",
+      askFallback: "allowlist",
+    });
+    detectInterpreterInlineEvalArgvMock.mockReturnValue({ kind: "python-c" });
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue(null);
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: true },
+      approvedByAsk: false,
+      deniedReason: null,
+    });
+    enforceStrictInlineEvalApprovalBoundaryMock.mockReturnValue({
+      approvedByAsk: false,
+      deniedReason: "approval-timeout",
+    });
+
+    const result = await processGatewayAllowlist({
+      command: "python3 -c 'print(1)'",
+      workdir: process.cwd(),
+      env: process.env as Record<string, string>,
+      pty: false,
+      defaultTimeoutSec: 30,
+      security: "allowlist",
+      ask: "always",
+      safeBins: new Set(),
+      safeBinProfiles: {},
+      strictInlineEval: true,
+      warnings: [],
+      approvalRunningNoticeMs: 0,
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+    });
+
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+        null,
+        "Exec denied (gateway id=req-1, approval-timeout): python3 -c 'print(1)'",
+      );
+    });
+    expect(runExecProcessMock).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -30,6 +30,7 @@ import {
   buildExecApprovalPendingToolResult,
   createExecApprovalDecisionState,
   createAndRegisterDefaultExecApprovalRequest,
+  enforceStrictInlineEvalApprovalBoundary,
   resolveApprovalDecisionOrUndefined,
   resolveExecHostApprovalContext,
   sendExecApprovalFollowupResult,
@@ -238,12 +239,18 @@ export async function processGatewayAllowlist(
         preResolvedDecision,
       })
     ) {
-      const { approvedByAsk, deniedReason } = createExecApprovalDecisionState({
+      const { baseDecision, approvedByAsk, deniedReason } = createExecApprovalDecisionState({
         decision: preResolvedDecision,
         askFallback,
       });
+      const strictInlineEvalDecision = enforceStrictInlineEvalApprovalBoundary({
+        baseDecision,
+        approvedByAsk,
+        deniedReason,
+        requiresInlineEvalApproval,
+      });
 
-      if (deniedReason || !approvedByAsk) {
+      if (strictInlineEvalDecision.deniedReason || !strictInlineEvalDecision.approvedByAsk) {
         throw new Error(
           buildHeadlessExecApprovalDeniedMessage({
             trigger: params.trigger,
@@ -331,6 +338,13 @@ export async function processGatewayAllowlist(
           }
         }
       }
+
+      ({ approvedByAsk, deniedReason } = enforceStrictInlineEvalApprovalBoundary({
+        baseDecision,
+        approvedByAsk,
+        deniedReason,
+        requiresInlineEvalApproval,
+      }));
 
       if (
         !approvedByAsk &&

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -36,9 +36,14 @@ const createExecApprovalDecisionStateMock = vi.hoisted(() =>
   })),
 );
 const buildExecApprovalPendingToolResultMock = vi.hoisted(() => vi.fn());
+const sendExecApprovalFollowupResultMock = vi.hoisted(() => vi.fn(async () => undefined));
+const enforceStrictInlineEvalApprovalBoundaryMock = vi.hoisted(() =>
+  vi.fn((value: { approvedByAsk: boolean; deniedReason: string | null }) => value),
+);
 const registerExecApprovalRequestForHostOrThrowMock = vi.hoisted(() =>
   vi.fn(async () => undefined),
 );
+const detectInterpreterInlineEvalArgvMock = vi.hoisted(() => vi.fn(() => null));
 
 vi.mock("../infra/exec-approvals.js", () => ({
   evaluateShellAllowlist: vi.fn(() => ({
@@ -59,7 +64,7 @@ vi.mock("../infra/exec-approvals.js", () => ({
 
 vi.mock("../infra/exec-inline-eval.js", () => ({
   describeInterpreterInlineEval: vi.fn(() => "inline-eval"),
-  detectInterpreterInlineEvalArgv: vi.fn(() => null),
+  detectInterpreterInlineEvalArgv: detectInterpreterInlineEvalArgvMock,
 }));
 
 vi.mock("../infra/node-shell.js", () => ({
@@ -84,7 +89,8 @@ vi.mock("./bash-tools.exec-host-shared.js", () => ({
   buildExecApprovalFollowupTarget: vi.fn(() => ({ approvalId: "approval-1" })),
   resolveApprovalDecisionOrUndefined: resolveApprovalDecisionOrUndefinedMock,
   createExecApprovalDecisionState: createExecApprovalDecisionStateMock,
-  sendExecApprovalFollowupResult: vi.fn(async () => undefined),
+  enforceStrictInlineEvalApprovalBoundary: enforceStrictInlineEvalApprovalBoundaryMock,
+  sendExecApprovalFollowupResult: sendExecApprovalFollowupResultMock,
   buildExecApprovalPendingToolResult: buildExecApprovalPendingToolResultMock,
   buildHeadlessExecApprovalDeniedMessage: vi.fn(() => "denied"),
 }));
@@ -189,6 +195,13 @@ describe("executeNodeHostCommand", () => {
       content: [],
       details: { status: "approval-pending" },
     });
+    sendExecApprovalFollowupResultMock.mockReset();
+    enforceStrictInlineEvalApprovalBoundaryMock.mockReset();
+    enforceStrictInlineEvalApprovalBoundaryMock.mockImplementation(
+      (value: { approvedByAsk: boolean; deniedReason: string | null }) => value,
+    );
+    detectInterpreterInlineEvalArgvMock.mockReset();
+    detectInterpreterInlineEvalArgvMock.mockReturnValue(null);
     registerExecApprovalRequestForHostOrThrowMock.mockReset();
   });
 
@@ -230,5 +243,48 @@ describe("executeNodeHostCommand", () => {
         }),
       }),
     );
+  });
+
+  it("denies timed-out inline-eval requests instead of invoking the node", async () => {
+    detectInterpreterInlineEvalArgvMock.mockReturnValue({ kind: "python-c" });
+    resolveApprovalDecisionOrUndefinedMock.mockResolvedValue(null);
+    createExecApprovalDecisionStateMock.mockReturnValue({
+      baseDecision: { timedOut: true },
+      approvedByAsk: true,
+      deniedReason: null,
+    });
+    enforceStrictInlineEvalApprovalBoundaryMock.mockReturnValue({
+      approvedByAsk: false,
+      deniedReason: "approval-timeout",
+    });
+    resolveExecHostApprovalContextMock.mockReturnValue({
+      approvals: { allowlist: [], file: { version: 1, agents: {} } },
+      hostSecurity: "full",
+      hostAsk: "off",
+      askFallback: "full",
+    });
+
+    const result = await executeNodeHostCommand({
+      command: "python3 -c 'print(1)'",
+      workdir: "/tmp/work",
+      env: {},
+      security: "full",
+      ask: "off",
+      strictInlineEval: true,
+      defaultTimeoutSec: 30,
+      approvalRunningNoticeMs: 0,
+      warnings: [],
+      agentId: "requested-agent",
+      sessionKey: "requested-session",
+    });
+
+    expect(result.details?.status).toBe("approval-pending");
+    await vi.waitFor(() => {
+      expect(sendExecApprovalFollowupResultMock).toHaveBeenCalledWith(
+        { approvalId: "approval-1" },
+        "Exec denied (node=node-1 id=approval-1, approval-timeout): python3 -c 'print(1)'",
+      );
+    });
+    expect(callGatewayToolMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -280,11 +280,18 @@ export async function executeNodeHostCommand(
         preResolvedDecision,
       })
     ) {
-      const { approvedByAsk, deniedReason } = execHostShared.createExecApprovalDecisionState({
-        decision: preResolvedDecision,
-        askFallback,
+      const { baseDecision, approvedByAsk, deniedReason } =
+        execHostShared.createExecApprovalDecisionState({
+          decision: preResolvedDecision,
+          askFallback,
+        });
+      const strictInlineEvalDecision = execHostShared.enforceStrictInlineEvalApprovalBoundary({
+        baseDecision,
+        approvedByAsk,
+        deniedReason,
+        requiresInlineEvalApproval: inlineEvalHit !== null,
       });
-      if (deniedReason || !approvedByAsk) {
+      if (strictInlineEvalDecision.deniedReason || !strictInlineEvalDecision.approvedByAsk) {
         throw new Error(
           execHostShared.buildHeadlessExecApprovalDeniedMessage({
             trigger: params.trigger,
@@ -295,8 +302,8 @@ export async function executeNodeHostCommand(
           }),
         );
       }
-      inlineApprovedByAsk = approvedByAsk;
-      inlineApprovalDecision = approvedByAsk ? "allow-once" : null;
+      inlineApprovedByAsk = strictInlineEvalDecision.approvedByAsk;
+      inlineApprovalDecision = strictInlineEvalDecision.approvedByAsk ? "allow-once" : null;
       inlineApprovalId = approvalId;
     } else {
       const followupTarget = execHostShared.buildExecApprovalFollowupTarget({
@@ -342,6 +349,16 @@ export async function executeNodeHostCommand(
         } else if (decision === "allow-always") {
           approvedByAsk = true;
           approvalDecision = "allow-always";
+        }
+
+        ({ approvedByAsk, deniedReason } = execHostShared.enforceStrictInlineEvalApprovalBoundary({
+          baseDecision,
+          approvedByAsk,
+          deniedReason,
+          requiresInlineEvalApproval: inlineEvalHit !== null,
+        }));
+        if (deniedReason) {
+          approvalDecision = null;
         }
 
         if (deniedReason) {

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -39,6 +39,7 @@ vi.mock("../infra/exec-approvals.js", async (importOriginal) => {
 
 let sendExecApprovalFollowupResult: typeof import("./bash-tools.exec-host-shared.js").sendExecApprovalFollowupResult;
 let maxExecApprovalFollowupFailureLogKeys: typeof import("./bash-tools.exec-host-shared.js").MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS;
+let enforceStrictInlineEvalApprovalBoundary: typeof import("./bash-tools.exec-host-shared.js").enforceStrictInlineEvalApprovalBoundary;
 let resolveExecHostApprovalContext: typeof import("./bash-tools.exec-host-shared.js").resolveExecHostApprovalContext;
 let sendExecApprovalFollowup: typeof import("./bash-tools.exec-approval-followup.js").sendExecApprovalFollowup;
 let logWarn: typeof import("../logger.js").logWarn;
@@ -47,6 +48,7 @@ beforeAll(async () => {
   ({
     sendExecApprovalFollowupResult,
     MAX_EXEC_APPROVAL_FOLLOWUP_FAILURE_LOG_KEYS: maxExecApprovalFollowupFailureLogKeys,
+    enforceStrictInlineEvalApprovalBoundary,
     resolveExecHostApprovalContext,
   } = await import("./bash-tools.exec-host-shared.js"));
   ({ sendExecApprovalFollowup } = await import("./bash-tools.exec-approval-followup.js"));
@@ -146,5 +148,35 @@ describe("resolveExecHostApprovalContext", () => {
     });
 
     expect(result.hostSecurity).toBe("full");
+  });
+});
+
+describe("enforceStrictInlineEvalApprovalBoundary", () => {
+  it("denies timeout-based fallback when strict inline-eval approval is required", () => {
+    expect(
+      enforceStrictInlineEvalApprovalBoundary({
+        baseDecision: { timedOut: true },
+        approvedByAsk: true,
+        deniedReason: null,
+        requiresInlineEvalApproval: true,
+      }),
+    ).toEqual({
+      approvedByAsk: false,
+      deniedReason: "approval-timeout",
+    });
+  });
+
+  it("keeps explicit approvals intact for strict inline-eval commands", () => {
+    expect(
+      enforceStrictInlineEvalApprovalBoundary({
+        baseDecision: { timedOut: false },
+        approvedByAsk: true,
+        deniedReason: null,
+        requiresInlineEvalApproval: true,
+      }),
+    ).toEqual({
+      approvedByAsk: true,
+      deniedReason: null,
+    });
   });
 });

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -341,6 +341,33 @@ export function createExecApprovalDecisionState(params: {
   };
 }
 
+export function enforceStrictInlineEvalApprovalBoundary(params: {
+  baseDecision: {
+    timedOut: boolean;
+  };
+  approvedByAsk: boolean;
+  deniedReason: string | null;
+  requiresInlineEvalApproval: boolean;
+}): {
+  approvedByAsk: boolean;
+  deniedReason: string | null;
+} {
+  if (
+    !params.baseDecision.timedOut ||
+    !params.requiresInlineEvalApproval ||
+    !params.approvedByAsk
+  ) {
+    return {
+      approvedByAsk: params.approvedByAsk,
+      deniedReason: params.deniedReason,
+    };
+  }
+  return {
+    approvedByAsk: false,
+    deniedReason: params.deniedReason ?? "approval-timeout",
+  };
+}
+
 export function shouldResolveExecApprovalUnavailableInline(params: {
   trigger?: string;
   unavailableReason: ExecApprovalUnavailableReason | null;


### PR DESCRIPTION
## Summary

- Problem: timed-out exec approval requests could still proceed on gateway or node hosts when `strictInlineEval` required explicit approval for inline interpreter execution.
- Why it matters: operators enabling `strictInlineEval` expect timeout fallback to keep those commands blocked instead of silently turning a missed approval into execution.
- What changed: the shared exec-host approval flow now fails closed for timed-out `strictInlineEval` requests, and gateway/node host tests lock in the timeout paths that used to proceed.
- What did NOT change (scope boundary): this does not change normal explicit `allow-once` / `allow-always` approvals, broader exec policy defaults, or node-side `system.run` policy behavior outside the host timeout path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #323
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: host-side timeout fallback treated a timed-out approval as execution permission before the strict inline-eval requirement was re-applied.
- Missing detection / guardrail: there was no final host-side check that "timed out" is not equivalent to an explicit operator approval for inline interpreter forms.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the node-side `system.run` guard already handled missing approval, but the gateway and node host approval paths still converted timeout fallback into `approvedByAsk: true` / `allow-once`.
- Why this regressed now: strict inline-eval approval was enforced earlier in the request flow, but timeout fallback stayed generic and did not re-check that stricter requirement at the last host decision point.
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/bash-tools.exec-host-shared.test.ts`, `src/agents/bash-tools.exec-host-gateway.test.ts`, `src/agents/bash-tools.exec-host-node.test.ts`
- Scenario the test should lock in: timed-out approval fallback must not execute `strictInlineEval` commands on gateway or node hosts, including the gateway `askFallback: "allowlist"` timeout path.
- Why this is the smallest reliable guardrail: the bug lives in the host approval boundary, so the closest reliable seam is the shared approval helper plus the mocked gateway/node host flows that decide whether execution proceeds.
- Existing test that already covers this (if any): node-side `invoke-system-run` tests already covered explicit inline-eval approval behavior after the host decision is made.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `strictInlineEval` commands now stay blocked when the approval request times out on gateway or node exec hosts, even if timeout fallback would otherwise auto-approve the request.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: command execution now fails closed for timed-out inline-eval approval requests; explicit approvals still work as before, and focused tests cover the gateway and node timeout paths.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local worktree runtime
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): exec approvals with `strictInlineEval: true`

### Steps

1. Configure exec approvals so inline interpreter forms require explicit approval.
2. Trigger a gateway or node exec request that uses an inline interpreter form such as `python3 -c ...`.
3. Let the approval request time out without an explicit operator decision.

### Expected

- The command remains blocked and the follow-up reports an approval timeout.

### Actual

- Before this change, timeout fallback could be converted into execution permission on gateway and node hosts.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: shared host timeout enforcement, gateway async timeout denial, gateway allowlist-timeout denial, and node async timeout denial via focused Vitest coverage.
- Edge cases checked: explicit approvals remain allowed by keeping the shared helper limited to timed-out fallback cases only.
- What you did **not** verify: full repo-wide build and end-to-end approval flows; the service-managed `pnpm build` remains post-turn validation.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the host approval-boundary helper and its gateway/node call sites.
- Files/config to restore: `src/agents/bash-tools.exec-host-shared.ts`, `src/agents/bash-tools.exec-host-gateway.ts`, `src/agents/bash-tools.exec-host-node.ts`
- Known bad symptoms reviewers should watch for: timed-out inline-eval approvals still executing, or explicit inline-eval approvals being denied unexpectedly.

## Risks and Mitigations

- Risk: host timeout denial could accidentally block explicit inline-eval approvals.
  - Mitigation: the shared helper only changes timed-out fallback cases, and the focused tests keep explicit approvals out of the deny path.
