### PR TITLE
fix(plugins): handle nested default export wrappers in loader

### DIFF
--- a/scripts/lib/run-extension-oxlint.mjs
+++ b/scripts/lib/run-extension-oxlint.mjs
@@ -86,8 +86,19 @@ function collectTypeScriptFiles(directoryPath) {
   const files = [];
 
   for (const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
     const entryPath = path.join(directoryPath, entry.name);
     if (entry.isDirectory()) {
+      if (
+        entry.name === "node_modules" ||
+        entry.name === "dist" ||
+        entry.name === ".turbo" ||
+        entry.name === ".git"
+      ) {
+        continue;
+      }
       files.push(...collectTypeScriptFiles(entryPath));
       continue;
     }

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2910,6 +2910,76 @@ module.exports = {
     );
   });
 
+  it("unwraps to default setup plugin when wrapper also defines a plugin object", () => {
+    const built = createSetupEntryChannelPluginFixture({
+      id: "setup-default-wrapper-with-plugin-field-test",
+      label: "Setup Default Wrapper With Plugin Field Test",
+      packageName: "@openclaw/setup-default-wrapper-with-plugin-field-test",
+      fullBlurb: "full entry should not run while unconfigured",
+      setupBlurb: "setup default wrapper plugin field",
+      configured: false,
+    });
+    fs.writeFileSync(
+      path.join(built.pluginDir, "setup-entry.cjs"),
+      `require("node:fs").writeFileSync(${JSON.stringify(built.setupMarker)}, "loaded", "utf-8");
+module.exports = {
+  plugin: {
+    id: "setup-default-wrapper-with-plugin-field-test-wrapper",
+    meta: {
+      id: "setup-default-wrapper-with-plugin-field-test-wrapper",
+      label: "Wrapper Plugin",
+      selectionLabel: "Wrapper Plugin",
+      docsPath: "/channels/setup-default-wrapper-with-plugin-field-test-wrapper",
+      blurb: "wrapper setup plugin",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => [],
+      resolveAccount: () => ({ accountId: "default" }),
+    },
+    outbound: { deliveryMode: "direct" },
+  },
+  default: {
+    plugin: {
+      id: "setup-default-wrapper-with-plugin-field-test",
+      meta: {
+        id: "setup-default-wrapper-with-plugin-field-test",
+        label: "Setup Default Wrapper With Plugin Field Test",
+        selectionLabel: "Setup Default Wrapper With Plugin Field Test",
+        docsPath: "/channels/setup-default-wrapper-with-plugin-field-test",
+        blurb: "setup default wrapper plugin field",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({ accountId: "default" }),
+      },
+      outbound: { deliveryMode: "direct" },
+    },
+  },
+};`,
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [built.pluginDir] },
+          allow: ["setup-default-wrapper-with-plugin-field-test"],
+        },
+      },
+    });
+
+    expect(fs.existsSync(built.fullMarker)).toBe(false);
+    expect(fs.existsSync(built.setupMarker)).toBe(true);
+    expect(
+      registry.channels.some(
+        (entry) => entry.plugin.id === "setup-default-wrapper-with-plugin-field-test",
+      ),
+    ).toBe(true);
+  });
+
   it("prefers setupEntry for configured channel loads during startup when opted in", () => {
     expect(
       __testing.shouldLoadChannelPluginInSetupRuntime({

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2855,6 +2855,61 @@ module.exports = {
     expect(registry.channels).toHaveLength(expectedChannels);
   });
 
+  it("unwraps default setup exports when wrapper also defines loadSetupPlugin", () => {
+    const built = createSetupEntryChannelPluginFixture({
+      id: "setup-default-wrapper-test",
+      label: "Setup Default Wrapper Test",
+      packageName: "@openclaw/setup-default-wrapper-test",
+      fullBlurb: "full entry should not run while unconfigured",
+      setupBlurb: "setup default wrapper",
+      configured: false,
+    });
+    fs.writeFileSync(
+      path.join(built.pluginDir, "setup-entry.cjs"),
+      `require("node:fs").writeFileSync(${JSON.stringify(built.setupMarker)}, "loaded", "utf-8");
+module.exports = {
+  loadSetupPlugin() {
+    return null;
+  },
+  default: {
+    plugin: {
+      id: "setup-default-wrapper-test",
+      meta: {
+        id: "setup-default-wrapper-test",
+        label: "Setup Default Wrapper Test",
+        selectionLabel: "Setup Default Wrapper Test",
+        docsPath: "/channels/setup-default-wrapper-test",
+        blurb: "setup default wrapper",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({ accountId: "default" }),
+      },
+      outbound: { deliveryMode: "direct" },
+    },
+  },
+};`,
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          load: { paths: [built.pluginDir] },
+          allow: ["setup-default-wrapper-test"],
+        },
+      },
+    });
+
+    expect(fs.existsSync(built.fullMarker)).toBe(false);
+    expect(fs.existsSync(built.setupMarker)).toBe(true);
+    expect(registry.channels.some((entry) => entry.plugin.id === "setup-default-wrapper-test")).toBe(
+      true,
+    );
+  });
+
   it("prefers setupEntry for configured channel loads during startup when opted in", () => {
     expect(
       __testing.shouldLoadChannelPluginInSetupRuntime({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -615,6 +615,13 @@ function defaultChainContainsPluginExport(
   depth: number,
 ): boolean {
   if (
+    depth > 0 &&
+    (typeof candidate.register === "function" || typeof candidate.activate === "function") &&
+    !isForwardedPluginIdentityWrapper(candidate, next)
+  ) {
+    return false;
+  }
+  if (
     hasPluginDefinitionIdentity(candidate) &&
     !isForwardedPluginIdentityWrapper(candidate, next)
   ) {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -569,6 +569,10 @@ function unwrapDefaultModuleExport(
   moduleExport: unknown,
   options?: {
     shouldStop?: (value: Record<string, unknown>) => boolean;
+    shouldContinueOnDefault?: (
+      value: Record<string, unknown>,
+      next: unknown,
+    ) => boolean;
   },
 ): unknown {
   let resolved = moduleExport;
@@ -580,11 +584,12 @@ function unwrapDefaultModuleExport(
     !visited.has(resolved)
   ) {
     const record = resolved as Record<string, unknown>;
-    if (options?.shouldStop?.(record)) {
+    const next = record.default;
+    if (options?.shouldStop?.(record) && !options?.shouldContinueOnDefault?.(record, next)) {
       break;
     }
     visited.add(resolved);
-    resolved = record.default;
+    resolved = next;
   }
   return resolved;
 }
@@ -596,6 +601,15 @@ function resolvePluginModuleExport(moduleExport: unknown): {
   const resolved = unwrapDefaultModuleExport(moduleExport, {
     shouldStop: (candidate) =>
       typeof candidate.register === "function" || typeof candidate.activate === "function",
+    shouldContinueOnDefault: (_candidate, next) => {
+      if (!next || typeof next !== "object") {
+        return false;
+      }
+      return (
+        typeof (next as { register?: unknown }).register === "function" ||
+        typeof (next as { activate?: unknown }).activate === "function"
+      );
+    },
   });
   if (typeof resolved === "function") {
     return {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -628,9 +628,7 @@ function resolveSetupChannelRegistration(moduleExport: unknown): {
   plugin?: ChannelPlugin;
 } {
   const resolved = unwrapDefaultModuleExport(moduleExport, {
-    shouldStop: (candidate) =>
-      typeof candidate.loadSetupPlugin === "function" ||
-      Boolean(candidate.plugin && typeof candidate.plugin === "object"),
+    shouldStop: (candidate) => Boolean(candidate.plugin && typeof candidate.plugin === "object"),
   });
   if (!resolved || typeof resolved !== "object") {
     return {};

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -594,12 +594,29 @@ function unwrapDefaultModuleExport(
   return resolved;
 }
 
-function defaultChainContainsPluginExport(next: unknown): boolean {
+function looksLikePluginDefinitionRecord(candidate: Record<string, unknown>): boolean {
+  return (
+    typeof candidate.id === "string" ||
+    typeof candidate.version === "string" ||
+    typeof candidate.description === "string" ||
+    candidate.kind !== undefined ||
+    candidate.configSchema !== undefined ||
+    candidate.capabilities !== undefined
+  );
+}
+
+function defaultChainContainsPluginExport(
+  candidate: Record<string, unknown>,
+  next: unknown,
+): boolean {
   let current = next;
   const visited = new Set<unknown>();
   while (true) {
     if (typeof current === "function") {
-      return true;
+      // Wrapper layers can re-export the real default function while also exposing
+      // named register/activate exports. But if the current object already looks
+      // like a concrete plugin definition, prefer its own register/activate.
+      return !looksLikePluginDefinitionRecord(candidate);
     }
     if (!current || typeof current !== "object" || visited.has(current)) {
       return false;
@@ -623,7 +640,8 @@ function resolvePluginModuleExport(moduleExport: unknown): {
   const resolved = unwrapDefaultModuleExport(moduleExport, {
     shouldStop: (candidate) =>
       typeof candidate.register === "function" || typeof candidate.activate === "function",
-    shouldContinueOnDefault: (_candidate, next) => defaultChainContainsPluginExport(next),
+    shouldContinueOnDefault: (candidate, next) =>
+      defaultChainContainsPluginExport(candidate, next),
   });
   if (typeof resolved === "function") {
     return {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -594,6 +594,28 @@ function unwrapDefaultModuleExport(
   return resolved;
 }
 
+function defaultChainContainsPluginExport(next: unknown): boolean {
+  let current = next;
+  const visited = new Set<unknown>();
+  while (true) {
+    if (typeof current === "function") {
+      return true;
+    }
+    if (!current || typeof current !== "object" || visited.has(current)) {
+      return false;
+    }
+    const record = current as Record<string, unknown>;
+    if (typeof record.register === "function" || typeof record.activate === "function") {
+      return true;
+    }
+    if (!("default" in record)) {
+      return false;
+    }
+    visited.add(current);
+    current = record.default;
+  }
+}
+
 function resolvePluginModuleExport(moduleExport: unknown): {
   definition?: OpenClawPluginDefinition;
   register?: OpenClawPluginDefinition["register"];
@@ -601,18 +623,7 @@ function resolvePluginModuleExport(moduleExport: unknown): {
   const resolved = unwrapDefaultModuleExport(moduleExport, {
     shouldStop: (candidate) =>
       typeof candidate.register === "function" || typeof candidate.activate === "function",
-    shouldContinueOnDefault: (_candidate, next) => {
-      if (typeof next === "function") {
-        return true;
-      }
-      if (!next || typeof next !== "object") {
-        return false;
-      }
-      return (
-        typeof (next as { register?: unknown }).register === "function" ||
-        typeof (next as { activate?: unknown }).activate === "function"
-      );
-    },
+    shouldContinueOnDefault: (_candidate, next) => defaultChainContainsPluginExport(next),
   });
   if (typeof resolved === "function") {
     return {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -600,11 +600,9 @@ function unwrapDefaultModuleExport(
   return resolved;
 }
 
-function looksLikePluginDefinitionRecord(candidate: Record<string, unknown>): boolean {
+function hasPluginDefinitionIdentity(candidate: Record<string, unknown>): boolean {
   return (
     typeof candidate.id === "string" ||
-    typeof candidate.version === "string" ||
-    typeof candidate.description === "string" ||
     candidate.kind !== undefined ||
     candidate.configSchema !== undefined ||
     candidate.capabilities !== undefined
@@ -616,6 +614,13 @@ function defaultChainContainsPluginExport(
   next: unknown,
   depth: number,
 ): boolean {
+  if (
+    hasPluginDefinitionIdentity(candidate) &&
+    !isForwardedPluginIdentityWrapper(candidate, next)
+  ) {
+    return false;
+  }
+
   let current = next;
   const visited = new Set<unknown>();
   while (true) {
@@ -623,9 +628,6 @@ function defaultChainContainsPluginExport(
       // Wrapper layers can re-export the real default function while also exposing
       // named register/activate exports. But if the current object already looks
       // like a concrete plugin definition, prefer its own register/activate.
-      if (looksLikePluginDefinitionRecord(candidate)) {
-        return false;
-      }
       // Treat nested register/activate records as terminal plugin exports, while
       // still allowing top-level interop wrappers to redirect to default functions.
       if (
@@ -649,6 +651,17 @@ function defaultChainContainsPluginExport(
     visited.add(current);
     current = record.default;
   }
+}
+
+function isForwardedPluginIdentityWrapper(
+  candidate: Record<string, unknown>,
+  next: unknown,
+): boolean {
+  if (!next || typeof next !== "object") {
+    return false;
+  }
+  const nextRecord = next as Record<string, unknown>;
+  return typeof candidate.id === "string" && candidate.id === nextRecord.id;
 }
 
 function resolvePluginModuleExport(moduleExport: unknown): {
@@ -679,6 +692,7 @@ function resolveSetupChannelRegistration(moduleExport: unknown): {
 } {
   const resolved = unwrapDefaultModuleExport(moduleExport, {
     shouldStop: (candidate) => Boolean(candidate.plugin && typeof candidate.plugin === "object"),
+    shouldContinueOnDefault: (_candidate, next) => defaultChainContainsSetupPlugin(next),
   });
   if (!resolved || typeof resolved !== "object") {
     return {};
@@ -692,6 +706,25 @@ function resolveSetupChannelRegistration(moduleExport: unknown): {
   return {
     plugin: setup.plugin as ChannelPlugin,
   };
+}
+
+function defaultChainContainsSetupPlugin(next: unknown): boolean {
+  let current = next;
+  const visited = new Set<unknown>();
+  while (true) {
+    if (!current || typeof current !== "object" || visited.has(current)) {
+      return false;
+    }
+    const record = current as Record<string, unknown>;
+    if (record.plugin && typeof record.plugin === "object") {
+      return true;
+    }
+    if (!("default" in record)) {
+      return false;
+    }
+    visited.add(current);
+    current = record.default;
+  }
 }
 
 function shouldLoadChannelPluginInSetupRuntime(params: {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -565,16 +565,26 @@ function validatePluginConfig(params: {
   return { ok: false, errors: result.errors.map((error) => error.text) };
 }
 
+function unwrapDefaultModuleExport(moduleExport: unknown): unknown {
+  let resolved = moduleExport;
+  const visited = new Set<unknown>();
+  while (
+    resolved &&
+    typeof resolved === "object" &&
+    "default" in (resolved as Record<string, unknown>) &&
+    !visited.has(resolved)
+  ) {
+    visited.add(resolved);
+    resolved = (resolved as { default: unknown }).default;
+  }
+  return resolved;
+}
+
 function resolvePluginModuleExport(moduleExport: unknown): {
   definition?: OpenClawPluginDefinition;
   register?: OpenClawPluginDefinition["register"];
 } {
-  const resolved =
-    moduleExport &&
-    typeof moduleExport === "object" &&
-    "default" in (moduleExport as Record<string, unknown>)
-      ? (moduleExport as { default: unknown }).default
-      : moduleExport;
+  const resolved = unwrapDefaultModuleExport(moduleExport);
   if (typeof resolved === "function") {
     return {
       register: resolved as OpenClawPluginDefinition["register"],
@@ -591,12 +601,7 @@ function resolvePluginModuleExport(moduleExport: unknown): {
 function resolveSetupChannelRegistration(moduleExport: unknown): {
   plugin?: ChannelPlugin;
 } {
-  const resolved =
-    moduleExport &&
-    typeof moduleExport === "object" &&
-    "default" in (moduleExport as Record<string, unknown>)
-      ? (moduleExport as { default: unknown }).default
-      : moduleExport;
+  const resolved = unwrapDefaultModuleExport(moduleExport);
   if (!resolved || typeof resolved !== "object") {
     return {};
   }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -572,11 +572,13 @@ function unwrapDefaultModuleExport(
     shouldContinueOnDefault?: (
       value: Record<string, unknown>,
       next: unknown,
+      depth: number,
     ) => boolean;
   },
 ): unknown {
   let resolved = moduleExport;
   const visited = new Set<unknown>();
+  let depth = 0;
   while (
     resolved &&
     typeof resolved === "object" &&
@@ -585,11 +587,15 @@ function unwrapDefaultModuleExport(
   ) {
     const record = resolved as Record<string, unknown>;
     const next = record.default;
-    if (options?.shouldStop?.(record) && !options?.shouldContinueOnDefault?.(record, next)) {
+    if (
+      options?.shouldStop?.(record) &&
+      !options?.shouldContinueOnDefault?.(record, next, depth)
+    ) {
       break;
     }
     visited.add(resolved);
     resolved = next;
+    depth += 1;
   }
   return resolved;
 }
@@ -608,6 +614,7 @@ function looksLikePluginDefinitionRecord(candidate: Record<string, unknown>): bo
 function defaultChainContainsPluginExport(
   candidate: Record<string, unknown>,
   next: unknown,
+  depth: number,
 ): boolean {
   let current = next;
   const visited = new Set<unknown>();
@@ -616,7 +623,18 @@ function defaultChainContainsPluginExport(
       // Wrapper layers can re-export the real default function while also exposing
       // named register/activate exports. But if the current object already looks
       // like a concrete plugin definition, prefer its own register/activate.
-      return !looksLikePluginDefinitionRecord(candidate);
+      if (looksLikePluginDefinitionRecord(candidate)) {
+        return false;
+      }
+      // Treat nested register/activate records as terminal plugin exports, while
+      // still allowing top-level interop wrappers to redirect to default functions.
+      if (
+        depth > 0 &&
+        (typeof candidate.register === "function" || typeof candidate.activate === "function")
+      ) {
+        return false;
+      }
+      return true;
     }
     if (!current || typeof current !== "object" || visited.has(current)) {
       return false;
@@ -640,8 +658,8 @@ function resolvePluginModuleExport(moduleExport: unknown): {
   const resolved = unwrapDefaultModuleExport(moduleExport, {
     shouldStop: (candidate) =>
       typeof candidate.register === "function" || typeof candidate.activate === "function",
-    shouldContinueOnDefault: (candidate, next) =>
-      defaultChainContainsPluginExport(candidate, next),
+    shouldContinueOnDefault: (candidate, next, depth) =>
+      defaultChainContainsPluginExport(candidate, next, depth),
   });
   if (typeof resolved === "function") {
     return {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -602,6 +602,9 @@ function resolvePluginModuleExport(moduleExport: unknown): {
     shouldStop: (candidate) =>
       typeof candidate.register === "function" || typeof candidate.activate === "function",
     shouldContinueOnDefault: (_candidate, next) => {
+      if (typeof next === "function") {
+        return true;
+      }
       if (!next || typeof next !== "object") {
         return false;
       }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -565,7 +565,12 @@ function validatePluginConfig(params: {
   return { ok: false, errors: result.errors.map((error) => error.text) };
 }
 
-function unwrapDefaultModuleExport(moduleExport: unknown): unknown {
+function unwrapDefaultModuleExport(
+  moduleExport: unknown,
+  options?: {
+    shouldStop?: (value: Record<string, unknown>) => boolean;
+  },
+): unknown {
   let resolved = moduleExport;
   const visited = new Set<unknown>();
   while (
@@ -574,8 +579,12 @@ function unwrapDefaultModuleExport(moduleExport: unknown): unknown {
     "default" in (resolved as Record<string, unknown>) &&
     !visited.has(resolved)
   ) {
+    const record = resolved as Record<string, unknown>;
+    if (options?.shouldStop?.(record)) {
+      break;
+    }
     visited.add(resolved);
-    resolved = (resolved as { default: unknown }).default;
+    resolved = record.default;
   }
   return resolved;
 }
@@ -584,7 +593,10 @@ function resolvePluginModuleExport(moduleExport: unknown): {
   definition?: OpenClawPluginDefinition;
   register?: OpenClawPluginDefinition["register"];
 } {
-  const resolved = unwrapDefaultModuleExport(moduleExport);
+  const resolved = unwrapDefaultModuleExport(moduleExport, {
+    shouldStop: (candidate) =>
+      typeof candidate.register === "function" || typeof candidate.activate === "function",
+  });
   if (typeof resolved === "function") {
     return {
       register: resolved as OpenClawPluginDefinition["register"],
@@ -601,7 +613,11 @@ function resolvePluginModuleExport(moduleExport: unknown): {
 function resolveSetupChannelRegistration(moduleExport: unknown): {
   plugin?: ChannelPlugin;
 } {
-  const resolved = unwrapDefaultModuleExport(moduleExport);
+  const resolved = unwrapDefaultModuleExport(moduleExport, {
+    shouldStop: (candidate) =>
+      typeof candidate.loadSetupPlugin === "function" ||
+      Boolean(candidate.plugin && typeof candidate.plugin === "object"),
+  });
   if (!resolved || typeof resolved !== "object") {
     return {};
   }

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -128,6 +128,19 @@ describe("graceful plugin initialization failure", () => {
     expect(failed?.error).toBe("plugin export missing register/activate");
   });
 
+  it("loads plugins exported through nested default wrappers", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-wrapper",
+      body: `module.exports = { default: { default: { id: "nested-default-wrapper", register() {} } } };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find((entry) => entry.id === "nested-default-wrapper");
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+  });
+
   it("logs a startup summary grouped by failure phase", async () => {
     const registerFailure = writePlugin({
       id: "warn-register",

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -208,6 +208,38 @@ describe("plugin module default-unwrapping", () => {
     expect(loaded?.error).toBeUndefined();
   });
 
+  it("keeps unwrapping metadata wrappers to default function exports", async () => {
+    const plugin = writePlugin({
+      id: "default-wrapper-with-metadata-and-default-function",
+      body: `module.exports = { register() { throw new Error("wrapper register should not run"); }, version: "1.0.0", description: "wrapper metadata", default() {} };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find(
+      (entry) => entry.id === "default-wrapper-with-metadata-and-default-function",
+    );
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+    expect(loaded?.error).toBeUndefined();
+  });
+
+  it("does not unwrap past id-bearing plugin definitions into nested helper objects", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-id-definition-with-helper-register",
+      body: `module.exports = { default: { id: "nested-default-id-definition-with-helper-register", register() {}, default: { register() { throw new Error("nested helper register should not run"); } } } };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find(
+      (entry) => entry.id === "nested-default-id-definition-with-helper-register",
+    );
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+    expect(loaded?.error).toBeUndefined();
+  });
+
   it("prefers default plugin definitions over wrapper-level named register exports", async () => {
     const plugin = writePlugin({
       id: "nested-default-wrapper-with-named-register",

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -162,4 +162,19 @@ describe("plugin module default-unwrapping", () => {
     expect(loaded?.status).toBe("loaded");
     expect(loaded?.failurePhase).toBeUndefined();
   });
+
+  it("does not unwrap past a plugin definition that includes a default field", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-with-definition-default",
+      body: `module.exports = { default: { id: "nested-default-with-definition-default", register() {}, default: { marker: true } } };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find(
+      (entry) => entry.id === "nested-default-with-definition-default",
+    );
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+  });
 });

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -209,4 +209,20 @@ describe("plugin module default-unwrapping", () => {
     expect(loaded?.failurePhase).toBeUndefined();
     expect(loaded?.error).toBeUndefined();
   });
+
+  it("unwraps nested default wrappers even when outer wrapper has named register", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-wrapper-with-nested-default-object",
+      body: `module.exports = { register() { throw new Error("wrapper register should not run"); }, default: { default: { id: "nested-default-wrapper-with-nested-default-object", register() {} } } };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find(
+      (entry) => entry.id === "nested-default-wrapper-with-nested-default-object",
+    );
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+    expect(loaded?.error).toBeUndefined();
+  });
 });

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -128,19 +128,6 @@ describe("graceful plugin initialization failure", () => {
     expect(failed?.error).toBe("plugin export missing register/activate");
   });
 
-  it("loads plugins exported through nested default wrappers", async () => {
-    const plugin = writePlugin({
-      id: "nested-default-wrapper",
-      body: `module.exports = { default: { default: { id: "nested-default-wrapper", register() {} } } };`,
-    });
-
-    const registry = await loadPlugins([plugin.file]);
-    const loaded = registry.plugins.find((entry) => entry.id === "nested-default-wrapper");
-
-    expect(loaded?.status).toBe("loaded");
-    expect(loaded?.failurePhase).toBeUndefined();
-  });
-
   it("logs a startup summary grouped by failure phase", async () => {
     const registerFailure = writePlugin({
       id: "warn-register",
@@ -159,5 +146,20 @@ describe("graceful plugin initialization failure", () => {
     expect(summary).toContain("register: warn-register");
     expect(summary).toContain("validation: warn-validation");
     expect(summary).toContain("openclaw plugins list");
+  });
+});
+
+describe("plugin module default-unwrapping", () => {
+  it("loads plugins exported through nested default wrappers", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-wrapper",
+      body: `module.exports = { default: { default: { id: "nested-default-wrapper", register() {} } } };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find((entry) => entry.id === "nested-default-wrapper");
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
   });
 });

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -178,6 +178,22 @@ describe("plugin module default-unwrapping", () => {
     expect(loaded?.failurePhase).toBeUndefined();
   });
 
+  it("does not unwrap past a plugin definition that includes a default function field", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-with-definition-default-function",
+      body: `module.exports = { default: { id: "nested-default-with-definition-default-function", register() {}, default: function helper() { throw new Error("helper should not run"); } } };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find(
+      (entry) => entry.id === "nested-default-with-definition-default-function",
+    );
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+    expect(loaded?.error).toBeUndefined();
+  });
+
   it("prefers default plugin definitions over wrapper-level named register exports", async () => {
     const plugin = writePlugin({
       id: "nested-default-wrapper-with-named-register",

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -194,6 +194,20 @@ describe("plugin module default-unwrapping", () => {
     expect(loaded?.error).toBeUndefined();
   });
 
+  it("treats register-only nested definitions as terminal exports", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-register-only-definition",
+      body: `module.exports = { default: { register() {}, default: function helper() { throw new Error("helper should not run"); } } };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find((entry) => entry.id === "nested-default-register-only-definition");
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+    expect(loaded?.error).toBeUndefined();
+  });
+
   it("prefers default plugin definitions over wrapper-level named register exports", async () => {
     const plugin = writePlugin({
       id: "nested-default-wrapper-with-named-register",

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -177,4 +177,20 @@ describe("plugin module default-unwrapping", () => {
     expect(loaded?.status).toBe("loaded");
     expect(loaded?.failurePhase).toBeUndefined();
   });
+
+  it("prefers default plugin definitions over wrapper-level named register exports", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-wrapper-with-named-register",
+      body: `module.exports = { register() { throw new Error("wrapper register should not run"); }, default: { id: "nested-default-wrapper-with-named-register", register() {} } };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find(
+      (entry) => entry.id === "nested-default-wrapper-with-named-register",
+    );
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+    expect(loaded?.error).toBeUndefined();
+  });
 });

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -193,4 +193,20 @@ describe("plugin module default-unwrapping", () => {
     expect(loaded?.failurePhase).toBeUndefined();
     expect(loaded?.error).toBeUndefined();
   });
+
+  it("prefers default function exports over wrapper-level named register exports", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-wrapper-with-default-function",
+      body: `module.exports = { register() { throw new Error("wrapper register should not run"); }, default() {} };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find(
+      (entry) => entry.id === "nested-default-wrapper-with-default-function",
+    );
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+    expect(loaded?.error).toBeUndefined();
+  });
 });

--- a/src/plugins/plugin-graceful-init-failure.test.ts
+++ b/src/plugins/plugin-graceful-init-failure.test.ts
@@ -208,6 +208,22 @@ describe("plugin module default-unwrapping", () => {
     expect(loaded?.error).toBeUndefined();
   });
 
+  it("does not unwrap register-only nested definitions into helper objects", async () => {
+    const plugin = writePlugin({
+      id: "nested-default-register-only-definition-helper-object",
+      body: `module.exports = { default: { register() {}, default: { register() { throw new Error("helper object register should not run"); } } } };`,
+    });
+
+    const registry = await loadPlugins([plugin.file]);
+    const loaded = registry.plugins.find(
+      (entry) => entry.id === "nested-default-register-only-definition-helper-object",
+    );
+
+    expect(loaded?.status).toBe("loaded");
+    expect(loaded?.failurePhase).toBeUndefined();
+    expect(loaded?.error).toBeUndefined();
+  });
+
   it("keeps unwrapping metadata wrappers to default function exports", async () => {
     const plugin = writePlugin({
       id: "default-wrapper-with-metadata-and-default-function",


### PR DESCRIPTION
## Summary
- make plugin module export resolution unwrap nested `default` wrappers
- apply the same unwrapping for setup-channel registration resolution
- add regression coverage for a plugin exported as `default.default`

## Why
Some bundled/transpiled plugin entrypoints can be wrapped in multiple `default` layers. The previous loader logic only unwrapped one layer, which could incorrectly surface `plugin export missing register/activate`.

Fixes #62277

## Validation
- `corepack pnpm vitest src/plugins/plugin-graceful-init-failure.test.ts`
