### PR TITLE
fix(daemon): skip machine-scope fallback on permission-denied bus errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 - Host exec/env sanitization: block additional request-scoped credential and config-path overrides such as `KUBECONFIG`, cloud credential-path env, `CARGO_HOME`, and `HELM_HOME` so host-run tools can no longer be redirected to attacker-chosen config or state. (#59119) Thanks @eleqtrizit.
 - Logging: make `logging.level` and `logging.consoleLevel` honor the documented severity threshold ordering again, and keep child loggers inheriting the parent `minLevel`. (#44646) Thanks @zhumengzhu.
 - Agents/sessions_send: pass `threadId` through announce delivery so cross-session notifications land in the correct Telegram forum topic instead of the group's general thread. (#62758) Thanks @jalehman.
+- Daemon/systemd: keep sudo systemctl calls scoped to the invoking user when machine-scoped systemctl fails, while still avoiding machine fallback for permission-denied user bus errors. (#62337) Thanks @Aftabbs.
 
 ## 2026.4.5
 

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -169,6 +169,43 @@ describe("systemd availability", () => {
 
     await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(true);
   });
+
+  it("does not fall back to machine scope when --user fails with permission denied", async () => {
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      expect(args).toEqual(["--user", "status"]);
+      cb(
+        createExecFileError("Failed to connect to bus: Permission denied", {
+          stderr: "Failed to connect to bus: Permission denied",
+          code: 1,
+        }),
+        "",
+        "",
+      );
+    });
+    // Only one call should be made — no machine-scope fallback for permission denied errors.
+    await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(false);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to direct --user when machine scope fails under sudo", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertMachineUserSystemctlArgs(args, "ai", "status");
+        cb(
+          createExecFileError("Failed to connect to bus: Permission denied", {
+            stderr: "Failed to connect to bus: Permission denied",
+            code: 1,
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      });
+    await expect(isSystemdUserServiceAvailable({ SUDO_USER: "ai" })).resolves.toBe(true);
+  });
 });
 
 describe("isSystemdServiceEnabled", () => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -206,6 +206,37 @@ describe("systemd availability", () => {
       });
     await expect(isSystemdUserServiceAvailable({ SUDO_USER: "ai" })).resolves.toBe(true);
   });
+
+  it("does not retry machine scope when sudo machine-scope already failed and --user also fails", async () => {
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        // First call: machine scope under sudo — fails with bus-unavailable (non-permission-denied)
+        assertMachineUserSystemctlArgs(args, "ai", "status");
+        cb(
+          createExecFileError("Failed to connect to bus: No such file or directory", {
+            stderr: "Failed to connect to bus: No such file or directory",
+            code: 1,
+          }),
+          "",
+          "",
+        );
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        // Second call: direct --user — also fails with bus-unavailable
+        assertUserSystemctlArgs(args, "status");
+        cb(
+          createExecFileError("Failed to connect to bus: No such file or directory", {
+            stderr: "Failed to connect to bus: No such file or directory",
+            code: 1,
+          }),
+          "",
+          "",
+        );
+      });
+    // Machine scope must NOT be called a third time; exactly 2 calls total.
+    await expect(isSystemdUserServiceAvailable({ SUDO_USER: "ai" })).resolves.toBe(false);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("isSystemdServiceEnabled", () => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -182,60 +182,26 @@ describe("systemd availability", () => {
         "",
       );
     });
-    // Only one call should be made — no machine-scope fallback for permission denied errors.
+    // Only one call should be made: no machine-scope fallback for permission denied errors.
     await expect(isSystemdUserServiceAvailable({ USER: "debian" })).resolves.toBe(false);
     expect(execFileMock).toHaveBeenCalledTimes(1);
   });
 
-  it("falls back to direct --user when machine scope fails under sudo", async () => {
-    execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertMachineUserSystemctlArgs(args, "ai", "status");
-        cb(
-          createExecFileError("Failed to connect to bus: Permission denied", {
-            stderr: "Failed to connect to bus: Permission denied",
-            code: 1,
-          }),
-          "",
-          "",
-        );
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        assertUserSystemctlArgs(args, "status");
-        cb(null, "", "");
-      });
-    await expect(isSystemdUserServiceAvailable({ SUDO_USER: "ai" })).resolves.toBe(true);
-  });
+  it("does not fall back to direct --user when machine scope fails under sudo", async () => {
+    execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
+      assertMachineUserSystemctlArgs(args, "ai", "status");
+      cb(
+        createExecFileError("Failed to connect to bus: No such file or directory", {
+          stderr: "Failed to connect to bus: No such file or directory",
+          code: 1,
+        }),
+        "",
+        "",
+      );
+    });
 
-  it("does not retry machine scope when sudo machine-scope already failed and --user also fails", async () => {
-    execFileMock
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        // First call: machine scope under sudo — fails with bus-unavailable (non-permission-denied)
-        assertMachineUserSystemctlArgs(args, "ai", "status");
-        cb(
-          createExecFileError("Failed to connect to bus: No such file or directory", {
-            stderr: "Failed to connect to bus: No such file or directory",
-            code: 1,
-          }),
-          "",
-          "",
-        );
-      })
-      .mockImplementationOnce((_cmd, args, _opts, cb) => {
-        // Second call: direct --user — also fails with bus-unavailable
-        assertUserSystemctlArgs(args, "status");
-        cb(
-          createExecFileError("Failed to connect to bus: No such file or directory", {
-            stderr: "Failed to connect to bus: No such file or directory",
-            code: 1,
-          }),
-          "",
-          "",
-        );
-      });
-    // Machine scope must NOT be called a third time; exactly 2 calls total.
     await expect(isSystemdUserServiceAvailable({ SUDO_USER: "ai" })).resolves.toBe(false);
