### PR TITLE
feat: expose replyToId in inbound_claim hook metadata

### DIFF
--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -48,6 +48,8 @@ export type CanonicalInboundMessageHookContext = {
   channelName?: string;
   isGroup: boolean;
   groupId?: string;
+  replyToId?: string;
+  replyToBody?: string;
 };
 
 export type CanonicalSentMessageHookContext = {
@@ -131,6 +133,8 @@ export function deriveInboundMessageHookContext(
     channelName: ctx.GroupChannel,
     isGroup,
     groupId: isGroup ? conversationId : undefined,
+    replyToId: ctx.ReplyToId,
+    replyToBody: ctx.ReplyToBody,
   };
 }
 
@@ -266,6 +270,8 @@ export function toPluginInboundClaimEvent(
       guildId: canonical.guildId,
       channelName: canonical.channelName,
       groupId: canonical.groupId,
+      replyToId: canonical.replyToId,
+      replyToBody: canonical.replyToBody,
     },
   };
 }


### PR DESCRIPTION
## Summary

Expose `replyToId` and `replyToBody` in the `inbound_claim` plugin hook metadata, enabling plugins to implement reply-aware message routing.

## Motivation

We're building a plugin that routes user replies to heartbeat messages back to the heartbeat session (instead of the main conversation session). This enables natural async conversations with heartbeat — user sees a heartbeat message, replies to it, and the reply goes to the right context.

Currently, `ReplyToId` and `ReplyToBody` exist in the Telegram bot context (`FinalizedMsgContext`) and are used to build the agent's inbound metadata (`inbound-meta.ts`), but they are not propagated to the plugin hook layer. Plugins in `inbound_claim` cannot determine which message the user replied to.

## Changes

One file, 6 lines added:

- `CanonicalInboundMessageHookContext`: add `replyToId?: string` and `replyToBody?: string`
- `deriveInboundMessageHookContext`: map from `ctx.ReplyToId` / `ctx.ReplyToBody`
- `toPluginInboundClaimEvent`: expose in `metadata`

## Impact

- No behavioral change for existing plugins (new fields are optional)
- Enables reply-aware routing for any plugin, not just our use case
- Consistent with how other context fields (senderId, threadId, etc.) are already propagated