### PR TITLE
fix(outbound): strip leaked tool-call XML in sanitizeUserFacingText path

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -20,6 +20,49 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  describe("tool-call XML stripping (#62820)", () => {
+    // Regression: when providers emit tool calls as plain text (e.g.
+    // MiniMax's `<minimax:tool_call><invoke>…`) instead of structured
+    // tool_calls[], the raw XML used to leak through sanitizeUserFacingText
+    // to messaging surfaces like WhatsApp, because stripFinalTagsFromText
+    // only stripped `<final>` tags. The fix now also chains
+    // stripToolCallXmlTags (already used by stripAssistantInternalScaffolding
+    // on iMessage/UI paths) so every surface that calls sanitizeUserFacingText
+    // gets the same tool-call XML scrubbing.
+    it("strips MiniMax-style text-based tool call blocks", () => {
+      const input =
+        'Let me check what reminders are active:\n<minimax:tool_call>\n<invoke name="exec">\n<parameter name="command">ls</parameter>\n</invoke>\n</minimax:tool_call>';
+      const result = sanitizeUserFacingText(input);
+      expect(result).not.toContain("<minimax:tool_call>");
+      expect(result).not.toContain("<invoke");
+      expect(result).toContain("Let me check what reminders are active:");
+    });
+
+    it("strips closed <tool_call> blocks from user-visible text", () => {
+      const input =
+        'Here you go. <tool_call> {"name": "read", "arguments": {"file_path": "test.md"}} </tool_call> Done.';
+      const result = sanitizeUserFacingText(input);
+      expect(result).not.toContain("<tool_call>");
+      expect(result).toContain("Here you go.");
+      expect(result).toContain("Done.");
+    });
+
+    it("strips dangling <tool_call> content to end-of-string", () => {
+      const input = 'Running now.\n<tool_call>\n{"name": "find", "arguments": {}}\n';
+      const result = sanitizeUserFacingText(input);
+      expect(result).not.toContain("<tool_call>");
+      expect(result).toContain("Running now.");
+    });
+
+    it("leaves legitimate prose that merely mentions tool calls untouched", () => {
+      // Fast-path TOOL_CALL_QUICK_RE only fires on actual `<tool_call>` /
+      // `<invoke>` markers, so prose like this should pass through unchanged.
+      const text =
+        "The README explains how to use the tool_call field in the structured tool_calls[] array.";
+      expect(sanitizeUserFacingText(text)).toBe(text);
+    });
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -12,6 +12,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "../../shared/string-coerce.js";
+import { stripToolCallXmlTags } from "../../shared/text/assistant-visible-text.js";
 export {
   extractLeadingHttpStatus,
   formatRawAssistantErrorForUi,
@@ -825,7 +826,15 @@ function stripFinalTagsFromText(text: unknown): string {
   if (!normalized) {
     return normalized;
   }
-  return normalized.replace(FINAL_TAG_RE, "");
+  // Strip <final> tags, then strip leaked text-based tool-call XML blocks
+  // (e.g. `<minimax:tool_call><invoke name="exec">…`) which some providers
+  // emit as plain text instead of structured tool_calls[]. Without this,
+  // raw XML leaks to messaging surfaces (WhatsApp, etc.) that sanitize
+  // outbound via normalize-reply → sanitizeUserFacingText. The stripper has
+  // a TOOL_CALL_QUICK_RE fast-path guard so it is a no-op on text that
+  // contains no tool-call markers.
+  const withoutFinal = normalized.replace(FINAL_TAG_RE, "");
+  return stripToolCallXmlTags(withoutFinal);
 }
 
 function collapseConsecutiveDuplicateBlocks(text: string): string {


### PR DESCRIPTION
## Summary

When providers emit tool calls as plain text instead of structured `tool_calls[]` — e.g. MiniMax's `<minimax:tool_call><invoke name="exec">…` or any model under `tool_choice: "auto"` that regresses to text-based tool invocation syntax — raw XML leaks to messaging surfaces like WhatsApp because `sanitizeUserFacingText` → `stripFinalTagsFromText` only strips `<final>` tags.

Fixes #62820

## Why the merged #60619 fix did not cover this path

PR #60619 added `stripToolCallXmlTags` to `src/shared/text/assistant-visible-text.ts` and chained it into `stripAssistantInternalScaffolding`. That function is used on the iMessage outbound path (`extensions/imessage/src/monitor/sanitize-outbound.ts:21`) and the Control UI format layer (`ui/src/ui/format.ts:84`).

The WhatsApp / auto-reply path goes through a **different** sanitizer chain:

```
src/auto-reply/reply/normalize-reply.ts:91
  └─ sanitizeUserFacingText()  (errors.ts:1040)
     └─ stripFinalTagsFromText()  (errors.ts:823)
        └─ only strips <final> tags ← bug
```

`sanitizeUserFacingText` is also on the main agent runner path (`src/auto-reply/reply/agent-runner-execution.ts:670`), task status (`src/tasks/task-status.ts:72`), chat history display (`src/agents/tools/chat-history-text.ts:63`), and exec approval followups (`src/agents/bash-tools.exec-approval-followup.ts:95/112/116`) — so the leak is not WhatsApp-only, it's every surface that consumes the older sanitizer.

## Fix

Chain `stripToolCallXmlTags` into `stripFinalTagsFromText` so every caller of `sanitizeUserFacingText` gets the same tool-call XML scrubbing that `stripAssistantInternalScaffolding` already applies on the newer surfaces.

```diff
+import { stripToolCallXmlTags } from "../../shared/text/assistant-visible-text.js";

 function stripFinalTagsFromText(text: unknown): string {
   const normalized = coerceText(text);
   if (!normalized) {
     return normalized;
   }
-  return normalized.replace(FINAL_TAG_RE, "");
+  const withoutFinal = normalized.replace(FINAL_TAG_RE, "");
+  return stripToolCallXmlTags(withoutFinal);
 }
```

`stripToolCallXmlTags` has a `TOOL_CALL_QUICK_RE` fast-path guard at the top (`assistant-visible-text.ts:166`), so it is a no-op on text that contains no `<tool_call>` / `<invoke>` / `<function_calls>` markers — negligible overhead on normal outbound text.

## Tests

Added 4 regression cases in `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`:

1. **MiniMax-style** — `<minimax:tool_call>` + `<invoke>` block is stripped, surrounding prose preserved.
2. **Closed `<tool_call>` blocks** — JSON-body tool call is stripped, surrounding prose preserved.
3. **Dangling `<tool_call>`** — content without a close tag is hidden to end-of-string (matches existing `stripToolCallXmlTags` contract already tested in `assistant-visible-text.test.ts`).
4. **Legitimate prose** — text that merely mentions the words "tool_call" in prose passes through unchanged (guards against the `TOOL_CALL_QUICK_RE` fast-path regressing to false positives).

## Notes

- Reporter @canh0chua in #62820 posted the exact RCA + one-line fix. This PR implements that fix and adds the regression tests.
- Adjacent work that already landed: #60619 (added `stripToolCallXmlTags` to `assistant-visible-text`), #61729 (strip tool_call/tool_result XML from assistant-visible text). Those covered the iMessage / UI / assistant-visible paths. This PR closes the remaining gap on the sanitizeUserFacingText path.