### PR TITLE
Gateway: add /hooks/message ingress with webhook auth parity

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -213,7 +213,7 @@ curl -X POST http://127.0.0.1:18789/hooks/wake \
 
 ### POST /hooks/agent
 
-Run an isolated agent turn:
+Run an isolated agent task (automation-only):
 
 ```bash
 curl -X POST http://127.0.0.1:18789/hooks/agent \
@@ -223,6 +223,34 @@ curl -X POST http://127.0.0.1:18789/hooks/agent \
 ```
 
 Fields: `message` (required), `name`, `agentId`, `wakeMode`, `deliver`, `channel`, `to`, `model`, `thinking`, `timeoutSeconds`.
+
+Use `/hooks/agent` when you want to execute automation logic. This route does not mirror output into chat UI by itself.
+
+### POST /hooks/message
+
+Use this endpoint for inbound transport where messages must appear in chat visibility paths:
+
+```bash
+curl -X POST http://127.0.0.1:18789/hooks/message \
+  -H 'Authorization: Bearer SECRET' \
+  -H 'Content-Type: application/json' \
+  -d '{"message":"Inbound update","requestId":"req-123","kind":"message"}'
+```
+
+Required fields:
+
+- `message`
+- `requestId`
+
+Optional fields:
+
+- `kind` (`message` or `event`, default `message`)
+- `sessionKey`, `source`, `sender`, `conversation`, `metadata`
+
+Behavior:
+
+- `kind=message`: inbound chat visibility path + auto-reply dispatch
+- `kind=event`: operational webhook event only (no auto-reply)
 
 ### Mapped hooks (POST /hooks/\<name\>)
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -3055,6 +3055,10 @@ Validation and safety notes:
 - `POST /hooks/wake` → `{ text, mode?: "now"|"next-heartbeat" }`
 - `POST /hooks/agent` → `{ message, name?, agentId?, sessionKey?, wakeMode?, deliver?, channel?, to?, model?, thinking?, timeoutSeconds? }`
   - `sessionKey` from request payload is accepted only when `hooks.allowRequestSessionKey=true` (default: `false`).
+  - Automation-only route: runs isolated agent tasks and returns run status metadata; it does not guarantee chat UI mirroring.
+- `POST /hooks/message` → `{ message, requestId, kind?: "message"|"event", sessionKey?, source?, sender?, conversation?, metadata? }`
+  - `kind="message"` is the chat visibility transport path (ingress + broadcast + optional auto-reply).
+  - `kind="event"` is operational-only (no auto-reply dispatch).
 - `POST /hooks/<name>` → resolved via `hooks.mappings`
 
 <Accordion title="Mapping details">

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -436,6 +436,7 @@ When validation fails:
     - Use a dedicated `hooks.token`; do not reuse the shared Gateway token.
     - Hook auth is header-only (`Authorization: Bearer ...` or `x-openclaw-token`); query-string tokens are rejected.
     - `hooks.path` cannot be `/`; keep webhook ingress on a dedicated subpath such as `/hooks`.
+    - Boundary: use `/hooks/message` for inbound chat transport and UI visibility; use `/hooks/agent` for automation task execution only.
     - Keep unsafe-content bypass flags disabled (`hooks.gmail.allowUnsafeExternalContent`, `hooks.mappings[].allowUnsafeExternalContent`) unless doing tightly scoped debugging.
     - If you enable `hooks.allowRequestSessionKey`, also set `hooks.allowedSessionKeyPrefixes` to bound caller-selected session keys.
     - For hook-driven agents, prefer strong modern model tiers and strict tool policy (for example messaging-only plus sandboxing where possible).

