### PR TITLE
fix(webchat): suppress NO_REPLY prefix fragments and case variants in chat stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI: allow deployments to configure grouped chat message max-width with a validated `gateway.controlUi.chatMessageMaxWidth` setting instead of patching bundled CSS after upgrades. Fixes #67935. Thanks @xiew4589-lang.
+- Control UI/WebChat: suppress streamed `NO_REPLY` prefix leftovers, including terminal single-letter fragments, so silent replies do not appear as assistant messages.
+- Auto-reply/groups: accept `/activate` as an alias for `/activation` while preserving the documented `/activation` command. Fixes #62827.
 - Control UI/sessions: bound the default Sessions tab query to recent activity and fewer rows, avoiding expensive full-history loads while keeping filters editable. Fixes #76050. (#76051) Thanks @Neomail2.
 - Plugins/doctor: repair missing configured provider and channel plugins from ClawHub before npm fallback, preserving ClawPack metadata in the install record. Thanks @vincentkoc.
 - Gateway/channels: cap startup fanout at four channel/account handoffs and recover from Bonjour ciao self-probe races, reducing Windows startup stalls with many Telegram accounts. Fixes #75687.

--- a/src/auto-reply/command-control.test.ts
+++ b/src/auto-reply/command-control.test.ts
@@ -1023,6 +1023,30 @@ describe("control command parsing", () => {
     });
   });
 
+  it("accepts /activate as alias for /activation", () => {
+    expect(parseActivationCommand("/activate mention")).toEqual({
+      hasCommand: true,
+      mode: "mention",
+    });
+    expect(parseActivationCommand("/activate always")).toEqual({
+      hasCommand: true,
+      mode: "always",
+    });
+    expect(parseActivationCommand("/activate: mention")).toEqual({
+      hasCommand: true,
+      mode: "mention",
+    });
+    expect(parseActivationCommand("/activate:")).toEqual({
+      hasCommand: true,
+    });
+    expect(parseActivationCommand("/activateion mention")).toEqual({
+      hasCommand: false,
+    });
+    expect(parseActivationCommand("activate mention")).toEqual({
+      hasCommand: false,
+    });
+  });
+
   it("treats bare commands as non-control", () => {
     expect(hasControlCommand("send")).toBe(false);
     expect(hasControlCommand("help")).toBe(false);

--- a/src/auto-reply/group-activation.ts
+++ b/src/auto-reply/group-activation.ts
@@ -28,7 +28,7 @@ export function parseActivationCommand(raw?: string): {
     const trimmedRest = rest.trimStart();
     return trimmedRest ? `/${cmd} ${trimmedRest}` : `/${cmd}`;
   });
-  const match = normalized.match(/^\/activation(?:\s+([a-zA-Z]+))?\s*$/i);
+  const match = normalized.match(/^\/activat(?:e|ion)(?:\s+([a-zA-Z]+))?\s*$/i);
   if (!match) {
     return { hasCommand: false };
   }

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -223,7 +223,7 @@ describe("handleChatEvent", () => {
     expect(state.chatMessages).toEqual([]);
   });
 
-  it.each(["no_reply", "ANNOUNCE_SKIP", "REPLY_SKIP"])(
+  it.each(["ANNOUNCE_SKIP", "REPLY_SKIP"])(
     "keeps plain-text %s final payload from another run without clearing active stream",
     (text) => {
       const state = createActiveStreamingState();
@@ -582,7 +582,7 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe(null);
   });
 
-  it.each(["no_reply", "ANNOUNCE_SKIP", "REPLY_SKIP"])(
+  it.each(["ANNOUNCE_SKIP", "REPLY_SKIP"])(
     "keeps plain-text %s final payload from own run",
     (text) => {
       const state = createState({
@@ -640,6 +640,120 @@ describe("handleChatEvent", () => {
     } as unknown as ChatEventPayload;
 
     expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatMessages).toEqual([]);
+  });
+
+  it("does not persist NO_REPLY prefix fragment 'NO' on final without message", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "NO",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([]);
+  });
+
+  it("does not persist NO_REPLY prefix fragment 'NO_' on abort", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "NO_",
+      chatStreamStartedAt: 100,
+    });
+    const payload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+      message: "not-an-assistant-message",
+    } as unknown as ChatEventPayload;
+
+    expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatMessages).toEqual([]);
+  });
+
+  it("does not set chatStream for NO_REPLY prefix delta 'NO'", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: null,
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "text", text: "NO" }] },
+    };
+
+    handleChatEvent(state, payload);
+    expect(state.chatStream).toBe(null);
+  });
+
+  it("does not persist a terminal N leftover from a NO_REPLY stream", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: null,
+      chatStreamStartedAt: 100,
+    });
+
+    expect(
+      handleChatEvent(state, {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "delta",
+        message: { role: "assistant", content: [{ type: "text", text: "N" }] },
+      }),
+    ).toBe("delta");
+    expect(state.chatStream).toBe("N");
+
+    expect(
+      handleChatEvent(state, {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "delta",
+        message: { role: "assistant", content: [{ type: "text", text: "NO" }] },
+      }),
+    ).toBe("delta");
+    expect(state.chatStream).toBe("N");
+
+    expect(
+      handleChatEvent(state, {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "final",
+        message: { role: "assistant", content: [{ type: "text", text: "NO_REPLY" }] },
+      }),
+    ).toBe("final");
+    expect(state.chatMessages).toEqual([]);
+    expect(state.chatStream).toBe(null);
+  });
+
+  it("ignores case on NO_REPLY final — drops no_reply lowercase", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: "no_reply",
+      chatStreamStartedAt: 100,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "no_reply" }],
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
     expect(state.chatMessages).toEqual([]);
   });
 
