### PR TITLE
fix: include property name in additionalProperties validation errors

### DIFF
--- a/src/plugins/schema-validator.test.ts
+++ b/src/plugins/schema-validator.test.ts
@@ -240,6 +240,24 @@ describe("schema validator", () => {
     expect(issue?.allowedValues).toBeUndefined();
   });
 
+  it("includes the unexpected property name in additionalProperties errors", () => {
+    const result = expectValidationFailure({
+      cacheKey: "schema-validator.test.additionalProperties",
+      schema: {
+        type: "object",
+        properties: {
+          allowed: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+      value: { allowed: "ok", extra: "not allowed" },
+    });
+
+    const issue = expectValidationIssue(result, "<root>");
+    expect(issue?.message).toContain("must NOT have additional properties");
+    expect(issue?.message).toContain("unexpected property: 'extra'");
+  });
+
   it("sanitizes terminal text while preserving structured fields", () => {
     const maliciousProperty = "evil\nkey\t\x1b[31mred\x1b[0m";
     const result = expectValidationFailure({

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -141,7 +141,13 @@ function formatAjvErrors(errors: ErrorObject[] | null | undefined): JsonSchemaVa
   }
   return errors.map((error) => {
     const path = resolveAjvErrorPath(error);
-    const baseMessage = error.message ?? "invalid";
+    let baseMessage = error.message ?? "invalid";
+    if (error.keyword === "additionalProperties") {
+      const additional = (error.params as { additionalProperty?: unknown }).additionalProperty;
+      if (typeof additional === "string" && additional) {
+        baseMessage = `${baseMessage} (unexpected property: '${additional}')`;
+      }
+    }
     const allowedValuesSummary = getAjvAllowedValuesSummary(error);
     const message = allowedValuesSummary
       ? appendAllowedValuesHint(baseMessage, allowedValuesSummary)


### PR DESCRIPTION
## Summary
- Enhanced `additionalProperties` AJV validation errors to include the offending property name
- Before: `must NOT have additional properties` — unhelpful for debugging
- After: `must NOT have additional properties (unexpected property: 'dreaming')` — immediately actionable

## Test plan
- [x] New unit test in `schema-validator.test.ts` verifying property name is included
- [x] All 11 existing schema-validator tests pass
- [ ] Manually verify error message renders correctly in terminal output

Closes #62541
