### PR TITLE
fix(windows): resolve ERR_UNSUPPORTED_ESM_URL_SCHEME on native Windows

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -5,6 +5,17 @@ import { access } from "node:fs/promises";
 import module from "node:module";
 import { fileURLToPath } from "node:url";
 
+// On Windows, jiti's native import path passes raw drive-letter paths (C:\...)
+// to import(), which Node's ESM loader rejects. Register a custom resolve hook
+// that converts these to file:// URLs.
+if (process.platform === "win32" && typeof module.register === "function") {
+  try {
+    module.register("./windows-esm-fix.mjs", import.meta.url);
+  } catch {
+    // Ignore if registration fails — non-critical on supported Node versions.
+  }
+}
+
 const MIN_NODE_MAJOR = 22;
 const MIN_NODE_MINOR = 12;
 const MIN_NODE_VERSION = `${MIN_NODE_MAJOR}.${MIN_NODE_MINOR}`;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "CHANGELOG.md",
     "LICENSE",
     "openclaw.mjs",
+    "windows-esm-fix.mjs",
     "README.md",
     "assets/",
     "dist/",

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -17,6 +17,13 @@ function ensureSymlink(targetValue, targetPath, type) {
     fs.symlinkSync(targetValue, targetPath, type);
     return;
   } catch (error) {
+    if (error?.code === "EPERM" && process.platform === "win32") {
+      // File symlinks on Windows require Developer Mode or admin privileges.
+      // Fall back to copying the file.
+      const resolvedSource = path.resolve(path.dirname(targetPath), targetValue);
+      fs.copyFileSync(resolvedSource, targetPath);
+      return;
+    }
     if (error?.code !== "EEXIST") {
       throw error;
     }
@@ -31,7 +38,16 @@ function ensureSymlink(targetValue, targetPath, type) {
   }
 
   removePathIfExists(targetPath);
-  fs.symlinkSync(targetValue, targetPath, type);
+  try {
+    fs.symlinkSync(targetValue, targetPath, type);
+  } catch (error) {
+    if (error?.code === "EPERM" && process.platform === "win32") {
+      const resolvedSource = path.resolve(path.dirname(targetPath), targetValue);
+      fs.copyFileSync(resolvedSource, targetPath);
+      return;
+    }
+    throw error;
+  }
 }
 
 function symlinkPath(sourcePath, targetPath, type) {

--- a/scripts/stage-bundled-plugin-runtime.mjs
+++ b/scripts/stage-bundled-plugin-runtime.mjs
@@ -12,7 +12,13 @@ function relativeSymlinkTarget(sourcePath, targetPath) {
   return relativeTarget || ".";
 }
 
-function ensureSymlink(targetValue, targetPath, type) {
+function copyFallback(targetValue, targetPath, resolveBase) {
+  const base = resolveBase ?? path.dirname(targetPath);
+  const resolvedSource = path.resolve(base, targetValue);
+  fs.copyFileSync(resolvedSource, targetPath);
+}
+
+function ensureSymlink(targetValue, targetPath, type, resolveBase) {
   try {
     fs.symlinkSync(targetValue, targetPath, type);
     return;
@@ -20,8 +26,7 @@ function ensureSymlink(targetValue, targetPath, type) {
     if (error?.code === "EPERM" && process.platform === "win32") {
       // File symlinks on Windows require Developer Mode or admin privileges.
       // Fall back to copying the file.
-      const resolvedSource = path.resolve(path.dirname(targetPath), targetValue);
-      fs.copyFileSync(resolvedSource, targetPath);
+      copyFallback(targetValue, targetPath, resolveBase);
       return;
     }
     if (error?.code !== "EEXIST") {
@@ -42,8 +47,7 @@ function ensureSymlink(targetValue, targetPath, type) {
     fs.symlinkSync(targetValue, targetPath, type);
   } catch (error) {
     if (error?.code === "EPERM" && process.platform === "win32") {
-      const resolvedSource = path.resolve(path.dirname(targetPath), targetValue);
-      fs.copyFileSync(resolvedSource, targetPath);
+      copyFallback(targetValue, targetPath, resolveBase);
       return;
     }
     throw error;
@@ -101,7 +105,9 @@ function stagePluginRuntimeOverlay(sourceDir, targetDir) {
     }
 
     if (dirent.isSymbolicLink()) {
-      ensureSymlink(fs.readlinkSync(sourcePath), targetPath);
+      // readlink value is relative to sourcePath's directory, pass it as resolveBase
+      // so the EPERM copy fallback resolves from the correct location.
+      ensureSymlink(fs.readlinkSync(sourcePath), targetPath, undefined, path.dirname(sourcePath));
       continue;
     }
 

--- a/src/channels/plugins/module-loader.ts
+++ b/src/channels/plugins/module-loader.ts
@@ -6,6 +6,7 @@ import { openBoundaryFileSync } from "../../infra/boundary-file-read.js";
 import {
   buildPluginLoaderJitiOptions,
   resolvePluginLoaderJitiConfig,
+  toSafeImportPath,
 } from "../../plugins/sdk-alias.js";
 
 const nodeRequire = createRequire(import.meta.url);
@@ -102,5 +103,5 @@ export function loadChannelPluginModule(params: {
       // Fall back to the Jiti loader path when require() cannot handle the entry.
     }
   }
-  return loadModule(safePath)(safePath);
+  return loadModule(safePath)(toSafeImportPath(safePath));
 }

--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -11,6 +11,7 @@ import {
   buildPluginLoaderJitiOptions,
   resolveLoaderPackageRoot,
   resolvePluginLoaderJitiConfig,
+  toSafeImportPath,
 } from "../plugins/sdk-alias.js";
 import type { AnyAgentTool, OpenClawPluginApi, PluginCommandContext } from "../plugins/types.js";
 
@@ -284,10 +285,10 @@ function loadBundledEntryModuleSync(importMetaUrl: string, specifier: string): u
     try {
       loaded = nodeRequire(modulePath);
     } catch {
-      loaded = getJiti(modulePath)(modulePath);
+      loaded = getJiti(modulePath)(toSafeImportPath(modulePath));
     }
   } else {
-    loaded = getJiti(modulePath)(modulePath);
+    loaded = getJiti(modulePath)(toSafeImportPath(modulePath));
   }
   loadedModuleExports.set(modulePath, loaded);
   return loaded;

--- a/src/plugin-sdk/facade-loader.ts
+++ b/src/plugin-sdk/facade-loader.ts
@@ -9,6 +9,7 @@ import {
   buildPluginLoaderJitiOptions,
   resolvePluginLoaderJitiConfig,
   resolveLoaderPackageRoot,
+  toSafeImportPath,
 } from "../plugins/sdk-alias.js";
 
 const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
@@ -260,7 +261,7 @@ export function loadFacadeModuleAtLocationSync<T extends object>(params: {
   try {
     loaded =
       params.loadModule?.(params.location.modulePath) ??
-      (getJiti(params.location.modulePath)(params.location.modulePath) as T);
+      (getJiti(params.location.modulePath)(toSafeImportPath(params.location.modulePath)) as T);
     Object.assign(sentinel, loaded);
     loadedFacadePluginIds.add(
       typeof params.trackedPluginId === "function"

--- a/src/plugins/bundled-capability-runtime.ts
+++ b/src/plugins/bundled-capability-runtime.ts
@@ -18,6 +18,7 @@ import {
   buildPluginLoaderAliasMap,
   buildPluginLoaderJitiOptions,
   shouldPreferNativeJiti,
+  toSafeImportPath,
   type PluginSdkResolutionPreference,
 } from "./sdk-alias.js";
 import type { OpenClawPluginDefinition, OpenClawPluginModule } from "./types.js";
@@ -284,7 +285,7 @@ export function loadBundledCapabilityRuntimeRegistry(params: {
 
     let mod: OpenClawPluginModule | null = null;
     try {
-      mod = getJiti(safeSource)(safeSource) as OpenClawPluginModule;
+      mod = getJiti(safeSource)(toSafeImportPath(safeSource)) as OpenClawPluginModule;
     } catch (error) {
       recordCapabilityLoadError(registry, record, String(error));
       continue;

--- a/src/plugins/bundled-channel-config-metadata.ts
+++ b/src/plugins/bundled-channel-config-metadata.ts
@@ -12,7 +12,7 @@ import type {
   PluginManifest,
   PluginManifestChannelConfig,
 } from "./manifest.js";
-import { buildPluginLoaderJitiOptions, resolvePluginLoaderJitiConfig } from "./sdk-alias.js";
+import { buildPluginLoaderJitiOptions, resolvePluginLoaderJitiConfig, toSafeImportPath } from "./sdk-alias.js";
 import type { PluginConfigUiHint } from "./types.js";
 
 const PUBLIC_SURFACE_SOURCE_EXTENSIONS = [".ts", ".mts", ".js", ".mjs", ".cts", ".cjs"] as const;
@@ -109,7 +109,7 @@ function resolveChannelConfigSchemaModulePath(pluginDir: string): string | undef
 
 function loadChannelConfigSurfaceModuleSync(modulePath: string): ChannelConfigSurface | null {
   try {
-    const imported = getJiti(modulePath)(modulePath) as Record<string, unknown>;
+    const imported = getJiti(modulePath)(toSafeImportPath(modulePath)) as Record<string, unknown>;
     return resolveConfigSchemaExport(imported);
   } catch {
     return null;

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -12,6 +12,7 @@ import {
   buildPluginLoaderAliasMap,
   buildPluginLoaderJitiOptions,
   shouldPreferNativeJiti,
+  toSafeImportPath,
 } from "./sdk-alias.js";
 
 const CONTRACT_API_EXTENSIONS = [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts"] as const;
@@ -207,7 +208,7 @@ function resolvePluginDoctorContracts(params?: {
     }
     let mod: PluginDoctorContractModule;
     try {
-      mod = getJiti(contractSource)(contractSource) as PluginDoctorContractModule;
+      mod = getJiti(contractSource)(toSafeImportPath(contractSource)) as PluginDoctorContractModule;
     } catch {
       continue;
     }

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3906,4 +3906,27 @@ export const runtimeValue = helperValue;`,
       platformSpy.mockRestore();
     }
   });
+
+  it("encodes special characters in Windows paths (# ? etc)", () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+    try {
+      const result = __testing.toSafeImportPath("C:\\Users\\foo#bar\\plugin.mjs");
+      expect(result).toContain("file:///");
+      expect(result).not.toContain("#bar");
+      expect(result).toContain("foo%23bar");
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
+
+  it("is a no-op on non-Windows platforms", () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    try {
+      expect(__testing.toSafeImportPath("C:\\Users\\alice\\plugin\\index.mjs")).toBe(
+        "C:\\Users\\alice\\plugin\\index.mjs",
+      );
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
 });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -68,6 +68,7 @@ import {
   resolvePluginRuntimeModulePath,
   resolvePluginSdkScopedAliasMap,
   shouldPreferNativeJiti,
+  toSafeImportPath,
 } from "./sdk-alias.js";
 import { hasKind, kindsEqual } from "./slots.js";
 import type {
@@ -180,32 +181,6 @@ export function clearPluginLoaderCache(): void {
 }
 
 const defaultLogger = () => createSubsystemLogger("plugins");
-
-/**
- * On Windows, the Node.js ESM loader requires absolute paths to be expressed
- * as file:// URLs (e.g. file:///C:/Users/...). Raw drive-letter paths like
- * C:\... are rejected with ERR_UNSUPPORTED_ESM_URL_SCHEME because the loader
- * mistakes the drive letter for an unknown URL scheme.
- *
- * This helper converts Windows absolute import specifiers to file:// URLs and
- * leaves everything else unchanged.
- */
-function toSafeImportPath(specifier: string): string {
-  if (process.platform !== "win32") {
-    return specifier;
-  }
-  if (specifier.startsWith("file://")) {
-    return specifier;
-  }
-  if (path.win32.isAbsolute(specifier)) {
-    const normalizedSpecifier = specifier.replaceAll("\\", "/");
-    if (normalizedSpecifier.startsWith("//")) {
-      return new URL(`file:${encodeURI(normalizedSpecifier)}`).href;
-    }
-    return new URL(`file:///${encodeURI(normalizedSpecifier)}`).href;
-  }
-  return specifier;
-}
 
 function createPluginJitiLoader(options: Pick<PluginLoadOptions, "pluginSdkResolution">) {
   const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -11,6 +11,7 @@ import {
   isBundledPluginExtensionPath,
   resolvePluginLoaderJitiConfig,
   resolveLoaderPackageRoot,
+  toSafeImportPath,
 } from "./sdk-alias.js";
 
 const OPENCLAW_PACKAGE_ROOT =
@@ -156,7 +157,7 @@ export function loadBundledPluginPublicArtifactModuleSync<T extends object>(para
   const sentinel = {} as T;
   loadedPublicSurfaceModules.set(location.modulePath, sentinel);
   try {
-    const loaded = getJiti(location.modulePath)(location.modulePath) as T;
+    const loaded = getJiti(location.modulePath)(toSafeImportPath(location.modulePath)) as T;
     Object.assign(sentinel, loaded);
     return sentinel;
   } catch (error) {

--- a/src/plugins/runtime/runtime-plugin-boundary.ts
+++ b/src/plugins/runtime/runtime-plugin-boundary.ts
@@ -8,6 +8,7 @@ import {
   resolvePluginSdkAliasFile,
   resolvePluginSdkScopedAliasMap,
   shouldPreferNativeJiti,
+  toSafeImportPath,
 } from "../sdk-alias.js";
 
 type PluginRuntimeRecord = {
@@ -154,7 +155,7 @@ export function loadPluginBoundaryModuleWithJiti<TModule>(
   modulePath: string,
   loaders: Map<boolean, ReturnType<typeof createJiti>>,
 ): TModule {
-  return getPluginBoundaryJiti(modulePath, loaders)(modulePath) as TModule;
+  return getPluginBoundaryJiti(modulePath, loaders)(toSafeImportPath(modulePath)) as TModule;
 }
 
 export function createCachedPluginBoundaryModuleLoader<TModule>(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -431,7 +431,10 @@ export function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {
     interopDefault: true,
     // Prefer Node's native sync ESM loader for built dist/*.js modules so
     // bundled plugins and plugin-sdk subpaths stay on the canonical module graph.
-    tryNative: true,
+    // Disabled on Windows: jiti's tryNative path calls nativeImport() with raw
+    // drive-letter paths (C:\...) which Node's ESM loader rejects with
+    // ERR_UNSUPPORTED_ESM_URL_SCHEME.
+    tryNative: process.platform !== "win32",
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
     ...(Object.keys(aliasMap).length > 0
       ? {
@@ -439,6 +442,37 @@ export function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {
         }
       : {}),
   };
+}
+
+/**
+ * On Windows, the Node.js ESM loader requires absolute paths to be expressed
+ * as file:// URLs (e.g. file:///C:/Users/...). Raw drive-letter paths like
+ * C:\... are rejected with ERR_UNSUPPORTED_ESM_URL_SCHEME because the loader
+ * mistakes the drive letter for an unknown URL scheme.
+ *
+ * This helper converts Windows absolute import specifiers to file:// URLs and
+ * leaves everything else unchanged.
+ */
+export function toSafeImportPath(specifier: string): string {
+  if (process.platform !== "win32") {
+    return specifier;
+  }
+  if (specifier.startsWith("file://")) {
+    return specifier;
+  }
+  if (path.win32.isAbsolute(specifier)) {
+    // Manual conversion instead of pathToFileURL — pathToFileURL uses host OS
+    // rules so it produces wrong results in cross-platform test environments
+    // (e.g. Linux CI mocking process.platform to "win32").
+    // encodeURI does not encode # or ?, so we patch those explicitly.
+    const normalized = specifier.replaceAll("\\", "/");
+    const encoded = encodeURI(normalized).replaceAll("#", "%23").replaceAll("?", "%3F");
+    if (normalized.startsWith("//")) {
+      return `file:${encoded}`;
+    }
+    return `file:///${encoded}`;
+  }
+  return specifier;
 }
 
 function supportsNativeJitiRuntime(): boolean {

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -14,6 +14,7 @@ import {
   buildPluginLoaderAliasMap,
   buildPluginLoaderJitiOptions,
   shouldPreferNativeJiti,
+  toSafeImportPath,
 } from "./sdk-alias.js";
 import type {
   CliBackendPlugin,
@@ -292,7 +293,7 @@ export function resolvePluginSetupRegistry(params?: {
 
     let mod: OpenClawPluginModule;
     try {
-      mod = getJiti(setupSource)(setupSource) as OpenClawPluginModule;
+      mod = getJiti(setupSource)(toSafeImportPath(setupSource)) as OpenClawPluginModule;
     } catch {
       continue;
     }
@@ -415,7 +416,7 @@ export function resolvePluginSetupProvider(params: {
 
   let mod: OpenClawPluginModule;
   try {
-    mod = getJiti(setupSource)(setupSource) as OpenClawPluginModule;
+    mod = getJiti(setupSource)(toSafeImportPath(setupSource)) as OpenClawPluginModule;
   } catch {
     setupProviderCache.set(cacheKey, null);
     return undefined;
@@ -515,7 +516,7 @@ export function resolvePluginSetupCliBackend(params: {
 
   let mod: OpenClawPluginModule;
   try {
-    mod = getJiti(setupSource)(setupSource) as OpenClawPluginModule;
+    mod = getJiti(setupSource)(toSafeImportPath(setupSource)) as OpenClawPluginModule;
   } catch {
     return undefined;
   }

--- a/windows-esm-fix.mjs
+++ b/windows-esm-fix.mjs
@@ -1,0 +1,11 @@
+// ESM loader hook: convert raw Windows drive-letter paths (C:\...) to file:// URLs.
+// Jiti's native import path passes resolved absolute paths directly to import(),
+// but Node's ESM loader rejects drive-letter paths as unknown URL schemes.
+import { pathToFileURL } from "node:url";
+
+export async function resolve(specifier, context, nextResolve) {
+  if (/^[a-zA-Z]:/.test(specifier)) {
+    return nextResolve(pathToFileURL(specifier).href, context);
+  }
+  return nextResolve(specifier, context);
+}


### PR DESCRIPTION
## Summary

- **Problem:** `openclaw onboard` and other plugin-loading code paths crash on native Windows with `ERR_UNSUPPORTED_ESM_URL_SCHEME: Received protocol 'c:'`. Jiti's native import path passes resolved absolute Windows paths (`C:\Users\...`) directly to `import()`, which Node's ESM loader rejects because it interprets the drive letter as an unknown URL scheme.
- **Why it matters:** OpenClaw is completely unusable on native Windows — onboarding, model selection, and gateway startup all fail.
- **What changed:** Three-layer fix: (1) ESM loader hook (`windows-esm-fix.mjs`) registered at startup converts drive-letter specifiers to `file://` URLs; (2) `toSafeImportPath()` shared helper wraps all `getJiti()` call sites; (3) build-time symlink fallback copies files on Windows when `EPERM`. Also fixes pre-existing TypeScript strict-mode errors in `memory-core` that blocked `pnpm build` on a clean checkout.
- **What did NOT change:** No changes to non-Windows behavior. `toSafeImportPath()` is a no-op when `process.platform !== "win32"`. The ESM loader hook only registers on Windows.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Integrations
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #61795
- Related #61832
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Jiti's `nativeImportOrRequire` in `jiti.mjs` calls `import()` with resolved absolute paths. On non-Windows this works because `/absolute/path` is a valid URL path. On Windows, `C:/Users/...` is parsed as scheme `c:`, which Node rejects. The existing fix in #61832 only patched the `getJiti()(path)` call sites in `loader.ts`, missing: (a) 9 other files with identical `getJiti()` patterns, and (b) jiti's own internal `import()` which is unreachable from application code.
- **Missing detection / guardrail:** No Windows CI lane for `openclaw onboard` integration smoke test.
- **Contributing context:** The `tryNative: true` jiti option triggers a code path in `jiti.mjs` that lacks the `pathToFileURL()` guard present in `jiti.cjs`. Additionally, the build itself fails on Windows without Developer Mode due to file symlink `EPERM` errors.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] End-to-end test
  - [x] Existing coverage already sufficient
- **Target test or file:** `src/plugins/loader.test.ts` — `"converts Windows absolute import specifiers"`
- **Scenario the test should lock in:** `toSafeImportPath("C:\\Users\\alice\\plugin\\index.mjs")` returns `"file:///C:/Users/alice/plugin/index.mjs"`
- **Why this is the smallest reliable guardrail:** The unit test validates the helper that all call sites depend on. The remaining gap is an e2e Windows onboard smoke test.
- **Existing test that already covers this:** Yes — the test from #61832 validates `toSafeImportPath`. This PR moves the function to `sdk-alias.ts` (shared) and reuses it across all loader files.
- **If no new test is added, why not:** The existing unit test covers the helper. A full Windows e2e onboard smoke test is out of scope for this fix.

## User-visible / Behavior Changes

`openclaw onboard`, `openclaw doctor --fix`, and gateway startup now complete successfully on native Windows 11. No changes to behavior on Linux/macOS.

## Diagram (if applicable)

```text
Before:
[jiti resolves path] -> C:\Users\...\plugin.js -> import("C:/Users/.../plugin.js") -> ERR_UNSUPPORTED_ESM_URL_SCHEME

After (layer 1 - ESM hook in openclaw.mjs):
[jiti resolves path] -> C:\Users\...\plugin.js -> import("C:/Users/.../plugin.js")
  -> windows-esm-fix.mjs resolve() -> import("file:///C:/Users/.../plugin.js") -> OK

After (layer 2 - toSafeImportPath at call sites):
[getJiti(path)] -> getJiti(path)(toSafeImportPath(path)) -> jiti receives file:///... -> OK
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 11 Pro 10.0.26200
- Runtime: Node.js v22.20.0, pnpm 10.32.1
- Model/provider: anthropic/claude-opus-4-6 via setup-token
- Integration/channel: Telegram
- Relevant config: Default QuickStart config, loopback gateway on port 18789

### Steps

1. Build from source on Windows: `pnpm install && pnpm build`
2. Run `openclaw onboard`
3. Select Anthropic provider, choose auth method, select a model

### Expected

Onboarding completes through channel selection, skills, hooks, and gateway setup.

### Actual (before fix)

Crashes with `Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'` immediately after model selection.

## Evidence

- [x] Trace/log snippets — Custom ESM loader hook captured the exact bad specifiers from jiti:
  ```
  === BAD SPECIFIER FOUND ===
  Specifier: C:/Users/ozgur/Documents/openclaw/dist/agents/models-config.runtime.js
  Parent URL: file:///C:/Users/ozgur/Documents/openclaw/node_modules/jiti/lib/jiti.mjs
  Conditions: ["node","import","module-sync","node-addons"]
  === END ===
  ```
- [x] Failing before + passing after — `openclaw onboard` completes fully after the fix, including model selection, channel config, skills install, hooks setup, and gateway service install.

## Human Verification (required)
- Openclaw onboard tested on windows 11.
- **Verified scenarios:** Full `openclaw onboard` on Windows 11 with Anthropic setup-token auth, Telegram channel, Brave Search, skills install (4 skills), hooks enable (4 hooks), gateway service reinstall. Also verified `openclaw doctor --fix` loads all 54 plugins with 0 errors.
- **Edge cases checked:** `openclaw --version`, `openclaw --help`, `openclaw doctor --fix` (plugin loading), multiple onboard runs with different auth methods (CLI and setup-token).
- **What you did not verify:** Linux/macOS regression (no-op on non-Windows by design), WSL2, Docker/Podman builds.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** `windows-esm-fix.mjs` ESM loader hook intercepts all `resolve()` calls on Windows, adding a regex test per specifier.
  - **Mitigation:** The regex `/^[a-zA-Z]:/` is trivially fast and only fires on Windows. Non-matching specifiers pass through with zero transformation. The hook is not registered on non-Windows platforms.
- **Risk:** `tryNative: false` on Windows means jiti uses its transform path instead of Node's native ESM loader for plugin loading.
  - **Mitigation:** This matches the existing `shouldPreferNativeJiti()` which already returns `false` on Windows. The ESM loader hook is the primary fix; `tryNative: false` is defense-in-depth.
