### PR TITLE
gateway: preserve operator approvals TLS fingerprint logic after rebase

### DIFF
--- a/src/gateway/operator-approvals-client.test.ts
+++ b/src/gateway/operator-approvals-client.test.ts
@@ -51,8 +51,18 @@ class MockGatewayClient {
 vi.mock("./client-bootstrap.js", () => ({
   resolveGatewayClientBootstrap: vi.fn(async () => ({
     url: "ws://127.0.0.1:18789",
+    urlSource: "local loopback",
     auth: { token: "secret", password: undefined },
   })),
+  resolveGatewayUrlOverrideSource: (urlSource: string) => {
+    if (urlSource === "cli --url") {
+      return "cli";
+    }
+    if (urlSource === "env OPENCLAW_GATEWAY_URL") {
+      return "env";
+    }
+    return undefined;
+  },
 }));
 
 vi.mock("./client.js", () => ({

--- a/src/gateway/operator-approvals-client.tls.test.ts
+++ b/src/gateway/operator-approvals-client.tls.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({
+  gatewayClientSpy: vi.fn(),
+  resolveBootstrapSpy: vi.fn(),
+  loadGatewayTlsRuntimeSpy: vi.fn(),
+}));
+
+vi.mock("./client.js", () => ({
+  GatewayClient: class GatewayClientMock {
+    constructor(opts: unknown) {
+      hoisted.gatewayClientSpy(opts);
+      return opts as object;
+    }
+  },
+}));
+
+vi.mock("./client-bootstrap.js", () => ({
+  resolveGatewayClientBootstrap: hoisted.resolveBootstrapSpy,
+  resolveGatewayUrlOverrideSource: (urlSource: string) => {
+    if (urlSource === "cli --url") {
+      return "cli";
+    }
+    if (urlSource === "env OPENCLAW_GATEWAY_URL") {
+      return "env";
+    }
+    return undefined;
+  },
+}));
+
+vi.mock("../infra/tls/gateway.js", () => ({
+  loadGatewayTlsRuntime: hoisted.loadGatewayTlsRuntimeSpy,
+}));
+
+describe("createOperatorApprovalsGatewayClient TLS fingerprint", () => {
+  beforeEach(() => {
+    hoisted.gatewayClientSpy.mockReset();
+    hoisted.resolveBootstrapSpy.mockReset().mockResolvedValue({
+      url: "wss://127.0.0.1:18789",
+      urlSource: "local loopback",
+      auth: { token: "token-1", password: undefined },
+    });
+    hoisted.loadGatewayTlsRuntimeSpy.mockReset().mockResolvedValue({
+      enabled: true,
+      fingerprintSha256: "local-fingerprint",
+    });
+  });
+
+  it("pins local TLS fingerprint for local loopback WSS", async () => {
+    const { createOperatorApprovalsGatewayClient } = await import("./operator-approvals-client.js");
+
+    await createOperatorApprovalsGatewayClient({
+      config: {
+        gateway: { mode: "local", bind: "lan", tls: { enabled: true } },
+      } as never,
+      clientDisplayName: "Telegram Exec Approvals (default)",
+    });
+
+    expect(hoisted.loadGatewayTlsRuntimeSpy).toHaveBeenCalledTimes(1);
+    expect(hoisted.gatewayClientSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://127.0.0.1:18789",
+        token: "token-1",
+        tlsFingerprint: "local-fingerprint",
+      }),
+    );
+  });
+
+  it("uses remote tlsFingerprint for env URL overrides", async () => {
+    hoisted.resolveBootstrapSpy.mockResolvedValue({
+      url: "wss://gateway-in-container.internal:9443/ws",
+      urlSource: "env OPENCLAW_GATEWAY_URL",
+      auth: { token: "token-1", password: undefined },
+    });
+
+    const { createOperatorApprovalsGatewayClient } = await import("./operator-approvals-client.js");
+
+    await createOperatorApprovalsGatewayClient({
+      config: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "wss://remote.example:9443/ws",
+            tlsFingerprint: "remote-fingerprint",
+          },
+        },
+      } as never,
+      clientDisplayName: "Telegram Exec Approvals (default)",
+    });
+
+    expect(hoisted.loadGatewayTlsRuntimeSpy).not.toHaveBeenCalled();
+    expect(hoisted.gatewayClientSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://gateway-in-container.internal:9443/ws",
+        tlsFingerprint: "remote-fingerprint",
+      }),
+    );
+  });
+
+  it("does not apply remote tlsFingerprint for CLI URL overrides", async () => {
+    hoisted.resolveBootstrapSpy.mockResolvedValue({
+      url: "wss://override.local:18789",
+      urlSource: "cli --url",
+      auth: { token: "token-1", password: undefined },
+    });
+
+    const { createOperatorApprovalsGatewayClient } = await import("./operator-approvals-client.js");
+
+    await createOperatorApprovalsGatewayClient({
+      config: {
+        gateway: {
+          mode: "remote",
+          remote: {
+            url: "wss://remote.example:9443/ws",
+            tlsFingerprint: "remote-fingerprint",
+          },
+        },
+      } as never,
+      clientDisplayName: "Telegram Exec Approvals (default)",
+    });
+
+    expect(hoisted.loadGatewayTlsRuntimeSpy).not.toHaveBeenCalled();
+    expect(hoisted.gatewayClientSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "wss://override.local:18789",
+        tlsFingerprint: undefined,
+      }),
+    );
+  });
+});