-    expect(execFileMock).toHaveBeenCalledTimes(2);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -351,7 +351,13 @@ function resolveSystemctlMachineUserScopeArgs(user: string): string[] {
 }
 
 function shouldFallbackToMachineUserScope(detail: string): boolean {
-  return isSystemdUserBusUnavailableDetail(detail);
+  if (!isSystemdUserBusUnavailableDetail(detail)) {
+    return false;
+  }
+  // "Permission denied" means the bus socket exists but this process cannot connect to it.
+  // The machine-scope approach targets the same bus infrastructure and will also fail,
+  // so do not trigger the fallback in this case.
+  return !detail.toLowerCase().includes("permission denied");
 }
 
 async function execSystemctlUser(
@@ -361,11 +367,15 @@ async function execSystemctlUser(
   const machineUser = resolveSystemctlMachineScopeUser(env);
   const sudoUser = env.SUDO_USER?.trim();
 
-  // Under sudo, prefer the invoking non-root user's scope directly.
+  // Under sudo, prefer the invoking non-root user's scope directly via machine scope.
+  // If machine scope fails (e.g. user session bus unreachable), fall through to direct --user.
   if (sudoUser && sudoUser !== "root" && machineUser) {
     const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
     if (machineScopeArgs.length > 0) {
-      return await execSystemctl([...machineScopeArgs, ...args]);
+      const machineResult = await execSystemctl([...machineScopeArgs, ...args]);
+      if (machineResult.code === 0) {
+        return machineResult;
+      }
     }
   }
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -366,6 +366,7 @@ async function execSystemctlUser(
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const machineUser = resolveSystemctlMachineScopeUser(env);
   const sudoUser = env.SUDO_USER?.trim();
+  let machineScopeAlreadyTried = false;
 
   // Under sudo, prefer the invoking non-root user's scope directly via machine scope.
   // If machine scope fails (e.g. user session bus unreachable), fall through to direct --user.
@@ -373,6 +374,7 @@ async function execSystemctlUser(
     const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
     if (machineScopeArgs.length > 0) {
       const machineResult = await execSystemctl([...machineScopeArgs, ...args]);
+      machineScopeAlreadyTried = true;
       if (machineResult.code === 0) {
         return machineResult;
       }
@@ -385,7 +387,7 @@ async function execSystemctlUser(
   }
 
   const detail = `${directResult.stderr} ${directResult.stdout}`.trim();
-  if (!machineUser || !shouldFallbackToMachineUserScope(detail)) {
+  if (!machineUser || machineScopeAlreadyTried || !shouldFallbackToMachineUserScope(detail)) {
     return directResult;
   }
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -366,18 +366,13 @@ async function execSystemctlUser(
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   const machineUser = resolveSystemctlMachineScopeUser(env);
   const sudoUser = env.SUDO_USER?.trim();
-  let machineScopeAlreadyTried = false;
 
   // Under sudo, prefer the invoking non-root user's scope directly via machine scope.
-  // If machine scope fails (e.g. user session bus unreachable), fall through to direct --user.
   if (sudoUser && sudoUser !== "root" && machineUser) {
     const machineScopeArgs = resolveSystemctlMachineUserScopeArgs(machineUser);
     if (machineScopeArgs.length > 0) {
-      const machineResult = await execSystemctl([...machineScopeArgs, ...args]);
-      machineScopeAlreadyTried = true;
-      if (machineResult.code === 0) {
-        return machineResult;
-      }
+      // Do not fall through to bare --user: under sudo that can target root's user manager.
+      return await execSystemctl([...machineScopeArgs, ...args]);
     }
   }
 
@@ -387,7 +382,7 @@ async function execSystemctlUser(
   }
 
   const detail = `${directResult.stderr} ${directResult.stdout}`.trim();
-  if (!machineUser || machineScopeAlreadyTried || !shouldFallbackToMachineUserScope(detail)) {
+  if (!machineUser || !shouldFallbackToMachineUserScope(detail)) {
     return directResult;
   }
 


### PR DESCRIPTION
## Summary

Fixes #61959

When `openclaw gateway status` is invoked locally (not under sudo), `systemctl --user status` fails with:

```
Failed to connect to bus: Permission denied
```

Because `isSystemdUserBusUnavailableDetail` matches this message broadly, `shouldFallbackToMachineUserScope` returns `true` and the code retries with `--machine home@ --user` (where `home` is the system hostname, not a username). This produces the confusing error seen in the issue.

### Root cause

`Permission denied` means the bus socket exists but the current process cannot connect to it. Retrying with `--machine user@` targets the same bus infrastructure and will fail identically. The fallback only makes sense when the bus is genuinely absent (e.g. `XDG_RUNTIME_DIR` / `DBUS_SESSION_BUS_ADDRESS` not set).

### Changes

- **`shouldFallbackToMachineUserScope`**: returns `false` when the error contains `"permission denied"`, even if it also matches the broader "failed to connect to bus" pattern.

- **`execSystemctlUser` sudo path**: previously returned the machine-scope result unconditionally (success or failure). Now tries machine scope first, and if it fails, falls through to a direct `--user` attempt. This gives a meaningful result in environments where machine scope is unavailable but a user session bus is accessible.

### Tests added

- _"does not fall back to machine scope when --user fails with permission denied"_ — asserts only one `execFile` call is made.
- _"falls back to direct --user when machine scope fails under sudo"_ — asserts the two-step retry works correctly.