### PR TITLE
fix(matrix/doctor): migrate legacy channels.matrix.dm.policy 'trusted' (fixes #62931)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Browser/security: re-run blocked-destination safety checks after interaction-driven main-frame navigations from click, evaluate, hook-triggered click, and batched action flows, so browser interactions cannot bypass the SSRF quarantine when they land on forbidden URLs. (#63226) Thanks @eleqtrizit.
 - Providers/Ollama: allow Ollama models using the native `api: "ollama"` path to optionally display thinking output when `/think` is set to a non-off level. (#62712) Thanks @hoyyeva.
 - QA/live auth: fail fast when live QA scenarios hit classified auth or runtime failure replies, including raw scenario wait paths, and sanitize missing-key guidance so gateway auth problems surface as actionable errors instead of timeouts. (#63333) Thanks @shakkernerd.
+- Matrix/doctor: migrate legacy `channels.matrix.dm.policy: "trusted"` configs back to compatible DM policies during `openclaw doctor --fix`, preserving explicit `allowFrom` boundaries as `allowlist` and defaulting empty legacy configs to `pairing`. (#62942) Thanks @lukeboyett.
 
 ## 2026.4.8
 

--- a/extensions/matrix/src/doctor-contract.ts
+++ b/extensions/matrix/src/doctor-contract.ts
@@ -72,8 +72,14 @@ function migrateLegacyTrustedDmPolicy(params: {
     return { entry: params.entry, changed: false };
   }
   const allowFromRaw = dm.allowFrom;
+  // Trim before counting: downstream allowlist normalization drops whitespace-only
+  // entries, so a config like ["   "] would otherwise migrate to "allowlist" and
+  // then end up with an empty allowFrom — silently blocking all DMs instead of
+  // falling through to the intended "pairing" default.
   const allowFromEntries = Array.isArray(allowFromRaw)
-    ? allowFromRaw.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+    ? allowFromRaw.filter(
+        (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
+      )
     : [];
   // "trusted" with an explicit allowFrom list maps to "allowlist" semantics.
   // "trusted" with no entries maps to "pairing" (the default secure mode), since

--- a/extensions/matrix/src/doctor-contract.ts
+++ b/extensions/matrix/src/doctor-contract.ts
@@ -71,35 +71,23 @@ function migrateLegacyTrustedDmPolicy(params: {
   if (!dm || dm.policy !== "trusted") {
     return { entry: params.entry, changed: false };
   }
-  // Always migrate "trusted" → "pairing" and leave dm.allowFrom intact.
-  //
-  // Both "pairing" and "allowlist" merge dm.allowFrom with the pairing store
-  // entries from core.channel.pairing.readAllowFromStore() in
-  // resolveMatrixMonitorAccessState (extensions/matrix/src/matrix/monitor/access-state.ts),
-  // so an explicit allowFrom list and previously paired senders are accepted
-  // under either policy. The only semantic difference is what happens to an
-  // unknown sender:
-  //
-  //   - "pairing":   send a pairing request reply (operator can approve)
-  //   - "allowlist": drop silently (no path for new senders to gain access)
-  //
-  // We don't know exactly what behavior legacy "trusted" had for unknown
-  // senders, but "pairing" is a strict superset of "allowlist" for accepting
-  // existing senders, and it preserves the ability to onboard new ones, which
-  // is the most likely intent of an operator who chose "trusted" in the first
-  // place. Mapping unconditionally to "pairing" also avoids the edge case
-  // where allowFrom is whitespace-only or otherwise effectively empty after
-  // downstream normalization.
-  const nextDm = { ...dm, policy: "pairing" };
   const allowFromRaw = dm.allowFrom;
-  const preservedCount = Array.isArray(allowFromRaw)
+  // Trim before counting: downstream allowlist normalization drops whitespace-only
+  // entries, so a config like ["   "] must still fall back to "pairing"
+  // instead of becoming an effectively empty allowlist.
+  const allowFromEntries = Array.isArray(allowFromRaw)
     ? allowFromRaw.filter(
         (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
       ).length
     : 0;
+  // Preserve the operator's existing trust boundary when an explicit allowFrom
+  // list is present; only fall back to pairing when the effective allowlist is
+  // empty.
+  const nextPolicy: "allowlist" | "pairing" = allowFromEntries > 0 ? "allowlist" : "pairing";
+  const nextDm = { ...dm, policy: nextPolicy };
   params.changes.push(
-    `Migrated ${params.pathPrefix}.dm.policy "trusted" → "pairing" (legacy alias removed; ` +
-      `${preservedCount > 0 ? `preserved ${preservedCount} ${params.pathPrefix}.dm.allowFrom ${preservedCount === 1 ? "entry" : "entries"}` : "no allowFrom entries present"}).`,
+    `Migrated ${params.pathPrefix}.dm.policy "trusted" → "${nextPolicy}" (legacy alias removed; ` +
+      `${allowFromEntries > 0 ? `preserved ${allowFromEntries} ${params.pathPrefix}.dm.allowFrom ${allowFromEntries === 1 ? "entry" : "entries"}` : "no allowFrom entries present, defaulting to pairing for safety"}).`,
   );
   return { entry: { ...params.entry, dm: nextDm }, changed: true };
 }

--- a/extensions/matrix/src/doctor-contract.ts
+++ b/extensions/matrix/src/doctor-contract.ts
@@ -71,24 +71,35 @@ function migrateLegacyTrustedDmPolicy(params: {
   if (!dm || dm.policy !== "trusted") {
     return { entry: params.entry, changed: false };
   }
+  // Always migrate "trusted" → "pairing" and leave dm.allowFrom intact.
+  //
+  // Both "pairing" and "allowlist" merge dm.allowFrom with the pairing store
+  // entries from core.channel.pairing.readAllowFromStore() in
+  // resolveMatrixMonitorAccessState (extensions/matrix/src/matrix/monitor/access-state.ts),
+  // so an explicit allowFrom list and previously paired senders are accepted
+  // under either policy. The only semantic difference is what happens to an
+  // unknown sender:
+  //
+  //   - "pairing":   send a pairing request reply (operator can approve)
+  //   - "allowlist": drop silently (no path for new senders to gain access)
+  //
+  // We don't know exactly what behavior legacy "trusted" had for unknown
+  // senders, but "pairing" is a strict superset of "allowlist" for accepting
+  // existing senders, and it preserves the ability to onboard new ones, which
+  // is the most likely intent of an operator who chose "trusted" in the first
+  // place. Mapping unconditionally to "pairing" also avoids the edge case
+  // where allowFrom is whitespace-only or otherwise effectively empty after
+  // downstream normalization.
+  const nextDm = { ...dm, policy: "pairing" };
   const allowFromRaw = dm.allowFrom;
-  // Trim before counting: downstream allowlist normalization drops whitespace-only
-  // entries, so a config like ["   "] would otherwise migrate to "allowlist" and
-  // then end up with an empty allowFrom — silently blocking all DMs instead of
-  // falling through to the intended "pairing" default.
-  const allowFromEntries = Array.isArray(allowFromRaw)
+  const preservedCount = Array.isArray(allowFromRaw)
     ? allowFromRaw.filter(
         (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
-      )
-    : [];
-  // "trusted" with an explicit allowFrom list maps to "allowlist" semantics.
-  // "trusted" with no entries maps to "pairing" (the default secure mode), since
-  // accepting all senders would silently widen access on upgrade.
-  const nextPolicy: "allowlist" | "pairing" = allowFromEntries.length > 0 ? "allowlist" : "pairing";
-  const nextDm = { ...dm, policy: nextPolicy };
+      ).length
+    : 0;
   params.changes.push(
-    `Migrated ${params.pathPrefix}.dm.policy "trusted" → "${nextPolicy}" (legacy alias removed; ` +
-      `${allowFromEntries.length > 0 ? `preserved ${allowFromEntries.length} ${params.pathPrefix}.dm.allowFrom entries` : "no allowFrom entries present, defaulting to pairing for safety"}).`,
+    `Migrated ${params.pathPrefix}.dm.policy "trusted" → "pairing" (legacy alias removed; ` +
+      `${preservedCount > 0 ? `preserved ${preservedCount} ${params.pathPrefix}.dm.allowFrom ${preservedCount === 1 ? "entry" : "entries"}` : "no allowFrom entries present"}).`,
   );
   return { entry: { ...params.entry, dm: nextDm }, changed: true };
 }

--- a/extensions/matrix/src/doctor-contract.ts
+++ b/extensions/matrix/src/doctor-contract.ts
@@ -45,6 +45,48 @@ function hasLegacyMatrixAccountPrivateNetworkAliases(value: unknown): boolean {
   );
 }
 
+function hasLegacyTrustedDmPolicy(value: unknown): boolean {
+  const root = isRecord(value) ? value : null;
+  if (!root) {
+    return false;
+  }
+  const dm = isRecord(root.dm) ? root.dm : null;
+  return dm?.policy === "trusted";
+}
+
+function hasLegacyMatrixAccountTrustedDmPolicies(value: unknown): boolean {
+  const accounts = isRecord(value) ? value : null;
+  if (!accounts) {
+    return false;
+  }
+  return Object.values(accounts).some((account) => hasLegacyTrustedDmPolicy(account));
+}
+
+function migrateLegacyTrustedDmPolicy(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+}): { entry: Record<string, unknown>; changed: boolean } {
+  const dm = isRecord(params.entry.dm) ? params.entry.dm : null;
+  if (!dm || dm.policy !== "trusted") {
+    return { entry: params.entry, changed: false };
+  }
+  const allowFromRaw = dm.allowFrom;
+  const allowFromEntries = Array.isArray(allowFromRaw)
+    ? allowFromRaw.filter((entry): entry is string => typeof entry === "string" && entry.length > 0)
+    : [];
+  // "trusted" with an explicit allowFrom list maps to "allowlist" semantics.
+  // "trusted" with no entries maps to "pairing" (the default secure mode), since
+  // accepting all senders would silently widen access on upgrade.
+  const nextPolicy: "allowlist" | "pairing" = allowFromEntries.length > 0 ? "allowlist" : "pairing";
+  const nextDm = { ...dm, policy: nextPolicy };
+  params.changes.push(
+    `Migrated ${params.pathPrefix}.dm.policy "trusted" → "${nextPolicy}" (legacy alias removed; ` +
+      `${allowFromEntries.length > 0 ? `preserved ${allowFromEntries.length} ${params.pathPrefix}.dm.allowFrom entries` : "no allowFrom entries present, defaulting to pairing for safety"}).`,
+  );
+  return { entry: { ...params.entry, dm: nextDm }, changed: true };
+}
+
 function normalizeMatrixRoomAllowAliases(params: {
   rooms: Record<string, unknown>;
   pathPrefix: string;
@@ -102,6 +144,18 @@ export const legacyConfigRules: ChannelDoctorLegacyConfigRule[] = [
       'channels.matrix.accounts.<id>.{groups,rooms}.<room>.allow is legacy; use channels.matrix.accounts.<id>.{groups,rooms}.<room>.enabled instead. Run "openclaw doctor --fix".',
     match: hasLegacyMatrixAccountRoomAllowAliases,
   },
+  {
+    path: ["channels", "matrix"],
+    message:
+      'channels.matrix.dm.policy "trusted" is legacy; use "allowlist" (with allowFrom entries) or "pairing" instead. Run "openclaw doctor --fix".',
+    match: hasLegacyTrustedDmPolicy,
+  },
+  {
+    path: ["channels", "matrix", "accounts"],
+    message:
+      'channels.matrix.accounts.<id>.dm.policy "trusted" is legacy; use "allowlist" (with allowFrom entries) or "pairing" instead. Run "openclaw doctor --fix".',
+    match: hasLegacyMatrixAccountTrustedDmPolicies,
+  },
 ];
 
 export function normalizeCompatibilityConfig({
@@ -126,6 +180,14 @@ export function normalizeCompatibilityConfig({
   });
   updatedMatrix = topLevelPrivateNetwork.entry;
   changed = changed || topLevelPrivateNetwork.changed;
+
+  const topLevelTrustedDmPolicy = migrateLegacyTrustedDmPolicy({
+    entry: updatedMatrix,
+    pathPrefix: "channels.matrix",
+    changes,
+  });
+  updatedMatrix = topLevelTrustedDmPolicy.entry;
+  changed = changed || topLevelTrustedDmPolicy.changed;
 
   const normalizeTopLevelRoomScope = (key: "groups" | "rooms") => {
     const rooms = isRecord(updatedMatrix[key]) ? updatedMatrix[key] : null;
@@ -165,6 +227,16 @@ export function normalizeCompatibilityConfig({
       });
       if (privateNetworkMigration.changed) {
         nextAccount = privateNetworkMigration.entry;
+        accountChanged = true;
+      }
+
+      const accountTrustedDmPolicy = migrateLegacyTrustedDmPolicy({
+        entry: nextAccount,
+        pathPrefix: `channels.matrix.accounts.${accountId}`,
+        changes,
+      });
+      if (accountTrustedDmPolicy.changed) {
+        nextAccount = accountTrustedDmPolicy.entry;
         accountChanged = true;
       }
 

--- a/extensions/matrix/src/doctor.test.ts
+++ b/extensions/matrix/src/doctor.test.ts
@@ -233,7 +233,12 @@ describe("matrix doctor", () => {
     );
   });
 
-  it("migrates legacy channels.matrix.dm.policy 'trusted' with allowFrom to 'allowlist'", () => {
+  it("migrates legacy channels.matrix.dm.policy 'trusted' with allowFrom to 'pairing' (allowFrom preserved)", () => {
+    // Always map "trusted" to "pairing": both policies accept the explicit
+    // allowFrom list AND any pairing-store entries via the merged
+    // effectiveAllowFrom in resolveMatrixMonitorAccessState. "pairing" also
+    // preserves the ability for new senders to request access, which most
+    // closely matches the intent of an operator who chose "trusted".
     const normalize = matrixDoctor.normalizeCompatibilityConfig;
     expect(normalize).toBeDefined();
     if (!normalize) {
@@ -258,11 +263,12 @@ describe("matrix doctor", () => {
       result.config.channels?.matrix as { dm?: { policy?: string; allowFrom?: string[] } }
     )?.dm;
 
-    expect(matrixDm?.policy).toBe("allowlist");
+    expect(matrixDm?.policy).toBe("pairing");
     expect(matrixDm?.allowFrom).toEqual(["@alice:example.org", "@bob:example.org"]);
     expect(result.changes).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('Migrated channels.matrix.dm.policy "trusted" → "allowlist"'),
+        expect.stringContaining('Migrated channels.matrix.dm.policy "trusted" → "pairing"'),
+        expect.stringContaining("preserved 2 channels.matrix.dm.allowFrom entries"),
       ]),
     );
   });
@@ -367,13 +373,13 @@ describe("matrix doctor", () => {
       }
     )?.accounts;
 
-    expect(accounts?.work?.dm?.policy).toBe("allowlist");
+    expect(accounts?.work?.dm?.policy).toBe("pairing");
     expect(accounts?.work?.dm?.allowFrom).toEqual(["@boss:example.org"]);
     expect(accounts?.personal?.dm?.policy).toBe("pairing");
     expect(result.changes).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          'Migrated channels.matrix.accounts.work.dm.policy "trusted" → "allowlist"',
+          'Migrated channels.matrix.accounts.work.dm.policy "trusted" → "pairing"',
         ),
         expect.stringContaining(
           'Migrated channels.matrix.accounts.personal.dm.policy "trusted" → "pairing"',

--- a/extensions/matrix/src/doctor.test.ts
+++ b/extensions/matrix/src/doctor.test.ts
@@ -233,12 +233,7 @@ describe("matrix doctor", () => {
     );
   });
 
-  it("migrates legacy channels.matrix.dm.policy 'trusted' with allowFrom to 'pairing' (allowFrom preserved)", () => {
-    // Always map "trusted" to "pairing": both policies accept the explicit
-    // allowFrom list AND any pairing-store entries via the merged
-    // effectiveAllowFrom in resolveMatrixMonitorAccessState. "pairing" also
-    // preserves the ability for new senders to request access, which most
-    // closely matches the intent of an operator who chose "trusted".
+  it("migrates legacy channels.matrix.dm.policy 'trusted' with allowFrom to 'allowlist'", () => {
     const normalize = matrixDoctor.normalizeCompatibilityConfig;
     expect(normalize).toBeDefined();
     if (!normalize) {
@@ -263,11 +258,11 @@ describe("matrix doctor", () => {
       result.config.channels?.matrix as { dm?: { policy?: string; allowFrom?: string[] } }
     )?.dm;
 
-    expect(matrixDm?.policy).toBe("pairing");
+    expect(matrixDm?.policy).toBe("allowlist");
     expect(matrixDm?.allowFrom).toEqual(["@alice:example.org", "@bob:example.org"]);
     expect(result.changes).toEqual(
       expect.arrayContaining([
-        expect.stringContaining('Migrated channels.matrix.dm.policy "trusted" → "pairing"'),
+        expect.stringContaining('Migrated channels.matrix.dm.policy "trusted" → "allowlist"'),
         expect.stringContaining("preserved 2 channels.matrix.dm.allowFrom entries"),
       ]),
     );
@@ -373,13 +368,13 @@ describe("matrix doctor", () => {
       }
     )?.accounts;
 
-    expect(accounts?.work?.dm?.policy).toBe("pairing");
+    expect(accounts?.work?.dm?.policy).toBe("allowlist");
     expect(accounts?.work?.dm?.allowFrom).toEqual(["@boss:example.org"]);
     expect(accounts?.personal?.dm?.policy).toBe("pairing");
     expect(result.changes).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          'Migrated channels.matrix.accounts.work.dm.policy "trusted" → "pairing"',
+          'Migrated channels.matrix.accounts.work.dm.policy "trusted" → "allowlist"',
         ),
         expect.stringContaining(
           'Migrated channels.matrix.accounts.personal.dm.policy "trusted" → "pairing"',

--- a/extensions/matrix/src/doctor.test.ts
+++ b/extensions/matrix/src/doctor.test.ts
@@ -232,4 +232,164 @@ describe("matrix doctor", () => {
       ]),
     );
   });
+
+  it("migrates legacy channels.matrix.dm.policy 'trusted' with allowFrom to 'allowlist'", () => {
+    const normalize = matrixDoctor.normalizeCompatibilityConfig;
+    expect(normalize).toBeDefined();
+    if (!normalize) {
+      return;
+    }
+
+    const result = normalize({
+      cfg: {
+        channels: {
+          matrix: {
+            dm: {
+              enabled: true,
+              policy: "trusted",
+              allowFrom: ["@alice:example.org", "@bob:example.org"],
+            },
+          },
+        },
+      } as never,
+    });
+
+    const matrixDm = (
+      result.config.channels?.matrix as { dm?: { policy?: string; allowFrom?: string[] } }
+    )?.dm;
+
+    expect(matrixDm?.policy).toBe("allowlist");
+    expect(matrixDm?.allowFrom).toEqual(["@alice:example.org", "@bob:example.org"]);
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Migrated channels.matrix.dm.policy "trusted" → "allowlist"'),
+      ]),
+    );
+  });
+
+  it("migrates legacy channels.matrix.dm.policy 'trusted' without allowFrom to 'pairing'", () => {
+    const normalize = matrixDoctor.normalizeCompatibilityConfig;
+    expect(normalize).toBeDefined();
+    if (!normalize) {
+      return;
+    }
+
+    const result = normalize({
+      cfg: {
+        channels: {
+          matrix: {
+            dm: {
+              enabled: true,
+              policy: "trusted",
+            },
+          },
+        },
+      } as never,
+    });
+
+    const matrixDm = (result.config.channels?.matrix as { dm?: { policy?: string } })?.dm;
+    expect(matrixDm?.policy).toBe("pairing");
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Migrated channels.matrix.dm.policy "trusted" → "pairing"'),
+      ]),
+    );
+  });
+
+  it("migrates legacy per-account channels.matrix.accounts.<id>.dm.policy 'trusted'", () => {
+    const normalize = matrixDoctor.normalizeCompatibilityConfig;
+    expect(normalize).toBeDefined();
+    if (!normalize) {
+      return;
+    }
+
+    const result = normalize({
+      cfg: {
+        channels: {
+          matrix: {
+            accounts: {
+              work: {
+                dm: {
+                  enabled: true,
+                  policy: "trusted",
+                  allowFrom: ["@boss:example.org"],
+                },
+              },
+              personal: {
+                dm: {
+                  enabled: true,
+                  policy: "trusted",
+                },
+              },
+            },
+          },
+        },
+      } as never,
+    });
+
+    const accounts = (
+      result.config.channels?.matrix as {
+        accounts?: Record<string, { dm?: { policy?: string; allowFrom?: string[] } }>;
+      }
+    )?.accounts;
+
+    expect(accounts?.work?.dm?.policy).toBe("allowlist");
+    expect(accounts?.work?.dm?.allowFrom).toEqual(["@boss:example.org"]);
+    expect(accounts?.personal?.dm?.policy).toBe("pairing");
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'Migrated channels.matrix.accounts.work.dm.policy "trusted" → "allowlist"',
+        ),
+        expect.stringContaining(
+          'Migrated channels.matrix.accounts.personal.dm.policy "trusted" → "pairing"',
+        ),
+      ]),
+    );
+  });
+
+  it("leaves modern dm.policy values untouched", () => {
+    const normalize = matrixDoctor.normalizeCompatibilityConfig;
+    expect(normalize).toBeDefined();
+    if (!normalize) {
+      return;
+    }
+
+    const result = normalize({
+      cfg: {
+        channels: {
+          matrix: {
+            dm: {
+              enabled: true,
+              policy: "allowlist",
+              allowFrom: ["@alice:example.org"],
+            },
+            accounts: {
+              work: {
+                dm: { enabled: true, policy: "pairing" },
+              },
+            },
+          },
+        },
+      } as never,
+    });
+
+    expect(result.changes).toEqual([]);
+    expect(result.config).toEqual({
+      channels: {
+        matrix: {
+          dm: {
+            enabled: true,
+            policy: "allowlist",
+            allowFrom: ["@alice:example.org"],
+          },
+          accounts: {
+            work: {
+              dm: { enabled: true, policy: "pairing" },
+            },
+          },
+        },
+      },
+    });
+  });
 });

--- a/extensions/matrix/src/doctor.test.ts
+++ b/extensions/matrix/src/doctor.test.ts
@@ -267,6 +267,40 @@ describe("matrix doctor", () => {
     );
   });
 
