### PR TITLE
Add lightContext support for spawned subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Docs: https://docs.openclaw.ai
 - UI/light mode: target both root and nested WebKit scrollbar thumbs in the light theme so page-level and container scrollbars stay visible on light backgrounds. (#61753) Thanks @chziyue.
 - Matrix/onboarding: add an invite auto-join setup step with explicit off warnings and strict stable-target validation so new Matrix accounts stop silently ignoring invited rooms and fresh DM-style invites unless operators opt in. (#62168) Thanks @gumadeiras.
 - Telegram/doctor: keep top-level access-control fallback in place during multi-account normalization while still promoting legacy default auth into `accounts.default`, so existing named bots keep inherited allowlists without dropping the legacy default bot. (#62263) Thanks @obviyus.
+- Agents/subagents: honor `sessions_spawn(lightContext: true)` for spawned subagent runs by preserving lightweight bootstrap context through the gateway and embedded runner instead of silently falling back to full workspace bootstrap injection. (#62264) Thanks @theSamPadilla.
 
 ## 2026.4.5
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -473,6 +473,8 @@ export function runAgentAttempt(params: {
     lane: params.opts.lane,
     abortSignal: params.opts.abortSignal,
     extraSystemPrompt: params.opts.extraSystemPrompt,
+    bootstrapContextMode: params.opts.bootstrapContextMode,
+    bootstrapContextRunKind: params.opts.bootstrapContextRunKind,
     internalEvents: params.opts.internalEvents,
     inputProvenance: params.opts.inputProvenance,
     streamParams: params.opts.streamParams,

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -85,6 +85,10 @@ export type AgentCommandOpts = {
   lane?: string;
   runId?: string;
   extraSystemPrompt?: string;
+  /** Bootstrap workspace context injection mode for this run. */
+  bootstrapContextMode?: "full" | "lightweight";
+  /** Run kind hint for bootstrap context behavior. */
+  bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
   internalEvents?: AgentInternalEvent[];
   inputProvenance?: InputProvenance;
   /** Per-call stream param overrides (best-effort). */

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -666,6 +666,8 @@ export async function runEmbeddedPiAgent(
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
             silentExpected: params.silentExpected,
+            bootstrapContextMode: params.bootstrapContextMode,
+            bootstrapContextRunKind: params.bootstrapContextRunKind,
             bootstrapPromptWarningSignaturesSeen,
             bootstrapPromptWarningSignature:
               bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -44,6 +44,7 @@ import {
   updateSessionStore,
   isAdminOnlyMethod,
 } from "./subagent-spawn.runtime.js";
+import type { BootstrapContextMode } from "./bootstrap-files.js";
 import { readStringParam } from "./tools/common.js";
 
 export const SUBAGENT_SPAWN_MODES = ["run", "session"] as const;
@@ -80,6 +81,7 @@ export type SpawnSubagentParams = {
   mode?: SpawnSubagentMode;
   cleanup?: "delete" | "keep";
   sandbox?: SpawnSubagentSandboxMode;
+  lightContext?: boolean;
   expectsCompletionMessage?: boolean;
   attachments?: Array<{
     name: string;
@@ -672,6 +674,10 @@ export async function spawnSubagentDirect(
     childSystemPrompt = `${childSystemPrompt}\n\n${materializedAttachments.systemPromptSuffix}`;
   }
 
+  const bootstrapContextMode: BootstrapContextMode | undefined = params.lightContext
+    ? "lightweight"
+    : undefined;
+
   const childTaskMessage = [
     `[Subagent Context] You are running as a subagent (depth ${childDepth}/${maxSpawnDepth}). Results auto-announce to your requester; do not busy-poll for status.`,
     spawnMode === "session"
@@ -742,6 +748,8 @@ export async function spawnSubagentDirect(
         thinking: thinkingOverride,
         timeout: runTimeoutSeconds,
         label: label || undefined,
+        bootstrapContextMode,
+        bootstrapContextRunKind: "default",
         ...publicSpawnedMetadata,
       },
       timeoutMs: 10_000,

--- a/src/agents/subagent-spawn.workspace.test.ts
+++ b/src/agents/subagent-spawn.workspace.test.ts
@@ -148,6 +148,31 @@ describe("spawnSubagentDirect workspace inheritance", () => {
     });
   });
 
+  it("passes lightweight bootstrap context flags for lightContext subagent spawns", async () => {
+    await spawnSubagentDirect(
+      {
+        task: "inspect workspace",
+        lightContext: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "telegram",
+        agentAccountId: "123",
+        agentTo: "456",
+        workspaceDir: "/tmp/requester-workspace",
+      },
+    );
+
+    const agentCall = hoisted.callGatewayMock.mock.calls.find(
+      ([request]) => (request as { method?: string }).method === "agent",
+    )?.[0] as { params?: Record<string, unknown> } | undefined;
+
+    expect(agentCall?.params).toMatchObject({
+      bootstrapContextMode: "lightweight",
+      bootstrapContextRunKind: "default",
+    });
+  });
+
   it("deletes the provisional child session when a non-thread subagent start fails", async () => {
     hoisted.callGatewayMock.mockImplementation(
       async (request: {

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -103,6 +103,25 @@ describe("sessions_spawn tool", () => {
     );
   });
 
+  it("passes lightContext through to subagent spawns", async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await tool.execute("call-light", {
+      task: "summarize this",
+      lightContext: true,
+    });
+
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "summarize this",
+        lightContext: true,
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("routes to ACP runtime when runtime=acp", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -122,6 +122,23 @@ describe("sessions_spawn tool", () => {
     );
   });
 
+  it('rejects lightContext when runtime is not "subagent"', async () => {
+    const tool = createSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+    });
+
+    await expect(
+      tool.execute("call-light-acp", {
+        runtime: "acp",
+        task: "summarize this",
+        lightContext: true,
+      }),
+    ).rejects.toThrow("lightContext is only supported for runtime='subagent'.");
+
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+  });
+
   it("routes to ACP runtime when runtime=acp", async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -97,7 +97,12 @@ const SessionsSpawnToolSchema = Type.Object({
   cleanup: optionalStringEnum(["delete", "keep"] as const),
   sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
   streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS),
-  lightContext: Type.Optional(Type.Boolean()),
+  lightContext: Type.Optional(
+    Type.Boolean({
+      description:
+        "When true, spawned subagent runs use lightweight bootstrap context. Only applies to runtime='subagent'.",
+    }),
+  ),
 
   // Inline attachments (snapshot-by-value).
   // NOTE: Attachment contents are redacted from transcript persistence by sanitizeToolCallInputs.
@@ -163,6 +168,9 @@ export function createSessionsSpawnTool(
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
       const streamTo = params.streamTo === "parent" ? "parent" : undefined;
       const lightContext = params.lightContext === true;
+      if (runtime === "acp" && lightContext) {
+        throw new Error("lightContext is only supported for runtime='subagent'.");
+      }
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -97,6 +97,7 @@ const SessionsSpawnToolSchema = Type.Object({
   cleanup: optionalStringEnum(["delete", "keep"] as const),
   sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
   streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS),
+  lightContext: Type.Optional(Type.Boolean()),
 
   // Inline attachments (snapshot-by-value).
   // NOTE: Attachment contents are redacted from transcript persistence by sanitizeToolCallInputs.
@@ -161,6 +162,7 @@ export function createSessionsSpawnTool(
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
       const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const lightContext = params.lightContext === true;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"
@@ -300,6 +302,7 @@ export function createSessionsSpawnTool(
           mode,
           cleanup,
           sandbox,
+          lightContext,
           expectsCompletionMessage: true,
           attachments,
           attachMountPath:

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -102,6 +102,16 @@ export const AgentParamsSchema = Type.Object(
     bestEffortDeliver: Type.Optional(Type.Boolean()),
     lane: Type.Optional(Type.String()),
     extraSystemPrompt: Type.Optional(Type.String()),
+    bootstrapContextMode: Type.Optional(
+      Type.Union([Type.Literal("full"), Type.Literal("lightweight")]),
+    ),
+    bootstrapContextRunKind: Type.Optional(
+      Type.Union([
+        Type.Literal("default"),
+        Type.Literal("heartbeat"),
+        Type.Literal("cron"),
+      ]),
+    ),
     internalEvents: Type.Optional(Type.Array(AgentInternalEventSchema)),
     inputProvenance: Type.Optional(InputProvenanceSchema),
     idempotencyKey: NonEmptyString,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -307,6 +307,8 @@ export const agentHandlers: GatewayRequestHandlers = {
       groupSpace?: string;
       lane?: string;
       extraSystemPrompt?: string;
+      bootstrapContextMode?: "full" | "lightweight";
+      bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
       internalEvents?: AgentInternalEvent[];
       idempotencyKey: string;
       timeout?: number;
@@ -828,6 +830,8 @@ export const agentHandlers: GatewayRequestHandlers = {
         runId,
         lane: request.lane,
         extraSystemPrompt: request.extraSystemPrompt,
+        bootstrapContextMode: request.bootstrapContextMode,
+        bootstrapContextRunKind: request.bootstrapContextRunKind,
         internalEvents: request.internalEvents,
         inputProvenance,
         // Internal-only: allow workspace override for spawned subagent runs.


### PR DESCRIPTION
## Summary

- Problem: `sessions_spawn(lightContext: true)` was accepted by the spawn/gateway layers, but spawned subagent runs still defaulted to full bootstrap context, so sandboxed local subagents continued injecting workspace bootstrap files.
- Why it matters: local/Ollama-style worker subagents were paying unnecessary prompt overhead, which hurts latency and makes smaller context windows less viable.
- What changed: added `lightContext?: boolean` support for spawned subagents and threaded `bootstrapContextMode` / `bootstrapContextRunKind` through the gateway, agent command, and embedded runner paths so lightweight mode reaches the actual attempt. This intentionally mirrors the existing heartbeat/cron `lightContext` pattern rather than introducing a new context-control API.
- What did NOT change (scope boundary): this does not redesign general prompt assembly or reduce non-bootstrap system/tool overhead, and it does not change default behavior unless `lightContext: true` is explicitly set.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #56029
- Related #56459
- Related #7957
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `lightContext` was added at the `sessions_spawn` API layer, but `bootstrapContextMode` / `bootstrapContextRunKind` were dropped across multiple downstream pass-through seams before the embedded subagent attempt, so spawned runs still used full bootstrap context.
- Missing detection / guardrail: there was no end-to-end or seam test proving that a `lightContext` spawn request reached the embedded runner/bootstrap resolver.
- Contributing context (if known): the initial plumbing looked correct at the spawn and gateway boundaries, which made it easy to miss that later agent-command and attempt-execution layers were rebuilding params without forwarding the new fields.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/subagent-spawn.workspace.test.ts`
  - `src/agents/tools/sessions-spawn-tool.test.ts`
- Scenario the test should lock in: when `sessions_spawn(... lightContext: true ...)` is used for a spawned subagent run, the request maps to `bootstrapContextMode: "lightweight"` and the downstream spawn/gateway path preserves that mode instead of falling back to full bootstrap context.
- Why this is the smallest reliable guardrail: the bug was in parameter plumbing across internal seams, so a focused seam test is cheaper and more reliable than only validating via full runtime/manual repros.
- Existing test that already covers this (if any): the updated spawn/tool tests cover the public API mapping and spawned request shape.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `sessions_spawn` now supports `lightContext: true` for spawned subagents.
- When enabled, spawned subagent runs use lightweight bootstrap context instead of full workspace bootstrap injection.
- Default behavior is unchanged when `lightContext` is omitted.
- The API shape intentionally mirrors existing heartbeat/cron `lightContext` behavior to keep subagent context control consistent with existing OpenClaw patterns.

## Diagram (if applicable)

Before:
`[sessions_spawn(lightContext: true)] -> [spawn/gateway accepts flag] -> [downstream pass-through drops it] -> [subagent runs with full bootstrap context]`

After:
`[sessions_spawn(lightContext: true)] -> [spawn/gateway/agent command preserve flag] -> [embedded runner receives lightweight mode] -> [subagent runs without bootstrap file injection]`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any Yes, explain risk + mitigation:
  - This changes spawned subagent behavior by allowing callers to opt into reduced bootstrap context. The main risk is behavioral: a subagent may have less workspace grounding when `lightContext` is enabled. Mitigation: this is opt-in only, defaults remain unchanged, and the change reduces injected workspace data instead of expanding privileges or access.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw install with sandboxed local subagent runs
- Model/provider: local Ollama-style worker via `agentId="local"` (tested with local Gemma setup)
- Integration/channel (if any): Telegram main session spawning a local subagent
- Relevant config (redacted):
  - `main.subagents.allowAgents = ["main", "local"]`
  - `agents.defaults.timeoutSeconds = 600`
  - `agents.defaults.subagents.runTimeoutSeconds = 600`
  - `agents.defaults.llm.idleTimeoutSeconds = 0`

### Steps

1. Build and install the patched OpenClaw locally.
2. Run a sandboxed spawned subagent task with `sessions_spawn(... runtime="subagent", agentId="local", sandbox="require", lightContext=true ...)`.
3. Compare prompt/bootstrap behavior before and after the pass-through fixes using the same trivial task.

### Expected

- `lightContext: true` should propagate through the spawned subagent path and enable lightweight bootstrap behavior.

### Actual

- Before fix: the request was accepted, but downstream pass-through gaps caused the subagent to still run with full bootstrap context.
- After fix: lightweight mode reached the embedded attempt, bootstrap injection dropped to zero files/chars for the trivial local subagent case, and input tokens dropped from about 9k to about 5k.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Built and installed the patched OpenClaw locally.
  - Confirmed `sessions_spawn(lightContext: true)` was accepted for sandboxed local subagents.
  - Reproduced the original issue where the flag was accepted but the spawned run still used full bootstrap context.
  - Traced and fixed the missing pass-through seams until the embedded runner received `bootstrapContextMode: "lightweight"`.
  - Re-ran the same trivial spawned local subagent task after removing temporary debug logs and confirmed the reduced token usage still held.
- Edge cases checked:
  - Main session/default runs continued using full bootstrap context.
  - Default spawned behavior remained unchanged when `lightContext` was not set.
- What you did not verify:
  - Broader performance impact across many different prompts/models.
  - Behavior across every non-local provider path.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Enabling `lightContext` may remove useful workspace bootstrap grounding for spawned subagents on tasks that depend on that context.
  - Mitigation: The behavior is explicitly opt-in, and default behavior remains unchanged.

- Risk: Future internal refactors could accidentally drop `bootstrapContextMode` / `bootstrapContextRunKind` across another internal seam.
  - Mitigation: The PR adds focused test coverage around the spawn/tool path and preserves the parameter plumbing explicitly through the affected layers.