### PR TITLE
fix(cli): add missing discord-api-types dependency (resolves #62224)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1259,6 +1259,7 @@
     "cli-highlight": "^2.1.11",
     "commander": "^14.0.3",
     "croner": "^10.0.1",
+    "discord-api-types": "^0.37.120",
     "dotenv": "^17.4.0",
     "express": "^5.2.1",
     "file-type": "22.0.0",


### PR DESCRIPTION
## Summary

Resolves #62224 - CLI crashes on all commands due to missing `discord-api-types` module after upgrading to 2026.4.5.

## Root Cause

@buape/carbon depends on `discord-api-types` but it was not properly installed in node_modules after v2026.4.5 upgrade.

## Fix

Add `discord-api-types` as a direct dependency in package.json.

## Test

`pnpm run build` passes