### PR TITLE
fix(browser): use numeric refs for --format ai snapshots instead of role refs

### DIFF
--- a/extensions/browser/src/browser/pw-ai.e2e.test.ts
+++ b/extensions/browser/src/browser/pw-ai.e2e.test.ts
@@ -103,10 +103,15 @@ describe("pw-ai", () => {
     });
 
     expect(res.refs).toMatchObject({
-      e1: { role: "button", name: "OK" },
-      e2: { role: "link", name: "Docs" },
+      1: { role: "button", name: "OK" },
+      2: { role: "link", name: "Docs" },
     });
+    // Snapshot text should use numeric refs instead of [ref=e1]
+    expect(res.snapshot).toContain("[1]");
+    expect(res.snapshot).toContain("[2]");
+    expect(res.snapshot).not.toContain("[ref=e1]");
 
+    // Internal aria-ref resolution still works with e-prefixed refs
     await clickViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
       targetId: "T1",

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -88,7 +88,23 @@ export async function snapshotAiViaPlaywright(opts: {
     refs: built.refs,
     mode: "aria",
   });
-  return truncated ? { snapshot, truncated, refs: built.refs } : { snapshot, refs: built.refs };
+
+  // Remap e-prefixed refs (e1, e2, ...) to numeric refs (1, 2, ...) for user-facing output.
+  const numericRefs: RoleRefMap = {};
+  let numericSnapshot = snapshot;
+  for (const [key, value] of Object.entries(built.refs)) {
+    if (/^e\d+$/.test(key)) {
+      const num = key.slice(1);
+      numericRefs[num] = value;
+      numericSnapshot = numericSnapshot.replace(`[ref=${key}]`, `[${num}]`);
+    } else {
+      numericRefs[key] = value;
+    }
+  }
+
+  return truncated
+    ? { snapshot: numericSnapshot, truncated, refs: numericRefs }
+    : { snapshot: numericSnapshot, refs: numericRefs };
 }
 
 export async function snapshotRoleViaPlaywright(opts: {


### PR DESCRIPTION
## Summary

Fixes #62550

Running `openclaw browser snapshot --format ai` reported `"format": "ai"` in JSON output but the snapshot text still used e-prefixed role refs (`[e1]`, `[e2]`, ...) instead of numeric refs (`[1]`, `[2]`, ...).

The `refs` object also contained role-mode metadata (`role`, `name`, `nth`) instead of the expected numeric keys.

**Fix:** In `snapshotAiViaPlaywright()`, remap e-prefixed refs to numeric refs after building the snapshot:
- `e1` → `1`, `e2` → `2`, etc.
- Replace `[ref=e1]` with `[1]` in snapshot text
- Return remapped refs object with numeric keys

## Test plan

- [x] Updated e2e test to expect numeric refs (`1`, `2`) instead of role refs (`e1`, `e2`)
- [x] Test verifies snapshot text contains `[1]` and `[2]` (not `[ref=e1]`)
- [x] Internal aria-ref resolution still works with e-prefixed refs (click via ref)