### PR TITLE
fix(net): strip external undici dispatcher from custom fetchImpl calls

### DIFF
--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -313,9 +313,21 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
       // because the default global fetch path will not honor per-request
       // dispatchers.
       const shouldUseRuntimeFetch = Boolean(dispatcher) && !supportsDispatcherInit;
-      const response = shouldUseRuntimeFetch
-        ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
-        : await defaultFetch(parsedUrl.toString(), init);
+      let response: Response;
+      if (shouldUseRuntimeFetch) {
+        response = await fetchWithRuntimeDispatcher(parsedUrl.toString(), init);
+      } else {
+        // Custom fetchImpl callers (e.g. Slack/Telegram media fetchers) typically
+        // wrap native Node.js fetch(), which may bundle a different undici version
+        // than the external dispatcher was created with.  Passing the external
+        // dispatcher through causes 'invalid onRequestStart' errors on undici 8.x.
+        // Strip it — SSRF DNS-pinning has already been validated above.
+        const { dispatcher: _stripDispatcher, ...initWithoutDispatcher } = init;
+        response = await defaultFetch(
+          parsedUrl.toString(),
+          initWithoutDispatcher as RequestInit,
+        );
+      }
 
       if (isRedirectStatus(response.status)) {
         const location = response.headers.get("location");


### PR DESCRIPTION
## Summary

- Fixes Slack file attachment downloads silently failing on OpenClaw 2026.4.5 with `InvalidArgumentError: invalid onRequestStart method`
- Root cause: `fetchWithSsrFGuard` passes an external undici dispatcher (from the bundled `undici` package) through `init` to custom `fetchImpl` callers. These custom fetchers (e.g. Slack/Telegram media) wrap Node's built-in `fetch()`, which bundles its own undici 8.x internally. The handler interface changed between undici 7→8, causing the version mismatch error.
- Fix: strip the `dispatcher` property from `init` before forwarding to custom `fetchImpl` callers. The SSRF DNS-pinning validation has already been performed before the custom fetcher is invoked, so security guarantees are preserved.

## Test plan

- [ ] Existing `fetch-guard.ssrf.test.ts` tests pass (no behavior change for runtime-fetch path)
- [ ] Slack file attachment download works on Node 22+ with undici 8.x
- [ ] Verify SSRF protection still blocks private IPs when custom fetchImpl is used

Fixes #62218

🤖 Generated with [Claude Code](https://claude.com/claude-code)