### PR TITLE
fix: the bundled qq bot extension extensions qqbot pe (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/provider hooks: stop recursive provider snapshot loads from overflowing the stack during plugin initialization, while still preserving cached nested provider-hook results. (#61922, #61938, #61946, #61951)
 - Discord/voice: re-arm DAVE receive passthrough without suppressing decrypt-failure rejoin recovery, and clear capture state before finalize teardown so rapid speaker restarts keep their next utterance. (#41536) Thanks @wit-oc.
 - Agents/exec: keep `strictInlineEval` commands blocked after approval timeouts on both gateway and node exec hosts, so timeout fallback no longer turns timed-out inline interpreter prompts into automatic execution.
+- QQ Bot/media: route gateway-side attachment and fallback downloads through guarded QQ/Tencent HTTPS fetches so QQ media handling no longer follows arbitrary remote hosts.
 
 ## 2026.4.5
 

--- a/extensions/qqbot/src/utils/file-utils.test.ts
+++ b/extensions/qqbot/src/utils/file-utils.test.ts
@@ -1,0 +1,61 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mediaRuntimeMocks = vi.hoisted(() => ({
+  fetchRemoteMedia: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  fetchRemoteMedia: (...args: unknown[]) => mediaRuntimeMocks.fetchRemoteMedia(...args),
+}));
+
+import { QQBOT_MEDIA_SSRF_POLICY, downloadFile } from "./file-utils.js";
+
+describe("qqbot file-utils downloadFile", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    mediaRuntimeMocks.fetchRemoteMedia.mockReset();
+    tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "qqbot-file-utils-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("downloads through the guarded media runtime with the qqbot SSRF policy", async () => {
+    mediaRuntimeMocks.fetchRemoteMedia.mockResolvedValueOnce({
+      buffer: Buffer.from("image-bytes"),
+      contentType: "image/png",
+      fileName: "remote.png",
+    });
+
+    const savedPath = await downloadFile(
+      "https://media.qq.com/assets/photo.png",
+      tempDir,
+      "photo.png",
+    );
+
+    expect(savedPath).toBeTruthy();
+    expect(savedPath).toMatch(/photo_\d+_[0-9a-f]{6}\.png$/);
+    expect(await fs.promises.readFile(savedPath!, "utf8")).toBe("image-bytes");
+    expect(mediaRuntimeMocks.fetchRemoteMedia).toHaveBeenCalledWith({
+      url: "https://media.qq.com/assets/photo.png",
+      filePathHint: "photo.png",
+      ssrfPolicy: QQBOT_MEDIA_SSRF_POLICY,
+    });
+    expect(QQBOT_MEDIA_SSRF_POLICY).toEqual({
+      hostnameAllowlist: ["*.myqcloud.com", "*.qpic.cn", "*.qq.com", "*.tencentcos.com"],
+      allowRfc2544BenchmarkRange: true,
+    });
+  });
+
+  it("rejects non-HTTPS URLs before attempting a fetch", async () => {
+    const savedPath = await downloadFile("http://media.qq.com/assets/photo.png", tempDir);
+
+    expect(savedPath).toBeNull();
+    expect(mediaRuntimeMocks.fetchRemoteMedia).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qqbot/src/utils/file-utils.ts
+++ b/extensions/qqbot/src/utils/file-utils.ts
@@ -1,12 +1,26 @@
 import crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { fetchRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
+import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 
 /** Maximum file size accepted by the QQ Bot API. */
 export const MAX_UPLOAD_SIZE = 20 * 1024 * 1024;
 
 /** Threshold used to treat an upload as a large file. */
 export const LARGE_FILE_THRESHOLD = 5 * 1024 * 1024;
+
+const QQBOT_MEDIA_HOSTNAME_ALLOWLIST = [
+  "*.myqcloud.com",
+  "*.qpic.cn",
+  "*.qq.com",
+  "*.tencentcos.com",
+];
+
+export const QQBOT_MEDIA_SSRF_POLICY: SsrFPolicy = {
+  hostnameAllowlist: QQBOT_MEDIA_HOSTNAME_ALLOWLIST,
+  allowRfc2544BenchmarkRange: true,
+};
 
 /** Result of local file-size validation. */
 export interface FileSizeCheckResult {
@@ -110,23 +124,29 @@ export async function downloadFile(
   originalFilename?: string,
 ): Promise<string | null> {
   try {
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      return null;
+    }
+    if (parsedUrl.protocol !== "https:") {
+      return null;
+    }
+
     if (!fs.existsSync(destDir)) {
       fs.mkdirSync(destDir, { recursive: true });
     }
 
-    const resp = await fetch(url, { redirect: "follow" });
-    if (!resp.ok || !resp.body) {
-      return null;
-    }
+    const fetched = await fetchRemoteMedia({
+      url: parsedUrl.toString(),
+      filePathHint: originalFilename,
+      ssrfPolicy: QQBOT_MEDIA_SSRF_POLICY,
+    });
 
     let filename = originalFilename?.trim() || "";
     if (!filename) {
-      try {
-        const urlPath = new URL(url).pathname;
-        filename = path.basename(urlPath) || "download";
-      } catch {
-        filename = "download";
-      }
+      filename = fetched.fileName?.trim() || path.basename(parsedUrl.pathname) || "download";
     }
 
     const ts = Date.now();
@@ -136,8 +156,7 @@ export async function downloadFile(
     const safeFilename = `${base}_${ts}_${rand}${ext}`;
 
     const destPath = path.join(destDir, safeFilename);
-    const buffer = Buffer.from(await resp.arrayBuffer());
-    await fs.promises.writeFile(destPath, buffer);
+    await fs.promises.writeFile(destPath, fetched.buffer);
     return destPath;
   } catch {
     return null;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: the bundled QQ Bot plugin downloaded attachment and fallback media URLs through a local raw `fetch()` helper with no hostname or redirect guard.
- Why it matters: inbound attachment URLs and prompt-driven outbound media fallback URLs could make the gateway fetch arbitrary remote hosts instead of only QQ/Tencent media origins.
- What changed: `extensions/qqbot/src/utils/file-utils.ts` now rejects non-HTTPS URLs and routes downloads through `fetchRemoteMedia()` with a QQ/Tencent SSRF allowlist, covering both inbound attachments and outbound fallback downloads in one boundary.
- What did NOT change (scope boundary): this does not change QQ API request code, operator-configured QQ endpoints, direct URL uploads handled by QQ itself, or unrelated raw-fetch callsites elsewhere in the plugin.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #329
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: QQ Bot implemented its own media download helper instead of reusing the shared guarded media-fetch boundary that other bundled channels already use.
- Missing detection / guardrail: there was no QQ Bot regression test at the shared download helper seam to assert guarded fetch usage and non-HTTPS rejection.
- Prior context (`git blame`, prior PR, issue, or refactor if known): Unknown.
- Why this regressed now: the plugin-owned helper stayed on the legacy raw-fetch path while other channel plugins were moved onto guarded media helpers.
- If unknown, what was ruled out: no core/plugin SDK contract change was required; the missing protection was local to the qqbot helper.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/qqbot/src/utils/file-utils.test.ts`
- Scenario the test should lock in: QQ Bot downloads must call `fetchRemoteMedia()` with the QQ/Tencent SSRF policy, and plain HTTP URLs must be rejected before any fetch happens.
- Why this is the smallest reliable guardrail: all known inbound attachment downloads and outbound fallback downloads flow through `downloadFile()`, so one helper test covers the real enforcement boundary without depending on higher-level delivery behavior.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

QQ Bot media downloads performed by the gateway now only accept HTTPS URLs and only follow QQ/Tencent media hosts through the shared guarded fetch path. Failed inbound downloads still fall back to the existing placeholder behavior.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: gateway-side QQ media downloads now go through the shared guarded media fetch wrapper and are narrowed to HTTPS plus a QQ/Tencent hostname allowlist. This reduces network reach rather than expanding it.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local worktree runtime
- Model/provider: N/A
- Integration/channel (if any): QQ Bot
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm test extensions/qqbot/src/utils/file-utils.test.ts`.
2. Run `node scripts/check-no-raw-channel-fetch.mjs`.
3. Confirm the helper test passes and the raw-fetch guard no longer flags `extensions/qqbot/src/utils/file-utils.ts`.

### Expected

- QQ Bot download helper uses the shared guarded media runtime with a QQ/Tencent allowlist, rejects `http://` URLs, and the raw-fetch guard reports no qqbot violation.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: helper-level regression test confirms guarded fetch usage, expected SSRF policy, file write, and non-HTTPS rejection; raw-fetch guard confirms the raw qqbot `fetch()` call is gone from guarded channel/plugin runtime sources.
- Edge cases checked: invalid/non-HTTPS URL input returns `null` without attempting a fetch.
- What you did **not** verify: live QQ platform behavior, real redirected CDN flows, and full-repo `pnpm build` (service-managed post-turn validation).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the qqbot helper/test/changelog commit in this branch.
- Files/config to restore: `extensions/qqbot/src/utils/file-utils.ts`, `extensions/qqbot/src/utils/file-utils.test.ts`, `CHANGELOG.md`
- Known bad symptoms reviewers should watch for: legitimate QQ-hosted media downloads unexpectedly failing because the allowlist is too narrow or a required flow still uses plain HTTP.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: QQ serves a legitimate media hostname outside the current QQ/Tencent allowlist.
  - Mitigation: the allowlist includes the main QQ/Tencent CDN families called out in the issue, the change is isolated to one helper, and higher-level qqbot flows already degrade to existing fallback behavior when a download returns `null`.
