### PR TITLE
fix(logging): route subagent announce output through subsystem logger

### DIFF
--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -214,8 +214,8 @@ describe("normalizeAgentCommandReplyPayloads", () => {
       result: createResult(),
     });
 
-    // runtime.log must NOT be called with the full body
-    expect(runtime.log).not.toHaveBeenCalledWith(longBody);
+    // runtime.log must NOT be called at all — announce output routes through announceLog
+    expect(runtime.log).not.toHaveBeenCalled();
     // subsystem logger info should get metadata-only line
     expect(announceLogInfoSpy).toHaveBeenCalledTimes(1);
     expect(announceLogInfoSpy).toHaveBeenCalledWith(expect.stringContaining("delivery:"));

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -7,6 +7,53 @@ import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/c
 import { deliverAgentCommandResult, normalizeAgentCommandReplyPayloads } from "./delivery.js";
 import type { AgentCommandOpts } from "./types.js";
 
+const { announceLogInfoSpy, announceLogDebugSpy } = vi.hoisted(() => ({
+  announceLogInfoSpy: vi.fn(),
+  announceLogDebugSpy: vi.fn(),
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: (subsystem: string) => {
+    if (subsystem === "agents/announce") {
+      return {
+        subsystem,
+        isEnabled: () => true,
+        trace: vi.fn(),
+        debug: announceLogDebugSpy,
+        info: announceLogInfoSpy,
+        warn: vi.fn(),
+        error: vi.fn(),
+        fatal: vi.fn(),
+        raw: vi.fn(),
+        child: () => ({
+          subsystem: `${subsystem}/child`,
+          isEnabled: () => true,
+          trace: vi.fn(),
+          debug: vi.fn(),
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          fatal: vi.fn(),
+          raw: vi.fn(),
+          child: vi.fn(),
+        }),
+      };
+    }
+    return {
+      subsystem,
+      isEnabled: () => false,
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      raw: vi.fn(),
+      child: vi.fn(),
+    };
+  },
+}));
+
 type NormalizeParams = Parameters<typeof normalizeAgentCommandReplyPayloads>[0];
 type RunResult = NormalizeParams["result"];
 
