### PR TITLE
fix: openclaw allows normal reply text to carry media (#345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - Agents/history: suppress commentary-only visible-text leaks in streaming and chat history views, and keep sanitized SSE history sequence numbers monotonic after transcript-only refreshes. (#61829) Thanks @100yenadmin.
 - Agents/history: use one shared assistant-visible sanitizer across embedded delivery and chat-history extraction so leaked `<tool_call>` and `<tool_result>` XML blocks stay hidden from user-facing replies. (#61729) Thanks @openperf.
 - Agents/history: keep truly legacy unsigned replay text unphased when mixed with phased OpenAI WS assistant blocks, while still inheriting message phase for id-only replay signatures. (#61529) Thanks @100yenadmin.
+- Auto-reply/media: block arbitrary absolute host-local `MEDIA:` paths from normal reply text, keep managed generated-media reply paths working, and require detected PDF or Office file content before host-local document sends are accepted.
 - Memory/dreaming: strip managed Light Sleep and REM blocks before daily-note ingestion so dreaming summaries stop re-ingesting their own staged output into new candidates. (#61720) Thanks @MonkeyLeeT.
 - Docs/i18n: relocalize final localized-page links after translation so generated locale pages stop keeping stale English-root links when targets appear later in the same run. (#61796) thanks @hxy91819.
 - Docs/i18n: remove the zh-CN homepage redirect override so Mintlify can resolve the localized Chinese homepage without self-redirecting `/zh-CN/index`.

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -84,6 +84,28 @@ describe("createReplyMediaPathNormalizer", () => {
     expect(saveMediaSource).not.toHaveBeenCalled();
   });
 
+  it("drops relative sandbox escapes when tools.fs.workspaceOnly is enabled", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: { tools: { fs: { workspaceOnly: true } } },
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["../sandboxes/session-1/screens/final.png"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
+    expect(saveMediaSource).not.toHaveBeenCalled();
+  });
+
   it("keeps managed generated media under the shared media root", async () => {
     vi.stubEnv("OPENCLAW_STATE_DIR", "/Users/peter/.openclaw");
     ensureSandboxWorkspaceForSession.mockResolvedValue({

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -18,6 +18,7 @@ describe("createReplyMediaPathNormalizer", () => {
   beforeEach(() => {
     ensureSandboxWorkspaceForSession.mockReset().mockResolvedValue(null);
     saveMediaSource.mockReset();
+    vi.unstubAllEnvs();
   });
 
   it("resolves workspace-relative media against the agent workspace", async () => {
@@ -61,7 +62,7 @@ describe("createReplyMediaPathNormalizer", () => {
     });
   });
 
-  it("keeps host-local media paths flexible when sandbox exists and workspaceOnly is off", async () => {
+  it("drops arbitrary host-local media paths when sandbox exists", async () => {
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
@@ -77,28 +78,54 @@ describe("createReplyMediaPathNormalizer", () => {
     });
 
     expect(result).toMatchObject({
-      mediaUrl: "/Users/peter/.openclaw/media/inbound/photo.png",
-      mediaUrls: ["/Users/peter/.openclaw/media/inbound/photo.png"],
+      mediaUrl: undefined,
+      mediaUrls: undefined,
     });
     expect(saveMediaSource).not.toHaveBeenCalled();
   });
 
-  it("keeps sandbox media strict when workspaceOnly is enabled", async () => {
+  it("keeps managed generated media under the shared media root", async () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/Users/peter/.openclaw");
     ensureSandboxWorkspaceForSession.mockResolvedValue({
       workspaceDir: "/tmp/sandboxes/session-1",
       containerWorkdir: "/workspace",
     });
     const normalize = createReplyMediaPathNormalizer({
-      cfg: { tools: { fs: { workspaceOnly: true } } },
+      cfg: {},
       sessionKey: "session-key",
       workspaceDir: "/tmp/agent-workspace",
     });
 
-    await expect(
-      normalize({
-        mediaUrls: ["/Users/peter/.openclaw/media/inbound/photo.png"],
-      }),
-    ).rejects.toThrow(/sandbox root|outside|escapes/i);
+    const result = await normalize({
+      mediaUrls: ["/Users/peter/.openclaw/media/tool-image-generation/generated.png"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: "/Users/peter/.openclaw/media/tool-image-generation/generated.png",
+      mediaUrls: ["/Users/peter/.openclaw/media/tool-image-generation/generated.png"],
+    });
+    expect(saveMediaSource).not.toHaveBeenCalled();
+  });
+
+  it("drops absolute file URLs outside managed reply media roots", async () => {
+    ensureSandboxWorkspaceForSession.mockResolvedValue({
+      workspaceDir: "/tmp/sandboxes/session-1",
+      containerWorkdir: "/workspace",
+    });
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["file:///Users/peter/.openclaw/media/inbound/photo.png"],
+    });
+
+    expect(result).toMatchObject({
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+    });
   });
 
   it("persists volatile agent-state media from the workspace into host outbound media", async () => {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -4,6 +4,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolvePathFromInput } from "../../agents/path-policy.js";
 import { assertMediaNotDataUrl, resolveSandboxedMediaSource } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
+import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { saveMediaSource } from "../../media/store.js";
@@ -73,6 +74,10 @@ export function createReplyMediaPathNormalizer(params: {
   const agentId = params.sessionKey
     ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
     : undefined;
+  const workspaceOnly = resolveEffectiveToolFsWorkspaceOnly({
+    cfg: params.cfg,
+    agentId,
+  });
   let sandboxRootPromise: Promise<string | undefined> | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
@@ -135,6 +140,9 @@ export function createReplyMediaPathNormalizer(params: {
         });
       } catch (err) {
         if (!isLikelyLocalMediaSource(media) || FILE_URL_RE.test(media)) {
+          throw err;
+        }
+        if (workspaceOnly) {
           throw err;
         }
         if (!path.isAbsolute(media)) {

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -4,10 +4,10 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolvePathFromInput } from "../../agents/path-policy.js";
 import { assertMediaNotDataUrl, resolveSandboxedMediaSource } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
-import { resolveEffectiveToolFsWorkspaceOnly } from "../../agents/tool-fs-policy.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose } from "../../globals.js";
 import { saveMediaSource } from "../../media/store.js";
+import { resolveConfigDir } from "../../utils.js";
 import type { ReplyPayload } from "../types.js";
 
 const HTTP_URL_RE = /^https?:\/\//i;
@@ -16,10 +16,35 @@ const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
 const HAS_FILE_EXT_RE = /\.\w{1,10}$/;
 const AGENT_STATE_MEDIA_DIRNAME = path.join(".openclaw", "media");
+const MANAGED_GLOBAL_MEDIA_SUBDIRS = new Set(["outbound"]);
 
 function isPathInside(root: string, candidate: string): boolean {
   const relative = path.relative(path.resolve(root), path.resolve(candidate));
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function isManagedGlobalReplyMediaPath(candidate: string): boolean {
+  const globalMediaRoot = path.join(resolveConfigDir(), "media");
+  const relative = path.relative(path.resolve(globalMediaRoot), path.resolve(candidate));
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return false;
+  }
+  const firstSegment = relative.split(path.sep)[0] ?? "";
+  return MANAGED_GLOBAL_MEDIA_SUBDIRS.has(firstSegment) || firstSegment.startsWith("tool-");
+}
+
+function isAllowedAbsoluteReplyMediaPath(params: {
+  candidate: string;
+  workspaceDir: string;
+  sandboxRoot?: string;
+}): boolean {
+  if (isManagedGlobalReplyMediaPath(params.candidate)) {
+    return true;
+  }
+  const volatileRoots = [params.workspaceDir, params.sandboxRoot]
+    .filter((root): root is string => Boolean(root))
+    .map((root) => path.join(path.resolve(root), AGENT_STATE_MEDIA_DIRNAME));
+  return volatileRoots.some((root) => isPathInside(root, params.candidate));
 }
 
 function isLikelyLocalMediaSource(media: string): boolean {
@@ -48,10 +73,6 @@ export function createReplyMediaPathNormalizer(params: {
   const agentId = params.sessionKey
     ? resolveSessionAgentId({ sessionKey: params.sessionKey, config: params.cfg })
     : undefined;
-  const workspaceOnly = resolveEffectiveToolFsWorkspaceOnly({
-    cfg: params.cfg,
-    agentId,
-  });
   let sandboxRootPromise: Promise<string | undefined> | undefined;
   const persistedMediaBySource = new Map<string, Promise<string>>();
 
@@ -113,22 +134,50 @@ export function createReplyMediaPathNormalizer(params: {
           sandboxRoot,
         });
       } catch (err) {
-        if (workspaceOnly || !isLikelyLocalMediaSource(media)) {
+        if (!isLikelyLocalMediaSource(media) || FILE_URL_RE.test(media)) {
           throw err;
         }
-        if (FILE_URL_RE.test(media)) {
+        if (!path.isAbsolute(media)) {
+          return resolvePathFromInput(media, params.workspaceDir);
+        }
+        if (
+          isAllowedAbsoluteReplyMediaPath({
+            candidate: media,
+            workspaceDir: params.workspaceDir,
+            sandboxRoot,
+          })
+        ) {
           return media;
         }
-        return resolvePathFromInput(media, params.workspaceDir);
+        throw new Error(
+          "Absolute host-local MEDIA paths are blocked in normal replies. Use a safe relative path or the message tool.",
+          { cause: err },
+        );
       }
     }
     if (!isLikelyLocalMediaSource(media)) {
       return media;
     }
     if (FILE_URL_RE.test(media)) {
+      throw new Error(
+        "Absolute host-local MEDIA file URLs are blocked in normal replies. Use a safe relative path or the message tool.",
+      );
+    }
+    if (!path.isAbsolute(media)) {
+      return resolvePathFromInput(media, params.workspaceDir);
+    }
+    if (
+      isAllowedAbsoluteReplyMediaPath({
+        candidate: media,
+        workspaceDir: params.workspaceDir,
+        sandboxRoot,
+      })
+    ) {
       return media;
     }
-    return resolvePathFromInput(media, params.workspaceDir);
+    throw new Error(
+      "Absolute host-local MEDIA paths are blocked in normal replies. Use a safe relative path or the message tool.",
+    );
   };
 
   return async (payload) => {
@@ -140,7 +189,13 @@ export function createReplyMediaPathNormalizer(params: {
     const normalizedMedia: string[] = [];
     const seen = new Set<string>();
     for (const media of mediaList) {
-      const normalized = await persistVolatileAgentMedia(await normalizeMediaSource(media));
+      let normalized: string;
+      try {
+        normalized = await persistVolatileAgentMedia(await normalizeMediaSource(media));
+      } catch (err) {
+        logVerbose(`dropping blocked reply media ${media}: ${String(err)}`);
+        continue;
+      }
       if (!normalized || seen.has(normalized)) {
         continue;
       }

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -16,15 +16,24 @@ const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
 
 let fixtureRoot = "";
+let fakePdfFile = "";
 let oversizedJpegFile = "";
+let realPdfFile = "";
 let tinyPngFile = "";
 
 beforeAll(async () => {
   ({ loadWebMedia } = await import("./web-media.js"));
   await mediaRootTracker.setup();
   fixtureRoot = await mediaRootTracker.make("case");
+  fakePdfFile = path.join(fixtureRoot, "fake.pdf");
+  realPdfFile = path.join(fixtureRoot, "real.pdf");
   tinyPngFile = path.join(fixtureRoot, "tiny.png");
   oversizedJpegFile = path.join(fixtureRoot, "oversized.jpg");
+  await fs.writeFile(fakePdfFile, "TOP_SECRET_TEXT", "utf8");
+  await fs.writeFile(
+    realPdfFile,
+    Buffer.from("%PDF-1.4\n1 0 obj\n<<>>\nendobj\ntrailer\n<<>>\n%%EOF"),
+  );
   await fs.writeFile(tinyPngFile, Buffer.from(TINY_PNG_BASE64, "base64"));
   await fs.writeFile(
     oversizedJpegFile,
@@ -173,6 +182,32 @@ describe("loadWebMedia", () => {
       });
       expect(result.kind).toBe("image");
       expect(result.buffer.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("host read capability", () => {
+    it("rejects document uploads that only match by file extension", async () => {
+      await expect(
+        loadWebMedia(fakePdfFile, {
+          maxBytes: 1024 * 1024,
+          localRoots: [fixtureRoot],
+          hostReadCapability: true,
+        }),
+      ).rejects.toMatchObject({
+        code: "path-not-allowed",
+      });
+    });
+
+    it("still allows real PDF uploads detected from file content", async () => {
+      const result = await loadWebMedia(realPdfFile, {
+        maxBytes: 1024 * 1024,
+        localRoots: [fixtureRoot],
+        hostReadCapability: true,
+      });
+
+      expect(result.kind).toBe("document");
+      expect(result.contentType).toBe("application/pdf");
+      expect(result.fileName).toBe("real.pdf");
     });
   });
 });

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -78,15 +78,6 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 ]);
-const HOST_READ_ALLOWED_DOCUMENT_EXTS = new Set([
-  ".doc",
-  ".docx",
-  ".pdf",
-  ".ppt",
-  ".pptx",
-  ".xls",
-  ".xlsx",
-]);
 const MB = 1024 * 1024;
 
 function formatMb(bytes: number, digits = 2): string {
@@ -124,18 +115,17 @@ function assertHostReadMediaAllowed(params: {
   mediaUrl: string;
   fileName?: string;
 }): void {
-  if (params.kind !== "document") {
+  if (params.kind === "image" || params.kind === "audio" || params.kind === "video") {
     return;
+  }
+  if (params.kind !== "document") {
+    throw new LocalMediaAccessError(
+      "path-not-allowed",
+      `Host-local media sends only allow images, audio, video, PDF, and Office documents (got ${params.contentType?.trim().toLowerCase() ?? "unknown"}).`,
+    );
   }
   const normalizedMime = params.contentType?.trim().toLowerCase();
   if (normalizedMime && HOST_READ_ALLOWED_DOCUMENT_MIMES.has(normalizedMime)) {
-    return;
-  }
-  const ext = path
-    .extname(params.fileName ?? params.mediaUrl)
-    .trim()
-    .toLowerCase();
-  if (ext && HOST_READ_ALLOWED_DOCUMENT_EXTS.has(ext)) {
     return;
   }
   throw new LocalMediaAccessError(
@@ -381,7 +371,9 @@ async function loadWebMediaInternal(
       throw err;
     }
   }
-  const mime = await detectMime({ buffer: data, filePath: mediaUrl });
+  const detectedMime = await detectMime({ buffer: data, filePath: mediaUrl });
+  const verifiedMime = hostReadCapability ? await detectMime({ buffer: data }) : detectedMime;
+  const mime = verifiedMime ?? detectedMime;
   const kind = kindFromMime(mime);
   let fileName = path.basename(mediaUrl) || undefined;
   if (fileName && !path.extname(fileName) && mime) {
@@ -392,8 +384,8 @@ async function loadWebMediaInternal(
   }
   if (hostReadCapability) {
     assertHostReadMediaAllowed({
-      contentType: mime,
-      kind,
+      contentType: verifiedMime,
+      kind: kindFromMime(detectedMime ?? verifiedMime),
       mediaUrl,
       fileName,
     });

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -112,8 +112,6 @@ function isHeicSource(opts: { contentType?: string; fileName?: string }): boolea
 function assertHostReadMediaAllowed(params: {
   contentType?: string;
   kind: MediaKind | undefined;
-  mediaUrl: string;
-  fileName?: string;
 }): void {
   if (params.kind === "image" || params.kind === "audio" || params.kind === "video") {
     return;
@@ -386,8 +384,6 @@ async function loadWebMediaInternal(
     assertHostReadMediaAllowed({
       contentType: verifiedMime,
       kind: kindFromMime(detectedMime ?? verifiedMime),
-      mediaUrl,
-      fileName,
     });
   }
   return await clampAndFinalize({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: normal reply text could still attach arbitrary host-local `MEDIA:` paths because the reply-media normalizer fell back to host path resolution when sandbox mapping failed.
- Why it matters: ordinary model-authored reply text is not supposed to act like a trusted host-file attachment surface, and document sends were still willing to trust filename-based MIME fallback.
- What changed: normal reply delivery now drops arbitrary absolute host-local reply media unless it is sandbox-resolved or already inside managed generated-media locations, and host-local document sends now require content-verified PDF or Office MIME detection.
- What did NOT change (scope boundary): this does not change structured message-tool sends, plugin-owned outbound flows, or remote `http(s)` media handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #345
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the normal reply-media path treated model-authored local `MEDIA:` entries too much like trusted outbound media inputs, so sandbox resolution failures could fall back to host path resolution, and the host-read document gate still trusted extension-derived MIME classification.
- Missing detection / guardrail: there was no reply-only boundary that distinguished managed/generated local media from arbitrary absolute host paths, and no regression that proved host-local document sends must be content-verified instead of filename-verified.
- Prior context (`git blame`, prior PR, issue, or refactor if known): not traced in detail for this patch.
- Why this regressed now: reply-media flexibility and host-read document allowlisting evolved independently, leaving the ordinary reply-text path more permissive than the intended prompt guidance.
- If unknown, what was ruled out: the issue is not in remote media fetch handling or structured message-tool attachment dispatch; it is in ordinary reply-text normalization plus host-read classification.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/reply-media-paths.test.ts` and `src/media/web-media.test.ts`
- Scenario the test should lock in: ordinary reply text drops arbitrary absolute host-local media while preserving managed generated-media paths, and host-local document sends reject fake `.pdf` files whose content does not verify as PDF or Office data.
- Why this is the smallest reliable guardrail: these two seams are the exact boundary crossings in the reply-text to outbound-media chain.
- Existing test that already covers this (if any): existing reply-media path tests already covered workspace-relative and sandbox-relative media resolution, and existing host-read tests already covered image vs plain-text attachment behavior.
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).
If none, write `None`.

- Normal assistant replies no longer attach arbitrary absolute host-local `MEDIA:` paths; managed generated-media reply paths still work.
- Host-local document sends now require content that actually verifies as PDF or Office data instead of only matching the filename extension.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: ordinary reply-text media access is narrowed so model-authored replies cannot reach arbitrary host-local absolute paths, and host-local document sends now require content-verified document MIME.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local worktree runtime
- Model/provider: N/A
- Integration/channel (if any): outbound media loader / auto-reply path
- Relevant config (redacted): default config plus sandbox-backed reply normalization in focused tests

### Steps

1. Normalize a reply payload that contains an arbitrary absolute host-local `MEDIA:` path.
2. Normalize a reply payload that contains a managed generated-media path under the OpenClaw media store.
3. Load a host-local fake `.pdf` through the host-read media path and compare it with a real PDF byte stream.

### Expected

- Arbitrary absolute host-local reply media is dropped.
- Managed generated-media reply paths are preserved.
- Fake `.pdf` files are rejected while real PDFs still load.

### Actual

- Focused tests now match those expectations.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: formatted the touched files; ran focused tests for reply-media normalization and host-read media loading; confirmed the original fake `.pdf` regression failed before the content-verification adjustment and passed after it.
- Edge cases checked: sandbox-relative media, managed generated-media paths under the shared media store, and absolute `file://` reply-media inputs.
- What you did **not** verify: full repo build and broader channel/plugin outbound send matrices were not run in-turn because `pnpm build` is a service-managed post-turn validation command for this workspace.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the reply-media normalizer and host-read document gate changes in `src/auto-reply/reply/reply-media-paths.ts` and `src/media/web-media.ts`.
- Files/config to restore: `src/auto-reply/reply/reply-media-paths.ts`, `src/media/web-media.ts`, and the matching focused tests if the behavior is intentionally reverted.
- Known bad symptoms reviewers should watch for: generated-media fallback replies unexpectedly dropping legitimate managed media, or real PDF/Office files being rejected on host-local sends.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some existing workflows may have been relying on absolute reply-text paths that point outside managed generated-media locations.
  - Mitigation: the patch still preserves sandbox-resolved paths, managed generated-media store paths, and volatile agent-state media that gets persisted before send.
- Risk: content-only MIME verification for host-local documents could reject uncommon document variants if they are not recognized by current MIME sniffing.
  - Mitigation: focused coverage now locks in real PDF acceptance, and the remaining risk is limited to host-local document sends under the host-read capability path.
