### PR TITLE
docs: clarify Bun install path in entry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Runtime: **Node 24 (recommended) or Node 22.16+**.
 ```bash
 npm install -g openclaw@latest
 # or: pnpm add -g openclaw@latest
+# or: bun add -g openclaw@latest
 
 openclaw onboard --install-daemon
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,11 +95,27 @@ The Gateway is the single source of truth for sessions, routing, and channel con
 
 ## Quick start
 
+Node remains the recommended Gateway runtime. Bun is supported for global CLI install, but use Node to run the Gateway in production.
+
 <Steps>
   <Step title="Install OpenClaw">
-    ```bash
-    npm install -g openclaw@latest
-    ```
+    <Tabs>
+      <Tab title="npm">
+        ```bash
+        npm install -g openclaw@latest
+        ```
+      </Tab>
+      <Tab title="pnpm">
+        ```bash
+        pnpm add -g openclaw@latest
+        ```
+      </Tab>
+      <Tab title="Bun">
+        ```bash
+        bun add -g openclaw@latest
+        ```
+      </Tab>
+    </Tabs>
   </Step>
   <Step title="Onboard and install the service">
     ```bash


### PR DESCRIPTION
## Summary
- add the Bun global install command to the README install snippet
- update the docs landing page quick start to show npm, pnpm, and Bun install options
- clarify that Node remains the recommended Gateway runtime

## Why
The main README and docs landing page were still presenting npm-only or incomplete install guidance, while the install docs already documented Bun support for the global CLI path. Aligning the entry docs removes that mismatch and makes the supported install paths easier to discover.

## Validation
- `git diff --check`
- `node scripts/docs-link-audit.mjs`
