### PR TITLE
fix: align memory vector DB typing with node sqlite

### DIFF
--- a/extensions/memory-core/src/memory/manager-vector-write.ts
+++ b/extensions/memory-core/src/memory/manager-vector-write.ts
@@ -1,8 +1,6 @@
-type VectorWriteDb = {
-  prepare: (sql: string) => {
-    run: (...params: unknown[]) => void;
-  };
-};
+import type { DatabaseSync } from "node:sqlite";
+
+type VectorWriteDb = Pick<DatabaseSync, "prepare">;
 
 const vectorToBlob = (embedding: number[]): Buffer =>
   Buffer.from(new Float32Array(embedding).buffer);


### PR DESCRIPTION
## What
This PR aligns the memory-core vector-write helper with the actual `node:sqlite` `DatabaseSync` prepare signature so current mainline type/lint verification can accept the existing memory-core call sites and tests again.

## Why
`pnpm check` on current `origin/main` was failing because `replaceMemoryVectorRow()` declared a handwritten `prepare().run()` contract using `unknown[]`, which is not assignable from `DatabaseSync`'s overloaded `run(...)` methods under TypeScript's parameter variance rules.

## Changes
- Use `DatabaseSync`'s `prepare` type in `manager-vector-write`
- Keep vector write behavior unchanged
- Preserve existing memory-core dedupe test coverage

## Testing
- `pnpm check`
- `pnpm test extensions/memory-core/src/memory/manager.vector-dedupe.test.ts`
- `pnpm build`
