### PR TITLE
fix(cron): clear stale CLI session identity on isolated session rollover

### DIFF
--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -235,9 +235,8 @@ describe("resolveCronSession", () => {
           cliSessionIds: { "claude-cli": "prev-cli-session-abc" },
           cliSessionBindings: {
             "claude-cli": {
-              cliSessionId: "prev-cli-session-abc",
-              modelOverride: "claude-opus-4-6",
-              providerOverride: "anthropic",
+              sessionId: "prev-cli-session-abc",
+              authProfileId: "anthropic-default",
             },
           },
           claudeCliSessionId: "prev-cli-session-abc",
@@ -265,7 +264,7 @@ describe("resolveCronSession", () => {
           cliSessionIds: { "codex-cli": "prev-codex-session-xyz" },
           cliSessionBindings: {
             "codex-cli": {
-              cliSessionId: "prev-codex-session-xyz",
+              sessionId: "prev-codex-session-xyz",
             },
           },
           claudeCliSessionId: "prev-claude-session-stale",
@@ -288,7 +287,7 @@ describe("resolveCronSession", () => {
           cliSessionIds: { "claude-cli": "live-cli-session-keep" },
           cliSessionBindings: {
             "claude-cli": {
-              cliSessionId: "live-cli-session-keep",
+              sessionId: "live-cli-session-keep",
             },
           },
           claudeCliSessionId: "live-cli-session-keep",
@@ -302,7 +301,7 @@ describe("resolveCronSession", () => {
       });
       expect(result.sessionEntry.cliSessionBindings).toEqual({
         "claude-cli": {
-          cliSessionId: "live-cli-session-keep",
+          sessionId: "live-cli-session-keep",
         },
       });
       expect(result.sessionEntry.claudeCliSessionId).toBe("live-cli-session-keep");

--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -226,6 +226,88 @@ describe("resolveCronSession", () => {
       expect(result.sessionEntry.deliveryContext).toBeUndefined();
     });
 
+    it("clears CLI session identity when forceNew is true (#62707)", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-cli",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          cliSessionIds: { "claude-cli": "prev-cli-session-abc" },
+          cliSessionBindings: {
+            "claude-cli": {
+              cliSessionId: "prev-cli-session-abc",
+              modelOverride: "claude-opus-4-6",
+              providerOverride: "anthropic",
+            },
+          },
+          claudeCliSessionId: "prev-cli-session-abc",
+          modelOverride: "claude-opus-4-6",
+        },
+        fresh: true,
+        forceNew: true,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      // CLI session identity must be cleared so the new session entry does
+      // not advertise a stale CLI session token from the previous run.
+      expect(result.sessionEntry.cliSessionIds).toBeUndefined();
+      expect(result.sessionEntry.cliSessionBindings).toBeUndefined();
+      expect(result.sessionEntry.claudeCliSessionId).toBeUndefined();
+      // Per-session model overrides must still be preserved
+      expect(result.sessionEntry.modelOverride).toBe("claude-opus-4-6");
+    });
+
+    it("clears CLI session identity when session is stale (#62707)", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "old-session-id",
+          updatedAt: NOW_MS - 86_400_000,
+          cliSessionIds: { "codex-cli": "prev-codex-session-xyz" },
+          cliSessionBindings: {
+            "codex-cli": {
+              cliSessionId: "prev-codex-session-xyz",
+            },
+          },
+          claudeCliSessionId: "prev-claude-session-stale",
+        },
+        fresh: false,
+      });
+
+      expect(result.isNewSession).toBe(true);
+      expect(result.sessionEntry.cliSessionIds).toBeUndefined();
+      expect(result.sessionEntry.cliSessionBindings).toBeUndefined();
+      expect(result.sessionEntry.claudeCliSessionId).toBeUndefined();
+    });
+
+    it("preserves CLI session identity when reusing fresh session (#62707)", () => {
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-keep",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          cliSessionIds: { "claude-cli": "live-cli-session-keep" },
+          cliSessionBindings: {
+            "claude-cli": {
+              cliSessionId: "live-cli-session-keep",
+            },
+          },
+          claudeCliSessionId: "live-cli-session-keep",
+        },
+        fresh: true,
+      });
+
+      expect(result.isNewSession).toBe(false);
+      expect(result.sessionEntry.cliSessionIds).toEqual({
+        "claude-cli": "live-cli-session-keep",
+      });
+      expect(result.sessionEntry.cliSessionBindings).toEqual({
+        "claude-cli": {
+          cliSessionId: "live-cli-session-keep",
+        },
+      });
+      expect(result.sessionEntry.claudeCliSessionId).toBe("live-cli-session-keep");
+    });
+
     it("preserves delivery routing metadata when reusing fresh session", () => {
       const result = resolveWithStoredEntry({
         entry: {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -77,12 +77,21 @@ export function resolveCronSession(params: {
     // replies instead of channel top-level messages.
     // deliveryContext must also be cleared because normalizeSessionEntryDelivery
     // repopulates lastThreadId from deliveryContext.threadId on store writes.
+    // CLI session identity (cliSessionIds, cliSessionBindings, claudeCliSessionId)
+    // must also be cleared so the new session entry does not advertise a stale
+    // CLI session that belongs to the previous run. The consumption-site guard
+    // in run-executor.ts already drops the resume id when isNewSession is true,
+    // but the entry itself should be coherent — a "new" session should not claim
+    // a prior CLI session resume token.
     ...(isNewSession && {
       lastChannel: undefined,
       lastTo: undefined,
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
+      cliSessionIds: undefined,
+      cliSessionBindings: undefined,
+      claudeCliSessionId: undefined,
     }),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };


### PR DESCRIPTION
## Summary

`resolveCronSession()` in `src/cron/isolated-agent/session.ts` spreads `...entry` into the new `sessionEntry` on `forceNew` / stale rollovers, which preserves `cliSessionIds`, `cliSessionBindings`, and `claudeCliSessionId` from the prior run. The existing `isNewSession` cleanup block clears delivery routing fields (`lastChannel` / `lastTo` / `lastThreadId` / `deliveryContext`) but does **not** clear CLI session identity, so the returned "new" session entry advertises a stale CLI session resume token.

The leak is currently masked at the consumption site by the `isNewSession` guard in `run-executor.ts:102-104` (added in commit `bbb73d3171`), but the entry itself violates its own invariant — a fresh isolated session should not claim a prior CLI session. Any new code path that reads `cliSessionIds` without independently checking `isNewSession` will pick up the stale identity.

Fixes #62707

## Root cause

```ts
// src/cron/isolated-agent/session.ts (before fix)
const sessionEntry: SessionEntry = {
  ...entry,            // spreads cliSessionIds / cliSessionBindings / claudeCliSessionId
  sessionId,
  updatedAt: params.nowMs,
  systemSent,
  ...(isNewSession && {
    lastChannel: undefined,
    lastTo: undefined,
    lastAccountId: undefined,
    lastThreadId: undefined,
    deliveryContext: undefined,
    // missing: cliSessionIds, cliSessionBindings, claudeCliSessionId
  }),
};
```

The masking guard at `run-executor.ts:102-104`:

```ts
const cliSessionId = params.cronSession.isNewSession
  ? undefined
  : getCliSessionId(params.cronSession.sessionEntry, providerOverride);
```

## Fix

Extend the existing `isNewSession` cleanup block in `session.ts` to also clear the three CLI session identity fields. The factory function now produces coherent session entries — a "new" session no longer carries CLI session resume tokens from prior runs.

## Tests

Added 3 cases to `src/cron/isolated-agent/session.test.ts` (mirrors the existing delivery-routing test pattern):

1. `forceNew=true` clears `cliSessionIds` / `cliSessionBindings` / `claudeCliSessionId` (asserts `modelOverride` still preserved).
2. Stale session rollover clears the same three fields.
3. Fresh session reuse **preserves** all three fields (so live CLI sessions still resume correctly).

## Notes

- Issue #62707 was filed by @alexey-pelykh with the exact diff in the body — this PR implements that diff plus regression tests. Credit to him for the RCA.
- Related: #51208 — fixing the root cause here may eventually allow the `run-executor.ts` masking guard to be relaxed for hook sessions without re-introducing the isolated-run leak. That follow-up is out of scope for this PR.