### PR TITLE
feat(memory-core): ingest session transcripts into dreaming corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Tools/media generation: report applied fallback geometry and duration settings consistently in tool results, add a shared normalization contract for image/music/video runtimes, and simplify the bundled image-generation-core runtime test to only verify the plugin-sdk re-export seam.
 - Gateway/sessions: add persisted compaction checkpoints plus Sessions UI branch/restore actions so operators can inspect and recover pre-compaction session state. (#62146) Thanks @scoootscooob.
 - Providers/Ollama: detect vision capability from the `/api/show` response and set image input on models that support it so Ollama vision models accept image attachments. (#62193) Thanks @BruceMacD.
+- Memory/dreaming: ingest redacted session transcripts into the dreaming corpus with per-day session-corpus notes, cursor checkpointing, and promotion/doctor support. (#62227) Thanks @vignesh07.
 
 ### Fixes
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
+import { resolveSessionTranscriptsDirForAgent } from "openclaw/plugin-sdk/memory-core";
 import { describe, expect, it, vi } from "vitest";
 import { registerMemoryDreamingPhases } from "./dreaming-phases.js";
 import {
@@ -317,6 +318,124 @@ describe("memory-core dreaming phases", () => {
     expect(after[0]?.endLine).toBe(4);
     expect(after[0]?.snippet).toContain("Move backups to S3 Glacier.");
     expect(after[0]?.snippet).toContain("Keep retention at 365 days.");
+  });
+
+  it("checkpoints session transcript ingestion and skips unchanged transcripts", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "session",
+          id: "dreaming-main",
+          timestamp: "2026-04-05T18:00:00.000Z",
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:01:00.000Z",
+            content: [{ type: "text", text: "Move backups to S3 Glacier." }],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            timestamp: "2026-04-05T18:02:00.000Z",
+            content: [{ type: "text", text: "Set retention to 365 days." }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+            memorySearch: {
+              enabled: true,
+              sources: ["memory", "sessions"],
+              experimental: {
+                sessionMemory: true,
+              },
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    const readSpy = vi.spyOn(fs, "readFile");
+    let transcriptReadCount = 0;
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      transcriptReadCount = readSpy.mock.calls.filter(
+        ([target]) => String(target) === transcriptPath,
+      ).length;
+      readSpy.mockRestore();
+      vi.unstubAllEnvs();
+    }
+
+    expect(transcriptReadCount).toBeLessThanOrEqual(1);
+
+    await expect(
+      fs.access(path.join(workspaceDir, "memory", ".dreams", "session-ingestion.json")),
+    ).resolves.toBeUndefined();
+    await expect(
+      fs.access(path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-05.txt")),
+    ).resolves.toBeUndefined();
+
+    const ranked = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-05T19:00:00.000Z"),
+    });
+    expect(ranked.map((candidate) => candidate.path)).toContain(
+      "memory/.dreams/session-corpus/2026-04-05.txt",
+    );
+    expect(ranked.map((candidate) => candidate.snippet)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Move backups to S3 Glacier."),
+        expect.stringContaining("Set retention to 365 days."),
+      ]),
+    );
   });
 
   it("keeps section context when chunking durable daily notes", async () => {

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -361,13 +361,6 @@ describe("memory-core dreaming phases", () => {
         agents: {
           defaults: {
             workspace: workspaceDir,
-            memorySearch: {
-              enabled: true,
-              sources: ["memory", "sessions"],
-              experimental: {
-                sessionMemory: true,
-              },
-            },
           },
         },
         plugins: {

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -580,7 +580,7 @@ describe("memory-core dreaming phases", () => {
             type: "message",
             message: {
               role: "user",
-              timestamp: "2026-04-06T01:01:00.000Z",
+              timestamp: "2026-04-05T18:01:00.000Z",
               content: [{ type: "text", text: oldMessage }],
             },
           }),
@@ -618,6 +618,190 @@ describe("memory-core dreaming phases", () => {
     const newCandidate = ranked.find((candidate) => candidate.snippet.includes("retention at 365"));
     expect(oldCandidate?.dailyCount).toBe(1);
     expect(newCandidate?.dailyCount).toBe(1);
+
+    const sessionCorpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+    const corpusFiles = (await fs.readdir(sessionCorpusDir)).filter((name) =>
+      name.endsWith(".txt"),
+    );
+    let combinedCorpus = "";
+    for (const fileName of corpusFiles) {
+      combinedCorpus += `${await fs.readFile(path.join(sessionCorpusDir, fileName), "utf-8")}\n`;
+    }
+    const oldOccurrences = combinedCorpus.match(/Move backups to S3 Glacier\./g)?.length ?? 0;
+    const newOccurrences = combinedCorpus.match(/Keep retention at 365 days\./g)?.length ?? 0;
+    expect(oldOccurrences).toBe(1);
+    expect(newOccurrences).toBe(1);
+  });
+
+  it("buckets session snippets by per-message day rather than file mtime", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-01T12:00:00.000Z",
+            content: [
+              { type: "text", text: "Old planning note that should stay out of lookback." },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            timestamp: "2026-04-05T18:02:00.000Z",
+            content: [{ type: "text", text: "Current reminder that should be in today corpus." }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const freshMtime = new Date("2026-04-06T01:05:00.000Z");
+    await fs.utimes(transcriptPath, freshMtime, freshMtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 2,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const corpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+    const corpusFiles = (await fs.readdir(corpusDir))
+      .filter((name) => name.endsWith(".txt"))
+      .toSorted();
+    expect(corpusFiles).toEqual(["2026-04-05.txt"]);
+    const dayCorpus = await fs.readFile(path.join(corpusDir, "2026-04-05.txt"), "utf-8");
+    expect(dayCorpus).toContain("Current reminder that should be in today corpus.");
+    expect(dayCorpus).not.toContain("Old planning note that should stay out of lookback.");
+  });
+
+  it("drains >80 unseen transcript messages across multiple unchanged sweeps", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+    const lines: string[] = [];
+    for (let index = 0; index < 160; index += 1) {
+      lines.push(
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: index % 2 === 0 ? "user" : "assistant",
+            timestamp: "2026-04-05T18:00:00.000Z",
+            content: [{ type: "text", text: `bulk-line-${index}` }],
+          },
+        }),
+      );
+    }
+    await fs.writeFile(transcriptPath, `${lines.join("\n")}\n`, "utf-8");
+    const mtime = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, mtime, mtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const corpusPath = path.join(
+      workspaceDir,
+      "memory",
+      ".dreams",
+      "session-corpus",
+      "2026-04-05.txt",
+    );
+    const corpus = await fs.readFile(corpusPath, "utf-8");
+    const persistedLines = corpus
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    expect(persistedLines).toHaveLength(160);
+    expect(corpus).toContain("bulk-line-0");
+    expect(corpus).toContain("bulk-line-159");
   });
 
   it("re-ingests rewritten session transcripts after truncate/reset", async () => {

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -431,6 +431,376 @@ describe("memory-core dreaming phases", () => {
     );
   });
 
+  it("redacts sensitive session content before writing session corpus", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:01:00.000Z",
+            content: [{ type: "text", text: "OPENAI_API_KEY=sk-1234567890abcdef" }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const mtime = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, mtime, mtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const corpusPath = path.join(
+      workspaceDir,
+      "memory",
+      ".dreams",
+      "session-corpus",
+      "2026-04-05.txt",
+    );
+    const corpus = await fs.readFile(corpusPath, "utf-8");
+    expect(corpus).not.toContain("OPENAI_API_KEY=sk-1234567890abcdef");
+    expect(corpus).toContain("OPENAI_API_KEY=sk-123…cdef");
+  });
+
+  it("dedupes reset/deleted session archives instead of double-ingesting", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+    const oldMessage = "Move backups to S3 Glacier.";
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:01:00.000Z",
+            content: [{ type: "text", text: oldMessage }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const dayOne = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, dayOne, dayOne);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+
+      const resetPath = path.join(
+        sessionsDir,
+        "dreaming-main.jsonl.reset.2026-04-06T01-00-00.000Z",
+      );
+      await fs.writeFile(resetPath, await fs.readFile(transcriptPath, "utf-8"), "utf-8");
+      const newMessage = "Keep retention at 365 days.";
+      await fs.writeFile(
+        transcriptPath,
+        [
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "user",
+              timestamp: "2026-04-06T01:01:00.000Z",
+              content: [{ type: "text", text: oldMessage }],
+            },
+          }),
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "assistant",
+              timestamp: "2026-04-06T01:02:00.000Z",
+              content: [{ type: "text", text: newMessage }],
+            },
+          }),
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+      const dayTwo = new Date("2026-04-06T01:05:00.000Z");
+      await fs.utimes(transcriptPath, dayTwo, dayTwo);
+      await fs.utimes(resetPath, dayTwo, dayTwo);
+
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const ranked = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-06T02:00:00.000Z"),
+    });
+    const oldCandidate = ranked.find((candidate) => candidate.snippet.includes(oldMessage));
+    const newCandidate = ranked.find((candidate) => candidate.snippet.includes("retention at 365"));
+    expect(oldCandidate?.dailyCount).toBe(1);
+    expect(newCandidate?.dailyCount).toBe(1);
+  });
+
+  it("re-ingests rewritten session transcripts after truncate/reset", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:01:00.000Z",
+            content: [{ type: "text", text: "Move backups to S3 Glacier." }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const dayOne = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, dayOne, dayOne);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+
+      await fs.writeFile(
+        transcriptPath,
+        [
+          JSON.stringify({
+            type: "message",
+            message: {
+              role: "assistant",
+              timestamp: "2026-04-06T01:02:00.000Z",
+              content: [{ type: "text", text: "Retention policy stays at 365 days." }],
+            },
+          }),
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+      const dayTwo = new Date("2026-04-06T01:05:00.000Z");
+      await fs.utimes(transcriptPath, dayTwo, dayTwo);
+
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const ranked = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-06T02:00:00.000Z"),
+    });
+    expect(ranked.map((candidate) => candidate.snippet)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Move backups to S3 Glacier."),
+        expect.stringContaining("Retention policy stays at 365 days."),
+      ]),
+    );
+  });
+
+  it("ingests sessions when dreaming is enabled even if memorySearch is disabled", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-phases-");
+    vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(workspaceDir, ".state"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const transcriptPath = path.join(sessionsDir, "dreaming-main.jsonl");
+    await fs.writeFile(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            timestamp: "2026-04-05T18:01:00.000Z",
+            content: [{ type: "text", text: "Glacier archive migration is now complete." }],
+          },
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+    const mtime = new Date("2026-04-05T18:05:00.000Z");
+    await fs.utimes(transcriptPath, mtime, mtime);
+
+    const { beforeAgentReply } = createHarness(
+      {
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+            memorySearch: {
+              enabled: false,
+            },
+          },
+        },
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 20,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    try {
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_light_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+
+    const ranked = await rankShortTermPromotionCandidates({
+      workspaceDir,
+      minScore: 0,
+      minRecallCount: 0,
+      minUniqueQueries: 0,
+      nowMs: Date.parse("2026-04-05T19:00:00.000Z"),
+    });
+    expect(ranked.map((candidate) => candidate.snippet)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Glacier archive migration is now complete."),
+      ]),
+    );
+  });
+
   it("keeps section context when chunking durable daily notes", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await fs.writeFile(

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -2,8 +2,14 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
+import { resolveMemorySearchConfig } from "openclaw/plugin-sdk/memory-core";
+import {
+  listSessionFilesForAgent,
+  sessionPathForFile,
+} from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 import {
+  formatMemoryDreamingDay,
   resolveMemoryCorePluginConfig,
   resolveMemoryDreamingWorkspaces,
   resolveMemoryLightDreamingConfig,
@@ -84,6 +90,18 @@ const DAILY_INGESTION_SCORE = 0.62;
 const DAILY_INGESTION_MAX_SNIPPET_CHARS = 280;
 const DAILY_INGESTION_MIN_SNIPPET_CHARS = 8;
 const DAILY_INGESTION_MAX_CHUNK_LINES = 4;
+const SESSION_INGESTION_STATE_RELATIVE_PATH = path.join(
+  "memory",
+  ".dreams",
+  "session-ingestion.json",
+);
+const SESSION_CORPUS_RELATIVE_DIR = path.join("memory", ".dreams", "session-corpus");
+const SESSION_INGESTION_SCORE = 0.58;
+const SESSION_INGESTION_MAX_SNIPPET_CHARS = 280;
+const SESSION_INGESTION_MIN_SNIPPET_CHARS = 12;
+const SESSION_INGESTION_MAX_MESSAGES_PER_SWEEP = 240;
+const SESSION_INGESTION_MAX_MESSAGES_PER_FILE = 80;
+const SESSION_INGESTION_MIN_MESSAGES_PER_FILE = 12;
 const GENERIC_DAY_HEADING_RE =
   /^(?:(?:mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|sun|sunday)(?:,\s+)?)?(?:(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4}[/-]\d{2}[/-]\d{2})$/i;
 const MANAGED_DAILY_DREAMING_BLOCKS = [
@@ -611,6 +629,485 @@ async function writeDailyIngestionState(
   await fs.rename(tmpPath, statePath);
 }
 
+type SessionIngestionFileState = {
+  mtimeMs: number;
+  size: number;
+  lineCount: number;
+  lastJsonlLine: number;
+};
+
+type SessionIngestionState = {
+  version: 1;
+  files: Record<string, SessionIngestionFileState>;
+};
+
+type SessionIngestionMessage = {
+  day: string;
+  snippet: string;
+  rendered: string;
+};
+
+type SessionIngestionCollectionResult = {
+  batches: DailyIngestionBatch[];
+  nextState: SessionIngestionState;
+  changed: boolean;
+};
+
+function normalizeWorkspaceKey(workspaceDir: string): string {
+  const resolved = path.resolve(workspaceDir).replace(/\\/g, "/");
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function resolveSessionIngestionStatePath(workspaceDir: string): string {
+  return path.join(workspaceDir, SESSION_INGESTION_STATE_RELATIVE_PATH);
+}
+
+function normalizeSessionIngestionState(raw: unknown): SessionIngestionState {
+  const record = asRecord(raw);
+  const filesRaw = asRecord(record?.files);
+  if (!filesRaw) {
+    return { version: 1, files: {} };
+  }
+  const files: Record<string, SessionIngestionFileState> = {};
+  for (const [key, value] of Object.entries(filesRaw)) {
+    const file = asRecord(value);
+    if (!file || key.trim().length === 0) {
+      continue;
+    }
+    const mtimeMs = Number(file.mtimeMs);
+    const size = Number(file.size);
+    const lineCount = Number(file.lineCount);
+    const lastJsonlLine = Number(file.lastJsonlLine);
+    if (
+      !Number.isFinite(mtimeMs) ||
+      mtimeMs < 0 ||
+      !Number.isFinite(size) ||
+      size < 0 ||
+      !Number.isFinite(lineCount) ||
+      lineCount < 0 ||
+      !Number.isFinite(lastJsonlLine) ||
+      lastJsonlLine < 0
+    ) {
+      continue;
+    }
+    files[key] = {
+      mtimeMs: Math.floor(mtimeMs),
+      size: Math.floor(size),
+      lineCount: Math.floor(lineCount),
+      lastJsonlLine: Math.floor(lastJsonlLine),
+    };
+  }
+  return { version: 1, files };
+}
+
+async function readSessionIngestionState(workspaceDir: string): Promise<SessionIngestionState> {
+  const statePath = resolveSessionIngestionStatePath(workspaceDir);
+  try {
+    const raw = await fs.readFile(statePath, "utf-8");
+    return normalizeSessionIngestionState(JSON.parse(raw) as unknown);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || err instanceof SyntaxError) {
+      return { version: 1, files: {} };
+    }
+    throw err;
+  }
+}
+
+async function writeSessionIngestionState(
+  workspaceDir: string,
+  state: SessionIngestionState,
+): Promise<void> {
+  const statePath = resolveSessionIngestionStatePath(workspaceDir);
+  await fs.mkdir(path.dirname(statePath), { recursive: true });
+  const tmpPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
+  await fs.writeFile(tmpPath, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
+  await fs.rename(tmpPath, statePath);
+}
+
+function normalizeSessionText(value: string): string {
+  return value
+    .replace(/\s*\n+\s*/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractSessionMessageText(content: unknown): string | null {
+  if (typeof content === "string") {
+    const normalized = normalizeSessionText(content);
+    return normalized.length > 0 ? normalized : null;
+  }
+  if (!Array.isArray(content)) {
+    return null;
+  }
+  const parts: string[] = [];
+  for (const block of content) {
+    const record = asRecord(block);
+    if (!record || record.type !== "text" || typeof record.text !== "string") {
+      continue;
+    }
+    const normalized = normalizeSessionText(record.text);
+    if (normalized.length > 0) {
+      parts.push(normalized);
+    }
+  }
+  if (parts.length === 0) {
+    return null;
+  }
+  return parts.join(" ");
+}
+
+function parseSessionTimestampMs(record: Record<string, unknown>): number | null {
+  const candidates = [record.timestamp, asRecord(record.message)?.timestamp];
+  for (const value of candidates) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      const ms = value > 0 && value < 1e11 ? value * 1000 : value;
+      if (Number.isFinite(ms) && ms > 0) {
+        return ms;
+      }
+    }
+    if (typeof value === "string") {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return null;
+}
+
+function formatSessionSnippet(role: "user" | "assistant", text: string): string {
+  const label = role === "user" ? "User" : "Assistant";
+  const normalized = normalizeSessionText(text);
+  if (!normalized) {
+    return "";
+  }
+  return `${label}: ${normalized}`
+    .slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS)
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildSessionStateKey(agentId: string, absolutePath: string): string {
+  return `${agentId}:${sessionPathForFile(absolutePath)}`;
+}
+
+function resolveSessionAgentsForWorkspace(
+  cfg: OpenClawConfig | undefined,
+  workspaceDir: string,
+): string[] {
+  if (!cfg) {
+    return [];
+  }
+  const target = normalizeWorkspaceKey(workspaceDir);
+  const workspaces = resolveMemoryDreamingWorkspaces(cfg);
+  const match = workspaces.find((entry) => normalizeWorkspaceKey(entry.workspaceDir) === target);
+  if (!match) {
+    return [];
+  }
+  return match.agentIds
+    .filter((agentId, index, all) => agentId.trim().length > 0 && all.indexOf(agentId) === index)
+    .toSorted();
+}
+
+async function appendSessionCorpusLines(params: {
+  workspaceDir: string;
+  day: string;
+  lines: SessionIngestionMessage[];
+}): Promise<MemorySearchResult[]> {
+  if (params.lines.length === 0) {
+    return [];
+  }
+  const relativePath = path.posix.join("memory", ".dreams", "session-corpus", `${params.day}.txt`);
+  const absolutePath = path.join(
+    params.workspaceDir,
+    SESSION_CORPUS_RELATIVE_DIR,
+    `${params.day}.txt`,
+  );
+  await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+  let existing = "";
+  try {
+    existing = await fs.readFile(absolutePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      throw err;
+    }
+  }
+  const normalizedExisting = existing.replace(/\r\n/g, "\n");
+  const existingLineCount =
+    normalizedExisting.length === 0
+      ? 0
+      : normalizedExisting.endsWith("\n")
+        ? normalizedExisting.slice(0, -1).split("\n").length
+        : normalizedExisting.split("\n").length;
+  const payload = `${params.lines.map((entry) => entry.rendered).join("\n")}\n`;
+  await fs.appendFile(absolutePath, payload, "utf-8");
+  return params.lines.map((entry, index) => {
+    const lineNumber = existingLineCount + index + 1;
+    return {
+      path: relativePath,
+      startLine: lineNumber,
+      endLine: lineNumber,
+      score: SESSION_INGESTION_SCORE,
+      snippet: entry.snippet,
+      source: "memory",
+    };
+  });
+}
+
+async function collectSessionIngestionBatches(params: {
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+  lookbackDays: number;
+  nowMs: number;
+  timezone?: string;
+  state: SessionIngestionState;
+}): Promise<SessionIngestionCollectionResult> {
+  if (!params.cfg) {
+    return {
+      batches: [],
+      nextState: { version: 1, files: {} },
+      changed: Object.keys(params.state.files).length > 0,
+    };
+  }
+  const agentIds = resolveSessionAgentsForWorkspace(params.cfg, params.workspaceDir);
+  const cutoffMs = calculateLookbackCutoffMs(params.nowMs, params.lookbackDays);
+  const batchByDay = new Map<string, SessionIngestionMessage[]>();
+  const nextFiles: Record<string, SessionIngestionFileState> = {};
+  let changed = false;
+
+  const sessionFiles: Array<{ agentId: string; absolutePath: string; sessionPath: string }> = [];
+  for (const agentId of agentIds) {
+    const memorySearch = resolveMemorySearchConfig(params.cfg, agentId);
+    if (
+      !memorySearch?.enabled ||
+      !memorySearch.experimental.sessionMemory ||
+      !memorySearch.sources.includes("sessions")
+    ) {
+      continue;
+    }
+    const files = await listSessionFilesForAgent(agentId);
+    for (const absolutePath of files) {
+      sessionFiles.push({
+        agentId,
+        absolutePath,
+        sessionPath: sessionPathForFile(absolutePath),
+      });
+    }
+  }
+
+  const sortedFiles = sessionFiles.toSorted((a, b) => {
+    if (a.agentId !== b.agentId) {
+      return a.agentId.localeCompare(b.agentId);
+    }
+    return a.sessionPath.localeCompare(b.sessionPath);
+  });
+
+  const totalCap = SESSION_INGESTION_MAX_MESSAGES_PER_SWEEP;
+  let remaining = totalCap;
+  const perFileCap = Math.min(
+    SESSION_INGESTION_MAX_MESSAGES_PER_FILE,
+    Math.max(
+      SESSION_INGESTION_MIN_MESSAGES_PER_FILE,
+      Math.ceil(totalCap / Math.max(1, sortedFiles.length)),
+    ),
+  );
+
+  for (const file of sortedFiles) {
+    if (remaining <= 0) {
+      break;
+    }
+    const stateKey = buildSessionStateKey(file.agentId, file.absolutePath);
+    const previous = params.state.files[stateKey];
+    const stat = await fs.stat(file.absolutePath).catch((err: unknown) => {
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    });
+    if (!stat) {
+      if (previous) {
+        changed = true;
+      }
+      continue;
+    }
+    const fingerprint = {
+      mtimeMs: Math.floor(Math.max(0, stat.mtimeMs)),
+      size: Math.floor(Math.max(0, stat.size)),
+    };
+    const cursorAtEnd = previous && previous.lastJsonlLine >= previous.lineCount;
+    const unchanged =
+      Boolean(previous) &&
+      previous.mtimeMs === fingerprint.mtimeMs &&
+      previous.size === fingerprint.size &&
+      cursorAtEnd;
+    if (unchanged) {
+      nextFiles[stateKey] = previous!;
+      continue;
+    }
+
+    const raw = await fs.readFile(file.absolutePath, "utf-8").catch((err: unknown) => {
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+        return "";
+      }
+      throw err;
+    });
+    const lines = raw.split(/\r?\n/);
+    const resetCursor =
+      !previous ||
+      fingerprint.size < previous.size ||
+      fingerprint.mtimeMs < previous.mtimeMs ||
+      previous.lastJsonlLine > lines.length;
+    let cursor = resetCursor ? 0 : previous.lastJsonlLine;
+    const fileCap = Math.max(1, Math.min(perFileCap, remaining));
+    let fileCount = 0;
+    let lastProcessedLine = cursor;
+
+    for (let index = cursor; index < lines.length; index += 1) {
+      if (fileCount >= fileCap || remaining <= 0) {
+        break;
+      }
+      const rawLine = lines[index] ?? "";
+      const lineNumber = index + 1;
+      lastProcessedLine = lineNumber;
+      if (!rawLine.trim()) {
+        continue;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rawLine);
+      } catch {
+        continue;
+      }
+      const record = asRecord(parsed);
+      if (!record || record.type !== "message") {
+        continue;
+      }
+      const message = asRecord(record.message);
+      if (!message) {
+        continue;
+      }
+      const role = message.role === "user" || message.role === "assistant" ? message.role : null;
+      if (!role) {
+        continue;
+      }
+      const text = extractSessionMessageText(message.content);
+      if (!text) {
+        continue;
+      }
+      const snippet = formatSessionSnippet(role, text);
+      if (snippet.length < SESSION_INGESTION_MIN_SNIPPET_CHARS) {
+        continue;
+      }
+      const timestampMs = parseSessionTimestampMs(record) ?? parseSessionTimestampMs(message);
+      const day = formatMemoryDreamingDay(timestampMs ?? fingerprint.mtimeMs, params.timezone);
+      if (!isDayWithinLookback(day, cutoffMs)) {
+        continue;
+      }
+      const source = `${file.agentId}/${file.sessionPath}#L${lineNumber}`;
+      const rendered = `[${source}] ${snippet}`.slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS + 64);
+      const bucket = batchByDay.get(day) ?? [];
+      bucket.push({ day, snippet, rendered });
+      batchByDay.set(day, bucket);
+      fileCount += 1;
+      remaining -= 1;
+    }
+
+    if (lastProcessedLine < cursor) {
+      lastProcessedLine = cursor;
+    }
+    cursor = Math.max(0, Math.min(lastProcessedLine, lines.length));
+    nextFiles[stateKey] = {
+      mtimeMs: fingerprint.mtimeMs,
+      size: fingerprint.size,
+      lineCount: lines.length,
+      lastJsonlLine: cursor,
+    };
+    if (
+      !previous ||
+      previous.mtimeMs !== fingerprint.mtimeMs ||
+      previous.size !== fingerprint.size ||
+      previous.lineCount !== lines.length ||
+      previous.lastJsonlLine !== cursor
+    ) {
+      changed = true;
+    }
+  }
+
+  for (const [key, state] of Object.entries(params.state.files)) {
+    if (!Object.hasOwn(nextFiles, key)) {
+      changed = true;
+      continue;
+    }
+    const next = nextFiles[key];
+    if (
+      !next ||
+      next.mtimeMs !== state.mtimeMs ||
+      next.size !== state.size ||
+      next.lineCount !== state.lineCount ||
+      next.lastJsonlLine !== state.lastJsonlLine
+    ) {
+      changed = true;
+    }
+  }
+
+  const batches: DailyIngestionBatch[] = [];
+  for (const day of [...batchByDay.keys()].toSorted()) {
+    const lines = batchByDay.get(day) ?? [];
+    if (lines.length === 0) {
+      continue;
+    }
+    const results = await appendSessionCorpusLines({
+      workspaceDir: params.workspaceDir,
+      day,
+      lines,
+    });
+    if (results.length > 0) {
+      batches.push({ day, results });
+    }
+  }
+
+  return {
+    batches,
+    nextState: { version: 1, files: nextFiles },
+    changed,
+  };
+}
+
+async function ingestSessionTranscriptSignals(params: {
+  workspaceDir: string;
+  cfg?: OpenClawConfig;
+  lookbackDays: number;
+  nowMs: number;
+  timezone?: string;
+}): Promise<void> {
+  const state = await readSessionIngestionState(params.workspaceDir);
+  const collected = await collectSessionIngestionBatches({
+    workspaceDir: params.workspaceDir,
+    cfg: params.cfg,
+    lookbackDays: params.lookbackDays,
+    nowMs: params.nowMs,
+    timezone: params.timezone,
+    state,
+  });
+  for (const batch of collected.batches) {
+    await recordShortTermRecalls({
+      workspaceDir: params.workspaceDir,
+      query: `__dreaming_sessions__:${batch.day}`,
+      results: batch.results,
+      signalType: "daily",
+      dedupeByQueryPerDay: true,
+      dayBucket: batch.day,
+      nowMs: params.nowMs,
+      timezone: params.timezone,
+    });
+  }
+  if (collected.changed) {
+    await writeSessionIngestionState(params.workspaceDir, collected.nextState);
+  }
+}
+
 type DailyIngestionCollectionResult = {
   batches: DailyIngestionBatch[];
   nextState: DailyIngestionState;
@@ -982,6 +1479,7 @@ export function previewRemDreaming(params: {
 
 async function runLightDreaming(params: {
   workspaceDir: string;
+  cfg?: OpenClawConfig;
   config: MemoryLightDreamingConfig & {
     timezone?: string;
     storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
@@ -996,6 +1494,13 @@ async function runLightDreaming(params: {
     workspaceDir: params.workspaceDir,
     lookbackDays: params.config.lookbackDays,
     limit: params.config.limit,
+    nowMs,
+    timezone: params.config.timezone,
+  });
+  await ingestSessionTranscriptSignals({
+    workspaceDir: params.workspaceDir,
+    cfg: params.cfg,
+    lookbackDays: params.config.lookbackDays,
     nowMs,
     timezone: params.config.timezone,
   });
@@ -1054,6 +1559,7 @@ async function runLightDreaming(params: {
 
 async function runRemDreaming(params: {
   workspaceDir: string;
+  cfg?: OpenClawConfig;
   config: MemoryRemDreamingConfig & {
     timezone?: string;
     storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
@@ -1068,6 +1574,13 @@ async function runRemDreaming(params: {
     workspaceDir: params.workspaceDir,
     lookbackDays: params.config.lookbackDays,
     limit: params.config.limit,
+    nowMs,
+    timezone: params.config.timezone,
+  });
+  await ingestSessionTranscriptSignals({
+    workspaceDir: params.workspaceDir,
+    cfg: params.cfg,
+    lookbackDays: params.config.lookbackDays,
     nowMs,
     timezone: params.config.timezone,
   });
@@ -1141,6 +1654,7 @@ export async function runDreamingSweepPhases(params: {
   if (light.enabled && light.limit > 0) {
     await runLightDreaming({
       workspaceDir: params.workspaceDir,
+      cfg: params.cfg,
       config: light,
       logger: params.logger,
       subagent: params.subagent,
@@ -1155,6 +1669,7 @@ export async function runDreamingSweepPhases(params: {
   if (rem.enabled && rem.limit > 0) {
     await runRemDreaming({
       workspaceDir: params.workspaceDir,
+      cfg: params.cfg,
       config: rem,
       logger: params.logger,
       subagent: params.subagent,
@@ -1207,6 +1722,7 @@ async function runPhaseIfTriggered(params: {
       if (params.phase === "light") {
         await runLightDreaming({
           workspaceDir,
+          cfg: params.cfg,
           config: params.config as MemoryLightDreamingConfig & {
             timezone?: string;
             storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
@@ -1217,6 +1733,7 @@ async function runPhaseIfTriggered(params: {
       } else {
         await runRemDreaming({
           workspaceDir,
+          cfg: params.cfg,
           config: params.config as MemoryRemDreamingConfig & {
             timezone?: string;
             storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -637,10 +637,12 @@ type SessionIngestionFileState = {
   mtimeMs: number;
   size: number;
   contentHash: string;
+  lineCount: number;
+  lastContentLine: number;
 };
 
 type SessionIngestionState = {
-  version: 2;
+  version: 3;
   files: Record<string, SessionIngestionFileState>;
   seenMessages: Record<string, string[]>;
 };
@@ -681,10 +683,20 @@ function normalizeSessionIngestionState(raw: unknown): SessionIngestionState {
       if (!Number.isFinite(mtimeMs) || mtimeMs < 0 || !Number.isFinite(size) || size < 0) {
         continue;
       }
+      const lineCountRaw = Number(file.lineCount);
+      const lastContentLineRaw = Number(file.lastContentLine);
+      const lineCount =
+        Number.isFinite(lineCountRaw) && lineCountRaw >= 0 ? Math.floor(lineCountRaw) : 0;
+      const lastContentLine =
+        Number.isFinite(lastContentLineRaw) && lastContentLineRaw >= 0
+          ? Math.floor(lastContentLineRaw)
+          : 0;
       files[key] = {
         mtimeMs: Math.floor(mtimeMs),
         size: Math.floor(size),
         contentHash: typeof file.contentHash === "string" ? file.contentHash.trim() : "",
+        lineCount,
+        lastContentLine: Math.min(lineCount, lastContentLine),
       };
     }
   }
@@ -706,7 +718,7 @@ function normalizeSessionIngestionState(raw: unknown): SessionIngestionState {
       }
     }
   }
-  return { version: 2, files, seenMessages };
+  return { version: 3, files, seenMessages };
 }
 
 async function readSessionIngestionState(workspaceDir: string): Promise<SessionIngestionState> {
@@ -717,7 +729,7 @@ async function readSessionIngestionState(workspaceDir: string): Promise<SessionI
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
     if (code === "ENOENT" || err instanceof SyntaxError) {
-      return { version: 2, files: {}, seenMessages: {} };
+      return { version: 3, files: {}, seenMessages: {} };
     }
     throw err;
   }
@@ -883,7 +895,7 @@ async function collectSessionIngestionBatches(params: {
   if (!params.cfg) {
     return {
       batches: [],
-      nextState: { version: 2, files: {}, seenMessages: {} },
+      nextState: { version: 3, files: {}, seenMessages: {} },
       changed:
         Object.keys(params.state.files).length > 0 ||
         Object.keys(params.state.seenMessages).length > 0,
@@ -947,11 +959,16 @@ async function collectSessionIngestionBatches(params: {
       mtimeMs: Math.floor(Math.max(0, stat.mtimeMs)),
       size: Math.floor(Math.max(0, stat.size)),
     };
+    const cursorAtEnd =
+      previous !== undefined &&
+      previous.lineCount > 0 &&
+      previous.lastContentLine >= previous.lineCount;
     const unchanged =
       Boolean(previous) &&
       previous.mtimeMs === fingerprint.mtimeMs &&
       previous.size === fingerprint.size &&
-      previous.contentHash.length > 0;
+      previous.contentHash.length > 0 &&
+      cursorAtEnd;
     if (unchanged) {
       nextFiles[stateKey] = previous!;
       continue;
@@ -966,7 +983,9 @@ async function collectSessionIngestionBatches(params: {
       previous &&
       previous.mtimeMs === fingerprint.mtimeMs &&
       previous.size === fingerprint.size &&
-      previous.contentHash === contentHash
+      previous.contentHash === contentHash &&
+      previous.lineCount === entry.lineMap.length &&
+      previous.lastContentLine >= previous.lineCount
     ) {
       nextFiles[stateKey] = previous;
       continue;
@@ -978,31 +997,41 @@ async function collectSessionIngestionBatches(params: {
     const newSeenHashes: string[] = [];
 
     const lines = entry.content.length > 0 ? entry.content.split("\n") : [];
-    const day = formatMemoryDreamingDay(fingerprint.mtimeMs, params.timezone);
-    if (!isDayWithinLookback(day, cutoffMs)) {
-      nextFiles[stateKey] = {
-        mtimeMs: fingerprint.mtimeMs,
-        size: fingerprint.size,
-        contentHash,
-      };
-      continue;
-    }
+    const lineCount = lines.length;
+    let cursor =
+      previous &&
+      previous.mtimeMs === fingerprint.mtimeMs &&
+      previous.size === fingerprint.size &&
+      previous.contentHash === contentHash &&
+      previous.lineCount === lineCount
+        ? Math.max(0, Math.min(previous.lastContentLine, lineCount))
+        : 0;
 
     const fileCap = Math.max(1, Math.min(perFileCap, remaining));
     let fileCount = 0;
-    for (let index = 0; index < lines.length; index += 1) {
+    let lastScannedContentLine = cursor;
+    for (let index = cursor; index < lines.length; index += 1) {
       if (fileCount >= fileCap || remaining <= 0) {
         break;
       }
+      lastScannedContentLine = index + 1;
       const rawSnippet = lines[index] ?? "";
       const snippet = normalizeSessionCorpusSnippet(rawSnippet);
       if (snippet.length < SESSION_INGESTION_MIN_SNIPPET_CHARS) {
         continue;
       }
       const lineNumber = entry.lineMap[index] ?? index + 1;
-      const messageHash = hashSessionMessageId(
-        `${file.agentId}\n${sessionScope}\n${lineNumber}\n${snippet}`,
+      const messageTimestampMs = entry.messageTimestampsMs[index] ?? 0;
+      const day = formatMemoryDreamingDay(
+        messageTimestampMs > 0 ? messageTimestampMs : fingerprint.mtimeMs,
+        params.timezone,
       );
+      if (!isDayWithinLookback(day, cutoffMs)) {
+        continue;
+      }
+      const dedupeBasis =
+        messageTimestampMs > 0 ? `ts:${Math.floor(messageTimestampMs)}` : `line:${lineNumber}`;
+      const messageHash = hashSessionMessageId(`${sessionScope}\n${dedupeBasis}\n${snippet}`);
       if (seenSet.has(messageHash)) {
         continue;
       }
@@ -1021,10 +1050,17 @@ async function collectSessionIngestionBatches(params: {
       remaining -= 1;
     }
 
+    if (lastScannedContentLine < cursor) {
+      lastScannedContentLine = cursor;
+    }
+    cursor = Math.max(0, Math.min(lastScannedContentLine, lineCount));
+
     nextFiles[stateKey] = {
       mtimeMs: fingerprint.mtimeMs,
       size: fingerprint.size,
       contentHash,
+      lineCount,
+      lastContentLine: cursor,
     };
     const mergedSeen = mergeTrackedMessageHashes(previousSeen, newSeenHashes);
     nextSeenMessages[sessionScope] = mergedSeen;
@@ -1035,7 +1071,9 @@ async function collectSessionIngestionBatches(params: {
       !previous ||
       previous.mtimeMs !== fingerprint.mtimeMs ||
       previous.size !== fingerprint.size ||
-      previous.contentHash !== contentHash
+      previous.contentHash !== contentHash ||
+      previous.lineCount !== lineCount ||
+      previous.lastContentLine !== cursor
     ) {
       changed = true;
     }
@@ -1055,6 +1093,13 @@ async function collectSessionIngestionBatches(params: {
       typeof state.contentHash === "string" &&
       state.contentHash.trim().length > 0 &&
       next.contentHash !== state.contentHash
+    ) {
+      changed = true;
+    }
+    if (
+      !next ||
+      next.lineCount !== state.lineCount ||
+      next.lastContentLine !== state.lastContentLine
     ) {
       changed = true;
     }
@@ -1091,7 +1136,7 @@ async function collectSessionIngestionBatches(params: {
 
   return {
     batches,
-    nextState: { version: 2, files: nextFiles, seenMessages: trimmedSeenMessages },
+    nextState: { version: 3, files: nextFiles, seenMessages: trimmedSeenMessages },
     changed,
   };
 }

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1,9 +1,12 @@
+import { createHash } from "node:crypto";
 import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
 import {
+  buildSessionEntry,
   listSessionFilesForAgent,
+  parseUsageCountedSessionIdFromFileName,
   sessionPathForFile,
 } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
@@ -101,6 +104,8 @@ const SESSION_INGESTION_MIN_SNIPPET_CHARS = 12;
 const SESSION_INGESTION_MAX_MESSAGES_PER_SWEEP = 240;
 const SESSION_INGESTION_MAX_MESSAGES_PER_FILE = 80;
 const SESSION_INGESTION_MIN_MESSAGES_PER_FILE = 12;
+const SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION = 4096;
+const SESSION_INGESTION_MAX_TRACKED_SCOPES = 2048;
 const GENERIC_DAY_HEADING_RE =
   /^(?:(?:mon|monday|tue|tues|tuesday|wed|wednesday|thu|thur|thurs|thursday|fri|friday|sat|saturday|sun|sunday)(?:,\s+)?)?(?:(?:jan|january|feb|february|mar|march|apr|april|may|jun|june|jul|july|aug|august|sep|sept|september|oct|october|nov|november|dec|december)\s+\d{1,2}(?:st|nd|rd|th)?(?:,\s*\d{4})?|\d{1,2}[/-]\d{1,2}(?:[/-]\d{2,4})?|\d{4}[/-]\d{2}[/-]\d{2})$/i;
 const MANAGED_DAILY_DREAMING_BLOCKS = [
@@ -631,13 +636,13 @@ async function writeDailyIngestionState(
 type SessionIngestionFileState = {
   mtimeMs: number;
   size: number;
-  lineCount: number;
-  lastJsonlLine: number;
+  contentHash: string;
 };
 
 type SessionIngestionState = {
-  version: 1;
+  version: 2;
   files: Record<string, SessionIngestionFileState>;
+  seenMessages: Record<string, string[]>;
 };
 
 type SessionIngestionMessage = {
@@ -664,39 +669,44 @@ function resolveSessionIngestionStatePath(workspaceDir: string): string {
 function normalizeSessionIngestionState(raw: unknown): SessionIngestionState {
   const record = asRecord(raw);
   const filesRaw = asRecord(record?.files);
-  if (!filesRaw) {
-    return { version: 1, files: {} };
-  }
   const files: Record<string, SessionIngestionFileState> = {};
-  for (const [key, value] of Object.entries(filesRaw)) {
-    const file = asRecord(value);
-    if (!file || key.trim().length === 0) {
-      continue;
+  if (filesRaw) {
+    for (const [key, value] of Object.entries(filesRaw)) {
+      const file = asRecord(value);
+      if (!file || key.trim().length === 0) {
+        continue;
+      }
+      const mtimeMs = Number(file.mtimeMs);
+      const size = Number(file.size);
+      if (!Number.isFinite(mtimeMs) || mtimeMs < 0 || !Number.isFinite(size) || size < 0) {
+        continue;
+      }
+      files[key] = {
+        mtimeMs: Math.floor(mtimeMs),
+        size: Math.floor(size),
+        contentHash: typeof file.contentHash === "string" ? file.contentHash.trim() : "",
+      };
     }
-    const mtimeMs = Number(file.mtimeMs);
-    const size = Number(file.size);
-    const lineCount = Number(file.lineCount);
-    const lastJsonlLine = Number(file.lastJsonlLine);
-    if (
-      !Number.isFinite(mtimeMs) ||
-      mtimeMs < 0 ||
-      !Number.isFinite(size) ||
-      size < 0 ||
-      !Number.isFinite(lineCount) ||
-      lineCount < 0 ||
-      !Number.isFinite(lastJsonlLine) ||
-      lastJsonlLine < 0
-    ) {
-      continue;
-    }
-    files[key] = {
-      mtimeMs: Math.floor(mtimeMs),
-      size: Math.floor(size),
-      lineCount: Math.floor(lineCount),
-      lastJsonlLine: Math.floor(lastJsonlLine),
-    };
   }
-  return { version: 1, files };
+  const seenMessagesRaw = asRecord(record?.seenMessages);
+  const seenMessages: Record<string, string[]> = {};
+  if (seenMessagesRaw) {
+    for (const [scope, value] of Object.entries(seenMessagesRaw)) {
+      if (scope.trim().length === 0 || !Array.isArray(value)) {
+        continue;
+      }
+      const unique = [
+        ...new Set(value.filter((entry): entry is string => typeof entry === "string")),
+      ]
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+        .slice(-SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION);
+      if (unique.length > 0) {
+        seenMessages[scope] = unique;
+      }
+    }
+  }
+  return { version: 2, files, seenMessages };
 }
 
 async function readSessionIngestionState(workspaceDir: string): Promise<SessionIngestionState> {
@@ -707,7 +717,7 @@ async function readSessionIngestionState(workspaceDir: string): Promise<SessionI
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
     if (code === "ENOENT" || err instanceof SyntaxError) {
-      return { version: 1, files: {} };
+      return { version: 2, files: {}, seenMessages: {} };
     }
     throw err;
   }
@@ -724,71 +734,79 @@ async function writeSessionIngestionState(
   await fs.rename(tmpPath, statePath);
 }
 
-function normalizeSessionText(value: string): string {
-  return value
-    .replace(/\s*\n+\s*/g, " ")
-    .replace(/\s+/g, " ")
-    .trim();
+function trimTrackedSessionScopes(
+  seenMessages: Record<string, string[]>,
+): Record<string, string[]> {
+  const keys = Object.keys(seenMessages);
+  if (keys.length <= SESSION_INGESTION_MAX_TRACKED_SCOPES) {
+    return seenMessages;
+  }
+  const keep = new Set(keys.toSorted().slice(-SESSION_INGESTION_MAX_TRACKED_SCOPES));
+  const next: Record<string, string[]> = {};
+  for (const [scope, hashes] of Object.entries(seenMessages)) {
+    if (keep.has(scope)) {
+      next[scope] = hashes;
+    }
+  }
+  return next;
 }
 
-function extractSessionMessageText(content: unknown): string | null {
-  if (typeof content === "string") {
-    const normalized = normalizeSessionText(content);
-    return normalized.length > 0 ? normalized : null;
-  }
-  if (!Array.isArray(content)) {
-    return null;
-  }
-  const parts: string[] = [];
-  for (const block of content) {
-    const record = asRecord(block);
-    if (!record || record.type !== "text" || typeof record.text !== "string") {
-      continue;
-    }
-    const normalized = normalizeSessionText(record.text);
-    if (normalized.length > 0) {
-      parts.push(normalized);
-    }
-  }
-  if (parts.length === 0) {
-    return null;
-  }
-  return parts.join(" ");
+function normalizeSessionCorpusSnippet(value: string): string {
+  return value.replace(/\s+/g, " ").trim().slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS);
 }
 
-function parseSessionTimestampMs(record: Record<string, unknown>): number | null {
-  const candidates = [record.timestamp, asRecord(record.message)?.timestamp];
-  for (const value of candidates) {
-    if (typeof value === "number" && Number.isFinite(value)) {
-      const ms = value > 0 && value < 1e11 ? value * 1000 : value;
-      if (Number.isFinite(ms) && ms > 0) {
-        return ms;
-      }
-    }
-    if (typeof value === "string") {
-      const parsed = Date.parse(value);
-      if (Number.isFinite(parsed)) {
-        return parsed;
-      }
-    }
-  }
-  return null;
+function hashSessionMessageId(value: string): string {
+  return createHash("sha1").update(value).digest("hex");
 }
 
-function formatSessionSnippet(role: "user" | "assistant", text: string): string {
-  const label = role === "user" ? "User" : "Assistant";
-  const normalized = normalizeSessionText(text);
-  if (!normalized) {
-    return "";
+function buildSessionScopeKey(agentId: string, absolutePath: string): string {
+  const fileName = path.basename(absolutePath);
+  const logicalSessionId = parseUsageCountedSessionIdFromFileName(fileName) ?? fileName;
+  return `${agentId}:${logicalSessionId}`;
+}
+
+function mergeTrackedMessageHashes(existing: string[], additions: string[]): string[] {
+  if (additions.length === 0) {
+    return existing;
   }
-  return `${label}: ${normalized}`
-    .slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS)
-    .replace(/\s+/g, " ")
-    .trim();
+  const seen = new Set(existing);
+  const next = existing.slice();
+  for (const hash of additions) {
+    if (!seen.has(hash)) {
+      seen.add(hash);
+      next.push(hash);
+    }
+  }
+  if (next.length <= SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION) {
+    return next;
+  }
+  return next.slice(-SESSION_INGESTION_MAX_TRACKED_MESSAGES_PER_SESSION);
+}
+
+function areStringArraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] !== b[index]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function buildSessionStateKey(agentId: string, absolutePath: string): string {
   return `${agentId}:${sessionPathForFile(absolutePath)}`;
+}
+
+function buildSessionRenderedLine(params: {
+  agentId: string;
+  sessionPath: string;
+  lineNumber: number;
+  snippet: string;
+}): string {
+  const source = `${params.agentId}/${params.sessionPath}#L${params.lineNumber}`;
+  return `[${source}] ${params.snippet}`.slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS + 64);
 }
 
 function resolveSessionAgentsForWorkspace(
@@ -865,14 +883,17 @@ async function collectSessionIngestionBatches(params: {
   if (!params.cfg) {
     return {
       batches: [],
-      nextState: { version: 1, files: {} },
-      changed: Object.keys(params.state.files).length > 0,
+      nextState: { version: 2, files: {}, seenMessages: {} },
+      changed:
+        Object.keys(params.state.files).length > 0 ||
+        Object.keys(params.state.seenMessages).length > 0,
     };
   }
   const agentIds = resolveSessionAgentsForWorkspace(params.cfg, params.workspaceDir);
   const cutoffMs = calculateLookbackCutoffMs(params.nowMs, params.lookbackDays);
   const batchByDay = new Map<string, SessionIngestionMessage[]>();
   const nextFiles: Record<string, SessionIngestionFileState> = {};
+  const nextSeenMessages: Record<string, string[]> = { ...params.state.seenMessages };
   let changed = false;
 
   const sessionFiles: Array<{ agentId: string; absolutePath: string; sessionPath: string }> = [];
@@ -926,101 +947,95 @@ async function collectSessionIngestionBatches(params: {
       mtimeMs: Math.floor(Math.max(0, stat.mtimeMs)),
       size: Math.floor(Math.max(0, stat.size)),
     };
-    const cursorAtEnd = previous && previous.lastJsonlLine >= previous.lineCount;
     const unchanged =
       Boolean(previous) &&
       previous.mtimeMs === fingerprint.mtimeMs &&
       previous.size === fingerprint.size &&
-      cursorAtEnd;
+      previous.contentHash.length > 0;
     if (unchanged) {
       nextFiles[stateKey] = previous!;
       continue;
     }
 
-    const raw = await fs.readFile(file.absolutePath, "utf-8").catch((err: unknown) => {
-      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
-        return "";
-      }
-      throw err;
-    });
-    const lines = raw.split(/\r?\n/);
-    const resetCursor =
-      !previous ||
-      fingerprint.size < previous.size ||
-      fingerprint.mtimeMs < previous.mtimeMs ||
-      previous.lastJsonlLine > lines.length;
-    let cursor = resetCursor ? 0 : previous.lastJsonlLine;
+    const entry = await buildSessionEntry(file.absolutePath);
+    if (!entry) {
+      continue;
+    }
+    const contentHash = entry.hash.trim();
+    if (
+      previous &&
+      previous.mtimeMs === fingerprint.mtimeMs &&
+      previous.size === fingerprint.size &&
+      previous.contentHash === contentHash
+    ) {
+      nextFiles[stateKey] = previous;
+      continue;
+    }
+
+    const sessionScope = buildSessionScopeKey(file.agentId, file.absolutePath);
+    const previousSeen = nextSeenMessages[sessionScope] ?? [];
+    let seenSet = new Set(previousSeen);
+    const newSeenHashes: string[] = [];
+
+    const lines = entry.content.length > 0 ? entry.content.split("\n") : [];
+    const day = formatMemoryDreamingDay(fingerprint.mtimeMs, params.timezone);
+    if (!isDayWithinLookback(day, cutoffMs)) {
+      nextFiles[stateKey] = {
+        mtimeMs: fingerprint.mtimeMs,
+        size: fingerprint.size,
+        contentHash,
+      };
+      continue;
+    }
+
     const fileCap = Math.max(1, Math.min(perFileCap, remaining));
     let fileCount = 0;
-    let lastProcessedLine = cursor;
-
-    for (let index = cursor; index < lines.length; index += 1) {
+    for (let index = 0; index < lines.length; index += 1) {
       if (fileCount >= fileCap || remaining <= 0) {
         break;
       }
-      const rawLine = lines[index] ?? "";
-      const lineNumber = index + 1;
-      lastProcessedLine = lineNumber;
-      if (!rawLine.trim()) {
-        continue;
-      }
-
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(rawLine);
-      } catch {
-        continue;
-      }
-      const record = asRecord(parsed);
-      if (!record || record.type !== "message") {
-        continue;
-      }
-      const message = asRecord(record.message);
-      if (!message) {
-        continue;
-      }
-      const role = message.role === "user" || message.role === "assistant" ? message.role : null;
-      if (!role) {
-        continue;
-      }
-      const text = extractSessionMessageText(message.content);
-      if (!text) {
-        continue;
-      }
-      const snippet = formatSessionSnippet(role, text);
+      const rawSnippet = lines[index] ?? "";
+      const snippet = normalizeSessionCorpusSnippet(rawSnippet);
       if (snippet.length < SESSION_INGESTION_MIN_SNIPPET_CHARS) {
         continue;
       }
-      const timestampMs = parseSessionTimestampMs(record) ?? parseSessionTimestampMs(message);
-      const day = formatMemoryDreamingDay(timestampMs ?? fingerprint.mtimeMs, params.timezone);
-      if (!isDayWithinLookback(day, cutoffMs)) {
+      const lineNumber = entry.lineMap[index] ?? index + 1;
+      const messageHash = hashSessionMessageId(
+        `${file.agentId}\n${sessionScope}\n${lineNumber}\n${snippet}`,
+      );
+      if (seenSet.has(messageHash)) {
         continue;
       }
-      const source = `${file.agentId}/${file.sessionPath}#L${lineNumber}`;
-      const rendered = `[${source}] ${snippet}`.slice(0, SESSION_INGESTION_MAX_SNIPPET_CHARS + 64);
+      const rendered = buildSessionRenderedLine({
+        agentId: file.agentId,
+        sessionPath: file.sessionPath,
+        lineNumber,
+        snippet,
+      });
       const bucket = batchByDay.get(day) ?? [];
       bucket.push({ day, snippet, rendered });
       batchByDay.set(day, bucket);
+      seenSet.add(messageHash);
+      newSeenHashes.push(messageHash);
       fileCount += 1;
       remaining -= 1;
     }
 
-    if (lastProcessedLine < cursor) {
-      lastProcessedLine = cursor;
-    }
-    cursor = Math.max(0, Math.min(lastProcessedLine, lines.length));
     nextFiles[stateKey] = {
       mtimeMs: fingerprint.mtimeMs,
       size: fingerprint.size,
-      lineCount: lines.length,
-      lastJsonlLine: cursor,
+      contentHash,
     };
+    const mergedSeen = mergeTrackedMessageHashes(previousSeen, newSeenHashes);
+    nextSeenMessages[sessionScope] = mergedSeen;
+    if (!areStringArraysEqual(mergedSeen, previousSeen)) {
+      changed = true;
+    }
     if (
       !previous ||
       previous.mtimeMs !== fingerprint.mtimeMs ||
       previous.size !== fingerprint.size ||
-      previous.lineCount !== lines.length ||
-      previous.lastJsonlLine !== cursor
+      previous.contentHash !== contentHash
     ) {
       changed = true;
     }
@@ -1032,13 +1047,28 @@ async function collectSessionIngestionBatches(params: {
       continue;
     }
     const next = nextFiles[key];
+    if (!next || next.mtimeMs !== state.mtimeMs || next.size !== state.size) {
+      changed = true;
+    }
     if (
-      !next ||
-      next.mtimeMs !== state.mtimeMs ||
-      next.size !== state.size ||
-      next.lineCount !== state.lineCount ||
-      next.lastJsonlLine !== state.lastJsonlLine
+      next &&
+      typeof state.contentHash === "string" &&
+      state.contentHash.trim().length > 0 &&
+      next.contentHash !== state.contentHash
     ) {
+      changed = true;
+    }
+  }
+
+  const trimmedSeenMessages = trimTrackedSessionScopes(nextSeenMessages);
+  for (const [scope, hashes] of Object.entries(trimmedSeenMessages)) {
+    const previous = params.state.seenMessages[scope] ?? [];
+    if (!areStringArraysEqual(previous, hashes)) {
+      changed = true;
+    }
+  }
+  for (const scope of Object.keys(params.state.seenMessages)) {
+    if (!Object.hasOwn(trimmedSeenMessages, scope)) {
       changed = true;
     }
   }
@@ -1061,7 +1091,7 @@ async function collectSessionIngestionBatches(params: {
 
   return {
     batches,
-    nextState: { version: 1, files: nextFiles },
+    nextState: { version: 2, files: nextFiles, seenMessages: trimmedSeenMessages },
     changed,
   };
 }

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -2,7 +2,6 @@ import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/memory-core";
-import { resolveMemorySearchConfig } from "openclaw/plugin-sdk/memory-core";
 import {
   listSessionFilesForAgent,
   sessionPathForFile,
@@ -878,14 +877,6 @@ async function collectSessionIngestionBatches(params: {
 
   const sessionFiles: Array<{ agentId: string; absolutePath: string; sessionPath: string }> = [];
   for (const agentId of agentIds) {
-    const memorySearch = resolveMemorySearchConfig(params.cfg, agentId);
-    if (
-      !memorySearch?.enabled ||
-      !memorySearch.experimental.sessionMemory ||
-      !memorySearch.sources.includes("sessions")
-    ) {
-      continue;
-    }
     const files = await listSessionFilesForAgent(agentId);
     for (const absolutePath of files) {
       sessionFiles.push({

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -55,6 +55,7 @@ describe("short-term promotion", () => {
   it("detects short-term daily memory paths", () => {
     expect(isShortTermMemoryPath("memory/2026-04-03.md")).toBe(true);
     expect(isShortTermMemoryPath("2026-04-03.md")).toBe(true);
+    expect(isShortTermMemoryPath("memory/.dreams/session-corpus/2026-04-03.txt")).toBe(true);
     expect(isShortTermMemoryPath("notes/2026-04-03.md")).toBe(false);
     expect(isShortTermMemoryPath("MEMORY.md")).toBe(false);
     expect(isShortTermMemoryPath("memory/network.md")).toBe(false);

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -13,6 +13,8 @@ import {
 import { asRecord } from "./dreaming-shared.js";
 
 const SHORT_TERM_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/;
+const SHORT_TERM_SESSION_CORPUS_RE =
+  /(?:^|\/)memory\/\.dreams\/session-corpus\/(\d{4})-(\d{2})-(\d{2})\.(?:md|txt)$/;
 const SHORT_TERM_BASENAME_RE = /^(\d{4})-(\d{2})-(\d{2})\.md$/;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_RECENCY_HALF_LIFE_DAYS = 14;
@@ -761,6 +763,9 @@ async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Pr
 export function isShortTermMemoryPath(filePath: string): boolean {
   const normalized = normalizeMemoryPath(filePath);
   if (SHORT_TERM_PATH_RE.test(normalized)) {
+    return true;
+  }
+  if (SHORT_TERM_SESSION_CORPUS_RE.test(normalized)) {
     return true;
   }
   return SHORT_TERM_BASENAME_RE.test(normalized);

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -177,6 +177,13 @@ function isShortTermMemoryPath(filePath: string): boolean {
   if (/(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/.test(normalized)) {
     return true;
   }
+  if (
+    /(?:^|\/)memory\/\.dreams\/session-corpus\/(\d{4})-(\d{2})-(\d{2})\.(?:md|txt)$/.test(
+      normalized,
+    )
+  ) {
+    return true;
+  }
   return /^(\d{4})-(\d{2})-(\d{2})\.md$/.test(normalized);
 }
 

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -5,19 +5,10 @@ const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "main"));
 const resolveAgentWorkspaceDir = vi.hoisted(() =>
   vi.fn((_cfg: OpenClawConfig, agentId: string) => `/workspace/${agentId}`),
 );
-const resolveMemorySearchConfig = vi.hoisted(() =>
-  vi.fn<(_cfg: OpenClawConfig, _agentId: string) => { enabled: boolean } | null>(() => ({
-    enabled: true,
-  })),
-);
 
 vi.mock("../agents/agent-scope.js", () => ({
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
-}));
-
-vi.mock("../agents/memory-search.js", () => ({
-  resolveMemorySearchConfig,
 }));
 
 import {
@@ -114,10 +105,7 @@ describe("memory dreaming host helpers", () => {
     expect(resolved.phases.rem.cron).toBe("15 */8 * * *");
   });
 
-  it("dedupes shared workspaces and skips agents without memory search", () => {
-    resolveMemorySearchConfig.mockImplementation((_cfg: OpenClawConfig, agentId: string) =>
-      agentId === "beta" ? null : { enabled: true },
-    );
+  it("dedupes shared workspaces across all configured agents", () => {
     resolveAgentWorkspaceDir.mockImplementation((_cfg: OpenClawConfig, agentId: string) => {
       if (agentId === "alpha") {
         return "/workspace/shared";
@@ -138,6 +126,10 @@ describe("memory dreaming host helpers", () => {
       {
         workspaceDir: "/workspace/shared",
         agentIds: ["alpha", "gamma"],
+      },
+      {
+        workspaceDir: "/workspace/beta",
+        agentIds: ["beta"],
       },
     ]);
   });

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { asNullableRecord } from "../shared/record-coerce.js";
 
@@ -587,9 +586,6 @@ export function resolveMemoryDreamingWorkspaces(cfg: OpenClawConfig): MemoryDrea
 
   const byWorkspace = new Map<string, MemoryDreamingWorkspace>();
   for (const agentId of agentIds) {
-    if (!resolveMemorySearchConfig(cfg, agentId)) {
-      continue;
-    }
     const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId)?.trim();
     if (!workspaceDir) {
       continue;

--- a/src/memory-host-sdk/engine-qmd.ts
+++ b/src/memory-host-sdk/engine-qmd.ts
@@ -7,6 +7,7 @@ export {
   sessionPathForFile,
   type SessionFileEntry,
 } from "./host/session-files.js";
+export { parseUsageCountedSessionIdFromFileName } from "../config/sessions/artifacts.js";
 export { parseQmdQueryJson, type QmdQueryResult } from "./host/qmd-query-parser.js";
 export {
   deriveQmdScopeChannel,

--- a/src/memory-host-sdk/host/session-files.test.ts
+++ b/src/memory-host-sdk/host/session-files.test.ts
@@ -89,6 +89,7 @@ describe("buildSessionEntry", () => {
     // Content line 2 → JSONL line 7 (the second user message)
     expect(entry!.lineMap).toBeDefined();
     expect(entry!.lineMap).toEqual([4, 6, 7]);
+    expect(entry!.messageTimestampsMs).toEqual([0, 0, 0]);
   });
 
   it("returns empty lineMap when no messages are found", async () => {
@@ -103,6 +104,7 @@ describe("buildSessionEntry", () => {
     expect(entry).not.toBeNull();
     expect(entry!.content).toBe("");
     expect(entry!.lineMap).toEqual([]);
+    expect(entry!.messageTimestampsMs).toEqual([]);
   });
 
   it("skips blank lines and invalid JSON without breaking lineMap", async () => {
@@ -119,5 +121,33 @@ describe("buildSessionEntry", () => {
     const entry = await buildSessionEntry(filePath);
     expect(entry).not.toBeNull();
     expect(entry!.lineMap).toEqual([3, 5]);
+    expect(entry!.messageTimestampsMs).toEqual([0, 0]);
+  });
+
+  it("captures message timestamps when present", async () => {
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-04-05T10:00:00.000Z",
+        message: { role: "user", content: "First" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          timestamp: "2026-04-05T10:01:00.000Z",
+          content: "Second",
+        },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "timestamps.jsonl");
+    await fs.writeFile(filePath, jsonlLines.join("\n"));
+
+    const entry = await buildSessionEntry(filePath);
+    expect(entry).not.toBeNull();
+    expect(entry!.messageTimestampsMs).toEqual([
+      Date.parse("2026-04-05T10:00:00.000Z"),
+      Date.parse("2026-04-05T10:01:00.000Z"),
+    ]);
   });
 });

--- a/src/memory-host-sdk/host/session-files.ts
+++ b/src/memory-host-sdk/host/session-files.ts
@@ -17,6 +17,8 @@ export type SessionFileEntry = {
   content: string;
   /** Maps each content line (0-indexed) to its 1-indexed JSONL source line. */
   lineMap: number[];
+  /** Maps each content line (0-indexed) to epoch ms; 0 means unknown timestamp. */
+  messageTimestampsMs: number[];
 };
 
 export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
@@ -72,6 +74,28 @@ export function extractSessionText(content: unknown): string | null {
   return parts.join(" ");
 }
 
+function parseSessionTimestampMs(
+  record: { timestamp?: unknown },
+  message: { timestamp?: unknown },
+): number {
+  const candidates = [message.timestamp, record.timestamp];
+  for (const value of candidates) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      const ms = value > 0 && value < 1e11 ? value * 1000 : value;
+      if (Number.isFinite(ms) && ms > 0) {
+        return ms;
+      }
+    }
+    if (typeof value === "string") {
+      const parsed = Date.parse(value);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+  }
+  return 0;
+}
+
 export async function buildSessionEntry(absPath: string): Promise<SessionFileEntry | null> {
   try {
     const stat = await fs.stat(absPath);
@@ -79,6 +103,7 @@ export async function buildSessionEntry(absPath: string): Promise<SessionFileEnt
     const lines = raw.split("\n");
     const collected: string[] = [];
     const lineMap: number[] = [];
+    const messageTimestampsMs: number[] = [];
     for (let jsonlIdx = 0; jsonlIdx < lines.length; jsonlIdx++) {
       const line = lines[jsonlIdx];
       if (!line.trim()) {
@@ -114,6 +139,12 @@ export async function buildSessionEntry(absPath: string): Promise<SessionFileEnt
       const label = message.role === "user" ? "User" : "Assistant";
       collected.push(`${label}: ${safe}`);
       lineMap.push(jsonlIdx + 1);
+      messageTimestampsMs.push(
+        parseSessionTimestampMs(
+          record as { timestamp?: unknown },
+          message as { timestamp?: unknown },
+        ),
+      );
     }
     const content = collected.join("\n");
     return {
@@ -121,9 +152,10 @@ export async function buildSessionEntry(absPath: string): Promise<SessionFileEnt
       absPath,
       mtimeMs: stat.mtimeMs,
       size: stat.size,
-      hash: hashText(content + "\n" + lineMap.join(",")),
+      hash: hashText(content + "\n" + lineMap.join(",") + "\n" + messageTimestampsMs.join(",")),
       content,
       lineMap,
+      messageTimestampsMs,
     };
   } catch (err) {
     log.debug(`Failed reading session file ${absPath}: ${String(err)}`);


### PR DESCRIPTION
## Summary
- add dreaming session-transcript ingestion with checkpointed cursors in `memory/.dreams/session-ingestion.json`
- append per-day session corpus snippets to `memory/.dreams/session-corpus/YYYY-MM-DD.txt` and feed them into short-term recall scoring
- decouple session ingestion from `agents.*.memorySearch` flags so dreaming only depends on dreaming/workspace config
- include session-corpus files in short-term path detection for promotion ranking and doctor stats

## Validation
- `pnpm test -- extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.test.ts`
- `pnpm tsgo`
- `pnpm check`
