### PR TITLE
fix(gateway): use already-aborted signal in stopChannel fallback

### DIFF
--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -490,7 +490,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             accountId: id,
             account,
             runtime: channelRuntimeEnvs[channelId],
-            abortSignal: abort?.signal ?? new AbortController().signal,
+            abortSignal: abort?.signal ?? AbortSignal.abort(),
             log: channelLogs[channelId],
             getStatus: () => getRuntime(channelId, id),
             setStatus: (next) => setRuntime(channelId, id, next),


### PR DESCRIPTION
## Summary

- In `stopChannel`, when no `AbortController` exists for an account (i.e. no running task), the fallback `new AbortController().signal` creates a signal from an anonymous controller that **can never be aborted**
- `stopAccount` implementations may use this signal for cleanup coordination (checking `signal.aborted`, passing to `fetch`, using with `sleepWithAbort`, etc.)
- A never-aborting signal can cause `stopAccount` to hang or timeout during graceful shutdown instead of completing immediately

### Fix

Replace `new AbortController().signal` with `AbortSignal.abort()`, which returns an already-aborted signal. This correctly communicates "this account is being stopped" to the plugin's `stopAccount` implementation.

### Context

On line 485, `abort?.abort()` is called — so if `abort` exists, its signal is already aborted. The fallback only fires when `abort` is undefined (no active task for this account). In both cases the intent is the same: tell `stopAccount` to shut down. `AbortSignal.abort()` makes the fallback consistent with the primary path.

## Test plan

- [x] All 14 tests in `server-channels.test.ts` pass
- [x] One-line change, minimal risk
- [x] `AbortSignal.abort()` is available since Node 15.12.0; project requires Node 22+

[AI-assisted]

🤖 Generated with [Claude Code](https://claude.com/claude-code)