### PR TITLE
Fix buffered text-only block reply fan-out

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1512,6 +1512,7 @@ export async function runEmbeddedAttempt(
           onReasoningStream: params.onReasoningStream,
           onReasoningEnd: params.onReasoningEnd,
           onBlockReply: params.onBlockReply,
+          bufferTextOnlyBlockReplies: params.bufferTextOnlyBlockReplies,
           onBlockReplyFlush: params.onBlockReplyFlush,
           blockReplyBreak: params.blockReplyBreak,
           blockReplyChunking: params.blockReplyChunking,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -108,6 +108,11 @@ export type RunEmbeddedPiAgentParams = {
   onPartialReply?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAssistantMessageStart?: () => void | Promise<void>;
   onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
+  /**
+   * True when downstream delivery keeps text-only block replies buffered until
+   * final reply assembly instead of sending them live.
+   */
+  bufferTextOnlyBlockReplies?: boolean;
   onBlockReplyFlush?: () => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-assistanttexts-final-answer-block-replies-are.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-assistanttexts-final-answer-block-replies-are.test.ts
@@ -28,6 +28,31 @@ describe("subscribeEmbeddedPiSession", () => {
 
     expect(subscription.assistantTexts).toEqual(["Final answer"]);
   });
+  it("keeps assistantTexts to the final answer when text-only block replies are buffered", () => {
+    const { session, emit } = createStubSessionHarness();
+    const onBlockReply = vi.fn();
+
+    const subscription = subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onBlockReply,
+      bufferTextOnlyBlockReplies: true,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "Draft " });
+    emitAssistantTextDelta({ emit, delta: "reply" });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Final answer" }],
+      },
+    });
+    emitAssistantTextEnd({ emit, content: "Draft reply" });
+
+    expect(subscription.assistantTexts).toEqual(["Final answer"]);
+  });
   it("suppresses partial replies when reasoning is enabled and block replies are disabled", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -257,9 +257,13 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   }) => {
     const { text, addedDuringMessage, chunkerHasBuffered } = args;
 
-    // If we're not streaming block replies, ensure the final payload includes
-    // the final text even when interim streaming was enabled.
-    if (state.includeReasoning && text && !params.onBlockReply) {
+    // If text-only block replies are not visible live, collapse any per-message
+    // buffered chunks back to the final assistant text before final payload assembly.
+    const shouldCollapseBufferedAssistantText =
+      Boolean(text) &&
+      (params.bufferTextOnlyBlockReplies === true ||
+        (state.includeReasoning && !params.onBlockReply));
+    if (shouldCollapseBufferedAssistantText) {
       if (assistantTexts.length > state.assistantTextBaseline) {
         assistantTexts.splice(
           state.assistantTextBaseline,

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -24,6 +24,12 @@ export type SubscribeEmbeddedPiSessionParams = {
   /** Called when a thinking/reasoning block ends (</think> tag processed). */
   onReasoningEnd?: () => void | Promise<void>;
   onBlockReply?: (payload: BlockReplyPayload) => void | Promise<void>;
+  /**
+   * When true, downstream delivery buffers text-only block replies instead of
+   * sending them live. Collapse any per-message buffered chunks back to the
+   * final visible assistant text so they do not fan out as end-of-turn replies.
+   */
+  bufferTextOnlyBlockReplies?: boolean;
   /** Flush pending block replies (e.g., before tool execution to preserve message boundaries). */
   onBlockReplyFlush?: () => void | Promise<void>;
   blockReplyBreak?: "text_end" | "message_end";

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1021,6 +1021,8 @@ export async function runAgentTurnWithFallback(params: {
                   await params.typingSignals.signalMessageStart();
                   await params.opts?.onAssistantMessageStart?.();
                 },
+                bufferTextOnlyBlockReplies:
+                  !params.blockStreamingEnabled && Boolean(params.opts?.onBlockReply),
                 onReasoningStream:
                   params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
                     ? async (payload) => {

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -494,6 +494,25 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("flags buffered text-only block replies when streaming is disabled", async () => {
+    const onBlockReply = vi.fn();
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+
+    const { run } = createMinimalRun({
+      opts: { onBlockReply },
+      blockStreamingEnabled: false,
+    });
+    await run();
+
+    const call = state.runEmbeddedPiAgentMock.mock.calls[0]?.[0] as
+      | { bufferTextOnlyBlockReplies?: unknown }
+      | undefined;
+    expect(call?.bufferTextOnlyBlockReplies).toBe(true);
+  });
+
   it("handles typing for normal and silent tool results", async () => {
     const cases = [
       {


### PR DESCRIPTION
## Summary
- collapse buffered text-only block reply chunks back to the final assistant text when block replies are buffered instead of streamed live
- thread an explicit buffered-block-reply flag from the reply runner into the embedded subscriber
- add regression coverage for the buffered subscriber path and runner propagation

## Testing
- npm exec --yes pnpm@10.32.1 -- test -- src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts -t "flags buffered text-only block replies when streaming is disabled"
- npm exec --yes pnpm@10.32.1 -- test -- src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-assistanttexts-final-answer-block-replies-are.test.ts
- npm exec --yes pnpm@10.32.1 -- lint -- src/agents/pi-embedded-subscribe.types.ts src/agents/pi-embedded-subscribe.ts src/agents/pi-embedded-runner/run/params.ts src/agents/pi-embedded-runner/run/attempt.ts src/auto-reply/reply/agent-runner-execution.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-assistanttexts-final-answer-block-replies-are.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts