### PR TITLE
fix(chat): webui image chat fix

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -508,6 +508,8 @@ export async function runEmbeddedAttempt(
             replyToMode: params.replyToMode,
             hasRepliedRef: params.hasRepliedRef,
             modelHasVision,
+            currentTurnHasImages:
+              (params.images?.length ?? 0) > 0 || (params.imageOrder?.length ?? 0) > 0,
             requireExplicitMessageTarget:
               params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
             disableMessageTool: params.disableMessageTool,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -311,6 +311,8 @@ export function createOpenClawCodingTools(options?: {
   allowGatewaySubagentBinding?: boolean;
   /** If true, the model has native vision capability */
   modelHasVision?: boolean;
+  /** If true, the current run already carries prompt images for native vision input. */
+  currentTurnHasImages?: boolean;
   /** Require explicit message targets (no implicit last-route sends). */
   requireExplicitMessageTarget?: boolean;
   /** If true, omit the message tool from the tool list. */
@@ -617,8 +619,17 @@ export function createOpenClawCodingTools(options?: {
           return [tool];
         })
       : tools;
+  // When the current run already includes uploaded images and the selected model
+  // can see them natively, hide the explicit image tool for this turn. This keeps
+  // the model from re-opening transient attachment cache paths that may not exist
+  // on the host anymore, while preserving the tool for text-only models or
+  // follow-up turns without prompt-local images.
+  const toolsForPromptImages =
+    options?.modelHasVision === true && options?.currentTurnHasImages === true
+      ? toolsForMemoryFlush.filter((tool) => tool.name !== "image")
+      : toolsForMemoryFlush;
   const toolsForMessageProvider = applyMessageProviderToolPolicy(
-    toolsForMemoryFlush,
+    toolsForPromptImages,
     options?.messageProvider,
   );
   const toolsForModelProvider = applyModelProviderToolPolicy(toolsForMessageProvider, {


### PR DESCRIPTION
## Summary

- Problem: vision-capable runs still injected the `image` tool even when the current user turn already included native image input.
- Why it matters: models with weak tool-calling discipline could ignore the tool description, hallucinate a local path or unrelated remote URL, and call `image` against the wrong target.
- What changed: the embedded runner now marks runs that already carry prompt images, and `createOpenClawCodingTools()` removes `image` from that turn’s tool list when the selected model already supports native image input.
- What did NOT change (scope boundary): image handling/storage, prompt-image loading, and non-vision or text-only runs still behave as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62514
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the runtime relied on tool-description guidance to discourage `image` tool use, but still exposed the tool even when the model already had native image inputs for the current turn.
- Missing detection / guardrail: there was no runtime guard that removed `image` from the tool list when `params.images` / prompt image order already indicated native image input.
- Contributing context (if known): `glm-4.6v` could ignore the descriptive prohibition and hallucinate nonexistent local attachment paths or unrelated public image URLs.

## User-visible / Behavior Changes

When a vision-capable model already receives image input in the current turn, the assistant no longer exposes the fallback `image` tool for that turn, reducing bogus image-tool calls against hallucinated paths or URLs.

## Diagram

```text
Before:
[user sends image] -> [native image input added] -> [image tool still injected] -> [model may hallucinate path/URL] -> [wrong image tool call]

After:
[user sends image] -> [native image input added] -> [image tool removed for this turn] -> [model answers from native image input]
