### PR TITLE
runtime: fail closed on plan stalls and retry session-delta sync

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-sync-ops.ts
@@ -76,6 +76,7 @@ const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
 const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const SESSION_DIRTY_DEBOUNCE_MS = 5000;
+const SESSION_DELTA_RETRY_DELAY_MS = 60_000;
 const SESSION_DELTA_READ_CHUNK_BYTES = 64 * 1024;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;
 const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
@@ -431,6 +432,11 @@ export abstract class MemoryManagerSyncOps {
     const pending = Array.from(this.sessionPendingFiles);
     this.sessionPendingFiles.clear();
     let shouldSync = false;
+    const retriableThresholds: Array<{
+      sessionFile: string;
+      restoreBytes: number;
+      restoreMessages: number;
+    }> = [];
     for (const sessionFile of pending) {
       const delta = await this.updateSessionDelta(sessionFile);
       if (!delta) {
@@ -454,10 +460,40 @@ export abstract class MemoryManagerSyncOps {
       delta.pendingMessages =
         messagesThreshold > 0 ? Math.max(0, delta.pendingMessages - messagesThreshold) : 0;
       shouldSync = true;
+      retriableThresholds.push({
+        sessionFile,
+        restoreBytes: bytesHit ? Math.max(bytesThreshold, 1) : 0,
+        restoreMessages: messagesHit ? Math.max(messagesThreshold, 1) : 0,
+      });
     }
     if (shouldSync) {
       void this.sync({ reason: "session-delta" }).catch((err) => {
         log.warn(`memory sync failed (session-delta): ${String(err)}`);
+        if (this.closed || !/\bfetch failed\b/i.test(String(err))) {
+          return;
+        }
+        for (const threshold of retriableThresholds) {
+          this.sessionPendingFiles.add(threshold.sessionFile);
+          const delta = this.sessionDeltas.get(threshold.sessionFile);
+          if (!delta) {
+            continue;
+          }
+          if (threshold.restoreBytes > 0) {
+            delta.pendingBytes += threshold.restoreBytes;
+          }
+          if (threshold.restoreMessages > 0) {
+            delta.pendingMessages += threshold.restoreMessages;
+          }
+        }
+        if (this.sessionWatchTimer) {
+          return;
+        }
+        this.sessionWatchTimer = setTimeout(() => {
+          this.sessionWatchTimer = null;
+          void this.processSessionDeltaBatch().catch((retryErr) => {
+            log.warn(`memory session delta failed: ${String(retryErr)}`);
+          });
+        }, SESSION_DELTA_RETRY_DELAY_MS);
       });
     }
   }

--- a/extensions/memory-core/src/memory/manager.sync-errors-do-not-crash.test.ts
+++ b/extensions/memory-core/src/memory/manager.sync-errors-do-not-crash.test.ts
@@ -1,5 +1,49 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runDetachedMemorySync } from "./manager-sync-ops.js";
+import { runDetachedMemorySync, MemoryManagerSyncOps } from "./manager-sync-ops.js";
+
+class TestMemoryManagerSyncOps extends MemoryManagerSyncOps {
+  protected readonly cfg = {} as never;
+  protected readonly agentId = "main";
+  protected readonly workspaceDir = os.tmpdir();
+  protected readonly settings = {
+    sync: { sessions: { deltaBytes: 1, deltaMessages: 0 } },
+    chunking: { size: 512, overlap: 0 },
+    store: { fts: { tokenizer: "unicode61" } },
+  } as never;
+  protected provider = null;
+  protected readonly batch = {
+    enabled: false,
+    wait: false,
+    concurrency: 1,
+    pollIntervalMs: 10,
+    timeoutMs: 10,
+  };
+  protected readonly vector = {
+    enabled: false,
+    available: false,
+  };
+  protected readonly cache = { enabled: false };
+  protected db = {} as never;
+  readonly syncSpy = vi.fn(async () => {});
+
+  protected computeProviderKey(): string {
+    return "test";
+  }
+  protected async sync(): Promise<void> {
+    await this.syncSpy();
+  }
+  protected async withTimeout<T>(promise: Promise<T>): Promise<T> {
+    return promise;
+  }
+  protected getIndexConcurrency(): number {
+    return 1;
+  }
+  protected pruneEmbeddingCacheIfNeeded(): void {}
+  protected async indexFile(): Promise<void> {}
+}
 
 describe("memory manager sync failures", () => {
   beforeEach(() => {
@@ -29,5 +73,30 @@ describe("memory manager sync failures", () => {
 
     process.off("unhandledRejection", handler);
     expect(unhandled).toHaveLength(0);
+  });
+
+  it("retries session-delta sync after fetch failures without losing pending session work", async () => {
+    const manager = new TestMemoryManagerSyncOps();
+    manager.syncSpy.mockRejectedValueOnce(new Error("TypeError: fetch failed")).mockResolvedValueOnce(undefined);
+
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-delta-"));
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(sessionFile, '{"role":"user","content":"hello"}\n', "utf8");
+    (manager as unknown as { sessionPendingFiles: Set<string> }).sessionPendingFiles.add(sessionFile);
+
+    await (manager as unknown as { processSessionDeltaBatch: () => Promise<void> }).processSessionDeltaBatch();
+    await vi.runAllTicks();
+
+    expect(manager.syncSpy).toHaveBeenCalledTimes(1);
+    expect(
+      (manager as unknown as { sessionPendingFiles: Set<string> }).sessionPendingFiles.has(sessionFile),
+    ).toBe(true);
+    expect(
+      (manager as unknown as { sessionWatchTimer: NodeJS.Timeout | null }).sessionWatchTimer,
+    ).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(manager.syncSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -324,7 +324,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       },
     });
     if (preflight.shouldInitializeProvider) {
-      await this.ensureProviderInitialized();
+      try {
+        await this.ensureProviderInitialized();
+      } catch (err) {
+        const message = String(err);
+        this.provider = null;
+        this.providerUnavailableReason = message;
+        log.warn(`memory search degrading to FTS-only after provider init failure: ${message}`);
+      }
     }
     const minScore = opts?.minScore ?? this.settings.query.minScore;
     const maxResults = opts?.maxResults ?? this.settings.query.maxResults;
@@ -386,7 +393,14 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         ? await this.searchKeyword(cleaned, candidates).catch(() => [])
         : [];
 
-    const queryVec = await this.embedQueryWithTimeout(cleaned);
+    let queryVec: number[] = [];
+    try {
+      queryVec = await this.embedQueryWithTimeout(cleaned);
+    } catch (err) {
+      const message = String(err);
+      this.providerUnavailableReason = message;
+      log.warn(`memory search degrading to keyword-only after query embedding failure: ${message}`);
+    }
     const hasVector = queryVec.some((v) => v !== 0);
     const vectorResults = hasVector
       ? await this.searchVector(queryVec, candidates).catch(() => [])

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1877,6 +1877,7 @@ export async function runEmbeddedAttempt(
                   `${params.provider}/${params.modelId} route=${preemptiveCompaction.route} ` +
                   `truncatedCount=${truncationResult.truncatedCount} ` +
                   `estimatedPromptTokens=${preemptiveCompaction.estimatedPromptTokens} ` +
+                  `promptUsageRatio=${preemptiveCompaction.promptUsageRatio.toFixed(2)} ` +
                   `promptBudgetBeforeReserve=${preemptiveCompaction.promptBudgetBeforeReserve} ` +
                   `overflowTokens=${preemptiveCompaction.overflowTokens} ` +
                   `toolResultReducibleChars=${preemptiveCompaction.toolResultReducibleChars} ` +
@@ -1908,6 +1909,7 @@ export async function runEmbeddedAttempt(
                 `provider=${params.provider}/${params.modelId} ` +
                 `route=${preemptiveCompaction.route} ` +
                 `estimatedPromptTokens=${preemptiveCompaction.estimatedPromptTokens} ` +
+                `promptUsageRatio=${preemptiveCompaction.promptUsageRatio.toFixed(2)} ` +
                 `promptBudgetBeforeReserve=${preemptiveCompaction.promptBudgetBeforeReserve} ` +
                 `overflowTokens=${preemptiveCompaction.overflowTokens} ` +
                 `toolResultReducibleChars=${preemptiveCompaction.toolResultReducibleChars} ` +

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -7,6 +7,10 @@ import {
 } from "./llm-idle-timeout.js";
 
 describe("resolveLlmIdleTimeoutMs", () => {
+  it("defaults to 120 seconds", () => {
+    expect(DEFAULT_LLM_IDLE_TIMEOUT_MS).toBe(120_000);
+  });
+
   it("returns default when config is undefined", () => {
     expect(resolveLlmIdleTimeoutMs(undefined)).toBe(DEFAULT_LLM_IDLE_TIMEOUT_MS);
   });

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -6,9 +6,9 @@ import type { OpenClawConfig } from "../../../config/config.js";
  * Default idle timeout for LLM streaming responses in milliseconds.
  * If no token is received within this time, the request is aborted.
  * Set to 0 to disable (never timeout).
- * Default: 60 seconds.
+ * Default: 120 seconds.
  */
-export const DEFAULT_LLM_IDLE_TIMEOUT_MS = 60_000;
+export const DEFAULT_LLM_IDLE_TIMEOUT_MS = 120_000;
 
 /**
  * Maximum safe timeout value (approximately 24.8 days).

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -84,6 +84,29 @@ describe("preemptive-compaction", () => {
     expect(result.estimatedPromptTokens).toBeLessThan(result.promptBudgetBeforeReserve);
   });
 
+  it("requests soft preemptive compaction when prompt pressure is high even before hard overflow", () => {
+    const longHistory = "old discussion with retained decisions and verbose context ".repeat(4200);
+    const reserveTokens = 5_000;
+    const estimatedPromptTokens = estimatePrePromptTokens({
+      messages: [makeAssistantHistory(longHistory)],
+      systemPrompt: verboseSystem,
+      prompt: verbosePrompt,
+    });
+    const targetPromptBudgetBeforeReserve = Math.ceil(estimatedPromptTokens / 0.72);
+    const result = shouldPreemptivelyCompactBeforePrompt({
+      messages: [makeAssistantHistory(longHistory)],
+      systemPrompt: verboseSystem,
+      prompt: verbosePrompt,
+      contextTokenBudget: targetPromptBudgetBeforeReserve + reserveTokens,
+      reserveTokens,
+    });
+
+    expect(result.overflowTokens).toBe(0);
+    expect(result.promptUsageRatio).toBeGreaterThanOrEqual(0.7);
+    expect(result.shouldCompact).toBe(true);
+    expect(result.route).toBe("compact_only");
+  });
+
   it("routes to direct tool-result truncation when recent tool tails can clearly absorb the overflow", () => {
     const medium = "alpha beta gamma delta epsilon ".repeat(2200);
     const messages: AgentMessage[] = [

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -8,6 +8,7 @@ export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
 
 const ESTIMATED_CHARS_PER_TOKEN = 4;
 const TRUNCATION_ROUTE_BUFFER_TOKENS = 512;
+const SOFT_COMPACTION_PRESSURE_RATIO = 0.7;
 
 export type PreemptiveCompactionRoute =
   | "fits"
@@ -50,6 +51,7 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
   promptBudgetBeforeReserve: number;
   overflowTokens: number;
   toolResultReducibleChars: number;
+  promptUsageRatio: number;
 } {
   const estimatedPromptTokens = estimatePrePromptTokens(params);
   const promptBudgetBeforeReserve = Math.max(
@@ -57,6 +59,8 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     Math.floor(params.contextTokenBudget) - Math.max(0, Math.floor(params.reserveTokens)),
   );
   const overflowTokens = Math.max(0, estimatedPromptTokens - promptBudgetBeforeReserve);
+  const promptUsageRatio =
+    promptBudgetBeforeReserve > 0 ? estimatedPromptTokens / promptBudgetBeforeReserve : 0;
   const toolResultPotential = estimateToolResultReductionPotential({
     messages: params.messages,
     contextWindowTokens: params.contextTokenBudget,
@@ -78,6 +82,8 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     } else {
       route = "compact_then_truncate";
     }
+  } else if (promptUsageRatio >= SOFT_COMPACTION_PRESSURE_RATIO) {
+    route = "compact_only";
   }
   return {
     route,
@@ -86,5 +92,6 @@ export function shouldPreemptivelyCompactBeforePrompt(params: {
     promptBudgetBeforeReserve,
     overflowTokens,
     toolResultReducibleChars,
+    promptUsageRatio,
   };
 }

--- a/src/agents/subagent-registry-helpers.ts
+++ b/src/agents/subagent-registry-helpers.ts
@@ -204,13 +204,11 @@ export async function safeRemoveAttachmentsDir(entry: SubagentRunRecord): Promis
   }
 }
 
-export function reconcileOrphanedRun(params: {
+export function markOrphanedRunForCleanup(params: {
   runId: string;
   entry: SubagentRunRecord;
   reason: SubagentRunOrphanReason;
   source: "restore" | "resume";
-  runs: Map<string, SubagentRunRecord>;
-  resumedRuns: Set<string>;
 }) {
   const now = Date.now();
   let changed = false;
@@ -230,33 +228,41 @@ export function reconcileOrphanedRun(params: {
     params.entry.endedReason = SUBAGENT_ENDED_REASON_ERROR;
     changed = true;
   }
-  if (params.entry.cleanupHandled !== true) {
-    params.entry.cleanupHandled = true;
+  if (params.entry.cleanupHandled !== false) {
+    params.entry.cleanupHandled = false;
     changed = true;
   }
-  if (typeof params.entry.cleanupCompletedAt !== "number") {
-    params.entry.cleanupCompletedAt = now;
+  if (typeof params.entry.cleanupCompletedAt === "number") {
+    params.entry.cleanupCompletedAt = undefined;
     changed = true;
   }
-  const shouldDeleteAttachments =
-    params.entry.cleanup === "delete" || !params.entry.retainAttachmentsOnKeep;
-  if (shouldDeleteAttachments) {
-    void safeRemoveAttachmentsDir(params.entry);
+  if (params.entry.suppressAnnounceReason !== undefined) {
+    params.entry.suppressAnnounceReason = undefined;
+    changed = true;
   }
-  const removed = params.runs.delete(params.runId);
-  params.resumedRuns.delete(params.runId);
-  if (!removed && !changed) {
+  if (params.entry.wakeOnDescendantSettle !== undefined) {
+    params.entry.wakeOnDescendantSettle = undefined;
+    changed = true;
+  }
+  if (params.entry.announceRetryCount !== undefined) {
+    params.entry.announceRetryCount = undefined;
+    changed = true;
+  }
+  if (params.entry.lastAnnounceRetryAt !== undefined) {
+    params.entry.lastAnnounceRetryAt = undefined;
+    changed = true;
+  }
+  if (!changed) {
     return false;
   }
   defaultRuntime.log(
-    `[warn] Subagent orphan run pruned source=${params.source} run=${params.runId} child=${params.entry.childSessionKey} reason=${params.reason}`,
+    `[warn] Subagent orphan run marked for parent reclaim source=${params.source} run=${params.runId} child=${params.entry.childSessionKey} reason=${params.reason}`,
   );
   return true;
 }
 
-export function reconcileOrphanedRestoredRuns(params: {
+export function markOrphanedRestoredRunsForCleanup(params: {
   runs: Map<string, SubagentRunRecord>;
-  resumedRuns: Set<string>;
 }) {
   const storeCache = new Map<string, Record<string, SessionEntry>>();
   let changed = false;
@@ -269,13 +275,11 @@ export function reconcileOrphanedRestoredRuns(params: {
       continue;
     }
     if (
-      reconcileOrphanedRun({
+      markOrphanedRunForCleanup({
         runId,
         entry,
         reason: orphanReason,
         source: "restore",
-        runs: params.runs,
-        resumedRuns: params.resumedRuns,
       })
     ) {
       changed = true;

--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -404,7 +404,7 @@ describe("subagent registry persistence", () => {
     expect(afterSecond.runs?.["run-4"]).toBeUndefined();
   });
 
-  it("reconciles orphaned restored runs by pruning them from registry", async () => {
+  it("reconciles orphaned restored runs into announced retained error records", async () => {
     const persisted = createPersistedEndedRun({
       runId: "run-orphan-restore",
       childSessionKey: "agent:main:subagent:ghost-restore",
@@ -417,12 +417,18 @@ describe("subagent registry persistence", () => {
 
     await restartRegistryAndFlush();
 
-    expect(announceSpy).not.toHaveBeenCalled();
+    expect(announceSpy).toHaveBeenCalledTimes(1);
     const after = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
       runs?: Record<string, unknown>;
     };
-    expect(after.runs?.["run-orphan-restore"]).toBeUndefined();
-    expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(0);
+    expect(after.runs?.["run-orphan-restore"]).toMatchObject({
+      outcome: {
+        status: "error",
+        error: "orphaned subagent run (missing-session-entry)",
+      },
+      cleanupHandled: true,
+    });
+    expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(1);
   });
 
   it("removes attachments when pruning orphaned restored runs", async () => {
@@ -556,7 +562,7 @@ describe("subagent registry persistence", () => {
     expect(resolved?.endedAt).toBe(220);
   });
 
-  it("resume guard prunes orphan runs before announce retry", async () => {
+  it("resume guard announces orphan runs back to the parent instead of pruning them silently", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-"));
     process.env.OPENCLAW_STATE_DIR = tempStateDir;
     const runId = "run-orphan-resume-guard";
@@ -587,10 +593,66 @@ describe("subagent registry persistence", () => {
     expect(changed).toBe(true);
     await flushQueuedRegistryWork();
 
-    expect(announceSpy).not.toHaveBeenCalled();
-    expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(0);
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childRunId: runId,
+        childSessionKey,
+        requesterSessionKey: "agent:main:main",
+        outcome: {
+          status: "error",
+          error: "orphaned subagent run (missing-session-entry)",
+        },
+      }),
+    );
+    expect(listSubagentRunsForRequester("agent:main:main")).toHaveLength(1);
     const persisted = loadSubagentRegistryFromDisk();
-    expect(persisted.has(runId)).toBe(false);
+    expect(persisted.get(runId)).toMatchObject({
+      outcome: {
+        status: "error",
+        error: "orphaned subagent run (missing-session-entry)",
+      },
+      cleanupHandled: true,
+    });
+  });
+
+  it("startup restore announces orphaned ended runs instead of silently dropping them", async () => {
+    announceSpy.mockClear();
+    const registryPath = await writePersistedRegistry(
+      createPersistedEndedRun({
+        runId: "run-orphan-restore",
+        childSessionKey: "agent:main:subagent:ghost-restore",
+        task: "restore orphan announce",
+        cleanup: "keep",
+      }),
+      { seedChildSessions: false },
+    );
+
+    await restartRegistryAndFlush();
+
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childRunId: "run-orphan-restore",
+        childSessionKey: "agent:main:subagent:ghost-restore",
+        requesterSessionKey: "agent:main:main",
+        outcome: {
+          status: "error",
+          error: "orphaned subagent run (missing-session-entry)",
+        },
+      }),
+    );
+    const persisted = await readPersistedRun<Record<string, unknown>>(
+      registryPath,
+      "run-orphan-restore",
+    );
+    expect(persisted).toMatchObject({
+      outcome: {
+        status: "error",
+        error: "orphaned subagent run (missing-session-entry)",
+      },
+      cleanupHandled: true,
+    });
   });
 
   it("uses isolated temp state when OPENCLAW_STATE_DIR is unset in tests", async () => {

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -23,8 +23,8 @@ import {
 import {
   ANNOUNCE_EXPIRY_MS,
   MAX_ANNOUNCE_RETRY_COUNT,
-  reconcileOrphanedRestoredRuns,
-  reconcileOrphanedRun,
+  markOrphanedRestoredRunsForCleanup,
+  markOrphanedRunForCleanup,
   resolveAnnounceRetryDelayMs,
   resolveSubagentRunOrphanReason,
   resolveSubagentSessionStatus,
@@ -331,19 +331,9 @@ function resumeSubagentRun(runId: string) {
   }
   const orphanReason = resolveSubagentRunOrphanReason({ entry });
   if (orphanReason) {
-    if (
-      reconcileOrphanedRun({
-        runId,
-        entry,
-        reason: orphanReason,
-        source: "resume",
-        runs: subagentRuns,
-        resumedRuns,
-      })
-    ) {
+    if (markOrphanedRunForCleanup({ runId, entry, reason: orphanReason, source: "resume" })) {
       persistSubagentRuns();
     }
-    return;
   }
   if (entry.cleanupCompletedAt) {
     return;
@@ -420,9 +410,8 @@ function restoreSubagentRunsOnce() {
       return;
     }
     if (
-      reconcileOrphanedRestoredRuns({
+      markOrphanedRestoredRunsForCleanup({
         runs: subagentRuns,
-        resumedRuns,
       })
     ) {
       persistSubagentRuns();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1253,6 +1253,105 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
+  it("fails closed with a visible reply when planning stalls without concrete progress", async () => {
+    setNoAbort();
+    vi.useFakeTimers();
+    const cfg = {
+      ...emptyConfig,
+      agents: {
+        defaults: {
+          verboseDefault: "on",
+        },
+      },
+    } satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      ChatType: "direct",
+      SessionKey: "agent:main:discord:channel:memory",
+    });
+
+    const replyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions, _cfg?: OpenClawConfig) => {
+        await opts?.onPlanUpdate?.({
+          phase: "update",
+          explanation: "Inspect code, patch it, run tests.",
+          steps: ["Inspect code", "Patch code", "Run tests"],
+        });
+        return await new Promise<ReplyPayload | undefined>((_resolve, reject) => {
+          opts?.abortSignal?.addEventListener(
+            "abort",
+            () => reject(opts.abortSignal?.reason ?? new Error("aborted")),
+            { once: true },
+          );
+        });
+      },
+    );
+
+    const pending = dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await vi.advanceTimersByTimeAsync(45_000);
+    const result = await pending;
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        text: "⚠️ Turn stalled after planning and was stopped instead of hanging silently. Please retry.",
+      }),
+    );
+    expect(result.queuedFinal).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it("does not trip the planning stall guard after concrete progress is emitted", async () => {
+    setNoAbort();
+    vi.useFakeTimers();
+    const cfg = {
+      ...emptyConfig,
+      agents: {
+        defaults: {
+          verboseDefault: "on",
+        },
+      },
+    } satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      ChatType: "direct",
+      SessionKey: "agent:main:discord:channel:memory",
+    });
+
+    const replyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions, _cfg?: OpenClawConfig) => {
+        await opts?.onPlanUpdate?.({
+          phase: "update",
+          explanation: "Inspect code, patch it, run tests.",
+          steps: ["Inspect code", "Patch code", "Run tests"],
+        });
+        await opts?.onToolResult?.({ text: "patched file" });
+        await new Promise((resolve) => setTimeout(resolve, 46_000));
+        return { text: "done" } satisfies ReplyPayload;
+      },
+    );
+
+    const pending = dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    await vi.advanceTimersByTimeAsync(46_000);
+    const result = await pending;
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "patched file" }),
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        isError: true,
+        text: "⚠️ Turn stalled after planning and was stopped instead of hanging silently. Please retry.",
+      }),
+    );
+    expect(result.queuedFinal).toBe(true);
+    vi.useRealTimers();
+  });
+
   it("suppresses plan and working-status progress when session verbose is off", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -71,6 +71,10 @@ let getReplyFromConfigRuntimePromise: Promise<
 let abortRuntimePromise: Promise<typeof import("./abort.runtime.js")> | null = null;
 let ttsRuntimePromise: Promise<typeof import("../../tts/tts.runtime.js")> | null = null;
 
+const CONTROL_PLANE_STALL_TIMEOUT_MS = 45_000;
+const CONTROL_PLANE_STALL_REPLY_TEXT =
+  "⚠️ Turn stalled after planning and was stopped instead of hanging silently. Please retry.";
+
 function loadRouteReplyRuntime() {
   routeReplyRuntimePromise ??= import("./route-reply.runtime.js");
   return routeReplyRuntimePromise;
@@ -89,6 +93,28 @@ function loadAbortRuntime() {
 function loadTtsRuntime() {
   ttsRuntimePromise ??= import("../../tts/tts.runtime.js");
   return ttsRuntimePromise;
+}
+
+function createAbortControllerWithForwardedSignal(signal?: AbortSignal): {
+  controller: AbortController;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  if (!signal) {
+    return { controller, cleanup: () => {} };
+  }
+  if (signal.aborted) {
+    controller.abort(signal.reason);
+    return { controller, cleanup: () => {} };
+  }
+  const onAbort = () => {
+    controller.abort(signal.reason);
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+  return {
+    controller,
+    cleanup: () => signal.removeEventListener("abort", onAbort),
+  };
 }
 
 async function maybeApplyTtsToReplyPayload(
@@ -289,6 +315,32 @@ export async function dispatchReplyFromConfig(params: {
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const hookRunner = getGlobalHookRunner();
+  const controlPlaneAbort = createAbortControllerWithForwardedSignal(
+    params.replyOptions?.abortSignal,
+  );
+  let controlPlaneStallTimer: NodeJS.Timeout | null = null;
+  let controlPlaneTimedOut = false;
+  let concreteProgressSeen = false;
+  const clearControlPlaneStallTimer = () => {
+    if (controlPlaneStallTimer) {
+      clearTimeout(controlPlaneStallTimer);
+      controlPlaneStallTimer = null;
+    }
+  };
+  const markConcreteProgress = () => {
+    concreteProgressSeen = true;
+    clearControlPlaneStallTimer();
+  };
+  const armControlPlaneStallTimer = () => {
+    if (concreteProgressSeen || controlPlaneStallTimer || ctx.CommandSource === "native") {
+      return;
+    }
+    controlPlaneStallTimer = setTimeout(() => {
+      controlPlaneStallTimer = null;
+      controlPlaneTimedOut = true;
+      controlPlaneAbort.controller.abort(new Error("control_plane_stall"));
+    }, CONTROL_PLANE_STALL_TIMEOUT_MS);
+  };
 
   // Extract message context for hooks (plugin and internal)
   const timestamp =
@@ -826,9 +878,11 @@ export async function dispatchReplyFromConfig(params: {
       ctx,
       {
         ...params.replyOptions,
+        abortSignal: controlPlaneAbort.controller.signal,
         typingPolicy: typing.typingPolicy,
         suppressTyping: typing.suppressTyping,
         onToolResult: (payload: ReplyPayload) => {
+          markConcreteProgress();
           const run = async () => {
             const ttsPayload = await maybeApplyTtsToReplyPayload({
               payload,
@@ -854,12 +908,14 @@ export async function dispatchReplyFromConfig(params: {
           if (phase !== "update") {
             return;
           }
+          armControlPlaneStallTimer();
           return sendPlanUpdate({ explanation, steps });
         },
         onApprovalEvent: ({ phase, status, command, message }) => {
           if (phase !== "requested") {
             return;
           }
+          markConcreteProgress();
           const label = summarizeApprovalLabel({ status, command, message });
           if (!label) {
             return;
@@ -870,6 +926,7 @@ export async function dispatchReplyFromConfig(params: {
           if (phase !== "end") {
             return;
           }
+          markConcreteProgress();
           const label = summarizePatchLabel({ summary, title });
           if (!label) {
             return;
@@ -877,6 +934,7 @@ export async function dispatchReplyFromConfig(params: {
           return maybeSendWorkingStatus(label);
         },
         onBlockReply: (payload: ReplyPayload, context?: BlockReplyContext) => {
+          markConcreteProgress();
           const run = async () => {
             // Suppress reasoning payloads — channels using this generic dispatch
             // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
@@ -1047,8 +1105,43 @@ export async function dispatchReplyFromConfig(params: {
     markIdle("message_completed");
     return { queuedFinal, counts };
   } catch (err) {
+    if (controlPlaneTimedOut) {
+      let queuedFinal = false;
+      let routedFinalCount = 0;
+      const payload: ReplyPayload = {
+        text: CONTROL_PLANE_STALL_REPLY_TEXT,
+        isError: true,
+      };
+      if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+        const result = await routeReplyRuntime.routeReply({
+          payload,
+          channel: originatingChannel,
+          to: originatingTo,
+          sessionKey: ctx.SessionKey,
+          accountId: ctx.AccountId,
+          threadId: routeThreadId,
+          cfg,
+          isGroup,
+          groupId,
+        });
+        queuedFinal = result.ok;
+        if (result.ok) {
+          routedFinalCount += 1;
+        }
+      } else {
+        queuedFinal = dispatcher.sendFinalReply(payload);
+      }
+      const counts = dispatcher.getQueuedCounts();
+      counts.final += routedFinalCount;
+      recordProcessed("error", { error: "control_plane_stall" });
+      markIdle("control_plane_stall");
+      return { queuedFinal, counts };
+    }
     recordProcessed("error", { error: String(err) });
     markIdle("message_error");
     throw err;
+  } finally {
+    clearControlPlaneStallTimer();
+    controlPlaneAbort.cleanup();
   }
 }

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -16,6 +16,18 @@ import {
   startDiagnosticHeartbeat,
 } from "./diagnostic.js";
 
+const EMBEDDED_RUN_STATE_KEY = Symbol.for("openclaw.embeddedRunState");
+
+function seedActiveEmbeddedRun(sessionId: string, sessionKey: string) {
+  (globalThis as Record<PropertyKey, unknown>)[EMBEDDED_RUN_STATE_KEY] = {
+    activeRuns: new Map([[sessionId, {}]]),
+    snapshots: new Map(),
+    sessionIdsByKey: new Map([[sessionKey, sessionId]]),
+    waiters: new Map(),
+    modelSwitchRequests: new Map(),
+  };
+}
+
 describe("diagnostic session state pruning", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -95,6 +107,7 @@ describe("stuck session diagnostics threshold", () => {
   afterEach(() => {
     resetDiagnosticEventsForTest();
     resetDiagnosticStateForTest();
+    delete (globalThis as Record<PropertyKey, unknown>)[EMBEDDED_RUN_STATE_KEY];
     vi.useRealTimers();
   });
 
@@ -110,6 +123,7 @@ describe("stuck session diagnostics threshold", () => {
           stuckSessionWarnMs: 30_000,
         },
       });
+      seedActiveEmbeddedRun("s1", "main");
       logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(61_000);
     } finally {
@@ -126,6 +140,7 @@ describe("stuck session diagnostics threshold", () => {
     });
     try {
       startDiagnosticHeartbeat();
+      seedActiveEmbeddedRun("s2", "main");
       logSessionStateChange({ sessionId: "s2", sessionKey: "main", state: "processing" });
       vi.advanceTimersByTime(31_000);
     } finally {
@@ -139,5 +154,35 @@ describe("stuck session diagnostics threshold", () => {
     expect(resolveStuckSessionWarnMs({ diagnostics: { stuckSessionWarnMs: -1 } })).toBe(120_000);
     expect(resolveStuckSessionWarnMs({ diagnostics: { stuckSessionWarnMs: 0 } })).toBe(120_000);
     expect(resolveStuckSessionWarnMs()).toBe(120_000);
+  });
+
+  it("reconciles ghost processing sessions back to idle", () => {
+    const events: Array<{ type: string; reason?: string }> = [];
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push({
+        type: event.type,
+        reason: "reason" in event ? String(event.reason ?? "") : "",
+      });
+    });
+    try {
+      startDiagnosticHeartbeat({
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs: 30_000,
+        },
+      });
+      logSessionStateChange({ sessionId: "ghost", sessionKey: "main", state: "processing" });
+      vi.advanceTimersByTime(31_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expect(getDiagnosticSessionState({ sessionId: "ghost" }).state).toBe("idle");
+    expect(
+      events.some(
+        (event) => event.type === "session.state" && event.reason === "stale_processing_reconciled",
+      ),
+    ).toBe(true);
+    expect(events.filter((event) => event.type === "session.stuck")).toHaveLength(0);
   });
 });

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -8,6 +8,7 @@ import {
   pruneDiagnosticSessionStates,
   resetDiagnosticSessionStateForTest,
   type SessionRef,
+  type SessionState,
   type SessionStateValue,
 } from "./diagnostic-session-state.js";
 import { createSubsystemLogger } from "./subsystem.js";
@@ -28,6 +29,18 @@ const MAX_STUCK_SESSION_WARN_MS = 24 * 60 * 60 * 1000;
 let commandPollBackoffRuntimePromise: Promise<
   typeof import("../agents/command-poll-backoff.runtime.js")
 > | null = null;
+const EMBEDDED_RUN_STATE_KEY = Symbol.for("openclaw.embeddedRunState");
+const REPLY_RUN_STATE_KEY = Symbol.for("openclaw.replyRunRegistry");
+
+type EmbeddedRunStateLike = {
+  activeRuns?: Map<string, unknown>;
+  sessionIdsByKey?: Map<string, string>;
+};
+
+type ReplyRunStateLike = {
+  activeSessionIdsByKey?: Map<string, string>;
+  activeKeysBySessionId?: Map<string, string>;
+};
 
 function loadCommandPollBackoffRuntime() {
   commandPollBackoffRuntimePromise ??= import("../agents/command-poll-backoff.runtime.js");
@@ -36,6 +49,46 @@ function loadCommandPollBackoffRuntime() {
 
 function markActivity() {
   lastActivityAt = Date.now();
+}
+
+function getEmbeddedRunState(): EmbeddedRunStateLike | undefined {
+  return (globalThis as Record<PropertyKey, unknown>)[EMBEDDED_RUN_STATE_KEY] as
+    | EmbeddedRunStateLike
+    | undefined;
+}
+
+function getReplyRunState(): ReplyRunStateLike | undefined {
+  return (globalThis as Record<PropertyKey, unknown>)[REPLY_RUN_STATE_KEY] as
+    | ReplyRunStateLike
+    | undefined;
+}
+
+function sessionHasLiveRun(state: SessionState): boolean {
+  const sessionId = state.sessionId?.trim();
+  const sessionKey = state.sessionKey?.trim();
+  const embedded = getEmbeddedRunState();
+  const reply = getReplyRunState();
+
+  if (sessionId) {
+    if (embedded?.activeRuns?.has(sessionId)) {
+      return true;
+    }
+    if (reply?.activeKeysBySessionId?.has(sessionId)) {
+      return true;
+    }
+  }
+
+  if (sessionKey) {
+    const embeddedSessionId = embedded?.sessionIdsByKey?.get(sessionKey);
+    if (embeddedSessionId && embedded?.activeRuns?.has(embeddedSessionId)) {
+      return true;
+    }
+    if (reply?.activeSessionIdsByKey?.has(sessionKey)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function resolveStuckSessionWarnMs(config?: OpenClawConfig): number {
@@ -349,6 +402,16 @@ export function startDiagnosticHeartbeat(
     const stuckSessionWarnMs = resolveStuckSessionWarnMs(heartbeatConfig);
     const now = Date.now();
     pruneDiagnosticSessionStates(now, true);
+    for (const [, state] of diagnosticSessionStates) {
+      if (state.state === "processing" && !sessionHasLiveRun(state)) {
+        logSessionStateChange({
+          sessionId: state.sessionId,
+          sessionKey: state.sessionKey,
+          state: "idle",
+          reason: "stale_processing_reconciled",
+        });
+      }
+    }
     const activeCount = Array.from(diagnosticSessionStates.values()).filter(
       (s) => s.state === "processing",
     ).length;

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -5,6 +5,7 @@ import { CommandLane } from "./lanes.js";
 const diagnosticMocks = vi.hoisted(() => ({
   logLaneEnqueue: vi.fn(),
   logLaneDequeue: vi.fn(),
+  logSessionStateChange: vi.fn(),
   diag: {
     debug: vi.fn(),
     warn: vi.fn(),
@@ -15,6 +16,7 @@ const diagnosticMocks = vi.hoisted(() => ({
 vi.mock("../logging/diagnostic.js", () => ({
   logLaneEnqueue: diagnosticMocks.logLaneEnqueue,
   logLaneDequeue: diagnosticMocks.logLaneDequeue,
+  logSessionStateChange: diagnosticMocks.logSessionStateChange,
   diagnosticLogger: diagnosticMocks.diag,
 }));
 
@@ -81,6 +83,7 @@ describe("command queue", () => {
     setCommandLaneConcurrency(CommandLane.Main, 1);
     diagnosticMocks.logLaneEnqueue.mockClear();
     diagnosticMocks.logLaneDequeue.mockClear();
+    diagnosticMocks.logSessionStateChange.mockClear();
     diagnosticMocks.diag.debug.mockClear();
     diagnosticMocks.diag.warn.mockClear();
     diagnosticMocks.diag.error.mockClear();
@@ -179,6 +182,40 @@ describe("command queue", () => {
     expect(diagnosticMocks.diag.debug).toHaveBeenCalledWith(
       expect.stringContaining("lane task interrupted: lane=nested"),
     );
+  });
+
+  it("fail-closes session lane state on failover timeout errors", async () => {
+    const error = new Error("LLM request timed out.");
+    error.name = "FailoverError";
+
+    await expect(
+      enqueueCommandInLane("session:agent:main:discord:channel:123", async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+
+    expect(diagnosticMocks.logSessionStateChange).toHaveBeenCalledWith({
+      sessionKey: "agent:main:discord:channel:123",
+      state: "idle",
+      reason: "lane_task_error_fail_closed",
+    });
+  });
+
+  it("fail-closes main lane state on failover timeout errors", async () => {
+    const error = new Error("LLM request timed out.");
+    error.name = "FailoverError";
+
+    await expect(
+      enqueueCommandInLane("main", async () => {
+        throw error;
+      }),
+    ).rejects.toBe(error);
+
+    expect(diagnosticMocks.logSessionStateChange).toHaveBeenCalledWith({
+      sessionKey: "agent:main:main",
+      state: "idle",
+      reason: "lane_task_error_fail_closed",
+    });
   });
 
   it("getActiveTaskCount returns count of currently executing tasks", async () => {

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -1,4 +1,9 @@
-import { diagnosticLogger as diag, logLaneDequeue, logLaneEnqueue } from "../logging/diagnostic.js";
+import {
+  diagnosticLogger as diag,
+  logLaneDequeue,
+  logLaneEnqueue,
+  logSessionStateChange,
+} from "../logging/diagnostic.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { CommandLane } from "./lanes.js";
 /**
@@ -55,6 +60,28 @@ type ActiveTaskWaiter = {
 
 function isExpectedNonErrorLaneFailure(err: unknown): boolean {
   return err instanceof Error && err.name === "LiveSessionModelSwitchError";
+}
+
+function isFailClosedLaneError(err: unknown): boolean {
+  return err instanceof Error && err.name === "FailoverError";
+}
+
+function resolveSessionRefForLane(lane: string): { sessionKey?: string } | null {
+  const normalized = normalizeLane(lane);
+  if (!normalized) {
+    return null;
+  }
+  if (normalized === "main") {
+    return { sessionKey: "agent:main:main" };
+  }
+  if (normalized.startsWith("session:")) {
+    const sessionKey = normalized.slice("session:".length).trim();
+    return sessionKey ? { sessionKey } : null;
+  }
+  if (normalized.startsWith("agent:")) {
+    return { sessionKey: normalized };
+  }
+  return null;
 }
 
 /**
@@ -203,6 +230,16 @@ function drainLane(lane: string) {
               diag.debug(
                 `lane task interrupted: lane=${lane} durationMs=${Date.now() - startTime} reason="${String(err)}"`,
               );
+            }
+            if (!isProbeLane && isFailClosedLaneError(err)) {
+              const sessionRef = resolveSessionRefForLane(lane);
+              if (sessionRef?.sessionKey) {
+                logSessionStateChange({
+                  sessionKey: sessionRef.sessionKey,
+                  state: "idle",
+                  reason: "lane_task_error_fail_closed",
+                });
+              }
             }
             if (completedCurrentGeneration) {
               notifyActiveTaskWaiters();


### PR DESCRIPTION
## Summary
- fail closed when a turn emits plan/control progress and then stalls without concrete work
- retry session-delta memory sync after fetch failures instead of hammering and dropping pending work
- add focused tests for both behaviors

## Why
Discord and main-session turns were freezing after control-plane events like `update_plan`, leaving sessions stuck in `processing` with no visible reply. Separately, memory session-delta sync was repeatedly logging `fetch failed` without preserving pending work for retry.

## Verification
- node scripts/run-vitest.mjs run --config vitest.auto-reply-reply.config.ts src/auto-reply/reply/dispatch-from-config.test.ts
- node scripts/run-vitest.mjs run --config vitest.extension-memory.config.ts extensions/memory-core/src/memory/manager.sync-errors-do-not-crash.test.ts
- NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.json --noEmit