@@ -135,6 +182,47 @@ describe("normalizeAgentCommandReplyPayloads", () => {
     expect(runtime.log).toHaveBeenCalledTimes(1);
     expect(runtime.log).toHaveBeenCalledWith("Options: on, off.");
     expect(delivered.payloads).toMatchObject([{ text: "Options: on, off." }]);
+  });
+
+  it("routes announce run output through subsystem logger instead of runtime.log", async () => {
+    announceLogInfoSpy.mockClear();
+    announceLogDebugSpy.mockClear();
+    const runtime = {
+      log: vi.fn(),
+    };
+
+    const longBody =
+      "Done.\n\nWhat changed\n- Found the false-success gap\n- Added a delivery contract\n" +
+      "Commit\n- edaf79fd3348f52e731931e8958f36821f01691c";
+
+    await deliverAgentCommandResult({
+      cfg: {} as OpenClawConfig,
+      deps: {} as CliDeps,
+      runtime: runtime as never,
+      opts: {
+        message: "announce trigger",
+        inputProvenance: {
+          kind: "inter_session",
+          sourceSessionKey: "agent:main:subagent:worker",
+          sourceChannel: "internal",
+          sourceTool: "subagent_announce",
+        },
+      } as AgentCommandOpts,
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      payloads: [{ text: longBody }],
+      result: createResult(),
+    });
+
+    // runtime.log must NOT be called with the full body
+    expect(runtime.log).not.toHaveBeenCalledWith(longBody);
+    // subsystem logger info should get metadata-only line
+    expect(announceLogInfoSpy).toHaveBeenCalledTimes(1);
+    expect(announceLogInfoSpy).toHaveBeenCalledWith(expect.stringContaining("delivery:"));
+    expect(announceLogInfoSpy).toHaveBeenCalledWith(expect.stringContaining("chars="));
+    // subsystem logger debug should get full body
+    expect(announceLogDebugSpy).toHaveBeenCalledTimes(1);
+    expect(announceLogDebugSpy).toHaveBeenCalledWith(longBody);
   });
 
   it("keeps LINE directive-only replies intact for local preview when delivery is disabled", async () => {

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -20,10 +20,17 @@ import {
   normalizeOutboundPayloadsForJson,
 } from "../../infra/outbound/payloads.js";
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import type { AgentCommandOpts } from "./types.js";
+
+const announceLog = createSubsystemLogger("agents/announce");
+
+function isAnnounceRun(opts: AgentCommandOpts): boolean {
+  return opts.inputProvenance?.sourceTool === "subagent_announce";
+}
 
 type RunResult = Awaited<ReturnType<(typeof import("../pi-embedded.js"))["runEmbeddedPiAgent"]>>;
 
@@ -289,12 +296,21 @@ export async function deliverAgentCommandResult(params: {
   }
 
   const deliveryPayloads = normalizeOutboundPayloads(normalizedReplyPayloads);
+  const announceRun = isAnnounceRun(opts);
   const logPayload = (payload: NormalizedOutboundPayload) => {
     if (opts.json) {
       return;
     }
     const output = formatOutboundPayloadLog(payload);
     if (!output) {
+      return;
+    }
+    if (announceRun) {
+      announceLog.info(
+        `delivery: session=${effectiveSessionKey ?? "unknown"} ` +
+          `run=${opts.runId ?? "unknown"} chars=${output.length}`,
+      );
+      announceLog.debug(output);
       return;
     }
     if (opts.lane === AGENT_LANE_NESTED) {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1,6 +1,6 @@
 import type { ConversationRef } from "../infra/outbound/session-binding-service.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAccountId } from "../routing/session-key.js";
-import { defaultRuntime } from "../runtime.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import {
   mergeDeliveryContext,
@@ -40,6 +40,8 @@ import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.js";
 
 export { resolveAnnounceOrigin } from "./subagent-announce-origin.js";
+
+const log = createSubsystemLogger("agents/announce");
 
 const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
@@ -171,8 +173,8 @@ export async function runAnnounceDeliveryWithRetry<T>(params: {
       }
       const nextAttempt = retryIndex + 2;
       const maxAttempts = retryDelaysMs.length + 1;
-      defaultRuntime.log(
-        `[warn] Subagent announce ${params.operation} transient failure, retrying ${nextAttempt}/${maxAttempts} in ${Math.round(delayMs / 1000)}s: ${summarizeDeliveryError(err)}`,
+      log.warn(
+        `${params.operation} transient failure, retrying ${nextAttempt}/${maxAttempts} in ${Math.round(delayMs / 1000)}s: ${summarizeDeliveryError(err)}`,
       );
       retryIndex += 1;
       await waitForAnnounceRetryDelay(delayMs, params.signal);

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -594,14 +594,15 @@ export async function runSubagentAnnounceFlow(params: {
             expectsCompletionMessage,
           })
         : targetRequesterOrigin;
+    const truncatedTask = taskLabel.length > 80 ? `${taskLabel.slice(0, 80)}…` : taskLabel;
     log.info(
-      `announce delivery: type=${announceType} task=${taskLabel} status=${outcome.status} ` +
+      `announce delivery: type=${announceType} task=${truncatedTask} status=${outcome.status} ` +
         `child=${params.childSessionKey} requester=${targetRequesterSessionKey} ` +
         `announceId=${announceId}`,
     );
     log.debug(
-      `announce body: announceId=${announceId} findingsChars=${findings.length} ` +
-        `triggerMessageChars=${triggerMessage.length}`,
+      `announce body: announceId=${announceId} task=${taskLabel} ` +
+        `findingsChars=${findings.length} triggerMessageChars=${triggerMessage.length}`,
     );
 
     const directIdempotencyKey = buildAnnounceIdempotencyKey(announceId);

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -594,15 +594,17 @@ export async function runSubagentAnnounceFlow(params: {
             expectsCompletionMessage,
           })
         : targetRequesterOrigin;
-    const truncatedTask = taskLabel.length > 80 ? `${taskLabel.slice(0, 80)}…` : taskLabel;
+    const infoTask = params.label?.trim() || undefined;
     log.info(
-      `announce delivery: type=${announceType} task=${truncatedTask} status=${outcome.status} ` +
-        `child=${params.childSessionKey} requester=${targetRequesterSessionKey} ` +
-        `announceId=${announceId}`,
+      `announce delivery: type=${announceType}` +
+        (infoTask ? ` task=${infoTask}` : "") +
+        ` status=${outcome.status}` +
+        ` child=${params.childSessionKey} requester=${targetRequesterSessionKey}` +
+        ` announceId=${announceId}`,
     );
     log.debug(
-      `announce body: announceId=${announceId} task=${taskLabel} ` +
-        `findingsChars=${findings.length} triggerMessageChars=${triggerMessage.length}`,
+      `announce body: announceId=${announceId} task=${taskLabel}` +
+        ` findingsChars=${findings.length} triggerMessageChars=${triggerMessage.length}`,
     );
 
     const directIdempotencyKey = buildAnnounceIdempotencyKey(announceId);

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,6 +1,6 @@
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
-import { defaultRuntime } from "../runtime.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { isCronSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { type DeliveryContext, normalizeDeliveryContext } from "../utils/delivery-context.js";
@@ -39,6 +39,8 @@ import {
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.js";
 import { isAnnounceSkip } from "./tools/sessions-send-tokens.js";
+
+const log = createSubsystemLogger("agents/announce");
 
 type SubagentAnnounceDeps = {
   callGateway: typeof callGateway;
@@ -592,6 +594,16 @@ export async function runSubagentAnnounceFlow(params: {
             expectsCompletionMessage,
           })
         : targetRequesterOrigin;
+    log.info(
+      `announce delivery: type=${announceType} task=${taskLabel} status=${outcome.status} ` +
+        `child=${params.childSessionKey} requester=${targetRequesterSessionKey} ` +
+        `announceId=${announceId}`,
+    );
+    log.debug(
+      `announce body: announceId=${announceId} findingsChars=${findings.length} ` +
+        `triggerMessageChars=${triggerMessage.length}`,
+    );
+
     const directIdempotencyKey = buildAnnounceIdempotencyKey(announceId);
     const delivery = await deliverSubagentAnnouncement({
       requesterSessionKey: targetRequesterSessionKey,
@@ -619,12 +631,12 @@ export async function runSubagentAnnounceFlow(params: {
     });
     didAnnounce = delivery.delivered;
     if (!delivery.delivered && delivery.path === "direct" && delivery.error) {
-      defaultRuntime.error?.(
-        `Subagent completion direct announce failed for run ${params.childRunId}: ${delivery.error}`,
+      log.error(
+        `completion direct announce failed: run=${params.childRunId} error=${delivery.error}`,
       );
     }
   } catch (err) {
-    defaultRuntime.error?.(`Subagent announce failed: ${String(err)}`);
+    log.error(`announce failed: ${String(err)}`);
     // Best-effort follow-ups; ignore failures to avoid breaking the caller response.
   } finally {
     // Patch label after all writes complete


### PR DESCRIPTION
## Summary

- Problem: Gateway file logs record full subagent announce/completion assistant response bodies as `info` lines, polluting operational logs with chat content.
- Why it matters: Logs become noisy and hard to debug; large multi-line summaries bloat file size; user-facing text mixed into system logs is misleading and a potential privacy concern.
- What changed: Announce delivery output now routes through `createSubsystemLogger("agents/announce")` — metadata at `info`, full body at `debug`. Announce-related error/warning logging in `subagent-announce.ts` and `subagent-announce-delivery.ts` also moved from `defaultRuntime` to the subsystem logger.
- What did NOT change (scope boundary): Normal (non-announce) agent delivery logging, channel delivery, session transcript writes, or any LLM behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62500
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `deliverAgentCommandResult()` in `delivery.ts` calls `runtime.log(output)` for announce run payloads. In the gateway process, `runtime.log()` → `console.log()` → `enableConsoleCapture()` intercepts all `console.log` calls and forwards them to the tslog root logger at `info` level via `getLogger().info(formatted)`, which writes to the rolling date file.
- Missing detection / guardrail: No distinction between announce-internal output and normal agent output in the delivery logging path. Announce runs use the same `logPayload()` / `logNestedOutput()` path as user-facing agent runs.
- Contributing context (if known): The announce delivery files (`subagent-announce.ts`, `subagent-announce-delivery.ts`) had no subsystem logger at all — errors went through `defaultRuntime.error()` which also hits the console capture path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/command/delivery.test.ts`
- Scenario the test should lock in: When `inputProvenance.sourceTool === "subagent_announce"`, `runtime.log()` must NOT receive the full payload body; instead `announceLog.info()` receives metadata and `announceLog.debug()` receives the full body.
- Why this is the smallest reliable guardrail: Tests the exact decision point in `logPayload()` without requiring a live gateway or real subagent completion.
- Existing test that already covers this (if any): None — this gap is why the log pollution went undetected.
- If no new test is added, why not: A new test is added.

## User-visible / Behavior Changes

- `openclaw logs` output no longer includes full subagent completion prose at default log level.
- Announce metadata (session, runId, payload size) still appears at `info`.
- Full announce body is available at `debug` level for troubleshooting.

## Diagram (if applicable)

```text
Before:
[subagent completes] → deliverAgentCommandResult → runtime.log(fullBody)
  → console.log(fullBody) → enableConsoleCapture → getLogger().info(fullBody)
  → openclaw-YYYY-MM-DD.log (info, no subsystem, full chat text)

After:
[subagent completes] → deliverAgentCommandResult → announceLog.info(metadata)
  → logToFile(fileLogger, "info", metadata)    ← clean operational log
  → announceLog.debug(fullBody)
  → logToFile(fileLogger, "debug", fullBody)   ← only at debug level
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+ / pnpm workspace
- Model/provider: Any
- Integration/channel (if any): Any channel with subagent spawning

### Steps

1. Start a gateway with `logging.level: debug` or default `info`
2. Spawn a subagent that produces a multi-line completion summary
3. Let the subagent complete and announce back to the parent session
4. Inspect gateway logs via `openclaw logs --plain --local-time`

### Expected

- Gateway file logs show only announce metadata (session, runId, chars) at `info` level
- Full completion body appears only at `debug` level

### Actual

- Before this fix: full completion body appears at `info` level with no subsystem tag
- After this fix: metadata-only at `info`, full body at `debug`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - New unit test confirms announce payloads route through subsystem logger instead of `runtime.log`
  - All 14 existing announce-related tests pass (delivery + announce + announce-delivery)
  - `pnpm check` lint/format clean
- Edge cases checked:
  - Non-announce agent runs still use the original `runtime.log()` path (unchanged)
  - `opts.json` mode still uses `runtime.log(JSON.stringify(...))` (unchanged)
  - Nested non-announce runs still use `logNestedOutput()` (unchanged)
- What you did **not** verify:
  - Full end-to-end gateway run with a real subagent completion (verified via code path analysis and unit test)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Announce errors previously written via `defaultRuntime.error()` now go through subsystem logger, which uses `rawConsole` instead of patched console.
  - Mitigation: Both paths write to stderr and file log at error level. The only difference is the subsystem logger adds a `[agents/announce]` tag, which is an improvement for filtering.

---

> **AI-assisted:** Built with Claude. All changes reviewed and understood. 14/14 related tests passing.