### PR TITLE
fix(zalo): check response.ok before parsing JSON body

### DIFF
--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -124,6 +124,15 @@ export async function callZaloApi<T = unknown>(
       signal: controller.signal,
     });
 
+    if (!response.ok) {
+      const errBody = await response.text().catch(() => "");
+      throw new ZaloApiError(
+        errBody || `Zalo API HTTP error: ${method}`,
+        response.status,
+        `HTTP ${response.status}`,
+      );
+    }
+
     const data = (await response.json()) as ZaloApiResponse<T>;
 
     if (!data.ok) {

--- a/extensions/zalo/src/api.ts
+++ b/extensions/zalo/src/api.ts
@@ -87,6 +87,7 @@ export class ZaloApiError extends Error {
     message: string,
     public readonly errorCode?: number,
     public readonly description?: string,
+    public readonly httpStatus?: number,
   ) {
     super(message);
     this.name = "ZaloApiError";
@@ -94,7 +95,7 @@ export class ZaloApiError extends Error {
 
   /** True if this is a long-polling timeout (no updates available) */
   get isPollingTimeout(): boolean {
-    return this.errorCode === 408;
+    return this.errorCode === 408 && this.httpStatus === undefined;
   }
 }
 
@@ -125,11 +126,29 @@ export async function callZaloApi<T = unknown>(
     });
 
     if (!response.ok) {
-      const errBody = await response.text().catch(() => "");
+      const text = await response.text().catch(() => "");
+      let parsed: ZaloApiResponse | undefined;
+      try {
+        parsed = JSON.parse(text) as ZaloApiResponse;
+      } catch {
+        // not JSON
+      }
+
+      if (parsed && parsed.error_code !== undefined) {
+        throw new ZaloApiError(
+          parsed.description ?? `Zalo API error: ${method}`,
+          parsed.error_code,
+          parsed.description,
+          response.status,
+        );
+      }
+
+      const truncated = text.length > 200 ? text.slice(0, 200) + "\u2026" : text;
       throw new ZaloApiError(
-        errBody || `Zalo API HTTP error: ${method}`,
-        response.status,
+        truncated || `Zalo API HTTP error: ${method}`,
+        undefined,
         `HTTP ${response.status}`,
+        response.status,
       );
     }
 


### PR DESCRIPTION
## Summary
- `callZaloApi` in `extensions/zalo/src/api.ts` calls `response.json()` without checking `response.ok`
- On HTTP errors (5xx, gateway timeouts), the response body may be HTML or plain text, causing a `SyntaxError: Unexpected token` instead of a clear error
- Fix: add `response.ok` guard before JSON parsing, throw `ZaloApiError` with HTTP status

### Review feedback addressed
- **Structured error preservation**: Non-2xx responses that contain valid Zalo JSON (`error_code`/`description` fields) are now parsed and thrown with full structured details — `probeZalo` can still read `err.description`
- **Body truncation**: Raw non-JSON response bodies are truncated to 200 characters to avoid huge HTML pages in error messages
- **`isPollingTimeout` disambiguation**: Added `httpStatus` property to `ZaloApiError`. `isPollingTimeout` now requires `httpStatus === undefined`, so HTTP 408 no longer collides with app-level polling timeout (error_code 408)

## Test plan
- [ ] Verify Zalo API calls still work normally (sendMessage, getMe)
- [ ] Verify HTTP errors produce clear `ZaloApiError` instead of JSON parse errors
- [ ] Verify non-2xx responses with Zalo JSON body preserve `error_code`/`description`
- [ ] Verify `isPollingTimeout` only matches app-level 408, not HTTP 408

🤖 Generated with [Claude Code](https://claude.com/claude-code)