### PR TITLE
fix: the nostr plugin exposes gateway authenticated h (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Docs: https://docs.openclaw.ai
 - QQ Bot/media: route gateway-side attachment and fallback downloads through guarded QQ/Tencent HTTPS fetches so QQ media handling no longer follows arbitrary remote hosts.
 - Exec/runtime events: mark background `notifyOnExit` summaries and ACP parent-stream relays as untrusted system events so lower-trust runtime output no longer re-enters later turns as trusted `System:` text.
 - Hooks/wake: queue direct and mapped wake-hook payloads as untrusted system events so external wake content no longer enters the main session as trusted input. (#62003)
+- Channels/Nostr: require `operator.admin` before gateway-auth profile updates or auto-merge imports can persist profile changes to config.
 
 ## 2026.4.5
 

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-08615a28ed3deb20a96c9cd8fd7237a4cbb209ceec93dca03b543979304459e4  plugin-sdk-api-baseline.json
-683c1249dc15529d8e79bc75e9c00484551cb74126befee507fffcf786e01833  plugin-sdk-api-baseline.jsonl
+7fc0a894ee8814047061fa1a561d5ba69362938fbfa117e36b9231a940b2d700  plugin-sdk-api-baseline.json
+6acb0efea6ded2886c88a9dbf22ecad490b15c126d175c4d3ee9fd9ba032d05f  plugin-sdk-api-baseline.jsonl

--- a/extensions/nostr/CHANGELOG.md
+++ b/extensions/nostr/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Version alignment with core OpenClaw release numbers.
+- Require `operator.admin` before gateway-auth profile updates or auto-merge imports can persist profile changes to config.
 
 ## 2026.4.5
 

--- a/extensions/nostr/src/nostr-profile-http.test.ts
+++ b/extensions/nostr/src/nostr-profile-http.test.ts
@@ -5,6 +5,17 @@
 import { IncomingMessage, ServerResponse } from "node:http";
 import { Socket } from "node:net";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/gateway-runtime", () => ({
+  getPluginRuntimeGatewayRequestScope: vi.fn(() => ({
+    client: {
+      connect: {
+        scopes: ["operator.admin"],
+      },
+    },
+  })),
+}));
+
 import {
   clearNostrProfileRateLimitStateForTest,
   createNostrProfileHttpHandler,
@@ -25,6 +36,7 @@ vi.mock("./nostr-profile-import.js", () => ({
   mergeProfiles: vi.fn((local, imported) => ({ ...imported, ...local })),
 }));
 
+import { getPluginRuntimeGatewayRequestScope } from "openclaw/plugin-sdk/gateway-runtime";
 import { publishNostrProfile, getNostrProfileState } from "./channel.js";
 import { importProfileFromRelays } from "./nostr-profile-import.js";
 import { TEST_HEX_PUBLIC_KEY, TEST_SETUP_RELAY_URLS } from "./test-fixtures.js";
@@ -165,6 +177,17 @@ function mockSuccessfulProfileImport() {
   });
 }
 
