### PR TITLE
Fix(gateway): fail closed critical auth stages

### DIFF
--- a/src/gateway/server-http.stages.test.ts
+++ b/src/gateway/server-http.stages.test.ts
@@ -91,4 +91,26 @@ describe("runGatewayHttpRequestStages", () => {
 
     consoleSpy.mockRestore();
   });
+
+  it("throws when a critical stage fails", async () => {
+    const stageC = vi.fn(() => true);
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const stages = [
+      {
+        name: "critical-auth",
+        critical: true,
+        run: () => {
+          throw new Error("auth failed");
+        },
+      },
+      { name: "c", run: stageC },
+    ];
+
+    await expect(runGatewayHttpRequestStages(stages)).rejects.toThrow("auth failed");
+    expect(stageC).not.toHaveBeenCalled();
+    expect(consoleSpy).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
 });

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -270,6 +270,7 @@ export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) =>
 type GatewayHttpRequestStage = {
   name: string;
   run: () => Promise<boolean> | boolean;
+  critical?: boolean;
 };
 
 export async function runGatewayHttpRequestStages(
@@ -281,6 +282,9 @@ export async function runGatewayHttpRequestStages(
         return true;
       }
     } catch (err) {
+      if (stage.critical) {
+        throw err;
+      }
       // Log and skip the failing stage so subsequent stages (control-ui,
       // gateway-probes, etc.) remain reachable.  A common trigger is a
       // plugin-owned route/runtime code can still fail to load when an
@@ -312,6 +316,7 @@ function buildPluginRequestStages(params: {
   return [
     {
       name: "plugin-auth",
+      critical: true,
       run: async () => {
         if (params.gatewayAuthBypassPaths.has(params.requestPath)) {
           return false;
@@ -891,6 +896,7 @@ export function createGatewayHttpServer(opts: {
       if (canvasHost) {
         requestStages.push({
           name: "canvas-auth",
+          critical: true,
           run: async () => {
             if (!isCanvasPath(requestPath)) {
               return false;


### PR DESCRIPTION
## Summary

- Problem: The Gateway HTTP stage runner used fail-open behavior: when a stage threw, it was skipped and later stages still ran.
- Why it matters: A throw in an auth stage could allow a downstream handler to run without confirmed auth.
- What changed: Added `critical?: boolean` to HTTP stages; `runGatewayHttpRequestStages` now rethrows for critical stages; marked `plugin-auth` and `canvas-auth` as critical; added a regression test.
- What did NOT change (scope boundary): No endpoint additions, no auth mode changes, no token/secret semantics changes, no public API/config contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The stage runner treated all stage exceptions as skippable and continued processing.
- Missing detection / guardrail: No “critical stage” fail-closed mechanism existed for security-sensitive stages.
- Contributing context (if known): Availability-oriented skip-on-error behavior was applied globally, including auth-adjacent paths.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-http.stages.test.ts`
- Scenario the test should lock in: A `critical: true` stage throw must abort the pipeline and prevent subsequent stage execution.
- Why this is the smallest reliable guardrail: It validates the exact shared runner behavior where the bug originated.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A (new regression test added).

## User-visible / Behavior Changes

None for normal successful requests.  
Internal security behavior changed: critical auth-stage failures are now fail-closed.

## Diagram (if applicable)

```text
Before:
[request] -> [critical auth stage throws] -> [stage skipped] -> [next handler runs]

After:
[request] -> [critical auth stage throws] -> [pipeline aborts] -> [no downstream handler execution]