### PR TITLE
Slack: treat ACP block text as visible output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Z.AI: default onboarding and endpoint detection to GLM-5.1 instead of GLM-5. (#61998) Thanks @serg0x.
 - Reply execution: prefer the active runtime snapshot over stale queued reply config during embedded reply and follow-up execution so SecretRef-backed reply turns stop crashing after secrets have already resolved. (#62693) Thanks @mbelinky.
 - Android/manual connect: allow blank port input only for TLS manual gateway endpoints so standard HTTPS Tailscale hosts default to `443` without silently changing cleartext manual connects. (#63134) Thanks @Tyler-RNG.
+- Slack/ACP: treat Slack ACP block replies as visible delivered output so OpenClaw stops re-sending the final fallback text after Slack already rendered the reply. (#62858) Thanks @gumadeiras.
 
 ## 2026.4.5
 

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -92,6 +92,21 @@ function requireSlackListPeers() {
 }
 
 describe("slackPlugin actions", () => {
+  it("treats ACP block text as visible delivered output", () => {
+    expect(
+      slackPlugin.outbound?.shouldTreatDeliveredTextAsVisible?.({
+        kind: "block",
+        text: "hello",
+      }),
+    ).toBe(true);
+    expect(
+      slackPlugin.outbound?.shouldTreatDeliveredTextAsVisible?.({
+        kind: "tool",
+        text: "hello",
+      }),
+    ).toBe(false);
+  });
+
   it("prefers session lookup for announce target routing", () => {
     expect(slackPlugin.meta.preferSessionLookupForAnnounceTarget).toBe(true);
   });

--- a/extensions/slack/src/channel.test.ts
+++ b/extensions/slack/src/channel.test.ts
@@ -92,21 +92,6 @@ function requireSlackListPeers() {
 }
 
 describe("slackPlugin actions", () => {
-  it("treats ACP block text as visible delivered output", () => {
-    expect(
-      slackPlugin.outbound?.shouldTreatDeliveredTextAsVisible?.({
-        kind: "block",
-        text: "hello",
-      }),
-    ).toBe(true);
-    expect(
-      slackPlugin.outbound?.shouldTreatDeliveredTextAsVisible?.({
-        kind: "tool",
-        text: "hello",
-      }),
-    ).toBe(false);
-  });
-
   it("prefers session lookup for announce target routing", () => {
     expect(slackPlugin.meta.preferSessionLookupForAnnounceTarget).toBe(true);
   });
@@ -386,6 +371,21 @@ describe("slackPlugin outbound", () => {
       },
     },
   };
+
+  it("treats ACP block text as visible delivered output", () => {
+    expect(
+      slackPlugin.outbound?.shouldTreatDeliveredTextAsVisible?.({
+        kind: "block",
+        text: "hello",
+      }),
+    ).toBe(true);
+    expect(
+      slackPlugin.outbound?.shouldTreatDeliveredTextAsVisible?.({
+        kind: "tool",
+        text: "hello",
+      }),
+    ).toBe(false);
+  });
 
   it("advertises the 8000-character Slack default chunk limit", () => {
     expect(slackOutbound.textChunkLimit).toBe(8000);

--- a/extensions/slack/src/channel.ts
+++ b/extensions/slack/src/channel.ts
@@ -93,6 +93,15 @@ async function resolveSlackHandleAction() {
   );
 }
 
+function shouldTreatSlackDeliveredTextAsVisible(params: {
+  kind: "tool" | "block" | "final";
+  text?: string;
+}): boolean {
+  return (
+    params.kind === "block" && typeof params.text === "string" && params.text.trim().length > 0
+  );
+}
+
 // Select the appropriate Slack token for read/write operations.
 function getTokenForOperation(
   account: ResolvedSlackAccount,
@@ -565,6 +574,7 @@ export const slackPlugin: ChannelPlugin<ResolvedSlackAccount, SlackProbe> = crea
       deliveryMode: "direct",
       chunker: null,
       textChunkLimit: SLACK_TEXT_LIMIT,
+      shouldTreatDeliveredTextAsVisible: shouldTreatSlackDeliveredTextAsVisible,
       shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload }) =>
         shouldSuppressLocalSlackExecApprovalPrompt({
           cfg,

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -35,7 +35,7 @@ const routeMocks = vi.hoisted(() => ({
 
 const channelPluginMocks = vi.hoisted(() => ({
   getChannelPlugin: vi.fn((channelId: string) => {
-    if (channelId !== "discord" && channelId !== "telegram") {
+    if (channelId !== "discord" && channelId !== "slack" && channelId !== "telegram") {
       return undefined;
     }
     return {
@@ -1019,6 +1019,36 @@ describe("tryDispatchAcpReply", () => {
     );
   });
 
+  it("does not deliver final fallback text when routed Slack block text was already visible", async () => {
+    setReadyAcpResolution();
+    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    queueTtsReplies(
+      { text: "Shared update." },
+      {} as ReturnType<typeof ttsMocks.maybeApplyTtsToPayload>,
+    );
+    mockRoutedTextTurn("Shared update.");
+
+    const { dispatcher } = createDispatcher();
+    const result = await runDispatch({
+      bodyForAgent: "run acp",
+      dispatcher,
+      shouldRouteToOriginating: true,
+      originatingChannel: "slack",
+      originatingTo: "channel:C123",
+    });
+
+    expect(result?.counts.block).toBe(1);
+    expect(result?.counts.final).toBe(0);
+    expect(routeMocks.routeReply).toHaveBeenCalledTimes(1);
+    expect(routeMocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "slack",
+        to: "channel:C123",
+        payload: expect.objectContaining({ text: "Shared update." }),
+      }),
+    );
+  });
+
   it("does not deliver final fallback text when direct block text was already visible", async () => {
     setReadyAcpResolution();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
@@ -1070,6 +1100,35 @@ describe("tryDispatchAcpReply", () => {
     expect(counts.final).toBe(0);
     expect(dispatcher.sendBlockReply).toHaveBeenCalledWith(
       expect.objectContaining({ text: "Received." }),
+    );
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("does not deliver final fallback text when direct Slack block text was already visible", async () => {
+    setReadyAcpResolution();
+    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    queueTtsReplies(
+      { text: "Slack says hi." },
+      {} as ReturnType<typeof ttsMocks.maybeApplyTtsToPayload>,
+    );
+    mockVisibleTextTurn("Slack says hi.");
+
+    const { dispatcher, counts } = createDispatcher();
+    const result = await runDispatch({
+      bodyForAgent: "reply",
+      dispatcher,
+      ctxOverrides: {
+        Provider: "slack",
+        Surface: "slack",
+      },
+    });
+
+    expect(result?.counts.block).toBe(0);
+    expect(result?.counts.final).toBe(0);
+    expect(counts.block).toBe(0);
+    expect(counts.final).toBe(0);
+    expect(dispatcher.sendBlockReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Slack says hi." }),
     );
     expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- mark Slack ACP block text as visible delivered output
- prevent ACP fallback text from being re-sent after Slack already showed the block reply
- cover the Slack outbound visibility contract with a regression test

## Testing
- pnpm test extensions/slack/src/channel.test.ts src/auto-reply/reply/dispatch-acp-delivery.test.ts
