### PR TITLE
fix(tts): use wav for Groq speech on OpenAI provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Docs: https://docs.openclaw.ai
 - Cron: load `jobId` into `id` when the on-disk store omits `id`, matching doctor migration and fixing `unknown cron job id` for hand-edited `jobs.json`. (#62246) Thanks @neeravmakwana.
 - Agents/model fallback: classify minimal HTTP 404 API errors (for example `404 status code (no body)`) as `model_not_found` so assistant failures throw into the fallback chain instead of stopping at the first fallback candidate. (#62119) Thanks @neeravmakwana.
 - Providers/Mistral: send `reasoning_effort` for `mistral/mistral-small-latest` (Mistral Small 4) with thinking-level mapping, and mark the catalog entry as reasoning-capable so adjustable reasoning matches Mistral’s Chat Completions API. (#62162) Thanks @neeravmakwana.
+- OpenAI TTS/Groq: send `wav` to Groq-compatible speech endpoints, honor explicit `responseFormat` overrides on OpenAI-compatible paths, and only mark voice-note output as voice-compatible when the actual format is `opus`. (#62233) Thanks @neeravmakwana.
 
 ## 2026.4.5
 

--- a/extensions/openai/speech-provider.test.ts
+++ b/extensions/openai/speech-provider.test.ts
@@ -77,6 +77,32 @@ describe("buildOpenAISpeechProvider", () => {
     });
   });
 
+  it("preserves talk responseFormat overrides", () => {
+    const provider = buildOpenAISpeechProvider();
+
+    expect(
+      provider.resolveTalkConfig?.({
+        cfg: {} as never,
+        timeoutMs: 30_000,
+        baseTtsConfig: {
+          providers: {
+            openai: {
+              apiKey: "sk-base",
+              responseFormat: "mp3",
+            },
+          },
+        },
+        talkProviderConfig: {
+          apiKey: "sk-talk",
+          responseFormat: " WAV ",
+        },
+      }),
+    ).toMatchObject({
+      apiKey: "sk-talk",
+      responseFormat: "wav",
+    });
+  });
+
   it("uses wav for Groq-compatible OpenAI TTS endpoints", async () => {
     const provider = buildOpenAISpeechProvider();
     const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {

--- a/extensions/openai/speech-provider.test.ts
+++ b/extensions/openai/speech-provider.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAISpeechProvider } from "./speech-provider.js";
 
 describe("buildOpenAISpeechProvider", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
   it("normalizes provider-owned speech config from raw provider config", () => {
     const provider = buildOpenAISpeechProvider();
     const resolved = provider.resolveConfig?.({
@@ -16,6 +23,7 @@ describe("buildOpenAISpeechProvider", () => {
             voice: "alloy",
             speed: 1.25,
             instructions: " Speak warmly ",
+            responseFormat: " WAV ",
           },
         },
       },
@@ -28,6 +36,7 @@ describe("buildOpenAISpeechProvider", () => {
       voice: "alloy",
       speed: 1.25,
       instructions: "Speak warmly",
+      responseFormat: "wav",
     });
   });
 
@@ -66,5 +75,62 @@ describe("buildOpenAISpeechProvider", () => {
     ).toEqual({
       handled: false,
     });
+  });
+
+  it("uses wav for Groq-compatible OpenAI TTS endpoints", async () => {
+    const provider = buildOpenAISpeechProvider();
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(init?.body).toBeTruthy();
+      const body = JSON.parse(String(init?.body)) as { response_format?: string };
+      expect(body.response_format).toBe("wav");
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await provider.synthesize({
+      text: "hello",
+      cfg: {} as never,
+      providerConfig: {
+        apiKey: "sk-test",
+        baseUrl: "https://api.groq.com/openai/v1",
+        model: "canopylabs/orpheus-v1-english",
+        voice: "daniel",
+      },
+      target: "audio-file",
+      timeoutMs: 1_000,
+    });
+
+    expect(result.outputFormat).toBe("wav");
+    expect(result.fileExtension).toBe(".wav");
+    expect(result.voiceCompatible).toBe(false);
+  });
+
+  it("honors explicit responseFormat overrides and clears voice-note compatibility when not opus", async () => {
+    const provider = buildOpenAISpeechProvider();
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(init?.body).toBeTruthy();
+      const body = JSON.parse(String(init?.body)) as { response_format?: string };
+      expect(body.response_format).toBe("wav");
+      return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await provider.synthesize({
+      text: "hello",
+      cfg: {} as never,
+      providerConfig: {
+        apiKey: "sk-test",
+        baseUrl: "https://proxy.example.com/openai/v1",
+        model: "canopylabs/orpheus-v1-english",
+        voice: "daniel",
+        responseFormat: "wav",
+      },
+      target: "voice-note",
+      timeoutMs: 1_000,
+    });
+
+    expect(result.outputFormat).toBe("wav");
+    expect(result.fileExtension).toBe(".wav");
+    expect(result.voiceCompatible).toBe(false);
   });
 });

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -21,6 +21,10 @@ import {
   openaiTTS,
 } from "./tts.js";
 
+const OPENAI_SPEECH_RESPONSE_FORMATS = ["mp3", "opus", "wav"] as const;
+
+type OpenAiSpeechResponseFormat = (typeof OPENAI_SPEECH_RESPONSE_FORMATS)[number];
+
 type OpenAITtsProviderConfig = {
   apiKey?: string;
   baseUrl: string;
@@ -28,6 +32,7 @@ type OpenAITtsProviderConfig = {
   voice: string;
   speed?: number;
   instructions?: string;
+  responseFormat?: OpenAiSpeechResponseFormat;
 };
 
 type OpenAITtsProviderOverrides = {
@@ -35,6 +40,57 @@ type OpenAITtsProviderOverrides = {
   voice?: string;
   speed?: number;
 };
+
+function normalizeOpenAISpeechResponseFormat(
+  value: unknown,
+): OpenAiSpeechResponseFormat | undefined {
+  const next = trimToUndefined(typeof value === "string" ? value : undefined)?.toLowerCase();
+  if (!next) {
+    return undefined;
+  }
+  if (
+    OPENAI_SPEECH_RESPONSE_FORMATS.includes(next as (typeof OPENAI_SPEECH_RESPONSE_FORMATS)[number])
+  ) {
+    return next as OpenAiSpeechResponseFormat;
+  }
+  throw new Error(`Invalid OpenAI speech responseFormat: ${next}`);
+}
+
+function isGroqSpeechBaseUrl(baseUrl: string): boolean {
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    return hostname === "groq.com" || hostname.endsWith(".groq.com");
+  } catch {
+    return false;
+  }
+}
+
+function resolveSpeechResponseFormat(
+  baseUrl: string,
+  target: "audio-file" | "voice-note",
+  configuredFormat?: OpenAiSpeechResponseFormat,
+): OpenAiSpeechResponseFormat {
+  if (configuredFormat) {
+    return configuredFormat;
+  }
+  if (isGroqSpeechBaseUrl(baseUrl)) {
+    return "wav";
+  }
+  return target === "voice-note" ? "opus" : "mp3";
+}
+
+function responseFormatToFileExtension(
+  format: OpenAiSpeechResponseFormat,
+): ".mp3" | ".opus" | ".wav" {
+  switch (format) {
+    case "opus":
+      return ".opus";
+    case "wav":
+      return ".wav";
+    default:
+      return ".mp3";
+  }
+}
 
 function normalizeOpenAIProviderConfig(
   rawConfig: Record<string, unknown>,
@@ -54,6 +110,7 @@ function normalizeOpenAIProviderConfig(
     voice: trimToUndefined(raw?.voice) ?? "coral",
     speed: asFiniteNumber(raw?.speed),
     instructions: trimToUndefined(raw?.instructions),
+    responseFormat: normalizeOpenAISpeechResponseFormat(raw?.responseFormat),
   };
 }
 
@@ -66,6 +123,8 @@ function readOpenAIProviderConfig(config: SpeechProviderConfig): OpenAITtsProvid
     voice: trimToUndefined(config.voice) ?? normalized.voice,
     speed: asFiniteNumber(config.speed) ?? normalized.speed,
     instructions: trimToUndefined(config.instructions) ?? normalized.instructions,
+    responseFormat:
+      normalizeOpenAISpeechResponseFormat(config.responseFormat) ?? normalized.responseFormat,
   };
 }
 
@@ -171,7 +230,11 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
       if (!apiKey) {
         throw new Error("OpenAI API key missing");
       }
-      const responseFormat = req.target === "voice-note" ? "opus" : "mp3";
+      const responseFormat = resolveSpeechResponseFormat(
+        config.baseUrl,
+        req.target,
+        config.responseFormat,
+      );
       const audioBuffer = await openaiTTS({
         text: req.text,
         apiKey,
@@ -186,8 +249,8 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
       return {
         audioBuffer,
         outputFormat: responseFormat,
-        fileExtension: responseFormat === "opus" ? ".opus" : ".mp3",
-        voiceCompatible: req.target === "voice-note",
+        fileExtension: responseFormatToFileExtension(responseFormat),
+        voiceCompatible: req.target === "voice-note" && responseFormat === "opus",
       };
     },
     synthesizeTelephony: async (req) => {

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -184,6 +184,7 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
     parseDirectiveToken,
     resolveTalkConfig: ({ baseTtsConfig, talkProviderConfig }) => {
       const base = normalizeOpenAIProviderConfig(baseTtsConfig);
+      const responseFormat = normalizeOpenAISpeechResponseFormat(talkProviderConfig.responseFormat);
       return {
         ...base,
         ...(talkProviderConfig.apiKey === undefined
@@ -209,6 +210,7 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
         ...(trimToUndefined(talkProviderConfig.instructions) == null
           ? {}
           : { instructions: trimToUndefined(talkProviderConfig.instructions) }),
+        ...(responseFormat == null ? {} : { responseFormat }),
       };
     },
     resolveTalkOverrides: ({ params }) => ({

--- a/extensions/openai/tts.ts
+++ b/extensions/openai/tts.ts
@@ -112,7 +112,7 @@ export async function openaiTTS(params: {
   voice: string;
   speed?: number;
   instructions?: string;
-  responseFormat: "mp3" | "opus" | "pcm";
+  responseFormat: "mp3" | "opus" | "pcm" | "wav";
   timeoutMs: number;
 }): Promise<Buffer> {
   const { text, apiKey, baseUrl, model, voice, speed, instructions, responseFormat, timeoutMs } =


### PR DESCRIPTION
## Summary

- Problem: the OpenAI speech provider always picked `mp3` for audio files and `opus` for voice notes, so Groq Orpheus requests were sent with unsupported formats.
- Why it matters: Groq TTS requests fail before audio delivery, which blocks TTS for Groq users configured through the OpenAI-compatible provider path.
- What changed: the OpenAI speech provider now auto-selects `wav` for Groq endpoints, honors an explicit `responseFormat` override for proxied OpenAI-compatible backends, and only marks voice-note output as voice-compatible when the actual format is `opus`.
- What did NOT change (scope boundary): this PR does not add a new dedicated Groq TTS provider or change telephony synthesis behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62215
- Related #62215
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/openai/speech-provider.ts` derived `responseFormat` only from the synthesis target and never from the configured endpoint, so Groq-compatible OpenAI TTS requests were always sent as `mp3` or `opus`.
- Missing detection / guardrail: the provider had no regression test covering Groq-compatible speech endpoints or non-`opus` voice-note metadata.
- Contributing context (if known): issue #62215 reported Groq Orpheus failing because the OpenAI-compatible provider path hardcoded unsupported formats.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/openai/speech-provider.test.ts`
- Scenario the test should lock in: Groq-compatible base URLs send `wav`, and explicit `responseFormat: "wav"` overrides keep voice-note metadata honest by returning `voiceCompatible: false`.
- Why this is the smallest reliable guardrail: the bug is in a small provider-local format selection branch, and the provider unit tests can assert both the outgoing request body and returned metadata directly.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Groq TTS configured through the OpenAI-compatible speech provider now requests `wav` instead of unsupported `mp3`/`opus` formats.
- Proxied OpenAI-compatible TTS backends can now opt into `responseFormat: "wav"` explicitly.
- Voice-note metadata is only marked voice-compatible when the returned audio format is actually `opus`.

## Diagram (if applicable)

```text
Before:
[Groq TTS request] -> [OpenAI speech provider picks mp3/opus from target] -> [Groq rejects unsupported format]

After:
[Groq TTS request] -> [OpenAI speech provider picks wav or configured override] -> [request matches backend format requirements]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 25.3.0
- Runtime/container: local pnpm/Bun repo workflow
- Model/provider: OpenAI speech provider with Groq-compatible endpoint (`canopylabs/orpheus-v1-english`)
- Integration/channel (if any): TTS
- Relevant config (redacted): `messages.tts.providers.openai` with Groq base URL or explicit `responseFormat: "wav"`

### Steps

1. Configure `messages.tts.providers.openai.baseUrl` to a Groq-compatible OpenAI endpoint and use an Orpheus model.
2. Trigger speech synthesis for an audio file or voice note.
3. Inspect the outgoing `response_format` and returned metadata.

### Expected

- Groq-compatible endpoints receive `response_format: "wav"`.
- Voice-note output is only marked voice-compatible when the returned format is `opus`.

### Actual

- Before this fix, audio-file requests always sent `mp3` and voice-note requests always sent `opus`, regardless of backend requirements.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/openai/speech-provider.test.ts extensions/openai/tts.test.ts`
  - `pnpm build`
  - local provider probe confirmed current Groq-targeted synth requests now use `wav`
- Edge cases checked:
  - Groq-compatible base URLs auto-select `wav`
  - explicit `responseFormat: "wav"` overrides work for proxied OpenAI-compatible backends
  - voice-note compatibility stays false when output is not `opus`
- What you did **not** verify:
  - live Groq API synthesis against a real key
  - `pnpm check`, which still fails on unrelated existing repo issues in `extensions/acpx` and `extensions/elevenlabs`
  - `pnpm test:extension openai`, which hit an unrelated timeout in `extensions/openai/openai-provider.test.ts`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: some OpenAI-compatible TTS backends may need a non-default audio format without using a Groq hostname.
  - Mitigation: this PR adds an explicit `responseFormat` override so proxied or custom endpoints can opt into `wav` without a larger provider redesign.

## AI Assistance

- This PR was prepared with AI assistance.
- Testing level: locally verified with focused regression tests plus `pnpm build`; broader unrelated repo failures are noted above.

Made with [Cursor](https://cursor.com)