### PR TITLE
fix(openrouter): use canonical openrouter/auto id to dedupe with pi-ai built-in

### DIFF
--- a/extensions/openrouter/provider-catalog.test.ts
+++ b/extensions/openrouter/provider-catalog.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { buildOpenrouterProvider } from "./provider-catalog.js";
+
+describe("openrouter provider catalog", () => {
+  it("builds the bundled OpenRouter provider defaults", () => {
+    const provider = buildOpenrouterProvider();
+
+    expect(provider.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(provider.api).toBe("openai-completions");
+    expect(provider.models?.length).toBeGreaterThan(0);
+  });
+
+  it("uses the canonical openrouter/auto id for the auto router (#62655)", () => {
+    // Regression: prior to this fix, the auto entry was id="auto" while pi-ai's
+    // built-in catalog uses id="openrouter/auto". `mergeCustomModels` dedupes by
+    // raw `provider+id` string equality, so both entries survived into the
+    // merged registry and the /models picker rendered two buttons ("OpenRouter
+    // Auto" + "Auto Router") for the same upstream model. Using the canonical
+    // prefixed id collapses the duplicate at the merge layer.
+    const provider = buildOpenrouterProvider();
+    const auto = provider.models?.find((m) => m.name === "OpenRouter Auto");
+
+    expect(auto).toBeDefined();
+    expect(auto?.id).toBe("openrouter/auto");
+  });
+
+  it("keeps every bundled model id namespaced under openrouter/", () => {
+    // Defensive: any future model added to this catalog should follow the same
+    // canonical-id convention. Without this, the same picker-duplicate bug
+    // (#62655) reappears for the new model.
+    const provider = buildOpenrouterProvider();
+    const ids = provider.models?.map((m) => m.id) ?? [];
+
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) {
+      expect(id.startsWith("openrouter/")).toBe(true);
+    }
+  });
+});

--- a/extensions/openrouter/provider-catalog.ts
+++ b/extensions/openrouter/provider-catalog.ts
@@ -1,7 +1,13 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
-const OPENROUTER_DEFAULT_MODEL_ID = "auto";
+// Use the canonical "openrouter/" prefix so this entry collapses with the
+// pi-ai built-in `openrouter/auto` in `mergeCustomModels` (which dedupes by
+// raw `provider+id` string equality). Without the prefix, both entries
+// survive into the merged registry and the /models picker shows two buttons
+// for the same upstream model. The other entries below (`openrouter/hunter-
+// alpha`, `openrouter/healer-alpha`) are already prefixed for the same reason.
+const OPENROUTER_DEFAULT_MODEL_ID = "openrouter/auto";
 const OPENROUTER_DEFAULT_CONTEXT_WINDOW = 200000;
 const OPENROUTER_DEFAULT_MAX_TOKENS = 8192;
 const OPENROUTER_DEFAULT_COST = {


### PR DESCRIPTION
## Summary

The bundled openrouter plugin's `provider-catalog.ts` registers the auto router with `id: "auto"` while pi-ai's built-in catalog uses `id: "openrouter/auto"`. `pi-coding-agent`'s `ModelRegistry.mergeCustomModels()` deduplicates by raw `provider+id` string equality, so both entries survive into the merged registry and the `/models` picker renders **two** buttons (`OpenRouter Auto` + `Auto Router`) for the same upstream model.

Fixes #62655

## Root cause

```ts
// extensions/openrouter/provider-catalog.ts (before fix)
const OPENROUTER_DEFAULT_MODEL_ID = "auto";  // ← no openrouter/ prefix

// pi-ai/dist/models.generated.js
"openrouter/auto": { id: "openrouter/auto", name: "Auto Router", ... }
```

`pi-coding-agent` `mergeCustomModels`:

```js
const existingIndex = merged.findIndex(
  (m) => m.provider === customModel.provider && m.id === customModel.id
);
```

`"auto" !== "openrouter/auto"` → both entries land in the merged registry → picker iterates and renders both.

## Why higher-level dedup misses it

`normalizeStaticProviderModelId` in `src/agents/model-ref-shared.ts:69-71` already canonicalizes bare IDs to `openrouter/<id>` for downstream consumers, but it only fires **above** `pi-coding-agent`'s `ModelRegistry`. By the time the picker catalog is built, the duplicate is already baked in at the lower layer.

## Fix

Use the canonical `openrouter/` prefix for the auto entry, matching:
- pi-ai's built-in id (`openrouter/auto`)
- The other two entries in the same file (`openrouter/hunter-alpha`, `openrouter/healer-alpha`)
- `OPENROUTER_DEFAULT_MODEL_REF` in `extensions/openrouter/onboard.ts:6`

After the change, `mergeCustomModels` collapses the bundled-plugin entry on top of the pi-ai entry (custom wins per its own semantics), and `name: "OpenRouter Auto"` cleanly overrides the pi-ai `Auto Router` label. The picker shows one button.

## Tests

Added `extensions/openrouter/provider-catalog.test.ts`:
1. `buildOpenrouterProvider()` smoke test (baseUrl, api, non-empty models).
2. **Regression**: auto entry has `id: "openrouter/auto"`.
3. **Defensive**: every bundled model id is namespaced under `openrouter/` so a future contributor can't reintroduce the same picker-duplicate bug for a new model.

## Scope

- 1 source line touched (plus a clarifying comment about why canonical id matters).
- `extensions/openrouter/media-understanding-provider.ts` also has `defaultModels: { image: "auto" }` but that's a different namespace (image-understanding pipeline, not consumed by `mergeCustomModels`/picker) — out of scope.
- Credit to @unitypeaceproject for the complete RCA in the issue body.