### PR TITLE
  fix: mitigate stale toolResult replay pollution

### DIFF
--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1030,6 +1030,54 @@ describe("sanitizeSessionHistory", () => {
     ).not.toBe(true);
   });
 
+  it("falls back to persisted replay time when toolResult timestamp is present but invalid", async () => {
+    setNonGoogleModelApi();
+    const persistedAt = Date.now() - 2 * 60 * 60 * 1000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_old", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: persistedAt - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_old",
+        toolName: "exec",
+        content: [{ type: "text", text: "old plugin output" }],
+        isError: false,
+        timestamp: { invalid: true },
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: Date.now(),
+          persistedAt,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: [
+        {
+          type: "text",
+          text: "[Previous environment diagnostic output omitted from replay for accuracy.]",
+        },
+      ],
+      __openclaw: expect.objectContaining({
+        replayOmitted: true,
+        diagnosticType: "openclaw.plugins_list",
+      }),
+    });
+  });
+
   it("preserves latest assistant thinking blocks for github-copilot models", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -985,6 +985,51 @@ describe("sanitizeSessionHistory", () => {
     });
   });
 
+  it("keeps fresh diagnostic tool results when only the persisted replay timestamp is recent", async () => {
+    setNonGoogleModelApi();
+    const taggedAt = Date.now() - 2 * 60 * 60 * 1000;
+    const persistedAt = Date.now() - 5_000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_recent", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: taggedAt - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_recent",
+        toolName: "exec",
+        content: [{ type: "text", text: "latest plugin output" }],
+        isError: false,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt,
+          persistedAt,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: [{ type: "text", text: "latest plugin output" }],
+      __openclaw: expect.objectContaining({
+        diagnosticType: "openclaw.plugins_list",
+      }),
+    });
+    expect(
+      (result[1] as { __openclaw?: { replayOmitted?: boolean } }).__openclaw?.replayOmitted,
+    ).not.toBe(true);
+  });
+
   it("preserves latest assistant thinking blocks for github-copilot models", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -944,6 +944,47 @@ describe("sanitizeSessionHistory", () => {
     ).not.toBe(true);
   });
 
+  it("replaces stale transient diagnostic tool results even when content has an unexpected shape", async () => {
+    setNonGoogleModelApi();
+    const oldTimestamp = Date.now() - 2 * 60 * 60 * 1000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_old", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: oldTimestamp - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_old",
+        toolName: "exec",
+        content: { stale: true },
+        isError: false,
+        timestamp: oldTimestamp,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: oldTimestamp,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: "[Previous environment diagnostic output omitted from replay for accuracy.]",
+      __openclaw: expect.objectContaining({
+        replayOmitted: true,
+      }),
+    });
+  });
+
   it("preserves latest assistant thinking blocks for github-copilot models", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -830,6 +830,120 @@ describe("sanitizeSessionHistory", () => {
     ).toBe(false);
   });
 
+  it("omits stale transient diagnostic tool results older than the replay threshold", async () => {
+    setNonGoogleModelApi();
+    const oldTimestamp = Date.now() - 2 * 60 * 60 * 1000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_old", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: oldTimestamp - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_old",
+        toolName: "exec",
+        content: [{ type: "text", text: "old plugin output" }],
+        isError: false,
+        timestamp: oldTimestamp,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: oldTimestamp,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: [
+        {
+          type: "text",
+          text: "[Previous environment diagnostic output omitted from replay for accuracy.]",
+        },
+      ],
+      __openclaw: expect.objectContaining({
+        replayOmitted: true,
+        diagnosticType: "openclaw.plugins_list",
+      }),
+    });
+  });
+
+  it("omits older transient diagnostic tool results when a newer result of the same type exists", async () => {
+    setNonGoogleModelApi();
+    const older = Date.now() - 10 * 60 * 1000;
+    const newer = Date.now() - 30 * 1000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_old", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: older - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_old",
+        toolName: "exec",
+        content: "plugins list old output",
+        isError: false,
+        timestamp: older,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: older,
+          sourceTool: "exec",
+        },
+      },
+      makeAssistantMessage([{ type: "toolCall", id: "call_new", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: newer - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_new",
+        toolName: "exec",
+        content: "(no output)",
+        isError: false,
+        timestamp: newer,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: newer,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: "[Previous environment diagnostic output omitted from replay for accuracy.]",
+      __openclaw: expect.objectContaining({
+        replayOmitted: true,
+      }),
+    });
+    expect(result[3]).toMatchObject({
+      role: "toolResult",
+      content: "(no output)",
+    });
+    expect(
+      (result[3] as { __openclaw?: { replayOmitted?: boolean } }).__openclaw?.replayOmitted,
+    ).not.toBe(true);
+  });
+
   it("preserves latest assistant thinking blocks for github-copilot models", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -804,6 +804,7 @@ export async function compactEmbeddedPiSessionDirect(
       const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
         allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
         allowedToolNames,
       });

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -327,7 +327,7 @@ function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): Agen
     }
     const latestIndex = latestByDiagnosticType.get(meta.diagnosticType) ?? i;
     const timestamp = parseMessageTimestamp(
-      (message as { timestamp?: unknown }).timestamp ?? meta.taggedAt ?? null,
+      (message as { timestamp?: unknown }).timestamp ?? meta.persistedAt ?? null,
     );
     const staleByNewerResult = latestIndex > i;
     const staleByAge =

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -303,16 +303,17 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
 }
 
 function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): AgentMessage[] {
-  const latestByDiagnosticType = new Map<string, number>();
+  const latestByDiagnosticKey = new Map<string, number>();
   for (let i = 0; i < messages.length; i += 1) {
     const meta = getToolResultReplayMetadata(messages[i]);
     if (!meta) {
       continue;
     }
-    latestByDiagnosticType.set(meta.diagnosticType, i);
+    const key = `${meta.diagnosticType}:${meta.diagnosticTarget ?? ""}`;
+    latestByDiagnosticKey.set(key, i);
   }
 
-  if (latestByDiagnosticType.size === 0) {
+  if (latestByDiagnosticKey.size === 0) {
     return messages;
   }
 
@@ -325,7 +326,8 @@ function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): Agen
     if (!meta) {
       continue;
     }
-    const latestIndex = latestByDiagnosticType.get(meta.diagnosticType) ?? i;
+    const key = `${meta.diagnosticType}:${meta.diagnosticTarget ?? ""}`;
+    const latestIndex = latestByDiagnosticKey.get(key) ?? i;
     const messageTimestamp = parseMessageTimestamp((message as { timestamp?: unknown }).timestamp);
     const persistedTimestamp = parseMessageTimestamp(meta.persistedAt ?? null);
     const timestamp = messageTimestamp ?? persistedTimestamp;

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -28,6 +28,11 @@ import {
   sanitizeToolUseResultPairing,
   stripToolResultDetails,
 } from "../session-transcript-repair.js";
+import {
+  getToolResultReplayMetadata,
+  replaceToolResultReplayContent,
+  STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS,
+} from "../tool-result-replay-metadata.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import {
@@ -297,6 +302,48 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
   return touched ? out : messages;
 }
 
