### PR TITLE
feat: expose prompt-cache runtime context to context engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Memory/wiki: add an opt-in `context.includeCompiledDigestPrompt` flag so memory prompt supplements can append a compact compiled wiki snapshot for legacy prompt assembly and context engines that explicitly consume memory prompt sections. Thanks @vincentkoc.
 - Plugin SDK/context engines: pass `availableTools` and `citationsMode` into `assemble()`, and expose `buildMemorySystemPromptAddition(...)` so non-legacy context engines can adopt the active memory prompt path without reimplementing it. Thanks @vincentkoc.
 - Providers/inferrs: add string-content compatibility for stricter OpenAI-compatible chat backends, document `inferrs` setup with a full config example, and add troubleshooting guidance for local backends that pass direct probes but fail on full agent-runtime prompts.
+- Agents/context engine: expose prompt-cache runtime context to context engines and keep current-turn prompt-cache usage aligned with the active attempt instead of stale prior-turn assistant state. (#62179) Thanks @jalehman.
 
 ### Fixes
 

--- a/src/agents/pi-embedded-runner/cache-ttl.test.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.test.ts
@@ -25,7 +25,7 @@ vi.mock("../../plugins/provider-runtime.js", async () => {
   };
 });
 
-import { isCacheTtlEligibleProvider } from "./cache-ttl.js";
+import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-ttl.js";
 
 describe("isCacheTtlEligibleProvider", () => {
   it("allows anthropic", () => {
@@ -83,5 +83,60 @@ describe("isCacheTtlEligibleProvider", () => {
         "anthropic-messages",
       ),
     ).toBe(true);
+  });
+});
+
+describe("readLastCacheTtlTimestamp", () => {
+  it("returns the latest matching timestamp for the active provider/model", () => {
+    const sessionManager = {
+      getEntries: () => [
+        {
+          type: "custom",
+          customType: "openclaw.cache-ttl",
+          data: {
+            timestamp: 1_700_000_000_000,
+            provider: "anthropic",
+            modelId: "claude-sonnet-4-5",
+          },
+        },
+        {
+          type: "custom",
+          customType: "openclaw.cache-ttl",
+          data: {
+            timestamp: 1_700_000_001_000,
+            provider: "google",
+            modelId: "gemini-3.1-pro-preview",
+          },
+        },
+      ],
+    };
+
+    expect(
+      readLastCacheTtlTimestamp(sessionManager, {
+        provider: "Anthropic",
+        modelId: "Claude-Sonnet-4-5",
+      }),
+    ).toBe(1_700_000_000_000);
+  });
+
+  it("ignores unscoped cache-ttl entries when a context filter is requested", () => {
+    const sessionManager = {
+      getEntries: () => [
+        {
+          type: "custom",
+          customType: "openclaw.cache-ttl",
+          data: {
+            timestamp: 1_700_000_000_000,
+          },
+        },
+      ],
+    };
+
+    expect(
+      readLastCacheTtlTimestamp(sessionManager, {
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-5",
+      }),
+    ).toBeNull();
   });
 });

--- a/src/agents/pi-embedded-runner/cache-ttl.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.ts
@@ -12,6 +12,11 @@ export type CacheTtlEntryData = {
   modelId?: string;
 };
 
+type CacheTtlContext = {
+  provider?: string;
+  modelId?: string;
+};
+
 export function isCacheTtlEligibleProvider(
   provider: string,
   modelId: string,
@@ -39,7 +44,32 @@ export function isCacheTtlEligibleProvider(
   );
 }
 
-export function readLastCacheTtlTimestamp(sessionManager: unknown): number | null {
+function normalizeCacheTtlKey(value: string | undefined): string | undefined {
+  return value?.trim().toLowerCase();
+}
+
+function matchesCacheTtlContext(
+  data: Partial<CacheTtlEntryData> | undefined,
+  context: CacheTtlContext | undefined,
+): boolean {
+  if (!context) {
+    return true;
+  }
+  const expectedProvider = normalizeCacheTtlKey(context.provider);
+  if (expectedProvider && normalizeCacheTtlKey(data?.provider) !== expectedProvider) {
+    return false;
+  }
+  const expectedModelId = normalizeCacheTtlKey(context.modelId);
+  if (expectedModelId && normalizeCacheTtlKey(data?.modelId) !== expectedModelId) {
+    return false;
+  }
+  return true;
+}
+
+export function readLastCacheTtlTimestamp(
+  sessionManager: unknown,
+  context?: CacheTtlContext,
+): number | null {
   const sm = sessionManager as { getEntries?: () => CustomEntryLike[] };
   if (!sm?.getEntries) {
     return null;
@@ -53,6 +83,9 @@ export function readLastCacheTtlTimestamp(sessionManager: unknown): number | nul
         continue;
       }
       const data = entry?.data as Partial<CacheTtlEntryData> | undefined;
+      if (!matchesCacheTtlContext(data, context)) {
+        continue;
+      }
       const ts = typeof data?.timestamp === "number" ? data.timestamp : null;
       if (ts && Number.isFinite(ts)) {
         last = ts;

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -59,7 +59,10 @@ function buildContextPruningFactory(params: {
     contextWindowTokens: resolveContextWindowTokens(params),
     isToolPrunable: makeToolPrunablePredicate(settings.tools),
     dropThinkingBlocks: transcriptPolicy.dropThinkingBlocks,
-    lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager),
+    lastCacheTouchAt: readLastCacheTtlTimestamp(params.sessionManager, {
+      provider: params.provider,
+      modelId: params.modelId,
+    }),
   });
 
   return contextPruningExtension;

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -124,6 +124,58 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     );
   });
 
