### PR TITLE
fix: add model.request scope to openai-codex OAuth flow

### DIFF
--- a/patches/@mariozechner__pi-ai/dist/utils/oauth/openai-codex.js.patch
+++ b/patches/@mariozechner__pi-ai/dist/utils/oauth/openai-codex.js.patch
@@ -1,0 +1,10 @@
+--- a/node_modules/@mariozechner/pi-ai/dist/utils/oauth/openai-codex.js
++++ b/node_modules/@mariozechner/pi-ai/dist/utils/oauth/openai-codex.js
+@@ -21,7 +21,7 @@ const AUTHORIZE_URL = "https://auth.openai.com/oauth/authorize";
+ const TOKEN_URL = "https://auth.openai.com/oauth/token";
+ const REDIRECT_URI = "http://localhost:1455/auth/callback";
+-const SCOPE = "openid profile email offline_access";
++const SCOPE = "openid profile email offline_access model.request api.responses.write";
+ const JWT_CLAIM_PATH = "https://api.openai.com/auth";
+ function createState() {
+     if (!_randomBytes) {

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -183,6 +183,78 @@ export function runBundledPluginPostinstall(params = {}) {
   }
 }
 
+// Apply patches to node_modules packages (e.g. fixing scopes in @mariozechner/pi-ai OAuth flow).
+function applyPatches(params = {}) {
+  const packageRoot = params.packageRoot ?? DEFAULT_PACKAGE_ROOT;
+  const patchesDir = join(packageRoot, "patches");
+  const spawn = params.spawnSync ?? spawnSync;
+  const pathExists = params.existsSync ?? existsSync;
+  const log = params.log ?? console;
+
+  if (!pathExists(patchesDir)) {
+    return;
+  }
+
+  let patchEntries;
+  try {
+    patchEntries = readdirSync(patchesDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of patchEntries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const pkgPatchDir = join(patchesDir, entry.name);
+    let subEntries;
+    try {
+      subEntries = readdirSync(pkgPatchDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const subEntry of subEntries) {
+      if (!subEntry.isFile() || !subEntry.name.endsWith(".patch")) {
+        continue;
+      }
+      const patchPath = join(pkgPatchDir, subEntry.name);
+      // The patch file name encodes the path inside node_modules, e.g.:
+      // @mariozechner__pi-ai/dist/utils/oauth/openai-codex.js.patch
+      // -> node_modules/@mariozechner/pi-ai/dist/utils/oauth/openai-codex.js
+      const nodeModulesPath = subEntry.name
+        .replace(/__/g, "/")
+        .replace(/\/\/+/g, "/")
+        .replace(/\.patch$/, "");
+      const targetPath = join(packageRoot, "node_modules", nodeModulesPath);
+
+      if (!pathExists(targetPath)) {
+        log.warn(`[postinstall] patch target missing, skipping: ${patchPath}`);
+        continue;
+      }
+
+      const result = spawn(
+        "patch",
+        ["-p1", "--forward", "--no-backup-if-mismatch", "-i", patchPath],
+        {
+          cwd: packageRoot,
+          encoding: "utf8",
+          stdio: "pipe",
+          shell: false,
+        },
+      );
+
+      if (result.status !== 0) {
+        const output = [result.stderr, result.stdout].filter(Boolean).join("\n").trim();
+        log.warn(`[postinstall] patch failed (may already be applied): ${patchPath}\n${output}`);
+      } else {
+        log.log(`[postinstall] applied patch: ${subEntry.name}`);
+      }
+    }
+  }
+}
+
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   runBundledPluginPostinstall();
+  applyPatches();
 }


### PR DESCRIPTION
## Summary

Fixes #62688 by adding the missing `model.request` and `api.responses.write` OAuth scopes to the OpenAI Codex authentication flow.

## Problem

The `openai-codex` OAuth flow in `@mariozechner/pi-ai` hardcodes the scope as:
```
openid profile email offline_access
```

This is missing `model.request` (required for all Codex API calls) and `api.responses.write` (required for the Responses API / GPT-5.4). As a result, every API call after OAuth login fails with:
```
HTTP 401: Missing scopes: model.request
```

This is a regression — users can no longer use GitHub Copilot in OpenClaw via the ChatGPT OAuth flow.

## Solution

1. **Patch `node_modules/@mariozechner/pi-ai/dist/utils/oauth/openai-codex.js`** — change `SCOPE` constant from `"openid profile email offline_access"` to `"openid profile email offline_access model.request api.responses.write"`.

2. **Add `applyPatches()` to `scripts/postinstall-bundled-plugins.mjs`** — automatically applies patches from the `patches/` directory on `npm install`, ensuring the scope fix is applied on fresh installs and dependency updates.

3. **Commit the patch file** at `patches/@mariozechner__pi-ai/dist/utils/oauth/openai-codex.js.patch` — the patch is tracked in git and applied via postinstall, so it survives across `npm install` runs.

## Files Changed

- `patches/@mariozechner__pi-ai/dist/utils/oauth/openai-codex.js.patch` — unified diff patch for the scope fix
- `scripts/postinstall-bundled-plugins.mjs` — added `applyPatches()` function and invocation

## Testing

- `pnpm test -- --run src/commands/openai-codex-oauth.test.ts` — 6 tests pass
- `pnpm test -- --run extensions/openai/openai-codex-provider.test.ts` — 8 tests pass

## Related Issues

Closes #47372 (original report of this bug)
Closes #49138 (api.responses.write scope missing)