--- a/src/cron/AGENTS.md
+++ b/src/cron/AGENTS.md
@@ -1,0 +1,26 @@
+# Cron Runtime Guide
+
+This guide applies to `src/cron/**` unless a deeper `AGENTS.md` overrides it.
+
+## Delivery Responsibility
+
+- Keep isolated-run execution separate from chat UI transport concerns.
+- `deliveryContract="cron-owned"` may queue main-session awareness after successful direct delivery when policy allows.
+- `deliveryContract="shared"` must not add extra main-session awareness mirrors; the caller owns any UI visibility behavior.
+
+## Delivery Semantics
+
+- `delivered` means the configured outbound delivery route completed for this run.
+- `deliveryAttempted` tracks whether cron attempted the configured delivery path, even when the run result remains `ok`.
+- Do not infer chat-UI mirroring from `delivered=true`.
+
+## Reliability Rules
+
+- Keep direct-delivery idempotency deterministic.
+- Preserve best-effort behavior: never convert partial delivery into a cached full success.
+- Keep stale-run suppression and no-reply suppression paths from triggering duplicate fallback announcements.
+
+## Test Expectations
+
+- Add or update tests when changing delivery contract branching.
+- Verify both `cron-owned` and `shared` paths for awareness-queue side effects.

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -111,6 +111,7 @@ function makeWithRunSession() {
 function makeBaseParams(overrides: {
   synthesizedText?: string;
   deliveryRequested?: boolean;
+  deliveryContract?: "cron-owned" | "shared";
   runSessionId?: string;
   sessionTarget?: string;
   deliveryBestEffort?: boolean;
@@ -135,6 +136,7 @@ function makeBaseParams(overrides: {
     timeoutMs: 30_000,
     resolvedDelivery,
     deliveryRequested: overrides.deliveryRequested ?? true,
+    deliveryContract: overrides.deliveryContract ?? "cron-owned",
     skipHeartbeatDelivery: false,
     deliveryBestEffort: overrides.deliveryBestEffort ?? false,
     deliveryPayloadHasStructuredContent: false,
@@ -359,6 +361,23 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     const params = makeBaseParams({
       synthesizedText: "Best-effort cron update.",
       deliveryBestEffort: true,
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryAttempted).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips main-session awareness for shared delivery-contract runs", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({
+      synthesizedText: "Hook agent finished.",
+      deliveryContract: "shared",
     });
     const state = await dispatchCronDelivery(params);
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -20,7 +20,7 @@ import {
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { pickSummaryFromOutput } from "./helpers.js";
-import type { RunCronAgentTurnResult } from "./run.js";
+import type { IsolatedDeliveryContract, RunCronAgentTurnResult } from "./run.js";
 import { expectsSubagentFollowup, isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
 function normalizeDeliveryTarget(channel: string, to: string): string {
@@ -69,6 +69,7 @@ type DispatchCronDeliveryParams = {
   timeoutMs: number;
   resolvedDelivery: DeliveryTargetResolution;
   deliveryRequested: boolean;
+  deliveryContract: IsolatedDeliveryContract;
   skipHeartbeatDelivery: boolean;
   skipMessagingToolDelivery?: boolean;
   deliveryBestEffort: boolean;
@@ -240,10 +241,18 @@ function buildDirectCronDeliveryIdempotencyKey(params: {
   return `cron-direct-delivery:v1:${params.runSessionId}:${params.delivery.channel}:${accountId}:${normalizedTo}:${threadId}`;
 }
 
-function shouldQueueCronAwareness(job: CronJob, deliveryBestEffort: boolean): boolean {
+function shouldQueueCronAwareness(params: {
+  job: CronJob;
+  deliveryBestEffort: boolean;
+  deliveryContract: IsolatedDeliveryContract;
+}): boolean {
   // Keep issue #52136 scoped to isolated runs. Session-bound cron jobs keep
   // their existing behavior, and best-effort sends may only partially deliver.
-  return job.sessionTarget === "isolated" && !deliveryBestEffort;
+  return (
+    params.deliveryContract === "cron-owned" &&
+    params.job.sessionTarget === "isolated" &&
+    !params.deliveryBestEffort
+  );
 }
 
 function resolveCronAwarenessMainSessionKey(params: {
@@ -533,7 +542,14 @@ export async function dispatchCronDelivery(
       // Intentionally leave partial success uncached: replay may duplicate the
       // successful subset, but caching it here would permanently drop the
       // failed payloads by converting the replay into delivered=true.
-      if (delivered && shouldQueueCronAwareness(params.job, params.deliveryBestEffort)) {
+      if (
+        delivered &&
+        shouldQueueCronAwareness({
+          job: params.job,
+          deliveryBestEffort: params.deliveryBestEffort,
+          deliveryContract: params.deliveryContract,
+        })
+      ) {
         await queueCronAwarenessSystemEvent({
           cfg: params.cfgWithAgentDefaults,
           jobId: params.job.id,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -92,7 +92,7 @@ export type RunCronAgentTurnResult = {
 
 type ResolvedCronDeliveryTarget = Awaited<ReturnType<typeof resolveDeliveryTarget>>;
 
-type IsolatedDeliveryContract = "cron-owned" | "shared";
+export type IsolatedDeliveryContract = "cron-owned" | "shared";
 
 function resolveCronToolPolicy(params: {
   deliveryRequested: boolean;

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -620,6 +620,7 @@ async function finalizeCronRun(params: {
     timeoutMs: prepared.timeoutMs,
     resolvedDelivery: prepared.resolvedDelivery,
     deliveryRequested: prepared.deliveryRequested,
+    deliveryContract: prepared.input.deliveryContract ?? "cron-owned",
     skipHeartbeatDelivery,
     skipMessagingToolDelivery,
     deliveryBestEffort: resolveCronDeliveryBestEffort(prepared.input.job),

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -23,6 +23,9 @@ This guide applies to `src/gateway/**` unless a deeper `AGENTS.md` overrides it.
 - For inbound message hooks, preserve `requestId` and session resolution deterministically.
 - Keep lifecycle logs deterministic with stable field order and stable event names.
 - Do not leak raw internal exceptions to hook clients; return generic 5xx errors and log details server-side.
+- Keep route responsibility explicit:
+  - `/hooks/agent` is automation execution only.
+  - `/hooks/message` is inbound chat visibility transport.
 
 ## Test Expectations
 

--- a/src/gateway/AGENTS.md
+++ b/src/gateway/AGENTS.md
@@ -1,0 +1,32 @@
+# Gateway Working Guide
+
+This guide applies to `src/gateway/**` unless a deeper `AGENTS.md` overrides it.
+
+## Hooks and Webhook Parity
+
+- Keep hook auth behavior consistent across hook routes.
+- Accept hook tokens only from `Authorization: Bearer` or `X-OpenClaw-Token`.
+- Reject query-string token auth on all hook routes.
+- Reuse shared constant-time secret checks and shared auth-failure rate-limit buckets.
+- Reuse shared client IP resolution (trusted proxy handling and fallback rules).
+
+## Request Safety and Replay Protection
+
+- Keep hook routes `POST`-only unless a route explicitly documents another method.
+- Reuse shared JSON body guards (size limit and timeout) instead of adding per-route readers.
+- Reuse existing hook idempotency extraction and replay cache behavior.
+- When adding a new idempotent hook payload, include a deterministic fallback key when no idempotency header is present.
+
+## Hook Message Ingress Conventions
+
+- Validate hook payloads at ingress with strict required/optional contracts.
+- For inbound message hooks, preserve `requestId` and session resolution deterministically.
+- Keep lifecycle logs deterministic with stable field order and stable event names.
+- Do not leak raw internal exceptions to hook clients; return generic 5xx errors and log details server-side.
+
+## Test Expectations
+
+- Add parity tests for auth and request guards when introducing new hook paths.
+- Cover idempotent replay behavior for retries.
+- Cover `kind`-specific behavior for message vs event payloads.
+- For webchat visibility tests, assert the live chat event path and auto-reply dispatch invocation for active sessions.

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -233,6 +233,7 @@ export type HookMessagePayload = {
 
 export type HookMessageDispatchPayload = HookMessagePayload & {
   idempotencyKey: string;
+  allowedSessionKeyPrefixes?: string[];
 };
 
 export type HookMessageDispatchResult = {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -233,6 +233,7 @@ export type HookMessagePayload = {
 
 export type HookMessageDispatchPayload = HookMessagePayload & {
   idempotencyKey: string;
+  chatIdempotencyKey?: string;
   allowedSessionKeyPrefixes?: string[];
 };
 

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -220,6 +220,97 @@ export type HookAgentDispatchPayload = Omit<HookAgentPayload, "sessionKey"> & {
   externalContentSource?: HookExternalContentSource;
 };
 
+export type HookMessagePayload = {
+  message: string;
+  requestId: string;
+  kind: "message" | "event";
+  sessionKey?: string;
+  source?: string;
+  sender?: Record<string, unknown>;
+  conversation?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+};
+
+export type HookMessageDispatchPayload = HookMessagePayload & {
+  idempotencyKey: string;
+};
+
+export type HookMessageDispatchResult = {
+  status: "accepted" | "event";
+  sessionKey: string;
+  runId?: string;
+};
+
+function isHookMessageRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function resolveOptionalHookMessageString(raw: unknown): string | undefined {
+  if (typeof raw !== "string") {
+    return undefined;
+  }
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function resolveOptionalHookMessageRecord(raw: unknown): Record<string, unknown> | undefined {
+  return isHookMessageRecord(raw) ? raw : undefined;
+}
+
+export function normalizeHookMessagePayload(
+  payload: Record<string, unknown>,
+): { ok: true; value: HookMessagePayload } | { ok: false; error: string } {
+  const message = resolveOptionalHookMessageString(payload.message);
+  if (!message) {
+    return { ok: false, error: "message required" };
+  }
+
+  const requestId = resolveOptionalHookMessageString(payload.requestId);
+  if (!requestId) {
+    return { ok: false, error: "requestId required" };
+  }
+
+  const kindRaw = payload.kind;
+  const kind =
+    kindRaw === undefined
+      ? "message"
+      : kindRaw === "message" || kindRaw === "event"
+        ? kindRaw
+        : null;
+  if (!kind) {
+    return { ok: false, error: "kind must be message|event" };
+  }
+
+  const sender = resolveOptionalHookMessageRecord(payload.sender);
+  if (payload.sender !== undefined && !sender) {
+    return { ok: false, error: "sender must be an object when provided" };
+  }
+
+  const conversation = resolveOptionalHookMessageRecord(payload.conversation);
+  if (payload.conversation !== undefined && !conversation) {
+    return { ok: false, error: "conversation must be an object when provided" };
+  }
+
+  const metadata = resolveOptionalHookMessageRecord(payload.metadata);
+  if (payload.metadata !== undefined && !metadata) {
+    return { ok: false, error: "metadata must be an object when provided" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      message,
+      requestId,
+      kind,
+      sessionKey: resolveOptionalHookMessageString(payload.sessionKey),
+      source: resolveOptionalHookMessageString(payload.source),
+      ...(sender ? { sender } : {}),
+      ...(conversation ? { conversation } : {}),
+      ...(metadata ? { metadata } : {}),
+    },
+  };
+}
+
 const listHookChannelValues = () => ["last", ...listChannelPlugins().map((plugin) => plugin.id)];
 
 export type HookMessageChannel = ChannelId;

--- a/src/gateway/server-http.hooks-request-timeout.test.ts
+++ b/src/gateway/server-http.hooks-request-timeout.test.ts
@@ -70,14 +70,46 @@ describe("createHooksRequestHandler timeout status mapping", () => {
     const firstHandled = await handler(firstReq, first.res);
     expect(firstHandled).toBe(true);
     expect(first.res.statusCode).toBe(200);
+    const firstPayload = JSON.parse((first.end.mock.calls[0] as [string])[0]) as {
+      sessionKey?: string;
+      status?: string;
+    };
 
     const secondReq = createHookRequest({ url: "/hooks/message" });
     const second = createResponse();
     const secondHandled = await handler(secondReq, second.res);
     expect(secondHandled).toBe(true);
     expect(second.res.statusCode).toBe(200);
+    const secondPayload = JSON.parse((second.end.mock.calls[0] as [string])[0]) as {
+      sessionKey?: string;
+      status?: string;
+    };
 
     expect(dispatchMessageHook).toHaveBeenCalledTimes(1);
+    expect(firstPayload.sessionKey).toBe("main");
+    expect(secondPayload.sessionKey).toBe(firstPayload.sessionKey);
+    expect(secondPayload.status).toBe(firstPayload.status);
+  });
+
+  test("returns 503 when /hooks/message dispatch is temporarily unavailable", async () => {
+    readJsonBodyMock.mockResolvedValue({
+      ok: true,
+      value: { message: "hello", requestId: "req-1" },
+    });
+    const dispatchMessageHook = vi.fn(async () => {
+      throw Object.assign(new Error("gateway context unavailable"), { statusCode: 503 });
+    });
+    const handler = createHooksHandler({ dispatchMessageHook });
+    const req = createHookRequest({ url: "/hooks/message" });
+    const { res, end } = createResponse();
+
+    const handled = await handler(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(503);
+    expect(end).toHaveBeenCalledWith(
+      JSON.stringify({ ok: false, error: "hook message dispatch unavailable" }),
+    );
   });
 
   test("shares hook auth rate-limit bucket across ipv4 and ipv4-mapped ipv6 forms", async () => {

--- a/src/gateway/server-http.hooks-request-timeout.test.ts
+++ b/src/gateway/server-http.hooks-request-timeout.test.ts
@@ -39,6 +39,47 @@ describe("createHooksRequestHandler timeout status mapping", () => {
     expect(dispatchAgentHook).not.toHaveBeenCalled();
   });
 
+  test("returns 413 for oversized /hooks/message payloads", async () => {
+    readJsonBodyMock.mockResolvedValue({ ok: false, error: "payload too large" });
+    const dispatchMessageHook = vi.fn();
+    const handler = createHooksHandler({ dispatchMessageHook });
+    const req = createHookRequest({ url: "/hooks/message" });
+    const { res, end } = createResponse();
+
+    const handled = await handler(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(413);
+    expect(end).toHaveBeenCalledWith(JSON.stringify({ ok: false, error: "payload too large" }));
+    expect(dispatchMessageHook).not.toHaveBeenCalled();
+  });
+
+  test("dedupes /hooks/message retries by requestId when idempotency header is absent", async () => {
+    readJsonBodyMock.mockResolvedValue({
+      ok: true,
+      value: { message: "hello", requestId: "req-1" },
+    });
+    const dispatchMessageHook = vi.fn(async () => ({
+      status: "accepted" as const,
+      sessionKey: "main",
+    }));
+    const handler = createHooksHandler({ dispatchMessageHook });
+
+    const firstReq = createHookRequest({ url: "/hooks/message" });
+    const first = createResponse();
+    const firstHandled = await handler(firstReq, first.res);
+    expect(firstHandled).toBe(true);
+    expect(first.res.statusCode).toBe(200);
+
+    const secondReq = createHookRequest({ url: "/hooks/message" });
+    const second = createResponse();
+    const secondHandled = await handler(secondReq, second.res);
+    expect(secondHandled).toBe(true);
+    expect(second.res.statusCode).toBe(200);
+
+    expect(dispatchMessageHook).toHaveBeenCalledTimes(1);
+  });
+
   test("shares hook auth rate-limit bucket across ipv4 and ipv4-mapped ipv6 forms", async () => {
     const handler = createHooksHandler({ bindHost: "127.0.0.1" });
 

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -187,6 +187,7 @@ export function createHooksHandler(
     | {
         dispatchWakeHook?: HooksHandlerDeps["dispatchWakeHook"];
         dispatchAgentHook?: HooksHandlerDeps["dispatchAgentHook"];
+        dispatchMessageHook?: HooksHandlerDeps["dispatchMessageHook"];
         bindHost?: string;
         getClientIpConfig?: HooksHandlerDeps["getClientIpConfig"];
       },
@@ -205,6 +206,8 @@ export function createHooksHandler(
     getClientIpConfig: options.getClientIpConfig,
     dispatchWakeHook: options.dispatchWakeHook ?? (() => {}),
     dispatchAgentHook: options.dispatchAgentHook ?? (() => "run-1"),
+    dispatchMessageHook:
+      options.dispatchMessageHook ?? (async () => ({ status: "accepted", sessionKey: "main" })),
   });
 }
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -128,6 +128,41 @@ type HookReplayScope = {
   dispatchScope: Record<string, unknown>;
 };
 
+function normalizeReplayScopeValue(value: unknown): unknown {
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => {
+      const normalized = normalizeReplayScopeValue(entry);
+      return normalized === undefined ? null : normalized;
+    });
+  }
+  if (typeof value === "object") {
+    const input = value as Record<string, unknown>;
+    const normalized: Record<string, unknown> = {};
+    for (const key of Object.keys(input).toSorted()) {
+      const next = normalizeReplayScopeValue(input[key]);
+      if (next !== undefined) {
+        normalized[key] = next;
+      }
+    }
+    return normalized;
+  }
+  return undefined;
+}
+
+function stringifyReplayScopeStable(value: unknown): string {
+  const normalized = normalizeReplayScopeValue(value);
+  return JSON.stringify(normalized ?? null);
+}
+
 function sendJson(res: ServerResponse, status: number, body: unknown) {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
@@ -431,7 +466,7 @@ export function createHooksRequestHandler(
     const idempotencyFingerprint = createHash("sha256").update(idem, "utf8").digest("hex");
     const scopeFingerprint = createHash("sha256")
       .update(
-        JSON.stringify({
+        stringifyReplayScopeStable({
           pathKey: params.pathKey,
           dispatchScope: params.dispatchScope,
         }),

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -690,6 +690,7 @@ export function createHooksRequestHandler(
         const dispatched = await dispatchMessageHook({
           ...normalized.value,
           sessionKey: resolvedSessionKey.value,
+          allowedSessionKeyPrefixes: hooksConfig.sessionPolicy.allowedSessionKeyPrefixes,
           idempotencyKey: effectiveIdempotencyKey,
         });
         rememberHookReplayEntry(
@@ -718,6 +719,17 @@ export function createHooksRequestHandler(
           typeof (err as { statusCode?: unknown }).statusCode === "number"
             ? (err as { statusCode: number }).statusCode
             : 500;
+        if (dispatchStatusCode === 400) {
+          const message =
+            typeof err === "object" &&
+            err !== null &&
+            "message" in err &&
+            typeof (err as { message?: unknown }).message === "string"
+              ? (err as { message: string }).message
+              : "invalid hook message request";
+          sendJson(res, 400, { ok: false, error: message });
+          return true;
+        }
         if (dispatchStatusCode === 503) {
           sendJson(res, 503, { ok: false, error: "hook message dispatch unavailable" });
           return true;

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -669,6 +669,9 @@ export function createHooksRequestHandler(
           metadata: normalized.value.metadata ?? null,
         },
       });
+      const chatIdempotencyKey = replayKey
+        ? `hookmsg:${createHash("sha256").update(replayKey, "utf8").digest("hex")}`
+        : effectiveIdempotencyKey;
       const cachedReplay = resolveCachedHookReplayEntry(replayKey, now);
       if (cachedReplay) {
         sendJson(res, 200, {
@@ -692,6 +695,7 @@ export function createHooksRequestHandler(
           sessionKey: resolvedSessionKey.value,
           allowedSessionKeyPrefixes: hooksConfig.sessionPolicy.allowedSessionKeyPrefixes,
           idempotencyKey: effectiveIdempotencyKey,
+          chatIdempotencyKey,
         });
         rememberHookReplayEntry(
           replayKey,

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -116,7 +116,9 @@ export type HookClientIpConfig = Readonly<{
 
 type HookReplayEntry = {
   ts: number;
-  runId: string;
+  runId?: string;
+  sessionKey?: string;
+  status?: string;
 };
 
 type HookReplayScope = {
@@ -439,7 +441,10 @@ export function createHooksRequestHandler(
     return `${tokenFingerprint}:${scopeFingerprint}:${idempotencyFingerprint}`;
   };
 
-  const resolveCachedHookRunId = (key: string | undefined, now: number): string | undefined => {
+  const resolveCachedHookReplayEntry = (
+    key: string | undefined,
+    now: number,
+  ): HookReplayEntry | undefined => {
     if (!key) {
       return undefined;
     }
@@ -450,16 +455,27 @@ export function createHooksRequestHandler(
     }
     hookReplayCache.delete(key);
     hookReplayCache.set(key, cached);
-    return cached.runId;
+    return cached;
   };
 
-  const rememberHookRunId = (key: string | undefined, runId: string, now: number) => {
+  const resolveCachedHookRunId = (key: string | undefined, now: number): string | undefined =>
+    resolveCachedHookReplayEntry(key, now)?.runId;
+
+  const rememberHookReplayEntry = (
+    key: string | undefined,
+    entry: Omit<HookReplayEntry, "ts">,
+    now: number,
+  ) => {
     if (!key) {
       return;
     }
     hookReplayCache.delete(key);
-    hookReplayCache.set(key, { ts: now, runId });
+    hookReplayCache.set(key, { ts: now, ...entry });
     pruneHookReplayCache(now);
+  };
+
+  const rememberHookRunId = (key: string | undefined, runId: string, now: number) => {
+    rememberHookReplayEntry(key, { runId }, now);
   };
 
   return async (req, res) => {
@@ -627,16 +643,14 @@ export function createHooksRequestHandler(
         return true;
       }
       const requestSessionKey = normalized.value.sessionKey;
-      if (requestSessionKey) {
-        const sessionKey = resolveHookSessionKey({
-          hooksConfig,
-          source: "request",
-          sessionKey: requestSessionKey,
-        });
-        if (!sessionKey.ok) {
-          sendJson(res, 400, { ok: false, error: sessionKey.error });
-          return true;
-        }
+      const resolvedSessionKey = resolveHookSessionKey({
+        hooksConfig,
+        source: "request",
+        sessionKey: requestSessionKey,
+      });
+      if (!resolvedSessionKey.ok) {
+        sendJson(res, 400, { ok: false, error: resolvedSessionKey.error });
+        return true;
       }
 
       const effectiveIdempotencyKey = idempotencyKey ?? normalized.value.requestId;
@@ -648,21 +662,23 @@ export function createHooksRequestHandler(
           requestId: normalized.value.requestId,
           message: normalized.value.message,
           kind: normalized.value.kind,
-          sessionKey: requestSessionKey ?? null,
+          sessionKey: requestSessionKey ?? hooksConfig.sessionPolicy.defaultSessionKey ?? null,
           source: normalized.value.source ?? null,
           sender: normalized.value.sender ?? null,
           conversation: normalized.value.conversation ?? null,
           metadata: normalized.value.metadata ?? null,
         },
       });
-      const cachedRunId = resolveCachedHookRunId(replayKey, now);
-      if (cachedRunId) {
+      const cachedReplay = resolveCachedHookReplayEntry(replayKey, now);
+      if (cachedReplay) {
         sendJson(res, 200, {
           ok: true,
           requestId: normalized.value.requestId,
-          status: normalized.value.kind === "event" ? "event" : "accepted",
-          ...(requestSessionKey ? { sessionKey: requestSessionKey } : {}),
-          ...(normalized.value.kind === "message" ? { runId: cachedRunId } : {}),
+          status: cachedReplay.status ?? (normalized.value.kind === "event" ? "event" : "accepted"),
+          sessionKey: cachedReplay.sessionKey ?? resolvedSessionKey.value,
+          ...(normalized.value.kind === "message" && cachedReplay.runId
+            ? { runId: cachedReplay.runId }
+            : {}),
         });
         return true;
       }
@@ -673,9 +689,18 @@ export function createHooksRequestHandler(
       try {
         const dispatched = await dispatchMessageHook({
           ...normalized.value,
+          sessionKey: resolvedSessionKey.value,
           idempotencyKey: effectiveIdempotencyKey,
         });
-        rememberHookRunId(replayKey, dispatched.runId ?? normalized.value.requestId, now);
+        rememberHookReplayEntry(
+          replayKey,
+          {
+            ...(dispatched.runId ? { runId: dispatched.runId } : {}),
+            sessionKey: dispatched.sessionKey,
+            status: dispatched.status,
+          },
+          now,
+        );
         sendJson(res, 200, {
           ok: true,
           requestId: normalized.value.requestId,
@@ -686,6 +711,17 @@ export function createHooksRequestHandler(
         return true;
       } catch (err) {
         logHooks.warn(`hook message dispatch failed: ${String(err)}`);
+        const dispatchStatusCode =
+          typeof err === "object" &&
+          err !== null &&
+          "statusCode" in err &&
+          typeof (err as { statusCode?: unknown }).statusCode === "number"
+            ? (err as { statusCode: number }).statusCode
+            : 500;
+        if (dispatchStatusCode === 503) {
+          sendJson(res, 503, { ok: false, error: "hook message dispatch unavailable" });
+          return true;
+        }
         sendJson(res, 500, { ok: false, error: "hook message dispatch failed" });
         return true;
       }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -43,11 +43,14 @@ import {
   getHookChannelError,
   getHookSessionKeyPrefixError,
   type HookAgentDispatchPayload,
+  type HookMessageDispatchPayload,
+  type HookMessageDispatchResult,
   type HooksConfigResolved,
   isHookAgentAllowed,
   isSessionKeyAllowedByPrefix,
   normalizeAgentPayload,
   normalizeHookHeaders,
+  normalizeHookMessagePayload,
   resolveHookIdempotencyKey,
   normalizeWakePayload,
   readJsonBody,
@@ -91,6 +94,7 @@ const HOOK_AUTH_FAILURE_WINDOW_MS = 60_000;
 type HookDispatchers = {
   dispatchWakeHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => void;
   dispatchAgentHook: (value: HookAgentDispatchPayload) => string;
+  dispatchMessageHook?: (value: HookMessageDispatchPayload) => Promise<HookMessageDispatchResult>;
 };
 
 function resolveMappedHookExternalContentSource(params: {
@@ -369,7 +373,14 @@ export function createHooksRequestHandler(
     getClientIpConfig?: () => HookClientIpConfig;
   } & HookDispatchers,
 ): HooksRequestHandler {
-  const { getHooksConfig, logHooks, dispatchAgentHook, dispatchWakeHook, getClientIpConfig } = opts;
+  const {
+    getHooksConfig,
+    logHooks,
+    dispatchAgentHook,
+    dispatchWakeHook,
+    dispatchMessageHook,
+    getClientIpConfig,
+  } = opts;
   const hookReplayCache = new Map<string, HookReplayEntry>();
   const hookAuthLimiter = createAuthRateLimiter({
     maxAttempts: HOOK_AUTH_FAILURE_LIMIT,
@@ -607,6 +618,77 @@ export function createHooksRequestHandler(
       rememberHookRunId(replayKey, runId, now);
       sendJson(res, 200, { ok: true, runId });
       return true;
+    }
+
+    if (subPath === "message") {
+      const normalized = normalizeHookMessagePayload(payload as Record<string, unknown>);
+      if (!normalized.ok) {
+        sendJson(res, 400, { ok: false, error: normalized.error });
+        return true;
+      }
+      const requestSessionKey = normalized.value.sessionKey;
+      if (requestSessionKey) {
+        const sessionKey = resolveHookSessionKey({
+          hooksConfig,
+          source: "request",
+          sessionKey: requestSessionKey,
+        });
+        if (!sessionKey.ok) {
+          sendJson(res, 400, { ok: false, error: sessionKey.error });
+          return true;
+        }
+      }
+
+      const effectiveIdempotencyKey = idempotencyKey ?? normalized.value.requestId;
+      const replayKey = buildHookReplayCacheKey({
+        pathKey: "message",
+        token,
+        idempotencyKey: effectiveIdempotencyKey,
+        dispatchScope: {
+          requestId: normalized.value.requestId,
+          message: normalized.value.message,
+          kind: normalized.value.kind,
+          sessionKey: requestSessionKey ?? null,
+          source: normalized.value.source ?? null,
+          sender: normalized.value.sender ?? null,
+          conversation: normalized.value.conversation ?? null,
+          metadata: normalized.value.metadata ?? null,
+        },
+      });
+      const cachedRunId = resolveCachedHookRunId(replayKey, now);
+      if (cachedRunId) {
+        sendJson(res, 200, {
+          ok: true,
+          requestId: normalized.value.requestId,
+          status: normalized.value.kind === "event" ? "event" : "accepted",
+          ...(requestSessionKey ? { sessionKey: requestSessionKey } : {}),
+          ...(normalized.value.kind === "message" ? { runId: cachedRunId } : {}),
+        });
+        return true;
+      }
+      if (!dispatchMessageHook) {
+        sendJson(res, 500, { ok: false, error: "hook message dispatch is unavailable" });
+        return true;
+      }
+      try {
+        const dispatched = await dispatchMessageHook({
+          ...normalized.value,
+          idempotencyKey: effectiveIdempotencyKey,
+        });
+        rememberHookRunId(replayKey, dispatched.runId ?? normalized.value.requestId, now);
+        sendJson(res, 200, {
+          ok: true,
+          requestId: normalized.value.requestId,
+          status: dispatched.status,
+          sessionKey: dispatched.sessionKey,
+          ...(dispatched.runId ? { runId: dispatched.runId } : {}),
+        });
+        return true;
+      } catch (err) {
+        logHooks.warn(`hook message dispatch failed: ${String(err)}`);
+        sendJson(res, 500, { ok: false, error: "hook message dispatch failed" });
+        return true;
+      }
     }
 
     if (hooksConfig.mappings.length > 0) {

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -35,6 +35,7 @@ import {
   createGatewayHttpServer,
   type HookClientIpConfig,
 } from "./server-http.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
 import type { DedupeEntry } from "./server-shared.js";
 import { createGatewayHooksRequestHandler } from "./server/hooks.js";
 import { listenGatewayHttpServer } from "./server/http-listen.js";
@@ -69,6 +70,7 @@ export async function createGatewayRuntimeState(params: {
   gatewayTls?: GatewayTlsRuntime;
   hooksConfig: () => HooksConfigResolved | null;
   getHookClientIpConfig: () => HookClientIpConfig;
+  getGatewayRequestContext?: () => GatewayRequestContext | undefined;
   pluginRegistry: PluginRegistry;
   pinChannelRegistry?: boolean;
   deps: CliDeps;
@@ -141,6 +143,7 @@ export async function createGatewayRuntimeState(params: {
       deps: params.deps,
       getHooksConfig: params.hooksConfig,
       getClientIpConfig: params.getHookClientIpConfig,
+      getGatewayRequestContext: params.getGatewayRequestContext,
       bindHost: params.bindHost,
       port: params.port,
       logHooks: params.logHooks,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -830,6 +830,40 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("applies hook session policy defaults for /hooks/message when sessionKey is omitted", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      defaultSessionKey: "hook:ingress",
+      allowedSessionKeyPrefixes: ["hook:"],
+    };
+    dispatchInboundMessageMock.mockReset();
+    dispatchInboundMessageMock.mockImplementation(async () => undefined);
+
+    await withGatewayServer(async ({ port }) => {
+      const response = await postHook(port, "/hooks/message", {
+        message: "inbound",
+        requestId: "msg-policy-default",
+      });
+      const rawBody = await response.text();
+      expect(response.status, rawBody).toBe(200);
+      const payload = JSON.parse(rawBody) as { sessionKey?: string };
+      expect(payload.sessionKey).toBe("agent:main:hook:ingress");
+
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+      });
+      const firstCall = dispatchInboundMessageMock.mock.calls[0]?.[0] as
+        | {
+            ctx?: {
+              SessionKey?: unknown;
+            };
+          }
+        | undefined;
+      expect(firstCall?.ctx?.SessionKey).toBe("agent:main:hook:ingress");
+    });
+  });
+
   test("persists /hooks/message inbound text and emits chat final updates", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     dispatchInboundMessageMock.mockReset();

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -97,11 +97,13 @@ async function expectFirstHookDelivery(
   idempotencyKey: string,
   headers?: Record<string, string>,
 ) {
+  const expectedCalls = cronIsolatedRun.mock.calls.length + 1;
   const first = await postAgentHookWithIdempotency(port, idempotencyKey, headers);
   const firstBody = (await first.json()) as { runId?: string };
   expect(firstBody.runId).toBeTruthy();
-  await waitForSystemEvent();
-  drainSystemEvents(resolveMainKey());
+  await vi.waitFor(() => {
+    expect(cronIsolatedRun).toHaveBeenCalledTimes(expectedCalls);
+  });
   return firstBody;
 }
 
@@ -122,15 +124,16 @@ describe("gateway server hooks", () => {
       mockIsolatedRunOkOnce();
       const resAgent = await postHook(port, "/hooks/agent", { message: "Do it", name: "Email" });
       expect(resAgent.status).toBe(200);
-      const agentEvents = await waitForSystemEvent();
-      expect(agentEvents.some((e) => e.includes("Hook Email: done"))).toBe(true);
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
       const firstCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         deliveryContract?: string;
         job?: { payload?: { externalContentSource?: string } };
       };
       expect(firstCall?.deliveryContract).toBe("shared");
       expect(firstCall?.job?.payload?.externalContentSource).toBe("webhook");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
 
       mockIsolatedRunOkOnce();
       const resAgentModel = await postHook(port, "/hooks/agent", {
@@ -139,12 +142,14 @@ describe("gateway server hooks", () => {
         model: "openai/gpt-4.1-mini",
       });
       expect(resAgentModel.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
       const call = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { payload?: { model?: string } };
       };
       expect(call?.job?.payload?.model).toBe("openai/gpt-4.1-mini");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
 
       mockIsolatedRunOkOnce();
       const resAgentWithId = await postHook(port, "/hooks/agent", {
@@ -153,12 +158,14 @@ describe("gateway server hooks", () => {
         agentId: "hooks",
       });
       expect(resAgentWithId.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
       const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
       };
       expect(routedCall?.job?.agentId).toBe("hooks");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
 
       mockIsolatedRunOkOnce();
       const resAgentUnknown = await postHook(port, "/hooks/agent", {
@@ -167,12 +174,14 @@ describe("gateway server hooks", () => {
         agentId: "missing-agent",
       });
       expect(resAgentUnknown.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
       const fallbackCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
       };
       expect(fallbackCall?.job?.agentId).toBe("main");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
 
       const resQuery = await postHook(
         port,
@@ -239,7 +248,9 @@ describe("gateway server hooks", () => {
         messages: [{ id: "msg-1", from: "Ada", subject: "Hello", snippet: "Hi", body: "Body" }],
       });
       expect(response.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
 
       const call = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         sessionKey?: string;
@@ -247,7 +258,45 @@ describe("gateway server hooks", () => {
       };
       expect(call?.sessionKey).toBe("main");
       expect(call?.job?.payload?.externalContentSource).toBe("gmail");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
+    });
+  });
+
+  test("does not mirror /hooks/agent run outcomes into main-session system events", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      cronIsolatedRun.mockReset();
+      cronIsolatedRun.mockResolvedValueOnce({
+        status: "ok",
+        summary: "done",
+        delivered: false,
+      });
+
+      const okResponse = await postHook(port, "/hooks/agent", {
+        message: "Run this task",
+        name: "No mirror",
+      });
+      expect(okResponse.status).toBe(200);
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
+
+      cronIsolatedRun.mockReset();
+      cronIsolatedRun.mockRejectedValueOnce(new Error("run failed"));
+
+      const failedResponse = await postHook(port, "/hooks/agent", {
+        message: "Run this task",
+        name: "No mirror",
+      });
+      expect(failedResponse.status).toBe(200);
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
     });
   });
 
@@ -337,12 +386,14 @@ describe("gateway server hooks", () => {
         body: JSON.stringify({ message: "No key" }),
       });
       expect(defaultRoute.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
       const defaultCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string }
         | undefined;
       expect(defaultCall?.sessionKey).toBe("hook:ingress");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
 
       cronIsolatedRun.mockClear();
       cronIsolatedRun.mockResolvedValue({ status: "ok", summary: "done" });
@@ -355,12 +406,14 @@ describe("gateway server hooks", () => {
         body: JSON.stringify({ subject: "hello", id: "42" }),
       });
       expect(mappedOk.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
       const mappedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string }
         | undefined;
       expect(mappedCall?.sessionKey).toBe("hook:mapped:42");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
 
       const requestBadPrefix = await postHook(port, "/hooks/agent", {
         message: "Bad key",
@@ -391,14 +444,16 @@ describe("gateway server hooks", () => {
         sessionKey: "agent:hooks:slack:channel:c123",
       });
       expect(resAgent.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
 
       const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string; job?: { agentId?: string } }
         | undefined;
       expect(routedCall?.job?.agentId).toBe("hooks");
       expect(routedCall?.sessionKey).toBe("agent:hooks:slack:channel:c123");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
     });
   });
 
@@ -420,14 +475,16 @@ describe("gateway server hooks", () => {
         sessionKey: "agent:main:slack:channel:c123",
       });
       expect(resAgent.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
 
       const routedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
         | { sessionKey?: string; job?: { agentId?: string } }
         | undefined;
       expect(routedCall?.job?.agentId).toBe("hooks");
       expect(routedCall?.sessionKey).toBe("agent:hooks:slack:channel:c123");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
     });
   });
 
@@ -500,7 +557,9 @@ describe("gateway server hooks", () => {
       mockIsolatedRunOk();
       await expectFirstHookDelivery(port, oversizedKey);
       await postAgentHookWithIdempotency(port, oversizedKey);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(2);
+      });
 
       expect(cronIsolatedRun).toHaveBeenCalledTimes(2);
     });
@@ -561,12 +620,14 @@ describe("gateway server hooks", () => {
       mockIsolatedRunOkOnce();
       const resNoAgent = await postHook(port, "/hooks/agent", { message: "No explicit agent" });
       expect(resNoAgent.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
       const noAgentCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
       };
       expect(noAgentCall?.job?.agentId).toBeUndefined();
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
 
       mockIsolatedRunOkOnce();
       const resAllowed = await postHook(port, "/hooks/agent", {
@@ -574,12 +635,14 @@ describe("gateway server hooks", () => {
         agentId: "hooks",
       });
       expect(resAllowed.status).toBe(200);
-      await waitForSystemEvent();
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
       const allowedCall = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as {
         job?: { agentId?: string };
       };
       expect(allowedCall?.job?.agentId).toBe("hooks");
-      drainSystemEvents(resolveMainKey());
+      expect(peekSystemEvents(resolveMainKey())).toHaveLength(0);
 
       const resDenied = await postHook(port, "/hooks/agent", {
         message: "Denied",

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -300,6 +300,37 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("uses cron-owned delivery contract for /hooks/agent when deliver is false", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      mockIsolatedRunOkOnce();
+      const response = await postHook(port, "/hooks/agent", {
+        message: "Run without outbound delivery",
+        name: "No outbound",
+        deliver: false,
+      });
+      expect(response.status).toBe(200);
+      await vi.waitFor(() => {
+        expect(cronIsolatedRun).toHaveBeenCalledTimes(1);
+      });
+
+      const call = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | {
+            deliveryContract?: string;
+            job?: {
+              delivery?: {
+                mode?: string;
+              };
+            };
+          }
+        | undefined;
+      expect(call?.deliveryContract).toBe("cron-owned");
+      expect(call?.job?.delivery?.mode).toBe("none");
+    });
+  });
+
   test("queues direct and mapped wake payloads as untrusted system events", async () => {
     testState.hooksConfig = {
       enabled: true,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -812,6 +812,36 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("dedupes /hooks/message retries when nested metadata key order differs", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    dispatchInboundMessageMock.mockReset();
+    dispatchInboundMessageMock.mockImplementation(async () => undefined);
+
+    await withGatewayServer(async ({ port }) => {
+      const first = await postHook(port, "/hooks/message", {
+        message: "ordered payload",
+        requestId: "msg-ordered-keys",
+        metadata: { alpha: 1, beta: 2 },
+        sender: { id: "sender-1", role: "member" },
+        conversation: { id: "conv-1", context: { a: 1, b: 2 } },
+      });
+      const firstBody = await first.text();
+      expect(first.status, firstBody).toBe(200);
+
+      const second = await postHook(port, "/hooks/message", {
+        message: "ordered payload",
+        requestId: "msg-ordered-keys",
+        metadata: { beta: 2, alpha: 1 },
+        sender: { role: "member", id: "sender-1" },
+        conversation: { context: { b: 2, a: 1 }, id: "conv-1" },
+      });
+      const secondBody = await second.text();
+      expect(second.status, secondBody).toBe(200);
+
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   test("routes /hooks/message kind=event without auto-reply dispatch", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     dispatchInboundMessageMock.mockReset();

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -8,8 +8,11 @@ import {
 } from "../infra/system-events.js";
 import { DEDUPE_TTL_MS } from "./server-constants.js";
 import {
+  connectWebchatClient,
   cronIsolatedRun,
+  dispatchInboundMessageMock,
   installGatewayTestHooks,
+  onceMessage,
   testState,
   withGatewayServer,
   waitForSystemEvent,
@@ -665,6 +668,160 @@ describe("gateway server hooks", () => {
       expect(allowed.status).toBe(200);
       await waitForSystemEvent();
       drainSystemEvents(resolveMainKey());
+    });
+  });
+
+  test("enforces /hooks/message auth parity and blocks query token auth", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    await withGatewayServer(async ({ port }) => {
+      const noAuth = await postHook(
+        port,
+        "/hooks/message",
+        { message: "inbound", requestId: "msg-auth-missing" },
+        { token: null },
+      );
+      expect(noAuth.status).toBe(401);
+
+      let throttled: Response | null = null;
+      for (let i = 0; i < 20; i++) {
+        throttled = await postHook(
+          port,
+          "/hooks/message",
+          { message: "inbound", requestId: `msg-auth-wrong-${i}` },
+          { token: "wrong" },
+        );
+      }
+      expect(throttled?.status).toBe(429);
+
+      const byBearer = await postHook(port, "/hooks/message", {
+        message: "inbound",
+        requestId: "msg-auth-bearer",
+      });
+      const byBearerBody = await byBearer.text();
+      expect(byBearer.status, byBearerBody).toBe(200);
+
+      const byHeader = await postHook(
+        port,
+        "/hooks/message",
+        { message: "inbound", requestId: "msg-auth-header" },
+        { token: null, headers: { "x-openclaw-token": HOOK_TOKEN } },
+      );
+      const byHeaderBody = await byHeader.text();
+      expect(byHeader.status, byHeaderBody).toBe(200);
+
+      const byQuery = await postHook(
+        port,
+        "/hooks/message?token=bad",
+        { message: "inbound", requestId: "msg-auth-query" },
+        { token: null },
+      );
+      expect(byQuery.status).toBe(400);
+    });
+  });
+
+  test("applies /hooks/message method guard and dedupes retries by requestId", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    dispatchInboundMessageMock.mockReset();
+    dispatchInboundMessageMock.mockImplementation(async () => undefined);
+
+    await withGatewayServer(async ({ port }) => {
+      const getResponse = await fetch(`http://127.0.0.1:${port}/hooks/message`, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${HOOK_TOKEN}` },
+      });
+      expect(getResponse.status).toBe(405);
+      expect(getResponse.headers.get("allow")).toBe("POST");
+
+      const first = await postHook(port, "/hooks/message", {
+        message: "dedupe me",
+        requestId: "msg-dedupe-1",
+      });
+      const firstBody = await first.text();
+      expect(first.status, firstBody).toBe(200);
+
+      const second = await postHook(port, "/hooks/message", {
+        message: "dedupe me",
+        requestId: "msg-dedupe-1",
+      });
+      expect(second.status).toBe(200);
+
+      expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("routes /hooks/message kind=event without auto-reply dispatch", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    dispatchInboundMessageMock.mockReset();
+    dispatchInboundMessageMock.mockImplementation(async () => undefined);
+
+    await withGatewayServer(async ({ port }) => {
+      const response = await postHook(port, "/hooks/message", {
+        message: "operational event",
+        requestId: "msg-event-1",
+        kind: "event",
+      });
+      expect(response.status).toBe(200);
+      const payload = (await response.json()) as { status?: string };
+      expect(payload.status).toBe("event");
+      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+    });
+  });
+
+  test("persists /hooks/message inbound text and emits chat final updates", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    dispatchInboundMessageMock.mockReset();
+    dispatchInboundMessageMock.mockImplementation(async () => undefined);
+
+    await withGatewayServer(async ({ port }) => {
+      const webchatWs = await connectWebchatClient({ port });
+      try {
+        const inboundText = "Inbound via webhook";
+        const requestId = "msg-ui-1";
+        const postResponse = await postHook(port, "/hooks/message", {
+          message: inboundText,
+          requestId,
+          kind: "message",
+        });
+        const rawPostPayload = await postResponse.text();
+        expect(postResponse.status, rawPostPayload).toBe(200);
+        const postPayload = JSON.parse(rawPostPayload) as { runId?: string; sessionKey?: string };
+        const runId = postPayload.runId ?? requestId;
+        const sessionKey = postPayload.sessionKey ?? "main";
+
+        const chatEvent = await onceMessage<{
+          type?: string;
+          event?: string;
+          payload?: Record<string, unknown>;
+        }>(
+          webchatWs,
+          (o) => {
+            if (o.type !== "event" || o.event !== "chat") {
+              return false;
+            }
+            const payload = o.payload;
+            return payload?.runId === runId && payload?.state === "final";
+          },
+          10_000,
+        );
+        expect(chatEvent.event).toBe("chat");
+        await vi.waitFor(() => {
+          expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);
+        });
+        const firstCall = dispatchInboundMessageMock.mock.calls[0]?.[0] as
+          | {
+              ctx?: {
+                SessionKey?: unknown;
+                Body?: unknown;
+                RawBody?: unknown;
+              };
+            }
+          | undefined;
+        expect(firstCall?.ctx?.SessionKey).toBe(sessionKey);
+        expect(firstCall?.ctx?.Body).toBe(inboundText);
+        expect(firstCall?.ctx?.RawBody).toBe(inboundText);
+      } finally {
+        webchatWs.close();
+      }
     });
   });
 });

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -830,6 +830,34 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("canonicalizes /hooks/message kind=event session keys before enqueueing", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      defaultSessionKey: "hook:ingress",
+      allowedSessionKeyPrefixes: ["hook:"],
+    };
+    dispatchInboundMessageMock.mockReset();
+    dispatchInboundMessageMock.mockImplementation(async () => undefined);
+
+    await withGatewayServer(async ({ port }) => {
+      const response = await postHook(port, "/hooks/message", {
+        message: "event via alias",
+        requestId: "msg-event-canonical",
+        kind: "event",
+      });
+      const body = (await response.json()) as { status?: string; sessionKey?: string };
+      expect(response.status).toBe(200);
+      expect(body.status).toBe("event");
+      expect(body.sessionKey).toBe("agent:main:hook:ingress");
+
+      const entries = peekSystemEventEntries("agent:main:hook:ingress");
+      expect(entries.some((entry) => entry.text === "event via alias")).toBe(true);
+      drainSystemEvents("agent:main:hook:ingress");
+      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+    });
+  });
+
   test("applies hook session policy defaults for /hooks/message when sessionKey is omitted", async () => {
     testState.hooksConfig = {
       enabled: true,
@@ -861,6 +889,58 @@ describe("gateway server hooks", () => {
           }
         | undefined;
       expect(firstCall?.ctx?.SessionKey).toBe("agent:main:hook:ingress");
+    });
+  });
+
+  test("scopes /hooks/message chat idempotency by replay identity", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:main:"],
+    };
+    dispatchInboundMessageMock.mockReset();
+    dispatchInboundMessageMock.mockImplementation(async () => undefined);
+
+    await withGatewayServer(async ({ port }) => {
+      const first = await postHook(port, "/hooks/message", {
+        message: "first",
+        requestId: "shared-request-id",
+        sessionKey: "agent:main:scope-a",
+      });
+      const firstBody = await first.text();
+      expect(first.status, firstBody).toBe(200);
+
+      const second = await postHook(port, "/hooks/message", {
+        message: "second",
+        requestId: "shared-request-id",
+        sessionKey: "agent:main:scope-b",
+      });
+      const secondBody = await second.text();
+      expect(second.status, secondBody).toBe(200);
+
+      await vi.waitFor(() => {
+        expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  test("returns /hooks/message INVALID_REQUEST failures as HTTP 400", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    testState.sessionConfig = { sendPolicy: { default: "deny" } };
+    dispatchInboundMessageMock.mockReset();
+    dispatchInboundMessageMock.mockImplementation(async () => undefined);
+
+    await withGatewayServer(async ({ port }) => {
+      const response = await postHook(port, "/hooks/message", {
+        message: "blocked by policy",
+        requestId: "msg-send-policy-deny",
+      });
+      const rawBody = await response.text();
+      expect(response.status, rawBody).toBe(400);
+      const payload = JSON.parse(rawBody) as { error?: string };
+      expect(payload.error ?? "").toMatch(/send blocked by session policy/i);
+      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -112,6 +112,7 @@ import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
 import { safeParseJson } from "./server-methods/nodes.helpers.js";
 import { createPluginApprovalHandlers } from "./server-methods/plugin-approval.js";
 import { createSecretsHandlers } from "./server-methods/secrets.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
 import { hasConnectedMobileNode } from "./server-mobile-nodes.js";
 import { loadGatewayModelCatalog } from "./server-model-catalog.js";
 import { createNodeSubscriptionManager } from "./server-node-subscriptions.js";
@@ -757,6 +758,7 @@ export async function startGatewayServer(
   const { wizardSessions, findRunningWizard, purgeWizardSession } = createWizardSessionTracker();
 
   const deps = createDefaultDeps();
+  let gatewayRequestContextRef: GatewayRequestContext | undefined;
   let canvasHostServer: CanvasHostServer | null = null;
   const gatewayTls = await loadGatewayTlsRuntime(cfgAtStart.gateway?.tls, log.child("tls"));
   if (cfgAtStart.gateway?.tls?.enabled && !gatewayTls.enabled) {
@@ -816,6 +818,7 @@ export async function startGatewayServer(
     gatewayTls,
     hooksConfig: () => hooksConfig,
     getHookClientIpConfig: () => hookClientIpConfig,
+    getGatewayRequestContext: () => gatewayRequestContextRef,
     pluginRegistry,
     pinChannelRegistry: !minimalTestGateway,
     deps,
@@ -1337,7 +1340,7 @@ export async function startGatewayServer(
 
     const canvasHostServerPort = (canvasHostServer as CanvasHostServer | null)?.port;
 
-    const gatewayRequestContext: import("./server-methods/types.js").GatewayRequestContext = {
+    const gatewayRequestContext: GatewayRequestContext = {
       deps,
       cron,
       cronStorePath,
@@ -1434,6 +1437,7 @@ export async function startGatewayServer(
       wizardRunner,
       broadcastVoiceWakeChanged,
     };
+    gatewayRequestContextRef = gatewayRequestContext;
 
     // Register a lazy fallback for plugin subagent dispatch in non-WS paths
     // (Telegram polling, WhatsApp, etc.) so later runtime swaps can expose the

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -327,6 +327,7 @@ export function createGatewayHooksRequestHandler(params: {
     void (async () => {
       try {
         const cfg = loadConfig();
+        const deliveryContract = value.deliver ? "shared" : "cron-owned";
         const result = await runCronIsolatedAgentTurn({
           cfg,
           deps,
@@ -334,10 +335,10 @@ export function createGatewayHooksRequestHandler(params: {
           message: value.message,
           sessionKey,
           lane: "cron",
-          deliveryContract: "shared",
+          deliveryContract,
         });
         logHooks.info(
-          `hook.agent.completed runId=${runId} jobId=${jobId} status=${result.status} delivered=${result.delivered === true} deliveryAttempted=${result.deliveryAttempted === true}`,
+          `hook.agent.completed runId=${runId} jobId=${jobId} status=${result.status} delivered=${result.delivered === true} deliveryAttempted=${result.deliveryAttempted === true} deliveryContract=${deliveryContract}`,
         );
       } catch (err) {
         logHooks.warn(`hook.agent.failed runId=${runId} jobId=${jobId} error=${String(err)}`);

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -15,7 +15,7 @@ import {
   type HooksConfigResolved,
   isSessionKeyAllowedByPrefix,
 } from "../hooks.js";
-import type { RequestFrame } from "../protocol/index.js";
+import { ErrorCodes, type RequestFrame } from "../protocol/index.js";
 import { createHooksRequestHandler, type HookClientIpConfig } from "../server-http.js";
 import { agentHandlers } from "../server-methods/agent.js";
 import { chatHandlers } from "../server-methods/chat.js";
@@ -192,6 +192,28 @@ function resolveHookMethodError(error: unknown, fallback: string): string {
   return message ?? fallback;
 }
 
+function resolveHookMethodStatusCode(error: unknown): number | undefined {
+  const record = toRecord(error);
+  if (!record) {
+    return undefined;
+  }
+  const statusCode = record.statusCode;
+  if (typeof statusCode === "number" && Number.isFinite(statusCode)) {
+    return statusCode;
+  }
+  const code = toOptionalString(record.code);
+  if (!code) {
+    return undefined;
+  }
+  if (code === ErrorCodes.INVALID_REQUEST) {
+    return 400;
+  }
+  if (code === ErrorCodes.UNAVAILABLE) {
+    return 503;
+  }
+  return undefined;
+}
+
 async function monitorHookMessageReply(params: {
   logHooks: SubsystemLogger;
   context: GatewayRequestContext;
@@ -337,21 +359,6 @@ export function createGatewayHooksRequestHandler(params: {
     });
     logHookMessageLifecycle(logHooks, "hook.message.received", receivedFields);
 
-    if (value.kind === "event") {
-      enqueueSystemEvent(value.message, {
-        sessionKey: requestedSessionKey,
-        trusted: false,
-      });
-      logHookMessageLifecycle(logHooks, "hook.message.persisted", {
-        ...receivedFields,
-        status: "event",
-      });
-      return {
-        status: "event" as const,
-        sessionKey: requestedSessionKey,
-      };
-    }
-
     const context = getGatewayRequestContext?.();
     if (!context) {
       logHookMessageLifecycle(logHooks, "hook.message.failed", {
@@ -392,10 +399,26 @@ export function createGatewayHooksRequestHandler(params: {
       throw Object.assign(new Error(prefixError), { statusCode: 400 });
     }
 
+    if (value.kind === "event") {
+      enqueueSystemEvent(value.message, {
+        sessionKey: targetSessionKey,
+        trusted: false,
+      });
+      logHookMessageLifecycle(logHooks, "hook.message.persisted", {
+        ...receivedFields,
+        sessionKey: targetSessionKey,
+        status: "event",
+      });
+      return {
+        status: "event" as const,
+        sessionKey: targetSessionKey,
+      };
+    }
+
     const sendParams = {
       sessionKey: targetSessionKey,
       message: value.message,
-      idempotencyKey: value.idempotencyKey,
+      idempotencyKey: value.chatIdempotencyKey ?? value.idempotencyKey,
     };
     const sendResult = await callGatewayMethodHandler({
       handler: chatHandlers["chat.send"],
@@ -410,6 +433,10 @@ export function createGatewayHooksRequestHandler(params: {
         sessionKey: targetSessionKey,
         status: sendError,
       });
+      const sendStatusCode = resolveHookMethodStatusCode(sendResult.error);
+      if (sendStatusCode !== undefined) {
+        throw Object.assign(new Error(sendError), { statusCode: sendStatusCode });
+      }
       throw new Error(sendError);
     }
 

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -8,10 +8,214 @@ import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
-import { type HookAgentDispatchPayload, type HooksConfigResolved } from "../hooks.js";
+import {
+  type HookAgentDispatchPayload,
+  type HookMessageDispatchPayload,
+  type HooksConfigResolved,
+} from "../hooks.js";
+import type { RequestFrame } from "../protocol/index.js";
 import { createHooksRequestHandler, type HookClientIpConfig } from "../server-http.js";
+import { agentHandlers } from "../server-methods/agent.js";
+import { chatHandlers } from "../server-methods/chat.js";
+import { sessionsHandlers } from "../server-methods/sessions.js";
+import type { GatewayRequestContext } from "../server-methods/types.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
+
+type HookMessageLifecycleFields = {
+  requestId: string;
+  sessionKey: string;
+  kind: "message" | "event";
+  source: string;
+  senderId: string;
+  conversationId: string;
+  groupId: string;
+  status: string;
+};
+
+type HookHandlerCallResult = {
+  ok: boolean;
+  payload?: unknown;
+  error?: unknown;
+};
+
+const HOOK_MESSAGE_WAIT_TIMEOUT_MS = 2_000;
+
+function toOptionalString(raw: unknown): string | undefined {
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (typeof raw === "number" || typeof raw === "bigint") {
+    return String(raw);
+  }
+  return undefined;
+}
+
+function toRecord(raw: unknown): Record<string, unknown> | undefined {
+  return typeof raw === "object" && raw !== null && !Array.isArray(raw)
+    ? (raw as Record<string, unknown>)
+    : undefined;
+}
+
+function readRecordString(
+  record: Record<string, unknown> | undefined,
+  keys: string[],
+): string | undefined {
+  if (!record) {
+    return undefined;
+  }
+  for (const key of keys) {
+    const value = toOptionalString(record[key]);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function resolveHookMessageLifecycleFields(params: {
+  value: HookMessageDispatchPayload;
+  sessionKey: string;
+  status: string;
+}): HookMessageLifecycleFields {
+  const senderId = readRecordString(params.value.sender, ["id", "senderId", "userId"]);
+  const conversationId = readRecordString(params.value.conversation, [
+    "id",
+    "conversationId",
+    "threadId",
+  ]);
+  const nestedGroup = toRecord(params.value.conversation?.group);
+  const groupId =
+    readRecordString(params.value.conversation, ["groupId"]) ??
+    readRecordString(nestedGroup, ["id", "groupId"]) ??
+    readRecordString(params.value.sender, ["groupId"]);
+
+  return {
+    requestId: params.value.requestId,
+    sessionKey: params.sessionKey,
+    kind: params.value.kind,
+    source: params.value.source ?? "-",
+    senderId: senderId ?? "-",
+    conversationId: conversationId ?? "-",
+    groupId: groupId ?? "-",
+    status: params.status,
+  };
+}
+
+function formatHookMessageLifecycleFields(fields: HookMessageLifecycleFields): string {
+  return [
+    `requestId=${fields.requestId}`,
+    `sessionKey=${fields.sessionKey}`,
+    `kind=${fields.kind}`,
+    `source=${fields.source}`,
+    `senderId=${fields.senderId}`,
+    `conversationId=${fields.conversationId}`,
+    `groupId=${fields.groupId}`,
+    `status=${fields.status}`,
+  ].join(" ");
+}
+
+function logHookMessageLifecycle(
+  logHooks: SubsystemLogger,
+  event: string,
+  fields: HookMessageLifecycleFields,
+): void {
+  logHooks.info(`${event} ${formatHookMessageLifecycleFields(fields)}`);
+}
+
+async function callGatewayMethodHandler(params: {
+  handler: (options: {
+    req: RequestFrame;
+    params: Record<string, unknown>;
+    respond: (
+      ok: boolean,
+      payload?: unknown,
+      error?: unknown,
+      meta?: Record<string, unknown>,
+    ) => void;
+    context: GatewayRequestContext;
+    client: null;
+    isWebchatConnect: () => false;
+  }) => Promise<void> | void;
+  req: RequestFrame;
+  requestParams: Record<string, unknown>;
+  context: GatewayRequestContext;
+}): Promise<HookHandlerCallResult> {
+  let result: HookHandlerCallResult = { ok: false };
+  await params.handler({
+    req: params.req,
+    params: params.requestParams,
+    respond: (ok, payload, error) => {
+      result = { ok, payload, error };
+    },
+    context: params.context,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+  return result;
+}
+
+function buildHookRequestFrame(
+  method: string,
+  requestId: string,
+  params: Record<string, unknown>,
+): RequestFrame {
+  return {
+    type: "req",
+    id: `hook-message:${method}:${requestId}`,
+    method,
+    params,
+  };
+}
+
+function resolveHookMethodError(error: unknown, fallback: string): string {
+  const message =
+    (toRecord(error) && toOptionalString((error as Record<string, unknown>).message)) ||
+    toOptionalString(error);
+  return message ?? fallback;
+}
+
+async function monitorHookMessageReply(params: {
+  logHooks: SubsystemLogger;
+  context: GatewayRequestContext;
+  fields: HookMessageLifecycleFields;
+  runId: string;
+}): Promise<void> {
+  const waitReq = buildHookRequestFrame("agent.wait", params.fields.requestId, {
+    runId: params.runId,
+    timeoutMs: HOOK_MESSAGE_WAIT_TIMEOUT_MS,
+  });
+  try {
+    const waitResult = await callGatewayMethodHandler({
+      handler: agentHandlers["agent.wait"],
+      req: waitReq,
+      requestParams: {
+        runId: params.runId,
+        timeoutMs: HOOK_MESSAGE_WAIT_TIMEOUT_MS,
+      },
+      context: params.context,
+    });
+    const waitPayload = toRecord(waitResult.payload);
+    const waitStatus = toOptionalString(waitPayload?.status) ?? (waitResult.ok ? "ok" : "failed");
+    if (waitResult.ok) {
+      logHookMessageLifecycle(params.logHooks, "hook.message.reply.completed", {
+        ...params.fields,
+        status: waitStatus,
+      });
+      return;
+    }
+    logHookMessageLifecycle(params.logHooks, "hook.message.failed", {
+      ...params.fields,
+      status: waitStatus,
+    });
+  } catch (err) {
+    logHookMessageLifecycle(params.logHooks, "hook.message.failed", {
+      ...params.fields,
+      status: resolveHookMethodError(err, "agent.wait failed"),
+    });
+  }
+}
 
 export function resolveHookClientIpConfig(cfg: OpenClawConfig): HookClientIpConfig {
   return {
@@ -24,11 +228,20 @@ export function createGatewayHooksRequestHandler(params: {
   deps: CliDeps;
   getHooksConfig: () => HooksConfigResolved | null;
   getClientIpConfig: () => HookClientIpConfig;
+  getGatewayRequestContext?: () => GatewayRequestContext | undefined;
   bindHost: string;
   port: number;
   logHooks: SubsystemLogger;
 }) {
-  const { deps, getHooksConfig, getClientIpConfig, bindHost, port, logHooks } = params;
+  const {
+    deps,
+    getHooksConfig,
+    getClientIpConfig,
+    getGatewayRequestContext,
+    bindHost,
+    port,
+    logHooks,
+  } = params;
 
   const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
     const sessionKey = resolveMainSessionKeyFromConfig();
@@ -114,6 +327,105 @@ export function createGatewayHooksRequestHandler(params: {
     return runId;
   };
 
+  const dispatchMessageHook = async (value: HookMessageDispatchPayload) => {
+    const requestedSessionKey = value.sessionKey ?? resolveMainSessionKeyFromConfig();
+    const receivedFields = resolveHookMessageLifecycleFields({
+      value,
+      sessionKey: requestedSessionKey,
+      status: "received",
+    });
+    logHookMessageLifecycle(logHooks, "hook.message.received", receivedFields);
+
+    if (value.kind === "event") {
+      enqueueSystemEvent(value.message, {
+        sessionKey: requestedSessionKey,
+        trusted: false,
+      });
+      logHookMessageLifecycle(logHooks, "hook.message.persisted", {
+        ...receivedFields,
+        status: "event",
+      });
+      return {
+        status: "event" as const,
+        sessionKey: requestedSessionKey,
+      };
+    }
+
+    const context = getGatewayRequestContext?.();
+    if (!context) {
+      logHookMessageLifecycle(logHooks, "hook.message.failed", {
+        ...receivedFields,
+        status: "gateway context unavailable",
+      });
+      throw new Error("gateway request context unavailable");
+    }
+
+    let targetSessionKey = requestedSessionKey;
+    const createParams = { key: requestedSessionKey };
+    const createResult = await callGatewayMethodHandler({
+      handler: sessionsHandlers["sessions.create"],
+      req: buildHookRequestFrame("sessions.create", value.requestId, createParams),
+      requestParams: createParams,
+      context,
+    });
+    if (!createResult.ok) {
+      const createError = resolveHookMethodError(createResult.error, "sessions.create failed");
+      logHookMessageLifecycle(logHooks, "hook.message.failed", {
+        ...receivedFields,
+        status: createError,
+      });
+      throw new Error(createError);
+    }
+    const createdPayload = toRecord(createResult.payload);
+    const createdKey = toOptionalString(createdPayload?.key);
+    targetSessionKey = createdKey ?? targetSessionKey;
+
+    const sendParams = {
+      sessionKey: targetSessionKey,
+      message: value.message,
+      idempotencyKey: value.idempotencyKey,
+    };
+    const sendResult = await callGatewayMethodHandler({
+      handler: chatHandlers["chat.send"],
+      req: buildHookRequestFrame("chat.send", value.requestId, sendParams),
+      requestParams: sendParams,
+      context,
+    });
+    if (!sendResult.ok) {
+      const sendError = resolveHookMethodError(sendResult.error, "chat.send failed");
+      logHookMessageLifecycle(logHooks, "hook.message.failed", {
+        ...receivedFields,
+        sessionKey: targetSessionKey,
+        status: sendError,
+      });
+      throw new Error(sendError);
+    }
+
+    const sendPayload = toRecord(sendResult.payload);
+    const runId = toOptionalString(sendPayload?.runId) ?? value.idempotencyKey;
+    const sendStatus = toOptionalString(sendPayload?.status) ?? "started";
+    const lifecycleFields = resolveHookMessageLifecycleFields({
+      value,
+      sessionKey: targetSessionKey,
+      status: sendStatus,
+    });
+
+    logHookMessageLifecycle(logHooks, "hook.message.persisted", lifecycleFields);
+    logHookMessageLifecycle(logHooks, "hook.message.reply.started", lifecycleFields);
+    void monitorHookMessageReply({
+      logHooks,
+      context,
+      fields: lifecycleFields,
+      runId,
+    });
+
+    return {
+      status: "accepted" as const,
+      sessionKey: targetSessionKey,
+      runId,
+    };
+  };
+
   return createHooksRequestHandler({
     getHooksConfig,
     bindHost,
@@ -121,6 +433,7 @@ export function createGatewayHooksRequestHandler(params: {
     logHooks,
     getClientIpConfig,
     dispatchAgentHook,
+    dispatchMessageHook,
     dispatchWakeHook,
   });
 }

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -7,10 +7,13 @@ import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
 import {
+  getHookSessionKeyPrefixError,
   type HookAgentDispatchPayload,
   type HookMessageDispatchPayload,
   type HooksConfigResolved,
+  isSessionKeyAllowedByPrefix,
 } from "../hooks.js";
 import type { RequestFrame } from "../protocol/index.js";
 import { createHooksRequestHandler, type HookClientIpConfig } from "../server-http.js";
@@ -113,6 +116,20 @@ function formatHookMessageLifecycleFields(fields: HookMessageLifecycleFields): s
     `groupId=${fields.groupId}`,
     `status=${fields.status}`,
   ].join(" ");
+}
+
+function isHookMessageSessionKeyAllowed(
+  sessionKey: string,
+  allowedPrefixes: string[] | undefined,
+): boolean {
+  if (!allowedPrefixes) {
+    return true;
+  }
+  if (isSessionKeyAllowedByPrefix(sessionKey, allowedPrefixes)) {
+    return true;
+  }
+  const parsed = parseAgentSessionKey(sessionKey);
+  return Boolean(parsed && isSessionKeyAllowedByPrefix(parsed.rest, allowedPrefixes));
 }
 
 function logHookMessageLifecycle(
@@ -365,6 +382,15 @@ export function createGatewayHooksRequestHandler(params: {
     const createdPayload = toRecord(createResult.payload);
     const createdKey = toOptionalString(createdPayload?.key);
     targetSessionKey = createdKey ?? targetSessionKey;
+    if (!isHookMessageSessionKeyAllowed(targetSessionKey, value.allowedSessionKeyPrefixes)) {
+      const prefixError = getHookSessionKeyPrefixError(value.allowedSessionKeyPrefixes ?? []);
+      logHookMessageLifecycle(logHooks, "hook.message.failed", {
+        ...receivedFields,
+        sessionKey: targetSessionKey,
+        status: prefixError,
+      });
+      throw Object.assign(new Error(prefixError), { statusCode: 400 });
+    }
 
     const sendParams = {
       sessionKey: targetSessionKey,

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -309,6 +309,9 @@ export function createGatewayHooksRequestHandler(params: {
   };
 
   const dispatchMessageHook = async (value: HookMessageDispatchPayload) => {
+    // HTTP ingress resolves hook session policy before invoking this dispatcher.
+    // Keep a main-session fallback for non-HTTP call sites/tests that may bypass
+    // that normalization.
     const requestedSessionKey = value.sessionKey ?? resolveMainSessionKeyFromConfig();
     const receivedFields = resolveHookMessageLifecycleFields({
       value,
@@ -338,7 +341,9 @@ export function createGatewayHooksRequestHandler(params: {
         ...receivedFields,
         status: "gateway context unavailable",
       });
-      throw new Error("gateway request context unavailable");
+      throw Object.assign(new Error("gateway request context unavailable"), {
+        statusCode: 503,
+      });
     }
 
     let targetSessionKey = requestedSessionKey;
@@ -383,7 +388,7 @@ export function createGatewayHooksRequestHandler(params: {
     }
 
     const sendPayload = toRecord(sendResult.payload);
-    const runId = toOptionalString(sendPayload?.runId) ?? value.idempotencyKey;
+    const runId = toOptionalString(sendPayload?.runId);
     const sendStatus = toOptionalString(sendPayload?.status) ?? "started";
     const lifecycleFields = resolveHookMessageLifecycleFields({
       value,
@@ -392,18 +397,28 @@ export function createGatewayHooksRequestHandler(params: {
     });
 
     logHookMessageLifecycle(logHooks, "hook.message.persisted", lifecycleFields);
-    logHookMessageLifecycle(logHooks, "hook.message.reply.started", lifecycleFields);
-    void monitorHookMessageReply({
-      logHooks,
-      context,
-      fields: lifecycleFields,
-      runId,
-    });
+    if (runId) {
+      logHookMessageLifecycle(logHooks, "hook.message.reply.started", lifecycleFields);
+      void monitorHookMessageReply({
+        logHooks,
+        context,
+        fields: lifecycleFields,
+        runId,
+      });
+    } else {
+      logHooks.warn(
+        `hook.message.reply.runid_missing requestId=${value.requestId} sessionKey=${targetSessionKey} status=${sendStatus}`,
+      );
+      logHookMessageLifecycle(logHooks, "hook.message.reply.completed", {
+        ...lifecycleFields,
+        status: "runId-unavailable",
+      });
+    }
 
     return {
       status: "accepted" as const,
       sessionKey: targetSessionKey,
-      runId,
+      ...(runId ? { runId } : {}),
     };
   };
 

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -7,7 +7,6 @@ import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
-import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
   type HookAgentDispatchPayload,
   type HookMessageDispatchPayload,
@@ -253,7 +252,6 @@ export function createGatewayHooksRequestHandler(params: {
 
   const dispatchAgentHook = (value: HookAgentDispatchPayload) => {
     const sessionKey = value.sessionKey;
-    const mainSessionKey = resolveMainSessionKeyFromConfig();
     const jobId = randomUUID();
     const now = Date.now();
     const delivery = value.deliver
@@ -299,28 +297,11 @@ export function createGatewayHooksRequestHandler(params: {
           lane: "cron",
           deliveryContract: "shared",
         });
-        const summary =
-          normalizeOptionalString(result.summary) ||
-          normalizeOptionalString(result.error) ||
-          result.status;
-        const prefix =
-          result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;
-        if (!result.delivered) {
-          enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
-            sessionKey: mainSessionKey,
-          });
-          if (value.wakeMode === "now") {
-            requestHeartbeatNow({ reason: `hook:${jobId}` });
-          }
-        }
+        logHooks.info(
+          `hook.agent.completed runId=${runId} jobId=${jobId} status=${result.status} delivered=${result.delivered === true} deliveryAttempted=${result.deliveryAttempted === true}`,
+        );
       } catch (err) {
-        logHooks.warn(`hook agent failed: ${String(err)}`);
-        enqueueSystemEvent(`Hook ${value.name} (error): ${String(err)}`, {
-          sessionKey: mainSessionKey,
-        });
-        if (value.wakeMode === "now") {
-          requestHeartbeatNow({ reason: `hook:${jobId}:error` });
-        }
+        logHooks.warn(`hook.agent.failed runId=${runId} jobId=${jobId} error=${String(err)}`);
       }
     })();
 

--- a/src/gateway/test-helpers.runtime-state.ts
+++ b/src/gateway/test-helpers.runtime-state.ts
@@ -7,6 +7,7 @@ import type { GetReplyOptions, ReplyPayload } from "../auto-reply/types.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AgentBinding } from "../config/types.agents.js";
 import type { HooksConfig } from "../config/types.hooks.js";
+import type { RunCronAgentTurnResult } from "../cron/isolated-agent.js";
 import type { TailscaleWhoisIdentity } from "../infra/tailscale.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
@@ -15,9 +16,7 @@ export type GetReplyFromConfigFn = (
   opts?: GetReplyOptions,
   configOverride?: OpenClawConfig,
 ) => Promise<ReplyPayload | ReplyPayload[] | undefined>;
-export type CronIsolatedRunFn = (
-  ...args: unknown[]
-) => Promise<{ status: string; summary: string }>;
+export type CronIsolatedRunFn = (...args: unknown[]) => Promise<RunCronAgentTurnResult>;
 export type AgentCommandFn = (...args: unknown[]) => Promise<void>;
 export type SendWhatsAppFn = (...args: unknown[]) => Promise<{ messageId: string; toJid: string }>;
 export type RunBtwSideQuestionFn = (...args: unknown[]) => Promise<unknown>;


### PR DESCRIPTION
## Summary
Adds a generic webhook ingress endpoint at `POST /hooks/message` with auth + safety parity to existing webhook routes, and enforces single-responsibility boundaries between `/hooks/agent` and `/hooks/message`.

Closes #62526.

## Single-Responsibility Boundary
- `/hooks/agent` is now automation-only (run isolated agent task) and no longer mirrors run summaries/errors into main-session system events.
- Shared delivery-contract runs no longer enqueue main-session awareness mirrors in cron delivery dispatch.
- `/hooks/message` remains the inbound transport path for chat visibility + optional auto-reply.

## Auth Parity Checklist
- [x] Accepts token from `Authorization: Bearer` and `X-OpenClaw-Token`
- [x] Rejects query token usage (`?token=...`) with `400`
- [x] Reuses shared constant-time secret compare path
- [x] Reuses shared auth failure limiter bucket + client IP normalization
- [x] Returns `401` on missing/invalid token
- [x] Returns `429` on repeated auth failures

## Request Safety Parity Checklist
- [x] `POST` only (`405` for non-POST)
- [x] Reuses existing body size and timeout guards
- [x] Reuses existing idempotency extraction and replay cache
- [x] Retries dedupe for `/hooks/message` via idempotency key, with `requestId` fallback when header is absent

## Webhook Contract (`/hooks/message`)
Required fields:
- `message: string`
- `requestId: string`

Optional fields:
- `kind: "message" | "event"` (defaults to `"message"`)
- `sessionKey`
- `source`
- `sender`
- `conversation`
- `metadata`

Behavior:
- `kind="message"`: dispatches through chat send path, emits chat final event path, triggers auto-reply dispatch
- `kind="event"`: records operational event path without auto-reply dispatch

## Logging
Adds deterministic lifecycle logs for ingress:
- `hook.message.received`
- `hook.message.persisted`
- `hook.message.reply.started`
- `hook.message.reply.completed`
- `hook.message.failed`

Each log line includes:
- `requestId`, `sessionKey`, `kind`, `source`, `senderId`, `conversationId`, `groupId`, `status`

## Test Evidence
Executed:
- `pnpm test src/gateway/server.hooks.test.ts src/gateway/server-http.hooks-request-timeout.test.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`
  - Result: gateway suites `2 passed / 28 tests`, cron delivery suite `1 passed / 32 tests`
- `pnpm test src/cron/isolated-agent/run.message-tool-policy.test.ts`
  - Result: `1 passed / 5 tests`

Coverage in updated tests includes:
- auth parity (`401`, `429`, valid auth headers, query-token rejection)
- safety parity (`405`, request guard behavior, dedupe retry semantics)
- message behavior (`kind=message` triggers dispatch and chat final path, `kind=event` avoids auto-reply dispatch)
- `/hooks/agent` no automatic main-session mirror side effects
- shared delivery-contract no awareness mirroring in cron dispatch
- UI validation (active webchat receives chat final update for webhook message flow)

## Notes
- `pnpm check` currently fails on unrelated pre-existing type errors in provider artifact surfaces outside this diff; targeted gateway/cron suites above are green.
