### PR TITLE
feat(feishu): add filter, sort, field_names to bitable list_records

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -189,12 +189,20 @@ async function listRecords(
   tableId: string,
   pageSize?: number,
   pageToken?: string,
+  filter?: string,
+  sort?: string,
+  fieldNames?: string,
+  automaticFields?: boolean,
 ) {
   const res = await client.bitable.appTableRecord.list({
     path: { app_token: appToken, table_id: tableId },
     params: {
       page_size: pageSize ?? 100,
       ...(pageToken && { page_token: pageToken }),
+      ...(filter && { filter }),
+      ...(sort && { sort }),
+      ...(fieldNames && { field_names: fieldNames }),
+      ...(automaticFields != null && { automatic_fields: automaticFields }),
     },
   });
   ensureLarkSuccess(res, "bitable.appTableRecord.list", { appToken, tableId, pageSize });
@@ -476,6 +484,30 @@ const ListRecordsSchema = Type.Object({
   page_token: Type.Optional(
     Type.String({ description: "Pagination token from previous response" }),
   ),
+  filter: Type.Optional(
+    Type.String({
+      description:
+        'Server-side filter expression. Examples: \'CurrentValue.[Status]="Done"\', \'AND(CurrentValue.[Status]="Open",CurrentValue.[Priority]="High")\'',
+    }),
+  ),
+  sort: Type.Optional(
+    Type.String({
+      description:
+        'JSON array of sort objects. Example: \'[{"field_name":"Created Time","desc":true}]\' for newest first',
+    }),
+  ),
+  field_names: Type.Optional(
+    Type.String({
+      description:
+        'JSON array of field names to return (reduces payload). Example: \'["Title","Status","URL"]\'',
+    }),
+  ),
+  automatic_fields: Type.Optional(
+    Type.Boolean({
+      description:
+        "If true, include system fields (created_time, last_modified_time, created_by, last_modified_by) in response",
+    }),
+  ),
 });
 
 const GetRecordSchema = Type.Object({
@@ -613,11 +645,16 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     table_id: string;
     page_size?: number;
     page_token?: string;
+    filter?: string;
+    sort?: string;
+    field_names?: string;
+    automatic_fields?: boolean;
     accountId?: string;
   }>({
     name: "feishu_bitable_list_records",
     label: "Feishu Bitable List Records",
-    description: "List records (rows) from a Bitable table with pagination support",
+    description:
+      "List records (rows) from a Bitable table with pagination, server-side filtering, and sorting",
     parameters: ListRecordsSchema,
     async execute({ params, defaultAccountId }) {
       return listRecords(
@@ -626,6 +663,10 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
         params.table_id,
         params.page_size,
         params.page_token,
+        params.filter,
+        params.sort,
+        params.field_names,
+        params.automatic_fields,
       );
     },
   });


### PR DESCRIPTION
## Summary

The Lark Bitable API supports server-side filtering, sorting, and field selection via `filter`, `sort`, `field_names`, and `automatic_fields` query parameters. Currently `feishu_bitable_list_records` only passes `page_size` and `page_token`, forcing agents to fetch entire tables and filter client-side.

This PR adds four optional parameters that are passed through to the Lark SDK:

- **`filter`** — Server-side filter expressions (e.g. `CurrentValue.[Status]="Done"`, `AND(CurrentValue.[Status]="Open",CurrentValue.[Priority]="High")`)
- **`sort`** — JSON array of sort objects for server-side ordering (e.g. `[{"field_name":"Created Time","desc":true}]` for newest-first)
- **`field_names`** — JSON array of field names to limit returned fields, reducing response payload
- **`automatic_fields`** — Boolean to include system fields (`created_time`, `last_modified_time`, etc.) in the response

All parameters are optional. Existing behavior is completely unaffected.

## Motivation

Without server-side filtering and sorting, agents working with Bitable tables must:
1. Page through the entire table (multiple API calls for large tables)
2. Transfer all fields for every record (high token consumption)
3. Filter and sort client-side (wasting context window and processing time)

With these parameters, an agent can fetch exactly the records it needs in a single API call. For example, fetching only "confirmed" bug reports sorted by creation time, returning only the title and description fields.

## Test plan

- [ ] Verify existing `feishu_bitable_list_records` calls without new params still work (backward compatible)
- [ ] Test `filter` parameter with simple expression
- [ ] Test `sort` parameter with descending order
- [ ] Test `field_names` parameter to limit returned fields
- [ ] Test `automatic_fields: true` returns system timestamps
- [ ] Test combinations of filter + sort + field_names