### PR TITLE
Add optional precedingText and messageId to before_tool_call hook context

### DIFF
--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -185,6 +185,19 @@ Hook guard semantics to keep in mind:
 - `message_sending`: `{ cancel: true }` is terminal and stops lower-priority handlers.
 - `message_sending`: `{ cancel: false }` is treated as no decision.
 
+The `before_tool_call` event payload is additive and currently includes:
+
+```ts
+{
+  toolName: string;
+  params: Record<string, unknown>;
+  runId?: string;
+  toolCallId?: string;
+  precedingText?: string;
+  messageId?: string;
+}
+```
+
 The `/approve` command handles both exec and plugin approvals with bounded fallback: when an exec approval id is not found, OpenClaw retries the same id through plugin approvals. Plugin approval forwarding can be configured independently via `approvals.plugin` in config.
 
 If custom approval plumbing needs to detect that same bounded fallback case,

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -11,6 +11,7 @@ import { sanitizeForConsole } from "./console-sanitize.js";
 import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
 import type { HookContext } from "./pi-tools.before-tool-call.js";
 import {
+  extractBeforeToolCallMessageContext,
   isToolWrappedWithBeforeToolCallHook,
   runBeforeToolCallHook,
 } from "./pi-tools.before-tool-call.js";
@@ -150,22 +151,25 @@ function splitToolExecuteArgs(args: ToolExecuteArgsAny): {
   params: unknown;
   onUpdate: AgentToolUpdateCallback<unknown> | undefined;
   signal: AbortSignal | undefined;
+  extensionContext: unknown;
 } {
   if (isLegacyToolExecuteArgs(args)) {
-    const [toolCallId, params, onUpdate, _ctx, signal] = args;
+    const [toolCallId, params, onUpdate, extensionContext, signal] = args;
     return {
       toolCallId,
       params,
       onUpdate,
       signal,
+      extensionContext,
     };
   }
-  const [toolCallId, params, signal, onUpdate] = args;
+  const [toolCallId, params, signal, onUpdate, extensionContext] = args;
   return {
     toolCallId,
     params,
     onUpdate,
     signal,
+    extensionContext,
   };
 }
 
