### PR TITLE
memory-core: don't abort auto provider selection on auth/config errors

### DIFF
--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -55,7 +55,31 @@ function shouldContinueAutoSelection(
   adapter: MemoryEmbeddingProviderAdapter,
   err: unknown,
 ): boolean {
-  return adapter.shouldContinueAutoSelection?.(err) ?? false;
+  // If the adapter doesn't provide guidance, be conservative-but-helpful:
+  // when auto-selecting providers, auth/config errors for a remote provider
+  // should not abort the entire memory search feature. Instead, try the next
+  // provider (e.g. local embeddings or another remote provider).
+  const explicit = adapter.shouldContinueAutoSelection?.(err);
+  if (typeof explicit === "boolean") {
+    return explicit;
+  }
+
+  const message = formatErrorMessage(err).toLowerCase();
+
+  // Heuristic: missing/invalid credentials or configuration for a remote
+  // provider should be treated as a soft-failure during auto selection.
+  // This avoids surfacing a generic "embedding/provider error" warning when
+  // the system can still provide FTS-only memory search results.
+  const looksLikeAuthOrConfigIssue =
+    /api[_ -]?key|missing .*key|no .*key|not configured|unauthori[sz]ed|forbidden|\b401\b|\b403\b/.test(
+      message,
+    );
+
+  if (adapter.id !== "local" && looksLikeAuthOrConfigIssue) {
+    return true;
+  }
+
+  return false;
 }
 
 function getAdapter(


### PR DESCRIPTION
### Problem
When `memorySearch.provider` is set to `auto` (the default), the first remote embedding provider candidate can throw on missing API key / unauthorized errors. Because the adapter doesn't always provide `shouldContinueAutoSelection`, this aborts auto selection and the `memory_search` tool returns a generic embedding/provider warning, even though the system can still provide FTS-only search.

### Fix
Add a small heuristic in `extensions/memory-core/src/memory/embeddings.ts` so that, when an adapter doesn't specify `shouldContinueAutoSelection`, common auth/config errors are treated as *soft failures* during auto-selection (continue to next provider).

### Why this helps
- Preserves the memory search feature (FTS-only results remain available)
- Avoids noisy warnings for users who haven't configured remote embedding provider creds
- Still respects explicit adapter guidance when provided

### Tests
- `pnpm exec vitest -c vitest.extension-memory.config.ts run`