### PR TITLE
Plugins: allowlist compat for capability provider fallback (#62205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
 - Auth/OpenAI Codex OAuth: reload fresh on-disk credentials inside the locked refresh path and retry once after `refresh_token_reused` rotates only the stored refresh token, so relogin/restart recovery stops getting stuck on stale cached auth state. Thanks @owen-ever.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin, @afurm, and @openperf.
 - Plugins/channels: keep bundled channel artifact and secret-contract loading stable under lazy loading, preserve plugin-schema defaults during install, and fix Windows `file://` plus native-Jiti plugin loader paths so onboarding, doctor, `openclaw secret`, and bundled plugin installs work again. (#61832, #61836, #61853, #61856) Thanks @Zeesejo and @SuperMarioYL.

--- a/src/image-generation/provider-registry.allowlist.test.ts
+++ b/src/image-generation/provider-registry.allowlist.test.ts
@@ -19,10 +19,14 @@ vi.mock("../plugins/manifest-registry.js", () => ({
   loadPluginManifestRegistry: mocks.loadPluginManifestRegistry,
 }));
 
-vi.mock("../plugins/bundled-compat.js", () => ({
-  withBundledPluginEnablementCompat: mocks.withBundledPluginEnablementCompat,
-  withBundledPluginVitestCompat: mocks.withBundledPluginVitestCompat,
-}));
+vi.mock("../plugins/bundled-compat.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/bundled-compat.js")>();
+  return {
+    ...actual,
+    withBundledPluginEnablementCompat: mocks.withBundledPluginEnablementCompat,
+    withBundledPluginVitestCompat: mocks.withBundledPluginVitestCompat,
+  };
+});
 
 let getImageGenerationProvider: typeof import("./provider-registry.js").getImageGenerationProvider;
 let listImageGenerationProviders: typeof import("./provider-registry.js").listImageGenerationProviders;
@@ -44,11 +48,11 @@ describe("image-generation provider registry allowlist fallback", () => {
     mocks.withBundledPluginVitestCompat.mockImplementation(({ config }) => config);
   });
 
