### PR TITLE
fix(whatsapp): preserve replies across reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WhatsApp/auto-reply: keep inbound reply, media, and composing sends on the current socket across reconnects, wait through reconnect gaps, and retry timeout-only send failures without dropping the active socket ref. (#62892) Thanks @mcaxtr.
+
 ## 2026.4.9
 
 ### Changes

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -1,3 +1,4 @@
+import type { WASocket } from "@whiskeysockets/baileys";
 import { resolveInboundDebounceMs } from "openclaw/plugin-sdk/channel-inbound";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import { waitForever } from "openclaw/plugin-sdk/cli-runtime";
@@ -165,6 +166,20 @@ export async function monitorWebChannel(
   process.once("SIGINT", handleSigint);
 
   let reconnectAttempts = 0;
+  const socketRef: { current: WASocket | null } = { current: null };
+  const disconnectRetryController = new AbortController();
+  const stopDisconnectRetries = () => {
+    if (!disconnectRetryController.signal.aborted) {
+      disconnectRetryController.abort();
+    }
+  };
+  if (abortSignal) {
+    if (abortSignal.aborted) {
+      stopDisconnectRetries();
+    } else {
+      abortSignal.addEventListener("abort", stopDisconnectRetries, { once: true });
+    }
+  }
 
   while (true) {
     if (stopRequested()) {
@@ -217,6 +232,11 @@ export async function monitorWebChannel(
       sendReadReceipts: account.sendReadReceipts,
       debounceMs: inboundDebounceMs,
       shouldDebounce,
+      socketRef,
+      shouldRetryDisconnect: () =>
+        keepAlive && !sigintStop && !stopRequested() && !disconnectRetryController.signal.aborted,
+      disconnectRetryPolicy: reconnectPolicy,
+      disconnectRetryAbortSignal: disconnectRetryController.signal,
       onMessage: async (msg: WebInboundMsg) => {
         active.handledMessages += 1;
         active.lastInboundAt = Date.now();
@@ -257,6 +277,7 @@ export async function monitorWebChannel(
     });
 
     const closeListener = async () => {
+      socketRef.current = null;
       setActiveWebListener(account.accountId, null);
       if (active.unregisterUnhandled) {
         active.unregisterUnhandled();
@@ -343,6 +364,7 @@ export async function monitorWebChannel(
     }
 
     if (!keepAlive) {
+      stopDisconnectRetries();
       await closeListener();
       process.removeListener("SIGINT", handleSigint);
       return;
@@ -363,6 +385,7 @@ export async function monitorWebChannel(
     statusController.noteReconnectAttempts(reconnectAttempts);
 
     if (stopRequested() || sigintStop || reason === "aborted") {
+      stopDisconnectRetries();
       await closeListener();
       break;
     }
@@ -396,6 +419,7 @@ export async function monitorWebChannel(
     });
 
     if (loggedOut) {
+      stopDisconnectRetries();
       statusController.noteClose({
         statusCode: numericStatusCode,
         loggedOut: true,
@@ -411,6 +435,7 @@ export async function monitorWebChannel(
     }
 
     if (isNonRetryableWebCloseStatus(statusCode)) {
+      stopDisconnectRetries();
       statusController.noteClose({
         statusCode: numericStatusCode,
         error: errorStr,
@@ -434,6 +459,7 @@ export async function monitorWebChannel(
 
     reconnectAttempts += 1;
     if (reconnectPolicy.maxAttempts > 0 && reconnectAttempts >= reconnectPolicy.maxAttempts) {
+      stopDisconnectRetries();
       statusController.noteClose({
         statusCode: numericStatusCode,
         error: errorStr,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -1,4 +1,4 @@
-import type { AnyMessageContent, proto, WAMessage } from "@whiskeysockets/baileys";
+import type { AnyMessageContent, proto, WAMessage, WASocket } from "@whiskeysockets/baileys";
 import { createInboundDebouncer, formatLocationText } from "openclaw/plugin-sdk/channel-inbound";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -6,7 +6,8 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/text-runtime";
 import { readWebSelfIdentity } from "../auth-store.js";
 import { getPrimaryIdentityId, resolveComparableIdentity } from "../identity.js";
-import { createWaSocket, getStatusCode, waitForWaConnection } from "../session.js";
+import { DEFAULT_RECONNECT_POLICY, computeBackoff, sleepWithAbort } from "../reconnect.js";
+import { createWaSocket, formatError, getStatusCode, waitForWaConnection } from "../session.js";
 import { resolveJidToE164 } from "../text-runtime.js";
 import { checkInboundAccessControl } from "./access-control.js";
 import {
@@ -28,9 +29,18 @@ import { createWebSendApi } from "./send-api.js";
 import type { WebInboundMessage, WebListenerCloseReason } from "./types.js";
 
 const LOGGED_OUT_STATUS = DisconnectReason?.loggedOut ?? 401;
+const RECONNECT_IN_PROGRESS_ERROR = "no active socket - reconnection in progress";
 
 function isGroupJid(jid: string): boolean {
   return (typeof isJidGroup === "function" ? isJidGroup(jid) : jid.endsWith("@g.us")) === true;
+}
+
+function isRetryableSendDisconnectError(err: unknown): boolean {
+  return /closed|reset|timed\s*out|disconnect|no active socket/i.test(formatError(err));
+}
+
+function shouldClearSocketRefAfterSendFailure(err: unknown): boolean {
+  return /closed|reset|disconnect|no active socket/i.test(formatError(err));
 }
 
 export async function monitorWebInbox(options: {
@@ -47,6 +57,20 @@ export async function monitorWebInbox(options: {
   debounceMs?: number;
   /** Optional debounce gating predicate. */
   shouldDebounce?: (msg: WebInboundMessage) => boolean;
+  /** Optional shared socket reference so reply closures can follow reconnects. */
+  socketRef?: { current: WASocket | null };
+  /** Whether send retries should wait for a reconnect. */
+  shouldRetryDisconnect?: () => boolean;
+  /** Reconnect timing for waiting through transient socket replacement gaps. */
+  disconnectRetryPolicy?: {
+    initialMs: number;
+    maxMs: number;
+    factor: number;
+    jitter: number;
+    maxAttempts: number;
+  };
+  /** Abort in-flight reconnect waits when shutdown becomes terminal. */
+  disconnectRetryAbortSignal?: AbortSignal;
 }) {
   const inboundLogger = getChildLogger({ module: "web-inbound" });
   const inboundConsoleLog = createSubsystemLogger("gateway/channels/whatsapp").child("inbound");
@@ -55,6 +79,16 @@ export async function monitorWebInbox(options: {
   });
   await waitForWaConnection(sock);
   const connectedAtMs = Date.now();
+  if (options.socketRef) {
+    options.socketRef.current = sock;
+  }
+  const getCurrentSock = () => (options.socketRef ? options.socketRef.current : sock);
+  const shouldRetryDisconnect = () => options.shouldRetryDisconnect?.() === true;
+  const disconnectRetryPolicy = options.disconnectRetryPolicy ?? DEFAULT_RECONNECT_POLICY;
+  const sendRetryMaxAttempts =
+    disconnectRetryPolicy.maxAttempts > 0
+      ? disconnectRetryPolicy.maxAttempts
+      : DEFAULT_RECONNECT_POLICY.maxAttempts;
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;
   const onClose = new Promise<WebListenerCloseReason>((resolve) => {
@@ -160,9 +194,43 @@ export async function monitorWebInbox(options: {
   };
 
   const sendTrackedMessage = async (jid: string, content: AnyMessageContent) => {
-    const result = await sock.sendMessage(jid, content);
-    rememberOutboundMessage(jid, result);
-    return result;
+    let lastErr: unknown = new Error(RECONNECT_IN_PROGRESS_ERROR);
+    for (let attempt = 1; ; attempt++) {
+      const currentSock = getCurrentSock();
+      if (currentSock) {
+        try {
+          const result = await currentSock.sendMessage(jid, content);
+          rememberOutboundMessage(jid, result);
+          return result;
+        } catch (err) {
+          if (!shouldRetryDisconnect() || !isRetryableSendDisconnectError(err)) {
+            throw err;
+          }
+          lastErr = err;
+          if (
+            shouldClearSocketRefAfterSendFailure(err) &&
+            options.socketRef?.current === currentSock
+          ) {
+            options.socketRef.current = null;
+          }
+        }
+      } else if (!shouldRetryDisconnect()) {
+        throw lastErr;
+      }
+
+      if (attempt >= sendRetryMaxAttempts) {
+        throw lastErr;
+      }
+      const delayMs = computeBackoff(disconnectRetryPolicy, attempt);
+      logVerbose(
+        `Waiting ${delayMs}ms for WhatsApp reconnect before retrying send to ${jid}: ${formatError(lastErr)}`,
+      );
+      try {
+        await sleepWithAbort(delayMs, options.disconnectRetryAbortSignal);
+      } catch {
+        throw lastErr;
+      }
+    }
   };
 
   const getGroupMeta = async (jid: string) => {
@@ -379,8 +447,12 @@ export async function monitorWebInbox(options: {
   ) => {
     const chatJid = inbound.remoteJid;
     const sendComposing = async () => {
+      const currentSock = getCurrentSock();
+      if (!currentSock) {
+        return;
+      }
       try {
-        await sock.sendPresenceUpdate("composing", chatJid);
+        await currentSock.sendPresenceUpdate("composing", chatJid);
       } catch (err) {
         logVerbose(`Presence update failed: ${String(err)}`);
       }
@@ -502,6 +574,9 @@ export async function monitorWebInbox(options: {
   ) => {
     try {
       if (update.connection === "close") {
+        if (options.socketRef?.current === sock) {
+          options.socketRef.current = null;
+        }
         const status = getStatusCode(update.lastDisconnect?.error);
         resolveClose({
           status,
@@ -550,7 +625,13 @@ export async function monitorWebInbox(options: {
   const sendApi = createWebSendApi({
     sock: {
       sendMessage: (jid: string, content: AnyMessageContent) => sendTrackedMessage(jid, content),
-      sendPresenceUpdate: (presence, jid?: string) => sock.sendPresenceUpdate(presence, jid),
+      sendPresenceUpdate: async (presence, jid?: string) => {
+        const currentSock = getCurrentSock();
+        if (!currentSock) {
+          throw new Error(RECONNECT_IN_PROGRESS_ERROR);
+        }
+        return currentSock.sendPresenceUpdate(presence, jid);
+      },
     },
     defaultAccountId: options.accountId,
   });

--- a/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts
@@ -1,8 +1,9 @@
 import fsSync from "node:fs";
 import path from "node:path";
 import "./monitor-inbox.test-harness.js";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  type InboxMonitorOptions,
   InboxOnMessage,
   buildNotifyMessageUpsert,
   getAuthDir,
@@ -11,6 +12,18 @@ import {
   startInboxMonitor,
   waitForMessageCalls,
 } from "./monitor-inbox.test-harness.js";
+
+const { sleepWithAbortMock } = vi.hoisted(() => ({
+  sleepWithAbortMock: vi.fn(async (_ms: number, _signal?: AbortSignal) => undefined),
+}));
+
+vi.mock("./reconnect.js", async () => {
+  const actual = await vi.importActual<typeof import("./reconnect.js")>("./reconnect.js");
+  return {
+    ...actual,
+    sleepWithAbort: (ms: number, signal?: AbortSignal) => sleepWithAbortMock(ms, signal),
+  };
+});
 
 let nextMessageSequence = 0;
 
@@ -21,6 +34,11 @@ function nextMessageId(label: string): string {
 
 describe("web monitor inbox", () => {
   installWebMonitorInboxUnitTestHooks();
+
+  beforeEach(() => {
+    sleepWithAbortMock.mockReset();
+    sleepWithAbortMock.mockImplementation(async (_ms: number, _signal?: AbortSignal) => undefined);
+  });
 
   async function expectQuotedReplyContext(quotedMessage: unknown) {
     const onMessage = vi.fn(async (msg) => {
@@ -182,6 +200,211 @@ describe("web monitor inbox", () => {
     await waitForMessageCalls(onMessage, 1);
 
     resolveHydration();
+    await listener.close();
+  });
+
+  it("uses a replacement socket for replies created before reconnect", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const socketRef: NonNullable<InboxMonitorOptions["socketRef"]> = { current: null };
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, { socketRef });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("replacement-socket"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "ping",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    const inbound = onMessage.mock.calls.at(0)?.at(0) as
+      | {
+          reply: (text: string) => Promise<void>;
+          sendMedia: (payload: Record<string, unknown>) => Promise<void>;
+          sendComposing: () => Promise<void>;
+        }
+      | undefined;
+    expect(inbound).toBeDefined();
+
+    const replacementSock = {
+      sendMessage: vi.fn(async () => undefined),
+      sendPresenceUpdate: vi.fn(async () => undefined),
+    };
+    socketRef.current = replacementSock as unknown as NonNullable<
+      InboxMonitorOptions["socketRef"]
+    >["current"];
+
+    await inbound?.reply("pong");
+    await inbound?.sendMedia({ text: "after-reconnect" });
+    await inbound?.sendComposing();
+
+    expect(replacementSock.sendMessage).toHaveBeenNthCalledWith(1, "999@s.whatsapp.net", {
+      text: "pong",
+    });
+    expect(replacementSock.sendMessage).toHaveBeenNthCalledWith(2, "999@s.whatsapp.net", {
+      text: "after-reconnect",
+    });
+    expect(replacementSock.sendPresenceUpdate).toHaveBeenCalledWith(
+      "composing",
+      "999@s.whatsapp.net",
+    );
+    expect(sock.sendMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("waits for a replacement socket before sending replies", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const socketRef: NonNullable<InboxMonitorOptions["socketRef"]> = { current: null };
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      socketRef,
+      shouldRetryDisconnect: () => true,
+      disconnectRetryPolicy: {
+        initialMs: 10,
+        maxMs: 10,
+        factor: 1,
+        jitter: 0,
+        maxAttempts: 2,
+      },
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("reconnect-gap"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "ping",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    const inbound = onMessage.mock.calls.at(0)?.at(0) as
+      | {
+          reply: (text: string) => Promise<void>;
+        }
+      | undefined;
+    expect(inbound).toBeDefined();
+
+    const replacementSock = {
+      sendMessage: vi.fn(async () => undefined),
+      sendPresenceUpdate: vi.fn(async () => undefined),
+    };
+    socketRef.current = null;
+    sleepWithAbortMock.mockImplementationOnce(async () => {
+      socketRef.current = replacementSock as unknown as NonNullable<
+        InboxMonitorOptions["socketRef"]
+      >["current"];
+    });
+
+    await inbound?.reply("pong");
+
+    expect(sleepWithAbortMock).toHaveBeenCalledWith(10, undefined);
+    expect(replacementSock.sendMessage).toHaveBeenCalledWith("999@s.whatsapp.net", {
+      text: "pong",
+    });
+    expect(sock.sendMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("retries timed-out sends on the same socket without clearing the socket ref", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const socketRef: NonNullable<InboxMonitorOptions["socketRef"]> = { current: null };
+
+    const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      socketRef,
+      shouldRetryDisconnect: () => true,
+      disconnectRetryPolicy: {
+        initialMs: 1,
+        maxMs: 1,
+        factor: 1,
+        jitter: 0,
+        maxAttempts: 2,
+      },
+    });
+    sock.ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("timeout-retry"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "ping",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    const inbound = onMessage.mock.calls.at(0)?.at(0) as
+      | {
+          reply: (text: string) => Promise<void>;
+        }
+      | undefined;
+    expect(inbound).toBeDefined();
+
+    sock.sendMessage
+      .mockRejectedValueOnce(new Error("operation timed out"))
+      .mockResolvedValueOnce({ key: { id: "after-timeout" } });
+
+    await inbound?.reply("pong");
+
+    expect(sock.sendMessage).toHaveBeenNthCalledWith(1, "999@s.whatsapp.net", {
+      text: "pong",
+    });
+    expect(sock.sendMessage).toHaveBeenNthCalledWith(2, "999@s.whatsapp.net", {
+      text: "pong",
+    });
+    expect(socketRef.current).toBe(sock);
+    expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
+
+    await listener.close();
+  });
+
+  it("bounds reconnect-gap retries even when reconnect attempts are unlimited", async () => {
+    const onMessage = vi.fn(async () => undefined);
+    const socketRef: NonNullable<InboxMonitorOptions["socketRef"]> = { current: null };
+
+    const { listener } = await startInboxMonitor(onMessage as InboxOnMessage, {
+      socketRef,
+      shouldRetryDisconnect: () => true,
+      disconnectRetryPolicy: {
+        initialMs: 1,
+        maxMs: 1,
+        factor: 1,
+        jitter: 0,
+        maxAttempts: 0,
+      },
+    });
+    getSock().ev.emit(
+      "messages.upsert",
+      buildNotifyMessageUpsert({
+        id: nextMessageId("unlimited-reconnect-send-bound"),
+        remoteJid: "999@s.whatsapp.net",
+        text: "ping",
+        timestamp: 1_700_000_000,
+        pushName: "Tester",
+      }),
+    );
+    await waitForMessageCalls(onMessage, 1);
+
+    const inbound = onMessage.mock.calls.at(0)?.at(0) as
+      | {
+          reply: (text: string) => Promise<void>;
+        }
+      | undefined;
+    expect(inbound).toBeDefined();
+
+    socketRef.current = null;
+
+    await expect(inbound?.reply("pong")).rejects.toThrow(
+      "no active socket - reconnection in progress",
+    );
+    expect(sleepWithAbortMock).toHaveBeenCalledTimes(11);
+
     await listener.close();
   });
 

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -112,6 +112,7 @@ export function getSock(): MockSock {
 
 type MonitorWebInbox = typeof import("./inbound.js").monitorWebInbox;
 export type InboxOnMessage = NonNullable<Parameters<MonitorWebInbox>[0]["onMessage"]>;
+export type InboxMonitorOptions = Parameters<MonitorWebInbox>[0];
 let monitorWebInbox: MonitorWebInbox;
 
 function expectInboxPairingReplyText(
@@ -156,7 +157,7 @@ export async function waitForMessageCalls(onMessage: ReturnType<typeof vi.fn>, c
 
 export async function startInboxMonitor(
   onMessage: InboxOnMessage,
-  options: { selfChatMode?: boolean } = {},
+  extraOptions: Partial<InboxMonitorOptions> = {},
 ) {
   if (!monitorWebInbox) {
     ({ monitorWebInbox } = await import("./inbound.js"));
@@ -166,7 +167,7 @@ export async function startInboxMonitor(
     onMessage,
     accountId: DEFAULT_ACCOUNT_ID,
     authDir: getAuthDir(),
-    selfChatMode: options.selfChatMode,
+    ...extraOptions,
   });
   return { listener, sock: getSock() };
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: WhatsApp inbound reply closures captured the socket that existed when the inbound message object was created, so a reconnect could leave later replies sending on a dead socket.
- Why it matters: long-running replies could be lost when the socket disconnected and reconnected before the send happened.
- What changed: the reconnect loop now owns a shared current-socket ref, and the inbound send path resolves reply/media/composing sends against that current socket and waits through reconnect gaps using the existing reconnect policy.
- What changed after review: timeout-only send failures still retry, but they no longer clear `socketRef.current`; only confirmed disconnect-style failures clear the ref.
- What did NOT change (scope boundary): this does not add a broader reconnect retry subsystem and does not change `deliver-reply.ts`, config, or user-facing defaults.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: `monitorWebInbox()` built `reply` / `sendMedia` / `sendComposing` closures against a specific Baileys socket, while `monitorWebChannel()` replaces that socket during reconnect.
- Missing detection / guardrail: there was no regression test proving that an inbound message created on socket A still sends successfully after reconnect swaps to socket B or during the reconnect gap.
- Contributing context (if known): the existing short retry behavior lived above the transport seam, so it could keep retrying stale send closures instead of re-resolving the active socket.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts`
- Scenario the test should lock in: an inbound reply created before reconnect should use the replacement socket, a reply sent during a reconnect gap should wait and succeed once a socket is available again, and a timed-out send should retry on the same socket without clearing the ref.
- Why this is the smallest reliable guardrail: the bug is born at the WhatsApp inbound transport seam, so this test exercises the exact closure and reconnect behavior without needing a full live WhatsApp setup.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- WhatsApp auto-replies that finish after a reconnect should now send on the replacement socket instead of being lost on the stale one.
- When the reply send lands during the reconnect gap, the send path waits through reconnect using the existing reconnect policy instead of failing immediately on the obsolete socket.
- Timeout-only send failures keep retrying on the active socket instead of forcing the reconnect-gap path.
- No config or default behavior changes outside this reconnect path.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[inbound message on socket A] -> [reply closure captures socket A] -> [socket A closes, socket B connects] -> [reply send uses socket A] -> [reply can be lost]

After:
[inbound message on socket A] -> [reply send resolves current socket at send time] -> [socket A closes, socket B connects] -> [reply send uses socket B or waits for reconnect] -> [reply delivered]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm workspace, local worktree
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): default WhatsApp reconnect policy; no config changes required

### Steps

1. Start a WhatsApp auto-reply flow and let the inbound message be accepted on socket A.
2. Force-close the active Meta/WhatsApp HTTPS socket, then temporarily block outbound `:443` for the gateway user to create a reconnect gap.
3. Let WhatsApp reconnect to socket B and wait for the reply to finish sending.

### Expected

- On the fixed branch, replies created before reconnect send successfully after reconnect, and timeout-only send failures do not strand the reply on a cleared socket ref.

### Actual

- On `main`, the real repro hit `WhatsApp Web connected.` and later still logged `Retrying text ... Connection Closed`, which dropped the reply.
- On this branch, the same reconnect window produced repeated `auto-reply sent (text)` logs after reconnect, and the reply arrived successfully.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification logs:

- Real repro on `main`: reconnect succeeded, then later send attempts logged `Retrying text ... Connection Closed`
- Real repro on this branch: reconnect succeeded, then later sends logged repeated `auto-reply sent (text)`
- `pnpm test extensions/whatsapp/src/monitor-inbox.streams-inbound-messages.test.ts` -> 1 file, 17 tests passed
- `pnpm build` -> passed
- follow-up reviewer fix commit: `eac0982b17`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran the focused WhatsApp inbox regression tests for replacement-socket sends, reconnect-gap waits, and timeout retry behavior; ran `pnpm build`; and manually reproduced the broken behavior on `main` versus the fixed behavior on this branch with a forced WhatsApp reconnect.
- Edge cases checked: reconnect-gap wait, replacement socket after reconnect, composing/media paths bound to the replacement socket, and timeout-only send retry behavior.
- What you did **not** verify: non-WhatsApp channels, or any broader retry-system behavior outside this transport seam.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: send retries now live in the WhatsApp inbound transport seam, so a reconnect policy with a very long wait could delay final failure longer than before.
  - Mitigation: the wait reuses the existing reconnect policy and stays scoped to the reconnect path; normal sends are unchanged.
- Risk: active-listener send APIs still use their existing path and are not changed by this PR.
  - Mitigation: scope is intentionally limited to the stale inbound reply closure bug addressed here.
