### PR TITLE
fix(docker): use built bundled plugins in runtime images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/doctor: keep top-level access-control fallback in place during multi-account normalization while still promoting legacy default auth into `accounts.default`, so existing named bots keep inherited allowlists without dropping the legacy default bot. (#62263) Thanks @obviyus.
 - Agents/subagents: honor `sessions_spawn(lightContext: true)` for spawned subagent runs by preserving lightweight bootstrap context through the gateway and embedded runner instead of silently falling back to full workspace bootstrap injection. (#62264) Thanks @theSamPadilla.
 - Slack/media: keep attachment downloads on the SSRF-guarded dispatcher path so Slack media fetching works on Node 22 without dropping pinned transport enforcement. (#62239) Thanks @openperf.
+- Docker/plugins: stop forcing bundled plugin discovery to `/app/extensions` in runtime images so packaged installs use compiled `dist/extensions` artifacts again and Node 24 containers do not boot through source-only plugin entry paths. Fixes #62044.
 
 ## 2026.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/doctor: keep top-level access-control fallback in place during multi-account normalization while still promoting legacy default auth into `accounts.default`, so existing named bots keep inherited allowlists without dropping the legacy default bot. (#62263) Thanks @obviyus.
 - Agents/subagents: honor `sessions_spawn(lightContext: true)` for spawned subagent runs by preserving lightweight bootstrap context through the gateway and embedded runner instead of silently falling back to full workspace bootstrap injection. (#62264) Thanks @theSamPadilla.
 - Slack/media: keep attachment downloads on the SSRF-guarded dispatcher path so Slack media fetching works on Node 22 without dropping pinned transport enforcement. (#62239) Thanks @openperf.
-- Docker/plugins: stop forcing bundled plugin discovery to `/app/extensions` in runtime images so packaged installs use compiled `dist/extensions` artifacts again and Node 24 containers do not boot through source-only plugin entry paths. Fixes #62044.
+- Docker/plugins: stop forcing bundled plugin discovery to `/app/extensions` in runtime images so packaged installs use compiled `dist/extensions` artifacts again and Node 24 containers do not boot through source-only plugin entry paths. Fixes #62044. (#62316) Thanks @gumadeiras.
 
 ## 2026.4.5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,10 +160,6 @@ COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 COPY --from=runtime-assets --chown=node:node /app/qa ./qa
 
-# In npm-installed Docker images, prefer the copied source extension tree for
-# bundled discovery so package metadata that points at source entries stays valid.
-ENV OPENCLAW_BUNDLED_PLUGINS_DIR=/app/${OPENCLAW_BUNDLED_PLUGIN_DIR}
-
 # Keep pnpm available in the runtime image for container-local workflows.
 # Use a shared Corepack home so the non-root `node` user does not need a
 # first-run network fetch when invoking pnpm.

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -50,12 +50,10 @@ describe("Dockerfile", () => {
     );
   });
 
-  it("pins bundled plugin discovery to copied source extensions in runtime images", async () => {
+  it("does not override bundled plugin discovery in runtime images", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     expect(dockerfile).toContain(`ARG OPENCLAW_BUNDLED_PLUGIN_DIR=${BUNDLED_PLUGIN_ROOT_DIR}`);
-    expect(dockerfile).toContain(
-      "ENV OPENCLAW_BUNDLED_PLUGINS_DIR=/app/${OPENCLAW_BUNDLED_PLUGIN_DIR}",
-    );
+    expect(dockerfile).not.toContain("ENV OPENCLAW_BUNDLED_PLUGINS_DIR=");
   });
 
   it("normalizes plugin and agent paths permissions in image layers", async () => {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -7,6 +7,10 @@ import { BUNDLED_PLUGIN_ROOT_DIR } from "../test/helpers/bundled-plugin-paths.js
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
 
+function collapseDockerContinuations(dockerfile: string): string {
+  return dockerfile.replace(/\\\r?\n[ \t]*/g, " ");
+}
+
 describe("Dockerfile", () => {
   it("uses shared multi-arch base image refs for all root Node stages", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
@@ -51,9 +55,9 @@ describe("Dockerfile", () => {
   });
 
   it("does not override bundled plugin discovery in runtime images", async () => {
-    const dockerfile = await readFile(dockerfilePath, "utf8");
+    const dockerfile = collapseDockerContinuations(await readFile(dockerfilePath, "utf8"));
     expect(dockerfile).toContain(`ARG OPENCLAW_BUNDLED_PLUGIN_DIR=${BUNDLED_PLUGIN_ROOT_DIR}`);
-    expect(dockerfile).not.toContain("ENV OPENCLAW_BUNDLED_PLUGINS_DIR=");
+    expect(dockerfile).not.toMatch(/^\s*ENV\b[^\n]*\bOPENCLAW_BUNDLED_PLUGINS_DIR\b/m);
   });
 
   it("normalizes plugin and agent paths permissions in image layers", async () => {


### PR DESCRIPTION
## Summary

- Problem: the Docker runtime image forced bundled plugin discovery to `/app/extensions`, which made packaged installs load raw source plugin entries instead of compiled runtime artifacts.
- Why it matters: on Node 24 this can boot through source-only plugin paths and crash fresh containers, with Matrix surfacing first in issue #62044.
- What changed: removed the Docker `OPENCLAW_BUNDLED_PLUGINS_DIR` override so packaged installs fall back to the normal resolver and use `dist/extensions`; updated the Dockerfile guard test; added a changelog fix entry.
- What did NOT change (scope boundary): no plugin loader redesign, no source-runtime compatibility work, no broader plugin import refactor.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #62044
- Related #50058
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: commit `a2a9a553e1e03fcd6a3ec01196f3cd7b58710b7e` added a Docker runtime override that pinned `OPENCLAW_BUNDLED_PLUGINS_DIR` to `/app/extensions`, bypassing the packaged-install resolver that already prefers `dist/extensions`.
- Missing detection / guardrail: the Dockerfile test locked in the source-tree override instead of asserting packaged-runtime default behavior.
- Contributing context (if known): the issue became user-visible after the Node 24 runtime image path started executing against source plugin graphs that are not the intended packaged runtime surface.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/dockerfile.test.ts`
- Scenario the test should lock in: runtime images must not override bundled plugin discovery away from packaged defaults.
- Why this is the smallest reliable guardrail: the regression was introduced directly in the Dockerfile and guarded by a Dockerfile-specific test.
- Existing test that already covers this (if any): `src/plugins/bundled-dir.test.ts` already covers packaged-install preference for `dist/extensions`.
- If no new test is added, why not: existing Dockerfile guard test was updated instead of adding a duplicate.

## User-visible / Behavior Changes

Docker runtime images now use compiled bundled plugin artifacts again instead of forcing source plugin discovery.

## Diagram (if applicable)

```text
Before:
[docker runtime] -> [/app/extensions override] -> [source plugin entrypoints] -> [Node 24 source-path crash]

After:
[docker runtime] -> [default packaged resolver] -> [dist/extensions] -> [compiled plugin artifacts]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo runtime; Docker packaging path
- Model/provider: N/A
- Integration/channel (if any): bundled Matrix plugin as first visible reproducer
- Relevant config (redacted): default packaged bundled-plugin resolution

### Steps

1. Inspect Docker runtime image config and bundled plugin resolver behavior.
2. Verify source bundled plugin path is forced by the Dockerfile override.
3. Remove the override so packaged installs fall back to `dist/extensions`.
4. Run targeted tests and full build.

### Expected

- Packaged Docker/runtime installs use compiled bundled plugin artifacts.

### Actual

- Before fix, Docker runtime images forced source plugin discovery.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test src/dockerfile.test.ts src/plugins/bundled-dir.test.ts`; `pnpm build`
- Edge cases checked: packaged resolver still prefers built bundled artifacts; Dockerfile no longer pins the wrong runtime env var.
- What you did **not** verify: full rebuilt Docker image boot smoke.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a Docker-specific workflow may have been relying on source plugin discovery.
  - Mitigation: packaged installs already prefer `dist/extensions`, and the built plugin manifests are the intended runtime surface.
