### PR TITLE
fix(memory): respect selected memory slot in dreaming config

### DIFF
--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -175,4 +175,61 @@ describe("memory dreaming host helpers", () => {
       },
     });
   });
+
+  it("resolves dreaming config from the selected memory slot plugin", () => {
+    expect(
+      resolveMemoryCorePluginConfig({
+        plugins: {
+          slots: {
+            memory: "memos-local-openclaw-plugin",
+          },
+          entries: {
+            "memos-local-openclaw-plugin": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig),
+    ).toEqual({
+      dreaming: {
+        enabled: true,
+      },
+    });
+  });
+
+  it("falls back to memory-core when memory slot is blank", () => {
+    expect(
+      resolveMemoryCorePluginConfig({
+        plugins: {
+          slots: {
+            memory: "   ",
+          },
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig),
+    ).toEqual({
+      dreaming: {
+        enabled: true,
+      },
+    });
+  });
 });

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -316,7 +316,7 @@ export function resolveMemoryCorePluginConfig(
   const slots = asNullableRecord(plugins?.slots);
   const entries = asNullableRecord(plugins?.entries);
   // Respect plugins.slots.memory when set; fall back to "memory-core"
-  const memoryPluginId = String(slots?.memory ?? "memory-core");
+  const memoryPluginId = normalizeTrimmedString(slots?.memory) ?? "memory-core";
   const memoryPlugin = asNullableRecord(entries?.[memoryPluginId]);
   return asNullableRecord(memoryPlugin?.config) ?? undefined;
 }

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -313,9 +313,12 @@ export function resolveMemoryCorePluginConfig(
 ): Record<string, unknown> | undefined {
   const root = asNullableRecord(cfg);
   const plugins = asNullableRecord(root?.plugins);
+  const slots = asNullableRecord(plugins?.slots);
   const entries = asNullableRecord(plugins?.entries);
-  const memoryCore = asNullableRecord(entries?.["memory-core"]);
-  return asNullableRecord(memoryCore?.config) ?? undefined;
+  // Respect plugins.slots.memory when set; fall back to "memory-core"
+  const memoryPluginId = String(slots?.memory ?? "memory-core");
+  const memoryPlugin = asNullableRecord(entries?.[memoryPluginId]);
+  return asNullableRecord(memoryPlugin?.config) ?? undefined;
 }
 
 export function resolveMemoryDreamingConfig(params: {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -158,6 +158,21 @@ const lazySessions = createLazy(() => import("./views/sessions.ts"));
 const lazySkills = createLazy(() => import("./views/skills.ts"));
 const lazyDreamingView = createLazy(() => import("./views/dreaming.ts"));
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normalizeTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 function resolveConfiguredDreaming(configValue: Record<string, unknown> | null): {
   enabled: boolean;
 } {
@@ -166,11 +181,13 @@ function resolveConfiguredDreaming(configValue: Record<string, unknown> | null):
       enabled: false,
     };
   }
-  const plugins = configValue.plugins as Record<string, unknown> | undefined;
-  const entries = plugins?.entries as Record<string, unknown> | undefined;
-  const memoryCore = entries?.["memory-core"] as Record<string, unknown> | undefined;
-  const config = memoryCore?.config as Record<string, unknown> | undefined;
-  const dreaming = config?.dreaming as Record<string, unknown> | undefined;
+  const plugins = asRecord(configValue.plugins);
+  const slots = asRecord(plugins?.slots);
+  const entries = asRecord(plugins?.entries);
+  const memoryPluginId = normalizeTrimmedString(slots?.memory) ?? "memory-core";
+  const memoryPlugin = asRecord(entries?.[memoryPluginId]);
+  const config = asRecord(memoryPlugin?.config);
+  const dreaming = asRecord(config?.dreaming);
   return {
     enabled: typeof dreaming?.enabled === "boolean" ? dreaming.enabled : false,
   };

--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -28,6 +28,14 @@ function createState(): { state: DreamingState; request: ReturnType<typeof vi.fn
   return { state, request };
 }
 
+function getConfigPatchRawPayload(request: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const call = request.mock.calls.find((entry) => entry[0] === "config.patch");
+  expect(call).toBeDefined();
+  const payload = call?.[1] as { raw?: unknown };
+  expect(typeof payload.raw).toBe("string");
+  return JSON.parse(payload.raw as string) as Record<string, unknown>;
+}
+
 describe("dreaming controller", () => {
   it("loads and normalizes dreaming status from doctor.memory.status", async () => {
     const { state, request } = createState();
@@ -117,8 +125,85 @@ describe("dreaming controller", () => {
         sessionKey: "main",
       }),
     );
+    expect(getConfigPatchRawPayload(request)).toEqual({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: false,
+              },
+            },
+          },
+        },
+      },
+    });
     expect(state.dreamingModeSaving).toBe(false);
     expect(state.dreamingStatusError).toBeNull();
+  });
+
+  it("patches dreaming config for the selected memory slot plugin", async () => {
+    const { state, request } = createState();
+    state.configSnapshot = {
+      hash: "hash-1",
+      config: {
+        plugins: {
+          slots: {
+            memory: "memos-local-openclaw-plugin",
+          },
+        },
+      },
+    };
+    request.mockResolvedValue({ ok: true });
+
+    const ok = await updateDreamingEnabled(state, true);
+
+    expect(ok).toBe(true);
+    expect(getConfigPatchRawPayload(request)).toEqual({
+      plugins: {
+        entries: {
+          "memos-local-openclaw-plugin": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("falls back to memory-core when memory slot is blank", async () => {
+    const { state, request } = createState();
+    state.configSnapshot = {
+      hash: "hash-1",
+      config: {
+        plugins: {
+          slots: {
+            memory: "   ",
+          },
+        },
+      },
+    };
+    request.mockResolvedValue({ ok: true });
+
+    const ok = await updateDreamingEnabled(state, true);
+
+    expect(ok).toBe(true);
+    expect(getConfigPatchRawPayload(request)).toEqual({
+      plugins: {
+        entries: {
+          "memory-core": {
+            config: {
+              dreaming: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      },
+    });
   });
 
   it("fails gracefully when config hash is missing", async () => {

--- a/ui/src/ui/controllers/dreaming.ts
+++ b/ui/src/ui/controllers/dreaming.ts
@@ -287,10 +287,10 @@ export async function updateDreamingEnabled(
   enabled: boolean,
 ): Promise<boolean> {
   // Respect plugins.slots.memory when set; fall back to "memory-core"
-  const cfg = state.configSnapshot?.config as Record<string, unknown> | null | undefined;
-  const plugins = cfg?.plugins as Record<string, unknown> | null | undefined;
-  const slots = plugins?.slots as Record<string, unknown> | null | undefined;
-  const memoryPluginId = String(slots?.memory ?? "memory-core");
+  const cfg = asRecord(state.configSnapshot?.config);
+  const plugins = asRecord(cfg?.plugins);
+  const slots = asRecord(plugins?.slots);
+  const memoryPluginId = normalizeTrimmedString(slots?.memory) ?? "memory-core";
   const ok = await writeDreamingPatch(state, {
     plugins: {
       entries: {

--- a/ui/src/ui/controllers/dreaming.ts
+++ b/ui/src/ui/controllers/dreaming.ts
@@ -286,10 +286,15 @@ export async function updateDreamingEnabled(
   state: DreamingState,
   enabled: boolean,
 ): Promise<boolean> {
+  // Respect plugins.slots.memory when set; fall back to "memory-core"
+  const cfg = state.configSnapshot?.config as Record<string, unknown> | null | undefined;
+  const plugins = cfg?.plugins as Record<string, unknown> | null | undefined;
+  const slots = plugins?.slots as Record<string, unknown> | null | undefined;
+  const memoryPluginId = String(slots?.memory ?? "memory-core");
   const ok = await writeDreamingPatch(state, {
     plugins: {
       entries: {
-        "memory-core": {
+        [memoryPluginId]: {
           config: {
             dreaming: {
               enabled,


### PR DESCRIPTION
## Summary

Read and write dreaming config from the plugin selected in `plugins.slots.memory` instead of hardcoding `memory-core`.

When a memory slot plugin (e.g. `memos-local-openclaw-plugin`) is configured via `plugins.slots.memory`, the Control UI dreaming toggle and `doctor.memory.status` now correctly target the selected plugin's config path (`plugins.entries.<slot>.config.dreaming`) rather than always targeting `plugins.entries.memory-core`.

## Changes

### `src/memory-host-sdk/dreaming.ts`
- `resolveMemoryCorePluginConfig()`: read `slots.memory` and use that plugin id; fall back to `memory-core` if not set

### `ui/src/ui/controllers/dreaming.ts`
- `updateDreamingEnabled()`: construct patch using the selected memory slot plugin id from `configSnapshot`

## Fixes

Fixes: #62098