### PR TITLE
chore: bump bundled acpx to 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Anthropic: restore Claude CLI as the preferred local Anthropic path in onboarding, model-auth guidance, and doctor flows again, and keep the Docker Claude CLI live lane aligned with the restored guidance.
 - Plugins/webhooks: add a bundled webhook ingress plugin so external automation can create and drive bound TaskFlows through per-route shared-secret endpoints. (#61892) Thanks @mbelinky.
 - Tools/media: document per-provider music and video generation capabilities, and add shared live video-to-video sweep coverage for providers that support local reference clips.
+- ACP/ACPX plugin: bump the bundled `acpx` pin to `0.5.1` so plugin-local installs and strict version checks pick up the latest published runtime release. (#62148) Thanks @onutc.
 
 ### Fixes
 

--- a/extensions/acpx/package.json
+++ b/extensions/acpx/package.json
@@ -4,7 +4,7 @@
   "description": "OpenClaw ACP runtime backend",
   "type": "module",
   "dependencies": {
-    "acpx": "0.5.0"
+    "acpx": "0.5.1"
   },
   "openclaw": {
     "extensions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,8 +267,8 @@ importers:
   extensions/acpx:
     dependencies:
       acpx:
-        specifier: 0.5.0
-        version: 0.5.0
+        specifier: 0.5.1
+        version: 0.5.1
 
   extensions/alibaba: {}
 
@@ -3713,8 +3713,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acpx@0.5.0:
-    resolution: {integrity: sha512-Yx52SiywF+1rO2oc+n87pSyBc2YJ8nPnFRCLK8CW3V3s1ZQ7o3B84FZ343AUafGLtXUAKXN9lm8i3RsGiFxRrw==}
+  acpx@0.5.1:
+    resolution: {integrity: sha512-r2sWGsztSwsO8JGJAswltQkMnRkKNmTH9faxwRWS9Ad28y2jZcyt7jR7auyCk0zwvDr+Zm/H1byVkWFpJWqzQQ==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
@@ -10240,7 +10240,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  acpx@0.5.0:
+  acpx@0.5.1:
     dependencies:
       '@agentclientprotocol/sdk': 0.17.1(zod@4.3.6)
       commander: 14.0.3


### PR DESCRIPTION
## Summary

- Problem: the bundled ACPX extension in OpenClaw was still pinned to `acpx@0.5.0` after `acpx 0.5.1` shipped.
- Why it matters: plugin-local ACPX installs and version checks would stay on the older runtime instead of the latest published release.
- What changed: bumped `extensions/acpx/package.json` to `0.5.1` and refreshed the matching `pnpm-lock.yaml` entries.
- What did NOT change (scope boundary): no OpenClaw ACP runtime logic, config schema, or extension code paths changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

The bundled ACPX runtime plugin now installs and expects `acpx@0.5.1` by default.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): ACPX bundled extension
- Relevant config (redacted): default ACPX extension pin

### Steps

1. Update `extensions/acpx/package.json` from `acpx@0.5.0` to `acpx@0.5.1`.
2. Refresh the workspace lock with `pnpm install --lockfile-only --filter ./extensions/acpx`.
3. Run `pnpm test:extension acpx`.

### Expected

- The bundled ACPX extension and workspace lock both reference `acpx@0.5.1`.
- ACPX extension tests pass.

### Actual

- Matched expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ACPX pin updated, lockfile refreshed, `pnpm test:extension acpx` passed.
- Edge cases checked: confirmed diff is scoped to `extensions/acpx/package.json` and `pnpm-lock.yaml` only.
- What you did **not** verify: full repo `pnpm lint` / commit-hook gate is currently blocked by unrelated upstream failures on latest `main` in `extensions/xai/**` and `extensions/memory-core/**`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the repo-wide gate is currently unstable on latest `main` for files outside this PR.
  - Mitigation: scoped ACPX extension test passed, and this PR only changes the ACPX package pin plus matching lockfile entries.
