### PR TITLE
fix(channel): guard setup catalog lookups

### DIFF
--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -7,7 +7,6 @@ import {
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelId, ChannelPlugin } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { normalizePluginsConfig, resolveEnableState } from "../../plugins/config-state.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
@@ -16,6 +15,7 @@ import {
   ensureChannelSetupPluginInstalled,
   loadChannelSetupPluginRegistrySnapshotForChannel,
 } from "./plugin-install.js";
+import { isTrustedWorkspaceChannelCatalogEntry } from "./workspace-trust.js";
 
 type ChannelPluginSnapshot = {
   channels: Array<{ plugin: ChannelPlugin }>;
@@ -72,20 +72,6 @@ function findScopedChannelPlugin(
     snapshot.channels.find((entry) => entry.plugin.id === channelId)?.plugin ??
     snapshot.channelSetups.find((entry) => entry.plugin.id === channelId)?.plugin
   );
-}
-
-function isTrustedWorkspaceChannelCatalogEntry(
-  entry: ChannelPluginCatalogEntry | undefined,
-  cfg: OpenClawConfig,
-): boolean {
-  if (entry?.origin !== "workspace") {
-    return true;
-  }
-  if (!entry.pluginId) {
-    return false;
-  }
-  return resolveEnableState(entry.pluginId, "workspace", normalizePluginsConfig(cfg.plugins))
-    .enabled;
 }
 
 function resolveTrustedCatalogEntry(params: {

--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginAutoEnableResult } from "../../config/plugin-auto-enable.js";
 
 const loadPluginManifestRegistry = vi.hoisted(() => vi.fn());
-const listChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((): unknown[] => []));
+const listChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((_args?: unknown): unknown[] => []));
 const listChatChannels = vi.hoisted(() => vi.fn((): Array<Record<string, string>> => []));
 const applyPluginAutoEnable = vi.hoisted(() =>
   vi.fn<(args: { config: unknown; env?: NodeJS.ProcessEnv }) => PluginAutoEnableResult>(
@@ -24,7 +24,7 @@ vi.mock("../../config/plugin-auto-enable.js", () => ({
 }));
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
-  listChannelPluginCatalogEntries: (_args?: unknown) => listChannelPluginCatalogEntries(),
+  listChannelPluginCatalogEntries: (args?: unknown) => listChannelPluginCatalogEntries(args),
 }));
 
 vi.mock("../../channels/registry.js", () => ({
@@ -115,5 +115,19 @@ describe("listManifestInstalledChannelIds", () => {
     });
 
     expect(resolved.entries.map((entry) => entry.id)).toEqual(["telegram"]);
+  });
+
+  it("excludes workspace catalog entries from setup discovery", () => {
+    resolveChannelSetupEntries({
+      cfg: {} as never,
+      installedPlugins: [],
+      workspaceDir: "/tmp/workspace",
+      env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(listChannelPluginCatalogEntries).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/workspace",
+      excludeWorkspace: true,
+    });
   });
 });

--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -184,32 +184,49 @@ describe("listManifestInstalledChannelIds", () => {
   });
 
   it("never offers workspace entries as installable setup options", () => {
-    listChannelPluginCatalogEntries.mockReturnValue([
-      {
-        id: "matrix",
-        pluginId: "matrix-plugin",
-        origin: "workspace",
-        meta: {
-          id: "matrix",
-          label: "Matrix",
-          selectionLabel: "Matrix",
-          docsPath: "/channels/matrix",
-          blurb: "homeserver",
-        },
-      },
-      {
-        id: "telegram",
-        pluginId: "@openclaw/telegram-plugin",
-        origin: "bundled",
-        meta: {
-          id: "telegram",
-          label: "Telegram",
-          selectionLabel: "Telegram",
-          docsPath: "/channels/telegram",
-          blurb: "bot token",
-        },
-      },
-    ]);
+    listChannelPluginCatalogEntries.mockImplementation((args?: unknown) =>
+      (args as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
+        ? [
+            {
+              id: "telegram",
+              pluginId: "@openclaw/telegram-plugin",
+              origin: "bundled",
+              meta: {
+                id: "telegram",
+                label: "Telegram",
+                selectionLabel: "Telegram",
+                docsPath: "/channels/telegram",
+                blurb: "bot token",
+              },
+            },
+          ]
+        : [
+            {
+              id: "matrix",
+              pluginId: "matrix-plugin",
+              origin: "workspace",
+              meta: {
+                id: "matrix",
+                label: "Matrix",
+                selectionLabel: "Matrix",
+                docsPath: "/channels/matrix",
+                blurb: "homeserver",
+              },
+            },
+            {
+              id: "telegram",
+              pluginId: "@openclaw/telegram-plugin",
+              origin: "bundled",
+              meta: {
+                id: "telegram",
+                label: "Telegram",
+                selectionLabel: "Telegram",
+                docsPath: "/channels/telegram",
+                blurb: "bot token",
+              },
+            },
+          ],
+    );
 
     const resolved = resolveChannelSetupEntries({
       cfg: {
@@ -224,8 +241,57 @@ describe("listManifestInstalledChannelIds", () => {
     });
 
     expect(resolved.installableCatalogEntries.map((entry) => entry.id)).toEqual(["telegram"]);
-    expect(listChannelPluginCatalogEntries).toHaveBeenCalledWith({
+    expect(listChannelPluginCatalogEntries).toHaveBeenNthCalledWith(1, {
       workspaceDir: "/tmp/workspace",
     });
+    expect(listChannelPluginCatalogEntries).toHaveBeenNthCalledWith(2, {
+      workspaceDir: "/tmp/workspace",
+      excludeWorkspace: true,
+    });
+  });
+
+  it("keeps bundled installable entries when a workspace shadow won the full catalog lookup", () => {
+    listChannelPluginCatalogEntries.mockImplementation((args?: unknown) =>
+      (args as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
+        ? [
+            {
+              id: "telegram",
+              pluginId: "@openclaw/telegram-plugin",
+              origin: "bundled",
+              meta: {
+                id: "telegram",
+                label: "Telegram",
+                selectionLabel: "Telegram",
+                docsPath: "/channels/telegram",
+                blurb: "bot token",
+              },
+            },
+          ]
+        : [
+            {
+              id: "telegram",
+              pluginId: "evil-telegram-plugin",
+              origin: "workspace",
+              meta: {
+                id: "telegram",
+                label: "Telegram",
+                selectionLabel: "Telegram",
+                docsPath: "/channels/telegram",
+                blurb: "bot token",
+              },
+            },
+          ],
+    );
+
+    const resolved = resolveChannelSetupEntries({
+      cfg: {} as never,
+      installedPlugins: [],
+      workspaceDir: "/tmp/workspace",
+      env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(resolved.installableCatalogEntries.map((entry) => entry.pluginId)).toEqual([
+      "@openclaw/telegram-plugin",
+    ]);
   });
 });

--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -117,17 +117,115 @@ describe("listManifestInstalledChannelIds", () => {
     expect(resolved.entries.map((entry) => entry.id)).toEqual(["telegram"]);
   });
 
-  it("excludes workspace catalog entries from setup discovery", () => {
-    resolveChannelSetupEntries({
+  it("keeps trusted workspace entries in installed discovery results", () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "matrix-plugin", channels: ["matrix"] }],
+      diagnostics: [],
+    });
+    listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "matrix",
+        pluginId: "matrix-plugin",
+        origin: "workspace",
+        meta: {
+          id: "matrix",
+          label: "Matrix",
+          selectionLabel: "Matrix",
+          docsPath: "/channels/matrix",
+          blurb: "homeserver",
+        },
+      },
+    ]);
+
+    const resolved = resolveChannelSetupEntries({
+      cfg: {
+        plugins: {
+          enabled: true,
+          allow: ["matrix-plugin"],
+        },
+      } as never,
+      installedPlugins: [],
+      workspaceDir: "/tmp/workspace",
+      env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(resolved.installedCatalogEntries.map((entry) => entry.id)).toEqual(["matrix"]);
+    expect(resolved.installableCatalogEntries).toEqual([]);
+  });
+
+  it("filters untrusted workspace entries out of installed discovery results", () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "matrix-plugin", channels: ["matrix"] }],
+      diagnostics: [],
+    });
+    listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "matrix",
+        pluginId: "matrix-plugin",
+        origin: "workspace",
+        meta: {
+          id: "matrix",
+          label: "Matrix",
+          selectionLabel: "Matrix",
+          docsPath: "/channels/matrix",
+          blurb: "homeserver",
+        },
+      },
+    ]);
+
+    const resolved = resolveChannelSetupEntries({
       cfg: {} as never,
       installedPlugins: [],
       workspaceDir: "/tmp/workspace",
       env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
     });
 