@@ -710,12 +824,11 @@ describe("loadChatHistory", () => {
 
     await loadChatHistory(state);
 
-    expect(state.chatMessages).toHaveLength(5);
+    expect(state.chatMessages).toHaveLength(4);
     expect(state.chatMessages[0]).toEqual(messages[0]);
-    expect(state.chatMessages[1]).toEqual(messages[2]);
-    expect(state.chatMessages[2]).toEqual(messages[3]);
-    expect(state.chatMessages[3]).toEqual(messages[4]);
-    expect(state.chatMessages[4]).toEqual(messages[5]);
+    expect(state.chatMessages[1]).toEqual(messages[3]);
+    expect(state.chatMessages[2]).toEqual(messages[4]);
+    expect(state.chatMessages[3]).toEqual(messages[5]);
     expect(state.chatThinkingLevel).toBe("low");
     expect(state.chatLoading).toBe(false);
   });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -15,7 +15,7 @@ import {
 } from "./scope-errors.ts";
 
 const HEARTBEAT_TOKEN = "HEARTBEAT_OK";
-const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/i;
 const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
 const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
@@ -45,6 +45,36 @@ function shouldApplyChatHistoryResult(
 
 function isSilentReplyStream(text: string): boolean {
   return SILENT_REPLY_PATTERN.test(text);
+}
+
+/**
+ * Returns true when text looks like a streaming prefix fragment of NO_REPLY
+ * (e.g. "NO" or "NO_" mid-stream) so we don't persist it as visible output.
+ * Mirrors the server-side isSilentReplyPrefixText guard in auto-reply/tokens.ts.
+ */
+function isSilentReplyPrefixStream(text: string): boolean {
+  const trimmed = text.trimStart();
+  if (!trimmed) {
+    return false;
+  }
+  // Only suppress all-uppercase fragments; avoids hiding natural "No..." text.
+  if (trimmed !== trimmed.toUpperCase()) {
+    return false;
+  }
+  const normalized = trimmed.toUpperCase();
+  if (!normalized || normalized.length < 2 || /[^A-Z_]/.test(normalized)) {
+    return false;
+  }
+  const token = "NO_REPLY";
+  if (!token.startsWith(normalized)) {
+    return false;
+  }
+  // Require an underscore or the exact two-letter "NO" lead fragment.
+  return normalized.includes("_") || normalized === "NO";
+}
+
+function isSilentReplyTerminalStream(text: string): boolean {
+  return isSilentReplyStream(text) || isSilentReplyPrefixStream(text) || text.trimStart() === "N";
 }
 
 function escapeRegExp(value: string): string {
@@ -749,14 +779,18 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
 
   if (payload.state === "delta") {
     const next = extractText(payload.message);
-    if (typeof next === "string" && !isSilentReplyStream(next)) {
+    if (
+      typeof next === "string" &&
+      !isSilentReplyStream(next) &&
+      !isSilentReplyPrefixStream(next)
+    ) {
       state.chatStream = next;
     }
   } else if (payload.state === "final") {
     const finalMessage = normalizeFinalAssistantMessage(payload.message);
     if (finalMessage && !isAssistantSilentReply(finalMessage)) {
       state.chatMessages = [...state.chatMessages, finalMessage];
-    } else if (state.chatStream?.trim() && !isSilentReplyStream(state.chatStream)) {
+    } else if (state.chatStream?.trim() && !isSilentReplyTerminalStream(state.chatStream)) {
       state.chatMessages = [
         ...state.chatMessages,
         {
@@ -775,7 +809,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
       state.chatMessages = [...state.chatMessages, normalizedMessage];
     } else {
       const streamedText = state.chatStream ?? "";
-      if (streamedText.trim() && !isSilentReplyStream(streamedText)) {
+      if (streamedText.trim() && !isSilentReplyTerminalStream(streamedText)) {
         state.chatMessages = [
           ...state.chatMessages,
           {


### PR DESCRIPTION
## Summary

Two related bugs caused `NO_REPLY` sentinel text to appear as visible messages in the webchat UI:

**Bug 1 — Case-insensitivity:** `SILENT_REPLY_PATTERN` lacked the `/i` flag, so lowercase variants like `no_reply` bypassed the client-side guard (server-side uses case-insensitive matching).

**Bug 2 — Streaming prefix fragments:** While streaming, the model emits partial tokens (`"N"`, `"NO"`, `"NO_"`, …) before the complete `"NO_REPLY"`. These were set on `chatStream` and could be persisted as visible messages when the final payload arrived and the `chatStream` → message fallback path ran. Users would see a bare `"NO"` message in chat.

## Changes

- Add `/i` flag to `SILENT_REPLY_PATTERN` to match server-side behaviour in `auto-reply/tokens.ts`
- Add `isSilentReplyPrefixStream()` mirroring the server-side `isSilentReplyPrefixText` guard — only suppresses all-uppercase fragments that are strict prefixes of `NO_REPLY` (guards against hiding natural `"No…"` text)
- Apply prefix check in the delta handler and both `chatStream` fallback paths (`final` and `aborted`)

## Test plan
- [ ] `NO_REPLY` final → no message shown (existing)
- [ ] `no_reply` (lowercase) final → no message shown (new)
- [ ] Streaming fragment `"NO"` as delta → not set on `chatStream` (new)
- [ ] `"NO"` as `chatStream` when silent final arrives → not persisted as message (new)
- [ ] `"NO_"` as `chatStream` on abort → not persisted as message (new)
- [ ] Legitimate `"No, I can't do that"` message → still shown (guard only fires on all-uppercase)
- [ ] Unit tests: `ui/src/ui/controllers/chat.test.ts` (ui suite)

Fixes #62835

🤖 Generated with [Claude Code](https://claude.com/claude-code)