### PR TITLE
fix(agents): preserve Anthropic refusal handling

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -264,4 +264,52 @@ describe("anthropic transport stream", () => {
       undefined,
     );
   });
+
+  it("preserves Anthropic refusal stop reasons as structured stream errors", async () => {
+    anthropicMessagesStreamMock.mockReturnValueOnce(
+      (async function* () {
+        yield {
+          type: "message_start",
+          message: { id: "msg_refusal", usage: { input_tokens: 12, output_tokens: 0 } },
+        };
+        yield {
+          type: "message_delta",
+          delta: { stop_reason: "refusal" },
+          usage: { input_tokens: 12, output_tokens: 0 },
+        };
+      })(),
+    );
+    const model = attachModelProviderRequestTransport(
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        api: "anthropic-messages",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"anthropic-messages">,
+      undefined,
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+
+    const stream = await Promise.resolve(
+      streamFn(
+        model,
+        {
+          messages: [{ role: "user", content: "do the refused thing" }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "sk-ant-api",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("Unhandled stop reason: refusal");
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -628,6 +628,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
         ) as AsyncIterable<Record<string, unknown>>;
         stream.push({ type: "start", partial: output as never });
         const blocks = output.content;
+        let terminalStopReason: string | undefined;
         for await (const event of anthropicStream) {
           if (event.type === "message_start") {
             const message = event.message as
@@ -820,6 +821,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             const delta = event.delta as { stop_reason?: string } | undefined;
             const usage = event.usage as Record<string, unknown> | undefined;
             if (delta?.stop_reason) {
+              terminalStopReason = delta.stop_reason;
               output.stopReason = mapStopReason(delta.stop_reason);
             }
             if (typeof usage?.input_tokens === "number") {
@@ -841,6 +843,12 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               output.usage.cacheWrite;
             calculateCost(model, output.usage);
           }
+        }
+        if (
+          output.stopReason === "error" &&
+          (terminalStopReason === "refusal" || terminalStopReason === "sensitive")
+        ) {
+          throw new Error(`Unhandled stop reason: ${terminalStopReason}`);
         }
         finalizeTransportStream({ stream, output, signal: transportOptions.signal });
       } catch (error) {

--- a/src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.test.ts
@@ -1,7 +1,11 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { createAssistantMessageEventStream, type Context, type Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-recovery.js";
+import {
+  extractUnhandledStopReason,
+  rollbackAnthropicRefusedTurn,
+  wrapStreamFnHandleSensitiveStopReason,
+} from "./attempt.stop-reason-recovery.js";
 
 const anthropicModel = {
   api: "anthropic-messages",
@@ -68,5 +72,78 @@ describe("wrapStreamFnHandleSensitiveStopReason", () => {
     expect(result.errorMessage).toBe(
       "The model stopped because the provider returned an unhandled stop reason: refusal_policy. Please rephrase and try again.",
     );
+  });
+});
+
+describe("extractUnhandledStopReason", () => {
+  it("parses raw unhandled stop reason markers", () => {
+    expect(extractUnhandledStopReason("Unhandled stop reason: refusal")).toBe("refusal");
+  });
+
+  it("parses normalized unhandled stop reason messages", () => {
+    expect(
+      extractUnhandledStopReason(
+        "The model stopped because the provider returned an unhandled stop reason: refusal. Please rephrase and try again.",
+      ),
+    ).toBe("refusal");
+  });
+});
+
+describe("rollbackAnthropicRefusedTurn", () => {
+  it("rewinds the refused assistant turn and the triggering user turn", () => {
+    const activeSession = {
+      agent: {
+        state: {
+          messages: [] as unknown[],
+        },
+      },
+    };
+    const leafs = [
+      {
+        type: "message",
+        parentId: "user-1",
+        message: {
+          role: "assistant",
+          errorMessage:
+            "The model stopped because the provider returned an unhandled stop reason: refusal. Please rephrase and try again.",
+        },
+      },
+      {
+        type: "message",
+        parentId: "assistant-0",
+        message: {
+          role: "user",
+        },
+      },
+      {
+        type: "message",
+        parentId: "root",
+        message: {
+          role: "assistant",
+        },
+      },
+    ];
+    let leafIndex = 0;
+    const sessionManager = {
+      getLeafEntry: () => leafs[Math.min(leafIndex, leafs.length - 1)] ?? null,
+      branch: (parentId: string) => {
+        expect(parentId).toBe(leafs[leafIndex]?.parentId);
+        leafIndex += 1;
+      },
+      resetLeaf: () => {
+        throw new Error("resetLeaf should not be called");
+      },
+      buildSessionContext: () => ({
+        messages: leafIndex === 1 ? [{ role: "user", content: "blocked request" }] : [],
+      }),
+    };
+
+    const changed = rollbackAnthropicRefusedTurn({
+      activeSession,
+      sessionManager,
+    });
+
+    expect(changed).toBe(true);
+    expect(activeSession.agent.state.messages).toEqual([]);
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractUnhandledStopReason,
   rollbackAnthropicRefusedTurn,
+  shouldRollbackAnthropicRefusedTurn,
   wrapStreamFnHandleSensitiveStopReason,
 } from "./attempt.stop-reason-recovery.js";
 
@@ -89,6 +90,18 @@ describe("extractUnhandledStopReason", () => {
   });
 });
 
+describe("shouldRollbackAnthropicRefusedTurn", () => {
+  it("requires an anthropic-messages run", () => {
+    expect(
+      shouldRollbackAnthropicRefusedTurn({
+        modelApi: "openai-responses",
+        errorMessage:
+          "The model stopped because the provider returned an unhandled stop reason: refusal. Please rephrase and try again.",
+      }),
+    ).toBe(false);
+  });
+});
+
 describe("rollbackAnthropicRefusedTurn", () => {
   it("rewinds the refused assistant turn and the triggering user turn", () => {
     const activeSession = {
@@ -141,9 +154,49 @@ describe("rollbackAnthropicRefusedTurn", () => {
     const changed = rollbackAnthropicRefusedTurn({
       activeSession,
       sessionManager,
+      modelApi: "anthropic-messages",
     });
 
     expect(changed).toBe(true);
     expect(activeSession.agent.state.messages).toEqual([]);
+  });
+
+  it("does not rewind non-anthropic refusal-shaped errors", () => {
+    const activeSession = {
+      agent: {
+        state: {
+          messages: ["unchanged"] as unknown[],
+        },
+      },
+    };
+    const sessionManager = {
+      getLeafEntry: () => ({
+        type: "message",
+        parentId: "user-1",
+        message: {
+          role: "assistant",
+          errorMessage:
+            "The model stopped because the provider returned an unhandled stop reason: refusal. Please rephrase and try again.",
+        },
+      }),
+      branch: () => {
+        throw new Error("branch should not be called");
+      },
+      resetLeaf: () => {
+        throw new Error("resetLeaf should not be called");
+      },
+      buildSessionContext: () => ({
+        messages: [],
+      }),
+    };
+
+    const changed = rollbackAnthropicRefusedTurn({
+      activeSession,
+      sessionManager,
+      modelApi: "openai-responses",
+    });
+
+    expect(changed).toBe(false);
+    expect(activeSession.agent.state.messages).toEqual(["unchanged"]);
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.ts
@@ -3,21 +3,116 @@ import { createAssistantMessageEventStream, streamSimple } from "@mariozechner/p
 import { buildStreamErrorAssistantMessage } from "../../stream-message-shared.js";
 
 const UNHANDLED_STOP_REASON_RE = /^Unhandled stop reason:\s*(.+)$/i;
+const NORMALIZED_UNHANDLED_STOP_REASON_RE =
+  /^The model stopped because the provider returned an unhandled stop reason:\s*(.+?)\.\s*Please rephrase and try again\.\s*$/i;
+
+type RefusedTurnLeafEntry =
+  | {
+      type?: string;
+      parentId?: string | null;
+      message?: {
+        role?: string;
+        errorMessage?: unknown;
+      };
+    }
+  | null
+  | undefined;
+
+type RefusedTurnSessionManager = {
+  getLeafEntry?: () => RefusedTurnLeafEntry;
+  branch: (entryId: string) => void;
+  resetLeaf: () => void;
+  buildSessionContext: () => { messages: unknown[] };
+};
+
+type RefusedTurnActiveSession = {
+  agent: {
+    state: {
+      messages: unknown[];
+    };
+  };
+};
 
 function formatUnhandledStopReasonErrorMessage(stopReason: string): string {
   return `The model stopped because the provider returned an unhandled stop reason: ${stopReason}. Please rephrase and try again.`;
 }
 
-function normalizeUnhandledStopReasonMessage(message: unknown): string | undefined {
+export function extractUnhandledStopReason(message: unknown): string | undefined {
   if (typeof message !== "string") {
     return undefined;
   }
-  const match = message.trim().match(UNHANDLED_STOP_REASON_RE);
+  const trimmed = message.trim();
+  const match =
+    trimmed.match(UNHANDLED_STOP_REASON_RE) ?? trimmed.match(NORMALIZED_UNHANDLED_STOP_REASON_RE);
   const stopReason = match?.[1]?.trim();
   if (!stopReason) {
     return undefined;
   }
+  return stopReason.toLowerCase();
+}
+
+function normalizeUnhandledStopReasonMessage(message: unknown): string | undefined {
+  const stopReason = extractUnhandledStopReason(message);
+  if (!stopReason) {
+    return undefined;
+  }
   return formatUnhandledStopReasonErrorMessage(stopReason);
+}
+
+export function isAnthropicRefusalStopReasonMessage(message: unknown): boolean {
+  const stopReason = extractUnhandledStopReason(message);
+  return stopReason === "refusal" || stopReason === "sensitive";
+}
+
+function rewindRefusedTurnLeaf(
+  sessionManager: RefusedTurnSessionManager,
+  activeSession: RefusedTurnActiveSession,
+  leafEntry: RefusedTurnLeafEntry,
+): boolean {
+  if (!leafEntry || leafEntry.type !== "message") {
+    return false;
+  }
+  if (leafEntry.parentId) {
+    sessionManager.branch(leafEntry.parentId);
+  } else {
+    sessionManager.resetLeaf();
+  }
+  activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+  return true;
+}
+
+export function rollbackAnthropicRefusedTurn(params: {
+  activeSession: RefusedTurnActiveSession;
+  sessionManager?: RefusedTurnSessionManager;
+}): boolean {
+  const sessionManager = params.sessionManager;
+  if (!sessionManager?.getLeafEntry) {
+    return false;
+  }
+
+  const assistantLeaf = sessionManager.getLeafEntry();
+  if (
+    assistantLeaf?.type !== "message" ||
+    assistantLeaf.message?.role !== "assistant" ||
+    !isAnthropicRefusalStopReasonMessage(assistantLeaf.message?.errorMessage)
+  ) {
+    return false;
+  }
+
+  const rewoundAssistant = rewindRefusedTurnLeaf(
+    sessionManager,
+    params.activeSession,
+    assistantLeaf,
+  );
+  if (!rewoundAssistant) {
+    return false;
+  }
+
+  const userLeaf = sessionManager.getLeafEntry();
+  if (userLeaf?.type === "message" && userLeaf.message?.role === "user") {
+    rewindRefusedTurnLeaf(sessionManager, params.activeSession, userLeaf);
+  }
+  return true;
 }
 
 function patchUnhandledStopReasonInAssistantMessage(message: unknown): void {

--- a/src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.ts
@@ -64,6 +64,16 @@ export function isAnthropicRefusalStopReasonMessage(message: unknown): boolean {
   return stopReason === "refusal" || stopReason === "sensitive";
 }
 
+export function shouldRollbackAnthropicRefusedTurn(params: {
+  modelApi?: string;
+  errorMessage?: unknown;
+}): boolean {
+  return (
+    params.modelApi === "anthropic-messages" &&
+    isAnthropicRefusalStopReasonMessage(params.errorMessage)
+  );
+}
+
 function rewindRefusedTurnLeaf(
   sessionManager: RefusedTurnSessionManager,
   activeSession: RefusedTurnActiveSession,
@@ -84,6 +94,7 @@ function rewindRefusedTurnLeaf(
 export function rollbackAnthropicRefusedTurn(params: {
   activeSession: RefusedTurnActiveSession;
   sessionManager?: RefusedTurnSessionManager;
+  modelApi?: string;
 }): boolean {
   const sessionManager = params.sessionManager;
   if (!sessionManager?.getLeafEntry) {
@@ -94,7 +105,10 @@ export function rollbackAnthropicRefusedTurn(params: {
   if (
     assistantLeaf?.type !== "message" ||
     assistantLeaf.message?.role !== "assistant" ||
-    !isAnthropicRefusalStopReasonMessage(assistantLeaf.message?.errorMessage)
+    !shouldRollbackAnthropicRefusedTurn({
+      modelApi: params.modelApi,
+      errorMessage: assistantLeaf.message?.errorMessage,
+    })
   ) {
     return false;
   }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   DefaultResourceLoader,
@@ -165,7 +166,11 @@ import {
   stripSessionsYieldArtifacts,
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
-import { wrapStreamFnHandleSensitiveStopReason } from "./attempt.stop-reason-recovery.js";
+import {
+  isAnthropicRefusalStopReasonMessage,
+  rollbackAnthropicRefusedTurn,
+  wrapStreamFnHandleSensitiveStopReason,
+} from "./attempt.stop-reason-recovery.js";
 import {
   appendAttemptCacheTtlIfNeeded,
   composeSystemPromptWithHookContext,
@@ -1453,6 +1458,7 @@ export async function runEmbeddedAttempt(
       scheduleAbortTimer(params.timeoutMs, "initial");
 
       let messagesSnapshot: AgentMessage[] = [];
+      let preservedRefusalAssistant: AssistantMessage | undefined;
       let sessionIdUsed = activeSession.sessionId;
       const onAbort = () => {
         const reason = params.abortSignal ? getAbortReason(params.abortSignal) : undefined;
@@ -1847,6 +1853,26 @@ export async function runEmbeddedAttempt(
         }
         messagesSnapshot = snapshotSelection.messagesSnapshot;
         sessionIdUsed = snapshotSelection.sessionIdUsed;
+        const refusalAssistant = messagesSnapshot
+          .slice()
+          .toReversed()
+          .find(
+            (message): message is AssistantMessage =>
+              message.role === "assistant" &&
+              isAnthropicRefusalStopReasonMessage(
+                (message as { errorMessage?: unknown }).errorMessage,
+              ),
+          );
+        if (
+          refusalAssistant &&
+          rollbackAnthropicRefusedTurn({
+            activeSession,
+            sessionManager,
+          })
+        ) {
+          preservedRefusalAssistant = refusalAssistant;
+          messagesSnapshot = activeSession.messages.slice();
+        }
 
         if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
           try {
@@ -1962,10 +1988,12 @@ export async function runEmbeddedAttempt(
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
 
-      const lastAssistant = messagesSnapshot
-        .slice()
-        .toReversed()
-        .find((m) => m.role === "assistant");
+      const lastAssistant =
+        preservedRefusalAssistant ??
+        messagesSnapshot
+          .slice()
+          .toReversed()
+          .find((m) => m.role === "assistant");
 
       const toolMetasNormalized = toolMetas
         .filter(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -167,8 +167,8 @@ import {
   waitForSessionsYieldAbortSettle,
 } from "./attempt.sessions-yield.js";
 import {
-  isAnthropicRefusalStopReasonMessage,
   rollbackAnthropicRefusedTurn,
+  shouldRollbackAnthropicRefusedTurn,
   wrapStreamFnHandleSensitiveStopReason,
 } from "./attempt.stop-reason-recovery.js";
 import {
@@ -1859,15 +1859,17 @@ export async function runEmbeddedAttempt(
           .find(
             (message): message is AssistantMessage =>
               message.role === "assistant" &&
-              isAnthropicRefusalStopReasonMessage(
-                (message as { errorMessage?: unknown }).errorMessage,
-              ),
+              shouldRollbackAnthropicRefusedTurn({
+                modelApi: params.model.api,
+                errorMessage: (message as { errorMessage?: unknown }).errorMessage,
+              }),
           );
         if (
           refusalAssistant &&
           rollbackAnthropicRefusedTurn({
             activeSession,
             sessionManager,
+            modelApi: params.model.api,
           })
         ) {
           preservedRefusalAssistant = refusalAssistant;


### PR DESCRIPTION
## What
This PR preserves Anthropic streaming refusal stop reasons instead of collapsing them into a generic unknown error, and rewinds refused turns only for `anthropic-messages` runs so later requests do not replay a refused turn.

## Why
Anthropic streaming refusals need to remain visible to higher layers so OpenClaw can show a user-facing refusal message and avoid replaying the refused assistant/user turn on the next call. Without that, future turns can keep refusing for the same replayed history. The rollback guard is intentionally limited to `anthropic-messages` runs so other providers cannot trigger transcript rewinds from lookalike error text.

## Changes
- Preserve refusal stop reasons in Anthropic stream transport
- Normalize refusal stop reason recovery in runner
- Rewind refused turns only for `anthropic-messages` runs
- Add focused transport and rollback tests

## Testing
- `pnpm test src/agents/anthropic-transport-stream.test.ts src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.test.ts`
- `pnpm exec oxfmt --check src/agents/anthropic-transport-stream.ts src/agents/anthropic-transport-stream.test.ts src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.ts src/agents/pi-embedded-runner/run/attempt.stop-reason-recovery.test.ts src/agents/pi-embedded-runner/run/attempt.ts`
- Focused tests passed and formatting is clean.
- `pnpm build` still fails on unrelated existing repo issues in `extensions/firecrawl/src/firecrawl-tools.test.ts` and `src/agents/pi-embedded-helpers/provider-error-patterns.ts`.
