### PR TITLE
fix(cron): guard agentSessionKey write in createPersistCronSessionEntry

### DIFF
--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -30,12 +30,21 @@ export function createPersistCronSessionEntry(params: {
     if (params.isFastTestEnv) {
       return;
     }
-    params.cronSession.store[params.agentSessionKey] = params.cronSession.sessionEntry;
+    // When sessionTarget is "isolated", runSessionKey differs from agentSessionKey
+    // (e.g. "agent:main:main:run:<id>" vs "agent:main:main"). Writing the
+    // cron-mutated entry (with model override) back to agentSessionKey would
+    // bleed the cron model into the parent session visible to sessions_list.
+    // Only write to agentSessionKey when the run IS the agent session. (#62344)
+    if (params.runSessionKey === params.agentSessionKey) {
+      params.cronSession.store[params.agentSessionKey] = params.cronSession.sessionEntry;
+    }
     if (params.runSessionKey !== params.agentSessionKey) {
       params.cronSession.store[params.runSessionKey] = params.cronSession.sessionEntry;
     }
     await params.updateSessionStore(params.cronSession.storePath, (store) => {
-      store[params.agentSessionKey] = params.cronSession.sessionEntry;
+      if (params.runSessionKey === params.agentSessionKey) {
+        store[params.agentSessionKey] = params.cronSession.sessionEntry;
+      }
       if (params.runSessionKey !== params.agentSessionKey) {
         store[params.runSessionKey] = params.cronSession.sessionEntry;
       }

--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -250,4 +250,49 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
     expect(cronSession.sessionEntry.model).toBe("claude-opus-4-6");
     expect(cronSession.sessionEntry.modelProvider).toBe("anthropic");
   });
+
+  it("does not bleed cron model override into parent session when sessionTarget is isolated (#62344)", async () => {
+    // sessionKey "cron:digest" → agentSessionKey "agent:default:cron:digest"
+    //                          → runSessionKey   "agent:default:cron:digest:run:test-session-id"
+    // These differ, so createPersistCronSessionEntry must NOT write the
+    // cron-mutated entry (model=Sonnet) to agentSessionKey. Before the fix,
+    // both keys were always written, bleeding the cron model into the parent
+    // session visible to sessions_list. (commit 870cc22, issue #62344)
+    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    // The agent-scoped key (parent session) must not carry the cron model.
+    // With the bug, cronSession.store["agent:default:cron:digest"] would be set.
+    const agentSessionKey = "agent:default:cron:digest";
+    const runSessionKey = `${agentSessionKey}:run:test-session-id`;
+
+    expect(cronSession.store[agentSessionKey]).toBeUndefined();
+    // The isolated run key SHOULD be written with the model.
+    const runEntry = cronSession.store[runSessionKey] as
+      | { model?: string; modelProvider?: string }
+      | undefined;
+    expect(runEntry).toBeDefined();
+    expect(runEntry?.model).toBe("claude-sonnet-4-6");
+    expect(runEntry?.modelProvider).toBe("anthropic");
+  });
+
+  it("still writes to agentSessionKey when sessionTarget is not isolated (keys equal)", async () => {
+    // When the job sessionKey is NOT a "cron:"-prefixed key, runSessionKey
+    // equals agentSessionKey and the parent session SHOULD be updated.
+    const jobWithNonCronKey = makeJob();
+    runWithModelFallbackMock.mockResolvedValueOnce(makeSuccessfulRunResult());
+
+    await runCronIsolatedAgentTurn(makeParams({ sessionKey: "main", job: jobWithNonCronKey }));
+
+    // "main" → agentSessionKey = "agent:default:main" (doesn't start with
+    // "cron:" so runSessionKey === agentSessionKey). The entry must be written.
+    const agentSessionKey = "agent:default:main";
+    const entry = cronSession.store[agentSessionKey] as
+      | { model?: string; modelProvider?: string }
+      | undefined;
+    expect(entry).toBeDefined();
+    expect(entry?.model).toBe("claude-sonnet-4-6");
+    expect(entry?.modelProvider).toBe("anthropic");
+  });
 });


### PR DESCRIPTION
## Summary

Closes #62344

**Root cause**: `src/cron/isolated-agent/run-session-state.ts` line 33 — `createPersistCronSessionEntry()` unconditionally writes the cron-mutated `sessionEntry` (carrying model override) to `agentSessionKey = "agent:main:main"` even when `sessionTarget: "isolated"` produces a distinct `runSessionKey`. Introduced in commit `870cc22`.

**Call path**: `runCronIsolatedAgentTurn` → `prepareCronRunContext` (run.ts:294) → `createPersistCronSessionEntry` → unconditional store write to `agentSessionKey`.

**Runtime proof**: When `sessionTarget: "isolated"`, `runSessionKey = "${agentSessionKey}:run:${runSessionId}"` differs from `agentSessionKey`, so the unconditional write mutates the parent session with cron's model override.

**Fix**: Guard both store writes in `createPersistCronSessionEntry` behind `runSessionKey === agentSessionKey`.

**G8**: Single callsite — `run.ts:294`. No other files affected.

## Test plan
- [x] New test: `does not bleed cron model override into parent session when sessionTarget is isolated`
- [x] New test: `still writes to agentSessionKey when keys are equal (non-isolated path)`
- [x] 8/8 tests pass in `run.cron-model-override.test.ts`
- [x] 75/75 test files pass in cron vitest project

🤖 Generated with [Claude Code](https://claude.com/claude-code)