### PR TITLE
Cron: normalize jobId to id when loading jobs.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Cron: load `jobId` into `id` when the on-disk store omits `id`, matching doctor migration and fixing `unknown cron job id` for hand-edited `jobs.json`. (#62246) Thanks @cesarfavero.
 - Auth/OpenAI Codex OAuth: reload fresh on-disk credentials inside the locked refresh path and retry once after `refresh_token_reused` rotates only the stored refresh token, so relogin/restart recovery stops getting stuck on stale cached auth state. Thanks @owen-ever.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin, @afurm, and @openperf.
 - Plugins/channels: keep bundled channel artifact and secret-contract loading stable under lazy loading, preserve plugin-schema defaults during install, and fix Windows `file://` plus native-Jiti plugin loader paths so onboarding, doctor, `openclaw secret`, and bundled plugin installs work again. (#61832, #61836, #61853, #61856) Thanks @Zeesejo and @SuperMarioYL.
@@ -58,6 +57,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: honor `sessions_spawn(lightContext: true)` for spawned subagent runs by preserving lightweight bootstrap context through the gateway and embedded runner instead of silently falling back to full workspace bootstrap injection. (#62264) Thanks @theSamPadilla.
 - Slack/media: keep attachment downloads on the SSRF-guarded dispatcher path so Slack media fetching works on Node 22 without dropping pinned transport enforcement. (#62239) Thanks @openperf.
 - Docker/plugins: stop forcing bundled plugin discovery to `/app/extensions` in runtime images so packaged installs use compiled `dist/extensions` artifacts again and Node 24 containers do not boot through source-only plugin entry paths. Fixes #62044. (#62316) Thanks @gumadeiras.
+- Cron: load `jobId` into `id` when the on-disk store omits `id`, matching doctor migration and fixing `unknown cron job id` for hand-edited `jobs.json`. (#62246) Thanks @neeravmakwana.
 
 ## 2026.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: load `jobId` into `id` when the on-disk store omits `id`, matching doctor migration and fixing `unknown cron job id` for hand-edited `jobs.json`. (#62246) Thanks @cesarfavero.
 - Auth/OpenAI Codex OAuth: reload fresh on-disk credentials inside the locked refresh path and retry once after `refresh_token_reused` rotates only the stored refresh token, so relogin/restart recovery stops getting stuck on stale cached auth state. Thanks @owen-ever.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin, @afurm, and @openperf.
 - Plugins/channels: keep bundled channel artifact and secret-contract loading stable under lazy loading, preserve plugin-schema defaults during install, and fix Windows `file://` plus native-Jiti plugin loader paths so onboarding, doctor, `openclaw secret`, and bundled plugin installs work again. (#61832, #61836, #61853, #61856) Thanks @Zeesejo and @SuperMarioYL.

--- a/src/commands/doctor-cron-store-migration.ts
+++ b/src/commands/doctor-cron-store-migration.ts
@@ -1,3 +1,4 @@
+import { normalizeCronJobIdentityFields } from "../cron/normalize-job-identity.js";
 import { parseAbsoluteTimeMs } from "../cron/parse.js";
 import { coerceFiniteScheduleNumber } from "../cron/schedule.js";
 import { inferLegacyName, normalizeOptionalText } from "../cron/service/normalize.js";
@@ -212,19 +213,11 @@ export function normalizeStoredCronJobs(
       mutated = true;
     }
 
-    const rawId = typeof raw.id === "string" ? raw.id.trim() : "";
-    const legacyJobId = typeof raw.jobId === "string" ? raw.jobId.trim() : "";
-    if (!rawId && legacyJobId) {
-      raw.id = legacyJobId;
-      mutated = true;
-      trackIssue("jobId");
-    } else if (rawId && raw.id !== rawId) {
-      raw.id = rawId;
+    const idNorm = normalizeCronJobIdentityFields(raw);
+    if (idNorm.mutated) {
       mutated = true;
     }
-    if ("jobId" in raw) {
-      delete raw.jobId;
-      mutated = true;
+    if (idNorm.legacyJobIdIssue) {
       trackIssue("jobId");
     }
 

--- a/src/cron/normalize-job-identity.test.ts
+++ b/src/cron/normalize-job-identity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCronJobIdentityFields } from "./normalize-job-identity.js";
+
+describe("normalizeCronJobIdentityFields", () => {
+  it("copies trimmed jobId into id when id is missing", () => {
+    const raw: Record<string, unknown> = {
+      jobId: "  stable-slug  ",
+      name: "n",
+    };
+    const r = normalizeCronJobIdentityFields(raw);
+    expect(r.mutated).toBe(true);
+    expect(r.legacyJobIdIssue).toBe(true);
+    expect(raw.id).toBe("stable-slug");
+    expect(raw.jobId).toBeUndefined();
+  });
+
+  it("trims id without reporting a legacy jobId issue when jobId is absent", () => {
+    const raw: Record<string, unknown> = {
+      id: "  trimmed-id  ",
+      name: "n",
+    };
+    const r = normalizeCronJobIdentityFields(raw);
+    expect(r.mutated).toBe(true);
+    expect(r.legacyJobIdIssue).toBe(false);
+    expect(raw.id).toBe("trimmed-id");
+  });
+
+  it("removes redundant jobId while keeping canonical id", () => {
+    const raw: Record<string, unknown> = {
+      id: "keep-me",
+      jobId: "keep-me",
+      name: "n",
+    };
+    const r = normalizeCronJobIdentityFields(raw);
+    expect(r.mutated).toBe(true);
+    expect(r.legacyJobIdIssue).toBe(true);
+    expect(raw.id).toBe("keep-me");
+    expect(raw.jobId).toBeUndefined();
+  });
+
+  it("ignores non-string jobId", () => {
+    const raw: Record<string, unknown> = {
+      id: "x",
+      jobId: 1,
+      name: "n",
+    };
+    const r = normalizeCronJobIdentityFields(raw);
+    expect(r.mutated).toBe(true);
+    expect(r.legacyJobIdIssue).toBe(true);
+    expect(raw.id).toBe("x");
+    expect(raw.jobId).toBeUndefined();
+  });
+});

--- a/src/cron/normalize-job-identity.ts
+++ b/src/cron/normalize-job-identity.ts
@@ -1,31 +1,18 @@
-/**
- * Align on-disk cron job identity with the canonical `id` field used by the scheduler.
- * Hand-edited or legacy JSON may use `jobId` without `id`; Gateway/API tools often refer to
- * the stable name as `jobId` in payloads while persisted jobs use `id`.
- */
 export function normalizeCronJobIdentityFields(raw: Record<string, unknown>): {
   mutated: boolean;
-  /** Matches doctor `normalizeStoredCronJobs` jobId issue bucket (alias migration or removal). */
   legacyJobIdIssue: boolean;
 } {
   const rawId = typeof raw.id === "string" ? raw.id.trim() : "";
   const legacyJobId = typeof raw.jobId === "string" ? raw.jobId.trim() : "";
   const hadJobIdKey = "jobId" in raw;
+  const normalizedId = rawId || legacyJobId;
+  const idChanged = Boolean(normalizedId && raw.id !== normalizedId);
 
-  let mutated = false;
-
-  if (!rawId && legacyJobId) {
-    raw.id = legacyJobId;
-    mutated = true;
-  } else if (rawId && raw.id !== rawId) {
-    raw.id = rawId;
-    mutated = true;
+  if (idChanged) {
+    raw.id = normalizedId;
   }
   if (hadJobIdKey) {
     delete raw.jobId;
-    mutated = true;
   }
-
-  const legacyJobIdIssue = Boolean((!rawId && legacyJobId) || hadJobIdKey);
-  return { mutated, legacyJobIdIssue };
+  return { mutated: idChanged || hadJobIdKey, legacyJobIdIssue: hadJobIdKey };
 }

--- a/src/cron/normalize-job-identity.ts
+++ b/src/cron/normalize-job-identity.ts
@@ -1,0 +1,31 @@
+/**
+ * Align on-disk cron job identity with the canonical `id` field used by the scheduler.
+ * Hand-edited or legacy JSON may use `jobId` without `id`; Gateway/API tools often refer to
+ * the stable name as `jobId` in payloads while persisted jobs use `id`.
+ */
+export function normalizeCronJobIdentityFields(raw: Record<string, unknown>): {
+  mutated: boolean;
+  /** Matches doctor `normalizeStoredCronJobs` jobId issue bucket (alias migration or removal). */
+  legacyJobIdIssue: boolean;
+} {
+  const rawId = typeof raw.id === "string" ? raw.id.trim() : "";
+  const legacyJobId = typeof raw.jobId === "string" ? raw.jobId.trim() : "";
+  const hadJobIdKey = "jobId" in raw;
+
+  let mutated = false;
+
+  if (!rawId && legacyJobId) {
+    raw.id = legacyJobId;
+    mutated = true;
+  } else if (rawId && raw.id !== rawId) {
+    raw.id = rawId;
+    mutated = true;
+  }
+  if (hadJobIdKey) {
+    delete raw.jobId;
+    mutated = true;
+  }
+
+  const legacyJobIdIssue = Boolean((!rawId && legacyJobId) || hadJobIdKey);
+  return { mutated, legacyJobIdIssue };
+}

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -134,6 +134,11 @@ describe("cron service store seam coverage", () => {
 
     await ensureLoaded(state);
 
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ storePath, jobId: "repro-stable-id" }),
+      expect.stringContaining("legacy jobId"),
+    );
+
     const job = findJobOrThrow(state, "repro-stable-id");
     expect(job.id).toBe("repro-stable-id");
     expect((job as { jobId?: unknown }).jobId).toBeUndefined();

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { setupCronServiceSuite } from "../service.test-harness.js";
+import { findJobOrThrow } from "./jobs.js";
 import { createCronServiceState } from "./state.js";
 import { ensureLoaded, persist } from "./store.js";
 
@@ -88,5 +89,59 @@ describe("cron service store seam coverage", () => {
     await persist(state);
     expect(typeof state.storeFileMtimeMs).toBe("number");
     expect((state.storeFileMtimeMs ?? 0) >= (firstMtime ?? 0)).toBe(true);
+  });
+
+  it("normalizes jobId-only jobs in memory so scheduler lookups resolve by stable id", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              jobId: "repro-stable-id",
+              name: "handed",
+              enabled: true,
+              createdAtMs: now - 60_000,
+              updatedAtMs: now - 60_000,
+              schedule: { kind: "every", everyMs: 60_000 },
+              sessionTarget: "main",
+              wakeMode: "now",
+              payload: { kind: "systemEvent", text: "tick" },
+              state: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state);
+
+    const job = findJobOrThrow(state, "repro-stable-id");
+    expect(job.id).toBe("repro-stable-id");
+    expect((job as { jobId?: unknown }).jobId).toBeUndefined();
+
+    const raw = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    expect(raw.jobs[0]?.jobId).toBe("repro-stable-id");
+    expect(raw.jobs[0]?.id).toBeUndefined();
   });
 });

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -35,7 +35,15 @@ export async function ensureLoaded(
   const loaded = await loadCronStore(state.deps.storePath);
   const jobs = (loaded.jobs ?? []) as unknown as CronJob[];
   for (const job of jobs) {
-    normalizeCronJobIdentityFields(job as unknown as Record<string, unknown>);
+    const raw = job as unknown as Record<string, unknown>;
+    const { legacyJobIdIssue } = normalizeCronJobIdentityFields(raw);
+    if (legacyJobIdIssue) {
+      const resolvedId = typeof raw.id === "string" ? raw.id : undefined;
+      state.deps.log.warn(
+        { storePath: state.deps.storePath, jobId: resolvedId },
+        "cron: job used legacy jobId field; normalized id in memory (run openclaw doctor --fix to persist canonical shape)",
+      );
+    }
     // Persisted legacy jobs may predate the required `enabled` field.
     // Keep runtime behavior backward-compatible without rewriting the store.
     if (typeof job.enabled !== "boolean") {

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { loadCronStore, saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
 import { recomputeNextRuns } from "./jobs.js";
@@ -34,6 +35,7 @@ export async function ensureLoaded(
   const loaded = await loadCronStore(state.deps.storePath);
   const jobs = (loaded.jobs ?? []) as unknown as CronJob[];
   for (const job of jobs) {
+    normalizeCronJobIdentityFields(job as unknown as Record<string, unknown>);
     // Persisted legacy jobs may predate the required `enabled` field.
     // Keep runtime behavior backward-compatible without rewriting the store.
     if (typeof job.enabled !== "boolean") {


### PR DESCRIPTION
## Summary

- Problem: Cron jobs stored with only `jobId` (no `id`) in `jobs.json` failed at runtime with `unknown cron job id` because the scheduler looked up jobs by `id` only. Doctor migration already fixed this on `doctor --fix`, but the gateway load path did not.
- Why it matters: Users editing the store or following docs that emphasize `jobId` expect stable identifiers to work without running doctor first.
- What changed: Shared `normalizeCronJobIdentityFields` runs when the cron service loads the store (and doctor migration reuses it) so `id` is set from `jobId` when needed and the legacy `jobId` key is dropped in memory.
- What did NOT change: On-disk files are not rewritten on load alone; the next explicit persist still writes the canonical shape.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62246
- Related #62246
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: The on-disk JSON shape allowed `jobId` without `id`; runtime lookup used `id` only, while doctor migration normalized the file separately.
- Missing detection / guardrail: Runtime load did not apply the same identity normalization as doctor.
- Contributing context: API and tools often refer to the stable name as `jobId` while persisted jobs use `id`.

## Regression Test Plan

- Coverage level: Unit test
- Target test: `src/cron/normalize-job-identity.test.ts`, `src/cron/service/store.test.ts`
- Scenario: A job with only `jobId` in `jobs.json` loads and `findJobOrThrow` resolves the stable id; disk file unchanged until persist.

## User-visible / Behavior Changes

- Cron jobs in `jobs.json` that only define `jobId` are now recognized by the scheduler and cron operations that resolve jobs by id without requiring `openclaw doctor --fix` first.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? No
- New network endpoints or listeners? No
- Trust boundary changes? No


Made with [Cursor](https://cursor.com)