### PR TITLE
perf: add includeTranscriptUsage opt-in to sessions.list, default off

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2270,7 +2270,9 @@ Notes:
         allowAgents: ["research"],
         model: "minimax/MiniMax-M2.7",
         maxConcurrent: 8,
+        startupWaitTimeoutMs: 60000,
         runTimeoutSeconds: 900,
+        completionAnnounceTimeoutMs: 90000,
         archiveAfterMinutes: 60,
       },
     },
@@ -2280,7 +2282,10 @@ Notes:
 
 - `model`: default model for spawned sub-agents. If omitted, sub-agents inherit the caller's model.
 - `allowAgents`: default allowlist of target agent ids for `sessions_spawn` when the requester agent does not set its own `subagents.allowAgents` (`["*"]` = any; default: same agent only).
+- `startupWaitTimeoutMs`: requester-side patience in milliseconds for sub-agent startup/setup RPCs before the child is considered launched. Default: `60000`. This affects early spawn bookkeeping and the primary startup RPC; it does not change child runtime abort behavior.
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
+- `completionAnnounceTimeoutMs`: preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls. Default: `90000`.
+- `announceTimeoutMs`: backward-compatible alias for `completionAnnounceTimeoutMs`. If both are set, `completionAnnounceTimeoutMs` wins.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 
 ---

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2767,6 +2767,8 @@ See [Plugins](/tools/plugin).
 
 ## Gateway
 
