### PR TITLE
fix(ui): keep session label edits attached to correct row after sorting

### DIFF
--- a/ui/src/ui/views/sessions.browser.test.ts
+++ b/ui/src/ui/views/sessions.browser.test.ts
@@ -1,0 +1,169 @@
+import { html, render } from "lit";
+import { describe, expect, it } from "vitest";
+import type { GatewaySessionRow, SessionsListResult } from "../types.ts";
+import { renderSessions, type SessionsProps } from "./sessions.ts";
+
+function makeRow(overrides: Partial<GatewaySessionRow>): GatewaySessionRow {
+  return {
+    key: "session-default",
+    kind: "direct",
+    updatedAt: Date.now(),
+    label: "",
+    displayName: "",
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    ...overrides,
+  };
+}
+
+function makeProps(rows: GatewaySessionRow[]): SessionsProps {
+  return {
+    loading: false,
+    result: {
+      path: "/tmp/sessions.json",
+      sessions: rows,
+      defaults: {
+        modelProvider: null,
+        model: null,
+        contextTokens: null,
+      },
+    } as SessionsListResult,
+    error: null,
+    activeMinutes: "",
+    limit: "",
+    includeGlobal: true,
+    includeUnknown: true,
+    basePath: "",
+    searchQuery: "",
+    sortColumn: "updated",
+    sortDir: "desc",
+    page: 0,
+    pageSize: 10,
+    selectedKeys: new Set(),
+    expandedCheckpointKey: null,
+    checkpointItemsByKey: {},
+    checkpointLoadingKey: null,
+    checkpointBusyKey: null,
+    checkpointErrorByKey: {},
+    onFiltersChange: () => {},
+    onSearchChange: () => {},
+    onSortChange: () => {},
+    onPageChange: () => {},
+    onPageSizeChange: () => {},
+    onRefresh: () => {},
+    onPatch: () => {},
+    onToggleSelect: () => {},
+    onSelectPage: () => {},
+    onDeselectPage: () => {},
+    onDeselectAll: () => {},
+    onDeleteSelected: () => {},
+    onNavigateToChat: () => {},
+    onToggleCheckpointDetails: () => {},
+    onBranchFromCheckpoint: () => {},
+    onRestoreCheckpoint: () => {},
+  };
+}
+
+describe("renderSessions", () => {
+  it("keeps edited label attached to the same session after reorder", async () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    let rows: GatewaySessionRow[] = [
+      makeRow({
+        key: "session-a",
+        label: "Alpha",
+        updatedAt: 100,
+      }),
+      makeRow({
+        key: "session-b",
+        label: "Beta",
+        updatedAt: 200,
+      }),
+    ];
+
+    let props = makeProps(rows);
+
+    const rerender = () => {
+      render(html`${renderSessions(props)}`, host);
+    };
+
+    props.onPatch = (key, patch) => {
+      rows = rows.map((row) => {
+        if (row.key !== key) {
+          return row;
+        }
+
+        const nextRow: GatewaySessionRow = {
+          ...row,
+          updatedAt: 300,
+        };
+
+        if ("label" in patch) {
+          nextRow.label = patch.label ?? undefined;
+        }
+        if ("thinkingLevel" in patch) {
+          nextRow.thinkingLevel = patch.thinkingLevel ?? undefined;
+        }
+        if ("fastMode" in patch) {
+          nextRow.fastMode = patch.fastMode ?? undefined;
+        }
+        if ("verboseLevel" in patch) {
+          nextRow.verboseLevel = patch.verboseLevel ?? undefined;
+        }
+        if ("reasoningLevel" in patch) {
+          nextRow.reasoningLevel = patch.reasoningLevel ?? undefined;
+        }
+
+        return nextRow;
+      });
+
+      props = {
+        ...props,
+        result: {
+          ...props.result!,
+          sessions: rows,
+        },
+      };
+      rerender();
+    };
+
+    rerender();
+    await Promise.resolve();
+
+    const beforeRows = Array.from(host.querySelectorAll("tbody tr"));
+    expect(beforeRows).toHaveLength(2);
+    expect(beforeRows[0]?.textContent).toContain("session-b");
+    expect(beforeRows[1]?.textContent).toContain("session-a");
+
+    const sessionARowBefore = beforeRows[1] as HTMLTableRowElement;
+    const input = sessionARowBefore.querySelector(
+      "input[placeholder='(optional)']",
+    ) as HTMLInputElement;
+
+    input.value = "Renamed A";
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    await Promise.resolve();
+
+    const afterRows = Array.from(host.querySelectorAll("tbody tr"));
+    expect(afterRows).toHaveLength(2);
+    expect(afterRows[0]?.textContent).toContain("session-a");
+    expect(afterRows[1]?.textContent).toContain("session-b");
+
+    const sessionARowAfter = afterRows[0] as HTMLTableRowElement;
+    const sessionBRowAfter = afterRows[1] as HTMLTableRowElement;
+
+    const inputA = sessionARowAfter.querySelector(
+      "input[placeholder='(optional)']",
+    ) as HTMLInputElement;
+    const inputB = sessionBRowAfter.querySelector(
+      "input[placeholder='(optional)']",
+    ) as HTMLInputElement;
+
+    expect(inputA.value).toBe("Renamed A");
+    expect(inputB.value).toBe("Beta");
+
+    host.remove();
+  });
+});

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { repeat } from "lit/directives/repeat.js";
 import { t } from "../../i18n/index.ts";
 import { formatRelativeTimestamp } from "../format.ts";
 import { icons } from "../icons.ts";
