### PR TITLE
fix(ui): render markdown in Dream Diary tab

### DIFF
--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -610,7 +610,35 @@
 }
 
 .dreams-diary__prose {
-  /* no styling container needed, just prose spacing */
+  animation: diary-text-stream 2.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.dreams-diary__prose p {
+  margin: 0 0 12px;
+  font-size: 14px;
+  line-height: 1.8;
+  color: color-mix(in oklab, var(--text) 85%, var(--muted));
+  font-style: italic;
+}
+
+.dreams-diary__prose p:last-child {
+  margin-bottom: 0;
+}
+
+.dreams-diary__prose strong {
+  font-style: normal;
+  font-weight: 600;
+}
+
+.dreams-diary__prose em {
+  font-style: italic;
+}
+
+.dreams-diary__prose code {
+  background: color-mix(in oklab, var(--text) 8%, transparent);
+  border-radius: 3px;
+  padding: 1px 4px;
+  font-size: 12px;
 }
 
 .dreams-diary__para {

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -1,5 +1,7 @@
 import { html, nothing } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
+import { toSanitizedMarkdownHtml } from "../markdown.ts";
 
 // ── Diary entry parser ─────────────────────────────────────────────────
 
@@ -414,14 +416,7 @@ function renderDiarySection(props: DreamingProps) {
         <div class="dreams-diary__accent"></div>
         ${entry.date ? html`<time class="dreams-diary__date">${entry.date}</time>` : nothing}
         <div class="dreams-diary__prose">
-          ${entry.body
-            .split("\n")
-            .map(
-              (para, i) =>
-                html`<p class="dreams-diary__para" style="animation-delay: ${0.3 + i * 0.15}s;">
-                  ${para}
-                </p>`,
-            )}
+          ${unsafeHTML(toSanitizedMarkdownHtml(entry.body))}
         </div>
       </article>
     </section>


### PR DESCRIPTION
## Summary

The Dream Diary tab in the Control UI displayed markdown source literally (e.g. `**bold**` rendered as literal `**bold**` instead of **bold**). Fix by applying the existing `toSanitizedMarkdownHtml()` pipeline to diary entry body text.

## Root Cause

Diary entries were rendered as plain text by splitting on newlines and wrapping each line in a `<p>` tag. The markdown was never parsed — it was displayed verbatim.

## Fix

- `ui/src/ui/views/dreaming.ts`: Replace plain-text paragraph rendering with `${unsafeHTML(toSanitizedMarkdownHtml(entry.body))}`
- `ui/src/styles/dreams.css`: Add `.dreams-diary__prose` CSS for rendered markdown elements (p, strong, em, code), preserving the original italic style

## Testing

Verified by inspection of:
- `ui/src/ui/chat/grouped-render.ts` which already uses `toSanitizedMarkdownHtml` for chat messages
- The diary entry body flow: `parseDiaryEntries` -> `entry.body` -> rendered as plain text

## Fixes

Fixes: #62413