### PR TITLE
fix(ui): accept dropped images with missing mime types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/chat: accept dropped or selected image files when the browser leaves the MIME type empty by using the image extension fallback only for missing MIME types, and preserve the resolved MIME through attachment previews and send serialization. Fixes #62371; carries forward #62392. Thanks @hy0235.
 - Control UI/Agents: redact tool-call args, partial/final results, derived exec output, and configured custom secret patterns before streaming tool events to the Control UI, so tool output cannot expose provider or channel credentials. Fixes #72283. (#72319) Thanks @volcano303 and @BunsDev.
 - Models/fallbacks: treat user-selected session models as exact choices, so `/model ollama/...` and model-picker switches fail visibly when the selected provider is unreachable instead of answering from an unrelated configured fallback. Fixes #73023. Thanks @pavelyortho-cyber.
 - CLI/model probes: fail local `infer model run` probes when the provider returns no text output, so unreachable local providers and empty completions no longer look like successful smoke tests. Refs #73023. Thanks @pavelyortho-cyber.

--- a/ui/src/ui/chat/attachment-support.test.ts
+++ b/ui/src/ui/chat/attachment-support.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSupportedChatAttachmentMimeType,
+  resolveSupportedChatAttachmentMimeType,
+} from "./attachment-support.ts";
+
+describe("attachment support", () => {
+  it("accepts image mime types directly", () => {
+    expect(isSupportedChatAttachmentMimeType("image/png")).toBe(true);
+    expect(resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: "image/png" })).toBe(
+      "image/png",
+    );
+  });
+
+  it("keeps current non-video file mime types directly", () => {
+    expect(isSupportedChatAttachmentMimeType("application/pdf")).toBe(true);
+    expect(
+      resolveSupportedChatAttachmentMimeType({ name: "brief.pdf", type: "application/pdf" }),
+    ).toBe("application/pdf");
+  });
+
+  it("falls back to supported file extensions when drag/drop mime type is empty", () => {
+    expect(resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: "" })).toBe(
+      "image/png",
+    );
+    expect(resolveSupportedChatAttachmentMimeType({ name: "photo.JPEG", type: "" })).toBe(
+      "image/jpeg",
+    );
+    expect(resolveSupportedChatAttachmentMimeType({ name: "photo.webp", type: null })).toBe(
+      "image/webp",
+    );
+  });
+
+  it("uses an octet fallback for unknown non-video files with missing mime type", () => {
+    expect(resolveSupportedChatAttachmentMimeType({ name: "notes.bin", type: "" })).toBe(
+      "application/octet-stream",
+    );
+  });
+
+  it("rejects video mime types and video extensions", () => {
+    expect(
+      resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: "video/mp4" }),
+    ).toBeNull();
+    expect(resolveSupportedChatAttachmentMimeType({ name: "clip.mp4", type: "" })).toBeNull();
+  });
+});

--- a/ui/src/ui/chat/attachment-support.test.ts
+++ b/ui/src/ui/chat/attachment-support.test.ts
@@ -50,6 +50,15 @@ describe("attachment support", () => {
     expect(isSupportedChatAttachmentMimeType(" video/mp4 ")).toBe(false);
     expect(resolveSupportedChatAttachmentMimeType({ name: "clip.mp4", type: "" })).toBeNull();
     expect(
+      resolveSupportedChatAttachmentMimeType({
+        name: "clip.mp4",
+        type: "application/octet-stream",
+      }),
+    ).toBeNull();
+    expect(
+      resolveSupportedChatAttachmentMimeType({ name: "clip.mp4", type: "text/plain" }),
+    ).toBeNull();
+    expect(
       resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: " video/mp4 " }),
     ).toBeNull();
   });

--- a/ui/src/ui/chat/attachment-support.test.ts
+++ b/ui/src/ui/chat/attachment-support.test.ts
@@ -42,5 +42,8 @@ describe("attachment support", () => {
       resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: "video/mp4" }),
     ).toBeNull();
     expect(resolveSupportedChatAttachmentMimeType({ name: "clip.mp4", type: "" })).toBeNull();
+    expect(
+      resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: " video/mp4 " }),
+    ).toBeNull();
   });
 });

--- a/ui/src/ui/chat/attachment-support.test.ts
+++ b/ui/src/ui/chat/attachment-support.test.ts
@@ -19,6 +19,12 @@ describe("attachment support", () => {
     ).toBe("application/pdf");
   });
 