+  it("migrates legacy 'trusted' policy with whitespace-only allowFrom entries to 'pairing'", () => {
+    // Whitespace-only entries are dropped by downstream allowlist normalization,
+    // so they must not count toward the allowFrom population check — otherwise
+    // the migration would emit policy="allowlist" with an effectively empty
+    // allowlist, silently blocking all DMs.
+    const normalize = matrixDoctor.normalizeCompatibilityConfig;
+    expect(normalize).toBeDefined();
+    if (!normalize) {
+      return;
+    }
+
+    const result = normalize({
+      cfg: {
+        channels: {
+          matrix: {
+            dm: {
+              enabled: true,
+              policy: "trusted",
+              allowFrom: ["   ", "\t", ""],
+            },
+          },
+        },
+      } as never,
+    });
+
+    const matrixDm = (result.config.channels?.matrix as { dm?: { policy?: string } })?.dm;
+    expect(matrixDm?.policy).toBe("pairing");
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('Migrated channels.matrix.dm.policy "trusted" → "pairing"'),
+      ]),
+    );
+  });
+
   it("migrates legacy channels.matrix.dm.policy 'trusted' without allowFrom to 'pairing'", () => {
     const normalize = matrixDoctor.normalizeCompatibilityConfig;
     expect(normalize).toBeDefined();


### PR DESCRIPTION
## Summary

Adds a doctor compatibility migration for the legacy `channels.matrix.dm.policy: "trusted"` value, which is no longer accepted by the schema as of `2026.4.7`. Without this migration the gateway hard-fails to start with a validation error, and `openclaw doctor --fix` (which the error message itself recommends) is a no-op for this case.

Fixes #62931

## Problem

In `2026.4.7` the schema for `channels.matrix.dm.policy` accepts only `"pairing" | "allowlist" | "open" | "disabled"`. Configs that previously held `"trusted"` (which appears to have been silently accepted in earlier releases) now fail validation:

```
Config invalid
File: ~/.openclaw/openclaw.json
Problem:
  - channels.matrix.dm.policy: Invalid option: expected one of "pairing"|"allowlist"|"open"|"disabled"

Run: openclaw doctor --fix
```

`openclaw doctor --fix` had no migration for this case and only re-printed the same validation error, contradicting its own advice. The user has to hand-edit the config file to recover, and the breaking enum change is not called out in the `2026.4.7` release notes.

## Fix

Adds `migrateLegacyTrustedDmPolicy()` to `extensions/matrix/src/doctor-contract.ts` and wires it into `normalizeCompatibilityConfig()` for both the top-level `channels.matrix.dm` path and the per-account `channels.matrix.accounts.<id>.dm` path.

The migration uses the safest semantically-equivalent mapping:

| Legacy state | Migrated to | Rationale |
|---|---|---|
| `policy: "trusted"` + non-empty `allowFrom` | `"allowlist"` | Preserves the explicit allowlist semantics that `"trusted"` had. |
| `policy: "trusted"` + no `allowFrom` | `"pairing"` | Defaults to the secure mode rather than silently widening access on upgrade. |

Two new `legacyConfigRules` entries are also added so the issue surfaces under the existing "Legacy config keys detected" channel before `--fix` is applied.

This works because `readConfigFileSnapshotInternal` preserves `sourceConfig` even when validation fails (`src/config/io.ts:1307`), so the doctor flow reaches `normalizeCompatibilityConfig` with the raw object containing the legacy value.

## Test plan

- [x] `pnpm vitest run extensions/matrix/src/doctor.test.ts` — 9 passed, 0 failed (5 existing + 4 new)
- [x] `pnpm tsgo` — 0 errors
- [x] `pnpm lint` (oxlint --type-aware) — 0 warnings, 0 errors over 10663 files
- [x] All pre-commit gates: conflict markers, host-env policy, webhook auth, pairing scope, tool-display
- [x] Manual repro: a `~/.openclaw/openclaw.json` with `channels.matrix.dm.policy: "trusted"` + `allowFrom` list now migrates cleanly to `"allowlist"` via `openclaw doctor --fix`, and the gateway starts successfully on the next run.

New test cases cover:

1. Top-level `dm.policy: "trusted"` + `allowFrom` → `"allowlist"` (preserves entries)
2. Top-level `dm.policy: "trusted"` + no `allowFrom` → `"pairing"` (safe default)
3. Per-account variant with both shapes in the same `accounts` map
4. Modern `"allowlist"` / `"pairing"` values are passed through untouched (no-op)

## Out of scope

This PR only addresses the migration. It does not:

- Add `"trusted"` back as a permanent schema alias (a deprecation-window approach would also be reasonable but is more invasive)
- Touch the `2026.4.7` release notes to retroactively flag the breaking change
- Change the original commit that removed the enum value

Either of those would be reasonable follow-ups but are independent of restoring `doctor --fix` to a working state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
