### PR TITLE
fix: use curl instead of node -e fetch in HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -270,6 +270,6 @@ USER node
 #   - GET /healthz (liveness) and GET /readyz (readiness)
 #   - aliases: /health and /ready
 # For external access from host/ingress, override bind to "lan" and set auth.
-HEALTHCHECK --interval=3m --timeout=10s --start-period=15s --retries=3 \
-  CMD node -e "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+HEALTHCHECK --interval=3m --timeout=10s --start-period=60s --retries=3 \
+  CMD curl -f http://127.0.0.1:18789/healthz
 CMD ["node", "openclaw.mjs", "gateway", "--allow-unconfigured"]


### PR DESCRIPTION
## Problem

Docker HEALTHCHECK using `node -e fetch` is unreliable in Node 24+:

1. `fetch()` is asynchronous — the process exits before the promise resolves, causing intermittent failures
2. Node 24's fetch implementation may not be fully initialized during container startup

## Fix

Replace the HEALTHCHECK with `curl -f` which is:
- Synchronous and reliable
- Already installed in the runtime image (line 162 of Dockerfile)

Also increase `--start-period` from 15s to 60s to accommodate slower container initialization.

**Before:**
```
HEALTHCHECK --interval=3m --timeout=10s --start-period=15s --retries=3   CMD node -e "fetch('http://127.0.0.1:18789/healthz').then((r)=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
```

**After:**
```
HEALTHCHECK --interval=3m --timeout=10s --start-period=60s --retries=3   CMD curl -f http://127.0.0.1:18789/healthz
```

Fixes #62850