### PR TITLE
Build: fix plugin-sdk dts TS errors (media tools + gateway TLS)

### DIFF
--- a/src/agents/tools/music-generate-tool.actions.ts
+++ b/src/agents/tools/music-generate-tool.actions.ts
@@ -84,10 +84,12 @@ export function createMusicGenerateListActionResult(
 export function createMusicGenerateStatusActionResult(
   sessionKey?: string,
 ): MusicGenerateActionResult {
+  const findActiveTask = (key?: string) =>
+    findActiveMusicGenerationTaskForSession(key) ?? undefined;
   return createMediaGenerateStatusActionResult({
     sessionKey,
     inactiveText: "No active music generation task is currently running for this session.",
-    findActiveTask: findActiveMusicGenerationTaskForSession,
+    findActiveTask,
     buildStatusText: buildMusicGenerationTaskStatusText,
     buildStatusDetails: buildMusicGenerationTaskStatusDetails,
   });
@@ -96,9 +98,11 @@ export function createMusicGenerateStatusActionResult(
 export function createMusicGenerateDuplicateGuardResult(
   sessionKey?: string,
 ): MusicGenerateActionResult | null {
+  const findActiveTask = (key?: string) =>
+    findActiveMusicGenerationTaskForSession(key) ?? undefined;
   return createMediaGenerateDuplicateGuardResult({
     sessionKey,
-    findActiveTask: findActiveMusicGenerationTaskForSession,
+    findActiveTask,
     buildStatusText: buildMusicGenerationTaskStatusText,
     buildStatusDetails: buildMusicGenerationTaskStatusDetails,
   });

--- a/src/agents/tools/video-generate-tool.actions.ts
+++ b/src/agents/tools/video-generate-tool.actions.ts
@@ -88,10 +88,12 @@ export function createVideoGenerateListActionResult(
 export function createVideoGenerateStatusActionResult(
   sessionKey?: string,
 ): VideoGenerateActionResult {
+  const findActiveTask = (key?: string) =>
+    findActiveVideoGenerationTaskForSession(key) ?? undefined;
   return createMediaGenerateStatusActionResult({
     sessionKey,
     inactiveText: "No active video generation task is currently running for this session.",
-    findActiveTask: findActiveVideoGenerationTaskForSession,
+    findActiveTask,
     buildStatusText: buildVideoGenerationTaskStatusText,
     buildStatusDetails: buildVideoGenerationTaskStatusDetails,
   });
@@ -100,9 +102,11 @@ export function createVideoGenerateStatusActionResult(
 export function createVideoGenerateDuplicateGuardResult(
   sessionKey?: string,
 ): VideoGenerateActionResult | null {
+  const findActiveTask = (key?: string) =>
+    findActiveVideoGenerationTaskForSession(key) ?? undefined;
   return createMediaGenerateDuplicateGuardResult({
     sessionKey,
-    findActiveTask: findActiveVideoGenerationTaskForSession,
+    findActiveTask,
     buildStatusText: buildVideoGenerationTaskStatusText,
     buildStatusDetails: buildVideoGenerationTaskStatusDetails,
   });

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -178,6 +178,7 @@ export class GatewayClient {
   private tickTimer: NodeJS.Timeout | null = null;
   private readonly requestTimeoutMs: number;
   private pendingStop: PendingStop | null = null;
+  private pendingTlsIdentityError: Error | null = null;
 
   constructor(opts: GatewayClientOptions) {
     this.opts = {
@@ -229,6 +230,7 @@ export class GatewayClient {
       return;
     }
     // Allow node screen snapshots and other large responses.
+    this.pendingTlsIdentityError = null;
     const wsOptions: ClientOptions = {
       maxPayload: 25 * 1024 * 1024,
     };
@@ -247,15 +249,19 @@ export class GatewayClient {
         );
         const expected = normalizeFingerprint(this.opts.tlsFingerprint ?? "");
         if (!expected) {
-          return new Error("gateway tls fingerprint missing");
+          this.pendingTlsIdentityError = new Error("gateway tls fingerprint missing");
+          return false;
         }
         if (!fingerprint) {
-          return new Error("gateway tls fingerprint unavailable");
+          this.pendingTlsIdentityError = new Error("gateway tls fingerprint unavailable");
+          return false;
         }
         if (fingerprint !== expected) {
-          return new Error("gateway tls fingerprint mismatch");
+          this.pendingTlsIdentityError = new Error("gateway tls fingerprint mismatch");
+          return false;
         }
-        return undefined;
+        this.pendingTlsIdentityError = null;
+        return true;
       };
       wsOptions.checkServerIdentity = checkServerIdentity;
     }
@@ -263,6 +269,7 @@ export class GatewayClient {
     this.ws = ws;
 
     ws.on("open", () => {
+      this.pendingTlsIdentityError = null;
       if (url.startsWith("wss://") && this.opts.tlsFingerprint) {
         const tlsError = this.validateTlsFingerprint();
         if (tlsError) {
@@ -314,7 +321,11 @@ export class GatewayClient {
     ws.on("error", (err) => {
       logDebug(`gateway client error: ${String(err)}`);
       if (!this.connectSent) {
-        this.opts.onConnectError?.(err instanceof Error ? err : new Error(String(err)));
+        const pendingTlsError = this.pendingTlsIdentityError;
+        this.pendingTlsIdentityError = null;
+        this.opts.onConnectError?.(
+          pendingTlsError ?? (err instanceof Error ? err : new Error(String(err))),
+        );
       }
     });
   }


### PR DESCRIPTION
## Summary
Fixes https://github.com/openclaw/openclaw/issues/62279

- **Media generate tools:** `findActiveMusicGenerationTaskForSession` / `findActiveVideoGenerationTaskForSession` return `null`, but `createMediaGenerate*` expects `undefined`. Wrap with `?? undefined` at the call site.
- **Gateway client:** `ws` `ClientOptions["checkServerIdentity"]` is typed to return `boolean`. Return booleans and stash a concrete `Error` for `onConnectError` when the TLS handshake fails (fingerprint missing / unavailable / mismatch).

## Test plan
- [x] `pnpm build:plugin-sdk:dts`
- [x] `pnpm build`


Made with [Cursor](https://cursor.com)