### PR TITLE
fix: strip OPENCLAW_SERVICE_* env vars from exec-spawned child processes

### DIFF
--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -46,7 +46,8 @@ enum HostEnvSecurityPolicy {
         "MAVEN_OPTS",
         "SBT_OPTS",
         "GRADLE_OPTS",
-        "ANT_OPTS"
+        "ANT_OPTS",
+        "OPENCLAW_SYSTEMD_UNIT"
     ]
 
     static let blockedOverrideKeys: Set<String> = [
@@ -155,6 +156,7 @@ enum HostEnvSecurityPolicy {
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_"
+        "BASH_FUNC_",
+        "OPENCLAW_SERVICE_"
     ]
 }

--- a/src/infra/host-env-security-policy.json
+++ b/src/infra/host-env-security-policy.json
@@ -40,7 +40,8 @@
     "MAVEN_OPTS",
     "SBT_OPTS",
     "GRADLE_OPTS",
-    "ANT_OPTS"
+    "ANT_OPTS",
+    "OPENCLAW_SYSTEMD_UNIT"
   ],
   "blockedOverrideKeys": [
     "HOME",
@@ -139,5 +140,5 @@
     "AWS_CONFIG_FILE"
   ],
   "blockedOverridePrefixes": ["GIT_CONFIG_", "NPM_CONFIG_", "CARGO_REGISTRIES_"],
-  "blockedPrefixes": ["DYLD_", "LD_", "BASH_FUNC_"]
+  "blockedPrefixes": ["DYLD_", "LD_", "BASH_FUNC_", "OPENCLAW_SERVICE_"]
 }

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -537,6 +537,25 @@ describe("isDangerousHostEnvOverrideVarName", () => {
     expect(isDangerousHostEnvOverrideVarName("BASH_ENV")).toBe(false);
     expect(isDangerousHostEnvOverrideVarName("FOO")).toBe(false);
   });
+
+  it("strips leaked OPENCLAW_SERVICE_* runtime markers from inherited env", () => {
+    const result = sanitizeHostExecEnv({
+      baseEnv: {
+        PATH: "/usr/bin",
+        OPENCLAW_SERVICE_KIND: "gateway",
+        OPENCLAW_SERVICE_MARKER: "openclaw",
+        OPENCLAW_SERVICE_VERSION: "2026.3.13",
+        OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service",
+        OPENCLAW_SHELL: "exec",
+      },
+    });
+    expect(result.PATH).toBe("/usr/bin");
+    expect(result.OPENCLAW_SHELL).toBe("exec");
+    expect(result.OPENCLAW_SERVICE_KIND).toBeUndefined();
+    expect(result.OPENCLAW_SERVICE_MARKER).toBeUndefined();
+    expect(result.OPENCLAW_SERVICE_VERSION).toBeUndefined();
+    expect(result.OPENCLAW_SYSTEMD_UNIT).toBeUndefined();
+  });
 });
 
 describe("sanitizeHostExecEnvWithDiagnostics", () => {


### PR DESCRIPTION
## Problem

When an Agent uses the exec tool to run openclaw CLI commands (e.g. openclaw cron list), the child process inherits internal Gateway environment variables such as:

- OPENCLAW_SERVICE_KIND=gateway
- OPENCLAW_SERVICE_MARKER=openclaw
- OPENCLAW_SERVICE_VERSION=2026.3.13
- OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service

When OPENCLAW_SERVICE_KIND=gateway is present, the CLI mistakenly identifies itself as the Gateway process rather than a client, skipping client authentication and causing WebSocket handshake failures:



## Fix

Add OPENCLAW_SERVICE_ to blockedPrefixes and OPENCLAW_SYSTEMD_UNIT to blockedKeys in the host env security policy. This ensures these internal runtime markers are stripped from the environment of any process spawned by the exec tool, while preserving OPENCLAW_SHELL=exec.

## Changes

| File | Change |
|---|---|
| src/infra/host-env-security-policy.json | Added OPENCLAW_SERVICE_ blocked prefix and OPENCLAW_SYSTEMD_UNIT blocked key |
| src/infra/host-env-security.test.ts | Added regression test verifying leaked markers are stripped |
| apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift | Regenerated from updated policy JSON |

Fixes #61095