+    expect(resolved.installedCatalogEntries).toEqual([]);
+  });
+
+  it("never offers workspace entries as installable setup options", () => {
+    listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "matrix",
+        pluginId: "matrix-plugin",
+        origin: "workspace",
+        meta: {
+          id: "matrix",
+          label: "Matrix",
+          selectionLabel: "Matrix",
+          docsPath: "/channels/matrix",
+          blurb: "homeserver",
+        },
+      },
+      {
+        id: "telegram",
+        pluginId: "@openclaw/telegram-plugin",
+        origin: "bundled",
+        meta: {
+          id: "telegram",
+          label: "Telegram",
+          selectionLabel: "Telegram",
+          docsPath: "/channels/telegram",
+          blurb: "bot token",
+        },
+      },
+    ]);
+
+    const resolved = resolveChannelSetupEntries({
+      cfg: {
+        plugins: {
+          enabled: true,
+          allow: ["matrix-plugin"],
+        },
+      } as never,
+      installedPlugins: [],
+      workspaceDir: "/tmp/workspace",
+      env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(resolved.installableCatalogEntries.map((entry) => entry.id)).toEqual(["telegram"]);
     expect(listChannelPluginCatalogEntries).toHaveBeenCalledWith({
       workspaceDir: "/tmp/workspace",
-      excludeWorkspace: true,
     });
   });
 });

--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -153,7 +153,54 @@ describe("listManifestInstalledChannelIds", () => {
     expect(resolved.installableCatalogEntries).toEqual([]);
   });
 
