### PR TITLE
fix(matrix): keep bundled plugin SDK self-imports on Jiti

### DIFF
--- a/src/plugins/runtime-plugin-boundary.whatsapp.test.ts
+++ b/src/plugins/runtime-plugin-boundary.whatsapp.test.ts
@@ -17,6 +17,10 @@ type HeavyModule = {
   ) => void;
 };
 
+type MatrixScopedModule = {
+  exportedDefaultAccountId: string;
+};
+
 const tempDirs: string[] = [];
 
 function writeRuntimeFixtureText(rootDir: string, relativePath: string, value: string) {
@@ -76,6 +80,54 @@ function createBundledWhatsAppRuntimeFixture() {
   return path.join(rootDir, "dist-runtime", "extensions", "whatsapp");
 }
 
+function createBundledMatrixScopedAliasFixture() {
+  const rootDir = makeTrackedTempDir("openclaw-matrix-boundary", tempDirs);
+  for (const [relativePath, value] of Object.entries({
+    "package.json": JSON.stringify(
+      {
+        name: "openclaw",
+        type: "module",
+        bin: {
+          openclaw: "openclaw.mjs",
+        },
+        exports: {
+          "./plugin-sdk": {
+            default: "./dist/plugin-sdk/index.js",
+          },
+          "./plugin-sdk/account-id": {
+            default: "./dist/plugin-sdk/account-id.js",
+          },
+        },
+      },
+      null,
+      2,
+    ),
+    "openclaw.mjs": "export {};\n",
+    "dist/plugin-sdk/index.js": "export {};\n",
+    "dist/plugin-sdk/account-id.js":
+      'export const DEFAULT_ACCOUNT_ID = "default-account";\n',
+    [bundledDistPluginFile("matrix", "index.js")]: "export default {};\n",
+    [bundledDistPluginFile("matrix", "package.json")]: JSON.stringify(
+      {
+        name: "@openclaw/matrix",
+        type: "module",
+      },
+      null,
+      2,
+    ),
+    [bundledDistPluginFile("matrix", "runtime-api.js")]: [
+      'import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";',
+      "export const exportedDefaultAccountId = DEFAULT_ACCOUNT_ID;",
+      "",
+    ].join("\n"),
+  })) {
+    writeRuntimeFixtureText(rootDir, relativePath, value);
+  }
+  stageBundledPluginRuntime({ repoRoot: rootDir });
+
+  return path.join(rootDir, "dist-runtime", "extensions", "matrix");
+}
+
 function loadWhatsAppBoundaryModules(runtimePluginDir: string) {
   const loaders = new Map<boolean, ReturnType<typeof import("jiti").createJiti>>();
   return {
@@ -112,5 +164,16 @@ afterEach(() => {
 describe("runtime plugin boundary whatsapp seam", () => {
   it("shares listener state between staged light and heavy runtime modules", () => {
     expectSharedWhatsAppListenerState(createBundledWhatsAppRuntimeFixture(), "work");
+  });
+
+  it("keeps bundled dist-runtime plugin-sdk self-imports on the alias-aware Jiti path", () => {
+    const runtimePluginDir = createBundledMatrixScopedAliasFixture();
+    const loaders = new Map<boolean, ReturnType<typeof import("jiti").createJiti>>();
+    const module = loadPluginBoundaryModuleWithJiti<MatrixScopedModule>(
+      path.join(runtimePluginDir, "runtime-api.js"),
+      loaders,
+    );
+
+    expect(module.exportedDefaultAccountId).toBe("default-account");
   });
 });

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -644,6 +644,9 @@ describe("plugin sdk alias helpers", () => {
 
   it("uses transpiled Jiti loads for source TypeScript plugin entries", () => {
     expect(shouldPreferNativeJiti("/repo/dist/plugins/runtime/index.js")).toBe(true);
+    expect(shouldPreferNativeJiti(`/repo/${bundledDistPluginFile("matrix", "runtime-api.js")}`)).toBe(
+      false,
+    );
     expect(
       shouldPreferNativeJiti(`/repo/${bundledPluginFile("discord", "src/channel.runtime.ts")}`),
     ).toBe(false);

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -449,6 +449,16 @@ export function shouldPreferNativeJiti(modulePath: string): boolean {
   if (process.platform === "win32") {
     return false;
   }
+  const normalizedModulePath = modulePath.replace(/\\/g, "/");
+  if (
+    normalizedModulePath.includes("/dist/extensions/") ||
+    normalizedModulePath.includes("/dist-runtime/extensions/")
+  ) {
+    // Bundled plugin entrypoints execute inside nested package scopes such as
+    // @openclaw/matrix. Native ESM resolution from there does not honor our
+    // openclaw/plugin-sdk alias map, so keep those loads on Jiti.
+    return false;
+  }
   switch (path.extname(modulePath).toLowerCase()) {
     case ".js":
     case ".mjs":


### PR DESCRIPTION
## Summary
- keep bundled `dist/extensions/*` and `dist-runtime/extensions/*` plugin entrypoints on the alias-aware Jiti path
- add a regression test for a bundled Matrix-style nested package that imports `openclaw/plugin-sdk/account-id`
- extend the `shouldPreferNativeJiti()` heuristic coverage for bundled plugin outputs

## Root cause
`shouldPreferNativeJiti()` treated bundled plugin JS entrypoints like generic transpiled runtime files and preferred native ESM loading.

For bundled plugins, those files execute inside nested package scopes such as `@openclaw/matrix`. Native ESM resolution from that scope does not honor the `openclaw/plugin-sdk/*` alias map, so imports like `openclaw/plugin-sdk/account-id` can fail with:

```text
Cannot find package 'openclaw' imported from .../extensions/matrix/src/matrix/credentials-read.ts
```

Keeping bundled plugin entrypoints on Jiti preserves the alias-aware boundary behavior that already works for source plugin entries.

Closes #62170.

## Testing
- `node scripts/run-vitest.mjs run --config <temporary-worktree-config> src/plugins/sdk-alias.test.ts src/plugins/runtime-plugin-boundary.whatsapp.test.ts`
- result: `29 passed`
