### PR TITLE
Fix local memory embedding VRAM fallback and logging file resolution

### DIFF
--- a/src/logging/config.test.ts
+++ b/src/logging/config.test.ts
@@ -1,31 +1,39 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { readLoggingConfig } from "./config.js";
-
-const loadConfigMock = vi.hoisted(() => vi.fn());
-
-vi.mock("../config/config.js", async () => {
-  const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
-  return {
-    ...actual,
-    loadConfig: () => loadConfigMock(),
-  };
-});
+import { readLoggingConfig, setLoggingConfigLoaderForTests } from "./config.js";
 
 const originalArgv = process.argv;
+const loadLoggingConfigMock = vi.fn();
 
 describe("readLoggingConfig", () => {
   afterEach(() => {
     process.argv = originalArgv;
-    loadConfigMock.mockReset();
+    loadLoggingConfigMock.mockReset();
+    setLoggingConfigLoaderForTests();
   });
 
   it("skips mutating config loads for config schema", async () => {
     process.argv = ["node", "openclaw", "config", "schema"];
-    loadConfigMock.mockImplementation(() => {
-      throw new Error("loadConfig should not be called");
+    setLoggingConfigLoaderForTests(() => {
+      throw new Error("loadLoggingConfig should not be called");
     });
 
     expect(readLoggingConfig()).toBeUndefined();
-    expect(loadConfigMock).not.toHaveBeenCalled();
+    expect(loadLoggingConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("loads logging config lazily when reads are allowed", () => {
+    setLoggingConfigLoaderForTests(() => {
+      loadLoggingConfigMock();
+      return {
+        level: "debug",
+        file: "/tmp/openclaw-YYYY-MM-DD.log",
+      };
+    });
+
+    expect(readLoggingConfig()).toEqual({
+      level: "debug",
+      file: "/tmp/openclaw-YYYY-MM-DD.log",
+    });
+    expect(loadLoggingConfigMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -1,10 +1,7 @@
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
-import type { OpenClawConfig } from "../config/config.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
+import { loadConfig, type OpenClawConfig } from "../config/config.js";
 
 type LoggingConfig = OpenClawConfig["logging"];
-
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
 export function shouldSkipMutatingLoggingConfigRead(argv: string[] = process.argv): boolean {
   const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
@@ -16,12 +13,7 @@ export function readLoggingConfig(): LoggingConfig | undefined {
     return undefined;
   }
   try {
-    const loaded = requireConfig?.("../config/config.js") as
-      | {
-          loadConfig?: () => OpenClawConfig;
-        }
-      | undefined;
-    const parsed = loaded?.loadConfig?.();
+    const parsed = loadConfig();
     const logging = parsed?.logging;
     if (!logging || typeof logging !== "object" || Array.isArray(logging)) {
       return undefined;

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -1,7 +1,34 @@
+import { fileURLToPath } from "node:url";
 import { getCommandPathWithRootOptions } from "../cli/argv.js";
-import { loadConfig, type OpenClawConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveNodeRequireFromMeta } from "./node-require.js";
 
 type LoggingConfig = OpenClawConfig["logging"];
+
+const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
+const configModulePath = fileURLToPath(new URL("../config/config.js", import.meta.url));
+type LoggingConfigLoader = () => LoggingConfig | undefined;
+const loadLoggingConfigDefault: LoggingConfigLoader = () => {
+  try {
+    const loaded = requireConfig?.(configModulePath) as
+      | {
+          loadConfig?: () => OpenClawConfig;
+        }
+      | undefined;
+    const logging = loaded?.loadConfig?.().logging;
+    if (!logging || typeof logging !== "object" || Array.isArray(logging)) {
+      return undefined;
+    }
+    return logging as LoggingConfig;
+  } catch {
+    return undefined;
+  }
+};
+let loadLoggingConfig: LoggingConfigLoader = loadLoggingConfigDefault;
+
+export function setLoggingConfigLoaderForTests(loader?: LoggingConfigLoader): void {
+  loadLoggingConfig = loader ?? loadLoggingConfigDefault;
+}
 
 export function shouldSkipMutatingLoggingConfigRead(argv: string[] = process.argv): boolean {
   const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);
@@ -12,14 +39,5 @@ export function readLoggingConfig(): LoggingConfig | undefined {
   if (shouldSkipMutatingLoggingConfigRead()) {
     return undefined;
   }
-  try {
-    const parsed = loadConfig();
-    const logging = parsed?.logging;
-    if (!logging || typeof logging !== "object" || Array.isArray(logging)) {
-      return undefined;
-    }
-    return logging as LoggingConfig;
-  } catch {
-    return undefined;
-  }
+  return loadLoggingConfig();
 }

--- a/src/logging/logger-settings.test.ts
+++ b/src/logging/logger-settings.test.ts
@@ -1,21 +1,14 @@
+import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { fallbackRequireMock, readLoggingConfigMock, shouldSkipMutatingLoggingConfigReadMock } =
-  vi.hoisted(() => ({
-    readLoggingConfigMock: vi.fn(() => undefined),
-    shouldSkipMutatingLoggingConfigReadMock: vi.fn(() => false),
-    fallbackRequireMock: vi.fn(() => {
-      throw new Error("config fallback should not be used in this test");
-    }),
-  }));
+const { readLoggingConfigMock, shouldSkipMutatingLoggingConfigReadMock } = vi.hoisted(() => ({
+  readLoggingConfigMock: vi.fn(() => undefined),
+  shouldSkipMutatingLoggingConfigReadMock: vi.fn(() => false),
+}));
 
 vi.mock("./config.js", () => ({
   readLoggingConfig: readLoggingConfigMock,
   shouldSkipMutatingLoggingConfigRead: shouldSkipMutatingLoggingConfigReadMock,
-}));
-
-vi.mock("./node-require.js", () => ({
-  resolveNodeRequireFromMeta: () => fallbackRequireMock,
 }));
 
 let originalTestFileLog: string | undefined;
@@ -34,7 +27,6 @@ beforeEach(() => {
   readLoggingConfigMock.mockClear();
   shouldSkipMutatingLoggingConfigReadMock.mockReset();
   shouldSkipMutatingLoggingConfigReadMock.mockReturnValue(false);
-  fallbackRequireMock.mockClear();
   logging.resetLogger();
   logging.setLoggerOverride(null);
 });
@@ -60,7 +52,6 @@ describe("getResolvedLoggerSettings", () => {
     const settings = logging.getResolvedLoggerSettings();
     expect(settings.level).toBe("silent");
     expect(readLoggingConfigMock).not.toHaveBeenCalled();
-    expect(fallbackRequireMock).not.toHaveBeenCalled();
   });
 
   it("reads logging config when test file logging is explicitly enabled", () => {
@@ -76,6 +67,18 @@ describe("getResolvedLoggerSettings", () => {
     const settings = logging.getResolvedLoggerSettings();
 
     expect(settings.level).toBe("info");
-    expect(fallbackRequireMock).not.toHaveBeenCalled();
+  });
+
+  it("expands YYYY-MM-DD placeholders in configured log file paths", () => {
+    process.env.OPENCLAW_TEST_FILE_LOG = "1";
+    readLoggingConfigMock.mockReturnValue({
+      level: "info",
+      file: "/tmp/openclaw-YYYY-MM-DD.log",
+    });
+
+    const settings = logging.getResolvedLoggerSettings();
+
+    expect(settings.file).toMatch(/^\/tmp\/openclaw-\d{4}-\d{2}-\d{2}\.log$/);
+    expect(path.basename(settings.file)).not.toContain("YYYY-MM-DD");
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -10,7 +10,6 @@ import { readLoggingConfig, shouldSkipMutatingLoggingConfigRead } from "./config
 import type { ConsoleStyle } from "./console.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
-import { resolveNodeRequireFromMeta } from "./node-require.js";
 import { loggingState } from "./state.js";
 import { formatTimestamp } from "./timestamps.js";
 
@@ -47,8 +46,6 @@ const LOG_PREFIX = "openclaw";
 const LOG_SUFFIX = ".log";
 const MAX_LOG_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const DEFAULT_MAX_LOG_FILE_BYTES = 500 * 1024 * 1024; // 500 MB
-
-const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
 export type LoggerSettings = {
   level?: LogLevel;
@@ -115,23 +112,14 @@ function resolveSettings(): ResolvedSettings {
 
   let cfg: OpenClawConfig["logging"] | undefined =
     (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
-  if (!cfg && !shouldSkipMutatingLoggingConfigRead()) {
-    try {
-      const loaded = requireConfig?.("../config/config.js") as
-        | {
-            loadConfig?: () => OpenClawConfig;
-          }
-        | undefined;
-      cfg = loaded?.loadConfig?.().logging;
-    } catch {
-      cfg = undefined;
-    }
+  if (!cfg && shouldSkipMutatingLoggingConfigRead()) {
+    cfg = undefined;
   }
   const defaultLevel =
     process.env.VITEST === "true" && process.env.OPENCLAW_TEST_FILE_LOG !== "1" ? "silent" : "info";
   const fromConfig = normalizeLogLevel(cfg?.level, defaultLevel);
   const level = envLevel ?? fromConfig;
-  const file = cfg?.file ?? defaultRollingPathForToday();
+  const file = resolveConfiguredLogFile(cfg?.file);
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
   return { level, file, maxFileBytes };
 }
@@ -340,6 +328,17 @@ function formatLocalDate(date: Date): string {
 function defaultRollingPathForToday(): string {
   const today = formatLocalDate(new Date());
   return path.join(DEFAULT_LOG_DIR, `${LOG_PREFIX}-${today}${LOG_SUFFIX}`);
+}
+
+function resolveConfiguredLogFile(file?: string): string {
+  if (typeof file !== "string") {
+    return defaultRollingPathForToday();
+  }
+  const trimmed = file.trim();
+  if (!trimmed) {
+    return defaultRollingPathForToday();
+  }
+  return trimmed.replaceAll("YYYY-MM-DD", formatLocalDate(new Date()));
 }
 
 function isRollingPath(file: string): boolean {

--- a/src/memory-host-sdk/host/embeddings.test.ts
+++ b/src/memory-host-sdk/host/embeddings.test.ts
@@ -681,6 +681,7 @@ describe("local embedding normalization", () => {
 
   it("falls back to CPU-only for one operation after repeated VRAM-style failures", async () => {
     const gpuModelDispose = vi.fn();
+    const cpuLlamaDispose = vi.fn();
     const cpuContext = {
       getEmbeddingFor: vi.fn().mockResolvedValue({
         vector: new Float32Array([0, 1, 0, 0]),
@@ -704,6 +705,7 @@ describe("local embedding normalization", () => {
           createEmbeddingContext: vi.fn().mockResolvedValue(cpuContext),
           dispose: gpuModelDispose,
         }),
+        dispose: cpuLlamaDispose,
       });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -728,6 +730,7 @@ describe("local embedding normalization", () => {
     );
     expect(cpuContext.dispose).toHaveBeenCalledTimes(1);
     expect(gpuModelDispose).toHaveBeenCalledTimes(1);
+    expect(cpuLlamaDispose).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/memory-host-sdk/host/embeddings.test.ts
+++ b/src/memory-host-sdk/host/embeddings.test.ts
@@ -644,7 +644,9 @@ describe("local embedding normalization", () => {
     const result = await createLocalProviderForTest();
     const provider = requireProvider(result);
 
-    await expect(provider.embedQuery("first")).rejects.toThrow("transient model resolution failure");
+    await expect(provider.embedQuery("first")).rejects.toThrow(
+      "transient model resolution failure",
+    );
 
     const embedding = await provider.embedQuery("second");
 
@@ -875,6 +877,66 @@ describe("local embedding ensureContext concurrency", () => {
     expect(getLlamaSpy).toHaveBeenCalledTimes(1);
     expect(loadModelSpy).toHaveBeenCalledTimes(1);
     expect(createContextSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("serializes the GPU-fit retry after a shared VRAM-style initialization failure", async () => {
+    let releaseFirstModelDispose: (() => void) | null = null;
+    const firstModelDispose = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirstModelDispose = resolve;
+        }),
+    );
+    const recoveredContext = {
+      getEmbeddingFor: vi.fn().mockResolvedValue({
+        vector: new Float32Array([1, 0, 0, 0]),
+      }),
+      dispose: vi.fn(),
+    };
+    const recoveredModel = {
+      createEmbeddingContext: vi.fn().mockResolvedValue(recoveredContext),
+      dispose: vi.fn(),
+    };
+    const loadModelSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        createEmbeddingContext: vi
+          .fn()
+          .mockRejectedValue(new Error("A context size of 24 is too large for the available VRAM")),
+        dispose: firstModelDispose,
+      })
+      .mockResolvedValueOnce(recoveredModel);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    vi.mocked(nodeLlamaModule.importNodeLlamaCpp).mockResolvedValue({
+      getLlama: vi.fn(async () => ({
+        loadModel: loadModelSpy,
+      })),
+      resolveModelFile: async () => "/fake/model.gguf",
+      LlamaLogLevel: { error: 0 },
+    } as never);
+
+    const result = await createLocalProvider();
+    const provider = requireProvider(result);
+
+    const first = provider.embedQuery("retry-a");
+    const second = provider.embedQuery("retry-b");
+
+    await vi.waitFor(() => {
+      expect(firstModelDispose).toHaveBeenCalledTimes(1);
+    });
+    releaseFirstModelDispose?.();
+
+    const [embeddingA, embeddingB] = await Promise.all([first, second]);
+
+    expect(embeddingA).toEqual([1, 0, 0, 0]);
+    expect(embeddingB).toEqual([1, 0, 0, 0]);
+    expect(loadModelSpy).toHaveBeenCalledTimes(2);
+    expect(recoveredModel.createEmbeddingContext).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("retrying once with a fresh GPU-fit calculation"),
+    );
   });
 });
 

--- a/src/memory-host-sdk/host/embeddings.test.ts
+++ b/src/memory-host-sdk/host/embeddings.test.ts
@@ -632,6 +632,103 @@ describe("local embedding normalization", () => {
       expect(magnitude).toBeCloseTo(1.0, 5);
     }
   });
+
+  it("retries GPU-fit initialization once after a VRAM-style failure", async () => {
+    const gpuContext = {
+      getEmbeddingFor: vi.fn().mockResolvedValue({
+        vector: new Float32Array([1, 0, 0, 0]),
+      }),
+      dispose: vi.fn(),
+    };
+    const loadModelSpy = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("A context size of 24 is too large for the available VRAM"))
+      .mockResolvedValueOnce({
+        createEmbeddingContext: vi.fn().mockResolvedValue(gpuContext),
+        dispose: vi.fn(),
+      });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    vi.mocked(nodeLlamaModule.importNodeLlamaCpp).mockResolvedValue({
+      getLlama: vi.fn(async () => ({
+        loadModel: loadModelSpy,
+      })),
+      resolveModelFile: async () => "/fake/model.gguf",
+      LlamaLogLevel: { error: 0 },
+    } as never);
+
+    const result = await createLocalProvider();
+    const provider = requireProvider(result);
+    const embedding = await provider.embedQuery("retry-me");
+
+    expect(embedding).toEqual([1, 0, 0, 0]);
+    expect(loadModelSpy).toHaveBeenCalledTimes(2);
+    expect(loadModelSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        gpuLayers: {
+          fitContext: {
+            contextSize: 24,
+            embeddingContext: true,
+          },
+        },
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("retrying once with a fresh GPU-fit calculation"),
+    );
+  });
+
+  it("falls back to CPU-only for one operation after repeated VRAM-style failures", async () => {
+    const gpuModelDispose = vi.fn();
+    const cpuContext = {
+      getEmbeddingFor: vi.fn().mockResolvedValue({
+        vector: new Float32Array([0, 1, 0, 0]),
+      }),
+      dispose: vi.fn(),
+    };
+    const getLlamaSpy = vi
+      .fn()
+      .mockResolvedValueOnce({
+        loadModel: vi
+          .fn()
+          .mockRejectedValueOnce(
+            new Error("A context size of 24 is too large for the available VRAM"),
+          )
+          .mockRejectedValueOnce(
+            new Error("A context size of 24 is too large for the available VRAM"),
+          ),
+      })
+      .mockResolvedValueOnce({
+        loadModel: vi.fn().mockResolvedValue({
+          createEmbeddingContext: vi.fn().mockResolvedValue(cpuContext),
+          dispose: gpuModelDispose,
+        }),
+      });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    vi.mocked(nodeLlamaModule.importNodeLlamaCpp).mockResolvedValue({
+      getLlama: getLlamaSpy,
+      resolveModelFile: async () => "/fake/model.gguf",
+      LlamaLogLevel: { error: 0 },
+    } as never);
+
+    const result = await createLocalProvider();
+    const provider = requireProvider(result);
+    const embedding = await provider.embedQuery("cpu-fallback");
+
+    expect(embedding).toEqual([0, 1, 0, 0]);
+    expect(getLlamaSpy).toHaveBeenNthCalledWith(1, { logLevel: 0 });
+    expect(getLlamaSpy).toHaveBeenNthCalledWith(2, { logLevel: 0, gpu: false });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("retrying once with a fresh GPU-fit calculation"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("falling back to CPU-only for this operation"),
+    );
+    expect(cpuContext.dispose).toHaveBeenCalledTimes(1);
+    expect(gpuModelDispose).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("local embedding ensureContext concurrency", () => {

--- a/src/memory-host-sdk/host/embeddings.test.ts
+++ b/src/memory-host-sdk/host/embeddings.test.ts
@@ -633,6 +633,27 @@ describe("local embedding normalization", () => {
     }
   });
 
+  it("retries model path resolution after a transient resolveModelFile failure", async () => {
+    const resolveModelFileMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient model resolution failure"))
+      .mockResolvedValueOnce("/fake/model.gguf");
+
+    mockSingleLocalEmbeddingVector([1, 0, 0, 0], resolveModelFileMock);
+
+    const result = await createLocalProviderForTest();
+    const provider = requireProvider(result);
+
+    await expect(provider.embedQuery("first")).rejects.toThrow("transient model resolution failure");
+
+    const embedding = await provider.embedQuery("second");
+
+    expect(embedding).toEqual([1, 0, 0, 0]);
+    expect(resolveModelFileMock).toHaveBeenCalledTimes(2);
+    expect(resolveModelFileMock).toHaveBeenNthCalledWith(1, DEFAULT_LOCAL_MODEL, undefined);
+    expect(resolveModelFileMock).toHaveBeenNthCalledWith(2, DEFAULT_LOCAL_MODEL, undefined);
+  });
+
   it("retries GPU-fit initialization once after a VRAM-style failure", async () => {
     const gpuContext = {
       getEmbeddingFor: vi.fn().mockResolvedValue({

--- a/src/memory-host-sdk/host/embeddings.ts
+++ b/src/memory-host-sdk/host/embeddings.ts
@@ -131,6 +131,7 @@ export async function createLocalEmbeddingProvider(
   let embeddingContext: LlamaEmbeddingContext | null = null;
   let initPromise: Promise<LlamaEmbeddingContext> | null = null;
   let resolvedModelPathPromise: Promise<string> | null = null;
+  let vramRecoveryPromise: Promise<LlamaEmbeddingContext> | null = null;
 
   const getResolvedModelPath = async (): Promise<string> => {
     if (!resolvedModelPathPromise) {
@@ -225,6 +226,30 @@ export async function createLocalEmbeddingProvider(
     };
   };
 
+  const retryGpuContextAfterVramFailure = async (): Promise<LlamaEmbeddingContext> => {
+    if (!vramRecoveryPromise) {
+      vramRecoveryPromise = (async () => {
+        console.warn(
+          "[openclaw] local memory embeddings hit VRAM limits during GPU-fit init; retrying once with a fresh GPU-fit calculation.",
+        );
+        await disposeGpuResources();
+        initPromise = null;
+        try {
+          return await ensureGpuContext();
+        } catch (err) {
+          if (isVramError(err)) {
+            await disposeGpuResources();
+            initPromise = null;
+          }
+          throw err;
+        }
+      })().finally(() => {
+        vramRecoveryPromise = null;
+      });
+    }
+    return vramRecoveryPromise;
+  };
+
   const withEmbeddingContext = async <T>(
     run: (context: LlamaEmbeddingContext) => Promise<T>,
   ): Promise<T> => {
@@ -234,13 +259,8 @@ export async function createLocalEmbeddingProvider(
       if (!isVramError(firstError)) {
         throw firstError;
       }
-      console.warn(
-        "[openclaw] local memory embeddings hit VRAM limits during GPU-fit init; retrying once with a fresh GPU-fit calculation.",
-      );
-      await disposeGpuResources();
-      initPromise = null;
       try {
-        return await run(await ensureGpuContext());
+        return await run(await retryGpuContextAfterVramFailure());
       } catch (secondError) {
         if (!isVramError(secondError)) {
           throw secondError;
@@ -248,8 +268,6 @@ export async function createLocalEmbeddingProvider(
         console.warn(
           "[openclaw] local memory embeddings hit VRAM limits again; falling back to CPU-only for this operation.",
         );
-        await disposeGpuResources();
-        initPromise = null;
         const temporary = await createTemporaryCpuContext();
         try {
           return await run(temporary.context);

--- a/src/memory-host-sdk/host/embeddings.ts
+++ b/src/memory-host-sdk/host/embeddings.ts
@@ -130,8 +130,35 @@ export async function createLocalEmbeddingProvider(
   let embeddingModel: LlamaModel | null = null;
   let embeddingContext: LlamaEmbeddingContext | null = null;
   let initPromise: Promise<LlamaEmbeddingContext> | null = null;
+  let resolvedModelPathPromise: Promise<string> | null = null;
 
-  const ensureContext = async (): Promise<LlamaEmbeddingContext> => {
+  const getResolvedModelPath = async (): Promise<string> => {
+    if (!resolvedModelPathPromise) {
+      resolvedModelPathPromise = resolveModelFile(modelPath, modelCacheDir || undefined);
+    }
+    return resolvedModelPathPromise;
+  };
+
+  const isVramError = (err: unknown): boolean => formatErrorMessage(err).includes("available VRAM");
+
+  const disposeGpuResources = async (): Promise<void> => {
+    const oldContext = embeddingContext;
+    const oldModel = embeddingModel;
+    embeddingContext = null;
+    embeddingModel = null;
+    if (oldContext) {
+      try {
+        await oldContext.dispose();
+      } catch {}
+    }
+    if (oldModel) {
+      try {
+        await oldModel.dispose();
+      } catch {}
+    }
+  };
+
+  const ensureGpuContext = async (): Promise<LlamaEmbeddingContext> => {
     if (embeddingContext) {
       return embeddingContext;
     }
@@ -144,8 +171,16 @@ export async function createLocalEmbeddingProvider(
           llama = await getLlama({ logLevel: LlamaLogLevel.error });
         }
         if (!embeddingModel) {
-          const resolved = await resolveModelFile(modelPath, modelCacheDir || undefined);
-          embeddingModel = await llama.loadModel({ modelPath: resolved });
+          const resolved = await getResolvedModelPath();
+          embeddingModel = await llama.loadModel({
+            modelPath: resolved,
+            gpuLayers: {
+              fitContext: {
+                contextSize: 24,
+                embeddingContext: true,
+              },
+            },
+          });
         }
         if (!embeddingContext) {
           embeddingContext = await embeddingModel.createEmbeddingContext();
@@ -159,21 +194,81 @@ export async function createLocalEmbeddingProvider(
     return initPromise;
   };
 
+  const createTemporaryCpuContext = async (): Promise<{
+    context: LlamaEmbeddingContext;
+    dispose: () => Promise<void>;
+  }> => {
+    const cpuLlama = await getLlama({ logLevel: LlamaLogLevel.error, gpu: false });
+    const cpuModel = await cpuLlama.loadModel({
+      modelPath: await getResolvedModelPath(),
+      gpuLayers: 0,
+    });
+    const cpuContext = await cpuModel.createEmbeddingContext();
+    return {
+      context: cpuContext,
+      dispose: async () => {
+        try {
+          await cpuContext.dispose();
+        } catch {}
+        try {
+          await cpuModel.dispose();
+        } catch {}
+      },
+    };
+  };
+
+  const withEmbeddingContext = async <T>(
+    run: (context: LlamaEmbeddingContext) => Promise<T>,
+  ): Promise<T> => {
+    try {
+      return await run(await ensureGpuContext());
+    } catch (firstError) {
+      if (!isVramError(firstError)) {
+        throw firstError;
+      }
+      console.warn(
+        "[openclaw] local memory embeddings hit VRAM limits during GPU-fit init; retrying once with a fresh GPU-fit calculation.",
+      );
+      await disposeGpuResources();
+      initPromise = null;
+      try {
+        return await run(await ensureGpuContext());
+      } catch (secondError) {
+        if (!isVramError(secondError)) {
+          throw secondError;
+        }
+        console.warn(
+          "[openclaw] local memory embeddings hit VRAM limits again; falling back to CPU-only for this operation.",
+        );
+        await disposeGpuResources();
+        initPromise = null;
+        const temporary = await createTemporaryCpuContext();
+        try {
+          return await run(temporary.context);
+        } finally {
+          await temporary.dispose();
+        }
+      }
+    }
+  };
+
   return {
     id: "local",
     model: modelPath,
     embedQuery: async (text) => {
-      const ctx = await ensureContext();
-      const embedding = await ctx.getEmbeddingFor(text);
+      const embedding = await withEmbeddingContext(async (context) =>
+        context.getEmbeddingFor(text),
+      );
       return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
     },
     embedBatch: async (texts) => {
-      const ctx = await ensureContext();
-      const embeddings = await Promise.all(
-        texts.map(async (text) => {
-          const embedding = await ctx.getEmbeddingFor(text);
-          return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
-        }),
+      const embeddings = await withEmbeddingContext(async (context) =>
+        Promise.all(
+          texts.map(async (text) => {
+            const embedding = await context.getEmbeddingFor(text);
+            return sanitizeAndNormalizeEmbedding(Array.from(embedding.vector));
+          }),
+        ),
       );
       return embeddings;
     },

--- a/src/memory-host-sdk/host/embeddings.ts
+++ b/src/memory-host-sdk/host/embeddings.ts
@@ -134,7 +134,12 @@ export async function createLocalEmbeddingProvider(
 
   const getResolvedModelPath = async (): Promise<string> => {
     if (!resolvedModelPathPromise) {
-      resolvedModelPathPromise = resolveModelFile(modelPath, modelCacheDir || undefined);
+      resolvedModelPathPromise = resolveModelFile(modelPath, modelCacheDir || undefined).catch(
+        (err) => {
+          resolvedModelPathPromise = null;
+          throw err;
+        },
+      );
     }
     return resolvedModelPathPromise;
   };

--- a/src/memory-host-sdk/host/embeddings.ts
+++ b/src/memory-host-sdk/host/embeddings.ts
@@ -213,6 +213,9 @@ export async function createLocalEmbeddingProvider(
         try {
           await cpuModel.dispose();
         } catch {}
+        try {
+          await cpuLlama.dispose();
+        } catch {}
       },
     };
   };


### PR DESCRIPTION
## Summary

This fixes two issues in local OpenClaw setups:

1. Logging could ignore a valid configured `logging.file` path because the logging runtime depended on a fragile built-module require path.
2. Local memory embeddings could fail hard on VRAM-fit initialization instead of retrying and degrading gracefully.

## Changes

- switch logging config reads to the real source config loader
- expand `YYYY-MM-DD` placeholders in configured log file paths before writing
- add GPU-fit local embedding init with one retry on VRAM-style failure
- fall back to CPU-only for that embedding operation if the second GPU-fit attempt also fails
- add targeted tests for both behaviors

## Reproduction

### Logging
Configure:
`logging.file = /home/user/.openclaw/logs/openclaw-YYYY-MM-DD.log`

Before:
- runtime could miss the configured path and fall back elsewhere
- placeholder expansion was not honored at write time

After:
- the configured path is resolved through the normal config loader
- `YYYY-MM-DD` expands to the real local date before file writes

### Local embeddings
Use local memory embeddings with `node-llama-cpp` on a machine where GPU-fit init can fail with:
`A context size of 24 is too large for the available VRAM`

Before:
- the operation failed unless GPU was disabled globally

After:
- retry once with a fresh GPU-fit init
- if it still fails, fall back to CPU-only for that operation
- the next operation starts fresh on the normal GPU-fit path

## Validation

Ran:
`./node_modules/.bin/vitest run src/logging/config.test.ts src/logging/logger-settings.test.ts src/memory-host-sdk/host/embeddings.test.ts`

Result:
- 3 test files passed
- 28 tests passed
