### PR TITLE
fix(auto-reply): avoid persisting heartbeat model to session entry #6…

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -585,6 +585,7 @@ export async function runReplyAgent(params: {
       cliSessionId,
       cliSessionBinding,
       usageIsContextSnapshot: isCliProvider(providerUsed, cfg),
+      isHeartbeat,
     });
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -301,6 +301,7 @@ export function createFollowupRunner(params: {
             queued.run.config,
           ),
           logLabel: "followup",
+          isHeartbeat: opts?.isHeartbeat === true,
         });
       }
 

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -89,6 +89,7 @@ export async function persistSessionUsageUpdate(params: {
   cliSessionId?: string;
   cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
   logLabel?: string;
+  isHeartbeat?: boolean;
 }): Promise<void> {
   const { storePath, sessionKey } = params;
   if (!storePath || !sessionKey) {
@@ -134,8 +135,11 @@ export async function persistSessionUsageUpdate(params: {
           });
           const existingEstimatedCostUsd = resolveNonNegativeNumber(entry.estimatedCostUsd) ?? 0;
           const patch: Partial<SessionEntry> = {
-            modelProvider: params.providerUsed ?? entry.modelProvider,
-            model: params.modelUsed ?? entry.model,
+            modelProvider:
+              params.isHeartbeat === true
+                ? entry.modelProvider
+                : (params.providerUsed ?? entry.modelProvider),
+            model: params.isHeartbeat === true ? entry.model : (params.modelUsed ?? entry.model),
             contextTokens: resolvedContextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),
@@ -174,8 +178,11 @@ export async function persistSessionUsageUpdate(params: {
         sessionKey,
         update: async (entry) => {
           const patch: Partial<SessionEntry> = {
-            modelProvider: params.providerUsed ?? entry.modelProvider,
-            model: params.modelUsed ?? entry.model,
+            modelProvider:
+              params.isHeartbeat === true
+                ? entry.modelProvider
+                : (params.providerUsed ?? entry.modelProvider),
+            model: params.isHeartbeat === true ? entry.model : (params.modelUsed ?? entry.model),
             contextTokens: params.contextTokensUsed ?? entry.contextTokens,
             systemPromptReport: params.systemPromptReport ?? entry.systemPromptReport,
             updatedAt: Date.now(),

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2329,6 +2329,35 @@ describe("persistSessionUsageUpdate", () => {
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
     expect(stored[sessionKey].estimatedCostUsd).toBe(0);
   });
+
+  it("does not overwrite persisted model fields for heartbeat turns", async () => {
+    const storePath = await createStorePath("openclaw-usage-heartbeat-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        modelProvider: "openai-codex",
+        model: "gpt-5.4",
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      usage: { input: 1_000, output: 200 },
+      modelUsed: "openai-codex/gpt-5.1-codex-mini",
+      providerUsed: "openai-codex",
+      contextTokensUsed: 200_000,
+      isHeartbeat: true,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].modelProvider).toBe("openai-codex");
+    expect(stored[sessionKey].model).toBe("gpt-5.4");
+  });
 });
 
 describe("initSessionState stale threadId fallback", () => {


### PR DESCRIPTION
## Summary

- Problem: Heartbeat turns persist `model` / `modelProvider` onto the session entry, causing UI surfaces (e.g. `chat.history`) to display the heartbeat model as the “current model” until the next user turn.
- Why it matters: The displayed session model becomes misleading and does not match what subsequent non-heartbeat turns will actually run.
- What changed: Threaded an `isHeartbeat` flag into usage persistence and, for heartbeat turns, keep the persisted `entry.model` / `entry.modelProvider` unchanged.
- What did NOT change: Actual model selection for replies; this is a persistence/display correctness fix only.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Fixes #62954

## User-visible / Behavior Changes

- Heartbeat turns no longer overwrite the session’s persisted “current model/provider” fields used by UI display.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node (repo default)
- Relevant config (redacted):
  - `agents.defaults.model` set to a non-heartbeat model
  - `agents.defaults.heartbeat.model` set to a different model

### Steps

1. Start a session using the default model (non-heartbeat).
2. Allow a heartbeat tick to run.
3. Inspect the session model shown in Control UI / `chat.history`.

### Expected

- The session continues to show the default model (non-heartbeat) as the current model.

### Actual (before)

- The session shows the heartbeat model as the current model until a non-heartbeat turn runs again.

## Evidence

- Added a unit test covering heartbeat persistence behavior:
  - `src/auto-reply/reply/session.test.ts`

## Tests

- `pnpm test src/auto-reply/reply/session.test.ts -t "persistSessionUsageUpdate"`