### PR TITLE
feat(whatsapp): handle message edits and revocations

### DIFF
--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -85,6 +85,22 @@ export async function monitorWebInbox(options: {
   // flushed to the agent). Used by the messages.update handler to silently
   // swap in the edited text before the agent ever sees the original.
   const pendingMessageIds = new Map<string, WebInboundMessage>();
+  // Track message IDs that have been fully processed (flushed + onMessage
+  // completed). Only edits to these messages trigger a notification — this
+  // prevents edits to ignored, historical, or access-denied messages from
+  // producing unexpected outbound replies.
+  const processedMessageIds = new Set<string>();
+  const MAX_PROCESSED_IDS = 512;
+  const rememberProcessedId = (id: string) => {
+    if (processedMessageIds.size >= MAX_PROCESSED_IDS) {
+      // Evict the oldest entry (Sets preserve insertion order).
+      const first = processedMessageIds.values().next().value;
+      if (first !== undefined) {
+        processedMessageIds.delete(first);
+      }
+    }
+    processedMessageIds.add(id);
+  };
 
   const debouncer = createInboundDebouncer<WebInboundMessage>({
     debounceMs: options.debounceMs ?? 0,
@@ -106,37 +122,43 @@ export async function monitorWebInbox(options: {
     },
     shouldDebounce: options.shouldDebounce,
     onFlush: async (entries) => {
-      // Clear pending tracking for all flushed entries.
-      for (const entry of entries) {
-        if (entry.id) {
-          pendingMessageIds.delete(entry.id);
-        }
-      }
       const last = entries.at(-1);
       if (!last) {
         return;
       }
+      let messageToDeliver: WebInboundMessage;
       if (entries.length === 1) {
-        await options.onMessage(last);
-        return;
+        messageToDeliver = last;
+      } else {
+        const mentioned = new Set<string>();
+        for (const entry of entries) {
+          for (const jid of entry.mentions ?? entry.mentionedJids ?? []) {
+            mentioned.add(jid);
+          }
+        }
+        const combinedBody = entries
+          .map((entry) => entry.body)
+          .filter(Boolean)
+          .join("\n");
+        messageToDeliver = {
+          ...last,
+          body: combinedBody,
+          mentions: mentioned.size > 0 ? Array.from(mentioned) : undefined,
+          mentionedJids: mentioned.size > 0 ? Array.from(mentioned) : undefined,
+        };
       }
-      const mentioned = new Set<string>();
+      // Deliver first, then update tracking. This closes the race where an
+      // edit event arrives after pendingMessageIds is cleared but before
+      // onMessage completes — without this ordering, Case 2 would fire
+      // a "already processed" notification while the agent is still handling
+      // the original body.
+      await options.onMessage(messageToDeliver);
       for (const entry of entries) {
-        for (const jid of entry.mentions ?? entry.mentionedJids ?? []) {
-          mentioned.add(jid);
+        if (entry.id) {
+          pendingMessageIds.delete(entry.id);
+          rememberProcessedId(entry.id);
         }
       }
-      const combinedBody = entries
-        .map((entry) => entry.body)
-        .filter(Boolean)
-        .join("\n");
-      const combinedMessage: WebInboundMessage = {
-        ...last,
-        body: combinedBody,
-        mentions: mentioned.size > 0 ? Array.from(mentioned) : undefined,
-        mentionedJids: mentioned.size > 0 ? Array.from(mentioned) : undefined,
-      };
-      await options.onMessage(combinedMessage);
     },
     onError: (err) => {
       inboundLogger.error({ error: String(err) }, "failed handling inbound web message");
@@ -581,19 +603,24 @@ export async function monitorWebInbox(options: {
         if (shouldLogVerbose()) {
           logVerbose(`Swapped pending message ${msgId} body to edited version: "${editedBody}"`);
         }
-      } else {
-        // ⚠️ Case 2: Already flushed — notify the user that we've seen an edit
-        // after the fact so they can decide whether to resend.
+      } else if (processedMessageIds.has(msgId)) {
+        // ⚠️ Case 2: Already flushed and confirmed processed — notify the user
+        // that we've seen an edit after the fact so they can decide to resend.
+        // We only notify for messages that passed access-control and were
+        // actually delivered to the agent; edits to ignored or historical
+        // messages are silently dropped.
         if (shouldLogVerbose()) {
-          logVerbose(`Edit received for already-flushed message ${msgId} — notifying user`);
+          logVerbose(`Edit received for already-processed message ${msgId} — notifying user`);
         }
         try {
           await sendTrackedMessage(remoteJid, {
-            text: `✏️ (你刚才编辑了一条消息，但我已经处理了原版。如果想重新处理，请把新内容重新发一遍。)`,
+            text: `✏️ (You edited a message I already processed. If you'd like me to handle the updated version, please resend it.)`,
           });
         } catch (err) {
           logVerbose(`Failed to send edit-notification for ${msgId}: ${String(err)}`);
         }
+      } else {
+        logVerbose(`Edit received for unknown/ignored message ${msgId} — skipping notification`);
       }
     }
   };

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -152,11 +152,17 @@ export async function monitorWebInbox(options: {
       // onMessage completes — without this ordering, Case 2 would fire
       // a "already processed" notification while the agent is still handling
       // the original body.
-      await options.onMessage(messageToDeliver);
-      for (const entry of entries) {
-        if (entry.id) {
-          pendingMessageIds.delete(entry.id);
-          rememberProcessedId(entry.id);
+      // Use try/finally so bookkeeping always runs even if onMessage rejects.
+      // Without this, a failed flush leaves IDs stuck in pendingMessageIds
+      // indefinitely, causing stale entries to misclassify later edits.
+      try {
+        await options.onMessage(messageToDeliver);
+      } finally {
+        for (const entry of entries) {
+          if (entry.id) {
+            pendingMessageIds.delete(entry.id);
+            rememberProcessedId(entry.id);
+          }
         }
       }
     },
@@ -550,8 +556,13 @@ export async function monitorWebInbox(options: {
       const msgId = key.id;
       const remoteJid = key.remoteJid;
 
-      // Only handle edits/revocations originating from the user (not fromMe = bot's own messages).
-      if (!msgId || !remoteJid || key.fromMe) {
+      // Skip messages with no id or remoteJid.
+      // Do NOT skip fromMe unconditionally: in self-chat mode the owner's own
+      // messages have fromMe=true but should still be tracked for edits.
+      // Instead, skip only outbound bot messages that were sent by sendTrackedMessage
+      // (those are already filtered by the rememberRecentOutboundMessage dedupe path
+      // in normalizeInboundMessage and will not be in pendingMessageIds).
+      if (!msgId || !remoteJid) {
         continue;
       }
 

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -152,16 +152,22 @@ export async function monitorWebInbox(options: {
       // onMessage completes — without this ordering, Case 2 would fire
       // a "already processed" notification while the agent is still handling
       // the original body.
-      // Use try/finally so bookkeeping always runs even if onMessage rejects.
-      // Without this, a failed flush leaves IDs stuck in pendingMessageIds
-      // indefinitely, causing stale entries to misclassify later edits.
+      // Use try/finally so pendingMessageIds is always cleared even if
+      // onMessage rejects — preventing stale entries from accumulating.
+      // rememberProcessedId runs only on success: a failed flush means the
+      // agent never actually processed the message, so later edits should
+      // not trigger a "already processed" notification.
+      let deliverySucceeded = false;
       try {
         await options.onMessage(messageToDeliver);
+        deliverySucceeded = true;
       } finally {
         for (const entry of entries) {
           if (entry.id) {
             pendingMessageIds.delete(entry.id);
-            rememberProcessedId(entry.id);
+            if (deliverySucceeded) {
+              rememberProcessedId(entry.id);
+            }
           }
         }
       }

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -81,6 +81,11 @@ export async function monitorWebInbox(options: {
     options.authDir,
     sock.user as { id?: string | null; lid?: string | null } | undefined,
   );
+  // Track message IDs that are currently buffered in the debouncer (not yet
+  // flushed to the agent). Used by the messages.update handler to silently
+  // swap in the edited text before the agent ever sees the original.
+  const pendingMessageIds = new Map<string, WebInboundMessage>();
+
   const debouncer = createInboundDebouncer<WebInboundMessage>({
     debounceMs: options.debounceMs ?? 0,
     buildKey: (msg) => {
@@ -101,6 +106,12 @@ export async function monitorWebInbox(options: {
     },
     shouldDebounce: options.shouldDebounce,
     onFlush: async (entries) => {
+      // Clear pending tracking for all flushed entries.
+      for (const entry of entries) {
+        if (entry.id) {
+          pendingMessageIds.delete(entry.id);
+        }
+      }
       const last = entries.at(-1);
       if (!last) {
         return;
@@ -447,6 +458,11 @@ export async function monitorWebInbox(options: {
       mediaType: enriched.mediaType,
       mediaFileName: enriched.mediaFileName,
     };
+    // Register this message as pending so the edit handler can swap its body
+    // before the debouncer flushes it to the agent.
+    if (inboundMessage.id) {
+      pendingMessageIds.set(inboundMessage.id, inboundMessage);
+    }
     try {
       const task = Promise.resolve(debouncer.enqueue(inboundMessage));
       void task.catch((err) => {
@@ -495,6 +511,93 @@ export async function monitorWebInbox(options: {
       await enqueueInboundMessage(msg, inbound, enriched);
     }
   };
+  // Handle message edits and revocations from WhatsApp.
+  //
+  // Two cases:
+  //   1. Message is still pending in the debouncer → silently swap the body,
+  //      the agent never sees the original typo.
+  //   2. Message already flushed (agent already replied) → send a notification
+  //      so the user knows their edit was seen after the fact.
+  const handleMessagesUpdate = async (
+    updates: Array<{
+      update: Partial<WAMessage>;
+      key: { id?: string; remoteJid?: string; fromMe?: boolean };
+    }>,
+  ) => {
+    for (const { update, key } of updates) {
+      const msgId = key.id;
+      const remoteJid = key.remoteJid;
+
+      // Only handle edits/revocations originating from the user (not fromMe = bot's own messages).
+      if (!msgId || !remoteJid || key.fromMe) {
+        continue;
+      }
+
+      // Detect revocation: protocolMessage with type REVOKE (0).
+      const protocolMsg = update.message?.protocolMessage;
+      const isRevoke =
+        protocolMsg != null &&
+        (protocolMsg.type === 0 || (protocolMsg as { type?: number }).type === 0);
+
+      if (isRevoke) {
+        logVerbose(`Message ${msgId} revoked by user — ignoring`);
+        continue;
+      }
+
+      // Detect edit: editedMessage present in the protocol message (type 14).
+      const isEdit =
+        protocolMsg != null &&
+        ((protocolMsg as { type?: number }).type === 14 || protocolMsg.editedMessage != null);
+
+      if (!isEdit) {
+        continue;
+      }
+
+      // Extract new text from the edited message.
+      // protocolMsg.editedMessage is proto.IMessage, which has .conversation
+      // and .extendedTextMessage directly (no intermediate .message wrapper).
+      const editedMsg = protocolMsg?.editedMessage as
+        | { conversation?: string | null; extendedTextMessage?: { text?: string | null } | null }
+        | null
+        | undefined;
+      const editedBody = editedMsg?.conversation ?? editedMsg?.extendedTextMessage?.text ?? null;
+
+      if (!editedBody) {
+        logVerbose(`Edit event for ${msgId} had no extractable text — skipping`);
+        continue;
+      }
+
+      recordChannelActivity({
+        channel: "whatsapp",
+        accountId: options.accountId,
+        direction: "inbound",
+      });
+
+      const pending = pendingMessageIds.get(msgId);
+      if (pending) {
+        // ✅ Case 1: Still buffered — swap the body in place. The debouncer
+        // will flush the updated version; the agent sees only the corrected text.
+        pending.body = editedBody;
+        if (shouldLogVerbose()) {
+          logVerbose(`Swapped pending message ${msgId} body to edited version: "${editedBody}"`);
+        }
+      } else {
+        // ⚠️ Case 2: Already flushed — notify the user that we've seen an edit
+        // after the fact so they can decide whether to resend.
+        if (shouldLogVerbose()) {
+          logVerbose(`Edit received for already-flushed message ${msgId} — notifying user`);
+        }
+        try {
+          await sendTrackedMessage(remoteJid, {
+            text: `✏️ (你刚才编辑了一条消息，但我已经处理了原版。如果想重新处理，请把新内容重新发一遍。)`,
+          });
+        } catch (err) {
+          logVerbose(`Failed to send edit-notification for ${msgId}: ${String(err)}`);
+        }
+      }
+    }
+  };
+
   const handleConnectionUpdate = (
     update: Partial<import("@whiskeysockets/baileys").ConnectionState>,
   ) => {
@@ -521,6 +624,15 @@ export async function monitorWebInbox(options: {
     "messages.upsert",
     handleMessagesUpsert as unknown as (...args: unknown[]) => void,
   );
+  const detachMessagesUpdate = attachEmitterListener(
+    sock.ev as unknown as {
+      on: (event: string, listener: (...args: unknown[]) => void) => void;
+      off?: (event: string, listener: (...args: unknown[]) => void) => void;
+      removeListener?: (event: string, listener: (...args: unknown[]) => void) => void;
+    },
+    "messages.update",
+    handleMessagesUpdate as unknown as (...args: unknown[]) => void,
+  );
   const detachConnectionUpdate = attachEmitterListener(
     sock.ev as unknown as {
       on: (event: string, listener: (...args: unknown[]) => void) => void;
@@ -543,6 +655,7 @@ export async function monitorWebInbox(options: {
     close: async () => {
       try {
         detachMessagesUpsert();
+        detachMessagesUpdate();
         detachConnectionUpdate();
         closeInboundMonitorSocket(sock);
       } catch (err) {


### PR DESCRIPTION
## Summary

This PR adds support for WhatsApp's native message edit feature, which was introduced in 2023.

Currently, if a user accidentally sends an incomplete message and then edits it in WhatsApp, the OpenClaw agent processes the original (unedited) version and has no awareness of the correction.

## Behaviour

Two cases are handled depending on timing:

**Case 1 — Message still buffered (agent has not replied yet)**
The edited body is swapped in-place before the debouncer flushes to the agent. The agent sees only the corrected text, as if the typo never happened. No visible change for the user.

**Case 2 — Message already flushed (agent already replied)**
A short notification is sent to the user letting them know the edit arrived after the fact, and asking them to resend if they want the corrected version processed.

Revocations (`protocolMessage.type === REVOKE`) are silently ignored with a verbose log.

## Implementation

Only **one file** changed: `extensions/whatsapp/src/inbound/monitor.ts`

- Added `pendingMessageIds: Map<string, WebInboundMessage>` to track messages currently buffered in the debouncer
- Entries are added when a message is enqueued and removed when flushed
- Added `handleMessagesUpdate` async handler that listens to the Baileys `messages.update` event
- Handler detects edits via `protocolMessage.editedMessage` (type 14) and extracts text from `conversation` or `extendedTextMessage.text`
- Listener is properly registered via `attachEmitterListener` and detached on socket close

## Testing

All existing checks pass:
- `pnpm format:check` ✅
- `pnpm tsgo` (TypeScript) ✅  
- `pnpm lint` (oxlint) ✅
- All custom lint rules ✅

## Related

Baileys events reference: `messages.update` emits `WAMessageUpdate[]` where each entry has `key` + `update: Partial<WAMessage>`.
