### PR TITLE
test(plugin-sdk): cover packaged telegram setup sidecars

### DIFF
--- a/src/plugin-sdk/channel-entry-contract.test.ts
+++ b/src/plugin-sdk/channel-entry-contract.test.ts
@@ -86,6 +86,53 @@ describe("loadBundledEntryExportSync", () => {
     }
   });
 
+  it("loads packaged telegram setup sidecars from dist-facing api modules", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
+    tempDirs.push(tempRoot);
+
+    const pluginRoot = path.join(tempRoot, "dist", "extensions", "telegram");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+
+    const importerPath = path.join(pluginRoot, "setup-entry.js");
+    const setupApiPath = path.join(pluginRoot, "setup-plugin-api.js");
+    const secretsApiPath = path.join(pluginRoot, "secret-contract-api.js");
+
+    fs.writeFileSync(importerPath, "export default {};\n", "utf8");
+    fs.writeFileSync(
+      setupApiPath,
+      'export const telegramSetupPlugin = { id: "telegram" };\n',
+      "utf8",
+    );
+    fs.writeFileSync(
+      secretsApiPath,
+      [
+        "export const collectRuntimeConfigAssignments = () => [];",
+        "export const secretTargetRegistryEntries = [];",
+        'export const channelSecrets = { TELEGRAM_TOKEN: { env: "TELEGRAM_TOKEN" } };',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    expect(
+      loadBundledEntryExportSync<{ id: string }>(pathToFileURL(importerPath).href, {
+        specifier: "./setup-plugin-api.js",
+        exportName: "telegramSetupPlugin",
+      }),
+    ).toEqual({ id: "telegram" });
+
+    expect(
+      loadBundledEntryExportSync<Record<string, unknown>>(pathToFileURL(importerPath).href, {
+        specifier: "./secret-contract-api.js",
+        exportName: "channelSecrets",
+      }),
+    ).toEqual({
+      TELEGRAM_TOKEN: {
+        env: "TELEGRAM_TOKEN",
+      },
+    });
+  });
+
   it("can disable source-tree fallback for dist bundled entry checks", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-entry-contract-"));
     tempDirs.push(tempRoot);


### PR DESCRIPTION
## Summary

- add focused regression coverage for packaged Telegram setup sidecar loading in `loadBundledEntryExportSync`
- keep this PR test-only and scoped to `src/plugin-sdk/channel-entry-contract.test.ts`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs
- [x] Test-only

## Scope

This PR is intentionally narrow.

It only adds one plugin-sdk contract test and does not change runtime behavior.

## Linked Issue/PR

- Follow-up to closed/superseded PR #62900
- Related #62867
- Related #62875
- Related #62880

## Root Cause / Context

The runtime packaging path for Telegram setup sidecars has already been fixed on `main` and released.

This follow-up only keeps targeted regression coverage so packaged/dist-facing setup facades (`setup-plugin-api.js` and `secret-contract-api.js`) are exercised explicitly in the plugin-sdk contract tests.

## Behavior Changes

Before:
- plugin-sdk contract tests did not explicitly assert the packaged Telegram setup facade load path

After:
- plugin-sdk contract tests include explicit coverage that a dist-only Telegram setup entry can load:
  - `telegramSetupPlugin` from `./setup-plugin-api.js`
  - `channelSecrets` from `./secret-contract-api.js`

## Tests

Passed locally:
- `node scripts/run-vitest.mjs run --config vitest.plugin-sdk.config.ts src/plugin-sdk/channel-entry-contract.test.ts`

## Risks and Mitigations

Risk:
- very low; test-only change

Mitigation:
- no runtime code changes; only contract test coverage added

## AI assistance

AI-assisted: drafted and implemented with Codex, then locally reviewed and tested by me.
