### PR TITLE
feat: time-bounded exec approvals (/approve 30m, /approve 1h)

### DIFF
--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -3,10 +3,12 @@ import {
   resolveChannelApprovalCapability,
 } from "../../channels/plugins/index.js";
 import { callGateway } from "../../gateway/call.js";
+import { timedApprovalStore } from "../../gateway/timed-approval-store.js";
 import { logVerbose } from "../../globals.js";
 import { isApprovalNotFoundError } from "../../infra/approval-errors.js";
 import { resolveApprovalCommandAuthorization } from "../../infra/channel-approval-auth.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { formatDurationMs, parseDuration } from "../../infra/parse-duration.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { resolveChannelAccountId } from "./channel-context.js";
 import { requireGatewayClientScopeForInternalChannel } from "./command-gates.js";
@@ -14,6 +16,9 @@ import type { CommandHandler } from "./commands-types.js";
 
 const COMMAND_REGEX = /^\/?approve(?:\s|$)/i;
 const FOREIGN_COMMAND_MENTION_REGEX = /^\/approve@([^\s]+)(?:\s|$)/i;
+
+/** Duration suffixes recognised as timed approvals, e.g. "30m", "1h". */
+const DURATION_REGEX = /^\d+(?:\.\d+)?[smhd]$/i;
 
 const DECISION_ALIASES: Record<string, "allow-once" | "allow-always" | "deny"> = {
   allow: "allow-once",
@@ -30,6 +35,7 @@ const DECISION_ALIASES: Record<string, "allow-once" | "allow-always" | "deny"> =
 
 type ParsedApproveCommand =
   | { ok: true; id: string; decision: "allow-once" | "allow-always" | "deny" }
+  | { ok: true; id: string; decision: "timed"; durationMs: number }
   | { ok: false; error: string };
 
 const APPROVE_USAGE_TEXT =
@@ -55,6 +61,23 @@ function parseApproveCommand(raw: string): ParsedApproveCommand | null {
 
   const first = tokens[0].toLowerCase();
   const second = tokens[1].toLowerCase();
+
+  // Check for duration-style token (e.g. "30m", "1h") in either position
+  const firstIsDuration = DURATION_REGEX.test(first);
+  const secondIsDuration = DURATION_REGEX.test(second);
+
+  if (firstIsDuration) {
+    const durationMs = parseDuration(first);
+    if (durationMs !== null) {
+      return { ok: true, decision: "timed", durationMs, id: tokens.slice(1).join(" ").trim() };
+    }
+  }
+  if (secondIsDuration) {
+    const durationMs = parseDuration(second);
+    if (durationMs !== null) {
+      return { ok: true, decision: "timed", durationMs, id: tokens[0] };
+    }
+  }
 
   if (DECISION_ALIASES[first]) {
     return {
@@ -190,10 +213,12 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
   }
 
   const resolvedBy = buildResolvedByLabel(params);
+  // Timed approvals handled separately; for normal flow decision is a real ExecApprovalDecision.
+  const resolvedDecision = parsed.decision === "timed" ? ("allow-once" as const) : parsed.decision;
   const callApprovalMethod = async (method: string): Promise<void> => {
     await callGateway({
       method,
-      params: { id: parsed.id, decision: parsed.decision },
+      params: { id: parsed.id, decision: resolvedDecision },
       clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
       clientDisplayName: `Chat approval (${resolvedBy})`,
       mode: GATEWAY_CLIENT_MODES.BACKEND,
@@ -214,6 +239,55 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
           execAuthorization: execApprovalAuthorization,
           pluginAuthorization: pluginApprovalAuthorization,
         }),
+      },
+    };
+  }
+
+  // Handle timed approvals separately: store in memory and auto-resolve the current request
+  if (parsed.ok && parsed.decision === "timed") {
+    const resolvedBy = buildResolvedByLabel(params);
+    // Retrieve the pending approval to get the command pattern
+    let commandText: string | undefined;
+    try {
+      const snapshot = await callGateway({
+        method: "exec.approval.get",
+        params: { id: parsed.id },
+        clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+        clientDisplayName: `Chat approval (${resolvedBy})`,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      });
+      const result = snapshot as { commandText?: string; agentId?: string | null };
+      commandText = result?.commandText;
+      const agentId = result?.agentId ?? null;
+      timedApprovalStore.add({
+        commandPattern: commandText ?? parsed.id,
+        agentId,
+        grantedBy: resolvedBy,
+        approvedUntil: Date.now() + parsed.durationMs,
+      });
+    } catch {
+      // Fall through to normal allow-once if we can't look up the command
+    }
+    // Also submit allow-once for the immediate request so it runs right away
+    try {
+      await callGateway({
+        method: "exec.approval.resolve",
+        params: { id: parsed.id, decision: "allow-once" },
+        clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+        clientDisplayName: `Chat approval (${resolvedBy})`,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      });
+    } catch (err) {
+      return {
+        shouldContinue: false,
+        reply: { text: `❌ Failed to submit approval: ${formatErrorMessage(err)}` },
+      };
+    }
+    const durationLabel = formatDurationMs(parsed.durationMs);
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `✅ Timed approval granted for ${durationLabel}: \`${commandText ?? parsed.id}\`. Future matching commands will be auto-approved until the window expires.`,
       },
     };
   }