+function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): AgentMessage[] {
+  const latestByDiagnosticType = new Map<string, number>();
+  for (let i = 0; i < messages.length; i += 1) {
+    const meta = getToolResultReplayMetadata(messages[i]);
+    if (!meta) {
+      continue;
+    }
+    latestByDiagnosticType.set(meta.diagnosticType, i);
+  }
+
+  if (latestByDiagnosticType.size === 0) {
+    return messages;
+  }
+
+  const now = Date.now();
+  let touched = false;
+  const out = [...messages];
+  for (let i = 0; i < out.length; i += 1) {
+    const message = out[i];
+    const meta = getToolResultReplayMetadata(message);
+    if (!meta) {
+      continue;
+    }
+    const latestIndex = latestByDiagnosticType.get(meta.diagnosticType) ?? i;
+    const timestamp = parseMessageTimestamp(
+      (message as { timestamp?: unknown }).timestamp ?? meta.taggedAt ?? null,
+    );
+    const staleByNewerResult = latestIndex > i;
+    const staleByAge =
+      timestamp !== null && now - timestamp > STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS;
+    if (!staleByNewerResult && !staleByAge) {
+      continue;
+    }
+    out[i] = replaceToolResultReplayContent(
+      message,
+      "[Previous environment diagnostic output omitted from replay for accuracy.]",
+    );
+    touched = true;
+  }
+  return touched ? out : messages;
+}
+
 function createProviderReplaySessionState(
   sessionManager: SessionManager,
 ): ProviderReplaySessionState {
@@ -425,8 +472,10 @@ export async function sanitizeSessionHistory(params: {
       })
     : sanitizedToolCalls;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);
+  const sanitizedTransientDiagnostics =
+    omitStaleTransientDiagnosticToolResults(sanitizedToolResults);
   const sanitizedCompactionUsage = ensureAssistantUsageSnapshots(
-    stripStaleAssistantUsageBeforeLatestCompaction(sanitizedToolResults),
+    stripStaleAssistantUsageBeforeLatestCompaction(sanitizedTransientDiagnostics),
   );
 
   const isOpenAIResponsesApi =

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -326,9 +326,9 @@ function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): Agen
       continue;
     }
     const latestIndex = latestByDiagnosticType.get(meta.diagnosticType) ?? i;