+  it("threads prompt-cache runtime context into overflow compaction", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: makeOverflowError(),
+          promptCache: {
+            retention: "short",
+            lastCallUsage: {
+              input: 150000,
+              cacheRead: 32000,
+              total: 182000,
+            },
+            observation: {
+              broke: false,
+              cacheRead: 32000,
+            },
+            lastCacheTouchAt: 1_700_000_000_000,
+          },
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted session",
+        tokensBefore: 150000,
+        tokensAfter: 80000,
+      }),
+    );
+
+    await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeContext: expect.objectContaining({
+          trigger: "overflow",
+          promptCache: expect.objectContaining({
+            retention: "short",
+            lastCallUsage: expect.objectContaining({
+              input: 150000,
+              cacheRead: 32000,
+            }),
+            observation: expect.objectContaining({
+              broke: false,
+              cacheRead: 32000,
+            }),
+            lastCacheTouchAt: 1_700_000_000_000,
+          }),
+        }),
+      }),
+    );
+  });
+
   it("passes observed overflow token counts into compaction when providers report them", async () => {
     const overflowError = new Error(
       '400 {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 277403 tokens > 200000 maximum"}}',

--- a/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
@@ -40,6 +40,19 @@ describe("timeout-triggered compaction", () => {
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         timedOut: true,
+        promptCache: {
+          retention: "short",
+          lastCallUsage: {
+            input: 150000,
+            cacheRead: 32000,
+            total: 182000,
+          },
+          observation: {
+            broke: false,
+            cacheRead: 32000,
+          },
+          lastCacheTouchAt: 1_700_000_000_000,
+        },
         lastAssistant: {
           usage: { input: 150000 },
         } as never,
@@ -67,6 +80,18 @@ describe("timeout-triggered compaction", () => {
         force: true,
         compactionTarget: "budget",
         runtimeContext: expect.objectContaining({
+          promptCache: expect.objectContaining({
+            retention: "short",
+            lastCallUsage: expect.objectContaining({
+              input: 150000,
+              cacheRead: 32000,
+            }),
+            observation: expect.objectContaining({
+              broke: false,
+              cacheRead: 32000,
+            }),
+            lastCacheTouchAt: 1_700_000_000_000,
+          }),
           trigger: "timeout_recovery",
           attempt: 1,
           maxAttempts: 2,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -803,6 +803,7 @@ export async function runEmbeddedPiAgent(
                     extraSystemPrompt: params.extraSystemPrompt,
                     ownerNumbers: params.ownerNumbers,
                   }),
+                  ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
                   runId: params.runId,
                   trigger: "timeout_recovery",
                   diagId: timeoutDiagId,
@@ -944,6 +945,7 @@ export async function runEmbeddedPiAgent(
                     extraSystemPrompt: params.extraSystemPrompt,
                     ownerNumbers: params.ownerNumbers,
                   }),
+                  ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
                   runId: params.runId,
                   trigger: "overflow",
                   ...(observedOverflowTokens !== undefined

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig } from "../../../config/config.js";
 import type {
+  ContextEnginePromptCacheInfo,
+  ContextEngineRuntimeContext,
+} from "../../../context-engine/types.js";
+import type {
   PluginHookAgentContext,
   PluginHookBeforeAgentStartResult,
   PluginHookBeforePromptBuildResult,
@@ -11,7 +15,6 @@ import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../mus
 import { prependSystemPromptAdditionAfterCacheBoundary } from "../../system-prompt-cache-boundary.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { buildActiveVideoGenerationTaskPromptContextForSession } from "../../video-generation-task-status.js";
-import type { CompactEmbeddedPiSessionParams } from "../compact.js";
 import { buildEmbeddedCompactionRuntimeContext } from "../compaction-runtime-context.js";
 import { log } from "../logger.js";
 import { shouldInjectHeartbeatPromptForTrigger } from "./trigger-policy.js";
@@ -179,28 +182,32 @@ export function buildAfterTurnRuntimeContext(params: {
   >;
   workspaceDir: string;
   agentDir: string;
-}): Partial<CompactEmbeddedPiSessionParams> {
-  return buildEmbeddedCompactionRuntimeContext({
-    sessionKey: params.attempt.sessionKey,
-    messageChannel: params.attempt.messageChannel,
-    messageProvider: params.attempt.messageProvider,
-    agentAccountId: params.attempt.agentAccountId,
-    currentChannelId: params.attempt.currentChannelId,
-    currentThreadTs: params.attempt.currentThreadTs,
-    currentMessageId: params.attempt.currentMessageId,
-    authProfileId: params.attempt.authProfileId,
-    workspaceDir: params.workspaceDir,
-    agentDir: params.agentDir,
-    config: params.attempt.config,
-    skillsSnapshot: params.attempt.skillsSnapshot,
-    senderIsOwner: params.attempt.senderIsOwner,
-    senderId: params.attempt.senderId,
-    provider: params.attempt.provider,
-    modelId: params.attempt.modelId,
-    thinkLevel: params.attempt.thinkLevel,
-    reasoningLevel: params.attempt.reasoningLevel,
-    bashElevated: params.attempt.bashElevated,
-    extraSystemPrompt: params.attempt.extraSystemPrompt,
-    ownerNumbers: params.attempt.ownerNumbers,
-  });
+  promptCache?: ContextEnginePromptCacheInfo;
+}): ContextEngineRuntimeContext {
+  return {
+    ...buildEmbeddedCompactionRuntimeContext({
+      sessionKey: params.attempt.sessionKey,
+      messageChannel: params.attempt.messageChannel,
+      messageProvider: params.attempt.messageProvider,
+      agentAccountId: params.attempt.agentAccountId,
+      currentChannelId: params.attempt.currentChannelId,
+      currentThreadTs: params.attempt.currentThreadTs,
+      currentMessageId: params.attempt.currentMessageId,
+      authProfileId: params.attempt.authProfileId,
+      workspaceDir: params.workspaceDir,
+      agentDir: params.agentDir,
+      config: params.attempt.config,
+      skillsSnapshot: params.attempt.skillsSnapshot,
+      senderIsOwner: params.attempt.senderIsOwner,
+      senderId: params.attempt.senderId,
+      provider: params.attempt.provider,
+      modelId: params.attempt.modelId,
+      thinkLevel: params.attempt.thinkLevel,
+      reasoningLevel: params.attempt.reasoningLevel,
+      bashElevated: params.attempt.bashElevated,
+      extraSystemPrompt: params.attempt.extraSystemPrompt,
+      ownerNumbers: params.attempt.ownerNumbers,
+    }),
+    ...(params.promptCache ? { promptCache: params.promptCache } : {}),
+  };
 }

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -12,7 +12,9 @@ import {
   runAttemptContextEngineBootstrap,
 } from "./attempt.context-engine-helpers.js";
 import {
+  cacheTtlEligibleModel,
   cleanupTempPaths,
+  createContextEngineAttemptRunner,
   createContextEngineBootstrapAndAssemble,
   expectCalledWithSessionKey,
   getHoisted,
@@ -28,6 +30,30 @@ const embeddedSessionId = "embedded-session";
 const sessionFile = "/tmp/session.jsonl";
 const seedMessage = { role: "user", content: "seed", timestamp: 1 } as AgentMessage;
 const doneMessage = { role: "assistant", content: "done", timestamp: 2 } as unknown as AgentMessage;
+
+function appendAssistantWithUsage(usage: {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+}) {
+  return async (
+    session: { messages: AgentMessage[] },
+    _prompt: string,
+    _options?: { images?: unknown[] },
+  ) => {
+    session.messages = [
+      ...session.messages,
+      {
+        role: "assistant",
+        content: "done",
+        timestamp: 2,
+        usage,
+      } as unknown as AgentMessage,
+    ];
+  };
+}
 
 function createTestContextEngine(params: Partial<AttemptContextEngine>): AttemptContextEngine {
   return {
@@ -117,6 +143,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
 
   afterEach(async () => {
     clearMemoryPluginState();
+    vi.restoreAllMocks();
     await cleanupTempPaths(tempPaths);
   });
 
@@ -303,6 +330,113 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
 
     expect(hoisted.runContextEngineMaintenanceMock).toHaveBeenCalledWith(
       expect.objectContaining({ reason: "bootstrap" }),
+    );
+  });
+
+  it("passes prompt-cache retention, last-call usage, and cache-touch metadata to afterTurn", async () => {
+    const afterTurn = vi.fn(async () => {});
+
+    await createContextEngineAttemptRunner({
+      contextEngine: {
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 1 }),
+        afterTurn,
+      },
+      attemptOverrides: {
+        config: {
+          agents: {
+            defaults: {
+              contextPruning: {
+                mode: "cache-ttl",
+              },
+            },
+          },
+        },
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-5",
+        model: cacheTtlEligibleModel,
+      },
+      sessionPrompt: appendAssistantWithUsage({
+        input: 10,
+        output: 5,
+        cacheRead: 40,
+        cacheWrite: 2,
+        total: 57,
+      }),
+      sessionKey,
+      tempPaths,
+    });
+
+    const afterTurnCall = afterTurn.mock.calls[0]?.[0] as
+      | { runtimeContext?: { promptCache?: Record<string, unknown> } }
+      | undefined;
+    const runtimeContext = afterTurnCall?.runtimeContext;
+
+    expect(runtimeContext?.promptCache).toEqual(
+      expect.objectContaining({
+        retention: "short",
+        lastCallUsage: {
+          input: 10,
+          output: 5,
+          cacheRead: 40,
+          cacheWrite: 2,
+          total: 57,
+        },
+        lastCacheTouchAt: expect.any(Number),
+      }),
+    );
+  });
+
+  it("omits prompt-cache metadata from afterTurn when no cache data is available", async () => {
+    const afterTurn = vi.fn(async () => {});
+
+    await createContextEngineAttemptRunner({
+      contextEngine: {
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 1 }),
+        afterTurn,
+      },
+      sessionKey,
+      tempPaths,
+    });
+
+    const afterTurnCall = afterTurn.mock.calls[0]?.[0] as
+      | { runtimeContext?: { promptCache?: unknown } }
+      | undefined;
+    const runtimeContext = afterTurnCall?.runtimeContext;
+
+    expect(runtimeContext?.promptCache).toBeUndefined();
+  });
+
+  it("threads prompt-cache break observations into afterTurn", async () => {
+    const afterTurn = vi.fn(async () => {});
+
+    await finalizeTurn(sessionKey, createTestContextEngine({ afterTurn }), {
+      runtimeContext: {
+        promptCache: {
+          observation: {
+            broke: true,
+            previousCacheRead: 5000,
+            cacheRead: 2000,
+            changes: [{ code: "systemPrompt", detail: "system prompt digest changed" }],
+          },
+        },
+      },
+    });
+
+    const afterTurnCall = afterTurn.mock.calls[0]?.[0] as
+      | { runtimeContext?: { promptCache?: Record<string, unknown> } }
+      | undefined;
+    const runtimeContext = afterTurnCall?.runtimeContext;
+    const observation = runtimeContext?.promptCache?.observation as
+      | { broke?: boolean; previousCacheRead?: number; cacheRead?: number; changes?: unknown[] }
+      | undefined;
+
+    expect(observation).toEqual(
+      expect.objectContaining({
+        broke: true,
+        previousCacheRead: 5000,
+        cacheRead: 2000,
+        changes: expect.arrayContaining([expect.objectContaining({ code: "systemPrompt" })]),
+      }),
     );
   });
 

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -18,6 +18,7 @@ import {
   createContextEngineBootstrapAndAssemble,
   expectCalledWithSessionKey,
   getHoisted,
+  type MutableSession,
   resetEmbeddedAttemptHarness,
 } from "./attempt.spawn-workspace.test-support.js";
 import {
@@ -30,6 +31,8 @@ const embeddedSessionId = "embedded-session";
 const sessionFile = "/tmp/session.jsonl";
 const seedMessage = { role: "user", content: "seed", timestamp: 1 } as AgentMessage;
 const doneMessage = { role: "assistant", content: "done", timestamp: 2 } as unknown as AgentMessage;
+type AfterTurnPromptCacheCall = { runtimeContext?: { promptCache?: Record<string, unknown> } };
+type AfterTurnUnknownPromptCacheCall = { runtimeContext?: { promptCache?: unknown } };
 
 function appendAssistantWithUsage(usage: {
   input?: number;
@@ -38,11 +41,7 @@ function appendAssistantWithUsage(usage: {
   cacheWrite?: number;
   total?: number;
 }) {
-  return async (
-    session: { messages: AgentMessage[] },
-    _prompt: string,
-    _options?: { images?: unknown[] },
-  ) => {
+  return async (session: MutableSession, _prompt: string, _options?: { images?: unknown[] }) => {
     session.messages = [
       ...session.messages,
       {
@@ -334,7 +333,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   });
 
   it("passes prompt-cache retention, last-call usage, and cache-touch metadata to afterTurn", async () => {
-    const afterTurn = vi.fn(async () => {});
+    const afterTurn = vi.fn(async (_params: AfterTurnPromptCacheCall) => {});
 
     await createContextEngineAttemptRunner({
       contextEngine: {
@@ -366,9 +365,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       tempPaths,
     });
 
-    const afterTurnCall = afterTurn.mock.calls[0]?.[0] as
-      | { runtimeContext?: { promptCache?: Record<string, unknown> } }
-      | undefined;
+    const afterTurnCall = afterTurn.mock.calls.at(0)?.[0];
     const runtimeContext = afterTurnCall?.runtimeContext;
 
     expect(runtimeContext?.promptCache).toEqual(
@@ -387,7 +384,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
   });
 
   it("omits prompt-cache metadata from afterTurn when no cache data is available", async () => {
-    const afterTurn = vi.fn(async () => {});
+    const afterTurn = vi.fn(async (_params: AfterTurnUnknownPromptCacheCall) => {});
 
     await createContextEngineAttemptRunner({
       contextEngine: {
@@ -398,16 +395,67 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       tempPaths,
     });
 
-    const afterTurnCall = afterTurn.mock.calls[0]?.[0] as
-      | { runtimeContext?: { promptCache?: unknown } }
-      | undefined;
+    const afterTurnCall = afterTurn.mock.calls.at(0)?.[0];
     const runtimeContext = afterTurnCall?.runtimeContext;
 
     expect(runtimeContext?.promptCache).toBeUndefined();
   });
 
+  it("does not reuse a prior turn's usage when the current attempt exits before a new assistant", async () => {
+    const afterTurn = vi.fn(async (_params: AfterTurnPromptCacheCall) => {});
+
+    await createContextEngineAttemptRunner({
+      contextEngine: {
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 1 }),
+        afterTurn,
+      },
+      attemptOverrides: {
+        config: {
+          agents: {
+            defaults: {
+              contextPruning: {
+                mode: "cache-ttl",
+              },
+            },
+          },
+        },
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-5",
+        model: cacheTtlEligibleModel,
+        contextTokenBudget: 1,
+        prompt: "force-preflight-overflow",
+      },
+      sessionMessages: [
+        seedMessage,
+        {
+          role: "assistant",
+          content: "prior turn",
+          timestamp: 2,
+          usage: {
+            input: 99,
+            output: 7,
+            cacheRead: 1234,
+            total: 1340,
+          },
+        } as unknown as AgentMessage,
+      ],
+      sessionKey,
+      tempPaths,
+    });
+
+    const afterTurnCall = afterTurn.mock.calls.at(0)?.[0];
+    const promptCache = afterTurnCall?.runtimeContext?.promptCache;
+
+    expect(promptCache).toEqual(
+      expect.objectContaining({
+        retention: "short",
+      }),
+    );
+    expect(promptCache?.lastCallUsage).toBeUndefined();
+  });
+
   it("threads prompt-cache break observations into afterTurn", async () => {
-    const afterTurn = vi.fn(async () => {});
+    const afterTurn = vi.fn(async (_params: AfterTurnPromptCacheCall) => {});
 
     await finalizeTurn(sessionKey, createTestContextEngine({ afterTurn }), {
       runtimeContext: {
@@ -422,9 +470,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       },
     });
 
-    const afterTurnCall = afterTurn.mock.calls[0]?.[0] as
-      | { runtimeContext?: { promptCache?: Record<string, unknown> } }
-      | undefined;
+    const afterTurnCall = afterTurn.mock.calls.at(0)?.[0];
     const runtimeContext = afterTurnCall?.runtimeContext;
     const observation = runtimeContext?.promptCache?.observation as
       | { broke?: boolean; previousCacheRead?: number; cacheRead?: number; changes?: unknown[] }

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -458,6 +458,20 @@ vi.mock("../cache-ttl.js", () => ({
     data: unknown,
   ) => sessionManager.appendCustomEntry?.("openclaw.cache-ttl", data),
   isCacheTtlEligibleProvider: (provider?: string) => provider === "anthropic",
+  readLastCacheTtlTimestamp: (sessionManager: {
+    appendCustomEntry?: { mock?: { calls?: unknown[][] } };
+  }) => {
+    const calls = sessionManager.appendCustomEntry?.mock?.calls ?? [];
+    for (let index = calls.length - 1; index >= 0; index -= 1) {
+      const [customType, data] = calls[index] ?? [];
+      if (customType !== "openclaw.cache-ttl") {
+        continue;
+      }
+      const timestamp = (data as { timestamp?: unknown } | undefined)?.timestamp;
+      return typeof timestamp === "number" ? timestamp : null;
+    }
+    return null;
+  },
 }));
 
 vi.mock("../compaction-runtime-context.js", () => ({
@@ -590,6 +604,12 @@ export function createSubscriptionMock(): SubscriptionMock {
     isCompactionInFlight: () => false,
   };
 }
+
+type SessionPromptOverride = (
+  session: MutableSession,
+  prompt: string,
+  options?: { images?: unknown[] },
+) => Promise<void>;
 
 let runEmbeddedAttemptPromise:
   | Promise<typeof import("./attempt.js").runEmbeddedAttempt>
@@ -799,6 +819,7 @@ export async function createContextEngineAttemptRunner(params: {
   };
   attemptOverrides?: Partial<Parameters<Awaited<ReturnType<typeof loadRunEmbeddedAttempt>>>[0]>;
   sessionMessages?: AgentMessage[];
+  sessionPrompt?: SessionPromptOverride;
   sessionKey: string;
   tempPaths: string[];
 }) {
@@ -830,7 +851,10 @@ export async function createContextEngineAttemptRunner(params: {
     .mockReturnValue({ messages: seedMessages });
 
   hoisted.createAgentSessionMock.mockImplementation(async () => ({
-    session: createDefaultEmbeddedSession({ initialMessages: seedMessages }),
+    session: createDefaultEmbeddedSession({
+      initialMessages: seedMessages,
+      prompt: params.sessionPrompt,
+    }),
   }));
 
   return await (

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -458,16 +458,32 @@ vi.mock("../cache-ttl.js", () => ({
     data: unknown,
   ) => sessionManager.appendCustomEntry?.("openclaw.cache-ttl", data),
   isCacheTtlEligibleProvider: (provider?: string) => provider === "anthropic",
-  readLastCacheTtlTimestamp: (sessionManager: {
-    appendCustomEntry?: { mock?: { calls?: unknown[][] } };
-  }) => {
+  readLastCacheTtlTimestamp: (
+    sessionManager: {
+      appendCustomEntry?: { mock?: { calls?: unknown[][] } };
+    },
+    context?: { provider?: string; modelId?: string },
+  ) => {
     const calls = sessionManager.appendCustomEntry?.mock?.calls ?? [];
     for (let index = calls.length - 1; index >= 0; index -= 1) {
       const [customType, data] = calls[index] ?? [];
       if (customType !== "openclaw.cache-ttl") {
         continue;
       }
-      const timestamp = (data as { timestamp?: unknown } | undefined)?.timestamp;
+      const entry = data as
+        | {
+            timestamp?: unknown;
+            provider?: string;
+            modelId?: string;
+          }
+        | undefined;
+      if (context?.provider && entry?.provider?.toLowerCase() !== context.provider.toLowerCase()) {
+        continue;
+      }
+      if (context?.modelId && entry?.modelId?.toLowerCase() !== context.modelId.toLowerCase()) {
+        continue;
+      }
+      const timestamp = entry?.timestamp;
       return typeof timestamp === "number" ? timestamp : null;
     }
     return null;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -289,6 +289,16 @@ function buildContextEnginePromptCacheInfo(params: {
   }
   return Object.keys(promptCache).length > 0 ? promptCache : undefined;
 }
+
+function findCurrentAttemptAssistantMessage(params: {
+  messagesSnapshot: AgentMessage[];
+  prePromptMessageCount: number;
+}): AgentMessage | undefined {
+  return params.messagesSnapshot
+    .slice(Math.max(0, params.prePromptMessageCount))
+    .toReversed()
+    .find((message) => message.role === "assistant");
+}
 export {
   decodeHtmlEntitiesInObject,
   wrapStreamFnRepairMalformedToolCallArguments,
@@ -2058,6 +2068,10 @@ export async function runEmbeddedAttempt(
           .slice()
           .toReversed()
           .find((m) => m.role === "assistant");
+        const currentAttemptAssistant = findCurrentAttemptAssistantMessage({
+          messagesSnapshot,
+          prePromptMessageCount,
+        });
         attemptUsage = getUsageTotals();
         cacheBreak = cacheObservabilityEnabled
           ? completePromptCacheObservation({
@@ -2066,9 +2080,9 @@ export async function runEmbeddedAttempt(
               usage: attemptUsage,
             })
           : null;
-        const lastCallUsage = normalizeUsage(
-          (lastAssistant as { usage?: UsageLike } | undefined)?.usage,
-        );
+        const lastCallUsage =
+          normalizeUsage((currentAttemptAssistant as { usage?: UsageLike } | undefined)?.usage) ??
+          normalizeUsage(attemptUsage);
         const promptCacheObservation =
           cacheObservabilityEnabled &&
           (cacheBreak || promptCacheChangesForTurn || typeof attemptUsage?.cacheRead === "number")

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2080,9 +2080,9 @@ export async function runEmbeddedAttempt(
               usage: attemptUsage,
             })
           : null;
-        const lastCallUsage =
-          normalizeUsage((currentAttemptAssistant as { usage?: UsageLike } | undefined)?.usage) ??
-          normalizeUsage(attemptUsage);
+        const lastCallUsage = normalizeUsage(
+          (currentAttemptAssistant as { usage?: UsageLike } | undefined)?.usage,
+        );
         const promptCacheObservation =
           cacheObservabilityEnabled &&
           (cacheBreak || promptCacheChangesForTurn || typeof attemptUsage?.cacheRead === "number")
@@ -2103,7 +2103,10 @@ export async function runEmbeddedAttempt(
           retention: effectivePromptCacheRetention,
           lastCallUsage,
           observation: promptCacheObservation,
-          lastCacheTouchAt: readLastCacheTtlTimestamp(sessionManager),
+          lastCacheTouchAt: readLastCacheTtlTimestamp(sessionManager, {
+            provider: params.provider,
+            modelId: params.modelId,
+          }),
         });
 
         if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -104,9 +104,10 @@ import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
 import { resolveTranscriptPolicy } from "../../transcript-policy.js";
+import { normalizeUsage, type NormalizedUsage, type UsageLike } from "../../usage.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../../workspace.js";
 import { isRunnerAbortError } from "../abort.js";
-import { isCacheTtlEligibleProvider } from "../cache-ttl.js";
+import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
 import { buildEmbeddedExtensionFactories } from "../extensions.js";
@@ -243,6 +244,51 @@ export {
   shouldInjectOllamaCompatNumCtx,
   wrapOllamaCompatNumCtx,
 } from "../../../plugin-sdk/ollama-runtime.js";
+
+function buildContextEnginePromptCacheInfo(params: {
+  retention?: "none" | "short" | "long";
+  lastCallUsage?: NormalizedUsage;
+  observation?:
+    | {
+        broke: boolean;
+        previousCacheRead?: number;
+        cacheRead?: number;
+        changes?: PromptCacheChange[] | null;
+      }
+    | undefined;
+  lastCacheTouchAt?: number | null;
+}): EmbeddedRunAttemptResult["promptCache"] {
+  const promptCache: NonNullable<EmbeddedRunAttemptResult["promptCache"]> = {};
+  if (params.retention) {
+    promptCache.retention = params.retention;
+  }
+  if (params.lastCallUsage) {
+    promptCache.lastCallUsage = { ...params.lastCallUsage };
+  }
+  if (params.observation) {
+    promptCache.observation = {
+      broke: params.observation.broke,
+      ...(typeof params.observation.previousCacheRead === "number"
+        ? { previousCacheRead: params.observation.previousCacheRead }
+        : {}),
+      ...(typeof params.observation.cacheRead === "number"
+        ? { cacheRead: params.observation.cacheRead }
+        : {}),
+      ...(params.observation.changes && params.observation.changes.length > 0
+        ? {
+            changes: params.observation.changes.map((change) => ({
+              code: change.code,
+              detail: change.detail,
+            })),
+          }
+        : {}),
+    };
+  }
+  if (typeof params.lastCacheTouchAt === "number" && Number.isFinite(params.lastCacheTouchAt)) {
+    promptCache.lastCacheTouchAt = params.lastCacheTouchAt;
+  }
+  return Object.keys(promptCache).length > 0 ? promptCache : undefined;
+}
 export {
   decodeHtmlEntitiesInObject,
   wrapStreamFnRepairMalformedToolCallArguments,
@@ -1040,6 +1086,12 @@ export async function runEmbeddedAttempt(
         params.model,
         agentDir,
       );
+      const effectivePromptCacheRetention = resolveCacheRetention(
+        effectiveExtraParams,
+        params.provider,
+        params.model.api,
+        params.modelId,
+      );
       const agentTransportOverride = resolveAgentTransportOverride({
         settingsManager,
         effectiveExtraParams,
@@ -1451,6 +1503,10 @@ export async function runEmbeddedAttempt(
         },
         abort: abortRun,
       };
+      let lastAssistant: AgentMessage | undefined;
+      let attemptUsage: NormalizedUsage | undefined;
+      let cacheBreak: ReturnType<typeof completePromptCacheObservation> = null;
+      let promptCache: EmbeddedRunAttemptResult["promptCache"];
       if (params.replyOperation) {
         params.replyOperation.attachBackend(queueHandle);
       }
@@ -1622,12 +1678,7 @@ export async function runEmbeddedAttempt(
             provider: params.provider,
             modelId: params.modelId,
             modelApi: params.model.api,
-            cacheRetention: resolveCacheRetention(
-              effectiveExtraParams,
-              params.provider,
-              params.model.api,
-              params.modelId,
-            ),
+            cacheRetention: effectivePromptCacheRetention,
             streamStrategy,
             transport: effectiveAgentTransport,
             systemPrompt: systemPromptText,
@@ -2003,6 +2054,44 @@ export async function runEmbeddedAttempt(
         messagesSnapshot = snapshotSelection.messagesSnapshot;
         sessionIdUsed = snapshotSelection.sessionIdUsed;
 
+        lastAssistant = messagesSnapshot
+          .slice()
+          .toReversed()
+          .find((m) => m.role === "assistant");
+        attemptUsage = getUsageTotals();
+        cacheBreak = cacheObservabilityEnabled
+          ? completePromptCacheObservation({
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+              usage: attemptUsage,
+            })
+          : null;
+        const lastCallUsage = normalizeUsage(
+          (lastAssistant as { usage?: UsageLike } | undefined)?.usage,
+        );
+        const promptCacheObservation =
+          cacheObservabilityEnabled &&
+          (cacheBreak || promptCacheChangesForTurn || typeof attemptUsage?.cacheRead === "number")
+            ? {
+                broke: Boolean(cacheBreak),
+                ...(typeof cacheBreak?.previousCacheRead === "number"
+                  ? { previousCacheRead: cacheBreak.previousCacheRead }
+                  : {}),
+                ...(typeof cacheBreak?.cacheRead === "number"
+                  ? { cacheRead: cacheBreak.cacheRead }
+                  : typeof attemptUsage?.cacheRead === "number"
+                    ? { cacheRead: attemptUsage.cacheRead }
+                    : {}),
+                changes: cacheBreak?.changes ?? promptCacheChangesForTurn,
+              }
+            : undefined;
+        promptCache = buildContextEnginePromptCacheInfo({
+          retention: effectivePromptCacheRetention,
+          lastCallUsage,
+          observation: promptCacheObservation,
+          lastCacheTouchAt: readLastCacheTtlTimestamp(sessionManager),
+        });
+
         if (promptError && promptErrorSource === "prompt" && !compactionOccurredThisAttempt) {
           try {
             sessionManager.appendCustomEntry("openclaw:prompt-error", {
@@ -2025,6 +2114,7 @@ export async function runEmbeddedAttempt(
             attempt: params,
             workspaceDir: effectiveWorkspace,
             agentDir,
+            promptCache,
           });
           await finalizeAttemptContextEngineTurn({
             contextEngine: params.contextEngine,
@@ -2136,24 +2226,13 @@ export async function runEmbeddedAttempt(
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
 
-      const lastAssistant = messagesSnapshot
-        .slice()
-        .toReversed()
-        .find((m) => m.role === "assistant");
-
       const toolMetasNormalized = toolMetas
         .filter(
           (entry): entry is { toolName: string; meta?: string } =>
             typeof entry.toolName === "string" && entry.toolName.trim().length > 0,
         )
         .map((entry) => ({ toolName: entry.toolName, meta: entry.meta }));
-      const attemptUsage = getUsageTotals();
       if (cacheObservabilityEnabled) {
-        const cacheBreak = completePromptCacheObservation({
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          usage: attemptUsage,
-        });
         if (cacheBreak) {
           const changeSummary =
             cacheBreak.changes?.map((change) => `${change.code}(${change.detail})`).join(", ") ??
@@ -2252,6 +2331,7 @@ export async function runEmbeddedAttempt(
           lastAssistant?.errorMessage && isCloudCodeAssistFormatError(lastAssistant.errorMessage),
         ),
         attemptUsage,
+        promptCache,
         compactionCount: getCompactionCount(),
         // Client tool call detected (OpenResponses hosted tools)
         clientToolCall: clientToolCallDetected ?? undefined,

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -3,7 +3,7 @@ import type { Api, AssistantMessage, Model } from "@mariozechner/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
-import type { ContextEngine } from "../../../context-engine/types.js";
+import type { ContextEngine, ContextEnginePromptCacheInfo } from "../../../context-engine/types.js";
 import type { PluginHookBeforeAgentStartResult } from "../../../plugins/types.js";
 import type { MessagingToolSend } from "../../pi-embedded-messaging.js";
 import type { ToolErrorSummary } from "../../tool-error-summary.js";
@@ -69,6 +69,7 @@ export type EmbeddedRunAttemptResult = {
   successfulCronAdds?: number;
   cloudCodeAssistFormatError: boolean;
   attemptUsage?: NormalizedUsage;
+  promptCache?: ContextEnginePromptCacheInfo;
   compactionCount?: number;
   /** Client tool call detected (OpenResponses hosted tools). */
   clientToolCall?: { name: string; params: Record<string, unknown> };

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -23,7 +23,7 @@ import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { asNullableObjectRecord } from "../shared/record-coerce.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { note } from "../terminal/note.js";
-import { isRecord, shortenHomePath } from "../utils.js";
+import { shortenHomePath } from "../utils.js";
 
 type DoctorPrompterLike = {
   confirmRuntimeRepair: (params: { message: string; initialValue?: boolean }) => Promise<boolean>;

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -23,7 +23,7 @@ import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { asNullableObjectRecord } from "../shared/record-coerce.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { note } from "../terminal/note.js";
-import { shortenHomePath } from "../utils.js";
+import { isRecord, shortenHomePath } from "../utils.js";
 
 type DoctorPrompterLike = {
   confirmRuntimeRepair: (params: { message: string; initialValue?: boolean }) => Promise<boolean>;

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -84,7 +84,52 @@ export type TranscriptRewriteResult = {
 
 export type ContextEngineMaintenanceResult = TranscriptRewriteResult;
 
+export type ContextEnginePromptCacheRetention = "none" | "short" | "long" | "in_memory" | "24h";
+
+export type ContextEnginePromptCacheUsage = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  total?: number;
+};
+
+export type ContextEnginePromptCacheObservationChangeCode =
+  | "cacheRetention"
+  | "model"
+  | "streamStrategy"
+  | "systemPrompt"
+  | "tools"
+  | "transport";
+
+export type ContextEnginePromptCacheObservationChange = {
+  code: ContextEnginePromptCacheObservationChangeCode;
+  detail: string;
+};
+
+export type ContextEnginePromptCacheObservation = {
+  broke: boolean;
+  previousCacheRead?: number;
+  cacheRead?: number;
+  changes?: ContextEnginePromptCacheObservationChange[];
+};
+
+export type ContextEnginePromptCacheInfo = {
+  /** Runtime-resolved retention for the actual provider/model/request path. */
+  retention?: ContextEnginePromptCacheRetention;
+  /** Usage from the most recent API call, not accumulated retry/tool-loop totals. */
+  lastCallUsage?: ContextEnginePromptCacheUsage;
+  /** Result from the runtime's prompt-cache observability heuristic. */
+  observation?: ContextEnginePromptCacheObservation;
+  /** Last known cache-touch timestamp from runtime-managed cache-TTL bookkeeping. */
+  lastCacheTouchAt?: number;
+  /** Known cache expiry time when the runtime can source it confidently. */
+  expiresAt?: number;
+};
+
 export type ContextEngineRuntimeContext = Record<string, unknown> & {
+  /** Optional prompt-cache telemetry for cache-aware engines. */
+  promptCache?: ContextEnginePromptCacheInfo;
   /**
    * Safe transcript rewrite helper implemented by the runtime.
    *


### PR DESCRIPTION
## Summary

- Problem: context engines only receive messages, token budget, and runtime context, so they cannot inspect OpenClaw prompt-cache telemetry when deciding post-turn maintenance or compaction.
- Why it matters: engines like lossless-claw need resolved cache retention, normalized last-call usage, and cache-break observations to make cache-aware decisions without duplicating embedded-runner logic.
- What changed: added a typed `runtimeContext.promptCache` payload, populated it in the embedded runner for `afterTurn()`, and forwarded it into `compact()` on the existing recovery paths that already have the attempt result.
- What did NOT change (scope boundary): no compaction policy changed, no lossless-claw behavior changed, and no expiry timestamps are invented for providers where OpenClaw cannot know them confidently.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts`, `src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts`, and the existing `buildAfterTurnRuntimeContext` tests in `src/agents/pi-embedded-runner/run/attempt.test.ts`.
- Scenario the test should lock in: `afterTurn()` receives prompt-cache info when available, the field stays absent/partial when unavailable, retention and cache-break observations are threaded through correctly, and `compact()` receives the same payload on the current recovery paths.
- Why this is the smallest reliable guardrail: the behavior is owned by the embedded-runner/context-engine seam, so extending the existing attempt helper and recovery-path harnesses exercises the actual plumbing without adding broad integration coverage.
- Existing test that already covers this (if any): existing `buildAfterTurnRuntimeContext` coverage remains in place and stays compatible with callers that ignore the new field.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[embedded runner finishes turn] -> [afterTurn(runtimeContext without prompt-cache data)]

After:
[embedded runner finishes turn]
  -> [resolve effective retention + normalize last-call usage + finalize cache observation]
  -> [afterTurn(runtimeContext.promptCache)]
  -> [retry/timeout compaction path reuses same promptCache payload]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm repo workflow
- Model/provider: N/A
- Integration/channel (if any): embedded runner / context-engine seam
- Relevant config (redacted): none required beyond test defaults

### Steps

1. Run `pnpm test src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts`.
2. Run `pnpm test src/agents/pi-embedded-runner/run/attempt.test.ts -t "buildAfterTurnRuntimeContext"`.
3. Confirm the prompt-cache payload appears only where expected and existing callers still pass.

### Expected

- Targeted tests pass.
- `runtimeContext.promptCache` is available to context engines when the embedded runner has cache telemetry.
- Existing behavior is unchanged for engines that ignore the new field.

### Actual

- Matched expected results locally.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran the targeted attempt/context-engine and timeout-compaction tests, plus the focused `buildAfterTurnRuntimeContext` coverage, against the final committed tree.
- Edge cases checked: missing cache data leaves `promptCache` absent, effective retention is the resolved value, and cache-break observations carry through when the heuristic reports a meaningful drop.
- What you did **not** verify: no broader end-to-end model-provider run, and no lossless-claw compaction policy changes in this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: `compact()` only receives prompt-cache info on recovery paths that already have an attempt result.
  - Mitigation: this keeps the change additive and aligned with the current call graph; broader compaction-context sourcing can be added later if an engine needs it.
- Risk: `expiresAt` is intentionally absent for Anthropic/OpenAI because OpenClaw cannot know it confidently.
  - Mitigation: the new type makes the field optional so engines can branch on real availability instead of guessed data.