### PR TITLE
feat: add assistant conclusion freshness gate

### DIFF
--- a/src/agents/assistant-conclusion-freshness-gate.ts
+++ b/src/agents/assistant-conclusion-freshness-gate.ts
@@ -1,0 +1,228 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import {
+  detectToolResultReplayPolicyMeta,
+  getToolResultReplayMetadata,
+  STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS,
+} from "./tool-result-replay-metadata.js";
+
+export const ASSISTANT_FRESHNESS_GATE_TEMPLATE_A =
+  "Freshness check required for this question. Before answering, you must make a fresh tool call in this turn to verify the current environment state. Do not answer from prior assistant conclusions or prior tool results alone, even if similar results already appear in history.";
+
+export const ASSISTANT_FRESHNESS_GATE_HISTORY_WINDOW = 50;
+export const ASSISTANT_FRESHNESS_GATE_ENV = "OPENCLAW_EXPERIMENT_ASSISTANT_FRESHNESS_GATE";
+
+export type AssistantConclusionQuestionType = "plugin_install_state" | "config_key_presence";
+
+export type AssistantFreshnessState = "not_high_risk" | "fresh" | "stale" | "missing";
+
+export type AssistantConclusionFreshnessGateResult = {
+  questionType?: AssistantConclusionQuestionType;
+  diagnosticType?: string;
+  freshnessState: AssistantFreshnessState;
+  prependSystemContext?: string;
+  templateId?: "A";
+  matchedTimestamp?: number;
+};
+
+function trimToDefinedString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function normalizePrompt(prompt: string): string {
+  return prompt.toLowerCase();
+}
+
+function detectPluginInstallQuestion(prompt: string): boolean {
+  return (
+    /(plugin|plugins|插件|plugins\.entries|plugins\.installs)/iu.test(prompt) &&
+    /(installed|install|enabled|enable|loaded|status|what.*plugins|哪些插件|什么插件|装了|安装|启用|还在|状态)/iu.test(
+      prompt,
+    )
+  );
+}
+
+function detectConfigPresenceQuestion(prompt: string): boolean {
+  return (
+    /(config|配置|openclaw\.json|plugins\.installs|plugins\.entries)/iu.test(prompt) &&
+    /(exists|exist|present|value|key|有|有没有|存在|值|配置项|字段|参数)/iu.test(prompt)
+  );
+}
+
+export function isAssistantConclusionFreshnessGateEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = trimToDefinedString(env[ASSISTANT_FRESHNESS_GATE_ENV])?.toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+export function detectAssistantConclusionQuestionType(
+  prompt: string,
+): { questionType: AssistantConclusionQuestionType; diagnosticType: string } | null {
+  const normalized = normalizePrompt(prompt);
+  if (detectConfigPresenceQuestion(normalized)) {
+    return {
+      questionType: "config_key_presence",
+      diagnosticType: "openclaw.config_snapshot",
+    };
+  }
+  if (detectPluginInstallQuestion(normalized)) {
+    return {
+      questionType: "plugin_install_state",
+      diagnosticType: "openclaw.plugins_list",
+    };
+  }
+  return null;
+}
+
+function isReplayOmitted(message: AgentMessage): boolean {
+  const meta = (message as { __openclaw?: unknown }).__openclaw;
+  return (
+    !!meta &&
+    typeof meta === "object" &&
+    (meta as { replayOmitted?: unknown }).replayOmitted === true
+  );
+}
+
+function getMessageTimestamp(message: AgentMessage, fallback: number): number {
+  const direct = (message as { timestamp?: unknown }).timestamp;
+  return typeof direct === "number" ? direct : fallback;
+}
+
+type AssistantToolCallBlock = {
+  type?: unknown;
+  id?: unknown;
+  name?: unknown;
+  arguments?: unknown;
+};
+
+function inferDiagnosticTypeFromHistoricalToolCall(params: {
+  messages: AgentMessage[];
+  toolResultIndex: number;
+  toolResult: AgentMessage;
+}): string | undefined {
+  const toolResult = params.toolResult as {
+    toolCallId?: unknown;
+    toolName?: unknown;
+  };
+  const toolCallId = trimToDefinedString(toolResult.toolCallId);
+  const toolName = trimToDefinedString(toolResult.toolName)?.toLowerCase() ?? "unknown";
+  if (!toolCallId) {
+    return undefined;
+  }
+
+  for (let index = params.toolResultIndex - 1; index >= 0; index -= 1) {
+    const message = params.messages[index] as {
+      role?: unknown;
+      content?: unknown;
+    };
+    if (message.role !== "assistant" || !Array.isArray(message.content)) {
+      continue;
+    }
+    for (const block of message.content as AssistantToolCallBlock[]) {
+      if (block?.type !== "toolCall") {
+        continue;
+      }
+      if (trimToDefinedString(block.id) !== toolCallId) {
+        continue;
+      }
+      const inferred = detectToolResultReplayPolicyMeta({
+        toolName: trimToDefinedString(block.name) ?? toolName,
+        args: block.arguments,
+        taggedAt: getMessageTimestamp(params.toolResult, Date.now()),
+      });
+      return inferred?.diagnosticType;
+    }
+  }
+  return undefined;
+}
+
+function inferReplayDiagnosticType(params: {
+  messages: AgentMessage[];
+  toolResultIndex: number;
+  toolResult: AgentMessage;
+}): string | undefined {
+  const replayMeta = getToolResultReplayMetadata(params.toolResult);
+  if (replayMeta?.diagnosticType) {
+    return replayMeta.diagnosticType;
+  }
+  return inferDiagnosticTypeFromHistoricalToolCall(params);
+}
+
+export function resolveAssistantConclusionFreshnessGate(params: {
+  prompt: string;
+  messages: unknown[];
+  now?: number;
+  historyWindow?: number;
+}): AssistantConclusionFreshnessGateResult {
+  const detected = detectAssistantConclusionQuestionType(params.prompt);
+  if (!detected) {
+    return { freshnessState: "not_high_risk" };
+  }
+
+  const now = params.now ?? Date.now();
+  const historyWindow = params.historyWindow ?? ASSISTANT_FRESHNESS_GATE_HISTORY_WINDOW;
+  const recentMessages = params.messages
+    .slice(Math.max(0, params.messages.length - historyWindow))
+    .filter((message): message is AgentMessage => !!message && typeof message === "object");
+
+  let sawMatchingEvidence = false;
+
+  for (let index = recentMessages.length - 1; index >= 0; index -= 1) {
+    const message = recentMessages[index];
+    if ((message as { role?: unknown }).role !== "toolResult") {
+      continue;
+    }
+    const diagnosticType = inferReplayDiagnosticType({
+      messages: recentMessages,
+      toolResultIndex: index,
+      toolResult: message,
+    });
+    if (diagnosticType !== detected.diagnosticType) {
+      continue;
+    }
+    sawMatchingEvidence = true;
+    if (isReplayOmitted(message)) {
+      continue;
+    }
+    const replayMeta = getToolResultReplayMetadata(message);
+    const messageTimestamp = getMessageTimestamp(message, replayMeta?.taggedAt ?? now);
+    if (now - messageTimestamp <= STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS) {
+      return {
+        questionType: detected.questionType,
+        diagnosticType: detected.diagnosticType,
+        freshnessState: "fresh",
+        matchedTimestamp: messageTimestamp,
+      };
+    }
+  }
+
+  return {
+    questionType: detected.questionType,
+    diagnosticType: detected.diagnosticType,
+    freshnessState: sawMatchingEvidence ? "stale" : "missing",
+    prependSystemContext: ASSISTANT_FRESHNESS_GATE_TEMPLATE_A,
+    templateId: "A",
+  };
+}
+
+export function summarizeAssistantConclusionFreshnessGateLog(
+  result: AssistantConclusionFreshnessGateResult,
+): string {
+  if (result.freshnessState === "not_high_risk") {
+    return "assistant freshness gate: not_high_risk";
+  }
+  const parts = [
+    `assistant freshness gate: ${result.freshnessState}`,
+    result.questionType ? `questionType=${result.questionType}` : undefined,
+    result.diagnosticType ? `diagnosticType=${result.diagnosticType}` : undefined,
+    result.templateId ? `template=${result.templateId}` : undefined,
+    typeof result.matchedTimestamp === "number"
+      ? `matchedTs=${result.matchedTimestamp}`
+      : undefined,
+  ].filter((part): part is string => !!trimToDefinedString(part));
+  return parts.join(" ");
+}