-    const timestamp = parseMessageTimestamp(
-      (message as { timestamp?: unknown }).timestamp ?? meta.persistedAt ?? null,
-    );
+    const messageTimestamp = parseMessageTimestamp((message as { timestamp?: unknown }).timestamp);
+    const persistedTimestamp = parseMessageTimestamp(meta.persistedAt ?? null);
+    const timestamp = messageTimestamp ?? persistedTimestamp;
     const staleByNewerResult = latestIndex > i;
     const staleByAge =
       timestamp !== null && now - timestamp > STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -826,6 +826,7 @@ export async function runEmbeddedAttempt(
       sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
         inputProvenance: params.inputProvenance,
         allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
         allowedToolNames,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -42,7 +42,10 @@ import {
   sanitizeToolResult,
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
-import { consumeAdjustedParamsForToolCall } from "./pi-tools.before-tool-call.js";
+import {
+  consumeAdjustedParamsForToolCall,
+  peekAdjustedParamsForToolCall,
+} from "./pi-tools.before-tool-call.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 import { recordPendingToolResultReplayMetadata } from "./tool-result-replay-metadata.js";
@@ -539,8 +542,11 @@ export function handleToolExecutionStart(
     const rawToolName = String(evt.toolName);
     const toolName = normalizeToolName(rawToolName);
     const toolCallId = String(evt.toolCallId);
-    const args = evt.args;
+    const startArgs = evt.args;
     const runId = ctx.params.runId;
+    const adjustedStartArgs = peekAdjustedParamsForToolCall(toolCallId, runId);
+    const args =
+      adjustedStartArgs && typeof adjustedStartArgs === "object" ? adjustedStartArgs : startArgs;
 
     // Track start time and args for after_tool_call hook.
     const startedAt = Date.now();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -546,7 +546,8 @@ export function handleToolExecutionStart(
     const startedAt = Date.now();
     toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: startedAt, args });
     recordPendingToolResultReplayMetadata({
-      sessionKey: ctx.params.sessionKey ?? ctx.params.sessionId,
+      sessionKey: ctx.params.sessionKey,
+      sessionId: ctx.params.sessionId,
       toolCallId,
       toolName,
       args,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -45,6 +45,7 @@ import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
 import { consumeAdjustedParamsForToolCall } from "./pi-tools.before-tool-call.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
+import { recordPendingToolResultReplayMetadata } from "./tool-result-replay-metadata.js";
 
 type ToolStartRecord = {
   startTime: number;
@@ -544,6 +545,12 @@ export function handleToolExecutionStart(
     // Track start time and args for after_tool_call hook.
     const startedAt = Date.now();
     toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: startedAt, args });
+    recordPendingToolResultReplayMetadata({
+      sessionKey: ctx.params.sessionKey ?? ctx.params.sessionId,
+      toolCallId,
+      toolName,
+      args,
+    });
 
     if (toolName === "read") {
       const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};

--- a/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -21,6 +21,7 @@ const hookMocks = vi.hoisted(() => ({
 
 const beforeToolCallMocks = vi.hoisted(() => ({
   consumeAdjustedParamsForToolCall: vi.fn((_: string): unknown => undefined),
+  peekAdjustedParamsForToolCall: vi.fn((_: string): unknown => undefined),
   isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
   runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
     blocked: false,
@@ -89,6 +90,7 @@ async function loadFreshAfterToolCallModulesForTest() {
   }));
   vi.doMock("./pi-tools.before-tool-call.js", () => ({
     consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,
+    peekAdjustedParamsForToolCall: beforeToolCallMocks.peekAdjustedParamsForToolCall,
     isToolWrappedWithBeforeToolCallHook: beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook,
     runBeforeToolCallHook: beforeToolCallMocks.runBeforeToolCallHook,
   }));
@@ -109,6 +111,8 @@ describe("after_tool_call fires exactly once in embedded runs", () => {
     hookMocks.runner.runBeforeToolCall.mockResolvedValue(undefined);
     beforeToolCallMocks.consumeAdjustedParamsForToolCall.mockClear();
     beforeToolCallMocks.consumeAdjustedParamsForToolCall.mockReturnValue(undefined);
+    beforeToolCallMocks.peekAdjustedParamsForToolCall.mockClear();
+    beforeToolCallMocks.peekAdjustedParamsForToolCall.mockReturnValue(undefined);
     beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook.mockClear();
     beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook.mockReturnValue(false);
     beforeToolCallMocks.runBeforeToolCallHook.mockClear();

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -17,6 +17,7 @@ type ToToolDefinitions = ToolDefinitionAdapterModule["toToolDefinitions"];
 type WrapToolWithAbortSignal = PiToolsAbortModule["wrapToolWithAbortSignal"];
 type BeforeToolCallTesting = BeforeToolCallModule["__testing"];
 type ConsumeAdjustedParamsForToolCall = BeforeToolCallModule["consumeAdjustedParamsForToolCall"];
+type PeekAdjustedParamsForToolCall = BeforeToolCallModule["peekAdjustedParamsForToolCall"];
 type WrapToolWithBeforeToolCallHook = BeforeToolCallModule["wrapToolWithBeforeToolCallHook"];
 
 let toClientToolDefinitions!: ToClientToolDefinitions;
@@ -24,6 +25,7 @@ let toToolDefinitions!: ToToolDefinitions;
 let wrapToolWithAbortSignal!: WrapToolWithAbortSignal;
 let beforeToolCallTesting!: BeforeToolCallTesting;
 let consumeAdjustedParamsForToolCall!: ConsumeAdjustedParamsForToolCall;
+let peekAdjustedParamsForToolCall!: PeekAdjustedParamsForToolCall;
 let wrapToolWithBeforeToolCallHook!: WrapToolWithBeforeToolCallHook;
 
 beforeEach(async () => {
@@ -34,6 +36,7 @@ beforeEach(async () => {
     ({
       __testing: beforeToolCallTesting,
       consumeAdjustedParamsForToolCall,
+      peekAdjustedParamsForToolCall,
       wrapToolWithBeforeToolCallHook,
     } = await import("./pi-tools.before-tool-call.js"));
   }
@@ -233,10 +236,19 @@ describe("before_tool_call hook integration", () => {
     await toolA.execute(sharedToolCallId, { path: "/tmp/a.txt" }, undefined, extensionContextA);
     await toolB.execute(sharedToolCallId, { path: "/tmp/b.txt" }, undefined, extensionContextB);
 
+    expect(peekAdjustedParamsForToolCall(sharedToolCallId, "run-a")).toEqual({
+      path: "/tmp/a.txt",
+      marker: "A",
+    });
+    expect(peekAdjustedParamsForToolCall(sharedToolCallId, "run-b")).toEqual({
+      path: "/tmp/b.txt",
+      marker: "B",
+    });
     expect(consumeAdjustedParamsForToolCall(sharedToolCallId, "run-a")).toEqual({
       path: "/tmp/a.txt",
       marker: "A",
     });
+    expect(peekAdjustedParamsForToolCall(sharedToolCallId, "run-a")).toBeUndefined();
     expect(consumeAdjustedParamsForToolCall(sharedToolCallId, "run-b")).toEqual({
       path: "/tmp/b.txt",
       marker: "B",

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -453,6 +453,11 @@ export function consumeAdjustedParamsForToolCall(toolCallId: string, runId?: str
   return params;
 }
 
+export function peekAdjustedParamsForToolCall(toolCallId: string, runId?: string): unknown {
+  const adjustedParamsKey = buildAdjustedParamsKey({ runId, toolCallId });
+  return adjustedParamsByToolCallId.get(adjustedParamsKey);
+}
+
 export const __testing = {
   BEFORE_TOOL_CALL_WRAPPED,
   buildAdjustedParamsKey,

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -23,6 +23,7 @@ export function guardSessionManager(
   opts?: {
     agentId?: string;
     sessionKey?: string;
+    sessionId?: string;
     inputProvenance?: InputProvenance;
     allowSyntheticToolResults?: boolean;
     allowedToolNames?: Iterable<string>;
@@ -67,6 +68,7 @@ export function guardSessionManager(
 
   const guard = installSessionToolResultGuard(sessionManager, {
     sessionKey: opts?.sessionKey,
+    sessionId: opts?.sessionId,
     transformMessageForPersistence: (message) =>
       applyInputProvenanceToUserMessage(message, opts?.inputProvenance),
     transformToolResultForPersistence: transform,

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 import {
@@ -352,7 +352,7 @@ describe("installSessionToolResultGuard", () => {
         role: "toolResult",
         toolCallId: "call_1",
         toolName: "read",
-        content: [{ type: "text", text: "{\"ok\":true}" }],
+        content: [{ type: "text", text: '{"ok":true}' }],
         isError: false,
         timestamp: Date.now(),
       }),
@@ -363,6 +363,47 @@ describe("installSessionToolResultGuard", () => {
     >;
     expect(messages[1]?.__openclaw?.transient).toBe(true);
     expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
+  });
+
+  it("stamps replay metadata with the persisted write time when toolResult timestamps are missing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-07T03:30:00.000Z"));
+
+    try {
+      const sm = SessionManager.inMemory();
+      installSessionToolResultGuard(sm, { sessionKey: "agent:main:main" });
+
+      sm.appendMessage(
+        asAppendMessage({
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+        }),
+      );
+      recordPendingToolResultReplayMetadata({
+        sessionKey: "agent:main:main",
+        toolCallId: "call_1",
+        toolName: "exec",
+        args: { command: "openclaw status" },
+        taggedAt: Date.now() - 90_000,
+      });
+      sm.appendMessage(
+        asAppendMessage({
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "exec",
+          content: [{ type: "text", text: "status output" }],
+          isError: false,
+        }),
+      );
+
+      const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+        AgentMessage & { __openclaw?: Record<string, unknown> }
+      >;
+      expect(messages[1]?.__openclaw?.persistedAt).toBe(Date.now());
+      expect(messages[1]?.__openclaw?.taggedAt).toBe(Date.now() - 90_000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("drains replay metadata when clearing pending tool calls", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -717,6 +717,16 @@ describe("installSessionToolResultGuard", () => {
       diagnosticType: "openclaw.plugin_path_probe",
       sourceTool: "exec",
     });
+    expect(
+      detectToolResultReplayPolicyMeta({
+        toolName: "read",
+        args: { path: "C:\\repo\\extensions\\telegram\\package.json" },
+      }),
+    ).toMatchObject({
+      transient: true,
+      diagnosticType: "openclaw.plugin_path_probe",
+      sourceTool: "read",
+    });
   });
 
   it("applies before_message_write to synthetic tool-result flushes", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -227,6 +227,40 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.__openclaw?.sourceTool).toBe("exec");
   });
 
+  it("uses sessionId fallback when sessionKey is unavailable", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { sessionId: "session-only" });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionId: "session-only",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "status output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[1]?.__openclaw?.transient).toBe(true);
+    expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.status");
+  });
+
   it("re-applies replay metadata after tool_result_persist transformations", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm, {
@@ -275,6 +309,103 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.__openclaw?.transient).toBe(true);
     expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
     expect(messages[1]?.__openclaw?.sourceTool).toBe("read");
+  });
+
+  it("drains replay metadata when clearing pending tool calls", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, { sessionKey: "agent:main:main" });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw plugins list" },
+    });
+
+    guard.clearPendingToolResults();
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "fresh output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[2]?.__openclaw?.transient).not.toBe(true);
+  });
+
+  it("drains replay metadata when synthetic tool results are disabled", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      allowSyntheticToolResults: false,
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw plugins list" },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "interrupt",
+        timestamp: Date.now(),
+      }),
+    );
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "fresh output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, [
+      "assistant",
+      "user",
+      "assistant",
+      "toolResult",
+    ]) as Array<AgentMessage & { __openclaw?: Record<string, unknown> }>;
+    expect(guard.getPendingIds()).toEqual([]);
+    expect(messages[3]?.__openclaw?.transient).not.toBe(true);
   });
 
   it("preserves ordering with multiple tool calls and partial results", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -3,6 +3,7 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
+import { recordPendingToolResultReplayMetadata } from "./tool-result-replay-metadata.js";
 
 type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
 
@@ -189,6 +190,91 @@ describe("installSessionToolResultGuard", () => {
       toolName?: string;
     }>;
     expect(messages[1]?.toolName).toBe("read");
+  });
+
+  it("tags persisted diagnostic exec tool results for replay policy", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { sessionKey: "agent:main:main" });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw plugins list" },
+    });
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "plugin output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[1]?.__openclaw?.transient).toBe(true);
+    expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.plugins_list");
+    expect(messages[1]?.__openclaw?.sourceTool).toBe("exec");
+  });
+
+  it("re-applies replay metadata after tool_result_persist transformations", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      transformToolResultForPersistence: (message) => {
+        if (message.role !== "toolResult") {
+          return message;
+        }
+        return {
+          role: "toolResult",
+          toolCallId: message.toolCallId,
+          toolName: message.toolName,
+          content: message.content,
+          isError: message.isError,
+          timestamp: message.timestamp,
+        } as AgentMessage;
+      },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "read",
+      args: { path: "/tmp/openclaw.json" },
+    });
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: '{"ok":true}' }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[1]?.__openclaw?.transient).toBe(true);
+    expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
+    expect(messages[1]?.__openclaw?.sourceTool).toBe("read");
   });
 
   it("preserves ordering with multiple tool calls and partial results", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -3,7 +3,10 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
-import { recordPendingToolResultReplayMetadata } from "./tool-result-replay-metadata.js";
+import {
+  detectToolResultReplayPolicyMeta,
+  recordPendingToolResultReplayMetadata,
+} from "./tool-result-replay-metadata.js";
 
 type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
 
@@ -309,6 +312,57 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.__openclaw?.transient).toBe(true);
     expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
     expect(messages[1]?.__openclaw?.sourceTool).toBe("read");
