### PR TITLE
fix(plugins): merge compat providers with active runtime

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -170,9 +170,26 @@ describe("resolvePluginCapabilityProviders", () => {
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
   });
 
-  it("keeps active capability providers even when cfg is passed", () => {
+  it("merges compat-loaded capability providers when cfg is passed and active registry is partial", () => {
     const active = createEmptyPluginRegistry();
     active.speechProviders.push({
+      pluginId: "openai",
+      pluginName: "openai",
+      source: "test",
+      provider: {
+        id: "openai",
+        label: "openai",
+        isConfigured: () => true,
+        synthesize: async () => ({
+          audioBuffer: Buffer.from("x"),
+          outputFormat: "mp3",
+          voiceCompatible: false,
+          fileExtension: ".mp3",
+        }),
+      },
+    } as never);
+    const compatLoaded = createEmptyPluginRegistry();
+    compatLoaded.speechProviders.push({
       pluginId: "microsoft",
       pluginName: "microsoft",
       source: "test",
@@ -189,18 +206,21 @@ describe("resolvePluginCapabilityProviders", () => {
         }),
       },
     } as never);
-    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) =>
-      params === undefined ? active : createEmptyPluginRegistry(),
-    );
+    mocks.resolveRuntimePluginRegistry.mockImplementation((params?: unknown) => {
+      if (params === undefined) {
+        return active;
+      }
+      return compatLoaded;
+    });
 
     const providers = resolvePluginCapabilityProviders({
       key: "speechProviders",
       cfg: { messages: { tts: { provider: "edge" } } } as OpenClawConfig,
     });
 
-    expectResolvedCapabilityProviderIds(providers, ["microsoft"]);
+    expectResolvedCapabilityProviderIds(providers, ["openai", "microsoft"]);
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
-    expect(mocks.resolveRuntimePluginRegistry).not.toHaveBeenCalledWith({
+    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
       config: expect.anything(),
     });
   });

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -28,7 +28,7 @@ type CapabilityContractKey =
   | "musicGenerationProviders";
 
 type CapabilityProviderForKey<K extends CapabilityProviderRegistryKey> =
-  PluginRegistry[K][number] extends { provider: infer T } ? T : never;
+  PluginRegistry[K][number] extends { provider: infer T extends { id: string } } ? T : never;
 
 const CAPABILITY_CONTRACT_KEY: Record<CapabilityProviderRegistryKey, CapabilityContractKey> = {
   memoryEmbeddingProviders: "memoryEmbeddingProviders",

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -79,13 +79,29 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
 }): CapabilityProviderForKey<K>[] {
   const activeRegistry = resolveRuntimePluginRegistry();
   const activeProviders = activeRegistry?.[params.key] ?? [];
-  if (activeProviders.length > 0) {
-    return activeProviders.map((entry) => entry.provider) as CapabilityProviderForKey<K>[];
+  const mappedActiveProviders = activeProviders.map(
+    (entry) => entry.provider,
+  ) as CapabilityProviderForKey<K>[];
+  if (activeProviders.length > 0 && params.cfg === undefined) {
+    return mappedActiveProviders;
   }
   const compatConfig = resolveCapabilityProviderConfig({ key: params.key, cfg: params.cfg });
   const loadOptions = compatConfig === undefined ? undefined : { config: compatConfig };
   const registry = resolveRuntimePluginRegistry(loadOptions);
-  return (registry?.[params.key] ?? []).map(
+  const compatProviders = (registry?.[params.key] ?? []).map(
     (entry) => entry.provider,
   ) as CapabilityProviderForKey<K>[];
+  if (mappedActiveProviders.length === 0) {
+    return compatProviders;
+  }
+  const mergedProviders = [...mappedActiveProviders];
+  const seen = new Set(mappedActiveProviders.map((provider) => provider.id));
+  for (const provider of compatProviders) {
+    if (seen.has(provider.id)) {
+      continue;
+    }
+    seen.add(provider.id);
+    mergedProviders.push(provider);
+  }
+  return mergedProviders;
 }

--- a/src/tts/provider-registry.test.ts
+++ b/src/tts/provider-registry.test.ts
@@ -74,8 +74,18 @@ describe("speech provider registry", () => {
     expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith();
   });
 
-  it("uses active plugin speech providers even when config is provided", () => {
-    resolveRuntimePluginRegistryMock.mockReturnValue({
+  it("merges compat-loaded speech providers when config is provided and active registry is partial", () => {
+    const active = {
+      ...createEmptyPluginRegistry(),
+      speechProviders: [
+        {
+          pluginId: "test-openai",
+          source: "test",
+          provider: createSpeechProvider("openai"),
+        },
+      ],
+    };
+    const compatLoaded = {
       ...createEmptyPluginRegistry(),
       speechProviders: [
         {
@@ -84,13 +94,28 @@ describe("speech provider registry", () => {
           provider: createSpeechProvider("microsoft", ["edge"]),
         },
       ],
-    });
+    };
+    resolveRuntimePluginRegistryMock.mockImplementation((params?: unknown) =>
+      params === undefined ? active : compatLoaded,
+    );
 
-    const cfg = {} as OpenClawConfig;
+    const cfg = { messages: { tts: { provider: "edge" } } } as OpenClawConfig;
 
-    expect(listSpeechProviders(cfg).map((provider) => provider.id)).toEqual(["microsoft"]);
+    expect(listSpeechProviders(cfg).map((provider) => provider.id)).toEqual(["openai", "microsoft"]);
     expect(getSpeechProvider("edge", cfg)?.id).toBe("microsoft");
     expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith();
+    expect(resolveRuntimePluginRegistryMock).toHaveBeenCalledWith({
+      config: expect.objectContaining({
+        messages: { tts: { provider: "edge" } },
+        plugins: {
+          entries: expect.objectContaining({
+            elevenlabs: { enabled: true },
+            microsoft: { enabled: true },
+            openai: { enabled: true },
+          }),
+        },
+      }),
+    });
   });
 
   it("loads speech providers from plugins when config is provided and no active providers exist", () => {


### PR DESCRIPTION
## Summary
- fix runtime capability resolution so compat-loaded providers are still considered when the active registry is only partial
- preserve already-active providers instead of replacing them when config-specific compat loading is needed
- add regression coverage for TTS provider lookup on a partially populated active registry

## Root cause
`resolvePluginCapabilityProviders()` returned the active runtime providers immediately whenever any provider for that capability existed. In the failing case, the active registry already had `openai`, so a config asking for Microsoft TTS never loaded or merged the compat-shaped `microsoft` provider registry. That made `getSpeechProvider("edge")` fall through to `microsoft: no provider registered`.

## Testing
- `node scripts/run-vitest.mjs run --config vitest.codex-standalone.config.ts src/plugins/capability-provider-runtime.test.ts src/tts/provider-registry.test.ts`

Closes #62117