### PR TITLE
fix(agents): honor image tool timeoutSeconds #62944

### DIFF
--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -611,6 +611,54 @@ describe("image tool implicit imageModel config", () => {
     __testing.setProviderDepsForTest();
   });
 
+  it("uses tools.media.image.timeoutSeconds for image requests", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("OPENAI_API_KEY", "openai-test");
+
+      const describeImageWithModel = vi.fn(async (params: ImageDescriptionRequest) => ({
+        text: "ok",
+        model: params.model,
+      }));
+      __testing.setProviderDepsForTest({
+        buildProviderRegistry: (overrides?: Record<string, MediaUnderstandingProvider>) =>
+          imageProviderHarness.buildProviderRegistry(overrides),
+        getMediaUnderstandingProvider: (
+          id: string,
+          registry: Map<string, MediaUnderstandingProvider>,
+        ) => imageProviderHarness.getMediaUnderstandingProvider(id, registry),
+        describeImageWithModel,
+        describeImagesWithModel: describeGenericImagesWithModel,
+      });
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.4-mini" },
+            imageModel: { primary: "openai/gpt-5.4-mini" },
+          },
+        },
+        tools: {
+          media: {
+            image: {
+              timeoutSeconds: 120,
+            },
+          },
+        },
+      };
+
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      await tool.execute("t1", {
+        prompt: "Describe the image.",
+        image: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      });
+
+      expect(describeImageWithModel).toHaveBeenCalledTimes(1);
+      const [call] = describeImageWithModel.mock.calls;
+      const [args] = call ?? [];
+      expect((args as ImageDescriptionRequest | undefined)?.timeoutMs).toBe(120_000);
+    });
+  });
+
   it("stays disabled without auth when no pairing is possible", async () => {
     await withTempAgentDir(async (agentDir) => {
       const cfg: OpenClawConfig = {

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -659,6 +659,104 @@ describe("image tool implicit imageModel config", () => {
     });
   });
 
+  it("defaults image request timeout to 30s when tools.media.image.timeoutSeconds is unset", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("OPENAI_API_KEY", "openai-test");
+
+      const describeImageWithModel = vi.fn(async (params: ImageDescriptionRequest) => ({
+        text: "ok",
+        model: params.model,
+      }));
+      __testing.setProviderDepsForTest({
+        buildProviderRegistry: (overrides?: Record<string, MediaUnderstandingProvider>) =>
+          imageProviderHarness.buildProviderRegistry(overrides),
+        getMediaUnderstandingProvider: (
+          id: string,
+          registry: Map<string, MediaUnderstandingProvider>,
+        ) => imageProviderHarness.getMediaUnderstandingProvider(id, registry),
+        describeImageWithModel,
+        describeImagesWithModel: describeGenericImagesWithModel,
+      });
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.4-mini" },
+            imageModel: { primary: "openai/gpt-5.4-mini" },
+          },
+        },
+        tools: {
+          media: {
+            image: {},
+          },
+        },
+      };
+
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      await tool.execute("t1", {
+        prompt: "Describe the image.",
+        image: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+      });
+
+      expect(describeImageWithModel).toHaveBeenCalledTimes(1);
+      const [args] = describeImageWithModel.mock.calls[0] ?? [];
+      expect((args as ImageDescriptionRequest | undefined)?.timeoutMs).toBe(30_000);
+    });
+  });
+
+  it("uses tools.media.image.timeoutSeconds for multi-image describeImagesWithModel requests", async () => {
+    await withTempAgentDir(async (agentDir) => {
+      vi.stubEnv("OPENAI_API_KEY", "openai-test");
+
+      const describeImagesWithModel = vi.fn(async (params: ImagesDescriptionRequest) => ({
+        text: "ok",
+        model: params.model,
+      }));
+      __testing.setProviderDepsForTest({
+        buildProviderRegistry: (overrides?: Record<string, MediaUnderstandingProvider>) =>
+          imageProviderHarness.buildProviderRegistry(overrides),
+        getMediaUnderstandingProvider: (
+          id: string,
+          registry: Map<string, MediaUnderstandingProvider>,
+        ) => imageProviderHarness.getMediaUnderstandingProvider(id, registry),
+        describeImageWithModel: async (params: ImageDescriptionRequest) => ({
+          text: "ok",
+          model: params.model,
+        }),
+        describeImagesWithModel,
+      });
+
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "openai/gpt-5.4-mini" },
+            imageModel: { primary: "openai/gpt-5.4-mini" },
+          },
+        },
+        tools: {
+          media: {
+            image: {
+              timeoutSeconds: 90,
+            },
+          },
+        },
+      };
+
+      const tool = requireImageTool(createImageTool({ config: cfg, agentDir }));
+      await tool.execute("t1", {
+        prompt: "Describe the images.",
+        images: [
+          `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+          `data:image/jpeg;base64,${ONE_PIXEL_JPEG_B64}`,
+        ],
+      });
+
+      expect(describeImagesWithModel).toHaveBeenCalledTimes(1);
+      const [args] = describeImagesWithModel.mock.calls[0] ?? [];
+      expect((args as ImagesDescriptionRequest | undefined)?.timeoutMs).toBe(90_000);
+    });
+  });
+
   it("stays disabled without auth when no pairing is possible", async () => {
     await withTempAgentDir(async (agentDir) => {
       const cfg: OpenClawConfig = {

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -6,6 +6,7 @@ import {
   resolveDefaultMediaModel,
 } from "../../media-understanding/defaults.js";
 import { getMediaUnderstandingProvider } from "../../media-understanding/provider-registry.js";
+import { resolveTimeoutMs } from "../../media-understanding/resolve.js";
 import { buildProviderRegistry } from "../../media-understanding/runner.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import {
@@ -45,6 +46,7 @@ import {
 
 const DEFAULT_PROMPT = "Describe the image.";
 const DEFAULT_MAX_IMAGES = 20;
+const DEFAULT_IMAGE_TOOL_TIMEOUT_SECONDS = 30;
 
 const imageToolProviderDeps = {
   buildProviderRegistry,
@@ -191,6 +193,10 @@ async function runImagePrompt(params: {
   const effectiveCfg = applyImageModelConfigDefaults(params.cfg, params.imageModelConfig);
   const providerCfg: OpenClawConfig = effectiveCfg ?? {};
   const providerRegistry = imageToolProviderDeps.buildProviderRegistry(undefined, providerCfg);
+  const timeoutMs = resolveTimeoutMs(
+    params.cfg?.tools?.media?.image?.timeoutSeconds,
+    DEFAULT_IMAGE_TOOL_TIMEOUT_SECONDS,
+  );
 
   const result = await runWithImageModelFallback({
     cfg: effectiveCfg,
@@ -216,7 +222,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -234,7 +240,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: params.prompt,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });
@@ -251,7 +257,7 @@ async function runImagePrompt(params: {
           model: modelId,
           prompt: `${params.prompt}\n\nDescribe image ${index + 1} of ${params.images.length}.`,
           maxTokens: resolveImageToolMaxTokens(undefined),
-          timeoutMs: 30_000,
+          timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
         });


### PR DESCRIPTION
## Summary
- Problem: The `image` tool always used a hardcoded 30s timeout, ignoring config.
- Why it matters: Slow/self-hosted vision models can be aborted prematurely even when users configure longer timeouts.
- What changed: The image tool now reads `tools.media.image.timeoutSeconds` (seconds) and forwards it as `timeoutMs`, defaulting to 30s when unset.
- What did NOT change (scope boundary): No changes to provider selection/fallback logic; only timeout wiring for image tool requests.

## Change Type (select all)
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)
- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
Fixes #62944

## User-visible / Behavior Changes
- The `image` tool now honors `tools.media.image.timeoutSeconds`. If unset, it falls back to 30 seconds (backward compatible).

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Relevant config (redacted)
```yaml
tools:
  media:
    image:
      timeoutSeconds: 120
```

### Tests
- `pnpm test src/agents/tools/image-tool.test.ts`

## Implementation Notes
- Code changes:
  - `src/agents/tools/image-tool.ts`
  - `src/agents/tools/image-tool.test.ts`
- Note: The repo config contract is `tools.media.image.timeoutSeconds` (not `tools.media.models.timeoutSeconds`).