### PR TITLE
feat(gateway): lifecycle shutdown metadata + restart outbox execution

### DIFF
--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,10 +1,40 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGatewayCloseHandler } from "./server-close.js";
 
-const mocks = {
-  logWarn: vi.fn(),
+type TestGatewayHookEvent = {
+  type?: string;
+  action?: string;
+  context?: Record<string, unknown>;
 };
-const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
-const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
+
+const { triggerInternalHook, readRestartSentinel, writeRestartSentinel } = vi.hoisted(() => ({
+  triggerInternalHook: vi.fn(
+    async (_event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => undefined,
+  ),
+  readRestartSentinel: vi.fn(async () => null),
+  writeRestartSentinel: vi.fn(async () => "sentinel.json"),
+}));
+
+vi.mock("../hooks/internal-hooks.js", async () => {
+  const actual = await vi.importActual<typeof import("../hooks/internal-hooks.js")>(
+    "../hooks/internal-hooks.js",
+  );
+  return {
+    ...actual,
+    triggerInternalHook,
+  };
+});
+
+vi.mock("../infra/restart-sentinel.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/restart-sentinel.js")>(
+    "../infra/restart-sentinel.js",
+  );
+  return {
+    ...actual,
+    readRestartSentinel,
+    writeRestartSentinel,
+  };
+});
 
 vi.mock("../channels/plugins/index.js", () => ({
   listChannelPlugins: () => [],
@@ -14,160 +44,182 @@ vi.mock("../hooks/gmail-watcher.js", () => ({
   stopGmailWatcher: vi.fn(async () => undefined),
 }));
 
-vi.mock("../logging/subsystem.js", () => ({
-  createSubsystemLogger: vi.fn(() => ({
-    warn: mocks.logWarn,
-  })),
-}));
-
-const { createGatewayCloseHandler } = await import("./server-close.js");
+function createCloseHarness(params?: {
+  lifecycleUnsub?: () => void;
+  broadcast?: (event: string, payload: unknown) => void;
+  stallWssClose?: boolean;
+}) {
+  const tickInterval = setInterval(() => undefined, 60_000);
+  const healthInterval = setInterval(() => undefined, 60_000);
+  const dedupeCleanup = setInterval(() => undefined, 60_000);
+  const close = createGatewayCloseHandler({
+    bonjourStop: null,
+    tailscaleCleanup: null,
+    canvasHost: null,
+    canvasHostServer: null,
+    stopChannel: vi.fn(async () => undefined),
+    pluginServices: null,
+    cron: { stop: vi.fn() },
+    heartbeatRunner: { stop: vi.fn() } as never,
+    updateCheckStop: null,
+    nodePresenceTimers: new Map(),
+    broadcast: params?.broadcast ?? vi.fn(),
+    tickInterval,
+    healthInterval,
+    dedupeCleanup,
+    mediaCleanup: null,
+    agentUnsub: null,
+    heartbeatUnsub: null,
+    transcriptUnsub: null,
+    lifecycleUnsub: params?.lifecycleUnsub ?? null,
+    chatRunState: { clear: vi.fn() },
+    clients: new Set(),
+    configReloader: { stop: vi.fn(async () => undefined) },
+    wss: {
+      close: (cb: () => void) => {
+        if (!params?.stallWssClose) {
+          cb();
+        }
+      },
+    } as never,
+    httpServer: {
+      close: (cb: (err?: Error | null) => void) => cb(null),
+      closeIdleConnections: vi.fn(),
+    } as never,
+  });
+  return {
+    close,
+    dispose() {
+      clearInterval(tickInterval);
+      clearInterval(healthInterval);
+      clearInterval(dedupeCleanup);
+    },
+  };
+}
 
 describe("createGatewayCloseHandler", () => {
   beforeEach(() => {
-    vi.useRealTimers();
-    mocks.logWarn.mockClear();
+    triggerInternalHook.mockReset();
+    triggerInternalHook.mockResolvedValue(undefined);
+    readRestartSentinel.mockReset();
+    readRestartSentinel.mockResolvedValue(null);
+    writeRestartSentinel.mockReset();
+    writeRestartSentinel.mockResolvedValue("sentinel.json");
   });
 
   it("unsubscribes lifecycle listeners during shutdown", async () => {
     const lifecycleUnsub = vi.fn();
-    const stopTaskRegistryMaintenance = vi.fn();
-    const close = createGatewayCloseHandler({
-      bonjourStop: null,
-      tailscaleCleanup: null,
-      canvasHost: null,
-      canvasHostServer: null,
-      stopChannel: vi.fn(async () => undefined),
-      pluginServices: null,
-      cron: { stop: vi.fn() },
-      heartbeatRunner: { stop: vi.fn() } as never,
-      updateCheckStop: null,
-      stopTaskRegistryMaintenance,
-      nodePresenceTimers: new Map(),
-      broadcast: vi.fn(),
-      tickInterval: setInterval(() => undefined, 60_000),
-      healthInterval: setInterval(() => undefined, 60_000),
-      dedupeCleanup: setInterval(() => undefined, 60_000),
-      mediaCleanup: null,
-      agentUnsub: null,
-      heartbeatUnsub: null,
-      transcriptUnsub: null,
-      lifecycleUnsub,
-      chatRunState: { clear: vi.fn() },
-      clients: new Set(),
-      configReloader: { stop: vi.fn(async () => undefined) },
-      wss: { close: (cb: () => void) => cb() } as never,
-      httpServer: {
-        close: (cb: (err?: Error | null) => void) => cb(null),
-        closeIdleConnections: vi.fn(),
-      } as never,
-    });
-
-    await close({ reason: "test shutdown" });
-
-    expect(lifecycleUnsub).toHaveBeenCalledTimes(1);
-    expect(stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
+    const harness = createCloseHarness({ lifecycleUnsub });
+    try {
+      await harness.close({ reason: "test shutdown", initiator: "SIGTERM" });
+      expect(lifecycleUnsub).toHaveBeenCalledTimes(1);
+    } finally {
+      harness.dispose();
+    }
   });
 
-  it("terminates lingering websocket clients when websocket close exceeds the grace window", async () => {
+  it("continues shutdown when websocket close callback stalls", async () => {
     vi.useFakeTimers();
+    const harness = createCloseHarness({ stallWssClose: true });
 
-    let closeCallback: (() => void) | null = null;
-    const terminate = vi.fn(() => {
-      closeCallback?.();
+    let settled = false;
+    const closePromise = harness.close().then(() => {
+      settled = true;
     });
-    const close = createGatewayCloseHandler({
-      bonjourStop: null,
-      tailscaleCleanup: null,
-      canvasHost: null,
-      canvasHostServer: null,
-      stopChannel: vi.fn(async () => undefined),
-      pluginServices: null,
-      cron: { stop: vi.fn() },
-      heartbeatRunner: { stop: vi.fn() } as never,
-      updateCheckStop: null,
-      stopTaskRegistryMaintenance: null,
-      nodePresenceTimers: new Map(),
-      broadcast: vi.fn(),
-      tickInterval: setInterval(() => undefined, 60_000),
-      healthInterval: setInterval(() => undefined, 60_000),
-      dedupeCleanup: setInterval(() => undefined, 60_000),
-      mediaCleanup: null,
-      agentUnsub: null,
-      heartbeatUnsub: null,
-      transcriptUnsub: null,
-      lifecycleUnsub: null,
-      chatRunState: { clear: vi.fn() },
-      clients: new Set(),
-      configReloader: { stop: vi.fn(async () => undefined) },
-      wss: {
-        clients: new Set([{ terminate }]),
-        close: (cb: () => void) => {
-          closeCallback = cb;
-        },
-      } as never,
-      httpServer: {
-        close: (cb: (err?: Error | null) => void) => cb(null),
-        closeIdleConnections: vi.fn(),
-      } as never,
-    });
+    await vi.advanceTimersByTimeAsync(2_100);
+    await Promise.resolve();
+    expect(settled).toBe(true);
 
-    const closePromise = close({ reason: "test shutdown" });
-    await vi.advanceTimersByTimeAsync(WEBSOCKET_CLOSE_GRACE_MS);
     await closePromise;
-
-    expect(terminate).toHaveBeenCalledTimes(1);
-    expect(
-      mocks.logWarn.mock.calls.some(([message]) =>
-        String(message).includes("websocket server close exceeded 1000ms"),
-      ),
-    ).toBe(true);
+    harness.dispose();
   });
 
-  it("continues shutdown when websocket close hangs without tracked clients", async () => {
-    vi.useFakeTimers();
+  it("emits gateway shutdown + pre-restart hooks with lifecycle metadata", async () => {
+    const harness = createCloseHarness();
+    try {
+      await harness.close({
+        reason: "gateway restarting",
+        restartExpectedMs: 123,
+        initiator: "SIGUSR1",
+        restartId: "restart-123",
+        correlationId: "corr-123",
+      });
 
-    const close = createGatewayCloseHandler({
-      bonjourStop: null,
-      tailscaleCleanup: null,
-      canvasHost: null,
-      canvasHostServer: null,
-      stopChannel: vi.fn(async () => undefined),
-      pluginServices: null,
-      cron: { stop: vi.fn() },
-      heartbeatRunner: { stop: vi.fn() } as never,
-      updateCheckStop: null,
-      stopTaskRegistryMaintenance: null,
-      nodePresenceTimers: new Map(),
-      broadcast: vi.fn(),
-      tickInterval: setInterval(() => undefined, 60_000),
-      healthInterval: setInterval(() => undefined, 60_000),
-      dedupeCleanup: setInterval(() => undefined, 60_000),
-      mediaCleanup: null,
-      agentUnsub: null,
-      heartbeatUnsub: null,
-      transcriptUnsub: null,
-      lifecycleUnsub: null,
-      chatRunState: { clear: vi.fn() },
-      clients: new Set(),
-      configReloader: { stop: vi.fn(async () => undefined) },
-      wss: {
-        clients: new Set(),
-        close: () => undefined,
-      } as never,
-      httpServer: {
-        close: (cb: (err?: Error | null) => void) => cb(null),
-        closeIdleConnections: vi.fn(),
-      } as never,
-    });
+      const hookCalls = triggerInternalHook.mock.calls as Array<
+        [TestGatewayHookEvent, { perHandlerTimeoutMs?: number }?]
+      >;
+      const shutdownEvent = hookCalls.find(
+        (call) => call[0]?.type === "gateway" && call[0]?.action === "shutdown",
+      )?.[0];
+      const preRestartEvent = hookCalls.find(
+        (call) => call[0]?.type === "gateway" && call[0]?.action === "pre-restart",
+      )?.[0];
 
-    const closePromise = close({ reason: "test shutdown" });
-    await vi.advanceTimersByTimeAsync(WEBSOCKET_CLOSE_GRACE_MS + WEBSOCKET_CLOSE_FORCE_CONTINUE_MS);
-    await closePromise;
+      expect(shutdownEvent?.context).toMatchObject({
+        reason: "gateway restarting",
+        restartExpectedMs: 123,
+        initiator: "SIGUSR1",
+        restartId: "restart-123",
+        correlationId: "corr-123",
+      });
+      expect(preRestartEvent?.context).toMatchObject({
+        reason: "gateway restarting",
+        restartExpectedMs: 123,
+        initiator: "SIGUSR1",
+        restartId: "restart-123",
+        correlationId: "corr-123",
+      });
+      expect(Array.isArray(preRestartEvent?.context?.outbox)).toBe(true);
+      expect(triggerInternalHook.mock.calls[0]?.[1]).toMatchObject({
+        perHandlerTimeoutMs: 1500,
+      });
+    } finally {
+      harness.dispose();
+    }
+  });
 
-    expect(
-      mocks.logWarn.mock.calls.some(([message]) =>
-        String(message).includes("websocket server close still pending after 250ms force window"),
-      ),
-    ).toBe(true);
+  it("persists hook outbox tasks into restart sentinel", async () => {
+    triggerInternalHook.mockImplementation(
+      async (event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => {
+        if (event.type === "gateway" && event.action === "pre-restart") {
+          const outbox = event.context?.outbox as Array<Record<string, unknown>>;
+          outbox.push({
+            message: "Gateway is back after restart",
+            sessionKey: "agent:main:main",
+          });
+        }
+      },
+    );
+
+    const harness = createCloseHarness();
+    try {
+      await harness.close({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+        initiator: "SIGUSR1",
+        restartId: "restart-abc",
+      });
+
+      expect(writeRestartSentinel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "restart",
+          status: "ok",
+          restartId: "restart-abc",
+          correlationId: "restart-abc",
+          initiator: "SIGUSR1",
+          suppressPrimaryNotice: true,
+          outbox: [
+            expect.objectContaining({
+              message: "Gateway is back after restart",
+              sessionKey: "agent:main:main",
+              restartId: "restart-abc",
+              correlationId: "restart-abc",
+            }),
+          ],
+        }),
+      );
+    } finally {
+      harness.dispose();
+    }
   });
 });

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -52,6 +52,9 @@ function createCloseHarness(params?: {
   const tickInterval = setInterval(() => undefined, 60_000);
   const healthInterval = setInterval(() => undefined, 60_000);
   const dedupeCleanup = setInterval(() => undefined, 60_000);
+  const stopTaskRegistryMaintenance = vi.fn();
+  const loggerWarn = vi.fn();
+  const stalledSocketTerminate = vi.fn();
   const close = createGatewayCloseHandler({
     bonjourStop: null,
     tailscaleCleanup: null,
@@ -72,6 +75,8 @@ function createCloseHarness(params?: {
     heartbeatUnsub: null,
     transcriptUnsub: null,
     lifecycleUnsub: params?.lifecycleUnsub ?? null,
+    stopTaskRegistryMaintenance,
+    logger: { warn: loggerWarn },
     chatRunState: { clear: vi.fn() },
     clients: new Set(),
     configReloader: { stop: vi.fn(async () => undefined) },
@@ -81,6 +86,7 @@ function createCloseHarness(params?: {
           cb();
         }
       },
+      clients: new Set([{ terminate: stalledSocketTerminate }]),
     } as never,
     httpServer: {
       close: (cb: (err?: Error | null) => void) => cb(null),
@@ -89,6 +95,9 @@ function createCloseHarness(params?: {
   });
   return {
     close,
+    stopTaskRegistryMaintenance,
+    loggerWarn,
+    stalledSocketTerminate,
     dispose() {
       clearInterval(tickInterval);
       clearInterval(healthInterval);
@@ -113,6 +122,7 @@ describe("createGatewayCloseHandler", () => {
     try {
       await harness.close({ reason: "test shutdown", initiator: "SIGTERM" });
       expect(lifecycleUnsub).toHaveBeenCalledTimes(1);
+      expect(harness.stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
     } finally {
       harness.dispose();
     }
@@ -129,6 +139,11 @@ describe("createGatewayCloseHandler", () => {
     await vi.advanceTimersByTimeAsync(2_100);
     await Promise.resolve();
     expect(settled).toBe(true);
+    expect(harness.stalledSocketTerminate).toHaveBeenCalledTimes(1);
+    expect(harness.loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("forcing client termination"),
+    );
+    expect(harness.stopTaskRegistryMaintenance).toHaveBeenCalledTimes(1);
 
     await closePromise;
     harness.dispose();

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createGatewayCloseHandler } from "./server-close.js";
 
 type TestGatewayHookEvent = {
@@ -210,10 +210,9 @@ describe("createGatewayCloseHandler", () => {
           suppressPrimaryNotice: true,
           outbox: [
             expect.objectContaining({
+              kind: "message",
               message: "Gateway is back after restart",
               sessionKey: "agent:main:main",
-              restartId: "restart-abc",
-              correlationId: "restart-abc",
             }),
           ],
         }),

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -8,14 +8,15 @@ type TestGatewayHookEvent = {
   context?: Record<string, unknown>;
 };
 
-const { triggerInternalHook, readRestartSentinel, writeRestartSentinel, subsystemLoggerWarn } = vi.hoisted(() => ({
-  triggerInternalHook: vi.fn(
-    async (_event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => undefined,
-  ),
-  readRestartSentinel: vi.fn(async () => null),
-  writeRestartSentinel: vi.fn(async () => "sentinel.json"),
-  subsystemLoggerWarn: vi.fn(),
-}));
+const { triggerInternalHook, readRestartSentinel, writeRestartSentinel, subsystemLoggerWarn } =
+  vi.hoisted(() => ({
+    triggerInternalHook: vi.fn(
+      async (_event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => undefined,
+    ),
+    readRestartSentinel: vi.fn(async () => null),
+    writeRestartSentinel: vi.fn(async () => "sentinel.json"),
+    subsystemLoggerWarn: vi.fn(),
+  }));
 
 vi.mock("../hooks/internal-hooks.js", async () => {
   const actual = await vi.importActual<typeof import("../hooks/internal-hooks.js")>(
@@ -325,9 +326,7 @@ describe("createGatewayCloseHandler", () => {
         restartExpectedMs: 1500,
       });
 
-      const payload = writeRestartSentinel.mock.calls.at(-1)?.[0] as
-        | RestartSentinelPayload
-        | undefined;
+      const payload = (writeRestartSentinel.mock.calls as Array<[RestartSentinelPayload]>).at(-1)?.[0];
       expect(payload?.outbox).toEqual([
         expect.objectContaining({
           kind: "message",
@@ -338,6 +337,95 @@ describe("createGatewayCloseHandler", () => {
             to: "119707338",
             accountId: "default",
           },
+        }),
+      ]);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("preserves nested deliveryContext threadId for normalized message outbox tasks", async () => {
+    triggerInternalHook.mockImplementation(
+      async (event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => {
+        if (event.type === "gateway" && event.action === "pre-restart") {
+          const outbox = event.context?.outbox as Array<Record<string, unknown>>;
+          outbox.push({
+            message: "Gateway is back after restart",
+            sessionKey: "agent:main:main",
+            deliveryContext: {
+              channel: "telegram",
+              to: "119707338",
+              accountId: "default",
+              threadId: "20",
+            },
+          });
+        }
+      },
+    );
+
+    const harness = createCloseHarness();
+    try {
+      await harness.close({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+      });
+
+      const payload = (writeRestartSentinel.mock.calls as Array<[RestartSentinelPayload]>).at(-1)?.[0];
+      expect(payload?.outbox).toEqual([
+        expect.objectContaining({
+          kind: "message",
+          message: "Gateway is back after restart",
+          sessionKey: "agent:main:main",
+          deliveryContext: {
+            channel: "telegram",
+            to: "119707338",
+            accountId: "default",
+            threadId: "20",
+          },
+        }),
+      ]);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("ignores malformed existing sentinel outbox entries when deciding notice suppression", async () => {
+    readRestartSentinel.mockResolvedValue({
+      payload: {
+        kind: "restart",
+        status: "ok",
+        ts: Date.now(),
+        sessionKey: "agent:main:main",
+        suppressPrimaryNotice: true,
+        outbox: [null],
+      },
+    });
+    triggerInternalHook.mockImplementation(
+      async (event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => {
+        if (event.type === "gateway" && event.action === "pre-restart") {
+          const outbox = event.context?.outbox as Array<Record<string, unknown>>;
+          outbox.push({
+            message: "Gateway is back after restart",
+            sessionKey: "agent:main:main",
+          });
+        }
+      },
+    );
+
+    const harness = createCloseHarness();
+    try {
+      await harness.close({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+      });
+
+      const payload = (writeRestartSentinel.mock.calls as Array<[RestartSentinelPayload]>).at(-1)?.[0];
+      expect(payload?.suppressPrimaryNotice).toBe(true);
+      expect(payload?.outbox).toEqual([
+        expect.objectContaining({
+          kind: "message",
+          message: "Gateway is back after restart",
+          sessionKey: "agent:main:main",
         }),
       ]);
     } finally {
@@ -364,9 +452,7 @@ describe("createGatewayCloseHandler", () => {
         restartExpectedMs: 1500,
       });
 
-      const payload = writeRestartSentinel.mock.calls.at(-1)?.[0] as
-        | RestartSentinelPayload
-        | undefined;
+      const payload = (writeRestartSentinel.mock.calls as Array<[RestartSentinelPayload]>).at(-1)?.[0];
       expect(payload?.outbox).toEqual([
         expect.objectContaining({
           kind: "message",

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -170,9 +170,7 @@ describe("createGatewayCloseHandler", () => {
         correlationId: "corr-123",
       });
       expect(Array.isArray(preRestartEvent?.context?.outbox)).toBe(true);
-      expect(triggerInternalHook.mock.calls[0]?.[1]).toMatchObject({
-        perHandlerTimeoutMs: 1500,
-      });
+      expect(triggerInternalHook.mock.calls[0]?.[1]).toBeUndefined();
     } finally {
       harness.dispose();
     }

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -464,4 +464,59 @@ describe("createGatewayCloseHandler", () => {
       harness.dispose();
     }
   });
+
+  it("preserves numeric thread ids while normalizing persisted outbox tasks", async () => {
+    triggerInternalHook.mockImplementation(
+      async (event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => {
+        if (event.type === "gateway" && event.action === "pre-restart") {
+          const outbox = event.context?.outbox as Array<Record<string, unknown>>;
+          outbox.push({
+            kind: "notify-session",
+            message: "notify after restart",
+            sessionKey: "agent:main:main",
+            threadId: 20,
+          });
+          outbox.push({
+            message: "message after restart",
+            sessionKey: "agent:main:main",
+            deliveryContext: {
+              channel: "telegram",
+              to: "119707338",
+              accountId: "default",
+              threadId: 21,
+            },
+          });
+        }
+      },
+    );
+
+    const harness = createCloseHarness();
+    try {
+      await harness.close({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+      });
+
+      const payload = (writeRestartSentinel.mock.calls as Array<[RestartSentinelPayload]>).at(-1)?.[0];
+      expect(payload?.outbox).toEqual([
+        expect.objectContaining({
+          kind: "notify-session",
+          message: "notify after restart",
+          threadId: "20",
+        }),
+        expect.objectContaining({
+          kind: "message",
+          message: "message after restart",
+          deliveryContext: expect.objectContaining({
+            channel: "telegram",
+            to: "119707338",
+            accountId: "default",
+            threadId: "21",
+          }),
+        }),
+      ]);
+    } finally {
+      harness.dispose();
+    }
+  });
 });

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RestartSentinelPayload } from "../infra/restart-sentinel.js";
 import { createGatewayCloseHandler } from "./server-close.js";
 
 type TestGatewayHookEvent = {
@@ -203,7 +204,7 @@ describe("createGatewayCloseHandler", () => {
   it("continues shutdown when a lifecycle hook stalls", async () => {
     vi.useFakeTimers();
     triggerInternalHook
-      .mockImplementationOnce(async () => await new Promise<void>(() => {}))
+      .mockImplementationOnce(async () => await new Promise<undefined>(() => {}))
       .mockResolvedValue(undefined);
 
     const harness = createCloseHarness();
@@ -233,7 +234,7 @@ describe("createGatewayCloseHandler", () => {
   it("falls back to subsystem logging when shutdown hook stalls without params.logger", async () => {
     vi.useFakeTimers();
     triggerInternalHook
-      .mockImplementationOnce(async () => await new Promise<void>(() => {}))
+      .mockImplementationOnce(async () => await new Promise<undefined>(() => {}))
       .mockResolvedValue(undefined);
 
     const harness = createCloseHarness({ omitLogger: true });
@@ -324,7 +325,9 @@ describe("createGatewayCloseHandler", () => {
         restartExpectedMs: 1500,
       });
 
-      const payload = writeRestartSentinel.mock.calls[0]?.[0];
+      const payload = writeRestartSentinel.mock.calls.at(-1)?.[0] as
+        | RestartSentinelPayload
+        | undefined;
       expect(payload?.outbox).toEqual([
         expect.objectContaining({
           kind: "message",
@@ -361,7 +364,9 @@ describe("createGatewayCloseHandler", () => {
         restartExpectedMs: 1500,
       });
 
-      const payload = writeRestartSentinel.mock.calls[0]?.[0];
+      const payload = writeRestartSentinel.mock.calls.at(-1)?.[0] as
+        | RestartSentinelPayload
+        | undefined;
       expect(payload?.outbox).toEqual([
         expect.objectContaining({
           kind: "message",

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -234,4 +234,77 @@ describe("createGatewayCloseHandler", () => {
       harness.dispose();
     }
   });
+
+  it("preserves legacy top-level routing fields for normalized message outbox tasks", async () => {
+    triggerInternalHook.mockImplementation(
+      async (event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => {
+        if (event.type === "gateway" && event.action === "pre-restart") {
+          const outbox = event.context?.outbox as Array<Record<string, unknown>>;
+          outbox.push({
+            message: "Gateway is back after restart",
+            sessionKey: "agent:main:main",
+            channel: "telegram",
+            to: "119707338",
+            accountId: "default",
+          });
+        }
+      },
+    );
+
+    const harness = createCloseHarness();
+    try {
+      await harness.close({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+      });
+
+      const payload = writeRestartSentinel.mock.calls[0]?.[0];
+      expect(payload?.outbox).toEqual([
+        expect.objectContaining({
+          kind: "message",
+          message: "Gateway is back after restart",
+          sessionKey: "agent:main:main",
+          deliveryContext: {
+            channel: "telegram",
+            to: "119707338",
+            accountId: "default",
+          },
+        }),
+      ]);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("does not suppress the primary notice when persisted outbox is not deliverable", async () => {
+    triggerInternalHook.mockImplementation(
+      async (event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => {
+        if (event.type === "gateway" && event.action === "pre-restart") {
+          const outbox = event.context?.outbox as Array<Record<string, unknown>>;
+          outbox.push({
+            message: "Gateway is back after restart",
+          });
+        }
+      },
+    );
+
+    const harness = createCloseHarness();
+    try {
+      await harness.close({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+      });
+
+      const payload = writeRestartSentinel.mock.calls[0]?.[0];
+      expect(payload?.outbox).toEqual([
+        expect.objectContaining({
+          kind: "message",
+          message: "Gateway is back after restart",
+        }),
+      ]);
+      expect(payload?.suppressPrimaryNotice).toBeUndefined();
+    } finally {
+      harness.dispose();
+    }
+  });
 });

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -7,12 +7,13 @@ type TestGatewayHookEvent = {
   context?: Record<string, unknown>;
 };
 
-const { triggerInternalHook, readRestartSentinel, writeRestartSentinel } = vi.hoisted(() => ({
+const { triggerInternalHook, readRestartSentinel, writeRestartSentinel, subsystemLoggerWarn } = vi.hoisted(() => ({
   triggerInternalHook: vi.fn(
     async (_event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => undefined,
   ),
   readRestartSentinel: vi.fn(async () => null),
   writeRestartSentinel: vi.fn(async () => "sentinel.json"),
+  subsystemLoggerWarn: vi.fn(),
 }));
 
 vi.mock("../hooks/internal-hooks.js", async () => {
@@ -44,10 +45,17 @@ vi.mock("../hooks/gmail-watcher.js", () => ({
   stopGmailWatcher: vi.fn(async () => undefined),
 }));
 
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: vi.fn(() => ({
+    warn: subsystemLoggerWarn,
+  })),
+}));
+
 function createCloseHarness(params?: {
   lifecycleUnsub?: () => void;
   broadcast?: (event: string, payload: unknown) => void;
   stallWssClose?: boolean;
+  omitLogger?: boolean;
 }) {
   const tickInterval = setInterval(() => undefined, 60_000);
   const healthInterval = setInterval(() => undefined, 60_000);
@@ -76,7 +84,7 @@ function createCloseHarness(params?: {
     transcriptUnsub: null,
     lifecycleUnsub: params?.lifecycleUnsub ?? null,
     stopTaskRegistryMaintenance,
-    logger: { warn: loggerWarn },
+    ...(params?.omitLogger ? {} : { logger: { warn: loggerWarn } }),
     chatRunState: { clear: vi.fn() },
     clients: new Set(),
     configReloader: { stop: vi.fn(async () => undefined) },
@@ -114,6 +122,7 @@ describe("createGatewayCloseHandler", () => {
     readRestartSentinel.mockResolvedValue(null);
     writeRestartSentinel.mockReset();
     writeRestartSentinel.mockResolvedValue("sentinel.json");
+    subsystemLoggerWarn.mockReset();
   });
 
   it("unsubscribes lifecycle listeners during shutdown", async () => {
@@ -212,6 +221,33 @@ describe("createGatewayCloseHandler", () => {
       expect(settled).toBe(true);
       expect(triggerInternalHook).toHaveBeenCalledTimes(2);
       expect(harness.loggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("shutdown hook timed out after 1500ms"),
+      );
+
+      await closePromise;
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("falls back to subsystem logging when shutdown hook stalls without params.logger", async () => {
+    vi.useFakeTimers();
+    triggerInternalHook
+      .mockImplementationOnce(async () => await new Promise<void>(() => {}))
+      .mockResolvedValue(undefined);
+
+    const harness = createCloseHarness({ omitLogger: true });
+    try {
+      let settled = false;
+      const closePromise = harness.close().then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(1_600);
+      await Promise.resolve();
+
+      expect(settled).toBe(true);
+      expect(subsystemLoggerWarn).toHaveBeenCalledWith(
         expect.stringContaining("shutdown hook timed out after 1500ms"),
       );
 

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -191,6 +191,36 @@ describe("createGatewayCloseHandler", () => {
     }
   });
 
+  it("continues shutdown when a lifecycle hook stalls", async () => {
+    vi.useFakeTimers();
+    triggerInternalHook
+      .mockImplementationOnce(async () => await new Promise<void>(() => {}))
+      .mockResolvedValue(undefined);
+
+    const harness = createCloseHarness();
+    try {
+      let settled = false;
+      const closePromise = harness
+        .close({ reason: "gateway restarting", restartExpectedMs: 123 })
+        .then(() => {
+          settled = true;
+        });
+
+      await vi.advanceTimersByTimeAsync(1_600);
+      await Promise.resolve();
+
+      expect(settled).toBe(true);
+      expect(triggerInternalHook).toHaveBeenCalledTimes(2);
+      expect(harness.loggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining("shutdown hook timed out after 1500ms"),
+      );
+
+      await closePromise;
+    } finally {
+      harness.dispose();
+    }
+  });
+
   it("persists hook outbox tasks into restart sentinel", async () => {
     triggerInternalHook.mockImplementation(
       async (event: TestGatewayHookEvent, _opts?: { perHandlerTimeoutMs?: number }) => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -1,15 +1,185 @@
+import { randomUUID } from "node:crypto";
 import type { Server as HttpServer } from "node:http";
 import type { WebSocketServer } from "ws";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
+import {
+  createInternalHookEvent,
+  triggerInternalHook,
+  type GatewayRestartOutboxTask,
+} from "../hooks/internal-hooks.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
-import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  formatDoctorNonInteractiveHint,
+  readRestartSentinel,
+  writeRestartSentinel,
+} from "../infra/restart-sentinel.js";
+import type { RestartOutboxTask, RestartSentinelPayload } from "../infra/restart-sentinel.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 
-const shutdownLog = createSubsystemLogger("gateway/shutdown");
-const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
-const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
+const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 1500;
+const GATEWAY_WSS_CLOSE_TIMEOUT_MS = 2000;
+
+type GatewayCloseOptions = {
+  reason?: string;
+  restartExpectedMs?: number | null;
+  /** Best-effort initiator/source (e.g. SIGUSR1, SIGTERM). */
+  initiator?: string;
+  /** Stable restart identifier for lifecycle correlation. */
+  restartId?: string;
+  /** Correlation identifier (alias of restartId by default). */
+  correlationId?: string;
+};
+
+function normalizeNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+async function closeWssWithTimeout(
+  closeFn: (cb: () => void) => void,
+  timeoutMs: number,
+): Promise<"closed" | "timeout"> {
+  return await new Promise<"closed" | "timeout">((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve("timeout");
+    }, timeoutMs);
+
+    closeFn(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve("closed");
+    });
+  });
+}
+
+function normalizeGatewayOutbox(
+  outbox: GatewayRestartOutboxTask[],
+  restartId?: string,
+  correlationId?: string,
+): RestartOutboxTask[] {
+  return outbox
+    .map((raw) => {
+      if (!raw || typeof raw !== "object") {
+        return null;
+      }
+      const message = normalizeNonEmptyString(raw.message);
+      if (!message) {
+        return null;
+      }
+      const sessionKey = normalizeNonEmptyString(raw.sessionKey);
+      const threadId = normalizeNonEmptyString(raw.threadId);
+      const deliveryContext = raw.deliveryContext;
+      const delivery =
+        deliveryContext && typeof deliveryContext === "object"
+          ? {
+              channel: normalizeNonEmptyString(deliveryContext.channel),
+              to: normalizeNonEmptyString(deliveryContext.to),
+              accountId: normalizeNonEmptyString(deliveryContext.accountId),
+            }
+          : undefined;
+      const resolvedRestartId = normalizeNonEmptyString(raw.restartId) ?? restartId;
+      const resolvedCorrelationId =
+        normalizeNonEmptyString(raw.correlationId) ?? correlationId ?? resolvedRestartId;
+      const rawKind = normalizeNonEmptyString((raw as { kind?: unknown }).kind);
+      const kind: RestartOutboxTask["kind"] =
+        rawKind === "system_event" ? "system_event" : "message";
+      const task: RestartOutboxTask = {
+        ...(kind === "message" ? { kind: "message" as const } : { kind: "system_event" as const }),
+        message,
+        ...(sessionKey ? { sessionKey } : {}),
+        ...(threadId ? { threadId } : {}),
+        ...(delivery?.channel || delivery?.to || delivery?.accountId
+          ? {
+              deliveryContext: {
+                ...(delivery.channel ? { channel: delivery.channel } : {}),
+                ...(delivery.to ? { to: delivery.to } : {}),
+                ...(delivery.accountId ? { accountId: delivery.accountId } : {}),
+              },
+            }
+          : {}),
+        ...(resolvedRestartId ? { restartId: resolvedRestartId } : {}),
+        ...(resolvedCorrelationId ? { correlationId: resolvedCorrelationId } : {}),
+      };
+      return task;
+    })
+    .filter((task): task is RestartOutboxTask => task !== null);
+}
+
+async function persistGatewayRestartOutbox(params: {
+  reason: string;
+  initiator?: string;
+  restartId?: string;
+  correlationId?: string;
+  outbox: GatewayRestartOutboxTask[];
+}) {
+  const normalizedOutbox = normalizeGatewayOutbox(
+    params.outbox,
+    params.restartId,
+    params.correlationId,
+  );
+
+  const existing = await readRestartSentinel().catch(() => null);
+  const existingPayload = existing?.payload;
+  const existingOutbox = Array.isArray(existingPayload?.outbox) ? existingPayload.outbox : [];
+  const mergedOutbox = [...existingOutbox, ...normalizedOutbox];
+
+  if (!existingPayload && mergedOutbox.length === 0) {
+    return;
+  }
+
+  const resolvedRestartId = params.restartId ?? existingPayload?.restartId;
+  const resolvedCorrelationId =
+    params.correlationId ?? existingPayload?.correlationId ?? resolvedRestartId;
+  const resolvedInitiator = params.initiator ?? existingPayload?.initiator;
+  const stats = {
+    ...existingPayload?.stats,
+    reason: existingPayload?.stats?.reason ?? params.reason,
+  };
+
+  const payload: RestartSentinelPayload = {
+    kind: existingPayload?.kind ?? "restart",
+    status: existingPayload?.status ?? "ok",
+    ts: existingPayload?.ts ?? Date.now(),
+    ...(resolvedRestartId ? { restartId: resolvedRestartId } : {}),
+    ...(resolvedCorrelationId ? { correlationId: resolvedCorrelationId } : {}),
+    ...(resolvedInitiator ? { initiator: resolvedInitiator } : {}),
+    ...(existingPayload?.sessionKey ? { sessionKey: existingPayload.sessionKey } : {}),
+    ...(existingPayload?.deliveryContext
+      ? { deliveryContext: existingPayload.deliveryContext }
+      : {}),
+    ...(existingPayload?.threadId ? { threadId: existingPayload.threadId } : {}),
+    ...(typeof existingPayload?.message === "string" || existingPayload?.message === null
+      ? { message: existingPayload.message }
+      : {}),
+    ...(existingPayload?.doctorHint
+      ? { doctorHint: existingPayload.doctorHint }
+      : { doctorHint: formatDoctorNonInteractiveHint() }),
+    ...(Object.keys(stats).length > 0 ? { stats } : {}),
+    ...(typeof existingPayload?.suppressPrimaryNotice === "boolean"
+      ? { suppressPrimaryNotice: existingPayload.suppressPrimaryNotice }
+      : !existingPayload && mergedOutbox.length > 0
+        ? { suppressPrimaryNotice: true }
+        : {}),
+    ...(mergedOutbox.length > 0 ? { outbox: mergedOutbox } : {}),
+  };
+
+  await writeRestartSentinel(payload).catch(() => {
+    // best-effort only
+  });
+}
 
 export function createGatewayCloseHandler(params: {
   bonjourStop: (() => Promise<void>) | null;
@@ -22,7 +192,6 @@ export function createGatewayCloseHandler(params: {
   cron: { stop: () => void };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
-  stopTaskRegistryMaintenance?: (() => void) | null;
   nodePresenceTimers: Map<string, ReturnType<typeof setInterval>>;
   broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
   tickInterval: ReturnType<typeof setInterval>;
@@ -40,7 +209,7 @@ export function createGatewayCloseHandler(params: {
   httpServer: HttpServer;
   httpServers?: HttpServer[];
 }) {
-  return async (opts?: { reason?: string; restartExpectedMs?: number | null }) => {
+  return async (opts?: GatewayCloseOptions) => {
     try {
       const reasonRaw = typeof opts?.reason === "string" ? opts.reason.trim() : "";
       const reason = reasonRaw || "gateway stopping";
@@ -48,6 +217,55 @@ export function createGatewayCloseHandler(params: {
         typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
           ? Math.max(0, Math.floor(opts.restartExpectedMs))
           : null;
+      const initiatorRaw = typeof opts?.initiator === "string" ? opts.initiator.trim() : "";
+      const initiator = initiatorRaw || undefined;
+      const restartId =
+        restartExpectedMs !== null
+          ? (normalizeNonEmptyString(opts?.restartId) ?? randomUUID())
+          : undefined;
+      const correlationIdRaw =
+        typeof opts?.correlationId === "string" ? opts.correlationId.trim() : "";
+      const correlationId = correlationIdRaw || restartId;
+      const outbox: GatewayRestartOutboxTask[] = [];
+
+      try {
+        const shutdownEvent = createInternalHookEvent("gateway", "shutdown", "gateway", {
+          reason,
+          restartExpectedMs,
+          ...(initiator ? { initiator } : {}),
+          ...(restartId ? { restartId } : {}),
+          ...(correlationId ? { correlationId } : {}),
+          outbox,
+        });
+        await triggerInternalHook(shutdownEvent, {
+          perHandlerTimeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
+        });
+
+        if (restartExpectedMs !== null) {
+          const preRestartEvent = createInternalHookEvent("gateway", "pre-restart", "gateway", {
+            reason,
+            restartExpectedMs,
+            ...(initiator ? { initiator } : {}),
+            ...(restartId ? { restartId } : {}),
+            ...(correlationId ? { correlationId } : {}),
+            outbox,
+          });
+          await triggerInternalHook(preRestartEvent, {
+            perHandlerTimeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
+          });
+
+          await persistGatewayRestartOutbox({
+            reason,
+            initiator,
+            restartId,
+            correlationId,
+            outbox,
+          });
+        }
+      } catch {
+        // Best-effort only; shutdown should proceed even if hooks fail.
+      }
+
       if (params.bonjourStop) {
         try {
           await params.bonjourStop();
@@ -82,11 +300,6 @@ export function createGatewayCloseHandler(params: {
       params.cron.stop();
       params.heartbeatRunner.stop();
       try {
-        params.stopTaskRegistryMaintenance?.();
-      } catch {
-        /* ignore */
-      }
-      try {
         params.updateCheckStop?.();
       } catch {
         /* ignore */
@@ -98,6 +311,9 @@ export function createGatewayCloseHandler(params: {
       params.broadcast("shutdown", {
         reason,
         restartExpectedMs,
+        ...(initiator ? { initiator } : {}),
+        ...(restartId ? { restartId } : {}),
+        ...(correlationId ? { correlationId } : {}),
       });
       clearInterval(params.tickInterval);
       clearInterval(params.healthInterval);
@@ -143,34 +359,14 @@ export function createGatewayCloseHandler(params: {
       }
       params.clients.clear();
       await params.configReloader.stop().catch(() => {});
-      const wsClients = params.wss.clients ?? new Set();
-      const closePromise = new Promise<void>((resolve) => params.wss.close(() => resolve()));
-      const closedWithinGrace = await Promise.race([
-        closePromise.then(() => true),
-        new Promise<false>((resolve) => setTimeout(() => resolve(false), WEBSOCKET_CLOSE_GRACE_MS)),
-      ]);
-      if (!closedWithinGrace) {
-        shutdownLog.warn(
-          `websocket server close exceeded ${WEBSOCKET_CLOSE_GRACE_MS}ms; forcing shutdown continuation with ${wsClients.size} tracked client(s)`,
+      const wssCloseResult = await closeWssWithTimeout(
+        (cb) => params.wss.close(() => cb()),
+        GATEWAY_WSS_CLOSE_TIMEOUT_MS,
+      );
+      if (wssCloseResult === "timeout") {
+        params.logger?.warn?.(
+          `[gateway] websocket server close timed out after ${GATEWAY_WSS_CLOSE_TIMEOUT_MS}ms, continuing shutdown`,
         );
-        for (const client of wsClients) {
-          try {
-            client.terminate();
-          } catch {
-            /* ignore */
-          }
-        }
-        await Promise.race([
-          closePromise,
-          new Promise<void>((resolve) =>
-            setTimeout(() => {
-              shutdownLog.warn(
-                `websocket server close still pending after ${WEBSOCKET_CLOSE_FORCE_CONTINUE_MS}ms force window; continuing shutdown`,
-              );
-              resolve();
-            }, WEBSOCKET_CLOSE_FORCE_CONTINUE_MS),
-          ),
-        ]);
       }
       const servers =
         params.httpServers && params.httpServers.length > 0

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -14,6 +14,7 @@ import {
 import type { RestartOutboxTask, RestartSentinelPayload } from "../infra/restart-sentinel.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 
+const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 1500;
 const GATEWAY_WSS_CLOSE_TIMEOUT_MS = 2000;
 
 type GatewayCloseOptions = {
@@ -266,6 +267,53 @@ export function createGatewayCloseHandler(params: {
       const correlationId = correlationIdRaw || restartId;
       const outbox: unknown[] = [];
 
+      const runHookWithTimeout = async (
+        event: ReturnType<typeof createInternalHookEvent>,
+        hookLabel: "shutdown" | "pre-restart",
+      ) => {
+        let settled = false;
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        const hookPromise = triggerInternalHook(event)
+          .then(() => {
+            if (!settled) {
+              settled = true;
+              if (timer) {
+                clearTimeout(timer);
+                timer = null;
+              }
+              return "completed" as const;
+            }
+            return "late" as const;
+          })
+          .catch((error) => {
+            if (!settled) {
+              settled = true;
+              if (timer) {
+                clearTimeout(timer);
+                timer = null;
+              }
+              throw error;
+            }
+            return "late" as const;
+          });
+        const timeoutPromise = new Promise<"timeout">((resolve) => {
+          timer = setTimeout(() => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            resolve("timeout");
+          }, GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS);
+        });
+        const outcome = await Promise.race([hookPromise, timeoutPromise]);
+        if (outcome === "timeout") {
+          (params.logger ?? logger).warn?.("gateway lifecycle hook timed out", {
+            hookLabel,
+            timeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
+          });
+        }
+      };
+
       try {
         const shutdownEvent = createInternalHookEvent("gateway", "shutdown", "gateway", {
           reason,
@@ -275,7 +323,7 @@ export function createGatewayCloseHandler(params: {
           ...(correlationId ? { correlationId } : {}),
           outbox,
         });
-        await triggerInternalHook(shutdownEvent);
+        await runHookWithTimeout(shutdownEvent, "shutdown");
 
         if (restartExpectedMs !== null) {
           const preRestartEvent = createInternalHookEvent("gateway", "pre-restart", "gateway", {
@@ -286,7 +334,7 @@ export function createGatewayCloseHandler(params: {
             ...(correlationId ? { correlationId } : {}),
             outbox,
           });
-          await triggerInternalHook(preRestartEvent);
+          await runHookWithTimeout(preRestartEvent, "pre-restart");
 
           await persistGatewayRestartOutbox({
             reason,

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -12,9 +12,11 @@ import {
   writeRestartSentinel,
 } from "../infra/restart-sentinel.js";
 import type { RestartOutboxTask, RestartSentinelPayload } from "../infra/restart-sentinel.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 
 const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 1500;
+const log = createSubsystemLogger("gateway/close");
 const GATEWAY_WSS_CLOSE_TIMEOUT_MS = 2000;
 
 type GatewayCloseOptions = {
@@ -308,7 +310,7 @@ export function createGatewayCloseHandler(params: {
         });
         const outcome = await Promise.race([hookPromise, timeoutPromise]);
         if (outcome === "timeout") {
-          params.logger?.warn?.(
+          (params.logger?.warn ?? log.warn)?.(
             `[gateway] ${hookLabel} hook timed out after ${GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS}ms, continuing shutdown`,
           );
         }

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -38,6 +38,19 @@ function normalizeNonEmptyString(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
+function normalizeThreadId(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return normalizeNonEmptyString(value);
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return undefined;
+}
+
 async function closeWssWithTimeout(
   closeFn: (cb: () => void) => void,
   timeoutMs: number,
@@ -81,8 +94,8 @@ function normalizeGatewayDeliveryContext(
     ...(normalizeNonEmptyString(deliveryContextRecord?.accountId ?? item.accountId)
       ? { accountId: normalizeNonEmptyString(deliveryContextRecord?.accountId ?? item.accountId)! }
       : {}),
-    ...(normalizeNonEmptyString(deliveryContextRecord?.threadId)
-      ? { threadId: normalizeNonEmptyString(deliveryContextRecord?.threadId)! }
+    ...(normalizeThreadId(deliveryContextRecord?.threadId ?? item.threadId)
+      ? { threadId: normalizeThreadId(deliveryContextRecord?.threadId ?? item.threadId)! }
       : {}),
   };
   return Object.keys(deliveryContext).length > 0 ? deliveryContext : undefined;
@@ -133,9 +146,7 @@ function normalizeGatewayOutbox(outbox: unknown[]): RestartOutboxTask[] {
         ...(normalizeNonEmptyString(item.accountId)
           ? { accountId: normalizeNonEmptyString(item.accountId)! }
           : {}),
-        ...(normalizeNonEmptyString(item.threadId)
-          ? { threadId: normalizeNonEmptyString(item.threadId)! }
-          : {}),
+        ...(normalizeThreadId(item.threadId) ? { threadId: normalizeThreadId(item.threadId)! } : {}),
       });
       continue;
     }
@@ -146,9 +157,7 @@ function normalizeGatewayOutbox(outbox: unknown[]): RestartOutboxTask[] {
       kind,
       message,
       ...(sessionKey ? { sessionKey } : {}),
-      ...(normalizeNonEmptyString(item.threadId)
-        ? { threadId: normalizeNonEmptyString(item.threadId)! }
-        : {}),
+      ...(normalizeThreadId(item.threadId) ? { threadId: normalizeThreadId(item.threadId)! } : {}),
       ...(deliveryContext && Object.keys(deliveryContext).length > 0 ? { deliveryContext } : {}),
       ...(normalizeNonEmptyString(item.restartId)
         ? { restartId: normalizeNonEmptyString(item.restartId)! }

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -4,11 +4,7 @@ import type { WebSocketServer } from "ws";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
-import {
-  createInternalHookEvent,
-  triggerInternalHook,
-  type GatewayRestartOutboxTask,
-} from "../hooks/internal-hooks.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import {
   formatDoctorNonInteractiveHint,
@@ -65,57 +61,85 @@ async function closeWssWithTimeout(
   });
 }
 
-function normalizeGatewayOutbox(
-  outbox: GatewayRestartOutboxTask[],
-  restartId?: string,
-  correlationId?: string,
-): RestartOutboxTask[] {
-  return outbox
-    .map((raw) => {
-      if (!raw || typeof raw !== "object") {
-        return null;
-      }
-      const message = normalizeNonEmptyString(raw.message);
-      if (!message) {
-        return null;
-      }
-      const sessionKey = normalizeNonEmptyString(raw.sessionKey);
-      const threadId = normalizeNonEmptyString(raw.threadId);
-      const deliveryContext = raw.deliveryContext;
-      const delivery =
-        deliveryContext && typeof deliveryContext === "object"
-          ? {
-              channel: normalizeNonEmptyString(deliveryContext.channel),
-              to: normalizeNonEmptyString(deliveryContext.to),
-              accountId: normalizeNonEmptyString(deliveryContext.accountId),
-            }
-          : undefined;
-      const resolvedRestartId = normalizeNonEmptyString(raw.restartId) ?? restartId;
-      const resolvedCorrelationId =
-        normalizeNonEmptyString(raw.correlationId) ?? correlationId ?? resolvedRestartId;
-      const rawKind = normalizeNonEmptyString((raw as { kind?: unknown }).kind);
-      const kind: RestartOutboxTask["kind"] =
-        rawKind === "system_event" ? "system_event" : "message";
-      const task: RestartOutboxTask = {
-        ...(kind === "message" ? { kind: "message" as const } : { kind: "system_event" as const }),
+function normalizeGatewayOutbox(outbox: unknown[]): RestartOutboxTask[] {
+  const normalized: RestartOutboxTask[] = [];
+  for (const raw of outbox) {
+    if (!raw || typeof raw !== "object") {
+      continue;
+    }
+    const item = raw as Record<string, unknown>;
+    const kindRaw = normalizeNonEmptyString(item.kind);
+    const kind =
+      kindRaw === "message" || kindRaw === "system_event" || kindRaw === "notify-session"
+        ? kindRaw
+        : "message";
+    const message = normalizeNonEmptyString(item.message);
+    if (!kind || !message) {
+      continue;
+    }
+
+    const sessionKey = normalizeNonEmptyString(item.sessionKey);
+
+    if (kind === "notify-session") {
+      normalized.push({
+        kind,
         message,
         ...(sessionKey ? { sessionKey } : {}),
-        ...(threadId ? { threadId } : {}),
-        ...(delivery?.channel || delivery?.to || delivery?.accountId
-          ? {
-              deliveryContext: {
-                ...(delivery.channel ? { channel: delivery.channel } : {}),
-                ...(delivery.to ? { to: delivery.to } : {}),
-                ...(delivery.accountId ? { accountId: delivery.accountId } : {}),
-              },
-            }
+        ...(normalizeNonEmptyString(item.channel)
+          ? { channel: normalizeNonEmptyString(item.channel)! }
           : {}),
-        ...(resolvedRestartId ? { restartId: resolvedRestartId } : {}),
-        ...(resolvedCorrelationId ? { correlationId: resolvedCorrelationId } : {}),
-      };
-      return task;
-    })
-    .filter((task): task is RestartOutboxTask => task !== null);
+        ...(normalizeNonEmptyString(item.to) ? { to: normalizeNonEmptyString(item.to)! } : {}),
+        ...(normalizeNonEmptyString(item.accountId)
+          ? { accountId: normalizeNonEmptyString(item.accountId)! }
+          : {}),
+        ...(normalizeNonEmptyString(item.threadId)
+          ? { threadId: normalizeNonEmptyString(item.threadId)! }
+          : {}),
+      });
+      continue;
+    }
+
+    const deliveryContextRaw = item.deliveryContext;
+    const deliveryContext =
+      deliveryContextRaw && typeof deliveryContextRaw === "object"
+        ? {
+            ...(normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).channel)
+              ? {
+                  channel: normalizeNonEmptyString(
+                    (deliveryContextRaw as Record<string, unknown>).channel,
+                  )!,
+                }
+              : {}),
+            ...(normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).to)
+              ? { to: normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).to)! }
+              : {}),
+            ...(normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).accountId)
+              ? {
+                  accountId: normalizeNonEmptyString(
+                    (deliveryContextRaw as Record<string, unknown>).accountId,
+                  )!,
+                }
+              : {}),
+          }
+        : undefined;
+
+    normalized.push({
+      kind,
+      message,
+      ...(sessionKey ? { sessionKey } : {}),
+      ...(normalizeNonEmptyString(item.threadId)
+        ? { threadId: normalizeNonEmptyString(item.threadId)! }
+        : {}),
+      ...(deliveryContext && Object.keys(deliveryContext).length > 0 ? { deliveryContext } : {}),
+      ...(normalizeNonEmptyString(item.restartId)
+        ? { restartId: normalizeNonEmptyString(item.restartId)! }
+        : {}),
+      ...(normalizeNonEmptyString(item.correlationId)
+        ? { correlationId: normalizeNonEmptyString(item.correlationId)! }
+        : {}),
+    });
+  }
+  return normalized;
 }
 
 async function persistGatewayRestartOutbox(params: {
@@ -123,13 +147,9 @@ async function persistGatewayRestartOutbox(params: {
   initiator?: string;
   restartId?: string;
   correlationId?: string;
-  outbox: GatewayRestartOutboxTask[];
+  outbox: unknown[];
 }) {
-  const normalizedOutbox = normalizeGatewayOutbox(
-    params.outbox,
-    params.restartId,
-    params.correlationId,
-  );
+  const normalizedOutbox = normalizeGatewayOutbox(params.outbox);
 
   const existing = await readRestartSentinel().catch(() => null);
   const existingPayload = existing?.payload;
@@ -202,6 +222,12 @@ export function createGatewayCloseHandler(params: {
   heartbeatUnsub: (() => void) | null;
   transcriptUnsub: (() => void) | null;
   lifecycleUnsub: (() => void) | null;
+  stopTaskRegistryMaintenance?: () => void;
+  logger?: {
+    info?: (...args: unknown[]) => void;
+    warn?: (...args: unknown[]) => void;
+    error?: (...args: unknown[]) => void;
+  };
   chatRunState: { clear: () => void };
   clients: Set<{ socket: { close: (code: number, reason: string) => void } }>;
   configReloader: { stop: () => Promise<void> };
@@ -226,7 +252,7 @@ export function createGatewayCloseHandler(params: {
       const correlationIdRaw =
         typeof opts?.correlationId === "string" ? opts.correlationId.trim() : "";
       const correlationId = correlationIdRaw || restartId;
-      const outbox: GatewayRestartOutboxTask[] = [];
+      const outbox: unknown[] = [];
 
       try {
         const shutdownEvent = createInternalHookEvent("gateway", "shutdown", "gateway", {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -179,9 +179,8 @@ async function persistGatewayRestartOutbox(params: {
   const suppressPrimaryNotice =
     typeof existingPayload?.suppressPrimaryNotice === "boolean"
       ? existingPayload.suppressPrimaryNotice &&
-        hasDeliverableGatewayOutboxTask(mergedOutbox, existingPayload?.sessionKey)
-      : !existingPayload &&
-          hasDeliverableGatewayOutboxTask(mergedOutbox, existingPayload?.sessionKey)
+        hasDeliverableGatewayOutboxTask(mergedOutbox, existingPayload.sessionKey)
+      : !existingPayload && hasDeliverableGatewayOutboxTask(mergedOutbox, undefined)
         ? true
         : undefined;
   const stats = {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -60,6 +60,38 @@ async function closeWssWithTimeout(
   });
 }
 
+function normalizeGatewayDeliveryContext(
+  item: Record<string, unknown>,
+): { channel?: string; to?: string; accountId?: string } | undefined {
+  const deliveryContextRaw = item.deliveryContext;
+  const deliveryContextRecord =
+    deliveryContextRaw && typeof deliveryContextRaw === "object"
+      ? (deliveryContextRaw as Record<string, unknown>)
+      : null;
+  const deliveryContext = {
+    ...(normalizeNonEmptyString(deliveryContextRecord?.channel ?? item.channel)
+      ? { channel: normalizeNonEmptyString(deliveryContextRecord?.channel ?? item.channel)! }
+      : {}),
+    ...(normalizeNonEmptyString(deliveryContextRecord?.to ?? item.to)
+      ? { to: normalizeNonEmptyString(deliveryContextRecord?.to ?? item.to)! }
+      : {}),
+    ...(normalizeNonEmptyString(deliveryContextRecord?.accountId ?? item.accountId)
+      ? { accountId: normalizeNonEmptyString(deliveryContextRecord?.accountId ?? item.accountId)! }
+      : {}),
+  };
+  return Object.keys(deliveryContext).length > 0 ? deliveryContext : undefined;
+}
+
+function hasDeliverableGatewayOutboxTask(
+  outbox: RestartOutboxTask[],
+  fallbackSessionKey?: string,
+): boolean {
+  return outbox.some((task) => {
+    const sessionKey = normalizeNonEmptyString(task.sessionKey) ?? fallbackSessionKey;
+    return typeof sessionKey === "string" && sessionKey.length > 0;
+  });
+}
+
 function normalizeGatewayOutbox(outbox: unknown[]): RestartOutboxTask[] {
   const normalized: RestartOutboxTask[] = [];
   for (const raw of outbox) {
@@ -98,29 +130,7 @@ function normalizeGatewayOutbox(outbox: unknown[]): RestartOutboxTask[] {
       continue;
     }
 
-    const deliveryContextRaw = item.deliveryContext;
-    const deliveryContext =
-      deliveryContextRaw && typeof deliveryContextRaw === "object"
-        ? {
-            ...(normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).channel)
-              ? {
-                  channel: normalizeNonEmptyString(
-                    (deliveryContextRaw as Record<string, unknown>).channel,
-                  )!,
-                }
-              : {}),
-            ...(normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).to)
-              ? { to: normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).to)! }
-              : {}),
-            ...(normalizeNonEmptyString((deliveryContextRaw as Record<string, unknown>).accountId)
-              ? {
-                  accountId: normalizeNonEmptyString(
-                    (deliveryContextRaw as Record<string, unknown>).accountId,
-                  )!,
-                }
-              : {}),
-          }
-        : undefined;
+    const deliveryContext = normalizeGatewayDeliveryContext(item);
 
     normalized.push({
       kind,
@@ -163,6 +173,13 @@ async function persistGatewayRestartOutbox(params: {
   const resolvedCorrelationId =
     params.correlationId ?? existingPayload?.correlationId ?? resolvedRestartId;
   const resolvedInitiator = params.initiator ?? existingPayload?.initiator;
+  const suppressPrimaryNotice =
+    typeof existingPayload?.suppressPrimaryNotice === "boolean"
+      ? existingPayload.suppressPrimaryNotice &&
+        hasDeliverableGatewayOutboxTask(mergedOutbox, existingPayload?.sessionKey)
+      : !existingPayload && hasDeliverableGatewayOutboxTask(mergedOutbox, existingPayload?.sessionKey)
+        ? true
+        : undefined;
   const stats = {
     ...existingPayload?.stats,
     reason: existingPayload?.stats?.reason ?? params.reason,
@@ -187,11 +204,7 @@ async function persistGatewayRestartOutbox(params: {
       ? { doctorHint: existingPayload.doctorHint }
       : { doctorHint: formatDoctorNonInteractiveHint() }),
     ...(Object.keys(stats).length > 0 ? { stats } : {}),
-    ...(typeof existingPayload?.suppressPrimaryNotice === "boolean"
-      ? { suppressPrimaryNotice: existingPayload.suppressPrimaryNotice }
-      : !existingPayload && mergedOutbox.length > 0
-        ? { suppressPrimaryNotice: true }
-        : {}),
+    ...(typeof suppressPrimaryNotice === "boolean" ? { suppressPrimaryNotice } : {}),
     ...(mergedOutbox.length > 0 ? { outbox: mergedOutbox } : {}),
   };
 

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -164,7 +164,7 @@ async function persistGatewayRestartOutbox(params: {
   const existing = await readRestartSentinel().catch(() => null);
   const existingPayload = existing?.payload;
   const existingOutbox = Array.isArray(existingPayload?.outbox) ? existingPayload.outbox : [];
-  const mergedOutbox = [...existingOutbox, ...normalizedOutbox];
+  const mergedOutbox: RestartOutboxTask[] = [...existingOutbox, ...normalizedOutbox];
 
   if (!existingPayload && mergedOutbox.length === 0) {
     return;
@@ -178,7 +178,8 @@ async function persistGatewayRestartOutbox(params: {
     typeof existingPayload?.suppressPrimaryNotice === "boolean"
       ? existingPayload.suppressPrimaryNotice &&
         hasDeliverableGatewayOutboxTask(mergedOutbox, existingPayload?.sessionKey)
-      : !existingPayload && hasDeliverableGatewayOutboxTask(mergedOutbox, existingPayload?.sessionKey)
+      : !existingPayload &&
+          hasDeliverableGatewayOutboxTask(mergedOutbox, existingPayload?.sessionKey)
         ? true
         : undefined;
   const stats = {
@@ -307,10 +308,9 @@ export function createGatewayCloseHandler(params: {
         });
         const outcome = await Promise.race([hookPromise, timeoutPromise]);
         if (outcome === "timeout") {
-          (params.logger ?? logger).warn?.("gateway lifecycle hook timed out", {
-            hookLabel,
-            timeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
-          });
+          params.logger?.warn?.(
+            `[gateway] ${hookLabel} hook timed out after ${GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS}ms, continuing shutdown`,
+          );
         }
       };
 

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -65,7 +65,7 @@ async function closeWssWithTimeout(
 
 function normalizeGatewayDeliveryContext(
   item: Record<string, unknown>,
-): { channel?: string; to?: string; accountId?: string } | undefined {
+): { channel?: string; to?: string; accountId?: string; threadId?: string } | undefined {
   const deliveryContextRaw = item.deliveryContext;
   const deliveryContextRecord =
     deliveryContextRaw && typeof deliveryContextRaw === "object"
@@ -81,6 +81,9 @@ function normalizeGatewayDeliveryContext(
     ...(normalizeNonEmptyString(deliveryContextRecord?.accountId ?? item.accountId)
       ? { accountId: normalizeNonEmptyString(deliveryContextRecord?.accountId ?? item.accountId)! }
       : {}),
+    ...(normalizeNonEmptyString(deliveryContextRecord?.threadId)
+      ? { threadId: normalizeNonEmptyString(deliveryContextRecord?.threadId)! }
+      : {}),
   };
   return Object.keys(deliveryContext).length > 0 ? deliveryContext : undefined;
 }
@@ -90,7 +93,11 @@ function hasDeliverableGatewayOutboxTask(
   fallbackSessionKey?: string,
 ): boolean {
   return outbox.some((task) => {
-    const sessionKey = normalizeNonEmptyString(task.sessionKey) ?? fallbackSessionKey;
+    if (!task || typeof task !== "object") {
+      return false;
+    }
+    const sessionKey =
+      normalizeNonEmptyString((task as { sessionKey?: unknown }).sessionKey) ?? fallbackSessionKey;
     return typeof sessionKey === "string" && sessionKey.length > 0;
   });
 }
@@ -165,7 +172,9 @@ async function persistGatewayRestartOutbox(params: {
 
   const existing = await readRestartSentinel().catch(() => null);
   const existingPayload = existing?.payload;
-  const existingOutbox = Array.isArray(existingPayload?.outbox) ? existingPayload.outbox : [];
+  const existingOutbox = Array.isArray(existingPayload?.outbox)
+    ? normalizeGatewayOutbox(existingPayload.outbox)
+    : [];
   const mergedOutbox: RestartOutboxTask[] = [...existingOutbox, ...normalizedOutbox];
 
   if (!existingPayload && mergedOutbox.length === 0) {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -370,6 +370,11 @@ export function createGatewayCloseHandler(params: {
           /* ignore */
         }
       }
+      try {
+        params.stopTaskRegistryMaintenance?.();
+      } catch {
+        /* ignore */
+      }
       params.chatRunState.clear();
       for (const c of params.clients) {
         try {
@@ -386,8 +391,19 @@ export function createGatewayCloseHandler(params: {
       );
       if (wssCloseResult === "timeout") {
         params.logger?.warn?.(
-          `[gateway] websocket server close timed out after ${GATEWAY_WSS_CLOSE_TIMEOUT_MS}ms, continuing shutdown`,
+          `[gateway] websocket server close timed out after ${GATEWAY_WSS_CLOSE_TIMEOUT_MS}ms, forcing client termination and continuing shutdown`,
         );
+        const wssClients = (params.wss as { clients?: Iterable<{ terminate?: () => void }> })
+          .clients;
+        if (wssClients) {
+          for (const socket of wssClients) {
+            try {
+              socket.terminate?.();
+            } catch {
+              /* ignore */
+            }
+          }
+        }
       }
       const servers =
         params.httpServers && params.httpServers.length > 0

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -14,7 +14,6 @@ import {
 import type { RestartOutboxTask, RestartSentinelPayload } from "../infra/restart-sentinel.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 
-const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 1500;
 const GATEWAY_WSS_CLOSE_TIMEOUT_MS = 2000;
 
 type GatewayCloseOptions = {
@@ -263,9 +262,7 @@ export function createGatewayCloseHandler(params: {
           ...(correlationId ? { correlationId } : {}),
           outbox,
         });
-        await triggerInternalHook(shutdownEvent, {
-          perHandlerTimeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
-        });
+        await triggerInternalHook(shutdownEvent);
 
         if (restartExpectedMs !== null) {
           const preRestartEvent = createInternalHookEvent("gateway", "pre-restart", "gateway", {
@@ -276,9 +273,7 @@ export function createGatewayCloseHandler(params: {
             ...(correlationId ? { correlationId } : {}),
             outbox,
           });
-          await triggerInternalHook(preRestartEvent, {
-            perHandlerTimeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
-          });
+          await triggerInternalHook(preRestartEvent);
 
           await persistGatewayRestartOutbox({
             reason,

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -73,7 +73,7 @@ function normalizeGatewayOutbox(outbox: unknown[]): RestartOutboxTask[] {
         ? kindRaw
         : "message";
     const message = normalizeNonEmptyString(item.message);
-    if (!kind || !message) {
+    if (!message) {
       continue;
     }
 

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -255,6 +255,42 @@ describe("scheduleRestartSentinelWake", () => {
     );
   });
 
+  it("executes persisted restart outbox notify-session tasks on startup", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        message: "restart message",
+        outbox: [
+          {
+            kind: "notify-session",
+            sessionKey: "agent:main:main",
+            message: "outbox message",
+            channel: "telegram",
+            to: "telegram:119707338",
+            accountId: "default",
+            threadId: "20",
+          },
+        ],
+      },
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenNthCalledWith(
+      1,
+      "outbox message",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+    expect(mocks.requestHeartbeatNow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "gateway.restart.outbox",
+        sessionKey: "agent:main:main",
+      }),
+    );
+  });
+
   it("does not wake the main session when the sentinel has no sessionKey", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
       payload: {

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -368,4 +368,24 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.requestHeartbeatNow).not.toHaveBeenCalled();
     expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
   });
+
+  it("ignores malformed persisted outbox entries", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        suppressPrimaryNotice: true,
+        outbox: [null, { foo: "bar" }, { kind: "notify-session", message: "ok" }],
+      },
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(1);
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "ok",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+  });
 });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -291,6 +291,32 @@ describe("scheduleRestartSentinelWake", () => {
     );
   });
 
+  it("honors suppressPrimaryNotice while still executing persisted outbox", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        message: "restart message",
+        suppressPrimaryNotice: true,
+        outbox: [
+          {
+            kind: "message",
+            message: "outbox legacy message",
+          },
+        ],
+      },
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "outbox legacy message",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+    expect(mocks.enqueueSystemEvent).not.toHaveBeenCalledWith("restart message", expect.anything());
+  });
+
   it("does not wake the main session when the sentinel has no sessionKey", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
       payload: {

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -285,8 +285,44 @@ describe("scheduleRestartSentinelWake", () => {
     );
     expect(mocks.requestHeartbeatNow).toHaveBeenCalledWith(
       expect.objectContaining({
-        reason: "gateway.restart.outbox",
+        reason: "hook:gateway.restart.outbox",
         sessionKey: "agent:main:main",
+      }),
+    );
+  });
+
+  it("preserves nested deliveryContext threadId for persisted message outbox", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue({
+      payload: {
+        sessionKey: "agent:main:main",
+        suppressPrimaryNotice: true,
+        outbox: [
+          {
+            kind: "message",
+            message: "outbox message",
+            deliveryContext: {
+              channel: "telegram",
+              to: "telegram:119707338",
+              accountId: "default",
+              threadId: "20",
+            },
+          },
+        ],
+      },
+    } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
+      "outbox message",
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        deliveryContext: expect.objectContaining({
+          channel: "telegram",
+          to: "telegram:119707338",
+          accountId: "default",
+          threadId: "20",
+        }),
       }),
     );
   });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -50,7 +50,7 @@ vi.mock("../config/sessions.js", () => ({
   resolveMainSessionKeyFromConfig: mocks.resolveMainSessionKeyFromConfig,
 }));
 
-vi.mock("../config/sessions/delivery-info.js", () => ({
+vi.mock("../config/sessions/thread-info.js", () => ({
   parseSessionThreadInfo: mocks.parseSessionThreadInfo,
 }));
 
@@ -369,12 +369,12 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
-  it("ignores malformed persisted outbox entries", async () => {
+  it("executes legacy persisted outbox entries without kind and skips malformed items", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
       payload: {
         sessionKey: "agent:main:main",
         suppressPrimaryNotice: true,
-        outbox: [null, { foo: "bar" }, { kind: "notify-session", message: "ok" }],
+        outbox: [null, { foo: "bar" }, { message: "legacy outbox message" }],
       },
     } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
 
@@ -382,8 +382,14 @@ describe("scheduleRestartSentinelWake", () => {
 
     expect(mocks.enqueueSystemEvent).toHaveBeenCalledTimes(1);
     expect(mocks.enqueueSystemEvent).toHaveBeenCalledWith(
-      "ok",
+      "legacy outbox message",
       expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+    expect(mocks.requestHeartbeatNow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: "hook:gateway.restart.outbox",
         sessionKey: "agent:main:main",
       }),
     );

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -127,6 +127,9 @@ function executePersistedRestartOutbox(params: {
     return;
   }
   for (const task of tasks) {
+    if (!task || typeof task !== "object") {
+      continue;
+    }
     if (task.kind !== "notify-session" && task.kind !== "message" && task.kind !== "system_event") {
       continue;
     }

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -141,7 +141,12 @@ function executePersistedRestartOutbox(params: {
     const deliveryContextRaw = "deliveryContext" in task ? task.deliveryContext : undefined;
     const deliveryContext =
       deliveryContextRaw && typeof deliveryContextRaw === "object"
-        ? (deliveryContextRaw as { channel?: unknown; to?: unknown; accountId?: unknown })
+        ? (deliveryContextRaw as {
+            channel?: unknown;
+            to?: unknown;
+            accountId?: unknown;
+            threadId?: unknown;
+          })
         : undefined;
     const dcChannel =
       deliveryContext && typeof deliveryContext.channel === "string"
@@ -153,6 +158,10 @@ function executePersistedRestartOutbox(params: {
       deliveryContext && typeof deliveryContext.accountId === "string"
         ? deliveryContext.accountId
         : undefined;
+    const dcThreadId =
+      deliveryContext && typeof deliveryContext.threadId === "string"
+        ? deliveryContext.threadId
+        : undefined;
     const taskChannel =
       "channel" in task && typeof task.channel === "string" ? task.channel : undefined;
     const taskTo = "to" in task && typeof task.to === "string" ? task.to : undefined;
@@ -161,14 +170,18 @@ function executePersistedRestartOutbox(params: {
     const taskThreadId =
       "threadId" in task && typeof task.threadId === "string" ? task.threadId : undefined;
 
+    const hasDeliveryContext =
+      dcChannel || dcTo || dcAccountId || dcThreadId || taskChannel || taskTo || taskAccountId || taskThreadId;
+
     enqueueSystemEvent(message, {
       sessionKey: sessionKeyRaw,
-      ...(dcChannel || dcTo || dcAccountId || taskChannel || taskTo || taskAccountId || taskThreadId
+      ...(hasDeliveryContext
         ? {
             deliveryContext: {
               ...(dcChannel ? { channel: dcChannel } : {}),
               ...(dcTo ? { to: dcTo } : {}),
               ...(dcAccountId ? { accountId: dcAccountId } : {}),
+              ...(dcThreadId ? { threadId: dcThreadId } : {}),
               ...(taskChannel ? { channel: taskChannel } : {}),
               ...(taskTo ? { to: taskTo } : {}),
               ...(taskAccountId ? { accountId: taskAccountId } : {}),
@@ -177,7 +190,7 @@ function executePersistedRestartOutbox(params: {
           }
         : {}),
     });
-    requestHeartbeatNow({ reason: "gateway.restart.outbox", sessionKey: sessionKeyRaw });
+    requestHeartbeatNow({ reason: "hook:gateway.restart.outbox", sessionKey: sessionKeyRaw });
   }
 }
 

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -126,13 +126,11 @@ function executePersistedRestartOutbox(params: {
   if (!Array.isArray(tasks) || tasks.length === 0) {
     return;
   }
-  for (const task of tasks) {
-    if (!task || typeof task !== "object") {
+  for (const rawTask of tasks) {
+    if (!rawTask || typeof rawTask !== "object") {
       continue;
     }
-    if (task.kind !== "notify-session" && task.kind !== "message" && task.kind !== "system_event") {
-      continue;
-    }
+    const task = rawTask as Record<string, unknown>;
     const message = typeof task.message === "string" ? task.message.trim() : "";
     const sessionKeyRaw =
       typeof task.sessionKey === "string" && task.sessionKey.trim().length > 0
@@ -141,7 +139,7 @@ function executePersistedRestartOutbox(params: {
     if (!message || !sessionKeyRaw) {
       continue;
     }
-    const deliveryContextRaw = "deliveryContext" in task ? task.deliveryContext : undefined;
+    const deliveryContextRaw = task.deliveryContext;
     const deliveryContext =
       deliveryContextRaw && typeof deliveryContextRaw === "object"
         ? (deliveryContextRaw as {
@@ -165,16 +163,20 @@ function executePersistedRestartOutbox(params: {
       deliveryContext && typeof deliveryContext.threadId === "string"
         ? deliveryContext.threadId
         : undefined;
-    const taskChannel =
-      "channel" in task && typeof task.channel === "string" ? task.channel : undefined;
-    const taskTo = "to" in task && typeof task.to === "string" ? task.to : undefined;
-    const taskAccountId =
-      "accountId" in task && typeof task.accountId === "string" ? task.accountId : undefined;
-    const taskThreadId =
-      "threadId" in task && typeof task.threadId === "string" ? task.threadId : undefined;
+    const taskChannel = typeof task.channel === "string" ? task.channel : undefined;
+    const taskTo = typeof task.to === "string" ? task.to : undefined;
+    const taskAccountId = typeof task.accountId === "string" ? task.accountId : undefined;
+    const taskThreadId = typeof task.threadId === "string" ? task.threadId : undefined;
 
     const hasDeliveryContext =
-      dcChannel || dcTo || dcAccountId || dcThreadId || taskChannel || taskTo || taskAccountId || taskThreadId;
+      dcChannel ||
+      dcTo ||
+      dcAccountId ||
+      dcThreadId ||
+      taskChannel ||
+      taskTo ||
+      taskAccountId ||
+      taskThreadId;
 
     enqueueSystemEvent(message, {
       sessionKey: sessionKeyRaw,

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -118,17 +118,24 @@ async function deliverRestartSentinelNotice(params: {
   }
 }
 
-function executePersistedRestartOutbox(tasks: RestartOutboxTask[] | undefined) {
+function executePersistedRestartOutbox(params: {
+  tasks: RestartOutboxTask[] | undefined;
+  fallbackSessionKey?: string;
+}) {
+  const { tasks, fallbackSessionKey } = params;
   if (!Array.isArray(tasks) || tasks.length === 0) {
     return;
   }
   for (const task of tasks) {
-    if (task.kind !== "notify-session") {
+    if (task.kind !== "notify-session" && task.kind !== "message" && task.kind !== "system_event") {
       continue;
     }
     const message = typeof task.message === "string" ? task.message.trim() : "";
-    const sessionKey = typeof task.sessionKey === "string" ? task.sessionKey.trim() : "";
-    if (!message || !sessionKey) {
+    const sessionKeyRaw =
+      typeof task.sessionKey === "string" && task.sessionKey.trim().length > 0
+        ? task.sessionKey.trim()
+        : fallbackSessionKey?.trim();
+    if (!message || !sessionKeyRaw) {
       continue;
     }
     const deliveryContextRaw = "deliveryContext" in task ? task.deliveryContext : undefined;
@@ -146,29 +153,31 @@ function executePersistedRestartOutbox(tasks: RestartOutboxTask[] | undefined) {
       deliveryContext && typeof deliveryContext.accountId === "string"
         ? deliveryContext.accountId
         : undefined;
+    const taskChannel =
+      "channel" in task && typeof task.channel === "string" ? task.channel : undefined;
+    const taskTo = "to" in task && typeof task.to === "string" ? task.to : undefined;
+    const taskAccountId =
+      "accountId" in task && typeof task.accountId === "string" ? task.accountId : undefined;
+    const taskThreadId =
+      "threadId" in task && typeof task.threadId === "string" ? task.threadId : undefined;
+
     enqueueSystemEvent(message, {
-      sessionKey,
-      ...(dcChannel ||
-      dcTo ||
-      dcAccountId ||
-      task.channel ||
-      task.to ||
-      task.accountId ||
-      task.threadId
+      sessionKey: sessionKeyRaw,
+      ...(dcChannel || dcTo || dcAccountId || taskChannel || taskTo || taskAccountId || taskThreadId
         ? {
             deliveryContext: {
               ...(dcChannel ? { channel: dcChannel } : {}),
               ...(dcTo ? { to: dcTo } : {}),
               ...(dcAccountId ? { accountId: dcAccountId } : {}),
-              ...(task.channel ? { channel: task.channel } : {}),
-              ...(task.to ? { to: task.to } : {}),
-              ...(task.accountId ? { accountId: task.accountId } : {}),
-              ...(task.threadId ? { threadId: task.threadId } : {}),
+              ...(taskChannel ? { channel: taskChannel } : {}),
+              ...(taskTo ? { to: taskTo } : {}),
+              ...(taskAccountId ? { accountId: taskAccountId } : {}),
+              ...(taskThreadId ? { threadId: taskThreadId } : {}),
             },
           }
         : {}),
     });
-    requestHeartbeatNow({ reason: "gateway.restart.outbox", sessionKey });
+    requestHeartbeatNow({ reason: "gateway.restart.outbox", sessionKey: sessionKeyRaw });
   }
 }
 
@@ -178,7 +187,13 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
     return;
   }
   const payload = sentinel.payload;
-  executePersistedRestartOutbox(payload.outbox);
+  executePersistedRestartOutbox({
+    tasks: payload.outbox,
+    fallbackSessionKey: payload.sessionKey,
+  });
+  if (payload.suppressPrimaryNotice) {
+    return;
+  }
   const sessionKey = payload.sessionKey?.trim();
   const message = formatRestartSentinelMessage(payload);
   const summary = summarizeRestartSentinel(payload);

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -13,6 +13,7 @@ import {
   consumeRestartSentinel,
   formatRestartSentinelMessage,
   summarizeRestartSentinel,
+  type RestartOutboxTask,
 } from "../infra/restart-sentinel.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -117,12 +118,63 @@ async function deliverRestartSentinelNotice(params: {
   }
 }
 
+function executePersistedRestartOutbox(tasks: RestartOutboxTask[] | undefined) {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    return;
+  }
+  for (const task of tasks) {
+    if (task.kind !== "notify-session") {
+      continue;
+    }
+    const message = typeof task.message === "string" ? task.message.trim() : "";
+    const sessionKey = typeof task.sessionKey === "string" ? task.sessionKey.trim() : "";
+    if (!message || !sessionKey) {
+      continue;
+    }
+    const deliveryContext = "deliveryContext" in task ? task.deliveryContext : undefined;
+    const dcChannel =
+      deliveryContext && typeof deliveryContext.channel === "string"
+        ? deliveryContext.channel
+        : undefined;
+    const dcTo =
+      deliveryContext && typeof deliveryContext.to === "string" ? deliveryContext.to : undefined;
+    const dcAccountId =
+      deliveryContext && typeof deliveryContext.accountId === "string"
+        ? deliveryContext.accountId
+        : undefined;
+    enqueueSystemEvent(message, {
+      sessionKey,
+      ...(dcChannel ||
+      dcTo ||
+      dcAccountId ||
+      task.channel ||
+      task.to ||
+      task.accountId ||
+      task.threadId
+        ? {
+            deliveryContext: {
+              ...(dcChannel ? { channel: dcChannel } : {}),
+              ...(dcTo ? { to: dcTo } : {}),
+              ...(dcAccountId ? { accountId: dcAccountId } : {}),
+              ...(task.channel ? { channel: task.channel } : {}),
+              ...(task.to ? { to: task.to } : {}),
+              ...(task.accountId ? { accountId: task.accountId } : {}),
+              ...(task.threadId ? { threadId: task.threadId } : {}),
+            },
+          }
+        : {}),
+    });
+    requestHeartbeatNow({ reason: "gateway.restart.outbox", sessionKey });
+  }
+}
+
 export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const sentinel = await consumeRestartSentinel();
   if (!sentinel) {
     return;
   }
   const payload = sentinel.payload;
+  executePersistedRestartOutbox(payload.outbox);
   const sessionKey = payload.sessionKey?.trim();
   const message = formatRestartSentinelMessage(payload);
   const summary = summarizeRestartSentinel(payload);

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -131,7 +131,11 @@ function executePersistedRestartOutbox(tasks: RestartOutboxTask[] | undefined) {
     if (!message || !sessionKey) {
       continue;
     }
-    const deliveryContext = "deliveryContext" in task ? task.deliveryContext : undefined;
+    const deliveryContextRaw = "deliveryContext" in task ? task.deliveryContext : undefined;
+    const deliveryContext =
+      deliveryContextRaw && typeof deliveryContextRaw === "object"
+        ? (deliveryContextRaw as { channel?: unknown; to?: unknown; accountId?: unknown })
+        : undefined;
     const dcChannel =
       deliveryContext && typeof deliveryContext.channel === "string"
         ? deliveryContext.channel

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -36,6 +36,7 @@ export type RestartOutboxTask =
         channel?: string;
         to?: string;
         accountId?: string;
+        threadId?: string;
       };
       restartId?: string;
       correlationId?: string;

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -55,6 +55,10 @@ export type RestartSentinelPayload = {
   kind: "config-apply" | "config-patch" | "update" | "restart";
   status: "ok" | "error" | "skipped";
   ts: number;
+  reason?: string;
+  initiator?: string;
+  restartId?: string;
+  correlationId?: string;
   sessionKey?: string;
   /** Delivery context captured at restart time to ensure channel routing survives restart. */
   deliveryContext?: {

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -17,6 +17,30 @@ export type RestartSentinelStep = {
   log?: RestartSentinelLog | null;
 };
 
+export type RestartOutboxTask =
+  | {
+      kind: "notify-session";
+      sessionKey?: string;
+      message: string;
+      channel?: string;
+      to?: string;
+      accountId?: string;
+      threadId?: string;
+    }
+  | {
+      kind: "message" | "system_event";
+      message: string;
+      sessionKey?: string;
+      threadId?: string;
+      deliveryContext?: {
+        channel?: string;
+        to?: string;
+        accountId?: string;
+      };
+      restartId?: string;
+      correlationId?: string;
+    };
+
 export type RestartSentinelStats = {
   mode?: string;
   root?: string;
@@ -40,9 +64,11 @@ export type RestartSentinelPayload = {
   };
   /** Thread ID for reply threading (e.g., Slack thread_ts). */
   threadId?: string;
+  outbox?: RestartOutboxTask[];
   message?: string | null;
   doctorHint?: string | null;
   stats?: RestartSentinelStats | null;
+  suppressPrimaryNotice?: boolean;
 };
 
 export type RestartSentinel = {


### PR DESCRIPTION
## Summary
This PR delivers the final lifecycle/restart behavior without intermediate churn:

- bounds websocket close during gateway shutdown
- emits/propagates restart lifecycle metadata (`reason`, `initiator`, `restartId`, `correlationId`)
- persists restart outbox tasks on shutdown and executes them on startup wake
- honors restart-sentinel payload typing/compatibility across the shutdown/startup path

## Included behavior
- startup executes persisted restart outbox tasks before primary restart notice
- supports persisted outbox task kinds: `notify-session`, `message`, `system_event`
- keeps focused tests passing for gateway close/restart-sentinel paths

## Validation
- `src/gateway/server-close.test.ts`
- `src/gateway/server-restart-sentinel.test.ts`
- lint clean on touched files