### PR TITLE
fix: add @buape/carbon and @larksuiteoapi/node-sdk as optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1379,6 +1379,8 @@
     }
   },
   "optionalDependencies": {
+    "@buape/carbon": "^0.14.0",
+    "@larksuiteoapi/node-sdk": "^1.60.0",
     "@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
     "openshell": "0.1.0"
   },


### PR DESCRIPTION
## Problem

Fresh `npm install -g openclaw` fails with:

```
Cannot find module '@buape/carbon'
Require stack:
- /usr/local/lib/node_modules/openclaw/dist/ui-7MjYF8PY.js
```

and similarly for `@larksuiteoapi/node-sdk` (Feishu/Lark plugin).

The bundled Discord and Feishu channel plugins `require()` these packages at runtime (in `dist/`), but they are not listed in `package.json` dependencies. They exist in the pnpm lockfile (`@buape/carbon@0.14.0`, `@larksuiteoapi/node-sdk@1.60.0`) but are not installed when users install via npm.

## Fix

Add both as `optionalDependencies` so they are installed by default but won't block installation on platforms where they can't be built.

## Reproduction

```bash
npm install -g openclaw@latest
openclaw --version   # crashes with Cannot find module '@buape/carbon'
```

Discovered while deploying OpenClaw in Azure Container Apps (Docker container with `npm install -g openclaw`).
