### PR TITLE
fix(matrix): contain sync outage failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - Auto-reply/NO_REPLY: strip glued leading `NO_REPLY` tokens before reply normalization and ACP-visible streaming so silent sentinel text no longer leaks into user-visible replies while preserving substantive `NO_REPLY ...` text. Thanks @frankekn.
 - Gateway/sessions: clear auto-fallback-pinned model overrides on `/reset` and `/new` while still preserving explicit user model selections, including legacy sessions created before override-source tracking existed. (#63155) Thanks @frankekn.
 - Codex CLI: pass OpenClaw's system prompt through Codex's `model_instructions_file` config override so fresh Codex CLI sessions receive the same prompt guidance as Claude CLI sessions.
+- Matrix/gateway: wait for Matrix sync readiness before marking startup successful, keep Matrix background handler failures contained, and route fatal Matrix sync stops through channel-level restart handling instead of crashing the whole gateway. (#62779) Thanks @gumadeiras.
 
 ## 2026.4.8
 
@@ -39,6 +40,8 @@ Docs: https://docs.openclaw.ai
 - Slack: honor ambient HTTP(S) proxy settings for Socket Mode WebSocket connections, including NO_PROXY exclusions, so proxy-only deployments can connect without a monkey patch. (#62878) Thanks @mjamiv.
 - Slack/actions: pass the already resolved read token into `downloadFile` so SecretRef-backed bot tokens no longer fail after a raw config re-read. (#62097) Thanks @martingarramon.
 - Network/fetch guard: skip target DNS pinning when trusted env-proxy mode is active so proxy-only sandboxes can let the trusted proxy resolve outbound hosts. (#59007) Thanks @cluster2600.
+
+## 2026.4.7-1
 
 ## 2026.4.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+<<<<<<< HEAD
+=======
+- Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
+>>>>>>> 6f55bbc752 (fix(matrix): finalize startup lifecycle handling)
 - CLI/infer: keep provider-backed infer behavior aligned with actual runtime execution by fixing explicit TTS override handling, profile-aware gateway TTS prefs resolution, per-request transcription `prompt`/`language` overrides, image output MIME/extension mismatches, configured web-search fallback behavior, and agent-vs-CLI web-search execution drift.
 - Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin and contributors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-<<<<<<< HEAD
-=======
-- Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
->>>>>>> 6f55bbc752 (fix(matrix): finalize startup lifecycle handling)
 - CLI/infer: keep provider-backed infer behavior aligned with actual runtime execution by fixing explicit TTS override handling, profile-aware gateway TTS prefs resolution, per-request transcription `prompt`/`language` overrides, image output MIME/extension mismatches, configured web-search fallback behavior, and agent-vs-CLI web-search execution drift.
 - Plugins/media: when `plugins.allow` is set, capability fallback now merges bundled capability plugin ids into the allowlist (not only `plugins.entries`), so media understanding providers such as OpenAI-compatible STT load for voice transcription without requiring `openai` in `plugins.allow`. (#62205) Thanks @neeravmakwana.
 - Agents/history and replies: buffer phaseless OpenAI WS text until a real assistant phase arrives, keep replay and SSE history sequence tracking aligned, hide commentary and leaked tool XML from user-visible history, and keep history-based follow-up replies on `final_answer` text only. (#61729, #61747, #61829, #61855, #61954) Thanks @100yenadmin and contributors.

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -496,6 +496,7 @@ export const matrixPlugin: ChannelPlugin<ResolvedMatrixAccount, MatrixProbe> =
             initialSyncLimit: account.config.initialSyncLimit,
             replyToMode: account.config.replyToMode,
             accountId: account.accountId,
+            setStatus: ctx.setStatus,
           });
         },
       },

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -233,6 +233,44 @@ describe("resolveSharedMatrixClient", () => {
     ).rejects.toThrow("Matrix shared client account mismatch");
   });
 
+  it("lets a later waiter abort while shared startup continues for the owner", async () => {
+    const mainAuth = authFor("main");
+    let resolveStartup: (() => void) | undefined;
+    const mainClient = {
+      ...createMockClient("main"),
+      start: vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            resolveStartup = resolve;
+          }),
+      ),
+    };
+
+    resolveMatrixAuthMock.mockResolvedValue(mainAuth);
+    createMatrixClientMock.mockResolvedValue(mainClient);
+
+    const ownerPromise = resolveSharedMatrixClient({ accountId: "main" });
+    await vi.waitFor(() => {
+      expect(mainClient.start).toHaveBeenCalledTimes(1);
+      expect(resolveStartup).toEqual(expect.any(Function));
+    });
+
+    const abortController = new AbortController();
+    const canceledWaiter = resolveSharedMatrixClient({
+      accountId: "main",
+      abortSignal: abortController.signal,
+    });
+    abortController.abort();
+
+    await expect(canceledWaiter).rejects.toMatchObject({
+      message: "Matrix startup aborted",
+      name: "AbortError",
+    });
+
+    resolveStartup?.();
+    await expect(ownerPromise).resolves.toBe(mainClient);
+  });
+
   it("recreates the shared client when dispatcherPolicy changes", async () => {
     const firstAuth = {
       ...authFor("main"),

--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -271,6 +271,48 @@ describe("resolveSharedMatrixClient", () => {
     await expect(ownerPromise).resolves.toBe(mainClient);
   });
 
+  it("keeps the shared startup lock while an aborted waiter exits early", async () => {
+    const mainAuth = authFor("main");
+    let resolveStartup: (() => void) | undefined;
+    const mainClient = {
+      ...createMockClient("main"),
+      start: vi.fn(
+        async () =>
+          await new Promise<void>((resolve) => {
+            resolveStartup = resolve;
+          }),
+      ),
+    };
+
+    resolveMatrixAuthMock.mockResolvedValue(mainAuth);
+    createMatrixClientMock.mockResolvedValue(mainClient);
+
+    const ownerPromise = resolveSharedMatrixClient({ accountId: "main" });
+    await vi.waitFor(() => {
+      expect(mainClient.start).toHaveBeenCalledTimes(1);
+      expect(resolveStartup).toEqual(expect.any(Function));
+    });
+
+    const abortController = new AbortController();
+    const abortedWaiter = resolveSharedMatrixClient({
+      accountId: "main",
+      abortSignal: abortController.signal,
+    });
+    abortController.abort();
+    await expect(abortedWaiter).rejects.toMatchObject({
+      message: "Matrix startup aborted",
+      name: "AbortError",
+    });
+
+    const followerPromise = resolveSharedMatrixClient({ accountId: "main" });
+    expect(mainClient.start).toHaveBeenCalledTimes(1);
+
+    resolveStartup?.();
+    await expect(ownerPromise).resolves.toBe(mainClient);
+    await expect(followerPromise).resolves.toBe(mainClient);
+    expect(mainClient.start).toHaveBeenCalledTimes(1);
+  });
+
   it("recreates the shared client when dispatcherPolicy changes", async () => {
     const firstAuth = {
       ...authFor("main"),

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -2,6 +2,7 @@ import { normalizeOptionalAccountId } from "openclaw/plugin-sdk/account-id";
 import type { CoreConfig } from "../../types.js";
 import type { MatrixClient } from "../sdk.js";
 import { LogService } from "../sdk/logger.js";
+import { awaitMatrixStartupWithAbort } from "../startup-abort.js";
 import { resolveMatrixAuth, resolveMatrixAuthContext } from "./config.js";
 import type { MatrixAuth } from "./types.js";
 
@@ -94,11 +95,15 @@ async function ensureSharedClientStarted(params: {
   encryption?: boolean;
   abortSignal?: AbortSignal;
 }): Promise<void> {
+  const waitForStart = async (startPromise: Promise<void>) => {
+    await awaitMatrixStartupWithAbort(startPromise, params.abortSignal);
+  };
+
   if (params.state.started) {
     return;
   }
   if (params.state.startPromise) {
-    await params.state.startPromise;
+    await waitForStart(params.state.startPromise);
     return;
   }
 
@@ -123,7 +128,7 @@ async function ensureSharedClientStarted(params: {
   })();
 
   try {
-    await params.state.startPromise;
+    await waitForStart(params.state.startPromise);
   } finally {
     params.state.startPromise = null;
   }

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -91,8 +91,6 @@ function deleteSharedClientState(state: SharedMatrixClientState): void {
 
 async function ensureSharedClientStarted(params: {
   state: SharedMatrixClientState;
-  timeoutMs?: number;
-  initialSyncLimit?: number;
   encryption?: boolean;
   abortSignal?: AbortSignal;
 }): Promise<void> {
@@ -170,8 +168,6 @@ async function resolveSharedMatrixClientState(
     if (shouldStart) {
       await ensureSharedClientStarted({
         state: existingState,
-        timeoutMs: params.timeoutMs,
-        initialSyncLimit: auth.initialSyncLimit,
         encryption: auth.encryption,
         abortSignal: params.abortSignal,
       });
@@ -185,8 +181,6 @@ async function resolveSharedMatrixClientState(
     if (shouldStart) {
       await ensureSharedClientStarted({
         state: pending,
-        timeoutMs: params.timeoutMs,
-        initialSyncLimit: auth.initialSyncLimit,
         encryption: auth.encryption,
         abortSignal: params.abortSignal,
       });
@@ -206,8 +200,6 @@ async function resolveSharedMatrixClientState(
     if (shouldStart) {
       await ensureSharedClientStarted({
         state: created,
-        timeoutMs: params.timeoutMs,
-        initialSyncLimit: auth.initialSyncLimit,
         encryption: auth.encryption,
         abortSignal: params.abortSignal,
       });

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -94,6 +94,7 @@ async function ensureSharedClientStarted(params: {
   timeoutMs?: number;
   initialSyncLimit?: number;
   encryption?: boolean;
+  abortSignal?: AbortSignal;
 }): Promise<void> {
   if (params.state.started) {
     return;
@@ -119,7 +120,7 @@ async function ensureSharedClientStarted(params: {
       }
     }
 
-    await client.start();
+    await client.start({ abortSignal: params.abortSignal });
     params.state.started = true;
   })();
 
@@ -138,6 +139,7 @@ async function resolveSharedMatrixClientState(
     auth?: MatrixAuth;
     startClient?: boolean;
     accountId?: string | null;
+    abortSignal?: AbortSignal;
   } = {},
 ): Promise<SharedMatrixClientState> {
   const requestedAccountId = normalizeOptionalAccountId(params.accountId);
@@ -171,6 +173,7 @@ async function resolveSharedMatrixClientState(
         timeoutMs: params.timeoutMs,
         initialSyncLimit: auth.initialSyncLimit,
         encryption: auth.encryption,
+        abortSignal: params.abortSignal,
       });
     }
     return existingState;
@@ -185,6 +188,7 @@ async function resolveSharedMatrixClientState(
         timeoutMs: params.timeoutMs,
         initialSyncLimit: auth.initialSyncLimit,
         encryption: auth.encryption,
+        abortSignal: params.abortSignal,
       });
     }
     return pending;
@@ -205,6 +209,7 @@ async function resolveSharedMatrixClientState(
         timeoutMs: params.timeoutMs,
         initialSyncLimit: auth.initialSyncLimit,
         encryption: auth.encryption,
+        abortSignal: params.abortSignal,
       });
     }
     return created;
@@ -221,6 +226,7 @@ export async function resolveSharedMatrixClient(
     auth?: MatrixAuth;
     startClient?: boolean;
     accountId?: string | null;
+    abortSignal?: AbortSignal;
   } = {},
 ): Promise<MatrixClient> {
   const state = await resolveSharedMatrixClientState(params);
@@ -235,6 +241,7 @@ export async function acquireSharedMatrixClient(
     auth?: MatrixAuth;
     startClient?: boolean;
     accountId?: string | null;
+    abortSignal?: AbortSignal;
   } = {},
 ): Promise<MatrixClient> {
   const state = await resolveSharedMatrixClientState(params);

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -107,7 +107,7 @@ async function ensureSharedClientStarted(params: {
     return;
   }
 
-  params.state.startPromise = (async () => {
+  const startPromise = (async () => {
     const client = params.state.client;
 
     // Initialize crypto if enabled
@@ -126,12 +126,16 @@ async function ensureSharedClientStarted(params: {
     await client.start({ abortSignal: params.abortSignal });
     params.state.started = true;
   })();
+  // Keep the shared startup lock until the underlying start fully settles, even
+  // if one waiter aborts early while another caller still owns the startup.
+  const guardedStart = startPromise.finally(() => {
+    if (params.state.startPromise === guardedStart) {
+      params.state.startPromise = null;
+    }
+  });
+  params.state.startPromise = guardedStart;
 
-  try {
-    await waitForStart(params.state.startPromise);
-  } finally {
-    params.state.startPromise = null;
-  }
+  await waitForStart(guardedStart);
 }
 
 async function resolveSharedMatrixClientState(

--- a/extensions/matrix/src/matrix/monitor/events.ts
+++ b/extensions/matrix/src/matrix/monitor/events.ts
@@ -49,6 +49,7 @@ export function registerMatrixMonitorEvents(params: {
   logger: RuntimeLogger;
   formatNativeDependencyHint: PluginRuntime["system"]["formatNativeDependencyHint"];
   onRoomMessage: (roomId: string, event: MatrixRawEvent) => void | Promise<void>;
+  runDetachedTask?: (label: string, task: () => Promise<void>) => Promise<void>;
 }): void {
   const {
     cfg,
@@ -65,6 +66,7 @@ export function registerMatrixMonitorEvents(params: {
     logger,
     formatNativeDependencyHint,
     onRoomMessage,
+    runDetachedTask,
   } = params;
   const { routeVerificationEvent, routeVerificationSummary } = createMatrixVerificationEventRouter({
     client,
@@ -75,11 +77,27 @@ export function registerMatrixMonitorEvents(params: {
     logVerboseMessage,
   });
 
+  const runMonitorTask = (label: string, task: () => Promise<void>) => {
+    if (runDetachedTask) {
+      return runDetachedTask(label, task);
+    }
+    return Promise.resolve()
+      .then(task)
+      .catch((error) => {
+        logVerboseMessage(`matrix: ${label} failed (${String(error)})`);
+      });
+  };
+
   client.on("room.message", (roomId: string, event: MatrixRawEvent) => {
     if (routeVerificationEvent(roomId, event)) {
       return;
     }
-    void onRoomMessage(roomId, event);
+    void runMonitorTask(
+      `room message handler room=${roomId} id=${event.event_id ?? "unknown"}`,
+      async () => {
+        await onRoomMessage(roomId, event);
+      },
+    );
   });
 
   client.on("room.encrypted_event", (roomId: string, event: MatrixRawEvent) => {
@@ -121,7 +139,9 @@ export function registerMatrixMonitorEvents(params: {
   );
 
   client.on("verification.summary", (summary) => {
-    void routeVerificationSummary(summary);
+    void runMonitorTask("verification summary handler", async () => {
+      await routeVerificationSummary(summary);
+    });
   });
 
   client.on("room.invite", (roomId: string, event: MatrixRawEvent) => {
@@ -179,7 +199,12 @@ export function registerMatrixMonitorEvents(params: {
       );
     }
     if (eventType === EventType.Reaction) {
-      void onRoomMessage(roomId, event);
+      void runMonitorTask(
+        `reaction handler room=${roomId} id=${event.event_id ?? "unknown"}`,
+        async () => {
+          await onRoomMessage(roomId, event);
+        },
+      );
       return;
     }
 

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -100,6 +100,9 @@ const hoisted = vi.hoisted(() => {
   const setActiveMatrixClient = vi.fn();
   const setMatrixRuntime = vi.fn();
   const backfillMatrixAuthDeviceIdAfterStartup = vi.fn(async () => undefined);
+  const runMatrixStartupMaintenance = vi.fn<
+    (params: { abortSignal?: AbortSignal }) => Promise<void>
+  >(async () => undefined);
   const setStatus = vi.fn();
   return {
     backfillMatrixAuthDeviceIdAfterStartup,
@@ -116,6 +119,7 @@ const hoisted = vi.hoisted(() => {
     releaseSharedClientInstance,
     resolveSharedMatrixClient,
     resolveTextChunkLimit,
+    runMatrixStartupMaintenance,
     setActiveMatrixClient,
     setMatrixRuntime,
     setStatus,
@@ -370,6 +374,10 @@ vi.mock("./startup-verification.js", () => ({
   ensureMatrixStartupVerification: vi.fn(),
 }));
 
+vi.mock("./startup.js", () => ({
+  runMatrixStartupMaintenance: hoisted.runMatrixStartupMaintenance,
+}));
+
 let monitorMatrixProvider: typeof import("./index.js").monitorMatrixProvider;
 
 describe("monitorMatrixProvider", () => {
@@ -431,6 +439,7 @@ describe("monitorMatrixProvider", () => {
     hoisted.inboundDeduper.flush.mockReset().mockResolvedValue(undefined);
     hoisted.inboundDeduper.stop.mockReset().mockResolvedValue(undefined);
     hoisted.backfillMatrixAuthDeviceIdAfterStartup.mockReset().mockResolvedValue(undefined);
+    hoisted.runMatrixStartupMaintenance.mockReset().mockResolvedValue(undefined);
     hoisted.createMatrixRoomMessageHandler.mockReset().mockReturnValue(vi.fn());
     hoisted.setStatus.mockReset();
     Object.values(hoisted.logger).forEach((mock) => mock.mockReset());
@@ -581,6 +590,36 @@ describe("monitorMatrixProvider", () => {
 
     await vi.waitFor(() => {
       expect(hoisted.callOrder).toContain("start-client");
+    });
+
+    abortController.abort();
+
+    await expect(monitorPromise).resolves.toBeUndefined();
+    expect(hoisted.releaseSharedClientInstance).toHaveBeenCalledWith(hoisted.client, "stop");
+    expect(hoisted.client.drainPendingDecryptions).not.toHaveBeenCalled();
+  });
+
+  it("aborts during startup maintenance and releases the shared client without persist", async () => {
+    const abortController = new AbortController();
+    hoisted.runMatrixStartupMaintenance.mockImplementation(
+      async (params: { abortSignal?: AbortSignal }) =>
+        await new Promise<void>((_resolve, reject) => {
+          params.abortSignal?.addEventListener(
+            "abort",
+            () => {
+              const error = new Error("Matrix startup aborted");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true },
+          );
+        }),
+    );
+
+    const monitorPromise = monitorMatrixProvider({ abortSignal: abortController.signal });
+
+    await vi.waitFor(() => {
+      expect(hoisted.runMatrixStartupMaintenance).toHaveBeenCalledTimes(1);
     });
 
     abortController.abort();

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -12,6 +12,34 @@ type DirectRoomTrackerOptions = {
 };
 
 const hoisted = vi.hoisted(() => {
+  const createEmitter = () => {
+    const listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    return {
+      on(event: string, listener: (...args: unknown[]) => void) {
+        let bucket = listeners.get(event);
+        if (!bucket) {
+          bucket = new Set();
+          listeners.set(event, bucket);
+        }
+        bucket.add(listener);
+        return this;
+      },
+      off(event: string, listener: (...args: unknown[]) => void) {
+        listeners.get(event)?.delete(listener);
+        return this;
+      },
+      emit(event: string, ...args: unknown[]) {
+        for (const listener of listeners.get(event) ?? []) {
+          listener(...args);
+        }
+        return true;
+      },
+      removeAllListeners() {
+        listeners.clear();
+        return this;
+      },
+    };
+  };
   const callOrder: string[] = [];
   const state = {
     startClientError: null as Error | null,
@@ -26,12 +54,12 @@ const hoisted = vi.hoisted(() => {
     flush: vi.fn(async () => undefined),
     stop: vi.fn(async () => undefined),
   };
-  const client = {
+  const client = Object.assign(createEmitter(), {
     id: "matrix-client",
     hasPersistedSyncState: vi.fn(() => false),
     stopSyncWithoutPersist: vi.fn(),
     drainPendingDecryptions: vi.fn(async () => undefined),
-  };
+  });
   const createMatrixRoomMessageHandler = vi.fn(() => vi.fn());
   const createDirectRoomTracker = vi.fn((_client: unknown, _opts?: DirectRoomTrackerOptions) => ({
     isDirectMessage: vi.fn(async () => false),
@@ -58,6 +86,7 @@ const hoisted = vi.hoisted(() => {
   const setActiveMatrixClient = vi.fn();
   const setMatrixRuntime = vi.fn();
   const backfillMatrixAuthDeviceIdAfterStartup = vi.fn(async () => undefined);
+  const setStatus = vi.fn();
   return {
     backfillMatrixAuthDeviceIdAfterStartup,
     callOrder,
@@ -74,6 +103,7 @@ const hoisted = vi.hoisted(() => {
     resolveTextChunkLimit,
     setActiveMatrixClient,
     setMatrixRuntime,
+    setStatus,
     state,
     stopThreadBindingManager,
   };
@@ -300,9 +330,17 @@ vi.mock("./direct.js", () => ({
 
 vi.mock("./events.js", () => ({
   registerMatrixMonitorEvents: vi.fn(
-    (params: { onRoomMessage: (roomId: string, event: unknown) => Promise<void> }) => {
+    (params: {
+      onRoomMessage: (roomId: string, event: unknown) => Promise<void>;
+      runDetachedTask?: (label: string, task: () => Promise<void>) => Promise<void>;
+    }) => {
       hoisted.callOrder.push("register-events");
-      hoisted.registeredOnRoomMessage = params.onRoomMessage;
+      hoisted.registeredOnRoomMessage = (roomId: string, event: unknown) =>
+        params.runDetachedTask
+          ? params.runDetachedTask("test room message", async () => {
+              await params.onRoomMessage(roomId, event);
+            })
+          : params.onRoomMessage(roomId, event);
     },
   ),
 }));
@@ -365,6 +403,7 @@ describe("monitorMatrixProvider", () => {
     hoisted.registeredOnRoomMessage = null;
     hoisted.setActiveMatrixClient.mockReset();
     hoisted.stopThreadBindingManager.mockReset();
+    hoisted.client.removeAllListeners();
     hoisted.client.hasPersistedSyncState.mockReset().mockReturnValue(false);
     hoisted.client.stopSyncWithoutPersist.mockReset();
     hoisted.client.drainPendingDecryptions.mockReset().mockResolvedValue(undefined);
@@ -375,6 +414,7 @@ describe("monitorMatrixProvider", () => {
     hoisted.inboundDeduper.stop.mockReset().mockResolvedValue(undefined);
     hoisted.backfillMatrixAuthDeviceIdAfterStartup.mockReset().mockResolvedValue(undefined);
     hoisted.createMatrixRoomMessageHandler.mockReset().mockReturnValue(vi.fn());
+    hoisted.setStatus.mockReset();
     Object.values(hoisted.logger).forEach((mock) => mock.mockReset());
   });
 
@@ -388,6 +428,112 @@ describe("monitorMatrixProvider", () => {
     expect(hoisted.resolveTextChunkLimit).not.toHaveBeenCalled();
     expect(hoisted.createMatrixRoomMessageHandler).not.toHaveBeenCalled();
     expect(hoisted.setActiveMatrixClient).not.toHaveBeenCalled();
+  });
+
+  it("publishes disconnected startup status and connected sync status without failing the monitor", async () => {
+    const abortController = new AbortController();
+    const monitorPromise = monitorMatrixProvider({
+      abortSignal: abortController.signal,
+      setStatus: hoisted.setStatus,
+    });
+
+    await vi.waitFor(() => {
+      expect(hoisted.callOrder).toContain("start-client");
+    });
+
+    expect(hoisted.setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        baseUrl: "https://matrix.example.org",
+        connected: false,
+        healthState: "starting",
+      }),
+    );
+
+    hoisted.client.emit("sync.state", "SYNCING", "RECONNECTING", undefined);
+
+    await vi.waitFor(() => {
+      expect(hoisted.setStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountId: "default",
+          connected: true,
+          healthState: "healthy",
+          lastError: null,
+        }),
+      );
+    });
+
+    abortController.abort();
+    await expect(monitorPromise).resolves.toBeUndefined();
+  });
+
+  it("contains room-message handler rejections inside monitor task tracking", async () => {
+    const abortController = new AbortController();
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason);
+    };
+
+    hoisted.createMatrixRoomMessageHandler.mockReturnValue(
+      vi.fn(async () => {
+        throw new Error("room handler exploded");
+      }),
+    );
+
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const monitorPromise = monitorMatrixProvider({ abortSignal: abortController.signal });
+      await vi.waitFor(() => {
+        expect(hoisted.callOrder).toContain("start-client");
+      });
+
+      const onRoomMessage = hoisted.registeredOnRoomMessage;
+      if (!onRoomMessage) {
+        throw new Error("expected room message handler to be registered");
+      }
+
+      await onRoomMessage("!room:example.org", { event_id: "$event" });
+      await Promise.resolve();
+
+      expect(unhandled).toHaveLength(0);
+      expect(hoisted.logger.warn).toHaveBeenCalledWith(
+        "matrix background task failed",
+        expect.objectContaining({
+          task: "test room message",
+          error: "Error: room handler exploded",
+        }),
+      );
+
+      abortController.abort();
+      await monitorPromise;
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  it("fails the channel task when Matrix sync emits an unexpected fatal error", async () => {
+    const abortController = new AbortController();
+    const monitorPromise = monitorMatrixProvider({
+      abortSignal: abortController.signal,
+      setStatus: hoisted.setStatus,
+    });
+
+    await vi.waitFor(() => {
+      expect(hoisted.callOrder).toContain("start-client");
+    });
+
+    hoisted.client.emit("sync.unexpected_error", new Error("sync exploded"));
+
+    await expect(monitorPromise).rejects.toThrow("sync exploded");
+    expect(hoisted.releaseSharedClientInstance).toHaveBeenCalledWith(hoisted.client, "persist");
+    expect(hoisted.setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        connected: false,
+        healthState: "error",
+        lastError: "sync exploded",
+      }),
+    );
   });
 
   it("registers Matrix thread bindings before starting the client", async () => {

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -83,6 +83,20 @@ const hoisted = vi.hoisted(() => {
   };
   const stopThreadBindingManager = vi.fn();
   const releaseSharedClientInstance = vi.fn(async () => true);
+  const resolveSharedMatrixClient = vi.fn(async (params: { startClient?: boolean }) => {
+    if (params.startClient === false) {
+      callOrder.push("prepare-client");
+      return client;
+    }
+    if (!callOrder.includes("create-manager")) {
+      throw new Error("Matrix client started before thread bindings were registered");
+    }
+    if (state.startClientError) {
+      throw state.startClientError;
+    }
+    callOrder.push("start-client");
+    return client;
+  });
   const setActiveMatrixClient = vi.fn();
   const setMatrixRuntime = vi.fn();
   const backfillMatrixAuthDeviceIdAfterStartup = vi.fn(async () => undefined);
@@ -100,6 +114,7 @@ const hoisted = vi.hoisted(() => {
     logger,
     registeredOnRoomMessage: null as null | ((roomId: string, event: unknown) => Promise<void>),
     releaseSharedClientInstance,
+    resolveSharedMatrixClient,
     resolveTextChunkLimit,
     setActiveMatrixClient,
     setMatrixRuntime,
@@ -267,20 +282,7 @@ vi.mock("../client.js", () => ({
   resolveMatrixAuthContext: vi.fn(() => ({
     accountId: "default",
   })),
-  resolveSharedMatrixClient: vi.fn(async (params: { startClient?: boolean }) => {
-    if (params.startClient === false) {
-      hoisted.callOrder.push("prepare-client");
-      return hoisted.client;
-    }
-    if (!hoisted.callOrder.includes("create-manager")) {
-      throw new Error("Matrix client started before thread bindings were registered");
-    }
-    if (hoisted.state.startClientError) {
-      throw hoisted.state.startClientError;
-    }
-    hoisted.callOrder.push("start-client");
-    return hoisted.client;
-  }),
+  resolveSharedMatrixClient: hoisted.resolveSharedMatrixClient,
 }));
 
 vi.mock("../client/shared.js", () => ({
@@ -391,6 +393,22 @@ describe("monitorMatrixProvider", () => {
     delete (hoisted.accountConfig as { rooms?: Record<string, unknown> }).rooms;
     hoisted.resolveTextChunkLimit.mockReset().mockReturnValue(4000);
     hoisted.releaseSharedClientInstance.mockReset().mockResolvedValue(true);
+    hoisted.resolveSharedMatrixClient
+      .mockReset()
+      .mockImplementation(async (params: { startClient?: boolean }) => {
+        if (params.startClient === false) {
+          hoisted.callOrder.push("prepare-client");
+          return hoisted.client;
+        }
+        if (!hoisted.callOrder.includes("create-manager")) {
+          throw new Error("Matrix client started before thread bindings were registered");
+        }
+        if (hoisted.state.startClientError) {
+          throw hoisted.state.startClientError;
+        }
+        hoisted.callOrder.push("start-client");
+        return hoisted.client;
+      });
     hoisted.createDirectRoomTracker.mockReset().mockReturnValue({
       isDirectMessage: vi.fn(async () => false),
     });
@@ -534,6 +552,42 @@ describe("monitorMatrixProvider", () => {
         lastError: "sync exploded",
       }),
     );
+  });
+
+  it("aborts stalled startup promptly and releases the shared client without persist", async () => {
+    const abortController = new AbortController();
+    hoisted.resolveSharedMatrixClient.mockImplementation(
+      async (params: { startClient?: boolean; abortSignal?: AbortSignal }) => {
+        if (params.startClient === false) {
+          hoisted.callOrder.push("prepare-client");
+          return hoisted.client;
+        }
+        hoisted.callOrder.push("start-client");
+        return await new Promise<typeof hoisted.client>((_resolve, reject) => {
+          params.abortSignal?.addEventListener(
+            "abort",
+            () => {
+              const error = new Error("Matrix startup aborted");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true },
+          );
+        });
+      },
+    );
+
+    const monitorPromise = monitorMatrixProvider({ abortSignal: abortController.signal });
+
+    await vi.waitFor(() => {
+      expect(hoisted.callOrder).toContain("start-client");
+    });
+
+    abortController.abort();
+
+    await expect(monitorPromise).resolves.toBeUndefined();
+    expect(hoisted.releaseSharedClientInstance).toHaveBeenCalledWith(hoisted.client, "stop");
+    expect(hoisted.client.drainPendingDecryptions).not.toHaveBeenCalled();
   });
 
   it("registers Matrix thread bindings before starting the client", async () => {

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -24,6 +24,7 @@ import {
   resolveSharedMatrixClient,
 } from "../client.js";
 import { releaseSharedClientInstance } from "../client/shared.js";
+import { isMatrixStartupAbortError } from "../startup-abort.js";
 import { createMatrixThreadBindingManager } from "../thread-bindings.js";
 import { registerMatrixAutoJoin } from "./auto-join.js";
 import { resolveMatrixMonitorConfig } from "./config.js";
@@ -395,6 +396,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       writeConfigFile: async (nextCfg) => await core.config.writeConfigFile(nextCfg),
       loadWebMedia: async (url, maxBytes) => await core.media.loadWebMedia(url, maxBytes),
       env: process.env,
+      abortSignal: opts.abortSignal,
     });
 
     await Promise.race([
@@ -411,7 +413,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       syncLifecycle.waitForFatalStop(),
     ]);
   } catch (err) {
-    if (opts.abortSignal?.aborted === true && err instanceof Error && err.name === "AbortError") {
+    if (opts.abortSignal?.aborted === true && isMatrixStartupAbortError(err)) {
       await cleanup("stop");
       return;
     }

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -1,5 +1,6 @@
 import { format } from "node:util";
 import { CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
+import { waitUntilAbort } from "openclaw/plugin-sdk/channel-lifecycle";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import {
   GROUP_POLICY_BLOCKED_LABEL,
@@ -33,6 +34,9 @@ import { createMatrixInboundEventDeduper } from "./inbound-dedupe.js";
 import { shouldPromoteRecentInviteRoom } from "./recent-invite.js";
 import { createMatrixRoomInfoResolver } from "./room-info.js";
 import { runMatrixStartupMaintenance } from "./startup.js";
+import { createMatrixMonitorStatusController } from "./status.js";
+import { createMatrixMonitorSyncLifecycle } from "./sync-lifecycle.js";
+import { createMatrixMonitorTaskRunner } from "./task-runner.js";
 
 export type MonitorMatrixOpts = {
   runtime?: RuntimeEnv;
@@ -42,6 +46,7 @@ export type MonitorMatrixOpts = {
   initialSyncLimit?: number;
   replyToMode?: ReplyToMode;
   accountId?: string | null;
+  setStatus?: (next: import("openclaw/plugin-sdk/channel-contract").ChannelAccountSnapshot) => void;
 };
 
 const DEFAULT_MEDIA_MAX_MB = 20;
@@ -140,6 +145,11 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     resolvedInitialSyncLimit === auth.initialSyncLimit
       ? auth
       : { ...auth, initialSyncLimit: resolvedInitialSyncLimit };
+  const statusController = createMatrixMonitorStatusController({
+    accountId: auth.accountId,
+    baseUrl: auth.homeserver,
+    statusSink: opts.setStatus,
+  });
   const client = await resolveSharedMatrixClient({
     cfg,
     auth: authWithLimit,
@@ -153,12 +163,15 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     auth,
     env: process.env,
   });
-  const inFlightRoomMessages = new Set<Promise<void>>();
-  const waitForInFlightRoomMessages = async () => {
-    while (inFlightRoomMessages.size > 0) {
-      await Promise.allSettled(Array.from(inFlightRoomMessages));
-    }
-  };
+  const monitorTaskRunner = createMatrixMonitorTaskRunner({
+    logger,
+    logVerboseMessage,
+  });
+  const syncLifecycle = createMatrixMonitorSyncLifecycle({
+    client,
+    statusController,
+    isStopping: () => cleanedUp || opts.abortSignal?.aborted === true,
+  });
   const cleanup = async () => {
     if (cleanedUp) {
       return;
@@ -167,11 +180,13 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     try {
       client.stopSyncWithoutPersist();
       await client.drainPendingDecryptions("matrix monitor shutdown");
-      await waitForInFlightRoomMessages();
+      await monitorTaskRunner.waitForIdle();
       threadBindingManager?.stop();
       await inboundDeduper.stop();
       await releaseSharedClientInstance(client, "persist");
     } finally {
+      syncLifecycle.dispose();
+      statusController.markStopped();
       setActiveMatrixClient(null, auth.accountId);
     }
   };
@@ -294,13 +309,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     getMemberDisplayName,
     needsRoomAliasesForConfig,
   });
-  const trackRoomMessage = (roomId: string, event: Parameters<typeof handleRoomMessage>[1]) => {
-    const task = Promise.resolve(handleRoomMessage(roomId, event)).finally(() => {
-      inFlightRoomMessages.delete(task);
-    });
-    inFlightRoomMessages.add(task);
-    return task;
-  };
 
   try {
     threadBindingManager = await createMatrixThreadBindingManager({
@@ -337,7 +345,8 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       warnedCryptoMissingRooms,
       logger,
       formatNativeDependencyHint: core.system.formatNativeDependencyHint,
-      onRoomMessage: trackRoomMessage,
+      onRoomMessage: handleRoomMessage,
+      runDetachedTask: monitorTaskRunner.runDetachedTask,
     });
 
     // Register Matrix thread bindings before the client starts syncing so threaded
@@ -385,8 +394,8 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       env: process.env,
     });
 
-    await new Promise<void>((resolve) => {
-      const stopAndResolve = async () => {
+    await Promise.race([
+      waitUntilAbort(opts.abortSignal, async () => {
         try {
           logVerboseMessage("matrix: stopping client");
           await cleanup();
@@ -394,22 +403,10 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
           logger.warn("matrix: failed during monitor shutdown cleanup", {
             error: String(err),
           });
-        } finally {
-          resolve();
         }
-      };
-      if (opts.abortSignal?.aborted) {
-        void stopAndResolve();
-        return;
-      }
-      opts.abortSignal?.addEventListener(
-        "abort",
-        () => {
-          void stopAndResolve();
-        },
-        { once: true },
-      );
-    });
+      }),
+      syncLifecycle.waitForFatalStop(),
+    ]);
   } catch (err) {
     await cleanup();
     throw err;

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -172,18 +172,20 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
     statusController,
     isStopping: () => cleanedUp || opts.abortSignal?.aborted === true,
   });
-  const cleanup = async () => {
+  const cleanup = async (mode: "persist" | "stop" = "persist") => {
     if (cleanedUp) {
       return;
     }
     cleanedUp = true;
     try {
       client.stopSyncWithoutPersist();
-      await client.drainPendingDecryptions("matrix monitor shutdown");
-      await monitorTaskRunner.waitForIdle();
+      if (mode === "persist") {
+        await client.drainPendingDecryptions("matrix monitor shutdown");
+        await monitorTaskRunner.waitForIdle();
+      }
       threadBindingManager?.stop();
       await inboundDeduper.stop();
-      await releaseSharedClientInstance(client, "persist");
+      await releaseSharedClientInstance(client, mode);
     } finally {
       syncLifecycle.dispose();
       statusController.markStopped();
@@ -356,6 +358,7 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       cfg,
       auth: authWithLimit,
       accountId: auth.accountId,
+      abortSignal: opts.abortSignal,
     });
     logVerboseMessage("matrix: client started");
 
@@ -408,6 +411,10 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       syncLifecycle.waitForFatalStop(),
     ]);
   } catch (err) {
+    if (opts.abortSignal?.aborted === true && err instanceof Error && err.name === "AbortError") {
+      await cleanup("stop");
+      return;
+    }
     await cleanup();
     throw err;
   }

--- a/extensions/matrix/src/matrix/monitor/startup.test.ts
+++ b/extensions/matrix/src/matrix/monitor/startup.test.ts
@@ -133,6 +133,7 @@ describe("runMatrixStartupMaintenance", () => {
         contentType: "image/png",
         fileName: "avatar.png",
       })),
+      abortSignal: undefined,
       env: {},
     };
   }
@@ -234,5 +235,23 @@ describe("runMatrixStartupMaintenance", () => {
       "Matrix startup verification request failed (non-fatal)",
       { error: "boom" },
     );
+  });
+
+  it("aborts maintenance before later startup steps continue", async () => {
+    const params = createParams();
+    params.auth.encryption = true;
+    const abortController = new AbortController();
+    params.abortSignal = abortController.signal;
+    vi.mocked(deps.syncMatrixOwnProfile).mockImplementation(async () => {
+      abortController.abort();
+      return createProfileSyncResult();
+    });
+
+    await expect(runMatrixStartupMaintenance(params, deps)).rejects.toMatchObject({
+      message: "Matrix startup aborted",
+      name: "AbortError",
+    });
+    expect(deps.ensureMatrixStartupVerification).not.toHaveBeenCalled();
+    expect(deps.maybeRestoreLegacyMatrixBackup).not.toHaveBeenCalled();
   });
 });

--- a/extensions/matrix/src/matrix/monitor/startup.ts
+++ b/extensions/matrix/src/matrix/monitor/startup.ts
@@ -2,6 +2,7 @@ import type { RuntimeLogger } from "../../runtime-api.js";
 import type { CoreConfig, MatrixConfig } from "../../types.js";
 import type { MatrixAuth } from "../client.js";
 import type { MatrixClient } from "../sdk.js";
+import { isMatrixStartupAbortError, throwIfMatrixStartupAborted } from "../startup-abort.js";
 
 type MatrixStartupClient = Pick<
   MatrixClient,
@@ -66,10 +67,12 @@ export async function runMatrixStartupMaintenance(
       maxBytes: number,
     ) => Promise<{ buffer: Buffer; contentType?: string; fileName?: string }>;
     env?: NodeJS.ProcessEnv;
+    abortSignal?: AbortSignal;
   },
   deps?: MatrixStartupMaintenanceDeps,
 ): Promise<void> {
   const runtimeDeps = deps ?? (await loadMatrixStartupMaintenanceDeps());
+  throwIfMatrixStartupAborted(params.abortSignal);
   try {
     const profileSync = await runtimeDeps.syncMatrixOwnProfile({
       client: params.client,
@@ -78,6 +81,7 @@ export async function runMatrixStartupMaintenance(
       avatarUrl: params.accountConfig.avatarUrl,
       loadAvatarFromUrl: async (url, maxBytes) => await params.loadWebMedia(url, maxBytes),
     });
+    throwIfMatrixStartupAborted(params.abortSignal);
     if (profileSync.displayNameUpdated) {
       params.logger.info(`matrix: profile display name updated for ${params.auth.userId}`);
     }
@@ -94,11 +98,15 @@ export async function runMatrixStartupMaintenance(
         avatarUrl: profileSync.resolvedAvatarUrl,
       });
       await params.writeConfigFile(updatedCfg as never);
+      throwIfMatrixStartupAborted(params.abortSignal);
       params.logVerboseMessage(
         `matrix: persisted converted avatar URL for account ${params.accountId} (${profileSync.resolvedAvatarUrl})`,
       );
     }
   } catch (err) {
+    if (isMatrixStartupAbortError(err)) {
+      throw err;
+    }
     params.logger.warn("matrix: failed to sync profile from config", { error: String(err) });
   }
 
@@ -107,6 +115,7 @@ export async function runMatrixStartupMaintenance(
   }
 
   try {
+    throwIfMatrixStartupAborted(params.abortSignal);
     const deviceHealth = runtimeDeps.summarizeMatrixDeviceHealth(
       await params.client.listOwnDevices(),
     );
@@ -116,18 +125,23 @@ export async function runMatrixStartupMaintenance(
       );
     }
   } catch (err) {
+    if (isMatrixStartupAbortError(err)) {
+      throw err;
+    }
     params.logger.debug?.("Failed to inspect matrix device hygiene (non-fatal)", {
       error: String(err),
     });
   }
 
   try {
+    throwIfMatrixStartupAborted(params.abortSignal);
     const startupVerification = await runtimeDeps.ensureMatrixStartupVerification({
       client: params.client,
       auth: params.auth,
       accountConfig: params.accountConfig,
       env: params.env,
     });
+    throwIfMatrixStartupAborted(params.abortSignal);
     if (startupVerification.kind === "verified") {
       params.logger.info("matrix: device is verified by its owner and ready for encrypted rooms");
     } else if (
@@ -158,17 +172,22 @@ export async function runMatrixStartupMaintenance(
       );
     }
   } catch (err) {
+    if (isMatrixStartupAbortError(err)) {
+      throw err;
+    }
     params.logger.debug?.("Failed to resolve matrix verification status (non-fatal)", {
       error: String(err),
     });
   }
 
   try {
+    throwIfMatrixStartupAborted(params.abortSignal);
     const legacyCryptoRestore = await runtimeDeps.maybeRestoreLegacyMatrixBackup({
       client: params.client,
       auth: params.auth,
       env: params.env,
     });
+    throwIfMatrixStartupAborted(params.abortSignal);
     if (legacyCryptoRestore.kind === "restored") {
       params.logger.info(
         `matrix: restored ${legacyCryptoRestore.imported}/${legacyCryptoRestore.total} room key(s) from legacy encrypted-state backup`,
@@ -189,6 +208,9 @@ export async function runMatrixStartupMaintenance(
       }
     }
   } catch (err) {
+    if (isMatrixStartupAbortError(err)) {
+      throw err;
+    }
     params.logger.warn("matrix: failed restoring legacy encrypted-state backup", {
       error: String(err),
     });

--- a/extensions/matrix/src/matrix/monitor/status.ts
+++ b/extensions/matrix/src/matrix/monitor/status.ts
@@ -90,6 +90,8 @@ export function createMatrixMonitorStatusController(params: {
         noteDisconnected({ state, at, error });
         return;
       }
+      // Unknown future SDK states inherit the current connectivity bit until the
+      // SDK classifies them as ready or disconnected. Avoid guessing here.
       status.lastEventAt = at;
       status.healthState = state.toLowerCase();
       emit();

--- a/extensions/matrix/src/matrix/monitor/status.ts
+++ b/extensions/matrix/src/matrix/monitor/status.ts
@@ -1,0 +1,109 @@
+import type { ChannelAccountSnapshot } from "openclaw/plugin-sdk/channel-contract";
+import { createConnectedChannelStatusPatch } from "openclaw/plugin-sdk/gateway-runtime";
+import { formatMatrixErrorMessage } from "../errors.js";
+import {
+  isMatrixDisconnectedSyncState,
+  isMatrixReadySyncState,
+  type MatrixSyncState,
+} from "../sync-state.js";
+
+type MatrixMonitorStatusSink = (patch: ChannelAccountSnapshot) => void;
+
+function cloneLastDisconnect(
+  value: ChannelAccountSnapshot["lastDisconnect"],
+): ChannelAccountSnapshot["lastDisconnect"] {
+  if (!value || typeof value === "string") {
+    return value ?? null;
+  }
+  return { ...value };
+}
+
+function formatSyncError(error: unknown): string | null {
+  if (!error) {
+    return null;
+  }
+  if (error instanceof Error) {
+    return error.message || error.name || "unknown";
+  }
+  return formatMatrixErrorMessage(error);
+}
+
+export type MatrixMonitorStatusController = ReturnType<typeof createMatrixMonitorStatusController>;
+
+export function createMatrixMonitorStatusController(params: {
+  accountId: string;
+  baseUrl?: string;
+  statusSink?: MatrixMonitorStatusSink;
+}) {
+  const status: ChannelAccountSnapshot = {
+    accountId: params.accountId,
+    ...(params.baseUrl ? { baseUrl: params.baseUrl } : {}),
+    connected: false,
+    lastConnectedAt: null,
+    lastDisconnect: null,
+    lastError: null,
+    healthState: "starting",
+  };
+
+  const emit = () => {
+    params.statusSink?.({
+      ...status,
+      lastDisconnect: cloneLastDisconnect(status.lastDisconnect),
+    });
+  };
+
+  const noteConnected = (at = Date.now()) => {
+    if (status.connected === true) {
+      status.lastEventAt = at;
+    } else {
+      Object.assign(status, createConnectedChannelStatusPatch(at));
+    }
+    status.lastError = null;
+    status.lastDisconnect = null;
+    status.healthState = "healthy";
+    emit();
+  };
+
+  const noteDisconnected = (params: { state: MatrixSyncState; at?: number; error?: unknown }) => {
+    const at = params.at ?? Date.now();
+    const error = formatSyncError(params.error);
+    status.connected = false;
+    status.lastEventAt = at;
+    status.lastDisconnect = {
+      at,
+      ...(error ? { error } : {}),
+    };
+    status.lastError = error;
+    status.healthState = params.state.toLowerCase();
+    emit();
+  };
+
+  emit();
+
+  return {
+    noteSyncState(state: MatrixSyncState, error?: unknown, at = Date.now()) {
+      if (isMatrixReadySyncState(state)) {
+        noteConnected(at);
+        return;
+      }
+      if (isMatrixDisconnectedSyncState(state)) {
+        noteDisconnected({ state, at, error });
+        return;
+      }
+      status.lastEventAt = at;
+      status.healthState = state.toLowerCase();
+      emit();
+    },
+    noteUnexpectedError(error: unknown, at = Date.now()) {
+      noteDisconnected({ state: "ERROR", at, error });
+    },
+    markStopped(at = Date.now()) {
+      status.connected = false;
+      status.lastEventAt = at;
+      if (status.healthState !== "error") {
+        status.healthState = "stopped";
+      }
+      emit();
+    },
+  };
+}

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -62,4 +62,50 @@ describe("createMatrixMonitorSyncLifecycle", () => {
       }),
     );
   });
+
+  it("ignores unexpected sync errors emitted during intentional shutdown", async () => {
+    const client = createClientEmitter();
+    const setStatus = vi.fn();
+    let stopping = false;
+    const lifecycle = createMatrixMonitorSyncLifecycle({
+      client: client as never,
+      statusController: createMatrixMonitorStatusController({
+        accountId: "default",
+        statusSink: setStatus,
+      }),
+      isStopping: () => stopping,
+    });
+
+    const waitPromise = lifecycle.waitForFatalStop();
+    stopping = true;
+    client.emit("sync.unexpected_error", new Error("shutdown noise"));
+    lifecycle.dispose();
+
+    await expect(waitPromise).resolves.toBeUndefined();
+    expect(setStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        healthState: "error",
+      }),
+    );
+  });
+
+  it("rejects a second concurrent fatal-stop waiter", async () => {
+    const client = createClientEmitter();
+    const lifecycle = createMatrixMonitorSyncLifecycle({
+      client: client as never,
+      statusController: createMatrixMonitorStatusController({
+        accountId: "default",
+      }),
+    });
+
+    const firstWait = lifecycle.waitForFatalStop();
+
+    await expect(lifecycle.waitForFatalStop()).rejects.toThrow(
+      "Matrix fatal-stop wait already in progress",
+    );
+
+    lifecycle.dispose();
+    await expect(firstWait).resolves.toBeUndefined();
+  });
 });

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -63,6 +63,30 @@ describe("createMatrixMonitorSyncLifecycle", () => {
     );
   });
 
+  it("marks unexpected STOPPED sync as an error state", async () => {
+    const client = createClientEmitter();
+    const setStatus = vi.fn();
+    const lifecycle = createMatrixMonitorSyncLifecycle({
+      client: client as never,
+      statusController: createMatrixMonitorStatusController({
+        accountId: "default",
+        statusSink: setStatus,
+      }),
+    });
+
+    const waitPromise = lifecycle.waitForFatalStop();
+    client.emit("sync.state", "STOPPED", "SYNCING", undefined);
+
+    await expect(waitPromise).rejects.toThrow("Matrix sync stopped unexpectedly");
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        healthState: "error",
+        lastError: "Matrix sync stopped unexpectedly",
+      }),
+    );
+  });
+
   it("ignores unexpected sync errors emitted during intentional shutdown", async () => {
     const client = createClientEmitter();
     const setStatus = vi.fn();

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -1,0 +1,65 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { createMatrixMonitorStatusController } from "./status.js";
+import { createMatrixMonitorSyncLifecycle } from "./sync-lifecycle.js";
+
+function createClientEmitter() {
+  return new EventEmitter() as unknown as {
+    on: (event: string, listener: (...args: unknown[]) => void) => unknown;
+    off: (event: string, listener: (...args: unknown[]) => void) => unknown;
+    emit: (event: string, ...args: unknown[]) => boolean;
+  };
+}
+
+describe("createMatrixMonitorSyncLifecycle", () => {
+  it("rejects the channel wait on unexpected sync errors", async () => {
+    const client = createClientEmitter();
+    const setStatus = vi.fn();
+    const lifecycle = createMatrixMonitorSyncLifecycle({
+      client: client as never,
+      statusController: createMatrixMonitorStatusController({
+        accountId: "default",
+        statusSink: setStatus,
+      }),
+    });
+
+    const waitPromise = lifecycle.waitForFatalStop();
+    client.emit("sync.unexpected_error", new Error("sync exploded"));
+
+    await expect(waitPromise).rejects.toThrow("sync exploded");
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        healthState: "error",
+        lastError: "sync exploded",
+      }),
+    );
+  });
+
+  it("ignores STOPPED emitted during intentional shutdown", async () => {
+    const client = createClientEmitter();
+    const setStatus = vi.fn();
+    let stopping = false;
+    const lifecycle = createMatrixMonitorSyncLifecycle({
+      client: client as never,
+      statusController: createMatrixMonitorStatusController({
+        accountId: "default",
+        statusSink: setStatus,
+      }),
+      isStopping: () => stopping,
+    });
+
+    const waitPromise = lifecycle.waitForFatalStop();
+    stopping = true;
+    client.emit("sync.state", "STOPPED", "SYNCING", undefined);
+    lifecycle.dispose();
+
+    await expect(waitPromise).resolves.toBeUndefined();
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        healthState: "stopped",
+      }),
+    );
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -114,6 +114,38 @@ describe("createMatrixMonitorSyncLifecycle", () => {
     );
   });
 
+  it("does not downgrade a fatal error to stopped during shutdown", async () => {
+    const client = createClientEmitter();
+    const setStatus = vi.fn();
+    let stopping = false;
+    const statusController = createMatrixMonitorStatusController({
+      accountId: "default",
+      statusSink: setStatus,
+    });
+    const lifecycle = createMatrixMonitorSyncLifecycle({
+      client: client as never,
+      statusController,
+      isStopping: () => stopping,
+    });
+
+    const waitPromise = lifecycle.waitForFatalStop();
+    client.emit("sync.unexpected_error", new Error("sync exploded"));
+    await expect(waitPromise).rejects.toThrow("sync exploded");
+
+    stopping = true;
+    client.emit("sync.state", "STOPPED", "SYNCING", undefined);
+    lifecycle.dispose();
+    statusController.markStopped();
+
+    expect(setStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        healthState: "error",
+        lastError: "sync exploded",
+      }),
+    );
+  });
+
   it("rejects a second concurrent fatal-stop waiter", async () => {
     const client = createClientEmitter();
     const lifecycle = createMatrixMonitorSyncLifecycle({

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -146,6 +146,33 @@ describe("createMatrixMonitorSyncLifecycle", () => {
     );
   });
 
+  it("ignores follow-up sync states after a fatal sync error", async () => {
+    const client = createClientEmitter();
+    const setStatus = vi.fn();
+    const lifecycle = createMatrixMonitorSyncLifecycle({
+      client: client as never,
+      statusController: createMatrixMonitorStatusController({
+        accountId: "default",
+        statusSink: setStatus,
+      }),
+    });
+
+    const waitPromise = lifecycle.waitForFatalStop();
+    client.emit("sync.unexpected_error", new Error("sync exploded"));
+    await expect(waitPromise).rejects.toThrow("sync exploded");
+
+    client.emit("sync.state", "RECONNECTING", "SYNCING", new Error("late reconnect"));
+    lifecycle.dispose();
+
+    expect(setStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        healthState: "error",
+        lastError: "sync exploded",
+      }),
+    );
+  });
+
   it("rejects a second concurrent fatal-stop waiter", async () => {
     const client = createClientEmitter();
     const lifecycle = createMatrixMonitorSyncLifecycle({

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts
@@ -114,6 +114,36 @@ describe("createMatrixMonitorSyncLifecycle", () => {
     );
   });
 
+  it("ignores non-terminal sync states emitted during intentional shutdown", async () => {
+    const client = createClientEmitter();
+    const setStatus = vi.fn();
+    let stopping = false;
+    const statusController = createMatrixMonitorStatusController({
+      accountId: "default",
+      statusSink: setStatus,
+    });
+    const lifecycle = createMatrixMonitorSyncLifecycle({
+      client: client as never,
+      statusController,
+      isStopping: () => stopping,
+    });
+
+    const waitPromise = lifecycle.waitForFatalStop();
+    stopping = true;
+    client.emit("sync.state", "ERROR", "RECONNECTING", new Error("shutdown noise"));
+    lifecycle.dispose();
+    statusController.markStopped();
+
+    await expect(waitPromise).resolves.toBeUndefined();
+    expect(setStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        accountId: "default",
+        healthState: "stopped",
+        lastError: null,
+      }),
+    );
+  });
+
   it("does not downgrade a fatal error to stopped during shutdown", async () => {
     const client = createClientEmitter();
     const setStatus = vi.fn();

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
@@ -36,10 +36,13 @@ export function createMatrixMonitorSyncLifecycle(params: {
   };
 
   const onSyncState = (state: MatrixSyncState, _prevState: string | null, error?: unknown) => {
-    params.statusController.noteSyncState(state, error);
     if (isMatrixTerminalSyncState(state) && !params.isStopping?.()) {
-      settleFatal(formatSyncLifecycleError(state, error));
+      const fatalError = formatSyncLifecycleError(state, error);
+      params.statusController.noteUnexpectedError(fatalError);
+      settleFatal(fatalError);
+      return;
     }
+    params.statusController.noteSyncState(state, error);
   };
 
   const onUnexpectedError = (error: Error) => {

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
@@ -43,10 +43,11 @@ export function createMatrixMonitorSyncLifecycle(params: {
   };
 
   const onUnexpectedError = (error: Error) => {
-    params.statusController.noteUnexpectedError(error);
-    if (!params.isStopping?.()) {
-      settleFatal(error);
+    if (params.isStopping?.()) {
+      return;
     }
+    params.statusController.noteUnexpectedError(error);
+    settleFatal(error);
   };
 
   params.client.on("sync.state", onSyncState);
@@ -56,6 +57,9 @@ export function createMatrixMonitorSyncLifecycle(params: {
     async waitForFatalStop(): Promise<void> {
       if (fatalError) {
         throw fatalError;
+      }
+      if (resolveFatalWait || rejectFatalWait) {
+        throw new Error("Matrix fatal-stop wait already in progress");
       }
       await new Promise<void>((resolve, reject) => {
         resolveFatalWait = resolve;

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
@@ -1,0 +1,73 @@
+import type { MatrixClient } from "../sdk.js";
+import type { MatrixSyncState } from "../sync-state.js";
+import type { MatrixMonitorStatusController } from "./status.js";
+
+function formatSyncLifecycleError(state: MatrixSyncState, error?: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  const message = typeof error === "string" && error.trim() ? error.trim() : undefined;
+  if (state === "STOPPED") {
+    return new Error(message ?? "Matrix sync stopped unexpectedly");
+  }
+  if (state === "ERROR") {
+    return new Error(message ?? "Matrix sync entered ERROR unexpectedly");
+  }
+  return new Error(message ?? `Matrix sync entered ${state} unexpectedly`);
+}
+
+export function createMatrixMonitorSyncLifecycle(params: {
+  client: MatrixClient;
+  statusController: MatrixMonitorStatusController;
+  isStopping?: () => boolean;
+}) {
+  let fatalError: Error | null = null;
+  let resolveFatalWait: (() => void) | null = null;
+  let rejectFatalWait: ((error: Error) => void) | null = null;
+
+  const settleFatal = (error: Error) => {
+    if (fatalError) {
+      return;
+    }
+    fatalError = error;
+    rejectFatalWait?.(error);
+    resolveFatalWait = null;
+    rejectFatalWait = null;
+  };
+
+  const onSyncState = (state: MatrixSyncState, _prevState: string | null, error?: unknown) => {
+    params.statusController.noteSyncState(state, error);
+    if (state === "STOPPED" && !params.isStopping?.()) {
+      settleFatal(formatSyncLifecycleError(state, error));
+    }
+  };
+
+  const onUnexpectedError = (error: Error) => {
+    params.statusController.noteUnexpectedError(error);
+    if (!params.isStopping?.()) {
+      settleFatal(error);
+    }
+  };
+
+  params.client.on("sync.state", onSyncState);
+  params.client.on("sync.unexpected_error", onUnexpectedError);
+
+  return {
+    async waitForFatalStop(): Promise<void> {
+      if (fatalError) {
+        throw fatalError;
+      }
+      await new Promise<void>((resolve, reject) => {
+        resolveFatalWait = resolve;
+        rejectFatalWait = (error) => reject(error);
+      });
+    },
+    dispose() {
+      resolveFatalWait?.();
+      resolveFatalWait = null;
+      rejectFatalWait = null;
+      params.client.off("sync.state", onSyncState);
+      params.client.off("sync.unexpected_error", onUnexpectedError);
+    },
+  };
+}

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
@@ -42,6 +42,9 @@ export function createMatrixMonitorSyncLifecycle(params: {
       settleFatal(fatalError);
       return;
     }
+    if (isMatrixTerminalSyncState(state) && fatalError) {
+      return;
+    }
     params.statusController.noteSyncState(state, error);
   };
 

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
@@ -1,5 +1,5 @@
 import type { MatrixClient } from "../sdk.js";
-import type { MatrixSyncState } from "../sync-state.js";
+import { isMatrixTerminalSyncState, type MatrixSyncState } from "../sync-state.js";
 import type { MatrixMonitorStatusController } from "./status.js";
 
 function formatSyncLifecycleError(state: MatrixSyncState, error?: unknown): Error {
@@ -37,7 +37,7 @@ export function createMatrixMonitorSyncLifecycle(params: {
 
   const onSyncState = (state: MatrixSyncState, _prevState: string | null, error?: unknown) => {
     params.statusController.noteSyncState(state, error);
-    if (state === "STOPPED" && !params.isStopping?.()) {
+    if (isMatrixTerminalSyncState(state) && !params.isStopping?.()) {
       settleFatal(formatSyncLifecycleError(state, error));
     }
   };

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
@@ -47,6 +47,12 @@ export function createMatrixMonitorSyncLifecycle(params: {
     if (fatalError) {
       return;
     }
+    // Operator-initiated shutdown can still emit transient sync states before
+    // the final STOPPED. Ignore that churn so intentional stops do not look
+    // like runtime failures.
+    if (params.isStopping?.() && !isMatrixTerminalSyncState(state)) {
+      return;
+    }
     params.statusController.noteSyncState(state, error);
   };
 

--- a/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
+++ b/extensions/matrix/src/matrix/monitor/sync-lifecycle.ts
@@ -42,7 +42,9 @@ export function createMatrixMonitorSyncLifecycle(params: {
       settleFatal(fatalError);
       return;
     }
-    if (isMatrixTerminalSyncState(state) && fatalError) {
+    // Fatal sync failures are sticky for telemetry; later SDK state churn during
+    // cleanup or reconnect should not overwrite the first recorded error.
+    if (fatalError) {
       return;
     }
     params.statusController.noteSyncState(state, error);

--- a/extensions/matrix/src/matrix/monitor/task-runner.ts
+++ b/extensions/matrix/src/matrix/monitor/task-runner.ts
@@ -1,0 +1,38 @@
+import type { RuntimeLogger } from "../../runtime-api.js";
+
+export function createMatrixMonitorTaskRunner(params: {
+  logger: RuntimeLogger;
+  logVerboseMessage: (message: string) => void;
+}) {
+  const inFlight = new Set<Promise<void>>();
+
+  const runDetachedTask = (label: string, task: () => Promise<void>): Promise<void> => {
+    let trackedTask!: Promise<void>;
+    trackedTask = Promise.resolve()
+      .then(task)
+      .catch((error) => {
+        const message = String(error);
+        params.logVerboseMessage(`matrix: ${label} failed (${message})`);
+        params.logger.warn("matrix background task failed", {
+          task: label,
+          error: message,
+        });
+      })
+      .finally(() => {
+        inFlight.delete(trackedTask);
+      });
+    inFlight.add(trackedTask);
+    return trackedTask;
+  };
+
+  const waitForIdle = async (): Promise<void> => {
+    while (inFlight.size > 0) {
+      await Promise.allSettled(Array.from(inFlight));
+    }
+  };
+
+  return {
+    runDetachedTask,
+    waitForIdle,
+  };
+}

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1070,6 +1070,36 @@ describe("MatrixClient event bridge", () => {
     await startExpectation;
   });
 
+  it("clears stale sync state before a restarted sync session waits for fresh readiness", async () => {
+    matrixJsClient.startClient = vi
+      .fn(async () => {
+        queueMicrotask(() => {
+          matrixJsClient.emit("sync", "PREPARED", null, undefined);
+        });
+      })
+      .mockImplementationOnce(async () => {
+        queueMicrotask(() => {
+          matrixJsClient.emit("sync", "PREPARED", null, undefined);
+        });
+      })
+      .mockImplementationOnce(async () => {});
+
+    const client = new MatrixClient("https://matrix.example.org", "token");
+
+    await client.start();
+    client.stopSyncWithoutPersist();
+
+    vi.useFakeTimers();
+    const restartPromise = client.start();
+    const restartExpectation = expect(restartPromise).rejects.toThrow(
+      "Matrix client did not reach a ready sync state within 30000ms",
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await restartExpectation;
+  });
+
   it("replays outstanding invite rooms at startup", async () => {
     matrixJsClient.getRooms = vi.fn(() => [
       {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -113,7 +113,7 @@ type MatrixJsClientStub = EventEmitter & {
 };
 
 function createMatrixJsClientStub(): MatrixJsClientStub {
-  const client = new EventEmitter();
+  const client = new EventEmitter() as MatrixJsClientStub;
   client.startClient = vi.fn(async () => {
     queueMicrotask(() => {
       client.emit("sync", "PREPARED", null, undefined);

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1027,6 +1027,34 @@ describe("MatrixClient event bridge", () => {
     });
   });
 
+  it("aborts before post-ready startup work when shutdown races ready sync", async () => {
+    matrixJsClient.startClient = vi.fn(async () => {
+      queueMicrotask(() => {
+        matrixJsClient.emit("sync", "PREPARED", null, undefined);
+      });
+    });
+
+    const abortController = new AbortController();
+    const client = new MatrixClient("https://matrix.example.org", "token");
+    const bootstrapCryptoSpy = vi.spyOn(
+      client as unknown as { bootstrapCryptoIfNeeded: () => Promise<void> },
+      "bootstrapCryptoIfNeeded",
+    );
+    bootstrapCryptoSpy.mockImplementation(async () => {});
+
+    client.on("sync.state", (state) => {
+      if (state === "PREPARED") {
+        abortController.abort();
+      }
+    });
+
+    await expect(client.start({ abortSignal: abortController.signal })).rejects.toMatchObject({
+      message: "Matrix startup aborted",
+      name: "AbortError",
+    });
+    expect(bootstrapCryptoSpy).not.toHaveBeenCalled();
+  });
+
   it("times out startup when no ready sync state arrives", async () => {
     vi.useFakeTimers();
     matrixJsClient.startClient = vi.fn(async () => {});

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -114,7 +114,11 @@ type MatrixJsClientStub = EventEmitter & {
 
 function createMatrixJsClientStub(): MatrixJsClientStub {
   const client = new EventEmitter() as MatrixJsClientStub;
-  client.startClient = vi.fn(async () => {});
+  client.startClient = vi.fn(async () => {
+    queueMicrotask(() => {
+      client.emit("sync", "PREPARED", null, undefined);
+    });
+  });
   client.stopClient = vi.fn();
   client.initRustCrypto = vi.fn(async () => {});
   client.getUserId = vi.fn(() => "@bot:example.org");
@@ -182,7 +186,12 @@ vi.mock("matrix-js-sdk/lib/matrix.js", async () => {
   );
   return {
     ...actual,
-    ClientEvent: { Event: "event", Room: "Room" },
+    ClientEvent: {
+      Event: "event",
+      Room: "Room",
+      Sync: "sync",
+      SyncUnexpectedError: "sync.unexpectedError",
+    },
     MatrixEventEvent: { Decrypted: "decrypted" },
     createClient: vi.fn((opts: Record<string, unknown>) => {
       lastCreateClientOpts = opts;
@@ -945,6 +954,62 @@ describe("MatrixClient event bridge", () => {
     });
 
     expect(invites).toEqual(["!invite:example.org"]);
+  });
+
+  it("waits for a ready sync state before resolving startup", async () => {
+    let releaseSyncReady: (() => void) | undefined;
+    matrixJsClient.startClient = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        releaseSyncReady = () => {
+          matrixJsClient.emit("sync", "PREPARED", null, undefined);
+          resolve();
+        };
+      });
+    });
+
+    const client = new MatrixClient("https://matrix.example.org", "token");
+    let resolved = false;
+    const startPromise = client.start().then(() => {
+      resolved = true;
+    });
+
+    await vi.waitFor(() => {
+      expect(releaseSyncReady).toEqual(expect.any(Function));
+    });
+    expect(resolved).toBe(false);
+
+    releaseSyncReady?.();
+    await startPromise;
+
+    expect(resolved).toBe(true);
+  });
+
+  it("rejects startup when sync reports an unexpected error before ready", async () => {
+    matrixJsClient.startClient = vi.fn(async () => {
+      const timer = setTimeout(() => {
+        matrixJsClient.emit("sync.unexpectedError", new Error("sync exploded"));
+      }, 0);
+      timer.unref?.();
+    });
+
+    const client = new MatrixClient("https://matrix.example.org", "token");
+
+    await expect(client.start()).rejects.toThrow("sync exploded");
+  });
+
+  it("times out startup when no ready sync state arrives", async () => {
+    vi.useFakeTimers();
+    matrixJsClient.startClient = vi.fn(async () => {});
+
+    const client = new MatrixClient("https://matrix.example.org", "token");
+    const startPromise = client.start();
+    const startExpectation = expect(startPromise).rejects.toThrow(
+      "Matrix client did not reach a ready sync state within 30000ms",
+    );
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    await startExpectation;
   });
 
   it("replays outstanding invite rooms at startup", async () => {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -113,7 +113,7 @@ type MatrixJsClientStub = EventEmitter & {
 };
 
 function createMatrixJsClientStub(): MatrixJsClientStub {
-  const client = new EventEmitter() as MatrixJsClientStub;
+  const client = new EventEmitter();
   client.startClient = vi.fn(async () => {
     queueMicrotask(() => {
       client.emit("sync", "PREPARED", null, undefined);
@@ -995,6 +995,36 @@ describe("MatrixClient event bridge", () => {
     const client = new MatrixClient("https://matrix.example.org", "token");
 
     await expect(client.start()).rejects.toThrow("sync exploded");
+  });
+
+  it("allows transient startup ERROR to recover into PREPARED", async () => {
+    matrixJsClient.startClient = vi.fn(async () => {
+      queueMicrotask(() => {
+        matrixJsClient.emit("sync", "ERROR", null, new Error("temporary outage"));
+        queueMicrotask(() => {
+          matrixJsClient.emit("sync", "PREPARED", "ERROR", undefined);
+        });
+      });
+    });
+
+    const client = new MatrixClient("https://matrix.example.org", "token");
+
+    await expect(client.start()).resolves.toBeUndefined();
+  });
+
+  it("aborts startup when the readiness wait is canceled", async () => {
+    matrixJsClient.startClient = vi.fn(async () => {});
+
+    const abortController = new AbortController();
+    const client = new MatrixClient("https://matrix.example.org", "token");
+    const startPromise = client.start({ abortSignal: abortController.signal });
+
+    abortController.abort();
+
+    await expect(startPromise).rejects.toMatchObject({
+      message: "Matrix startup aborted",
+      name: "AbortError",
+    });
   });
 
   it("times out startup when no ready sync state arrives", async () => {

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -536,6 +536,7 @@ export class MatrixClient {
       clearInterval(this.idbPersistTimer);
       this.idbPersistTimer = null;
     }
+    this.currentSyncState = null;
     this.client.stopClient();
     this.started = false;
   }

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -146,6 +146,18 @@ const MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS = {
   strict: true,
 } satisfies MatrixCryptoBootstrapOptions;
 
+function createMatrixStartupAbortError(): Error {
+  const error = new Error("Matrix startup aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfMatrixStartupAborted(abortSignal?: AbortSignal): void {
+  if (abortSignal?.aborted === true) {
+    throw createMatrixStartupAbortError();
+  }
+}
+
 function createMatrixExplicitBootstrapOptions(params?: {
   forceResetCrossSigning?: boolean;
 }): MatrixCryptoBootstrapOptions {
@@ -449,9 +461,7 @@ export class MatrixClient {
       };
 
       const onAbort = () => {
-        const error = new Error("Matrix startup aborted");
-        error.name = "AbortError";
-        settleReject(error);
+        settleReject(createMatrixStartupAbortError());
       };
 
       this.on("sync.state", onSyncState);
@@ -479,9 +489,11 @@ export class MatrixClient {
       return;
     }
 
+    throwIfMatrixStartupAborted(opts.abortSignal);
     await this.ensureCryptoSupportInitialized();
+    throwIfMatrixStartupAborted(opts.abortSignal);
     this.registerBridge();
-    await this.initializeCryptoIfNeeded();
+    await this.initializeCryptoIfNeeded(opts.abortSignal);
 
     await this.client.startClient({
       initialSyncLimit: this.initialSyncLimit,
@@ -490,9 +502,11 @@ export class MatrixClient {
       abortSignal: opts.abortSignal,
       timeoutMs: opts.readyTimeoutMs,
     });
+    throwIfMatrixStartupAborted(opts.abortSignal);
     if (opts.bootstrapCrypto && this.autoBootstrapCrypto) {
-      await this.bootstrapCryptoIfNeeded();
+      await this.bootstrapCryptoIfNeeded(opts.abortSignal);
     }
+    throwIfMatrixStartupAborted(opts.abortSignal);
     this.started = true;
     this.emitOutstandingInviteEvents();
     await this.refreshDmCache().catch(noop);
@@ -576,10 +590,11 @@ export class MatrixClient {
     await this.stopPersistPromise;
   }
 
-  private async bootstrapCryptoIfNeeded(): Promise<void> {
+  private async bootstrapCryptoIfNeeded(abortSignal?: AbortSignal): Promise<void> {
     if (!this.encryptionEnabled || !this.cryptoInitialized || this.cryptoBootstrapped) {
       return;
     }
+    throwIfMatrixStartupAborted(abortSignal);
     await this.ensureCryptoSupportInitialized();
     const crypto = this.client.getCrypto() as MatrixCryptoBootstrapApi | undefined;
     if (!crypto) {
@@ -593,6 +608,7 @@ export class MatrixClient {
       crypto,
       MATRIX_INITIAL_CRYPTO_BOOTSTRAP_OPTIONS,
     );
+    throwIfMatrixStartupAborted(abortSignal);
     if (!initial.crossSigningPublished || initial.ownDeviceVerified === false) {
       const status = await this.getOwnDeviceVerificationStatus();
       if (status.signedByOwner) {
@@ -610,6 +626,7 @@ export class MatrixClient {
             crypto,
             MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS,
           );
+          throwIfMatrixStartupAborted(abortSignal);
           if (repaired.crossSigningPublished && repaired.ownDeviceVerified !== false) {
             LogService.info(
               "MatrixClientLite",
@@ -633,26 +650,30 @@ export class MatrixClient {
     this.cryptoBootstrapped = true;
   }
 
-  private async initializeCryptoIfNeeded(): Promise<void> {
+  private async initializeCryptoIfNeeded(abortSignal?: AbortSignal): Promise<void> {
     if (!this.encryptionEnabled || this.cryptoInitialized) {
       return;
     }
+    throwIfMatrixStartupAborted(abortSignal);
     const { persistIdbToDisk, restoreIdbFromDisk } = await loadMatrixCryptoRuntime();
 
     // Restore persisted IndexedDB crypto store before initializing WASM crypto.
     await restoreIdbFromDisk(this.idbSnapshotPath);
+    throwIfMatrixStartupAborted(abortSignal);
 
     try {
       await this.client.initRustCrypto({
         cryptoDatabasePrefix: this.cryptoDatabasePrefix,
       });
       this.cryptoInitialized = true;
+      throwIfMatrixStartupAborted(abortSignal);
 
       // Persist the crypto store after successful init (captures fresh keys on first run).
       await persistIdbToDisk({
         snapshotPath: this.idbSnapshotPath,
         databasePrefix: this.cryptoDatabasePrefix,
       });
+      throwIfMatrixStartupAborted(abortSignal);
 
       // Periodically persist to capture new Olm sessions and room keys.
       this.idbPersistTimer = setInterval(() => {

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -44,6 +44,11 @@ import type {
   MessageEventContent,
 } from "./sdk/types.js";
 import type { MatrixVerificationSummary } from "./sdk/verification-manager.js";
+import {
+  isMatrixReadySyncState,
+  isMatrixTerminalSyncState,
+  type MatrixSyncState,
+} from "./sync-state.js";
 
 export { ConsoleLogger, LogService };
 export type {
@@ -221,6 +226,7 @@ export class MatrixClient {
   private readonly autoBootstrapCrypto: boolean;
   private stopPersistPromise: Promise<void> | null = null;
   private verificationSummaryListenerBound = false;
+  private currentSyncState: MatrixSyncState | null = null;
 
   readonly dms = {
     update: async (): Promise<boolean> => {
@@ -371,6 +377,76 @@ export class MatrixClient {
     await this.startSyncSession({ bootstrapCrypto: true });
   }
 
+  private async waitForInitialSyncReady(timeoutMs = 30_000): Promise<void> {
+    if (isMatrixReadySyncState(this.currentSyncState)) {
+      return;
+    }
+    if (isMatrixTerminalSyncState(this.currentSyncState)) {
+      throw new Error(`Matrix sync entered ${this.currentSyncState} during startup`);
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+      const cleanup = () => {
+        this.off("sync.state", onSyncState);
+        this.off("sync.unexpected_error", onUnexpectedError);
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = undefined;
+        }
+      };
+
+      const settleResolve = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        resolve();
+      };
+
+      const settleReject = (error: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(error);
+      };
+
+      const onSyncState = (state: MatrixSyncState, _prevState: string | null, error?: unknown) => {
+        if (isMatrixReadySyncState(state)) {
+          settleResolve();
+          return;
+        }
+        if (isMatrixTerminalSyncState(state)) {
+          settleReject(
+            new Error(
+              error instanceof Error && error.message
+                ? error.message
+                : `Matrix sync entered ${state} during startup`,
+            ),
+          );
+        }
+      };
+
+      const onUnexpectedError = (error: Error) => {
+        settleReject(error);
+      };
+
+      this.on("sync.state", onSyncState);
+      this.on("sync.unexpected_error", onUnexpectedError);
+      timeoutId = setTimeout(() => {
+        settleReject(
+          new Error(`Matrix client did not reach a ready sync state within ${timeoutMs}ms`),
+        );
+      }, timeoutMs);
+      timeoutId.unref?.();
+    });
+  }
+
   private async startSyncSession(opts: { bootstrapCrypto: boolean }): Promise<void> {
     if (this.started) {
       return;
@@ -383,6 +459,7 @@ export class MatrixClient {
     await this.client.startClient({
       initialSyncLimit: this.initialSyncLimit,
     });
+    await this.waitForInitialSyncReady();
     if (opts.bootstrapCrypto && this.autoBootstrapCrypto) {
       await this.bootstrapCryptoIfNeeded();
     }
@@ -1586,6 +1663,20 @@ export class MatrixClient {
     // Some SDK invite transitions are surfaced as room lifecycle events instead of raw timeline events.
     this.client.on(ClientEvent.Room, (room) => {
       this.emitMembershipForRoom(room);
+    });
+    this.client.on(
+      ClientEvent.Sync,
+      (state: MatrixSyncState, prevState: string | null, data?: unknown) => {
+        this.currentSyncState = state;
+        const error =
+          data && typeof data === "object" && "error" in data
+            ? (data as { error?: unknown }).error
+            : undefined;
+        this.emitter.emit("sync.state", state, prevState, error);
+      },
+    );
+    this.client.on(ClientEvent.SyncUnexpectedError, (error: Error) => {
+      this.emitter.emit("sync.unexpected_error", error);
     });
   }
 

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -44,6 +44,7 @@ import type {
   MessageEventContent,
 } from "./sdk/types.js";
 import type { MatrixVerificationSummary } from "./sdk/verification-manager.js";
+import { createMatrixStartupAbortError, throwIfMatrixStartupAborted } from "./startup-abort.js";
 import {
   isMatrixReadySyncState,
   isMatrixTerminalSyncState,
@@ -145,18 +146,6 @@ const MATRIX_AUTOMATIC_REPAIR_BOOTSTRAP_OPTIONS = {
   allowSecretStorageRecreateWithoutRecoveryKey: true,
   strict: true,
 } satisfies MatrixCryptoBootstrapOptions;
-
-function createMatrixStartupAbortError(): Error {
-  const error = new Error("Matrix startup aborted");
-  error.name = "AbortError";
-  return error;
-}
-
-function throwIfMatrixStartupAborted(abortSignal?: AbortSignal): void {
-  if (abortSignal?.aborted === true) {
-    throw createMatrixStartupAbortError();
-  }
-}
 
 function createMatrixExplicitBootstrapOptions(params?: {
   forceResetCrossSigning?: boolean;

--- a/extensions/matrix/src/matrix/sdk.ts
+++ b/extensions/matrix/src/matrix/sdk.ts
@@ -373,11 +373,21 @@ export class MatrixClient {
     }
   }
 
-  async start(): Promise<void> {
-    await this.startSyncSession({ bootstrapCrypto: true });
+  async start(opts: { abortSignal?: AbortSignal; readyTimeoutMs?: number } = {}): Promise<void> {
+    await this.startSyncSession({
+      bootstrapCrypto: true,
+      abortSignal: opts.abortSignal,
+      readyTimeoutMs: opts.readyTimeoutMs,
+    });
   }
 
-  private async waitForInitialSyncReady(timeoutMs = 30_000): Promise<void> {
+  private async waitForInitialSyncReady(
+    params: {
+      timeoutMs?: number;
+      abortSignal?: AbortSignal;
+    } = {},
+  ): Promise<void> {
+    const timeoutMs = params.timeoutMs ?? 30_000;
     if (isMatrixReadySyncState(this.currentSyncState)) {
       return;
     }
@@ -388,10 +398,12 @@ export class MatrixClient {
     await new Promise<void>((resolve, reject) => {
       let settled = false;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      const abortSignal = params.abortSignal;
 
       const cleanup = () => {
         this.off("sync.state", onSyncState);
         this.off("sync.unexpected_error", onUnexpectedError);
+        abortSignal?.removeEventListener("abort", onAbort);
         if (timeoutId) {
           clearTimeout(timeoutId);
           timeoutId = undefined;
@@ -436,8 +448,19 @@ export class MatrixClient {
         settleReject(error);
       };
 
+      const onAbort = () => {
+        const error = new Error("Matrix startup aborted");
+        error.name = "AbortError";
+        settleReject(error);
+      };
+
       this.on("sync.state", onSyncState);
       this.on("sync.unexpected_error", onUnexpectedError);
+      if (abortSignal?.aborted) {
+        onAbort();
+        return;
+      }
+      abortSignal?.addEventListener("abort", onAbort, { once: true });
       timeoutId = setTimeout(() => {
         settleReject(
           new Error(`Matrix client did not reach a ready sync state within ${timeoutMs}ms`),
@@ -447,7 +470,11 @@ export class MatrixClient {
     });
   }
 
-  private async startSyncSession(opts: { bootstrapCrypto: boolean }): Promise<void> {
+  private async startSyncSession(opts: {
+    bootstrapCrypto: boolean;
+    abortSignal?: AbortSignal;
+    readyTimeoutMs?: number;
+  }): Promise<void> {
     if (this.started) {
       return;
     }
@@ -459,7 +486,10 @@ export class MatrixClient {
     await this.client.startClient({
       initialSyncLimit: this.initialSyncLimit,
     });
-    await this.waitForInitialSyncReady();
+    await this.waitForInitialSyncReady({
+      abortSignal: opts.abortSignal,
+      timeoutMs: opts.readyTimeoutMs,
+    });
     if (opts.bootstrapCrypto && this.autoBootstrapCrypto) {
       await this.bootstrapCryptoIfNeeded();
     }

--- a/extensions/matrix/src/matrix/sdk/types.ts
+++ b/extensions/matrix/src/matrix/sdk/types.ts
@@ -1,3 +1,4 @@
+import type { MatrixSyncState } from "../sync-state.js";
 import type {
   MatrixVerificationRequestLike,
   MatrixVerificationSummary,
@@ -31,6 +32,8 @@ export type MatrixClientEventMap = {
   "room.failed_decryption": [roomId: string, event: MatrixRawEvent, error: Error];
   "room.invite": [roomId: string, event: MatrixRawEvent];
   "room.join": [roomId: string, event: MatrixRawEvent];
+  "sync.state": [state: MatrixSyncState, prevState: string | null, error?: unknown];
+  "sync.unexpected_error": [error: Error];
   "verification.summary": [summary: MatrixVerificationSummary];
 };
 

--- a/extensions/matrix/src/matrix/startup-abort.ts
+++ b/extensions/matrix/src/matrix/startup-abort.ts
@@ -1,0 +1,15 @@
+export function createMatrixStartupAbortError(): Error {
+  const error = new Error("Matrix startup aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+export function throwIfMatrixStartupAborted(abortSignal?: AbortSignal): void {
+  if (abortSignal?.aborted === true) {
+    throw createMatrixStartupAbortError();
+  }
+}
+
+export function isMatrixStartupAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}

--- a/extensions/matrix/src/matrix/startup-abort.ts
+++ b/extensions/matrix/src/matrix/startup-abort.ts
@@ -13,3 +13,32 @@ export function throwIfMatrixStartupAborted(abortSignal?: AbortSignal): void {
 export function isMatrixStartupAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
+
+export async function awaitMatrixStartupWithAbort<T>(
+  promise: Promise<T>,
+  abortSignal?: AbortSignal,
+): Promise<T> {
+  if (!abortSignal) {
+    return await promise;
+  }
+  if (abortSignal.aborted) {
+    throw createMatrixStartupAbortError();
+  }
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      abortSignal.removeEventListener("abort", onAbort);
+      reject(createMatrixStartupAbortError());
+    };
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        abortSignal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        abortSignal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}

--- a/extensions/matrix/src/matrix/sync-state.ts
+++ b/extensions/matrix/src/matrix/sync-state.ts
@@ -1,0 +1,26 @@
+export type MatrixSyncState =
+  | "PREPARED"
+  | "SYNCING"
+  | "CATCHUP"
+  | "RECONNECTING"
+  | "ERROR"
+  | "STOPPED"
+  | (string & {});
+
+export function isMatrixReadySyncState(
+  state: MatrixSyncState | null | undefined,
+): state is "PREPARED" | "SYNCING" | "CATCHUP" {
+  return state === "PREPARED" || state === "SYNCING" || state === "CATCHUP";
+}
+
+export function isMatrixDisconnectedSyncState(
+  state: MatrixSyncState | null | undefined,
+): state is "RECONNECTING" | "ERROR" | "STOPPED" {
+  return state === "RECONNECTING" || state === "ERROR" || state === "STOPPED";
+}
+
+export function isMatrixTerminalSyncState(
+  state: MatrixSyncState | null | undefined,
+): state is "ERROR" | "STOPPED" {
+  return state === "ERROR" || state === "STOPPED";
+}

--- a/extensions/matrix/src/matrix/sync-state.ts
+++ b/extensions/matrix/src/matrix/sync-state.ts
@@ -21,6 +21,7 @@ export function isMatrixDisconnectedSyncState(
 
 export function isMatrixTerminalSyncState(
   state: MatrixSyncState | null | undefined,
-): state is "ERROR" | "STOPPED" {
-  return state === "ERROR" || state === "STOPPED";
+): state is "STOPPED" {
+  // matrix-js-sdk can recover from ERROR to PREPARED during initial sync.
+  return state === "STOPPED";
 }


### PR DESCRIPTION
## Summary

- Problem: Matrix startup reported success before sync was actually ready, and detached Matrix monitor tasks could reject without an owner.
- Why it matters: a homeserver outage could escalate from a channel-scoped failure into a process-wide unhandled rejection crash loop, bypassing `gateway.channelMaxRestartsPerHour`.
- What changed: Matrix startup now waits for ready sync states, monitor status/fatal sync handling is owned inside the Matrix plugin, and detached monitor work is centrally contained and drained on shutdown.
- What did NOT change (scope boundary): no core Matrix special-casing in gateway orchestration, no new config surface, no global unhandled-rejection policy change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62376
- Related #62168
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Matrix plugin treated `matrix-js-sdk` startup as ready too early, then left background room-message/verification tasks detached from channel lifecycle ownership.
- Missing detection / guardrail: Matrix sync fatality and detached task rejection never fed back into the Matrix channel task, so global unhandled rejection policy killed the whole gateway before channel restart budgeting could apply.
- Contributing context (if known): `matrix-js-sdk` emits long-lived sync state transitions after `startClient()` returns, and replayed/in-flight events during outage windows made orphaned async failures much easier to hit.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/matrix/sdk.test.ts`, `extensions/matrix/src/matrix/monitor/index.test.ts`, `extensions/matrix/src/matrix/monitor/sync-lifecycle.test.ts`
- Scenario the test should lock in: startup does not resolve before ready sync, startup times out/fails on sync fatal, detached monitor task failures do not escape as unhandled rejections, and fatal sync errors reject the Matrix channel task.
- Why this is the smallest reliable guardrail: the bug lives at the Matrix SDK/monitor seam, below a full gateway e2e but above pure helper-local logic.
- Existing test that already covers this (if any): none sufficiently covered the startup-readiness or detached-task ownership seam.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Matrix startup now waits for real sync readiness before the channel is considered started.
- Fatal Matrix sync failures now stop/restart the Matrix channel instead of crashing the whole gateway process.
- Matrix channel runtime status now reflects `starting`, `healthy`, `error`, and `stopped` transitions more accurately.

## Diagram (if applicable)

```text
Before:
[matrix startClient returns] -> [Matrix marked started] -> [background task rejects] -> [global unhandled rejection] -> [gateway exits]

After:
[matrix startClient returns] -> [wait for ready sync] -> [background task or sync fatal] -> [Matrix channel task rejects] -> [gateway channel restart policy]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / local repo workspace
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): Matrix account with unreachable homeserver or fatal sync failure after startup

### Steps

1. Configure Matrix and start the gateway with an unreachable or failing homeserver.
2. Let Matrix startup or replayed inbound event handling hit a sync/background-task failure.
3. Observe whether the whole gateway exits or only the Matrix channel fails.

### Expected

- Matrix stays channel-scoped: startup waits for readiness, fatal sync failures reject the Matrix channel task, and gateway restart budgeting applies at the channel layer.

### Actual

- Before this change the gateway could exit from unhandled Matrix monitor rejections, bypassing channel restart controls.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted Matrix tests for startup readiness, startup timeout, unexpected sync fatal, detached room-message failure containment, and intentional shutdown STOPPED handling; local `pnpm build`.
- Edge cases checked: fatal sync error after startup, detached task rejection sink, intentional shutdown not misclassified as fatal, startup timeout branch with fake timers.
- What you did **not** verify: full repo `pnpm check` remains blocked by unrelated preexisting `tsgo` failures in `extensions/msteams/src/attachments.graph.test.ts`, `src/agents/subagent-registry.test.ts`, and `src/infra/host-env-security.test.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Matrix `sync.state = ERROR` remains SDK-owned reconnect behavior and is not automatically escalated into channel restart.
  - Mitigation: this PR only escalates clear fatal paths (`sync.unexpected_error`, unexpected STOPPED, startup readiness failure) to avoid fighting the SDK on transient reconnects.
