### PR TITLE
fix: stabilize telegram automation delivery

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -53,6 +53,7 @@ import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
+import { registerQueuedFollowupLifecycle } from "./queue-lifecycle.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import {
   enqueueFollowupRun,
@@ -68,6 +69,7 @@ import {
   type ReplyOperation,
 } from "./reply-run-registry.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
+import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
@@ -198,6 +200,38 @@ export async function runReplyAgent(params: {
           buffer: createAudioAsVoiceBuffer({ isAudioPayload }),
         })
       : null;
+  const sendQueueLifecyclePayload = async (payload: ReplyPayload) => {
+    const { originatingChannel, originatingTo } = followupRun;
+    const shouldRouteToOriginating = isRoutableChannel(originatingChannel) && originatingTo;
+    if (!shouldRouteToOriginating && !opts?.onBlockReply) {
+      return;
+    }
+    if (shouldRouteToOriginating) {
+      const result = await routeReply({
+        payload,
+        channel: originatingChannel,
+        to: originatingTo,
+        sessionKey: followupRun.run.sessionKey,
+        accountId: followupRun.originatingAccountId,
+        threadId: followupRun.originatingThreadId,
+        cfg: followupRun.run.config,
+      });
+      if (result.ok) {
+        return;
+      }
+      const provider = resolveOriginMessageProvider({
+        provider: followupRun.run.messageProvider,
+      });
+      const origin = resolveOriginMessageProvider({
+        originatingChannel,
+      });
+      if (opts?.onBlockReply && origin && origin === provider) {
+        await opts.onBlockReply(payload);
+      }
+      return;
+    }
+    await opts?.onBlockReply?.(payload);
+  };
   const touchActiveSessionEntry = async () => {
     if (!activeSessionEntry || !activeSessionStore || !sessionKey) {
       return;
@@ -251,7 +285,7 @@ export async function runReplyAgent(params: {
   }
 
   if (activeRunQueueAction === "enqueue-followup") {
-    enqueueFollowupRun(
+    const enqueued = enqueueFollowupRun(
       queueKey,
       followupRun,
       resolvedQueue,
@@ -259,6 +293,13 @@ export async function runReplyAgent(params: {
       queuedRunFollowupTurn,
       false,
     );
+    if (enqueued) {
+      registerQueuedFollowupLifecycle({
+        queueKey,
+        run: followupRun,
+        sendNotice: sendQueueLifecyclePayload,
+      });
+    }
     // Re-check liveness after enqueue so a stale active snapshot cannot leave
     // the followup queue idle if the original run already finished.
     if (!isRunActive?.()) {

--- a/src/auto-reply/reply/commands-status.test.ts
+++ b/src/auto-reply/reply/commands-status.test.ts
@@ -408,32 +408,82 @@ describe("buildStatusReply subagent summary", () => {
     expect(reply?.text).not.toContain("all done");
   });
 
-  it("falls back to same-agent task counts without details when the current session has none", async () => {
+  it("shows automation counts without details when the current session has none", async () => {
     createRunningTaskRun({
-      runtime: "subagent",
-      requesterSessionKey: "agent:main:other",
-      childSessionKey: "agent:main:subagent:status-agent-fallback-running",
-      runId: "run-status-agent-fallback-running",
+      runtime: "cron",
+      ownerKey: "system:cron:status-automation-running",
+      scopeKind: "system",
+      requesterSessionKey: "system:cron:status-automation-running",
+      childSessionKey: "agent:main:cron:status-automation-running",
+      runId: "run-status-automation-running",
       agentId: "main",
       task: "hidden task title",
       progressSummary: "hidden progress detail",
     });
     createQueuedTaskRun({
       runtime: "cron",
-      requesterSessionKey: "agent:main:another",
-      childSessionKey: "agent:main:subagent:status-agent-fallback-queued",
-      runId: "run-status-agent-fallback-queued",
+      ownerKey: "system:cron:status-automation-queued",
+      scopeKind: "system",
+      requesterSessionKey: "system:cron:status-automation-queued",
+      childSessionKey: "agent:main:cron:status-automation-queued",
+      runId: "run-status-automation-queued",
       agentId: "main",
       task: "another hidden task title",
     });
 
     const reply = await buildStatusReplyForTest({ sessionKey: "agent:main:empty-session" });
 
-    expect(reply?.text).toContain("📌 Tasks: 2 active · 2 total · agent-local");
+    expect(reply?.text).toContain("📌 Automation: 2 active · 2 total");
     expect(reply?.text).not.toContain("hidden task title");
     expect(reply?.text).not.toContain("hidden progress detail");
     expect(reply?.text).not.toContain("subagent");
     expect(reply?.text).not.toContain("cron");
+  });
+
+  it("shows automation separately when the current session already has task detail", async () => {
+    createRunningTaskRun({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:main:subagent:status-session-live",
+      runId: "run-status-session-live",
+      task: "visible background task",
+    });
+    createQueuedTaskRun({
+      runtime: "cron",
+      ownerKey: "system:cron:status-automation-extra",
+      scopeKind: "system",
+      requesterSessionKey: "system:cron:status-automation-extra",
+      childSessionKey: "agent:main:cron:status-automation-extra",
+      runId: "run-status-automation-extra",
+      agentId: "main",
+      task: "hidden automation task",
+    });
+
+    const reply = await buildStatusReplyForTest({});
+
+    expect(reply?.text).toContain("📌 Tasks: 1 active · 1 total");
+    expect(reply?.text).toContain("📌 Automation: 1 active · 1 total");
+    expect(reply?.text).not.toContain("hidden automation task");
+  });
+
+  it("counts cron-owned session tasks as automation without surfacing their detail", async () => {
+    createRunningTaskRun({
+      runtime: "subagent",
+      ownerKey: "agent:main:cron:status-automation-owned",
+      requesterSessionKey: "agent:main:cron:status-automation-owned",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:status-automation-owned-child",
+      runId: "run-status-automation-owned",
+      agentId: "main",
+      task: "hidden cron-owned task",
+      progressSummary: "hidden cron-owned detail",
+    });
+
+    const reply = await buildStatusReplyForTest({ sessionKey: "agent:main:empty-session" });
+
+    expect(reply?.text).toContain("📌 Automation: 1 active · 1 total");
+    expect(reply?.text).not.toContain("hidden cron-owned task");
+    expect(reply?.text).not.toContain("hidden cron-owned detail");
   });
 
   it("uses transcript usage fallback in /status output", async () => {

--- a/src/auto-reply/reply/commands-status.ts
+++ b/src/auto-reply/reply/commands-status.ts
@@ -24,7 +24,7 @@ import {
 import type { MediaUnderstandingDecision } from "../../media-understanding/types.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import {
-  listTasksForAgentIdForStatus,
+  listAutomationTasksForAgentIdForStatus,
   listTasksForSessionKeyForStatus,
 } from "../../tasks/task-status-access.js";
 import {
@@ -82,12 +82,12 @@ function formatSessionTaskLine(sessionKey: string): string | undefined {
   return parts.length ? `📌 Tasks: ${parts.join(" · ")}` : undefined;
 }
 
-function formatAgentTaskCountsLine(agentId: string): string | undefined {
-  const snapshot = buildTaskStatusSnapshot(listTasksForAgentIdForStatus(agentId));
+function formatAutomationTaskCountsLine(agentId: string): string | undefined {
+  const snapshot = buildTaskStatusSnapshot(listAutomationTasksForAgentIdForStatus(agentId));
   if (snapshot.totalCount === 0) {
     return undefined;
   }
-  return `📌 Tasks: ${snapshot.activeCount} active · ${snapshot.totalCount} total · agent-local`;
+  return `📌 Automation: ${snapshot.activeCount} active · ${snapshot.totalCount} total`;
 }
 
 export async function buildStatusReply(params: {
@@ -262,14 +262,20 @@ export async function buildStatusText(params: {
 
   let subagentsLine: string | undefined;
   let taskLine: string | undefined;
+  let automationTaskLine: string | undefined;
   if (sessionKey) {
     const { mainKey, alias } = resolveMainSessionAlias(cfg);
     const requesterKey = resolveInternalSessionKey({ key: sessionKey, alias, mainKey });
     taskLine = params.skipDefaultTaskLookup
       ? params.taskLineOverride
       : (params.taskLineOverride ?? formatSessionTaskLine(requesterKey));
-    if (!taskLine && !params.skipDefaultTaskLookup) {
-      taskLine = formatAgentTaskCountsLine(statusAgentId);
+    if (!params.skipDefaultTaskLookup) {
+      automationTaskLine = formatAutomationTaskCountsLine(statusAgentId);
+    }
+    if (!taskLine) {
+      taskLine = automationTaskLine;
+    } else if (automationTaskLine) {
+      taskLine = `${taskLine}\n${automationTaskLine}`;
     }
     const runs = listControlledSubagentRuns(requesterKey);
     const verboseEnabled = resolvedVerboseLevel && resolvedVerboseLevel !== "off";

--- a/src/auto-reply/reply/commands-tasks.test.ts
+++ b/src/auto-reply/reply/commands-tasks.test.ts
@@ -149,12 +149,14 @@ describe("buildTasksReply", () => {
     expect(reply.text).not.toContain("done a while ago");
   });
 
-  it("falls back to agent-local counts when the current session has no visible tasks", async () => {
+  it("shows automation counts separately when the current session has no visible tasks", async () => {
     createRunningTaskRun({
-      runtime: "subagent",
-      requesterSessionKey: "agent:main:other-session",
-      childSessionKey: "agent:main:subagent:tasks-agent-fallback",
-      runId: "run-tasks-agent-fallback",
+      runtime: "cron",
+      ownerKey: "system:cron:tasks-automation-running",
+      scopeKind: "system",
+      requesterSessionKey: "system:cron:tasks-automation-running",
+      childSessionKey: "agent:main:cron:tasks-automation-running",
+      runId: "run-tasks-automation-running",
       agentId: "main",
       task: "hidden background task",
       progressSummary: "hidden progress detail",
@@ -165,9 +167,58 @@ describe("buildTasksReply", () => {
     });
 
     expect(reply.text).toContain("All clear - nothing linked to this session right now.");
-    expect(reply.text).toContain("Agent-local: 1 active · 1 total");
+    expect(reply.text).toContain("Automation: 1 active · 1 total");
     expect(reply.text).not.toContain("hidden background task");
     expect(reply.text).not.toContain("hidden progress detail");
+  });
+
+  it("keeps automation visible separately when the current session has its own tasks", async () => {
+    createRunningTaskRun({
+      runtime: "subagent",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:main:subagent:tasks-visible",
+      runId: "run-tasks-visible",
+      task: "visible session task",
+    });
+    createQueuedTaskRun({
+      runtime: "cron",
+      ownerKey: "system:cron:tasks-automation-queued",
+      scopeKind: "system",
+      requesterSessionKey: "system:cron:tasks-automation-queued",
+      childSessionKey: "agent:main:cron:tasks-automation-queued",
+      runId: "run-tasks-automation-queued",
+      agentId: "main",
+      task: "hidden automation task",
+    });
+
+    const reply = await buildTasksReplyForTest();
+
+    expect(reply.text).toContain("Current session: 1 active · 1 total");
+    expect(reply.text).toContain("Automation: 1 active · 1 total");
+    expect(reply.text).not.toContain("hidden automation task");
+  });
+
+  it("counts cron-owned session tasks as automation instead of current-session detail", async () => {
+    createRunningTaskRun({
+      runtime: "subagent",
+      ownerKey: "agent:main:cron:tasks-automation-owned",
+      requesterSessionKey: "agent:main:cron:tasks-automation-owned",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:tasks-automation-owned-child",
+      runId: "run-tasks-automation-owned",
+      agentId: "main",
+      task: "hidden cron-owned task",
+      progressSummary: "hidden cron-owned detail",
+    });
+
+    const reply = await buildTasksReplyForTest({
+      sessionKey: "agent:main:empty-session",
+    });
+
+    expect(reply.text).toContain("All clear - nothing linked to this session right now.");
+    expect(reply.text).toContain("Automation: 1 active · 1 total");
+    expect(reply.text).not.toContain("hidden cron-owned task");
+    expect(reply.text).not.toContain("hidden cron-owned detail");
   });
 });
 

--- a/src/auto-reply/reply/commands-tasks.ts
+++ b/src/auto-reply/reply/commands-tasks.ts
@@ -4,7 +4,7 @@ import { formatDurationCompact } from "../../infra/format-time/format-duration.t
 import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import {
-  listTasksForAgentIdForStatus,
+  listAutomationTasksForAgentIdForStatus,
   listTasksForSessionKeyForStatus,
 } from "../../tasks/task-status-access.js";
 import {
@@ -41,12 +41,12 @@ function formatTaskHeadline(snapshot: ReturnType<typeof buildTaskStatusSnapshot>
   return `Current session: ${snapshot.activeCount} active · ${snapshot.totalCount} total`;
 }
 
-function formatAgentFallbackLine(agentId: string): string | undefined {
-  const snapshot = buildTaskStatusSnapshot(listTasksForAgentIdForStatus(agentId));
+function formatAutomationLine(agentId: string): string | undefined {
+  const snapshot = buildTaskStatusSnapshot(listAutomationTasksForAgentIdForStatus(agentId));
   if (snapshot.totalCount === 0) {
     return undefined;
   }
-  return `Agent-local: ${snapshot.activeCount} active · ${snapshot.totalCount} total`;
+  return `Automation: ${snapshot.activeCount} active · ${snapshot.totalCount} total`;
 }
 
 function formatTaskTiming(task: TaskRecord): string | undefined {
@@ -83,6 +83,7 @@ export function buildTasksText(params: { sessionKey: string; agentId: string }):
     listTasksForSessionKeyForStatus(params.sessionKey),
   );
   const lines = ["📋 Tasks", formatTaskHeadline(sessionSnapshot)];
+  const automationLine = formatAutomationLine(params.agentId);
 
   if (sessionSnapshot.totalCount > 0) {
     const visible = sessionSnapshot.visible.slice(0, MAX_VISIBLE_TASKS);
@@ -97,12 +98,14 @@ export function buildTasksText(params: { sessionKey: string; agentId: string }):
     if (hiddenCount > 0) {
       lines.push("", `+${hiddenCount} more recent task${hiddenCount === 1 ? "" : "s"}`);
     }
+    if (automationLine) {
+      lines.push("", automationLine);
+    }
     return lines.join("\n");
   }
 
-  const agentFallback = formatAgentFallbackLine(params.agentId);
-  if (agentFallback) {
-    lines.push(agentFallback);
+  if (automationLine) {
+    lines.push(automationLine);
   }
   return lines.join("\n");
 }

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -113,6 +113,10 @@ function clearFollowupQueueForFollowupTest(key: string): number {
   return cleared;
 }
 
+function getFollowupQueueDepthForFollowupTest(key: string): number {
+  return FOLLOWUP_TEST_QUEUES.get(key.trim())?.items.length ?? 0;
+}
+
 function enqueueFollowupRunForFollowupTest(key: string, run: FollowupRun): boolean {
   const queue = getFollowupTestQueue(key);
   queue.items.push(run);
@@ -222,7 +226,6 @@ async function persistRunSessionUsageForFollowupTest(
   }
   await saveSessionStore(storePath, store);
 }
-
 vi.mock(
   "../../agents/model-fallback.js",
   async () => await import("../../test-utils/model-fallback.mock.js"),
@@ -246,6 +249,7 @@ vi.mock("../../agents/pi-embedded.js", () => ({
 vi.mock("./queue.js", () => ({
   clearFollowupQueue: clearFollowupQueueForFollowupTest,
   enqueueFollowupRun: enqueueFollowupRunForFollowupTest,
+  getFollowupQueueDepth: getFollowupQueueDepthForFollowupTest,
   refreshQueuedFollowupSession: refreshQueuedFollowupSessionForFollowupTest,
 }));
 vi.mock("./session-run-accounting.js", () => ({
@@ -265,6 +269,11 @@ const { createFollowupRunner } = await import("./followup-runner.js");
 const { loadSessionStore, saveSessionStore, clearSessionStoreCacheForTest } =
   await import("../../config/sessions/store.js");
 const { clearFollowupQueue, enqueueFollowupRun } = await import("./queue.js");
+const {
+  registerQueuedFollowupLifecycle,
+  consumeQueuedFollowupStartNotice,
+  resetQueuedFollowupLifecycleForTests,
+} = await import("./queue-lifecycle.js");
 const sessionRunAccounting = await import("./session-run-accounting.js");
 const { createMockFollowupRun, createMockTypingController } = await import("./test-helpers.js");
 
@@ -294,12 +303,14 @@ beforeEach(async () => {
   clearFollowupQueue("main");
   FOLLOWUP_TEST_QUEUES.clear();
   FOLLOWUP_TEST_SESSION_STORES.clear();
+  resetQueuedFollowupLifecycleForTests();
 });
 
 afterEach(async () => {
   clearFollowupQueue("main");
   FOLLOWUP_TEST_QUEUES.clear();
   FOLLOWUP_TEST_SESSION_STORES.clear();
+  resetQueuedFollowupLifecycleForTests();
   vi.clearAllTimers();
   vi.useRealTimers();
   clearSessionStoreCacheForTest();
@@ -772,6 +783,198 @@ describe("createFollowupRunner bootstrap warning dedupe", () => {
     expect(call?.allowGatewaySubagentBinding).toBe(true);
     expect(call?.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
     expect(call?.bootstrapPromptWarningSignature).toBe("sig-b");
+  });
+});
+
+describe("createFollowupRunner queue lifecycle", () => {
+  it("prepends a resumed notice without counting the current item as backlog", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T12:00:00.000Z"));
+
+    const onBlockReply = createAsyncReplySpy();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      meta: {},
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+      sessionKey: "main",
+    });
+
+    const queued = createQueuedRun({
+      run: {
+        sessionKey: "main",
+      },
+    });
+    enqueueFollowupRun("main", queued, { mode: "queue" });
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run: queued,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_100);
+    await runner(queued);
+
+    expect(onBlockReply).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        text: "Resumed after backlog cleared after 2s. Thanks for waiting.",
+      }),
+    );
+    expect(onBlockReply).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "hello world!" }),
+    );
+  });
+
+  it("clears queued lifecycle state when messaging-tool suppression drops followup payloads", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T12:00:00.000Z"));
+
+    const onBlockReply = createAsyncReplySpy();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      meta: {},
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+      sessionKey: "main",
+    });
+
+    const queued = createQueuedRun({
+      run: {
+        messageProvider: "slack",
+        sessionKey: "main",
+      },
+    });
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run: queued,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_100);
+    await runner(queued);
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(
+      consumeQueuedFollowupStartNotice({
+        queueKey: "main",
+        run: queued,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("clears queued lifecycle state when the followup produces no payloads", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T12:00:00.000Z"));
+
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [],
+      meta: {},
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply: createAsyncReplySpy() },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+      sessionKey: "main",
+    });
+
+    const queued = createQueuedRun({
+      run: {
+        sessionKey: "main",
+      },
+    });
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run: queued,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_100);
+    await runner(queued);
+
+    expect(
+      consumeQueuedFollowupStartNotice({
+        queueKey: "main",
+        run: queued,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("consumes lifecycle refs carried by synthesized followup runs", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T12:00:00.000Z"));
+
+    const onBlockReply = createAsyncReplySpy();
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "batch reply" }],
+      meta: {},
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-6",
+      sessionKey: "main",
+    });
+
+    const first = createQueuedRun({
+      prompt: "first",
+      messageId: "first-msg",
+      run: {
+        sessionKey: "main",
+      },
+    });
+    const second = createQueuedRun({
+      prompt: "second",
+      messageId: "second-msg",
+      run: {
+        sessionKey: "main",
+      },
+    });
+    enqueueFollowupRun("main", first, { mode: "collect" });
+    enqueueFollowupRun("main", second, { mode: "collect" });
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run: first,
+    });
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run: second,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_100);
+    await runner({
+      ...second,
+      prompt: "[Queued messages while agent was busy]",
+      enqueuedAt: Date.now(),
+      messageId: "summary-msg",
+      lifecycleRefs: [first, second],
+    });
+
+    expect(onBlockReply).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        text: "Resumed after backlog cleared after 2s. Thanks for waiting.",
+      }),
+    );
+    expect(
+      consumeQueuedFollowupStartNotice({
+        queueKey: "main",
+        refs: [first, second],
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -24,12 +24,33 @@ import { runPreflightCompactionIfNeeded } from "./agent-runner-memory.js";
 import { resolveRunAuthProfile } from "./agent-runner-utils.js";
 import { resolveFollowupDeliveryPayloads } from "./followup-delivery.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
-import { refreshQueuedFollowupSession, type FollowupRun } from "./queue.js";
+import { consumeQueuedFollowupStartNotice } from "./queue-lifecycle.js";
+import {
+  getFollowupQueueDepth,
+  refreshQueuedFollowupSession,
+  type FollowupLifecycleRef,
+  type FollowupRun,
+} from "./queue.js";
 import { createReplyOperation } from "./reply-run-registry.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
+
+function resolveQueuedLifecycleRefs(queued: FollowupRun): FollowupLifecycleRef[] {
+  if (queued.lifecycleRefs?.length) {
+    return queued.lifecycleRefs;
+  }
+  return [
+    {
+      messageId: queued.messageId,
+      enqueuedAt: queued.enqueuedAt,
+      run: {
+        sessionId: queued.run.sessionId,
+      },
+    },
+  ];
+}
 
 export function createFollowupRunner(params: {
   opts?: GetReplyOptions;
@@ -304,6 +325,18 @@ export function createFollowupRunner(params: {
         });
       }
 
+      const queueKey = queued.run.sessionKey ?? sessionKey;
+      const lifecycleRefs = resolveQueuedLifecycleRefs(queued);
+      const startNotice = queueKey
+        ? consumeQueuedFollowupStartNotice({
+            queueKey,
+            refs: lifecycleRefs,
+            remainingQueuedCount: Math.max(
+              0,
+              getFollowupQueueDepth(queueKey) - lifecycleRefs.length,
+            ),
+          })
+        : undefined;
       const payloadArray = runResult.payloads ?? [];
       if (payloadArray.length === 0) {
         return;
@@ -336,6 +369,9 @@ export function createFollowupRunner(params: {
       if (finalPayloads.length === 0) {
         return;
       }
+      if (startNotice) {
+        finalPayloads.unshift(startNotice);
+      }
 
       if (autoCompactionCount > 0) {
         const previousSessionId = queued.run.sessionId;
@@ -353,7 +389,6 @@ export function createFollowupRunner(params: {
         const refreshedSessionEntry =
           sessionKey && sessionStore ? sessionStore[sessionKey] : undefined;
         if (refreshedSessionEntry) {
-          const queueKey = queued.run.sessionKey ?? sessionKey;
           if (queueKey) {
             refreshQueuedFollowupSession({
               key: queueKey,

--- a/src/auto-reply/reply/queue-lifecycle.test.ts
+++ b/src/auto-reply/reply/queue-lifecycle.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearQueuedFollowupLifecycleForQueue,
+  consumeQueuedFollowupStartNotice,
+  registerQueuedFollowupLifecycle,
+  resetQueuedFollowupLifecycleForTests,
+} from "./queue-lifecycle.js";
+import { createMockFollowupRun } from "./test-helpers.js";
+
+describe("queue lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T12:00:00.000Z"));
+    resetQueuedFollowupLifecycleForTests();
+  });
+
+  afterEach(() => {
+    resetQueuedFollowupLifecycleForTests();
+    vi.useRealTimers();
+  });
+
+  it("emits queued and delayed notices at their thresholds", async () => {
+    const notices: string[] = [];
+    const run = createMockFollowupRun();
+
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run,
+      sendNotice: (payload) => {
+        if (payload.text) {
+          notices.push(payload.text);
+        }
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(notices).toEqual([
+      "Queued behind earlier work. I have your message and will reply when the lane clears.",
+    ]);
+
+    await vi.advanceTimersByTimeAsync(28_000);
+    expect(notices).toEqual([
+      "Queued behind earlier work. I have your message and will reply when the lane clears.",
+      "Still queued behind earlier work. I still have your message and will reply when the lane clears.",
+    ]);
+  });
+
+  it("emits a resumed notice when a queued turn starts after backlog clears", async () => {
+    const run = createMockFollowupRun();
+
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_100);
+
+    expect(
+      consumeQueuedFollowupStartNotice({
+        queueKey: "main",
+        run,
+      }),
+    ).toEqual({
+      text: "Resumed after backlog cleared after 2s. Thanks for waiting.",
+    });
+  });
+
+  it("emits a catching-up notice when backlog remains behind the resumed turn", async () => {
+    const run = createMockFollowupRun();
+
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_100);
+
+    expect(
+      consumeQueuedFollowupStartNotice({
+        queueKey: "main",
+        run,
+        remainingQueuedCount: 1,
+      }),
+    ).toEqual({
+      text: "Catching up after backlog cleared after 2s. Thanks for waiting.",
+    });
+  });
+
+  it("consumes multiple queued refs when a synthesized batch starts", async () => {
+    const first = createMockFollowupRun({
+      messageId: "first-msg",
+    });
+    const second = createMockFollowupRun({
+      messageId: "second-msg",
+      enqueuedAt: first.enqueuedAt + 100,
+    });
+
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run: first,
+    });
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run: second,
+    });
+
+    await vi.advanceTimersByTimeAsync(2_100);
+
+    expect(
+      consumeQueuedFollowupStartNotice({
+        queueKey: "main",
+        refs: [first, second],
+      }),
+    ).toEqual({
+      text: "Resumed after backlog cleared after 2s. Thanks for waiting.",
+    });
+    expect(
+      consumeQueuedFollowupStartNotice({
+        queueKey: "main",
+        refs: [first, second],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("clears queued lifecycle state for a queue without leaking notices", async () => {
+    const notices: string[] = [];
+    const run = createMockFollowupRun();
+
+    registerQueuedFollowupLifecycle({
+      queueKey: "main",
+      run,
+      sendNotice: (payload) => {
+        if (payload.text) {
+          notices.push(payload.text);
+        }
+      },
+    });
+
+    clearQueuedFollowupLifecycleForQueue("main");
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    expect(notices).toEqual([]);
+    expect(
+      consumeQueuedFollowupStartNotice({
+        queueKey: "main",
+        run,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/queue-lifecycle.ts
+++ b/src/auto-reply/reply/queue-lifecycle.ts
@@ -1,0 +1,180 @@
+import { formatDurationCompact } from "../../infra/format-time/format-duration.ts";
+import { resolveGlobalMap } from "../../shared/global-singleton.js";
+import type { ReplyPayload } from "../types.js";
+import type { FollowupLifecycleRef } from "./queue.js";
+
+type QueueLifecycleNoticeKind = "queued" | "delayed";
+
+type QueueLifecycleEntry = {
+  queueKey: string;
+  enqueuedAt: number;
+  queuedSent: boolean;
+  delayedSent: boolean;
+  queuedTimer?: ReturnType<typeof setTimeout>;
+  delayedTimer?: ReturnType<typeof setTimeout>;
+  sendNotice?: (payload: ReplyPayload) => Promise<void> | void;
+};
+
+const QUEUED_NOTICE_AFTER_MS = 2_000;
+const DELAYED_NOTICE_AFTER_MS = 30_000;
+
+const QUEUE_LIFECYCLE_STATE_KEY = Symbol.for("openclaw.followupQueueLifecycle");
+
+function getLifecycleState() {
+  return resolveGlobalMap<string, QueueLifecycleEntry>(QUEUE_LIFECYCLE_STATE_KEY);
+}
+
+function resolveLifecycleKey(params: { queueKey: string; run: FollowupLifecycleRef }): string {
+  return JSON.stringify([
+    params.queueKey,
+    params.run.run.sessionId,
+    params.run.messageId?.trim() ?? "",
+    params.run.enqueuedAt,
+  ]);
+}
+
+function clearLifecycleTimers(entry: QueueLifecycleEntry): void {
+  if (entry.queuedTimer) {
+    clearTimeout(entry.queuedTimer);
+    entry.queuedTimer = undefined;
+  }
+  if (entry.delayedTimer) {
+    clearTimeout(entry.delayedTimer);
+    entry.delayedTimer = undefined;
+  }
+}
+
+function buildQueueNotice(kind: QueueLifecycleNoticeKind): ReplyPayload {
+  if (kind === "delayed") {
+    return {
+      text: "Still queued behind earlier work. I still have your message and will reply when the lane clears.",
+    };
+  }
+  return {
+    text: "Queued behind earlier work. I have your message and will reply when the lane clears.",
+  };
+}
+
+function formatWaitDuration(waitedMs: number): string | undefined {
+  return formatDurationCompact(waitedMs, { spaced: true }) ?? undefined;
+}
+
+async function emitLifecycleNotice(
+  lifecycleKey: string,
+  kind: QueueLifecycleNoticeKind,
+): Promise<void> {
+  const entry = getLifecycleState().get(lifecycleKey);
+  if (!entry) {
+    return;
+  }
+  if (kind === "queued") {
+    if (entry.queuedSent) {
+      return;
+    }
+    entry.queuedSent = true;
+  } else {
+    if (entry.delayedSent) {
+      return;
+    }
+    entry.delayedSent = true;
+  }
+  await entry.sendNotice?.(buildQueueNotice(kind));
+}
+
+export function registerQueuedFollowupLifecycle(params: {
+  queueKey: string;
+  run: FollowupLifecycleRef;
+  sendNotice?: (payload: ReplyPayload) => Promise<void> | void;
+}): void {
+  const lifecycleKey = resolveLifecycleKey(params);
+  const lifecycleState = getLifecycleState();
+  const existing = lifecycleState.get(lifecycleKey);
+  if (existing) {
+    clearLifecycleTimers(existing);
+  }
+  const entry: QueueLifecycleEntry = {
+    queueKey: params.queueKey,
+    enqueuedAt: params.run.enqueuedAt,
+    queuedSent: false,
+    delayedSent: false,
+    sendNotice: params.sendNotice,
+  };
+  lifecycleState.set(lifecycleKey, entry);
+  entry.queuedTimer = setTimeout(() => {
+    void emitLifecycleNotice(lifecycleKey, "queued");
+  }, QUEUED_NOTICE_AFTER_MS);
+  entry.delayedTimer = setTimeout(() => {
+    void emitLifecycleNotice(lifecycleKey, "delayed");
+  }, DELAYED_NOTICE_AFTER_MS);
+}
+
+export function consumeQueuedFollowupStartNotice(params: {
+  queueKey: string;
+  run?: FollowupLifecycleRef;
+  refs?: FollowupLifecycleRef[];
+  remainingQueuedCount?: number;
+}): ReplyPayload | undefined {
+  const refs = params.refs?.length ? params.refs : params.run ? [params.run] : [];
+  if (refs.length === 0) {
+    return undefined;
+  }
+  const lifecycleState = getLifecycleState();
+  const entries = refs
+    .map((ref) => {
+      const lifecycleKey = resolveLifecycleKey({
+        queueKey: params.queueKey,
+        run: ref,
+      });
+      const entry = lifecycleState.get(lifecycleKey);
+      return entry ? { lifecycleKey, entry } : undefined;
+    })
+    .filter((entry): entry is { lifecycleKey: string; entry: QueueLifecycleEntry } =>
+      Boolean(entry),
+    );
+  if (entries.length === 0) {
+    return undefined;
+  }
+  for (const { lifecycleKey, entry } of entries) {
+    clearLifecycleTimers(entry);
+    lifecycleState.delete(lifecycleKey);
+  }
+  const oldestEnqueuedAt = Math.min(...entries.map(({ entry }) => entry.enqueuedAt));
+  const waitedMs = Date.now() - oldestEnqueuedAt;
+  const queuedSent = entries.some(({ entry }) => entry.queuedSent);
+  const delayedSent = entries.some(({ entry }) => entry.delayedSent);
+  const shouldExplain = queuedSent || delayedSent || waitedMs >= QUEUED_NOTICE_AFTER_MS;
+  if (!shouldExplain) {
+    return undefined;
+  }
+  const shouldCatchUp =
+    delayedSent || (params.remainingQueuedCount ?? 0) > 0 || waitedMs >= DELAYED_NOTICE_AFTER_MS;
+  const waitDuration = formatWaitDuration(waitedMs);
+  return {
+    text: shouldCatchUp
+      ? `Catching up after backlog cleared${waitDuration ? ` after ${waitDuration}` : ""}. Thanks for waiting.`
+      : `Resumed after backlog cleared${waitDuration ? ` after ${waitDuration}` : ""}. Thanks for waiting.`,
+  };
+}
+
+export function clearQueuedFollowupLifecycleForQueue(queueKey: string): void {
+  const cleaned = queueKey.trim();
+  if (!cleaned) {
+    return;
+  }
+  const lifecycleState = getLifecycleState();
+  for (const [key, entry] of lifecycleState.entries()) {
+    if (entry.queueKey !== cleaned) {
+      continue;
+    }
+    clearLifecycleTimers(entry);
+    lifecycleState.delete(key);
+  }
+}
+
+export function resetQueuedFollowupLifecycleForTests(): void {
+  const lifecycleState = getLifecycleState();
+  for (const entry of lifecycleState.values()) {
+    clearLifecycleTimers(entry);
+  }
+  lifecycleState.clear();
+}

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -141,6 +141,54 @@ describe("followup queue collect routing", () => {
     expect(calls[0]?.originatingTo).toBe("channel:A");
   });
 
+  it("carries lifecycle refs for collected batches", async () => {
+    const key = `test-collect-lifecycle-refs-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const done = createDeferred<void>();
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run);
+      done.resolve();
+    };
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    const first = createRun({
+      prompt: "one",
+      messageId: "one-msg",
+      originatingChannel: "slack",
+      originatingTo: "channel:A",
+    });
+    const second = createRun({
+      prompt: "two",
+      messageId: "two-msg",
+      originatingChannel: "slack",
+      originatingTo: "channel:A",
+    });
+
+    enqueueFollowupRun(key, first, settings);
+    enqueueFollowupRun(key, second, settings);
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls[0]?.lifecycleRefs).toEqual([
+      expect.objectContaining({
+        messageId: "one-msg",
+        enqueuedAt: first.enqueuedAt,
+        run: { sessionId: first.run.sessionId },
+      }),
+      expect.objectContaining({
+        messageId: "two-msg",
+        enqueuedAt: second.enqueuedAt,
+        run: { sessionId: second.run.sessionId },
+      }),
+    ]);
+  });
+
   it("collects Slack messages in same thread and preserves string thread id", async () => {
     const key = `test-collect-slack-thread-same-${Date.now()}`;
     const calls: FollowupRun[] = [];
@@ -334,5 +382,46 @@ describe("followup queue collect routing", () => {
     expect(calls[0]?.originatingAccountId).toBe("work");
     expect(calls[0]?.originatingThreadId).toBe("1739142736.000100");
     expect(calls[0]?.prompt).toContain("[Queue overflow] Dropped 1 message due to cap.");
+  });
+
+  it("carries the current item lifecycle ref on overflow summaries", async () => {
+    const key = `test-overflow-summary-lifecycle-${Date.now()}`;
+    const calls: FollowupRun[] = [];
+    const done = createDeferred<void>();
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run);
+      done.resolve();
+    };
+    const settings: QueueSettings = {
+      mode: "followup",
+      debounceMs: 0,
+      cap: 1,
+      dropPolicy: "summarize",
+    };
+
+    enqueueFollowupRun(
+      key,
+      createRun({
+        prompt: "first",
+        messageId: "first-msg",
+      }),
+      settings,
+    );
+    const second = createRun({
+      prompt: "second",
+      messageId: "second-msg",
+    });
+    enqueueFollowupRun(key, second, settings);
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(calls[0]?.lifecycleRefs).toEqual([
+      expect.objectContaining({
+        messageId: "second-msg",
+        enqueuedAt: second.enqueuedAt,
+        run: { sessionId: second.run.sessionId },
+      }),
+    ]);
   });
 });

--- a/src/auto-reply/reply/queue.ts
+++ b/src/auto-reply/reply/queue.ts
@@ -10,6 +10,7 @@ export {
 export { resolveQueueSettings } from "./queue/settings.js";
 export { clearFollowupQueue, refreshQueuedFollowupSession } from "./queue/state.js";
 export type {
+  FollowupLifecycleRef,
   FollowupRun,
   QueueDedupeMode,
   QueueDropPolicy,

--- a/src/auto-reply/reply/queue/cleanup.test.ts
+++ b/src/auto-reply/reply/queue/cleanup.test.ts
@@ -4,6 +4,7 @@ import { __testing, clearSessionQueues } from "./cleanup.js";
 const followupQueueMocks = vi.hoisted(() => ({
   clearFollowupDrainCallback: vi.fn(),
   clearFollowupQueue: vi.fn(() => 2),
+  clearQueuedFollowupLifecycleForQueue: vi.fn(),
 }));
 
 const commandQueueMocks = vi.hoisted(() => ({
@@ -16,6 +17,10 @@ vi.mock("./drain.js", () => ({
 
 vi.mock("./state.js", () => ({
   clearFollowupQueue: followupQueueMocks.clearFollowupQueue,
+}));
+
+vi.mock("../queue-lifecycle.js", () => ({
+  clearQueuedFollowupLifecycleForQueue: followupQueueMocks.clearQueuedFollowupLifecycleForQueue,
 }));
 
 vi.mock("../../../process/command-queue.js", () => ({
@@ -31,6 +36,7 @@ describe("clearSessionQueues", () => {
     __testing.resetDepsForTests();
     followupQueueMocks.clearFollowupDrainCallback.mockReset();
     followupQueueMocks.clearFollowupQueue.mockReset().mockReturnValue(2);
+    followupQueueMocks.clearQueuedFollowupLifecycleForQueue.mockReset();
     commandQueueMocks.clearCommandLane.mockReset().mockReturnValue(3);
   });
 
@@ -48,6 +54,7 @@ describe("clearSessionQueues", () => {
       keys: ["alpha"],
     });
     expect(followupQueueMocks.clearFollowupQueue).toHaveBeenCalledWith("alpha");
+    expect(followupQueueMocks.clearQueuedFollowupLifecycleForQueue).toHaveBeenCalledWith("alpha");
     expect(followupQueueMocks.clearFollowupDrainCallback).toHaveBeenCalledWith("alpha");
     expect(commandQueueMocks.clearCommandLane).toHaveBeenCalledWith("session:alpha");
   });

--- a/src/auto-reply/reply/queue/cleanup.ts
+++ b/src/auto-reply/reply/queue/cleanup.ts
@@ -1,6 +1,7 @@
 import { resolveEmbeddedSessionLane } from "../../../agents/pi-embedded-runner/lanes.js";
 import { clearCommandLane } from "../../../process/command-queue.js";
 import { normalizeOptionalString } from "../../../shared/string-coerce.js";
+import { clearQueuedFollowupLifecycleForQueue } from "../queue-lifecycle.js";
 import { clearFollowupDrainCallback } from "./drain.js";
 import { clearFollowupQueue } from "./state.js";
 
@@ -64,6 +65,7 @@ export function clearSessionQueues(keys: Array<string | undefined>): ClearSessio
     }
     seen.add(cleaned);
     clearedKeys.push(cleaned);
+    clearQueuedFollowupLifecycleForQueue(cleaned);
     followupCleared += clearFollowupQueue(cleaned);
     clearFollowupDrainCallback(cleaned);
     laneCleared += clearLane(resolveLane(cleaned));

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../utils/queue-helpers.js";
 import { isRoutableChannel } from "../route-reply.js";
 import { FOLLOWUP_QUEUES } from "./state.js";
-import type { FollowupRun } from "./types.js";
+import type { FollowupLifecycleRef, FollowupRun } from "./types.js";
 
 // Persists the most recent runFollowup callback per queue key so that
 // enqueueFollowupRun can restart a drain that finished and deleted the queue.
@@ -46,6 +46,16 @@ type OriginRoutingMetadata = Pick<
   FollowupRun,
   "originatingChannel" | "originatingTo" | "originatingAccountId" | "originatingThreadId"
 >;
+
+function toLifecycleRef(run: FollowupRun): FollowupLifecycleRef {
+  return {
+    messageId: run.messageId,
+    enqueuedAt: run.enqueuedAt,
+    run: {
+      sessionId: run.run.sessionId,
+    },
+  };
+}
 
 function resolveOriginRoutingMetadata(items: FollowupRun[]): OriginRoutingMetadata {
   return {
@@ -133,6 +143,7 @@ export function scheduleFollowupDrain(
             prompt,
             run,
             enqueuedAt: Date.now(),
+            lifecycleRefs: items.map(toLifecycleRef),
             ...routing,
           });
           queue.items.splice(0, items.length);
@@ -154,6 +165,7 @@ export function scheduleFollowupDrain(
                 prompt: summaryPrompt,
                 run,
                 enqueuedAt: Date.now(),
+                lifecycleRefs: [toLifecycleRef(item)],
                 originatingChannel: item.originatingChannel,
                 originatingTo: item.originatingTo,
                 originatingAccountId: item.originatingAccountId,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -19,12 +19,25 @@ export type QueueSettings = {
 
 export type QueueDedupeMode = "message-id" | "prompt" | "none";
 
+export type FollowupLifecycleRef = {
+  messageId?: string;
+  enqueuedAt: number;
+  run: {
+    sessionId: string;
+  };
+};
+
 export type FollowupRun = {
   prompt: string;
   /** Provider message ID, when available (for deduplication). */
   messageId?: string;
   summaryLine?: string;
   enqueuedAt: number;
+  /**
+   * Original queued items represented by this run when the drain synthesizes a
+   * summary or collect prompt.
+   */
+  lifecycleRefs?: FollowupLifecycleRef[];
   /**
    * Originating channel for reply routing.
    * When set, replies should be routed back to this provider

--- a/src/commands/doctor-cron-store-migration.test.ts
+++ b/src/commands/doctor-cron-store-migration.test.ts
@@ -284,6 +284,60 @@ describe("normalizeStoredCronJobs", () => {
     expect(schedule.staggerMs).toBeUndefined();
   });
 
+  it("defaults quiet migrated automation jobs to delivery.mode none and flags missing toolsAllow", () => {
+    const { job, result } = normalizeOneJob(
+      makeLegacyJob({
+        id: "job-quiet-migrated",
+        sessionKey: "agent:main:cron:job-quiet-migrated",
+        sessionTarget: "isolated",
+        payload: {
+          kind: "agentTurn",
+          message: "quiet cron",
+        },
+      }),
+    );
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.missingToolsAllow).toBe(1);
+    expect(job.delivery).toEqual({ mode: "none" });
+  });
+
+  it("does not flag migrated automation jobs that already carry explicit toolsAllow", () => {
+    const { job, result } = normalizeOneJob(
+      makeLegacyJob({
+        id: "job-explicit-tools",
+        sessionKey: "agent:main:cron:job-explicit-tools",
+        sessionTarget: "isolated",
+        payload: {
+          kind: "agentTurn",
+          message: "quiet cron",
+          toolsAllow: ["read"],
+        },
+      }),
+    );
+
+    expect(result.issues.missingToolsAllow).toBeUndefined();
+    expect(job.delivery).toEqual({ mode: "none" });
+  });
+
+  it("keeps non-cron isolated sessions announced and does not require toolsAllow", () => {
+    const { job, result } = normalizeOneJob(
+      makeLegacyJob({
+        id: "job-custom-session",
+        sessionKey: "agent:main:telegram:dm:12345",
+        sessionTarget: "isolated",
+        payload: {
+          kind: "agentTurn",
+          message: "reply in the human lane",
+        },
+      }),
+    );
+
+    expect(result.mutated).toBe(true);
+    expect(result.issues.missingToolsAllow).toBeUndefined();
+    expect(job.delivery).toEqual({ mode: "announce" });
+  });
+
   it("migrates legacy string schedules and command-only payloads (#18445)", () => {
     const { job, result } = normalizeOneJob({
       id: "imessage-refresh",

--- a/src/commands/doctor-cron-store-migration.ts
+++ b/src/commands/doctor-cron-store-migration.ts
@@ -3,6 +3,7 @@ import { parseAbsoluteTimeMs } from "../cron/parse.js";
 import { coerceFiniteScheduleNumber } from "../cron/schedule.js";
 import { inferLegacyName } from "../cron/service/normalize.js";
 import { normalizeCronStaggerMs, resolveDefaultCronStaggerMs } from "../cron/stagger.js";
+import { isCronSessionKey } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -19,7 +20,8 @@ type CronStoreIssueKey =
   | "legacyPayloadProvider"
   | "legacyTopLevelPayloadFields"
   | "legacyTopLevelDeliveryFields"
-  | "legacyDeliveryMode";
+  | "legacyDeliveryMode"
+  | "missingToolsAllow";
 
 type CronStoreIssues = Partial<Record<CronStoreIssueKey, number>>;
 
@@ -31,6 +33,10 @@ type NormalizeCronStoreJobsResult = {
 
 function incrementIssue(issues: CronStoreIssues, key: CronStoreIssueKey) {
   issues[key] = (issues[key] ?? 0) + 1;
+}
+
+function isDedicatedAutomationCronSession(sessionKey: unknown): boolean {
+  return typeof sessionKey === "string" && isCronSessionKey(sessionKey);
 }
 
 function normalizePayloadKind(payload: Record<string, unknown>) {
@@ -496,16 +502,23 @@ export function normalizeStoredCronJobs(
       payload: payloadRecord,
     });
 
+    const isDedicatedAutomationSession = isDedicatedAutomationCronSession(raw.sessionKey);
     if (isIsolatedAgentTurn && payloadKind === "agentTurn") {
       if (!hasDelivery && normalizedLegacy.delivery) {
         raw.delivery = normalizedLegacy.delivery;
         mutated = true;
       } else if (!hasDelivery) {
-        raw.delivery = { mode: "announce" };
+        raw.delivery = isDedicatedAutomationSession ? { mode: "none" } : { mode: "announce" };
         mutated = true;
       } else if (normalizedLegacy.mutated && normalizedLegacy.delivery) {
         raw.delivery = normalizedLegacy.delivery;
         mutated = true;
+      }
+      if (
+        isDedicatedAutomationSession &&
+        (!payloadRecord || !Array.isArray((payloadRecord as { toolsAllow?: unknown }).toolsAllow))
+      ) {
+        trackIssue("missingToolsAllow");
       }
     } else if (normalizedLegacy.mutated && normalizedLegacy.delivery) {
       raw.delivery = normalizedLegacy.delivery;

--- a/src/cron/isolated-agent.delivery-awareness.test.ts
+++ b/src/cron/isolated-agent.delivery-awareness.test.ts
@@ -74,7 +74,7 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
 
       expect(result.status).toBe("ok");
       expect(result.delivered).toBe(true);
-      expect(peekSystemEvents("agent:main:main")).toEqual(["hello from cron"]);
+      expect(peekSystemEvents("agent:main:automation-status")).toEqual(["hello from cron"]);
     });
   });
 
@@ -101,7 +101,7 @@ describe("runCronIsolatedAgentTurn cron delivery awareness", () => {
 
       expect(result.status).toBe("ok");
       expect(result.delivered).toBe(true);
-      expect(peekSystemEvents("global")).toEqual(["global cron digest"]);
+      expect(peekSystemEvents("agent:main:automation-status")).toEqual(["global cron digest"]);
     });
   });
 });

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -3,10 +3,7 @@ import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.j
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  resolveAgentMainSessionKey,
-  resolveMainSessionKey,
-} from "../../config/sessions/main-session.js";
+import { resolveAutomationStatusSessionKey } from "../../infra/automation-status-session.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { OutboundDeliveryResult } from "../../infra/outbound/deliver.js";
@@ -246,15 +243,6 @@ function shouldQueueCronAwareness(job: CronJob, deliveryBestEffort: boolean): bo
   return job.sessionTarget === "isolated" && !deliveryBestEffort;
 }
 
-function resolveCronAwarenessMainSessionKey(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
-}): string {
-  return params.cfg.session?.scope === "global"
-    ? resolveMainSessionKey(params.cfg)
-    : resolveAgentMainSessionKey({ cfg: params.cfg, agentId: params.agentId });
-}
-
 async function queueCronAwarenessSystemEvent(params: {
   cfg: OpenClawConfig;
   jobId: string;
@@ -272,15 +260,12 @@ async function queueCronAwarenessSystemEvent(params: {
   try {
     const { enqueueSystemEvent } = await loadDeliveryOutboundRuntime();
     enqueueSystemEvent(text, {
-      sessionKey: resolveCronAwarenessMainSessionKey({
-        cfg: params.cfg,
-        agentId: params.agentId,
-      }),
+      sessionKey: resolveAutomationStatusSessionKey(params.agentId),
       contextKey: params.deliveryIdempotencyKey,
     });
   } catch (err) {
     logWarn(
-      `[cron:${params.jobId}] failed to queue isolated cron awareness for the main session: ${formatErrorMessage(err)}`,
+      `[cron:${params.jobId}] failed to queue isolated cron awareness for the automation status session: ${formatErrorMessage(err)}`,
     );
   }
 }

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -683,6 +683,85 @@ describe("createJob delivery defaults", () => {
     });
     expect(job.delivery).toBeUndefined();
   });
+
+  it("requires explicit delivery.mode for migrated automation session jobs", () => {
+    const state = createMockState(now);
+    expect(() =>
+      createJob(state, {
+        name: "migrated-automation-missing-delivery",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        sessionKey: "agent:main:cron:job-1",
+        payload: { kind: "agentTurn", message: "hello", toolsAllow: ["read"] },
+      } as Parameters<typeof createJob>[1]),
+    ).toThrow("cron automation session jobs require explicit delivery.mode");
+  });
+
+  it("requires explicit payload.toolsAllow for migrated automation session jobs", () => {
+    const state = createMockState(now);
+    expect(() =>
+      createJob(state, {
+        name: "migrated-automation-missing-tools",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        sessionKey: "agent:main:cron:job-1",
+        payload: { kind: "agentTurn", message: "hello" },
+        delivery: { mode: "none" },
+      } as Parameters<typeof createJob>[1]),
+    ).toThrow("cron automation session jobs require explicit payload.toolsAllow");
+  });
+});
+
+describe("automation session patch validation", () => {
+  it("rejects patches against migrated automation jobs that still lack explicit delivery", () => {
+    const now = Date.now();
+    const job: CronJob = {
+      id: "job-automation-patch-delivery",
+      name: "job-automation-patch-delivery",
+      enabled: true,
+      createdAtMs: now,
+      updatedAtMs: now,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      sessionKey: "agent:main:cron:job-automation-patch-delivery",
+      payload: { kind: "agentTurn", message: "hello", toolsAllow: ["read"] },
+      delivery: undefined,
+      state: {},
+    };
+
+    expect(() => applyJobPatch(job, { enabled: false })).toThrow(
+      "cron automation session jobs require explicit delivery.mode",
+    );
+  });
+
+  it("rejects patches that clear toolsAllow on migrated automation session jobs", () => {
+    const now = Date.now();
+    const job: CronJob = {
+      id: "job-automation-patch-tools",
+      name: "job-automation-patch-tools",
+      enabled: true,
+      createdAtMs: now,
+      updatedAtMs: now,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      sessionKey: "agent:main:cron:job-automation-patch-tools",
+      payload: { kind: "agentTurn", message: "hello", toolsAllow: ["read"] },
+      delivery: { mode: "none" },
+      state: {},
+    };
+
+    expect(() =>
+      applyJobPatch(job, {
+        payload: { kind: "agentTurn", message: "hello", toolsAllow: null },
+      }),
+    ).toThrow("cron automation session jobs require explicit payload.toolsAllow");
+  });
 });
 
 describe("recomputeNextRuns", () => {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -213,6 +213,62 @@ function assertFailureDestinationSupport(job: Pick<CronJob, "sessionTarget" | "d
   }
 }
 
+function isDedicatedAutomationCronSession(job: Pick<CronJob, "sessionKey" | "agentId">): boolean {
+  const sessionKey = job.sessionKey?.trim().toLowerCase();
+  if (!sessionKey) {
+    return false;
+  }
+  return sessionKey.startsWith(`agent:${normalizeAgentId(job.agentId)}:cron:`);
+}
+
+function assertMigratedAutomationContract(
+  job: Pick<CronJob, "sessionTarget" | "payload" | "delivery" | "sessionKey" | "agentId">,
+) {
+  const isIsolatedLike =
+    job.sessionTarget === "isolated" ||
+    job.sessionTarget === "current" ||
+    job.sessionTarget.startsWith("session:");
+  if (
+    !isIsolatedLike ||
+    job.payload.kind !== "agentTurn" ||
+    !isDedicatedAutomationCronSession(job)
+  ) {
+    return;
+  }
+  if (!job.delivery?.mode) {
+    throw new Error("cron automation session jobs require explicit delivery.mode");
+  }
+  if (!Array.isArray(job.payload.toolsAllow)) {
+    throw new Error("cron automation session jobs require explicit payload.toolsAllow");
+  }
+}
+
+function assertMigratedAutomationCreateInput(
+  input: Pick<CronJobCreate, "sessionTarget" | "payload" | "delivery"> & {
+    sessionKey?: unknown;
+    agentId?: unknown;
+  },
+) {
+  const sessionKey = normalizeOptionalSessionKey(input.sessionKey);
+  const agentId = normalizeOptionalAgentId(input.agentId);
+  const isIsolatedLike =
+    input.sessionTarget === "isolated" ||
+    input.sessionTarget === "current" ||
+    input.sessionTarget.startsWith("session:");
+  const isDedicatedAutomationSession = Boolean(
+    sessionKey?.toLowerCase().startsWith(`agent:${normalizeAgentId(agentId)}:cron:`),
+  );
+  if (!isIsolatedLike || input.payload.kind !== "agentTurn" || !isDedicatedAutomationSession) {
+    return;
+  }
+  if (!input.delivery?.mode) {
+    throw new Error("cron automation session jobs require explicit delivery.mode");
+  }
+  if (!Array.isArray(input.payload.toolsAllow)) {
+    throw new Error("cron automation session jobs require explicit payload.toolsAllow");
+  }
+}
+
 export function findJobOrThrow(state: CronServiceState, id: string) {
   const job = state.store?.jobs.find((j) => j.id === id);
   if (!job) {
@@ -513,6 +569,7 @@ export function nextWakeAtMs(state: CronServiceState) {
 export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {
   const now = state.deps.nowMs();
   const id = crypto.randomUUID();
+  assertMigratedAutomationCreateInput(input as CronJobCreate & { sessionKey?: unknown });
   const schedule =
     input.schedule.kind === "every"
       ? {
@@ -565,6 +622,7 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
   assertMainSessionAgentId(job, state.deps.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
+  assertMigratedAutomationContract(job);
   job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
   return job;
 }
@@ -644,6 +702,7 @@ export function applyJobPatch(
   assertMainSessionAgentId(job, opts?.defaultAgentId);
   assertDeliverySupport(job);
   assertFailureDestinationSupport(job);
+  assertMigratedAutomationContract(job);
 }
 
 function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronPayload {

--- a/src/infra/automation-status-session.ts
+++ b/src/infra/automation-status-session.ts
@@ -1,0 +1,12 @@
+import { normalizeAgentId } from "../routing/session-key.js";
+
+const AUTOMATION_STATUS_SESSION_SUFFIX = "automation-status";
+
+export function resolveAutomationStatusSessionKey(agentId?: string): string {
+  return `agent:${normalizeAgentId(agentId)}:${AUTOMATION_STATUS_SESSION_SUFFIX}`;
+}
+
+export function isAutomationStatusSessionKey(sessionKey: string | undefined | null): boolean {
+  const trimmed = sessionKey?.trim().toLowerCase();
+  return Boolean(trimmed?.endsWith(`:${AUTOMATION_STATUS_SESSION_SUFFIX}`));
+}

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -30,12 +30,15 @@ export class GatewayDrainingError extends Error {
 // the main auto-reply workflow.
 
 type QueueEntry = {
+  entryId: number;
   task: () => Promise<unknown>;
   resolve: (value: unknown) => void;
   reject: (reason?: unknown) => void;
   enqueuedAt: number;
   warnAfterMs: number;
   onWait?: (waitMs: number, queuedAhead: number) => void;
+  waitNotified: boolean;
+  waitTimer?: ReturnType<typeof setTimeout>;
 };
 
 type LaneState = {
@@ -69,6 +72,7 @@ function getQueueState() {
     lanes: new Map<string, LaneState>(),
     activeTaskWaiters: new Set<ActiveTaskWaiter>(),
     nextTaskId: 1,
+    nextEntryId: 1,
   }));
   // Schema migration: the singleton may have been created by an older code
   // version (e.g. v2026.4.2) that did not include `activeTaskWaiters`.  After
@@ -106,6 +110,49 @@ function getLaneState(lane: string): LaneState {
   };
   queueState.lanes.set(lane, created);
   return created;
+}
+
+function resolveQueuedAhead(state: LaneState, entryId: number): number | undefined {
+  const index = state.queue.findIndex((entry) => entry.entryId === entryId);
+  return index >= 0 ? index : undefined;
+}
+
+function clearWaitTimer(entry: QueueEntry): void {
+  if (!entry.waitTimer) {
+    return;
+  }
+  clearTimeout(entry.waitTimer);
+  entry.waitTimer = undefined;
+}
+
+function notifyLaneWait(state: LaneState, entry: QueueEntry): void {
+  if (entry.waitNotified) {
+    return;
+  }
+  const queuedAhead = resolveQueuedAhead(state, entry.entryId);
+  if (queuedAhead === undefined) {
+    return;
+  }
+  const waitedMs = Date.now() - entry.enqueuedAt;
+  entry.waitNotified = true;
+  try {
+    entry.onWait?.(waitedMs, queuedAhead);
+  } catch (err) {
+    diag.error(`lane onWait callback failed: lane=${state.lane} error="${String(err)}"`);
+  }
+  diag.warn(
+    `lane wait exceeded: lane=${state.lane} waitedMs=${waitedMs} queueAhead=${queuedAhead}`,
+  );
+}
+
+function scheduleWaitThreshold(state: LaneState, entry: QueueEntry): void {
+  clearWaitTimer(entry);
+  if (!(entry.warnAfterMs > 0)) {
+    return;
+  }
+  entry.waitTimer = setTimeout(() => {
+    notifyLaneWait(state, entry);
+  }, entry.warnAfterMs);
 }
 
 function completeTask(state: LaneState, taskId: number, taskGeneration: number): boolean {
@@ -165,12 +212,14 @@ function drainLane(lane: string) {
       while (state.activeTaskIds.size < state.maxConcurrent && state.queue.length > 0) {
         const entry = state.queue.shift() as QueueEntry;
         const waitedMs = Date.now() - entry.enqueuedAt;
-        if (waitedMs >= entry.warnAfterMs) {
+        clearWaitTimer(entry);
+        if (waitedMs >= entry.warnAfterMs && !entry.waitNotified) {
           try {
             entry.onWait?.(waitedMs, state.queue.length);
           } catch (err) {
             diag.error(`lane onWait callback failed: lane=${lane} error="${String(err)}"`);
           }
+          entry.waitNotified = true;
           diag.warn(
             `lane wait exceeded: lane=${lane} waitedMs=${waitedMs} queueAhead=${state.queue.length}`,
           );
@@ -251,14 +300,18 @@ export function enqueueCommandInLane<T>(
   const warnAfterMs = opts?.warnAfterMs ?? 2_000;
   const state = getLaneState(cleaned);
   return new Promise<T>((resolve, reject) => {
-    state.queue.push({
+    const entry: QueueEntry = {
+      entryId: queueState.nextEntryId++,
       task: () => task(),
       resolve: (value) => resolve(value as T),
       reject,
       enqueuedAt: Date.now(),
       warnAfterMs,
       onWait: opts?.onWait,
-    });
+      waitNotified: false,
+    };
+    state.queue.push(entry);
+    scheduleWaitThreshold(state, entry);
     logLaneEnqueue(cleaned, getLaneDepth(state));
     drainLane(cleaned);
   });
@@ -300,6 +353,7 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
   const removed = state.queue.length;
   const pending = state.queue.splice(0);
   for (const entry of pending) {
+    clearWaitTimer(entry);
     entry.reject(new CommandLaneClearedError(cleaned));
   }
   return removed;
@@ -313,11 +367,17 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
 export function resetCommandQueueStateForTest(): void {
   const queueState = getQueueState();
   queueState.gatewayDraining = false;
+  for (const state of queueState.lanes.values()) {
+    for (const entry of state.queue) {
+      clearWaitTimer(entry);
+    }
+  }
   queueState.lanes.clear();
   for (const waiter of Array.from(queueState.activeTaskWaiters)) {
     resolveActiveTaskWaiter(waiter, { drained: true });
   }
   queueState.nextTaskId = 1;
+  queueState.nextEntryId = 1;
 }
 
 /**

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -7,6 +7,7 @@ import {
   registerAgentRunContext,
   resetAgentRunContextForTest,
 } from "../infra/agent-events.js";
+import { resolveAutomationStatusSessionKey } from "../infra/automation-status-session.js";
 import {
   hasPendingHeartbeatWake,
   resetHeartbeatWakeStateForTests,
@@ -685,6 +686,116 @@ describe("task-registry", () => {
       ]);
       expect(hasPendingHeartbeatWake()).toBe(true);
       expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("routes system-owned task fallbacks to the automation status sink", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const task = createTaskRecord({
+        runtime: "cron",
+        ownerKey: "system:cron:nightly-digest",
+        scopeKind: "system",
+        childSessionKey: "agent:main:cron:nightly-digest",
+        agentId: "main",
+        runId: "run-system-fallback",
+        task: "Nightly digest",
+        status: "succeeded",
+        notifyPolicy: "done_only",
+        deliveryStatus: "pending",
+        terminalSummary: "Digest sent to storage.",
+      });
+
+      await maybeDeliverTaskTerminalUpdate(task.taskId);
+
+      await waitForAssertion(() =>
+        expect(findTaskByRunId("run-system-fallback")).toMatchObject({
+          deliveryStatus: "session_queued",
+          status: "succeeded",
+        }),
+      );
+      expect(peekSystemEvents(resolveAutomationStatusSessionKey("main"))).toEqual([
+        expect.stringContaining("Background task done: Nightly digest"),
+      ]);
+      expect(peekSystemEvents("agent:main:main")).toEqual([]);
+      expect(hasPendingHeartbeatWake()).toBe(false);
+    });
+  });
+
+  it("routes blocked system-owned followups to the automation status sink without waking the human lane", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const task = createTaskRecord({
+        runtime: "cron",
+        ownerKey: "system:cron:nightly-repair",
+        scopeKind: "system",
+        childSessionKey: "agent:main:cron:nightly-repair",
+        agentId: "main",
+        runId: "run-system-blocked",
+        task: "Nightly repair",
+        status: "succeeded",
+        notifyPolicy: "done_only",
+        deliveryStatus: "pending",
+        terminalOutcome: "blocked",
+        terminalSummary: "Writable session or apply_patch authorization required.",
+      });
+
+      await maybeDeliverTaskTerminalUpdate(task.taskId);
+
+      await waitForAssertion(() =>
+        expect(findTaskByRunId("run-system-blocked")).toMatchObject({
+          deliveryStatus: "session_queued",
+          terminalOutcome: "blocked",
+        }),
+      );
+      expect(peekSystemEvents(resolveAutomationStatusSessionKey("main"))).toEqual([
+        expect.stringContaining("Background task blocked: Nightly repair"),
+        expect.stringContaining("Task needs follow-up: Nightly repair"),
+      ]);
+      expect(peekSystemEvents("agent:main:main")).toEqual([]);
+      expect(hasPendingHeartbeatWake()).toBe(false);
+    });
+  });
+
+  it("routes cron-owned session task fallbacks to the automation status sink", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const task = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:cron:nightly-digest",
+        requesterSessionKey: "agent:main:cron:nightly-digest",
+        scopeKind: "session",
+        childSessionKey: "agent:main:acp:nightly-digest-child",
+        agentId: "main",
+        runId: "run-cron-owned-fallback",
+        label: "Nightly digest child task",
+        task: "Nightly digest child task",
+        status: "succeeded",
+        notifyPolicy: "done_only",
+        deliveryStatus: "pending",
+        terminalSummary: "Saved summary to automation storage.",
+      });
+
+      await maybeDeliverTaskTerminalUpdate(task.taskId);
+
+      await waitForAssertion(() =>
+        expect(findTaskByRunId("run-cron-owned-fallback")).toMatchObject({
+          deliveryStatus: "session_queued",
+          status: "succeeded",
+        }),
+      );
+      expect(peekSystemEvents(resolveAutomationStatusSessionKey("main"))).toEqual([
+        expect.stringContaining("Background task done: Nightly digest child task"),
+      ]);
+      expect(peekSystemEvents("agent:main:cron:nightly-digest")).toEqual([]);
+      expect(peekSystemEvents("agent:main:main")).toEqual([]);
+      expect(hasPendingHeartbeatWake()).toBe(false);
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1,11 +1,12 @@
 import crypto from "node:crypto";
 import type { OpenClawConfig } from "../config/config.js";
 import { onAgentEvent } from "../infra/agent-events.js";
+import { resolveAutomationStatusSessionKey } from "../infra/automation-status-session.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { parseAgentSessionKey } from "../routing/session-key.js";
+import { isCronSessionKey, parseAgentSessionKey } from "../routing/session-key.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
@@ -950,21 +951,41 @@ function resolveMissingOwnerDeliveryStatus(task: TaskRecord): TaskDeliveryStatus
   return task.scopeKind === "system" ? "not_applicable" : "parent_missing";
 }
 
+export function isAutomationTaskRecord(
+  task: Pick<TaskRecord, "scopeKind" | "ownerKey" | "requesterSessionKey">,
+): boolean {
+  return (
+    task.scopeKind === "system" ||
+    task.ownerKey.trim().toLowerCase().startsWith("system:") ||
+    isCronSessionKey(task.ownerKey) ||
+    isCronSessionKey(task.requesterSessionKey)
+  );
+}
+
+function shouldRouteTaskFallbackToAutomationStatus(task: TaskRecord): boolean {
+  return isAutomationTaskRecord(task);
+}
+
 function queueTaskSystemEvent(task: TaskRecord, text: string) {
   const owner = resolveTaskDeliveryOwner(task);
   const ownerKey = owner.sessionKey?.trim();
-  if (!ownerKey) {
+  const targetSessionKey = shouldRouteTaskFallbackToAutomationStatus(task)
+    ? resolveAutomationStatusSessionKey(task.agentId)
+    : ownerKey;
+  if (!targetSessionKey) {
     return false;
   }
   enqueueSystemEvent(text, {
-    sessionKey: ownerKey,
+    sessionKey: targetSessionKey,
     contextKey: `task:${task.taskId}`,
-    deliveryContext: owner.requesterOrigin,
+    deliveryContext: targetSessionKey === ownerKey ? owner.requesterOrigin : undefined,
   });
-  requestHeartbeatNow({
-    reason: "background-task",
-    sessionKey: ownerKey,
-  });
+  if (targetSessionKey === ownerKey) {
+    requestHeartbeatNow({
+      reason: "background-task",
+      sessionKey: ownerKey,
+    });
+  }
   return true;
 }
 
@@ -975,18 +996,23 @@ function queueBlockedTaskFollowup(task: TaskRecord) {
   }
   const owner = resolveTaskDeliveryOwner(task);
   const ownerKey = owner.sessionKey?.trim();
-  if (!ownerKey) {
+  const targetSessionKey = shouldRouteTaskFallbackToAutomationStatus(task)
+    ? resolveAutomationStatusSessionKey(task.agentId)
+    : ownerKey;
+  if (!targetSessionKey) {
     return false;
   }
   enqueueSystemEvent(followupText, {
-    sessionKey: ownerKey,
+    sessionKey: targetSessionKey,
     contextKey: `task:${task.taskId}:blocked-followup`,
-    deliveryContext: owner.requesterOrigin,
+    deliveryContext: targetSessionKey === ownerKey ? owner.requesterOrigin : undefined,
   });
-  requestHeartbeatNow({
-    reason: "background-task-blocked",
-    sessionKey: ownerKey,
-  });
+  if (targetSessionKey === ownerKey) {
+    requestHeartbeatNow({
+      reason: "background-task-blocked",
+      sessionKey: ownerKey,
+    });
+  }
   return true;
 }
 
@@ -1018,14 +1044,15 @@ export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<Ta
     }
     const owner = resolveTaskDeliveryOwner(latest);
     const ownerSessionKey = owner.sessionKey?.trim();
-    if (!ownerSessionKey) {
+    const shouldRouteToAutomationStatus = shouldRouteTaskFallbackToAutomationStatus(latest);
+    if (!ownerSessionKey && !shouldRouteToAutomationStatus) {
       return updateTask(taskId, {
         deliveryStatus: resolveMissingOwnerDeliveryStatus(latest),
         lastEventAt: Date.now(),
       });
     }
     const eventText = formatTaskTerminalMessage(latest);
-    if (!canDeliverTaskToRequesterOrigin(latest)) {
+    if (!ownerSessionKey || !canDeliverTaskToRequesterOrigin(latest)) {
       try {
         queueTaskSystemEvent(latest, eventText);
         if (latest.terminalOutcome === "blocked") {
@@ -1121,13 +1148,14 @@ export async function maybeDeliverTaskStateChangeUpdate(
   try {
     const owner = resolveTaskDeliveryOwner(current);
     const ownerSessionKey = owner.sessionKey?.trim();
-    if (!ownerSessionKey) {
+    const shouldRouteToAutomationStatus = shouldRouteTaskFallbackToAutomationStatus(current);
+    if (!ownerSessionKey && !shouldRouteToAutomationStatus) {
       return updateTask(taskId, {
         deliveryStatus: resolveMissingOwnerDeliveryStatus(current),
         lastEventAt: Date.now(),
       });
     }
-    if (!canDeliverTaskToRequesterOrigin(current)) {
+    if (!ownerSessionKey || !canDeliverTaskToRequesterOrigin(current)) {
       queueTaskSystemEvent(current, eventText);
       upsertTaskDeliveryState({
         taskId,

--- a/src/tasks/task-status-access.ts
+++ b/src/tasks/task-status-access.ts
@@ -1,4 +1,8 @@
-import { listTasksForAgentId, listTasksForSessionKey } from "./task-registry.js";
+import {
+  isAutomationTaskRecord,
+  listTasksForAgentId,
+  listTasksForSessionKey,
+} from "./task-registry.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 export function listTasksForSessionKeyForStatus(sessionKey: string): TaskRecord[] {
@@ -7,4 +11,8 @@ export function listTasksForSessionKeyForStatus(sessionKey: string): TaskRecord[
 
 export function listTasksForAgentIdForStatus(agentId: string): TaskRecord[] {
   return listTasksForAgentId(agentId);
+}
+
+export function listAutomationTasksForAgentIdForStatus(agentId: string): TaskRecord[] {
+  return listTasksForAgentId(agentId).filter((task) => isAutomationTaskRecord(task));
 }


### PR DESCRIPTION
## Summary
- reserve the human Telegram DM lane for interactive followups only
- route cron awareness and cron-owned task fallbacks into the automation status session
- make queue lifecycle notices truthful for queued, delayed, resumed, catch-up, and synthesized followups
- tighten cron migration defaults so only dedicated cron sessions are quieted automatically

## Verification
- pre-commit hooks passed during the clean upstream cherry-pick commit
- focused Vitest runs remain slow in this worktree, same harness issue seen earlier, so no clean full targeted pass is claimed here
- previously verified slices on the original branch covered doctor cron migration, queue lifecycle, and cron-owned task fallback behavior