### PR TITLE
fix(speech-core): send Weixin TTS as voice notes

### DIFF
--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { _test } from "./tts.js";
+
+describe("speech-core TTS voice-note routing", () => {
+  it("treats openclaw-weixin as a voice-note-capable channel", () => {
+    expect(_test.supportsVoiceNoteReplies("openclaw-weixin")).toBe(true);
+  });
+
+  it("keeps non-voice-note channels on the regular audio-file path", () => {
+    expect(_test.supportsVoiceNoteReplies("discord" as never)).toBe(false);
+    expect(_test.supportsVoiceNoteReplies(null)).toBe(false);
+  });
+});

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -525,10 +525,20 @@ export function setLastTtsAttempt(entry: TtsStatusEntry | undefined): void {
   lastTtsAttempt = entry;
 }
 
-const OPUS_CHANNELS = new Set(["telegram", "feishu", "whatsapp", "matrix"]);
+const VOICE_NOTE_CHANNELS = new Set([
+  "telegram",
+  "feishu",
+  "whatsapp",
+  "matrix",
+  "openclaw-weixin",
+]);
 
 function resolveChannelId(channel: string | undefined): ChannelId | null {
   return channel ? normalizeChannelId(channel) : null;
+}
+
+function supportsVoiceNoteReplies(channelId: ChannelId | null): boolean {
+  return channelId !== null && VOICE_NOTE_CHANNELS.has(channelId);
 }
 
 export function resolveTtsProviderOrder(primary: TtsProvider, cfg?: OpenClawConfig): TtsProvider[] {
@@ -740,7 +750,7 @@ export async function synthesizeSpeech(params: {
 
   const { config, providers } = setup;
   const channelId = resolveChannelId(params.channel);
-  const target = channelId && OPUS_CHANNELS.has(channelId) ? "voice-note" : "audio-file";
+  const target = supportsVoiceNoteReplies(channelId) ? "voice-note" : "audio-file";
 
   const errors: string[] = [];
   const attemptedProviders: string[] = [];
@@ -1094,8 +1104,7 @@ export async function maybeApplyTtsToPayload(params: {
     };
 
     const channelId = resolveChannelId(params.channel);
-    const shouldVoice =
-      channelId !== null && OPUS_CHANNELS.has(channelId) && result.voiceCompatible === true;
+    const shouldVoice = supportsVoiceNoteReplies(channelId) && result.voiceCompatible === true;
     return {
       ...nextPayload,
       mediaUrl: result.audioPath,
@@ -1125,4 +1134,5 @@ export const _test = {
   getResolvedSpeechProviderConfig,
   formatTtsProviderError,
   sanitizeTtsErrorForLog,
+  supportsVoiceNoteReplies,
 };


### PR DESCRIPTION
## Summary

- Problem: `openclaw-weixin` replies with synthesized audio as a regular file instead of a voice-note payload.
- Why it matters: Weixin users do not receive TTS in the native voice-message format that the channel expects.
- What changed: added `openclaw-weixin` to the speech-core voice-note channel allowlist and covered it with a focused regression test.
- What did NOT change (scope boundary): no Feishu hook work, no broader channel routing changes, and no provider behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #61191
- Related #62056
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: speech-core only treated a fixed set of channels as voice-note-capable, and `openclaw-weixin` was missing from that set.
- Missing detection / guardrail: there was no regression test covering voice-note routing for the Weixin channel id.
- Contributing context (if known): TTS routing used the same hardcoded allowlist in both synthesis target selection and outbound payload shaping.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/speech-core/src/tts.test.ts`
- Scenario the test should lock in: `openclaw-weixin` chooses the voice-note path while non-voice-note channels still use the regular audio-file path.
- Why this is the smallest reliable guardrail: the bug is a channel allowlist decision in shared TTS routing logic, so a focused unit test on that branch point is enough to catch regressions.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Weixin TTS replies now mark compatible synthesized audio as voice notes instead of regular file attachments.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): `openclaw-weixin`
- Relevant config (redacted): default speech-core routing

### Steps

1. Trigger speech-core TTS for a reply targeting `openclaw-weixin`.
2. Observe the routing decision used for synthesis and outbound payload shaping.
3. Compare with a non-voice-note channel such as `discord`.

### Expected

- `openclaw-weixin` uses the voice-note path.
- Non-voice-note channels continue to use regular audio files.

### Actual

- Before this patch, `openclaw-weixin` fell through to the regular audio-file path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test extensions/speech-core/src/tts.test.ts` and `pnpm check`; confirmed the post-rebase diff only touches `extensions/speech-core/src/tts.ts` and `extensions/speech-core/src/tts.test.ts`.
- Edge cases checked: non-voice-note channel ids and `null` channel ids still return `false` from the routing helper.
- What you did **not** verify: live Weixin delivery against a connected account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: another channel id alias could exist outside the current normalization path.
  - Mitigation: the fix goes through the existing normalized `ChannelId` helper and keeps the decision logic centralized in one helper.