### PR TITLE
fix(matrix): align probe account types with probeMatrix signature

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,282 @@
+# Architecture
+
+**Analysis Date:** 2026-03-28
+
+## Pattern Overview
+
+**Overall:** Multi-layer plugin-driven gateway + messaging system with an embedded LLM agent core
+
+**Key Characteristics:**
+
+- Central gateway server (`src/gateway/server.impl.ts`) brokers all real-time communication via WebSocket (JSON-RPC-style protocol)
+- Channel plugins normalize heterogeneous messaging surfaces (Telegram, Discord, Slack, Signal, WhatsApp, etc.) into a common pipeline
+- An embedded AI agent (`@mariozechner/pi-agent-core`) drives AI responses; all model I/O flows through `src/agents/pi-embedded-runner/`
+- Plugin SDK (`src/plugin-sdk/`) provides a stable public contract boundary between core and bundled/third-party extensions
+- Strict module boundaries enforced by CLAUDE.md files in key directories
+
+## Layers
+
+**CLI / Entry Point:**
+
+- Purpose: Parse argv, register lazy commands, bootstrap config, load plugins
+- Location: `src/cli/`
+- Contains: Commander-based program builder, per-command registrars, profile env handling, progress utilities
+- Depends on: `src/config/`, `src/gateway/`, `src/plugins/`
+- Used by: `openclaw.mjs` (Node entry), `pnpm openclaw ...` (Bun dev runner)
+
+**Config:**
+
+- Purpose: Load, validate, migrate, and snapshot `openclaw.json`; provide typed config to all layers
+- Location: `src/config/`
+- Contains: Zod schemas, per-channel type modules (`types.telegram.ts`, etc.), IO helpers, legacy migrations, merge-patch
+- Depends on: nothing internal (leaf layer)
+- Used by: every other layer
+
+**Gateway Server:**
+
+- Purpose: Runs the persistent local server; manages channels, plugins, sessions, auth, and RPC
+- Location: `src/gateway/server.impl.ts`, `src/gateway/server.ts` (re-export)
+- Contains: `startGatewayServer()`, channel manager, session handlers, model catalog, cron runner, health monitor, canvas host bootstrap
+- Depends on: `src/config/`, `src/channels/`, `src/agents/`, `src/plugins/`, `src/daemon/`
+- Used by: `src/cli/gateway-cli.ts` (`openclaw gateway run`), macOS app
+
+**Gateway Protocol:**
+
+- Purpose: Defines the typed wire contract for gateway ↔ clients (CLI, mobile, web UI, nodes)
+- Location: `src/gateway/protocol/`
+- Contains: JSON-RPC frame types (`frames.ts`), per-domain schema files (`schema/agent.ts`, `schema/channels.ts`, etc.), AJV validators
+- Depends on: nothing internal
+- Used by: `src/gateway/client.ts`, mobile apps, Control UI
+
+**Gateway Client:**
+
+- Purpose: WebSocket client that connects CLI commands and node-host runners to the gateway
+- Location: `src/gateway/client.ts`
+- Contains: `GatewayClient` class — device auth handshake, request/response multiplexing, reconnect
+- Depends on: `src/gateway/protocol/`, `src/infra/`
+- Used by: CLI commands, `src/node-host/`, `src/acp/server.ts`
+
+**Channel Plugins:**
+
+- Purpose: Normalize each messaging platform into a common adapter contract
+- Location: `src/channels/plugins/` (core), `extensions/*/src/` (per-channel plugin bundles)
+- Contains: `ChannelPlugin` type (`types.plugin.ts`), adapter interfaces (`types.adapters.ts`), registry, allowlist logic
+- Depends on: `src/config/`, `src/plugin-sdk/`
+- Used by: gateway server, auto-reply pipeline, routing
+
+**Auto-Reply Pipeline:**
+
+- Purpose: Process inbound messages: route, parse directives, run agent, dispatch reply
+- Location: `src/auto-reply/`
+- Contains: `dispatch.ts` (top-level dispatch), `reply/get-reply.ts` (orchestration), `reply/agent-runner.ts` (LLM turn execution), `reply/reply-dispatcher.ts` (outbound delivery with typing delay), command registry
+- Depends on: `src/agents/`, `src/routing/`, `src/channels/`, `src/config/`
+- Used by: gateway server's inbound message handlers
+
+**Agent / LLM Core:**
+
+- Purpose: Execute LLM turns via `@mariozechner/pi-agent-core`; handle auth profiles, model fallback, subagents, skills, sandboxing
+- Location: `src/agents/`
+- Contains: `pi-embedded-runner/run.ts` (main agent run), `pi-embedded-subscribe.ts` (streaming output processor), `model-auth.ts`, `models-config.ts`, `skills.ts`, `subagent-registry.ts`, `bash-tools.ts`
+- Depends on: `src/config/`, `src/infra/`, `src/plugins/`
+- Used by: `src/auto-reply/reply/agent-runner.ts`
+
+**Plugin Runtime:**
+
+- Purpose: Load, validate, and expose plugin capabilities to core (channels, providers, tools, hooks, web search, TTS, media)
+- Location: `src/plugins/`
+- Contains: manifest registry, loader, capability-provider runtime, hook runner, bundled plugin metadata (`bundled-plugin-metadata.generated.ts`)
+- Depends on: `src/config/`, `src/plugin-sdk/`
+- Used by: gateway server, agent runner, CLI
+
+**Plugin SDK:**
+
+- Purpose: Public API surface consumed by bundled and third-party plugins
+- Location: `src/plugin-sdk/`
+- Contains: `core.ts` (re-exports), channel contract, provider entry, runtime facade
+- Depends on: internal type definitions only (no implementation pull-through)
+- Used by: `extensions/*/src/` plugin packages
+
+**Routing:**
+
+- Purpose: Map (channel, accountId, peer) tuples to (agentId, sessionKey)
+- Location: `src/routing/`
+- Contains: `resolve-route.ts`, `session-key.ts`, `bindings.ts`, `account-lookup.ts`
+- Depends on: `src/config/`
+- Used by: auto-reply pipeline, gateway server
+
+**Infra:**
+
+- Purpose: Cross-cutting utilities — FS helpers, HTTP, networking, exec approvals, update checks, heartbeat, pairing, secrets, logging
+- Location: `src/infra/`
+- Contains: hundreds of focused utility modules; notably `exec-approvals.ts`, `outbound/`, `heartbeat-runner.ts`, `device-identity.ts`, `secure-random.ts`
+- Depends on: `src/config/` (paths only)
+- Used by: all layers
+
+**Daemon / Service Manager:**
+
+- Purpose: Install and manage the gateway as a system service (launchd, systemd, Windows Task Scheduler)
+- Location: `src/daemon/`
+- Contains: `service.ts` (unified interface), `launchd.ts`, `systemd.ts`, `schtasks.ts`
+- Depends on: `src/infra/`, `src/config/`
+- Used by: `src/commands/` onboard/setup flows, `openclaw gateway install`
+
+**Node Host:**
+
+- Purpose: Run a remote node that connects to a gateway and handles tool invocations
+- Location: `src/node-host/`
+- Contains: `runner.ts`, `invoke.ts`, `exec-policy.ts`
+- Depends on: `src/gateway/client.ts`, `src/infra/`
+- Used by: mobile apps (Android/iOS embed Node.js and run this), remote machines
+
+**ACP (Agent Client Protocol):**
+
+- Purpose: Serve the standard Agent-Client Protocol bridge, translating ACP requests into gateway calls
+- Location: `src/acp/`
+- Contains: `server.ts`, `translator.ts`, `control-plane/manager.ts`, `runtime/`
+- Depends on: `src/gateway/client.ts`, `@agentclientprotocol/sdk`
+- Used by: `openclaw acp` command, external ACP-capable clients
+
+**TUI:**
+
+- Purpose: Terminal UI for interactive chat sessions against the gateway
+- Location: `src/tui/`
+- Contains: `tui.ts`, `gateway-chat.ts`, component tree built with `@mariozechner/pi-tui`
+- Depends on: `src/gateway/client.ts`, `src/routing/`
+- Used by: `openclaw tui` command
+
+**Canvas Host:**
+
+- Purpose: Local HTTP/WS server for the a2ui canvas (agent-rendered interactive UI)
+- Location: `src/canvas-host/`
+- Contains: `server.ts`, `a2ui.ts`, `file-resolver.ts`
+- Depends on: `src/config/`, `src/infra/`
+- Used by: gateway server startup
+
+**Control UI (Web UI):**
+
+- Purpose: React SPA served from the gateway for browser-based management
+- Location: `ui/src/`
+- Contains: `main.ts`, `ui/` (React components), `app-gateway.ts`
+- Depends on: gateway WebSocket protocol
+- Used by: browsers connecting to `http://localhost:<port>`
+
+## Data Flow
+
+**Inbound Message → AI Reply:**
+
+1. Channel plugin monitor receives message (e.g. Telegram bot update)
+2. Message is normalized into a `MsgContext` in `src/auto-reply/templating.ts`
+3. `dispatchInboundMessage()` in `src/auto-reply/dispatch.ts` is called
+4. `getReplyFromConfig()` in `src/auto-reply/reply/get-reply.ts` resolves directives, model, session
+5. `runPreparedReply()` in `src/auto-reply/reply/get-reply-run.ts` invokes `runReplyAgent()`
+6. `runReplyAgent()` in `src/auto-reply/reply/agent-runner.ts` calls `runEmbeddedPiAgent()` in `src/agents/pi-embedded-runner/run.ts`
+7. `runEmbeddedAttempt()` in `src/agents/pi-embedded-runner/run/attempt.ts` calls `@mariozechner/pi-agent-core` via `@mariozechner/pi-ai`
+8. `subscribeEmbeddedPiSession()` in `src/agents/pi-embedded-subscribe.ts` streams output blocks back
+9. `ReplyDispatcher` in `src/auto-reply/reply/reply-dispatcher.ts` delivers reply payloads via channel plugin's outbound adapter
+
+**CLI Command → Gateway RPC:**
+
+1. `openclaw.mjs` → `run-main.ts` → `route.ts` → lazy command registrar
+2. Command creates `GatewayClient` from `src/gateway/client.ts`
+3. Client sends typed JSON-RPC request per `src/gateway/protocol/`
+4. Gateway server dispatches to handler in `src/gateway/server-methods.ts`
+5. Response returned to CLI command
+
+**State Management:**
+
+- Config read from `~/.openclaw/openclaw.json`, validated with Zod, cached with reload support (`src/config/io.ts`)
+- Session transcripts stored as JSONL under `~/.openclaw/sessions/` and `~/.openclaw/agents/<id>/sessions/`
+- Plugin state in `~/.openclaw/plugins/`
+
+## Key Abstractions
+
+**ChannelPlugin:**
+
+- Purpose: Adapter contract for a messaging platform (monitor, outbound, config, auth, pairing, etc.)
+- Examples: `extensions/telegram/src/`, `extensions/discord/src/`, `extensions/signal/src/`
+- Pattern: Objects implementing adapter interfaces from `src/channels/plugins/types.adapters.ts`; registered via plugin manifest
+
+**OpenClawPluginApi (Plugin Runtime):**
+
+- Purpose: Facade passed to plugins at runtime; provides access to config, channels, media, TTS, web search, model auth, system events
+- Examples: `src/plugins/runtime/index.ts` (factory), consumed by `extensions/*/src/`
+- Pattern: Created per plugin load; passed as `api` argument to plugin `init()` / lifecycle hooks
+
+**ReplyDispatcher:**
+
+- Purpose: Buffers, normalizes, and sequentially delivers reply payloads from an agent run
+- Examples: `src/auto-reply/reply/reply-dispatcher.ts`
+- Pattern: Created per inbound message; registered in global `dispatcher-registry.ts` so gateway drain waits for all in-flight deliveries before restart
+
+**GatewayServer:**
+
+- Purpose: Central runtime state holder — owns channel manager, session registry, node registry, plugin registry, cron service
+- Examples: `src/gateway/server.impl.ts` → `startGatewayServer()`
+- Pattern: Single long-lived process; config reloaded hot via `src/gateway/config-reload.ts`
+
+**SessionKey:**
+
+- Purpose: Stable identifier mapping a (agent, channel, account, peer) tuple to a conversation
+- Examples: `src/routing/session-key.ts`
+- Pattern: String like `<agentId>/<channelId>/<accountId>/<peerKind>/<peerId>`; used as both storage key and concurrency lane
+
+## Entry Points
+
+**`openclaw.mjs`:**
+
+- Location: `openclaw.mjs`
+- Triggers: Direct `node openclaw.mjs` or installed `openclaw` binary
+- Responsibilities: Node version guard, compile cache, lazy ESM import of `src/cli/run-main.ts`
+
+**`src/cli/run-main.ts`:**
+
+- Location: `src/cli/run-main.ts`
+- Triggers: Called from `openclaw.mjs`
+- Responsibilities: Normalize argv, route CLI (container, profile, primary command), build Commander program, execute
+
+**`src/cli/program/build-program.ts`:**
+
+- Location: `src/cli/program/build-program.ts`
+- Triggers: Called by `run-main.ts`
+- Responsibilities: Construct Commander instance, register lazy command stubs, attach pre-action hooks
+
+**`src/gateway/server.impl.ts` (`startGatewayServer`):**
+
+- Location: `src/gateway/server.impl.ts`
+- Triggers: `openclaw gateway run` command via `src/cli/gateway-cli.ts`
+- Responsibilities: Load config, load plugins, start HTTP/WS server, bootstrap channels, start cron/heartbeat/maintenance timers
+
+**`src/node-host/runner.ts`:**
+
+- Location: `src/node-host/runner.ts`
+- Triggers: Mobile app Node.js module or `openclaw nodes run`
+- Responsibilities: Connect to gateway as a node, register capabilities, dispatch tool invocations
+
+**`src/acp/server.ts` (`serveAcpGateway`):**
+
+- Location: `src/acp/server.ts`
+- Triggers: `openclaw acp` command
+- Responsibilities: Bridge ACP stdio protocol to gateway WebSocket
+
+## Error Handling
+
+**Strategy:** Fail-fast with structured error objects; LLM turn failures use failover/retry with backoff
+
+**Patterns:**
+
+- Auth failures → `FailoverError` class in `src/agents/failover-error.ts`; triggers auth profile rotation via `src/agents/model-auth.ts`
+- Config load failures → Zod validation errors surfaced via `doctor` command
+- Gateway WS errors → `GatewayClient` reconnects with backoff; CLI commands surface structured error codes from `ConnectErrorDetailCodes`
+- Unhandled rejections → captured by `src/infra/unhandled-rejections.ts`; logged and process exits on fatal
+
+## Cross-Cutting Concerns
+
+**Logging:** `src/logging/` (`createSubsystemLogger`, structured JSONL to `~/.openclaw/openclaw-YYYY-MM-DD.log`); `src/cli/log-level-option.ts` for CLI verbosity
+**Validation:** Zod schemas in `src/config/` for all config; AJV validators generated from JSON schema in `src/gateway/protocol/`
+**Authentication:** Multi-surface: gateway auth token (Bearer), device token (crypto keypair), OAuth flows per provider; resolved in `src/secrets/runtime.ts` and `src/gateway/startup-auth.ts`
+**Secrets:** `SecretRef` indirection (`src/secrets/`) — config values may reference env vars or credential files; resolved at runtime
+**Plugin Isolation:** Each extension is a pnpm workspace package under `extensions/`; loaded at runtime via `src/plugins/loader.ts` with manifest validation
+
+---
+
+_Architecture analysis: 2026-03-28_

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,253 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-03-28
+
+## Tech Debt
+
+**Large files exceeding 700 LOC guideline (120 offenders):**
+
+- Issue: 120 production source files exceed the 700 LOC guideline; the top offenders are massive and hard to reason about or test in isolation.
+- Files:
+  - `src/plugins/types.ts` (2442 lines)
+  - `src/config/io.ts` (2285 lines)
+  - `src/gateway/server-methods/chat.ts` (1875 lines)
+  - `src/agents/pi-embedded-runner/run/attempt.ts` (1871 lines)
+  - `src/acp/control-plane/manager.core.ts` (1732 lines)
+  - `src/config/zod-schema.providers-core.ts` (1562 lines)
+  - `src/channels/plugins/setup-wizard-helpers.ts` (1531 lines)
+  - `src/security/audit.ts` (1504 lines)
+  - `src/gateway/server.impl.ts` (1496 lines)
+  - `src/agents/pi-embedded-runner/run.ts` (1428 lines)
+  - `src/plugins/loader.ts` (1410 lines)
+  - `src/cli/config-cli.ts` (1390 lines)
+  - `src/gateway/session-utils.ts` (1370 lines)
+  - `src/security/audit-extra.sync.ts` (1359 lines)
+  - `src/security/audit-extra.async.ts` (1324 lines)
+  - `src/cron/service/timer.ts` (1263 lines)
+  - `src/gateway/server/ws-connection/message-handler.ts` (1248 lines)
+  - `src/gateway/server-methods/sessions.ts` (1210 lines)
+  - `src/infra/heartbeat-runner.ts` (1200 lines)
+  - `src/gateway/server-methods/nodes.ts` (1194 lines)
+- Impact: Large files reduce discoverability, make test coverage harder, and increase merge conflict surface.
+- Fix approach: Progressively split by extracting cohesive sub-responsibilities into dedicated modules. Prioritize files that also have no unit tests (see Test Coverage Gaps section).
+
+**Legacy config migration layer with no retirement mechanism:**
+
+- Issue: 13 legacy migration files exist under `src/config/` with no documented deprecation timeline or retirement gate. Migrations accumulate without being removed after the target config format becomes universal.
+- Files:
+  - `src/config/legacy-migrate.ts`
+  - `src/config/legacy.ts`
+  - `src/config/legacy.shared.ts`
+  - `src/config/legacy.migrations.ts`
+  - `src/config/legacy.migrations.audio.ts`
+  - `src/config/legacy.migrations.channels.ts`
+  - `src/config/legacy.migrations.runtime.ts`
+  - `src/config/legacy-web-search.ts`
+  - `src/config/sessions/store-migrations.ts`
+- Impact: Boot path runs migrations on every startup; as config shapes diverge further, migration logic becomes increasingly risky to modify.
+- Fix approach: Add a minimum supported config version check; once a version is universally deployed, retire the corresponding migration(s) and remove dead code.
+
+**`no-await-in-loop` suppressions in security-critical paths:**
+
+- Issue: 18 `eslint-disable-next-line no-await-in-loop` suppressions in production source; the majority are concentrated in security audit code paths where parallelism bugs would be silent and consequential.
+- Files:
+  - `src/security/fix.ts` (lines 328, 352, 354, 358, 361, 367, 371, 381, 453 — 9 suppressions)
+  - `src/security/audit-extra.async.ts` (lines 744, 807, 924, 1039, 1078 — 5 suppressions)
+  - `src/config/includes-scan.ts` (line 79)
+  - `src/test-utils/ports.ts` (lines 69, 82, 84 — test utilities)
+- Impact: Sequential awaits inside loops prevent parallelism and degrade audit performance; in `fix.ts` they may cause partial-apply race conditions.
+- Fix approach: Replace loop awaits with `Promise.all`/`Promise.allSettled` batching where safe; add unit tests that assert batch behavior for the security paths.
+
+**Scattered debug environment variable checks with no central registry:**
+
+- Issue: `OPENCLAW_DEBUG_INGRESS_TIMING` is checked independently in 4 separate files; `OPENCLAW_DEBUG_HEALTH` in 2. There is no central registry of debug flags, their expected values, or documentation.
+- Files:
+  - `src/agents/model-catalog.ts:41`
+  - `src/agents/auth-profiles/store.ts:398`
+  - `src/auto-reply/reply/model-selection.ts:45`
+  - `src/auto-reply/reply/session.ts:217`
+  - `src/commands/health.ts:78,623`
+- Impact: New contributors have no discovery path for debug flags; flags can drift out of sync across duplicated check sites.
+- Fix approach: Create a `src/infra/debug-flags.ts` module that exports typed flag accessors; replace all direct `process.env` checks with imports from that module.
+
+**`express` dependency isolated to a single file:**
+
+- Issue: `express` is imported only in `src/media/server.ts` while the rest of the project avoids it entirely.
+- Files: `src/media/server.ts` (lines 3, 108)
+- Impact: Adds a full Express dependency (with its own middleware chain, types, and security surface) for a single server. Inconsistent with the rest of the HTTP layer.
+- Fix approach: Migrate `src/media/server.ts` to Node's built-in `http` module or to whichever HTTP framework the gateway uses; then remove `express` from `package.json`.
+
+**`hono` in dependencies but no production imports found:**
+
+- Issue: `hono@4.12.9` and `@hono/node-server@1.19.10` appear in both `dependencies` and `pnpm.overrides` in `package.json`, but no `import ... from "hono"` exists in production source files.
+- Files: `package.json` (lines 1212, 1279–1280)
+- Impact: Unused dependency adds install size and supply-chain attack surface; the override pinning it hints at an abandoned or in-progress migration that was never completed or reverted.
+- Fix approach: Confirm whether a migration to Hono is planned. If not, remove the dependency and the override entry.
+
+---
+
+## Known Bugs
+
+**Markdown blockquote triple-newline output:**
+
+- Symptoms: Rendering a blockquote followed by a paragraph produces `\n\n\n` (triple newline) instead of the correct `\n\n`. The bug is documented and the tests are currently failing.
+- Files: `src/markdown/ir.blockquote-spacing.test.ts:15` (documents the bug), `src/markdown/ir.ts` (root cause: `blockquote_close` handler adds an extra `\n`)
+- Root cause: `paragraph_close` inside a blockquote already emits `\n\n`; `blockquote_close` then emits another `\n`, producing three total. Container block closings should not add their own spacing.
+- Fix: Remove or suppress the extra `\n` emission in the `blockquote_close` handler in `src/markdown/ir.ts`.
+
+**ACP error kind conflation with `end_turn`:**
+
+- Symptoms: Transient server errors (timeouts, rate limits) reported as `end_turn` stop reason to clients instead of a structured error kind, causing clients to misinterpret errors as normal completion.
+- Files: `src/acp/translator.ts:897–900`
+- Root cause: ACP's `ChatEventSchema` has no structured `errorKind` field; `end_turn` is used as a stopgap fallback. Acknowledged via `TODO` comment in source.
+- Fix: Add an `errorKind` discriminated field to `ChatEventSchema` and use it in `translator.ts` to distinguish `refusal` / `timeout` / `rate_limit` / `server_error`.
+
+**Typing keepalive loop runaway edge case:**
+
+- Symptoms: If the dispatcher exits early or errors before firing its `onIdle` callback, the typing keepalive loop runs forever. Currently mitigated by a defensive `markDispatchIdle()` call in the `finally` block.
+- Files: `src/auto-reply/reply/agent-runner.ts:790–800`
+- Risk: The mitigation is a safety net; a path that bypasses both the dispatcher callback and the `finally` block (e.g., unhandled rejection) would still leak. Regression precedent: issue #26881.
+- Fix: Add a test verifying that the keepalive loop terminates when the dispatcher throws; audit for any code paths that could skip the `finally` block.
+
+**Cron timer hot-loop on stuck `runningAtMs`:**
+
+- Symptoms: When a job has a stuck `runningAtMs` marker and a past-due `nextRunAtMs`, `findDueJobs` skips the job while `recomputeNextRunsForMaintenance` does not advance `nextRunAtMs`, causing `armTimer` to be called with `delay === 0` in a tight loop that saturates the event loop and fills logs to cap.
+- Files: `src/cron/service/timer.ts:535–554`
+- Mitigation: A `MIN_REFIRE_GAP_MS` floor is applied to `delay === 0` cases. Root cause (stuck `runningAtMs`) is not self-healing.
+- Fix: Add a `runningAtMs` watchdog that clears the marker after a configurable staleness threshold; add an integration test simulating a stuck job.
+
+---
+
+## Security Considerations
+
+**Large number of unguarded `JSON.parse` calls:**
+
+- Risk: `JSON.parse` throws on malformed input. The codebase has approximately 538 `JSON.parse` calls in production source; only a small fraction are wrapped in `try/catch`. Malformed or attacker-controlled JSON from external channels, tool responses, or network payloads can produce uncaught exceptions that crash request handlers or leak stack traces.
+- Files: Widespread across `src/`; highest density in `src/config/`, `src/gateway/`, `src/acp/`, `src/channels/`.
+- Current mitigation: None systematic. Some callers use Zod `.safeParse()` after parsing, which catches schema errors but not the initial parse throw.
+- Recommendations: Introduce a shared `safeJsonParse<T>` utility in `src/infra/` that returns `Result<T, Error>`; mandate its use for all externally-sourced JSON.
+
+**`globalThis.window` mutation for gaxios compat:**
+
+- Risk: `src/infra/gaxios-fetch-compat.ts:256` mutates `globalThis` to inject a synthetic `window.fetch` shim. This can interfere with any code (including plugins) that performs `typeof window` environment detection, potentially enabling plugins or third-party code to access APIs gated behind that check.
+- Files: `src/infra/gaxios-fetch-compat.ts:251–256`
+- Current mitigation: The mutation is conditional on `installState !== "not-installed"` and the presence of native `fetch`.
+- Recommendations: Replace the global mutation with a fetch-wrapper approach that passes the custom fetch directly to gaxios options instead of polluting the global environment.
+
+**`as any` casts bypassing type safety in security/gateway code:**
+
+- Risk: `as any` casts in gateway and auth code allow values of unknown shape to pass through without type validation, which can mask injection or shape-confusion bugs.
+- Files:
+  - `src/gateway/tools-invoke-http.ts:276,278,323,345` — tool schema and execute calls cast to `any`
+  - `src/gateway/server.auth.shared.ts:243,316` — auth response objects cast to `any`
+- Current mitigation: None; these are raw type suppressions.
+- Recommendations: Replace `as any` with proper discriminated union types or Zod validation at the boundary; treat these files as high-priority candidates for type hardening.
+
+---
+
+## Performance Bottlenecks
+
+**Sequential `no-await-in-loop` in security audit paths:**
+
+- Problem: Security audit and fix operations in `src/security/fix.ts` and `src/security/audit-extra.async.ts` await items one at a time inside loops rather than batching. On large plugin installs or audit runs, this serializes what could be parallel I/O.
+- Files: `src/security/fix.ts` (9 suppressions), `src/security/audit-extra.async.ts` (5 suppressions)
+- Cause: Sequential pattern chosen for simplicity; no benchmarks exist for the audit paths.
+- Improvement path: Batch independent checks with `Promise.allSettled`; measure audit time on a fixture with 20+ plugins before and after.
+
+---
+
+## Fragile Areas
+
+**`src/gateway/server/ws-connection/message-handler.ts` (1248 lines, no unit tests):**
+
+- Files: `src/gateway/server/ws-connection/message-handler.ts`
+- Why fragile: All WebSocket message routing flows through this single file. No unit tests exist. Any regression in message dispatch, session lookup, or error handling will only be caught by e2e tests (if covered there).
+- Safe modification: Read the integration tests under `src/gateway/server.sessions.gateway-server-sessions-*.test.ts` for indirect coverage before touching this file. Add targeted unit tests before making logic changes.
+- Test coverage: No `message-handler.test.ts` file exists.
+
+**`src/security/audit-extra.async.ts` (1324 lines, no unit tests):**
+
+- Files: `src/security/audit-extra.async.ts`
+- Why fragile: Contains async audit logic with multiple sequential loop patterns; no unit test file.
+- Safe modification: The extensive `src/security/audit.test.ts` (3977 lines) covers some paths indirectly. Add focused unit tests for the `audit-extra.async` exports before modifying.
+- Test coverage: No `audit-extra.async.test.ts` file exists.
+
+**`src/acp/control-plane/manager.core.ts` (1732 lines, no unit tests):**
+
+- Files: `src/acp/control-plane/manager.core.ts`
+- Why fragile: ACP control-plane manager is the central coordinator for agent/session lifecycle; no unit tests exist for its 1732-line surface.
+- Safe modification: Trace the call chain from `src/acp/translator.ts` before modifying state transitions.
+- Test coverage: No `manager.core.test.ts` file exists.
+
+**`src/gateway/server.impl.ts` (1496 lines, no unit tests):**
+
+- Files: `src/gateway/server.impl.ts`
+- Why fragile: Gateway server implementation; changes here affect all connected clients. No dedicated unit test file.
+- Safe modification: Rely on `src/gateway/server.sessions.gateway-server-sessions-*.test.ts` for regression signals; add unit tests for any new methods before shipping.
+- Test coverage: No `server.impl.test.ts` file exists.
+
+**`src/infra/heartbeat-runner.ts` (1200 lines, no unit tests):**
+
+- Files: `src/infra/heartbeat-runner.ts`
+- Why fragile: Heartbeat orchestration affects connection health reporting across all channel types. No unit test file.
+- Safe modification: Changes should be validated with integration-level tests manually before merging.
+- Test coverage: No `heartbeat-runner.test.ts` file exists.
+
+---
+
+## Dependencies at Risk
+
+**`express` — orphaned single-file dependency:**
+
+- Risk: Full Express framework maintained for a single file (`src/media/server.ts`). Express has a larger attack surface than Node's native HTTP server and adds unnecessary transitive dependencies.
+- Impact: Any Express CVE requires a project-level response despite near-zero usage.
+- Migration plan: Rewrite `src/media/server.ts` using Node's native `http`/`https` or the project's existing HTTP infrastructure; remove `express` from `package.json`.
+
+**`hono` + `@hono/node-server` — unused pinned overrides:**
+
+- Risk: Two packages pinned in `pnpm.overrides` with no production imports. Override pinning forces a specific version for all transitive dependents, which can mask future incompatibilities.
+- Impact: Dead weight in the dependency graph; override could silently conflict with a future package that legitimately depends on a different Hono version.
+- Migration plan: Remove from `dependencies` and `pnpm.overrides` if no active Hono migration is planned; document the intent in a tracking issue if migration is deferred.
+
+---
+
+## Test Coverage Gaps
+
+**WebSocket message handler — core dispatch path untested:**
+
+- What's not tested: All WebSocket message routing, session lookup, error dispatch, and protocol handling in `src/gateway/server/ws-connection/message-handler.ts`.
+- Files: `src/gateway/server/ws-connection/message-handler.ts` (1248 lines)
+- Risk: Protocol bugs, session leaks, and error-handling regressions go undetected until e2e tests catch them (if at all).
+- Priority: High
+
+**Async security audit — audit loop logic untested at unit level:**
+
+- What's not tested: The async audit sweep logic, sequential loop patterns, and per-check error handling in `src/security/audit-extra.async.ts`.
+- Files: `src/security/audit-extra.async.ts` (1324 lines)
+- Risk: Silent correctness bugs in audit results; `no-await-in-loop` suppressions make race conditions hard to catch without focused tests.
+- Priority: High
+
+**ACP control-plane manager — session lifecycle untested:**
+
+- What's not tested: Agent session creation, state transitions, error handling, and cancellation paths in `src/acp/control-plane/manager.core.ts`.
+- Files: `src/acp/control-plane/manager.core.ts` (1732 lines)
+- Risk: ACP session management regressions propagate silently; the `end_turn` conflation bug (see Known Bugs) went undiscovered partly due to this gap.
+- Priority: High
+
+**Gateway server implementation — method-level behavior untested:**
+
+- What's not tested: Individual method behaviors, auth path edge cases, and session binding in `src/gateway/server.impl.ts`.
+- Files: `src/gateway/server.impl.ts` (1496 lines)
+- Risk: Regressions in gateway session handling affect all clients; currently only catchable via slow integration tests.
+- Priority: High
+
+**Heartbeat runner — connection health logic untested:**
+
+- What's not tested: Heartbeat scheduling, connection state transitions, backoff logic, and cleanup in `src/infra/heartbeat-runner.ts`.
+- Files: `src/infra/heartbeat-runner.ts` (1200 lines)
+- Risk: Silent failures in connection health reporting across all channel types.
+- Priority: Medium
+
+---
+
+_Concerns audit: 2026-03-28_

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,204 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-03-28
+
+## Naming Patterns
+
+**Files:**
+
+- Source files: `kebab-case.ts` (e.g., `pairing-store.ts`, `session-key.ts`)
+- Test files: `<source-name>.test.ts` co-located with source
+- E2E test files: `<source-name>.e2e.test.ts`
+- Live/integration tests: `<source-name>.live.test.ts`
+- Specialized variants use dot-separated suffixes: `pairing-store.ts`, `pairing-store.test.ts`, `pairing-messages.test.ts`
+- Generated files use `.generated.ts` suffix (e.g., `bundled-channel-config-metadata.generated.ts`)
+- Runtime boundary files use `.runtime.ts` suffix for lazy-loading seams
+
+**Functions:**
+
+- camelCase for all functions and methods: `resolveAgentRoute`, `loadConfig`, `createDefaultDeps`
+- Factory functions prefixed with `create`: `createDefaultDeps`, `createTestRegistry`, `createStubPlugin`, `createTrackedTempDirs`
+- Boolean predicates prefixed with `is`/`has`: `isConfigured`, `isEmbeddedPiRunActive`, `hasText`
+- Resolver/normalizer functions prefixed with `resolve` or `normalize`: `resolveConfigDir`, `normalizeE164`, `resolveAgentRoute`
+- Reset functions for test state suffixed with `ForTest`: `resetContextWindowCacheForTest`, `clearPairingAllowFromReadCacheForTest`
+- Internal test-only exports named `__testing` (e.g., `__testing.resetSigusr1State()`)
+
+**Variables:**
+
+- camelCase for locals and module-level bindings
+- SCREAMING_SNAKE_CASE for module-level constants: `DEFAULT_ACCOUNT_ID`, `CONFIG_DIR`, `DEVICE_BOOTSTRAP_TOKEN_TTL_MS`
+- `Symbol.for(...)` keys use namespaced strings: `Symbol.for("openclaw.pluginRegistryState")`
+
+**Types:**
+
+- PascalCase for all types and interfaces: `OpenClawConfig`, `ChannelPlugin`, `BackoffPolicy`
+- No `I` prefix for interfaces; use plain PascalCase
+- Discriminated union variants: `{ ok: true; ... } | { ok: false; reason: ...; error?: ... }`
+- Type suffix for complex union types: `BoundaryFileOpenResult`, `PairingSetupCommandResult`
+- Module-internal types use no export; external contracts use `export type`
+
+## Code Style
+
+**Formatting:**
+
+- Tool: `oxfmt` (Oxc formatter)
+- Run: `pnpm format` (write), `pnpm format:check` (check)
+- All TypeScript source formatted with oxfmt before commit
+
+**Linting:**
+
+- Tool: `oxlint` with `--type-aware` flag
+- Run: `pnpm lint`
+- Additional custom lint scripts in `scripts/` for boundary enforcement:
+  - `scripts/check-extension-plugin-sdk-boundary.mjs`
+  - `scripts/check-webhook-auth-body-order.mjs`
+  - `scripts/check-no-pairing-store-group-auth.mjs`
+  - `scripts/check-no-raw-channel-fetch.mjs`
+- Full check: `pnpm check` (tsgo + lint + boundary checks)
+- Line count guidance: ~500 LOC per file (advisory); enforced via `pnpm check:loc --max 500`
+- `typescript/no-explicit-any` is enforced; disable only with `// oxlint-disable-next-line typescript/no-explicit-any` on the specific line, never file-wide
+
+**TypeScript:**
+
+- `strict: true` in `tsconfig.json`
+- `noEmit: true` for type-checks; actual build uses tsdown
+- `import type` for type-only imports: `import type { OpenClawConfig } from "../config/config.js"`
+- Type assertions avoided; prefer type guards and discriminated unions
+- Never use `@ts-nocheck`
+
+## Import Organization
+
+**Order:**
+
+1. Node.js built-ins with `node:` prefix: `import fs from "node:fs"`, `import path from "node:path"`
+2. Vitest test imports (in test files): `import { describe, expect, it, vi } from "vitest"`
+3. External packages
+4. Internal relative imports (deeper modules first, then local)
+
+**Extensions:**
+
+- All relative imports use `.js` extension even for `.ts` source files (ESM resolution):
+  `import { resolveOAuthDir } from "../config/paths.js"`
+
+**Path Aliases:**
+
+- `openclaw/plugin-sdk` → `src/plugin-sdk/index.ts`
+- `openclaw/plugin-sdk/*` → `src/plugin-sdk/*.ts`
+- `openclaw/extension-api` → `src/extensionAPI.ts`
+- Configured in `tsconfig.json` `paths` and `vitest.config.ts` `resolve.alias`
+
+**Barrel Files:**
+
+- Thin re-export barrel pattern for module facades: `src/config/config.ts` simply re-exports from `./io.js`, `./types.js`, `./paths.js`, etc.
+- `export *` used for type-heavy submodule re-exports
+- Plugin SDK entry points in `src/plugin-sdk/` are hand-curated subpath exports, not catch-all barrels
+
+## Error Handling
+
+**Patterns:**
+
+- Domain-specific Error subclasses for errors callers need to distinguish:
+  - `src/infra/net/ssrf.ts`: `SsrFBlockedError`
+  - `src/infra/fs-safe.ts`: `SafeOpenError`
+  - `src/config/io.ts`: `ConfigRuntimeRefreshError`
+  - `src/secrets/resolve.ts`: `SecretProviderResolutionError`, `SecretRefResolutionError`
+  - `src/plugins/loader.ts`: `PluginLoadFailureError`
+- Discriminated `Result` union pattern for recoverable outcomes (no throw):
+  ```typescript
+  type SomeResult =
+    | { ok: true; path: string; fd: number }
+    | { ok: false; reason: string; error?: unknown };
+  ```
+  Used extensively in `src/infra/` (e.g., `BoundaryFileOpenResult`, `PairingSetupCommandResult`)
+- Callers narrow the result with `if (!result.ok)` before accessing success fields
+- `safeParseJson<T>` (`src/utils.ts`) for non-throwing JSON parsing — returns `null` on error
+- `try/catch` with `{ cause: err }` on re-throws to preserve error chain
+
+## Logging
+
+**Framework:**
+
+- Custom logger wrapping `@clack/prompts` + subsystem-aware routing
+- Entry points in `src/logger.ts`: `logInfo`, `logWarn`, `logError`, `logSuccess`, `logDebug`
+- Structured file logging via `src/logging/logger.ts` with level configuration
+- Subsystem prefix convention: `"subsystem: message"` auto-routes to `createSubsystemLogger`
+
+**Patterns:**
+
+- Use `logInfo`/`logWarn`/`logError` from `src/logger.ts` — never raw `console.log` in production paths
+- Use `logDebug` (gated by `isVerbose()`) for verbose diagnostic output
+- CLI progress: use `src/cli/progress.ts` (`osc-progress` + `@clack/prompts` spinner); never hand-roll spinners
+- Terminal colors: use `src/terminal/palette.ts` LOBSTER_PALETTE tokens; never hardcode hex colors
+
+## Comments
+
+**When to Comment:**
+
+- Tricky or non-obvious logic always gets a brief inline comment
+- Pre-compiled regex constants annotated: `// Pre-compiled regex`
+- Deliberate lint suppressions always have a comment explaining why
+- Module-level context comments at file top for non-obvious boundaries (e.g., `src/agents/context.ts`)
+
+**JSDoc/TSDoc:**
+
+- Used on exported utility functions with non-obvious semantics:
+  ```typescript
+  /**
+   * Safely parse JSON, returning null on error instead of throwing.
+   */
+  export function safeParseJson<T>(raw: string): T | null;
+  ```
+  ```typescript
+  /**
+   * Type guard for Record<string, unknown> ...
+   */
+  export function isRecord(value: unknown): value is Record<string, unknown>;
+  ```
+- Internal helpers generally not doc-commented; JSDoc reserved for public API surface
+
+## Function Design
+
+**Size:** Keep functions focused; extract helpers rather than duplicating inline. Files kept under ~500 LOC when feasible.
+
+**Parameters:**
+
+- Prefer a single options object parameter for functions with 3+ args:
+  `function resolveAgentRoute(params: { cfg: OpenClawConfig; channel: ...; peer?: ...; }): ...`
+- Optional params typed as `T | undefined` in the options object
+- Default parameter values via nullish coalescing in body, not default args in signatures
+
+**Return Values:**
+
+- Async functions always return `Promise<T>` (no mixed sync/async)
+- Functions returning discriminated results use the `{ ok: true/false }` pattern
+- Type assertions (`as`) minimized; use generics and narrowing instead
+
+## Module Design
+
+**Exports:**
+
+- Named exports always; no default exports except for Vitest config files
+- Type-only exports use `export type` keyword (enforced by `allowImportingTsExtensions`)
+- Re-export aggregation through thin barrel files (not monolithic `index.ts` dumps)
+
+**Lazy Loading:**
+
+- Dynamic `await import("x")` isolated to `*.runtime.ts` boundary files
+- No mixing of static and dynamic imports for the same module in production paths
+- Per-channel module caches in `src/cli/deps.ts` via `createLazySender`
+
+**Dependency Injection:**
+
+- `createDefaultDeps()` pattern in `src/cli/deps.ts` for injecting channel send functions
+- Test overrides pass mock deps directly to functions; no global singleton mutation
+- Internal test state exposed via `__testing` export namespace (e.g., `__testing.resetSigusr1State()`)
+
+**Prototype Mutation:**
+
+- Never use `applyPrototypeMixins`, `Object.defineProperty` on `.prototype`, or `Class.prototype` mutation
+- Use explicit inheritance (`A extends B`) or helper composition
+- Tests prefer per-instance stubs over prototype-level patching
+
+---
+
+_Convention analysis: 2026-03-28_

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,350 @@
+# External Integrations
+
+**Analysis Date:** 2026-03-28
+
+## AI / LLM Providers
+
+Each provider is a bundled plugin under `extensions/<provider>/` using the Plugin SDK. Auth resolves from environment variables via `src/plugins/bundled-provider-auth-env-vars.generated.ts`.
+
+**Anthropic:**
+
+- Extension: `extensions/anthropic/`
+- Auth env: `ANTHROPIC_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`
+- Vertex variant: `extensions/anthropic-vertex/` via `@anthropic-ai/vertex-sdk` ^0.14.4
+  - Auth: GCP Application Default Credentials (`GOOGLE_APPLICATION_CREDENTIALS`) or service account JSON
+
+**OpenAI:**
+
+- Extension: `extensions/openai/`
+- SDK: `openai` ^6.33.0
+- Auth env: `OPENAI_API_KEY`
+- Includes: standard chat, image generation, speech (TTS), media understanding, Codex (OAuth)
+- OpenAI Codex OAuth flow: `extensions/openai-codex-auth/`, `src/commands/openai-codex-oauth.ts`
+
+**Google (Gemini):**
+
+- Extension: `extensions/google/`
+- Auth env: `GEMINI_API_KEY`, `GOOGLE_API_KEY`
+- Vertex variant: uses `@anthropic-ai/vertex-sdk` + GCP ADC
+
+**AWS Bedrock:**
+
+- Extension: `extensions/amazon-bedrock/`
+- SDK: `@aws-sdk/client-bedrock` ^3.1019.0
+- Auth: AWS credentials (standard AWS SDK credential chain)
+
+**GitHub Copilot:**
+
+- Extension: `extensions/github-copilot/`, `extensions/copilot-proxy/`
+- Auth env: `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`
+- OAuth login: `extensions/openai-codex-auth/`, `src/plugin-sdk/github-copilot-login.ts`
+
+**Other AI Providers (all via extensions):**
+
+- Groq: `extensions/groq/` - Auth: `GROQ_API_KEY`
+- Mistral: `extensions/mistral/` - Auth: `MISTRAL_API_KEY`
+- DeepSeek: `extensions/deepseek/` - Auth: `DEEPSEEK_API_KEY`
+- xAI (Grok): `extensions/xai/` - Auth: `XAI_API_KEY`
+- Together AI: `extensions/together/` - Auth: `TOGETHER_API_KEY`
+- OpenRouter: `extensions/openrouter/` - Auth: `OPENROUTER_API_KEY`
+- Perplexity: `extensions/perplexity/` - Auth: `PERPLEXITY_API_KEY`
+- Ollama: `extensions/ollama/` - Auth: `OLLAMA_API_KEY` (optional for local)
+- HuggingFace: `extensions/huggingface/` - Auth: `HUGGINGFACE_HUB_TOKEN`, `HF_TOKEN`
+- NVIDIA: `extensions/nvidia/` - Auth: `NVIDIA_API_KEY`
+- Fal: `extensions/fal/` - Auth: `FAL_KEY`
+- Venice: `extensions/venice/` - Auth: `VENICE_API_KEY`
+- Chutes: `extensions/chutes/` - Auth: `CHUTES_API_KEY`, `CHUTES_OAUTH_TOKEN`
+- Cloudflare AI Gateway: `extensions/cloudflare-ai-gateway/` - Auth: `CLOUDFLARE_AI_GATEWAY_API_KEY`
+- Vercel AI Gateway: `extensions/vercel-ai-gateway/` - Auth: `AI_GATEWAY_API_KEY`
+- LiteLLM: `extensions/litellm/` - Auth: `LITELLM_API_KEY`
+- BytePlus: `extensions/byteplus/` - Auth: `BYTEPLUS_API_KEY`
+- VolcEngine: `extensions/volcengine/` - Auth: `VOLCANO_ENGINE_API_KEY`
+- MiniMax: `extensions/minimax/` - Auth: `MINIMAX_API_KEY`, `MINIMAX_OAUTH_TOKEN`
+- Moonshot: `extensions/moonshot/` - Auth: `MOONSHOT_API_KEY`
+- Kimi / Kimi Coding: `extensions/kimi/`, `extensions/kimi-coding/` - Auth: `KIMI_API_KEY`, `KIMICODE_API_KEY`
+- ModelStudio: `extensions/modelstudio/` - Auth: `MODELSTUDIO_API_KEY`
+- Qianfan: `extensions/qianfan/` - Auth: `QIANFAN_API_KEY`
+- SGLang: `extensions/sglang/` - Auth: `SGLANG_API_KEY`
+- vLLM: `extensions/vllm/` - Auth: `VLLM_API_KEY`
+- Microsoft Azure OpenAI (Foundry): `extensions/microsoft-foundry/` - Auth: `AZURE_OPENAI_API_KEY`
+- Kilocode: `extensions/kilocode/` - Auth: `KILOCODE_API_KEY`
+- ZAI: `extensions/zai/` - Auth: `ZAI_API_KEY`, `Z_AI_API_KEY`
+- Xiaomi: `extensions/xiaomi/` - Auth: `XIAOMI_API_KEY`
+- OpenCode / OpenCode Go: `extensions/opencode/`, `extensions/opencode-go/` - Auth: `OPENCODE_API_KEY`
+
+## Messaging Channel Integrations
+
+All channels are plugins. Core channels use bundled extensions; community channels may use external extensions.
+
+**Telegram:**
+
+- Extension: `extensions/telegram/`
+- SDK: `grammy` ^1.41.1 + `@grammyjs/runner` + `@grammyjs/transformer-throttler`
+- Auth: Bot token (raw token configured in gateway)
+- Config docs: `docs/channels/telegram.md`
+
+**Discord:**
+
+- Extension: `extensions/discord/`
+- SDK: `@buape/carbon` + `discord-api-types` + `@discordjs/voice`
+- Auth: Bot token; guild allowlist via `channels.discord.guilds` config (JSON object, not dotted path)
+- Supports Discord webhooks for delivery (`extensions/discord/src/monitor/reply-delivery.ts`)
+- Config docs: `docs/channels/discord.md`
+
+**Slack:**
+
+- Extension: `extensions/slack/`
+- SDK: `@slack/bolt` + `@slack/web-api`
+- Auth: Bot token + signing secret
+- Config docs: `docs/channels/slack.md`
+
+**WhatsApp (Web):**
+
+- Extension: `extensions/whatsapp/`
+- SDK: `@whiskeysockets/baileys` (native build required)
+- Auth: QR code scan (WhatsApp Web protocol, no official API)
+- Config docs: `docs/channels/whatsapp.md`
+
+**Matrix:**
+
+- Extension: `extensions/matrix/`
+- SDK: `matrix-js-sdk` 41.2.0 + `@matrix-org/matrix-sdk-crypto-nodejs` (native build)
+- Auth: Access token or password (homeserver URL + credentials)
+- Config docs: `docs/channels/matrix.md`
+
+**Signal:**
+
+- Extension: `extensions/signal/`
+- Auth: Signal account (via signal-cli bridge)
+- Config docs: `docs/channels/signal.md`
+
+**Microsoft Teams:**
+
+- Extension: `extensions/msteams/`
+- Auth: Azure AD bot credentials
+- Config docs: `docs/channels/msteams.md` (if present)
+
+**LINE:**
+
+- SDK: `@line/bot-sdk` ^10.6.0 (core dependency)
+- Extension: `extensions/line/`
+
+**Zalo / ZaloUser:**
+
+- Extensions: `extensions/zalo/`, `extensions/zalouser/`
+
+**Feishu:**
+
+- Extension: `extensions/feishu/`
+
+**Mattermost:**
+
+- Extension: `extensions/mattermost/`
+
+**Twitch:**
+
+- Extension: `extensions/twitch/`
+
+**IRC:**
+
+- Extension: `extensions/irc/`
+
+**Nostr:**
+
+- Extension: `extensions/nostr/`
+
+**Google Chat:**
+
+- Extension: `extensions/googlechat/`
+
+**Nextcloud Talk:**
+
+- Extension: `extensions/nextcloud-talk/`
+
+**Synology Chat:**
+
+- Extension: `extensions/synology-chat/`
+
+**Tlon:**
+
+- Extension: `extensions/tlon/`
+- SDK: `@tloncorp/api` + `@tloncorp/tlon-skill` (native build)
+
+**iMessage (via BlueBubbles):**
+
+- Extension: `extensions/bluebubbles/`
+- Plugin SDK seams: `src/plugin-sdk/bluebubbles.ts`, `src/plugin-sdk/bluebubbles-policy.ts`
+- Config docs: `docs/channels/imessage.md`
+
+**iMessage (macOS native):**
+
+- Core source: `src/imessage/`
+- Requires macOS + Messages app access
+
+**Voice Call:**
+
+- Extension: `extensions/voice-call/`
+
+**Phone Control:**
+
+- Extension: `extensions/phone-control/`
+
+**Web (WebSocket):**
+
+- Core source: `src/web/`, `src/channel-web.ts`
+- Control UI served via gateway HTTP server; clients connect over WebSocket
+
+## Data Storage
+
+**Databases:**
+
+- SQLite (Node.js built-in `node:sqlite`) - Memory search storage (`extensions/memory-core/src/memory/`)
+  - Vector extension: `sqlite-vec` 0.1.7 for similarity queries
+  - Config: `agents.defaults.memorySearch.local.vector.enabled` + optional `extensionPath`
+- LanceDB (`@lancedb/lancedb` ^0.27.1) - Optional vector store (`extensions/memory-lancedb/`)
+  - For long-term memory with auto-recall/capture
+
+**File Storage:**
+
+- Local filesystem only
+- Config: `~/.openclaw/openclaw.json`
+- Credentials: `~/.openclaw/credentials/`
+- Sessions: `~/.openclaw/agents/<agentId>/sessions/*.jsonl`
+- Logs: `/tmp/openclaw/openclaw-YYYY-MM-DD.log` (structured), `/tmp/openclaw-gateway.log` (stdout)
+
+**Caching:**
+
+- In-memory only (no external cache service)
+
+## Authentication & Identity
+
+**Auth Provider:**
+
+- Custom (no third-party auth service)
+- API key authentication for the local gateway: `OPENCLAW_API_KEY` env var
+- Provider-specific keys stored as SecretRef in config
+- Credentials stored at `~/.openclaw/credentials/` (web provider login)
+- Device pairing uses QR codes (`src/pairing/`, `qrcode-terminal`)
+
+## Search & Web Tools
+
+**Web Search:**
+
+- Brave Search: `extensions/brave/` - Auth: `BRAVE_API_KEY`
+- Exa: `extensions/exa/` - Auth: `EXA_API_KEY`
+- Tavily: `extensions/tavily/` - Auth: `TAVILY_API_KEY`
+- Firecrawl: `extensions/firecrawl/` - Auth: `FIRECRAWL_API_KEY`
+- DuckDuckGo: `extensions/duckduckgo/` (no API key)
+- Perplexity: `extensions/perplexity/`
+- Linq: `extensions/linq/`
+
+**Browser Automation:**
+
+- Playwright Core: `playwright-core` 1.58.2 (`extensions/browser/src/browser/`)
+- Used for web scraping, screenshot capture, page interaction
+
+## Monitoring & Observability
+
+**Error Tracking:**
+
+- None (no external error tracking service detected)
+
+**OpenTelemetry (optional plugin):**
+
+- Extension: `extensions/diagnostics-otel/`
+- SDKs: `@opentelemetry/sdk-node`, `@opentelemetry/exporter-trace-otlp-proto`, `@opentelemetry/exporter-logs-otlp-proto`, `@opentelemetry/exporter-metrics-otlp-proto`
+- Export endpoint: configurable via env (standard OTLP endpoint)
+
+**Logs:**
+
+- Structured file logging via `tslog` (`src/logging/logger.ts`)
+- Log files: `/tmp/openclaw/openclaw-YYYY-MM-DD.log`
+- macOS unified logs: query via `scripts/clawlog.sh`
+- Gateway stdout/stderr: `/tmp/openclaw-gateway.log`
+
+## Network & Discovery
+
+**Tailscale:**
+
+- Used for gateway network discovery and remote access
+- Integration: `src/infra/tailscale.ts`, `src/shared/tailscale-status.ts`
+- No SDK; invokes `tailscale status` CLI and parses JSON output
+
+**Bonjour/mDNS (local network discovery):**
+
+- SDK: `@homebridge/ciao` ^1.3.5
+- Used for local gateway discovery (`src/infra/bonjour-discovery.ts`, `src/infra/bonjour-ciao.ts`)
+
+**SSRF Protection:**
+
+- Custom SSRF guard via `undici` (`src/infra/net/ssrf.ts`, `src/infra/net/fetch-guard.ts`)
+
+## Protocol Standards
+
+**MCP (Model Context Protocol):**
+
+- SDK: `@modelcontextprotocol/sdk` 1.28.0
+- Server and client support (`src/mcp/`)
+- MCP channels: Docker test in `scripts/e2e/mcp-channels-docker.sh`
+
+**ACP (Agent Client Protocol):**
+
+- SDK: `@agentclientprotocol/sdk` 0.17.0
+- Server: `src/acp/server.startup.ts`
+
+## CI/CD & Deployment
+
+**Hosting:**
+
+- Local gateway (self-hosted); no cloud hosting requirement for core
+- macOS: launchctl LaunchAgent `com.openclaw.gateway`
+- Linux: direct process (no systemd user session on tested Ubuntu snapshot)
+- Cloud example: Fly.io (`flawd-bot` app, managed separately)
+
+**CI Pipeline:**
+
+- GitHub Actions (`.github/workflows/`)
+- Trusted publishing for npm (no `NPM_TOKEN` for core)
+- Docker-based E2E tests: `scripts/e2e/*.sh`
+- Parallels VM smoke tests: macOS, Windows, Linux (`scripts/e2e/parallels-*.sh`)
+
+**Deployment Targets:**
+
+- npm package: `openclaw` (CLI + gateway)
+- macOS app: `.app` bundle via `scripts/package-mac-app.sh`
+- iOS: via Xcode / `scripts/ios-beta-release.sh`
+- Android: Gradle AAB via `apps/android/scripts/build-release-aab.ts`
+
+## Webhooks & Callbacks
+
+**Incoming (gateway HTTP endpoints):**
+
+- Telegram: optional webhook mode (port configurable; `extensions/telegram/src/channel.ts`)
+- Discord: webhook delivery for replies (`extensions/discord/src/monitor/reply-delivery.ts`)
+- Gateway WebSocket: clients connect to gateway for control UI and CLI bridge
+- Plugin HTTP handlers registered via Plugin SDK (`src/plugins/` loader enforces no-raw-register policy per `pnpm lint:plugins:no-register-http-handler`)
+
+**Outgoing:**
+
+- AI provider API calls (all providers)
+- Channel API calls (Telegram Bot API, Discord API, Slack API, etc.)
+- Webhook delivery for Discord replies
+
+## Environment Configuration
+
+**Required env vars (by use case):**
+
+- Gateway auth: `OPENCLAW_API_KEY`
+- AI providers: per-provider key (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`)
+- Messaging channels: tokens set during `openclaw onboard` (stored in config, not env)
+- GCP/Vertex: `GOOGLE_APPLICATION_CREDENTIALS` (service account JSON path) or ADC
+
+**Secrets location:**
+
+- `~/.openclaw/openclaw.json` (SecretRef entries pointing to env vars or literal values)
+- `~/.openclaw/credentials/` (OAuth tokens from `openclaw login`)
+- Never committed; strict JSON format validated at startup
+
+---
+
+_Integration audit: 2026-03-28_

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,147 @@
+# Technology Stack
+
+**Analysis Date:** 2026-03-28
+
+## Languages
+
+**Primary:**
+
+- TypeScript (ESM) - All core source code under `src/`, extensions under `extensions/`, packages under `packages/`
+- JavaScript (ESM) - Build and utility scripts under `scripts/`, entry point `openclaw.mjs`
+
+**Secondary:**
+
+- Swift - macOS app (`apps/macos/`), iOS app (`apps/ios/`), shared kit (`apps/shared/OpenClawKit/`)
+- Kotlin - Android app (`apps/android/`)
+
+## Runtime
+
+**Environment:**
+
+- Node.js >= 22.14.0 (required; keeps Node + Bun paths working)
+- Bun (preferred for TypeScript execution in dev, scripts, and tests; `bun <file.ts>`)
+
+**Package Manager:**
+
+- pnpm (workspace monorepo)
+- Lockfile: `pnpm-lock.yaml` present
+- Bun also supported; both lockfile/patching must stay in sync when touching deps
+
+## Frameworks
+
+**Core:**
+
+- `commander` ^14.0.3 - CLI argument parsing (`src/cli/`)
+- `express` ^5.2.1 - HTTP server used in media pipeline (`src/media/server.ts`)
+- `hono` 4.12.9 (pinned override) - Web framework (used in web provider and control UI)
+- `ws` ^8.20.0 - WebSocket server/client for gateway protocol (`src/gateway/`)
+- `zod` ^4.3.6 - Config schema validation (`src/config/zod-schema.*.ts`)
+- `@sinclair/typebox` 0.34.48 (pinned override) - Tool input schema definitions
+
+**Testing:**
+
+- `vitest` ^4.1.2 - Test runner (multiple configs: `vitest.unit.config.ts`, `vitest.gateway.config.ts`, `vitest.e2e.config.ts`, `vitest.channels.config.ts`, `vitest.extensions.config.ts`, `vitest.live.config.ts`, `vitest.contracts.config.ts`)
+- `@vitest/coverage-v8` ^4.1.2 - V8 coverage provider
+
+**Build/Dev:**
+
+- `tsdown` 0.21.7 (devDep) - TypeScript bundler, invoked via `scripts/tsdown-build.mjs`
+- `tsx` ^4.21.0 - TypeScript execution for scripts (`node --import tsx`)
+- `typescript` ^6.0.2 - Type checking (`pnpm tsgo` uses `@typescript/native-preview`)
+- `@typescript/native-preview` 7.0.0-dev.20260326.1 - Fast type check (`pnpm tsgo`)
+- `jiti` ^2.4.2 - Runtime module resolution alias for `openclaw/plugin-sdk` in plugin installs
+
+**Linting/Formatting:**
+
+- `oxlint` ^1.57.0 - Linting (`pnpm lint`)
+- `oxfmt` 0.42.0 - Formatting (`pnpm format`)
+- `oxlint-tsgolint` ^0.17.4 - TypeScript-specific lint rules
+
+**UI:**
+
+- `lit` ^3.3.2 + `@lit/context` + `@lit-labs/signals` - Web component UI (`ui/`)
+- `signal-utils` 0.21.1 - Signal utilities for reactive UI
+
+## Key Dependencies
+
+**Critical:**
+
+- `@modelcontextprotocol/sdk` 1.28.0 - MCP server/client integration (`src/mcp/`)
+- `@agentclientprotocol/sdk` 0.17.0 - ACP server integration (`src/acp/`)
+- `@mariozechner/pi-agent-core`, `pi-ai`, `pi-coding-agent`, `pi-tui` 0.63.1 - Embedded agent runtime (`src/agents/pi-embedded-runner/`)
+- `matrix-js-sdk` 41.2.0 - Matrix protocol support (core + `extensions/matrix/`)
+- `grammy` ^1.41.1 - Telegram Bot API client (`extensions/telegram/`)
+- `@whiskeysockets/baileys` - WhatsApp Web protocol (`extensions/whatsapp/`)
+- `@slack/bolt` + `@slack/web-api` - Slack API (`extensions/slack/`)
+- `@buape/carbon` + `discord-api-types` - Discord API (`extensions/discord/`)
+- `@line/bot-sdk` ^10.6.0 - LINE messaging API (core dependency)
+
+**Infrastructure:**
+
+- `undici` ^7.24.6 - HTTP fetch with SSRF protection (`src/infra/net/`)
+- `@homebridge/ciao` ^1.3.5 - Bonjour/mDNS service discovery (`src/infra/bonjour-discovery.ts`)
+- `chokidar` ^5.0.0 - File system watching
+- `croner` ^10.0.1 - Cron job scheduling (`src/cron/schedule.ts`)
+- `sqlite-vec` 0.1.7 - SQLite vector extension for semantic memory search
+- Node.js built-in `node:sqlite` - SQLite database (used in `extensions/memory-core/`)
+- `@lancedb/lancedb` ^0.27.1 - Vector database for long-term memory (`extensions/memory-lancedb/`)
+- `tslog` ^4.10.2 - Structured logging (`src/logging/logger.ts`)
+- `sharp` ^0.34.5 - Image processing
+- `pdfjs-dist` ^5.5.207 - PDF parsing
+- `playwright-core` 1.58.2 - Browser automation (`extensions/browser/`)
+- `@lydell/node-pty` 1.2.0-beta.3 (native build) - PTY/terminal sessions
+- `node-edge-tts` ^1.2.10 - Text-to-speech (Edge TTS)
+- `@mozilla/readability` ^0.6.0 + `linkedom` ^0.18.12 - Web content extraction
+- `markdown-it` ^14.1.1 - Markdown rendering
+- `jszip` ^3.10.1 - ZIP file handling
+- `yaml` ^2.7.0 - YAML config parsing
+- `json5` ^2.2.3 - JSON5 config file support
+- `uuid` ^13.0.0 - UUID generation
+- `ajv` ^8.18.0 - JSON schema validation
+- `qrcode-terminal` ^0.12.0 - QR code display for device pairing
+- `dotenv` ^17.3.1 - Environment variable loading
+
+**AI Provider SDKs:**
+
+- `@anthropic-ai/vertex-sdk` ^0.14.4 - Anthropic on Google Vertex AI (`src/agents/anthropic-vertex-stream.ts`)
+- `@aws-sdk/client-bedrock` ^3.1019.0 - AWS Bedrock (`extensions/amazon-bedrock/`)
+- `openai` ^6.33.0 (in `extensions/memory-lancedb/` and `extensions/openai/`) - OpenAI API client
+
+## Configuration
+
+**Environment:**
+
+- Config file: `~/.openclaw/openclaw.json` (strict JSON, validated by Zod schema)
+- Environment variables for API keys (see provider env vars in `src/plugins/bundled-provider-auth-env-vars.generated.ts`)
+- Credentials stored at `~/.openclaw/credentials/` (web provider login)
+- Sessions stored at `~/.openclaw/sessions/` (Pi agent sessions)
+- `.env` files loaded via `dotenv`
+
+**Build:**
+
+- `tsconfig.json` - TypeScript compiler options (module: NodeNext, target: es2023, strict mode)
+- `tsconfig.plugin-sdk.dts.json` - Plugin SDK declaration file generation
+- `scripts/tsdown-build.mjs` - Main build driver
+- `scripts/runtime-postbuild.mjs` - Post-build runtime fixups
+- Output: `dist/`
+
+## Platform Requirements
+
+**Development:**
+
+- Node.js >= 22.14.0
+- pnpm (workspace install: `pnpm install`)
+- Bun (preferred for TypeScript execution and test runs)
+- Pre-commit hooks: `prek install`
+
+**Production:**
+
+- Node.js >= 22.14.0 (for running `dist/`)
+- macOS app: built via `scripts/package-mac-app.sh` (requires Xcode + SwiftFormat)
+- iOS: Xcode + xcodegen (`scripts/ios-configure-signing.sh`)
+- Android: Gradle (`apps/android/`)
+- Deployment: Gateway runs as local process (macOS: launchctl `com.openclaw.gateway`); no external cloud requirement
+
+---
+
+_Stack analysis: 2026-03-28_

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,414 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-03-28
+
+## Directory Layout
+
+```
+openclaw/                          # Repo root
+├── src/                           # Core TypeScript source (CLI + gateway)
+│   ├── entry.ts                   # CLI process entry point (fast-path, respawn, profile)
+│   ├── index.ts                   # Library entry point
+│   ├── runtime.ts                 # Core runtime bootstrap
+│   ├── library.ts                 # Public library surface
+│   ├── cli/                       # CLI wiring: argument parsing, option handling, sub-commands
+│   ├── commands/                  # Command implementations (agent, send, models, config, etc.)
+│   ├── agents/                    # AI agent core: model selection, session, tools, providers
+│   ├── channels/                  # Channel abstractions: routing, allowlists, session meta
+│   ├── gateway/                   # Gateway server: HTTP, WebSocket, auth, sessions
+│   ├── config/                    # Config schema (zod), IO, migrations, validation
+│   ├── infra/                     # Infrastructure: filesystem, networking, OS utilities
+│   ├── media/                     # Media pipeline: audio, image, video, ffmpeg
+│   ├── terminal/                  # Terminal UI: palette, table, progress, ANSI
+│   ├── tui/                       # Interactive TUI (chat interface)
+│   ├── plugin-sdk/                # Plugin SDK public surface and runtime API
+│   ├── extensions/                # Core extension implementations (loaded via plugin-sdk)
+│   ├── routing/                   # Message routing logic (account lookup, session key)
+│   ├── sessions/                  # Session lifecycle events and identifiers
+│   ├── security/                  # Security audit, path checks, tool policy
+│   ├── secrets/                   # Secret resolution, ref system, credential store
+│   ├── hooks/                     # Hook system: install, fire-and-forget, Gmail watcher
+│   ├── flows/                     # Onboarding/setup flows (channel setup, doctor)
+│   ├── interactive/               # Interactive prompts (clack-prompter wrapper)
+│   ├── wizard/                    # Setup wizard state machine
+│   ├── pairing/                   # Device pairing: challenge, store, messages
+│   ├── process/                   # Child process management: exec, kill-tree, command queue
+│   ├── acp/                       # ACP (agent control protocol) client
+│   ├── canvas-host/               # Canvas/A2UI host server and file resolver
+│   ├── mcp/                       # MCP channel server bridge
+│   ├── tts/                       # Text-to-speech providers and runtime
+│   ├── image-generation/          # Image generation provider registry
+│   ├── web-search/                # Web search provider registry
+│   ├── context-engine/            # Context injection engine
+│   ├── link-understanding/        # URL/link content extraction
+│   ├── markdown/                  # Markdown rendering utilities
+│   ├── polls/                     # Poll parameter handling
+│   ├── shared/                    # Shared types/utilities used by both core and extensions
+│   ├── types/                     # TypeScript ambient type declarations (*.d.ts)
+│   └── utils/                     # Small pure utility functions
+├── extensions/                    # Plugin workspace packages (one dir per plugin)
+│   ├── openai/                    # OpenAI provider plugin (@openclaw/openai-provider)
+│   ├── anthropic/                 # Anthropic provider plugin
+│   ├── telegram/                  # Telegram channel plugin
+│   ├── discord/                   # Discord channel plugin
+│   ├── slack/                     # Slack channel plugin
+│   ├── signal/                    # Signal channel plugin
+│   ├── matrix/                    # Matrix channel plugin
+│   ├── msteams/                   # Microsoft Teams channel plugin
+│   ├── whatsapp/                  # WhatsApp channel plugin
+│   ├── voice-call/                # Voice call channel plugin
+│   ├── browser/                   # Browser tool plugin
+│   ├── memory-core/               # Memory core engine plugin
+│   ├── memory-lancedb/            # LanceDB memory backend plugin
+│   ├── shared/                    # Shared code imported by multiple extensions
+│   └── ...                        # ~80 total extension packages
+├── apps/                          # Native app workspaces
+│   ├── ios/                       # iOS app (Swift/SwiftUI)
+│   │   └── Sources/               # Feature directories: Chat, Gateway, Onboarding, Settings, etc.
+│   ├── android/                   # Android app (Kotlin/Jetpack Compose)
+│   │   └── app/src/main/java/ai/openclaw/app/
+│   └── macos/                     # macOS app (Swift/SwiftUI)
+│       └── Sources/               # OpenClaw, OpenClawDiscovery, OpenClawIPC, OpenClawMacCLI, OpenClawProtocol
+├── packages/                      # Internal pnpm workspace utility packages
+│   ├── clawdbot/                  # Clawdbot package
+│   ├── memory-host-sdk/           # Memory host SDK
+│   └── moltbot/                   # Moltbot package
+├── ui/                            # Web control UI (Vite + React)
+│   └── src/                       # Frontend source
+├── skills/                        # Bundled skills (Markdown prompt files, ~50+ skills)
+├── test/                          # Cross-cutting test infrastructure
+│   ├── helpers/                   # Shared test helpers (temp-home, gateway harness, etc.)
+│   ├── mocks/                     # Shared mock implementations
+│   ├── fixtures/                  # Test fixtures (JSON contracts, plugin inventories)
+│   ├── scripts/                   # Test-only scripts
+│   └── *.test.ts                  # Top-level integration and architecture tests
+├── test-fixtures/                 # Static fixture data for tests
+├── docs/                          # Documentation (Mintlify, served at docs.openclaw.ai)
+├── scripts/                       # Build, release, check, and maintenance scripts
+├── .agents/                       # Agent skills (maintainer workflows)
+├── .github/                       # CI workflows, issue templates, labeler config
+├── .planning/                     # GSD planning documents (codebase maps, phase plans)
+├── dist/                          # Build output (compiled JS, generated; not edited)
+├── dist-runtime/                  # Runtime-only build output
+├── vendor/                        # Vendored source code
+├── patches/                       # pnpm patches for dependencies
+├── openclaw.mjs                   # CLI wrapper/launcher script
+├── tsdown.config.ts               # Build config (tsdown/rollup)
+├── tsconfig.json                  # TypeScript base config
+├── package.json                   # Root package manifest + scripts
+├── pnpm-workspace.yaml            # pnpm workspace definition
+└── vitest.config.ts               # Primary Vitest config
+```
+
+## Directory Purposes
+
+**`src/cli/`:**
+
+- Purpose: CLI argument parsing, command registration, option handling, banners, and program wiring
+- Contains: `program.ts` (root CLI program), per-command `*-cli.ts` files, config/plugins/secrets/models CLI modules
+- Key files: `src/cli/program.ts`, `src/cli/run-main.ts`, `src/cli/progress.ts`, `src/cli/banner.ts`
+- Depends on: `src/commands/`, `src/gateway/`, `src/config/`, `src/infra/`
+
+**`src/commands/`:**
+
+- Purpose: Business logic for each CLI command (agent, message, models, skills, cron, webhooks, etc.)
+- Contains: Command handler implementations, command-specific types and utilities
+- Key files: `src/commands/agent.ts`, `src/commands/agents.ts`, `src/commands/agent-via-gateway.ts`
+- Note: Commands follow dependency injection via `createDefaultDeps` pattern
+
+**`src/agents/`:**
+
+- Purpose: AI agent core — model config, session lifecycle, tool execution, provider management, memory
+- Contains: `pi-embedded-runner.ts` (agent session runner), `model-catalog.ts`, `pi-tools.ts`, skill loading, subagent registry, auth profiles
+- Key files: `src/agents/pi-embedded-runner.ts`, `src/agents/model-selection.ts`, `src/agents/openclaw-tools.ts`
+
+**`src/gateway/`:**
+
+- Purpose: Gateway server — HTTP/WS server, channel management, auth, session control, config reload
+- Contains: `server.ts` (main server), `server-http.ts`, `server-ws-runtime.ts`, `server-channels.ts`, credential management, probe endpoints
+- Key files: `src/gateway/server.ts`, `src/gateway/server-startup.ts`, `src/gateway/credentials.ts`
+
+**`src/config/`:**
+
+- Purpose: Config schema definition (zod), IO, validation, legacy migrations, channel-specific type blocks
+- Contains: `schema.ts`, `config.ts`, `io.ts`, `zod-schema.ts`, `legacy-migrate.ts`, per-channel `types.*.ts` files
+- Key files: `src/config/schema.ts`, `src/config/config.ts`, `src/config/io.ts`
+
+**`src/infra/`:**
+
+- Purpose: Infrastructure layer — filesystem, networking, process management, OS detection, update checks
+- Contains: Utilities for paths, ports, SSH, bonjour discovery, system presence, tailscale, restart logic
+- Key files: `src/infra/env.ts`, `src/infra/fs-safe.ts`, `src/infra/ports.ts`, `src/infra/gateway-processes.ts`
+
+**`src/media/`:**
+
+- Purpose: Media pipeline — image processing, audio handling, ffmpeg execution, file context
+- Contains: `src/media/ffmpeg-exec.ts`, `src/media/audio.ts`, `src/media/image-ops.ts`, inbound path policy
+- Key files: `src/media/ffmpeg-exec.ts`, `src/media/host.ts`
+
+**`src/terminal/`:**
+
+- Purpose: Terminal output utilities — shared palette (never hardcode colors), ANSI helpers, table renderer, progress bars
+- Contains: `palette.ts`, `table.ts`, `progress-line.ts`, `stream-writer.ts`, `safe-text.ts`, `links.ts`
+- Key files: `src/terminal/palette.ts` (use for all TTY colors), `src/terminal/table.ts`
+
+**`src/plugin-sdk/`:**
+
+- Purpose: Plugin SDK public surface — APIs available to extension plugins and external developers
+- Contains: `index.ts` (main SDK export), per-feature runtime modules (`channel-runtime.ts`, `provider-runtime.ts`, etc.)
+- Key files: `src/plugin-sdk/index.ts`, `src/plugin-sdk/channel-contract.ts`, `src/plugin-sdk/provider-entry.ts`
+- Note: Extensions import from `openclaw/plugin-sdk`; this resolves via jiti alias at runtime
+
+**`src/extensions/`:**
+
+- Purpose: Core extension implementations that ship with openclaw (not standalone packages)
+- Contains: Channel/provider implementations loaded via plugin-sdk (`discord.ts`, `telegram.ts`, `openai.ts`, etc.)
+- Note: Distinguished from `extensions/` workspace packages which are full npm packages
+
+**`src/channels/`:**
+
+- Purpose: Channel-agnostic abstractions — allowlists, account resolution, run state machine, typing, command gating
+- Contains: `run-state-machine.ts`, `allowlists/`, `targets.ts`, `session.ts`, `command-gating.ts`
+- Key files: `src/channels/run-state-machine.ts`, `src/channels/registry.ts`
+
+**`src/shared/`:**
+
+- Purpose: Types and utilities shared by core and extension code across architectural layers
+- Contains: Device auth store, chat content types, node resolution, gateway bind URL, usage aggregates
+- Key files: `src/shared/chat-envelope.ts`, `src/shared/device-auth-store.ts`
+
+**`src/security/`:**
+
+- Purpose: Security auditing, path validation, tool policy, dangerous config detection
+- Contains: `audit.ts`, `scan-paths.ts`, `dangerous-tools.ts`, `skill-scanner.ts`, `safe-regex.ts`
+
+**`src/secrets/`:**
+
+- Purpose: Secret resolution — ref system, credential matrix, config IO, provider env vars
+- Contains: `resolve.ts`, `plan.ts`, `configure.ts`, `runtime.ts`, `ref-contract.ts`
+
+**`extensions/` (workspace packages):**
+
+- Purpose: Standalone publishable plugin packages (LLM providers, messaging channels, tools)
+- Structure: Each directory is a pnpm workspace package with its own `package.json` + `openclaw.plugin.json`
+- Key files: `extensions/<name>/index.ts` (plugin entry), `extensions/<name>/package.json`
+- Convention: Plugin entry declared in `openclaw.extensions` array in `package.json`
+
+**`ui/`:**
+
+- Purpose: Web control UI served by the gateway (Vite + React)
+- Contains: `ui/src/` (React components), `ui/vite.config.ts`, `ui/package.json`
+- Key files: `ui/src/`, `ui/index.html`
+
+**`test/`:**
+
+- Purpose: Cross-cutting test infrastructure — harnesses, mocks, and integration tests not owned by one module
+- Contains: `test/helpers/` (shared helpers), `test/mocks/` (shared mocks), `test/fixtures/` (JSON contracts)
+- Key files: `test/helpers/gateway-e2e-harness.ts`, `test/helpers/temp-home.ts`, `test/global-setup.ts`
+
+**`skills/`:**
+
+- Purpose: Bundled Markdown skill files shipped with openclaw (available without Clawhub)
+- Contains: One directory per skill with Markdown prompt files
+- Examples: `skills/github/`, `skills/coding-agent/`, `skills/ffmpeg/`
+
+**`scripts/`:**
+
+- Purpose: Build, release, lint boundary checks, and maintenance shell scripts / TypeScript scripts
+- Contains: Architecture smell checks, plugin SDK boundary validators, release scripts, committer helper
+- Key files: `scripts/committer`, `scripts/release-check.ts`, `scripts/check-architecture-smells.mjs`
+
+## Key File Locations
+
+**Entry Points:**
+
+- `src/entry.ts`: CLI process entry (spawned by `openclaw.mjs` wrapper)
+- `src/index.ts`: Library entry (for SDK consumers)
+- `src/runtime.ts`: Core runtime module bootstrap
+- `src/gateway/server.ts`: Gateway HTTP/WS server
+
+**Configuration:**
+
+- `src/config/schema.ts`: Zod config schema (canonical config structure)
+- `src/config/config.ts`: Config loading and access
+- `src/config/io.ts`: Config file read/write
+- `tsconfig.json`: TypeScript base configuration
+- `tsdown.config.ts`: Build configuration (produces `dist/`)
+- `vitest.config.ts`: Primary unit test config
+
+**Core Logic:**
+
+- `src/agents/pi-embedded-runner.ts`: Agent session runner (the main agent loop)
+- `src/agents/model-selection.ts`: Model selection and routing
+- `src/agents/models-config.ts`: Model/provider configuration merging
+- `src/agents/skills.ts`: Skill loading and workspace snapshot
+- `src/channels/run-state-machine.ts`: Channel message run state machine
+- `src/routing/resolve-route.ts`: Message routing resolution
+- `src/gateway/server-startup.ts`: Gateway startup sequence
+
+**Shared Utilities:**
+
+- `src/terminal/palette.ts`: Color palette — use for all TTY output colors
+- `src/terminal/table.ts`: Table renderer for status output
+- `src/cli/progress.ts`: Progress bars and spinners (osc-progress + @clack/prompts)
+- `src/infra/env.ts`: Environment variable utilities
+- `src/infra/fs-safe.ts`: Safe filesystem operations
+
+**Testing:**
+
+- `test/helpers/gateway-e2e-harness.ts`: Full gateway E2E test harness
+- `test/helpers/temp-home.ts`: Temporary home directory for isolated tests
+- `test/global-setup.ts`: Global Vitest setup
+- `test/setup.ts`: Per-file Vitest setup
+
+## Naming Conventions
+
+**Files:**
+
+- `kebab-case` throughout: `model-selection.ts`, `gateway-processes.ts`
+- Tests co-located with source: `model-selection.test.ts` next to `model-selection.ts`
+- E2E tests: `*.e2e.test.ts`
+- Live (real API) tests: `*.live.test.ts`
+- Runtime-only modules (lazy loading boundary): `*.runtime.ts`
+- Test helpers shared within a module: `*.test-helpers.ts` or `test-helpers.ts`
+- Contract tests: `*.contract.test.ts`
+- Coverage-focused tests: `*.coverage.test.ts`
+
+**Multi-file modules:**
+
+- Dot-separated namespacing: `pi-embedded-subscribe.handlers.tools.ts`
+- Shared types split out: `server-methods.ts` + `server-methods-list.ts`
+- Config types per channel: `src/config/types.discord.ts`, `src/config/types.telegram.ts`
+
+**Directories:**
+
+- `kebab-case` for all directories
+- Feature domains get their own directory when they contain 3+ files
+- Channel-specific code under `src/channels/` (core) or `extensions/<channel>/` (plugins)
+
+**Exports:**
+
+- Named exports preferred over default exports
+- Barrel files (`index.ts`) used at package boundaries, not within deep module trees
+
+## Where to Add New Code
+
+**New CLI command:**
+
+- Implement: `src/cli/<command>-cli.ts`
+- Business logic: `src/commands/<command>.ts`
+- Register in: `src/cli/program.ts` (or the relevant sub-program)
+- Tests: `src/cli/<command>-cli.test.ts` and `src/commands/<command>.test.ts`
+
+**New channel (core):**
+
+- Implementation: `src/extensions/<channel>.ts` + supporting files
+- Config types: `src/config/types.<channel>.ts`
+- Config schema: add to `src/config/zod-schema.channels.ts`
+- Plugin SDK registration: `src/plugin-sdk/<channel>-surface.ts` (if needed)
+- Documentation: `docs/channels/<channel>.md`
+- Update: `src/channels/channels-misc.test.ts`, `.github/labeler.yml`
+
+**New channel (extension plugin):**
+
+- Create workspace package: `extensions/<channel>/`
+- Entry: `extensions/<channel>/index.ts`
+- Manifest: `extensions/<channel>/package.json` with `openclaw.extensions` array
+- Tests: `extensions/<channel>/*.test.ts`
+
+**New LLM provider:**
+
+- Extension package: `extensions/<provider>/`
+- Entry: `extensions/<provider>/index.ts` (implement `ProviderPlugin`)
+- Models: `extensions/<provider>/default-models.ts` or inline
+- Config types: `src/config/types.models.ts` or extend provider schema
+- Tests: include contract tests (`provider.contract.test.ts`)
+
+**New agent tool:**
+
+- Core tool: `src/agents/openclaw-tools.ts` or new `src/agents/<tool-name>.ts`
+- Tool schema: `src/agents/schema/<tool>.ts`
+- Tests: `src/agents/openclaw-tools.<tool-name>.test.ts`
+
+**New infra utility:**
+
+- Small utility: `src/infra/<utility>.ts` + `src/infra/<utility>.test.ts`
+- If shared with extensions: `src/shared/<utility>.ts`
+
+**New skill:**
+
+- Directory: `skills/<skill-name>/`
+- Entry: `skills/<skill-name>/README.md` (Markdown prompt)
+
+**New config key:**
+
+- Schema: `src/config/schema.ts` and corresponding `src/config/zod-schema.ts`
+- Types: `src/config/types.ts` (or channel-specific `types.<channel>.ts`)
+- Defaults: `src/config/defaults.ts`
+- Migration: `src/config/legacy-migrate.ts` if replacing old key
+
+**New terminal UI element:**
+
+- Color: use existing token from `src/terminal/palette.ts`; do not hardcode ANSI codes
+- Tables: use `src/terminal/table.ts`
+- Progress/spinners: use `src/cli/progress.ts`
+
+## Special Directories
+
+**`dist/`:**
+
+- Purpose: Compiled JavaScript output from `pnpm build`
+- Generated: Yes (tsdown/rollup)
+- Committed: No (gitignored)
+
+**`dist-runtime/`:**
+
+- Purpose: Runtime-only build subset
+- Generated: Yes
+- Committed: No
+
+**`node_modules/`:**
+
+- Purpose: pnpm-installed dependencies
+- Generated: Yes
+- Committed: No
+
+**`.planning/`:**
+
+- Purpose: GSD planning documents (codebase maps, phase plans)
+- Generated: By GSD tooling
+- Committed: Yes (used for AI-assisted development)
+
+**`src/generated/`:**
+
+- Purpose: Auto-generated TypeScript files (channel config metadata, etc.)
+- Key file: `src/config/bundled-channel-config-metadata.generated.ts`
+- Committed: Yes (checked in, regenerated by scripts)
+
+**`src/canvas-host/a2ui/`:**
+
+- Purpose: Bundled A2UI canvas application
+- Key file: `src/canvas-host/a2ui/.bundle.hash`
+- Regenerate: `pnpm canvas:a2ui:bundle` — commit hash as separate commit; never edit bundle directly
+
+**`docs/zh-CN/`:**
+
+- Purpose: Auto-generated Chinese i18n docs
+- Generated: Yes, by `scripts/docs-i18n`
+- Committed: Yes
+- Note: Do not edit manually; update English docs and rerun pipeline
+
+**`test-fixtures/`:**
+
+- Purpose: Static JSON and data fixtures for tests
+- Committed: Yes
+
+**`patches/`:**
+
+- Purpose: pnpm patches for dependencies requiring local modifications
+- Committed: Yes
+- Note: Patched dependencies must use exact versions (no `^`/`~`); changes require explicit approval
+
+---
+
+_Structure analysis: 2026-03-28_

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,412 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-03-28
+
+## Test Framework
+
+**Runner:**
+
+- Vitest (version from `package.json`)
+- Config: `vitest.config.ts` (base), `vitest.unit.config.ts` (unit), `vitest.e2e.config.ts` (e2e), `vitest.gateway.config.ts`, `vitest.channels.config.ts`, `vitest.live.config.ts`, `vitest.extensions.config.ts`
+- Pool: `forks` (process isolation)
+- Timeout: 120,000ms default; 180,000ms on Windows
+- Workers: CI=3 (2 on Windows), local=resolved via `scripts/test-planner/runtime-profile.mjs`
+- `unstubEnvs: true` and `unstubGlobals: true` — environment/global stubs are automatically restored after each test
+
+**Assertion Library:**
+
+- Vitest built-in `expect`
+
+**Run Commands:**
+
+```bash
+pnpm test                        # Run all tests (parallel planner)
+pnpm test:watch                  # Watch mode (vitest)
+pnpm test:coverage               # Coverage with v8 provider (unit config)
+pnpm test:fast                   # Fast unit run (vitest.unit.config.ts, no planner)
+pnpm test:e2e                    # E2E tests only
+pnpm test:gateway                # Gateway tests only
+pnpm test:channels               # Channel surface tests only
+pnpm test:extensions             # Extension tests only
+pnpm test:live                   # Live tests (real API keys required)
+pnpm test -- <filter> [args]     # Targeted run (use this, not raw vitest)
+```
+
+**Running a targeted test:**
+
+```bash
+pnpm test -- src/pairing/pairing-store.test.ts
+pnpm test -- src/polls.test.ts -t "clamps poll duration"
+```
+
+## Test File Organization
+
+**Location:**
+
+- Unit tests: co-located with source file as `<source-name>.test.ts`
+  - `src/utils.ts` → `src/utils.test.ts`
+  - `src/pairing/pairing-store.ts` → `src/pairing/pairing-store.test.ts`
+- E2E tests: co-located, named `<name>.e2e.test.ts`
+  - `src/agents/subagent-announce.format.e2e.test.ts`
+  - `src/plugins/wired-hooks-after-tool-call.e2e.test.ts`
+- Live tests (real API keys): `<name>.live.test.ts`
+  - `src/agents/anthropic.setup-token.live.test.ts`
+  - `src/image-generation/runtime.live.test.ts`
+- Cross-cutting/integration tests: `test/` directory
+  - `test/architecture-smells.test.ts`
+  - `test/extension-plugin-sdk-boundary.test.ts`
+  - `test/gateway.multi.e2e.test.ts`
+
+**Naming:**
+
+- Test files match source filename: `<module>.test.ts`
+- Specialization via dot prefix: `pairing-store.test.ts`, `pairing-messages.test.ts`
+- E2E suffix: `*.e2e.test.ts`
+- Live suffix: `*.live.test.ts`
+- Integration E2E: `*.integration.e2e.test.ts`
+
+**Structure:**
+
+```
+src/
+├── pairing/
+│   ├── pairing-store.ts
+│   ├── pairing-store.test.ts       ← co-located unit test
+│   ├── pairing-messages.ts
+│   └── pairing-messages.test.ts    ← separate concern test file
+├── infra/
+│   ├── device-bootstrap.ts
+│   ├── device-bootstrap.test.ts
+│   ├── archive.ts
+│   └── archive-helpers.test.ts
+test/
+├── setup.ts                        ← global setup
+├── test-env.ts                     ← HOME/state isolation helper
+└── architecture-smells.test.ts     ← cross-repo structural tests
+```
+
+## Test Structure
+
+**Suite Organization:**
+
+```typescript
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Top-level describe with module name
+describe("device bootstrap tokens", () => {
+  // Setup helpers defined inside describe
+  const tempDirs = createTrackedTempDirs();
+  const createTempDir = () => tempDirs.make("openclaw-device-bootstrap-test-");
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await tempDirs.cleanup();
+  });
+
+  it("issues bootstrap tokens and persists them with an expiry", async () => {
+    // Arrange: vi.useFakeTimers / vi.setSystemTime for time-sensitive tests
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-14T12:00:00Z"));
+
+    const baseDir = await createTempDir();
+
+    // Act
+    const issued = await issueDeviceBootstrapToken({ baseDir });
+
+    // Assert
+    expect(issued.token).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(issued.expiresAtMs).toBe(Date.now() + DEVICE_BOOTSTRAP_TOKEN_TTL_MS);
+  });
+});
+```
+
+**Patterns:**
+
+- `beforeAll`/`afterAll` for shared expensive setup (e.g., temp directories, fixture roots)
+- `beforeEach`/`afterEach` for per-test state resets (caches, timers, mocks)
+- `vi.useFakeTimers()` + `vi.setSystemTime()` for time-sensitive tests; always `vi.useRealTimers()` in `afterEach`
+- Helper functions defined at describe-scope to reduce repetition: `withTempDir`, `expectResolvedSetupOk`, `expectResolvedRoute`
+- `it.each([...])` for table-driven/parameterized tests (widely used)
+
+## Mocking
+
+**Framework:** Vitest (`vi`)
+
+**Module-level mock (static, hoisted):**
+
+```typescript
+vi.mock("../infra/device-bootstrap.js", () => ({
+  issueDeviceBootstrapToken: vi.fn(async () => ({
+    token: "bootstrap-123",
+    expiresAtMs: 123,
+  })),
+}));
+
+// Access mock for assertions
+const issueDeviceBootstrapTokenMock = vi.mocked(
+  (await import("../infra/device-bootstrap.js")).issueDeviceBootstrapToken,
+);
+```
+
+**Partial module mock (keep real + override):**
+
+```typescript
+import { mergeMockedModule } from "../test-utils/vitest-module-mocks.js";
+
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  return mergeMockedModule(await importOriginal(), (actual) => ({
+    loadSessionStore: vi.fn(),
+  }));
+});
+```
+
+Helper: `src/test-utils/vitest-module-mocks.ts`
+
+**Spy on imported module function:**
+
+```typescript
+const loadSessionStoreSpy = vi.spyOn(configSessions, "loadSessionStore");
+const callGatewaySpy = vi.spyOn(gatewayCall, "callGateway");
+
+// Set implementation
+callGatewaySpy.mockImplementation(async (_req) => ({ runId: "run-main", status: "ok" }));
+```
+
+**Environment variable stubbing:**
+
+```typescript
+vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "");
+vi.stubEnv("OPENCLAW_HOME", "/srv/openclaw-home");
+// Automatically restored after each test (unstubEnvs: true in vitest.config.ts)
+```
+
+**Fake timers:**
+
+```typescript
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(process, "kill").mockImplementation(() => true);
+});
+
+afterEach(async () => {
+  await vi.runOnlyPendingTimersAsync();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// Advance time
+vi.advanceTimersByTime(1000);
+await vi.advanceTimersByTimeAsync(0);
+await vi.runAllTimersAsync();
+```
+
+**What to Mock:**
+
+- External process calls (`callGateway`, `process.kill`, `process.emit`)
+- Filesystem operations when testing logic above I/O layer
+- Module functions that make network calls or spawn processes
+- Time (via fake timers) for TTL/expiry logic
+
+**What NOT to Mock:**
+
+- The module under test itself
+- Pure utility functions with no side effects
+- `node:` built-ins when testing actual I/O behavior (use real temp dirs instead)
+
+## Fixtures and Factories
+
+**Temp Directory Factories:**
+
+```typescript
+// Simple one-off temp dir
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-test-"));
+
+// Tracked temp dirs (preferred for tests with multiple dirs — auto-cleanup)
+const tempDirs = createTrackedTempDirs();
+const createTempDir = () => tempDirs.make("openclaw-device-bootstrap-test-");
+afterEach(async () => {
+  await tempDirs.cleanup();
+});
+```
+
+Helpers: `src/test-utils/tracked-temp-dirs.ts`, `src/test-utils/temp-home.ts`, `src/test-utils/fixture-suite.ts`
+
+**Environment Isolation:**
+
+```typescript
+import { withEnvAsync, withEnv, captureEnv } from "../test-utils/env.js";
+
+await withEnvAsync({ OPENCLAW_STATE_DIR: dir }, async () => {
+  // Test runs with isolated env
+});
+```
+
+Helper: `src/test-utils/env.ts`
+
+**Channel Plugin Stubs (for routing/session tests):**
+
+```typescript
+import { createTestRegistry, createChannelTestPluginBase } from "../test-utils/channel-plugins.js";
+
+const registry = createTestRegistry([
+  { pluginId: "discord", plugin: createStubPlugin({ id: "discord" }), source: "test" },
+]);
+```
+
+Helpers: `src/test-utils/channel-plugins.ts`, `src/test-utils/channel-plugin-test-fixtures.ts`
+
+**Global test registry (from `test/setup.ts`):**
+
+- All tests automatically get a default plugin registry with stubs for: `discord`, `slack`, `telegram`, `whatsapp`, `signal`, `imessage`
+- Registry is reset after each test via `afterEach`
+- Override the registry in specific tests by calling `setActivePluginRegistry(customRegistry)`
+
+**Assertion helpers:**
+
+```typescript
+import { withEnvAsync } from "../test-utils/env.js";
+
+// Custom assertion helpers defined per-test-file
+function expectResolvedSetupOk(resolved: ResolvedSetup, params: { authLabel: string; ... }) {
+  expect(resolved.ok).toBe(true);
+  if (!resolved.ok) throw new Error("expected setup resolution to succeed");
+  expect(resolved.authLabel).toBe(params.authLabel);
+}
+```
+
+**Location:**
+
+- Test-specific helpers: defined at describe-scope within the test file
+- Shared test utilities: `src/test-utils/` directory
+- Test fixtures/data: `test/fixtures/`, `test-fixtures/`
+- Secret test vectors: `src/test-utils/secret-ref-test-vectors.ts`
+
+## Coverage
+
+**Requirements:** V8 provider with enforced thresholds on `src/**/*.ts`:
+
+- Lines: 70%
+- Functions: 70%
+- Statements: 70%
+- Branches: 55%
+
+**View Coverage:**
+
+```bash
+pnpm test:coverage
+# Coverage report lands in coverage/ directory (lcov + text)
+```
+
+**Coverage scope:** Only files actually exercised by the test suite (`all: false`). Large integration surfaces (agents, channels, gateway, plugins, acp) are excluded from coverage thresholds and validated via e2e/manual/contract tests instead.
+
+## Test Types
+
+**Unit Tests (`*.test.ts`):**
+
+- Scope: single module or function, fully isolated
+- Use temp dirs, fake timers, `vi.mock`, `vi.spyOn`
+- ~2055 test files under `src/`
+- Run with: `pnpm test:fast` or `pnpm test`
+
+**E2E Tests (`*.e2e.test.ts`):**
+
+- Scope: end-to-end flows; spawn subprocesses or run full agent cycles
+- May require gateway running
+- Run with: `pnpm test:e2e`
+- Separate config: `vitest.e2e.config.ts`
+
+**Live Tests (`*.live.test.ts`):**
+
+- Scope: real API integrations (OpenAI, Anthropic, etc.)
+- Require real API keys: `CLAWDBOT_LIVE_TEST=1 pnpm test:live`
+- Excluded from normal test runs
+- Docker variants: `pnpm test:docker:live-models`
+
+**Contract Tests (`src/channels/plugins/contracts/`, `src/plugins/contracts/`):**
+
+- Validate channel plugin interface contracts
+- Run serially: `pnpm test:contracts`
+- Config: `vitest.contracts.config.ts`
+
+**Gateway Tests:**
+
+- Auth compat, reconnect, protocol: `pnpm test:gateway`
+- Config: `vitest.gateway.config.ts`
+
+**Docker E2E:**
+
+- Install smoke, onboarding, OpenWebUI, QR import: `pnpm test:docker:all`
+- Scripts in `scripts/e2e/`
+
+## Common Patterns
+
+**Async Testing:**
+
+```typescript
+it("resolves after delay using fake timers", async () => {
+  vi.useFakeTimers();
+  const promise = sleep(1000);
+  vi.advanceTimersByTime(1000);
+  await expect(promise).resolves.toBeUndefined();
+  vi.useRealTimers();
+});
+```
+
+**Error Testing:**
+
+```typescript
+it("enforces max option count when configured", () => {
+  expect(() =>
+    normalizePollInput({ question: "Q", options: ["A", "B", "C"] }, { maxOptions: 2 }),
+  ).toThrow(/at most 2/);
+});
+```
+
+**Parameterized (table-driven) Tests:**
+
+```typescript
+it.each([
+  { durationHours: undefined, expected: 24 },
+  { durationHours: 999, expected: 48 },
+  { durationHours: 1, expected: 1 },
+])("clamps poll duration for $durationHours hours", ({ durationHours, expected }) => {
+  expect(normalizePollDurationHours(durationHours, { defaultHours: 24, maxHours: 48 })).toBe(
+    expected,
+  );
+});
+```
+
+**Discriminated Result Assertion:**
+
+```typescript
+const result = await someOperation();
+expect(result.ok).toBe(true);
+if (!result.ok) {
+  throw new Error("expected ok result");
+}
+// TypeScript now narrows to ok: true branch
+expect(result.payload.bootstrapToken).toBe("bootstrap-123");
+```
+
+**Testing Internal State (via `__testing` export):**
+
+```typescript
+import { __testing, scheduleGatewaySigusr1Restart } from "./restart.js";
+
+beforeEach(() => {
+  __testing.resetSigusr1State();
+});
+afterEach(async () => {
+  __testing.resetSigusr1State();
+});
+```
+
+**Low-memory / Serial Mode:**
+
+```bash
+OPENCLAW_TEST_PROFILE=low OPENCLAW_TEST_SERIAL_GATEWAY=1 pnpm test
+```
+
+---
+
+_Testing analysis: 2026-03-28_

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,631 @@
+# OpenClaw Architecture
+
+> A comprehensive guide to OpenClaw's codebase structure, design patterns, and message flow.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Project Structure](#project-structure)
+3. [Entry Points](#entry-points)
+4. [Message Flow](#message-flow)
+5. [Gateway Architecture](#gateway-architecture)
+6. [Channel System](#channel-system)
+7. [Agent Execution](#agent-execution)
+8. [Provider System](#provider-system)
+9. [Tool System](#tool-system)
+10. [Skills System](#skills-system)
+11. [Plugin System](#plugin-system)
+12. [Configuration](#configuration)
+13. [Key Design Patterns](#key-design-patterns)
+14. [Extension Points](#extension-points)
+
+---
+
+## Overview
+
+OpenClaw is a multi-channel AI assistant platform that routes messages from various chat platforms (WhatsApp, Telegram, Discord, Slack, Signal, iMessage, etc.) through a unified gateway to AI model providers (Anthropic Claude, OpenAI, Google Gemini, etc.).
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                         User Devices                                 │
+│   WhatsApp  │  Telegram  │  Discord  │  Slack  │  Signal  │  ...    │
+└──────┬──────┴─────┬──────┴─────┬─────┴────┬────┴────┬─────┴─────────┘
+       │            │            │          │         │
+       └────────────┴────────────┴──────────┴─────────┘
+                              │
+                    ┌─────────▼─────────┐
+                    │     Gateway       │
+                    │  (WebSocket/HTTP) │
+                    └─────────┬─────────┘
+                              │
+          ┌───────────────────┼───────────────────┐
+          │                   │                   │
+   ┌──────▼──────┐    ┌───────▼───────┐   ┌──────▼──────┐
+   │   Routing   │    │    Agent      │   │   Config    │
+   │  (Sessions) │    │  (PI Core)    │   │   Reload    │
+   └──────┬──────┘    └───────┬───────┘   └─────────────┘
+          │                   │
+          │           ┌───────▼───────┐
+          │           │    Tools      │
+          │           │  (60+ tools)  │
+          │           └───────┬───────┘
+          │                   │
+          └───────────────────┼───────────────────┐
+                              │                   │
+                    ┌─────────▼─────────┐  ┌──────▼──────┐
+                    │   AI Providers    │  │   Skills    │
+                    │ Claude/GPT/Gemini │  │  (Bundled)  │
+                    └───────────────────┘  └─────────────┘
+```
+
+---
+
+## Project Structure
+
+### Core Directories (`/src/`)
+
+| Directory | Purpose |
+|-----------|---------|
+| `cli/` | Command-line interface, Commander program, commands |
+| `commands/` | CLI command implementations (send, status, login, etc.) |
+| `gateway/` | WebSocket/HTTP server, channel coordination |
+| `agents/` | Agent execution (PI core), tools, skills |
+| `channels/` | Channel abstractions, plugins, routing |
+| `auto-reply/` | Message dispatch, response generation |
+| `routing/` | Session key resolution and normalization |
+| `config/` | Configuration loading, validation, sessions |
+| `plugins/` | Plugin discovery, loading, registry |
+| `infra/` | Infrastructure (logging, errors, binary management) |
+
+### Channel-Specific Directories
+
+| Directory | Channel |
+|-----------|---------|
+| `telegram/` | Telegram Bot API (grammy) |
+| `discord/` | Discord.js integration |
+| `whatsapp/` | WhatsApp Web via Baileys |
+| `slack/` | Slack Bolt SDK |
+| `signal/` | Signal via signal-cli |
+| `imessage/` | iMessage via BlueBubbles |
+| `web/` | WhatsApp Web provider |
+
+### Extensions (`/extensions/`)
+
+Plugin-based extensions for additional channels, providers, and features:
+
+- **Channels:** `googlechat`, `line`, `matrix`, `msteams`, `zalo`, `zalouser`
+- **Providers:** `copilot-proxy`, `google-gemini-cli-auth`, `qwen-portal-auth`
+- **Memory:** `memory-core`, `memory-lancedb`
+- **Features:** `voice-call`, `lobster`, `llm-task`
+
+---
+
+## Entry Points
+
+### CLI Entry (`/src/index.ts`)
+
+```typescript
+// Main CLI entry point
+export { buildProgram } from "./cli/program/build-program.js"
+export { runCli } from "./cli/run.js"
+```
+
+- Loads environment and configuration
+- Builds Commander program with all commands
+- Exports public API for programmatic use
+
+### Process Wrapper (`/src/entry.ts`)
+
+- Suppresses experimental Node.js warnings
+- Platform-specific normalization (Windows arg fixing)
+- Handles CLI profile selection and respawning
+
+### Gateway Entry (`/src/gateway/server.impl.ts`)
+
+- Initializes all gateway subsystems
+- Starts WebSocket/HTTP server
+- Coordinates channel lifecycle
+
+---
+
+## Message Flow
+
+### Incoming Message Pipeline
+
+```
+1. Channel Webhook/Listener
+   └── src/telegram/bot-handlers.ts
+   └── src/whatsapp/message-handler.ts
+   └── etc.
+        │
+2. Message Normalization
+   └── src/auto-reply/dispatch.ts
+   └── dispatchInboundMessage()
+        │
+3. Session Routing
+   └── src/routing/session-key.ts
+   └── Resolves: agent:main:telegram:dm:123456
+        │
+4. Agent Dispatch
+   └── src/auto-reply/reply/dispatch-from-config.ts
+   └── Routes to configured agent
+        │
+5. Agent Execution
+   └── src/agents/pi-embedded-runner.ts
+   └── runEmbeddedPiAgent()
+        │
+6. AI Provider Call
+   └── src/auto-reply/reply/provider-dispatcher.ts
+   └── Claude, GPT, Gemini, etc.
+        │
+7. Response Streaming
+   └── src/agents/pi-embedded-block-chunker.ts
+   └── Smart paragraph/code block detection
+        │
+8. Channel Delivery
+   └── src/telegram/send.ts
+   └── src/whatsapp/send.ts
+   └── etc.
+```
+
+### Session Key Format
+
+Session keys determine conversation context:
+
+```
+agent:{agentId}:{mainKey}
+agent:{agentId}:{channel}:{accountId}:{peerId}
+
+Examples:
+- agent:main:main                    # Default session
+- agent:main:telegram:dm:123456      # Telegram DM
+- agent:main:discord:guild:789       # Discord server
+```
+
+**Resolution:** `src/routing/session-key.ts`
+
+---
+
+## Gateway Architecture
+
+### Purpose
+
+The gateway is a centralized WebSocket server that:
+- Manages channel lifecycle (start/stop/status)
+- Routes messages between channels and agents
+- Coordinates agent execution and events
+- Provides hot-reload for configuration
+- Handles device/client pairing
+
+### Core Files
+
+| File | Purpose |
+|------|---------|
+| `server.impl.ts` | Main server bootstrap |
+| `server-channels.ts` | Channel manager (`createChannelManager`) |
+| `server-chat.ts` | Agent event streaming |
+| `server-methods.ts` | RPC method handlers |
+| `protocol/` | WebSocket protocol definitions |
+
+### WebSocket Protocol
+
+Methods available via WebSocket/HTTP:
+- `agent` - Agent control and events
+- `chat` - Message sending
+- `config` - Configuration queries
+- `sessions` - Session management
+- `channels` - Channel status and control
+- `health` - Health checks
+
+---
+
+## Channel System
+
+### Channel Registry
+
+```typescript
+// src/channels/registry.ts
+const CHAT_CHANNEL_ORDER = [
+  "telegram", "whatsapp", "discord",
+  "googlechat", "slack", "signal", "imessage"
+]
+```
+
+### Channel Plugin Interface
+
+Each channel implements adapters:
+
+```typescript
+// src/channels/plugins/types.plugin.ts
+type ChannelPlugin<ResolvedAccount = any> = {
+  id: ChannelId
+  meta: ChannelMeta
+  capabilities: ChannelCapabilities
+
+  // Core adapters
+  config: ChannelConfigAdapter<ResolvedAccount>
+  outbound?: ChannelOutboundAdapter
+  gateway?: ChannelGatewayAdapter<ResolvedAccount>
+  messaging?: ChannelMessagingAdapter
+
+  // Feature adapters
+  groups?: ChannelGroupAdapter
+  mentions?: ChannelMentionAdapter
+  threading?: ChannelThreadingAdapter
+  commands?: ChannelCommandAdapter
+}
+```
+
+### Channel Dock (Metadata)
+
+```typescript
+// src/channels/dock.ts
+interface ChannelDock {
+  capabilities: {
+    chatTypes: ("dm" | "group")[]
+    nativeCommands: boolean
+    reactions: boolean
+    media: MediaCapabilities
+    threads: boolean
+    blockStreaming: boolean
+  }
+  outboundLimits: {
+    maxTextLength: number  // e.g., Telegram: 4000, Discord: 2000
+  }
+}
+```
+
+---
+
+## Agent Execution
+
+### PI Embedded Runner
+
+The agent execution engine uses PI Agent Core:
+
+```typescript
+// src/agents/pi-embedded-runner.ts
+async function runEmbeddedPiAgent(ctx: AgentRunContext): Promise<void> {
+  // 1. Load session history
+  // 2. Resolve auth profiles (Anthropic, OpenAI, etc.)
+  // 3. Build system prompt with available tools
+  // 4. Execute agent loop
+  // 5. Emit events and stream responses
+}
+```
+
+### Agent Events
+
+```typescript
+// src/infra/agent-events.ts
+type AgentEventStream = "lifecycle" | "tool" | "assistant" | "error"
+
+type AgentEventPayload = {
+  runId: string
+  seq: number
+  stream: AgentEventStream
+  ts: number
+  data: Record<string, unknown>
+  sessionKey?: string
+}
+```
+
+Events are broadcast to connected clients in real-time.
+
+---
+
+## Provider System
+
+### Supported Providers
+
+| Provider | Models |
+|----------|--------|
+| Anthropic | Claude 3.5, Claude 3 Opus/Sonnet/Haiku |
+| OpenAI | GPT-4o, GPT-4 Turbo, o1 |
+| Google | Gemini 2.0, 1.5 Pro/Flash |
+| AWS Bedrock | Claude, Titan |
+| Ollama | Local models |
+| GitHub Copilot | Token exchange |
+
+### Model Configuration
+
+```typescript
+// src/agents/models-config.providers.ts
+interface ModelDefinitionConfig {
+  id: string
+  name: string
+  cost: { input, output, cacheRead, cacheWrite }
+  contextWindow: number
+  maxTokens: number
+  input: ("text" | "image" | "audio")[]
+  reasoning?: boolean
+}
+```
+
+### Auth Profiles
+
+```typescript
+// src/agents/auth-profiles.ts
+// Manages multiple credentials per provider
+// Fallback ordering: Current → Last used → Explicit → First available
+```
+
+---
+
+## Tool System
+
+### Tool Categories
+
+OpenClaw includes ~60 tools organized by function:
+
+| Category | Tools | Location |
+|----------|-------|----------|
+| **Messaging** | send, edit, react, fetch | `tools/message-tool.ts` |
+| **Browser** | navigate, click, screenshot | `tools/browser-tool.ts` |
+| **Web** | fetch, search | `tools/web-fetch.ts`, `web-search.ts` |
+| **Media** | image gen, TTS | `tools/image-tool.ts`, `tts-tool.ts` |
+| **System** | bash, gateway, nodes | `tools/bash-tools.exec.ts` |
+| **Channel** | telegram, discord, slack actions | `tools/*-actions.ts` |
+
+### Tool Schema Definition
+
+Uses TypeBox for type-safe schemas:
+
+```typescript
+// Example from message-tool.ts
+const buildSendSchema = () => ({
+  message: Type.Optional(Type.String()),
+  media: Type.Optional(Type.String()),
+  buttons: Type.Optional(Type.Array(buttonSchema)),
+  target: Type.Optional(channelTargetSchema())
+})
+```
+
+### Tool Policy
+
+```typescript
+// src/agents/pi-tools.policy.ts
+// Controls which tools are available per session
+// Filters based on: config, allowlists, channel type, sandbox mode
+```
+
+---
+
+## Skills System
+
+### What are Skills?
+
+Skills are bundled or custom commands that agents can invoke. They're discovered from the workspace and loaded via YAML frontmatter.
+
+### Skill Metadata
+
+```yaml
+---
+name: Weather
+source: openclaw-bundled
+description: Get weather forecasts
+os: [darwin, linux, win32]
+requires:
+  bins: [curl]
+  env: []
+---
+```
+
+### Skill Discovery
+
+1. Bundled: `/extensions/*/skills/`
+2. Workspace: `~/.clawdbot/agents/<agentId>/skills/`
+3. Filtered by: OS, binaries, env vars, config paths
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `skills/types.ts` | Skill metadata types |
+| `skills/workspace.ts` | Discovery and loading |
+| `skills/frontmatter.ts` | YAML parsing |
+| `skills/config.ts` | Eligibility checking |
+
+---
+
+## Plugin System
+
+### Plugin Registry
+
+```typescript
+// src/plugins/registry.ts
+type PluginRegistry = {
+  plugins: PluginRecord[]
+  tools: PluginToolRegistration[]
+  hooks: PluginHookRegistration[]
+  channels: PluginChannelRegistration[]
+  providers: PluginProviderRegistration[]
+  gatewayHandlers: GatewayRequestHandlers
+  httpHandlers: PluginHttpRegistration[]
+  cliRegistrars: PluginCliRegistration[]
+  services: PluginServiceRegistration[]
+  commands: PluginCommandRegistration[]
+}
+```
+
+### Plugin API
+
+```typescript
+// src/plugins/types.ts
+type OpenClawPluginApi = {
+  id: string
+  logger: PluginLogger
+
+  // Registration methods
+  registerTool(factory, options)
+  registerHook(name, handler, options)
+  registerChannel(plugin)
+  registerProvider(provider)
+  registerCliCommand(definition)
+  registerGatewayHandler(path, handler)
+  registerHttpHandler(handler)
+  registerService(service)
+}
+```
+
+### Plugin Loading
+
+```typescript
+// src/plugins/loader.ts
+// 1. Discovers plugins from ~/.clawdbot/plugins/ and bundled extensions
+// 2. Loads via dynamic import
+// 3. Validates manifests
+// 4. Registers with global registry
+```
+
+---
+
+## Configuration
+
+### Config Schema
+
+```typescript
+// src/config/types.ts
+type OpenClawConfig = {
+  agents?: Record<string, AgentConfig>
+  channels?: {
+    telegram?: TelegramConfig
+    whatsapp?: WhatsAppConfig
+    discord?: DiscordConfig
+    slack?: SlackConfig
+    signal?: SignalConfig
+    // ...
+  }
+  models?: ModelProviderConfig[]
+  hooks?: HookConfig[]
+  sandbox?: SandboxConfig
+}
+```
+
+### Config Locations
+
+- Global: `~/.clawdbot/openclaw.json` or `~/.openclaw/openclaw.json`
+- Sessions: `~/.clawdbot/sessions/{sessionKey}.jsonl`
+
+### Hot Reload
+
+```typescript
+// src/gateway/config-reload.ts
+// Detects file changes and reloads:
+// - Channel configurations
+// - Model providers
+// - Skills
+// - Agent settings
+```
+
+---
+
+## Key Design Patterns
+
+### 1. Dependency Injection
+
+```typescript
+// src/cli/deps.ts
+function createDefaultDeps(): CliDeps {
+  return {
+    sendMessageWhatsApp,
+    sendMessageTelegram,
+    sendMessageDiscord,
+    // ...
+  }
+}
+```
+
+### 2. Factory Pattern
+
+- Channel plugins created per account
+- Tool factories receive context
+- Adapters are functions receiving config
+
+### 3. Plugin Slots
+
+- **Hooks:** Named events with handler registration
+- **Gateway methods:** RPC handlers per channel
+- **HTTP routes:** Extensible routing
+
+### 4. Session-Based Routing
+
+```
+agent:{agentId} → channel → account → peer
+```
+
+Resolves to correct session storage and conversation context.
+
+### 5. Block Streaming
+
+Messages streamed in semantic blocks (paragraphs, code blocks) for:
+- Reduced token count
+- Improved perceived responsiveness
+- Better formatting
+
+---
+
+## Extension Points
+
+### Adding a Channel
+
+1. Create plugin in `extensions/{channelId}/`
+2. Implement `ChannelPlugin` with adapters
+3. Register in plugin `index.ts`
+
+### Adding a Provider
+
+1. Create `ProviderPlugin` in plugin
+2. Implement auth flow
+3. Define model capabilities
+
+### Adding Tools
+
+```typescript
+api.registerTool(
+  (ctx) => ({
+    name: "my_tool",
+    description: "Does something",
+    inputSchema: mySchema,
+    execute: async (input) => { /* ... */ }
+  }),
+  { category: "custom" }
+)
+```
+
+### Adding Hooks
+
+```typescript
+api.registerHook("message:received", async (msg) => {
+  // Handle incoming message
+})
+```
+
+### Adding Gateway Methods
+
+```typescript
+api.registerGatewayHandler("custom/method", async (req, res) => {
+  // Handle RPC request
+})
+```
+
+---
+
+## Critical Files Reference
+
+| Purpose | File |
+|---------|------|
+| CLI entry | `src/index.ts` |
+| Gateway bootstrap | `src/gateway/server.impl.ts` |
+| Message dispatch | `src/auto-reply/dispatch.ts` |
+| Agent execution | `src/agents/pi-embedded-runner.ts` |
+| Session routing | `src/routing/session-key.ts` |
+| Tool definitions | `src/agents/tools/` |
+| Skill loading | `src/agents/skills/workspace.ts` |
+| Plugin registry | `src/plugins/registry.ts` |
+| Channel plugins | `src/channels/plugins/` |
+| Config types | `src/config/types.ts` |
+
+---
+
+*Generated by OpenClaw architecture review*

--- a/docs/CHAT-COMMANDS.md
+++ b/docs/CHAT-COMMANDS.md
@@ -1,0 +1,381 @@
+# OpenClaw Chat Commands
+
+> A comprehensive guide to slash commands available in OpenClaw chat sessions.
+
+Send these commands via WhatsApp, Telegram, Discord, or any connected channel to control your OpenClaw experience.
+
+---
+
+## Quick Reference
+
+| Command | Description |
+|---------|-------------|
+| `/help` | Show available commands |
+| `/status` | Show current status |
+| `/usage full` | Enable token/cost footer |
+| `/model` | Show or change AI model |
+| `/think high` | Enable extended thinking |
+| `/reset` | Reset conversation |
+| `/stop` | Stop current response |
+
+---
+
+## Commands by Category
+
+### Session Management
+
+Control your conversation sessions.
+
+| Command | Aliases | Description | Usage |
+|---------|---------|-------------|-------|
+| `/reset` | | Reset the current session | `/reset` or `/reset keep-system` |
+| `/new` | | Start a new session | `/new` or `/new <name>` |
+| `/stop` | | Stop the current run | `/stop` |
+| `/compact` | | Compact session context (reduce tokens) | `/compact` or `/compact <instructions>` |
+
+**Examples:**
+```
+/reset              # Clear conversation history
+/new project-x      # Start fresh session named "project-x"
+/compact            # Summarize context to save tokens
+/stop               # Interrupt a long-running response
+```
+
+---
+
+### Options & Preferences
+
+Customize how OpenClaw responds.
+
+#### `/usage` - Token & Cost Tracking
+
+Show token usage and costs per response.
+
+| Mode | Description |
+|------|-------------|
+| `off` | No usage footer (default) |
+| `tokens` | Show input/output token counts |
+| `full` | Tokens + session key + estimated cost |
+| `cost` | Cost summary only |
+
+```
+/usage full         # Enable detailed usage footer
+/usage tokens       # Show just token counts
+/usage off          # Disable usage footer
+```
+
+#### `/think` - Thinking Level
+
+Control how much the AI "thinks" before responding. Higher levels = more thorough but slower.
+
+| Level | Aliases | Description |
+|-------|---------|-------------|
+| `off` | | No extended thinking |
+| `minimal` | | Light thinking |
+| `low` | `/t low` | Basic reasoning |
+| `medium` | `/t medium` | Moderate depth |
+| `high` | `/t high` | Deep reasoning |
+| `xhigh` | `/t xhigh` | Maximum thinking (slowest) |
+
+```
+/think high         # Enable deep thinking
+/t medium           # Shorthand for medium thinking
+/thinking off       # Disable extended thinking
+```
+
+#### `/verbose` - Verbose Mode
+
+Show detailed tool calls and internal operations.
+
+```
+/verbose on         # Show tool calls, searches, etc.
+/verbose off        # Hide internal details
+/v on               # Shorthand
+```
+
+#### `/reasoning` - Reasoning Visibility
+
+Control visibility of AI's reasoning process.
+
+| Mode | Description |
+|------|-------------|
+| `on` | Show reasoning after response |
+| `off` | Hide reasoning |
+| `stream` | Stream reasoning in real-time |
+
+```
+/reasoning on       # Show reasoning summary
+/reason stream      # Stream reasoning live
+```
+
+#### `/elevated` - Elevated Mode
+
+Control permission level for potentially destructive operations.
+
+| Mode | Description |
+|------|-------------|
+| `off` | Standard permissions |
+| `on` | Elevated permissions enabled |
+| `ask` | Ask before elevated operations |
+| `full` | Full elevated access |
+
+```
+/elevated on        # Enable elevated mode
+/elev ask           # Prompt before elevated ops
+```
+
+#### `/model` - AI Model Selection
+
+Show or change the AI model.
+
+```
+/model                          # Show current model
+/model anthropic/claude-sonnet  # Switch to Sonnet
+/model openai/gpt-4o            # Switch to GPT-4o
+/model google/gemini-2.0-flash  # Switch to Gemini
+```
+
+#### `/models` - List Available Models
+
+List all available model providers and their models.
+
+```
+/models             # List all providers
+/models anthropic   # List Anthropic models
+/models openai      # List OpenAI models
+```
+
+#### `/queue` - Message Queue Settings
+
+Control how multiple messages are handled.
+
+| Mode | Description |
+|------|-------------|
+| `steer` | New messages steer current response |
+| `interrupt` | New messages interrupt current response |
+| `followup` | Queue messages for sequential processing |
+| `collect` | Batch messages together |
+
+```
+/queue interrupt              # Interrupt mode
+/queue followup debounce=2s   # Wait 2s between messages
+/queue collect cap=5          # Collect up to 5 messages
+```
+
+#### `/exec` - Execution Defaults
+
+Set defaults for shell command execution.
+
+```
+/exec host=local security=sandbox
+/exec ask=on node=my-server
+```
+
+---
+
+### Status & Information
+
+Get information about your session and setup.
+
+| Command | Aliases | Description |
+|---------|---------|-------------|
+| `/help` | | Show available commands |
+| `/commands` | | List all slash commands |
+| `/status` | | Show current status (model, session, channels) |
+| `/whoami` | `/id` | Show your sender ID |
+| `/context` | | Explain how context is built |
+
+```
+/status             # See current config
+/whoami             # See your ID (useful for allowlists)
+/context            # Understand context window usage
+```
+
+---
+
+### Management & Admin
+
+Manage access, configuration, and subagents.
+
+#### `/allowlist` - Access Control
+
+Manage who can use the bot.
+
+```
+/allowlist                    # Show current allowlist
+/allowlist add +15551234567   # Add phone number
+/allowlist remove +15551234567
+```
+
+#### `/approve` - Execution Approvals
+
+Approve or deny pending exec requests.
+
+```
+/approve            # Show pending requests
+/approve yes        # Approve pending request
+/approve no         # Deny pending request
+```
+
+#### `/config` - Configuration
+
+View or modify configuration values.
+
+| Action | Description |
+|--------|-------------|
+| `show` | Show all config |
+| `get` | Get specific value |
+| `set` | Set a value |
+| `unset` | Remove a value |
+
+```
+/config show                              # Show all config
+/config get agents.main.model             # Get specific setting
+/config set agents.main.thinkLevel high   # Set a value
+/config unset agents.main.thinkLevel      # Remove override
+```
+
+#### `/debug` - Runtime Debug Overrides
+
+Set temporary debug values (resets on restart).
+
+```
+/debug show                   # Show current overrides
+/debug set logging.level debug
+/debug reset                  # Clear all overrides
+```
+
+#### `/subagents` - Subagent Management
+
+Manage background agent runs.
+
+| Action | Description |
+|--------|-------------|
+| `list` | List running subagents |
+| `stop` | Stop a subagent |
+| `log` | View subagent logs |
+| `info` | Get subagent details |
+| `send` | Send message to subagent |
+
+```
+/subagents list               # See running agents
+/subagents stop 1             # Stop subagent #1
+/subagents log 1 50           # Last 50 lines of log
+/subagents send 1 stop task   # Send message to subagent
+```
+
+#### `/activation` - Group Activation Mode
+
+Control how the bot responds in groups.
+
+| Mode | Description |
+|------|-------------|
+| `mention` | Only respond when @mentioned |
+| `always` | Respond to all messages |
+
+```
+/activation mention   # Require @mention in groups
+/activation always    # Respond to everything
+```
+
+#### `/send` - Send Policy
+
+Control outbound message permissions.
+
+```
+/send on              # Allow sending
+/send off             # Block sending
+/send inherit         # Use parent config
+```
+
+---
+
+### Media & TTS
+
+Control text-to-speech and media features.
+
+#### `/tts` - Text-to-Speech
+
+| Action | Description |
+|--------|-------------|
+| `on` | Enable TTS for responses |
+| `off` | Disable TTS |
+| `status` | Show current TTS settings |
+| `provider` | Set voice provider |
+| `limit` | Set max characters for TTS |
+| `summary` | Toggle AI summary for long texts |
+| `audio` | Generate TTS from custom text |
+
+**Providers:** `edge`, `elevenlabs`, `openai`
+
+```
+/tts on                       # Enable TTS
+/tts provider openai          # Use OpenAI voices
+/tts limit 500                # Max 500 chars
+/tts audio Hello world!       # Generate specific audio
+```
+
+---
+
+### Tools & Skills
+
+Run tools and skills directly.
+
+| Command | Description |
+|---------|-------------|
+| `/bash` | Run shell commands (host-only) |
+| `/skill` | Run a skill by name |
+| `/restart` | Restart OpenClaw gateway |
+
+```
+/bash ls -la                  # Run shell command
+/skill weather Dallas         # Run weather skill
+/restart                      # Restart gateway
+```
+
+---
+
+### Channel Docks
+
+Switch reply channel (when multiple channels connected).
+
+```
+/dock-telegram        # Reply via Telegram
+/dock-whatsapp        # Reply via WhatsApp
+/dock-discord         # Reply via Discord
+```
+
+---
+
+## Command Shortcuts
+
+| Shortcut | Full Command |
+|----------|--------------|
+| `/t` | `/think` |
+| `/v` | `/verbose` |
+| `/id` | `/whoami` |
+| `/elev` | `/elevated` |
+| `/reason` | `/reasoning` |
+
+---
+
+## Tips
+
+1. **See all commands:** Send `/commands` for a full list
+2. **Get help on a command:** Most commands show help when called without arguments
+3. **Cost tracking:** Use `/usage full` to monitor token usage and estimated costs
+4. **Deep thinking:** Use `/think high` for complex problems requiring careful analysis
+5. **Save context:** Use `/compact` when conversations get long
+6. **Quick reset:** `/reset` clears history but keeps your settings
+
+---
+
+## Configuration Persistence
+
+- **Session settings** (model, think level, etc.) persist for the current session
+- **Config changes** via `/config set` persist across sessions
+- **Debug overrides** reset when the gateway restarts
+
+---
+
+*For more details, see the [OpenClaw Documentation](https://docs.openclaw.ai)*

--- a/docs/PROCESSES.md
+++ b/docs/PROCESSES.md
@@ -1,0 +1,312 @@
+# OpenClaw Process System
+
+> Understanding how OpenClaw manages shell command execution through the "Process" abstraction.
+
+## What is a "Process" in OpenClaw?
+
+In OpenClaw, a **Process** (also called a **ProcessSession**) is a managed abstraction around a shell command execution. When the AI agent runs a bash command, OpenClaw wraps it in a `ProcessSession` object that tracks:
+
+- The command being executed
+- Standard output/error streams
+- Exit codes and signals
+- Timing information
+- Background/foreground state
+
+## Key Data Structures
+
+### ProcessSession (Running Process)
+
+Defined in `src/agents/bash-process-registry.ts`:
+
+```typescript
+interface ProcessSession {
+  id: string;                    // Human-readable slug (e.g., "nova-gulf")
+  command: string;               // The shell command being executed
+  scopeKey?: string;             // Scope for isolation (agent/session)
+  sessionKey?: string;           // Parent conversation session
+
+  // Process handle
+  child?: ChildProcessWithoutNullStreams;  // Node.js child process
+  stdin?: SessionStdin;          // Write interface for input
+  pid?: number;                  // OS process ID
+
+  // Timing
+  startedAt: number;             // Unix timestamp (ms)
+
+  // Output management
+  maxOutputChars: number;        // Output cap (default: 200,000)
+  totalOutputChars: number;      // Total chars received
+  pendingStdout: string[];       // Buffered stdout chunks
+  pendingStderr: string[];       // Buffered stderr chunks
+  aggregated: string;            // Combined output (capped)
+  tail: string;                  // Last 2000 chars for quick preview
+  truncated: boolean;            // Was output truncated?
+
+  // State
+  exited: boolean;               // Has process exited?
+  exitCode?: number | null;      // Exit code (0 = success)
+  exitSignal?: NodeJS.Signals;   // Kill signal if any
+  backgrounded: boolean;         // Is this a background process?
+  notifyOnExit?: boolean;        // Notify agent when done?
+}
+```
+
+### FinishedSession (Completed Process)
+
+When a process exits, it becomes a `FinishedSession`:
+
+```typescript
+interface FinishedSession {
+  id: string;
+  command: string;
+  scopeKey?: string;
+  startedAt: number;
+  endedAt: number;               // When it finished
+  cwd?: string;                  // Working directory
+  status: ProcessStatus;         // "completed" | "failed" | "killed"
+  exitCode?: number | null;
+  exitSignal?: NodeJS.Signals;
+  aggregated: string;            // Full output (capped)
+  tail: string;                  // Last 2000 chars
+  truncated: boolean;
+  totalOutputChars: number;
+}
+```
+
+### ProcessStatus
+
+```typescript
+type ProcessStatus = "running" | "completed" | "failed" | "killed";
+```
+
+## Process Lifecycle
+
+### 1. Instantiation
+
+When the agent calls the `exec` tool:
+
+```
+Agent calls exec("npm install")
+       │
+       ▼
+┌─────────────────────────────────────┐
+│  createSessionSlug()                │
+│  → Generates "nova-gulf"            │
+└─────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────┐
+│  Spawn child process                │
+│  - PTY (interactive) or             │
+│  - Regular child_process            │
+│  - Docker exec (if sandbox enabled) │
+└─────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────┐
+│  Create ProcessSession object       │
+│  {                                  │
+│    id: "nova-gulf",                 │
+│    command: "npm install",          │
+│    pid: 12345,                      │
+│    startedAt: 1706812800000,        │
+│    ...                              │
+│  }                                  │
+└─────────────────────────────────────┘
+       │
+       ▼
+┌─────────────────────────────────────┐
+│  addSession(session)                │
+│  → Adds to runningSessions Map      │
+└─────────────────────────────────────┘
+```
+
+### 2. Output Collection
+
+As the process runs:
+
+```typescript
+// stdout/stderr handlers continuously append output
+appendOutput(session, "stdout", chunk);
+appendOutput(session, "stderr", chunk);
+
+// Output is:
+// - Added to pendingStdout/pendingStderr buffers
+// - Aggregated into session.aggregated (capped at maxOutputChars)
+// - Tail updated (last 2000 chars for quick preview)
+```
+
+### 3. Polling (Background Processes)
+
+When verbose mode shows `Process: poll nova-gulf`:
+
+```typescript
+// Agent calls process tool with action="poll"
+case "poll": {
+  // Drain pending output buffers
+  const { stdout, stderr } = drainSession(session);
+
+  // Check if exited
+  if (session.exited) {
+    markExited(session, exitCode, exitSignal, status);
+    // Move to finishedSessions
+  }
+
+  // Return current output to agent
+  return { content: [...], details: { status, output } };
+}
+```
+
+### 4. Completion
+
+When process exits:
+
+```typescript
+markExited(session, exitCode, exitSignal, status);
+// → Sets session.exited = true
+// → Records exit code/signal
+// → Moves from runningSessions to finishedSessions
+// → Optionally notifies agent via system event
+```
+
+## Session ID Generation
+
+The human-readable slugs like "nova-gulf" are generated in `src/agents/session-slug.ts`:
+
+```typescript
+const SLUG_ADJECTIVES = [
+  "amber", "briny", "brisk", "calm", "clear", "cool", "crisp",
+  "dawn", "delta", "ember", "faint", "fast", "fresh", "gentle",
+  "glow", "good", "grand", "keen", "kind", "lucky", "marine",
+  "mellow", "mild", "neat", "nimble", "nova", "oceanic", "plaid",
+  "quick", "quiet", "rapid", "salty", "sharp", "swift", "tender",
+  "tidal", "tidy", "tide", "vivid", "warm", "wild", "young"
+];
+
+const SLUG_NOUNS = [
+  "atlas", "basil", "bison", "bloom", "breeze", "canyon", "cedar",
+  "claw", "cloud", "comet", "coral", "cove", "crest", "crustacean",
+  "daisy", "dune", "ember", "falcon", "fjord", "forest", "glade",
+  "gulf", "harbor", "haven", "kelp", "lagoon", "lobster", "meadow",
+  "mist", "nudibranch", "nexus", "ocean", "orbit", "otter", "pine",
+  "prairie", "reef", "ridge", "river", "rook", "sable", "sage",
+  "seaslug", "shell", "shoal", "shore", "slug", "summit", "tidepool",
+  "trail", "valley", "wharf", "willow", "zephyr"
+];
+
+function createSessionSlug(): string {
+  // Combines random adjective + noun
+  // e.g., "nova" + "gulf" = "nova-gulf"
+  // Ensures uniqueness across running + finished sessions
+}
+```
+
+## Process Registry
+
+Two in-memory Maps track all processes:
+
+```typescript
+// Currently running processes
+const runningSessions = new Map<string, ProcessSession>();
+
+// Recently finished processes (kept for TTL period)
+const finishedSessions = new Map<string, FinishedSession>();
+```
+
+### TTL and Cleanup
+
+Finished sessions are automatically pruned after a TTL (default: 30 minutes):
+
+```typescript
+const DEFAULT_JOB_TTL_MS = 30 * 60 * 1000;  // 30 minutes
+const MIN_JOB_TTL_MS = 60 * 1000;           // 1 minute
+const MAX_JOB_TTL_MS = 3 * 60 * 60 * 1000;  // 3 hours
+
+// Sweeper runs periodically to clean up old finished sessions
+function pruneFinishedSessions() {
+  const cutoff = Date.now() - jobTtlMs;
+  for (const [id, session] of finishedSessions.entries()) {
+    if (session.endedAt < cutoff) {
+      finishedSessions.delete(id);
+    }
+  }
+}
+```
+
+## Process Tool Actions
+
+The `process` tool (`src/agents/bash-tools.process.ts`) provides these actions:
+
+| Action | Description |
+|--------|-------------|
+| `list` | List all running/finished background processes |
+| `poll` | Get new output from a background process |
+| `log` | Get full aggregated output history |
+| `write` | Write text to process stdin |
+| `send-keys` | Send special keys (Ctrl+C, etc.) |
+| `submit` | Write text + press Enter |
+| `paste` | Paste text (for PTY processes) |
+| `kill` | Terminate a running process |
+
+## Execution Hosts
+
+Processes can run in different environments:
+
+| Host | Description |
+|------|-------------|
+| `gateway` | Direct execution on the gateway host **(default)** |
+| `sandbox` | Docker container with isolation (opt-in via config) |
+| `node` | Remote execution on a paired device |
+
+**Note:** By default (`sandbox.mode: "off"`), all commands execute directly on the gateway host machine—no Docker container is involved. Docker sandboxing is only enabled when explicitly configured in `openclaw.json`:
+
+```json
+{
+  "agents": {
+    "defaults": {
+      "sandbox": {
+        "mode": "docker"
+      }
+    }
+  }
+}
+```
+
+When sandbox mode is `"docker"`, commands run inside an isolated container with:
+- Read-only root filesystem
+- No network access by default
+- Dropped capabilities (`ALL`)
+- Resource limits (memory, CPU, PIDs)
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/agents/bash-process-registry.ts` | ProcessSession type, registry Maps, output management |
+| `src/agents/bash-tools.exec.ts` | `exec` tool - spawns processes |
+| `src/agents/bash-tools.process.ts` | `process` tool - poll/list/kill/write |
+| `src/agents/session-slug.ts` | Human-readable ID generation |
+| `src/agents/bash-tools.shared.ts` | Shared utilities (kill, sandbox args) |
+
+## Example: What Happens When You See "Process: poll nova-gulf"
+
+1. Agent previously ran a command that was **backgrounded** (e.g., `npm install &` or a long-running task)
+2. The command was assigned the ID `nova-gulf`
+3. Agent is now calling `process({ action: "poll", sessionId: "nova-gulf" })`
+4. This drains any new output that accumulated since last poll
+5. Returns the output + current status (running/completed/failed) to the agent
+6. Agent uses this to decide if it needs to wait longer or can proceed
+
+## Configuration
+
+Environment variables that affect process behavior:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PI_BASH_MAX_OUTPUT_CHARS` | 200,000 | Max output chars to keep |
+| `PI_BASH_JOB_TTL_MS` | 1,800,000 | How long to keep finished sessions |
+| `OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS` | 200,000 | Max pending buffer size |
+
+---
+
+*This document explains the Process abstraction in OpenClaw as of version 2026.1.29*

--- a/docs/message-flow.md
+++ b/docs/message-flow.md
@@ -1,0 +1,89 @@
+```mermaid
+graph TD
+    subgraph WhatsApp Protocol
+        A[WhatsApp Server] -->|WebSocket frame| B[Baileys noise-handler<br/>decodeFrame]
+        B --> C[Baileys messages-recv<br/>processNodeWithBuffer]
+        C -->|messages.upsert event| D[Baileys event-buffer<br/>flush + emit]
+    end
+
+    subgraph Inbound Monitor
+        D --> E[handleMessagesUpsert<br/>src/web/inbound/monitor.ts:154]
+        E --> F{upsert.type?}
+        F -->|not notify or append| Z1[return - ignore]
+        F -->|notify or append| G[Loop: for each msg]
+
+        G --> H[resolveJidToE164<br/>Convert JID to phone number<br/>e.g. 15551234567@s.whatsapp.net → +15551234567]
+        H --> I[checkInboundAccessControl<br/>src/web/inbound/access-control.ts:20]
+        I --> J{access.allowed?}
+        J -->|false| Z2[continue - skip message]
+        J -->|true| K[Mark message as read<br/>sock.readMessages]
+
+        K --> L{upsert.type === append?}
+        L -->|yes| Z3[continue - skip auto-reply<br/>historical/offline catch-up]
+        L -->|no - notify| M[Extract message content]
+    end
+
+    subgraph Message Extraction
+        M --> M1[extractLocationData]
+        M1 --> M2[extractText<br/>Get message body]
+        M2 --> M3[describeReplyContext<br/>Quoted message info]
+        M3 --> M4[downloadInboundMedia<br/>Images, audio, docs]
+    end
+
+    subgraph Debouncer
+        M4 --> N[Define callbacks<br/>sendComposing, reply, sendMedia]
+        N --> O[Build WebInboundMessage object]
+        O --> P[debouncer.enqueue<br/>src/web/inbound/monitor.ts:331]
+        P --> Q{Multiple rapid messages<br/>from same sender?}
+        Q -->|yes| R[Combine bodies with newlines]
+        Q -->|no| S[Pass single message]
+        R --> T[onFlush → options.onMessage]
+        S --> T
+    end
+
+    subgraph Auto-Reply Monitor
+        T --> U[onMessage callback<br/>src/web/auto-reply/monitor.ts:207]
+        U --> V[processForRoute<br/>src/web/auto-reply/monitor/on-message.ts:167]
+    end
+
+    subgraph Message Processing
+        V --> W[processMessage<br/>src/web/auto-reply/monitor/process-message.ts]
+        W --> W1[Echo detection<br/>Skip if bot is replying to itself]
+        W1 --> W2[maybeSendAckReaction<br/>Send 👍 typing reaction]
+        W2 --> W3[Resolve text chunk limit<br/>Default 4000 chars for WhatsApp]
+        W3 --> W4[Check command authorization<br/>Is sender allowed to run /commands?]
+        W4 --> W5[Build ctxPayload<br/>finalizeInboundContext with Body,<br/>From, To, SessionKey, etc.]
+        W5 --> W6[updateLastRouteInBackground<br/>Remember where to deliver replies]
+        W6 --> W7[recordSessionMetaFromInbound<br/>Update session metadata]
+    end
+
+    subgraph Dispatch Chain
+        W7 --> X1[dispatchReplyWithBufferedBlockDispatcher<br/>src/auto-reply/reply/provider-dispatcher.ts:14<br/>Select buffered dispatch strategy]
+        X1 --> X2[dispatchInboundMessageWithBufferedDispatcher<br/>src/auto-reply/dispatch.ts:34<br/>Create typing indicator + dispatcher]
+        X2 --> X3[dispatchInboundMessage<br/>src/auto-reply/dispatch.ts:17<br/>Finalize message context]
+        X3 --> X4[dispatchReplyFromConfig<br/>src/auto-reply/reply/dispatch-from-config.ts:82<br/>Orchestration: hooks, dedup,<br/>routing, TTS, diagnostics]
+        X4 --> X5[getReplyFromConfig<br/>Send message to LLM]
+    end
+
+    subgraph Response Delivery
+        X5 -->|streaming response| Y1{Response chunk type}
+        Y1 -->|tool use| Y2[dispatcher.sendToolResult<br/>Intermediate tool update]
+        Y1 -->|block| Y3[dispatcher.sendBlock<br/>Streaming chunk]
+        Y1 -->|final| Y4[dispatcher.sendFinal<br/>Completed reply]
+
+        Y2 --> Y5[deliver callback]
+        Y3 --> Y5
+        Y4 --> Y5
+
+        Y5 --> Y6[deliverWebReply<br/>Apply responsePrefix e.g. openclaw<br/>Chunk text if over limit<br/>Send via Baileys sock.sendMessage]
+        Y6 --> Y7[rememberSentText<br/>Register in echo tracker]
+        Y7 --> Y8[WhatsApp message<br/>delivered to user]
+    end
+
+    style A fill:#25D366,color:#fff
+    style Y8 fill:#25D366,color:#fff
+    style X5 fill:#7B61FF,color:#fff
+    style Z1 fill:#999,color:#fff
+    style Z2 fill:#999,color:#fff
+    style Z3 fill:#999,color:#fff
+```

--- a/docs/reference/AGENTS.default.md
+++ b/docs/reference/AGENTS.default.md
@@ -113,6 +113,7 @@ git commit -m "Add Clawd workspace"
 - **OpenHue CLI** — Philips Hue lighting control for scenes and automations.
 - **OpenAI Whisper** — Local speech-to-text for quick dictation and voicemail transcripts.
 - **Gemini CLI** — Google Gemini models from the terminal for fast Q&A.
+- **ffmpeg** — Video and audio editing — trim, convert, filter, merge, extract audio, create GIFs, and inspect media.
 - **agent-tools** — Utility toolkit for automations and helper scripts.
 
 ## Usage Notes

--- a/extensions/matrix/src/channel-account-paths.ts
+++ b/extensions/matrix/src/channel-account-paths.ts
@@ -1,7 +1,9 @@
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import { PAIRING_APPROVED_MESSAGE } from "openclaw/plugin-sdk/channel-status";
+import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/infra-runtime";
 import { formatMatrixErrorMessage } from "./matrix/errors.js";
 import type { MatrixProbe } from "./matrix/probe.js";
+import type { SsrFPolicy } from "./runtime-api.js";
 import type { CoreConfig } from "./types.js";
 
 type ResolveMatrixAuth = (params: { cfg: CoreConfig; accountId?: string }) => Promise<{
@@ -10,8 +12,8 @@ type ResolveMatrixAuth = (params: { cfg: CoreConfig; accountId?: string }) => Pr
   userId: string;
   deviceId?: string;
   allowPrivateNetwork?: boolean;
-  ssrfPolicy?: unknown;
-  dispatcherPolicy?: unknown;
+  ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
 }>;
 
 type ProbeMatrix = (params: {
@@ -19,11 +21,11 @@ type ProbeMatrix = (params: {
   accessToken: string;
   userId: string;
   deviceId?: string;
-  timeoutMs?: number;
-  accountId?: string;
+  timeoutMs: number;
+  accountId?: string | null;
   allowPrivateNetwork?: boolean;
-  ssrfPolicy?: unknown;
-  dispatcherPolicy?: unknown;
+  ssrfPolicy?: SsrFPolicy;
+  dispatcherPolicy?: PinnedDispatcherPolicy;
 }) => Promise<MatrixProbe>;
 
 type SendMessageMatrix = (
@@ -42,7 +44,7 @@ export function createMatrixProbeAccount(params: {
     cfg,
   }: {
     account: { accountId?: string };
-    timeoutMs?: number;
+    timeoutMs: number;
     cfg: unknown;
   }): Promise<MatrixProbe> => {
     try {

--- a/plans/ffmpeg-skill.md
+++ b/plans/ffmpeg-skill.md
@@ -1,0 +1,56 @@
+# Plan: Add ffmpeg CLI Skill
+
+## Context
+
+The OpenClaw project integrates CLI tools as **skills** — markdown files (`SKILL.md`) with YAML frontmatter that teach the agent how to use CLI commands via the existing `exec` tool. Examples include `sonoscli` (Sonos speakers), `openhue` (Philips Hue lights), and `spotify-player`.
+
+There is an existing `video-frames` skill (`skills/video-frames/SKILL.md`) that uses ffmpeg, but it only extracts single frames via a wrapper shell script. There is no skill for general-purpose video/audio editing with ffmpeg.
+
+**Goal**: Add a comprehensive `ffmpeg` skill so the agent can perform video and audio editing tasks — trimming, concatenation, format conversion, filters, audio extraction, GIF creation, and more — using the same skill pattern as Sonos and Hue.
+
+## Approach
+
+Create a new `skills/ffmpeg/SKILL.md` as a separate skill, keeping `video-frames` unchanged. No TypeScript code changes needed — this is purely a skill definition (markdown + frontmatter). The agent will invoke ffmpeg/ffprobe directly via the `exec` tool, guided by the SKILL.md instructions.
+
+## Files Created
+
+### 1. `skills/ffmpeg/SKILL.md`
+
+**Frontmatter** (follows exact pattern from `skills/sonoscli/SKILL.md` and `skills/openhue/SKILL.md`):
+
+- `name`: `ffmpeg`
+- `description`: Short summary of capabilities
+- `homepage`: `https://ffmpeg.org`
+- `metadata.openclaw.emoji`: `"🎬"`
+- `metadata.openclaw.requires.bins`: `["ffmpeg", "ffprobe"]`
+- `metadata.openclaw.install`: brew formula `"ffmpeg"` (installs both binaries)
+
+**Content sections** (teach the agent direct ffmpeg/ffprobe commands, no wrapper scripts):
+
+1. **Quick Start** — inspect, convert, trim (3 examples)
+2. **Media Inspection (ffprobe)** — get duration/resolution/codec, JSON output, specific fields
+3. **Trimming & Cutting** — precise vs fast trim, removing middle sections
+4. **Concatenation** — same-codec concat (file list + `-c copy`), mixed-format concat (filter_complex)
+5. **Format Conversion** — MP4/WebM/MOV conversions, video-to-GIF (basic + palette method)
+6. **Video Filters** — scale, crop, rotate, speed change, text overlay
+7. **Audio Operations** — extract, replace, remove, volume adjust, fade in/out
+8. **Advanced** — framerate change, image sequence to video, picture-in-picture, side-by-side
+9. **Common Options Reference** — table of frequently-used flags (`-i`, `-c copy`, `-crf`, `-ss`, `-t`, `-vf`, `-af`, `-y`, etc.)
+10. **Tips** — inspect first, use `-c copy` when possible, test on short clips, use `-hide_banner -loglevel error`
+
+### 2. `plans/ffmpeg-skill.md`
+
+This plan document saved to the project root `/plans/` folder.
+
+## Files NOT Modified
+
+- `skills/video-frames/SKILL.md` — remains as-is (narrow frame extraction skill)
+- No TypeScript source files — skills are purely markdown
+- No config schema changes — skill discovery is automatic
+
+## Verification
+
+1. **Skill loads correctly**: Run `openclaw` and verify the ffmpeg skill appears in the available skills list (requires `ffmpeg` and `ffprobe` on PATH)
+2. **Agent uses the skill**: Ask the agent "trim the first 30 seconds from video.mp4" and confirm it reads the SKILL.md and constructs correct ffmpeg commands
+3. **Frontmatter parses**: Verify the YAML frontmatter matches the schema used by existing skills (compare with `skills/sonoscli/SKILL.md`)
+4. **Binary check works**: Remove ffmpeg from PATH temporarily and verify the skill is filtered out

--- a/skills/ffmpeg/SKILL.md
+++ b/skills/ffmpeg/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: ffmpeg
+description: Video and audio editing — trim, convert, filter, merge, extract audio, create GIFs, and inspect media.
+homepage: https://ffmpeg.org
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🎬",
+        "requires": { "bins": ["ffmpeg", "ffprobe"] },
+        "install":
+          [
+            {
+              "id": "brew",
+              "kind": "brew",
+              "formula": "ffmpeg",
+              "bins": ["ffmpeg", "ffprobe"],
+              "label": "Install ffmpeg (brew)",
+            },
+          ],
+      },
+  }
+---
+
+# ffmpeg CLI
+
+Use `ffmpeg` and `ffprobe` for video/audio editing, conversion, and inspection.
+
+## Quick start
+
+Inspect a file:
+
+```bash
+ffprobe -v error -show_format -show_streams input.mp4
+```
+
+Convert format:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 output.webm
+```
+
+Trim (fast, no re-encode):
+
+```bash
+ffmpeg -hide_banner -y -ss 00:00:10 -i input.mp4 -t 00:00:30 -c copy output.mp4
+```
+
+## Media inspection (ffprobe)
+
+Duration, resolution, codec:
+
+```bash
+ffprobe -v error -select_streams v:0 -show_entries stream=width,height,duration,codec_name input.mp4
+```
+
+JSON output:
+
+```bash
+ffprobe -v error -print_format json -show_format -show_streams input.mp4
+```
+
+Duration only (seconds):
+
+```bash
+ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 input.mp4
+```
+
+## Trimming and cutting
+
+Precise trim (re-encodes):
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -ss 00:00:10 -t 00:00:30 output.mp4
+```
+
+Fast trim (stream copy, may be slightly imprecise on keyframes):
+
+```bash
+ffmpeg -hide_banner -y -ss 00:00:10 -i input.mp4 -t 00:00:30 -c copy output.mp4
+```
+
+Remove a middle section (keep 0-10s and 20s-end):
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -filter_complex \
+  "[0:v]trim=0:10,setpts=PTS-STARTPTS[v1]; \
+   [0:a]atrim=0:10,asetpts=PTS-STARTPTS[a1]; \
+   [0:v]trim=20,setpts=PTS-STARTPTS[v2]; \
+   [0:a]atrim=20,asetpts=PTS-STARTPTS[a2]; \
+   [v1][a1][v2][a2]concat=n=2:v=1:a=1[vout][aout]" \
+  -map "[vout]" -map "[aout]" output.mp4
+```
+
+## Concatenation
+
+Same codec (no re-encode):
+
+```bash
+printf "file '%s'\n" video1.mp4 video2.mp4 video3.mp4 > /tmp/concat-list.txt
+ffmpeg -hide_banner -y -f concat -safe 0 -i /tmp/concat-list.txt -c copy output.mp4
+```
+
+Different formats (re-encodes):
+
+```bash
+ffmpeg -hide_banner -y -i video1.mp4 -i video2.mov \
+  -filter_complex "[0:v][0:a][1:v][1:a]concat=n=2:v=1:a=1[vout][aout]" \
+  -map "[vout]" -map "[aout]" output.mp4
+```
+
+## Format conversion
+
+MOV to MP4:
+
+```bash
+ffmpeg -hide_banner -y -i input.mov -c:v libx264 -crf 23 -c:a aac output.mp4
+```
+
+MP4 to WebM:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -c:v libvpx-vp9 -crf 30 -b:v 0 -c:a libopus output.webm
+```
+
+Video to GIF:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -vf "fps=10,scale=320:-1:flags=lanczos" output.gif
+```
+
+High-quality GIF (two-pass with palette):
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -vf "fps=10,scale=320:-1:flags=lanczos,palettegen" /tmp/palette.png
+ffmpeg -hide_banner -y -i input.mp4 -i /tmp/palette.png \
+  -filter_complex "fps=10,scale=320:-1:flags=lanczos[x];[x][1:v]paletteuse" output.gif
+```
+
+## Video filters
+
+Scale / resize:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -vf "scale=1280:720" output.mp4
+ffmpeg -hide_banner -y -i input.mp4 -vf "scale=-1:720" output.mp4   # preserve aspect
+```
+
+Crop:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -vf "crop=640:480:0:0" output.mp4
+```
+
+Rotate:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -vf "transpose=1" output.mp4   # 90 clockwise
+ffmpeg -hide_banner -y -i input.mp4 -vf "transpose=2" output.mp4   # 90 counter-clockwise
+```
+
+Speed change:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -vf "setpts=0.5*PTS" -af "atempo=2.0" output.mp4   # 2x
+ffmpeg -hide_banner -y -i input.mp4 -vf "setpts=2.0*PTS" -af "atempo=0.5" output.mp4   # 0.5x
+```
+
+Text overlay:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 \
+  -vf "drawtext=text='Hello':fontsize=24:fontcolor=white:x=10:y=10" output.mp4
+```
+
+## Audio operations
+
+Extract audio:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -vn -c:a copy output.m4a
+ffmpeg -hide_banner -y -i input.mp4 -vn -c:a libmp3lame -q:a 2 output.mp3
+```
+
+Replace audio track:
+
+```bash
+ffmpeg -hide_banner -y -i video.mp4 -i audio.mp3 -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 output.mp4
+```
+
+Remove audio:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -an -c:v copy output.mp4
+```
+
+Adjust volume:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -af "volume=2.0" output.mp4
+```
+
+Fade in/out:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -af "afade=t=in:st=0:d=3,afade=t=out:st=27:d=3" output.mp4
+```
+
+## Advanced
+
+Change framerate:
+
+```bash
+ffmpeg -hide_banner -y -i input.mp4 -r 30 output.mp4
+```
+
+Image sequence to video:
+
+```bash
+ffmpeg -hide_banner -y -framerate 30 -pattern_type glob -i '*.png' -c:v libx264 -pix_fmt yuv420p output.mp4
+```
+
+Picture-in-picture:
+
+```bash
+ffmpeg -hide_banner -y -i main.mp4 -i overlay.mp4 \
+  -filter_complex "[1:v]scale=320:240[pip];[0:v][pip]overlay=10:10" output.mp4
+```
+
+Side-by-side:
+
+```bash
+ffmpeg -hide_banner -y -i left.mp4 -i right.mp4 -filter_complex "[0:v][1:v]hstack=inputs=2" output.mp4
+```
+
+## Common options
+
+- `-i file` — input file
+- `-c copy` — stream copy (no re-encode, fast)
+- `-c:v codec` — video codec (`libx264`, `libx265`, `libvpx-vp9`)
+- `-c:a codec` — audio codec (`aac`, `libmp3lame`, `libopus`)
+- `-crf N` — quality (lower = better; 18-28 typical)
+- `-b:v 1M` — video bitrate
+- `-r N` — framerate
+- `-vf "filter"` — video filter
+- `-af "filter"` — audio filter
+- `-ss HH:MM:SS` — start time
+- `-t duration` — duration
+- `-to HH:MM:SS` — end time
+- `-an` — strip audio
+- `-vn` — strip video
+- `-y` — overwrite without asking
+- `-hide_banner` — suppress build info
+- `-loglevel error` — errors only
+
+## Tips
+
+- Always inspect with `ffprobe` before editing.
+- Use `-c copy` when possible to avoid slow re-encoding.
+- Place `-ss` before `-i` for fast seek (stream copy); after `-i` for precise seek (re-encode).
+- Test complex filter chains on short clips first.
+- Use `-hide_banner -loglevel error` for cleaner output.
+- For speed changes with audio, pair `-vf setpts` with `-af atempo`.


### PR DESCRIPTION
## Summary
- Aligns `ProbeMatrix`, `ResolveMatrixAuth`, and the inner function types in `channel-account-paths.ts` with the actual `probeMatrix()` signature in `probe.ts`
- `timeoutMs` was optional but `probeMatrix` requires it (and the core `ChannelStatusAdapter` contract at `types.adapters.ts:277` passes it as required)
- `ssrfPolicy`/`dispatcherPolicy` were typed as `unknown` instead of their concrete `SsrFPolicy`/`PinnedDispatcherPolicy` types
- `accountId` was `string` instead of `string | null` to match the probe param

## Context
This causes `build:plugin-sdk:dts` (`tsc -p tsconfig.plugin-sdk.dts.json`) to fail with TS2345. The types drifted when the `probeMatrix` function was refactored to require `timeoutMs` and use concrete policy types, but the local type aliases in `channel-account-paths.ts` were not updated to match.

## Test plan
- [x] `pnpm build` passes (including `build:plugin-sdk:dts`)
- [x] `pnpm test -- extensions/matrix/src/channel.account-paths.test.ts` — 2/2 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)