### PR TITLE
fix(plugins): add missing configSchema to deepgram and groq manifests

### DIFF
--- a/extensions/deepgram/openclaw.plugin.json
+++ b/extensions/deepgram/openclaw.plugin.json
@@ -1,3 +1,8 @@
 {
-  "id": "deepgram"
+  "id": "deepgram",
+  "configSchema": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": true
+  }
 }

--- a/extensions/groq/openclaw.plugin.json
+++ b/extensions/groq/openclaw.plugin.json
@@ -1,3 +1,8 @@
 {
-  "id": "groq"
+  "id": "groq",
+  "configSchema": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": true
+  }
 }

--- a/src/plugins/bundled-plugin-metadata.generated.ts
+++ b/src/plugins/bundled-plugin-metadata.generated.ts
@@ -469,6 +469,28 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
     },
   },
   {
+    dirName: "deepgram",
+    idHint: "deepgram",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/deepgram-provider",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw Deepgram media-understanding provider",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "deepgram",
+      configSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: true,
+      },
+    },
+  },
+  {
     dirName: "diagnostics-otel",
     idHint: "diagnostics-otel",
     source: {
@@ -1047,6 +1069,28 @@ export const GENERATED_BUNDLED_PLUGIN_METADATA = [
         properties: {},
       },
       channels: ["googlechat"],
+    },
+  },
+  {
+    dirName: "groq",
+    idHint: "groq",
+    source: {
+      source: "./index.ts",
+      built: "index.js",
+    },
+    packageName: "@openclaw/groq-provider",
+    packageVersion: "2026.3.14",
+    packageDescription: "OpenClaw Groq media-understanding provider",
+    packageManifest: {
+      extensions: ["./index.ts"],
+    },
+    manifest: {
+      id: "groq",
+      configSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: true,
+      },
     },
   },
   {


### PR DESCRIPTION
## Summary

- Add required `configSchema` to `extensions/deepgram/openclaw.plugin.json` and `extensions/groq/openclaw.plugin.json`
- Regenerate `bundled-plugin-metadata.generated.ts`

When deepgram and groq were moved from `src/` to `extensions/` in 3dcc802, their manifests were created with only `"id"`. The plugin manifest loader (`src/plugins/manifest.ts`) requires `configSchema` for all extension plugins — without it, gateway config validation fails on startup:

```
Invalid config at ~/.openclaw/openclaw.json:
- plugins: plugin: plugin manifest requires configSchema
- plugins: plugin: plugin manifest requires configSchema
```

This causes downstream failures in channels (e.g. telegram debounce flush errors).

## Test plan

- [x] `pnpm build` passes
- [x] Gateway starts and health check returns `{"ok":true,"status":"live"}`
- [x] No more `configSchema` validation errors in logs