### PR TITLE
feat(talk): add local models tts support for Talk Mode in MacOS

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fb90e7b1977f43661ac91681d16da11f9ddd85630407ef170eaada0a6ee39972",
+  "originHash" : "e12ea28f7adb7a6028907e5481cdc79cd2e76a36be6566e6c2fa5c5600fe8ef3",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -29,12 +29,48 @@
       }
     },
     {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "menubarextraaccess",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/orchetect/MenuBarExtraAccess",
       "state" : {
         "revision" : "707dff6f55217b3ef5b6be84ced3e83511d4df5c",
         "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "mlx-audio-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Blaizzy/mlx-audio-swift",
+      "state" : {
+        "branch" : "main",
+        "revision" : "2fd41458059e2d80403436167d5263f585d120d4"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "state" : {
+        "revision" : "25b00d4e22e61ec9c41efda47990cd2084ec87ff",
+        "version" : "2.31.3"
       }
     },
     {
@@ -51,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
-        "version" : "2.9.0"
+        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
+        "version" : "2.9.1"
       }
     },
     {
@@ -65,6 +101,33 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "swift-concurrency-extras",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
@@ -74,12 +137,48 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "bb4ba815dab96d4edc1e0b86d7b9acf9ff973a84",
+        "version" : "4.3.1"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "8c0f217f01000dd30f60d6e536569ad4e74291f9",
+        "version" : "1.11.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
+        "version" : "2.97.1"
       }
     },
     {
@@ -110,6 +209,15 @@
       }
     },
     {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
+      "state" : {
+        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
+        "version" : "1.2.1"
+      }
+    },
+    {
       "identity" : "swiftui-math",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/swiftui-math",
@@ -125,6 +233,15 @@
       "state" : {
         "revision" : "5b06b811c0f5313b6b84bbef98c635a630638c38",
         "version" : "0.3.1"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
       }
     }
   ],

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.10.1"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
         .package(url: "https://github.com/steipete/Peekaboo.git", branch: "main"),
+        .package(url: "https://github.com/Blaizzy/mlx-audio-swift", branch: "main"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../../Swabble"),
     ],
