### PR TITLE
fix(acp): stabilize bridge session keys

### DIFF
--- a/src/acp/translator.session-rate-limit.test.ts
+++ b/src/acp/translator.session-rate-limit.test.ts
@@ -203,6 +203,19 @@ describe("acp unsupported bridge session setup", () => {
 });
 
 describe("acp session UX bridge behavior", () => {
+  it("uses ACP bridge session keys for new CLI sessions without metadata", async () => {
+    const sessionStore = createInMemorySessionStore();
+    const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(), {
+      sessionStore,
+    });
+
+    const result = await agent.newSession(createNewSessionRequest());
+
+    expect(sessionStore.getSession(result.sessionId)?.sessionKey).toMatch(/^acp-bridge:/);
+
+    sessionStore.clearAllSessionsForTest();
+  });
+
   it("returns initial modes and thought-level config options for new sessions", async () => {
     const sessionStore = createInMemorySessionStore();
     const agent = new AcpGatewayAgent(createAcpConnection(), createAcpGateway(), {

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -12,9 +12,10 @@ type PendingPromptHarness = {
   runId: string;
 };
 
-async function createPendingPromptHarness(): Promise<PendingPromptHarness> {
+async function createPendingPromptHarness(
+  sessionKey = "agent:main:main",
+): Promise<PendingPromptHarness> {
   const sessionId = "session-1";
-  const sessionKey = "agent:main:main";
 
   let runId: string | undefined;
   const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
@@ -88,6 +89,23 @@ describe("acp translator stop reason mapping", () => {
         sessionKey: "agent:main:main",
         seq: 1,
         state: "error",
+      }),
+    );
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
+  it("matches canonical gateway session keys for ACP bridge sessions", async () => {
+    const { agent, promptPromise, runId } = await createPendingPromptHarness(
+      "acp-bridge:bridge-session",
+    );
+
+    await agent.handleGatewayEvent(
+      createChatEvent({
+        runId,
+        sessionKey: "agent:main:acp-bridge:bridge-session",
+        seq: 1,
+        state: "final",
       }),
     );
 

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -408,6 +408,24 @@ function buildSystemProvenanceReceipt(params: {
   ].join("\n");
 }
 
+function stripAgentSessionKeyPrefix(sessionKey: string): string {
+  const raw = sessionKey.trim();
+  const parts = raw.split(":").filter(Boolean);
+  if (parts.length >= 3 && parts[0]?.toLowerCase() === "agent") {
+    return parts.slice(2).join(":");
+  }
+  return raw;
+}
+
+function isSameGatewaySessionKey(left: string, right: string): boolean {
+  const normalizedLeft = left.trim().toLowerCase();
+  const normalizedRight = right.trim().toLowerCase();
+  if (normalizedLeft === normalizedRight) {
+    return true;
+  }
+  return stripAgentSessionKeyPrefix(normalizedLeft) === stripAgentSessionKeyPrefix(normalizedRight);
+}
+
 export class AcpGatewayAgent implements Agent {
   private connection: AgentSideConnection;
   private gateway: GatewayClient;
@@ -522,7 +540,7 @@ export class AcpGatewayAgent implements Agent {
     const meta = parseSessionMeta(params._meta);
     const sessionKey = await this.resolveSessionKeyFromMeta({
       meta,
-      fallbackKey: `acp:${sessionId}`,
+      fallbackKey: `acp-bridge:${sessionId}`,
     });
 
     const session = this.sessionStore.createSession({
@@ -1038,7 +1056,7 @@ export class AcpGatewayAgent implements Agent {
 
   private findPendingBySessionKey(sessionKey: string, runId?: string): PendingPrompt | undefined {
     for (const pending of this.pendingPrompts.values()) {
-      if (pending.sessionKey !== sessionKey) {
+      if (!isSameGatewaySessionKey(pending.sessionKey, sessionKey)) {
         continue;
       }
       if (runId && pending.idempotencyKey !== runId) {

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -136,6 +136,27 @@ describe("task-registry maintenance issue #60299", () => {
     expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
   });
 
+  it("marks active cron tasks lost when their child session is terminal", async () => {
+    const childSessionKey = "agent:main:main";
+    const task = makeStaleTask({
+      runtime: "cron",
+      sourceId: "cron-job-terminal-child",
+      childSessionKey,
+    });
+
+    const { mod, currentTasks } = await loadMaintenanceModule({
+      tasks: [task],
+      activeCronJobIds: ["cron-job-terminal-child"],
+      sessionStore: { [childSessionKey]: { status: "done", endedAt: Date.now() - 1_000 } },
+    });
+
+    expect(await mod.runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({
+      status: "lost",
+      error: "backing session missing",
+    });
+  });
+
   it("marks chat-backed cli tasks lost after the owning run context disappears", async () => {
     const channelKey = "agent:main:slack:channel:C1234567890";
     const task = makeStaleTask({

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -98,6 +98,23 @@ function isTerminalTask(task: TaskRecord): boolean {
   return !isActiveTask(task);
 }
 
+function isTerminalSessionEntry(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const record = entry as { endedAt?: unknown; status?: unknown };
+  const status = typeof record.status === "string" ? record.status.trim().toLowerCase() : "";
+  return (
+    Boolean(record.endedAt) ||
+    status === "done" ||
+    status === "timeout" ||
+    status === "killed" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "error"
+  );
+}
+
 function hasLostGraceExpired(task: TaskRecord, now: number): boolean {
   const referenceAt = task.lastEventAt ?? task.startedAt ?? task.createdAt;
   return now - referenceAt >= TASK_RECONCILE_GRACE_MS;
@@ -117,7 +134,12 @@ function hasActiveCliRun(task: TaskRecord): boolean {
 function hasBackingSession(task: TaskRecord): boolean {
   if (task.runtime === "cron") {
     const jobId = task.sourceId?.trim();
-    return jobId ? taskRegistryMaintenanceRuntime.isCronJobActive(jobId) : false;
+    if (!jobId || !taskRegistryMaintenanceRuntime.isCronJobActive(jobId)) {
+      return false;
+    }
+    if (!task.childSessionKey?.trim()) {
+      return true;
+    }
   }
 
   if (task.runtime === "cli" && hasActiveCliRun(task)) {
@@ -137,7 +159,7 @@ function hasBackingSession(task: TaskRecord): boolean {
     }
     return Boolean(acpEntry.entry);
   }
-  if (task.runtime === "subagent" || task.runtime === "cli") {
+  if (task.runtime === "subagent" || task.runtime === "cli" || task.runtime === "cron") {
     if (task.runtime === "cli") {
       const chatType = deriveSessionChatType(childSessionKey);
       if (chatType === "channel" || chatType === "group" || chatType === "direct") {
@@ -147,7 +169,8 @@ function hasBackingSession(task: TaskRecord): boolean {
     const agentId = taskRegistryMaintenanceRuntime.parseAgentSessionKey(childSessionKey)?.agentId;
     const storePath = taskRegistryMaintenanceRuntime.resolveStorePath(undefined, { agentId });
     const store = taskRegistryMaintenanceRuntime.loadSessionStore(storePath);
-    return Boolean(findSessionEntryByKey(store, childSessionKey));
+    const entry = findSessionEntryByKey(store, childSessionKey);
+    return Boolean(entry) && !isTerminalSessionEntry(entry);
   }
 
   return true;


### PR DESCRIPTION
# PR: fix(acp): stabilize bridge session keys

## Summary
- Use `acp-bridge:<uuid>` for ACP bridge fallback sessions created without metadata.
- Match pending ACP prompts across raw and Gateway-canonical session keys, e.g. `acp-bridge:<uuid>` and `agent:main:acp-bridge:<uuid>`.
- Treat terminal child sessions as missing backing sessions during task registry maintenance for `cron`, `cli`, and `subagent` tasks.

## Why
`acpx ... openclaw exec ...` could hang or fail because ACP bridge fallback keys used `acp:<uuid>`. Gateway canonicalization turned those into `agent:main:acp:<uuid>`, which collided with internal OpenClaw ACP runtime session semantics and expected `/acp spawn` metadata. After switching to `acp-bridge:<uuid>`, final Gateway chat events still arrive under the canonical key, so pending prompt lookup also needs raw/canonical key equivalence.

The task maintenance change prevents stale tasks from staying live solely because a child session record still exists after it has already reached a terminal state.

## Validation
- `pnpm install`
- `pnpm tsgo`
- `git diff --check`
- `pnpm vitest run src/acp/translator.stop-reason.test.ts --reporter=verbose -t 'matches canonical gateway session keys for ACP bridge sessions'`
- `pnpm vitest run src/acp/translator.session-rate-limit.test.ts --reporter=verbose -t 'uses ACP bridge session keys for new CLI sessions without metadata'`
- `pnpm vitest run src/tasks/task-registry.maintenance.issue-60299.test.ts --reporter=verbose -t 'marks active cron tasks lost when their child session is terminal'`

## Note
Running the full `src/tasks/task-registry.maintenance.issue-60299.test.ts` file hung on the pre-existing `marks chat-backed cli tasks lost after the owning run context disappears` case, apparently around plugin bootstrap/session chat-type derivation. The new cron terminal-child regression test passes when run directly.