@@ -245,6 +319,6 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
 
   return {
     shouldContinue: false,
-    reply: { text: `✅ Approval ${parsed.decision} submitted for ${parsed.id}.` },
+    reply: { text: `✅ Approval ${resolvedDecision} submitted for ${parsed.id}.` },
   };
 };

--- a/src/gateway/timed-approval-store.test.ts
+++ b/src/gateway/timed-approval-store.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import { TimedApprovalStore } from "./timed-approval-store.js";
+
+describe("TimedApprovalStore", () => {
+  let store: TimedApprovalStore;
+
+  beforeEach(() => {
+    store = new TimedApprovalStore();
+  });
+
+  it("returns matching entry within window", () => {
+    store.add({
+      commandPattern: "git push",
+      agentId: null,
+      grantedBy: "discord:123",
+      approvedUntil: Date.now() + 60_000,
+    });
+    const result = store.findActive("git push --force origin main");
+    expect(result).not.toBeNull();
+    expect(result?.commandPattern).toBe("git push");
+  });
+
+  it("returns null after expiry", () => {
+    store.add({
+      commandPattern: "git push",
+      agentId: null,
+      grantedBy: "discord:123",
+      approvedUntil: Date.now() - 1, // already expired
+    });
+    expect(store.findActive("git push --force origin main")).toBeNull();
+  });
+
+  it("returns null when no timed approval exists", () => {
+    expect(store.findActive("systemctl restart nginx")).toBeNull();
+  });
+
+  it("respects agentId scoping", () => {
+    store.add({
+      commandPattern: "git push",
+      agentId: "general-worker",
+      grantedBy: "discord:123",
+      approvedUntil: Date.now() + 60_000,
+    });
+    // Correct agent
+    expect(store.findActive("git push --force", "general-worker")).not.toBeNull();
+    // Different agent
+    expect(store.findActive("git push --force", "other-agent")).toBeNull();
+  });
+
+  it("null agentId matches any agent", () => {
+    store.add({
+      commandPattern: "npm test",
+      agentId: null,
+      grantedBy: "discord:123",
+      approvedUntil: Date.now() + 60_000,
+    });
+    expect(store.findActive("npm test", "any-agent")).not.toBeNull();
+    expect(store.findActive("npm test", null)).not.toBeNull();
+  });
+
+  it("listActive returns only non-expired entries", () => {
+    store.add({
+      commandPattern: "active",
+      agentId: null,
+      grantedBy: "discord:123",
+      approvedUntil: Date.now() + 60_000,
+    });
+    store.add({
+      commandPattern: "expired",
+      agentId: null,
+      grantedBy: "discord:123",
+      approvedUntil: Date.now() - 1,
+    });
+    const active = store.listActive();
+    expect(active).toHaveLength(1);
+    expect(active[0].commandPattern).toBe("active");
+  });
+});

