### PR TITLE
fix(discord): normalize DM messages to use user:<id> as originatingTo for acp

### DIFF
--- a/extensions/discord/src/monitor/agent-components.ts
+++ b/extensions/discord/src/monitor/agent-components.ts
@@ -154,6 +154,14 @@ function resolveDiscordComponentChatType(interactionCtx: ComponentInteractionCon
   return "channel";
 }
 
+export function resolveDiscordComponentOriginatingTo(
+  interactionCtx: Pick<ComponentInteractionContext, "isDirectMessage" | "userId" | "channelId">,
+) {
+  return interactionCtx.isDirectMessage
+    ? `user:${interactionCtx.userId}`
+    : `channel:${interactionCtx.channelId}`;
+}
+
 async function dispatchPluginDiscordInteractiveEvent(params: {
   ctx: AgentComponentContext;
   interaction: AgentComponentInteraction;
@@ -463,7 +471,7 @@ async function dispatchDiscordComponentEvent(params: {
     MessageSid: interaction.rawData.id,
     Timestamp: timestamp,
     OriginatingChannel: "discord" as const,
-    OriginatingTo: `channel:${interactionCtx.channelId}`,
+    OriginatingTo: resolveDiscordComponentOriginatingTo(interactionCtx),
   });
 
   await recordInboundSession({

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -239,11 +239,18 @@ function getLastRouteUpdate():
 }
 
 function getLastDispatchCtx():
-  | { SessionKey?: string; MessageThreadId?: string | number }
+  | { SessionKey?: string; MessageThreadId?: string | number; OriginatingTo?: string; To?: string }
   | undefined {
   const callArgs = dispatchInboundMessage.mock.calls.at(-1) as unknown[] | undefined;
   const params = callArgs?.[0] as
-    | { ctx?: { SessionKey?: string; MessageThreadId?: string | number } }
+    | {
+        ctx?: {
+          SessionKey?: string;
+          MessageThreadId?: string | number;
+          OriginatingTo?: string;
+          To?: string;
+        };
+      }
     | undefined;
   return params?.ctx;
 }
@@ -596,6 +603,10 @@ describe("processDiscordMessage session routing", () => {
       channel: "discord",
       to: "user:U1",
       accountId: "default",
+    });
+    expect(getLastDispatchCtx()).toMatchObject({
+      To: "channel:dm1",
+      OriginatingTo: "user:U1",
     });
   });
 

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -443,6 +443,9 @@ export async function processDiscordMessage(
         }))
       : undefined;
 
+  const originatingTo =
+    autoThreadContext?.OriginatingTo ?? (isDirectMessage ? lastRouteTo : replyTarget);
+
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
     BodyForAgent: baseText ?? text,
@@ -482,7 +485,7 @@ export async function processDiscordMessage(
     CommandSource: "text" as const,
     // Originating channel for reply routing.
     OriginatingChannel: "discord" as const,
-    OriginatingTo: autoThreadContext?.OriginatingTo ?? replyTarget,
+    OriginatingTo: originatingTo,
   });
   const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
   observer?.onReplyPlanResolved?.({

--- a/extensions/discord/src/monitor/monitor.agent-components.test.ts
+++ b/extensions/discord/src/monitor/monitor.agent-components.test.ts
@@ -13,7 +13,11 @@ import {
   upsertPairingRequestMock,
 } from "../test-support/component-runtime.js";
 import { resolveComponentInteractionContext } from "./agent-components-helpers.js";
-import { createAgentComponentButton, createAgentSelectMenu } from "./agent-components.js";
+import {
+  createAgentComponentButton,
+  createAgentSelectMenu,
+  resolveDiscordComponentOriginatingTo,
+} from "./agent-components.js";
 
 describe("agent components", () => {
   const defaultDmSessionKey = buildAgentSessionKey({
@@ -257,6 +261,23 @@ describe("agent components", () => {
       }),
     );
     expect(readAllowFromStoreMock).not.toHaveBeenCalled();
+  });
+
+  it("uses user conversation ids for direct-message component originating targets", () => {
+    expect(
+      resolveDiscordComponentOriginatingTo({
+        isDirectMessage: true,
+        userId: "123456789",
+        channelId: "dm-channel",
+      }),
+    ).toBe("user:123456789");
+    expect(
+      resolveDiscordComponentOriginatingTo({
+        isDirectMessage: false,
+        userId: "123456789",
+        channelId: "guild-channel",
+      }),
+    ).toBe("channel:guild-channel");
   });
 
   it("blocks DM component interactions in disabled mode without reading pairing store", async () => {


### PR DESCRIPTION
## Summary

- Running `/acp spawn codex --bind here` in a Discord DM successfully created the ACP session, but all follow-up messages were dispatched to the default agent instead of the spawned codex agent.
- `OriginatingTo` was sourced from `replyTarget` (always `channel:...`), which does not distinguish DMs from guild channels. The binding was stored under `channel:<dmChannelId>`, but the preflight binding lookup uses `user:<userId>` for DMs, so the binding was never matched.
- Two code paths are affected: text messages (`message-handler.process.ts`) and component interactions (`agent-components.ts`). Both now align with the convention already established in `native-command-context.ts`: `user:<userId>` for DMs, `channel:<channelId>` for guild channels.
- Two changed files with corresponding test coverage. No behavior changes beyond the described fix. Guild channel and non-DM paths are unaffected.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Root Cause

`OriginatingTo` was sourced from `replyTarget`, whose job is Discord API message delivery (`channel:...` always), not conversation identity. These concepts diverge in DMs where the conversation should be keyed by `user:<userId>`. The native slash command path (`native-command-context.ts`) already handled this correctly, but the text message and component interaction paths did not.

No existing test asserted `OriginatingTo` for DM message or component-interaction paths.

## Regression Test Plan

- [x] Unit test
- `extensions/discord/src/monitor/message-handler.process.test.ts` — verifies DM inbound sets `OriginatingTo: "user:<id>"`.
- `extensions/discord/src/monitor/monitor.agent-components.test.ts` — verifies `resolveDiscordComponentOriginatingTo` returns `"user:<id>"` for DM and `"channel:<id>"` for guild.

## User-visible / Behavior Changes

ACP `--bind here` now works correctly in Discord DMs. No other behavior changes.

## Diagram

```text
Before (DM text message path):
  OriginatingTo = replyTarget = "channel:<dmChannelId>"
  -> binding key: "channel:<dmChannelId>"
  -> preflight lookup uses "user:<userId>" -> no match -> default agent

After:
  OriginatingTo = lastRouteTo = "user:<userId>"
  -> binding key: "user:<userId>"
  -> preflight lookup uses "user:<userId>" -> match -> bound agent (e.g. codex)
```

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

None. The change narrows `OriginatingTo` to the correct convention for DMs; guild paths are unaffected.