+  });
+
+  it("re-applies replay metadata after before_message_write rewrites", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      beforeMessageWriteHook: ({ message }) => {
+        if (message.role !== "toolResult") {
+          return undefined;
+        }
+        return {
+          message: castAgentMessage({
+            role: "toolResult",
+            toolCallId: message.toolCallId,
+            toolName: message.toolName,
+            content: message.content,
+            isError: message.isError,
+            timestamp: message.timestamp,
+          }),
+        };
+      },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "read",
+      args: { path: "/tmp/openclaw.json" },
+    });
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "{\"ok\":true}" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[1]?.__openclaw?.transient).toBe(true);
+    expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
   });
 
   it("drains replay metadata when clearing pending tool calls", () => {
@@ -640,6 +694,29 @@ describe("installSessionToolResultGuard", () => {
 
     const text = getToolResultText(getPersistedMessages(sm));
     expect(text).toBe("rewritten by hook");
+  });
+
+  it("detects bundled plugin package probes as transient diagnostics", () => {
+    expect(
+      detectToolResultReplayPolicyMeta({
+        toolName: "read",
+        args: { path: "/repo/extensions/telegram/package.json" },
+      }),
+    ).toMatchObject({
+      transient: true,
+      diagnosticType: "openclaw.plugin_path_probe",
+      sourceTool: "read",
+    });
+    expect(
+      detectToolResultReplayPolicyMeta({
+        toolName: "exec",
+        args: { command: "cat extensions/telegram/package.json" },
+      }),
+    ).toMatchObject({
+      transient: true,
+      diagnosticType: "openclaw.plugin_path_probe",
+      sourceTool: "exec",
+    });
   });
 
   it("applies before_message_write to synthetic tool-result flushes", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 import {
+  consumePendingToolResultReplayMetadata,
   detectToolResultReplayPolicyMeta,
+  drainPendingToolResultReplayMetadataForSession,
   recordPendingToolResultReplayMetadata,
 } from "./tool-result-replay-metadata.js";
 
@@ -508,6 +510,55 @@ describe("installSessionToolResultGuard", () => {
       AgentMessage & { __openclaw?: Record<string, unknown> }
     >;
     expect(messages[0]?.__openclaw?.transient).not.toBe(true);
+  });
+
+  it("drains replay metadata by exact session key without prefix overreach", () => {
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:thread",
+      toolCallId: "call_2",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+
+    expect(
+      consumePendingToolResultReplayMetadata({
+        sessionKey: "agent:main:thread",
+        toolCallId: "call_2",
+      }),
+    ).toMatchObject({ diagnosticType: "openclaw.status" });
+
+    // Re-record thread entry, then drain only the base session.
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:thread",
+      toolCallId: "call_2",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+
+    expect(
+      drainPendingToolResultReplayMetadataForSession({
+        sessionKey: "agent:main",
+      }),
+    ).toBe(1);
+
+    expect(
+      consumePendingToolResultReplayMetadata({
+        sessionKey: "agent:main",
+        toolCallId: "call_1",
+      }),
+    ).toBeNull();
+    expect(
+      consumePendingToolResultReplayMetadata({
+        sessionKey: "agent:main:thread",
+        toolCallId: "call_2",
+      }),
+    ).toMatchObject({ diagnosticType: "openclaw.status" });
   });
 
   it("drains replay metadata when synthetic tool results are disabled", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -448,6 +448,68 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[2]?.__openclaw?.transient).not.toBe(true);
   });
 
+  it("drains replay metadata when clearing with empty pending state", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      beforeMessageWriteHook: ({ message }) => {
+        if ((message as { role?: unknown }).role !== "assistant") {
+          return undefined;
+        }
+        const content = (message as { content?: unknown }).content;
+        const hasToolCall =
+          Array.isArray(content) &&
+          content.some(
+            (block) =>
+              !!block &&
+              typeof block === "object" &&
+              ((block as { type?: unknown }).type === "toolCall" ||
+                (block as { type?: unknown }).type === "toolUse"),
+          );
+        return hasToolCall ? { block: true } : undefined;
+      },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw plugins list" },
+    });
+
+    // pendingState is empty because assistant tool-call persistence was blocked,
+    // so clearPendingToolResults must still drain session replay metadata.
+    guard.clearPendingToolResults();
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "fresh output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[0]?.__openclaw?.transient).not.toBe(true);
+  });
+
   it("drains replay metadata when synthetic tool results are disabled", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -503,6 +503,68 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[3]?.__openclaw?.transient).not.toBe(true);
   });
 
