### PR TITLE
fix: add "file" param alias to tool display path resolution

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -5,6 +5,7 @@
     "detailKeys": [
       "command",
       "path",
+      "file",
       "url",
       "targetUrl",
       "targetId",

--- a/src/agents/tool-display-common.ts
+++ b/src/agents/tool-display-common.ts
@@ -175,7 +175,7 @@ export function resolvePathArg(args: unknown): string | undefined {
   if (!record) {
     return undefined;
   }
-  for (const candidate of [record.path, record.file_path, record.filePath]) {
+  for (const candidate of [record.path, record.file, record.file_path, record.filePath]) {
     if (typeof candidate !== "string") {
       continue;
     }


### PR DESCRIPTION
Redo of #61868. Minimal targeted fix that only adds the `file` param alias to tool display path resolution.

## Changes

**`src/agents/tool-display-common.ts`** — Added `record.file` to the candidate list in `resolvePathArg()`, so tools that use `"file"` instead of `"path"` / `"file_path"` / `"filePath"` will still resolve the display detail.

**`apps/shared/.../tool-display.json`** — Added `"file"` to the fallback `detailKeys` array so generic tools using the `file` param show the file path in the display summary.