### PR TITLE
Tasks: allow `openclaw tasks cancel` for CLI runtime (#62419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- CLI/tasks: `openclaw tasks cancel` now records operator cancellation for CLI runtime tasks instead of returning "Task runtime does not support cancellation yet", so stuck `running` CLI tasks can be cleared. (#62419) Thanks @neeravmakwana.
+- Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
 - CLI/infer: keep provider-backed infer behavior aligned with actual runtime execution by fixing explicit TTS override handling, profile-aware gateway TTS prefs resolution, per-request transcription `prompt`/`language` overrides, image output MIME/extension mismatches, configured web-search fallback behavior, and agent-vs-CLI web-search execution drift.
 - Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin and contributors.
@@ -188,6 +188,7 @@ Docs: https://docs.openclaw.ai
 - Agents/model resolution: keep explicit-model runtime comparisons on the configured workspace plugin registry, so workspace-installed providers do not silently fall back to stale explicit metadata during runtime model lookup.
 - Providers/Z.AI: default onboarding and endpoint detection to GLM-5.1 instead of GLM-5. (#61998) Thanks @serg0x.
 - Cron/isolated: resolve auth profiles without treating every isolated run as a brand-new auth session, so profile-based providers (for example OpenRouter) keep a stable credential choice instead of rotating or ignoring stored keys. (#62783) Thanks @neeravmakwana.
+- CLI/tasks: `openclaw tasks cancel` now records operator cancellation for CLI runtime tasks instead of returning "Task runtime does not support cancellation yet", so stuck `running` CLI tasks can be cleared. (#62419) Thanks @neeravmakwana.
 
 ## 2026.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/tasks: `openclaw tasks cancel` now records operator cancellation for CLI runtime tasks instead of returning "Task runtime does not support cancellation yet", so stuck `running` CLI tasks can be cleared. (#62419) Thanks @neeravmakwana.
 - CLI/infer: keep provider-backed infer behavior aligned with actual runtime execution by fixing explicit TTS override handling, profile-aware gateway TTS prefs resolution, per-request transcription `prompt`/`language` overrides, image output MIME/extension mismatches, configured web-search fallback behavior, and agent-vs-CLI web-search execution drift.
 - Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin and contributors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
 - CLI/infer: keep provider-backed infer behavior aligned with actual runtime execution by fixing explicit TTS override handling, profile-aware gateway TTS prefs resolution, per-request transcription `prompt`/`language` overrides, image output MIME/extension mismatches, configured web-search fallback behavior, and agent-vs-CLI web-search execution drift.
 - Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin and contributors.

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -180,7 +180,7 @@ The lookup token accepts a task ID, run ID, or session key. Shows the full recor
 openclaw tasks cancel <lookup>
 ```
 
-For ACP and subagent tasks, this kills the child session. Status transitions to `cancelled` and a delivery notification is sent.
+For ACP and subagent tasks, this kills the child session. For CLI-tracked tasks, cancellation is recorded in the task registry (there is no separate child runtime handle). Status transitions to `cancelled` and a delivery notification is sent when applicable.
 
 ### `tasks notify`
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -268,7 +268,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("does not overwrite operator-cancelled terminal status with lifecycle end", async () => {
+  it("ignores late agent events for operator-cancelled tasks", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
@@ -301,9 +301,18 @@ describe("task-registry", () => {
           endedAt: 999,
         },
       });
+      emitAgentEvent({
+        runId: "run-cancel-then-end",
+        stream: "error",
+        data: {
+          error: "late error",
+        },
+      });
 
       expect(findTaskByRunId("run-cancel-then-end")).toMatchObject({
         status: "cancelled",
+        endedAt: 200,
+        lastEventAt: 200,
         error: "Cancelled by operator.",
       });
     });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -268,6 +268,47 @@ describe("task-registry", () => {
     });
   });
 
+  it("does not overwrite operator-cancelled terminal status with lifecycle end", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const task = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:main",
+        runId: "run-cancel-then-end",
+        task: "Do the thing",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        startedAt: 100,
+      });
+
+      markTaskTerminalById({
+        taskId: task.taskId,
+        status: "cancelled",
+        endedAt: 200,
+        lastEventAt: 200,
+        error: "Cancelled by operator.",
+      });
+
+      emitAgentEvent({
+        runId: "run-cancel-then-end",
+        stream: "lifecycle",
+        data: {
+          phase: "end",
+          endedAt: 999,
+        },
+      });
+
+      expect(findTaskByRunId("run-cancel-then-end")).toMatchObject({
+        status: "cancelled",
+        error: "Cancelled by operator.",
+      });
+    });
+  });
+
   it("summarizes task pressure by status and runtime", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
@@ -1919,6 +1960,39 @@ describe("task-registry", () => {
           }),
         ),
       );
+    });
+  });
+
+  it("cancels CLI-tracked tasks without childSessionKey", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      const task = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "telegram:123",
+        },
+        runId: "run-cli-no-child",
+        task: "Legacy row",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expect(result).toMatchObject({
+        found: true,
+        cancelled: true,
+        task: expect.objectContaining({
+          taskId: task.taskId,
+          status: "cancelled",
+        }),
+      });
     });
   });
 });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1872,4 +1872,53 @@ describe("task-registry", () => {
       );
     });
   });
+
+  it("cancels CLI-tracked tasks in the registry without ACP or subagent teardown", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      hoisted.cancelSessionMock.mockClear();
+      hoisted.killSubagentRunAdminMock.mockClear();
+
+      const task = createTaskRecord({
+        runtime: "cli",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "telegram:123",
+        },
+        childSessionKey: "agent:main:main",
+        runId: "run-cancel-cli",
+        task: "Investigate issue",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+      expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        found: true,
+        cancelled: true,
+        task: expect.objectContaining({
+          taskId: task.taskId,
+          status: "cancelled",
+          error: "Cancelled by operator.",
+        }),
+      });
+      await waitForAssertion(() =>
+        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channel: "telegram",
+            to: "telegram:123",
+            content: "Background task cancelled: Investigate issue (run run-canc).",
+          }),
+        ),
+      );
+    });
+  });
 });

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1749,6 +1749,10 @@ export async function cancelTaskById(params: {
           task: cloneTaskRecord(task),
         };
       }
+    } else if (task.runtime === "cli") {
+      // CLI tasks key `childSessionKey` to the main agent session; there is no separate ACP or
+      // subagent session manager to stop. Record operator cancellation in the registry (same as
+      // after ACP/subagent teardown succeeds).
     } else {
       return {
         found: true,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1329,6 +1329,9 @@ function ensureListener() {
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
       }
+      if (isTerminalTaskStatus(current.status)) {
+        delete patch.status;
+      }
       const stateChangeEvent =
         patch.status && patch.status !== current.status
           ? appendTaskEvent({
@@ -1719,7 +1722,7 @@ export async function cancelTaskById(params: {
     };
   }
   const childSessionKey = task.childSessionKey?.trim();
-  if (!childSessionKey) {
+  if (!childSessionKey && task.runtime !== "cli") {
     return {
       found: true,
       cancelled: false,

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1305,6 +1305,9 @@ function ensureListener() {
     }
     const now = evt.ts || Date.now();
     for (const current of scopedTasks) {
+      if (isTerminalTaskStatus(current.status)) {
+        continue;
+      }
       const patch: Partial<TaskRecord> = {
         lastEventAt: now,
       };
@@ -1328,9 +1331,6 @@ function ensureListener() {
         }
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
-      }
-      if (isTerminalTaskStatus(current.status)) {
-        delete patch.status;
       }
       const stateChangeEvent =
         patch.status && patch.status !== current.status
@@ -1722,47 +1722,45 @@ export async function cancelTaskById(params: {
     };
   }
   const childSessionKey = task.childSessionKey?.trim();
-  if (!childSessionKey && task.runtime !== "cli") {
-    return {
-      found: true,
-      cancelled: false,
-      reason: "Task has no cancellable child session.",
-      task: cloneTaskRecord(task),
-    };
-  }
   try {
-    if (task.runtime === "acp") {
-      const { getAcpSessionManager } = await loadTaskRegistryControlRuntime();
-      await getAcpSessionManager().cancelSession({
-        cfg: params.cfg,
-        sessionKey: childSessionKey,
-        reason: "task-cancel",
-      });
-    } else if (task.runtime === "subagent") {
-      const { killSubagentRunAdmin } = await loadTaskRegistryControlRuntime();
-      const result = await killSubagentRunAdmin({
-        cfg: params.cfg,
-        sessionKey: childSessionKey,
-      });
-      if (!result.found || !result.killed) {
+    if (task.runtime !== "cli") {
+      if (!childSessionKey) {
         return {
           found: true,
           cancelled: false,
-          reason: result.found ? "Subagent was not running." : "Subagent task not found.",
+          reason: "Task has no cancellable child session.",
           task: cloneTaskRecord(task),
         };
       }
-    } else if (task.runtime === "cli") {
-      // CLI tasks key `childSessionKey` to the main agent session; there is no separate ACP or
-      // subagent session manager to stop. Record operator cancellation in the registry (same as
-      // after ACP/subagent teardown succeeds).
-    } else {
-      return {
-        found: true,
-        cancelled: false,
-        reason: "Task runtime does not support cancellation yet.",
-        task: cloneTaskRecord(task),
-      };
+      if (task.runtime === "acp") {
+        const { getAcpSessionManager } = await loadTaskRegistryControlRuntime();
+        await getAcpSessionManager().cancelSession({
+          cfg: params.cfg,
+          sessionKey: childSessionKey,
+          reason: "task-cancel",
+        });
+      } else if (task.runtime === "subagent") {
+        const { killSubagentRunAdmin } = await loadTaskRegistryControlRuntime();
+        const result = await killSubagentRunAdmin({
+          cfg: params.cfg,
+          sessionKey: childSessionKey,
+        });
+        if (!result.found || !result.killed) {
+          return {
+            found: true,
+            cancelled: false,
+            reason: result.found ? "Subagent was not running." : "Subagent task not found.",
+            task: cloneTaskRecord(task),
+          };
+        }
+      } else {
+        return {
+          found: true,
+          cancelled: false,
+          reason: "Task runtime does not support cancellation yet.",
+          task: cloneTaskRecord(task),
+        };
+      }
     }
     const updated = updateTask(task.taskId, {
       status: "cancelled",


### PR DESCRIPTION
## Summary

- Problem: `openclaw tasks cancel` returned "Task runtime does not support cancellation yet" for CLI-tracked tasks (for example gateway agent runs), so operators could not clear stuck `running` rows.
- Why it matters: CLI tasks can remain `running` when follow-up bookkeeping never runs; without a working cancel path there was no supported way to mark them terminal.
- What changed: `cancelTaskById` treats `runtime === "cli"` like other local cancellations: record `cancelled` in the task registry (CLI uses the main session as `childSessionKey`; there is no separate ACP/subagent session to stop). Docs and changelog updated; unit test covers the path.
- What did NOT change: Cron and any other non-ACP/subagent/CLI runtimes still return the unsupported message. Maintenance/audit behavior for `stale_running` is unchanged (audit remains informational).

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #62419
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `cancelTaskById` only wired teardown for ACP and subagent runtimes; CLI fell through to the unsupported branch despite using a normal session key.
- Missing detection / guardrail: Unit tests only covered ACP and subagent cancellation.

## Regression Test Plan

- Coverage: Unit test (`src/tasks/task-registry.test.ts`) asserts CLI cancel updates the task to `cancelled`, does not call ACP/subagent hooks, and delivers the expected terminal message when delivery is pending.

## User-visible / Behavior Changes

- `openclaw tasks cancel` succeeds for active CLI-tracked tasks and sets status to `cancelled` with operator error text.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No (registry state only for CLI cancel)
- Data access scope changed? No

## Repro + Verification

### Environment

- Unit test run: `pnpm test src/tasks/task-registry.test.ts -t "cancels"`

### Steps

1. Create a running CLI task record with `childSessionKey` set.
2. Call `cancelTaskById`.
3. Expect `cancelled: true` and no ACP/subagent control calls.

### Expected

- Task transitions to `cancelled`.

### Actual

- Matches test expectations.

## Evidence

- [x] New unit test for CLI cancel path

## Human Verification

- Verified scenarios: Scoped Vitest for cancel tests in `task-registry.test.ts`.
- Edge cases checked: Confirms ACP/subagent mocks are not invoked for CLI.
- What I did not verify: Full `pnpm check` / `pnpm build` (local tree has unrelated TS/build failures on this checkout).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Cancelling while a CLI run is still live does not abort the agent run; it only updates task registry state (same class of limitation as other operator-driven terminal updates if completion races).
  - Mitigation: Matches prior behavior for non-CLI paths that only had registry + session kill where applicable; documented in `docs/automation/tasks.md`.


Made with [Cursor](https://cursor.com)