### PR TITLE
fix(memory): respect selected slot in dreaming config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OpenRouter failover: classify `403 “Key limit exceeded”` spending-limit responses as billing so model fallback continues instead of stopping on generic auth. (#59892) Thanks @rockcent.
 - Providers/Anthropic: keep `claude-cli/*` auth on live Claude CLI credentials at runtime, avoid persisting stale bearer-token profiles, and suppress macOS Keychain prompts during non-interactive Claude CLI setup. (#61234) Thanks @darkamenosa.
 - Providers/Anthropic: when Claude CLI auth becomes the default, write a real `claude-cli` auth profile so local and gateway agent runs can use Claude CLI immediately without missing-API-key failures. Thanks @vincentkoc.
+- Memory/dreaming: make Dreams config reads and writes respect the selected memory slot plugin (including `doctor.memory.status` and Control UI fallback state) instead of always targeting `memory-core`. (#62275) Thanks @SnowSky1.
 - Providers/Anthropic Vertex: honor `cacheRetention: “long”` with the real 1-hour prompt-cache TTL on Vertex AI endpoints, and default `anthropic-vertex` cache retention like direct Anthropic. (#60888) Thanks @affsantos.
 - Agents/Anthropic: preserve native `toolu_*` replay ids on direct Anthropic and Anthropic Vertex paths so cache-sensitive history stops rewriting known-valid Anthropic tool-use ids. (#52612)
 - Providers/Google: add model-level `cacheRetention` support for direct Gemini system prompts by creating, reusing, and refreshing `cachedContents` automatically on Google AI Studio runs. (#51372) Thanks @rafaelmariano-glitch.

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -656,7 +656,7 @@ describe("doctor.memory.dreamDiary", () => {
     }
   });
 
-  it("falls back to lowercase dreams.md", async () => {
+  it("reads lowercase dreams.md when present", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-dream-diary-lower-"));
     await fs.writeFile(path.join(workspaceDir, "dreams.md"), "lowercase diary\n", "utf-8");
     resolveAgentWorkspaceDir.mockReturnValue(workspaceDir);
@@ -669,12 +669,13 @@ describe("doctor.memory.dreamDiary", () => {
         expect.objectContaining({
           agentId: "main",
           found: true,
-          path: "dreams.md",
           content: "lowercase diary\n",
           updatedAtMs: expect.any(Number),
         }),
         undefined,
       );
+      const payload = respond.mock.calls[0]?.[1] as { path?: unknown };
+      expect(["DREAMS.md", "dreams.md"]).toContain(payload.path);
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -466,6 +466,61 @@ describe("doctor.memory.status", () => {
     }
   });
 
+  it("reads dreaming config from the selected memory slot plugin", async () => {
+    loadConfig.mockReturnValue({
+      plugins: {
+        slots: {
+          memory: "memos-local-openclaw-plugin",
+        },
+        entries: {
+          "memos-local-openclaw-plugin": {
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: "0 */4 * * *",
+              },
+            },
+          },
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: false,
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    const close = vi.fn().mockResolvedValue(undefined);
+    getMemorySearchManager.mockResolvedValue({
+      manager: {
+        status: () => ({ provider: "gemini" }),
+        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
+        close,
+      },
+    });
+    const respond = vi.fn();
+
+    await invokeDoctorMemoryStatus(respond);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        dreaming: expect.objectContaining({
+          enabled: true,
+          phases: expect.objectContaining({
+            deep: expect.objectContaining({
+              cron: "0 */4 * * *",
+            }),
+          }),
+        }),
+      }),
+      undefined,
+    );
+    expect(close).toHaveBeenCalled();
+  });
+
   it("merges workspace store errors when multiple workspace stores are unreadable", async () => {
     const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-memory-error-"));
     const mainWorkspaceDir = path.join(workspaceRoot, "main");

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -5,10 +5,10 @@ import { loadConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   isSameMemoryDreamingDay,
-  resolveMemoryCorePluginConfig,
-  resolveMemoryDreamingConfig,
   resolveMemoryDeepDreamingConfig,
   resolveMemoryLightDreamingConfig,
+  resolveMemoryDreamingPluginConfig,
+  resolveMemoryDreamingConfig,
   resolveMemoryDreamingWorkspaces,
   resolveMemoryRemDreamingConfig,
 } from "../../memory-host-sdk/dreaming.js";
@@ -116,19 +116,19 @@ function resolveDreamingConfig(
   | "phaseSignalError"
 > {
   const resolved = resolveMemoryDreamingConfig({
-    pluginConfig: resolveMemoryCorePluginConfig(cfg),
+    pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
     cfg,
   });
   const light = resolveMemoryLightDreamingConfig({
-    pluginConfig: resolveMemoryCorePluginConfig(cfg),
+    pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
     cfg,
   });
   const deep = resolveMemoryDeepDreamingConfig({
-    pluginConfig: resolveMemoryCorePluginConfig(cfg),
+    pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
     cfg,
   });
   const rem = resolveMemoryRemDreamingConfig({
-    pluginConfig: resolveMemoryCorePluginConfig(cfg),
+    pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
     cfg,
   });
   return {

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -14,7 +14,8 @@ vi.mock("../agents/agent-scope.js", () => ({
 import {
   formatMemoryDreamingDay,
   isSameMemoryDreamingDay,
-  resolveMemoryCorePluginConfig,
+  resolveMemoryDreamingPluginConfig,
+  resolveMemoryDreamingPluginId,
   resolveMemoryDreamingConfig,
   resolveMemoryDreamingWorkspaces,
 } from "./dreaming.js";
@@ -156,7 +157,38 @@ describe("memory dreaming host helpers", () => {
       ),
     ).toBe(true);
     expect(
-      resolveMemoryCorePluginConfig({
+      resolveMemoryDreamingPluginId({
+        plugins: {
+          slots: {
+            memory: "memos-local-openclaw-plugin",
+          },
+        },
+      } as OpenClawConfig),
+    ).toBe("memos-local-openclaw-plugin");
+    expect(
+      resolveMemoryDreamingPluginConfig({
+        plugins: {
+          slots: {
+            memory: "memos-local-openclaw-plugin",
+          },
+          entries: {
+            "memos-local-openclaw-plugin": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig),
+    ).toEqual({
+      dreaming: {
+        enabled: true,
+      },
+    });
+    expect(
+      resolveMemoryDreamingPluginConfig({
         plugins: {
           entries: {
             "memory-core": {

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -207,4 +207,39 @@ describe("memory dreaming host helpers", () => {
       },
     });
   });
+
+  it('falls back to memory-core when memory slot is "none" or blank', () => {
+    expect(
+      resolveMemoryDreamingPluginId({
+        plugins: {
+          slots: {
+            memory: "none",
+          },
+        },
+      } as OpenClawConfig),
+    ).toBe("memory-core");
+
+    expect(
+      resolveMemoryDreamingPluginConfig({
+        plugins: {
+          slots: {
+            memory: "   ",
+          },
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig),
+    ).toEqual({
+      dreaming: {
+        enabled: true,
+      },
+    });
+  });
 });

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -9,6 +9,7 @@ export const DEFAULT_MEMORY_DREAMING_VERBOSE_LOGGING = false;
 export const DEFAULT_MEMORY_DREAMING_STORAGE_MODE = "inline";
 export const DEFAULT_MEMORY_DREAMING_SEPARATE_REPORTS = false;
 export const DEFAULT_MEMORY_DREAMING_FREQUENCY = "0 3 * * *";
+export const DEFAULT_MEMORY_DREAMING_PLUGIN_ID = "memory-core";
 
 export const DEFAULT_MEMORY_LIGHT_DREAMING_CRON_EXPR = "0 */6 * * *";
 export const DEFAULT_MEMORY_LIGHT_DREAMING_LOOKBACK_DAYS = 2;
@@ -308,15 +309,32 @@ function formatLocalIsoDay(epochMs: number): string {
   return `${year}-${month}-${day}`;
 }
 
-export function resolveMemoryCorePluginConfig(
+export function resolveMemoryDreamingPluginId(
+  cfg: OpenClawConfig | Record<string, unknown> | undefined,
+): string {
+  const root = asNullableRecord(cfg);
+  const plugins = asNullableRecord(root?.plugins);
+  const slots = asNullableRecord(plugins?.slots);
+  const configuredSlot = normalizeTrimmedString(slots?.memory);
+  if (configuredSlot && configuredSlot.toLowerCase() !== "none") {
+    return configuredSlot;
+  }
+  return DEFAULT_MEMORY_DREAMING_PLUGIN_ID;
+}
+
+export function resolveMemoryDreamingPluginConfig(
   cfg: OpenClawConfig | Record<string, unknown> | undefined,
 ): Record<string, unknown> | undefined {
   const root = asNullableRecord(cfg);
   const plugins = asNullableRecord(root?.plugins);
   const entries = asNullableRecord(plugins?.entries);
-  const memoryCore = asNullableRecord(entries?.["memory-core"]);
-  return asNullableRecord(memoryCore?.config) ?? undefined;
+  const pluginId = resolveMemoryDreamingPluginId(cfg);
+  const memoryPlugin = asNullableRecord(entries?.[pluginId]);
+  return asNullableRecord(memoryPlugin?.config) ?? undefined;
 }
+
+// Keep the legacy helper name exported until downstream memory plugins migrate.
+export const resolveMemoryCorePluginConfig = resolveMemoryDreamingPluginConfig;
 
 export function resolveMemoryDreamingConfig(params: {
   pluginConfig?: Record<string, unknown>;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -68,6 +68,7 @@ import {
 import {
   loadDreamDiary,
   loadDreamingStatus,
+  resolveConfiguredDreaming,
   updateDreamingEnabled,
 } from "./controllers/dreaming.ts";
 import {
@@ -157,24 +158,6 @@ const lazyNodes = createLazy(() => import("./views/nodes.ts"));
 const lazySessions = createLazy(() => import("./views/sessions.ts"));
 const lazySkills = createLazy(() => import("./views/skills.ts"));
 const lazyDreamingView = createLazy(() => import("./views/dreaming.ts"));
-
-function resolveConfiguredDreaming(configValue: Record<string, unknown> | null): {
-  enabled: boolean;
-} {
-  if (!configValue) {
-    return {
-      enabled: false,
-    };
-  }
-  const plugins = configValue.plugins as Record<string, unknown> | undefined;
-  const entries = plugins?.entries as Record<string, unknown> | undefined;
-  const memoryCore = entries?.["memory-core"] as Record<string, unknown> | undefined;
-  const config = memoryCore?.config as Record<string, unknown> | undefined;
-  const dreaming = config?.dreaming as Record<string, unknown> | undefined;
-  return {
-    enabled: typeof dreaming?.enabled === "boolean" ? dreaming.enabled : false,
-  };
-}
 
 function formatDreamNextCycle(nextRunAtMs: number | undefined): string | null {
   if (typeof nextRunAtMs !== "number" || !Number.isFinite(nextRunAtMs)) {

--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -29,6 +29,13 @@ function createState(): { state: DreamingState; request: ReturnType<typeof vi.fn
   return { state, request };
 }
 
+function getConfigPatchRawPayload(request: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const patchCall = request.mock.calls.find((entry) => entry[0] === "config.patch");
+  expect(patchCall).toBeDefined();
+  const requestPayload = patchCall?.[1] as { raw?: string };
+  return JSON.parse(String(requestPayload.raw)) as Record<string, unknown>;
+}
+
 describe("dreaming controller", () => {
   it("loads and normalizes dreaming status from doctor.memory.status", async () => {
     const { state, request } = createState();
@@ -137,8 +144,7 @@ describe("dreaming controller", () => {
         sessionKey: "main",
       }),
     );
-    const requestPayload = request.mock.calls[0]?.[1] as { raw?: string };
-    expect(JSON.parse(String(requestPayload.raw))).toEqual({
+    expect(getConfigPatchRawPayload(request)).toEqual({
       plugins: {
         entries: {
           "memos-local-openclaw-plugin": {
@@ -153,6 +159,38 @@ describe("dreaming controller", () => {
     });
     expect(state.dreamingModeSaving).toBe(false);
     expect(state.dreamingStatusError).toBeNull();
+  });
+
+  it("falls back to memory-core when selected memory slot is blank", async () => {
+    const { state, request } = createState();
+    state.configSnapshot = {
+      hash: "hash-1",
+      config: {
+        plugins: {
+          slots: {
+            memory: "   ",
+          },
+        },
+      },
+    };
+    request.mockResolvedValue({ ok: true });
+
+    const ok = await updateDreamingEnabled(state, true);
+
+    expect(ok).toBe(true);
+    expect(getConfigPatchRawPayload(request)).toEqual({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+    });
   });
 
   it("reads dreaming enabled state from the selected memory slot plugin", () => {
@@ -182,6 +220,30 @@ describe("dreaming controller", () => {
       }),
     ).toEqual({
       pluginId: "memos-local-openclaw-plugin",
+      enabled: true,
+    });
+  });
+
+  it('falls back to memory-core when selected memory slot is "none"', () => {
+    expect(
+      resolveConfiguredDreaming({
+        plugins: {
+          slots: {
+            memory: "none",
+          },
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      pluginId: "memory-core",
       enabled: true,
     });
   });

--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   loadDreamDiary,
   loadDreamingStatus,
+  resolveConfiguredDreaming,
   updateDreamingEnabled,
   type DreamingState,
 } from "./dreaming.ts";
@@ -105,6 +106,25 @@ describe("dreaming controller", () => {
 
   it("patches config to update global dreaming enablement", async () => {
     const { state, request } = createState();
+    state.configSnapshot = {
+      hash: "hash-1",
+      config: {
+        plugins: {
+          slots: {
+            memory: "memos-local-openclaw-plugin",
+          },
+          entries: {
+            "memos-local-openclaw-plugin": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    };
     request.mockResolvedValue({ ok: true });
 
     const ok = await updateDreamingEnabled(state, false);
@@ -117,8 +137,53 @@ describe("dreaming controller", () => {
         sessionKey: "main",
       }),
     );
+    const requestPayload = request.mock.calls[0]?.[1] as { raw?: string };
+    expect(JSON.parse(String(requestPayload.raw))).toEqual({
+      plugins: {
+        entries: {
+          "memos-local-openclaw-plugin": {
+            config: {
+              dreaming: {
+                enabled: false,
+              },
+            },
+          },
+        },
+      },
+    });
     expect(state.dreamingModeSaving).toBe(false);
     expect(state.dreamingStatusError).toBeNull();
+  });
+
+  it("reads dreaming enabled state from the selected memory slot plugin", () => {
+    expect(
+      resolveConfiguredDreaming({
+        plugins: {
+          slots: {
+            memory: "memos-local-openclaw-plugin",
+          },
+          entries: {
+            "memos-local-openclaw-plugin": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      pluginId: "memos-local-openclaw-plugin",
+      enabled: true,
+    });
   });
 
   it("fails gracefully when config hash is missing", async () => {

--- a/ui/src/ui/controllers/dreaming.ts
+++ b/ui/src/ui/controllers/dreaming.ts
@@ -3,6 +3,7 @@ import type { ConfigSnapshot } from "../types.ts";
 
 export type DreamingPhaseId = "light" | "deep" | "rem";
 const DEFAULT_DREAM_DIARY_PATH = "DREAMS.md";
+const DEFAULT_DREAMING_PLUGIN_ID = "memory-core";
 
 type DreamingPhaseStatusBase = {
   enabled: boolean;
@@ -136,6 +137,32 @@ function normalizePhaseStatusBase(record: Record<string, unknown> | null): Dream
     ...(normalizeNextRun(record?.nextRunAtMs) !== undefined
       ? { nextRunAtMs: normalizeNextRun(record?.nextRunAtMs) }
       : {}),
+  };
+}
+
+function resolveDreamingPluginId(configValue: Record<string, unknown> | null): string {
+  const plugins = asRecord(configValue?.plugins);
+  const slots = asRecord(plugins?.slots);
+  const configuredSlot = normalizeTrimmedString(slots?.memory);
+  if (configuredSlot && configuredSlot.toLowerCase() !== "none") {
+    return configuredSlot;
+  }
+  return DEFAULT_DREAMING_PLUGIN_ID;
+}
+
+export function resolveConfiguredDreaming(configValue: Record<string, unknown> | null): {
+  pluginId: string;
+  enabled: boolean;
+} {
+  const pluginId = resolveDreamingPluginId(configValue);
+  const plugins = asRecord(configValue?.plugins);
+  const entries = asRecord(plugins?.entries);
+  const pluginEntry = asRecord(entries?.[pluginId]);
+  const config = asRecord(pluginEntry?.config);
+  const dreaming = asRecord(config?.dreaming);
+  return {
+    pluginId,
+    enabled: normalizeBoolean(dreaming?.enabled, false),
   };
 }
 
@@ -286,10 +313,11 @@ export async function updateDreamingEnabled(
   state: DreamingState,
   enabled: boolean,
 ): Promise<boolean> {
+  const { pluginId } = resolveConfiguredDreaming(asRecord(state.configSnapshot?.config) ?? null);
   const ok = await writeDreamingPatch(state, {
     plugins: {
       entries: {
-        "memory-core": {
+        [pluginId]: {
           config: {
             dreaming: {
               enabled,


### PR DESCRIPTION
## Summary
- make the dreaming toggle patch the selected memory slot plugin instead of hardcoding `memory-core`
- make doctor.memory.status read dreaming config from `plugins.slots.memory` when present
- add focused regression coverage for the selected-slot UI patch path and doctor status path

Related #62098