@@ -180,21 +184,35 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
       description: tool.description ?? "",
       parameters: tool.parameters,
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
-        const { toolCallId, params, onUpdate, signal } = splitToolExecuteArgs(args);
+        const { toolCallId, params, onUpdate, signal, extensionContext } =
+          splitToolExecuteArgs(args);
         let executeParams = params;
         try {
           if (!beforeHookWrapped) {
+            const messageContext = extractBeforeToolCallMessageContext({
+              extensionContext,
+              toolCallId,
+            });
             const hookOutcome = await runBeforeToolCallHook({
               toolName: name,
               params,
               toolCallId,
+              ctx: messageContext,
             });
             if (hookOutcome.blocked) {
               throw new Error(hookOutcome.reason);
             }
             executeParams = hookOutcome.params;
           }
-          const rawResult = await tool.execute(toolCallId, executeParams, signal, onUpdate);
+          const rawResult = await (
+            tool.execute as (
+              toolCallId: string,
+              params: unknown,
+              signal: AbortSignal | undefined,
+              onUpdate: AgentToolUpdateCallback<unknown> | undefined,
+              extensionContext?: unknown,
+            ) => Promise<unknown>
+          )(toolCallId, executeParams, signal, onUpdate, extensionContext);
           const result = normalizeToolExecutionResult({
             toolName: normalizedName,
             result: rawResult,
@@ -278,12 +296,16 @@ export function toClientToolDefinitions(
       description: func.description ?? "",
       parameters: func.parameters as ToolDefinition["parameters"],
       execute: async (...args: ToolExecuteArgs): Promise<AgentToolResult<unknown>> => {
-        const { toolCallId, params } = splitToolExecuteArgs(args);
+        const { toolCallId, params, extensionContext } = splitToolExecuteArgs(args);
+        const messageContext = extractBeforeToolCallMessageContext({
+          extensionContext,
+          toolCallId,
+        });
         const outcome = await runBeforeToolCallHook({
           toolName: func.name,
           params,
           toolCallId,
-          ctx: hookContext,
+          ctx: { ...hookContext, ...messageContext },
         });
         if (outcome.blocked) {
           throw new Error(outcome.reason);

--- a/src/agents/pi-tools.abort.ts
+++ b/src/agents/pi-tools.abort.ts
@@ -58,12 +58,12 @@ export function wrapToolWithAbortSignal(
   }
   const wrappedTool: AnyAgentTool = {
     ...tool,
-    execute: async (toolCallId, params, signal, onUpdate) => {
+    execute: async (toolCallId, params, signal, onUpdate, extensionContext?: unknown) => {
       const combined = combineAbortSignals(signal, abortSignal);
       if (combined?.aborted) {
         throwAbortError();
       }
-      return await execute(toolCallId, params, combined, onUpdate);
+      return await execute(toolCallId, params, combined, onUpdate, extensionContext);
     },
   };
   copyPluginToolMeta(tool, wrappedTool);

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -104,6 +104,7 @@ describe("before_tool_call hook integration", () => {
       { path: "/tmp/file" },
       undefined,
       extensionContext,
+      undefined,
     );
   });
 
@@ -122,6 +123,7 @@ describe("before_tool_call hook integration", () => {
       { cmd: "ls", mode: "safe" },
       undefined,
       extensionContext,
+      undefined,
     );
   });
 
@@ -289,6 +291,52 @@ describe("before_tool_call hook integration", () => {
         sessionKey: "main",
         toolCallId: "call-ctx",
       },
+    );
+  });
+
+  it("forwards extensionContext through wrapped tool execution", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const baseTool = { name: "read", execute, description: "read", parameters: {} } as any;
+    const wrapped = wrapToolWithBeforeToolCallHook(baseTool, {
+      agentId: "main",
+      sessionKey: "main",
+    });
+    const [def] = toToolDefinitions([wrapped]);
+    const extensionContext = {
+      sessionManager: {
+        getLeafEntry: () => ({
+          id: "msg-extension-context",
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Inspect file first." },
+              {
+                type: "toolCall",
+                id: "call-extension-context",
+                name: "read",
+                arguments: { path: "/tmp/file" },
+              },
+            ],
+          },
+        }),
+      },
+    } as Parameters<typeof def.execute>[4];
+
+    await def.execute(
+      "call-extension-context",
+      { path: "/tmp/file" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-extension-context",
+      { path: "/tmp/file" },
+      undefined,
+      undefined,
+      extensionContext,
     );
   });
 });

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -243,6 +243,54 @@ describe("before_tool_call hook integration", () => {
     });
     expect(consumeAdjustedParamsForToolCall(sharedToolCallId, "run-a")).toBeUndefined();
   });
+
+  it("passes precedingText and messageId from the assistant tool-call message", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const baseTool = { name: "read", execute, description: "read", parameters: {} } as any;
+    const wrapped = wrapToolWithBeforeToolCallHook(baseTool, {
+      agentId: "main",
+      sessionKey: "main",
+    });
+    const [def] = toToolDefinitions([wrapped]);
+    const extensionContext = {
+      sessionManager: {
+        getLeafEntry: () => ({
+          id: "msg-assistant-1",
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "I should inspect the target file first." },
+              {
+                type: "toolCall",
+                id: "call-ctx",
+                name: "read",
+                arguments: { path: "/tmp/file" },
+              },
+            ],
+          },
+        }),
+      },
+    } as Parameters<typeof def.execute>[4];
+
+    await def.execute("call-ctx", { path: "/tmp/file" }, undefined, undefined, extensionContext);
+
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "read",
+        params: { path: "/tmp/file" },
+        toolCallId: "call-ctx",
+        precedingText: "I should inspect the target file first.",
+        messageId: "msg-assistant-1",
+      },
+      {
+        toolName: "read",
+        agentId: "main",
+        sessionKey: "main",
+        toolCallId: "call-ctx",
+      },
+    );
+  });
 });
 
 describe("before_tool_call hook deduplication (#15502)", () => {
@@ -335,5 +383,63 @@ describe("before_tool_call hook integration for client tools", () => {
       value: "ok",
       extra: true,
     });
+  });
+
+  it("passes precedingText and messageId to client tool hooks", async () => {
+    const onClientToolCall = vi.fn();
+    const handler = installBeforeToolCallHook({
+      runBeforeToolCallImpl: async () => undefined,
+    });
+    const [tool] = toClientToolDefinitions(
+      [
+        {
+          type: "function",
+          function: {
+            name: "client_tool",
+            description: "Client tool",
+            parameters: { type: "object", properties: { value: { type: "string" } } },
+          },
+        },
+      ],
+      onClientToolCall,
+      { agentId: "main", sessionKey: "main" },
+    );
+    const extensionContext = {
+      sessionManager: {
+        getLeafEntry: () => ({
+          id: "msg-client-1",
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Need client-side confirmation before dispatch." },
+              {
+                type: "toolCall",
+                id: "client-call-ctx",
+                name: "client_tool",
+                arguments: { value: "ok" },
+              },
+            ],
+          },
+        }),
+      },
+    } as Parameters<typeof tool.execute>[4];
+    await tool.execute("client-call-ctx", { value: "ok" }, undefined, undefined, extensionContext);
+
+    expect(handler).toHaveBeenCalledWith(
+      {
+        toolName: "client_tool",
+        params: { value: "ok" },
+        toolCallId: "client-call-ctx",
+        precedingText: "Need client-side confirmation before dispatch.",
+        messageId: "msg-client-1",
+      },
+      {
+        toolName: "client_tool",
+        agentId: "main",
+        sessionKey: "main",
+        toolCallId: "client-call-ctx",
+      },
+    );
   });
 });

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -396,6 +396,63 @@ describe("before_tool_call hook deduplication (#15502)", () => {
 
     expect(beforeToolCallHook).toHaveBeenCalledTimes(1);
   });
