### PR TITLE
fix(discord): remove leaked error listener on gateway supervisor dispose

### DIFF
--- a/extensions/discord/src/monitor/gateway-supervisor.ts
+++ b/extensions/discord/src/monitor/gateway-supervisor.ts
@@ -199,6 +199,7 @@ export function createDiscordGatewaySupervisor(params: {
       if (phase === "disposed") {
         return;
       }
+      emitter.off("error", onGatewayError);
       lifecycleHandler = undefined;
       phase = "disposed";
       pending.length = 0;


### PR DESCRIPTION
## Summary

- `createDiscordGatewaySupervisor` registers `emitter.on("error", onGatewayError)` but `dispose()` never calls `emitter.off()`, leaking the handler and its entire closure (params, pending queue, seenLateEventKeys set, lifecycleHandler)
- The handler keeps firing on the emitter after disposal, running the `logLateEvent("disposed")` path and growing `seenLateEventKeys` indefinitely
- Prevents GC of the disposed supervisor's state for as long as the emitter lives

### Fix

Add `emitter.off("error", onGatewayError)` as the first operation in `dispose()`, before transitioning to the "disposed" phase. This follows the same cleanup pattern used in `src/gateway/http-common.ts` which pairs `.on()` with `.off()`.

## Test plan

- [x] Verified no existing tests break (no test file for this module exists yet)
- [x] One-line change — minimal risk
- [x] Control flow: the `off()` call runs before `phase = "disposed"`, so any error events arriving between `off()` and phase assignment are handled by the still-active `onGatewayError` function normally

[AI-assisted]

🤖 Generated with [Claude Code](https://claude.com/claude-code)