--- a/src/gateway/operator-approvals-client.ts
+++ b/src/gateway/operator-approvals-client.ts
@@ -39,6 +39,9 @@ export async function createOperatorApprovalsGatewayClient(
     ? await loadGatewayTlsRuntime(params.config.gateway?.tls)
     : undefined;
   const remoteTlsFingerprint =
+    // Env overrides may still inherit configured remote TLS pinning for private cert deployments.
+    // CLI overrides remain explicit-only and intentionally skip config remote TLS to avoid
+    // accidentally pinning against caller-supplied target URLs.
     isRemoteMode && gatewayUrlOverrideSource !== "cli"
       ? trimToUndefined(params.config.gateway?.remote?.tlsFingerprint)
       : undefined;

--- a/src/gateway/operator-approvals-client.ts
+++ b/src/gateway/operator-approvals-client.ts
@@ -1,7 +1,16 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
-import { resolveGatewayClientBootstrap } from "./client-bootstrap.js";
+import {
+  resolveGatewayClientBootstrap,
+  resolveGatewayUrlOverrideSource,
+} from "./client-bootstrap.js";
 import { GatewayClient, type GatewayClientOptions } from "./client.js";
+
+function trimToUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
 
 export async function createOperatorApprovalsGatewayClient(
   params: Pick<
@@ -18,10 +27,29 @@ export async function createOperatorApprovalsGatewayClient(
     env: process.env,
   });
 
+  const gatewayUrlOverrideSource = resolveGatewayUrlOverrideSource(bootstrap.urlSource);
+  const isRemoteMode = params.config.gateway?.mode === "remote";
+  const remoteUrl = isRemoteMode ? trimToUndefined(params.config.gateway?.remote?.url) : undefined;
+  const useLocalTls =
+    params.config.gateway?.tls?.enabled === true &&
+    !gatewayUrlOverrideSource &&
+    !remoteUrl &&
+    bootstrap.url.startsWith("wss://");
+  const tlsRuntime = useLocalTls
+    ? await loadGatewayTlsRuntime(params.config.gateway?.tls)
+    : undefined;
+  const remoteTlsFingerprint =
+    isRemoteMode && gatewayUrlOverrideSource !== "cli"
+      ? trimToUndefined(params.config.gateway?.remote?.tlsFingerprint)
+      : undefined;
+  const tlsFingerprint =
+    remoteTlsFingerprint || (tlsRuntime?.enabled ? tlsRuntime.fingerprintSha256 : undefined);
+
   return new GatewayClient({
     url: bootstrap.url,
     token: bootstrap.auth.token,
     password: bootstrap.auth.password,
+    tlsFingerprint,
     clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
     clientDisplayName: params.clientDisplayName,
     mode: GATEWAY_CLIENT_MODES.BACKEND,


### PR DESCRIPTION
## Summary
- preserve TLS fingerprint handling in operator approvals gateway client after rebasing onto latest main
- keep existing operator approvals behavior while adding fingerprint propagation for local/remote gateway modes
- add focused TLS behavior coverage in src/gateway/operator-approvals-client.tls.test.ts
- update existing operator-approvals-client.test.ts mock for bootstrap API changes

## Why
Operator approvals are a high-trust flow. This keeps the approvals client aligned with existing gateway TLS-fingerprint hardening behavior and avoids drift after rebases.

## Validation
- pnpm -s vitest run src/gateway/operator-approvals-client.test.ts src/gateway/operator-approvals-client.tls.test.ts

## Notes
- branch is rebased on latest upstream main as of today.