+- `gateway.connectChallengeTimeoutMs`: WebSocket pre-auth/connect handshake timeout in milliseconds. Default: `10000`. Raise this when local control-plane stalls can delay connect challenge completion enough to trip a handshake-timeout before the session is connected.
+
 ```json5
 {
   gateway: {

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -83,7 +83,9 @@ Use `sessions_spawn`:
 - Then runs an announce step and posts the announce reply to the requester chat channel
 - Default model: inherits the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.list[].subagents.model`); an explicit `sessions_spawn.model` still wins.
 - Default thinking: inherits the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.list[].subagents.thinking`); an explicit `sessions_spawn.thinking` still wins.
+- Default startup patience: sub-agent startup/setup RPCs use `agents.defaults.subagents.startupWaitTimeoutMs` when set; otherwise they fall back to `60000` ms. This is requester-side wait budget only.
 - Default run timeout: if `sessions_spawn.runTimeoutSeconds` is omitted, OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout).
+- Default completion announce timeout: completion delivery uses `agents.defaults.subagents.completionAnnounceTimeoutMs` when set, otherwise falls back to the legacy alias `agents.defaults.subagents.announceTimeoutMs`, then to `90000` ms.
 
 Tool params:
 
@@ -149,7 +151,9 @@ Auto-archive:
 - Archive uses `sessions.delete` and renames the transcript to `*.deleted.<timestamp>` (same folder).
 - `cleanup: "delete"` archives immediately after announce (still keeps the transcript via rename).
 - Auto-archive is best-effort; pending timers are lost if the gateway restarts.
+- `startupWaitTimeoutMs` does **not** stop a child that eventually starts; it only controls how long the requester waits for startup/setup RPCs before surfacing a timeout.
 - `runTimeoutSeconds` does **not** auto-archive; it only stops the run. The session remains until auto-archive.
+- `completionAnnounceTimeoutMs` only affects final completion announce delivery. It does not change startup wait or child runtime limits.
 - Auto-archive applies equally to depth-1 and depth-2 sessions.
 - Browser cleanup is separate from archive cleanup: tracked browser tabs/processes are best-effort closed when the run finishes, even if the transcript/session record is kept.
 
@@ -167,7 +171,10 @@ By default, sub-agents cannot spawn their own sub-agents (`maxSpawnDepth: 1`). Y
         maxSpawnDepth: 2, // allow sub-agents to spawn children (default: 1)
         maxChildrenPerAgent: 5, // max active children per agent session (default: 5)
         maxConcurrent: 8, // global concurrency lane cap (default: 8)
-        runTimeoutSeconds: 900, // default timeout for sessions_spawn when omitted (0 = no timeout)
+        startupWaitTimeoutMs: 60000, // requester wait budget for startup/setup RPCs before launch
+        runTimeoutSeconds: 900, // child runtime timeout when sessions_spawn omits it (0 = no timeout)
+        completionAnnounceTimeoutMs: 90000, // preferred completion announce delivery timeout
+        announceTimeoutMs: 90000, // legacy alias for completionAnnounceTimeoutMs
       },
     },
   },

--- a/src/acp/translator.ts
+++ b/src/acp/translator.ts
@@ -1236,6 +1236,7 @@ export class AcpGatewayAgent implements Agent {
       limit: 200,
       search: sessionKey,
       includeDerivedTitles: true,
+      includeTranscriptUsage: true,
     });
     const session = result.sessions.find((entry) => entry.key === sessionKey);
     if (!session) {

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-startup-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-startup-timeout.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import "./test-helpers/fast-core-tools.js";
+import {
+  getCallGatewayMock,
+  getSessionsSpawnTool,
+  resetSessionsSpawnConfigOverride,
+  setSessionsSpawnConfigOverride,
+  setupSessionsSpawnGatewayMock,
+  type GatewayRequest,
+} from "./openclaw-tools.subagents.sessions-spawn.test-harness.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+const MAIN_SESSION_KEY = "agent:test:main";
+
+function configureDefaults(subagents: Record<string, unknown>) {
+  setSessionsSpawnConfigOverride({
+    session: { mainKey: "main", scope: "per-sender" },
+    agents: { defaults: { subagents } },
+  });
+}
+
+function findSubagentStartupCall(
+  calls: Array<GatewayRequest>,
+): (GatewayRequest & { timeoutMs?: number }) | undefined {
+  return calls.find((entry) => {
+    if (entry.method !== "agent") {
+      return false;
+    }
+    const params = entry.params as { lane?: string } | undefined;
+    return params?.lane === "subagent";
+  }) as (GatewayRequest & { timeoutMs?: number }) | undefined;
+}
+
+function findSessionsPatchCall(
+  calls: Array<GatewayRequest>,
+): (GatewayRequest & { timeoutMs?: number }) | undefined {
+  return calls.find((entry) => entry.method === "sessions.patch") as
+    | (GatewayRequest & { timeoutMs?: number })
+    | undefined;
+}
+
+function findSessionsDeleteCall(
+  calls: Array<GatewayRequest>,
+): (GatewayRequest & { timeoutMs?: number }) | undefined {
+  return calls.find((entry) => entry.method === "sessions.delete") as
+    | (GatewayRequest & { timeoutMs?: number })
+    | undefined;
+}
+
+describe("sessions_spawn subagent startup wait timeout", () => {
+  beforeEach(() => {
+    resetSessionsSpawnConfigOverride();
+    resetSubagentRegistryForTests();
+    getCallGatewayMock().mockClear();
+  });
+
+  it("falls back to 60s startup wait patience when config key is absent", async () => {
+    configureDefaults({ maxConcurrent: 8 });
+    const gateway = setupSessionsSpawnGatewayMock({});
+    const tool = await getSessionsSpawnTool({ agentSessionKey: MAIN_SESSION_KEY });
+
+    const result = await tool.execute("call-startup-timeout-default", { task: "hello" });
+
+    expect(result.details).toMatchObject({ status: "accepted" });
+    expect(findSubagentStartupCall(gateway.calls)?.timeoutMs).toBe(60_000);
+  });
+
+  it("honors configured startupWaitTimeoutMs for pre-launch setup and the primary startup RPC", async () => {
+    configureDefaults({ maxConcurrent: 8, startupWaitTimeoutMs: 45_000 });
+    const gateway = setupSessionsSpawnGatewayMock({});
+    const tool = await getSessionsSpawnTool({ agentSessionKey: MAIN_SESSION_KEY });
+
+    const result = await tool.execute("call-startup-timeout-configured", { task: "hello" });
+
+    expect(result.details).toMatchObject({ status: "accepted" });
+    expect(findSessionsPatchCall(gateway.calls)?.timeoutMs).toBe(45_000);
+    expect(findSubagentStartupCall(gateway.calls)?.timeoutMs).toBe(45_000);
+  });
+
+  it("keeps cleanup-path waits on their short budget when startup fails", async () => {
+    configureDefaults({ maxConcurrent: 8, startupWaitTimeoutMs: 45_000 });
+    const calls: Array<GatewayRequest> = [];
+    getCallGatewayMock().mockImplementation(async (request: GatewayRequest) => {
+      calls.push(request);
+      if (request.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (request.method === "agent") {
+        throw new Error("spawn startup failed");
+      }
+      if (request.method === "sessions.delete") {
+        return { ok: true };
+      }
+      return {};
+    });
+    const tool = await getSessionsSpawnTool({ agentSessionKey: MAIN_SESSION_KEY });
+
+    const result = await tool.execute("call-startup-timeout-cleanup", { task: "hello" });
+
+    expect(result.details).toMatchObject({
+      status: "error",
+      error: "spawn startup failed",
+    });
+    expect(findSubagentStartupCall(calls)?.timeoutMs).toBe(45_000);
+    expect(findSessionsDeleteCall(calls)?.timeoutMs).toBe(10_000);
+  });
+});

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -64,11 +64,14 @@ function resolveDirectAnnounceTransientRetryDelaysMs() {
 }
 
 export function resolveSubagentAnnounceTimeoutMs(cfg: ReturnType<typeof loadConfig>): number {
-  const configured = cfg.agents?.defaults?.subagents?.announceTimeoutMs;
-  if (typeof configured !== "number" || !Number.isFinite(configured)) {
+  const configured = cfg.agents?.defaults?.subagents?.completionAnnounceTimeoutMs;
+  const legacyConfigured = cfg.agents?.defaults?.subagents?.announceTimeoutMs;
+  const effectiveConfigured =
+    typeof configured === "number" && Number.isFinite(configured) ? configured : legacyConfigured;
+  if (typeof effectiveConfigured !== "number" || !Number.isFinite(effectiveConfigured)) {
     return DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS;
   }
-  return Math.min(Math.max(1, Math.floor(configured)), MAX_TIMER_SAFE_TIMEOUT_MS);
+  return Math.min(Math.max(1, Math.floor(effectiveConfigured)), MAX_TIMER_SAFE_TIMEOUT_MS);
 }
 
 export function isInternalAnnounceRequesterSession(sessionKey: string | undefined): boolean {

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -122,13 +122,13 @@ vi.mock("./subagent-announce-delivery.js", () => ({
             }),
       },
     });
+    const configured = configOverride.agents?.defaults?.subagents?.completionAnnounceTimeoutMs;
+    const legacyConfigured = configOverride.agents?.defaults?.subagents?.announceTimeoutMs;
+    const effectiveConfigured =
+      typeof configured === "number" && Number.isFinite(configured) ? configured : legacyConfigured;
     const timeoutMs =
-      typeof configOverride.agents?.defaults?.subagents?.announceTimeoutMs === "number" &&
-      Number.isFinite(configOverride.agents.defaults.subagents.announceTimeoutMs)
-        ? Math.min(
-            Math.max(1, Math.floor(configOverride.agents.defaults.subagents.announceTimeoutMs)),
-            2_147_000_000,
-          )
+      typeof effectiveConfigured === "number" && Number.isFinite(effectiveConfigured)
+        ? Math.min(Math.max(1, Math.floor(effectiveConfigured)), 2_147_000_000)
         : 120_000;
     const retryDelaysMs =
       process.env.OPENCLAW_TEST_FAST === "1" ? [8, 16, 32] : [5_000, 10_000, 20_000];

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -317,8 +317,16 @@ describe("subagent announce timeout config", () => {
   });
 
   it("prefers completionAnnounceTimeoutMs over legacy announceTimeoutMs", async () => {
-    configOverride.agents.defaults.subagents.announceTimeoutMs = 45_000;
-    configOverride.agents.defaults.subagents.completionAnnounceTimeoutMs = 55_000;
+    configOverride = {
+      agents: {
+        defaults: {
+          subagents: {
+            announceTimeoutMs: 45_000,
+            completionAnnounceTimeoutMs: 55_000,
+          },
+        },
+      },
+    };
     await runAnnounceFlowForTest("run-completion-timeout-preferred", {
       requesterOrigin: { channel: "discord", to: "12345" },
       expectsCompletionMessage: true,

--- a/src/agents/subagent-announce.timeout.test.ts
+++ b/src/agents/subagent-announce.timeout.test.ts
@@ -160,11 +160,14 @@ vi.mock("./subagent-announce-delivery.js", () => ({
   resolveSubagentCompletionOrigin: async (params: { requesterOrigin?: unknown }) =>
     params.requesterOrigin,
   resolveSubagentAnnounceTimeoutMs: (cfg: typeof configOverride) => {
-    const configured = cfg.agents?.defaults?.subagents?.announceTimeoutMs;
-    if (typeof configured !== "number" || !Number.isFinite(configured)) {
+    const configured = cfg.agents?.defaults?.subagents?.completionAnnounceTimeoutMs;
+    const legacyConfigured = cfg.agents?.defaults?.subagents?.announceTimeoutMs;
+    const effectiveConfigured =
+      typeof configured === "number" && Number.isFinite(configured) ? configured : legacyConfigured;
+    if (typeof effectiveConfigured !== "number" || !Number.isFinite(effectiveConfigured)) {
       return 120_000;
     }
-    return Math.min(Math.max(1, Math.floor(configured)), 2_147_000_000);
+    return Math.min(Math.max(1, Math.floor(effectiveConfigured)), 2_147_000_000);
   },
   runAnnounceDeliveryWithRetry: async <T>(params: { run: () => Promise<T> }) => await params.run(),
 }));
@@ -311,6 +314,20 @@ describe("subagent announce timeout config", () => {
       (call) => call.method === "agent" && call.expectFinal === true,
     );
     expect(completionDirectAgentCall?.timeoutMs).toBe(120_000);
+  });
+
+  it("prefers completionAnnounceTimeoutMs over legacy announceTimeoutMs", async () => {
+    configOverride.agents.defaults.subagents.announceTimeoutMs = 45_000;
+    configOverride.agents.defaults.subagents.completionAnnounceTimeoutMs = 55_000;
+    await runAnnounceFlowForTest("run-completion-timeout-preferred", {
+      requesterOrigin: { channel: "discord", to: "12345" },
+      expectsCompletionMessage: true,
+    });
+
+    const completionDirectAgentCall = findGatewayCall(
+      (call) => call.method === "agent" && call.expectFinal === true,
+    );
+    expect(completionDirectAgentCall?.timeoutMs).toBe(55_000);
   });
 
   it("retries gateway timeout for externally delivered completion announces before giving up", async () => {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -252,7 +252,7 @@ async function cleanupProvisionalSession(
         emitLifecycleHooks: options?.emitLifecycleHooks === true,
         deleteTranscript: options?.deleteTranscript === true,
       },
-      timeoutMs: 10_000,
+      timeoutMs: startupWaitTimeoutMs,
     });
   } catch {
     // Best-effort cleanup only.

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -45,7 +45,6 @@ import {
   isAdminOnlyMethod,
 } from "./subagent-spawn.runtime.js";
 import { readStringParam } from "./tools/common.js";
-import { MAX_SAFE_TIMEOUT_MS } from "./timeout.js";
 
 export const SUBAGENT_SPAWN_MODES = ["run", "session"] as const;
 export type SpawnSubagentMode = (typeof SUBAGENT_SPAWN_MODES)[number];
@@ -55,13 +54,15 @@ export type SpawnSubagentSandboxMode = (typeof SUBAGENT_SPAWN_SANDBOX_MODES)[num
 export { decodeStrictBase64 };
 
 const DEFAULT_SUBAGENT_STARTUP_TIMEOUT_MS = 60_000;
+const SUBAGENT_MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
+const SUBAGENT_SUBAGENT_MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
 export function resolveSubagentStartupWaitTimeoutMs(cfg: ReturnType<typeof loadConfig>): number {
   const configured = cfg.agents?.defaults?.subagents?.startupWaitTimeoutMs;
   if (typeof configured !== "number" || !Number.isFinite(configured)) {
     return DEFAULT_SUBAGENT_STARTUP_TIMEOUT_MS;
   }
-  return Math.min(Math.max(1, Math.floor(configured)), MAX_SAFE_TIMEOUT_MS);
+  return Math.min(Math.max(1, Math.floor(configured)), SUBAGENT_MAX_SAFE_TIMEOUT_MS);
 }
 
 type SubagentSpawnDeps = {
@@ -252,7 +253,7 @@ async function cleanupProvisionalSession(
         emitLifecycleHooks: options?.emitLifecycleHooks === true,
         deleteTranscript: options?.deleteTranscript === true,
       },
-      timeoutMs: startupWaitTimeoutMs,
+      timeoutMs: 10_000,
     });
   } catch {
     // Best-effort cleanup only.
@@ -756,7 +757,7 @@ export async function spawnSubagentDirect(
         label: label || undefined,
         ...publicSpawnedMetadata,
       },
-      timeoutMs: 10_000,
+      timeoutMs: startupWaitTimeoutMs,
     });
     const runId = readGatewayRunId(response);
     if (runId) {

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -53,6 +53,16 @@ export type SpawnSubagentSandboxMode = (typeof SUBAGENT_SPAWN_SANDBOX_MODES)[num
 
 export { decodeStrictBase64 };
 
+const DEFAULT_SUBAGENT_STARTUP_TIMEOUT_MS = 60_000;
+
+export function resolveSubagentStartupWaitTimeoutMs(cfg: ReturnType<typeof loadConfig>): number {
+  const configured = cfg.agents?.defaults?.subagents?.startupWaitTimeoutMs;
+  if (typeof configured !== "number" || !Number.isFinite(configured)) {
+    return DEFAULT_SUBAGENT_STARTUP_TIMEOUT_MS;
+  }
+  return Math.min(Math.max(1, Math.floor(configured)), MAX_SAFE_TIMEOUT_MS);
+}
+
 type SubagentSpawnDeps = {
   callGateway: typeof callGateway;
   getGlobalHookRunner: () => SubagentLifecycleHookRunner | null;
@@ -409,6 +419,7 @@ export async function spawnSubagentDirect(
     typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
       ? Math.max(0, Math.floor(params.runTimeoutSeconds))
       : cfgSubagentTimeout;
+  const startupWaitTimeoutMs = resolveSubagentStartupWaitTimeoutMs(cfg);
   let modelApplied = false;
   let threadBindingReady = false;
   const { mainKey, alias } = resolveMainSessionAlias(cfg);

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -45,6 +45,7 @@ import {
   isAdminOnlyMethod,
 } from "./subagent-spawn.runtime.js";
 import { readStringParam } from "./tools/common.js";
+import { MAX_SAFE_TIMEOUT_MS } from "./timeout.js";
 
 export const SUBAGENT_SPAWN_MODES = ["run", "session"] as const;
 export type SpawnSubagentMode = (typeof SUBAGENT_SPAWN_MODES)[number];

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -539,7 +539,7 @@ export async function spawnSubagentDirect(
       await callSubagentGateway({
         method: "sessions.patch",
         params: { key: childSessionKey, ...patch },
-        timeoutMs: 10_000,
+        timeoutMs: startupWaitTimeoutMs,
       });
       return undefined;
     } catch (err) {

--- a/src/config/gateway-connect-challenge-timeout.test.ts
+++ b/src/config/gateway-connect-challenge-timeout.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { validateConfigObject } from "./validation.js";
+
+describe("gateway.connectChallengeTimeoutMs", () => {
+  it("accepts values above the old 10-second handshake cap", () => {
+    const result = validateConfigObject({
+      gateway: {
+        connectChallengeTimeoutMs: 20_000,
+      },
+    });
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/config/gateway-connect-challenge-timeout.test.ts
+++ b/src/config/gateway-connect-challenge-timeout.test.ts
@@ -18,6 +18,6 @@ describe("gateway.connectChallengeTimeoutMs", () => {
       },
     });
     expect(result.ok).toBe(false);
-    expect(result.issues.join("\n")).toContain("connectChallengeTimeoutMs");
+    expect(JSON.stringify(result.issues)).toContain("connectChallengeTimeoutMs");
   });
 });

--- a/src/config/gateway-connect-challenge-timeout.test.ts
+++ b/src/config/gateway-connect-challenge-timeout.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-
 import { validateConfigObject } from "./validation.js";
 
 describe("gateway.connectChallengeTimeoutMs", () => {
@@ -10,5 +9,15 @@ describe("gateway.connectChallengeTimeoutMs", () => {
       },
     });
     expect(result.ok).toBe(true);
+  });
+
+  it("rejects values above the runtime max", () => {
+    const result = validateConfigObject({
+      gateway: {
+        connectChallengeTimeoutMs: 300_001,
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.issues.join("\n")).toContain("connectChallengeTimeoutMs");
   });
 });

--- a/src/config/gateway-connect-challenge-timeout.test.ts
+++ b/src/config/gateway-connect-challenge-timeout.test.ts
@@ -18,6 +18,9 @@ describe("gateway.connectChallengeTimeoutMs", () => {
       },
     });
     expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected config validation to fail");
+    }
     expect(JSON.stringify(result.issues)).toContain("connectChallengeTimeoutMs");
   });
 });

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4791,27 +4791,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   thinking: {
                     type: "string",
                   },
-                  startupWaitTimeoutMs: {
-                    description:
-                      "Requester-side wait budget in milliseconds for the primary sub-agent startup RPC (default: 60000).",
-                    type: "integer",
-                    exclusiveMinimum: 0,
-                    maximum: 9007199254740991,
-                  },
                   runTimeoutSeconds: {
                     type: "integer",
                     minimum: 0,
                     maximum: 9007199254740991,
                   },
-                  completionAnnounceTimeoutMs: {
-                    description:
-                      "Preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls (default: 90000).",
-                    type: "integer",
-                    exclusiveMinimum: 0,
-                    maximum: 9007199254740991,
-                  },
                   announceTimeoutMs: {
-                    description: "Backward-compatible alias for completionAnnounceTimeoutMs.",
                     type: "integer",
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
@@ -20752,7 +20737,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
           connectChallengeTimeoutMs: {
             type: "integer",
             minimum: 1,
-            maximum: 9007199254740991,
+            maximum: 300000,
             description:
               "WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.",
           },

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4791,12 +4791,27 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   thinking: {
                     type: "string",
                   },
+                  startupWaitTimeoutMs: {
+                    description:
+                      "Requester-side wait budget in milliseconds for the primary sub-agent startup RPC (default: 60000).",
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
                   runTimeoutSeconds: {
                     type: "integer",
                     minimum: 0,
                     maximum: 9007199254740991,
                   },
+                  completionAnnounceTimeoutMs: {
+                    description:
+                      "Preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls (default: 90000).",
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
                   announceTimeoutMs: {
+                    description: "Backward-compatible alias for completionAnnounceTimeoutMs.",
                     type: "integer",
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
@@ -20733,6 +20748,13 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             title: "Gateway Channel Max Restarts Per Hour",
             description:
               "Maximum number of health-monitor-initiated channel restarts allowed within a rolling one-hour window. Once hit, further restarts are skipped until the window expires. Default: 10.",
+          },
+          connectChallengeTimeoutMs: {
+            type: "integer",
+            minimum: 1,
+            maximum: 9007199254740991,
+            description:
+              "WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.",
           },
           tailscale: {
             type: "object",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2938,6 +2938,13 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
           defaults: {
             type: "object",
             properties: {
+              params: {
+                type: "object",
+                propertyNames: {
+                  type: "string",
+                },
+                additionalProperties: {},
+              },
               model: {
                 anyOf: [
                   {
@@ -3146,6 +3153,15 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 title: "Workspace",
                 description:
                   "Default workspace path exposed to agent runtime tools for filesystem context and repo-aware behavior. Set this explicitly when running from wrappers so path resolution stays deterministic.",
+              },
+              skills: {
+                type: "array",
+                items: {
+                  type: "string",
+                },
+                title: "Skills",
+                description:
+                  "Optional default skill allowlist inherited by agents that omit agents.list[].skills. Omit for unrestricted skills, set [] to give inheriting agents no skills, and remember explicit agents.list[].skills replaces this default instead of merging with it.",
               },
               repoRoot: {
                 type: "string",
@@ -4169,6 +4185,19 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 },
                 additionalProperties: false,
               },
+              llm: {
+                type: "object",
+                properties: {
+                  idleTimeoutSeconds: {
+                    description:
+                      "Idle timeout for LLM streaming responses in seconds. If no token is received within this time, the request is aborted. Set to 0 to disable. Default: 60 seconds.",
+                    type: "integer",
+                    minimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                },
+                additionalProperties: false,
+              },
               compaction: {
                 type: "object",
                 properties: {
@@ -4357,6 +4386,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     title: "Compaction Memory Flush",
                     description:
                       "Pre-compaction memory flush settings that run an agentic memory write before heavy compaction. Keep enabled for long sessions so salient context is persisted before aggressive trimming.",
+                  },
+                  notifyUser: {
+                    type: "boolean",
+                    title: "Compaction Notify User",
+                    description:
+                      "When enabled, sends a brief compaction notice to the user (e.g. '🧹 Compacting context...') when compaction starts. Disabled by default to keep compaction silent and non-intrusive.",
                   },
                 },
                 additionalProperties: false,
@@ -4701,16 +4736,16 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
               subagents: {
                 type: "object",
                 properties: {
-                  maxConcurrent: {
-                    type: "integer",
-                    exclusiveMinimum: 0,
-                    maximum: 9007199254740991,
-                  },
                   allowAgents: {
                     type: "array",
                     items: {
                       type: "string",
                     },
+                  },
+                  maxConcurrent: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
                   },
                   maxSpawnDepth: {
                     description:
@@ -4756,30 +4791,28 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   thinking: {
                     type: "string",
                   },
-                  startupWaitTimeoutMs: {
-                    description:
-                      "Requester-side wait budget in milliseconds for the primary sub-agent startup RPC (default: 60000).",
-                    type: "integer",
-                    exclusiveMinimum: 0,
-                    maximum: 9007199254740991,
-                  },
                   runTimeoutSeconds: {
                     type: "integer",
                     minimum: 0,
                     maximum: 9007199254740991,
                   },
+                  startupWaitTimeoutMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
                   completionAnnounceTimeoutMs: {
-                    description:
-                      "Preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls (default: 90000).",
                     type: "integer",
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
                   },
                   announceTimeoutMs: {
-                    description: "Backward-compatible alias for completionAnnounceTimeoutMs.",
                     type: "integer",
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
+                  },
+                  requireAgentId: {
+                    type: "boolean",
                   },
                 },
                 additionalProperties: false,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -20746,7 +20746,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
           },
           connectChallengeTimeoutMs: {
             type: "integer",
-            minimum: 1,
+            minimum: 250,
             maximum: 300000,
             description:
               "WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -3019,6 +3019,60 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   },
                 ],
               },
+              videoGenerationModel: {
+                anyOf: [
+                  {
+                    type: "string",
+                  },
+                  {
+                    type: "object",
+                    properties: {
+                      primary: {
+                        type: "string",
+                        title: "Video Generation Model",
+                        description:
+                          "Optional video-generation model (provider/model) used by the shared video generation capability.",
+                      },
+                      fallbacks: {
+                        type: "array",
+                        items: {
+                          type: "string",
+                        },
+                        title: "Video Generation Model Fallbacks",
+                        description: "Ordered fallback video-generation models (provider/model).",
+                      },
+                    },
+                    additionalProperties: false,
+                  },
+                ],
+              },
+              musicGenerationModel: {
+                anyOf: [
+                  {
+                    type: "string",
+                  },
+                  {
+                    type: "object",
+                    properties: {
+                      primary: {
+                        type: "string",
+                        title: "Music Generation Model",
+                        description:
+                          "Optional music-generation model (provider/model) used by the shared music generation capability.",
+                      },
+                      fallbacks: {
+                        type: "array",
+                        items: {
+                          type: "string",
+                        },
+                        title: "Music Generation Model Fallbacks",
+                        description: "Ordered fallback music-generation models (provider/model).",
+                      },
+                    },
+                    additionalProperties: false,
+                  },
+                ],
+              },
               pdfModel: {
                 anyOf: [
                   {
@@ -4651,6 +4705,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     type: "integer",
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
+                  },
+                  allowAgents: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
                   },
                   maxSpawnDepth: {
                     description:

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2938,13 +2938,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
           defaults: {
             type: "object",
             properties: {
-              params: {
-                type: "object",
-                propertyNames: {
-                  type: "string",
-                },
-                additionalProperties: {},
-              },
               model: {
                 anyOf: [
                   {
@@ -3026,60 +3019,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   },
                 ],
               },
-              videoGenerationModel: {
-                anyOf: [
-                  {
-                    type: "string",
-                  },
-                  {
-                    type: "object",
-                    properties: {
-                      primary: {
-                        type: "string",
-                        title: "Video Generation Model",
-                        description:
-                          "Optional video-generation model (provider/model) used by the shared video generation capability.",
-                      },
-                      fallbacks: {
-                        type: "array",
-                        items: {
-                          type: "string",
-                        },
-                        title: "Video Generation Model Fallbacks",
-                        description: "Ordered fallback video-generation models (provider/model).",
-                      },
-                    },
-                    additionalProperties: false,
-                  },
-                ],
-              },
-              musicGenerationModel: {
-                anyOf: [
-                  {
-                    type: "string",
-                  },
-                  {
-                    type: "object",
-                    properties: {
-                      primary: {
-                        type: "string",
-                        title: "Music Generation Model",
-                        description:
-                          "Optional music-generation model (provider/model) used by the shared music generation capability.",
-                      },
-                      fallbacks: {
-                        type: "array",
-                        items: {
-                          type: "string",
-                        },
-                        title: "Music Generation Model Fallbacks",
-                        description: "Ordered fallback music-generation models (provider/model).",
-                      },
-                    },
-                    additionalProperties: false,
-                  },
-                ],
-              },
               pdfModel: {
                 anyOf: [
                   {
@@ -3153,15 +3092,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 title: "Workspace",
                 description:
                   "Default workspace path exposed to agent runtime tools for filesystem context and repo-aware behavior. Set this explicitly when running from wrappers so path resolution stays deterministic.",
-              },
-              skills: {
-                type: "array",
-                items: {
-                  type: "string",
-                },
-                title: "Skills",
-                description:
-                  "Optional default skill allowlist inherited by agents that omit agents.list[].skills. Omit for unrestricted skills, set [] to give inheriting agents no skills, and remember explicit agents.list[].skills replaces this default instead of merging with it.",
               },
               repoRoot: {
                 type: "string",
@@ -4185,19 +4115,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 },
                 additionalProperties: false,
               },
-              llm: {
-                type: "object",
-                properties: {
-                  idleTimeoutSeconds: {
-                    description:
-                      "Idle timeout for LLM streaming responses in seconds. If no token is received within this time, the request is aborted. Set to 0 to disable. Default: 60 seconds.",
-                    type: "integer",
-                    minimum: 0,
-                    maximum: 9007199254740991,
-                  },
-                },
-                additionalProperties: false,
-              },
               compaction: {
                 type: "object",
                 properties: {
@@ -4386,12 +4303,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     title: "Compaction Memory Flush",
                     description:
                       "Pre-compaction memory flush settings that run an agentic memory write before heavy compaction. Keep enabled for long sessions so salient context is persisted before aggressive trimming.",
-                  },
-                  notifyUser: {
-                    type: "boolean",
-                    title: "Compaction Notify User",
-                    description:
-                      "When enabled, sends a brief compaction notice to the user (e.g. '🧹 Compacting context...') when compaction starts. Disabled by default to keep compaction silent and non-intrusive.",
                   },
                 },
                 additionalProperties: false,
@@ -4736,12 +4647,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
               subagents: {
                 type: "object",
                 properties: {
-                  allowAgents: {
-                    type: "array",
-                    items: {
-                      type: "string",
-                    },
-                  },
                   maxConcurrent: {
                     type: "integer",
                     exclusiveMinimum: 0,
@@ -4791,18 +4696,30 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   thinking: {
                     type: "string",
                   },
+                  startupWaitTimeoutMs: {
+                    description:
+                      "Requester-side wait budget in milliseconds for the primary sub-agent startup RPC (default: 60000).",
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
                   runTimeoutSeconds: {
                     type: "integer",
                     minimum: 0,
                     maximum: 9007199254740991,
                   },
-                  announceTimeoutMs: {
+                  completionAnnounceTimeoutMs: {
+                    description:
+                      "Preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls (default: 90000).",
                     type: "integer",
                     exclusiveMinimum: 0,
                     maximum: 9007199254740991,
                   },
-                  requireAgentId: {
-                    type: "boolean",
+                  announceTimeoutMs: {
+                    description: "Backward-compatible alias for completionAnnounceTimeoutMs.",
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
                   },
                 },
                 additionalProperties: false,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -120,12 +120,18 @@ export type CliBackendConfig = {
 };
 
 export type AgentDefaultsConfig = {
+  /** Global default provider params applied to all models before per-model and per-agent overrides. */
+  params?: Record<string, unknown>;
   /** Primary model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   model?: AgentModelConfig;
   /** Optional image-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   imageModel?: AgentModelConfig;
   /** Optional image-generation model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   imageGenerationModel?: AgentModelConfig;
+  /** Optional video-generation model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
+  videoGenerationModel?: AgentModelConfig;
+  /** Optional music-generation model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
+  musicGenerationModel?: AgentModelConfig;
   /** Optional PDF-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   pdfModel?: AgentModelConfig;
   /** Maximum PDF file size in megabytes (default: 10). */
@@ -136,6 +142,8 @@ export type AgentDefaultsConfig = {
   models?: Record<string, AgentModelEntryConfig>;
   /** Agent working directory (preferred). Used as the default cwd for agent runs. */
   workspace?: string;
+  /** Optional default allowlist of skills for agents that do not set agents.list[].skills. */
+  skills?: string[];
   /** Optional repository root for system prompt runtime line (overrides auto-detect). */
   repoRoot?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
@@ -181,6 +189,8 @@ export type AgentDefaultsConfig = {
   cliBackends?: Record<string, CliBackendConfig>;
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */
   contextPruning?: AgentContextPruningConfig;
+  /** LLM timeout configuration. */
+  llm?: AgentLlmConfig;
   /** Compaction tuning and pre-compaction memory flush behavior. */
   compaction?: AgentCompactionConfig;
   /** Embedded Pi runner hardening and compatibility controls. */
@@ -247,7 +257,7 @@ export type AgentDefaultsConfig = {
     /** Session key for heartbeat runs ("main" or explicit session key). */
     session?: string;
     /** Delivery target ("last", "none", or a channel id). */
-    target?: "last" | "none" | ChannelId;
+    target?: ChannelId;
     /** Direct/DM delivery policy. Default: "allow". */
     directPolicy?: "allow" | "block";
     /** Optional delivery override (E.164 for WhatsApp, chat id for Telegram). Supports :topic:NNN suffix for Telegram topics. */
@@ -284,6 +294,8 @@ export type AgentDefaultsConfig = {
   maxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
+    /** Default allowlist of target agent ids for sessions_spawn. Use "*" to allow any. */
+    allowAgents?: string[];
     /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */
     maxConcurrent?: number;
     /** Maximum depth allowed for sessions_spawn chains. Default behavior: 1 (no nested spawns). */
@@ -296,14 +308,16 @@ export type AgentDefaultsConfig = {
     model?: AgentModelConfig;
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
-    /** Requester-side wait budget in ms for the primary sub-agent startup request (default: 60000). */
-    startupWaitTimeoutMs?: number;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
     runTimeoutSeconds?: number;
-    /** Preferred gateway timeout in ms for sub-agent completion announce delivery calls (default: 90000). */
+    /** Gateway timeout in ms for sub-agent startup/setup RPCs before launch is considered failed (default: 60000). */
+    startupWaitTimeoutMs?: number;
+    /** Preferred gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
     completionAnnounceTimeoutMs?: number;
-    /** Backward-compatible alias for completionAnnounceTimeoutMs. */
+    /** Legacy alias for completionAnnounceTimeoutMs. */
     announceTimeoutMs?: number;
+    /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
+    requireAgentId?: boolean;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;
@@ -350,7 +364,7 @@ export type AgentCompactionConfig = {
    * Set to [] to disable post-compaction context injection entirely.
    */
   postCompactionSections?: string[];
-  /** Optional model override for compaction summarization (e.g. "openrouter/anthropic/claude-sonnet-4-5").
+  /** Optional model override for compaction summarization (e.g. "openrouter/anthropic/claude-sonnet-4-6").
    * When set, compaction uses this model instead of the agent's primary model.
    * Falls back to the primary model when unset. */
   model?: string;
@@ -362,6 +376,11 @@ export type AgentCompactionConfig = {
    * Default: false (existing behavior preserved).
    */
   truncateAfterCompaction?: boolean;
+  /**
+   * Send a "🧹 Compacting context..." notice to the user when compaction starts.
+   * Default: false (silent by default).
+   */
+  notifyUser?: boolean;
 };
 
 export type AgentCompactionMemoryFlushConfig = {
@@ -378,4 +397,17 @@ export type AgentCompactionMemoryFlushConfig = {
   prompt?: string;
   /** System prompt appended for the memory flush turn. */
   systemPrompt?: string;
+};
+
+/**
+ * LLM timeout configuration.
+ */
+export type AgentLlmConfig = {
+  /**
+   * Idle timeout for LLM streaming responses in seconds.
+   * If no token is received within this time, the request is aborted.
+   * Set to 0 to disable (never timeout).
+   * Default: 60 seconds.
+   */
+  idleTimeoutSeconds?: number;
 };

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -120,18 +120,12 @@ export type CliBackendConfig = {
 };
 
 export type AgentDefaultsConfig = {
-  /** Global default provider params applied to all models before per-model and per-agent overrides. */
-  params?: Record<string, unknown>;
   /** Primary model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   model?: AgentModelConfig;
   /** Optional image-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   imageModel?: AgentModelConfig;
   /** Optional image-generation model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   imageGenerationModel?: AgentModelConfig;
-  /** Optional video-generation model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
-  videoGenerationModel?: AgentModelConfig;
-  /** Optional music-generation model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
-  musicGenerationModel?: AgentModelConfig;
   /** Optional PDF-capable model and fallbacks (provider/model). Accepts string or {primary,fallbacks}. */
   pdfModel?: AgentModelConfig;
   /** Maximum PDF file size in megabytes (default: 10). */
@@ -142,8 +136,6 @@ export type AgentDefaultsConfig = {
   models?: Record<string, AgentModelEntryConfig>;
   /** Agent working directory (preferred). Used as the default cwd for agent runs. */
   workspace?: string;
-  /** Optional default allowlist of skills for agents that do not set agents.list[].skills. */
-  skills?: string[];
   /** Optional repository root for system prompt runtime line (overrides auto-detect). */
   repoRoot?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
@@ -189,8 +181,6 @@ export type AgentDefaultsConfig = {
   cliBackends?: Record<string, CliBackendConfig>;
   /** Opt-in: prune old tool results from the LLM context to reduce token usage. */
   contextPruning?: AgentContextPruningConfig;
-  /** LLM timeout configuration. */
-  llm?: AgentLlmConfig;
   /** Compaction tuning and pre-compaction memory flush behavior. */
   compaction?: AgentCompactionConfig;
   /** Embedded Pi runner hardening and compatibility controls. */
@@ -257,7 +247,7 @@ export type AgentDefaultsConfig = {
     /** Session key for heartbeat runs ("main" or explicit session key). */
     session?: string;
     /** Delivery target ("last", "none", or a channel id). */
-    target?: ChannelId;
+    target?: "last" | "none" | ChannelId;
     /** Direct/DM delivery policy. Default: "allow". */
     directPolicy?: "allow" | "block";
     /** Optional delivery override (E.164 for WhatsApp, chat id for Telegram). Supports :topic:NNN suffix for Telegram topics. */
@@ -294,8 +284,6 @@ export type AgentDefaultsConfig = {
   maxConcurrent?: number;
   /** Sub-agent defaults (spawned via sessions_spawn). */
   subagents?: {
-    /** Default allowlist of target agent ids for sessions_spawn. Use "*" to allow any. */
-    allowAgents?: string[];
     /** Max concurrent sub-agent runs (global lane: "subagent"). Default: 1. */
     maxConcurrent?: number;
     /** Maximum depth allowed for sessions_spawn chains. Default behavior: 1 (no nested spawns). */
@@ -308,12 +296,14 @@ export type AgentDefaultsConfig = {
     model?: AgentModelConfig;
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Requester-side wait budget in ms for the primary sub-agent startup request (default: 60000). */
+    startupWaitTimeoutMs?: number;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
     runTimeoutSeconds?: number;
-    /** Gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
+    /** Preferred gateway timeout in ms for sub-agent completion announce delivery calls (default: 90000). */
+    completionAnnounceTimeoutMs?: number;
+    /** Backward-compatible alias for completionAnnounceTimeoutMs. */
     announceTimeoutMs?: number;
-    /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
-    requireAgentId?: boolean;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;
@@ -360,7 +350,7 @@ export type AgentCompactionConfig = {
    * Set to [] to disable post-compaction context injection entirely.
    */
   postCompactionSections?: string[];
-  /** Optional model override for compaction summarization (e.g. "openrouter/anthropic/claude-sonnet-4-6").
+  /** Optional model override for compaction summarization (e.g. "openrouter/anthropic/claude-sonnet-4-5").
    * When set, compaction uses this model instead of the agent's primary model.
    * Falls back to the primary model when unset. */
   model?: string;
@@ -372,11 +362,6 @@ export type AgentCompactionConfig = {
    * Default: false (existing behavior preserved).
    */
   truncateAfterCompaction?: boolean;
-  /**
-   * Send a "🧹 Compacting context..." notice to the user when compaction starts.
-   * Default: false (silent by default).
-   */
-  notifyUser?: boolean;
 };
 
 export type AgentCompactionMemoryFlushConfig = {
@@ -393,17 +378,4 @@ export type AgentCompactionMemoryFlushConfig = {
   prompt?: string;
   /** System prompt appended for the memory flush turn. */
   systemPrompt?: string;
-};
-
-/**
- * LLM timeout configuration.
- */
-export type AgentLlmConfig = {
-  /**
-   * Idle timeout for LLM streaming responses in seconds.
-   * If no token is received within this time, the request is aborted.
-   * Set to 0 to disable (never timeout).
-   * Default: 60 seconds.
-   */
-  idleTimeoutSeconds?: number;
 };

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -406,6 +406,8 @@ export type GatewayConfig = {
   http?: GatewayHttpConfig;
   push?: GatewayPushConfig;
   nodes?: GatewayNodesConfig;
+  /** WebSocket pre-auth/connect handshake timeout in milliseconds (default: 10000). */
+  connectChallengeTimeoutMs?: number;
   /**
    * IPs of trusted reverse proxies (e.g. Traefik, nginx). When a connection
    * arrives from one of these IPs, the Gateway trusts `x-forwarded-for`

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -12,12 +12,32 @@ describe("agent defaults schema", () => {
     ).not.toThrow();
   });
 
-  it("accepts videoGenerationModel", () => {
+  it("accepts positive subagent startupWaitTimeoutMs", () => {
     expect(() =>
       AgentDefaultsSchema.parse({
-        videoGenerationModel: {
-          primary: "qwen/wan2.6-t2v",
-          fallbacks: ["minimax/video-01"],
+        subagents: {
+          startupWaitTimeoutMs: 60_000,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects invalid subagent startupWaitTimeoutMs", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        subagents: {
+          startupWaitTimeoutMs: 0,
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("accepts both completionAnnounceTimeoutMs and announceTimeoutMs during the alias window", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        subagents: {
+          completionAnnounceTimeoutMs: 90_000,
+          announceTimeoutMs: 45_000,
         },
       }),
     ).not.toThrow();

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -19,6 +19,8 @@ export const AgentDefaultsSchema = z
     model: AgentModelSchema.optional(),
     imageModel: AgentModelSchema.optional(),
     imageGenerationModel: AgentModelSchema.optional(),
+    videoGenerationModel: AgentModelSchema.optional(),
+    musicGenerationModel: AgentModelSchema.optional(),
     pdfModel: AgentModelSchema.optional(),
     pdfMaxBytesMb: z.number().positive().optional(),
     pdfMaxPages: z.number().int().positive().optional(),
@@ -168,6 +170,7 @@ export const AgentDefaultsSchema = z
     subagents: z
       .object({
         maxConcurrent: z.number().int().positive().optional(),
+        allowAgents: z.array(z.string()).optional(),
         maxSpawnDepth: z
           .number()
           .int()

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -16,13 +16,9 @@ import {
 
 export const AgentDefaultsSchema = z
   .object({
-    /** Global default provider params applied to all models before per-model and per-agent overrides. */
-    params: z.record(z.string(), z.unknown()).optional(),
     model: AgentModelSchema.optional(),
     imageModel: AgentModelSchema.optional(),
     imageGenerationModel: AgentModelSchema.optional(),
-    videoGenerationModel: AgentModelSchema.optional(),
-    musicGenerationModel: AgentModelSchema.optional(),
     pdfModel: AgentModelSchema.optional(),
     pdfMaxBytesMb: z.number().positive().optional(),
     pdfMaxPages: z.number().int().positive().optional(),
@@ -41,7 +37,6 @@ export const AgentDefaultsSchema = z
       )
       .optional(),
     workspace: z.string().optional(),
-    skills: z.array(z.string()).optional(),
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
     contextInjection: z.union([z.literal("always"), z.literal("continuation-skip")]).optional(),
@@ -91,19 +86,6 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
-    llm: z
-      .object({
-        idleTimeoutSeconds: z
-          .number()
-          .int()
-          .nonnegative()
-          .optional()
-          .describe(
-            "Idle timeout for LLM streaming responses in seconds. If no token is received within this time, the request is aborted. Set to 0 to disable. Default: 60 seconds.",
-          ),
-      })
-      .strict()
-      .optional(),
     compaction: z
       .object({
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
@@ -145,7 +127,6 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
-        notifyUser: z.boolean().optional(),
       })
       .strict()
       .optional(),
@@ -186,7 +167,6 @@ export const AgentDefaultsSchema = z
     maxConcurrent: z.number().int().positive().optional(),
     subagents: z
       .object({
-        allowAgents: z.array(z.string()).optional(),
         maxConcurrent: z.number().int().positive().optional(),
         maxSpawnDepth: z
           .number()
@@ -209,9 +189,29 @@ export const AgentDefaultsSchema = z
         archiveAfterMinutes: z.number().int().min(0).optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
+        startupWaitTimeoutMs: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            "Requester-side wait budget in milliseconds for the primary sub-agent startup RPC (default: 60000).",
+          ),
         runTimeoutSeconds: z.number().int().min(0).optional(),
-        announceTimeoutMs: z.number().int().positive().optional(),
-        requireAgentId: z.boolean().optional(),
+        completionAnnounceTimeoutMs: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe(
+            "Preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls (default: 90000).",
+          ),
+        announceTimeoutMs: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("Backward-compatible alias for completionAnnounceTimeoutMs."),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -16,6 +16,8 @@ import {
 
 export const AgentDefaultsSchema = z
   .object({
+    /** Global default provider params applied to all models before per-model and per-agent overrides. */
+    params: z.record(z.string(), z.unknown()).optional(),
     model: AgentModelSchema.optional(),
     imageModel: AgentModelSchema.optional(),
     imageGenerationModel: AgentModelSchema.optional(),
@@ -39,6 +41,7 @@ export const AgentDefaultsSchema = z
       )
       .optional(),
     workspace: z.string().optional(),
+    skills: z.array(z.string()).optional(),
     repoRoot: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
     contextInjection: z.union([z.literal("always"), z.literal("continuation-skip")]).optional(),
@@ -88,6 +91,19 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
+    llm: z
+      .object({
+        idleTimeoutSeconds: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe(
+            "Idle timeout for LLM streaming responses in seconds. If no token is received within this time, the request is aborted. Set to 0 to disable. Default: 60 seconds.",
+          ),
+      })
+      .strict()
+      .optional(),
     compaction: z
       .object({
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
@@ -129,6 +145,7 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        notifyUser: z.boolean().optional(),
       })
       .strict()
       .optional(),
@@ -169,8 +186,8 @@ export const AgentDefaultsSchema = z
     maxConcurrent: z.number().int().positive().optional(),
     subagents: z
       .object({
-        maxConcurrent: z.number().int().positive().optional(),
         allowAgents: z.array(z.string()).optional(),
+        maxConcurrent: z.number().int().positive().optional(),
         maxSpawnDepth: z
           .number()
           .int()
@@ -192,29 +209,11 @@ export const AgentDefaultsSchema = z
         archiveAfterMinutes: z.number().int().min(0).optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
-        startupWaitTimeoutMs: z
-          .number()
-          .int()
-          .positive()
-          .optional()
-          .describe(
-            "Requester-side wait budget in milliseconds for the primary sub-agent startup RPC (default: 60000).",
-          ),
         runTimeoutSeconds: z.number().int().min(0).optional(),
-        completionAnnounceTimeoutMs: z
-          .number()
-          .int()
-          .positive()
-          .optional()
-          .describe(
-            "Preferred gateway timeout in milliseconds for sub-agent completion announce delivery calls (default: 90000).",
-          ),
-        announceTimeoutMs: z
-          .number()
-          .int()
-          .positive()
-          .optional()
-          .describe("Backward-compatible alias for completionAnnounceTimeoutMs."),
+        startupWaitTimeoutMs: z.number().int().positive().optional(),
+        completionAnnounceTimeoutMs: z.number().int().positive().optional(),
+        announceTimeoutMs: z.number().int().positive().optional(),
+        requireAgentId: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -733,7 +733,7 @@ export const OpenClawSchema = z
         connectChallengeTimeoutMs: z
           .number()
           .int()
-          .min(1)
+          .min(250)
           .max(300_000)
           .describe(
             "WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.",

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -730,7 +730,15 @@ export const OpenClawSchema = z
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
         channelMaxRestartsPerHour: z.number().int().min(1).optional(),
-connectChallengeTimeoutMs: z.number().int().min(1).describe("WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.").optional(),
+        connectChallengeTimeoutMs: z
+          .number()
+          .int()
+          .min(1)
+          .max(300_000)
+          .describe(
+            "WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.",
+          )
+          .optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -730,6 +730,7 @@ export const OpenClawSchema = z
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
         channelStaleEventThresholdMinutes: z.number().int().min(1).optional(),
         channelMaxRestartsPerHour: z.number().int().min(1).optional(),
+connectChallengeTimeoutMs: z.number().int().min(1).describe("WebSocket pre-auth/connect handshake timeout in milliseconds for gateway clients and server-side handshake enforcement (default: 10000). Raise this when local control-plane stalls can delay connect challenge completion.").optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -24,6 +24,7 @@ let lastClientOptions: {
   token?: string;
   password?: string;
   tlsFingerprint?: string;
+  connectChallengeTimeoutMs?: number;
   scopes?: string[];
   deviceIdentity?: unknown;
   onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
@@ -55,6 +56,7 @@ vi.mock("./client.js", () => ({
       url?: string;
       token?: string;
       password?: string;
+      connectChallengeTimeoutMs?: number;
       scopes?: string[];
       onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
       onClose?: (code: number, reason: string) => void;
@@ -92,6 +94,7 @@ class StubGatewayClient {
     url?: string;
     token?: string;
     password?: string;
+    connectChallengeTimeoutMs?: number;
     scopes?: string[];
     onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
     onClose?: (code: number, reason: string) => void;
@@ -727,13 +730,25 @@ describe("callGateway error details", () => {
     expect(errMessage).toContain("gateway closed (1006");
   });
 
-  it("forwards caller timeout to client requests", async () => {
+  it("forwards caller timeout to client requests and connect handshake budget", async () => {
     setLocalLoopbackGatewayConfig();
 
     await callGateway({ method: "health", timeoutMs: 45_000 });
 
+    expect(lastClientOptions?.connectChallengeTimeoutMs).toBe(45_000);
     expect(lastRequestOptions?.method).toBe("health");
     expect(lastRequestOptions?.opts?.timeoutMs).toBe(45_000);
+  });
+
+  it("falls back to configured connect handshake budget when caller timeout is absent", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback", connectChallengeTimeoutMs: 25_000 },
+    });
+    setGatewayNetworkDefaults();
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.connectChallengeTimeoutMs).toBe(25_000);
   });
 
   it("does not inject wrapper timeout defaults into expectFinal requests", async () => {

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -751,6 +751,32 @@ describe("callGateway error details", () => {
     expect(lastClientOptions?.connectChallengeTimeoutMs).toBe(25_000);
   });
 
+  it("uses configured connect handshake budget as the default outer timeout floor", async () => {
+    vi.useFakeTimers();
+    startMode = "silent";
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback", connectChallengeTimeoutMs: 25_000 },
+    });
+    setGatewayNetworkDefaults();
+
+    const promise = callGateway({ method: "health" }).catch((caught) => caught);
+
+    await vi.advanceTimersByTimeAsync(10_001);
+    await Promise.resolve();
+
+    let settled = false;
+    void promise.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    const err = await promise;
+    expect(err).toBeInstanceOf(Error);
+    expect(String(err)).toContain("gateway timeout after 25000ms");
+  });
+
   it("does not inject wrapper timeout defaults into expectFinal requests", async () => {
     setLocalLoopbackGatewayConfig();
 

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -706,12 +706,22 @@ async function executeGatewayRequestWithScopes<T>(params: {
   token?: string;
   password?: string;
   tlsFingerprint?: string;
+  connectChallengeTimeoutMs?: number;
   timeoutMs: number;
   safeTimerTimeoutMs: number;
   connectionDetails: GatewayConnectionDetails;
 }): Promise<T> {
-  const { opts, scopes, url, token, password, tlsFingerprint, timeoutMs, safeTimerTimeoutMs } =
-    params;
+  const {
+    opts,
+    scopes,
+    url,
+    token,
+    password,
+    tlsFingerprint,
+    connectChallengeTimeoutMs,
+    timeoutMs,
+    safeTimerTimeoutMs,
+  } = params;
   // Yield to the event loop before starting the WebSocket connection.
   // On Windows with large dist bundles, heavy synchronous module loading
   // can starve the event loop, preventing timely processing of the
@@ -738,6 +748,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       token,
       password,
       tlsFingerprint,
+      connectChallengeTimeoutMs,
       instanceId: opts.instanceId ?? randomUUID(),
       clientName: opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
       clientDisplayName: opts.clientDisplayName,
@@ -811,6 +822,10 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     urlSource: context.urlOverrideSource,
     ...(opts.configPath ? { configPath: opts.configPath } : {}),
   });
+  const connectChallengeTimeoutMs =
+    typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
+      ? timeoutMs
+      : context.config.gateway?.connectChallengeTimeoutMs;
   const url = connectionDetails.url;
   const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
   const { token, password } = resolvedCredentials;
@@ -821,6 +836,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     token,
     password,
     tlsFingerprint,
+    connectChallengeTimeoutMs,
     timeoutMs,
     safeTimerTimeoutMs,
     connectionDetails,

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -37,6 +37,7 @@ import {
   type GatewayRemoteCredentialFallback,
   type GatewayRemoteCredentialPrecedence,
 } from "./credentials.js";
+import { getPreauthHandshakeTimeoutMsFromEnv } from "./handshake-timeouts.js";
 import {
   CLI_DEFAULT_OPERATOR_SCOPES,
   resolveLeastPrivilegeOperatorScopesForMethod,
@@ -278,12 +279,17 @@ type ResolvedGatewayCallContext = {
   remotePasswordFallback?: GatewayRemoteCredentialFallback;
 };
 
-function resolveGatewayCallTimeout(timeoutValue: unknown): {
+function resolveGatewayCallTimeout(
+  timeoutValue: unknown,
+  defaultTimeoutMs = 10_000,
+): {
   timeoutMs: number;
   safeTimerTimeoutMs: number;
 } {
   const timeoutMs =
-    typeof timeoutValue === "number" && Number.isFinite(timeoutValue) ? timeoutValue : 10_000;
+    typeof timeoutValue === "number" && Number.isFinite(timeoutValue)
+      ? timeoutValue
+      : defaultTimeoutMs;
   const safeTimerTimeoutMs = Math.max(1, Math.min(Math.floor(timeoutMs), 2_147_483_647));
   return { timeoutMs, safeTimerTimeoutMs };
 }
@@ -804,8 +810,15 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   opts: CallGatewayBaseOptions,
   scopes: OperatorScope[],
 ): Promise<T> {
-  const { timeoutMs, safeTimerTimeoutMs } = resolveGatewayCallTimeout(opts.timeoutMs);
   const context = resolveGatewayCallContext(opts);
+  const configuredConnectChallengeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv(
+    process.env,
+    context.config.gateway?.connectChallengeTimeoutMs,
+  );
+  const { timeoutMs, safeTimerTimeoutMs } = resolveGatewayCallTimeout(
+    opts.timeoutMs,
+    configuredConnectChallengeTimeoutMs,
+  );
   const resolvedCredentials = await resolveGatewayCredentials(context);
   ensureExplicitGatewayAuth({
     urlOverride: context.urlOverride,
@@ -825,7 +838,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   const connectChallengeTimeoutMs =
     typeof opts.timeoutMs === "number" && Number.isFinite(opts.timeoutMs)
       ? timeoutMs
-      : context.config.gateway?.connectChallengeTimeoutMs;
+      : configuredConnectChallengeTimeoutMs;
   const url = connectionDetails.url;
   const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
   const { token, password } = resolvedCredentials;

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -23,6 +23,7 @@ import {
 import { VERSION } from "../version.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
 import { resolveConnectChallengeTimeoutMs } from "./handshake-timeouts.js";
+import { loadConfig } from "../config/validation.js";
 import { isLoopbackHost, isSecureWebSocketUrl } from "./net.js";
 import {
   ConnectErrorDetailCodes,

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -23,7 +23,6 @@ import {
 import { VERSION } from "../version.js";
 import { buildDeviceAuthPayloadV3 } from "./device-auth.js";
 import { resolveConnectChallengeTimeoutMs } from "./handshake-timeouts.js";
-import { loadConfig } from "../config/validation.js";
 import { isLoopbackHost, isSecureWebSocketUrl } from "./net.js";
 import {
   ConnectErrorDetailCodes,

--- a/src/gateway/handshake-timeouts.configured.test.ts
+++ b/src/gateway/handshake-timeouts.configured.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_CONNECT_CHALLENGE_TIMEOUT_MS,
+  getPreauthHandshakeTimeoutMsFromEnv,
+} from "./handshake-timeouts.js";
+
+describe("getPreauthHandshakeTimeoutMsFromEnv", () => {
+  it("falls back to configured gateway timeout when env overrides are absent", () => {
+    expect(getPreauthHandshakeTimeoutMsFromEnv({}, 45_000)).toBe(45_000);
+  });
+
+  it("prefers env overrides over the configured gateway timeout", () => {
+    expect(
+      getPreauthHandshakeTimeoutMsFromEnv({ OPENCLAW_HANDSHAKE_TIMEOUT_MS: "75" }, 45_000),
+    ).toBe(75);
+  });
+
+  it("clamps configured gateway timeout into the safe range", () => {
+    expect(getPreauthHandshakeTimeoutMsFromEnv({}, 999_999_999)).toBe(
+      MAX_CONNECT_CHALLENGE_TIMEOUT_MS,
+    );
+  });
+});

--- a/src/gateway/handshake-timeouts.ts
+++ b/src/gateway/handshake-timeouts.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS = 10_000;
 export const MIN_CONNECT_CHALLENGE_TIMEOUT_MS = 250;
-export const MAX_CONNECT_CHALLENGE_TIMEOUT_MS = DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
+export const MAX_CONNECT_CHALLENGE_TIMEOUT_MS = 300_000;
 
 export function clampConnectChallengeTimeoutMs(timeoutMs: number): number {
   return Math.max(
@@ -33,7 +33,7 @@ export function resolveConnectChallengeTimeoutMs(timeoutMs?: number | null): num
   return DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
 }
 
-export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = process.env): number {
+export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = process.env, configuredMs?: unknown): number {
   const configuredTimeout =
     env.OPENCLAW_HANDSHAKE_TIMEOUT_MS || (env.VITEST && env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
   if (configuredTimeout) {

--- a/src/gateway/handshake-timeouts.ts
+++ b/src/gateway/handshake-timeouts.ts
@@ -22,11 +22,14 @@ export function getConnectChallengeTimeoutMsFromEnv(
   return undefined;
 }
 
-export function resolveConnectChallengeTimeoutMs(timeoutMs?: number | null): number {
+export function resolveConnectChallengeTimeoutMs(
+  timeoutMs?: number | null,
+  env: NodeJS.ProcessEnv = process.env,
+): number {
   if (typeof timeoutMs === "number" && Number.isFinite(timeoutMs)) {
     return clampConnectChallengeTimeoutMs(timeoutMs);
   }
-  const envOverride = getConnectChallengeTimeoutMsFromEnv();
+  const envOverride = getConnectChallengeTimeoutMsFromEnv(env);
   if (envOverride !== undefined) {
     return clampConnectChallengeTimeoutMs(envOverride);
   }
@@ -47,5 +50,6 @@ export function getPreauthHandshakeTimeoutMsFromEnv(
   }
   return resolveConnectChallengeTimeoutMs(
     typeof configuredMs === "number" && Number.isFinite(configuredMs) ? configuredMs : undefined,
+    env,
   );
 }

--- a/src/gateway/handshake-timeouts.ts
+++ b/src/gateway/handshake-timeouts.ts
@@ -33,7 +33,10 @@ export function resolveConnectChallengeTimeoutMs(timeoutMs?: number | null): num
   return DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
 }
 
-export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = process.env, configuredMs?: unknown): number {
+export function getPreauthHandshakeTimeoutMsFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredMs?: unknown,
+): number {
   const configuredTimeout =
     env.OPENCLAW_HANDSHAKE_TIMEOUT_MS || (env.VITEST && env.OPENCLAW_TEST_HANDSHAKE_TIMEOUT_MS);
   if (configuredTimeout) {
@@ -42,5 +45,7 @@ export function getPreauthHandshakeTimeoutMsFromEnv(env: NodeJS.ProcessEnv = pro
       return parsed;
     }
   }
-  return DEFAULT_PREAUTH_HANDSHAKE_TIMEOUT_MS;
+  return resolveConnectChallengeTimeoutMs(
+    typeof configuredMs === "number" && Number.isFinite(configuredMs) ? configuredMs : undefined,
+  );
 }

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -17,6 +17,14 @@ export const SessionsListParamsSchema = Type.Object(
      * Performs a file read per session - use `limit` to bound result set on large stores.
      */
     includeLastMessage: Type.Optional(Type.Boolean()),
+    /**
+     * Run the per-session transcript fallback to resolve usage/cost/context data that is
+     * missing from the session store (totalTokens, contextTokens, estimatedCostUsd).
+     * Performs a synchronous full-transcript read per session when the store values are
+     * absent — expensive on large stores.  Default false (opt-in).
+     * Use this flag only when the caller needs token/cost/context enrichment.
+     */
+    includeTranscriptUsage: Type.Optional(Type.Boolean()),
     label: Type.Optional(SessionLabelString),
     spawnedBy: Type.Optional(NonEmptyString),
     agentId: Type.Optional(NonEmptyString),

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -132,7 +132,9 @@ function emitSessionsChanged(
   if (connIds.size === 0) {
     return;
   }
-  const sessionRow = payload.sessionKey ? loadGatewaySessionRow(payload.sessionKey) : null;
+  const sessionRow = payload.sessionKey
+    ? loadGatewaySessionRow(payload.sessionKey, { includeTranscriptUsage: true })
+    : null;
   context.broadcastToConnIds(
     "sessions.changed",
     {

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -612,7 +612,7 @@ describe("gateway server sessions", () => {
         modelProvider?: string;
         model?: string;
       }>;
-    }>(ws, "sessions.list", {});
+    }>(ws, "sessions.list", { includeTranscriptUsage: true });
 
     expect(listed.ok).toBe(true);
     const parent = listed.payload?.sessions.find((session) => session.key === "agent:main:main");
@@ -627,6 +627,76 @@ describe("gateway server sessions", () => {
     expect(child?.estimatedCostUsd).toBe(0.0042);
     expect(child?.modelProvider).toBe("anthropic");
     expect(child?.model).toBe("claude-sonnet-4-6");
+
+    ws.close();
+  });
+
+  test("sessions.list default path omits transcript usage fallback", async () => {
+    const { dir } = await createSessionStoreDir();
+    testState.agentConfig = {
+      models: {
+        "anthropic/claude-sonnet-4-6": { params: { context1m: true } },
+      },
+    };
+    await fs.writeFile(
+      path.join(dir, "sess-no-usage.jsonl"),
+      [
+        JSON.stringify({ type: "session", version: 1, id: "sess-no-usage" }),
+        JSON.stringify({
+          message: {
+            role: "assistant",
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            usage: {
+              input: 2_000,
+              output: 500,
+              cacheRead: 1_000,
+              cost: { total: 0.0042 },
+            },
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-no-usage",
+          updatedAt: Date.now(),
+          modelProvider: "anthropic",
+          model: "claude-sonnet-4-6",
+          // Deliberately zeroed so without includeTranscriptUsage the fallback would be needed
+          totalTokens: 0,
+          totalTokensFresh: false,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    // Default call — no includeTranscriptUsage
+    const listed = await rpcReq<{
+      sessions: Array<{
+        key: string;
+        totalTokens?: number;
+        totalTokensFresh?: boolean;
+        contextTokens?: number;
+        estimatedCostUsd?: number;
+      }>;
+    }>(ws, "sessions.list", {});
+
+    expect(listed.ok).toBe(true);
+    const session = listed.payload?.sessions.find((s) => s.key === "agent:main:main");
+    expect(session).toBeDefined();
+    // Without opt-in the transcript fallback must NOT fire — usage fields stay unset
+    expect(session?.totalTokens).toBeUndefined();
+    // totalTokensFresh comes from store metadata, not transcript scan — skip asserting it
+    expect(session?.estimatedCostUsd).toBeUndefined();
+    // contextTokens may still resolve from the model catalog without reading the transcript
+    // so we only assert it is NOT derived from the transcript path (no regression on store-based data)
 
     ws.close();
   });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { WebSocket, WebSocketServer } from "ws";
+import { loadConfig } from "../../config/config.js";
 import { resolveCanvasHostUrl } from "../../infra/canvas-host-url.js";
 import { removeRemoteNodeInfo } from "../../infra/skills-remote.js";
 import { upsertPresence } from "../../infra/system-presence.js";
@@ -9,7 +10,6 @@ import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { getPreauthHandshakeTimeoutMsFromEnv } from "../handshake-timeouts.js";
-import { loadConfig } from "../../config/validation.js";
 import { isLoopbackAddress } from "../net.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
@@ -292,7 +292,10 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       close();
     });
 
-    const handshakeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv(process.env, loadConfig().gateway?.connectChallengeTimeoutMs);
+    const handshakeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv(
+      process.env,
+      loadConfig().gateway?.connectChallengeTimeoutMs,
+    );
     const handshakeTimer = setTimeout(() => {
       if (!client) {
         handshakeState = "failed";

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -9,6 +9,7 @@ import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { getPreauthHandshakeTimeoutMsFromEnv } from "../handshake-timeouts.js";
+import { loadConfig } from "../../config/validation.js";
 import { isLoopbackAddress } from "../net.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
 import { formatError } from "../server-utils.js";
@@ -291,7 +292,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       close();
     });
 
-    const handshakeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv();
+    const handshakeTimeoutMs = getPreauthHandshakeTimeoutMsFromEnv(process.env, loadConfig().gateway?.connectChallengeTimeoutMs);
     const handshakeTimer = setTimeout(() => {
       if (!client) {
         handshakeState = "failed";

--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -293,7 +293,7 @@ describe("listSessionsFromStore search", () => {
             totalTokensFresh: false,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]?.estimatedCostUsd).toBe(0.1234);
@@ -385,7 +385,7 @@ describe("listSessionsFromStore search", () => {
             cacheWrite: 0,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]?.totalTokens).toBe(6_643);
@@ -449,7 +449,7 @@ describe("listSessionsFromStore search", () => {
             cacheWrite: 0,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]?.totalTokens).toBe(3_200);
@@ -523,7 +523,7 @@ describe("listSessionsFromStore search", () => {
             totalTokensFresh: false,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]).toMatchObject({
@@ -605,7 +605,7 @@ describe("listSessionsFromStore search", () => {
             totalTokensFresh: false,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]).toMatchObject({
@@ -673,7 +673,7 @@ describe("listSessionsFromStore search", () => {
             totalTokensFresh: false,
           } as SessionEntry,
         },
-        opts: {},
+        opts: { includeTranscriptUsage: true },
       });
 
       expect(result.sessions[0]).toMatchObject({

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1151,6 +1151,12 @@ export function buildGatewaySessionRow(params: {
   now?: number;
   includeDerivedTitles?: boolean;
   includeLastMessage?: boolean;
+  /**
+   * When true, run the expensive per-session transcript scan to resolve
+   * totalTokens / contextTokens / estimatedCostUsd that are absent from the
+   * store.  Default false so the hot listing path stays cheap.
+   */
+  includeTranscriptUsage?: boolean;
 }): GatewaySessionRow {
   const { cfg, storePath, store, key, entry } = params;
   const now = params.now ?? Date.now();
@@ -1209,7 +1215,8 @@ export function buildGatewaySessionRow(params: {
       entry,
     }) === undefined;
   const transcriptUsage =
-    needsTranscriptTotalTokens || needsTranscriptContextTokens || needsTranscriptEstimatedCostUsd
+    params.includeTranscriptUsage === true &&
+    (needsTranscriptTotalTokens || needsTranscriptContextTokens || needsTranscriptEstimatedCostUsd)
       ? resolveTranscriptUsageFallback({
           cfg,
           key,
@@ -1335,7 +1342,12 @@ export function buildGatewaySessionRow(params: {
 
 export function loadGatewaySessionRow(
   sessionKey: string,
-  options?: { includeDerivedTitles?: boolean; includeLastMessage?: boolean; now?: number },
+  options?: {
+    includeDerivedTitles?: boolean;
+    includeLastMessage?: boolean;
+    includeTranscriptUsage?: boolean;
+    now?: number;
+  },
 ): GatewaySessionRow | null {
   const { cfg, storePath, store, entry, canonicalKey } = loadSessionEntry(sessionKey);
   if (!entry) {
@@ -1350,6 +1362,7 @@ export function loadGatewaySessionRow(
     now: options?.now,
     includeDerivedTitles: options?.includeDerivedTitles,
     includeLastMessage: options?.includeLastMessage,
+    includeTranscriptUsage: options?.includeTranscriptUsage,
   });
 }
 
@@ -1366,6 +1379,7 @@ export function listSessionsFromStore(params: {
   const includeUnknown = opts.includeUnknown === true;
   const includeDerivedTitles = opts.includeDerivedTitles === true;
   const includeLastMessage = opts.includeLastMessage === true;
+  const includeTranscriptUsage = opts.includeTranscriptUsage === true;
   const spawnedBy = typeof opts.spawnedBy === "string" ? opts.spawnedBy : "";
   const label = typeof opts.label === "string" ? opts.label.trim() : "";
   const agentId = typeof opts.agentId === "string" ? normalizeAgentId(opts.agentId) : "";
@@ -1429,6 +1443,7 @@ export function listSessionsFromStore(params: {
         now,
         includeDerivedTitles,
         includeLastMessage,
+        includeTranscriptUsage,
       }),
     )
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));


### PR DESCRIPTION
## Summary

The default `sessions.list` hot path was doing synchronous full-transcript reads via `resolveTranscriptUsageFallback` for every session in the store whenever `totalTokens`, `contextTokens`, or `estimatedCostUsd` were absent from the store entry. On large stores this meant hundreds of blocking file reads per `sessions.list` call — a corpus-wide transcript scan triggered by the most common listing path.

## Changes

### Schema (`src/gateway/protocol/schema/sessions.ts`)
- Add `includeTranscriptUsage?: boolean` to `SessionsListParamsSchema`
- Default is **false** (opt-in, not opt-out)
- JSDoc on the new field explains the cost and when to use it

### Core logic (`src/gateway/session-utils.ts`)
- `buildGatewaySessionRow`: gate `resolveTranscriptUsageFallback` behind `params.includeTranscriptUsage === true`
  - Store-present values (`totalTokens`, `estimatedCostUsd`, etc.) still resolve from the store without the flag — only the expensive transcript scan is skipped
- `loadGatewaySessionRow`: add `includeTranscriptUsage` to options signature and pass through
- `listSessionsFromStore`: decode `opts.includeTranscriptUsage` and pass it to `buildGatewaySessionRow`

### Known callers that need enrichment (updated)
- `src/gateway/server-methods/sessions.ts` — `emitSessionsChanged`: pass `includeTranscriptUsage: true` to `loadGatewaySessionRow`. Mutation events are single-session and should carry full usage.
- `src/acp/translator.ts` — `getGatewaySessionRow`: pass `includeTranscriptUsage: true`. This call fetches a single session to display token/cost/context to the ACP client.

### Callers confirmed safe without the flag
- ACP `unstable_listSessions` — only uses `key/displayName/updatedAt/kind/channel`
- Agent `sessions_list` tool — does not read `totalTokens`/`estimatedCostUsd`/`contextTokens` from the listing rows
- TUI `listSessions` — uses `includeDerivedTitles`/`includeLastMessage` but not usage

## Tests

- `src/gateway/session-utils.search.test.ts`: update 6 existing call sites that assert transcript-fallback behavior to pass `includeTranscriptUsage: true` — these are unit tests that explicitly verify the opt-in path
- `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`:
  - Update `'sessions.list surfaces transcript usage and model fallbacks'` to pass `includeTranscriptUsage: true`
  - Add `'sessions.list default path omits transcript usage fallback'` — asserts that the default (no flag) call returns `totalTokens: undefined` and `estimatedCostUsd: undefined` for a session with zeroed store values

## Validation

Ran targeted test suites:
- `session-utils.test.ts` — 28/28 pass
- `session-utils.subagent.test.ts` — 39/39 pass
- `session-utils.search.test.ts` — 25/25 pass (was 6 failures before test updates)
- `sessions-resolve.test.ts` — pass
- `server.sessions.gateway-server-sessions-a.test.ts` — 45/46 pass (1 pre-existing timeout in `sessions.create` test, present before this change)
- `acp/translator.session-rate-limit.test.ts` — 42/42 pass
- `agents/tools/sessions-list-tool.test.ts`, `sessions.test.ts` — pass

Full `tsc --noEmit` OOM'd in this environment; vitest's esbuild compilation of all changed files found no type errors.

## Compatibility risk

**Contract change:** External clients calling `sessions.list` and relying on transcript-derived `totalTokens`/`estimatedCostUsd`/`contextTokens` for sessions where the store values are absent/zeroed must add `includeTranscriptUsage: true` to their params. Store-recorded values (non-zero `totalTokens`, explicit `estimatedCostUsd`, etc.) continue to work without the flag.