+  it("rejects image-looking files when the browser provides a non-image mime type", () => {
+    expect(
+      resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: "text/plain" }),
+    ).toBeNull();
+  });
+
   it("falls back to supported file extensions when drag/drop mime type is empty", () => {
     expect(resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: "" })).toBe(
       "image/png",
@@ -41,6 +47,7 @@ describe("attachment support", () => {
     expect(
       resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: "video/mp4" }),
     ).toBeNull();
+    expect(isSupportedChatAttachmentMimeType(" video/mp4 ")).toBe(false);
     expect(resolveSupportedChatAttachmentMimeType({ name: "clip.mp4", type: "" })).toBeNull();
     expect(
       resolveSupportedChatAttachmentMimeType({ name: "photo.png", type: " video/mp4 " }),

--- a/ui/src/ui/chat/attachment-support.ts
+++ b/ui/src/ui/chat/attachment-support.ts
@@ -42,6 +42,9 @@ export function resolveSupportedChatAttachmentMimeType(file: {
   if (typeof file.type === "string") {
     const mimeType = file.type.trim();
     if (mimeType.length > 0) {
+      if (!isSupportedChatAttachmentFile({ name: fileName, type: mimeType })) {
+        return null;
+      }
       if (!mimeType.startsWith("image/") && resolveImageExtensionMimeType(fileName)) {
         return null;
       }

--- a/ui/src/ui/chat/attachment-support.ts
+++ b/ui/src/ui/chat/attachment-support.ts
@@ -25,9 +25,11 @@ export function resolveSupportedChatAttachmentMimeType(file: {
   name?: string | null;
   type?: string | null;
 }): string | null {
-  const explicitType = file.type;
-  if (typeof explicitType === "string" && explicitType.length > 0) {
-    return isSupportedChatAttachmentMimeType(explicitType) ? explicitType : null;
+  if (typeof file.type === "string") {
+    const mimeType = file.type.trim();
+    if (mimeType.length > 0) {
+      return isSupportedChatAttachmentMimeType(mimeType) ? mimeType : null;
+    }
   }
   const fileName = typeof file.name === "string" ? file.name.trim().toLowerCase() : "";
   if (fileName) {
@@ -37,7 +39,7 @@ export function resolveSupportedChatAttachmentMimeType(file: {
       }
     }
   }
-  return isSupportedChatAttachmentFile({ name: fileName, type: explicitType ?? "" })
+  return isSupportedChatAttachmentFile({ name: fileName, type: "" })
     ? "application/octet-stream"
     : null;
 }

--- a/ui/src/ui/chat/attachment-support.ts
+++ b/ui/src/ui/chat/attachment-support.ts
@@ -2,8 +2,16 @@ export const CHAT_ATTACHMENT_ACCEPT =
   "image/*,audio/*,application/pdf,text/*,.csv,.json,.md,.txt,.zip," +
   ".doc,.docx,.xls,.xlsx,.ppt,.pptx";
 
+const CHAT_ATTACHMENT_EXTENSION_MIME_TYPES: Record<string, string> = {
+  ".gif": "image/gif",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".webp": "image/webp",
+};
+
 export function isSupportedChatAttachmentMimeType(mimeType: string | null | undefined): boolean {
-  return typeof mimeType === "string" && !mimeType.startsWith("video/");
+  return typeof mimeType === "string" && mimeType.length > 0 && !mimeType.startsWith("video/");
 }
 
 export function isSupportedChatAttachmentFile(file: Pick<File, "name" | "type">): boolean {
@@ -11,4 +19,25 @@ export function isSupportedChatAttachmentFile(file: Pick<File, "name" | "type">)
     return false;
   }
   return !/\.(?:avi|m4v|mov|mp4|mpeg|mpg|webm)$/i.test(file.name);
+}
+
+export function resolveSupportedChatAttachmentMimeType(file: {
+  name?: string | null;
+  type?: string | null;
+}): string | null {
+  const explicitType = file.type;
+  if (typeof explicitType === "string" && explicitType.length > 0) {
+    return isSupportedChatAttachmentMimeType(explicitType) ? explicitType : null;
+  }
+  const fileName = typeof file.name === "string" ? file.name.trim().toLowerCase() : "";
+  if (fileName) {
+    for (const [extension, mimeType] of Object.entries(CHAT_ATTACHMENT_EXTENSION_MIME_TYPES)) {
+      if (fileName.endsWith(extension)) {
+        return mimeType;
+      }
+    }
+  }
+  return isSupportedChatAttachmentFile({ name: fileName, type: explicitType ?? "" })
+    ? "application/octet-stream"
+    : null;
 }

--- a/ui/src/ui/chat/attachment-support.ts
+++ b/ui/src/ui/chat/attachment-support.ts
@@ -11,7 +11,11 @@ const CHAT_ATTACHMENT_EXTENSION_MIME_TYPES: Record<string, string> = {
 };
 
 export function isSupportedChatAttachmentMimeType(mimeType: string | null | undefined): boolean {
-  return typeof mimeType === "string" && mimeType.length > 0 && !mimeType.startsWith("video/");
+  if (typeof mimeType !== "string") {
+    return false;
+  }
+  const normalized = mimeType.trim();
+  return normalized.length > 0 && !normalized.startsWith("video/");
 }
 
 export function isSupportedChatAttachmentFile(file: Pick<File, "name" | "type">): boolean {
@@ -21,22 +25,33 @@ export function isSupportedChatAttachmentFile(file: Pick<File, "name" | "type">)
   return !/\.(?:avi|m4v|mov|mp4|mpeg|mpg|webm)$/i.test(file.name);
 }
 
+function resolveImageExtensionMimeType(fileName: string): string | null {
+  for (const [extension, mimeType] of Object.entries(CHAT_ATTACHMENT_EXTENSION_MIME_TYPES)) {
+    if (fileName.endsWith(extension)) {
+      return mimeType;
+    }
+  }
+  return null;
+}
+
 export function resolveSupportedChatAttachmentMimeType(file: {
   name?: string | null;
   type?: string | null;
 }): string | null {
+  const fileName = typeof file.name === "string" ? file.name.trim().toLowerCase() : "";
   if (typeof file.type === "string") {
     const mimeType = file.type.trim();
     if (mimeType.length > 0) {
+      if (!mimeType.startsWith("image/") && resolveImageExtensionMimeType(fileName)) {
+        return null;
+      }
       return isSupportedChatAttachmentMimeType(mimeType) ? mimeType : null;
     }
   }
-  const fileName = typeof file.name === "string" ? file.name.trim().toLowerCase() : "";
   if (fileName) {
-    for (const [extension, mimeType] of Object.entries(CHAT_ATTACHMENT_EXTENSION_MIME_TYPES)) {
-      if (fileName.endsWith(extension)) {
-        return mimeType;
-      }
+    const imageMimeType = resolveImageExtensionMimeType(fileName);
+    if (imageMimeType) {
+      return imageMimeType;
     }
   }
   return isSupportedChatAttachmentFile({ name: fileName, type: "" })

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -743,6 +743,39 @@ describe("sendChatMessage", () => {
     });
   });
 
+  it("serializes the resolved attachment mime type when the data url omits one", async () => {
+    const request = vi.fn().mockResolvedValue({ runId: "run-1", status: "started" });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    const content = Buffer.from("png").toString("base64");
+    const result = await sendChatMessage(state, "inspect", [
+      {
+        id: "att-1",
+        dataUrl: `data:;base64,${content}`,
+        mimeType: "image/png",
+        fileName: "photo.png",
+      },
+    ]);
+
+    expect(result).toEqual(expect.any(String));
+    expect(request).toHaveBeenCalledWith(
+      "chat.send",
+      expect.objectContaining({
+        attachments: [
+          {
+            type: "image",
+            mimeType: "image/png",
+            fileName: "photo.png",
+            content,
+          },
+        ],
+      }),
+    );
+  });
+
   it("formats structured non-auth connect failures for chat send", async () => {
     const request = vi.fn().mockRejectedValue(
       new GatewayRequestError({

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -449,12 +449,12 @@ export async function loadChatHistory(state: ChatState) {
   }
 }
 
-function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string } | null {
-  const match = /^data:([^;]+);base64,(.+)$/.exec(dataUrl);
+function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string | null } | null {
+  const match = /^data:([^;]*);base64,(.+)$/.exec(dataUrl);
   if (!match) {
     return null;
   }
-  return { mimeType: match[1], content: match[2] };
+  return { mimeType: match[1] || null, content: match[2] };
 }
 
 function buildApiAttachments(attachments?: ChatAttachment[]) {
@@ -466,9 +466,10 @@ function buildApiAttachments(attachments?: ChatAttachment[]) {
           if (!parsed) {
             return null;
           }
+          const mimeType = att.mimeType || parsed.mimeType || "application/octet-stream";
           return {
-            type: parsed.mimeType.startsWith("image/") ? "image" : "file",
-            mimeType: parsed.mimeType,
+            type: mimeType.startsWith("image/") ? "image" : "file",
+            mimeType,
             fileName: att.fileName,
             content: parsed.content,
           };

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -477,6 +477,29 @@ describe("chat attachment picker", () => {
     expect(preview.textContent).toContain("brief.pdf");
   });
 
+  it("uses image extension fallback for file attachments with missing mime types", async () => {
+    const onAttachmentsChange = vi.fn();
+    const container = renderChatView({ onAttachmentsChange });
+    const input = container.querySelector<HTMLInputElement>(".agent-chat__file-input");
+    const file = new File(["png"], "photo.png");
+
+    expect(input).not.toBeNull();
+    Object.defineProperty(input!, "files", {
+      configurable: true,
+      value: [file],
+    });
+    input?.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await vi.waitFor(() => {
+      expect(onAttachmentsChange).toHaveBeenCalledWith([
+        expect.objectContaining({
+          fileName: "photo.png",
+          mimeType: "image/png",
+        }),
+      ]);
+    });
+  });
+
   it("filters video file attachments", () => {
     const onAttachmentsChange = vi.fn();
     const container = renderChatView({ onAttachmentsChange });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -4,7 +4,7 @@ import { repeat } from "lit/directives/repeat.js";
 import type { CompactionStatus, FallbackStatus } from "../app-tool-stream.ts";
 import {
   CHAT_ATTACHMENT_ACCEPT,
-  isSupportedChatAttachmentFile,
+  resolveSupportedChatAttachmentMimeType,
 } from "../chat/attachment-support.ts";
 import { buildChatItems } from "../chat/build-chat-items.ts";
 import { renderChatQueue } from "../chat/chat-queue.ts";
@@ -204,11 +204,11 @@ function generateAttachmentId(): string {
   return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
-function chatAttachmentFromFile(file: File, dataUrl: string): ChatAttachment {
+function chatAttachmentFromFile(file: File, dataUrl: string, mimeType: string): ChatAttachment {
   return {
     id: generateAttachmentId(),
     dataUrl,
-    mimeType: file.type || "application/octet-stream",
+    mimeType,
     fileName: file.name || undefined,
   };
 }
@@ -241,7 +241,7 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
     const reader = new FileReader();
     reader.addEventListener("load", () => {
       const dataUrl = reader.result as string;
-      const newAttachment = chatAttachmentFromFile(file, dataUrl);
+      const newAttachment = chatAttachmentFromFile(file, dataUrl, file.type || item.type);
       const current = props.attachments ?? [];
       props.onAttachmentsChange?.([...current, newAttachment]);
     });
@@ -258,13 +258,14 @@ function handleFileSelect(e: Event, props: ChatProps) {
   const additions: ChatAttachment[] = [];
   let pending = 0;
   for (const file of input.files) {
-    if (!isSupportedChatAttachmentFile(file)) {
+    const mimeType = resolveSupportedChatAttachmentMimeType(file);
+    if (!mimeType) {
       continue;
     }
     pending++;
     const reader = new FileReader();
     reader.addEventListener("load", () => {
-      additions.push(chatAttachmentFromFile(file, reader.result as string));
+      additions.push(chatAttachmentFromFile(file, reader.result as string, mimeType));
       pending--;
       if (pending === 0) {
         props.onAttachmentsChange?.([...current, ...additions]);
@@ -285,13 +286,14 @@ function handleDrop(e: DragEvent, props: ChatProps) {
   const additions: ChatAttachment[] = [];
   let pending = 0;
   for (const file of files) {
-    if (!isSupportedChatAttachmentFile(file)) {
+    const mimeType = resolveSupportedChatAttachmentMimeType(file);
+    if (!mimeType) {
       continue;
     }
     pending++;
     const reader = new FileReader();
     reader.addEventListener("load", () => {
-      additions.push(chatAttachmentFromFile(file, reader.result as string));
+      additions.push(chatAttachmentFromFile(file, reader.result as string, mimeType));
       pending--;
       if (pending === 0) {
         props.onAttachmentsChange?.([...current, ...additions]);

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -204,10 +204,14 @@ function generateAttachmentId(): string {
   return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
+function normalizeAttachmentDataUrl(dataUrl: string, mimeType: string): string {
+  return dataUrl.replace(/^data:(;base64,)/, `data:${mimeType}$1`);
+}
+
 function chatAttachmentFromFile(file: File, dataUrl: string, mimeType: string): ChatAttachment {
   return {
     id: generateAttachmentId(),
-    dataUrl,
+    dataUrl: normalizeAttachmentDataUrl(dataUrl, mimeType),
     mimeType,
     fileName: file.name || undefined,
   };


### PR DESCRIPTION
## Summary

Drag/drop image attachments in the Control UI currently rely on the browser providing a populated file MIME type. In some drag/drop flows that comes through empty, so the image gets silently ignored even though the drop is accepted.

This updates the attachment path to fall back to common image file extensions when the MIME type is missing, and adds focused test coverage for that case.

## Testing

- [x] This PR fixes a bug or regression
- `corepack pnpm exec vitest run ui/src/ui/chat/attachment-support.test.ts --config vitest.unit.config.ts`

Closes #62371