### PR TITLE
fix(auto-reply): accept /activate as alias for /activation command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI: allow deployments to configure grouped chat message max-width with a validated `gateway.controlUi.chatMessageMaxWidth` setting instead of patching bundled CSS after upgrades. Fixes #67935. Thanks @xiew4589-lang.
+- Auto-reply/groups: accept `/activate` as an alias for `/activation` while preserving the documented `/activation` command. Fixes #62827.
 - Control UI/sessions: bound the default Sessions tab query to recent activity and fewer rows, avoiding expensive full-history loads while keeping filters editable. Fixes #76050. (#76051) Thanks @Neomail2.
 - Plugins/doctor: repair missing configured provider and channel plugins from ClawHub before npm fallback, preserving ClawPack metadata in the install record. Thanks @vincentkoc.
 - Gateway/channels: cap startup fanout at four channel/account handoffs and recover from Bonjour ciao self-probe races, reducing Windows startup stalls with many Telegram accounts. Fixes #75687.

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -1023,6 +1023,30 @@ describe("control command parsing", () => {
     });
   });
 
+  it("accepts /activate as alias for /activation", () => {
+    expect(parseActivationCommand("/activate mention")).toEqual({
+      hasCommand: true,
+      mode: "mention",
+    });
+    expect(parseActivationCommand("/activate always")).toEqual({
+      hasCommand: true,
+      mode: "always",
+    });
+    expect(parseActivationCommand("/activate: mention")).toEqual({
+      hasCommand: true,
+      mode: "mention",
+    });
+    expect(parseActivationCommand("/activate:")).toEqual({
+      hasCommand: true,
+    });
+    expect(parseActivationCommand("/activateion mention")).toEqual({
+      hasCommand: false,
+    });
+    expect(parseActivationCommand("activate mention")).toEqual({
+      hasCommand: false,
+    });
+  });
+
   it("treats bare commands as non-control", () => {
     expect(hasControlCommand("send")).toBe(false);
     expect(hasControlCommand("help")).toBe(false);

--- a/src/auto-reply/group-activation.ts
+++ b/src/auto-reply/group-activation.ts
@@ -28,7 +28,7 @@ export function parseActivationCommand(raw?: string): {
     const trimmedRest = rest.trimStart();
     return trimmedRest ? `/${cmd} ${trimmedRest}` : `/${cmd}`;
   });
-  const match = normalized.match(/^\/activation(?:\s+([a-zA-Z]+))?\s*$/i);
+  const match = normalized.match(/^\/activat(?:e|ion)(?:\s+([a-zA-Z]+))?\s*$/i);
   if (!match) {
     return { hasCommand: false };
   }


### PR DESCRIPTION
## Summary

- The `/activate mention` and `/activate always` commands were silently ignored because the parser regex only matched `/activation` exactly
- Changed regex from `/^\/activation.../` to `/^\/activate?ion.../` so both forms are accepted
- Added test cases covering `/activate mention`, `/activate always`, `/activate: mention`, `/activate:`, and bare `activate` (no slash, should still fail)

Fixes #62827

## Test plan
- [ ] `/activate mention` → sets group activation to mention
- [ ] `/activate always` → sets group activation to always
- [ ] `/activation mention` → still works (no regression)
- [ ] `activate mention` (no slash) → still ignored
- [ ] Unit tests in `src/auto-reply/command-control.test.ts` (auto-reply suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)