+  it("drains replay metadata even when flush runs with empty pending state", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      beforeMessageWriteHook: ({ message }) => {
+        if ((message as { role?: unknown }).role !== "assistant") {
+          return undefined;
+        }
+        const content = (message as { content?: unknown }).content;
+        const hasToolCall =
+          Array.isArray(content) &&
+          content.some(
+            (block) =>
+              !!block &&
+              typeof block === "object" &&
+              ((block as { type?: unknown }).type === "toolCall" ||
+                (block as { type?: unknown }).type === "toolUse"),
+          );
+        return hasToolCall ? { block: true } : undefined;
+      },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+
+    // Pending tool-call state is empty because assistant toolCall persistence was blocked,
+    // but replay metadata should still be drained for the session.
+    guard.flushPendingToolResults();
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "fresh output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[0]?.__openclaw?.transient).not.toBe(true);
+  });
+
   it("preserves ordering with multiple tool calls and partial results", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -22,6 +22,7 @@ import {
   applyToolResultReplayMetadata,
   consumePendingToolResultReplayMetadata,
   resolveToolResultReplaySessionKey,
+  stampPersistedToolResultReplayMetadata,
 } from "./tool-result-replay-metadata.js";
 
 /**
@@ -177,7 +178,7 @@ export function installSessionToolResultGuard(
         ),
       );
       if (flushed) {
-        originalAppend(flushed as never);
+        originalAppend(stampPersistedToolResultReplayMetadata(flushed, replayMeta) as never);
       }
     }
     pendingState.clear();
@@ -237,7 +238,10 @@ export function installSessionToolResultGuard(
       if (!persisted) {
         return undefined;
       }
-      const replayTaggedPersisted = applyToolResultReplayMetadata(persisted, replayMeta);
+      const replayTaggedPersisted = stampPersistedToolResultReplayMetadata(
+        applyToolResultReplayMetadata(persisted, replayMeta),
+        replayMeta,
+      );
       return originalAppend(replayTaggedPersisted as never);
     }
 

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -21,6 +21,7 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 import {
   applyToolResultReplayMetadata,
   consumePendingToolResultReplayMetadata,
+  drainPendingToolResultReplayMetadataForSession,
   resolveToolResultReplaySessionKey,
   stampPersistedToolResultReplayMetadata,
 } from "./tool-result-replay-metadata.js";
@@ -156,6 +157,7 @@ export function installSessionToolResultGuard(
 
   const flushPendingToolResults = () => {
     if (pendingState.size() === 0) {
+      drainPendingToolResultReplayMetadataForSession({ sessionKey: replaySessionKey });
       return;
     }
     for (const [id, name] of pendingState.entries()) {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -187,12 +187,17 @@ export function installSessionToolResultGuard(
   };
 
   const clearPendingToolResults = () => {
+    if (pendingState.size() === 0) {
+      drainPendingToolResultReplayMetadataForSession({ sessionKey: replaySessionKey });
+      return;
+    }
     for (const [id] of pendingState.entries()) {
       consumePendingToolResultReplayMetadata({
         sessionKey: replaySessionKey,
         toolCallId: id,
       });
     }
+    drainPendingToolResultReplayMetadataForSession({ sessionKey: replaySessionKey });
     pendingState.clear();
   };
 

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -18,6 +18,10 @@ import {
 import { createPendingToolCallState } from "./session-tool-result-state.js";
 import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
+import {
+  applyToolResultReplayMetadata,
+  consumePendingToolResultReplayMetadata,
+} from "./tool-result-replay-metadata.js";
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -149,12 +153,22 @@ export function installSessionToolResultGuard(
     if (allowSyntheticToolResults) {
       for (const [id, name] of pendingState.entries()) {
         const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
+        const replayMeta = consumePendingToolResultReplayMetadata({
+          sessionKey: opts?.sessionKey,
+          toolCallId: id,
+        });
         const flushed = applyBeforeWriteHook(
-          persistToolResult(persistMessage(synthetic), {
-            toolCallId: id,
-            toolName: name,
-            isSynthetic: true,
-          }),
+          applyToolResultReplayMetadata(
+            persistToolResult(
+              applyToolResultReplayMetadata(persistMessage(synthetic), replayMeta),
+              {
+                toolCallId: id,
+                toolName: name,
+                isSynthetic: true,
+              },
+            ),
+            replayMeta,
+          ),
         );
         if (flushed) {
           originalAppend(flushed as never);
@@ -188,20 +202,27 @@ export function installSessionToolResultGuard(
     if (nextRole === "toolResult") {
       const id = extractToolResultId(nextMessage as Extract<AgentMessage, { role: "toolResult" }>);
       const toolName = id ? pendingState.getToolName(id) : undefined;
+      const replayMeta = consumePendingToolResultReplayMetadata({
+        sessionKey: opts?.sessionKey,
+        toolCallId: id ?? undefined,
+      });
       if (id) {
         pendingState.delete(id);
       }
       const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
+      const taggedToolResult = applyToolResultReplayMetadata(normalizedToolResult, replayMeta);
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
-      const capped = capToolResultSize(persistMessage(normalizedToolResult));
-      const persisted = applyBeforeWriteHook(
+      const capped = capToolResultSize(persistMessage(taggedToolResult));
+      const persistedToolResult = applyToolResultReplayMetadata(
         persistToolResult(capped, {
           toolCallId: id ?? undefined,
           toolName,
           isSynthetic: false,
         }),
+        replayMeta,
       );
+      const persisted = applyBeforeWriteHook(persistedToolResult);
       if (!persisted) {
         return undefined;
       }

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -21,6 +21,7 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 import {
   applyToolResultReplayMetadata,
   consumePendingToolResultReplayMetadata,
+  resolveToolResultReplaySessionKey,
 } from "./tool-result-replay-metadata.js";
 
 /**
@@ -73,6 +74,8 @@ export function installSessionToolResultGuard(
   opts?: {
     /** Optional session key for transcript update broadcasts. */
     sessionKey?: string;
+    /** Optional session id fallback when no session key exists. */
+    sessionId?: string;
     /**
      * Optional transform applied to any message before persistence.
      */
@@ -127,6 +130,10 @@ export function installSessionToolResultGuard(
 
   const allowSyntheticToolResults = opts?.allowSyntheticToolResults ?? true;
   const beforeWrite = opts?.beforeMessageWriteHook;
+  const replaySessionKey = resolveToolResultReplaySessionKey({
+    sessionKey: opts?.sessionKey,
+    sessionId: opts?.sessionId,
+  });
 
   /**
    * Run the before_message_write hook. Returns the (possibly modified) message,
@@ -150,35 +157,39 @@ export function installSessionToolResultGuard(
     if (pendingState.size() === 0) {
       return;
     }
-    if (allowSyntheticToolResults) {
-      for (const [id, name] of pendingState.entries()) {
-        const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
-        const replayMeta = consumePendingToolResultReplayMetadata({
-          sessionKey: opts?.sessionKey,
-          toolCallId: id,
-        });
-        const flushed = applyBeforeWriteHook(
-          applyToolResultReplayMetadata(
-            persistToolResult(
-              applyToolResultReplayMetadata(persistMessage(synthetic), replayMeta),
-              {
-                toolCallId: id,
-                toolName: name,
-                isSynthetic: true,
-              },
-            ),
-            replayMeta,
-          ),
-        );
-        if (flushed) {
-          originalAppend(flushed as never);
-        }
+    for (const [id, name] of pendingState.entries()) {
+      const replayMeta = consumePendingToolResultReplayMetadata({
+        sessionKey: replaySessionKey,
+        toolCallId: id,
+      });
+      if (!allowSyntheticToolResults) {
+        continue;
+      }
+      const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
+      const flushed = applyBeforeWriteHook(
+        applyToolResultReplayMetadata(
+          persistToolResult(applyToolResultReplayMetadata(persistMessage(synthetic), replayMeta), {
+            toolCallId: id,
+            toolName: name,
+            isSynthetic: true,
+          }),
+          replayMeta,
+        ),
+      );
+      if (flushed) {
+        originalAppend(flushed as never);
       }
     }
     pendingState.clear();
   };
 
   const clearPendingToolResults = () => {
+    for (const [id] of pendingState.entries()) {
+      consumePendingToolResultReplayMetadata({
+        sessionKey: replaySessionKey,
+        toolCallId: id,
+      });
+    }
     pendingState.clear();
   };
 
@@ -203,7 +214,7 @@ export function installSessionToolResultGuard(
       const id = extractToolResultId(nextMessage as Extract<AgentMessage, { role: "toolResult" }>);
       const toolName = id ? pendingState.getToolName(id) : undefined;
       const replayMeta = consumePendingToolResultReplayMetadata({
-        sessionKey: opts?.sessionKey,
+        sessionKey: replaySessionKey,
         toolCallId: id ?? undefined,
       });
       if (id) {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -237,7 +237,8 @@ export function installSessionToolResultGuard(
       if (!persisted) {
         return undefined;
       }
-      return originalAppend(persisted as never);
+      const replayTaggedPersisted = applyToolResultReplayMetadata(persisted, replayMeta);
+      return originalAppend(replayTaggedPersisted as never);
     }
 
     // Skip tool call extraction for aborted/errored assistant messages.

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -59,10 +59,14 @@ function matchExecDiagnosticType(command: string): ReplayDiagnosticType | null {
     return "openclaw.config_snapshot";
   }
   if (
-    /\bcat\s+["']?[^"'`\s]*openclaw\.json["']?/iu.test(command) ||
-    /\bcat\s+["']?[^"'`\s]*extensions[\\/][^/"'`\\\s]+[\\/]package\.json["']?/iu.test(command)
+    /\bcat\s+"[^"]*openclaw\.json"/iu.test(command) ||
+    /\bcat\s+'[^']*openclaw\.json'/iu.test(command) ||
+    /\bcat\s+[^"'`\s]*openclaw\.json(?:\s|$)/iu.test(command) ||
+    /\bcat\s+"[^"]*extensions[\\/][^"]+[\\/]package\.json"/iu.test(command) ||
+    /\bcat\s+'[^']*extensions[\\/][^']+[\\/]package\.json'/iu.test(command) ||
+    /\bcat\s+[^"'`\s]*extensions[\\/][^/"'`\\\s]+[\\/]package\.json(?:\s|$)/iu.test(command)
   ) {
-    return command.includes("openclaw.json")
+    return /openclaw\.json/iu.test(command)
       ? "openclaw.config_snapshot"
       : "openclaw.plugin_path_probe";
   }

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -11,6 +11,8 @@ type ReplayDiagnosticType =
 type ToolResultReplayPolicyMeta = {
   transient: true;
   diagnosticType: ReplayDiagnosticType;
+  /** Command string (exec/bash) or file path (read) used to identify the specific target. */
+  diagnosticTarget?: string;
   taggedAt: number;
   persistedAt?: number;
   sourceTool: string;
@@ -20,6 +22,7 @@ type OpenClawReplayMetaEnvelope = {
   __openclaw?: Record<string, unknown> & {
     transient?: boolean;
     diagnosticType?: string;
+    diagnosticTarget?: string;
     taggedAt?: number;
     persistedAt?: number;
     sourceTool?: string;
@@ -107,6 +110,7 @@ export function detectToolResultReplayPolicyMeta(params: {
     return {
       transient: true,
       diagnosticType,
+      diagnosticTarget: command,
       taggedAt,
       sourceTool: toolName,
     };
@@ -124,6 +128,7 @@ export function detectToolResultReplayPolicyMeta(params: {
     return {
       transient: true,
       diagnosticType,
+      diagnosticTarget: filePath,
       taggedAt,
       sourceTool: toolName,
     };
@@ -186,6 +191,7 @@ export function applyToolResultReplayMetadata(
       ...next.__openclaw,
       transient: true,
       diagnosticType: meta.diagnosticType,
+      diagnosticTarget: meta.diagnosticTarget,
       taggedAt: meta.taggedAt,
       sourceTool: meta.sourceTool,
     },
@@ -205,6 +211,7 @@ export function getToolResultReplayMetadata(
   return {
     transient: true,
     diagnosticType: meta.diagnosticType as ReplayDiagnosticType,
+    diagnosticTarget: typeof meta.diagnosticTarget === "string" ? meta.diagnosticTarget : undefined,
     taggedAt: typeof meta.taggedAt === "number" ? meta.taggedAt : 0,
     persistedAt: typeof meta.persistedAt === "number" ? meta.persistedAt : undefined,
     sourceTool: typeof meta.sourceTool === "string" ? meta.sourceTool : "unknown",
@@ -232,6 +239,7 @@ export function stampPersistedToolResultReplayMetadata(
       ...next.__openclaw,
       transient: true,
       diagnosticType: meta.diagnosticType,
+      diagnosticTarget: meta.diagnosticTarget,
       taggedAt: meta.taggedAt,
       persistedAt,
       sourceTool: meta.sourceTool,

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -12,6 +12,7 @@ type ToolResultReplayPolicyMeta = {
   transient: true;
   diagnosticType: ReplayDiagnosticType;
   taggedAt: number;
+  persistedAt?: number;
   sourceTool: string;
 };
 
@@ -20,6 +21,7 @@ type OpenClawReplayMetaEnvelope = {
     transient?: boolean;
     diagnosticType?: string;
     taggedAt?: number;
+    persistedAt?: number;
     sourceTool?: string;
     replayOmitted?: boolean;
   };
@@ -200,8 +202,37 @@ export function getToolResultReplayMetadata(
     transient: true,
     diagnosticType: meta.diagnosticType as ReplayDiagnosticType,
     taggedAt: typeof meta.taggedAt === "number" ? meta.taggedAt : 0,
+    persistedAt: typeof meta.persistedAt === "number" ? meta.persistedAt : undefined,
     sourceTool: typeof meta.sourceTool === "string" ? meta.sourceTool : "unknown",
   };
+}
+
+export function stampPersistedToolResultReplayMetadata(
+  message: AgentMessage,
+  meta: ToolResultReplayPolicyMeta | null,
+): AgentMessage {
+  if (!meta || (message as { role?: unknown }).role !== "toolResult") {
+    return message;
+  }
+  const next = message as AgentMessage &
+    OpenClawReplayMetaEnvelope & {
+      timestamp?: unknown;
+    };
+  const persistedAt =
+    typeof next.timestamp === "number" && Number.isFinite(next.timestamp)
+      ? next.timestamp
+      : Date.now();
+  return {
+    ...next,
+    __openclaw: {
+      ...next.__openclaw,
+      transient: true,
+      diagnosticType: meta.diagnosticType,
+      taggedAt: meta.taggedAt,
+      persistedAt,
+      sourceTool: meta.sourceTool,
+    },
+  } as unknown as AgentMessage;
 }
 
 export function replaceToolResultReplayContent(

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -1,0 +1,223 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export const STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS = 60 * 60 * 1000;
+
+type ReplayDiagnosticType =
+  | "openclaw.plugins_list"
+  | "openclaw.status"
+  | "openclaw.config_snapshot"
+  | "openclaw.plugin_path_probe";
+
+type ToolResultReplayPolicyMeta = {
+  transient: true;
+  diagnosticType: ReplayDiagnosticType;
+  taggedAt: number;
+  sourceTool: string;
+};
+
+type OpenClawReplayMetaEnvelope = {
+  __openclaw?: Record<string, unknown> & {
+    transient?: boolean;
+    diagnosticType?: string;
+    taggedAt?: number;
+    sourceTool?: string;
+    replayOmitted?: boolean;
+  };
+};
+
+const pendingToolResultReplayMeta = new Map<string, ToolResultReplayPolicyMeta>();
+
+function buildPendingKey(sessionKey: string, toolCallId: string): string {
+  return `${sessionKey}:${toolCallId}`;
+}
+
+function trimString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function matchExecDiagnosticType(command: string): ReplayDiagnosticType | null {
+  if (/^\s*openclaw\s+plugins\s+list(?:\s|$)/iu.test(command)) {
+    return "openclaw.plugins_list";
+  }
+  if (/^\s*openclaw\s+status(?:\s|$)/iu.test(command)) {
+    return "openclaw.status";
+  }
+  if (/^\s*openclaw\s+config\s+get(?:\s|$)/iu.test(command)) {
+    return "openclaw.config_snapshot";
+  }
+  if (
+    /\bcat\s+["']?[^"'`\s]*openclaw\.json["']?/iu.test(command) ||
+    /\bcat\s+["']?[^"'`\s]*extensions\/openclaw-[^/"'`\s]+\/package\.json["']?/iu.test(command)
+  ) {
+    return command.includes("openclaw.json")
+      ? "openclaw.config_snapshot"
+      : "openclaw.plugin_path_probe";
+  }
+  return null;
+}
+
+function matchReadDiagnosticType(filePath: string): ReplayDiagnosticType | null {
+  if (/openclaw\.json$/iu.test(filePath)) {
+    return "openclaw.config_snapshot";
+  }
+  if (/extensions\/openclaw-[^/]+\/package\.json$/iu.test(filePath)) {
+    return "openclaw.plugin_path_probe";
+  }
+  return null;
+}
+
+export function detectToolResultReplayPolicyMeta(params: {
+  toolName: string;
+  args: unknown;
+  taggedAt?: number;
+}): ToolResultReplayPolicyMeta | null {
+  const toolName = params.toolName.trim().toLowerCase();
+  const taggedAt = params.taggedAt ?? Date.now();
+  const record =
+    params.args && typeof params.args === "object"
+      ? (params.args as Record<string, unknown>)
+      : undefined;
+
+  if (toolName === "exec" || toolName === "bash") {
+    const command = trimString(record?.command);
+    if (!command) {
+      return null;
+    }
+    const diagnosticType = matchExecDiagnosticType(command);
+    if (!diagnosticType) {
+      return null;
+    }
+    return {
+      transient: true,
+      diagnosticType,
+      taggedAt,
+      sourceTool: toolName,
+    };
+  }
+
+  if (toolName === "read") {
+    const filePath = trimString(record?.path) ?? trimString(record?.file_path);
+    if (!filePath) {
+      return null;
+    }
+    const diagnosticType = matchReadDiagnosticType(filePath);
+    if (!diagnosticType) {
+      return null;
+    }
+    return {
+      transient: true,
+      diagnosticType,
+      taggedAt,
+      sourceTool: toolName,
+    };
+  }
+
+  return null;
+}
+
+export function recordPendingToolResultReplayMetadata(params: {
+  sessionKey?: string;
+  toolCallId?: string;
+  toolName: string;
+  args: unknown;
+  taggedAt?: number;
+}): void {
+  const sessionKey = trimString(params.sessionKey);
+  const toolCallId = trimString(params.toolCallId);
+  if (!sessionKey || !toolCallId) {
+    return;
+  }
+  const meta = detectToolResultReplayPolicyMeta({
+    toolName: params.toolName,
+    args: params.args,
+    taggedAt: params.taggedAt,
+  });
+  if (!meta) {
+    return;
+  }
+  pendingToolResultReplayMeta.set(buildPendingKey(sessionKey, toolCallId), meta);
+}
+
+export function consumePendingToolResultReplayMetadata(params: {
+  sessionKey?: string;
+  toolCallId?: string;
+}): ToolResultReplayPolicyMeta | null {
+  const sessionKey = trimString(params.sessionKey);
+  const toolCallId = trimString(params.toolCallId);
+  if (!sessionKey || !toolCallId) {
+    return null;
+  }
+  const key = buildPendingKey(sessionKey, toolCallId);
+  const meta = pendingToolResultReplayMeta.get(key) ?? null;
+  pendingToolResultReplayMeta.delete(key);
+  return meta;
+}
+
+export function applyToolResultReplayMetadata(
+  message: AgentMessage,
+  meta: ToolResultReplayPolicyMeta | null,
+): AgentMessage {
+  if (!meta || (message as { role?: unknown }).role !== "toolResult") {
+    return message;
+  }
+  const next = message as AgentMessage & OpenClawReplayMetaEnvelope;
+  return {
+    ...next,
+    __openclaw: {
+      ...next.__openclaw,
+      transient: true,
+      diagnosticType: meta.diagnosticType,
+      taggedAt: meta.taggedAt,
+      sourceTool: meta.sourceTool,
+    },
+  } as unknown as AgentMessage;
+}
+
+export function getToolResultReplayMetadata(
+  message: AgentMessage,
+): ToolResultReplayPolicyMeta | null {
+  if ((message as { role?: unknown }).role !== "toolResult") {
+    return null;
+  }
+  const meta = (message as OpenClawReplayMetaEnvelope).__openclaw;
+  if (!meta || meta.transient !== true || typeof meta.diagnosticType !== "string") {
+    return null;
+  }
+  return {
+    transient: true,
+    diagnosticType: meta.diagnosticType as ReplayDiagnosticType,
+    taggedAt: typeof meta.taggedAt === "number" ? meta.taggedAt : 0,
+    sourceTool: typeof meta.sourceTool === "string" ? meta.sourceTool : "unknown",
+  };
+}
+
+export function replaceToolResultReplayContent(
+  message: AgentMessage,
+  replacementText: string,
+): AgentMessage {
+  if ((message as { role?: unknown }).role !== "toolResult") {
+    return message;
+  }
+  const next = message as AgentMessage &
+    OpenClawReplayMetaEnvelope & {
+      content?: unknown;
+    };
+  const replacement =
+    typeof next.content === "string"
+      ? replacementText
+      : Array.isArray(next.content)
+        ? [{ type: "text", text: replacementText }]
+        : next.content;
+  return {
+    ...next,
+    ...(replacement !== undefined ? { content: replacement } : {}),
+    __openclaw: {
+      ...next.__openclaw,
+      replayOmitted: true,
+    },
+  } as unknown as AgentMessage;
+}

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -58,7 +58,7 @@ function matchExecDiagnosticType(command: string): ReplayDiagnosticType | null {
   }
   if (
     /\bcat\s+["']?[^"'`\s]*openclaw\.json["']?/iu.test(command) ||
-    /\bcat\s+["']?[^"'`\s]*extensions\/openclaw-[^/"'`\s]+\/package\.json["']?/iu.test(command)
+    /\bcat\s+["']?[^"'`\s]*extensions\/[^/"'`\s]+\/package\.json["']?/iu.test(command)
   ) {
     return command.includes("openclaw.json")
       ? "openclaw.config_snapshot"
@@ -71,7 +71,7 @@ function matchReadDiagnosticType(filePath: string): ReplayDiagnosticType | null 
   if (/openclaw\.json$/iu.test(filePath)) {
     return "openclaw.config_snapshot";
   }
-  if (/extensions\/openclaw-[^/]+\/package\.json$/iu.test(filePath)) {
+  if (/extensions\/[^/]+\/package\.json$/iu.test(filePath)) {
     return "openclaw.plugin_path_probe";
   }
   return null;

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -43,6 +43,15 @@ function buildPendingKey(sessionKey: string, toolCallId: string): string {
   return `${sessionKey}:${toolCallId}`;
 }
 
+function extractSessionKeyFromPendingKey(pendingKey: string): string | undefined {
+  const separatorIndex = pendingKey.lastIndexOf(":");
+  if (separatorIndex <= 0) {
+    return undefined;
+  }
+  const sessionKey = pendingKey.slice(0, separatorIndex).trim();
+  return sessionKey || undefined;
+}
+
 function trimString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -185,10 +194,9 @@ export function drainPendingToolResultReplayMetadataForSession(params: {
   if (!sessionKey) {
     return 0;
   }
-  const prefix = `${sessionKey}:`;
   let drained = 0;
   for (const key of pendingToolResultReplayMeta.keys()) {
-    if (!key.startsWith(prefix)) {
+    if (extractSessionKeyFromPendingKey(key) !== sessionKey) {
       continue;
     }
     pendingToolResultReplayMeta.delete(key);

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -58,7 +58,7 @@ function matchExecDiagnosticType(command: string): ReplayDiagnosticType | null {
   }
   if (
     /\bcat\s+["']?[^"'`\s]*openclaw\.json["']?/iu.test(command) ||
-    /\bcat\s+["']?[^"'`\s]*extensions\/[^/"'`\s]+\/package\.json["']?/iu.test(command)
+    /\bcat\s+["']?[^"'`\s]*extensions[\\/][^/"'`\\\s]+[\\/]package\.json["']?/iu.test(command)
   ) {
     return command.includes("openclaw.json")
       ? "openclaw.config_snapshot"
@@ -71,7 +71,7 @@ function matchReadDiagnosticType(filePath: string): ReplayDiagnosticType | null 
   if (/openclaw\.json$/iu.test(filePath)) {
     return "openclaw.config_snapshot";
   }
-  if (/extensions\/[^/]+\/package\.json$/iu.test(filePath)) {
+  if (/extensions[\\/][^/\\]+[\\/]package\.json$/iu.test(filePath)) {
     return "openclaw.plugin_path_probe";
   }
   return null;

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -177,6 +177,26 @@ export function consumePendingToolResultReplayMetadata(params: {
   return meta;
 }
 
+export function drainPendingToolResultReplayMetadataForSession(params: {
+  sessionKey?: string;
+  sessionId?: string;
+}): number {
+  const sessionKey = resolveToolResultReplaySessionKey(params);
+  if (!sessionKey) {
+    return 0;
+  }
+  const prefix = `${sessionKey}:`;
+  let drained = 0;
+  for (const key of pendingToolResultReplayMeta.keys()) {
+    if (!key.startsWith(prefix)) {
+      continue;
+    }
+    pendingToolResultReplayMeta.delete(key);
+    drained += 1;
+  }
+  return drained;
+}
+
 export function applyToolResultReplayMetadata(
   message: AgentMessage,
   meta: ToolResultReplayPolicyMeta | null,

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -27,6 +27,13 @@ type OpenClawReplayMetaEnvelope = {
 
 const pendingToolResultReplayMeta = new Map<string, ToolResultReplayPolicyMeta>();
 
+export function resolveToolResultReplaySessionKey(params: {
+  sessionKey?: string;
+  sessionId?: string;
+}): string | undefined {
+  return trimString(params.sessionKey) ?? trimString(params.sessionId);
+}
+
 function buildPendingKey(sessionKey: string, toolCallId: string): string {
   return `${sessionKey}:${toolCallId}`;
 }
@@ -121,12 +128,13 @@ export function detectToolResultReplayPolicyMeta(params: {
 
 export function recordPendingToolResultReplayMetadata(params: {
   sessionKey?: string;
+  sessionId?: string;
   toolCallId?: string;
   toolName: string;
   args: unknown;
   taggedAt?: number;
 }): void {
-  const sessionKey = trimString(params.sessionKey);
+  const sessionKey = resolveToolResultReplaySessionKey(params);
   const toolCallId = trimString(params.toolCallId);
   if (!sessionKey || !toolCallId) {
     return;
@@ -144,9 +152,10 @@ export function recordPendingToolResultReplayMetadata(params: {
 
 export function consumePendingToolResultReplayMetadata(params: {
   sessionKey?: string;
+  sessionId?: string;
   toolCallId?: string;
 }): ToolResultReplayPolicyMeta | null {
-  const sessionKey = trimString(params.sessionKey);
+  const sessionKey = resolveToolResultReplaySessionKey(params);
   const toolCallId = trimString(params.toolCallId);
   if (!sessionKey || !toolCallId) {
     return null;
@@ -211,7 +220,7 @@ export function replaceToolResultReplayContent(
       ? replacementText
       : Array.isArray(next.content)
         ? [{ type: "text", text: replacementText }]
-        : next.content;
+        : replacementText;
   return {
     ...next,
     ...(replacement !== undefined ? { content: replacement } : {}),


### PR DESCRIPTION
## Summary

  This change mitigates stale diagnostic `toolResult` replay pollution in session history.

  It adds structured replay metadata for transient environment-diagnostic tool results, then omits stale results during replay when they are either:

  - older than the replay threshold, or
  - superseded by a newer result of the same diagnostic type

  Transcript history is preserved. Only replay input is reduced.

  ## What changed

  - add structured replay metadata for transient diagnostic tool results
    - `src/agents/tool-result-replay-metadata.ts`

  - tag diagnostic tool results at persistence time
    - `src/agents/pi-embedded-subscribe.handlers.tools.ts`
    - `src/agents/session-tool-result-guard.ts`

  - omit stale transient diagnostic tool results during replay
    - `src/agents/pi-embedded-runner/replay-history.ts`

  - add focused tests
    - `src/agents/session-tool-result-guard.test.ts`
    - `src/agents/pi-embedded-runner.sanitize-session-history.test.ts`

  ## Scope

  This PR is intentionally limited to replay-time mitigation for stale diagnostic `toolResult` entries.

  It does **not** attempt to solve broader assistant-level context pollution or stale natural-language conclusions in session history.

  ## Behavior

  This targets replayed environment-state diagnostics such as:

  - `openclaw plugins list`
  - `openclaw status`
  - `openclaw config get ...`
  - reads of current OpenClaw config files
  - plugin path / package metadata probes
  - other transient environment checks routed through diagnostic tool results

  The stored transcript is not rewritten.
  Only replayed stale diagnostic content is replaced with an omission marker.

  ## Validation

  ### Focused tests
  Passed:

  ```bash
  pnpm vitest run src/agents/session-tool-result-guard.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts

  - 59/59 tests passed

  Passed:

  node scripts/tsdown-build.mjs

  ### Remote behavior validation

  Validated on a main-based build deployed to a remote verification environment.

  Manual replay check:

  1. read a file successfully
  2. delete the file
  3. ask again in the same session
  4. ask a third follow-up in the same session

  Observed result:

  - the later replies reflected the current missing-file state
  - the earlier successful file content was not replayed as current truth

  ## Notes

  This patch was migrated onto current main structure, where replay cleanup is anchored in:

  - src/agents/pi-embedded-runner/replay-history.ts

  rather than older historical entrypoints used in earlier local prototypes.