-  it("filters untrusted workspace entries out of installed discovery results", () => {
+  it("filters untrusted workspace entries out of installed discovery results when no non-workspace fallback exists", () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "matrix-plugin", channels: ["matrix"] }],
+      diagnostics: [],
+    });
+    listChannelPluginCatalogEntries.mockImplementation((args?: unknown) =>
+      (args as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
+        ? [] // no bundled/global fallback for this workspace-only channel
+        : [
+            {
+              id: "matrix",
+              pluginId: "matrix-plugin",
+              origin: "workspace",
+              meta: {
+                id: "matrix",
+                label: "Matrix",
+                selectionLabel: "Matrix",
+                docsPath: "/channels/matrix",
+                blurb: "homeserver",
+              },
+            },
+          ],
+    );
+
+    const resolved = resolveChannelSetupEntries({
+      cfg: {} as never,
+      installedPlugins: [],
+      workspaceDir: "/tmp/workspace",
+      env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(resolved.installedCatalogEntries).toEqual([]);
+  });
+
+  it("keeps auto-enabled workspace entries in installed discovery results", () => {
+    const autoEnabledConfig = {
+      plugins: {
+        enabled: true,
+        allow: ["matrix-plugin"],
+      },
+    } as never;
+    applyPluginAutoEnable.mockImplementation(({ config }) => ({
+      config: config === autoEnabledConfig ? config : autoEnabledConfig,
+      changes: ["matrix-plugin"] as string[],
+      autoEnabledReasons: {
+        "matrix-plugin": ["matrix configured"],
+      },
+    }));
     loadPluginManifestRegistry.mockReturnValue({
       plugins: [{ id: "matrix-plugin", channels: ["matrix"] }],
       diagnostics: [],
@@ -180,7 +227,58 @@ describe("listManifestInstalledChannelIds", () => {
       env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
     });
 
-    expect(resolved.installedCatalogEntries).toEqual([]);
+    expect(resolved.installedCatalogEntries.map((entry) => entry.id)).toEqual(["matrix"]);
+  });
+
+  it("falls back to non-workspace entry for installed channels with untrusted workspace shadow", () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "@openclaw/telegram-plugin", channels: ["telegram"] }],
+      diagnostics: [],
+    });
+    listChannelPluginCatalogEntries.mockImplementation((args?: unknown) =>
+      (args as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
+        ? [
+            {
+              id: "telegram",
+              pluginId: "@openclaw/telegram-plugin",
+              origin: "bundled",
+              meta: {
+                id: "telegram",
+                label: "Telegram",
+                selectionLabel: "Telegram",
+                docsPath: "/channels/telegram",
+                blurb: "bot token",
+              },
+            },
+          ]
+        : [
+            {
+              id: "telegram",
+              pluginId: "evil-telegram-plugin",
+              origin: "workspace",
+              meta: {
+                id: "telegram",
+                label: "Telegram",
+                selectionLabel: "Telegram",
+                docsPath: "/channels/telegram",
+                blurb: "bot token",
+              },
+            },
+          ],
+    );
+
+    const resolved = resolveChannelSetupEntries({
+      cfg: {} as never, // no plugins.allow → workspace plugin is untrusted
+      installedPlugins: [],
+      workspaceDir: "/tmp/workspace",
+      env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
+    });
+
+    // Bundled entry must appear as installed; untrusted workspace shadow must not be used
+    expect(resolved.installedCatalogEntries.map((entry) => entry.pluginId)).toEqual([
+      "@openclaw/telegram-plugin",
+    ]);
+    expect(resolved.installableCatalogEntries).toEqual([]);
   });
 
   it("never offers workspace entries as installable setup options", () => {

--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -84,6 +84,21 @@ describe("listManifestInstalledChannelIds", () => {
     expect(installedIds).toEqual(new Set(["slack"]));
   });
 
+  it("ignores channels declared only by untrusted workspace manifests", () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "matrix-plugin", origin: "workspace", channels: ["matrix"] }],
+      diagnostics: [],
+    });
+
+    const installedIds = listManifestInstalledChannelIds({
+      cfg: {} as never,
+      workspaceDir: "/tmp/workspace",
+      env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(installedIds).toEqual(new Set());
+  });
+
   it("filters channels hidden from setup out of interactive entries", () => {
     listChatChannels.mockReturnValue([
       {
@@ -195,7 +210,7 @@ describe("listManifestInstalledChannelIds", () => {
       },
     } as never;
     applyPluginAutoEnable.mockImplementation(({ config }) => ({
-      config: config === autoEnabledConfig ? config : autoEnabledConfig,
+      config: (config === autoEnabledConfig ? config : autoEnabledConfig) as never,
       changes: ["matrix-plugin"] as string[],
       autoEnabledReasons: {
         "matrix-plugin": ["matrix configured"],
@@ -388,6 +403,56 @@ describe("listManifestInstalledChannelIds", () => {
       env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
     });
 
+    expect(resolved.installableCatalogEntries.map((entry) => entry.pluginId)).toEqual([
+      "@openclaw/telegram-plugin",
+    ]);
+  });
+
+  it("keeps bundled installable entries when only an untrusted workspace manifest declares the channel", () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "evil-telegram-plugin", origin: "workspace", channels: ["telegram"] }],
+      diagnostics: [],
+    });
+    listChannelPluginCatalogEntries.mockImplementation((args?: unknown) =>
+      (args as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
+        ? [
+            {
+              id: "telegram",
+              pluginId: "@openclaw/telegram-plugin",
+              origin: "bundled",
+              meta: {
+                id: "telegram",
+                label: "Telegram",
+                selectionLabel: "Telegram",
+                docsPath: "/channels/telegram",
+                blurb: "bot token",
+              },
+            },
+          ]
+        : [
+            {
+              id: "telegram",
+              pluginId: "evil-telegram-plugin",
+              origin: "workspace",
+              meta: {
+                id: "telegram",
+                label: "Telegram",
+                selectionLabel: "Telegram",
+                docsPath: "/channels/telegram",
+                blurb: "bot token",
+              },
+            },
+          ],
+    );
+
+    const resolved = resolveChannelSetupEntries({
+      cfg: {} as never,
+      installedPlugins: [],
+      workspaceDir: "/tmp/workspace",
+      env: { OPENCLAW_HOME: "/tmp/home" } as NodeJS.ProcessEnv,
+    });
+
+    expect(resolved.installedCatalogEntries).toEqual([]);
     expect(resolved.installableCatalogEntries.map((entry) => entry.pluginId)).toEqual([
       "@openclaw/telegram-plugin",
     ]);

--- a/src/commands/channel-setup/discovery.ts
+++ b/src/commands/channel-setup/discovery.ts
@@ -75,7 +75,10 @@ export function resolveChannelSetupEntries(params: {
     env: params.env,
   });
   const installedPluginIds = new Set(params.installedPlugins.map((plugin) => plugin.id));
-  const catalogEntries = listChannelPluginCatalogEntries({ workspaceDir });
+  const catalogEntries = listChannelPluginCatalogEntries({
+    workspaceDir,
+    excludeWorkspace: true,
+  });
   const installedCatalogEntries = catalogEntries.filter(
     (entry) =>
       !installedPluginIds.has(entry.id) &&

--- a/src/commands/channel-setup/discovery.ts
+++ b/src/commands/channel-setup/discovery.ts
@@ -77,6 +77,10 @@ export function resolveChannelSetupEntries(params: {
   });
   const installedPluginIds = new Set(params.installedPlugins.map((plugin) => plugin.id));
   const catalogEntries = listChannelPluginCatalogEntries({ workspaceDir });
+  const nonWorkspaceCatalogEntries = listChannelPluginCatalogEntries({
+    workspaceDir,
+    excludeWorkspace: true,
+  });
   const installedCatalogEntries = catalogEntries.filter(
     (entry) =>
       !installedPluginIds.has(entry.id) &&
@@ -84,11 +88,10 @@ export function resolveChannelSetupEntries(params: {
       isTrustedWorkspaceChannelCatalogEntry(entry, params.cfg) &&
       shouldShowChannelInSetup(entry.meta),
   );
-  const installableCatalogEntries = catalogEntries.filter(
+  const installableCatalogEntries = nonWorkspaceCatalogEntries.filter(
     (entry) =>
       !installedPluginIds.has(entry.id) &&
       !manifestInstalledIds.has(entry.id as ChannelChoice) &&
-      entry.origin !== "workspace" &&
       shouldShowChannelInSetup(entry.meta),
   );
 

--- a/src/commands/channel-setup/discovery.ts
+++ b/src/commands/channel-setup/discovery.ts
@@ -10,6 +10,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import type { ChannelChoice } from "../onboard-types.js";
+import { isTrustedWorkspaceChannelCatalogEntry } from "./workspace-trust.js";
 
 type ChannelCatalogEntry = {
   id: ChannelChoice;
@@ -75,20 +76,19 @@ export function resolveChannelSetupEntries(params: {
     env: params.env,
   });
   const installedPluginIds = new Set(params.installedPlugins.map((plugin) => plugin.id));
-  const catalogEntries = listChannelPluginCatalogEntries({
-    workspaceDir,
-    excludeWorkspace: true,
-  });
+  const catalogEntries = listChannelPluginCatalogEntries({ workspaceDir });
   const installedCatalogEntries = catalogEntries.filter(
     (entry) =>
       !installedPluginIds.has(entry.id) &&
       manifestInstalledIds.has(entry.id as ChannelChoice) &&
+      isTrustedWorkspaceChannelCatalogEntry(entry, params.cfg) &&
       shouldShowChannelInSetup(entry.meta),
   );
   const installableCatalogEntries = catalogEntries.filter(
     (entry) =>
       !installedPluginIds.has(entry.id) &&
       !manifestInstalledIds.has(entry.id as ChannelChoice) &&
+      entry.origin !== "workspace" &&
       shouldShowChannelInSetup(entry.meta),
   );
 

--- a/src/commands/channel-setup/discovery.ts
+++ b/src/commands/channel-setup/discovery.ts
@@ -69,9 +69,13 @@ export function resolveChannelSetupEntries(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): ResolvedChannelSetupEntries {
-  const workspaceDir = resolveWorkspaceDir(params.cfg, params.workspaceDir);
+  const resolvedConfig = applyPluginAutoEnable({
+    config: params.cfg,
+    env: params.env ?? process.env,
+  }).config;
+  const workspaceDir = resolveWorkspaceDir(resolvedConfig, params.workspaceDir);
   const manifestInstalledIds = listManifestInstalledChannelIds({
-    cfg: params.cfg,
+    cfg: resolvedConfig,
     workspaceDir,
     env: params.env,
   });
@@ -81,13 +85,32 @@ export function resolveChannelSetupEntries(params: {
     workspaceDir,
     excludeWorkspace: true,
   });
-  const installedCatalogEntries = catalogEntries.filter(
-    (entry) =>
-      !installedPluginIds.has(entry.id) &&
-      manifestInstalledIds.has(entry.id as ChannelChoice) &&
-      isTrustedWorkspaceChannelCatalogEntry(entry, params.cfg) &&
-      shouldShowChannelInSetup(entry.meta),
+  const nonWorkspaceCatalogById = new Map(
+    nonWorkspaceCatalogEntries.map((entry) => [entry.id, entry]),
   );
+  // Build installed entries from the full catalog so trusted workspace entries are included.
+  // When a workspace shadow is present but untrusted, fall back to the non-workspace entry
+  // for that channel so an already-installed non-workspace channel is not silently dropped.
+  const installedCatalogEntries: ChannelPluginCatalogEntry[] = [];
+  for (const entry of catalogEntries) {
+    if (
+      installedPluginIds.has(entry.id) ||
+      !manifestInstalledIds.has(entry.id as ChannelChoice) ||
+      !shouldShowChannelInSetup(entry.meta)
+    ) {
+      continue;
+    }
+    if (isTrustedWorkspaceChannelCatalogEntry(entry, resolvedConfig)) {
+      installedCatalogEntries.push(entry);
+    } else {
+      // Untrusted workspace shadow: use the non-workspace entry so the installed channel
+      // remains visible in setup instead of disappearing behind the shadow.
+      const fallback = nonWorkspaceCatalogById.get(entry.id);
+      if (fallback && shouldShowChannelInSetup(fallback.meta)) {
+        installedCatalogEntries.push(fallback);
+      }
+    }
+  }
   const installableCatalogEntries = nonWorkspaceCatalogEntries.filter(
     (entry) =>
       !installedPluginIds.has(entry.id) &&

--- a/src/commands/channel-setup/discovery.ts
+++ b/src/commands/channel-setup/discovery.ts
@@ -10,7 +10,10 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import { loadPluginManifestRegistry } from "../../plugins/manifest-registry.js";
 import type { ChannelChoice } from "../onboard-types.js";
-import { isTrustedWorkspaceChannelCatalogEntry } from "./workspace-trust.js";
+import {
+  isTrustedWorkspaceChannelCatalogEntry,
+  isTrustedWorkspacePlugin,
+} from "./workspace-trust.js";
 
 type ChannelCatalogEntry = {
   id: ChannelChoice;
@@ -50,7 +53,15 @@ export function listManifestInstalledChannelIds(params: {
       config: resolvedConfig,
       workspaceDir,
       env: params.env ?? process.env,
-    }).plugins.flatMap((plugin) => plugin.channels as ChannelChoice[]),
+    }).plugins.flatMap((plugin) =>
+      isTrustedWorkspacePlugin({
+        pluginId: plugin.id,
+        origin: plugin.origin,
+        cfg: resolvedConfig,
+      })
+        ? (plugin.channels as ChannelChoice[])
+        : [],
+    ),
   );
 }
 
@@ -111,10 +122,13 @@ export function resolveChannelSetupEntries(params: {
       }
     }
   }
+  const setupInstalledCatalogIds = new Set(
+    installedCatalogEntries.map((entry) => entry.id as ChannelChoice),
+  );
   const installableCatalogEntries = nonWorkspaceCatalogEntries.filter(
     (entry) =>
       !installedPluginIds.has(entry.id) &&
-      !manifestInstalledIds.has(entry.id as ChannelChoice) &&
+      !setupInstalledCatalogIds.has(entry.id as ChannelChoice) &&
       shouldShowChannelInSetup(entry.meta),
   );
 

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -455,6 +455,10 @@ describe("ensureChannelSetupPluginInstalled", () => {
         includeSetupOnlyChannelPlugins: true,
       }),
     );
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledWith("telegram", {
+      workspaceDir: "/tmp/openclaw-workspace",
+      excludeWorkspace: true,
+    });
   });
 
   it("keeps full reloads when the active plugin registry is already populated", () => {
@@ -547,6 +551,10 @@ describe("ensureChannelSetupPluginInstalled", () => {
         activate: false,
       }),
     );
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledWith("telegram", {
+      workspaceDir: "/tmp/openclaw-workspace",
+      excludeWorkspace: true,
+    });
   });
 
   it("does not scope by raw channel id when no trusted plugin mapping exists", () => {

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -435,7 +435,10 @@ describe("ensureChannelSetupPluginInstalled", () => {
   it("scopes channel reloads when setup starts from an empty registry", () => {
     const runtime = makeRuntime();
     const cfg: OpenClawConfig = {};
-    getChannelPluginCatalogEntry.mockReturnValue({ pluginId: "@openclaw/telegram-plugin" });
+    getChannelPluginCatalogEntry.mockImplementation(
+      (_channel: string, args?: { excludeWorkspace?: boolean }) =>
+        args?.excludeWorkspace ? { pluginId: "@openclaw/telegram-plugin" } : undefined,
+    );
 
     reloadChannelSetupPluginRegistryForChannel({
       cfg,
@@ -455,7 +458,10 @@ describe("ensureChannelSetupPluginInstalled", () => {
         includeSetupOnlyChannelPlugins: true,
       }),
     );
-    expect(getChannelPluginCatalogEntry).toHaveBeenCalledWith("telegram", {
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(1, "telegram", {
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(2, "telegram", {
       workspaceDir: "/tmp/openclaw-workspace",
       excludeWorkspace: true,
     });
@@ -493,7 +499,10 @@ describe("ensureChannelSetupPluginInstalled", () => {
   it("scopes channel reloads when the global registry is populated but the pinned channel registry is empty", () => {
     const runtime = makeRuntime();
     const cfg: OpenClawConfig = {};
-    getChannelPluginCatalogEntry.mockReturnValue({ pluginId: "@openclaw/telegram-plugin" });
+    getChannelPluginCatalogEntry.mockImplementation(
+      (_channel: string, args?: { excludeWorkspace?: boolean }) =>
+        args?.excludeWorkspace ? { pluginId: "@openclaw/telegram-plugin" } : undefined,
+    );
     const activeRegistry = createEmptyPluginRegistry();
     activeRegistry.plugins.push(
       createPluginRecord({
@@ -530,7 +539,10 @@ describe("ensureChannelSetupPluginInstalled", () => {
   it("can load a channel-scoped snapshot without activating the global registry", () => {
     const runtime = makeRuntime();
     const cfg: OpenClawConfig = {};
-    getChannelPluginCatalogEntry.mockReturnValue({ pluginId: "@openclaw/telegram-plugin" });
+    getChannelPluginCatalogEntry.mockImplementation(
+      (_channel: string, args?: { excludeWorkspace?: boolean }) =>
+        args?.excludeWorkspace ? { pluginId: "@openclaw/telegram-plugin" } : undefined,
+    );
 
     loadChannelSetupPluginRegistrySnapshotForChannel({
       cfg,
@@ -551,7 +563,10 @@ describe("ensureChannelSetupPluginInstalled", () => {
         activate: false,
       }),
     );
-    expect(getChannelPluginCatalogEntry).toHaveBeenCalledWith("telegram", {
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(1, "telegram", {
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(2, "telegram", {
       workspaceDir: "/tmp/openclaw-workspace",
       excludeWorkspace: true,
     });
@@ -573,7 +588,10 @@ describe("ensureChannelSetupPluginInstalled", () => {
         onlyPluginIds: expect.anything(),
       }),
     );
-    expect(getChannelPluginCatalogEntry).toHaveBeenCalledWith("telegram", {
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(1, "telegram", {
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(2, "telegram", {
       workspaceDir: "/tmp/openclaw-workspace",
       excludeWorkspace: true,
     });
@@ -632,5 +650,47 @@ describe("ensureChannelSetupPluginInstalled", () => {
         activate: false,
       }),
     );
+  });
+
+  it("preserves trusted workspace mappings when no explicit plugin id is passed", () => {
+    const runtime = makeRuntime();
+    const cfg: OpenClawConfig = {
+      plugins: {
+        enabled: true,
+        allow: ["matrix-plugin"],
+      },
+    };
+    getChannelPluginCatalogEntry.mockReturnValue({
+      id: "matrix",
+      pluginId: "matrix-plugin",
+      origin: "workspace",
+      meta: {
+        id: "matrix",
+        label: "Matrix",
+        selectionLabel: "Matrix",
+        docsPath: "/channels/matrix",
+        blurb: "homeserver",
+      },
+      install: {
+        npmSpec: "@openclaw/matrix-plugin",
+      },
+    });
+
+    loadChannelSetupPluginRegistrySnapshotForChannel({
+      cfg,
+      runtime,
+      channel: "matrix",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+
+    expect(loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["matrix-plugin"],
+      }),
+    );
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledTimes(1);
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledWith("matrix", {
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
   });
 });

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -573,6 +573,10 @@ describe("ensureChannelSetupPluginInstalled", () => {
         onlyPluginIds: expect.anything(),
       }),
     );
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledWith("telegram", {
+      workspaceDir: "/tmp/openclaw-workspace",
+      excludeWorkspace: true,
+    });
   });
 
   it("scopes snapshots by a unique discovered manifest match when catalog mapping is missing", () => {

--- a/src/commands/channel-setup/plugin-install.ts
+++ b/src/commands/channel-setup/plugin-install.ts
@@ -276,6 +276,7 @@ function resolveScopedChannelPluginId(params: {
   return (
     getChannelPluginCatalogEntry(params.channel, {
       workspaceDir: params.workspaceDir,
+      excludeWorkspace: true,
     })?.pluginId ?? resolveUniqueManifestScopedChannelPluginId(params)
   );
 }

--- a/src/commands/channel-setup/plugin-install.ts
+++ b/src/commands/channel-setup/plugin-install.ts
@@ -22,6 +22,7 @@ import type { PluginRegistry } from "../../plugins/registry.js";
 import { getActivePluginChannelRegistry } from "../../plugins/runtime.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { WizardPrompter } from "../../wizard/prompts.js";
+import { isTrustedWorkspaceChannelCatalogEntry } from "./workspace-trust.js";
 
 type InstallChoice = "npm" | "local" | "skip";
 
@@ -272,6 +273,12 @@ function resolveScopedChannelPluginId(params: {
   const explicitPluginId = params.pluginId?.trim();
   if (explicitPluginId) {
     return explicitPluginId;
+  }
+  const catalogEntry = getChannelPluginCatalogEntry(params.channel, {
+    workspaceDir: params.workspaceDir,
+  });
+  if (catalogEntry && isTrustedWorkspaceChannelCatalogEntry(catalogEntry, params.cfg)) {
+    return catalogEntry?.pluginId ?? resolveUniqueManifestScopedChannelPluginId(params);
   }
   return (
     getChannelPluginCatalogEntry(params.channel, {

--- a/src/commands/channel-setup/workspace-trust.ts
+++ b/src/commands/channel-setup/workspace-trust.ts
@@ -1,0 +1,17 @@
+import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import { normalizePluginsConfig, resolveEnableState } from "../../plugins/config-state.js";
+
+export function isTrustedWorkspaceChannelCatalogEntry(
+  entry: ChannelPluginCatalogEntry | undefined,
+  cfg: OpenClawConfig,
+): boolean {
+  if (entry?.origin !== "workspace") {
+    return true;
+  }
+  if (!entry.pluginId) {
+    return false;
+  }
+  return resolveEnableState(entry.pluginId, "workspace", normalizePluginsConfig(cfg.plugins))
+    .enabled;
+}

--- a/src/commands/channel-setup/workspace-trust.ts
+++ b/src/commands/channel-setup/workspace-trust.ts
@@ -1,17 +1,33 @@
 import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizePluginsConfig, resolveEnableState } from "../../plugins/config-state.js";
+import type { PluginOrigin } from "../../plugins/types.js";
+
+export function isTrustedWorkspacePlugin(params: {
+  pluginId: string | undefined;
+  origin: PluginOrigin | undefined;
+  cfg: OpenClawConfig;
+}): boolean {
+  if (params.origin !== "workspace") {
+    return true;
+  }
+  if (!params.pluginId) {
+    return false;
+  }
+  return resolveEnableState(
+    params.pluginId,
+    "workspace",
+    normalizePluginsConfig(params.cfg.plugins),
+  ).enabled;
+}
 
 export function isTrustedWorkspaceChannelCatalogEntry(
   entry: ChannelPluginCatalogEntry | undefined,
   cfg: OpenClawConfig,
 ): boolean {
-  if (entry?.origin !== "workspace") {
-    return true;
-  }
-  if (!entry.pluginId) {
-    return false;
-  }
-  return resolveEnableState(entry.pluginId, "workspace", normalizePluginsConfig(cfg.plugins))
-    .enabled;
+  return isTrustedWorkspacePlugin({
+    pluginId: entry?.pluginId,
+    origin: entry?.origin,
+    cfg,
+  });
 }

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -6,6 +6,9 @@ const resolveAgentWorkspaceDir = vi.hoisted(() =>
 );
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn((_cfg?: unknown) => "default"));
 const listChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((_args?: unknown): unknown[] => []));
+const isTrustedWorkspaceChannelCatalogEntry = vi.hoisted(() =>
+  vi.fn((_entry?: unknown, _cfg?: unknown) => true),
+);
 const getChannelSetupPlugin = vi.hoisted(() => vi.fn((_channel?: unknown) => undefined));
 const listChannelSetupPlugins = vi.hoisted(() => vi.fn((): unknown[] => []));
 const collectChannelStatus = vi.hoisted(() =>
@@ -49,6 +52,11 @@ vi.mock("../commands/channel-setup/plugin-install.js", () => ({
   })),
 }));
 
+vi.mock("../commands/channel-setup/workspace-trust.js", () => ({
+  isTrustedWorkspaceChannelCatalogEntry: (entry?: unknown, cfg?: unknown) =>
+    isTrustedWorkspaceChannelCatalogEntry(entry, cfg),
+}));
+
 vi.mock("../config/channel-configured.js", () => ({
   isChannelConfigured: vi.fn(() => false),
 }));
@@ -68,6 +76,7 @@ describe("setupChannels", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listChannelPluginCatalogEntries.mockReturnValue([]);
+    isTrustedWorkspaceChannelCatalogEntry.mockReturnValue(true);
     collectChannelStatus.mockResolvedValue({
       installedPlugins: [],
       catalogEntries: [],
@@ -77,7 +86,7 @@ describe("setupChannels", () => {
     });
   });
 
-  it("excludes workspace catalog entries while preloading scoped setup plugins", async () => {
+  it("queries the full catalog (including trusted workspace entries) while preloading scoped setup plugins", async () => {
     const prompter = {
       confirm: vi.fn(async () => false),
       note: vi.fn(async () => {}),
@@ -85,9 +94,37 @@ describe("setupChannels", () => {
 
     await setupChannels({} as never, {} as never, prompter, {});
 
+    // Preload uses the full catalog; workspace trust filtering is applied per-entry
+    // rather than via excludeWorkspace so trusted workspace channels remain discoverable.
     expect(listChannelPluginCatalogEntries).toHaveBeenCalledWith({
       workspaceDir: "/tmp/openclaw-workspace",
-      excludeWorkspace: true,
     });
+  });
+
+  it("skips untrusted workspace catalog entries during preload", async () => {
+    const untrustedEntry = {
+      id: "matrix",
+      origin: "workspace",
+      pluginId: "malicious-plugin",
+      meta: {},
+    };
+    listChannelPluginCatalogEntries.mockReturnValue([untrustedEntry]);
+    // Simulate untrusted workspace entry
+    isTrustedWorkspaceChannelCatalogEntry.mockReturnValue(false);
+
+    const loadChannelSetupPluginRegistrySnapshotForChannel = vi.fn(() => ({
+      channels: [],
+      channelSetups: [],
+    }));
+
+    const prompter = {
+      confirm: vi.fn(async () => false),
+      note: vi.fn(async () => {}),
+    } as unknown as WizardPrompter;
+
+    await setupChannels({} as never, {} as never, prompter, {});
+
+    // The untrusted entry must not reach loadScopedChannelPlugin
+    expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
   });
 });

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WizardPrompter } from "../wizard/prompts.js";
+
+const resolveAgentWorkspaceDir = vi.hoisted(() =>
+  vi.fn((_cfg?: unknown, _agentId?: unknown) => "/tmp/openclaw-workspace"),
+);
+const resolveDefaultAgentId = vi.hoisted(() => vi.fn((_cfg?: unknown) => "default"));
+const listChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((_args?: unknown): unknown[] => []));
+const getChannelSetupPlugin = vi.hoisted(() => vi.fn((_channel?: unknown) => undefined));
+const listChannelSetupPlugins = vi.hoisted(() => vi.fn((): unknown[] => []));
+const collectChannelStatus = vi.hoisted(() =>
+  vi.fn(async (_args?: unknown) => ({
+    installedPlugins: [],
+    catalogEntries: [],
+    installedCatalogEntries: [],
+    statusByChannel: new Map(),
+    statusLines: [],
+  })),
+);
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: (cfg?: unknown, agentId?: unknown) =>
+    resolveAgentWorkspaceDir(cfg, agentId),
+  resolveDefaultAgentId: (cfg?: unknown) => resolveDefaultAgentId(cfg),
+}));
+
+vi.mock("../channels/plugins/catalog.js", () => ({
+  listChannelPluginCatalogEntries: (args?: unknown) => listChannelPluginCatalogEntries(args),
+}));
+
+vi.mock("../channels/plugins/setup-registry.js", () => ({
+  getChannelSetupPlugin: (channel?: unknown) => getChannelSetupPlugin(channel),
+  listChannelSetupPlugins: () => listChannelSetupPlugins(),
+}));
+
+vi.mock("../channels/registry.js", () => ({
+  listChatChannels: () => [],
+}));
+
+vi.mock("../commands/channel-setup/registry.js", () => ({
+  resolveChannelSetupWizardAdapterForPlugin: vi.fn(),
+}));
+
+vi.mock("../commands/channel-setup/plugin-install.js", () => ({
+  ensureChannelSetupPluginInstalled: vi.fn(),
+  loadChannelSetupPluginRegistrySnapshotForChannel: vi.fn(() => ({
+    channels: [],
+    channelSetups: [],
+  })),
+}));
+
+vi.mock("../config/channel-configured.js", () => ({
+  isChannelConfigured: vi.fn(() => false),
+}));
+
+vi.mock("./channel-setup.status.js", () => ({
+  collectChannelStatus: (args?: unknown) => collectChannelStatus(args),
+  noteChannelPrimer: vi.fn(),
+  resolveChannelSelectionNoteLines: vi.fn(() => []),
+  resolveChannelSetupSelectionContributions: vi.fn(() => []),
+  resolveQuickstartDefault: vi.fn(() => undefined),
+  noteChannelStatus: vi.fn(),
+}));
+
+import { setupChannels } from "./channel-setup.js";
+
+describe("setupChannels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listChannelPluginCatalogEntries.mockReturnValue([]);
+    collectChannelStatus.mockResolvedValue({
+      installedPlugins: [],
+      catalogEntries: [],
+      installedCatalogEntries: [],
+      statusByChannel: new Map(),
+      statusLines: [],
+    });
+  });
+
+  it("excludes workspace catalog entries while preloading scoped setup plugins", async () => {
+    const prompter = {
+      confirm: vi.fn(async () => false),
+      note: vi.fn(async () => {}),
+    } as unknown as WizardPrompter;
+
+    await setupChannels({} as never, {} as never, prompter, {});
+
+    expect(listChannelPluginCatalogEntries).toHaveBeenCalledWith({
+      workspaceDir: "/tmp/openclaw-workspace",
+      excludeWorkspace: true,
+    });
+  });
+});

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -6,11 +6,21 @@ const resolveAgentWorkspaceDir = vi.hoisted(() =>
 );
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn((_cfg?: unknown) => "default"));
 const listChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((_args?: unknown): unknown[] => []));
+const getChannelPluginCatalogEntry = vi.hoisted(() =>
+  vi.fn((_channel?: unknown, _args?: unknown): unknown => undefined),
+);
 const isTrustedWorkspaceChannelCatalogEntry = vi.hoisted(() =>
   vi.fn((_entry?: unknown, _cfg?: unknown) => true),
 );
 const getChannelSetupPlugin = vi.hoisted(() => vi.fn((_channel?: unknown) => undefined));
 const listChannelSetupPlugins = vi.hoisted(() => vi.fn((): unknown[] => []));
+const loadChannelSetupPluginRegistrySnapshotForChannel = vi.hoisted(() =>
+  vi.fn((_args?: unknown) => ({
+    channels: [],
+    channelSetups: [],
+  })),
+);
+const isChannelConfigured = vi.hoisted(() => vi.fn((_cfg?: unknown, _channel?: unknown) => false));
 const collectChannelStatus = vi.hoisted(() =>
   vi.fn(async (_args?: unknown) => ({
     installedPlugins: [],
@@ -28,6 +38,8 @@ vi.mock("../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../channels/plugins/catalog.js", () => ({
+  getChannelPluginCatalogEntry: (channel?: unknown, args?: unknown) =>
+    getChannelPluginCatalogEntry(channel, args),
   listChannelPluginCatalogEntries: (args?: unknown) => listChannelPluginCatalogEntries(args),
 }));
 
@@ -46,10 +58,8 @@ vi.mock("../commands/channel-setup/registry.js", () => ({
 
 vi.mock("../commands/channel-setup/plugin-install.js", () => ({
   ensureChannelSetupPluginInstalled: vi.fn(),
-  loadChannelSetupPluginRegistrySnapshotForChannel: vi.fn(() => ({
-    channels: [],
-    channelSetups: [],
-  })),
+  loadChannelSetupPluginRegistrySnapshotForChannel: (args?: unknown) =>
+    loadChannelSetupPluginRegistrySnapshotForChannel(args),
 }));
 
 vi.mock("../commands/channel-setup/workspace-trust.js", () => ({
@@ -58,7 +68,7 @@ vi.mock("../commands/channel-setup/workspace-trust.js", () => ({
 }));
 
 vi.mock("../config/channel-configured.js", () => ({
-  isChannelConfigured: vi.fn(() => false),
+  isChannelConfigured: (cfg?: unknown, channel?: unknown) => isChannelConfigured(cfg, channel),
 }));
 
 vi.mock("./channel-setup.status.js", () => ({
@@ -76,7 +86,9 @@ describe("setupChannels", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listChannelPluginCatalogEntries.mockReturnValue([]);
+    getChannelPluginCatalogEntry.mockReturnValue(undefined);
     isTrustedWorkspaceChannelCatalogEntry.mockReturnValue(true);
+    isChannelConfigured.mockReturnValue(false);
     collectChannelStatus.mockResolvedValue({
       installedPlugins: [],
       catalogEntries: [],
@@ -108,14 +120,16 @@ describe("setupChannels", () => {
       pluginId: "malicious-plugin",
       meta: {},
     };
+    const bundledFallbackEntry = {
+      id: "matrix",
+      origin: "bundled",
+      pluginId: "matrix",
+      meta: {},
+    };
     listChannelPluginCatalogEntries.mockReturnValue([untrustedEntry]);
-    // Simulate untrusted workspace entry
     isTrustedWorkspaceChannelCatalogEntry.mockReturnValue(false);
-
-    const loadChannelSetupPluginRegistrySnapshotForChannel = vi.fn(() => ({
-      channels: [],
-      channelSetups: [],
-    }));
+    getChannelPluginCatalogEntry.mockReturnValue(bundledFallbackEntry);
+    isChannelConfigured.mockReturnValue(true);
 
     const prompter = {
       confirm: vi.fn(async () => false),
@@ -124,7 +138,16 @@ describe("setupChannels", () => {
 
     await setupChannels({} as never, {} as never, prompter, {});
 
-    // The untrusted entry must not reach loadScopedChannelPlugin
-    expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledWith("matrix", {
+      workspaceDir: "/tmp/openclaw-workspace",
+      excludeWorkspace: true,
+    });
+    expect(loadChannelSetupPluginRegistrySnapshotForChannel).toHaveBeenCalledWith({
+      cfg: {},
+      runtime: {},
+      channel: "matrix",
+      pluginId: "matrix",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
   });
 });

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -23,6 +23,7 @@ import type {
   ChannelOnboardingPostWriteHook,
   SetupChannelsOptions,
 } from "../commands/channel-setup/types.js";
+import { isTrustedWorkspaceChannelCatalogEntry } from "../commands/channel-setup/workspace-trust.js";
 import type { ChannelChoice } from "../commands/onboard-types.js";
 import { isChannelConfigured } from "../config/channel-configured.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -146,11 +147,15 @@ export async function setupChannels(
   };
   const preloadConfiguredExternalPlugins = () => {
     // Keep setup memory bounded by snapshot-loading only configured external plugins.
+    // Use the full catalog (including trusted workspace entries) so that a configured
+    // trusted workspace channel plugin is still preloaded here. Untrusted workspace
+    // entries are skipped via the trust check below, preserving the security guard
+    // added for GHSA-82qx-6vj7-p8m2 without dropping legitimate workspace channels.
     const workspaceDir = resolveWorkspaceDir();
-    for (const entry of listChannelPluginCatalogEntries({
-      workspaceDir,
-      excludeWorkspace: true,
-    })) {
+    for (const entry of listChannelPluginCatalogEntries({ workspaceDir })) {
+      if (!isTrustedWorkspaceChannelCatalogEntry(entry, next)) {
+        continue;
+      }
       const channel = entry.id as ChannelChoice;
       if (getVisibleChannelPlugin(channel)) {
         continue;

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -147,7 +147,10 @@ export async function setupChannels(
   const preloadConfiguredExternalPlugins = () => {
     // Keep setup memory bounded by snapshot-loading only configured external plugins.
     const workspaceDir = resolveWorkspaceDir();
-    for (const entry of listChannelPluginCatalogEntries({ workspaceDir })) {
+    for (const entry of listChannelPluginCatalogEntries({
+      workspaceDir,
+      excludeWorkspace: true,
+    })) {
       const channel = entry.id as ChannelChoice;
       if (getVisibleChannelPlugin(channel)) {
         continue;

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -1,5 +1,8 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { listChannelPluginCatalogEntries } from "../channels/plugins/catalog.js";
+import {
+  getChannelPluginCatalogEntry,
+  listChannelPluginCatalogEntries,
+} from "../channels/plugins/catalog.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import {
   getChannelSetupPlugin,
@@ -153,19 +156,27 @@ export async function setupChannels(
     // added for GHSA-82qx-6vj7-p8m2 without dropping legitimate workspace channels.
     const workspaceDir = resolveWorkspaceDir();
     for (const entry of listChannelPluginCatalogEntries({ workspaceDir })) {
+      let resolvedEntry = entry;
       if (!isTrustedWorkspaceChannelCatalogEntry(entry, next)) {
-        continue;
+        const fallbackEntry = getChannelPluginCatalogEntry(entry.id, {
+          workspaceDir,
+          excludeWorkspace: true,
+        });
+        if (!fallbackEntry) {
+          continue;
+        }
+        resolvedEntry = fallbackEntry;
       }
-      const channel = entry.id as ChannelChoice;
+      const channel = resolvedEntry.id as ChannelChoice;
       if (getVisibleChannelPlugin(channel)) {
         continue;
       }
       const explicitlyEnabled =
-        next.plugins?.entries?.[entry.pluginId ?? channel]?.enabled === true;
+        next.plugins?.entries?.[resolvedEntry.pluginId ?? channel]?.enabled === true;
       if (!explicitlyEnabled && !isChannelConfigured(next, channel)) {
         continue;
       }
-      void loadScopedChannelPlugin(channel, entry.pluginId);
+      void loadScopedChannelPlugin(channel, resolvedEntry.pluginId);
     }
   };
   preloadConfiguredExternalPlugins();


### PR DESCRIPTION
## Summary
- Guards the remaining channel-setup catalog lookups so setup-scoped plugin resolution only considers non-workspace entries by default
- Keeps bundled channel setup behavior consistent across preload, discovery, and scoped reload paths

## Changes
- Added `excludeWorkspace: true` to the remaining setup-flow catalog lookups in `channel-setup.ts`, `discovery.ts`, and `plugin-install.ts`
- Added regression coverage for setup discovery, scoped registry reload/snapshot resolution, and setup preload behavior

## Validation
- Ran `corepack pnpm test src/commands/channel-setup/discovery.test.ts src/commands/channel-setup/plugin-install.test.ts src/flows/channel-setup.test.ts`
- Ran the commit gate via `scripts/committer`, which passed `pnpm check`
- Ran `claude -p "/review"` locally; it did not complete a diff review because it requested PR-list access instead

## Notes
- This keeps trusted workspace plugin resolution on the existing trust-aware path and only removes the remaining implicit workspace shadow lookups from setup flows
- Co-author credit from the earlier private draft was preserved in the commit trailer
