### PR TITLE
Speed up Discord permission audits

### DIFF
--- a/extensions/discord/src/audit-core.ts
+++ b/extensions/discord/src/audit-core.ts
@@ -1,7 +1,4 @@
-import type {
-  DiscordGuildChannelConfig,
-  DiscordGuildEntry,
-} from "openclaw/plugin-sdk/config-runtime";
+import type { DiscordGuildEntry } from "openclaw/plugin-sdk/config-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 
@@ -23,8 +20,9 @@ export type DiscordChannelPermissionsAudit = {
 };
 
 const REQUIRED_CHANNEL_PERMISSIONS = ["ViewChannel", "SendMessages"] as const;
+const MAX_PARALLEL_DISCORD_AUDIT_CHANNELS = 6;
 
-function shouldAuditChannelConfig(config: DiscordGuildChannelConfig | undefined) {
+function shouldAuditChannelConfig(config: { enabled?: boolean } | undefined) {
   if (!config) {
     return true;
   }
@@ -57,7 +55,7 @@ export function listConfiguredGuildChannelKeys(
       if (channelId === "*") {
         continue;
       }
-      if (!shouldAuditChannelConfig(value as DiscordGuildChannelConfig | undefined)) {
+      if (!shouldAuditChannelConfig(value as { enabled?: boolean } | undefined)) {
         continue;
       }
       ids.add(channelId);
@@ -101,32 +99,46 @@ export async function auditDiscordChannelPermissionsWithFetcher(params: {
 
   const required = [...REQUIRED_CHANNEL_PERMISSIONS];
   const channels: DiscordChannelPermissionsAuditEntry[] = [];
+  channels.length = params.channelIds.length;
+  const workerCount = Math.min(params.channelIds.length, MAX_PARALLEL_DISCORD_AUDIT_CHANNELS);
+  let nextIndex = 0;
 
-  for (const channelId of params.channelIds) {
-    try {
-      const perms = await params.fetchChannelPermissions(channelId, {
-        token,
-        accountId: params.accountId ?? undefined,
-      });
-      const missing = required.filter((p) => !perms.permissions.includes(p));
-      channels.push({
-        channelId,
-        ok: missing.length === 0,
-        missing: missing.length ? missing : undefined,
-        error: null,
-        matchKey: channelId,
-        matchSource: "id",
-      });
-    } catch (err) {
-      channels.push({
-        channelId,
-        ok: false,
-        error: formatErrorMessage(err),
-        matchKey: channelId,
-        matchSource: "id",
-      });
-    }
-  }
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= params.channelIds.length) {
+          return;
+        }
+
+        const channelId = params.channelIds[index];
+        try {
+          const perms = await params.fetchChannelPermissions(channelId, {
+            token,
+            accountId: params.accountId ?? undefined,
+          });
+          const missing = required.filter((p) => !perms.permissions.includes(p));
+          channels[index] = {
+            channelId,
+            ok: missing.length === 0,
+            missing: missing.length ? missing : undefined,
+            error: null,
+            matchKey: channelId,
+            matchSource: "id",
+          };
+        } catch (err) {
+          channels[index] = {
+            channelId,
+            ok: false,
+            error: formatErrorMessage(err),
+            matchKey: channelId,
+            matchSource: "id",
+          };
+        }
+      }
+    }),
+  );
 
   return {
     ok: channels.every((c) => c.ok),

--- a/extensions/discord/src/audit.test.ts
+++ b/extensions/discord/src/audit.test.ts
@@ -141,4 +141,33 @@ describe("discord audit", () => {
     expect(collected.channelIds).toEqual(["111"]);
     expect(collected.unresolvedChannels).toBe(1);
   });
+
+  it("audits channels concurrently while preserving configured order", async () => {
+    let activeRequests = 0;
+    let maxConcurrentRequests = 0;
+    fetchChannelPermissionsDiscordMock.mockImplementation(async (channelId: string) => {
+      activeRequests += 1;
+      maxConcurrentRequests = Math.max(maxConcurrentRequests, activeRequests);
+      const delayMs = channelId === "111" ? 15 : channelId === "222" ? 1 : 5;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      activeRequests -= 1;
+      return {
+        channelId,
+        permissions: ["ViewChannel", "SendMessages"],
+        raw: "0",
+        isDm: false,
+      };
+    });
+
+    const audit = await auditDiscordChannelPermissionsWithFetcher({
+      token: "t",
+      accountId: "default",
+      channelIds: ["111", "222", "333"],
+      timeoutMs: 1000,
+      fetchChannelPermissions: fetchChannelPermissionsDiscordMock,
+    });
+
+    expect(maxConcurrentRequests).toBeGreaterThan(1);
+    expect(audit.channels.map((channel) => channel.channelId)).toEqual(["111", "222", "333"]);
+  });
 });

