### PR TITLE
fix(directives): preserve think/verbose levels through inline directive clearing

### DIFF
--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -278,6 +278,11 @@ export async function resolveReplyDirectives(params: {
         modelAliases: configuredAliases,
       });
       if (directiveOnlyCheck.cleaned.trim().length > 0) {
+        // Preserve thinking/verbose levels when clearing inline directives.
+        // The levels should still apply to the run even when the message has
+        // real content alongside the directive (e.g. webchat /think injection).
+        const preservedThinkLevel = parsedDirectives.thinkLevel;
+        const preservedVerboseLevel = parsedDirectives.verboseLevel;
         const allowInlineStatus =
           parsedDirectives.hasStatusDirective && allowTextCommands && command.isAuthorizedSender;
         parsedDirectives = allowInlineStatus
@@ -286,6 +291,19 @@ export async function resolveReplyDirectives(params: {
               hasStatusDirective: true,
             }
           : clearInlineDirectives(parsedDirectives.cleaned);
+        // Re-inject preserved levels so they take effect for this run,
+        // but only for authorized senders — unauthorized users must not be
+        // able to escalate thinking effort via inline directives.
+        if (command.isAuthorizedSender) {
+          if (preservedThinkLevel !== undefined) {
+            parsedDirectives.thinkLevel = preservedThinkLevel;
+            parsedDirectives.hasThinkDirective = true;
+          }
+          if (preservedVerboseLevel !== undefined) {
+            parsedDirectives.verboseLevel = preservedVerboseLevel;
+            parsedDirectives.hasVerboseDirective = true;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
When a message contains both real content and inline directives (e.g. webchat `/think` injection), `clearInlineDirectives` strips the directive syntax but also discards the parsed `thinkLevel` and `verboseLevel`. This causes the thinking effort to silently fall back to defaults for that run.

**Fix:** Capture `thinkLevel` and `verboseLevel` before clearing, then re-inject them into the cleaned directives so they take effect for the run.

**Files changed:** `src/auto-reply/reply/get-reply-directives.ts` (+14 lines)

Related: #38729 (enables xhigh for Anthropic — this PR ensures the level survives from input to execution)