### PR TITLE
fix(sessions): provider-qualified context limits (#62472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Z.AI: default onboarding and endpoint detection to GLM-5.1 instead of GLM-5. (#61998) Thanks @serg0x.
 - Cron/isolated: resolve auth profiles without treating every isolated run as a brand-new auth session, so profile-based providers (for example OpenRouter) keep a stable credential choice instead of rotating or ignoring stored keys. (#62783) Thanks @neeravmakwana.
 - CLI/tasks: `openclaw tasks cancel` now records operator cancellation for CLI runtime tasks instead of returning "Task runtime does not support cancellation yet", so stuck `running` CLI tasks can be cleared. (#62419) Thanks @neeravmakwana.
+- Sessions/context: resolve context window limits using the active provider plus model (not bare model id alone) when persisting session usage, applying inline directives, and sizing memory-flush / preflight compaction thresholds, so duplicate model ids across providers no longer leak the wrong `contextTokens` into the session store or `/status`. (#62472) Thanks @neeravmakwana.
 
 ## 2026.4.5
 

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -358,6 +358,8 @@ export async function runPreflightCompactionIfNeeded(params: {
   }
 
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
+    cfg: params.cfg,
+    provider: params.followupRun.run.provider,
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
@@ -523,6 +525,8 @@ export async function runMemoryFlushIfNeeded(params: {
     params.sessionEntry ??
     (params.sessionKey ? params.sessionStore?.[params.sessionKey] : undefined);
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
+    cfg: params.cfg,
+    provider: params.followupRun.run.provider,
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,4 +1,4 @@
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -502,7 +502,12 @@ export async function runReplyAgent(params: {
       : undefined;
     const contextTokensUsed =
       agentCfgContextTokens ??
-      lookupContextTokens(modelUsed) ??
+      resolveContextTokensForModel({
+        cfg,
+        provider: providerUsed,
+        model: modelUsed,
+        allowAsyncLoad: false,
+      }) ??
       activeSessionEntry?.contextTokens ??
       DEFAULT_CONTEXT_TOKENS;
 

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -501,15 +501,14 @@ export async function runReplyAgent(params: {
       ? runResult.meta?.agentMeta?.cliSessionBinding
       : undefined;
     const contextTokensUsed =
-      agentCfgContextTokens ??
       resolveContextTokensForModel({
         cfg,
         provider: providerUsed,
         model: modelUsed,
+        contextTokensOverride: agentCfgContextTokens,
+        fallbackContextTokens: activeSessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
         allowAsyncLoad: false,
-      }) ??
-      activeSessionEntry?.contextTokens ??
-      DEFAULT_CONTEXT_TOKENS;
+      }) ?? DEFAULT_CONTEXT_TOKENS;
 
     await persistRunSessionUsage({
       storePath,

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -3,7 +3,7 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { lookupCachedContextTokens } from "../../agents/context-cache.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -221,6 +221,12 @@ export async function persistInlineDirectives(params: {
     provider,
     model,
     contextTokens:
-      agentCfg?.contextTokens ?? lookupCachedContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+      resolveContextTokensForModel({
+        cfg,
+        provider,
+        model,
+        contextTokensOverride: agentCfg?.contextTokens,
+        allowAsyncLoad: false,
+      }) ?? DEFAULT_CONTEXT_TOKENS,
   };
 }

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1103,6 +1103,63 @@ describe("createFollowupRunner messaging tool dedupe", () => {
     persistSpy.mockRestore();
   });
 
+  it("uses providerUsed for snapshot freshness when agent metadata overrides the run provider", async () => {
+    const storePath = "/tmp/openclaw-followup-usage-provider.json";
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = { sessionId: "session", updatedAt: Date.now() };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    const persistSpy = vi.spyOn(sessionRunAccounting, "persistRunSessionUsage");
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      meta: {
+        agentMeta: {
+          usage: { input: 10, output: 5 },
+          lastCallUsage: { input: 6, output: 3 },
+          model: "claude-opus-4-6",
+          provider: "anthropic",
+        },
+      },
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply: createAsyncReplySpy() },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      storePath,
+    });
+
+    await expect(
+      runner(
+        createQueuedRun({
+          run: {
+            provider: "openai",
+            config: {
+              agents: {
+                defaults: {
+                  cliBackends: {
+                    anthropic: {},
+                  },
+                },
+              },
+            } as OpenClawConfig,
+          },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(persistSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerUsed: "anthropic",
+        usageIsContextSnapshot: true,
+      }),
+    );
+    persistSpy.mockRestore();
+  });
+
   it("does not fall back to dispatcher when cross-channel origin routing fails", async () => {
     routeReplyMock.mockResolvedValueOnce({
       ok: false,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -292,15 +292,14 @@ export function createFollowupRunner(params: {
       const providerUsed =
         runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider;
       const contextTokensUsed =
-        agentCfgContextTokens ??
         resolveContextTokensForModel({
           cfg: queued.run.config,
           provider: providerUsed,
           model: modelUsed,
+          contextTokensOverride: agentCfgContextTokens,
+          fallbackContextTokens: sessionEntry?.contextTokens ?? DEFAULT_CONTEXT_TOKENS,
           allowAsyncLoad: false,
-        }) ??
-        sessionEntry?.contextTokens ??
-        DEFAULT_CONTEXT_TOKENS;
+        }) ?? DEFAULT_CONTEXT_TOKENS;
 
       if (storePath && sessionKey) {
         await persistRunSessionUsage({

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -314,7 +314,7 @@ export function createFollowupRunner(params: {
           contextTokensUsed,
           systemPromptReport: runResult.meta?.systemPromptReport,
           cliSessionBinding: runResult.meta?.agentMeta?.cliSessionBinding,
-          usageIsContextSnapshot: isCliProvider(fallbackProvider ?? run.provider, runtimeConfig),
+          usageIsContextSnapshot: isCliProvider(providerUsed, runtimeConfig),
           logLabel: "followup",
         });
       }

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -5,7 +5,7 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import { resolveRunModelFallbacksOverride } from "../../agents/agent-scope.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
@@ -289,9 +289,16 @@ export function createFollowupRunner(params: {
       const usage = runResult.meta?.agentMeta?.usage;
       const promptTokens = runResult.meta?.agentMeta?.promptTokens;
       const modelUsed = runResult.meta?.agentMeta?.model ?? fallbackModel ?? defaultModel;
+      const providerUsed =
+        runResult.meta?.agentMeta?.provider ?? fallbackProvider ?? queued.run.provider;
       const contextTokensUsed =
         agentCfgContextTokens ??
-        lookupContextTokens(modelUsed) ??
+        resolveContextTokensForModel({
+          cfg: queued.run.config,
+          provider: providerUsed,
+          model: modelUsed,
+          allowAsyncLoad: false,
+        }) ??
         sessionEntry?.contextTokens ??
         DEFAULT_CONTEXT_TOKENS;
 
@@ -304,7 +311,7 @@ export function createFollowupRunner(params: {
           lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
           promptTokens,
           modelUsed,
-          providerUsed: fallbackProvider,
+          providerUsed,
           contextTokensUsed,
           systemPromptReport: runResult.meta?.systemPromptReport,
           cliSessionBinding: runResult.meta?.agentMeta?.cliSessionBinding,

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,16 +1,23 @@
 import crypto from "node:crypto";
-import { lookupContextTokens } from "../../agents/context.js";
+import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 
 export function resolveMemoryFlushContextWindowTokens(params: {
   modelId?: string;
   agentCfgContextTokens?: number;
+  cfg?: OpenClawConfig;
+  provider?: string;
 }): number {
   return (
-    lookupContextTokens(params.modelId, { allowAsyncLoad: false }) ??
-    params.agentCfgContextTokens ??
-    DEFAULT_CONTEXT_TOKENS
+    resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.provider,
+      model: params.modelId,
+      contextTokensOverride: params.agentCfgContextTokens,
+      allowAsyncLoad: false,
+    }) ?? DEFAULT_CONTEXT_TOKENS
   );
 }
 

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -10,8 +10,6 @@ export function resolveMemoryFlushContextWindowTokens(params: {
   cfg?: OpenClawConfig;
   provider?: string;
 }): number {
-  // Match agent-runner / followup-runner / directive persist: agent `contextTokens`
-  // overrides provider/model resolution when set (via resolveContextTokensForModel).
   return (
     resolveContextTokensForModel({
       cfg: params.cfg,

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -10,6 +10,8 @@ export function resolveMemoryFlushContextWindowTokens(params: {
   cfg?: OpenClawConfig;
   provider?: string;
 }): number {
+  // Match agent-runner / followup-runner / directive persist: agent `contextTokens`
+  // overrides provider/model resolution when set (via resolveContextTokensForModel).
   return (
     resolveContextTokensForModel({
       cfg: params.cfg,

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -369,6 +369,31 @@ describe("resolveMemoryFlushContextWindowTokens", () => {
   it("falls back to agent config or default tokens", () => {
     expect(resolveMemoryFlushContextWindowTokens({ agentCfgContextTokens: 42_000 })).toBe(42_000);
   });
+
+  it("uses provider-specific configured limits when the same model id exists on multiple providers", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "provider-a": { models: [{ id: "shared-model", contextWindow: 200_000 }] },
+          "provider-b": { models: [{ id: "shared-model", contextWindow: 512_000 }] },
+        },
+      },
+    };
+    expect(
+      resolveMemoryFlushContextWindowTokens({
+        cfg: cfg as never,
+        provider: "provider-b",
+        modelId: "shared-model",
+      }),
+    ).toBe(512_000);
+    expect(
+      resolveMemoryFlushContextWindowTokens({
+        cfg: cfg as never,
+        provider: "provider-a",
+        modelId: "shared-model",
+      }),
+    ).toBe(200_000);
+  });
 });
 
 describe("incrementCompactionCount", () => {

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -394,6 +394,24 @@ describe("resolveMemoryFlushContextWindowTokens", () => {
       }),
     ).toBe(200_000);
   });
+
+  it("prefers agent contextTokens override over the provider configured window", () => {
+    const cfg = {
+      models: {
+        providers: {
+          "provider-b": { models: [{ id: "shared-model", contextWindow: 512_000 }] },
+        },
+      },
+    };
+    expect(
+      resolveMemoryFlushContextWindowTokens({
+        cfg: cfg as never,
+        provider: "provider-b",
+        modelId: "shared-model",
+        agentCfgContextTokens: 100_000,
+      }),
+    ).toBe(100_000);
+  });
 });
 
 describe("incrementCompactionCount", () => {


### PR DESCRIPTION
## Summary

- **Problem:** Session usage persistence, inline directive handling, and memory-flush / preflight compaction sizing used bare model ids (`lookupContextTokens` / `lookupCachedContextTokens`) for context limits. When several providers expose the same model id with different configured context windows, the wrong limit could be written to `sessionEntry.contextTokens` and affect `/status`, compaction, and flush behavior (#62472).
- **Why it matters:** Persisted `contextTokens` drives usage display, compaction thresholds, and related safeguards; a stale or collided value can make the runtime overly conservative or inconsistent with the active provider.
- **What changed:** Use `resolveContextTokensForModel({ cfg, provider, model, allowAsyncLoad: false })` in the auto-reply agent and follow-up runners, in `persistInlineDirectives` return value, and in `resolveMemoryFlushContextWindowTokens` (threading `cfg` + `provider` from the follow-up run). Follow-up runs now resolve `providerUsed` from agent meta when present, matching the main reply path.
- **What did NOT change:** CLI `updateSessionStoreAfterAgentRun` already used provider-qualified resolution; gateway session row building and status logic were left as-is. The global context cache structure is unchanged; resolution goes through the existing `resolveContextTokensForModel` contract.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62472
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Mixed strategies: `resolveContextTokensForModel` correctly scans `cfg.models.providers` per provider, but several hot paths still used bare-model cache lookups or cached tokens keyed only by model id, so duplicate ids across providers could leak the wrong window into persisted session metadata.
- **Missing detection / guardrail:** Unit coverage did not assert provider-qualified resolution for `resolveMemoryFlushContextWindowTokens` when two providers list the same model id with different limits.
- **Contributing context (if known):** N/A

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/auto-reply/reply/reply-state.test.ts`
- **Scenario the test should lock in:** Two providers in config share one model id with different `contextWindow` values; `resolveMemoryFlushContextWindowTokens` returns the limit for the requested `provider`.
- **Why this is the smallest reliable guardrail:** Exercises the same `resolveContextTokensForModel` path used by reply usage persistence and memory sizing without standing up a full channel run.
- **Existing test that already covers this (if any):** Partial — `resolveContextTokensForModel` tests in `src/agents/context.lookup.test.ts`; this adds coverage at the memory-flush entry point.
- **If no new test is added, why not:** N/A — test added.

## User-visible / Behavior Changes

- Session `contextTokens` and related usage / flush thresholds should match the **active provider’s** configured window when multiple providers reuse the same model id.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? **No**
- New network endpoints or trust boundaries? **No**

## Testing

- `pnpm exec oxlint --type-aware` on touched `src/auto-reply/reply/*.ts` files
- `pnpm test src/auto-reply/reply/reply-state.test.ts -t resolveMemoryFlushContextWindowTokens`