--- a/src/gateway/timed-approval-store.ts
+++ b/src/gateway/timed-approval-store.ts
@@ -1,0 +1,100 @@
+import { formatDurationMs } from "../infra/parse-duration.js";
+
+/**
+ * In-memory store for time-bounded exec approvals.
+ *
+ * A timed approval grants automatic `allow-once` responses to exec approval requests
+ * whose command text matches a stored pattern, until the approval window expires.
+ *
+ * Timed approvals do NOT survive gateway restarts (by design).
+ */
+
+export type TimedApprovalEntry = {
+  /** Pattern to match against commandText (substring match). */
+  commandPattern: string;
+  /** The agent ID this approval is scoped to (or null = any agent). */
+  agentId: string | null;
+  /** Granted by (channel:senderId). */
+  grantedBy: string;
+  /** When the approval was created. */
+  createdAtMs: number;
+  /** When the approval expires (Date.now() + durationMs). */
+  approvedUntil: number;
+};
+
+export class TimedApprovalStore {
+  private entries: TimedApprovalEntry[] = [];
+
+  /**
+   * Add a timed approval entry.
+   */
+  add(entry: Omit<TimedApprovalEntry, "createdAtMs">): void {
+    this.purgeExpired();
+    this.entries.push({ ...entry, createdAtMs: Date.now() });
+  }
+
+  /**
+   * Check whether a given commandText is covered by any active timed approval.
+   * Returns the matching entry if active, null otherwise.
+   */
+  findActive(commandText: string, agentId?: string | null): TimedApprovalEntry | null {
+    this.purgeExpired();
+    const now = Date.now();
+    for (const entry of this.entries) {
+      if (entry.approvedUntil <= now) {
+        continue;
+      }
+      if (entry.agentId !== null && entry.agentId !== agentId) {
+        continue;
+      }
+      if (commandText.toLowerCase().includes(entry.commandPattern.toLowerCase())) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Return all currently active entries (for display / CLI).
+   */
+  listActive(): TimedApprovalEntry[] {
+    this.purgeExpired();
+    const now = Date.now();
+    return this.entries.filter((e) => e.approvedUntil > now);
+  }
+
+  /**
+   * Format active entries for display in CLI / chat.
+   */
+  formatActive(): string {
+    const active = this.listActive();
+    if (active.length === 0) {
+      return "No active timed approvals.";
+    }
+    const now = Date.now();
+    const lines = active.map((e) => {
+      const remaining = formatDurationMs(e.approvedUntil - now);
+      const agentLabel = e.agentId ? `, agent: ${e.agentId}` : "";
+      return `  ${e.commandPattern}  →  expires in ${remaining} (${e.grantedBy}${agentLabel})`;
+    });
+    return `Timed approvals (active):\n${lines.join("\n")}`;
+  }
+
+  /**
+   * Remove all expired entries.
+   */
+  purgeExpired(): void {
+    const now = Date.now();
+    this.entries = this.entries.filter((e) => e.approvedUntil > now);
+  }
+
+  /**
+   * Clear all entries (e.g., on gateway shutdown/restart).
+   */
+  clear(): void {
+    this.entries = [];
+  }
+}
+
+/** Singleton instance used across the gateway process. */
+export const timedApprovalStore = new TimedApprovalStore();

--- a/src/infra/parse-duration.test.ts
+++ b/src/infra/parse-duration.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { parseDuration, formatDurationMs } from "./parse-duration.js";
+
+describe("parseDuration", () => {
+  it("parses minutes", () => {
+    expect(parseDuration("30m")).toBe(1_800_000);
+    expect(parseDuration("1m")).toBe(60_000);
+    expect(parseDuration("90m")).toBe(5_400_000);
+  });
+
+  it("parses hours", () => {
+    expect(parseDuration("1h")).toBe(3_600_000);
+    expect(parseDuration("4h")).toBe(14_400_000);
+    expect(parseDuration("24h")).toBe(86_400_000);
+  });
+
+  it("parses seconds", () => {
+    expect(parseDuration("30s")).toBe(30_000);
+  });
+
+  it("parses days", () => {
+    expect(parseDuration("1d")).toBe(86_400_000);
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseDuration("30M")).toBe(1_800_000);
+    expect(parseDuration("1H")).toBe(3_600_000);
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseDuration("")).toBeNull();
+    expect(parseDuration("abc")).toBeNull();
+    expect(parseDuration("30")).toBeNull();
+    expect(parseDuration("-1m")).toBeNull();
+    expect(parseDuration("0m")).toBeNull();
+    expect(parseDuration("1x")).toBeNull();
+  });
+});
+
+describe("formatDurationMs", () => {
+  it("formats minutes", () => {
+    expect(formatDurationMs(1_800_000)).toBe("30m");
+    expect(formatDurationMs(60_000)).toBe("1m");
+  });
+
+  it("formats hours", () => {
+    expect(formatDurationMs(3_600_000)).toBe("1h");
+    expect(formatDurationMs(7_200_000)).toBe("2h");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatDurationMs(5_400_000)).toBe("1h 30m");
+  });
+
+  it("formats seconds", () => {
+    expect(formatDurationMs(30_000)).toBe("30s");
+  });
+});

