### PR TITLE
fix(slack): honor HTTPS_PROXY for Socket Mode WebSocket connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- Slack: honor ambient HTTP(S) proxy settings for Socket Mode WebSocket connections, including NO_PROXY exclusions, so proxy-only deployments can connect without a monkey patch. (#62878) Thanks @mjamiv.
+
 ## 2026.4.7-1
 
 ### Fixes

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "dependencies": {
     "@slack/bolt": "^4.6.0",
-    "@slack/web-api": "^7.15.0"
+    "@slack/web-api": "^7.15.0",
+    "https-proxy-agent": "^9.0.0"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@slack/web-api", () => {
   const WebClient = vi.fn(function WebClientMock(
@@ -79,5 +79,74 @@ describe("slack web client config", () => {
         retryConfig: SLACK_WRITE_RETRY_OPTIONS,
       }),
     );
+  });
+});
+
+describe("slack proxy agent", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Clear all proxy env vars before each test
+    for (const key of ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"]) {
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    // Restore original env
+    for (const key of ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"]) {
+      if (originalEnv[key] !== undefined) {
+        process.env[key] = originalEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  it("sets agent from HTTPS_PROXY env var", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeDefined();
+    expect(options.agent!.constructor.name).toBe("HttpsProxyAgent");
+  });
+
+  it("falls back to HTTP_PROXY when HTTPS_PROXY is not set", () => {
+    process.env.HTTP_PROXY = "http://proxy.example.com:3128";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeDefined();
+  });
+
+  it("does not set agent when no proxy env var is configured", () => {
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeUndefined();
+  });
+
+  it("does not override an explicitly provided agent", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    const customAgent = {} as never;
+    const options = resolveSlackWebClientOptions({ agent: customAgent });
+
+    expect(options.agent).toBe(customAgent);
+  });
+
+  it("prefers lowercase https_proxy over uppercase", () => {
+    process.env.https_proxy = "http://lower.example.com:3128";
+    process.env.HTTPS_PROXY = "http://upper.example.com:3128";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeDefined();
+    // HttpsProxyAgent stores the proxy URL — verify it picked the lower-case one
+    expect((options.agent as { proxy: { href: string } }).proxy.href).toContain("lower.example.com");
+  });
+
+  it("also applies proxy agent to write client options", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    const options = resolveSlackWriteClientOptions();
+
+    expect(options.agent).toBeDefined();
+    expect(options.agent!.constructor.name).toBe("HttpsProxyAgent");
   });
 });

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -85,7 +85,14 @@ describe("slack web client config", () => {
 describe("slack proxy agent", () => {
   const originalEnv = { ...process.env };
 
-  const PROXY_KEYS = ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy", "NO_PROXY", "no_proxy"];
+  const PROXY_KEYS = [
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "https_proxy",
+    "http_proxy",
+    "NO_PROXY",
+    "no_proxy",
+  ];
 
   beforeEach(() => {
     for (const key of PROXY_KEYS) {
@@ -139,7 +146,17 @@ describe("slack proxy agent", () => {
 
     expect(options.agent).toBeDefined();
     // HttpsProxyAgent stores the proxy URL — verify it picked the lower-case one
-    expect((options.agent as { proxy: { href: string } }).proxy.href).toContain("lower.example.com");
+    expect((options.agent as unknown as { proxy: { href: string } }).proxy.href).toContain(
+      "lower.example.com",
+    );
+  });
+
+  it("treats empty lowercase https_proxy as authoritative over uppercase", () => {
+    process.env.https_proxy = "";
+    process.env.HTTPS_PROXY = "http://upper.example.com:3128";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeUndefined();
   });
 
   it("also applies proxy agent to write client options", () => {
@@ -161,6 +178,14 @@ describe("slack proxy agent", () => {
   it("respects no_proxy (lowercase) excluding .slack.com", () => {
     process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
     process.env.no_proxy = ".slack.com";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeUndefined();
+  });
+
+  it("respects space-separated no_proxy entries", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    process.env.no_proxy = "localhost *.slack.com";
     const options = resolveSlackWebClientOptions();
 
     expect(options.agent).toBeUndefined();

--- a/extensions/slack/src/client.test.ts
+++ b/extensions/slack/src/client.test.ts
@@ -85,16 +85,16 @@ describe("slack web client config", () => {
 describe("slack proxy agent", () => {
   const originalEnv = { ...process.env };
 
+  const PROXY_KEYS = ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy", "NO_PROXY", "no_proxy"];
+
   beforeEach(() => {
-    // Clear all proxy env vars before each test
-    for (const key of ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"]) {
+    for (const key of PROXY_KEYS) {
       delete process.env[key];
     }
   });
 
   afterEach(() => {
-    // Restore original env
-    for (const key of ["HTTPS_PROXY", "HTTP_PROXY", "https_proxy", "http_proxy"]) {
+    for (const key of PROXY_KEYS) {
       if (originalEnv[key] !== undefined) {
         process.env[key] = originalEnv[key];
       } else {
@@ -148,5 +148,45 @@ describe("slack proxy agent", () => {
 
     expect(options.agent).toBeDefined();
     expect(options.agent!.constructor.name).toBe("HttpsProxyAgent");
+  });
+
+  it("respects NO_PROXY excluding slack.com", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    process.env.NO_PROXY = "localhost,slack.com,.internal.corp";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeUndefined();
+  });
+
+  it("respects no_proxy (lowercase) excluding .slack.com", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    process.env.no_proxy = ".slack.com";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeUndefined();
+  });
+
+  it("respects NO_PROXY wildcard", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    process.env.NO_PROXY = "*";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeUndefined();
+  });
+
+  it("does not skip proxy when NO_PROXY excludes unrelated hosts", () => {
+    process.env.HTTPS_PROXY = "http://proxy.example.com:3128";
+    process.env.NO_PROXY = "localhost,.internal.corp";
+    const options = resolveSlackWebClientOptions();
+
+    expect(options.agent).toBeDefined();
+  });
+
+  it("degrades gracefully on malformed proxy URL", () => {
+    process.env.HTTPS_PROXY = "not-a-valid-url://:::bad";
+    const options = resolveSlackWebClientOptions();
+
+    // Should not throw; falls back to no agent
+    expect(options.agent).toBeUndefined();
   });
 });

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -1,5 +1,6 @@
 import { type RetryOptions, type WebClientOptions, WebClient } from "@slack/web-api";
 import { HttpsProxyAgent } from "https-proxy-agent";
+import { resolveEnvHttpProxyUrl } from "openclaw/plugin-sdk/infra-runtime";
 
 export const SLACK_DEFAULT_RETRY_OPTIONS: RetryOptions = {
   retries: 2,
@@ -17,43 +18,32 @@ export const SLACK_WRITE_RETRY_OPTIONS: RetryOptions = {
  * Check whether a hostname is excluded from proxying by `NO_PROXY` / `no_proxy`.
  * Supports comma-separated entries with optional leading dots (e.g. `.slack.com`).
  */
-function isHostExcludedByNoProxy(
-  hostname: string,
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
+function isHostExcludedByNoProxy(hostname: string, env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env.no_proxy ?? env.NO_PROXY;
   if (!raw) {
     return false;
   }
-  const entries = raw.split(",").map((e) => e.trim().toLowerCase()).filter(Boolean);
+  const entries = raw
+    .split(/[,\s]+/)
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
   const lower = hostname.toLowerCase();
   for (const entry of entries) {
     if (entry === "*") {
       return true;
     }
-    // Strip optional leading dot for comparison so `.slack.com` matches both
-    // `slack.com` (apex) and `wss-primary.slack.com` (subdomain).
-    const bare = entry.startsWith(".") ? entry.slice(1) : entry;
+    // Strip optional wildcard/leading dot so `*.slack.com` and `.slack.com`
+    // match both `slack.com` (apex) and Slack subdomains.
+    const bare = entry.startsWith("*.")
+      ? entry.slice(2)
+      : entry.startsWith(".")
+        ? entry.slice(1)
+        : entry;
     if (lower === bare || lower.endsWith(`.${bare}`)) {
       return true;
     }
   }
   return false;
-}
-
-/**
- * Resolve the proxy URL from env vars following undici EnvHttpProxyAgent
- * semantics: lower-case takes precedence, HTTPS prefers https_proxy then
- * falls back to http_proxy.  Returns `undefined` when no proxy is configured.
- */
-function resolveProxyUrlFromEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
-  return (
-    env.https_proxy?.trim() ||
-    env.HTTPS_PROXY?.trim() ||
-    env.http_proxy?.trim() ||
-    env.HTTP_PROXY?.trim() ||
-    undefined
-  );
 }
 
 /**
@@ -72,7 +62,7 @@ function resolveProxyUrlFromEnv(env: NodeJS.ProcessEnv = process.env): string | 
  * are excluded by `NO_PROXY`.
  */
 function resolveSlackProxyAgent(): HttpsProxyAgent<string> | undefined {
-  const proxyUrl = resolveProxyUrlFromEnv();
+  const proxyUrl = resolveEnvHttpProxyUrl("https");
   if (!proxyUrl) {
     return undefined;
   }
@@ -81,7 +71,7 @@ function resolveSlackProxyAgent(): HttpsProxyAgent<string> | undefined {
     return undefined;
   }
   try {
-    return new HttpsProxyAgent<string>(proxyUrl);
+    return new HttpsProxyAgent(proxyUrl);
   } catch {
     // Malformed proxy URL — degrade gracefully to direct connection.
     return undefined;

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -14,6 +14,47 @@ export const SLACK_WRITE_RETRY_OPTIONS: RetryOptions = {
 };
 
 /**
+ * Check whether a hostname is excluded from proxying by `NO_PROXY` / `no_proxy`.
+ * Supports comma-separated entries with optional leading dots (e.g. `.slack.com`).
+ */
+function isHostExcludedByNoProxy(
+  hostname: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const raw = env.no_proxy ?? env.NO_PROXY;
+  if (!raw) {
+    return false;
+  }
+  const entries = raw.split(",").map((e) => e.trim().toLowerCase()).filter(Boolean);
+  const lower = hostname.toLowerCase();
+  for (const entry of entries) {
+    if (entry === "*") {
+      return true;
+    }
+    // Exact match or suffix match (with leading dot)
+    if (lower === entry || lower.endsWith(entry.startsWith(".") ? entry : `.${entry}`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve the proxy URL from env vars following undici EnvHttpProxyAgent
+ * semantics: lower-case takes precedence, HTTPS prefers https_proxy then
+ * falls back to http_proxy.  Returns `undefined` when no proxy is configured.
+ */
+function resolveProxyUrlFromEnv(env: NodeJS.ProcessEnv = process.env): string | undefined {
+  return (
+    env.https_proxy?.trim() ||
+    env.HTTPS_PROXY?.trim() ||
+    env.http_proxy?.trim() ||
+    env.HTTP_PROXY?.trim() ||
+    undefined
+  );
+}
+
+/**
  * Build an HTTPS proxy agent from env vars (HTTPS_PROXY, HTTP_PROXY, etc.)
  * for use as the `agent` option in Slack WebClient and Socket Mode connections.
  *
@@ -22,21 +63,27 @@ export const SLACK_WRITE_RETRY_OPTIONS: RetryOptions = {
  * WebSocket upgrade request through the proxy.  This fixes Socket Mode in
  * environments where outbound traffic must go through an HTTP CONNECT proxy.
  *
- * Returns `undefined` when no proxy env var is configured.
+ * Respects `NO_PROXY` / `no_proxy` — if `*.slack.com` (or a matching pattern)
+ * appears in the exclusion list, returns `undefined` so the connection is direct.
+ *
+ * Returns `undefined` when no proxy env var is configured or when Slack hosts
+ * are excluded by `NO_PROXY`.
  */
 function resolveSlackProxyAgent(): HttpsProxyAgent<string> | undefined {
-  // Match undici EnvHttpProxyAgent semantics: lower-case takes precedence,
-  // HTTPS prefers https_proxy then falls back to http_proxy.
-  const proxyUrl =
-    process.env.https_proxy?.trim() ||
-    process.env.HTTPS_PROXY?.trim() ||
-    process.env.http_proxy?.trim() ||
-    process.env.HTTP_PROXY?.trim() ||
-    undefined;
+  const proxyUrl = resolveProxyUrlFromEnv();
   if (!proxyUrl) {
     return undefined;
   }
-  return new HttpsProxyAgent<string>(proxyUrl);
+  // Slack Socket Mode connects to these hosts; skip proxy if excluded.
+  if (isHostExcludedByNoProxy("slack.com")) {
+    return undefined;
+  }
+  try {
+    return new HttpsProxyAgent<string>(proxyUrl);
+  } catch {
+    // Malformed proxy URL — degrade gracefully to direct connection.
+    return undefined;
+  }
 }
 
 export function resolveSlackWebClientOptions(options: WebClientOptions = {}): WebClientOptions {

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -31,8 +31,10 @@ function isHostExcludedByNoProxy(
     if (entry === "*") {
       return true;
     }
-    // Exact match or suffix match (with leading dot)
-    if (lower === entry || lower.endsWith(entry.startsWith(".") ? entry : `.${entry}`)) {
+    // Strip optional leading dot for comparison so `.slack.com` matches both
+    // `slack.com` (apex) and `wss-primary.slack.com` (subdomain).
+    const bare = entry.startsWith(".") ? entry.slice(1) : entry;
+    if (lower === bare || lower.endsWith(`.${bare}`)) {
       return true;
     }
   }

--- a/extensions/slack/src/client.ts
+++ b/extensions/slack/src/client.ts
@@ -1,4 +1,5 @@
 import { type RetryOptions, type WebClientOptions, WebClient } from "@slack/web-api";
+import { HttpsProxyAgent } from "https-proxy-agent";
 
 export const SLACK_DEFAULT_RETRY_OPTIONS: RetryOptions = {
   retries: 2,
@@ -12,9 +13,36 @@ export const SLACK_WRITE_RETRY_OPTIONS: RetryOptions = {
   retries: 0,
 };
 
+/**
+ * Build an HTTPS proxy agent from env vars (HTTPS_PROXY, HTTP_PROXY, etc.)
+ * for use as the `agent` option in Slack WebClient and Socket Mode connections.
+ *
+ * When set, this agent is forwarded through @slack/bolt → @slack/socket-mode →
+ * SlackWebSocket as the `httpAgent`, which the `ws` library uses to tunnel the
+ * WebSocket upgrade request through the proxy.  This fixes Socket Mode in
+ * environments where outbound traffic must go through an HTTP CONNECT proxy.
+ *
+ * Returns `undefined` when no proxy env var is configured.
+ */
+function resolveSlackProxyAgent(): HttpsProxyAgent<string> | undefined {
+  // Match undici EnvHttpProxyAgent semantics: lower-case takes precedence,
+  // HTTPS prefers https_proxy then falls back to http_proxy.
+  const proxyUrl =
+    process.env.https_proxy?.trim() ||
+    process.env.HTTPS_PROXY?.trim() ||
+    process.env.http_proxy?.trim() ||
+    process.env.HTTP_PROXY?.trim() ||
+    undefined;
+  if (!proxyUrl) {
+    return undefined;
+  }
+  return new HttpsProxyAgent<string>(proxyUrl);
+}
+
 export function resolveSlackWebClientOptions(options: WebClientOptions = {}): WebClientOptions {
   return {
     ...options,
+    agent: options.agent ?? resolveSlackProxyAgent(),
     retryConfig: options.retryConfig ?? SLACK_DEFAULT_RETRY_OPTIONS,
   };
 }
@@ -22,6 +50,7 @@ export function resolveSlackWebClientOptions(options: WebClientOptions = {}): We
 export function resolveSlackWriteClientOptions(options: WebClientOptions = {}): WebClientOptions {
   return {
     ...options,
+    agent: options.agent ?? resolveSlackProxyAgent(),
     retryConfig: options.retryConfig ?? SLACK_WRITE_RETRY_OPTIONS,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,6 +941,9 @@ importers:
       '@slack/web-api':
         specifier: ^7.15.0
         version: 7.15.0
+      https-proxy-agent:
+        specifier: ^9.0.0
+        version: 9.0.0
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Slack Socket Mode ignores `HTTPS_PROXY`/`HTTP_PROXY` env vars — the `ws` library opens a direct WebSocket connection to `wss-primary.slack.com`, bypassing any configured proxy. This breaks Socket Mode in proxy-only environments (sandboxed containers, corporate networks, NVIDIA OpenShell).

This PR creates an `HttpsProxyAgent` from proxy env vars and passes it as the `agent` option through `@slack/bolt` → `@slack/socket-mode` → `SlackWebSocket` → `ws`, so the WebSocket upgrade request is tunneled through the HTTP CONNECT proxy.

### Changes

- **`extensions/slack/src/client.ts`**: `resolveSlackWebClientOptions()` and `resolveSlackWriteClientOptions()` now set `agent` to an `HttpsProxyAgent` when `HTTPS_PROXY`/`HTTP_PROXY` env vars are present. Follows undici `EnvHttpProxyAgent` semantics (lower-case takes precedence).
- **`extensions/slack/package.json`**: Added `https-proxy-agent` dependency (same version as Discord extension).
- **`extensions/slack/src/client.test.ts`**: Tests for proxy agent creation, env var precedence, explicit agent override, and no-op when no proxy is configured.

### How it works

The `agent` flows through:
1. `resolveSlackWebClientOptions()` → `{ agent: HttpsProxyAgent }`
2. `new App({ clientOptions })` (Bolt)
3. `new SocketModeReceiver({ clientOptions })` → `new SocketModeClient({ clientOptions })`
4. `SlackWebSocket({ httpAgent: clientOptions.agent })`
5. `new ws.WebSocket(url, { agent: httpAgent })` — tunneled through proxy ✅

### Prior art

Mirrors the existing Discord gateway proxy support in `extensions/discord/src/monitor/gateway-plugin.ts`, which uses the same `https-proxy-agent` library.

### Production validation

We've been running an equivalent monkey-patch (`openclaw-ws-proxy-patch.js`) across 4 OpenClaw agents on NVIDIA OpenShell sandboxes since March 2026, routing all Slack Socket Mode traffic through an HTTP CONNECT proxy at `10.200.0.1:3128`. This PR replaces that workaround with a proper fix.

Fixes #57405

## Test plan

- [ ] `HTTPS_PROXY` set → Socket Mode connects through proxy
- [ ] No proxy env vars → Socket Mode connects directly (no behavior change)
- [ ] Explicit `clientOptions.agent` → not overridden by proxy detection
- [ ] `HTTP_PROXY` fallback when `HTTPS_PROXY` not set
- [ ] Lower-case `https_proxy` takes precedence over upper-case `HTTPS_PROXY`
- [ ] Unit tests pass: `extensions/slack/src/client.test.ts`