### PR TITLE
fix: restore origin/main typecheck regressions

### DIFF
--- a/extensions/elevenlabs/speech-provider.ts
+++ b/extensions/elevenlabs/speech-provider.ts
@@ -9,6 +9,7 @@ import type {
 import {
   asBoolean,
   asFiniteNumber,
+  asFiniteNumber as asNumber,
   asObject,
   normalizeApplyTextNormalization,
   normalizeLanguageCode,

--- a/extensions/openai/shared.ts
+++ b/extensions/openai/shared.ts
@@ -1,6 +1,8 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
-import { findCatalogTemplate } from "openclaw/plugin-sdk/provider-catalog-shared";
+import {
+  type ConfiguredProviderCatalogEntry,
+  findCatalogTemplate,
+} from "openclaw/plugin-sdk/provider-catalog-shared";
 import {
   cloneFirstTemplateModel,
   matchesExactOrPrefix,
@@ -41,7 +43,7 @@ export function buildOpenAISyntheticCatalogEntry(
     contextWindow: number;
     contextTokens?: number;
   },
-): ProviderRuntimeModel | undefined {
+): ConfiguredProviderCatalogEntry | undefined {
   if (!template) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

- Problem: `origin/main`'s `check` lane was failing in `pnpm tsgo`.
- Why it matters: the branch was red before the later test lanes could finish, blocking normal validation.
- What changed: restored the missing numeric helper alias in `extensions/elevenlabs/speech-provider.ts` and corrected `extensions/openai/shared.ts` to return catalog entries instead of full runtime models.
- What did NOT change (scope boundary): no runtime behavior, provider logic, or bash-tools tests were changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: a helper rename/import drift in the ElevenLabs provider and an over-broad return type in the OpenAI synthetic catalog helper.
- Missing detection / guardrail: `pnpm tsgo` caught it, but only in the `check` lane after the changes landed.
- Contributing context (if known): the later `bash-tools` failures were downstream noise after the typecheck breakage, not independent regressions.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `pnpm tsgo` via `pnpm check`
- Scenario the test should lock in: provider helpers stay aligned with the speech/plugin SDK and provider catalog contracts.
- Why this is the smallest reliable guardrail: both failures were compile-time contract mismatches rather than runtime behavior changes.
- Existing test that already covers this (if any): `pnpm tsgo`
- If no new test is added, why not: the existing typecheck lane is already the direct guardrail for these regressions.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
N/A
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: ElevenLabs, OpenAI
- Integration/channel (if any): N/A
- Relevant config (redacted): default local repo state on `origin/main`

### Steps

1. Check out the failing `origin/main` tip.
2. Run `pnpm check` or `pnpm tsgo`.
3. Observe the compile errors in the two provider files.

### Expected

- `pnpm check` passes.

### Actual

- `pnpm tsgo` failed before the fix due to the provider type/import regressions.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reran `pnpm tsgo`, targeted `pnpm test src/agents/bash-tools.exec-host-gateway.test.ts src/agents/bash-tools.exec-host-node.test.ts`, and full `pnpm check`.
- Edge cases checked: confirmed the bash-tools failures disappeared without code changes once the compile regressions were fixed.
- What you did **not** verify: broader full-suite CI beyond the touched surfaces.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the `asNumber` alias could hide a real semantic mismatch if callers expected different coercion behavior.
  - Mitigation: it intentionally reuses the existing finite-number helper already used throughout this provider.
- Risk: synthetic OpenAI catalog rows could lose fields if the contract expectation changed again.
  - Mitigation: the helper is now typed to the actual catalog augmentation contract rather than a richer runtime model shape.