@@ -410,7 +411,11 @@ export function renderSessions(props: SessionsProps) {
                       </td>
                     </tr>
                   `
-                : paginated.flatMap((row) => renderRows(row, props))}
+                : repeat(
+                    paginated,
+                    (row) => row.key,
+                    (row) => renderRows(row, props),
+                  )}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary

* Problem: Editing a session label could visually apply the change to the wrong row when the table reorders.
* Why it matters: Users may accidentally modify the wrong session label due to DOM reuse after sorting.
* What changed: Use Lit `repeat()` keyed by `row.key` to ensure stable identity for session rows.
* What did NOT change (scope boundary): No changes to session storage, sorting logic, or backend APIs.

## Change Type (select all)

* [x] Bug fix
* [ ] Feature
* [ ] Refactor required for the fix
* [ ] Docs
* [ ] Security hardening
* [ ] Chore/infra

## Scope (select all touched areas)

* [ ] Gateway / orchestration
* [ ] Skills / tool execution
* [ ] Auth / tokens
* [ ] Memory / storage
* [ ] Integrations
* [ ] API / contracts
* [x] UI / DX
* [ ] CI/CD / infra

## Linked Issue/PR

* Closes #
* Related #
* [x] This PR fixes a bug or regression

## Root Cause (if applicable)

* Root cause: Session rows were rendered without stable keyed repetition, allowing DOM/input state reuse after list reordering.
* Missing detection / guardrail: No UI-level regression test ensuring row identity remains stable during resorting.
* Contributing context (if known): Editing a label updates `updatedAt`, which triggers table reordering.

## Regression Test Plan

* Coverage level that should have caught this:

  * [ ] Unit test
  * [ ] Seam / integration test
  * [x] End-to-end test
  * [ ] Existing coverage already sufficient
* Target test or file: `ui/src/ui/views/sessions.browser.test.ts`
* Scenario the test locks in: Editing a label triggers a row reorder, and the edited label remains attached to the same session key
* Why this is the smallest reliable guardrail: This bug depends on UI row identity during reorder, so browser-level rendering coverage is the most direct guardrail
* Existing test that already covers this (if any): None known

## User-visible / Behavior Changes

Label edits remain attached to the correct session even when the table reorders.

## Diagram (if applicable)

Before:
edit label -> row reorder -> label appears on wrong row

After:
edit label -> row reorder -> label stays on same session

## Security Impact (required)

* New permissions/capabilities? No
* Secrets/tokens handling changed? No
* New/changed network calls? No
* Command/tool execution surface changed? No
* Data access scope changed? No

## Repro + Verification

### Environment

* OS: Ubuntu (cloud VM)
* Runtime/container: Node + pnpm
* Model/provider: N/A
* Integration/channel (if any): N/A
* Relevant config (redacted): default

### Steps

1. Open Sessions UI
2. Edit label of a session
3. Observe row reorder after update

### Expected

* Label remains attached to the same session

### Actual

* Label visually moved to another row

## Evidence

* [ ] Failing test/log before + passing after
* [ ] Trace/log snippets
* [x] Screenshot/recording
* [ ] Perf numbers (if relevant)

## Human Verification (required)

* Verified scenarios:

  * Editing label triggers reorder
  * Label remains attached after fix
* Edge cases checked:

  * multiple sessions
  * direct + group sessions
* What you did **not** verify:

  * automated UI tests

## Compatibility / Migration

* Backward compatible? Yes
* Config/env changes? No
* Migration needed? No

## Risks and Mitigations

* Risk: Minimal UI rendering change

  * Mitigation: Stable keyed rendering only affects row identity
