### PR TITLE
Fix: code consistency improvements (parseInt + DNS \r stripping)

### DIFF
--- a/src/infra/widearea-dns.ts
+++ b/src/infra/widearea-dns.ts
@@ -40,7 +40,11 @@ function dnsLabel(raw: string, fallback: string): string {
 }
 
 function txtQuote(value: string): string {
-  const escaped = value.replaceAll("\\", "\\\\").replaceAll('"', '\\"').replaceAll("\n", "\\n");
+  const escaped = value
+    .replaceAll("\\", "\\\\")
+    .replaceAll('"', '\\"')
+    .replaceAll("\n", "\\n")
+    .replaceAll("\r", "");
   return `"${escaped}"`;
 }
 

--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -240,7 +240,7 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
 
       // Special handling for suspicious-network: check port
       if (rule.ruleId === "suspicious-network") {
-        const port = parseInt(match[1], 10);
+        const port = Number.parseInt(match[1], 10);
         if (STANDARD_PORTS.has(port)) {
           continue;
         }


### PR DESCRIPTION
## Summary

Minor code quality fixes addressing two issues found during code review:

- **`src/security/skill-scanner.ts`**: Replace bare `parseInt()` with `Number.parseInt()` on line 243 for consistency with the rest of the file and codebase convention.
- **`src/infra/widearea-dns.ts`**: Add `\r` (carriage return) stripping in `txtQuote()` to prevent malformed DNS zone file output when input values contain Windows-style line endings.

## Changes

| File | Change |
|------|--------|
| `src/security/skill-scanner.ts` | `parseInt` → `Number.parseInt` |
| `src/infra/widearea-dns.ts` | Add `.replaceAll("\r", "")` in `txtQuote()` |

## Test plan

- [x] Verify `Number.parseInt` behaves identically to global `parseInt` with radix 10
- [x] Verify DNS zone file generation strips carriage returns correctly