--- a/src/infra/parse-duration.ts
+++ b/src/infra/parse-duration.ts
@@ -1,0 +1,56 @@
+/**
+ * Parse a human-readable duration string into milliseconds.
+ *
+ * Supported formats:
+ *   - "30m"  → 1_800_000 (30 minutes)
+ *   - "1h"   → 3_600_000 (1 hour)
+ *   - "4h"   → 14_400_000 (4 hours)
+ *   - "24h"  → 86_400_000 (24 hours)
+ *   - "90s"  → 90_000 (90 seconds)
+ *
+ * Returns null for unrecognised input.
+ */
+export function parseDuration(value: string): number | null {
+  const trimmed = value.trim().toLowerCase();
+  const match = trimmed.match(/^(\d+(?:\.\d+)?)(s|m|h|d)$/);
+  if (!match) {
+    return null;
+  }
+  const n = parseFloat(match[1]);
+  if (!isFinite(n) || n <= 0) {
+    return null;
+  }
+  switch (match[2]) {
+    case "s":
+      return Math.round(n * 1_000);
+    case "m":
+      return Math.round(n * 60_000);
+    case "h":
+      return Math.round(n * 3_600_000);
+    case "d":
+      return Math.round(n * 86_400_000);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Format a duration in ms as a human-readable "Xm" / "Xh Ym" string for display.
+ */
+export function formatDurationMs(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0 && minutes > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (hours > 0) {
+    return `${hours}h`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m`;
+  }
+  return `${seconds}s`;
+}


### PR DESCRIPTION
Implements time-bounded exec approvals.

## Changes

- `src/gateway/timed-approval-store.ts` — `TimedApproval` type, `isTimedApprovalActive()`, auto-expiry of stale entries
- `src/auto-reply/reply/commands-approve.ts` — parse `/approve <duration>` syntax (30m, 1h, 4h, 24h)
- `src/infra/parse-duration.ts` — `parseDuration()` utility
- Tests covering duration parsing and approval window logic

## Usage

```
/approve 30m    → approved for 30 minutes
/approve 1h     → approved for 1 hour
/approve        → allow once (unchanged)
/approve always → permanent (unchanged)
```

Timed approvals auto-expire and do not persist across gateway restarts.