### PR TITLE
fix: session history reload, old session click, cron orphan recovery

### DIFF
--- a/src/cron/session-reaper.test.ts
+++ b/src/cron/session-reaper.test.ts
@@ -255,4 +255,42 @@ describe("sweepCronRunSessions", () => {
     });
     expect(r3.swept).toBe(false);
   });
+
+  it("recovers orphaned running sessions older than 2h and marks them done", async () => {
+    const now = Date.now();
+    const store: Record<string, { sessionId: string; updatedAt: number; status?: string }> = {
+      "agent:main:cron:job1:run:stuck-run": {
+        sessionId: "stuck-run",
+        updatedAt: now - 3 * 3_600_000, // 3h ago — stuck running
+        status: "running",
+      },
+      "agent:main:cron:job1:run:recent-run": {
+        sessionId: "recent-run",
+        updatedAt: now - 30 * 60_000, // 30min ago — actively running
+        status: "running",
+      },
+      "agent:main:cron:job1:run:done-run": {
+        sessionId: "done-run",
+        updatedAt: now - 3 * 3_600_000, // 3h ago but already done
+        status: "done",
+      },
+    };
+    fs.writeFileSync(storePath, JSON.stringify(store));
+
+    const result = await sweepCronRunSessions({
+      sessionStorePath: storePath,
+      nowMs: now,
+      log,
+      force: true,
+    });
+
+    expect(result.swept).toBe(true);
+    expect(result.orphansRecovered).toBe(1);
+    expect(result.pruned).toBe(0); // not pruned yet — gives UI time to show done status
+
+    const updated = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    expect(updated["agent:main:cron:job1:run:stuck-run"].status).toBe("done");
+    expect(updated["agent:main:cron:job1:run:recent-run"].status).toBe("running"); // untouched
+    expect(updated["agent:main:cron:job1:run:done-run"].status).toBe("done"); // untouched
+  });
 });

--- a/src/cron/session-reaper.ts
+++ b/src/cron/session-reaper.ts
@@ -16,6 +16,14 @@ import type { Logger } from "./service/state.js";
 
 const DEFAULT_RETENTION_MS = 24 * 3_600_000; // 24 hours
 
+/**
+ * How long a cron:run session may stay in status="running" before the reaper
+ * assumes the gateway crashed mid-run and marks it done.  Two hours covers
+ * any realistic cron job while still cleaning up within a reasonable window
+ * after a hard restart.
+ */
+const ORPHAN_RUNNING_THRESHOLD_MS = 2 * 3_600_000; // 2 hours
+
 /** Minimum interval between reaper sweeps (avoid running every timer tick). */
 const MIN_SWEEP_INTERVAL_MS = 5 * 60_000; // 5 minutes
 
