### PR TITLE
fix: openclaw accepts remote media urls from normal q (#344)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - iOS: pin release versioning to an explicit CalVer in `apps/ios/version.json`, keep TestFlight iteration on the same short version until maintainers intentionally promote the next gateway version, and add the documented `pnpm ios:version:pin -- --from-gateway` workflow for release trains. (#63001) Thanks @ngutman.
+- Providers/Anthropic: restore Claude CLI as the preferred local Anthropic path in onboarding, model-auth guidance, and doctor flows again, and keep the Docker Claude CLI live lane aligned with the restored guidance.
 
 ### Fixes
 
@@ -22,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/NO_REPLY: strip glued leading `NO_REPLY` tokens before reply normalization and ACP-visible streaming so silent sentinel text no longer leaks into user-visible replies while preserving substantive `NO_REPLY ...` text. Thanks @frankekn.
 - Gateway/sessions: clear auto-fallback-pinned model overrides on `/reset` and `/new` while still preserving explicit user model selections, including legacy sessions created before override-source tracking existed. (#63155) Thanks @frankekn.
 - Codex CLI: pass OpenClaw's system prompt through Codex's `model_instructions_file` config override so fresh Codex CLI sessions receive the same prompt guidance as Claude CLI sessions.
+- QQBot/media: stop treating ordinary reply-text remote URLs as deliverable media unless they are approved QQ/Tencent HTTPS hosts, and route the remaining markdown probes plus fallback downloads through the guarded media fetch path.
 
 ## 2026.4.8
 

--- a/extensions/qqbot/src/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/outbound-deliver.test.ts
@@ -245,14 +245,12 @@ describe("qqbot outbound deliver", () => {
   });
 
   it("does not append a duplicate markdown image when approval normalizes the URL", async () => {
-    fileUtilsMocks.resolveApprovedQqbotRemoteMediaUrl.mockImplementation(async (url: string) =>
-      url === "https://media.qq.com" ? "https://media.qq.com/" : url,
-    );
+    fileUtilsMocks.resolveApprovedQqbotRemoteMediaUrl.mockResolvedValueOnce("https://qq.com/a.png");
     imageSizeMocks.getImageSize.mockResolvedValue({ width: 640, height: 480 });
 
     await sendPlainReply(
       {},
-      "hello ![x](https://media.qq.com)",
+      "hello ![x](https://qq.com:443/a.png)",
       buildEvent(),
       buildAccountContext(true),
       sendWithRetry,
@@ -261,12 +259,13 @@ describe("qqbot outbound deliver", () => {
     );
 
     expect(imageSizeMocks.getImageSize).toHaveBeenCalledTimes(1);
+    expect(imageSizeMocks.getImageSize).toHaveBeenCalledWith("https://qq.com/a.png");
     expect(apiMocks.sendC2CMessage).toHaveBeenCalledTimes(1);
     expect(apiMocks.sendC2CMessage).toHaveBeenCalledWith(
       "app-id",
       "token",
       "user-1",
-      "hello ![img](https://media.qq.com/)",
+      "hello ![img](https://qq.com/a.png)",
       "msg-1",
       undefined,
     );

--- a/extensions/qqbot/src/outbound-deliver.test.ts
+++ b/extensions/qqbot/src/outbound-deliver.test.ts
@@ -21,6 +21,16 @@ const runtimeMocks = vi.hoisted(() => ({
   chunkMarkdownText: vi.fn((text: string) => [text]),
 }));
 
+const imageSizeMocks = vi.hoisted(() => ({
+  getImageSize: vi.fn(),
+  formatQQBotMarkdownImage: vi.fn((url: string) => `![img](${url})`),
+  hasQQBotImageSize: vi.fn(() => false),
+}));
+
+const fileUtilsMocks = vi.hoisted(() => ({
+  resolveApprovedQqbotRemoteMediaUrl: vi.fn(async (url: string) => url),
+}));
+
 vi.mock("./api.js", () => ({
   sendC2CMessage: apiMocks.sendC2CMessage,
   sendDmMessage: apiMocks.sendDmMessage,
@@ -49,9 +59,14 @@ vi.mock("./runtime.js", () => ({
 }));
 
 vi.mock("./utils/image-size.js", () => ({
-  getImageSize: vi.fn(),
-  formatQQBotMarkdownImage: vi.fn((url: string) => `![img](${url})`),
-  hasQQBotImageSize: vi.fn(() => false),
+  getImageSize: imageSizeMocks.getImageSize,
+  formatQQBotMarkdownImage: imageSizeMocks.formatQQBotMarkdownImage,
+  hasQQBotImageSize: imageSizeMocks.hasQQBotImageSize,
+}));
+
+vi.mock("./utils/file-utils.js", () => ({
+  resolveApprovedQqbotRemoteMediaUrl: (...args: unknown[]) =>
+    fileUtilsMocks.resolveApprovedQqbotRemoteMediaUrl(...args),
 }));
 
 import {
@@ -95,6 +110,9 @@ describe("qqbot outbound deliver", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     runtimeMocks.chunkMarkdownText.mockImplementation((text: string) => [text]);
+    fileUtilsMocks.resolveApprovedQqbotRemoteMediaUrl.mockImplementation(
+      async (url: string) => url,
+    );
   });
 
   it("sends plain replies through the shared text chunk sender", async () => {
@@ -141,7 +159,7 @@ describe("qqbot outbound deliver", () => {
 
   it("routes media-tag text segments through the shared chunk sender", async () => {
     await parseAndSendMediaTags(
-      "before<qqimg>https://example.com/a.png</qqimg>after",
+      "before<qqimg>/tmp/a.png</qqimg>after",
       buildEvent(),
       buildAccountContext(false),
       sendWithRetry,
@@ -167,5 +185,90 @@ describe("qqbot outbound deliver", () => {
       undefined,
     );
     expect(outboundMocks.sendPhoto).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips remote media tags from reply text when the URL is not approved", async () => {
+    fileUtilsMocks.resolveApprovedQqbotRemoteMediaUrl.mockResolvedValueOnce(null);
+
+    await parseAndSendMediaTags(
+      "before<qqmedia>https://example.com/a.png</qqmedia>after",
+      buildEvent(),
+      buildAccountContext(false),
+      sendWithRetry,
+      consumeQuoteRef,
+    );
+
+    expect(apiMocks.sendC2CMessage).toHaveBeenNthCalledWith(
+      1,
+      "app-id",
+      "token",
+      "user-1",
+      "before",
+      "msg-1",
+      undefined,
+    );
+    expect(apiMocks.sendC2CMessage).toHaveBeenNthCalledWith(
+      2,
+      "app-id",
+      "token",
+      "user-1",
+      "after",
+      "msg-1",
+      undefined,
+    );
+    expect(outboundMocks.sendMedia).not.toHaveBeenCalled();
+  });
+
+  it("does not probe disallowed remote markdown image URLs from reply text", async () => {
+    fileUtilsMocks.resolveApprovedQqbotRemoteMediaUrl.mockResolvedValueOnce(null);
+    imageSizeMocks.getImageSize.mockResolvedValue({ width: 640, height: 480 });
+
+    await sendPlainReply(
+      {},
+      "hello ![x](https://example.com/a.png)",
+      buildEvent(),
+      buildAccountContext(true),
+      sendWithRetry,
+      consumeQuoteRef,
+      [],
+    );
+
+    expect(imageSizeMocks.getImageSize).not.toHaveBeenCalled();
+    expect(apiMocks.sendC2CMessage).toHaveBeenCalledWith(
+      "app-id",
+      "token",
+      "user-1",
+      "hello",
+      "msg-1",
+      undefined,
+    );
+  });
+
+  it("does not append a duplicate markdown image when approval normalizes the URL", async () => {
+    fileUtilsMocks.resolveApprovedQqbotRemoteMediaUrl.mockImplementation(async (url: string) =>
+      url === "https://media.qq.com" ? "https://media.qq.com/" : url,
+    );
+    imageSizeMocks.getImageSize.mockResolvedValue({ width: 640, height: 480 });
+
+    await sendPlainReply(
+      {},
+      "hello ![x](https://media.qq.com)",
+      buildEvent(),
+      buildAccountContext(true),
+      sendWithRetry,
+      consumeQuoteRef,
+      [],
+    );
+
+    expect(imageSizeMocks.getImageSize).toHaveBeenCalledTimes(1);
+    expect(apiMocks.sendC2CMessage).toHaveBeenCalledTimes(1);
+    expect(apiMocks.sendC2CMessage).toHaveBeenCalledWith(
+      "app-id",
+      "token",
+      "user-1",
+      "hello ![img](https://media.qq.com/)",
+      "msg-1",
+      undefined,
+    );
   });
 });

--- a/extensions/qqbot/src/outbound-deliver.ts
+++ b/extensions/qqbot/src/outbound-deliver.ts
@@ -29,6 +29,7 @@ import {
 import { getQQBotRuntime } from "./runtime.js";
 import { chunkText, TEXT_CHUNK_LIMIT } from "./text-utils.js";
 import type { ResolvedQQBotAccount } from "./types.js";
+import { resolveApprovedQqbotRemoteMediaUrl } from "./utils/file-utils.js";
 import { getImageSize, formatQQBotMarkdownImage, hasQQBotImageSize } from "./utils/image-size.js";
 import { normalizeMediaTags } from "./utils/media-tags.js";
 import { normalizePath, isLocalPath as isLocalFilePath } from "./utils/platform.js";
@@ -61,6 +62,25 @@ export type SendWithRetryFn = <T>(sendFn: (token: string) => Promise<T>) => Prom
 
 /** Consume a quote ref exactly once. */
 export type ConsumeQuoteRefFn = () => string | undefined;
+
+function formatLoggedUrl(url: string, maxLength = 80): string {
+  return url.length > maxLength ? `${url.slice(0, maxLength)}...` : url;
+}
+
+async function resolveApprovedReplyTextRemoteMediaUrl(params: {
+  url: string;
+  prefix: string;
+  log?: DeliverAccountContext["log"];
+}): Promise<string | null> {
+  const approvedUrl = await resolveApprovedQqbotRemoteMediaUrl(params.url);
+  if (approvedUrl) {
+    return approvedUrl;
+  }
+  params.log?.info(
+    `${params.prefix} Ignored remote reply-text media URL outside approved QQ/Tencent HTTPS hosts: ${formatLoggedUrl(params.url)}`,
+  );
+  return null;
+}
 
 function resolveQQBotMediaTargetContext(
   event: DeliverEventContext,
@@ -192,6 +212,20 @@ export async function parseAndSendMediaTags(
     let mediaPath = decodeMediaPath(normalizeOptionalString(match[2]) ?? "", log, prefix);
 
     if (mediaPath) {
+      const isRemoteUrl = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
+      if (isRemoteUrl) {
+        const approvedUrl = await resolveApprovedReplyTextRemoteMediaUrl({
+          url: mediaPath,
+          prefix,
+          log,
+        });
+        if (!approvedUrl) {
+          lastIndex = match.index + match[0].length;
+          continue;
+        }
+        mediaPath = approvedUrl;
+      }
+
       const typeMap: Record<string, QueueItem["type"]> = {
         qqmedia: "media",
         qqvoice: "voice",
@@ -271,6 +305,23 @@ export interface PlainReplyPayload {
   mediaUrl?: string;
 }
 
+interface ApprovedMarkdownImageMatch {
+  originalMatch: RegExpMatchArray;
+  normalizedMatch: RegExpMatchArray;
+}
+
+function normalizeMarkdownMatchUrl(
+  match: RegExpMatchArray,
+  normalizedUrl: string,
+): RegExpMatchArray {
+  const normalizedMatch = [...match] as RegExpMatchArray;
+  normalizedMatch.index = match.index;
+  normalizedMatch.input = match.input;
+  normalizedMatch.groups = match.groups;
+  normalizedMatch[2] = normalizedUrl;
+  return normalizedMatch;
+}
+
 /**
  * Send a reply that does not contain structured media tags.
  * Handles markdown image embeds, Base64 media, plain-text chunking, and local media routing.
@@ -300,7 +351,7 @@ export async function sendPlainReply(
       if (!collectedImageUrls.includes(url)) {
         collectedImageUrls.push(url);
         log?.info(
-          `${prefix} Collected ${isDataUrl ? "Base64" : "media URL"}: ${isDataUrl ? `(length: ${url.length})` : url.slice(0, 80) + "..."}`,
+          `${prefix} Collected ${isDataUrl ? "Base64" : "media URL"}: ${isDataUrl ? `(length: ${url.length})` : formatLoggedUrl(url)}`,
         );
       }
       return true;
@@ -327,17 +378,32 @@ export async function sendPlainReply(
   // Extract markdown images.
   const mdImageRegex = /!\[([^\]]*)\]\(([^)]+)\)/gi;
   const mdMatches = [...replyText.matchAll(mdImageRegex)];
+  const approvedMdMatches: ApprovedMarkdownImageMatch[] = [];
   for (const m of mdMatches) {
     const url = m[2]?.trim();
-    if (url && !collectedImageUrls.includes(url)) {
-      if (url.startsWith("http://") || url.startsWith("https://")) {
-        collectedImageUrls.push(url);
-        log?.info(`${prefix} Extracted HTTP image from markdown: ${url.slice(0, 80)}...`);
-      } else if (isLocalFilePath(url)) {
-        if (!localMediaToSend.includes(url)) {
-          localMediaToSend.push(url);
-          log?.info(`${prefix} Collected local media from markdown for auto-routing: ${url}`);
-        }
+    if (!url) {
+      continue;
+    }
+    if (url.startsWith("http://") || url.startsWith("https://")) {
+      const approvedUrl = await resolveApprovedReplyTextRemoteMediaUrl({ url, prefix, log });
+      if (!approvedUrl) {
+        continue;
+      }
+      approvedMdMatches.push({
+        originalMatch: m,
+        normalizedMatch: normalizeMarkdownMatchUrl(m, approvedUrl),
+      });
+      if (!collectedImageUrls.includes(approvedUrl)) {
+        collectedImageUrls.push(approvedUrl);
+        log?.info(
+          `${prefix} Extracted approved HTTP image from markdown: ${formatLoggedUrl(approvedUrl)}`,
+        );
+      }
+    } else if (isLocalFilePath(url)) {
+      approvedMdMatches.push({ originalMatch: m, normalizedMatch: m });
+      if (!localMediaToSend.includes(url)) {
+        localMediaToSend.push(url);
+        log?.info(`${prefix} Collected local media from markdown for auto-routing: ${url}`);
       }
     }
   }
@@ -346,11 +412,20 @@ export async function sendPlainReply(
   const bareUrlRegex =
     /(?<![(["'])(https?:\/\/[^\s)"'<>]+\.(?:png|jpg|jpeg|gif|webp)(?:\?[^\s"'<>]*)?)/gi;
   const bareUrlMatches = [...replyText.matchAll(bareUrlRegex)];
+  const approvedBareUrlMatches: RegExpMatchArray[] = [];
   for (const m of bareUrlMatches) {
     const url = m[1];
-    if (url && !collectedImageUrls.includes(url)) {
-      collectedImageUrls.push(url);
-      log?.info(`${prefix} Extracted bare image URL: ${url.slice(0, 80)}...`);
+    if (!url) {
+      continue;
+    }
+    const approvedUrl = await resolveApprovedReplyTextRemoteMediaUrl({ url, prefix, log });
+    if (!approvedUrl) {
+      continue;
+    }
+    approvedBareUrlMatches.push(m);
+    if (!collectedImageUrls.includes(approvedUrl)) {
+      collectedImageUrls.push(approvedUrl);
+      log?.info(`${prefix} Extracted approved bare image URL: ${formatLoggedUrl(approvedUrl)}`);
     }
   }
 
@@ -361,9 +436,16 @@ export async function sendPlainReply(
 
   // Strip markdown image tags that are neither HTTP URLs nor collected local paths
   // to prevent leaking unresolvable paths (e.g. relative paths) to the user.
+  const approvedMarkdownImageUrls = new Set(
+    approvedMdMatches
+      .map((match) => match.originalMatch[2]?.trim())
+      .filter((url): url is string => Boolean(url)),
+  );
   for (const m of mdMatches) {
     const url = m[2]?.trim();
-    if (url && !url.startsWith("http://") && !url.startsWith("https://") && !isLocalFilePath(url)) {
+    const keepMarkdownImage =
+      Boolean(url) && (approvedMarkdownImageUrls.has(url) || (url ? isLocalFilePath(url) : false));
+    if (!keepMarkdownImage) {
       textWithoutImages = textWithoutImages.replace(m[0], "").trim();
     }
   }
@@ -372,8 +454,8 @@ export async function sendPlainReply(
     await sendMarkdownReply(
       textWithoutImages,
       collectedImageUrls,
-      mdMatches,
-      bareUrlMatches,
+      approvedMdMatches,
+      approvedBareUrlMatches,
       event,
       actx,
       sendWithRetry,
@@ -383,8 +465,8 @@ export async function sendPlainReply(
     await sendPlainTextReply(
       textWithoutImages,
       collectedImageUrls,
-      mdMatches,
-      bareUrlMatches,
+      approvedMdMatches,
+      approvedBareUrlMatches,
       event,
       actx,
       sendWithRetry,
@@ -639,7 +721,7 @@ async function sendVoiceWithTimeout(
 async function sendMarkdownReply(
   textWithoutImages: string,
   imageUrls: string[],
-  mdMatches: RegExpMatchArray[],
+  mdMatches: ApprovedMarkdownImageMatch[],
   bareUrlMatches: RegExpMatchArray[],
   event: DeliverEventContext,
   actx: DeliverAccountContext,
@@ -701,7 +783,7 @@ async function sendMarkdownReply(
   }
 
   // Handle public image URLs.
-  const existingMdUrls = new Set(mdMatches.map((m) => m[2]));
+  const existingMdUrls = new Set(mdMatches.map((match) => match.normalizedMatch[2]));
   const imagesToAppend: string[] = [];
 
   for (const url of httpImageUrls) {
@@ -721,9 +803,12 @@ async function sendMarkdownReply(
 
   // Backfill dimensions for existing markdown images.
   let result = textWithoutImages;
-  for (const m of mdMatches) {
-    const fullMatch = m[0];
-    const imgUrl = m[2];
+  for (const { originalMatch, normalizedMatch } of mdMatches) {
+    const fullMatch = originalMatch[0];
+    const imgUrl = normalizedMatch[2];
+    if (!imgUrl) {
+      continue;
+    }
     const isHttpUrl = imgUrl.startsWith("http://") || imgUrl.startsWith("https://");
     if (isHttpUrl && !hasQQBotImageSize(fullMatch)) {
       try {
@@ -774,7 +859,7 @@ async function sendMarkdownReply(
 async function sendPlainTextReply(
   textWithoutImages: string,
   imageUrls: string[],
-  mdMatches: RegExpMatchArray[],
+  mdMatches: ApprovedMarkdownImageMatch[],
   bareUrlMatches: RegExpMatchArray[],
   event: DeliverEventContext,
   actx: DeliverAccountContext,
@@ -787,8 +872,8 @@ async function sendPlainTextReply(
   const imgMediaTarget = resolveQQBotMediaTargetContext(event, account, prefix);
 
   let result = textWithoutImages;
-  for (const m of mdMatches) {
-    result = result.replace(m[0], "").trim();
+  for (const { originalMatch } of mdMatches) {
+    result = result.replace(originalMatch[0], "").trim();
   }
   for (const m of bareUrlMatches) {
     result = result.replace(m[0], "").trim();

--- a/extensions/qqbot/src/outbound-deliver.ts
+++ b/extensions/qqbot/src/outbound-deliver.ts
@@ -443,8 +443,11 @@ export async function sendPlainReply(
   );
   for (const m of mdMatches) {
     const url = m[2]?.trim();
-    const keepMarkdownImage =
-      Boolean(url) && (approvedMarkdownImageUrls.has(url) || (url ? isLocalFilePath(url) : false));
+    if (!url) {
+      textWithoutImages = textWithoutImages.replace(m[0], "").trim();
+      continue;
+    }
+    const keepMarkdownImage = approvedMarkdownImageUrls.has(url) || isLocalFilePath(url);
     if (!keepMarkdownImage) {
       textWithoutImages = textWithoutImages.replace(m[0], "").trim();
     }

--- a/extensions/qqbot/src/outbound.ts
+++ b/extensions/qqbot/src/outbound.ts
@@ -35,6 +35,7 @@ import {
   fileExistsAsync,
   formatFileSize,
   readFileAsync,
+  resolveApprovedQqbotRemoteMediaUrl,
 } from "./utils/file-utils.js";
 import { normalizeMediaTags } from "./utils/media-tags.js";
 import { decodeCronPayload } from "./utils/payload.js";
@@ -273,6 +274,21 @@ function shouldDirectUploadUrl(account: ResolvedQQBotAccount): boolean {
   return account.config?.urlDirectUpload !== false;
 }
 
+async function resolveAllowedRemoteMediaUrl(params: {
+  mediaPath: string;
+  prefix: string;
+  caller: string;
+}): Promise<string | null> {
+  const approvedUrl = await resolveApprovedQqbotRemoteMediaUrl(params.mediaPath);
+  if (approvedUrl) {
+    return approvedUrl;
+  }
+  debugWarn(
+    `${params.prefix} ${params.caller}: rejected remote URL outside approved QQ/Tencent HTTPS media hosts: ${params.mediaPath.slice(0, 80)}`,
+  );
+  return null;
+}
+
 /**
  * Send a photo from a local file, public URL, or Base64 data URL.
  */
@@ -281,10 +297,22 @@ export async function sendPhoto(
   imagePath: string,
 ): Promise<OutboundResult> {
   const prefix = ctx.logPrefix ?? "[qqbot]";
-  const mediaPath = resolveQQBotLocalMediaPath(normalizePath(imagePath));
+  let mediaPath = resolveQQBotLocalMediaPath(normalizePath(imagePath));
   const isLocal = isLocalFilePath(mediaPath);
   const isHttp = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
   const isData = mediaPath.startsWith("data:");
+
+  if (isHttp) {
+    const approvedUrl = await resolveAllowedRemoteMediaUrl({
+      mediaPath,
+      prefix,
+      caller: "sendPhoto",
+    });
+    if (!approvedUrl) {
+      return { channel: "qqbot", error: "Remote media URL is not allowed for QQ Bot delivery" };
+    }
+    mediaPath = approvedUrl;
+  }
 
   // Force a local download before upload when direct URL upload is disabled.
   if (isHttp && !shouldDirectUploadUrl(ctx.account)) {
@@ -412,8 +440,20 @@ export async function sendVoice(
   transcodeEnabled: boolean = true,
 ): Promise<OutboundResult> {
   const prefix = ctx.logPrefix ?? "[qqbot]";
-  const mediaPath = resolveQQBotLocalMediaPath(normalizePath(voicePath));
+  let mediaPath = resolveQQBotLocalMediaPath(normalizePath(voicePath));
   const isHttp = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
+
+  if (isHttp) {
+    const approvedUrl = await resolveAllowedRemoteMediaUrl({
+      mediaPath,
+      prefix,
+      caller: "sendVoice",
+    });
+    if (!approvedUrl) {
+      return { channel: "qqbot", error: "Remote media URL is not allowed for QQ Bot delivery" };
+    }
+    mediaPath = approvedUrl;
+  }
 
   if (isHttp) {
     if (shouldDirectUploadUrl(ctx.account)) {
@@ -551,8 +591,20 @@ export async function sendVideoMsg(
   videoPath: string,
 ): Promise<OutboundResult> {
   const prefix = ctx.logPrefix ?? "[qqbot]";
-  const mediaPath = resolveQQBotLocalMediaPath(normalizePath(videoPath));
+  let mediaPath = resolveQQBotLocalMediaPath(normalizePath(videoPath));
   const isHttp = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
+
+  if (isHttp) {
+    const approvedUrl = await resolveAllowedRemoteMediaUrl({
+      mediaPath,
+      prefix,
+      caller: "sendVideoMsg",
+    });
+    if (!approvedUrl) {
+      return { channel: "qqbot", error: "Remote media URL is not allowed for QQ Bot delivery" };
+    }
+    mediaPath = approvedUrl;
+  }
 
   if (isHttp && !shouldDirectUploadUrl(ctx.account)) {
     debugLog(`${prefix} sendVideoMsg: urlDirectUpload=false, downloading URL first...`);
@@ -672,8 +724,21 @@ export async function sendDocument(
   filePath: string,
 ): Promise<OutboundResult> {
   const prefix = ctx.logPrefix ?? "[qqbot]";
-  const mediaPath = resolveQQBotLocalMediaPath(normalizePath(filePath));
+  let mediaPath = resolveQQBotLocalMediaPath(normalizePath(filePath));
   const isHttp = mediaPath.startsWith("http://") || mediaPath.startsWith("https://");
+
+  if (isHttp) {
+    const approvedUrl = await resolveAllowedRemoteMediaUrl({
+      mediaPath,
+      prefix,
+      caller: "sendDocument",
+    });
+    if (!approvedUrl) {
+      return { channel: "qqbot", error: "Remote media URL is not allowed for QQ Bot delivery" };
+    }
+    mediaPath = approvedUrl;
+  }
+
   const fileName = sanitizeFileName(path.basename(mediaPath));
 
   if (isHttp && !shouldDirectUploadUrl(ctx.account)) {

--- a/extensions/qqbot/src/utils/file-utils.test.ts
+++ b/extensions/qqbot/src/utils/file-utils.test.ts
@@ -7,17 +7,36 @@ const mediaRuntimeMocks = vi.hoisted(() => ({
   fetchRemoteMedia: vi.fn(),
 }));
 
+const ssrfRuntimeMocks = vi.hoisted(() => ({
+  resolvePinnedHostnameWithPolicy: vi.fn(),
+}));
+
 vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
   fetchRemoteMedia: (...args: unknown[]) => mediaRuntimeMocks.fetchRemoteMedia(...args),
 }));
 
-import { QQBOT_MEDIA_SSRF_POLICY, downloadFile } from "./file-utils.js";
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  resolvePinnedHostnameWithPolicy: (...args: unknown[]) =>
+    ssrfRuntimeMocks.resolvePinnedHostnameWithPolicy(...args),
+}));
+
+import {
+  QQBOT_MEDIA_SSRF_POLICY,
+  downloadFile,
+  resolveApprovedQqbotRemoteMediaUrl,
+} from "./file-utils.js";
 
 describe("qqbot file-utils downloadFile", () => {
   let tempDir: string;
 
   beforeEach(async () => {
     mediaRuntimeMocks.fetchRemoteMedia.mockReset();
+    ssrfRuntimeMocks.resolvePinnedHostnameWithPolicy.mockReset();
+    ssrfRuntimeMocks.resolvePinnedHostnameWithPolicy.mockResolvedValue({
+      hostname: "media.qq.com",
+      addresses: ["203.0.113.10"],
+      lookup: vi.fn(),
+    });
     tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "qqbot-file-utils-"));
   });
 
@@ -41,6 +60,9 @@ describe("qqbot file-utils downloadFile", () => {
     expect(savedPath).toBeTruthy();
     expect(savedPath).toMatch(/photo_\d+_[0-9a-f]{6}\.png$/);
     expect(await fs.promises.readFile(savedPath!, "utf8")).toBe("image-bytes");
+    expect(ssrfRuntimeMocks.resolvePinnedHostnameWithPolicy).toHaveBeenCalledWith("media.qq.com", {
+      policy: QQBOT_MEDIA_SSRF_POLICY,
+    });
     expect(mediaRuntimeMocks.fetchRemoteMedia).toHaveBeenCalledWith({
       url: "https://media.qq.com/assets/photo.png",
       filePathHint: "photo.png",
@@ -55,6 +77,31 @@ describe("qqbot file-utils downloadFile", () => {
   it("rejects non-HTTPS URLs before attempting a fetch", async () => {
     const savedPath = await downloadFile("http://media.qq.com/assets/photo.png", tempDir);
 
+    expect(savedPath).toBeNull();
+    expect(ssrfRuntimeMocks.resolvePinnedHostnameWithPolicy).not.toHaveBeenCalled();
+    expect(mediaRuntimeMocks.fetchRemoteMedia).not.toHaveBeenCalled();
+  });
+
+  it("returns an approved normalized URL only after SSRF policy validation", async () => {
+    const approvedUrl = await resolveApprovedQqbotRemoteMediaUrl(
+      "https://media.qq.com/assets/photo.png?x=1",
+    );
+
+    expect(approvedUrl).toBe("https://media.qq.com/assets/photo.png?x=1");
+    expect(ssrfRuntimeMocks.resolvePinnedHostnameWithPolicy).toHaveBeenCalledWith("media.qq.com", {
+      policy: QQBOT_MEDIA_SSRF_POLICY,
+    });
+  });
+
+  it("rejects URLs when hostname validation fails", async () => {
+    ssrfRuntimeMocks.resolvePinnedHostnameWithPolicy.mockRejectedValue(new Error("blocked"));
+
+    const approvedUrl = await resolveApprovedQqbotRemoteMediaUrl(
+      "https://example.com/assets/photo.png",
+    );
+    const savedPath = await downloadFile("https://example.com/assets/photo.png", tempDir);
+
+    expect(approvedUrl).toBeNull();
     expect(savedPath).toBeNull();
     expect(mediaRuntimeMocks.fetchRemoteMedia).not.toHaveBeenCalled();
   });

--- a/extensions/qqbot/src/utils/file-utils.ts
+++ b/extensions/qqbot/src/utils/file-utils.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { fetchRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
-import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+import { resolvePinnedHostnameWithPolicy, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -26,6 +26,28 @@ export const QQBOT_MEDIA_SSRF_POLICY: SsrFPolicy = {
   hostnameAllowlist: QQBOT_MEDIA_HOSTNAME_ALLOWLIST,
   allowRfc2544BenchmarkRange: true,
 };
+
+/** Normalize and validate a remote QQ Bot media URL against the shared HTTPS + SSRF policy. */
+export async function resolveApprovedQqbotRemoteMediaUrl(url: string): Promise<string | null> {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return null;
+  }
+  if (parsedUrl.protocol !== "https:") {
+    return null;
+  }
+
+  try {
+    await resolvePinnedHostnameWithPolicy(parsedUrl.hostname, {
+      policy: QQBOT_MEDIA_SSRF_POLICY,
+    });
+    return parsedUrl.toString();
+  } catch {
+    return null;
+  }
+}
 
 /** Result of local file-size validation. */
 export interface FileSizeCheckResult {
@@ -129,22 +151,18 @@ export async function downloadFile(
   originalFilename?: string,
 ): Promise<string | null> {
   try {
-    let parsedUrl: URL;
-    try {
-      parsedUrl = new URL(url);
-    } catch {
+    const approvedUrl = await resolveApprovedQqbotRemoteMediaUrl(url);
+    if (!approvedUrl) {
       return null;
     }
-    if (parsedUrl.protocol !== "https:") {
-      return null;
-    }
+    const parsedUrl = new URL(approvedUrl);
 
     if (!fs.existsSync(destDir)) {
       fs.mkdirSync(destDir, { recursive: true });
     }
 
     const fetched = await fetchRemoteMedia({
-      url: parsedUrl.toString(),
+      url: approvedUrl,
       filePathHint: originalFilename,
       ssrfPolicy: QQBOT_MEDIA_SSRF_POLICY,
     });

--- a/extensions/qqbot/src/utils/image-size.ts
+++ b/extensions/qqbot/src/utils/image-size.ts
@@ -5,7 +5,9 @@
  */
 
 import { Buffer } from "buffer";
+import { fetchRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import { debugLog } from "./debug-log.js";
+import { QQBOT_MEDIA_SSRF_POLICY, resolveApprovedQqbotRemoteMediaUrl } from "./file-utils.js";
 
 export interface ImageSize {
   width: number;
@@ -150,40 +152,42 @@ export async function getImageSizeFromUrl(
   url: string,
   timeoutMs = 5000,
 ): Promise<ImageSize | null> {
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const approvedUrl = await resolveApprovedQqbotRemoteMediaUrl(url);
+  if (!approvedUrl) {
+    debugLog(`[image-size] Rejected remote image URL: ${url.slice(0, 60)}...`);
+    return null;
+  }
 
-    // Request only the first 64 KB, which is enough for common headers.
-    const response = await fetch(url, {
-      signal: controller.signal,
-      headers: {
-        Range: "bytes=0-65535",
-        "User-Agent": "QQBot-Image-Size-Detector/1.0",
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const fetched = await fetchRemoteMedia({
+      url: approvedUrl,
+      maxBytes: 64 * 1024,
+      maxRedirects: 0,
+      ssrfPolicy: QQBOT_MEDIA_SSRF_POLICY,
+      requestInit: {
+        signal: controller.signal,
+        headers: {
+          Range: "bytes=0-65535",
+          "User-Agent": "QQBot-Image-Size-Detector/1.0",
+        },
       },
     });
 
-    clearTimeout(timeoutId);
-
-    if (!response.ok && response.status !== 206) {
-      debugLog(`[image-size] Failed to fetch ${url}: ${response.status}`);
-      return null;
-    }
-
-    const arrayBuffer = await response.arrayBuffer();
-    const buffer = Buffer.from(arrayBuffer);
-
-    const size = parseImageSize(buffer);
+    const size = parseImageSize(fetched.buffer);
     if (size) {
       debugLog(
-        `[image-size] Got size from URL: ${size.width}x${size.height} - ${url.slice(0, 60)}...`,
+        `[image-size] Got size from URL: ${size.width}x${size.height} - ${approvedUrl.slice(0, 60)}...`,
       );
     }
 
     return size;
   } catch (err) {
-    debugLog(`[image-size] Error fetching ${url.slice(0, 60)}...: ${String(err)}`);
+    debugLog(`[image-size] Error fetching ${approvedUrl.slice(0, 60)}...: ${String(err)}`);
     return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: ordinary QQBot reply text could turn arbitrary remote URLs into `<qqmedia>` sends or markdown image probes.
- Why it matters: those reply-text URLs were treated as deliverable media instead of untrusted text and could trigger outbound fetch behavior in two separate paths.
- What changed: reply-text remote media URLs are now ignored unless they pass the existing QQ/Tencent HTTPS policy, outbound remote media helpers validate that same policy before direct upload or fallback download, and markdown size probing now uses the guarded media runtime.
- What did NOT change (scope boundary): local file paths, Base64 media, and existing tool-collected/local media delivery behavior were not refactored.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #344
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the QQBot reply-text parser accepted remote URLs as media inputs, but the shared enforcement only existed on part of the later fallback-download path and not on the reply-text admission points or markdown image probe helper.
- Missing detection / guardrail: there was no single reply-text remote-media gate shared across `<qqmedia>` handling, markdown image collection, direct URL upload, and markdown size probing.
- Prior context (`git blame`, prior PR, issue, or refactor if known): unknown.
- Why this regressed now: this behavior appears to be legacy feature behavior rather than a recent refactor regression.
- If unknown, what was ruled out: ruled out a fix that only changed `downloadFile()`, because markdown image probing and direct URL upload would still accept the same reply-text URLs.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should have caught this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/qqbot/src/outbound-deliver.test.ts` and `extensions/qqbot/src/utils/file-utils.test.ts`
- Scenario the test should lock in: unapproved remote reply-text URLs are ignored in both `<qqmedia>` and markdown-image paths, while the shared QQBot media helper still validates approved HTTPS hosts before fetching.
- Why this is the smallest reliable guardrail: the vulnerable behavior crossed the reply-text parser and the remote-media helper seam, so coverage needs one test at each of those real boundaries.
- Existing test that already covers this (if any): `extensions/qqbot/src/utils/file-utils.test.ts` already covered guarded download behavior and was extended rather than replaced.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- QQBot no longer treats arbitrary remote URLs in ordinary reply text as deliverable media.
- Local file paths and Base64 image flows continue to work as before.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): Yes
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: markdown image probing now goes through the guarded media runtime and ordinary reply-text remote URLs must pass the existing QQ/Tencent HTTPS policy before any outbound media handling continues.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local worktree runtime
- Model/provider: N/A
- Integration/channel (if any): QQBot
- Relevant config (redacted): default QQBot markdown support

### Steps

1. Send a QQBot reply that includes `<qqmedia>https://example.com/a.png</qqmedia>` or `![x](https://example.com/a.png)`.
2. Deliver the reply through the QQBot outbound helpers.
3. Observe whether the remote URL is accepted as media or probed for dimensions.

### Expected

- Ordinary reply-text remote URLs outside the approved QQ/Tencent HTTPS set are ignored.

### Actual

- The focused tests now confirm those URLs are ignored and not probed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran focused QQBot delivery tests covering remote `<qqmedia>` reply text, remote markdown image reply text, local media-tag delivery, and guarded download helper validation.
- Edge cases checked: non-HTTPS URLs are rejected before fetch, hostname validation failures stop guarded downloads, and local/media Base64 flows remain untouched by the new reply-text filter.
- What you did **not** verify: full `pnpm build` was not run in-turn because it is configured as the service-managed post-turn validation command.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the QQBot reply-text remote-media gating and helper validation changes in this branch.
- Files/config to restore: `extensions/qqbot/src/outbound-deliver.ts`, `extensions/qqbot/src/outbound.ts`, `extensions/qqbot/src/utils/file-utils.ts`, `extensions/qqbot/src/utils/image-size.ts`
- Known bad symptoms reviewers should watch for: approved QQ/Tencent HTTPS media URLs unexpectedly ignored, or local QQBot media replies failing when no remote URL is involved.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some existing QQBot workflows may have relied on arbitrary third-party remote URLs in ordinary reply text.
  - Mitigation: the change is intentionally narrow to ordinary reply-text remote URLs; local paths, Base64 payloads, and approved QQ/Tencent HTTPS media URLs still continue through the same delivery helpers.
