### PR TITLE
fix: only drop streamed payloads, not all final payloads

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -187,27 +187,34 @@ describe("buildReplyPayloads media filter integration", () => {
     await expectSameTargetRepliesSuppressed({ provider: "lark", to: "ou_abc123" });
   });
 
-  it("drops all final payloads when block pipeline streamed successfully", async () => {
+  it("drops only streamed payloads when block pipeline streamed successfully", async () => {
+    const streamedText = "already streamed";
+    const newText = "response";
     const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
       didStream: () => true,
       isAborted: () => false,
-      hasSentPayload: () => false,
+      hasSentPayload: (payload) => payload.text === streamedText,
       enqueue: () => {},
       flush: async () => {},
       stop: () => {},
       hasBuffered: () => false,
     };
-    // shouldDropFinalPayloads short-circuits to [] when the pipeline streamed
-    // without aborting, so hasSentPayload is never reached.
+    // When the pipeline streamed successfully, only payloads that were
+    // actually sent via hasSentPayload are filtered out. New content
+    // generated after tool calls (never streamed) is preserved.
     const { replyPayloads } = await buildReplyPayloads({
       ...baseParams,
       blockStreamingEnabled: true,
       blockReplyPipeline: pipeline,
       replyToMode: "all",
-      payloads: [{ text: "response", replyToId: "post-123" }],
+      payloads: [
+        { text: streamedText, replyToId: "post-123" },
+        { text: newText, replyToId: "post-456" },
+      ],
     });
 
-    expect(replyPayloads).toHaveLength(0);
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0].text).toBe(newText);
   });
 
   it("drops all final payloads during silent turns, including media-only payloads", async () => {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -158,12 +158,6 @@ export async function buildReplyPayloads(params: {
   ).filter(isRenderablePayload);
   const silentFilteredPayloads = params.silentExpected ? [] : replyTaggedPayloads;
 
-  // Drop final payloads only when block streaming succeeded end-to-end.
-  // If streaming aborted (e.g., timeout), fall back to final payloads.
-  const shouldDropFinalPayloads =
-    params.blockStreamingEnabled &&
-    Boolean(params.blockReplyPipeline?.didStream()) &&
-    !params.blockReplyPipeline?.isAborted();
   const messagingToolSentTexts = params.messagingToolSentTexts ?? [];
   const messagingToolSentTargets = params.messagingToolSentTargets ?? [];
   const shouldCheckMessagingToolDedupe =
@@ -214,13 +208,14 @@ export async function buildReplyPayloads(params: {
       })
     : dedupedPayloads;
   // Filter out payloads already sent via pipeline or directly during tool flush.
-  const filteredPayloads = shouldDropFinalPayloads
-    ? []
-    : params.blockStreamingEnabled
-      ? mediaFilteredPayloads.filter(
-          (payload) => !params.blockReplyPipeline?.hasSentPayload(payload),
-        )
-      : params.directlySentBlockKeys?.size
+  // When block streaming is enabled, use hasSentPayload to deduplicate — only
+  // drop payloads that were actually streamed. New content generated after tool
+  // calls (never streamed) is preserved and delivered as a final payload.
+  const filteredPayloads = params.blockStreamingEnabled
+    ? mediaFilteredPayloads.filter(
+        (payload) => !params.blockReplyPipeline?.hasSentPayload(payload),
+      )
+    : params.directlySentBlockKeys?.size
         ? mediaFilteredPayloads.filter(
             (payload) => !params.directlySentBlockKeys!.has(createBlockReplyContentKey(payload)),
           )


### PR DESCRIPTION
## Problem

When block streaming is enabled (`blockStreamingDefault: "on"`), text generated by the agent **before** tool calls is correctly streamed to the user. However, text generated **after** tool calls (final payloads) is silently dropped and never delivered.

### Root cause

In `src/auto-reply/reply/agent-runner-payloads.ts`, when block streaming succeeds:

```typescript
const shouldDropFinalPayloads =
    blockStreamingEnabled &&
    Boolean(blockReplyPipeline?.didStream()) &&
    !blockReplyPipeline?.isAborted();

const filteredPayloads = shouldDropFinalPayloads
    ? []    // ← Drops ALL final payloads
    : ...
```

The `shouldDropFinalPayloads` flag was designed to prevent duplicate delivery — if text was already streamed via the pipeline, the final payload would be a duplicate. However, it drops **all** final payloads unconditionally, including new content generated after tool calls that was never streamed.

### Example flow

```
Agent generates: "Analyzing your business..."  → streamed via pipeline ✓
Agent calls: data_collection_tool              → executes
Agent calls: pdf_generation_tool               → executes
Agent generates: "Your score is 72/100..."     → final payload → DROPPED ✗
```

The "Analyzing..." text is correctly streamed. The pipeline marks `didStream() = true`. When the turn ends, the summary text ("Your score is 72/100...") is a new final payload that was never streamed — but it gets dropped because `shouldDropFinalPayloads` discards everything.

### Impact

This affects any channel with block streaming enabled where the agent generates text both before and after tool calls. Known affected:
- WhatsApp Business
- Feishu (#38258, #34093)
- Telegram usage footer (#17832)
- Any channel using `blockStreamingDefault: "on"` with tool-calling agents

The current workaround has been to disable block streaming per-channel (#38422), which forces all text to arrive together at the end of the turn — a degraded UX.

## Fix

Change the `shouldDropFinalPayloads` branch from unconditionally dropping all payloads to filtering via `hasSentPayload()`:

```typescript
const filteredPayloads = shouldDropFinalPayloads
    ? mediaFilteredPayloads.filter(
        (payload) => !params.blockReplyPipeline?.hasSentPayload(payload),
      )
    : ...
```

This preserves the deduplication behavior (payloads already streamed are still filtered out) while allowing new content generated after tool calls to be delivered normally.

## Related issues

- #34093 — Feishu channel silently drops replies when blockStreamingDefault is on (open)
- #38258 — Feishu: messages not delivered when blockStreamingDefault is 'on' (closed with workaround)
- #47335 — Reply generated but not delivered when compaction triggers session rollover (open)
- #17832 — Usage footer not sent to Telegram when blockStreaming is enabled (closed)

## Test plan

- [x] Tested with WhatsApp Business channel: agent generates "Analyzing..." (streamed immediately), calls 3 tools, then generates summary text (delivered as final payload)
- [x] Without fix: summary text is silently dropped
- [x] With fix: summary text is delivered correctly
- [x] Verified no duplicate messages — streamed text is still filtered by `hasSentPayload()`
- [x] Verified `hasSentPayload()` uses content-based matching via `createBlockReplyContentKey()`