### PR TITLE
perf: cache hasIndexedContent() to avoid redundant SQLite queries

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -569,6 +569,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       } catch {}
     }
     this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(pathname, source);
+    this.hasIndexedContentCached = null;
   }
 
   private upsertFileRecord(entry: MemoryFileEntry | SessionFileEntry, source: MemorySource): void {
@@ -654,6 +655,9 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           )
           .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
       }
+    }
+    if (chunks.length > 0) {
+      this.hasIndexedContentCached = true;
     }
     if (this.vector.enabled && !vectorReady && chunks.length > 0) {
       const errDetail = this.vector.loadError ? `: ${this.vector.loadError}` : "";

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -148,6 +148,8 @@ export abstract class MemoryManagerSyncOps {
   protected closed = false;
   protected dirty = false;
   protected sessionsDirty = false;
+  /** Cached result of hasIndexedContent(); reset to null when chunks are modified. */
+  protected hasIndexedContentCached: boolean | null = null;
   protected sessionsDirtyFiles = new Set<string>();
   protected sessionPendingFiles = new Set<string>();
   protected sessionDeltas = new Map<
@@ -780,6 +782,7 @@ export abstract class MemoryManagerSyncOps {
         } catch {}
       }
       deleteChunksByPathAndSource.run(stale.path, "memory");
+      this.hasIndexedContentCached = null;
       if (deleteFtsRowsByPathAndSource) {
         try {
           deleteFtsRowsByPathAndSource.run(stale.path, "memory");
@@ -920,6 +923,7 @@ export abstract class MemoryManagerSyncOps {
         } catch {}
       }
       deleteChunksByPathAndSource.run(stale.path, "sessions");
+      this.hasIndexedContentCached = null;
       if (deleteFtsRowsByPathSourceAndModel) {
         try {
           deleteFtsRowsByPathSourceAndModel.run(
@@ -1308,6 +1312,7 @@ export abstract class MemoryManagerSyncOps {
   private resetIndex() {
     this.db.exec(`DELETE FROM files`);
     this.db.exec(`DELETE FROM chunks`);
+    this.hasIndexedContentCached = null;
     if (this.fts.enabled && this.fts.available) {
       try {
         this.db.exec(`DROP TABLE IF EXISTS ${FTS_TABLE}`);

--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -1176,6 +1176,7 @@ export abstract class MemoryManagerSyncOps {
       } else {
         this.db = originalDb;
       }
+      this.hasIndexedContentCached = null;
       this.fts.available = originalState.ftsAvailable;
       this.fts.loadError = originalState.ftsError;
       this.vector.available = originalDbClosed ? null : originalState.vectorAvailable;
@@ -1185,6 +1186,7 @@ export abstract class MemoryManagerSyncOps {
     };
 
     this.db = tempDb;
+    this.hasIndexedContentCached = null;
     this.vectorReady = null;
     this.vector.available = null;
     this.vector.loadError = undefined;
@@ -1246,6 +1248,7 @@ export abstract class MemoryManagerSyncOps {
       await this.swapIndexFiles(dbPath, tempDbPath);
 
       this.db = openMemoryDatabaseAtPath(dbPath, this.settings.store.vector.enabled);
+      this.hasIndexedContentCached = null;
       this.vectorReady = null;
       this.vector.available = null;
       this.vector.loadError = undefined;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -555,15 +555,20 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   }
 
   private hasIndexedContent(): boolean {
+    if (this.hasIndexedContentCached !== null) {
+      return this.hasIndexedContentCached;
+    }
     const chunkRow = this.db.prepare(`SELECT 1 as found FROM chunks LIMIT 1`).get() as
       | {
           found?: number;
         }
       | undefined;
     if (chunkRow?.found === 1) {
+      this.hasIndexedContentCached = true;
       return true;
     }
     if (!this.fts.enabled || !this.fts.available) {
+      this.hasIndexedContentCached = false;
       return false;
     }
     const ftsRow = this.db.prepare(`SELECT 1 as found FROM ${FTS_TABLE} LIMIT 1`).get() as
@@ -571,7 +576,9 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
           found?: number;
         }
       | undefined;
-    return ftsRow?.found === 1;
+    const result = ftsRow?.found === 1;
+    this.hasIndexedContentCached = result;
+    return result;
   }
 
   private async searchVector(


### PR DESCRIPTION
## Summary

- Cache the result of `hasIndexedContent()` which queries SQLite (`SELECT 1 FROM chunks LIMIT 1` + FTS table) on every `search()` call
- Cache is set to `true` after chunk inserts, invalidated (reset to `null`) after deletes and full index resets
- 3 files changed, 17 insertions — minimal, focused fix

### Files changed

| File | Change |
|------|--------|
| `extensions/memory-core/src/memory/manager-sync-ops.ts` | Added `hasIndexedContentCached` field to base class; invalidate on chunk delete and `resetIndex()` |
| `extensions/memory-core/src/memory/manager-embedding-ops.ts` | Set cache to `true` after chunk insert; invalidate on chunk delete |
| `extensions/memory-core/src/memory/manager.ts` | Use cached value in `hasIndexedContent()`, populate on miss |

Closes #62513

## Test plan

- [x] `manager-search.test.ts` passes (3/3)
- [x] oxlint clean
- [ ] Verify search performance improvement with large memory indices
