### PR TITLE
fix: prevent full re-render on every keystroke in webchat input

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -79,6 +79,11 @@ export async function handleAbortChat(host: ChatHost) {
     return;
   }
   host.chatMessage = "";
+  // chatMessage is intentionally non-reactive (@state removed) to avoid full
+  // re-renders on every keystroke.  Explicitly request an update so the
+  // textarea reflects the cleared draft — abortChatRun may not mutate any
+  // other reactive property, leaving the DOM stale.
+  (host as unknown as OpenClawApp).requestUpdate();
   await abortChatRun(host as unknown as OpenClawApp);
 }
 
@@ -127,6 +132,7 @@ async function sendChatMessageNow(
   const ok = Boolean(runId);
   if (!ok && opts?.previousDraft != null) {
     host.chatMessage = opts.previousDraft;
+    (host as unknown as OpenClawApp).requestUpdate();
   }
   if (!ok && opts?.previousAttachments) {
     host.chatAttachments = opts.previousAttachments;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -154,7 +154,9 @@ export class OpenClawApp extends LitElement {
   @state() sessionKey = this.settings.sessionKey;
   @state() chatLoading = false;
   @state() chatSending = false;
-  @state() chatMessage = "";
+  // Not @state — draft changes must not trigger full re-render on every keystroke.
+  // Textarea value is managed by the browser natively; Lit syncs it on other state changes.
+  chatMessage = "";
   @state() chatMessages: unknown[] = [];
   @state() chatToolMessages: unknown[] = [];
   @state() chatStreamSegments: Array<{ text: string; ts: number }> = [];

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1065,6 +1065,9 @@ export function renderChat(props: ChatProps) {
         if (prev !== null) {
           e.preventDefault();
           props.onDraftChange(prev);
+          // chatMessage is non-reactive; explicitly refresh so the
+          // textarea reflects the recalled history entry.
+          requestUpdate();
         }
         return;
       }
@@ -1072,6 +1075,9 @@ export function renderChat(props: ChatProps) {
         const next = inputHistory.down();
         e.preventDefault();
         props.onDraftChange(next ?? "");
+        // chatMessage is non-reactive; explicitly refresh so the
+        // textarea reflects the recalled history entry.
+        requestUpdate();
         return;
       }
     }


### PR DESCRIPTION
Rebased version of #61660. Removes @state() from chatMessage to stop Lit from scheduling a re-render on every property assignment, then adds a debounce for the message stream.