@@ -54,6 +55,9 @@ let package = Package(
                 .product(name: "Sparkle", package: "Sparkle"),
                 .product(name: "PeekabooBridge", package: "Peekaboo"),
                 .product(name: "PeekabooAutomationKit", package: "Peekaboo"),
+                .product(name: "MLXAudio", package: "mlx-audio-swift"),
+                .product(name: "MLXAudioTTS", package: "mlx-audio-swift"),
+                .product(name: "MLXAudioCore", package: "mlx-audio-swift"),
             ],
             exclude: [
                 "Resources/Info.plist",

--- a/apps/macos/Sources/OpenClaw/TalkAudioPlayer.swift
+++ b/apps/macos/Sources/OpenClaw/TalkAudioPlayer.swift
@@ -156,3 +156,186 @@ struct TalkPlaybackResult {
     let finished: Bool
     let interruptedAt: Double?
 }
+
+// MARK: - Streaming Audio Player
+
+/// Plays audio chunks in sequence for streaming TTS
+@MainActor
+final class TalkStreamingAudioPlayer: NSObject, @preconcurrency AVAudioPlayerDelegate {
+    private let logger = Logger(subsystem: "ai.openclaw", category: "talk.streaming")
+    private var audioEngine: AVAudioEngine?
+    private var playerNode: AVAudioPlayerNode?
+    private var currentFormat: AVAudioFormat?
+    private var isPlaying = false
+    private var isStopped = false
+    private var lastBufferCompleted = true
+    private var buffersScheduled = 0
+    private var buffersCompleted = 0
+    
+    override init() {
+        super.init()
+        setupAudioEngine()
+    }
+    
+    private func setupAudioEngine() {
+        let engine = AVAudioEngine()
+        let player = AVAudioPlayerNode()
+        
+        engine.attach(player)
+        
+        // Connect player to main mixer with standard format
+        let format = engine.mainMixerNode.inputFormat(forBus: 0)
+        engine.connect(player, to: engine.mainMixerNode, format: format)
+        
+        self.audioEngine = engine
+        self.playerNode = player
+        self.currentFormat = format
+        
+        do {
+            try engine.start()
+            self.logger.info("Audio engine started for streaming")
+        } catch {
+            self.logger.error("Failed to start audio engine: \(error.localizedDescription)")
+        }
+    }
+    
+    /// Queue an audio chunk for playback
+    func queueAudio(data: Data, sampleRate: Double = 16000.0) throws {
+        guard !isStopped else { return }
+        guard let playerNode = self.playerNode,
+              let audioEngine = self.audioEngine,
+              let engineFormat = self.currentFormat else {
+            throw NSError(
+                domain: "TalkStreamingAudioPlayer",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Player node not initialized"]
+            )
+        }
+        
+        // Write to temp file and read as AVAudioFile
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString + ".wav")
+        try data.write(to: tempURL)
+        defer {
+            try? FileManager.default.removeItem(at: tempURL)
+        }
+        
+        let file = try AVAudioFile(forReading: tempURL)
+        let frameCount = AVAudioFrameCount(file.length)
+        
+        guard let sourceBuffer = AVAudioPCMBuffer(pcmFormat: file.processingFormat, 
+                                                  frameCapacity: frameCount) else {
+            throw NSError(
+                domain: "TalkStreamingAudioPlayer",
+                code: -2,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to create source audio buffer"]
+            )
+        }
+        
+        try file.read(into: sourceBuffer)
+        sourceBuffer.frameLength = frameCount
+        
+        // Convert to engine format if needed
+        let bufferToSchedule: AVAudioPCMBuffer
+        if file.processingFormat != engineFormat {
+            self.logger.info(
+                "Converting audio from \(file.processingFormat.sampleRate)Hz/\(file.processingFormat.channelCount)ch to \(engineFormat.sampleRate)Hz/\(engineFormat.channelCount)ch"
+            )
+            
+            guard let converter = AVAudioConverter(from: file.processingFormat, to: engineFormat) else {
+                throw NSError(
+                    domain: "TalkStreamingAudioPlayer",
+                    code: -3,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to create audio converter"]
+                )
+            }
+            
+            // Calculate converted frame count
+            let convertedFrameCount = AVAudioFrameCount(
+                Double(frameCount) * engineFormat.sampleRate / file.processingFormat.sampleRate
+            )
+            guard let convertedBuffer = AVAudioPCMBuffer(pcmFormat: engineFormat, 
+                                                        frameCapacity: convertedFrameCount) else {
+                throw NSError(
+                    domain: "TalkStreamingAudioPlayer",
+                    code: -4,
+                    userInfo: [NSLocalizedDescriptionKey: "Failed to create converted audio buffer"]
+                )
+            }
+            
+            // Perform conversion
+            var error: NSError?
+            nonisolated(unsafe) let sourceBuffer = sourceBuffer
+            let inputBlock: AVAudioConverterInputBlock = { _, outStatus in
+                outStatus.pointee = .haveData
+                return sourceBuffer
+            }
+            
+            converter.convert(to: convertedBuffer, error: &error, withInputFrom: inputBlock)
+            
+            if let error = error {
+                throw error
+            }
+            
+            bufferToSchedule = convertedBuffer
+        } else {
+            bufferToSchedule = sourceBuffer
+        }
+        
+        // Schedule buffer for playback
+        buffersScheduled += 1
+        let bufferIndex = buffersScheduled
+        lastBufferCompleted = false
+        
+        playerNode.scheduleBuffer(bufferToSchedule, at: nil, options: []) { [weak self] in
+            guard let self = self else { return }
+            Task { @MainActor in
+                self.buffersCompleted += 1
+                self.logger.info("Buffer \(bufferIndex) completed (\(self.buffersCompleted)/\(self.buffersScheduled))")
+                
+                // Check if this is the last buffer
+                if self.buffersCompleted == self.buffersScheduled {
+                    self.lastBufferCompleted = true
+                }
+            }
+        }
+        
+        // Start playing if not already
+        if !isPlaying {
+            playerNode.play()
+            isPlaying = true
+            self.logger.info("Started streaming audio playback")
+        }
+    }
+    
+    /// Stop streaming playback
+    func stop() {
+        isStopped = true
+        playerNode?.stop()
+        audioEngine?.stop()
+        isPlaying = false
+        lastBufferCompleted = true
+        self.logger.info("Stopped streaming audio playback")
+    }
+    
+    /// Reset for new stream
+    func reset() {
+        stop()
+        isStopped = false
+        buffersScheduled = 0
+        buffersCompleted = 0
+        lastBufferCompleted = true
+        setupAudioEngine()
+    }
+    
+    /// Wait for all queued audio to finish
+    func waitForCompletion() async {
+        // Wait until all scheduled buffers have completed
+        while !lastBufferCompleted && !isStopped {
+            try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
+        }
+        
+        self.logger.info("All audio buffers completed (\(self.buffersCompleted)/\(self.buffersScheduled))")
+    }
+}
+

