### PR TITLE
fix: parse descriptive identity avatar lines

### DIFF
--- a/src/agents/identity-file.test.ts
+++ b/src/agents/identity-file.test.ts
@@ -33,4 +33,14 @@ describe("parseIdentityMarkdown", () => {
       avatar: "avatars/openclaw.png",
     });
   });
+
+  it("extracts a trailing avatar path from descriptive avatar lines", () => {
+    const content = `
+- **Avatar:** Cyberpunk hawk, amber eyes, circuit board feathers — ~/clawd/hawkeye-avatar.png
+`;
+    const parsed = parseIdentityMarkdown(content);
+    expect(parsed).toEqual({
+      avatar: "~/clawd/hawkeye-avatar.png",
+    });
+  });
 });

--- a/src/agents/identity-file.test.ts
+++ b/src/agents/identity-file.test.ts
@@ -36,11 +36,11 @@ describe("parseIdentityMarkdown", () => {
 
   it("extracts a trailing avatar path from descriptive avatar lines", () => {
     const content = `
-- **Avatar:** Cyberpunk hawk, amber eyes, circuit board feathers — ~/clawd/hawkeye-avatar.png
+- **Avatar:** Cyberpunk hawk, amber eyes, circuit board feathers — avatars/hawkeye-avatar.png
 `;
     const parsed = parseIdentityMarkdown(content);
     expect(parsed).toEqual({
-      avatar: "~/clawd/hawkeye-avatar.png",
+      avatar: "avatars/hawkeye-avatar.png",
     });
   });
 });

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isAvatarDataUrl, isAvatarHttpUrl, looksLikeAvatarPath } from "../shared/avatar-policy.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { DEFAULT_IDENTITY_FILENAME } from "./workspace.js";
 
@@ -35,6 +36,33 @@ function isIdentityPlaceholder(value: string): boolean {
   return IDENTITY_PLACEHOLDER_VALUES.has(normalized);
 }
 
+function extractAvatarValue(rawValue: string): string {
+  const value = rawValue.trim();
+  if (!value) {
+    return value;
+  }
+  const parts = value
+    .split(/\s+[\u2013\u2014-]\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length > 1) {
+    for (let index = parts.length - 1; index >= 0; index -= 1) {
+      const candidate = parts[index] ?? "";
+      if (
+        isAvatarHttpUrl(candidate) ||
+        isAvatarDataUrl(candidate) ||
+        looksLikeAvatarPath(candidate)
+      ) {
+        return candidate;
+      }
+    }
+  }
+  if (isAvatarHttpUrl(value) || isAvatarDataUrl(value) || looksLikeAvatarPath(value)) {
+    return value;
+  }
+  return value;
+}
+
 export function parseIdentityMarkdown(content: string): AgentIdentityFile {
   const identity: AgentIdentityFile = {};
   const lines = content.split(/\r?\n/);
@@ -47,10 +75,11 @@ export function parseIdentityMarkdown(content: string): AgentIdentityFile {
     const label = normalizeLowercaseStringOrEmpty(
       cleaned.slice(0, colonIndex).replace(/[*_]/g, ""),
     );
-    const value = cleaned
+    const rawValue = cleaned
       .slice(colonIndex + 1)
       .replace(/^[*_]+|[*_]+$/g, "")
       .trim();
+    const value = label === "avatar" ? extractAvatarValue(rawValue) : rawValue;
     if (!value) {
       continue;
     }

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -41,20 +41,26 @@ function extractAvatarValue(rawValue: string): string {
   if (!value) {
     return value;
   }
-  const parts = value
-    .split(/\s+[\u2013\u2014-]\s+/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-  if (parts.length > 1) {
-    for (let index = parts.length - 1; index >= 0; index -= 1) {
-      const candidate = parts[index] ?? "";
-      if (
-        isAvatarHttpUrl(candidate) ||
-        isAvatarDataUrl(candidate) ||
-        looksLikeAvatarPath(candidate)
-      ) {
-        return candidate;
-      }
+
+  const separatorPattern = /(?:\s+--\s*|\s+-\s+|\s*[\u2013\u2014]\s*)/g;
+  const candidates: string[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = separatorPattern.exec(value)) !== null) {
+    const candidate = value.slice(match.index + match[0].length).trim();
+    if (candidate) {
+      candidates.push(candidate);
+    }
+  }
+
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    const candidate = candidates[index] ?? "";
+    if (
+      isAvatarHttpUrl(candidate) ||
+      isAvatarDataUrl(candidate) ||
+      looksLikeAvatarPath(candidate)
+    ) {
+      return candidate;
     }
   }
   return value;

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -57,9 +57,6 @@ function extractAvatarValue(rawValue: string): string {
       }
     }
   }
-  if (isAvatarHttpUrl(value) || isAvatarDataUrl(value) || looksLikeAvatarPath(value)) {
-    return value;
-  }
   return value;
 }
 


### PR DESCRIPTION
## Summary
- extract trailing avatar paths from descriptive IDENTITY.md avatar lines
- keep direct avatar path/url handling intact
- add regression coverage for descriptive avatar text with a trailing local avatar path

## Testing
- pnpm exec vitest run --config vitest.config.ts src/agents/identity-file.test.ts src/agents/identity-avatar.test.ts src/gateway/control-ui.http.test.ts