### PR TITLE
fix: add "file" param alias to tool display path resolution

### DIFF
--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -175,7 +175,7 @@ export function resolvePathArg(args: unknown): string | undefined {
   if (!record) {
     return undefined;
   }
-  for (const candidate of [record.path, record.file_path, record.filePath]) {
+  for (const candidate of [record.path, record.file, record.file_path, record.filePath]) {
     if (typeof candidate !== "string") {
       continue;
     }


### PR DESCRIPTION
Redo of #61868. Minimal 1-line fix: adds `file` to the candidate list in `resolvePathArg()` so that Read/Write/Edit tool summaries display the file path when the model uses the `file` parameter alias.

Fixes #54882