### PR TITLE
Control UI: guard stale session history reloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Slack/media: preserve bearer auth across same-origin `files.slack.com` redirects while still stripping it on cross-origin Slack CDN hops, so `url_private_download` image attachments load again. (#62960) Thanks @vincentkoc.
+- Control UI: guard stale session-history reloads during fast session switches so the selected session and rendered transcript stay in sync. (#62975) Thanks @scoootscooob.
 
 ## 2026.4.8
 

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -48,6 +48,16 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("refreshChatAvatar", () => {
   beforeAll(async () => {
     await loadChatHelpers();
@@ -89,6 +99,53 @@ describe("refreshChatAvatar", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(host.chatAvatarUrl).toBeNull();
+  });
+
+  it("ignores stale avatar responses after switching sessions", async () => {
+    const mainRequest = createDeferred<{ avatarUrl?: string }>();
+    const opsRequest = createDeferred<{ avatarUrl?: string }>();
+    const fetchMock = vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url === "avatar/main?meta=1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => mainRequest.promise,
+        });
+      }
+      if (url === "avatar/ops?meta=1") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => opsRequest.promise,
+        });
+      }
+      throw new Error(`Unexpected avatar URL: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const host = makeHost({ basePath: "", sessionKey: "agent:main:main" });
+
+    const firstRefresh = refreshChatAvatar(host);
+    host.sessionKey = "agent:ops:main";
+    const secondRefresh = refreshChatAvatar(host);
+
+    mainRequest.resolve({ avatarUrl: "/avatar/main" });
+    await firstRefresh;
+    expect(host.chatAvatarUrl).toBeNull();
+
+    opsRequest.resolve({ avatarUrl: "/avatar/ops" });
+    await secondRefresh;
+
+    expect(host.chatAvatarUrl).toBe("/avatar/ops");
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "avatar/main?meta=1",
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "avatar/ops?meta=1",
+      expect.objectContaining({ method: "GET" }),
+    );
   });
 });
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -425,10 +425,24 @@ async function refreshChatModels(host: ChatHost) {
 }
 
 export const flushChatQueueForEvent = flushChatQueue;
+const chatAvatarRequestVersions = new WeakMap<object, number>();
 
 type SessionDefaultsSnapshot = {
   defaultAgentId?: string;
 };
+
+function beginChatAvatarRequest(host: ChatHost): number {
+  const key = host as object;
+  const nextVersion = (chatAvatarRequestVersions.get(key) ?? 0) + 1;
+  chatAvatarRequestVersions.set(key, nextVersion);
+  return nextVersion;
+}
+
+function shouldApplyChatAvatarResult(host: ChatHost, version: number, sessionKey: string): boolean {
+  return (
+    chatAvatarRequestVersions.get(host as object) === version && host.sessionKey === sessionKey
+  );
+}
 
 function resolveAgentIdForSession(host: ChatHost): string | null {
   const parsed = parseAgentSessionKey(host.sessionKey);
@@ -453,23 +467,35 @@ export async function refreshChatAvatar(host: ChatHost) {
     host.chatAvatarUrl = null;
     return;
   }
+  const sessionKey = host.sessionKey;
+  const requestVersion = beginChatAvatarRequest(host);
   const agentId = resolveAgentIdForSession(host);
   if (!agentId) {
-    host.chatAvatarUrl = null;
+    if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+      host.chatAvatarUrl = null;
+    }
     return;
   }
   host.chatAvatarUrl = null;
   const url = buildAvatarMetaUrl(host.basePath, agentId);
   try {
     const res = await fetch(url, { method: "GET" });
+    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+      return;
+    }
     if (!res.ok) {
       host.chatAvatarUrl = null;
       return;
     }
     const data = (await res.json()) as { avatarUrl?: unknown };
+    if (!shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+      return;
+    }
     const avatarUrl = typeof data.avatarUrl === "string" ? data.avatarUrl.trim() : "";
     host.chatAvatarUrl = avatarUrl || null;
   } catch {
-    host.chatAvatarUrl = null;
+    if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
+      host.chatAvatarUrl = null;
+    }
   }
 }

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -1,9 +1,32 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+const { refreshChatMock, refreshChatAvatarMock, loadChatHistoryMock, loadSessionsMock } =
+  vi.hoisted(() => ({
+    refreshChatMock: vi.fn(),
+    refreshChatAvatarMock: vi.fn(),
+    loadChatHistoryMock: vi.fn(),
+    loadSessionsMock: vi.fn(),
+  }));
+
+vi.mock("./app-chat.ts", () => ({
+  refreshChat: refreshChatMock,
+  refreshChatAvatar: refreshChatAvatarMock,
+}));
+
+vi.mock("./controllers/chat.ts", () => ({
+  loadChatHistory: loadChatHistoryMock,
+}));
+
+vi.mock("./controllers/sessions.ts", () => ({
+  loadSessions: loadSessionsMock,
+}));
+
 import {
   isCronSessionKey,
   parseSessionKey,
   resolveSessionDisplayName,
+  switchChatSession,
 } from "./app-render.helpers.ts";
+import type { AppViewState } from "./app-view-state.ts";
 import type { SessionsListResult } from "./types.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
@@ -282,5 +305,67 @@ describe("isCronSessionKey", () => {
     expect(isCronSessionKey("main")).toBe(false);
     expect(isCronSessionKey("discord:group:eng")).toBe(false);
     expect(isCronSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
+  });
+});
+
+describe("switchChatSession", () => {
+  it("refreshes the chat avatar after clearing session-scoped state", async () => {
+    const settings: AppViewState["settings"] = {
+      gatewayUrl: "",
+      token: "",
+      locale: "en",
+      sessionKey: "main",
+      lastActiveSessionKey: "main",
+      theme: "claw",
+      themeMode: "dark",
+      splitRatio: 0.6,
+      navWidth: 280,
+      navCollapsed: false,
+      navGroupsCollapsed: {},
+      borderRadius: 50,
+      chatFocusMode: false,
+      chatShowThinking: false,
+      chatShowToolCalls: true,
+    };
+    const state = {
+      sessionKey: "main",
+      chatMessage: "draft",
+      chatAttachments: [{ mimeType: "image/png", dataUrl: "data:image/png;base64,AAA" }],
+      chatMessages: [{ role: "assistant", content: "old" }],
+      chatToolMessages: [{ id: "tool-1" }],
+      chatStreamSegments: [{ text: "segment", ts: 1 }],
+      chatThinkingLevel: "high",
+      chatStream: "stream",
+      lastError: "oops",
+      compactionStatus: { phase: "active" },
+      fallbackStatus: { phase: "active" },
+      chatAvatarUrl: "/avatar/old",
+      chatQueue: [{ id: "queued" }],
+      chatRunId: "run-1",
+      chatStreamStartedAt: 1,
+      settings,
+      applySettings(next: typeof settings) {
+        state.settings = next;
+      },
+      loadAssistantIdentity: vi.fn(),
+      resetToolStream: vi.fn(),
+      resetChatScroll: vi.fn(),
+    } as unknown as AppViewState;
+
+    refreshChatAvatarMock.mockResolvedValue(undefined);
+    loadChatHistoryMock.mockResolvedValue(undefined);
+    loadSessionsMock.mockResolvedValue(undefined);
+
+    switchChatSession(state, "agent:main:test-b");
+    await Promise.resolve();
+
+    expect(refreshChatAvatarMock).toHaveBeenCalledWith(state);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
+    expect(loadSessionsMock).toHaveBeenCalledWith(state, {
+      activeMinutes: 0,
+      limit: 0,
+      includeGlobal: true,
+      includeUnknown: true,
+    });
   });
 });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -48,7 +48,17 @@ function resolveSidebarChatSessionKey(state: AppViewState): string {
 function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string) {
   state.sessionKey = sessionKey;
   state.chatMessage = "";
+  state.chatAttachments = [];
+  state.chatMessages = [];
+  state.chatToolMessages = [];
+  state.chatStreamSegments = [];
+  state.chatThinkingLevel = null;
   state.chatStream = null;
+  state.lastError = null;
+  state.compactionStatus = null;
+  state.fallbackStatus = null;
+  state.chatAvatarUrl = null;
+  state.chatQueue = [];
   (state as unknown as OpenClawApp).chatStreamStartedAt = null;
   state.chatRunId = null;
   (state as unknown as OpenClawApp).resetToolStream();
@@ -504,20 +514,7 @@ export function renderChatMobileToggle(state: AppViewState) {
 }
 
 export function switchChatSession(state: AppViewState, nextSessionKey: string) {
-  state.sessionKey = nextSessionKey;
-  state.chatMessage = "";
-  state.chatStream = null;
-  // P1: Clear queued chat items from the previous session
-  (state as unknown as { chatQueue: unknown[] }).chatQueue = [];
-  (state as unknown as OpenClawApp).chatStreamStartedAt = null;
-  state.chatRunId = null;
-  (state as unknown as OpenClawApp).resetToolStream();
-  (state as unknown as OpenClawApp).resetChatScroll();
-  state.applySettings({
-    ...state.settings,
-    sessionKey: nextSessionKey,
-    lastActiveSessionKey: nextSessionKey,
-  });
+  resetChatStateForSessionSwitch(state, nextSessionKey);
   void state.loadAssistantIdentity();
   syncUrlWithSessionKey(
     state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,7 +1,7 @@
 import { html, nothing } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { t } from "../i18n/index.ts";
-import { refreshChat } from "./app-chat.ts";
+import { refreshChat, refreshChatAvatar } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { OpenClawApp } from "./app.ts";
@@ -516,6 +516,7 @@ export function renderChatMobileToggle(state: AppViewState) {
 export function switchChatSession(state: AppViewState, nextSessionKey: string) {
   resetChatStateForSessionSwitch(state, nextSessionKey);
   void state.loadAssistantIdentity();
+  void refreshChatAvatar(state);
   syncUrlWithSessionKey(
     state as unknown as Parameters<typeof syncUrlWithSessionKey>[0],
     nextSessionKey,

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -28,6 +28,16 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
   };
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function createActiveStreamingState() {
   return createState({
     sessionKey: "main",
@@ -661,5 +671,52 @@ describe("loadChatHistory", () => {
     expect(state.chatThinkingLevel).toBeNull();
     expect(state.lastError).toContain("operator.read");
     expect(state.chatLoading).toBe(false);
+  });
+
+  it("ignores stale history responses after switching sessions", async () => {
+    const mainRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const otherRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const request = vi.fn((_method: string, params?: { sessionKey?: string }) => {
+      if (params?.sessionKey === "main") {
+        return mainRequest.promise;
+      }
+      if (params?.sessionKey === "other") {
+        return otherRequest.promise;
+      }
+      throw new Error(`Unexpected sessionKey: ${String(params?.sessionKey)}`);
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [{ role: "assistant", content: [{ type: "text", text: "visible old" }] }],
+    });
+
+    const firstLoad = loadChatHistory(state);
+    state.sessionKey = "other";
+    const secondLoad = loadChatHistory(state);
+
+    mainRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "main history" }] }],
+      thinkingLevel: "high",
+    });
+    await firstLoad;
+
+    expect(state.chatLoading).toBe(true);
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "visible old" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBeNull();
+
+    otherRequest.resolve({
+      messages: [{ role: "assistant", content: [{ type: "text", text: "other history" }] }],
+      thinkingLevel: "low",
+    });
+    await secondLoad;
+
+    expect(state.chatLoading).toBe(false);
+    expect(state.chatMessages).toEqual([
+      { role: "assistant", content: [{ type: "text", text: "other history" }] },
+    ]);
+    expect(state.chatThinkingLevel).toBe("low");
   });
 });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -11,6 +11,26 @@ import {
 } from "./scope-errors.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+const chatHistoryRequestVersions = new WeakMap<object, number>();
+
+function beginChatHistoryRequest(state: ChatState): number {
+  const key = state as object;
+  const nextVersion = (chatHistoryRequestVersions.get(key) ?? 0) + 1;
+  chatHistoryRequestVersions.set(key, nextVersion);
+  return nextVersion;
+}
+
+function isLatestChatHistoryRequest(state: ChatState, version: number): boolean {
+  return chatHistoryRequestVersions.get(state as object) === version;
+}
+
+function shouldApplyChatHistoryResult(
+  state: ChatState,
+  version: number,
+  sessionKey: string,
+): boolean {
+  return isLatestChatHistoryRequest(state, version) && state.sessionKey === sessionKey;
+}
 
 function isSilentReplyStream(text: string): boolean {
   return SILENT_REPLY_PATTERN.test(text);
@@ -73,16 +93,21 @@ export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;
   }
+  const sessionKey = state.sessionKey;
+  const requestVersion = beginChatHistoryRequest(state);
   state.chatLoading = true;
   state.lastError = null;
   try {
     const res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
       "chat.history",
       {
-        sessionKey: state.sessionKey,
+        sessionKey,
         limit: 200,
       },
     );
+    if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey)) {
+      return;
+    }
     const messages = Array.isArray(res.messages) ? res.messages : [];
     state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
     state.chatThinkingLevel = res.thinkingLevel ?? null;
@@ -92,6 +117,9 @@ export async function loadChatHistory(state: ChatState) {
     state.chatStream = null;
     state.chatStreamStartedAt = null;
   } catch (err) {
+    if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey)) {
+      return;
+    }
     if (isMissingOperatorReadScopeError(err)) {
       state.chatMessages = [];
       state.chatThinkingLevel = null;
@@ -100,7 +128,9 @@ export async function loadChatHistory(state: ChatState) {
       state.lastError = String(err);
     }
   } finally {
-    state.chatLoading = false;
+    if (isLatestChatHistoryRequest(state, requestVersion)) {
+      state.chatLoading = false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Problem: switching sessions in the control UI could leave the selector on the new session while an older `chat.history` response repopulated the previous transcript.
- Why it matters: the rendered session could look out of sync until a manual refresh, which makes session switching feel unreliable.
- What changed: guard overlapping chat-history loads so only the latest request for the current `sessionKey` can apply, and clear session-scoped chat state immediately when the user switches sessions.
- What did NOT change (scope boundary): this PR does not introduce auto-follow behavior for the latest active session; it keeps the existing explicit-session-selection design.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `loadChatHistory` applied whichever async `chat.history` response finished last, even if the user had already switched to a different session before that response returned.
- Missing detection / guardrail: there was no regression test covering overlapping history loads across a session switch.
- Contributing context (if known): the session-switch path updated `sessionKey` immediately, but the rendered transcript still depended on a separate async history reload without a stale-request guard.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/controllers/chat.test.ts`
- Scenario the test should lock in: two `chat.history` requests overlap across a session switch, and the older response must not overwrite the newer session.
- Why this is the smallest reliable guardrail: the bug is in the client-side async controller behavior, and the controller test can reproduce the race deterministically without a full gateway/browser setup.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Switching sessions in the control UI now clears the previous session transcript immediately and ignores stale history responses from the prior session.
- The selected session no longer appears visually out of sync with the rendered transcript after a fast switch.

## Diagram (if applicable)

```text
Before:
[user switches session] -> [new selector value] -> [old chat.history response finishes later] -> [old transcript shows until refresh]

After:
[user switches session] -> [old session UI state cleared] -> [latest chat.history only] -> [new transcript stays in sync]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm dev workspace
- Model/provider: N/A
- Integration/channel (if any): Control UI
- Relevant config (redacted): default local gateway at `127.0.0.1:18789`

### Steps

1. Open the control UI and select one session.
2. Trigger or simulate a fast switch to another session while chat history requests overlap.
3. Observe whether the rendered transcript can be overwritten by the older request.

### Expected

- The control UI should render only the newly selected session.

### Actual

- Before the fix, an older `chat.history` response could win and keep showing the previous session until refresh.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran the targeted control-UI chat controller and helper/view tests after the fix.
- Edge cases checked: overlapping history loads across a session switch; immediate session-state clearing during manual session changes.
- What you did **not** verify: I did not run the full repo-wide `pnpm check`/`tsgo` lane to green because latest `main` currently has unrelated TypeScript failures in `extensions/feishu/src/accounts.test.ts` and `extensions/nostr/src/nostr-profile.fuzz.test.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: clearing session-scoped chat state on switch could briefly show an empty thread while the new history loads.
  - Mitigation: that empty/loading state is preferable to showing the wrong session transcript, and the latest-request guard keeps the replacement history aligned with the selected session.
