### PR TITLE
Onboarding improvement: prompt Codex users to enable native web search

### DIFF
--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -106,7 +106,7 @@ vi.mock("./onboard-channels.js", () => ({
 
 vi.mock("./onboard-search.js", () => ({
   resolveSearchProviderOptions: mocks.resolveSearchProviderOptions,
-  setupSearch: mocks.setupSearch,
+  setupManagedSearch: mocks.setupSearch,
 }));
 
 import { WizardCancelledError } from "../wizard/prompts.js";
@@ -167,10 +167,10 @@ function setupBaseWizardState(config: OpenClawConfig = {}) {
     intro: vi.fn(async () => {}),
     outro: vi.fn(async () => {}),
     note: vi.fn(async () => {}),
-    select: vi.fn(async () => "firecrawl"),
+    select: vi.fn(async (params: unknown) => mocks.clackSelect(params)),
     multiselect: vi.fn(async () => []),
-    text: vi.fn(async () => ""),
-    confirm: vi.fn(async () => true),
+    text: vi.fn(async (params: unknown) => mocks.clackText(params)),
+    confirm: vi.fn(async (params: unknown) => mocks.clackConfirm(params)),
     progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
   });
 }

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -45,6 +45,7 @@ import {
 } from "./onboard-helpers.js";
 import { promptRemoteGatewayConfig } from "./onboard-remote.js";
 import { setupSkills } from "./onboard-skills.js";
+import { promptCodexNativeWebSearchSetup } from "./web-search-codex-setup.js";
 
 type ConfigureSectionChoice = WizardSection | "__continue";
 
@@ -164,9 +165,7 @@ async function promptWebToolsConfig(
   type WebSearchConfig = NonNullable<NonNullable<OpenClawConfig["tools"]>["web"]>["search"];
   const existingSearch = nextConfig.tools?.web?.search;
   const existingFetch = nextConfig.tools?.web?.fetch;
-  const { resolveSearchProviderOptions, setupSearch } = await import("./onboard-search.js");
-  const { describeCodexNativeWebSearch, isCodexNativeWebSearchRelevant } =
-    await import("../agents/codex-native-web-search.js");
+  const { resolveSearchProviderOptions, setupManagedSearch } = await import("./onboard-search.js");
   const searchProviderOptions = resolveSearchProviderOptions(nextConfig);
 
   note(
@@ -193,75 +192,15 @@ async function promptWebToolsConfig(
   let workingConfig = nextConfig;
 
   if (enableSearch) {
-    const codexRelevant = isCodexNativeWebSearchRelevant({ config: nextConfig });
-    let configureManagedProvider = true;
-
-    if (codexRelevant) {
-      note(
-        [
-          "Codex-capable models can optionally use native Codex web search.",
-          "Managed web_search still controls non-Codex models.",
-          "If no managed provider is configured, non-Codex models still rely on provider auto-detect and may have no search available.",
-          ...(describeCodexNativeWebSearch(nextConfig)
-            ? [describeCodexNativeWebSearch(nextConfig)!]
-            : ["Recommended mode: cached."]),
-        ].join("\n"),
-        "Codex native search",
-      );
-
-      const enableCodexNative = guardCancel(
-        await confirm({
-          message: "Enable native Codex web search for Codex-capable models?",
-          initialValue: existingSearch?.openaiCodex?.enabled === true,
-        }),
-        runtime,
-      );
-
-      if (enableCodexNative) {
-        const codexMode = guardCancel(
-          await select({
-            message: "Codex native web search mode",
-            options: [
-              {
-                value: "cached",
-                label: "cached (recommended)",
-                hint: "Uses cached web content",
-              },
-              {
-                value: "live",
-                label: "live",
-                hint: "Allows live external web access",
-              },
-            ],
-            initialValue: existingSearch?.openaiCodex?.mode ?? "cached",
-          }),
-          runtime,
-        );
-        nextSearch = {
-          ...nextSearch,
-          openaiCodex: {
-            ...existingSearch?.openaiCodex,
-            enabled: true,
-            mode: codexMode,
-          },
-        };
-        configureManagedProvider = guardCancel(
-          await confirm({
-            message: "Configure or change a managed web search provider now?",
-            initialValue: Boolean(existingSearch?.provider),
-          }),
-          runtime,
-        );
-      } else {
-        nextSearch = {
-          ...nextSearch,
-          openaiCodex: {
-            ...existingSearch?.openaiCodex,
-            enabled: false,
-          },
-        };
-      }
-    }
+    const codexSetup = await promptCodexNativeWebSearchSetup({
+      config: workingConfig,
+      prompter,
+    });
+    workingConfig = codexSetup.config;
+    nextSearch = {
+      ...workingConfig.tools?.web?.search,
+    };
+    const { configureManagedProvider } = codexSetup;
 
     if (searchProviderOptions.length === 0) {
       if (configureManagedProvider) {
@@ -276,19 +215,18 @@ async function promptWebToolsConfig(
       }
       if (nextSearch.openaiCodex?.enabled !== true) {
         nextSearch = {
-          ...existingSearch,
+          ...workingConfig.tools?.web?.search,
           enabled: false,
         };
       }
     } else if (configureManagedProvider) {
-      workingConfig = await setupSearch(workingConfig, runtime, prompter);
+      const codexSearch = workingConfig.tools?.web?.search?.openaiCodex;
+      const searchEnabled = workingConfig.tools?.web?.search?.enabled;
+      workingConfig = await setupManagedSearch(workingConfig, runtime, prompter);
       nextSearch = {
         ...workingConfig.tools?.web?.search,
-        enabled: workingConfig.tools?.web?.search?.provider ? true : existingSearch?.enabled,
-        openaiCodex: {
-          ...existingSearch?.openaiCodex,
-          ...(nextSearch.openaiCodex as Record<string, unknown> | undefined),
-        },
+        enabled: workingConfig.tools?.web?.search?.provider ? true : searchEnabled,
+        ...(codexSearch ? { openaiCodex: codexSearch } : {}),
       };
     }
   }

--- a/src/commands/onboard-search.test.ts
+++ b/src/commands/onboard-search.test.ts
@@ -152,12 +152,15 @@ function createPrompter(params: {
   selectValue?: string;
   selectValues?: string[];
   textValue?: string;
+  confirmValue?: boolean;
+  confirmValues?: boolean[];
 }): {
   prompter: WizardPrompter;
   notes: Array<{ title?: string; message: string }>;
 } {
   const notes: Array<{ title?: string; message: string }> = [];
   const remainingSelectValues = [...(params.selectValues ?? [])];
+  const remainingConfirmValues = [...(params.confirmValues ?? [])];
   const prompter: WizardPrompter = {
     intro: vi.fn(async () => {}),
     outro: vi.fn(async () => {}),
@@ -169,7 +172,9 @@ function createPrompter(params: {
     ) as unknown as WizardPrompter["select"],
     multiselect: vi.fn(async () => []) as unknown as WizardPrompter["multiselect"],
     text: vi.fn(async () => params.textValue ?? ""),
-    confirm: vi.fn(async () => true),
+    confirm: vi.fn(
+      async () => remainingConfirmValues.shift() ?? params.confirmValue ?? true,
+    ) as unknown as WizardPrompter["confirm"],
     progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
   };
   return { prompter, notes };
@@ -323,6 +328,55 @@ describe("setupSearch", () => {
     expect(result.tools?.web?.search?.enabled).toBe(true);
     expect(pluginWebSearchApiKey(result, "brave")).toBe("BSA-test-key");
     expect(result.plugins?.entries?.brave?.enabled).toBe(true);
+  });
+
+  it("can enable native Codex search during onboarding without a managed provider", async () => {
+    const cfg: OpenClawConfig = {
+      auth: {
+        profiles: {
+          "openai-codex:default": {
+            provider: "openai-codex",
+            mode: "oauth",
+          },
+        },
+      },
+    };
+    const { prompter } = createPrompter({
+      selectValues: ["cached"],
+      confirmValues: [true, false],
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search).toEqual({
+      enabled: true,
+      openaiCodex: {
+        enabled: true,
+        mode: "cached",
+      },
+    });
+    expect(prompter.text).not.toHaveBeenCalled();
+  });
+
+  it("still lets onboarding configure a managed provider after declining native Codex search", async () => {
+    const cfg: OpenClawConfig = {
+      auth: {
+        profiles: {
+          "openai-codex:default": {
+            provider: "openai-codex",
+            mode: "oauth",
+          },
+        },
+      },
+    };
+    const { prompter } = createPrompter({
+      selectValue: "perplexity",
+      textValue: "pplx-test-key",
+      confirmValues: [false],
+    });
+    const result = await setupSearch(cfg, runtime, prompter);
+    expect(result.tools?.web?.search?.provider).toBe("perplexity");
+    expect(result.tools?.web?.search?.enabled).toBe(true);
+    expect(result.tools?.web?.search?.openaiCodex?.enabled).toBe(false);
+    expect(pluginWebSearchApiKey(result, "perplexity")).toBe("pplx-test-key");
   });
 
   it("sets provider and key for gemini", async () => {

--- a/src/commands/onboard-search.ts
+++ b/src/commands/onboard-search.ts
@@ -1,3 +1,19 @@
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  applySearchKey,
+  applySearchProviderSelection,
+  hasExistingKey,
+  hasKeyInEnv,
+  listSearchProviderOptions,
+  resolveExistingKey,
+  resolveSearchProviderOptions,
+  runSearchSetupFlow,
+} from "../flows/search-setup.js";
+import type { SetupSearchOptions } from "../flows/search-setup.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { promptCodexNativeWebSearchSetup } from "./web-search-codex-setup.js";
+
 export {
   applySearchKey,
   applySearchProviderSelection,
@@ -6,6 +22,22 @@ export {
   listSearchProviderOptions,
   resolveExistingKey,
   resolveSearchProviderOptions,
-  runSearchSetupFlow as setupSearch,
+  runSearchSetupFlow as setupManagedSearch,
 } from "../flows/search-setup.js";
 export type { SearchProvider, SetupSearchOptions } from "../flows/search-setup.js";
+
+export async function setupSearch(
+  config: OpenClawConfig,
+  runtime: RuntimeEnv,
+  prompter: WizardPrompter,
+  opts?: SetupSearchOptions,
+): Promise<OpenClawConfig> {
+  const codexSetup = await promptCodexNativeWebSearchSetup({
+    config,
+    prompter,
+  });
+  if (!codexSetup.configureManagedProvider) {
+    return codexSetup.config;
+  }
+  return runSearchSetupFlow(codexSetup.config, runtime, prompter, opts);
+}

--- a/src/commands/web-search-codex-setup.ts
+++ b/src/commands/web-search-codex-setup.ts
@@ -1,0 +1,109 @@
+import {
+  describeCodexNativeWebSearch,
+  isCodexNativeWebSearchRelevant,
+} from "../agents/codex-native-web-search.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+
+export type CodexNativeWebSearchSetupResult = {
+  config: OpenClawConfig;
+  configureManagedProvider: boolean;
+};
+
+export async function promptCodexNativeWebSearchSetup(params: {
+  config: OpenClawConfig;
+  prompter: WizardPrompter;
+}): Promise<CodexNativeWebSearchSetupResult> {
+  if (!isCodexNativeWebSearchRelevant({ config: params.config })) {
+    return {
+      config: params.config,
+      configureManagedProvider: true,
+    };
+  }
+
+  const existingSearch = params.config.tools?.web?.search;
+  const codexSearchDescription = describeCodexNativeWebSearch(params.config);
+
+  await params.prompter.note(
+    [
+      "Codex-capable models can optionally use native Codex web search.",
+      "Managed web_search still controls non-Codex models.",
+      "If no managed provider is configured, non-Codex models still rely on provider auto-detect and may have no search available.",
+      ...(codexSearchDescription ? [codexSearchDescription] : ["Recommended mode: cached."]),
+    ].join("\n"),
+    "Codex native search",
+  );
+
+  const enableCodexNative = await params.prompter.confirm({
+    message: "Enable native Codex web search for Codex-capable models?",
+    initialValue: existingSearch?.openaiCodex?.enabled === true,
+  });
+
+  if (!enableCodexNative) {
+    return {
+      config: {
+        ...params.config,
+        tools: {
+          ...params.config.tools,
+          web: {
+            ...params.config.tools?.web,
+            search: {
+              ...existingSearch,
+              openaiCodex: {
+                ...existingSearch?.openaiCodex,
+                enabled: false,
+              },
+            },
+          },
+        },
+      },
+      configureManagedProvider: true,
+    };
+  }
+
+  const codexMode = await params.prompter.select({
+    message: "Codex native web search mode",
+    options: [
+      {
+        value: "cached" as const,
+        label: "cached (recommended)",
+        hint: "Uses cached web content",
+      },
+      {
+        value: "live" as const,
+        label: "live",
+        hint: "Allows live external web access",
+      },
+    ],
+    initialValue: existingSearch?.openaiCodex?.mode ?? "cached",
+  });
+
+  const config = {
+    ...params.config,
+    tools: {
+      ...params.config.tools,
+      web: {
+        ...params.config.tools?.web,
+        search: {
+          ...existingSearch,
+          enabled: true,
+          openaiCodex: {
+            ...existingSearch?.openaiCodex,
+            enabled: true,
+            mode: codexMode,
+          },
+        },
+      },
+    },
+  };
+
+  const configureManagedProvider = await params.prompter.confirm({
+    message: "Configure or change a managed web search provider now?",
+    initialValue: Boolean(existingSearch?.provider),
+  });
+
+  return {
+    config,
+    configureManagedProvider,
+  };
+}


### PR DESCRIPTION
## Summary

When onboarding/configure detects OpenAI Codex OAuth or another Codex-capable default, offer native Codex web search first.

This lets Codex users enable the built-in native search path without choosing a separate managed provider (but still allows to do so, which I am happy to remove to simplify?) 

<img width="779" height="532" alt="Screenshot 2026-04-06 at 5 13 35 PM" src="https://github.com/user-attachments/assets/c89e9013-d54a-4d19-b445-aa82952a27e0" />

If they decline it, continue into the existing managed-provider flow so providers like Perplexity still remain available.

<img width="764" height="280" alt="Screenshot 2026-04-06 at 4 53 20 PM" src="https://github.com/user-attachments/assets/0756173f-840f-4eca-9815-669ebdd98e79" />

<img width="743" height="476" alt="Screenshot 2026-04-06 at 4 53 31 PM" src="https://github.com/user-attachments/assets/b9cd8c85-b855-444f-825f-61a24c01ba31" />

it is possible that we should instead just add this as an option to the list of search providers - open to feedback

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## User-visible / Behavior Changes

See screenshots linked above, TL;DR suggests to enable built in web search instead of taking user through the search providers selection

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

This has been possible before with configuration, just exposing during onboarding

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout via `pnpm`, disposable config dir created by `scripts/tmp-
onboard-codex-web-search.fish`
- Model/provider: OpenAI Codex OAuth, default Codex-capable model (`openai-codex/gpt-5.4`)
- Integration/channel (if any): none
- Relevant config (redacted):
  ```json
  {
    "auth": {
      "profiles": {
        "<redacted>": {
          "provider": "openai-codex"
        }
      }
    },
    "tools": {
      "web": {
        "search": {
          "enabled": true
        }
      }
    }
  }

### Steps

1. Run onboarding in a fresh disposable env with scripts/tmp-onboard-codex-web-search.fish.
2. During onboarding, choose OpenAI Codex OAuth.
3. Continue to web search setup.
4. Accept or decline the native Codex web search prompt.

### Expected

- If onboarding already established OpenAI Codex auth/model context, prompt the user to enable native
  Codex web search.
- If the user declines, continue into the existing managed-provider flow so providers like Perplexity
  can still be selected.

### Actual

- Before this change, onboarding only offered managed search providers and did not surface the native
  Codex web search option.
- After this change, onboarding shows the native Codex web search prompt for Codex-relevant setups, and
  declining it still leads to the managed-provider picker.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording (see above)
- [ ] Perf numbers (if relevant)

## Human Verification (required)

### Verified scenarios
- Fresh onboarding in a disposable env now shows the native Codex web search prompt after choosing
  OpenAI Codex OAuth.
- Search is working with no API keys provided
- Declining the native Codex prompt still reaches the managed-provider selection flow.
- `pnpm test src/commands/configure.wizard.test.ts` passed.
- Targeted onboarding coverage for enabling native Codex web search passed.
- pnpm build passed.

### Edge cases checked:
- Prompt is gated to Codex-relevant setups. 
- Configure and onboarding now share the same prompt/helper path.
- Managed providers remain available if the user backs out of native Codex search.

setting up with non-codex-oauth flow does goes straight into web search provider flow 
<img width="747" height="517" alt="Screenshot 2026-04-06 at 5 04 35 PM" src="https://github.com/user-attachments/assets/04e7fa27-b895-4e90-8ac3-c63bbd64aa51" />

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`) (sort of since onboarding changes config but does not add new config?)
- Migration needed? (`No`)

## Risks and Mitigations

No risks, 100% bug free code, I asked codex to make no mistakes 🫠