--- a/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
+++ b/apps/macos/Sources/OpenClaw/TalkMLXSpeechSynthesizer.swift
@@ -1,0 +1,238 @@
+import Foundation
+import OSLog
+import MLXAudioTTS
+import MLXAudioCore
+
+/// Local speech synthesizer using MLX Audio for on-device TTS.
+@MainActor
+public final class TalkMLXSpeechSynthesizer {
+    public enum SynthesizeError: Error {
+        case canceled
+        case modelNotLoaded
+        case synthesisTimeout
+        case noAudioGenerated
+        case audioPlaybackFailed
+    }
+
+    public static let shared = TalkMLXSpeechSynthesizer()
+
+    private let logger = Logger(subsystem: "ai.openclaw", category: "talk.mlx")
+    private var model: SopranoModel?
+    private var currentToken = UUID()
+    private var watchdog: Task<Void, Never>?
+    private var modelLoaded = false
+    
+    private init() {
+        // Model will be loaded on first use
+    }
+
+    /// Load the MLX TTS model. Should be called before first use.
+    public func loadModel() async throws {
+        guard !modelLoaded else { return }
+        
+        self.logger.info("talk mlx loading model...")
+//
+//        #if canImport(MLXAudio)
+        // Initialize the MLX Audio synthesizer
+        // The package should support various TTS models
+        do {
+            // Load a TTS model from HuggingFace
+            self.model = try await SopranoModel.fromPretrained("mlx-community/Soprano-80M-bf16")
+            
+//            self.synthesizer = try await MLXAudioSynthesizer(
+//                modelConfiguration: .defaultTTS()
+//            )
+            self.modelLoaded = true
+            self.logger.info("talk mlx model loaded successfully")
+        } catch {
+            self.logger.error("talk mlx model load failed: \(error.localizedDescription, privacy: .public)")
+            throw error
+        }
+//        #else
+//        self.logger.error("talk mlx not available: MLXAudio package not installed")
+//        throw NSError(
+//            domain: "MLXAudio",
+//            code: -1,
+//            userInfo: [NSLocalizedDescriptionKey: "MLXAudio package not installed"]
+//        )
+//        #endif
+    }
+
+    /// Stop any ongoing synthesis and playback.
+    public func stop() {
+        self.currentToken = UUID()
+        self.watchdog?.cancel()
+        self.watchdog = nil
+        // Cancel any ongoing synthesis
+    }
+
+    /// Synthesize and speak text using the local MLX model.
+    /// - Parameters:
+    ///   - text: The text to synthesize
+    ///   - language: Optional language code (e.g., "en", "es")
+    ///   - speed: Speech speed multiplier (0.5-2.0)
+    ///   - voicePreset: Optional voice preset name
+    public func speak(
+        text: String,
+        language: String? = nil,
+        speed: Double? = nil,
+        voicePreset: String? = nil
+    ) async throws {
+        // https://github.com/Blaizzy/mlx-audio-swift/blob/b76c81fa3d15600e68323b94d740bb346f3455ef/Sources/MLXAudioTTS/Generation.swift#L24
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let token = self.currentToken
+
+        // Ensure model is loaded
+        if !modelLoaded {
+            try await self.loadModel()
+        }
+
+        guard let model = self.model else {
+            throw SynthesizeError.modelNotLoaded
+        }
+
+        guard self.currentToken == token else {
+            throw SynthesizeError.canceled
+        }
+
+        // Generate audio using streaming for lower latency
+        self.logger.info("talk mlx generating audio stream for \(trimmed)")
+        
+        try await self.playAudioStream(model: model, text: trimmed, token: token)
+    }
+
+    private func playAudio(data: Data, token: UUID) async throws {
+        guard self.currentToken == token else {
+            throw SynthesizeError.canceled
+        }
+
+        // Use the existing TalkAudioPlayer for playback
+        let result = await TalkAudioPlayer.shared.play(data: data)
+        
+        guard self.currentToken == token else {
+            throw SynthesizeError.canceled
+        }
+
+        if !result.finished && result.interruptedAt == nil {
+            throw SynthesizeError.audioPlaybackFailed
+        }
+    }
+    
+    /// Stream audio generation and playback for lower latency
+    private func playAudioStream(model: SopranoModel, text: String, token: UUID) async throws {
+        let streamingPlayer = TalkStreamingAudioPlayer()
+        defer {
+            Task { @MainActor in
+                streamingPlayer.stop()
+            }
+        }
+        
+        let sampleRate = Double(model.sampleRate)
+        var totalSamples = 0
+        
+        self.logger.info("talk mlx starting streaming synthesis")
+        
+        // Use generateStream for streaming synthesis
+        let audioStream = try await model.generateStream(text: text)
+        
+        for try await audioChunk in audioStream {
+            guard self.currentToken == token else {
+                throw SynthesizeError.canceled
+            }
+            
+            // Handle the AudioGeneration enum cases
+            switch audioChunk {
+            case .audio(let mlxArray):
+                // Convert MLXArray to Float samples
+                let samples = mlxArray.asArray(Float.self)
+                totalSamples += samples.count
+                
+                // Create WAV data for this chunk
+                let audioData = Self.makeWAVData(samples: samples, sampleRate: sampleRate)
+                self.logger.info("talk mlx streaming chunk: \(samples.count) samples, \(audioData.count) bytes")
+                
+                // Queue this chunk for playback
+                try streamingPlayer.queueAudio(data: audioData, sampleRate: sampleRate)
+                
+            case .token(let tokenId):
+                self.logger.debug("talk mlx generated token: \(tokenId)")
+                
+            case .info(let info):
+                self.logger.info("talk mlx generation info: \(String(describing: info))")
+            }
+        }
+        
+        self.logger.info("talk mlx streaming complete: \(totalSamples) total samples")
+        
+        // Wait for all audio to finish playing
+        await streamingPlayer.waitForCompletion()
+        
+        guard self.currentToken == token else {
+            throw SynthesizeError.canceled
+        }
+    }
+}
+
+// MARK: - WAV Helpers
+
+extension TalkMLXSpeechSynthesizer {
+    /// Build a WAV file in memory from raw 32-bit float PCM samples (mono, IEEE float format).
+    /// This mirrors what `saveAudioArray` writes to disk but avoids any file I/O.
+    private static func makeWAVData(samples: [Float], sampleRate: Double) -> Data {
+        let numChannels: UInt16 = 1
+        let bitsPerSample: UInt16 = 32
+        let sampleRateInt = UInt32(sampleRate)
+        let byteRate: UInt32 = sampleRateInt * UInt32(numChannels) * UInt32(bitsPerSample) / 8
+        let blockAlign: UInt16 = numChannels * bitsPerSample / 8
+        let dataSize = UInt32(samples.count) * 4  // 4 bytes per Float32
+        let chunkSize: UInt32 = 36 + dataSize
+
+        var data = Data(capacity: Int(44 + dataSize))
+
+        // Appends an integer as little-endian bytes
+        func write<T: FixedWidthInteger>(_ value: T) {
+            var v = value.littleEndian
+            withUnsafeBytes(of: &v) { data.append(contentsOf: $0) }
+        }
+
+        // RIFF header
+        data.append(contentsOf: "RIFF".utf8)
+        write(chunkSize)
+        data.append(contentsOf: "WAVE".utf8)
+
+        // fmt sub-chunk (IEEE float, tag = 3)
+        data.append(contentsOf: "fmt ".utf8)
+        write(UInt32(16))       // sub-chunk size
+        write(UInt16(3))        // audio format: IEEE float
+        write(numChannels)
+        write(sampleRateInt)
+        write(byteRate)
+        write(blockAlign)
+        write(bitsPerSample)
+
+        // data sub-chunk
+        data.append(contentsOf: "data".utf8)
+        write(dataSize)
+        samples.withUnsafeBytes { data.append(contentsOf: $0) }
+
+        return data
+    }
+}
+
+// MARK: - MLX Audio Configuration Extensions
+
+/// Configuration for MLX synthesis
+public struct MLXSynthesisConfiguration {
+    /// Language code (ISO 639-1)
+    public var language: String?
+    /// Speech speed multiplier (0.5-2.0)
+    public var speed: Double = 1.0
+    /// Voice preset identifier
+    public var voicePreset: String?
+    /// Sample rate for output audio
+    public var sampleRate: Int = 44100
+    
+    public init() {}
+}

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -18,6 +18,7 @@ actor TalkModeRuntime {
     private static let defaultModelIdFallback = "eleven_v3"
     private static let defaultTalkProvider = "elevenlabs"
     private static let defaultSilenceTimeoutMs = TalkDefaults.silenceTimeoutMs
+    private static let defaultUseLocalVoice = false
 
     private final class RMSMeter: @unchecked Sendable {
         private let lock = NSLock()
@@ -687,13 +688,35 @@ actor TalkModeRuntime {
         await MainActor.run { TalkModeController.shared.updatePhase(.speaking) }
         self.phase = .speaking
         await TalkSystemSpeechSynthesizer.shared.stop()
+        
+        if Self.defaultUseLocalVoice {
+            try await self.playLocalVoice(input: input)
+        } else {
         // Use app locale as fallback when no explicit language is set (e.g. system voice without ElevenLabs directive).
         let appLocale = await MainActor.run { AppStateStore.shared.voiceWakeLocaleID }
         let ttsLanguage = input.language ?? appLocale
         try await TalkSystemSpeechSynthesizer.shared.speak(
             text: input.cleanedText,
             language: ttsLanguage)
+        }
         self.ttsLogger.info("talk system voice done")
+    }
+
+    private func playLocalVoice(input: TalkPlaybackInput) async throws {
+        self.ttsLogger.info("talk local voice (MLX) start chars=\(input.cleanedText.count, privacy: .public)")
+        await self.stopMLX()
+        
+        // Extract voice preset from directive if available
+        let voicePreset = input.directive?.voiceId
+        let speed = input.directive?.speed
+        
+        try await self.playMLX(
+            text: input.cleanedText,
+            language: input.language,
+            speed: speed,
+            voicePreset: voicePreset
+        )
+        self.ttsLogger.info("talk local voice (MLX) done")
     }
 
     private func prepareForPlayback(generation: Int) async -> Bool {
@@ -753,6 +776,7 @@ actor TalkModeRuntime {
         let interruptedAt = usePCM ? await self.stopPCM() : await self.stopMP3()
         _ = usePCM ? await self.stopMP3() : await self.stopPCM()
         await TalkSystemSpeechSynthesizer.shared.stop()
+        await self.stopMLX()
         guard self.phase == .speaking else { return }
         if reason == .speech, let interruptedAt {
             self.lastInterruptedAtSeconds = interruptedAt
@@ -793,6 +817,26 @@ extension TalkModeRuntime {
     @MainActor
     private func stopMP3() -> Double? {
         StreamingAudioPlayer.shared.stop()
+    }
+
+    @MainActor
+    private func playMLX(
+        text: String,
+        language: String?,
+        speed: Double?,
+        voicePreset: String?) async throws
+    {
+        try await TalkMLXSpeechSynthesizer.shared.speak(
+            text: text,
+            language: language,
+            speed: speed,
+            voicePreset: voicePreset
+        )
+    }
+
+    @MainActor
+    private func stopMLX() {
+        TalkMLXSpeechSynthesizer.shared.stop()
     }
 
     // MARK: - Config


### PR DESCRIPTION
## Summary

Adds support for a third voice provider in addition to elevenlabs and the local OS voice generation.       This third approach is based on custom models running locally using MLX and the AudioMLX library.      

For now it is hardcoded to use one of the models (Kokoro) and the logic is disabled by default.

## Change Type (select all)

- [ ] Bug fix
- [X] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [X] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR


## Root Cause (if applicable)

## Regression Test Plan (if applicable)

## User-visible / Behavior Changes

None

## Diagram (if applicable)

N/A

## Repro + Verification

### Environment

- OS: MacOS

### Steps

1. Enable defaultUseLocalVoice = true in the code 
2. Run the app and enable Talk Mode

### Expected
- Talk Mode works without the standard robotic voice of MacOS

### Actual
- Talk Mode uses the standard robotic voice of MacOS

## Evidence

## Human Verification (required)


## Review Conversations

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

None