### PR TITLE
fix(security): wire describeUnknownError through formatErrorMessage for credential redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - Tools/web search/Exa: show Exa Search in onboarding and configure provider pickers again by marking the bundled Exa provider as setup-visible. Thanks @vincentkoc.
 - Docs/i18n: relocalize final localized-page links after translation and remove the zh-CN homepage redirect override so localized Mintlify pages resolve to the correct language roots again. (#61796) Thanks @hxy91819.
 - Plugins/provider hooks: stop recursive provider snapshot loads from overflowing the stack during plugin initialization, while still preserving cached nested provider-hook results. (#61922, #61938, #61946, #61951)
+- Security/errors: wire `describeUnknownError` through `formatErrorMessage` so user-facing error serialisation gets the same credential redaction that logging already applies. (#62189) Thanks @ademczuk.
 
 ## 2026.4.5
 

--- a/src/agents/pi-embedded-runner/utils.ts
+++ b/src/agents/pi-embedded-runner/utils.ts
@@ -1,5 +1,6 @@
 import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 
 export function mapThinkingLevel(level?: ThinkLevel): ThinkingLevel {
   // pi-agent-core supports "xhigh"; OpenClaw enables it for specific models.
@@ -17,18 +18,13 @@ export function mapThinkingLevel(level?: ThinkLevel): ThinkingLevel {
 }
 
 export function describeUnknownError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  if (typeof error === "string") {
-    return error;
-  }
-  try {
-    const serialized = JSON.stringify(error);
-    return serialized ?? "Unknown error";
-  } catch {
-    return "Unknown error";
-  }
+  // Delegate to formatErrorMessage which applies redactSensitiveText,
+  // preventing stack traces, file paths, and credentials from leaking
+  // into user-facing error messages and gateway error handling.
+  // Guard: JSON.stringify(undefined) returns undefined at runtime despite
+  // the string type signature, so preserve a fallback for callers that
+  // chain string methods on the result.
+  return formatErrorMessage(error) || "Unknown error";
 }
 
 export type { ReasoningLevel, ThinkLevel };

--- a/src/secrets/shared.ts
+++ b/src/secrets/shared.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { formatErrorMessage } from "../infra/errors.js";
 export { isRecord } from "../utils.js";
 
 export function isNonEmptyString(value: unknown): value is string {
@@ -61,22 +62,8 @@ export function writeTextFileAtomic(pathname: string, value: string, mode = 0o60
 }
 
 export function describeUnknownError(err: unknown): string {
-  if (err instanceof Error && err.message.trim().length > 0) {
-    return err.message;
-  }
-  if (typeof err === "string" && err.trim().length > 0) {
-    return err;
-  }
-  if (typeof err === "number" || typeof err === "bigint") {
-    return err.toString();
-  }
-  if (typeof err === "boolean") {
-    return err ? "true" : "false";
-  }
-  try {
-    const serialized = JSON.stringify(err);
-    return serialized ?? "unknown error";
-  } catch {
-    return "unknown error";
-  }
+  // Delegate to formatErrorMessage which applies redactSensitiveText,
+  // preventing credentials and internal paths from leaking into
+  // user-facing error output.
+  return formatErrorMessage(err) || "unknown error";
 }


### PR DESCRIPTION
## Summary

- Problem: `describeUnknownError()` in `pi-embedded-runner/utils.ts` and `secrets/shared.ts` serialises arbitrary error objects with raw `JSON.stringify()`. Error objects in Node.js regularly carry stack traces, internal file paths, DB connection strings, and API keys embedded in URL parameters.
- Why it matters: the serialised output flows into user-facing error messages and gateway error handling, exposing credentials to end users and connected chat channels.
- What changed: both `describeUnknownError` implementations now delegate to `formatErrorMessage()` from `infra/errors.ts`, which already applies `redactSensitiveText()` with 17+ regex patterns covering token prefixes (`sk-`, `ghp_`, `xox*`), Bearer headers, PEM blocks, and ENV-style credential assignments.
- What did NOT change: `formatErrorMessage` itself is untouched. No new redaction patterns added. No changes to how errors are thrown or caught. Call sites that already used `formatErrorMessage` directly are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #54291
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `describeUnknownError` was written independently in two files (`pi-embedded-runner/utils.ts` and `secrets/shared.ts`) before `formatErrorMessage` + `redactSensitiveText` existed in `infra/errors.ts`. When the centralised redaction was added, these two call sites weren't updated to use it.
- Missing detection / guardrail: no lint rule or test asserting that error serialisation passes through the redaction pipeline.
- Contributing context: the `formatErrorMessage` function in `infra/errors.ts` already handles the full type-narrowing chain (Error instances, strings, numbers, booleans, unknown objects) with `JSON.stringify` as a last resort, then pipes everything through `redactSensitiveText`. The two `describeUnknownError` functions duplicated this logic minus the redaction step.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Existing coverage already sufficient
- Target test or file: `src/infra/errors.ts` is exercised transitively by the pi-embedded-runner test suite (281 passing tests in `vitest.infra.config.ts`)
- Scenario the test should lock in: error objects containing credential-like strings get redacted before reaching user-facing output
- Why this is the smallest reliable guardrail: the existing `redactSensitiveText` regex suite already covers the credential patterns. Wiring through `formatErrorMessage` picks up that coverage automatically.
- If no new test is added, why not: `formatErrorMessage` and `redactSensitiveText` both have their own test coverage. Adding a test for the delegation itself would just be testing that a function call works, not behaviour.

## User-visible / Behavior Changes

Error messages returned to users and logged to channels will have credentials redacted where they weren't before. Some error detail (stack traces, internal paths) may be shorter than before. This is the intended fix.

## Diagram (if applicable)

```text
Before:
  catch (err) -> describeUnknownError(err) -> JSON.stringify(err) -> user sees raw credentials

After:
  catch (err) -> describeUnknownError(err) -> formatErrorMessage(err) -> redactSensitiveText() -> user sees [REDACTED]
```

## Security Impact (required)

- New permissions/capabilities? No
- Touches auth, secrets, or tokens? Yes - reduces exposure of leaked credentials in error messages
- Handles user input? No
- New dependencies? No
- Relevant CWE: CWE-209 (Generation of Error Message Containing Sensitive Information)

## Repro + Verification

**Environment**: openclaw 2026.4.6, Node.js 22+, Ubuntu/macOS/Windows

**Steps to reproduce the original issue**:
1. Trigger any error path that hits `describeUnknownError` (e.g. a provider auth failure with a token in the URL)
2. The raw token appears in the error message shown to the user or sent to a chat channel

**Expected after fix**: tokens matching known patterns (`sk-*`, `ghp_*`, `Bearer *`, etc.) get replaced with `[REDACTED]`

**Verification**:
```bash
pnpm tsgo         # types pass (pre-existing failures only)
node scripts/run-vitest.mjs run --config vitest.infra.config.ts  # 281 pass, 3 pre-existing failures
```

## Human Verification (required)

- I've verified that `formatErrorMessage` in `infra/errors.ts` already handles all the type-narrowing branches that the two removed `describeUnknownError` bodies handled (Error, string, number, bigint, boolean, unknown object via JSON.stringify)
- I've confirmed `redactSensitiveText` covers token prefixes, Bearer headers, PEM blocks, ENV assignments, and common secret patterns (17+ regex patterns)
- I ran the full infra test suite before and after the change - identical results (281 pass, 3 pre-existing failures unrelated to this change)
- I haven't verified every possible error object shape across all 15+ call sites of `describeUnknownError` end-to-end. The type signatures match and the delegation is straightforward, but a call site passing something unusual could theoretically behave differently with `formatErrorMessage`'s cause-chain traversal.

## Compatibility / Migration

No migration needed. The function signatures are unchanged. All existing callers continue to work. The only observable difference is shorter, redacted error messages.

## Risks and Mitigations

| Risk | Mitigation |
|------|-----------|
| `formatErrorMessage` traverses `.cause` chains, which the old `describeUnknownError` didn't. Could produce longer messages for nested errors. | The cause-chain output is still piped through `redactSensitiveText`, so credentials won't leak even in longer messages. The extra context from cause chains is generally useful for debugging. |
| Circular import risk (`secrets/shared.ts` importing from `infra/errors.ts`) | Verified: `infra/errors.ts` imports only from `logging/redact.ts`. No circular dependency. |