+function mockGatewayScopes(scopes: string[]) {
+  vi.mocked(getPluginRuntimeGatewayRequestScope).mockReturnValue({
+    client: {
+      connect: {
+        scopes,
+      },
+    },
+    isWebchatConnect: () => false,
+  });
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -173,6 +196,7 @@ describe("nostr-profile-http", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearNostrProfileRateLimitStateForTest();
+    mockGatewayScopes(["operator.admin"]);
   });
 
   describe("route matching", () => {
@@ -291,6 +315,27 @@ describe("nostr-profile-http", () => {
 
       await run();
       expect(res._getStatusCode()).toBe(403);
+    });
+
+    it("rejects profile mutation without operator.admin scope", async () => {
+      mockGatewayScopes(["operator.write"]);
+      const { ctx, res, run } = createProfileHttpHarness(
+        "PUT",
+        "/api/channels/nostr/default/profile",
+        {
+          body: { name: "attacker" },
+        },
+      );
+
+      await run();
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(JSON.parse(res._getData())).toEqual({
+        ok: false,
+        error: "missing scope: operator.admin",
+      });
+      expect(ctx.updateConfigProfile).not.toHaveBeenCalled();
+      expect(publishNostrProfile).not.toHaveBeenCalled();
     });
 
     it("rejects cross-origin profile mutation attempts", async () => {
@@ -503,6 +548,44 @@ describe("nostr-profile-http", () => {
       const data = expectImportSuccessResponse(res);
       expect(data.saved).toBe(true);
       expect(ctx.updateConfigProfile).toHaveBeenCalled();
+    });
+
+    it("rejects auto-merge import without operator.admin scope", async () => {
+      mockGatewayScopes(["operator.write"]);
+      const { ctx, res, run } = createProfileHttpHarness(
+        "POST",
+        "/api/channels/nostr/default/profile/import",
+        {
+          body: { autoMerge: true },
+        },
+      );
+
+      await run();
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(JSON.parse(res._getData())).toEqual({
+        ok: false,
+        error: "missing scope: operator.admin",
+      });
+      expect(importProfileFromRelays).not.toHaveBeenCalled();
+      expect(ctx.updateConfigProfile).not.toHaveBeenCalled();
+    });
+
+    it("allows non-admin import previews when auto-merge is not requested", async () => {
+      mockGatewayScopes(["operator.write"]);
+      const { res, run } = createProfileHttpHarness(
+        "POST",
+        "/api/channels/nostr/default/profile/import",
+        {
+          body: {},
+        },
+      );
+
+      mockSuccessfulProfileImport();
+      await run();
+
+      const data = expectImportSuccessResponse(res);
+      expect(data.saved).toBe(false);
     });
 
     it("returns error when account not found", async () => {

--- a/extensions/nostr/src/nostr-profile-http.ts
+++ b/extensions/nostr/src/nostr-profile-http.ts
@@ -8,6 +8,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { getPluginRuntimeGatewayRequestScope } from "openclaw/plugin-sdk/gateway-runtime";
 import { z } from "openclaw/plugin-sdk/zod";
 import {
   createFixedWindowRateLimiter,
@@ -45,6 +46,7 @@ export interface NostrProfileHttpContext {
 const RATE_LIMIT_WINDOW_MS = 60_000; // 1 minute
 const RATE_LIMIT_MAX_REQUESTS = 5; // 5 requests per minute
 const RATE_LIMIT_MAX_TRACKED_KEYS = 2_048;
+const ADMIN_SCOPE = "operator.admin";
 const profileRateLimiter = createFixedWindowRateLimiter({
   windowMs: RATE_LIMIT_WINDOW_MS,
   maxRequests: RATE_LIMIT_MAX_REQUESTS,
@@ -315,6 +317,20 @@ function enforceLoopbackMutationGuards(
   return true;
 }
 
+function enforceAdminMutationScope(
+  ctx: NostrProfileHttpContext,
+  res: ServerResponse,
+  actionLabel: string,
+): boolean {
+  const scopes = getPluginRuntimeGatewayRequestScope()?.client?.connect?.scopes ?? [];
+  if (scopes.includes(ADMIN_SCOPE)) {
+    return true;
+  }
+  ctx.log?.warn?.(`Rejected ${actionLabel} without ${ADMIN_SCOPE} gateway scope`);
+  sendJson(res, 403, { ok: false, error: `missing scope: ${ADMIN_SCOPE}` });
+  return false;
+}
+
 // ============================================================================
 // HTTP Handler
 // ============================================================================
@@ -397,6 +413,9 @@ async function handleUpdateProfile(
   req: IncomingMessage,
   res: ServerResponse,
 ): Promise<true> {
+  if (!enforceAdminMutationScope(ctx, res, "profile update")) {
+    return true;
+  }
   if (!enforceLoopbackMutationGuards(ctx, req, res)) {
     return true;
   }
@@ -527,6 +546,10 @@ async function handleImportProfile(
     }
   } catch {
     // Ignore body parse errors - use defaults
+  }
+
+  if (autoMerge && !enforceAdminMutationScope(ctx, res, "profile import merge")) {
+    return true;
   }
 
   ctx.log?.info(`[${accountId}] Importing profile for ${pubkey.slice(0, 8)}...`);

--- a/src/plugin-sdk/gateway-runtime.ts
+++ b/src/plugin-sdk/gateway-runtime.ts
@@ -7,3 +7,7 @@ export {
   withOperatorApprovalsGatewayClient,
 } from "../gateway/operator-approvals-client.js";
 export type { EventFrame } from "../gateway/protocol/index.js";
+export {
+  getPluginRuntimeGatewayRequestScope,
+  type PluginRuntimeGatewayRequestScope,
+} from "../plugins/runtime/gateway-request-scope.js";


### PR DESCRIPTION
# PR Template

## Summary

- Problem: The nostr plugin exposes gateway-authenticated HTTP profile mutation routes that can persist profile changes to config without re-checking `operator.admin`.
- Why it matters: shared-secret bearer plugin routes still run with write-scoped runtime context, so config persistence needs its own admin gate on the Nostr mutation path.
- What changed: Nostr profile updates now require `operator.admin`, Nostr import only requires `operator.admin` when `autoMerge=true`, and the current plugin gateway request scope is exposed on the Plugin SDK gateway runtime surface so the handler can enforce that cleanly.
- What did NOT change (scope boundary): shared-secret plugin-route runtime scopes still normalize to `operator.write`, non-persisting Nostr import previews still work, and no other plugin route auth behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #347
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the Nostr HTTP mutation handler trusted gateway-auth plugin route access plus loopback/origin checks and then called `updateConfigProfile(...)`, which persists through `runtime.config.writeConfigFile(...)`, without checking that the current plugin gateway request scope includes `operator.admin`.
- Missing detection / guardrail: there was no route-local regression that covered write-scoped shared-secret bearer plugin routes reaching a config-persistence sink on the Nostr path.
- Prior context (`git blame`, prior PR, issue, or refactor if known): existing gateway tests already lock in that shared-secret bearer plugin routes normalize to `operator.write`; this change keeps that behavior and adds the missing Nostr-side persistence gate.
- Why this regressed now: the Nostr profile route was implemented as a gateway-auth plugin endpoint with local-input guards, but persistent config mutation remained an admin-class action elsewhere in the gateway model.
- If unknown, what was ruled out: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/nostr/src/nostr-profile-http.test.ts`
- Scenario the test should lock in: write-scoped callers cannot use `PUT /api/channels/nostr/:accountId/profile` or `POST /api/channels/nostr/:accountId/profile/import` with `autoMerge=true` to persist config, while non-persisting import preview still works without admin.
- Why this is the smallest reliable guardrail: it exercises the real Nostr HTTP handler at the persistence boundary while existing gateway coverage already proves the shared-secret plugin-route runtime scope remains write-scoped.
- Existing test that already covers this (if any): `src/gateway/server.plugin-http-auth.test.ts` covers the surrounding shared-secret bearer runtime-scope behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Gateway-auth Nostr profile updates now return `missing scope: operator.admin` unless the current plugin gateway request scope includes `operator.admin`.
- Gateway-auth Nostr profile imports only require admin when `autoMerge=true`; non-persisting import preview stays available.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: persistent Nostr profile writes are now reduced to `operator.admin` callers only; the risk is intentional tightening of an existing route, and the mitigation is a route-local admin check before either persistence path runs.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local worktree runtime
- Model/provider: N/A
- Integration/channel (if any): Nostr gateway-auth HTTP profile routes
- Relevant config (redacted): shared-secret gateway auth; focused Vitest runs with `OPENCLAW_LOCAL_CHECK=0`

### Steps

1. Call the Nostr profile HTTP handler with write-scoped gateway runtime context.
2. Attempt a profile update or import with `autoMerge=true`.
3. Verify the handler returns 403 with `missing scope: operator.admin`, then rerun with admin scope and verify the normal path still works.

### Expected

- Non-admin callers cannot persist Nostr profile config.
- Admin callers keep the existing persistence behavior.
- Import preview without `autoMerge=true` stays allowed.

### Actual

- The new focused regressions pass and the existing gateway runtime-scope regression still passes.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `OPENCLAW_LOCAL_CHECK=0 pnpm test extensions/nostr/src/nostr-profile-http.test.ts`; `OPENCLAW_LOCAL_CHECK=0 pnpm test src/gateway/server.plugin-http-auth.test.ts -t "keeps write runtime scopes for shared-secret bearer gateway-auth plugin routes"`; `OPENCLAW_LOCAL_CHECK=0 pnpm plugin-sdk:api:gen`
- Edge cases checked: non-admin update denied; non-admin auto-merge import denied; non-admin import preview still allowed; existing shared-secret plugin-route write-scope behavior unchanged.
- What you did **not** verify: full `pnpm build` was not run here because it is the service-managed post-turn validation command for this workspace.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the Nostr handler admin check and the Plugin SDK gateway-runtime export together.
- Files/config to restore: `extensions/nostr/src/nostr-profile-http.ts`, `extensions/nostr/src/nostr-profile-http.test.ts`, `src/plugin-sdk/gateway-runtime.ts`, `docs/.generated/plugin-sdk-api-baseline.sha256`, and the matching changelog entries.
- Known bad symptoms reviewers should watch for: Nostr profile update or auto-merge import calls returning `missing scope: operator.admin` for callers that were expected to have admin scope.

## Risks and Mitigations

- Risk: another plugin route could still treat config persistence as a write-scoped action if it omits its own admin gate.
  - Mitigation: this PR fixes the concrete Nostr path from the report and adds an explicit Plugin SDK seam plus regression coverage at that route boundary.