--- a/src/agents/assistant-conclusion-freshness-gate.ts
+++ b/src/agents/assistant-conclusion-freshness-gate.ts
@@ -61,12 +61,17 @@ export function isAssistantConclusionFreshnessGateEnabled(
 
 export function detectAssistantConclusionQuestionType(
   prompt: string,
-): { questionType: AssistantConclusionQuestionType; diagnosticType: string } | null {
+): {
+  questionType: AssistantConclusionQuestionType;
+  diagnosticType: string;
+  diagnosticTargetHint?: string;
+} | null {
   const normalized = normalizePrompt(prompt);
   if (detectConfigPresenceQuestion(normalized)) {
     return {
       questionType: "config_key_presence",
       diagnosticType: "openclaw.config_snapshot",
+      diagnosticTargetHint: extractConfigTargetHint(normalized),
     };
   }
   if (detectPluginInstallQuestion(normalized)) {
@@ -180,12 +185,69 @@ function inferReplayDiagnosticType(params: {
   messages: AgentMessage[];
   toolResultIndex: number;
   toolResult: AgentMessage;
-}): string | undefined {
+}): { diagnosticType?: string; diagnosticTarget?: string } | undefined {
   const replayMeta = getToolResultReplayMetadata(params.toolResult);
   if (replayMeta?.diagnosticType) {
-    return replayMeta.diagnosticType;
+    return {
+      diagnosticType: replayMeta.diagnosticType,
+      diagnosticTarget: replayMeta.diagnosticTarget,
+    };
   }
-  return inferDiagnosticTypeFromHistoricalToolCall(params);
+  const diagnosticType = inferDiagnosticTypeFromHistoricalToolCall(params);
+  if (!diagnosticType) {
+    return undefined;
+  }
+  return { diagnosticType };
+}
+
+function extractConfigTargetHint(normalizedPrompt: string): string | undefined {
+  if (/plugins\.entries/iu.test(normalizedPrompt)) {
+    return "plugins.entries";
+  }
+  if (/plugins\.installs/iu.test(normalizedPrompt)) {
+    return "plugins.installs";
+  }
+  const dottedPathMatches = normalizedPrompt.match(/\b[a-z_][a-z0-9_-]*(?:\.[a-z0-9_-]+)+\b/giu);
+  return dottedPathMatches?.[0];
+}
+
+function extractConfigPathFromDiagnosticTarget(diagnosticTarget?: string): string | undefined {
+  const target = trimToDefinedString(diagnosticTarget)?.toLowerCase();
+  if (!target) {
+    return undefined;
+  }
+  if (/openclaw\.json/iu.test(target)) {
+    return "__full_config_snapshot__";
+  }
+  const gatewayPath = target.match(/^[a-z_][a-z0-9_-]*(?:\.[a-z0-9_-]+)+$/iu);
+  if (gatewayPath?.[0]) {
+    return gatewayPath[0].toLowerCase();
+  }
+  const cliPath = target.match(/openclaw\s+config\s+get(?:\s+--\S+)*\s+["']?([^"'`\s]+)["']?/iu);
+  return cliPath?.[1]?.toLowerCase();
+}
+
+function isSameOrNestedConfigPath(a: string, b: string): boolean {
+  return a === b || a.startsWith(`${b}.`) || b.startsWith(`${a}.`);
+}
+
+function matchesDiagnosticTarget(params: {
+  questionType: AssistantConclusionQuestionType;
+  diagnosticTargetHint?: string;
+  evidenceDiagnosticTarget?: string;
+}): boolean {
+  if (params.questionType !== "config_key_presence") {
+    return true;
+  }
+  const hint = trimToDefinedString(params.diagnosticTargetHint)?.toLowerCase();
+  if (!hint) {
+    return true;
+  }
+  const evidencePath = extractConfigPathFromDiagnosticTarget(params.evidenceDiagnosticTarget);
+  if (!evidencePath || evidencePath === "__full_config_snapshot__") {
+    return true;
+  }
+  return isSameOrNestedConfigPath(hint, evidencePath);
 }
 
 export function resolveAssistantConclusionFreshnessGate(params: {
@@ -212,12 +274,21 @@ export function resolveAssistantConclusionFreshnessGate(params: {
     if ((message as { role?: unknown }).role !== "toolResult") {
       continue;
     }
-    const diagnosticType = inferReplayDiagnosticType({
+    const diagnostic = inferReplayDiagnosticType({
       messages: recentMessages,
       toolResultIndex: index,
       toolResult: message,
     });
-    if (diagnosticType !== detected.diagnosticType) {
+    if (diagnostic?.diagnosticType !== detected.diagnosticType) {
+      continue;
+    }
+    if (
+      !matchesDiagnosticTarget({
+        questionType: detected.questionType,
+        diagnosticTargetHint: detected.diagnosticTargetHint,
+        evidenceDiagnosticTarget: diagnostic.diagnosticTarget,
+      })
+    ) {
       continue;
     }
     sawMatchingEvidence = true;

--- a/src/agents/assistant-conclusion-freshness-gate.ts
+++ b/src/agents/assistant-conclusion-freshness-gate.ts
@@ -141,7 +141,7 @@ function inferDiagnosticTypeFromHistoricalToolCall(params: {
   messages: AgentMessage[];
   toolResultIndex: number;
   toolResult: AgentMessage;
-}): string | undefined {
+}): { diagnosticType?: string; diagnosticTarget?: string } | undefined {
   const toolResult = params.toolResult as {
     toolCallId?: unknown;
     toolUseId?: unknown;
@@ -175,7 +175,13 @@ function inferDiagnosticTypeFromHistoricalToolCall(params: {
         args: normalized.args,
         taggedAt: getMessageTimestamp(params.toolResult) ?? Date.now(),
       });
-      return inferred?.diagnosticType;
+      if (!inferred?.diagnosticType) {
+        return undefined;
+      }
+      return {
+        diagnosticType: inferred.diagnosticType,
+        diagnosticTarget: inferred.diagnosticTarget,
+      };
     }
   }
   return undefined;
@@ -193,11 +199,11 @@ function inferReplayDiagnosticType(params: {
       diagnosticTarget: replayMeta.diagnosticTarget,
     };
   }
-  const diagnosticType = inferDiagnosticTypeFromHistoricalToolCall(params);
-  if (!diagnosticType) {
+  const inferred = inferDiagnosticTypeFromHistoricalToolCall(params);
+  if (!inferred?.diagnosticType) {
     return undefined;
   }
-  return { diagnosticType };
+  return inferred;
 }
 
 function extractConfigTargetHint(normalizedPrompt: string): string | undefined {

--- a/src/agents/assistant-conclusion-freshness-gate.ts
+++ b/src/agents/assistant-conclusion-freshness-gate.ts
@@ -96,6 +96,22 @@ function parseFiniteTimestamp(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
+function parseJsonObjectString(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return value;
+  }
+  try {
+    const parsed = JSON.parse(trimmed);
+    return parsed && typeof parsed === "object" ? parsed : value;
+  } catch {
+    return value;
+  }
+}
+
 function getMessageTimestamp(message: AgentMessage): number | undefined {
   return parseFiniteTimestamp((message as { timestamp?: unknown }).timestamp);
 }
@@ -172,7 +188,7 @@ function inferDiagnosticTypeFromHistoricalToolCall(params: {
       }
       const inferred = detectToolResultReplayPolicyMeta({
         toolName: normalized.name ?? toolName,
-        args: normalized.args,
+        args: parseJsonObjectString(normalized.args),
         taggedAt: getMessageTimestamp(params.toolResult) ?? Date.now(),
       });
       if (!inferred?.diagnosticType) {

--- a/src/agents/assistant-conclusion-freshness-gate.ts
+++ b/src/agents/assistant-conclusion-freshness-gate.ts
@@ -87,9 +87,12 @@ function isReplayOmitted(message: AgentMessage): boolean {
   );
 }
 
-function getMessageTimestamp(message: AgentMessage, fallback: number): number {
-  const direct = (message as { timestamp?: unknown }).timestamp;
-  return typeof direct === "number" ? direct : fallback;
+function parseFiniteTimestamp(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function getMessageTimestamp(message: AgentMessage): number | undefined {
+  return parseFiniteTimestamp((message as { timestamp?: unknown }).timestamp);
 }
 
 type AssistantToolCallBlock = {
@@ -132,7 +135,7 @@ function inferDiagnosticTypeFromHistoricalToolCall(params: {
       const inferred = detectToolResultReplayPolicyMeta({
         toolName: trimToDefinedString(block.name) ?? toolName,
         args: block.arguments,
-        taggedAt: getMessageTimestamp(params.toolResult, Date.now()),
+        taggedAt: getMessageTimestamp(params.toolResult) ?? Date.now(),
       });
       return inferred?.diagnosticType;
     }
@@ -189,7 +192,11 @@ export function resolveAssistantConclusionFreshnessGate(params: {
       continue;
     }
     const replayMeta = getToolResultReplayMetadata(message);
-    const messageTimestamp = getMessageTimestamp(message, replayMeta?.taggedAt ?? now);
+    const messageTimestamp =
+      getMessageTimestamp(message) ?? parseFiniteTimestamp(replayMeta?.taggedAt);
+    if (messageTimestamp === undefined) {
+      continue;
+    }
     if (now - messageTimestamp <= STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS) {
       return {
         questionType: detected.questionType,

--- a/src/agents/assistant-conclusion-freshness-gate.ts
+++ b/src/agents/assistant-conclusion-freshness-gate.ts
@@ -98,9 +98,39 @@ function getMessageTimestamp(message: AgentMessage): number | undefined {
 type AssistantToolCallBlock = {
   type?: unknown;
   id?: unknown;
+  toolCallId?: unknown;
+  toolUseId?: unknown;
+  call_id?: unknown;
   name?: unknown;
+  toolName?: unknown;
+  functionName?: unknown;
   arguments?: unknown;
+  input?: unknown;
 };
+
+function extractHistoricalToolCallData(
+  block: AssistantToolCallBlock,
+): { id?: string; name?: string; args: unknown } | null {
+  const type = trimToDefinedString(block?.type);
+  if (type !== "toolCall" && type !== "toolUse" && type !== "functionCall") {
+    return null;
+  }
+  const id =
+    trimToDefinedString(block.id) ??
+    trimToDefinedString(block.toolCallId) ??
+    trimToDefinedString(block.toolUseId) ??
+    trimToDefinedString(block.call_id);
+  const name =
+    trimToDefinedString(block.name) ??
+    trimToDefinedString(block.toolName) ??
+    trimToDefinedString(block.functionName);
+  const args = block.arguments ?? block.input;
+  return { id, name, args };
+}
+
+function isErroredToolResult(message: AgentMessage): boolean {
+  return (message as { isError?: unknown }).isError === true;
+}
 
 function inferDiagnosticTypeFromHistoricalToolCall(params: {
   messages: AgentMessage[];
@@ -109,9 +139,11 @@ function inferDiagnosticTypeFromHistoricalToolCall(params: {
 }): string | undefined {
   const toolResult = params.toolResult as {
     toolCallId?: unknown;
+    toolUseId?: unknown;
     toolName?: unknown;
   };
-  const toolCallId = trimToDefinedString(toolResult.toolCallId);
+  const toolCallId =
+    trimToDefinedString(toolResult.toolCallId) ?? trimToDefinedString(toolResult.toolUseId);
   const toolName = trimToDefinedString(toolResult.toolName)?.toLowerCase() ?? "unknown";
   if (!toolCallId) {
     return undefined;
@@ -126,15 +158,16 @@ function inferDiagnosticTypeFromHistoricalToolCall(params: {
       continue;
     }
     for (const block of message.content as AssistantToolCallBlock[]) {
-      if (block?.type !== "toolCall") {
+      const normalized = extractHistoricalToolCallData(block);
+      if (!normalized) {
         continue;
       }
-      if (trimToDefinedString(block.id) !== toolCallId) {
+      if (normalized.id !== toolCallId) {
         continue;
       }
       const inferred = detectToolResultReplayPolicyMeta({
-        toolName: trimToDefinedString(block.name) ?? toolName,
-        args: block.arguments,
+        toolName: normalized.name ?? toolName,
+        args: normalized.args,
         taggedAt: getMessageTimestamp(params.toolResult) ?? Date.now(),
       });
       return inferred?.diagnosticType;
@@ -189,6 +222,9 @@ export function resolveAssistantConclusionFreshnessGate(params: {
     }
     sawMatchingEvidence = true;
     if (isReplayOmitted(message)) {
+      continue;
+    }
+    if (isErroredToolResult(message)) {
       continue;
     }
     const replayMeta = getToolResultReplayMetadata(message);

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1030,6 +1030,54 @@ describe("sanitizeSessionHistory", () => {
     ).not.toBe(true);
   });
 
+  it("falls back to persisted replay time when toolResult timestamp is present but invalid", async () => {
+    setNonGoogleModelApi();
+    const persistedAt = Date.now() - 2 * 60 * 60 * 1000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_old", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: persistedAt - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_old",
+        toolName: "exec",
+        content: [{ type: "text", text: "old plugin output" }],
+        isError: false,
+        timestamp: { invalid: true },
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: Date.now(),
+          persistedAt,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: [
+        {
+          type: "text",
+          text: "[Previous environment diagnostic output omitted from replay for accuracy.]",
+        },
+      ],
+      __openclaw: expect.objectContaining({
+        replayOmitted: true,
+        diagnosticType: "openclaw.plugins_list",
+      }),
+    });
+  });
+
   it("preserves latest assistant thinking blocks for github-copilot models", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -985,6 +985,51 @@ describe("sanitizeSessionHistory", () => {
     });
   });
 
+  it("keeps fresh diagnostic tool results when only the persisted replay timestamp is recent", async () => {
+    setNonGoogleModelApi();
+    const taggedAt = Date.now() - 2 * 60 * 60 * 1000;
+    const persistedAt = Date.now() - 5_000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_recent", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: taggedAt - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_recent",
+        toolName: "exec",
+        content: [{ type: "text", text: "latest plugin output" }],
+        isError: false,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt,
+          persistedAt,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: [{ type: "text", text: "latest plugin output" }],
+      __openclaw: expect.objectContaining({
+        diagnosticType: "openclaw.plugins_list",
+      }),
+    });
+    expect(
+      (result[1] as { __openclaw?: { replayOmitted?: boolean } }).__openclaw?.replayOmitted,
+    ).not.toBe(true);
+  });
+
   it("preserves latest assistant thinking blocks for github-copilot models", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -944,6 +944,47 @@ describe("sanitizeSessionHistory", () => {
     ).not.toBe(true);
   });
 
+  it("replaces stale transient diagnostic tool results even when content has an unexpected shape", async () => {
+    setNonGoogleModelApi();
+    const oldTimestamp = Date.now() - 2 * 60 * 60 * 1000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_old", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: oldTimestamp - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_old",
+        toolName: "exec",
+        content: { stale: true },
+        isError: false,
+        timestamp: oldTimestamp,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: oldTimestamp,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: "[Previous environment diagnostic output omitted from replay for accuracy.]",
+      __openclaw: expect.objectContaining({
+        replayOmitted: true,
+      }),
+    });
+  });
+
   it("preserves latest assistant thinking blocks for github-copilot models", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -830,6 +830,120 @@ describe("sanitizeSessionHistory", () => {
     ).toBe(false);
   });
 
+  it("omits stale transient diagnostic tool results older than the replay threshold", async () => {
+    setNonGoogleModelApi();
+    const oldTimestamp = Date.now() - 2 * 60 * 60 * 1000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_old", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: oldTimestamp - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_old",
+        toolName: "exec",
+        content: [{ type: "text", text: "old plugin output" }],
+        isError: false,
+        timestamp: oldTimestamp,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: oldTimestamp,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: [
+        {
+          type: "text",
+          text: "[Previous environment diagnostic output omitted from replay for accuracy.]",
+        },
+      ],
+      __openclaw: expect.objectContaining({
+        replayOmitted: true,
+        diagnosticType: "openclaw.plugins_list",
+      }),
+    });
+  });
+
+  it("omits older transient diagnostic tool results when a newer result of the same type exists", async () => {
+    setNonGoogleModelApi();
+    const older = Date.now() - 10 * 60 * 1000;
+    const newer = Date.now() - 30 * 1000;
+    const messages = castAgentMessages([
+      makeAssistantMessage([{ type: "toolCall", id: "call_old", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: older - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_old",
+        toolName: "exec",
+        content: "plugins list old output",
+        isError: false,
+        timestamp: older,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: older,
+          sourceTool: "exec",
+        },
+      },
+      makeAssistantMessage([{ type: "toolCall", id: "call_new", name: "exec", arguments: {} }], {
+        stopReason: "toolUse",
+        timestamp: newer - 1,
+      }),
+      {
+        role: "toolResult",
+        toolCallId: "call_new",
+        toolName: "exec",
+        content: "(no output)",
+        isError: false,
+        timestamp: newer,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: newer,
+          sourceTool: "exec",
+        },
+      },
+    ]);
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      sessionManager: mockSessionManager,
+      sessionId: TEST_SESSION_ID,
+    });
+
+    expect(result[1]).toMatchObject({
+      role: "toolResult",
+      content: "[Previous environment diagnostic output omitted from replay for accuracy.]",
+      __openclaw: expect.objectContaining({
+        replayOmitted: true,
+      }),
+    });
+    expect(result[3]).toMatchObject({
+      role: "toolResult",
+      content: "(no output)",
+    });
+    expect(
+      (result[3] as { __openclaw?: { replayOmitted?: boolean } }).__openclaw?.replayOmitted,
+    ).not.toBe(true);
+  });
+
   it("preserves latest assistant thinking blocks for github-copilot models", async () => {
     setNonGoogleModelApi();
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -804,6 +804,7 @@ export async function compactEmbeddedPiSessionDirect(
       const sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
         allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
         allowedToolNames,
       });

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -327,7 +327,7 @@ function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): Agen
     }
     const latestIndex = latestByDiagnosticType.get(meta.diagnosticType) ?? i;
     const timestamp = parseMessageTimestamp(
-      (message as { timestamp?: unknown }).timestamp ?? meta.taggedAt ?? null,
+      (message as { timestamp?: unknown }).timestamp ?? meta.persistedAt ?? null,
     );
     const staleByNewerResult = latestIndex > i;
     const staleByAge =

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -303,16 +303,17 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
 }
 
 function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): AgentMessage[] {
-  const latestByDiagnosticType = new Map<string, number>();
+  const latestByDiagnosticKey = new Map<string, number>();
   for (let i = 0; i < messages.length; i += 1) {
     const meta = getToolResultReplayMetadata(messages[i]);
     if (!meta) {
       continue;
     }
-    latestByDiagnosticType.set(meta.diagnosticType, i);
+    const key = `${meta.diagnosticType}:${meta.diagnosticTarget ?? ""}`;
+    latestByDiagnosticKey.set(key, i);
   }
 
-  if (latestByDiagnosticType.size === 0) {
+  if (latestByDiagnosticKey.size === 0) {
     return messages;
   }
 
@@ -325,7 +326,8 @@ function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): Agen
     if (!meta) {
       continue;
     }
-    const latestIndex = latestByDiagnosticType.get(meta.diagnosticType) ?? i;
+    const key = `${meta.diagnosticType}:${meta.diagnosticTarget ?? ""}`;
+    const latestIndex = latestByDiagnosticKey.get(key) ?? i;
     const messageTimestamp = parseMessageTimestamp((message as { timestamp?: unknown }).timestamp);
     const persistedTimestamp = parseMessageTimestamp(meta.persistedAt ?? null);
     const timestamp = messageTimestamp ?? persistedTimestamp;

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -28,6 +28,11 @@ import {
   sanitizeToolUseResultPairing,
   stripToolResultDetails,
 } from "../session-transcript-repair.js";
+import {
+  getToolResultReplayMetadata,
+  replaceToolResultReplayContent,
+  STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS,
+} from "../tool-result-replay-metadata.js";
 import type { TranscriptPolicy } from "../transcript-policy.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import {
@@ -297,6 +302,48 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
   return touched ? out : messages;
 }
 
+function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): AgentMessage[] {
+  const latestByDiagnosticType = new Map<string, number>();
+  for (let i = 0; i < messages.length; i += 1) {
+    const meta = getToolResultReplayMetadata(messages[i]);
+    if (!meta) {
+      continue;
+    }
+    latestByDiagnosticType.set(meta.diagnosticType, i);
+  }
+
+  if (latestByDiagnosticType.size === 0) {
+    return messages;
+  }
+
+  const now = Date.now();
+  let touched = false;
+  const out = [...messages];
+  for (let i = 0; i < out.length; i += 1) {
+    const message = out[i];
+    const meta = getToolResultReplayMetadata(message);
+    if (!meta) {
+      continue;
+    }
+    const latestIndex = latestByDiagnosticType.get(meta.diagnosticType) ?? i;
+    const timestamp = parseMessageTimestamp(
+      (message as { timestamp?: unknown }).timestamp ?? meta.taggedAt ?? null,
+    );
+    const staleByNewerResult = latestIndex > i;
+    const staleByAge =
+      timestamp !== null && now - timestamp > STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS;
+    if (!staleByNewerResult && !staleByAge) {
+      continue;
+    }
+    out[i] = replaceToolResultReplayContent(
+      message,
+      "[Previous environment diagnostic output omitted from replay for accuracy.]",
+    );
+    touched = true;
+  }
+  return touched ? out : messages;
+}
+
 function createProviderReplaySessionState(
   sessionManager: SessionManager,
 ): ProviderReplaySessionState {
@@ -425,8 +472,10 @@ export async function sanitizeSessionHistory(params: {
       })
     : sanitizedToolCalls;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);
+  const sanitizedTransientDiagnostics =
+    omitStaleTransientDiagnosticToolResults(sanitizedToolResults);
   const sanitizedCompactionUsage = ensureAssistantUsageSnapshots(
-    stripStaleAssistantUsageBeforeLatestCompaction(sanitizedToolResults),
+    stripStaleAssistantUsageBeforeLatestCompaction(sanitizedTransientDiagnostics),
   );
 
   const isOpenAIResponsesApi =

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -326,9 +326,9 @@ function omitStaleTransientDiagnosticToolResults(messages: AgentMessage[]): Agen
       continue;
     }
     const latestIndex = latestByDiagnosticType.get(meta.diagnosticType) ?? i;
-    const timestamp = parseMessageTimestamp(
-      (message as { timestamp?: unknown }).timestamp ?? meta.persistedAt ?? null,
-    );
+    const messageTimestamp = parseMessageTimestamp((message as { timestamp?: unknown }).timestamp);
+    const persistedTimestamp = parseMessageTimestamp(meta.persistedAt ?? null);
+    const timestamp = messageTimestamp ?? persistedTimestamp;
     const staleByNewerResult = latestIndex > i;
     const staleByAge =
       timestamp !== null && now - timestamp > STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS;

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -10,6 +10,11 @@ import type {
 } from "../../../plugins/types.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
+import {
+  isAssistantConclusionFreshnessGateEnabled,
+  resolveAssistantConclusionFreshnessGate,
+  summarizeAssistantConclusionFreshnessGateLog,
+} from "../../assistant-conclusion-freshness-gate.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../music-generation-task-status.js";
 import { prependSystemPromptAdditionAfterCacheBoundary } from "../../system-prompt-cache-boundary.js";
@@ -38,7 +43,22 @@ export async function resolvePromptBuildHookResult(params: {
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
+  freshnessGateEnv?: Record<string, string | undefined>;
 }): Promise<PluginHookBeforePromptBuildResult> {
+  const freshnessGateEnabled = isAssistantConclusionFreshnessGateEnabled(
+    params.freshnessGateEnv ?? process.env,
+  );
+  const freshnessGateResult = freshnessGateEnabled
+    ? resolveAssistantConclusionFreshnessGate({
+        prompt: params.prompt,
+        messages: params.messages,
+      })
+    : { freshnessState: "not_high_risk" as const };
+  log.debug(
+    freshnessGateEnabled
+      ? summarizeAssistantConclusionFreshnessGateLog(freshnessGateResult)
+      : "assistant freshness gate: disabled",
+  );
   const promptBuildResult = params.hookRunner?.hasHooks("before_prompt_build")
     ? await params.hookRunner
         .runBeforePromptBuild(
@@ -78,6 +98,7 @@ export async function resolvePromptBuildHookResult(params: {
       legacyResult?.prependContext,
     ]),
     prependSystemContext: joinPresentTextSegments([
+      freshnessGateResult.prependSystemContext,
       promptBuildResult?.prependSystemContext,
       legacyResult?.prependSystemContext,
     ]),

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -276,6 +276,68 @@ describe("resolveAssistantConclusionFreshnessGate", () => {
     });
   });
 
+  it("does not treat mismatched config-target evidence as fresh", () => {
+    const now = 2_500_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "What is the value of plugins.installs.openclaw-qqbot in config?",
+      now,
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call_cfg_target",
+          toolName: "gateway",
+          content: "gateway.mode=true",
+          timestamp: now - 5_000,
+          __openclaw: {
+            transient: true,
+            diagnosticType: "openclaw.config_snapshot",
+            diagnosticTarget: "gateway.mode",
+            taggedAt: now - 5_000,
+            sourceTool: "gateway",
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "config_key_presence",
+      diagnosticType: "openclaw.config_snapshot",
+      freshnessState: "missing",
+      prependSystemContext: ASSISTANT_FRESHNESS_GATE_TEMPLATE_A,
+    });
+  });
+
+  it("allows broad openclaw.json snapshots for config-target freshness", () => {
+    const now = 2_600_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "What is the value of plugins.installs.openclaw-qqbot in config?",
+      now,
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call_cfg_full",
+          toolName: "read",
+          content: "{...}",
+          timestamp: now - 5_000,
+          __openclaw: {
+            transient: true,
+            diagnosticType: "openclaw.config_snapshot",
+            diagnosticTarget: "/repo/openclaw.json",
+            taggedAt: now - 5_000,
+            sourceTool: "read",
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "config_key_presence",
+      diagnosticType: "openclaw.config_snapshot",
+      freshnessState: "fresh",
+      matchedTimestamp: now - 5_000,
+    });
+  });
+
   it("treats recent gateway config.get history as fresh evidence via toolCall fallback", () => {
     const now = 4_000_000;
     const result = resolveAssistantConclusionFreshnessGate({

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,6 +1,18 @@
 import { streamSimple } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
+import {
+  isOllamaCompatProvider,
+  resolveOllamaCompatNumCtxEnabled,
+  shouldInjectOllamaCompatNumCtx,
+  wrapOllamaCompatNumCtx,
+} from "../../../plugin-sdk/ollama-runtime.js";
+import {
+  ASSISTANT_FRESHNESS_GATE_ENV,
+  ASSISTANT_FRESHNESS_GATE_TEMPLATE_A,
+  isAssistantConclusionFreshnessGateEnabled,
+  resolveAssistantConclusionFreshnessGate,
+} from "../../assistant-conclusion-freshness-gate.js";
 import { appendBootstrapPromptWarning } from "../../bootstrap-budget.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../../system-prompt-cache-boundary.js";
 import { buildAgentSystemPrompt } from "../../system-prompt.js";
@@ -125,6 +137,299 @@ describe("resolvePromptBuildHookResult", () => {
     expect(result.prependContext).toBe("prompt context\n\nlegacy context");
     expect(result.prependSystemContext).toBe("prompt prepend\n\nlegacy prepend");
     expect(result.appendSystemContext).toBe("prompt append\n\nlegacy append");
+  });
+
+  it("prepends internal freshness gate before hook-provided system context when fresh evidence is missing", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(() => true),
+      runBeforePromptBuild: vi.fn(async () => ({
+        prependSystemContext: "prompt prepend",
+      })),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+    };
+
+    const result = await resolvePromptBuildHookResult({
+      prompt: "What plugins are currently installed?",
+      messages: [],
+      hookCtx: {},
+      hookRunner,
+      freshnessGateEnv: {
+        [ASSISTANT_FRESHNESS_GATE_ENV]: "1",
+      },
+    });
+
+    expect(result.prependSystemContext).toBe(
+      `${ASSISTANT_FRESHNESS_GATE_TEMPLATE_A}\n\nprompt prepend`,
+    );
+  });
+
+  it("does not inject freshness gate by default when the feature flag is unset", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(() => true),
+      runBeforePromptBuild: vi.fn(async () => ({
+        prependSystemContext: "prompt prepend",
+      })),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+    };
+
+    const result = await resolvePromptBuildHookResult({
+      prompt: "What plugins are currently installed?",
+      messages: [],
+      hookCtx: {},
+      hookRunner,
+      freshnessGateEnv: {},
+    });
+
+    expect(result.prependSystemContext).toBe("prompt prepend");
+  });
+
+  it("does not inject freshness gate when fresh structured evidence already exists", async () => {
+    const now = Date.now();
+    const messages = [
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: "plugin output",
+        timestamp: now - 1_000,
+        __openclaw: {
+          transient: true,
+          diagnosticType: "openclaw.plugins_list",
+          taggedAt: now - 1_000,
+          sourceTool: "exec",
+        },
+      },
+    ];
+
+    const result = await resolvePromptBuildHookResult({
+      prompt: "What plugins are currently installed?",
+      messages,
+      hookCtx: {},
+      hookRunner: undefined,
+    });
+
+    expect(result.prependSystemContext).toBeUndefined();
+  });
+});
+
+describe("resolveAssistantConclusionFreshnessGate", () => {
+  it("treats the feature flag as disabled by default", () => {
+    expect(isAssistantConclusionFreshnessGateEnabled({})).toBe(false);
+  });
+
+  it("accepts explicit truthy feature flag values", () => {
+    expect(
+      isAssistantConclusionFreshnessGateEnabled({
+        [ASSISTANT_FRESHNESS_GATE_ENV]: "1",
+      }),
+    ).toBe(true);
+    expect(
+      isAssistantConclusionFreshnessGateEnabled({
+        [ASSISTANT_FRESHNESS_GATE_ENV]: "true",
+      }),
+    ).toBe(true);
+  });
+
+  it("classifies plugin install questions and injects gate when no evidence exists", () => {
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "What plugins are installed right now?",
+      messages: [],
+      now: 1_000_000,
+    });
+
+    expect(result).toMatchObject({
+      questionType: "plugin_install_state",
+      diagnosticType: "openclaw.plugins_list",
+      freshnessState: "missing",
+      prependSystemContext: ASSISTANT_FRESHNESS_GATE_TEMPLATE_A,
+      templateId: "A",
+    });
+  });
+
+  it("classifies config questions and treats old evidence as stale", () => {
+    const now = 2_000_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "Does the config contain this key?",
+      now,
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call_cfg",
+          toolName: "read",
+          content: "config json",
+          timestamp: now - 2 * 60 * 60 * 1000,
+          __openclaw: {
+            transient: true,
+            diagnosticType: "openclaw.config_snapshot",
+            taggedAt: now - 2 * 60 * 60 * 1000,
+            sourceTool: "read",
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "config_key_presence",
+      diagnosticType: "openclaw.config_snapshot",
+      freshnessState: "stale",
+      prependSystemContext: ASSISTANT_FRESHNESS_GATE_TEMPLATE_A,
+    });
+  });
+
+  it("treats recent gateway config.get history as fresh evidence via toolCall fallback", () => {
+    const now = 4_000_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "当前配置里有没有 plugins.installs.openclaw-qqbot 这一项？",
+      now,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_cfg_gateway_1",
+              name: "gateway",
+              arguments: {
+                action: "config.get",
+                path: "plugins.installs",
+              },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_cfg_gateway_1",
+          toolName: "gateway",
+          content: [
+            {
+              type: "text",
+              text: '{"ok":true}',
+            },
+          ],
+          details: {
+            ok: true,
+            result: {
+              path: "plugins.installs",
+            },
+          },
+          timestamp: now - 5_000,
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "config_key_presence",
+      diagnosticType: "openclaw.config_snapshot",
+      freshnessState: "fresh",
+    });
+    expect(result.prependSystemContext).toBeUndefined();
+  });
+
+  it("treats recent gateway plugins.entries history as fresh evidence via toolCall fallback", () => {
+    const now = 5_000_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "qqbot 现在在 plugins.entries 里还是 enabled 吗？",
+      now,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_plugins_entries_1",
+              name: "gateway",
+              arguments: {
+                action: "config.get",
+                path: "plugins.entries",
+              },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_plugins_entries_1",
+          toolName: "gateway",
+          content: [
+            {
+              type: "text",
+              text: '{"ok":true}',
+            },
+          ],
+          details: {
+            ok: true,
+            result: {
+              path: "plugins.entries",
+            },
+          },
+          timestamp: now - 10_000,
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "plugin_install_state",
+      diagnosticType: "openclaw.plugins_list",
+      freshnessState: "fresh",
+    });
+    expect(result.prependSystemContext).toBeUndefined();
+  });
+
+  it("ignores replay-omitted evidence when evaluating freshness", () => {
+    const now = 3_000_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "What plugins are installed right now?",
+      now,
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "exec",
+          content: "old plugin output",
+          timestamp: now - 5_000,
+          __openclaw: {
+            transient: true,
+            diagnosticType: "openclaw.plugins_list",
+            taggedAt: now - 5_000,
+            sourceTool: "exec",
+            replayOmitted: true,
+          },
+        },
+      ],
+    });
+
+    expect(result.freshnessState).toBe("stale");
+    expect(result.prependSystemContext).toBe(ASSISTANT_FRESHNESS_GATE_TEMPLATE_A);
+  });
+
+  it("treats tagged gateway config.get evidence as fresh for config questions", () => {
+    const now = 4_000_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "Does the config currently contain this key?",
+      now,
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call_gateway_cfg",
+          toolName: "gateway",
+          content: "config json",
+          timestamp: now - 5_000,
+          __openclaw: {
+            transient: true,
+            diagnosticType: "openclaw.config_snapshot",
+            taggedAt: now - 5_000,
+            sourceTool: "gateway",
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "config_key_presence",
+      diagnosticType: "openclaw.config_snapshot",
+      freshnessState: "fresh",
+      matchedTimestamp: now - 5_000,
+    });
+    expect(result.prependSystemContext).toBeUndefined();
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -439,6 +439,113 @@ describe("resolveAssistantConclusionFreshnessGate", () => {
     });
   });
 
