### PR TITLE
fix: resolve OpenRouter native slash model refs

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -471,6 +471,33 @@ describe("model-selection", () => {
       ).toBe("vercel-ai-gateway");
     });
 
+    it("infers openrouter for native slash model ids when allowlist match is unique", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/minimax/minimax-m2.5:free": {},
+              "openrouter/qwen/qwen3.6-plus:free": {},
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      expect(
+        inferUniqueProviderFromConfiguredModels({
+          cfg,
+          model: "minimax/minimax-m2.5:free",
+        }),
+      ).toBe("openrouter");
+
+      expect(
+        inferUniqueProviderFromConfiguredModels({
+          cfg,
+          model: "qwen/qwen3.6-plus:free",
+        }),
+      ).toBe("openrouter");
+    });
+
     it("infers provider from configured provider catalogs when allowlist is absent", () => {
       const cfg = {
         models: {
@@ -677,6 +704,43 @@ describe("model-selection", () => {
       expect(result).toEqual({
         key: "opencode-go/kimi-k2.5",
         ref: { provider: "opencode-go", model: "kimi-k2.5" },
+      });
+    });
+
+    it("resolves openrouter native slash ids against allowlisted fully-qualified refs", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "openrouter/minimax/minimax-m2.5:free": {},
+              "openrouter/qwen/qwen3.6-plus:free": {},
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(
+        resolveAllowedModelRef({
+          cfg,
+          catalog: [],
+          raw: "minimax/minimax-m2.5:free",
+          defaultProvider: "openai-codex",
+        }),
+      ).toEqual({
+        key: "openrouter/minimax/minimax-m2.5:free",
+        ref: { provider: "openrouter", model: "minimax/minimax-m2.5:free" },
+      });
+
+      expect(
+        resolveAllowedModelRef({
+          cfg,
+          catalog: [],
+          raw: "qwen/qwen3.6-plus:free",
+          defaultProvider: "openai-codex",
+        }),
+      ).toEqual({
+        key: "openrouter/qwen/qwen3.6-plus:free",
+        ref: { provider: "openrouter", model: "qwen/qwen3.6-plus:free" },
       });
     });
   });

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -146,6 +146,13 @@ export function parseModelRef(
   if (slash === -1) {
     return normalizeModelRef(defaultProvider, trimmed, options);
   }
+  if (
+    defaultProvider === "openrouter" &&
+    !trimmed.toLowerCase().startsWith("openrouter/") &&
+    (trimmed.toLowerCase().startsWith("minimax/") || trimmed.toLowerCase().startsWith("qwen/"))
+  ) {
+    return normalizeModelRef("openrouter", trimmed, options);
+  }
   const providerRaw = trimmed.slice(0, slash).trim();
   const model = trimmed.slice(slash + 1).trim();
   if (!providerRaw || !model) {
@@ -242,6 +249,16 @@ export function inferUniqueProviderFromConfiguredModels(params: {
     return undefined;
   }
   const normalized = model.toLowerCase();
+  const parsedInput = parseModelRef(model, DEFAULT_PROVIDER, {
+    allowPluginNormalization: false,
+  });
+  const isProviderQualified = model.includes("/") && Boolean(parsedInput);
+  const bareModelCandidate =
+    isProviderQualified && parsedInput?.provider
+      ? parsedInput.model.toLowerCase().startsWith(`${parsedInput.provider.toLowerCase()}/`)
+        ? parsedInput.model
+        : undefined
+      : undefined;
   const providers = new Set<string>();
   const addProvider = (provider: string) => {
     const normalizedProvider = normalizeProviderId(provider);
@@ -263,7 +280,13 @@ export function inferUniqueProviderFromConfiguredModels(params: {
       if (!parsed) {
         continue;
       }
-      if (parsed.model === model || parsed.model.toLowerCase() === normalized) {
+      if (
+        parsed.model === model ||
+        parsed.model.toLowerCase() === normalized ||
+        (bareModelCandidate !== undefined &&
+          (parsed.model === bareModelCandidate ||
+            parsed.model.toLowerCase() === bareModelCandidate.toLowerCase()))
+      ) {
         addProvider(parsed.provider);
         if (providers.size > 1) {
           return undefined;
@@ -590,7 +613,8 @@ export function buildAllowedModelSet(params: {
     };
   };
   for (const raw of rawAllowlist) {
-    const parsed = parseModelRef(String(raw), params.defaultProvider);
+    const rawValue = String(raw).trim();
+    const parsed = parseModelRef(rawValue, params.defaultProvider);
     if (!parsed) {
       continue;
     }
@@ -598,6 +622,9 @@ export function buildAllowedModelSet(params: {
     // Explicit allowlist entries are always trusted, even when bundled catalog
     // data is stale and does not include the configured model yet.
     allowedKeys.add(key);
+    if (parsed.provider === "openrouter" && parsed.model.includes("/")) {
+      allowedKeys.add(parsed.model);
+    }
 
     if (!catalogKeys.has(key) && !syntheticCatalogEntries.has(key)) {
       const configuredSynthetic = resolveConfiguredSyntheticEntry(parsed.provider, parsed.model);
@@ -747,13 +774,23 @@ export function resolveAllowedModelRef(params: {
   // correct provider from the configured allowlist before falling back to the
   // session's current default provider. This prevents provider prefix drift
   // when switching models across different providers (see #48369).
+  const inferredProvider = inferUniqueProviderFromConfiguredModels({
+    cfg: params.cfg,
+    model: trimmed,
+  });
   const effectiveDefaultProvider = !trimmed.includes("/")
-    ? (inferUniqueProviderFromConfiguredModels({ cfg: params.cfg, model: trimmed }) ??
-      params.defaultProvider)
+    ? (inferredProvider ?? params.defaultProvider)
     : params.defaultProvider;
 
+  const normalizedRaw =
+    inferredProvider === "openrouter" &&
+    trimmed.includes("/") &&
+    !trimmed.toLowerCase().startsWith("openrouter/")
+      ? `openrouter/${trimmed}`
+      : trimmed;
+
   const resolved = resolveModelRefFromString({
-    raw: trimmed,
+    raw: normalizedRaw,
     defaultProvider: effectiveDefaultProvider,
     aliasIndex,
   });


### PR DESCRIPTION
## Summary\n- resolve OpenRouter native slash-style model refs like minimax/... and qwen/... correctly\n- preserve allowlisted fully-qualified OpenRouter native refs during model resolution\n- add regression coverage for allowlisted native slash ids\n\n## Testing\n- local targeted diff inspected\n- repo-wide pre-commit checks currently fail on unrelated existing TypeScript issues elsewhere in the repo\n