@@ -39,6 +47,8 @@ export function resolveRetentionMs(cronConfig?: CronConfig): number | null {
 export type ReaperResult = {
   swept: boolean;
   pruned: number;
+  /** Sessions whose status was "running" but haven't been updated recently — marked done. */
+  orphansRecovered: number;
 };
 
 /**
@@ -66,20 +76,22 @@ export async function sweepCronRunSessions(params: {
 
   // Throttle: don't sweep more often than every 5 minutes.
   if (!params.force && now - lastSweepAtMs < MIN_SWEEP_INTERVAL_MS) {
-    return { swept: false, pruned: 0 };
+    return { swept: false, pruned: 0, orphansRecovered: 0 };
   }
 
   const retentionMs = resolveRetentionMs(params.cronConfig);
   if (retentionMs === null) {
     lastSweepAtMsByStore.set(storePath, now);
-    return { swept: false, pruned: 0 };
+    return { swept: false, pruned: 0, orphansRecovered: 0 };
   }
 
   let pruned = 0;
+  let orphansRecovered = 0;
   const prunedSessions = new Map<string, string | undefined>();
   try {
     await updateSessionStore(storePath, (store) => {
       const cutoff = now - retentionMs;
+      const orphanCutoff = now - ORPHAN_RUNNING_THRESHOLD_MS;
       for (const key of Object.keys(store)) {
         if (!isCronRunSessionKey(key)) {
           continue;
@@ -89,6 +101,16 @@ export async function sweepCronRunSessions(params: {
           continue;
         }
         const updatedAt = entry.updatedAt ?? 0;
+        // Recover orphaned "running" sessions before the deletion cutoff check.
+        // If a run is still marked "running" but hasn't been updated for longer
+        // than ORPHAN_RUNNING_THRESHOLD_MS, the gateway likely crashed mid-run.
+        if (entry.status === "running" && updatedAt < orphanCutoff) {
+          store[key] = { ...entry, status: "done", endedAt: updatedAt };
+          orphansRecovered++;
+          // Skip the retention-prune check — let the next sweep delete it so
+          // the UI briefly reflects the corrected "done" status.
+          continue;
+        }
         if (updatedAt < cutoff) {
           if (!prunedSessions.has(entry.sessionId) || entry.sessionFile) {
             prunedSessions.set(entry.sessionId, entry.sessionFile);
@@ -100,7 +122,7 @@ export async function sweepCronRunSessions(params: {
     });
   } catch (err) {
     params.log.warn({ err: String(err) }, "cron-reaper: failed to sweep session store");
-    return { swept: false, pruned: 0 };
+    return { swept: false, pruned: 0, orphansRecovered: 0 };
   }
 
   lastSweepAtMsByStore.set(storePath, now);
@@ -133,6 +155,12 @@ export async function sweepCronRunSessions(params: {
     }
   }
 
+  if (orphansRecovered > 0) {
+    params.log.info(
+      { orphansRecovered },
+      `cron-reaper: recovered ${orphansRecovered} orphaned running cron run session(s)`,
+    );
+  }
   if (pruned > 0) {
     params.log.info(
       { pruned, retentionMs },
@@ -140,7 +168,7 @@ export async function sweepCronRunSessions(params: {
     );
   }
 
-  return { swept: true, pruned };
+  return { swept: true, pruned, orphansRecovered };
 }
 
 /** Reset the throttle timer (for tests). */

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -394,8 +394,19 @@ export function loadSessionEntry(sessionKey: string) {
     store,
   });
   const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys);
-  const legacyKey = freshestMatch?.key !== canonicalKey ? freshestMatch?.key : undefined;
-  return { cfg, storePath, store, entry: freshestMatch?.entry, canonicalKey, legacyKey };
+  // Prefer an exact key match over the freshest-updatedAt match. Without this,
+  // clicking an archived compound-key session (e.g. agent:main:main:<oldId>)
+  // returns the NEW primary-key session because it has a newer updatedAt.
+  const trimmedKey = sessionKey.trim();
+  const exactEntry = store[trimmedKey] ?? store[canonicalKey];
+  const resolvedEntry = exactEntry ?? freshestMatch?.entry;
+  const resolvedKey = exactEntry
+    ? store[trimmedKey]
+      ? trimmedKey
+      : canonicalKey
+    : freshestMatch?.key;
+  const legacyKey = resolvedKey !== canonicalKey ? resolvedKey : undefined;
+  return { cfg, storePath, store, entry: resolvedEntry, canonicalKey, legacyKey };
 }
 
 export function resolveFreshestSessionStoreMatchFromStoreKeys(

--- a/ui/src/ui/chat-event-reload.ts
+++ b/ui/src/ui/chat-event-reload.ts
@@ -4,7 +4,12 @@ export function shouldReloadHistoryForFinalEvent(payload?: ChatEventPayload): bo
   if (!payload || payload.state !== "final") {
     return false;
   }
-  if (!payload.message || typeof payload.message !== "object") {
+  // Don't reload when message is undefined — this is normal for /new and /reset
+  // slash commands which create a new session without an assistant response.
+  if (!payload.message) {
+    return false;
+  }
+  if (typeof payload.message !== "object") {
     return true;
   }
   const message = payload.message as Record<string, unknown>;


### PR DESCRIPTION
## Summary

3 bug fixes for session management:

- `fix(chat)`: don't reload history for /new and /reset commands
- `fix(session)`: prefer exact key match over freshest-updatedAt match  
- `fix(cron)`: auto-recover orphaned running sessions in reaper sweep

## Motivation

- Session history was being reset when clicking New Chat toolbar button
- Clicking old session in sidebar loaded wrong session (newest instead of exact match)
- 14 cron sessions were stuck in 'running' state after system restart

## Changes

- `ui/src/ui/chat-event-reload.ts` - skip history reload for /new and /reset commands
- `src/gateway/session-utils.ts` - exact key match priority in session resolution
- `src/cron/session-reaper.ts` - auto-mark orphaned sessions as done after 2 hours

## Testing

- [x] Tested on local deployment
- [x] Session sidebar functionality verified
- [x] Cron reaper sweep tested