### PR TITLE
fix(control-ui): prevent looping conversation loads when switching chats

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -504,6 +504,14 @@ export function renderChatMobileToggle(state: AppViewState) {
 }
 
 export function switchChatSession(state: AppViewState, nextSessionKey: string) {
+  const chatState = state as unknown as ChatState;
+  if (
+    !nextSessionKey ||
+    (state.sessionKey === nextSessionKey &&
+      chatState.chatHistoryLoadingSessionKey === nextSessionKey)
+  ) {
+    return;
+  }
   state.sessionKey = nextSessionKey;
   state.chatMessage = "";
   state.chatStream = null;
@@ -524,7 +532,7 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
     nextSessionKey,
     true,
   );
-  void loadChatHistory(state as unknown as ChatState);
+  void loadChatHistory(chatState);
   void refreshSessionOptions(state);
 }
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -40,6 +40,8 @@ export type ChatState = {
   chatLoading: boolean;
   chatMessages: unknown[];
   chatThinkingLevel: string | null;
+  chatHistoryLoadSeq?: number;
+  chatHistoryLoadingSessionKey?: string | null;
   chatSending: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
@@ -73,16 +75,23 @@ export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;
   }
+  const sessionKey = state.sessionKey;
+  const loadSeq = (state.chatHistoryLoadSeq ?? 0) + 1;
+  state.chatHistoryLoadSeq = loadSeq;
+  state.chatHistoryLoadingSessionKey = sessionKey;
   state.chatLoading = true;
   state.lastError = null;
   try {
     const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
       "chat.history",
       {
-        sessionKey: state.sessionKey,
+        sessionKey,
         limit: 200,
       },
     );
+    if (state.chatHistoryLoadSeq !== loadSeq || state.sessionKey !== sessionKey) {
+      return;
+    }
     const messages = Array.isArray(res.messages) ? res.messages : [];
     state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
     state.chatThinkingLevel = res.thinkingLevel ?? null;
@@ -92,6 +101,9 @@ export async function loadChatHistory(state: ChatState) {
     state.chatStream = null;
     state.chatStreamStartedAt = null;
   } catch (err) {
+    if (state.chatHistoryLoadSeq !== loadSeq || state.sessionKey !== sessionKey) {
+      return;
+    }
     if (isMissingOperatorReadScopeError(err)) {
       state.chatMessages = [];
       state.chatThinkingLevel = null;
@@ -100,7 +112,12 @@ export async function loadChatHistory(state: ChatState) {
       state.lastError = String(err);
     }
   } finally {
-    state.chatLoading = false;
+    if (state.chatHistoryLoadingSessionKey === sessionKey) {
+      state.chatHistoryLoadingSessionKey = null;
+    }
+    if (state.chatHistoryLoadSeq === loadSeq && state.sessionKey === sessionKey) {
+      state.chatLoading = false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary\n- guard chat history requests so stale responses cannot overwrite a newly selected session\n- ignore duplicate session switches while the same session is already loading\n- prevent the Control UI left-panel conversation picker from getting stuck in a loading loop\n\n## Testing\n- pnpm ui:build\n