### PR TITLE
fix(openrouter): restore attribution wrapper in extra params

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams-openrouter.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams-openrouter.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runExtraParamsPayloadCase } from "./pi-embedded-runner-extraparams.test-support.js";
 import { __testing as extraParamsTesting } from "./pi-embedded-runner/extra-params.js";
 import {
-  createOpenRouterSystemCacheWrapper,
   createOpenRouterWrapper,
   isProxyReasoningUnsupported,
 } from "./pi-embedded-runner/proxy-stream-wrappers.js";
@@ -38,7 +37,7 @@ beforeEach(() => {
       const skipReasoningInjection =
         params.context.modelId === "auto" || isProxyReasoningUnsupported(params.context.modelId);
       const thinkingLevel = skipReasoningInjection ? undefined : params.context.thinkingLevel;
-      return createOpenRouterSystemCacheWrapper(createOpenRouterWrapper(streamFn, thinkingLevel));
+      return createOpenRouterWrapper(streamFn, thinkingLevel);
     },
   });
 });

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -17,6 +17,7 @@ import {
   shouldApplySiliconFlowThinkingOffCompat,
 } from "./moonshot-stream-wrappers.js";
 import {
+  createOpenAIAttributionHeadersWrapper,
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIStringContentWrapper,
 } from "./openai-stream-wrappers.js";
@@ -392,6 +393,7 @@ function applyPostPluginStreamWrappers(
   ctx: ApplyExtraParamsContext & { providerWrapperHandled: boolean },
 ): void {
   ctx.agent.streamFn = createOpenRouterSystemCacheWrapper(ctx.agent.streamFn);
+  ctx.agent.streamFn = createOpenAIAttributionHeadersWrapper(ctx.agent.streamFn);
   ctx.agent.streamFn = createOpenAIStringContentWrapper(ctx.agent.streamFn);
 
   if (!ctx.providerWrapperHandled) {


### PR DESCRIPTION
## Summary
- restore the OpenRouter attribution wrapper in the `applyExtraParamsToAgent()` post-wrapper chain
- keep the existing `pi-embedded-runner` regression test green for OpenRouter attribution headers on chat-path models
- scope stays narrow: no changes to direct-completion attribution behavior, only the extra-params wrapper path

## Validation
- `pnpm.cmd exec vitest run src/agents/pi-embedded-runner-extraparams.test.ts`
- `pnpm.cmd exec oxlint src/agents/pi-embedded-runner/extra-params.ts src/agents/pi-embedded-runner-extraparams.test.ts`