### PR TITLE
fix(slack): forward resolved botToken to downloadSlackFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Slack: honor ambient HTTP(S) proxy settings for Socket Mode WebSocket connections, including NO_PROXY exclusions, so proxy-only deployments can connect without a monkey patch. (#62878) Thanks @mjamiv.
 - Network/fetch guard: skip target DNS pinning when trusted env-proxy mode is active so proxy-only sandboxes can let the trusted proxy resolve outbound hosts. (#59007) Thanks @cluster2600.
+- Slack/actions: pass the already resolved read token into `downloadFile` so SecretRef-backed bot tokens no longer fail after a raw config re-read. (#62097) Thanks @martingarramon.
 
 ## 2026.4.7-1
 

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -244,12 +244,26 @@ describe("handleSlackAction", () => {
 
   it("forwards resolved botToken to action functions instead of relying on config re-read", async () => {
     downloadSlackFile.mockResolvedValueOnce(null);
-    await handleSlackAction(
-      { action: "downloadFile", fileId: "F123" },
-      slackConfig(),
-    );
+    await handleSlackAction({ action: "downloadFile", fileId: "F123" }, slackConfig());
     const opts = downloadSlackFile.mock.calls[0]?.[1] as { token?: string } | undefined;
     expect(opts?.token).toBe("tok");
+  });
+
+  it("keeps resolved userToken for downloadFile reads when configured", async () => {
+    downloadSlackFile.mockResolvedValueOnce(null);
+    await handleSlackAction(
+      { action: "downloadFile", fileId: "F123" },
+      slackConfig({
+        accounts: {
+          default: {
+            botToken: "xoxb-bot",
+            userToken: "xoxp-user",
+          },
+        },
+      }),
+    );
+    const opts = downloadSlackFile.mock.calls[0]?.[1] as { token?: string } | undefined;
+    expect(opts?.token).toBe("xoxp-user");
   });
 
   it.each([

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -242,6 +242,16 @@ describe("handleSlackAction", () => {
     );
   });
 
+  it("forwards resolved botToken to action functions instead of relying on config re-read", async () => {
+    downloadSlackFile.mockResolvedValueOnce(null);
+    await handleSlackAction(
+      { action: "downloadFile", fileId: "F123" },
+      slackConfig(),
+    );
+    const opts = downloadSlackFile.mock.calls[0]?.[1] as { token?: string } | undefined;
+    expect(opts?.token).toBe("tok");
+  });
+
   it.each([
     {
       name: "JSON blocks",

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -383,8 +383,10 @@ export async function handleSlackAction(
         const maxBytes = account.config?.mediaMaxMb
           ? account.config.mediaMaxMb * 1024 * 1024
           : 20 * 1024 * 1024;
+        const readToken = getTokenForOperation("read");
         const downloaded = await slackActionRuntime.downloadSlackFile(fileId, {
           ...readOpts,
+          ...(readToken && !readOpts?.token ? { token: readToken } : {}),
           maxBytes,
           channelId,
           threadId: threadId ?? undefined,


### PR DESCRIPTION
Closes #62088

When `buildActionOpts` returns `undefined` (default single-account setup, no token override), `downloadSlackFile` calls `resolveToken(undefined, undefined)` which re-reads raw config via `loadConfig()`. If `botToken` is a SecretRef object (`{source: "env", key: "SLACK_BOT_TOKEN"}`), `normalizeResolvedSecretInputString` rejects it because it expects a resolved string — the download fails with a misleading "bot token is required" error.

The fix injects the already-resolved `botToken` from the gateway runtime snapshot into the download call as a fallback when `readOpts` doesn't carry an explicit token. This mirrors the approach used for Discord's identical bug (b51214ec3e).

**Note:** The same `resolveToken` re-read pattern exists in other Slack action call sites (send, edit, read, pin, etc.) — those are candidates for a follow-up pass using the same token-forwarding pattern.

**Testing:** New test in `action-runtime.test.ts` verifies the resolved botToken reaches `downloadSlackFile` opts. All 37 existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)