### PR TITLE
fix(slack): remove test harness export from production barrel

### DIFF
--- a/extensions/slack/contract-api.ts
+++ b/extensions/slack/contract-api.ts
@@ -3,7 +3,6 @@ export {
   collectRuntimeConfigAssignments,
   secretTargetRegistryEntries,
 } from "./src/secret-contract.js";
-export { createSlackOutboundPayloadHarness } from "./src/outbound-payload-harness.js";
 export type {
   SlackInteractiveHandlerContext,
   SlackInteractiveHandlerRegistration,

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -1,6 +1,6 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { describe, expect, it } from "vitest";
-import { createSlackOutboundPayloadHarness } from "../contract-api.js";
+import { createSlackOutboundPayloadHarness } from "./outbound-payload-harness.js";
 
 function createHarness(params: {
   payload: ReplyPayload;

--- a/test/helpers/channels/outbound-payload-contract.ts
+++ b/test/helpers/channels/outbound-payload-contract.ts
@@ -1,5 +1,5 @@
 import { beforeEach, expect, it, type Mock, vi } from "vitest";
-import { createSlackOutboundPayloadHarness } from "../../../extensions/slack/contract-api.js";
+import { createSlackOutboundPayloadHarness } from "../../../extensions/slack/src/outbound-payload-harness.js";
 import { whatsappOutbound } from "../../../extensions/whatsapp/test-api.js";
 import {
   chunkTextForOutbound as chunkZaloTextForOutbound,


### PR DESCRIPTION
## Summary

- Remove `createSlackOutboundPayloadHarness` export from `extensions/slack/contract-api.ts`
- Update test files to import directly from the harness source module

## Problem

`contract-api.ts` re-exports `createSlackOutboundPayloadHarness`, which imports `vi` from `vitest` and `primeChannelOutboundSendMock` from `openclaw/plugin-sdk/testing`. The bundler follows the import chain and pulls these test-only dependencies into the production dist.

At runtime, `vi` is `undefined` and `vi.fn()` throws:
```
TypeError: Cannot read properties of undefined (reading 't')
```

## Fix

Remove the test harness from the production barrel. Test files that need it now import directly from `./src/outbound-payload-harness.js`:

- `extensions/slack/src/outbound-payload.test.ts`
- `test/helpers/channels/outbound-payload-contract.ts`

Fixes #62949

## Test plan

- [x] `pnpm check` passes (lint, typecheck, format)
- [ ] `pnpm test` — scoped Slack outbound tests still pass
- [ ] `pnpm build` — verify `dist/extensions/slack/contract-api.js` no longer imports vitest