### PR TITLE
fix(auto-reply): support /activate alias in group activation command

### DIFF
--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -855,6 +855,20 @@ describe("control command parsing", () => {
     });
   });
 
+  it("supports /activate alias (not just /activation)", () => {
+    expect(parseActivationCommand("/activate mention")).toEqual({
+      hasCommand: true,
+      mode: "mention",
+    });
+    expect(parseActivationCommand("/activate always")).toEqual({
+      hasCommand: true,
+      mode: "always",
+    });
+    expect(parseActivationCommand("/activate")).toEqual({
+      hasCommand: true,
+    });
+  });
+
   it("treats bare commands as non-control", () => {
     expect(hasControlCommand("send")).toBe(false);
     expect(hasControlCommand("help")).toBe(false);

--- a/src/auto-reply/group-activation.ts
+++ b/src/auto-reply/group-activation.ts
@@ -28,10 +28,10 @@ export function parseActivationCommand(raw?: string): {
     const trimmedRest = rest.trimStart();
     return trimmedRest ? `/${cmd} ${trimmedRest}` : `/${cmd}`;
   });
-  const match = normalized.match(/^\/activation(?:\s+([a-zA-Z]+))?\s*$/i);
+  const match = normalized.match(/^\/activat(e|ion)(?:\s+([a-zA-Z]+))?\s*$/i);
   if (!match) {
     return { hasCommand: false };
   }
-  const mode = normalizeGroupActivation(match[1]);
+  const mode = normalizeGroupActivation(match[2]);
   return { hasCommand: true, mode };
 }


### PR DESCRIPTION
## Summary

The group activation command only recognized `/activation` but not `/activate`. The regex was `\/activation(?:\s+...)?` so typing `/activate mention` would silently do nothing.

Fix by updating the regex to accept both `/activate` and `/activation`: `\/activat(e|ion)(?:\s+...)`.

## Changes

- `src/auto-reply/group-activation.ts`: update command-match regex to accept both `/activate` and `/activation` (group index adjusted accordingly)
- `src/auto-reply/command-control.test.ts`: add test coverage for `/activate` alias

## Testing

Added test cases:
- `/activate mention` -> `{hasCommand: true, mode: "mention"}`
- `/activate always` -> `{hasCommand: true, mode: "always"}`
- `/activate` -> `{hasCommand: true}`

## Fixes

Fixes: #62827