-  it("honors explicit allowlists when fallback loading bundled providers", () => {
+  it("adds bundled capability plugin ids to plugins.allow before fallback registry load", () => {
     const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
     const compatConfig = {
       plugins: {
-        allow: ["custom-plugin"],
+        allow: ["custom-plugin", "openai"],
         entries: { openai: { enabled: true } },
       },
     };

--- a/src/media-understanding/provider-registry.allowlist.test.ts
+++ b/src/media-understanding/provider-registry.allowlist.test.ts
@@ -19,10 +19,14 @@ vi.mock("../plugins/manifest-registry.js", () => ({
   loadPluginManifestRegistry: mocks.loadPluginManifestRegistry,
 }));
 
-vi.mock("../plugins/bundled-compat.js", () => ({
-  withBundledPluginEnablementCompat: mocks.withBundledPluginEnablementCompat,
-  withBundledPluginVitestCompat: mocks.withBundledPluginVitestCompat,
-}));
+vi.mock("../plugins/bundled-compat.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/bundled-compat.js")>();
+  return {
+    ...actual,
+    withBundledPluginEnablementCompat: mocks.withBundledPluginEnablementCompat,
+    withBundledPluginVitestCompat: mocks.withBundledPluginVitestCompat,
+  };
+});
 
 let buildMediaUnderstandingRegistry: typeof import("./provider-registry.js").buildMediaUnderstandingRegistry;
 let getMediaUnderstandingProvider: typeof import("./provider-registry.js").getMediaUnderstandingProvider;
@@ -44,11 +48,11 @@ describe("media-understanding provider registry allowlist fallback", () => {
     mocks.withBundledPluginVitestCompat.mockImplementation(({ config }) => config);
   });
 
-  it("honors explicit allowlists when fallback loading bundled providers", () => {
+  it("adds bundled capability plugin ids to plugins.allow before fallback registry load", () => {
     const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
     const compatConfig = {
       plugins: {
-        allow: ["custom-plugin"],
+        allow: ["custom-plugin", "openai"],
         entries: { openai: { enabled: true } },
       },
     };

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -30,10 +30,14 @@ vi.mock("./manifest-registry.js", () => ({
   loadPluginManifestRegistry: mocks.loadPluginManifestRegistry,
 }));
 
-vi.mock("./bundled-compat.js", () => ({
-  withBundledPluginEnablementCompat: mocks.withBundledPluginEnablementCompat,
-  withBundledPluginVitestCompat: mocks.withBundledPluginVitestCompat,
-}));
+vi.mock("./bundled-compat.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./bundled-compat.js")>();
+  return {
+    ...actual,
+    withBundledPluginEnablementCompat: mocks.withBundledPluginEnablementCompat,
+    withBundledPluginVitestCompat: mocks.withBundledPluginVitestCompat,
+  };
+});
 
 let resolvePluginCapabilityProviders: typeof import("./capability-provider-runtime.js").resolvePluginCapabilityProviders;
 
@@ -47,6 +51,7 @@ function expectNoResolvedCapabilityProviders(providers: Array<{ id: string }>) {
 
 function expectBundledCompatLoadPath(params: {
   cfg: OpenClawConfig;
+  allowlistCompat: OpenClawConfig;
   enablementCompat: {
     plugins: {
       allow?: string[];
@@ -59,7 +64,7 @@ function expectBundledCompatLoadPath(params: {
     env: process.env,
   });
   expect(mocks.withBundledPluginEnablementCompat).toHaveBeenCalledWith({
-    config: params.cfg,
+    config: params.allowlistCompat,
     pluginIds: ["openai"],
   });
   expect(mocks.withBundledPluginVitestCompat).toHaveBeenCalledWith({
@@ -74,13 +79,18 @@ function expectBundledCompatLoadPath(params: {
 
 function createCompatChainConfig() {
   const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
+  const allowlistCompat = {
+    plugins: {
+      allow: ["custom-plugin", "openai"],
+    },
+  } as OpenClawConfig;
   const enablementCompat = {
     plugins: {
-      allow: ["custom-plugin"],
+      allow: ["custom-plugin", "openai"],
       entries: { openai: { enabled: true } },
     },
   };
-  return { cfg, enablementCompat };
+  return { cfg, allowlistCompat, enablementCompat };
 }
 
 function setBundledCapabilityFixture(contractKey: string) {
@@ -111,6 +121,7 @@ function expectCompatChainApplied(params: {
     | "imageGenerationProviders";
   contractKey: string;
   cfg: OpenClawConfig;
+  allowlistCompat: OpenClawConfig;
   enablementCompat: {
     plugins: {
       allow?: string[];
@@ -213,20 +224,26 @@ describe("resolvePluginCapabilityProviders", () => {
     ["mediaUnderstandingProviders", "mediaUnderstandingProviders"],
     ["imageGenerationProviders", "imageGenerationProviders"],
   ] as const)("applies bundled compat before fallback loading for %s", (key, contractKey) => {
-    const { cfg, enablementCompat } = createCompatChainConfig();
+    const { cfg, allowlistCompat, enablementCompat } = createCompatChainConfig();
     expectCompatChainApplied({
       key,
       contractKey,
       cfg,
+      allowlistCompat,
       enablementCompat,
     });
   });
 
-  it("does not re-add bundled capability plugins excluded by an explicit allowlist", () => {
+  it("applies allowlist compat before enablement when fallback bundle loading runs", () => {
     const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
+    const allowlistCompat = {
+      plugins: {
+        allow: ["custom-plugin", "openai"],
+      },
+    } as OpenClawConfig;
     const enablementCompat = {
       plugins: {
-        allow: ["custom-plugin"],
+        allow: ["custom-plugin", "openai"],
         entries: { openai: { enabled: true } },
       },
     };
@@ -240,7 +257,7 @@ describe("resolvePluginCapabilityProviders", () => {
     );
 
     expect(mocks.withBundledPluginEnablementCompat).toHaveBeenCalledWith({
-      config: cfg,
+      config: allowlistCompat,
       pluginIds: ["openai"],
     });
     expect(mocks.withBundledPluginVitestCompat).toHaveBeenCalledWith({

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -118,7 +118,9 @@ function expectCompatChainApplied(params: {
     | "realtimeTranscriptionProviders"
     | "realtimeVoiceProviders"
     | "mediaUnderstandingProviders"
-    | "imageGenerationProviders";
+    | "imageGenerationProviders"
+    | "videoGenerationProviders"
+    | "musicGenerationProviders";
   contractKey: string;
   cfg: OpenClawConfig;
   allowlistCompat: OpenClawConfig;
@@ -223,6 +225,8 @@ describe("resolvePluginCapabilityProviders", () => {
     ["realtimeVoiceProviders", "realtimeVoiceProviders"],
     ["mediaUnderstandingProviders", "mediaUnderstandingProviders"],
     ["imageGenerationProviders", "imageGenerationProviders"],
+    ["videoGenerationProviders", "videoGenerationProviders"],
+    ["musicGenerationProviders", "musicGenerationProviders"],
   ] as const)("applies bundled compat before fallback loading for %s", (key, contractKey) => {
     const { cfg, allowlistCompat, enablementCompat } = createCompatChainConfig();
     expectCompatChainApplied({
@@ -231,42 +235,6 @@ describe("resolvePluginCapabilityProviders", () => {
       cfg,
       allowlistCompat,
       enablementCompat,
-    });
-  });
-
-  it("applies allowlist compat before enablement when fallback bundle loading runs", () => {
-    const cfg = { plugins: { allow: ["custom-plugin"] } } as OpenClawConfig;
-    const allowlistCompat = {
-      plugins: {
-        allow: ["custom-plugin", "openai"],
-      },
-    } as OpenClawConfig;
-    const enablementCompat = {
-      plugins: {
-        allow: ["custom-plugin", "openai"],
-        entries: { openai: { enabled: true } },
-      },
-    };
-
-    setBundledCapabilityFixture("speechProviders");
-    mocks.withBundledPluginEnablementCompat.mockReturnValue(enablementCompat);
-    mocks.withBundledPluginVitestCompat.mockReturnValue(enablementCompat);
-
-    expectNoResolvedCapabilityProviders(
-      resolvePluginCapabilityProviders({ key: "speechProviders", cfg }),
-    );
-
-    expect(mocks.withBundledPluginEnablementCompat).toHaveBeenCalledWith({
-      config: allowlistCompat,
-      pluginIds: ["openai"],
-    });
-    expect(mocks.withBundledPluginVitestCompat).toHaveBeenCalledWith({
-      config: enablementCompat,
-      pluginIds: ["openai"],
-      env: process.env,
-    });
-    expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith({
-      config: enablementCompat,
     });
   });
 

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  withBundledPluginAllowlistCompat,
   withBundledPluginEnablementCompat,
   withBundledPluginVitestCompat,
 } from "./bundled-compat.js";
@@ -62,8 +63,12 @@ function resolveCapabilityProviderConfig(params: {
   cfg?: OpenClawConfig;
 }) {
   const pluginIds = resolveBundledCapabilityCompatPluginIds(params);
-  const enablementCompat = withBundledPluginEnablementCompat({
+  const allowlistCompat = withBundledPluginAllowlistCompat({
     config: params.cfg,
+    pluginIds,
+  });
+  const enablementCompat = withBundledPluginEnablementCompat({
+    config: allowlistCompat,
     pluginIds,
   });
   return withBundledPluginVitestCompat({


### PR DESCRIPTION
## Summary

- **Problem:** With a non-empty `plugins.allow` list that omitted bundled capability plugins (for example `openai`), capability fallback only added `plugins.entries`, so the loader still treated those plugins as blocked and media-understanding providers (including OpenAI-compatible STT) never registered.
- **Why it matters:** Voice and other STT flows that use `tools.media.audio` with `provider: "openai"` could pass raw audio to the model instead of a transcript when an allowlist was used to scope plugins.
- **What changed:** `resolveCapabilityProviderConfig` now applies `withBundledPluginAllowlistCompat` before `withBundledPluginEnablementCompat`, matching the order in `applyPluginCompatibilityOverrides` (allowlist, then enablement, then vitest compat).
- **What did NOT change:** `plugins.deny` remains authoritative; denylisted plugins are not enabled by this path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62205
- Related #62205
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Enablement-only compat did not merge bundled capability plugin ids into `plugins.allow`, so `resolvePluginActivationState` returned `not-in-allowlist` and the bundled plugin did not load.
- **Missing detection / guardrail:** Allowlist fallback tests mocked enablement without exercising the allowlist layer.
- **Contributing context:** Same layering as `withBundledPluginAllowlistCompat` + `withBundledPluginEnablementCompat` in provider resolution tests.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:** Unit test
- **Target test or file:** `src/plugins/capability-provider-runtime.test.ts`, `src/media-understanding/provider-registry.allowlist.test.ts`, `src/image-generation/provider-registry.allowlist.test.ts`
- **Scenario the test should lock in:** Enablement compat receives config after allowlist compat merges capability plugin ids into `plugins.allow` when `plugins.allow` is non-empty.
- **Why this is the smallest reliable guardrail:** Asserts the compat chain order and expected config shape without requiring a full Telegram or gateway run.

## User-visible / Behavior Changes

- With `plugins.allow` set, bundled capability plugins needed for capability fallback (media understanding, image generation, speech, and other keys using the same path) are merged into the allowlist so providers such as STT load without manually listing every capability plugin id.

## Diagram (if applicable)

N/A

## Security Impact (required)

- **New permissions/capabilities?** No
- **Trust boundary changes?** No
- **Notes:** `plugins.deny` still blocks plugins before allowlist evaluation.

## Verification

- `pnpm test` (scoped): `src/plugins/capability-provider-runtime.test.ts`, `src/media-understanding/provider-registry.allowlist.test.ts`, `src/image-generation/provider-registry.allowlist.test.ts`
- `pnpm check` / `pnpm build`: local `pnpm check` fails on unrelated `acpx` extension TypeScript resolution (`acpx/dist/runtime.js`); scoped lint on touched files is clean.

Made with [Cursor](https://cursor.com)