+
+  it("preserves extensionContext through abort-wrapped before_tool_call hooks", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const baseTool = { name: "read", execute, description: "read", parameters: {} } as any;
+
+    const abortController = new AbortController();
+    const wrapped = wrapToolWithBeforeToolCallHook(baseTool, {
+      agentId: "main",
+      sessionKey: "main",
+    });
+    const withAbort = wrapToolWithAbortSignal(wrapped, abortController.signal);
+    const [def] = toToolDefinitions([withAbort]);
+    const extensionContext = {
+      sessionManager: {
+        getLeafEntry: () => ({
+          id: "msg-abort-ctx-1",
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "Need to inspect the file before continuing." },
+              {
+                type: "toolCall",
+                id: "call-abort-ctx",
+                name: "read",
+                arguments: { path: "/tmp/file" },
+              },
+            ],
+          },
+        }),
+      },
+    } as Parameters<typeof def.execute>[4];
+
+    await def.execute(
+      "call-abort-ctx",
+      { path: "/tmp/file" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "read",
+        params: { path: "/tmp/file" },
+        toolCallId: "call-abort-ctx",
+        precedingText: "Need to inspect the file before continuing.",
+        messageId: "msg-abort-ctx-1",
+      },
+      {
+        toolName: "read",
+        agentId: "main",
+        sessionKey: "main",
+        toolCallId: "call-abort-ctx",
+      },
+    );
+  });
 });
 
 describe("before_tool_call hook integration for client tools", () => {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -488,7 +488,13 @@ export function wrapToolWithBeforeToolCallHook(
       }
       const normalizedToolName = normalizeToolName(toolName || "tool");
       try {
-        const result = await execute(toolCallId, outcome.params, signal, onUpdate);
+        const result = await execute(
+          toolCallId,
+          outcome.params,
+          signal,
+          onUpdate,
+          extensionContext,
+        );
         await recordLoopOutcome({
           ctx,
           toolName: normalizedToolName,

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -7,6 +7,7 @@ import { PluginApprovalResolutions, type PluginApprovalResolution } from "../plu
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { isPlainObject } from "../utils.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
+import { collectTextContentBlocks } from "./content-blocks.js";
 import { normalizeToolName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -18,6 +19,8 @@ export type HookContext = {
   sessionId?: string;
   runId?: string;
   loopDetection?: ToolLoopDetectionConfig;
+  precedingText?: string;
+  messageId?: string;
 };
 
 type HookOutcome = { blocked: true; reason: string } | { blocked: false; params: unknown };
@@ -93,6 +96,77 @@ function shouldEmitLoopWarning(state: SessionState, warningKey: string, count: n
     }
   }
   return true;
+}
+
+function extractPrecedingTextFromAssistantMessage(
+  message: unknown,
+  toolCallId?: string,
+): string | undefined {
+  if (!toolCallId || !message || typeof message !== "object") {
+    return undefined;
+  }
+  const assistantMessage = message as {
+    role?: unknown;
+    content?: unknown;
+  };
+  if (assistantMessage.role !== "assistant" || !Array.isArray(assistantMessage.content)) {
+    return undefined;
+  }
+  const precedingBlocks: unknown[] = [];
+  let foundTarget = false;
+  for (const block of assistantMessage.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as { type?: unknown; id?: unknown };
+    if (
+      record.id === toolCallId &&
+      (record.type === "toolCall" || record.type === "toolUse" || record.type === "functionCall")
+    ) {
+      foundTarget = true;
+      break;
+    }
+    precedingBlocks.push(block);
+  }
+  if (!foundTarget) {
+    return undefined;
+  }
+  const precedingText = collectTextContentBlocks(precedingBlocks).join("\n").trim();
+  return precedingText || undefined;
+}
+
+export function extractBeforeToolCallMessageContext(args: {
+  extensionContext?: unknown;
+  toolCallId?: string;
+}): Pick<HookContext, "precedingText" | "messageId"> {
+  const sessionManager = (
+    args.extensionContext as
+      | {
+          sessionManager?: { getLeafEntry?: () => unknown };
+        }
+      | null
+      | undefined
+  )?.sessionManager;
+  const leafEntry = sessionManager?.getLeafEntry?.() as
+    | {
+        id?: unknown;
+        type?: unknown;
+        message?: unknown;
+      }
+    | undefined;
+  if (!leafEntry || leafEntry.type !== "message") {
+    return {};
+  }
+  const precedingText = extractPrecedingTextFromAssistantMessage(
+    leafEntry.message,
+    args.toolCallId,
+  );
+  const messageId =
+    typeof leafEntry.id === "string" && leafEntry.id.trim().length > 0 ? leafEntry.id : undefined;
+  return {
+    ...(precedingText ? { precedingText } : {}),
+    ...(messageId ? { messageId } : {}),
+  };
 }
 
 async function recordLoopOutcome(args: {
@@ -206,6 +280,8 @@ export async function runBeforeToolCallHook(args: {
         params: normalizedParams,
         ...(args.ctx?.runId && { runId: args.ctx.runId }),
         ...(args.toolCallId && { toolCallId: args.toolCallId }),
+        ...(args.ctx?.precedingText && { precedingText: args.ctx.precedingText }),
+        ...(args.ctx?.messageId && { messageId: args.ctx.messageId }),
       },
       toolContext,
     );
@@ -388,12 +464,13 @@ export function wrapToolWithBeforeToolCallHook(
   const toolName = tool.name || "tool";
   const wrappedTool: AnyAgentTool = {
     ...tool,
-    execute: async (toolCallId, params, signal, onUpdate) => {
+    execute: async (toolCallId, params, signal, onUpdate, extensionContext?: unknown) => {
+      const messageContext = extractBeforeToolCallMessageContext({ extensionContext, toolCallId });
       const outcome = await runBeforeToolCallHook({
         toolName,
         params,
         toolCallId,
-        ctx,
+        ctx: { ...ctx, ...messageContext },
         signal,
       });
       if (outcome.blocked) {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2705,6 +2705,10 @@ export type PluginHookBeforeToolCallEvent = {
   runId?: string;
   /** Provider-specific tool call ID when available. */
   toolCallId?: string;
+  /** Assistant text content that appeared before this tool call in the same message. */
+  precedingText?: string;
+  /** Session transcript entry id for the assistant message that requested this tool call. */
+  messageId?: string;
 };
 
 export const PluginApprovalResolutions = {


### PR DESCRIPTION
Summary

This PR takes a minimal pass on #12617 by extending the `before_tool_call` hook with two optional fields:
- `precedingText`
- `messageId`

The current event shape remains intact. This is an additive, backwards-compatible change intended to make compliance/audit/governance plugins easier to build without coupling OpenClaw to any one policy framework.

What changed

- added optional `precedingText` to the `before_tool_call` hook event
- added optional `messageId` to the `before_tool_call` hook event
- plumbed both fields into the hook invocation
- added focused tests
- updated docs

Why this is narrow

This PR intentionally does not add broader context fields or policy semantics. It keeps the first step small and focused while addressing the immediate hook-context gap raised in #12617.
