### PR TITLE
fix(test): remove unused imports breaking oxlint for all open PRs

### DIFF
--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -1,11 +1,4 @@
 import { describe, expect, it } from "vitest";
-import {
-  IMessageConfigSchema,
-  SignalConfigSchema,
-  TelegramConfigSchema,
-  WhatsAppConfigSchema,
-} from "../plugin-sdk/channel-config-schema.js";
-import { findLegacyConfigIssues } from "./legacy.js";
 import { validateConfigObject } from "./validation.js";
 import {
   DiscordConfigSchema,


### PR DESCRIPTION
## Summary

- Problem: 5 unused imports in `config.legacy-config-detection.rejects-routing-allowfrom.test.ts` cause oxlint to fail with `no-unused-vars` errors. This breaks the `check` job for every open PR in the repo.
- Why it matters: no PR can pass CI until this is fixed. The imports were left behind after a config validation refactor.
- What changed: removed 3 unused import lines (IMessageConfigSchema, SignalConfigSchema, TelegramConfigSchema, WhatsAppConfigSchema from channel-config-schema, and findLegacyConfigIssues from legacy).
- What did NOT change: no production code touched. Test logic is unchanged - these identifiers weren't referenced in any test body.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: config validation refactor removed usage of these identifiers from the test body but left the import statements.
- Missing detection / guardrail: oxlint wasn't in the pre-commit hook at the time of the refactor.

## Regression Test Plan (if applicable)

- [x] Existing coverage already sufficient
- If no new test is added, why not: this IS a test file cleanup. The lint itself is the guardrail.

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Touches auth, secrets, or tokens? No
- Handles user input? No
- New dependencies? No

## Repro + Verification

```bash
pnpm check   # fails before, passes after
```

## Human Verification (required)

- Confirmed all 5 identifiers appear only on their import lines, never in the test body
- Ran `pnpm check` locally - passes clean (0 warnings, 0 errors)
- No test logic was removed or modified, only import statements