--- a/extensions/discord/src/send.permissions.ts
+++ b/extensions/discord/src/send.permissions.ts
@@ -1,7 +1,7 @@
 import type { RequestClient } from "@buape/carbon";
 import type { APIChannel, APIGuild, APIGuildMember, APIRole } from "discord-api-types/v10";
 import { ChannelType, PermissionFlagsBits, Routes } from "discord-api-types/v10";
-import { resolveDiscordRest } from "./client.js";
+import { createDiscordRestClient, resolveDiscordRest } from "./client.js";
 import type { DiscordPermissionsSummary, DiscordReactOpts } from "./send.types.js";
 
 const PERMISSION_ENTRIES = Object.entries(PermissionFlagsBits).filter(
@@ -9,6 +9,25 @@ const PERMISSION_ENTRIES = Object.entries(PermissionFlagsBits).filter(
 );
 const ALL_PERMISSIONS = PERMISSION_ENTRIES.reduce((acc, [, value]) => acc | value, 0n);
 const ADMINISTRATOR_BIT = PermissionFlagsBits.Administrator;
+const DISCORD_PERMISSION_CACHE_TTL_MS = 30_000;
+
+type DiscordGuildPermissionContext = {
+  botId: string;
+  member: APIGuildMember;
+  rolesById: Map<string, APIRole>;
+};
+
+type DiscordTimedCacheEntry<T> = {
+  expiresAt: number;
+  value?: T;
+  promise?: Promise<T>;
+};
+
+const discordBotIdCache = new Map<string, DiscordTimedCacheEntry<string>>();
+const discordGuildPermissionContextCache = new Map<
+  string,
+  DiscordTimedCacheEntry<DiscordGuildPermissionContext>
+>();
 
 function addPermissionBits(base: bigint, add?: string) {
   if (!add) {
@@ -52,6 +71,80 @@ async function fetchBotUserId(rest: RequestClient) {
     throw new Error("Failed to resolve bot user id");
   }
   return me.id;
+}
+
+function getDiscordGuildPermissionCacheKey(token: string, guildId: string) {
+  return `${token}\u0000${guildId}`;
+}
+
+async function getOrLoadDiscordTimedCacheEntry<T>(
+  cache: Map<string, DiscordTimedCacheEntry<T>>,
+  key: string,
+  load: () => Promise<T>,
+): Promise<T> {
+  const now = Date.now();
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > now) {
+    if (cached.value !== undefined) {
+      return cached.value;
+    }
+    if (cached.promise) {
+      return await cached.promise;
+    }
+  }
+
+  const promise = load()
+    .then((value) => {
+      cache.set(key, {
+        expiresAt: Date.now() + DISCORD_PERMISSION_CACHE_TTL_MS,
+        value,
+      });
+      return value;
+    })
+    .catch((err) => {
+      if (cache.get(key)?.promise === promise) {
+        cache.delete(key);
+      }
+      throw err;
+    });
+
+  cache.set(key, {
+    expiresAt: now + DISCORD_PERMISSION_CACHE_TTL_MS,
+    promise,
+  });
+  return await promise;
+}
+
+async function fetchDiscordGuildPermissionContext(
+  rest: RequestClient,
+  token: string,
+  guildId: string,
+): Promise<DiscordGuildPermissionContext> {
+  return await getOrLoadDiscordTimedCacheEntry(
+    discordGuildPermissionContextCache,
+    getDiscordGuildPermissionCacheKey(token, guildId),
+    async () => {
+      const botId = await getOrLoadDiscordTimedCacheEntry(
+        discordBotIdCache,
+        token,
+        async () => await fetchBotUserId(rest),
+      );
+      const [guild, member] = await Promise.all([
+        rest.get(Routes.guild(guildId)) as Promise<APIGuild>,
+        rest.get(Routes.guildMember(guildId, botId)) as Promise<APIGuildMember>,
+      ]);
+      return {
+        botId,
+        member,
+        rolesById: new Map<string, APIRole>((guild.roles ?? []).map((role) => [role.id, role])),
+      };
+    },
+  );
+}
+
+export function __resetDiscordPermissionCacheForTest() {
+  discordBotIdCache.clear();
+  discordGuildPermissionContextCache.clear();
 }
 
 /**
@@ -155,7 +248,7 @@ export async function fetchChannelPermissionsDiscord(
   channelId: string,
   opts: DiscordReactOpts = {},
 ): Promise<DiscordPermissionsSummary> {
-  const rest = resolveDiscordRest(opts);
+  const { rest, token } = createDiscordRestClient(opts, opts.cfg);
   const channel = (await rest.get(Routes.channel(channelId))) as APIChannel;
   const channelType = "type" in channel ? channel.type : undefined;
   const guildId = "guild_id" in channel ? channel.guild_id : undefined;
@@ -169,13 +262,11 @@ export async function fetchChannelPermissionsDiscord(
     };
   }
 
-  const botId = await fetchBotUserId(rest);
-  const [guild, member] = await Promise.all([
-    rest.get(Routes.guild(guildId)) as Promise<APIGuild>,
-    rest.get(Routes.guildMember(guildId, botId)) as Promise<APIGuildMember>,
-  ]);
-
-  const rolesById = new Map<string, APIRole>((guild.roles ?? []).map((role) => [role.id, role]));
+  const { botId, member, rolesById } = await fetchDiscordGuildPermissionContext(
+    rest,
+    token,
+    guildId,
+  );
   const everyoneRole = rolesById.get(guildId);
   let base = 0n;
   if (everyoneRole?.permissions) {

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -18,6 +18,7 @@ let sendMessageDiscord: typeof import("./send.js").sendMessageDiscord;
 let unpinMessageDiscord: typeof import("./send.js").unpinMessageDiscord;
 let loadWebMedia: typeof import("openclaw/plugin-sdk/web-media").loadWebMedia;
 let __resetDiscordDirectoryCacheForTest: typeof import("./directory-cache.js").__resetDiscordDirectoryCacheForTest;
+let __resetDiscordPermissionCacheForTest: typeof import("./send.permissions.js").__resetDiscordPermissionCacheForTest;
 let rememberDiscordDirectoryUser: typeof import("./directory-cache.js").rememberDiscordDirectoryUser;
 
 beforeAll(async () => {
@@ -38,11 +39,13 @@ beforeAll(async () => {
   ({ loadWebMedia } = await import("openclaw/plugin-sdk/web-media"));
   ({ __resetDiscordDirectoryCacheForTest, rememberDiscordDirectoryUser } =
     await import("./directory-cache.js"));
+  ({ __resetDiscordPermissionCacheForTest } = await import("./send.permissions.js"));
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
   __resetDiscordDirectoryCacheForTest();
+  __resetDiscordPermissionCacheForTest();
 });
 
 describe("sendMessageDiscord", () => {
@@ -591,6 +594,41 @@ describe("fetchChannelPermissionsDiscord", () => {
     });
     expect(res.permissions).toContain("Administrator");
     expect(res.permissions).toContain("ViewChannel");
+  });
+
+  it("reuses bot and guild permission context across channels in the same guild", async () => {
+    const { rest, getMock } = makeDiscordRest();
+    const perms = PermissionFlagsBits.ViewChannel | PermissionFlagsBits.SendMessages;
+    getMock
+      .mockResolvedValueOnce({
+        id: "chan1",
+        guild_id: "guild1",
+        permission_overwrites: [],
+      })
+      .mockResolvedValueOnce({ id: "bot1" })
+      .mockResolvedValueOnce({
+        id: "guild1",
+        roles: [{ id: "guild1", permissions: perms.toString() }],
+      })
+      .mockResolvedValueOnce({ roles: [] })
+      .mockResolvedValueOnce({
+        id: "chan2",
+        guild_id: "guild1",
+        permission_overwrites: [],
+      });
+
+    await fetchChannelPermissionsDiscord("chan1", { rest, token: "t" });
+    const second = await fetchChannelPermissionsDiscord("chan2", { rest, token: "t" });
+
+    expect(second.permissions).toContain("ViewChannel");
+    expect(second.permissions).toContain("SendMessages");
+    expect(getMock.mock.calls.map((call) => call[0])).toEqual([
+      Routes.channel("chan1"),
+      Routes.user("@me"),
+      Routes.guild("guild1"),
+      Routes.guildMember("guild1", "bot1"),
+      Routes.channel("chan2"),
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- speed up the Discord permission audit path that feeds `channels.status`
- audit Discord channel permissions with a small bounded worker pool while preserving output order
- cache Discord bot and guild/member permission context for 30 seconds to avoid repeated REST fetches across channels
- add regression coverage for concurrent ordered audits and cross-channel permission-context reuse

## Context
This fixes a slow Discord audit path that caused `openclaw channels status --probe --json` to time out when many Discord channels were configured, even though the gateway itself was healthy.

## Verification
- `node scripts/run-vitest.mjs run extensions/discord/src/audit.test.ts extensions/discord/src/send.sends-basic-channel-messages.test.ts`
- pre-commit `pnpm check` gate passed during commit creation