### PR TITLE
Fix: HTTP 404 classification for model fallback chain (#62119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/model fallback: classify minimal HTTP 404 API errors (for example `404 status code (no body)`) as `model_not_found` so assistant failures throw into the fallback chain instead of stopping at the first fallback candidate. (#62119)
 - Auth/OpenAI Codex OAuth: reload fresh on-disk credentials inside the locked refresh path and retry once after `refresh_token_reused` rotates only the stored refresh token, so relogin/restart recovery stops getting stuck on stale cached auth state. Thanks @owen-ever.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin, @afurm, and @openperf.
 - Plugins/channels: keep bundled channel artifact and secret-contract loading stable under lazy loading, preserve plugin-schema defaults during install, and fix Windows `file://` plus native-Jiti plugin loader paths so onboarding, doctor, `openclaw secret`, and bundled plugin installs work again. (#61832, #61836, #61853, #61856) Thanks @Zeesejo and @SuperMarioYL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Agents/model fallback: classify minimal HTTP 404 API errors (for example `404 status code (no body)`) as `model_not_found` so assistant failures throw into the fallback chain instead of stopping at the first fallback candidate. (#62119)
 - Auth/OpenAI Codex OAuth: reload fresh on-disk credentials inside the locked refresh path and retry once after `refresh_token_reused` rotates only the stored refresh token, so relogin/restart recovery stops getting stuck on stale cached auth state. Thanks @owen-ever.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin, @afurm, and @openperf.
 - Plugins/channels: keep bundled channel artifact and secret-contract loading stable under lazy loading, preserve plugin-schema defaults during install, and fix Windows `file://` plus native-Jiti plugin loader paths so onboarding, doctor, `openclaw secret`, and bundled plugin installs work again. (#61832, #61836, #61853, #61856) Thanks @Zeesejo and @SuperMarioYL.
@@ -59,6 +58,7 @@ Docs: https://docs.openclaw.ai
 - Slack/media: keep attachment downloads on the SSRF-guarded dispatcher path so Slack media fetching works on Node 22 without dropping pinned transport enforcement. (#62239) Thanks @openperf.
 - Docker/plugins: stop forcing bundled plugin discovery to `/app/extensions` in runtime images so packaged installs use compiled `dist/extensions` artifacts again and Node 24 containers do not boot through source-only plugin entry paths. Fixes #62044. (#62316) Thanks @gumadeiras.
 - Cron: load `jobId` into `id` when the on-disk store omits `id`, matching doctor migration and fixing `unknown cron job id` for hand-edited `jobs.json`. (#62246) Thanks @neeravmakwana.
+- Agents/model fallback: classify minimal HTTP 404 API errors (for example `404 status code (no body)`) as `model_not_found` so assistant failures throw into the fallback chain instead of stopping at the first fallback candidate. (#62119)
 
 ## 2026.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Docs: https://docs.openclaw.ai
 - Slack/media: keep attachment downloads on the SSRF-guarded dispatcher path so Slack media fetching works on Node 22 without dropping pinned transport enforcement. (#62239) Thanks @openperf.
 - Docker/plugins: stop forcing bundled plugin discovery to `/app/extensions` in runtime images so packaged installs use compiled `dist/extensions` artifacts again and Node 24 containers do not boot through source-only plugin entry paths. Fixes #62044. (#62316) Thanks @gumadeiras.
 - Cron: load `jobId` into `id` when the on-disk store omits `id`, matching doctor migration and fixing `unknown cron job id` for hand-edited `jobs.json`. (#62246) Thanks @neeravmakwana.
-- Agents/model fallback: classify minimal HTTP 404 API errors (for example `404 status code (no body)`) as `model_not_found` so assistant failures throw into the fallback chain instead of stopping at the first fallback candidate. (#62119)
+- Agents/model fallback: classify minimal HTTP 404 API errors (for example `404 status code (no body)`) as `model_not_found` so assistant failures throw into the fallback chain instead of stopping at the first fallback candidate. (#62119) Thanks @neeravmakwana.
 
 ## 2026.4.5
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -663,6 +663,14 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("HTTP 404: insufficient credits")).toBe("billing");
   });
 
+  it("does not map HTTP 404 plus context-overflow text to model_not_found", () => {
+    expect(
+      classifyFailoverReason(
+        "HTTP 404: INVALID_ARGUMENT: input exceeds the maximum number of tokens",
+      ),
+    ).toBeNull();
+  });
+
   it("keeps raw HTTP 400 wrappers aligned with structured provider classification", () => {
     expect(
       classifyFailoverReason("HTTP 400: ThrottlingException: Too many concurrent requests"),

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -652,6 +652,17 @@ describe("classifyFailoverReason", () => {
     expect(classifyFailoverReason("HTTP 410: insufficient credits")).toBe("billing");
   });
 
+  it("classifies HTTP 404 assistant errors as model_not_found so model fallback can continue", () => {
+    expect(classifyFailoverReason("404 status code (no body)")).toBe("model_not_found");
+    expect(classifyFailoverReason("HTTP 404: No body")).toBe("model_not_found");
+  });
+
+  it("preserves session and auth billing signals on HTTP 404 text", () => {
+    expect(classifyFailoverReason("HTTP 404: session not found")).toBe("session_expired");
+    expect(classifyFailoverReason("HTTP 404: invalid_api_key")).toBe("auth");
+    expect(classifyFailoverReason("HTTP 404: insufficient credits")).toBe("billing");
+  });
+
   it("keeps raw HTTP 400 wrappers aligned with structured provider classification", () => {
     expect(
       classifyFailoverReason("HTTP 400: ThrottlingException: Too many concurrent requests"),

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -584,10 +584,7 @@ function classifyFailoverClassificationFromHttpStatus(
     return toReasonClassification("timeout");
   }
   if (status === 410) {
-    // HTTP 410 is only a true session-expiry signal when the payload says the
-    // remote session/conversation is gone. Generic 410/no-body responses from
-    // OpenAI-compatible proxies are better treated as retryable transport-path
-    // failures so we do not clear session state or poison auth-profile health.
+    // Generic 410/no-body responses behave like transport failures, not session expiry.
     if (
       messageReason === "session_expired" ||
       messageReason === "billing" ||
@@ -599,8 +596,9 @@ function classifyFailoverClassificationFromHttpStatus(
     return toReasonClassification("timeout");
   }
   if (status === 404) {
-    // Bare "404 status code (no body)" style errors must still classify as failover so
-    // embedded runs throw FailoverError and outer model fallback can continue (#62119).
+    if (messageClassification?.kind === "context_overflow") {
+      return messageClassification;
+    }
     if (
       messageReason === "session_expired" ||
       messageReason === "billing" ||

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -598,6 +598,19 @@ function classifyFailoverClassificationFromHttpStatus(
     }
     return toReasonClassification("timeout");
   }
+  if (status === 404) {
+    // Bare "404 status code (no body)" style errors must still classify as failover so
+    // embedded runs throw FailoverError and outer model fallback can continue (#62119).
+    if (
+      messageReason === "session_expired" ||
+      messageReason === "billing" ||
+      messageReason === "auth_permanent" ||
+      messageReason === "auth"
+    ) {
+      return messageClassification;
+    }
+    return toReasonClassification("model_not_found");
+  }
   if (status === 503) {
     if (messageReason === "overloaded") {
       return messageClassification;


### PR DESCRIPTION
## Summary

- **Problem:** Assistant errors shaped like `404 status code (no body)` did not classify as a failover signal, so the embedded runner returned an error payload without throwing. The outer model fallback layer then treated the attempt as success (`candidate_succeeded`) and skipped remaining fallback models.
- **Why it matters:** Users with a broken primary or first fallback (for example a 404 from the provider) never reached the next configured fallback.
- **What changed:** In `classifyFailoverClassificationFromHttpStatus`, HTTP **404** now maps to `model_not_found` by default, while preserving message-based **session**, **auth**, and **billing** signals (same pattern as HTTP 410).
- **What did NOT change:** Other status codes, the embedded runner loop structure, and `runWithModelFallback` behavior beyond what classification fixes.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration (agent model fallback path)

## Linked Issue/PR

- Closes #62119
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** `classifyFailoverClassificationFromHttpStatus` had no branch for HTTP 404, and bare 404 text without `not found` wording did not match `isModelNotFoundErrorMessage`, so `classifyFailoverReason` returned `null`.
- **Missing detection / guardrail:** HTTP status 404 as a first-class failover signal alongside other status codes.
- **Contributing context:** Reported in #62119 with logs showing `embedded_run_agent_end` with `isError=true` alongside `candidate_succeeded`.

## Regression Test Plan

- **Coverage:** Unit test
- **Target test file:** `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- **Scenario:** `classifyFailoverReason("404 status code (no body)")` → `model_not_found`; 404 + session/auth/billing strings still follow message classification.

## User-visible / Behavior Changes

- When a fallback model returns a minimal HTTP 404 error, OpenClaw can continue to the next configured model in the fallback chain instead of stopping after the first fallback candidate.

## Diagram

N/A

## Security Impact

- **New permissions/capabilities?** No

## Testing

- `pnpm test src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` (pass)
- Full `pnpm check` was not green in this workspace due to missing `acpx/dist/runtime.js` in `extensions/acpx` (pre-existing / local env). Targeted `oxfmt` + `oxlint` on touched files passed.


Made with [Cursor](https://cursor.com)