+  it("does not treat errored tool results as fresh evidence", () => {
+    const now = 6_100_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "What plugins are installed right now?",
+      now,
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call_error_plugins",
+          toolName: "exec",
+          isError: true,
+          content: "command failed",
+          timestamp: now - 2_000,
+          __openclaw: {
+            transient: true,
+            diagnosticType: "openclaw.plugins_list",
+            taggedAt: now - 2_000,
+            sourceTool: "exec",
+          },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "plugin_install_state",
+      diagnosticType: "openclaw.plugins_list",
+      freshnessState: "stale",
+      prependSystemContext: ASSISTANT_FRESHNESS_GATE_TEMPLATE_A,
+    });
+  });
+
+  it("recognizes toolUse blocks with input in historical fallback inference", () => {
+    const now = 6_200_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "qqbot is enabled in plugins.entries, right?",
+      now,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolUse",
+              id: "call_tool_use_1",
+              name: "gateway",
+              input: {
+                action: "config.get",
+                path: "plugins.entries",
+              },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolUseId: "call_tool_use_1",
+          toolName: "gateway",
+          content: [{ type: "text", text: '{"ok":true}' }],
+          timestamp: now - 5_000,
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "plugin_install_state",
+      diagnosticType: "openclaw.plugins_list",
+      freshnessState: "fresh",
+    });
+    expect(result.prependSystemContext).toBeUndefined();
+  });
+
+  it("recognizes functionCall blocks in historical fallback inference", () => {
+    const now = 6_300_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "Does the config currently contain this key?",
+      now,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "functionCall",
+              id: "call_function_1",
+              name: "gateway",
+              arguments: {
+                action: "config.get",
+                path: "plugins.installs",
+              },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_function_1",
+          toolName: "gateway",
+          content: [{ type: "text", text: '{"ok":true}' }],
+          timestamp: now - 5_000,
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "config_key_presence",
+      diagnosticType: "openclaw.config_snapshot",
+      freshnessState: "fresh",
+    });
+    expect(result.prependSystemContext).toBeUndefined();
+  });
+
   it("treats tagged gateway config.get evidence as fresh for config questions", () => {
     const now = 4_000_000;
     const result = resolveAssistantConclusionFreshnessGate({

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -387,6 +387,50 @@ describe("resolveAssistantConclusionFreshnessGate", () => {
     expect(result.prependSystemContext).toBeUndefined();
   });
 
+  it("does not treat unrelated config target as fresh via toolCall fallback", () => {
+    const now = 4_100_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "当前配置里有没有 plugins.installs.openclaw-qqbot 这一项？",
+      now,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_cfg_gateway_mismatch_1",
+              name: "gateway",
+              arguments: {
+                action: "config.get",
+                path: "gateway.mode",
+              },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_cfg_gateway_mismatch_1",
+          toolName: "gateway",
+          content: [{ type: "text", text: '{"ok":true}' }],
+          details: {
+            ok: true,
+            result: {
+              path: "gateway.mode",
+            },
+          },
+          timestamp: now - 5_000,
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "config_key_presence",
+      diagnosticType: "openclaw.config_snapshot",
+      freshnessState: "missing",
+      prependSystemContext: ASSISTANT_FRESHNESS_GATE_TEMPLATE_A,
+    });
+  });
+
   it("treats recent gateway plugins.entries history as fresh evidence via toolCall fallback", () => {
     const now = 5_000_000;
     const result = resolveAssistantConclusionFreshnessGate({

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -480,6 +480,44 @@ describe("resolveAssistantConclusionFreshnessGate", () => {
     expect(result.prependSystemContext).toBeUndefined();
   });
 
+  it("treats stringified toolCall arguments as fresh evidence via fallback inference", () => {
+    const now = 5_100_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "qqbot 现在在 plugins.entries 里还是 enabled 吗？",
+      now,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_plugins_entries_string_args_1",
+              name: "gateway",
+              arguments: JSON.stringify({
+                action: "config.get",
+                path: "plugins.entries",
+              }),
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_plugins_entries_string_args_1",
+          toolName: "gateway",
+          content: [{ type: "text", text: '{"ok":true}' }],
+          timestamp: now - 8_000,
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "plugin_install_state",
+      diagnosticType: "openclaw.plugins_list",
+      freshnessState: "fresh",
+    });
+    expect(result.prependSystemContext).toBeUndefined();
+  });
+
   it("ignores replay-omitted evidence when evaluating freshness", () => {
     const now = 3_000_000;
     const result = resolveAssistantConclusionFreshnessGate({

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -401,6 +401,44 @@ describe("resolveAssistantConclusionFreshnessGate", () => {
     expect(result.prependSystemContext).toBe(ASSISTANT_FRESHNESS_GATE_TEMPLATE_A);
   });
 
+  it("does not treat timestamp-less historical fallback evidence as fresh", () => {
+    const now = 6_000_000;
+    const result = resolveAssistantConclusionFreshnessGate({
+      prompt: "qqbot is enabled in plugins.entries, right?",
+      now,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_plugins_entries_no_ts",
+              name: "gateway",
+              arguments: {
+                action: "config.get",
+                path: "plugins.entries",
+              },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call_plugins_entries_no_ts",
+          toolName: "gateway",
+          content: [{ type: "text", text: '{"ok":true}' }],
+          details: { ok: true, result: { path: "plugins.entries" } },
+        },
+      ],
+    });
+
+    expect(result).toMatchObject({
+      questionType: "plugin_install_state",
+      diagnosticType: "openclaw.plugins_list",
+      freshnessState: "stale",
+      prependSystemContext: ASSISTANT_FRESHNESS_GATE_TEMPLATE_A,
+    });
+  });
+
   it("treats tagged gateway config.get evidence as fresh for config questions", () => {
     const now = 4_000_000;
     const result = resolveAssistantConclusionFreshnessGate({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -826,6 +826,7 @@ export async function runEmbeddedAttempt(
       sessionManager = guardSessionManager(SessionManager.open(params.sessionFile), {
         agentId: sessionAgentId,
         sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
         inputProvenance: params.inputProvenance,
         allowSyntheticToolResults: transcriptPolicy.allowSyntheticToolResults,
         allowedToolNames,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -42,7 +42,10 @@ import {
   sanitizeToolResult,
 } from "./pi-embedded-subscribe.tools.js";
 import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
-import { consumeAdjustedParamsForToolCall } from "./pi-tools.before-tool-call.js";
+import {
+  consumeAdjustedParamsForToolCall,
+  peekAdjustedParamsForToolCall,
+} from "./pi-tools.before-tool-call.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
 import { recordPendingToolResultReplayMetadata } from "./tool-result-replay-metadata.js";
@@ -539,8 +542,11 @@ export function handleToolExecutionStart(
     const rawToolName = String(evt.toolName);
     const toolName = normalizeToolName(rawToolName);
     const toolCallId = String(evt.toolCallId);
-    const args = evt.args;
+    const startArgs = evt.args;
     const runId = ctx.params.runId;
+    const adjustedStartArgs = peekAdjustedParamsForToolCall(toolCallId, runId);
+    const args =
+      adjustedStartArgs && typeof adjustedStartArgs === "object" ? adjustedStartArgs : startArgs;
 
     // Track start time and args for after_tool_call hook.
     const startedAt = Date.now();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -546,7 +546,8 @@ export function handleToolExecutionStart(
     const startedAt = Date.now();
     toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: startedAt, args });
     recordPendingToolResultReplayMetadata({
-      sessionKey: ctx.params.sessionKey ?? ctx.params.sessionId,
+      sessionKey: ctx.params.sessionKey,
+      sessionId: ctx.params.sessionId,
       toolCallId,
       toolName,
       args,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -45,6 +45,7 @@ import { inferToolMetaFromArgs } from "./pi-embedded-utils.js";
 import { consumeAdjustedParamsForToolCall } from "./pi-tools.before-tool-call.js";
 import { buildToolMutationState, isSameToolMutationAction } from "./tool-mutation.js";
 import { normalizeToolName } from "./tool-policy.js";
+import { recordPendingToolResultReplayMetadata } from "./tool-result-replay-metadata.js";
 
 type ToolStartRecord = {
   startTime: number;
@@ -544,6 +545,12 @@ export function handleToolExecutionStart(
     // Track start time and args for after_tool_call hook.
     const startedAt = Date.now();
     toolStartData.set(buildToolStartKey(runId, toolCallId), { startTime: startedAt, args });
+    recordPendingToolResultReplayMetadata({
+      sessionKey: ctx.params.sessionKey ?? ctx.params.sessionId,
+      toolCallId,
+      toolName,
+      args,
+    });
 
     if (toolName === "read") {
       const record = args && typeof args === "object" ? (args as Record<string, unknown>) : {};

--- a/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -21,6 +21,7 @@ const hookMocks = vi.hoisted(() => ({
 
 const beforeToolCallMocks = vi.hoisted(() => ({
   consumeAdjustedParamsForToolCall: vi.fn((_: string): unknown => undefined),
+  peekAdjustedParamsForToolCall: vi.fn((_: string): unknown => undefined),
   isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
   runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
     blocked: false,
@@ -89,6 +90,7 @@ async function loadFreshAfterToolCallModulesForTest() {
   }));
   vi.doMock("./pi-tools.before-tool-call.js", () => ({
     consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,
+    peekAdjustedParamsForToolCall: beforeToolCallMocks.peekAdjustedParamsForToolCall,
     isToolWrappedWithBeforeToolCallHook: beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook,
     runBeforeToolCallHook: beforeToolCallMocks.runBeforeToolCallHook,
   }));
@@ -109,6 +111,8 @@ describe("after_tool_call fires exactly once in embedded runs", () => {
     hookMocks.runner.runBeforeToolCall.mockResolvedValue(undefined);
     beforeToolCallMocks.consumeAdjustedParamsForToolCall.mockClear();
     beforeToolCallMocks.consumeAdjustedParamsForToolCall.mockReturnValue(undefined);
+    beforeToolCallMocks.peekAdjustedParamsForToolCall.mockClear();
+    beforeToolCallMocks.peekAdjustedParamsForToolCall.mockReturnValue(undefined);
     beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook.mockClear();
     beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook.mockReturnValue(false);
     beforeToolCallMocks.runBeforeToolCallHook.mockClear();

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -17,6 +17,7 @@ type ToToolDefinitions = ToolDefinitionAdapterModule["toToolDefinitions"];
 type WrapToolWithAbortSignal = PiToolsAbortModule["wrapToolWithAbortSignal"];
 type BeforeToolCallTesting = BeforeToolCallModule["__testing"];
 type ConsumeAdjustedParamsForToolCall = BeforeToolCallModule["consumeAdjustedParamsForToolCall"];
+type PeekAdjustedParamsForToolCall = BeforeToolCallModule["peekAdjustedParamsForToolCall"];
 type WrapToolWithBeforeToolCallHook = BeforeToolCallModule["wrapToolWithBeforeToolCallHook"];
 
 let toClientToolDefinitions!: ToClientToolDefinitions;
@@ -24,6 +25,7 @@ let toToolDefinitions!: ToToolDefinitions;
 let wrapToolWithAbortSignal!: WrapToolWithAbortSignal;
 let beforeToolCallTesting!: BeforeToolCallTesting;
 let consumeAdjustedParamsForToolCall!: ConsumeAdjustedParamsForToolCall;
+let peekAdjustedParamsForToolCall!: PeekAdjustedParamsForToolCall;
 let wrapToolWithBeforeToolCallHook!: WrapToolWithBeforeToolCallHook;
 
 beforeEach(async () => {
@@ -34,6 +36,7 @@ beforeEach(async () => {
     ({
       __testing: beforeToolCallTesting,
       consumeAdjustedParamsForToolCall,
+      peekAdjustedParamsForToolCall,
       wrapToolWithBeforeToolCallHook,
     } = await import("./pi-tools.before-tool-call.js"));
   }
@@ -233,10 +236,19 @@ describe("before_tool_call hook integration", () => {
     await toolA.execute(sharedToolCallId, { path: "/tmp/a.txt" }, undefined, extensionContextA);
     await toolB.execute(sharedToolCallId, { path: "/tmp/b.txt" }, undefined, extensionContextB);
 
+    expect(peekAdjustedParamsForToolCall(sharedToolCallId, "run-a")).toEqual({
+      path: "/tmp/a.txt",
+      marker: "A",
+    });
+    expect(peekAdjustedParamsForToolCall(sharedToolCallId, "run-b")).toEqual({
+      path: "/tmp/b.txt",
+      marker: "B",
+    });
     expect(consumeAdjustedParamsForToolCall(sharedToolCallId, "run-a")).toEqual({
       path: "/tmp/a.txt",
       marker: "A",
     });
+    expect(peekAdjustedParamsForToolCall(sharedToolCallId, "run-a")).toBeUndefined();
     expect(consumeAdjustedParamsForToolCall(sharedToolCallId, "run-b")).toEqual({
       path: "/tmp/b.txt",
       marker: "B",

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -453,6 +453,11 @@ export function consumeAdjustedParamsForToolCall(toolCallId: string, runId?: str
   return params;
 }
 
+export function peekAdjustedParamsForToolCall(toolCallId: string, runId?: string): unknown {
+  const adjustedParamsKey = buildAdjustedParamsKey({ runId, toolCallId });
+  return adjustedParamsByToolCallId.get(adjustedParamsKey);
+}
+
 export const __testing = {
   BEFORE_TOOL_CALL_WRAPPED,
   buildAdjustedParamsKey,

--- a/src/agents/session-tool-result-guard-wrapper.ts
+++ b/src/agents/session-tool-result-guard-wrapper.ts
@@ -23,6 +23,7 @@ export function guardSessionManager(
   opts?: {
     agentId?: string;
     sessionKey?: string;
+    sessionId?: string;
     inputProvenance?: InputProvenance;
     allowSyntheticToolResults?: boolean;
     allowedToolNames?: Iterable<string>;
@@ -67,6 +68,7 @@ export function guardSessionManager(
 
   const guard = installSessionToolResultGuard(sessionManager, {
     sessionKey: opts?.sessionKey,
+    sessionId: opts?.sessionId,
     transformMessageForPersistence: (message) =>
       applyInputProvenanceToUserMessage(message, opts?.inputProvenance),
     transformToolResultForPersistence: transform,

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 import {
@@ -352,7 +352,7 @@ describe("installSessionToolResultGuard", () => {
         role: "toolResult",
         toolCallId: "call_1",
         toolName: "read",
-        content: [{ type: "text", text: "{\"ok\":true}" }],
+        content: [{ type: "text", text: '{"ok":true}' }],
         isError: false,
         timestamp: Date.now(),
       }),
@@ -363,6 +363,47 @@ describe("installSessionToolResultGuard", () => {
     >;
     expect(messages[1]?.__openclaw?.transient).toBe(true);
     expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
+  });
+
+  it("stamps replay metadata with the persisted write time when toolResult timestamps are missing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-07T03:30:00.000Z"));
+
+    try {
+      const sm = SessionManager.inMemory();
+      installSessionToolResultGuard(sm, { sessionKey: "agent:main:main" });
+
+      sm.appendMessage(
+        asAppendMessage({
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+        }),
+      );
+      recordPendingToolResultReplayMetadata({
+        sessionKey: "agent:main:main",
+        toolCallId: "call_1",
+        toolName: "exec",
+        args: { command: "openclaw status" },
+        taggedAt: Date.now() - 90_000,
+      });
+      sm.appendMessage(
+        asAppendMessage({
+          role: "toolResult",
+          toolCallId: "call_1",
+          toolName: "exec",
+          content: [{ type: "text", text: "status output" }],
+          isError: false,
+        }),
+      );
+
+      const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+        AgentMessage & { __openclaw?: Record<string, unknown> }
+      >;
+      expect(messages[1]?.__openclaw?.persistedAt).toBe(Date.now());
+      expect(messages[1]?.__openclaw?.taggedAt).toBe(Date.now() - 90_000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("drains replay metadata when clearing pending tool calls", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -717,6 +717,16 @@ describe("installSessionToolResultGuard", () => {
       diagnosticType: "openclaw.plugin_path_probe",
       sourceTool: "exec",
     });
+    expect(
+      detectToolResultReplayPolicyMeta({
+        toolName: "read",
+        args: { path: "C:\\repo\\extensions\\telegram\\package.json" },
+      }),
+    ).toMatchObject({
+      transient: true,
+      diagnosticType: "openclaw.plugin_path_probe",
+      sourceTool: "read",
+    });
   });
 
   it("applies before_message_write to synthetic tool-result flushes", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -227,6 +227,40 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.__openclaw?.sourceTool).toBe("exec");
   });
 
+  it("uses sessionId fallback when sessionKey is unavailable", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { sessionId: "session-only" });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionId: "session-only",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "status output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[1]?.__openclaw?.transient).toBe(true);
+    expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.status");
+  });
+
   it("re-applies replay metadata after tool_result_persist transformations", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm, {
@@ -275,6 +309,103 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.__openclaw?.transient).toBe(true);
     expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
     expect(messages[1]?.__openclaw?.sourceTool).toBe("read");
+  });
+
+  it("drains replay metadata when clearing pending tool calls", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, { sessionKey: "agent:main:main" });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw plugins list" },
+    });
+
+    guard.clearPendingToolResults();
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "fresh output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[2]?.__openclaw?.transient).not.toBe(true);
+  });
+
+  it("drains replay metadata when synthetic tool results are disabled", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      allowSyntheticToolResults: false,
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw plugins list" },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "user",
+        content: "interrupt",
+        timestamp: Date.now(),
+      }),
+    );
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "fresh output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, [
+      "assistant",
+      "user",
+      "assistant",
+      "toolResult",
+    ]) as Array<AgentMessage & { __openclaw?: Record<string, unknown> }>;
+    expect(guard.getPendingIds()).toEqual([]);
+    expect(messages[3]?.__openclaw?.transient).not.toBe(true);
   });
 
   it("preserves ordering with multiple tool calls and partial results", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -959,6 +959,20 @@ describe("installSessionToolResultGuard", () => {
     });
   });
 
+  it("classifies nested plugins.entries gateway paths as plugins_list diagnostics", () => {
+    expect(
+      detectToolResultReplayPolicyMeta({
+        toolName: "gateway",
+        args: { action: "config.get", path: "plugins.entries.openclaw-qqbot.enabled" },
+      }),
+    ).toMatchObject({
+      transient: true,
+      diagnosticType: "openclaw.plugins_list",
+      diagnosticTarget: "plugins.entries.openclaw-qqbot.enabled",
+      sourceTool: "gateway",
+    });
+  });
+
   it("applies before_message_write to synthetic tool-result flushes", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -3,6 +3,7 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
+import { recordPendingToolResultReplayMetadata } from "./tool-result-replay-metadata.js";
 
 type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
 
@@ -189,6 +190,91 @@ describe("installSessionToolResultGuard", () => {
       toolName?: string;
     }>;
     expect(messages[1]?.toolName).toBe("read");
+  });
+
+  it("tags persisted diagnostic exec tool results for replay policy", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, { sessionKey: "agent:main:main" });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw plugins list" },
+    });
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "plugin output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[1]?.__openclaw?.transient).toBe(true);
+    expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.plugins_list");
+    expect(messages[1]?.__openclaw?.sourceTool).toBe("exec");
+  });
+
+  it("re-applies replay metadata after tool_result_persist transformations", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      transformToolResultForPersistence: (message) => {
+        if (message.role !== "toolResult") {
+          return message;
+        }
+        return {
+          role: "toolResult",
+          toolCallId: message.toolCallId,
+          toolName: message.toolName,
+          content: message.content,
+          isError: message.isError,
+          timestamp: message.timestamp,
+        } as AgentMessage;
+      },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "read",
+      args: { path: "/tmp/openclaw.json" },
+    });
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: '{"ok":true}' }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[1]?.__openclaw?.transient).toBe(true);
+    expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
+    expect(messages[1]?.__openclaw?.sourceTool).toBe("read");
   });
 
   it("preserves ordering with multiple tool calls and partial results", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -3,7 +3,10 @@ import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
-import { recordPendingToolResultReplayMetadata } from "./tool-result-replay-metadata.js";
+import {
+  detectToolResultReplayPolicyMeta,
+  recordPendingToolResultReplayMetadata,
+} from "./tool-result-replay-metadata.js";
 
 type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
 
@@ -309,6 +312,57 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[1]?.__openclaw?.transient).toBe(true);
     expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
     expect(messages[1]?.__openclaw?.sourceTool).toBe("read");
+  });
+
+  it("re-applies replay metadata after before_message_write rewrites", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      beforeMessageWriteHook: ({ message }) => {
+        if (message.role !== "toolResult") {
+          return undefined;
+        }
+        return {
+          message: castAgentMessage({
+            role: "toolResult",
+            toolCallId: message.toolCallId,
+            toolName: message.toolName,
+            content: message.content,
+            isError: message.isError,
+            timestamp: message.timestamp,
+          }),
+        };
+      },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "read",
+      args: { path: "/tmp/openclaw.json" },
+    });
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "{\"ok\":true}" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[1]?.__openclaw?.transient).toBe(true);
+    expect(messages[1]?.__openclaw?.diagnosticType).toBe("openclaw.config_snapshot");
   });
 
   it("drains replay metadata when clearing pending tool calls", () => {
@@ -640,6 +694,29 @@ describe("installSessionToolResultGuard", () => {
 
     const text = getToolResultText(getPersistedMessages(sm));
     expect(text).toBe("rewritten by hook");
+  });
+
+  it("detects bundled plugin package probes as transient diagnostics", () => {
+    expect(
+      detectToolResultReplayPolicyMeta({
+        toolName: "read",
+        args: { path: "/repo/extensions/telegram/package.json" },
+      }),
+    ).toMatchObject({
+      transient: true,
+      diagnosticType: "openclaw.plugin_path_probe",
+      sourceTool: "read",
+    });
+    expect(
+      detectToolResultReplayPolicyMeta({
+        toolName: "exec",
+        args: { command: "cat extensions/telegram/package.json" },
+      }),
+    ).toMatchObject({
+      transient: true,
+      diagnosticType: "openclaw.plugin_path_probe",
+      sourceTool: "exec",
+    });
   });
 
   it("applies before_message_write to synthetic tool-result flushes", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -945,6 +945,20 @@ describe("installSessionToolResultGuard", () => {
     });
   });
 
+  it("preserves gateway config.get path as diagnostic target", () => {
+    expect(
+      detectToolResultReplayPolicyMeta({
+        toolName: "gateway",
+        args: { action: "config.get", path: "plugins.installs.openclaw-qqbot" },
+      }),
+    ).toMatchObject({
+      transient: true,
+      diagnosticType: "openclaw.config_snapshot",
+      diagnosticTarget: "plugins.installs.openclaw-qqbot",
+      sourceTool: "gateway",
+    });
+  });
+
   it("applies before_message_write to synthetic tool-result flushes", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
 import {
+  consumePendingToolResultReplayMetadata,
   detectToolResultReplayPolicyMeta,
+  drainPendingToolResultReplayMetadataForSession,
   recordPendingToolResultReplayMetadata,
 } from "./tool-result-replay-metadata.js";
 
@@ -508,6 +510,55 @@ describe("installSessionToolResultGuard", () => {
       AgentMessage & { __openclaw?: Record<string, unknown> }
     >;
     expect(messages[0]?.__openclaw?.transient).not.toBe(true);
+  });
+
+  it("drains replay metadata by exact session key without prefix overreach", () => {
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:thread",
+      toolCallId: "call_2",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+
+    expect(
+      consumePendingToolResultReplayMetadata({
+        sessionKey: "agent:main:thread",
+        toolCallId: "call_2",
+      }),
+    ).toMatchObject({ diagnosticType: "openclaw.status" });
+
+    // Re-record thread entry, then drain only the base session.
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:thread",
+      toolCallId: "call_2",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+
+    expect(
+      drainPendingToolResultReplayMetadataForSession({
+        sessionKey: "agent:main",
+      }),
+    ).toBe(1);
+
+    expect(
+      consumePendingToolResultReplayMetadata({
+        sessionKey: "agent:main",
+        toolCallId: "call_1",
+      }),
+    ).toBeNull();
+    expect(
+      consumePendingToolResultReplayMetadata({
+        sessionKey: "agent:main:thread",
+        toolCallId: "call_2",
+      }),
+    ).toMatchObject({ diagnosticType: "openclaw.status" });
   });
 
   it("drains replay metadata when synthetic tool results are disabled", () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -448,6 +448,68 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[2]?.__openclaw?.transient).not.toBe(true);
   });
 
+  it("drains replay metadata when clearing with empty pending state", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      beforeMessageWriteHook: ({ message }) => {
+        if ((message as { role?: unknown }).role !== "assistant") {
+          return undefined;
+        }
+        const content = (message as { content?: unknown }).content;
+        const hasToolCall =
+          Array.isArray(content) &&
+          content.some(
+            (block) =>
+              !!block &&
+              typeof block === "object" &&
+              ((block as { type?: unknown }).type === "toolCall" ||
+                (block as { type?: unknown }).type === "toolUse"),
+          );
+        return hasToolCall ? { block: true } : undefined;
+      },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw plugins list" },
+    });
+
+    // pendingState is empty because assistant tool-call persistence was blocked,
+    // so clearPendingToolResults must still drain session replay metadata.
+    guard.clearPendingToolResults();
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "fresh output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[0]?.__openclaw?.transient).not.toBe(true);
+  });
+
   it("drains replay metadata when synthetic tool results are disabled", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm, {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -503,6 +503,68 @@ describe("installSessionToolResultGuard", () => {
     expect(messages[3]?.__openclaw?.transient).not.toBe(true);
   });
 
+  it("drains replay metadata even when flush runs with empty pending state", () => {
+    const sm = SessionManager.inMemory();
+    const guard = installSessionToolResultGuard(sm, {
+      sessionKey: "agent:main:main",
+      beforeMessageWriteHook: ({ message }) => {
+        if ((message as { role?: unknown }).role !== "assistant") {
+          return undefined;
+        }
+        const content = (message as { content?: unknown }).content;
+        const hasToolCall =
+          Array.isArray(content) &&
+          content.some(
+            (block) =>
+              !!block &&
+              typeof block === "object" &&
+              ((block as { type?: unknown }).type === "toolCall" ||
+                (block as { type?: unknown }).type === "toolUse"),
+          );
+        return hasToolCall ? { block: true } : undefined;
+      },
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    recordPendingToolResultReplayMetadata({
+      sessionKey: "agent:main:main",
+      toolCallId: "call_1",
+      toolName: "exec",
+      args: { command: "openclaw status" },
+    });
+
+    // Pending tool-call state is empty because assistant toolCall persistence was blocked,
+    // but replay metadata should still be drained for the session.
+    guard.flushPendingToolResults();
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "exec", arguments: {} }],
+      }),
+    );
+    sm.appendMessage(
+      asAppendMessage({
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "exec",
+        content: [{ type: "text", text: "fresh output" }],
+        isError: false,
+        timestamp: Date.now(),
+      }),
+    );
+
+    const messages = expectPersistedRoles(sm, ["toolResult"]) as Array<
+      AgentMessage & { __openclaw?: Record<string, unknown> }
+    >;
+    expect(messages[0]?.__openclaw?.transient).not.toBe(true);
+  });
+
   it("preserves ordering with multiple tool calls and partial results", () => {
     const sm = SessionManager.inMemory();
     const guard = installSessionToolResultGuard(sm);

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -22,6 +22,7 @@ import {
   applyToolResultReplayMetadata,
   consumePendingToolResultReplayMetadata,
   resolveToolResultReplaySessionKey,
+  stampPersistedToolResultReplayMetadata,
 } from "./tool-result-replay-metadata.js";
 
 /**
@@ -177,7 +178,7 @@ export function installSessionToolResultGuard(
         ),
       );
       if (flushed) {
-        originalAppend(flushed as never);
+        originalAppend(stampPersistedToolResultReplayMetadata(flushed, replayMeta) as never);
       }
     }
     pendingState.clear();
@@ -237,7 +238,10 @@ export function installSessionToolResultGuard(
       if (!persisted) {
         return undefined;
       }
-      const replayTaggedPersisted = applyToolResultReplayMetadata(persisted, replayMeta);
+      const replayTaggedPersisted = stampPersistedToolResultReplayMetadata(
+        applyToolResultReplayMetadata(persisted, replayMeta),
+        replayMeta,
+      );
       return originalAppend(replayTaggedPersisted as never);
     }
 

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -21,6 +21,7 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 import {
   applyToolResultReplayMetadata,
   consumePendingToolResultReplayMetadata,
+  drainPendingToolResultReplayMetadataForSession,
   resolveToolResultReplaySessionKey,
   stampPersistedToolResultReplayMetadata,
 } from "./tool-result-replay-metadata.js";
@@ -156,6 +157,7 @@ export function installSessionToolResultGuard(
 
   const flushPendingToolResults = () => {
     if (pendingState.size() === 0) {
+      drainPendingToolResultReplayMetadataForSession({ sessionKey: replaySessionKey });
       return;
     }
     for (const [id, name] of pendingState.entries()) {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -187,12 +187,17 @@ export function installSessionToolResultGuard(
   };
 
   const clearPendingToolResults = () => {
+    if (pendingState.size() === 0) {
+      drainPendingToolResultReplayMetadataForSession({ sessionKey: replaySessionKey });
+      return;
+    }
     for (const [id] of pendingState.entries()) {
       consumePendingToolResultReplayMetadata({
         sessionKey: replaySessionKey,
         toolCallId: id,
       });
     }
+    drainPendingToolResultReplayMetadataForSession({ sessionKey: replaySessionKey });
     pendingState.clear();
   };
 

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -18,6 +18,10 @@ import {
 import { createPendingToolCallState } from "./session-tool-result-state.js";
 import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
+import {
+  applyToolResultReplayMetadata,
+  consumePendingToolResultReplayMetadata,
+} from "./tool-result-replay-metadata.js";
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -149,12 +153,22 @@ export function installSessionToolResultGuard(
     if (allowSyntheticToolResults) {
       for (const [id, name] of pendingState.entries()) {
         const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
+        const replayMeta = consumePendingToolResultReplayMetadata({
+          sessionKey: opts?.sessionKey,
+          toolCallId: id,
+        });
         const flushed = applyBeforeWriteHook(
-          persistToolResult(persistMessage(synthetic), {
-            toolCallId: id,
-            toolName: name,
-            isSynthetic: true,
-          }),
+          applyToolResultReplayMetadata(
+            persistToolResult(
+              applyToolResultReplayMetadata(persistMessage(synthetic), replayMeta),
+              {
+                toolCallId: id,
+                toolName: name,
+                isSynthetic: true,
+              },
+            ),
+            replayMeta,
+          ),
         );
         if (flushed) {
           originalAppend(flushed as never);
@@ -188,20 +202,27 @@ export function installSessionToolResultGuard(
     if (nextRole === "toolResult") {
       const id = extractToolResultId(nextMessage as Extract<AgentMessage, { role: "toolResult" }>);
       const toolName = id ? pendingState.getToolName(id) : undefined;
+      const replayMeta = consumePendingToolResultReplayMetadata({
+        sessionKey: opts?.sessionKey,
+        toolCallId: id ?? undefined,
+      });
       if (id) {
         pendingState.delete(id);
       }
       const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
+      const taggedToolResult = applyToolResultReplayMetadata(normalizedToolResult, replayMeta);
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.
-      const capped = capToolResultSize(persistMessage(normalizedToolResult));
-      const persisted = applyBeforeWriteHook(
+      const capped = capToolResultSize(persistMessage(taggedToolResult));
+      const persistedToolResult = applyToolResultReplayMetadata(
         persistToolResult(capped, {
           toolCallId: id ?? undefined,
           toolName,
           isSynthetic: false,
         }),
+        replayMeta,
       );
+      const persisted = applyBeforeWriteHook(persistedToolResult);
       if (!persisted) {
         return undefined;
       }

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -21,6 +21,7 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 import {
   applyToolResultReplayMetadata,
   consumePendingToolResultReplayMetadata,
+  resolveToolResultReplaySessionKey,
 } from "./tool-result-replay-metadata.js";
 
 /**
@@ -73,6 +74,8 @@ export function installSessionToolResultGuard(
   opts?: {
     /** Optional session key for transcript update broadcasts. */
     sessionKey?: string;
+    /** Optional session id fallback when no session key exists. */
+    sessionId?: string;
     /**
      * Optional transform applied to any message before persistence.
      */
@@ -127,6 +130,10 @@ export function installSessionToolResultGuard(
 
   const allowSyntheticToolResults = opts?.allowSyntheticToolResults ?? true;
   const beforeWrite = opts?.beforeMessageWriteHook;
+  const replaySessionKey = resolveToolResultReplaySessionKey({
+    sessionKey: opts?.sessionKey,
+    sessionId: opts?.sessionId,
+  });
 
   /**
    * Run the before_message_write hook. Returns the (possibly modified) message,
@@ -150,35 +157,39 @@ export function installSessionToolResultGuard(
     if (pendingState.size() === 0) {
       return;
     }
-    if (allowSyntheticToolResults) {
-      for (const [id, name] of pendingState.entries()) {
-        const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
-        const replayMeta = consumePendingToolResultReplayMetadata({
-          sessionKey: opts?.sessionKey,
-          toolCallId: id,
-        });
-        const flushed = applyBeforeWriteHook(
-          applyToolResultReplayMetadata(
-            persistToolResult(
-              applyToolResultReplayMetadata(persistMessage(synthetic), replayMeta),
-              {
-                toolCallId: id,
-                toolName: name,
-                isSynthetic: true,
-              },
-            ),
-            replayMeta,
-          ),
-        );
-        if (flushed) {
-          originalAppend(flushed as never);
-        }
+    for (const [id, name] of pendingState.entries()) {
+      const replayMeta = consumePendingToolResultReplayMetadata({
+        sessionKey: replaySessionKey,
+        toolCallId: id,
+      });
+      if (!allowSyntheticToolResults) {
+        continue;
+      }
+      const synthetic = makeMissingToolResult({ toolCallId: id, toolName: name });
+      const flushed = applyBeforeWriteHook(
+        applyToolResultReplayMetadata(
+          persistToolResult(applyToolResultReplayMetadata(persistMessage(synthetic), replayMeta), {
+            toolCallId: id,
+            toolName: name,
+            isSynthetic: true,
+          }),
+          replayMeta,
+        ),
+      );
+      if (flushed) {
+        originalAppend(flushed as never);
       }
     }
     pendingState.clear();
   };
 
   const clearPendingToolResults = () => {
+    for (const [id] of pendingState.entries()) {
+      consumePendingToolResultReplayMetadata({
+        sessionKey: replaySessionKey,
+        toolCallId: id,
+      });
+    }
     pendingState.clear();
   };
 
@@ -203,7 +214,7 @@ export function installSessionToolResultGuard(
       const id = extractToolResultId(nextMessage as Extract<AgentMessage, { role: "toolResult" }>);
       const toolName = id ? pendingState.getToolName(id) : undefined;
       const replayMeta = consumePendingToolResultReplayMetadata({
-        sessionKey: opts?.sessionKey,
+        sessionKey: replaySessionKey,
         toolCallId: id ?? undefined,
       });
       if (id) {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -237,7 +237,8 @@ export function installSessionToolResultGuard(
       if (!persisted) {
         return undefined;
       }
-      return originalAppend(persisted as never);
+      const replayTaggedPersisted = applyToolResultReplayMetadata(persisted, replayMeta);
+      return originalAppend(replayTaggedPersisted as never);
     }
 
     // Skip tool call extraction for aborted/errored assistant messages.

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -59,10 +59,14 @@ function matchExecDiagnosticType(command: string): ReplayDiagnosticType | null {
     return "openclaw.config_snapshot";
   }
   if (
-    /\bcat\s+["']?[^"'`\s]*openclaw\.json["']?/iu.test(command) ||
-    /\bcat\s+["']?[^"'`\s]*extensions[\\/][^/"'`\\\s]+[\\/]package\.json["']?/iu.test(command)
+    /\bcat\s+"[^"]*openclaw\.json"/iu.test(command) ||
+    /\bcat\s+'[^']*openclaw\.json'/iu.test(command) ||
+    /\bcat\s+[^"'`\s]*openclaw\.json(?:\s|$)/iu.test(command) ||
+    /\bcat\s+"[^"]*extensions[\\/][^"]+[\\/]package\.json"/iu.test(command) ||
+    /\bcat\s+'[^']*extensions[\\/][^']+[\\/]package\.json'/iu.test(command) ||
+    /\bcat\s+[^"'`\s]*extensions[\\/][^/"'`\\\s]+[\\/]package\.json(?:\s|$)/iu.test(command)
   ) {
-    return command.includes("openclaw.json")
+    return /openclaw\.json/iu.test(command)
       ? "openclaw.config_snapshot"
       : "openclaw.plugin_path_probe";
   }

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -11,6 +11,8 @@ type ReplayDiagnosticType =
 type ToolResultReplayPolicyMeta = {
   transient: true;
   diagnosticType: ReplayDiagnosticType;
+  /** Command string (exec/bash) or file path (read) used to identify the specific target. */
+  diagnosticTarget?: string;
   taggedAt: number;
   persistedAt?: number;
   sourceTool: string;
@@ -20,6 +22,7 @@ type OpenClawReplayMetaEnvelope = {
   __openclaw?: Record<string, unknown> & {
     transient?: boolean;
     diagnosticType?: string;
+    diagnosticTarget?: string;
     taggedAt?: number;
     persistedAt?: number;
     sourceTool?: string;
@@ -107,6 +110,7 @@ export function detectToolResultReplayPolicyMeta(params: {
     return {
       transient: true,
       diagnosticType,
+      diagnosticTarget: command,
       taggedAt,
       sourceTool: toolName,
     };
@@ -124,6 +128,7 @@ export function detectToolResultReplayPolicyMeta(params: {
     return {
       transient: true,
       diagnosticType,
+      diagnosticTarget: filePath,
       taggedAt,
       sourceTool: toolName,
     };
@@ -186,6 +191,7 @@ export function applyToolResultReplayMetadata(
       ...next.__openclaw,
       transient: true,
       diagnosticType: meta.diagnosticType,
+      diagnosticTarget: meta.diagnosticTarget,
       taggedAt: meta.taggedAt,
       sourceTool: meta.sourceTool,
     },
@@ -205,6 +211,7 @@ export function getToolResultReplayMetadata(
   return {
     transient: true,
     diagnosticType: meta.diagnosticType as ReplayDiagnosticType,
+    diagnosticTarget: typeof meta.diagnosticTarget === "string" ? meta.diagnosticTarget : undefined,
     taggedAt: typeof meta.taggedAt === "number" ? meta.taggedAt : 0,
     persistedAt: typeof meta.persistedAt === "number" ? meta.persistedAt : undefined,
     sourceTool: typeof meta.sourceTool === "string" ? meta.sourceTool : "unknown",
@@ -232,6 +239,7 @@ export function stampPersistedToolResultReplayMetadata(
       ...next.__openclaw,
       transient: true,
       diagnosticType: meta.diagnosticType,
+      diagnosticTarget: meta.diagnosticTarget,
       taggedAt: meta.taggedAt,
       persistedAt,
       sourceTool: meta.sourceTool,

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -143,6 +143,19 @@ export function detectToolResultReplayPolicyMeta(params: {
     };
   }
 
+  if (toolName === "gateway") {
+    const action = trimString(record?.action);
+    if (action !== "config.get") {
+      return null;
+    }
+    return {
+      transient: true,
+      diagnosticType: "openclaw.config_snapshot",
+      taggedAt,
+      sourceTool: toolName,
+    };
+  }
+
   return null;
 }
 

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -12,6 +12,7 @@ type ToolResultReplayPolicyMeta = {
   transient: true;
   diagnosticType: ReplayDiagnosticType;
   taggedAt: number;
+  persistedAt?: number;
   sourceTool: string;
 };
 
@@ -20,6 +21,7 @@ type OpenClawReplayMetaEnvelope = {
     transient?: boolean;
     diagnosticType?: string;
     taggedAt?: number;
+    persistedAt?: number;
     sourceTool?: string;
     replayOmitted?: boolean;
   };
@@ -200,8 +202,37 @@ export function getToolResultReplayMetadata(
     transient: true,
     diagnosticType: meta.diagnosticType as ReplayDiagnosticType,
     taggedAt: typeof meta.taggedAt === "number" ? meta.taggedAt : 0,
+    persistedAt: typeof meta.persistedAt === "number" ? meta.persistedAt : undefined,
     sourceTool: typeof meta.sourceTool === "string" ? meta.sourceTool : "unknown",
   };
+}
+
+export function stampPersistedToolResultReplayMetadata(
+  message: AgentMessage,
+  meta: ToolResultReplayPolicyMeta | null,
+): AgentMessage {
+  if (!meta || (message as { role?: unknown }).role !== "toolResult") {
+    return message;
+  }
+  const next = message as AgentMessage &
+    OpenClawReplayMetaEnvelope & {
+      timestamp?: unknown;
+    };
+  const persistedAt =
+    typeof next.timestamp === "number" && Number.isFinite(next.timestamp)
+      ? next.timestamp
+      : Date.now();
+  return {
+    ...next,
+    __openclaw: {
+      ...next.__openclaw,
+      transient: true,
+      diagnosticType: meta.diagnosticType,
+      taggedAt: meta.taggedAt,
+      persistedAt,
+      sourceTool: meta.sourceTool,
+    },
+  } as unknown as AgentMessage;
 }
 
 export function replaceToolResultReplayContent(

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -1,0 +1,223 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+
+export const STALE_TOOL_RESULT_REPLAY_THRESHOLD_MS = 60 * 60 * 1000;
+
+type ReplayDiagnosticType =
+  | "openclaw.plugins_list"
+  | "openclaw.status"
+  | "openclaw.config_snapshot"
+  | "openclaw.plugin_path_probe";
+
+type ToolResultReplayPolicyMeta = {
+  transient: true;
+  diagnosticType: ReplayDiagnosticType;
+  taggedAt: number;
+  sourceTool: string;
+};
+
+type OpenClawReplayMetaEnvelope = {
+  __openclaw?: Record<string, unknown> & {
+    transient?: boolean;
+    diagnosticType?: string;
+    taggedAt?: number;
+    sourceTool?: string;
+    replayOmitted?: boolean;
+  };
+};
+
+const pendingToolResultReplayMeta = new Map<string, ToolResultReplayPolicyMeta>();
+
+function buildPendingKey(sessionKey: string, toolCallId: string): string {
+  return `${sessionKey}:${toolCallId}`;
+}
+
+function trimString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function matchExecDiagnosticType(command: string): ReplayDiagnosticType | null {
+  if (/^\s*openclaw\s+plugins\s+list(?:\s|$)/iu.test(command)) {
+    return "openclaw.plugins_list";
+  }
+  if (/^\s*openclaw\s+status(?:\s|$)/iu.test(command)) {
+    return "openclaw.status";
+  }
+  if (/^\s*openclaw\s+config\s+get(?:\s|$)/iu.test(command)) {
+    return "openclaw.config_snapshot";
+  }
+  if (
+    /\bcat\s+["']?[^"'`\s]*openclaw\.json["']?/iu.test(command) ||
+    /\bcat\s+["']?[^"'`\s]*extensions\/openclaw-[^/"'`\s]+\/package\.json["']?/iu.test(command)
+  ) {
+    return command.includes("openclaw.json")
+      ? "openclaw.config_snapshot"
+      : "openclaw.plugin_path_probe";
+  }
+  return null;
+}
+
+function matchReadDiagnosticType(filePath: string): ReplayDiagnosticType | null {
+  if (/openclaw\.json$/iu.test(filePath)) {
+    return "openclaw.config_snapshot";
+  }
+  if (/extensions\/openclaw-[^/]+\/package\.json$/iu.test(filePath)) {
+    return "openclaw.plugin_path_probe";
+  }
+  return null;
+}
+
+export function detectToolResultReplayPolicyMeta(params: {
+  toolName: string;
+  args: unknown;
+  taggedAt?: number;
+}): ToolResultReplayPolicyMeta | null {
+  const toolName = params.toolName.trim().toLowerCase();
+  const taggedAt = params.taggedAt ?? Date.now();
+  const record =
+    params.args && typeof params.args === "object"
+      ? (params.args as Record<string, unknown>)
+      : undefined;
+
+  if (toolName === "exec" || toolName === "bash") {
+    const command = trimString(record?.command);
+    if (!command) {
+      return null;
+    }
+    const diagnosticType = matchExecDiagnosticType(command);
+    if (!diagnosticType) {
+      return null;
+    }
+    return {
+      transient: true,
+      diagnosticType,
+      taggedAt,
+      sourceTool: toolName,
+    };
+  }
+
+  if (toolName === "read") {
+    const filePath = trimString(record?.path) ?? trimString(record?.file_path);
+    if (!filePath) {
+      return null;
+    }
+    const diagnosticType = matchReadDiagnosticType(filePath);
+    if (!diagnosticType) {
+      return null;
+    }
+    return {
+      transient: true,
+      diagnosticType,
+      taggedAt,
+      sourceTool: toolName,
+    };
+  }
+
+  return null;
+}
+
+export function recordPendingToolResultReplayMetadata(params: {
+  sessionKey?: string;
+  toolCallId?: string;
+  toolName: string;
+  args: unknown;
+  taggedAt?: number;
+}): void {
+  const sessionKey = trimString(params.sessionKey);
+  const toolCallId = trimString(params.toolCallId);
+  if (!sessionKey || !toolCallId) {
+    return;
+  }
+  const meta = detectToolResultReplayPolicyMeta({
+    toolName: params.toolName,
+    args: params.args,
+    taggedAt: params.taggedAt,
+  });
+  if (!meta) {
+    return;
+  }
+  pendingToolResultReplayMeta.set(buildPendingKey(sessionKey, toolCallId), meta);
+}
+
+export function consumePendingToolResultReplayMetadata(params: {
+  sessionKey?: string;
+  toolCallId?: string;
+}): ToolResultReplayPolicyMeta | null {
+  const sessionKey = trimString(params.sessionKey);
+  const toolCallId = trimString(params.toolCallId);
+  if (!sessionKey || !toolCallId) {
+    return null;
+  }
+  const key = buildPendingKey(sessionKey, toolCallId);
+  const meta = pendingToolResultReplayMeta.get(key) ?? null;
+  pendingToolResultReplayMeta.delete(key);
+  return meta;
+}
+
+export function applyToolResultReplayMetadata(
+  message: AgentMessage,
+  meta: ToolResultReplayPolicyMeta | null,
+): AgentMessage {
+  if (!meta || (message as { role?: unknown }).role !== "toolResult") {
+    return message;
+  }
+  const next = message as AgentMessage & OpenClawReplayMetaEnvelope;
+  return {
+    ...next,
+    __openclaw: {
+      ...next.__openclaw,
+      transient: true,
+      diagnosticType: meta.diagnosticType,
+      taggedAt: meta.taggedAt,
+      sourceTool: meta.sourceTool,
+    },
+  } as unknown as AgentMessage;
+}
+
+export function getToolResultReplayMetadata(
+  message: AgentMessage,
+): ToolResultReplayPolicyMeta | null {
+  if ((message as { role?: unknown }).role !== "toolResult") {
+    return null;
+  }
+  const meta = (message as OpenClawReplayMetaEnvelope).__openclaw;
+  if (!meta || meta.transient !== true || typeof meta.diagnosticType !== "string") {
+    return null;
+  }
+  return {
+    transient: true,
+    diagnosticType: meta.diagnosticType as ReplayDiagnosticType,
+    taggedAt: typeof meta.taggedAt === "number" ? meta.taggedAt : 0,
+    sourceTool: typeof meta.sourceTool === "string" ? meta.sourceTool : "unknown",
+  };
+}
+
+export function replaceToolResultReplayContent(
+  message: AgentMessage,
+  replacementText: string,
+): AgentMessage {
+  if ((message as { role?: unknown }).role !== "toolResult") {
+    return message;
+  }
+  const next = message as AgentMessage &
+    OpenClawReplayMetaEnvelope & {
+      content?: unknown;
+    };
+  const replacement =
+    typeof next.content === "string"
+      ? replacementText
+      : Array.isArray(next.content)
+        ? [{ type: "text", text: replacementText }]
+        : next.content;
+  return {
+    ...next,
+    ...(replacement !== undefined ? { content: replacement } : {}),
+    __openclaw: {
+      ...next.__openclaw,
+      replayOmitted: true,
+    },
+  } as unknown as AgentMessage;
+}

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -58,7 +58,7 @@ function matchExecDiagnosticType(command: string): ReplayDiagnosticType | null {
   }
   if (
     /\bcat\s+["']?[^"'`\s]*openclaw\.json["']?/iu.test(command) ||
-    /\bcat\s+["']?[^"'`\s]*extensions\/openclaw-[^/"'`\s]+\/package\.json["']?/iu.test(command)
+    /\bcat\s+["']?[^"'`\s]*extensions\/[^/"'`\s]+\/package\.json["']?/iu.test(command)
   ) {
     return command.includes("openclaw.json")
       ? "openclaw.config_snapshot"
@@ -71,7 +71,7 @@ function matchReadDiagnosticType(filePath: string): ReplayDiagnosticType | null 
   if (/openclaw\.json$/iu.test(filePath)) {
     return "openclaw.config_snapshot";
   }
-  if (/extensions\/openclaw-[^/]+\/package\.json$/iu.test(filePath)) {
+  if (/extensions\/[^/]+\/package\.json$/iu.test(filePath)) {
     return "openclaw.plugin_path_probe";
   }
   return null;

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -43,6 +43,15 @@ function buildPendingKey(sessionKey: string, toolCallId: string): string {
   return `${sessionKey}:${toolCallId}`;
 }
 
+function extractSessionKeyFromPendingKey(pendingKey: string): string | undefined {
+  const separatorIndex = pendingKey.lastIndexOf(":");
+  if (separatorIndex <= 0) {
+    return undefined;
+  }
+  const sessionKey = pendingKey.slice(0, separatorIndex).trim();
+  return sessionKey || undefined;
+}
+
 function trimString(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;
@@ -185,10 +194,9 @@ export function drainPendingToolResultReplayMetadataForSession(params: {
   if (!sessionKey) {
     return 0;
   }
-  const prefix = `${sessionKey}:`;
   let drained = 0;
   for (const key of pendingToolResultReplayMeta.keys()) {
-    if (!key.startsWith(prefix)) {
+    if (extractSessionKeyFromPendingKey(key) !== sessionKey) {
       continue;
     }
     pendingToolResultReplayMeta.delete(key);

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -58,7 +58,7 @@ function matchExecDiagnosticType(command: string): ReplayDiagnosticType | null {
   }
   if (
     /\bcat\s+["']?[^"'`\s]*openclaw\.json["']?/iu.test(command) ||
-    /\bcat\s+["']?[^"'`\s]*extensions\/[^/"'`\s]+\/package\.json["']?/iu.test(command)
+    /\bcat\s+["']?[^"'`\s]*extensions[\\/][^/"'`\\\s]+[\\/]package\.json["']?/iu.test(command)
   ) {
     return command.includes("openclaw.json")
       ? "openclaw.config_snapshot"
@@ -71,7 +71,7 @@ function matchReadDiagnosticType(filePath: string): ReplayDiagnosticType | null 
   if (/openclaw\.json$/iu.test(filePath)) {
     return "openclaw.config_snapshot";
   }
-  if (/extensions\/[^/]+\/package\.json$/iu.test(filePath)) {
+  if (/extensions[\\/][^/\\]+[\\/]package\.json$/iu.test(filePath)) {
     return "openclaw.plugin_path_probe";
   }
   return null;

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -177,6 +177,26 @@ export function consumePendingToolResultReplayMetadata(params: {
   return meta;
 }
 
+export function drainPendingToolResultReplayMetadataForSession(params: {
+  sessionKey?: string;
+  sessionId?: string;
+}): number {
+  const sessionKey = resolveToolResultReplaySessionKey(params);
+  if (!sessionKey) {
+    return 0;
+  }
+  const prefix = `${sessionKey}:`;
+  let drained = 0;
+  for (const key of pendingToolResultReplayMeta.keys()) {
+    if (!key.startsWith(prefix)) {
+      continue;
+    }
+    pendingToolResultReplayMeta.delete(key);
+    drained += 1;
+  }
+  return drained;
+}
+
 export function applyToolResultReplayMetadata(
   message: AgentMessage,
   meta: ToolResultReplayPolicyMeta | null,

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -148,9 +148,12 @@ export function detectToolResultReplayPolicyMeta(params: {
     if (action !== "config.get") {
       return null;
     }
+    const path = trimString(record?.path);
+    const diagnosticType =
+      path === "plugins.entries" ? "openclaw.plugins_list" : "openclaw.config_snapshot";
     return {
       transient: true,
-      diagnosticType: "openclaw.config_snapshot",
+      diagnosticType,
       taggedAt,
       sourceTool: toolName,
     };

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -27,6 +27,13 @@ type OpenClawReplayMetaEnvelope = {
 
 const pendingToolResultReplayMeta = new Map<string, ToolResultReplayPolicyMeta>();
 
+export function resolveToolResultReplaySessionKey(params: {
+  sessionKey?: string;
+  sessionId?: string;
+}): string | undefined {
+  return trimString(params.sessionKey) ?? trimString(params.sessionId);
+}
+
 function buildPendingKey(sessionKey: string, toolCallId: string): string {
   return `${sessionKey}:${toolCallId}`;
 }
@@ -121,12 +128,13 @@ export function detectToolResultReplayPolicyMeta(params: {
 
 export function recordPendingToolResultReplayMetadata(params: {
   sessionKey?: string;
+  sessionId?: string;
   toolCallId?: string;
   toolName: string;
   args: unknown;
   taggedAt?: number;
 }): void {
-  const sessionKey = trimString(params.sessionKey);
+  const sessionKey = resolveToolResultReplaySessionKey(params);
   const toolCallId = trimString(params.toolCallId);
   if (!sessionKey || !toolCallId) {
     return;
@@ -144,9 +152,10 @@ export function recordPendingToolResultReplayMetadata(params: {
 
 export function consumePendingToolResultReplayMetadata(params: {
   sessionKey?: string;
+  sessionId?: string;
   toolCallId?: string;
 }): ToolResultReplayPolicyMeta | null {
-  const sessionKey = trimString(params.sessionKey);
+  const sessionKey = resolveToolResultReplaySessionKey(params);
   const toolCallId = trimString(params.toolCallId);
   if (!sessionKey || !toolCallId) {
     return null;
@@ -211,7 +220,7 @@ export function replaceToolResultReplayContent(
       ? replacementText
       : Array.isArray(next.content)
         ? [{ type: "text", text: replacementText }]
-        : next.content;
+        : replacementText;
   return {
     ...next,
     ...(replacement !== undefined ? { content: replacement } : {}),

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -150,7 +150,9 @@ export function detectToolResultReplayPolicyMeta(params: {
     }
     const path = trimString(record?.path);
     const diagnosticType =
-      path === "plugins.entries" ? "openclaw.plugins_list" : "openclaw.config_snapshot";
+      path && /^plugins\.entries(?:\.|$)/iu.test(path)
+        ? "openclaw.plugins_list"
+        : "openclaw.config_snapshot";
     return {
       transient: true,
       diagnosticType,

--- a/src/agents/tool-result-replay-metadata.ts
+++ b/src/agents/tool-result-replay-metadata.ts
@@ -154,6 +154,7 @@ export function detectToolResultReplayPolicyMeta(params: {
     return {
       transient: true,
       diagnosticType,
+      diagnosticTarget: path,
       taggedAt,
       sourceTool: toolName,
     };


### PR DESCRIPTION
## Summary

  This change adds an experimental assistant-conclusion freshness gate for high-risk environment-state questions.

  The goal is to reduce cases where the model reuses stale assistant conclusions for questions about current OpenClaw state, especially when the answer should be based on fresh environment evidence
  from the current turn.

  This PR is intentionally scoped as a minimal Phase 2 prototype on top of the existing replay-mitigation foundation.

  ## What this does

  When enabled, the gate inspects the current user question before prompt build.

  For a small set of high-risk question types, it checks recent structured evidence in session history:

  - plugin enabled state
  - config key presence

  If fresh evidence is missing or stale, it prepends a system instruction that tells the model:

  - do not answer from prior assistant conclusions alone
  - make a fresh tool call in this turn first
  - then answer from the current result

  If recent fresh structured evidence already exists, the gate allows reuse and avoids unnecessary repeated checks.

  ## Scope

  This PR is intentionally narrow.

  Included:
  - experimental freshness gate for:
    - plugin enabled state
    - config key presence
  - prompt-build integration
  - focused tests

  Not included:
  - broader assistant-history rewriting
  - compaction changes
  - wider command-family expansion
  - full stale/conflict/multi-model coverage beyond the current prototype scope

  ## Key files

  - `src/agents/assistant-conclusion-freshness-gate.ts`
  - `src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts`
  - `src/agents/pi-embedded-runner/run/attempt.test.ts`

  ## Feature flag

  This feature is **default off**.

  Enable it explicitly with:

  ```bash
  OPENCLAW_EXPERIMENT_ASSISTANT_FRESHNESS_GATE=1

  Accepted truthy values:

  - 1
  - true
  - yes
  - on

  If the flag is not set, OpenClaw keeps its existing behavior and does not enable freshness-gate logic.

  ## Behavior details

  The gate does not silently execute tools outside the normal agent loop.

  It works by injecting a minimal system instruction during prompt build, so the model remains responsible for issuing the tool call in the current turn.

  This keeps the implementation aligned with the existing OpenClaw architecture.

  ## Validation

  ### Local

  Passed targeted replay and gate-related tests.

  Phase 1 regression:

  pnpm vitest run --project agents src/agents/session-tool-result-guard.test.ts src/agents/pi-embedded-runner.sanitize-session-history.test.ts

  - 59/59 passed

  Build:

  node scripts/tsdown-build.mjs

  - passed

  ### Remote verification

  Validated on a main-based remote deployment with the feature flag enabled.

  Confirmed behaviors:

  1. config_key_presence

  - first question triggers a fresh check
  - follow-up in the same session reuses fresh evidence instead of re-querying

  2. plugin_enabled_state

  - first question triggers a fresh check
  - follow-up in the same session reuses fresh evidence instead of re-querying

  ## Notes

  This PR depends conceptually on the earlier replay-mitigation work because it reuses structured diagnostic evidence.

  However, this PR only addresses assistant-conclusion freshness for the current prototype scope.

  It does not claim to solve all context-pollution cases.