### PR TITLE
[codex] fix(kimi-coding): parse downgraded tool tags

### DIFF
--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -38,6 +38,9 @@ const KIMI_XML_TOOL_TEXT = `I'll read the required memory files first. Let me ch
 <parameter name="path">/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md</parameter>
 </invoke>
 </function_calls>`;
+const KIMI_EXEC_TOOL_TEXT = `Let me check the memory files for today and yesterday. I'll use the shell to read them since the read tool isn't available in this runtime.
+<exec>cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md 2>/dev/null && echo "---EOF---" || echo "FILE_NOT_FOUND: 2026-04-08.md"
+cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null && echo "---EOF---" || echo "FILE_NOT_FOUND: 2026-04-07.md"</exec>`;
 
 describe("kimi tool-call markup wrapper", () => {
   it("converts tagged Kimi tool-call text into structured tool calls", async () => {
@@ -260,6 +263,46 @@ describe("kimi tool-call markup wrapper", () => {
           name: "read",
           arguments: {
             path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md",
+          },
+        },
+      ],
+      stopReason: "toolUse",
+    });
+  });
+
+  it("extracts downgraded exec tags while preserving surrounding text", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: KIMI_EXEC_TOOL_TEXT }],
+      stopReason: "stop",
+    };
+    const baseStreamFn: StreamFn = () =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }) as ReturnType<StreamFn>;
+
+    const wrapped = createKimiToolCallMarkupWrapper(baseStreamFn);
+    const stream = wrapped(
+      { api: "anthropic-messages", provider: "kimi", id: "k2p5" } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    ) as FakeStream;
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "Let me check the memory files for today and yesterday. I'll use the shell to read them since the read tool isn't available in this runtime.\n",
+        },
+        {
+          type: "toolCall",
+          id: "exec:0",
+          name: "exec",
+          arguments: {
+            command: `cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md 2>/dev/null && echo "---EOF---" || echo "FILE_NOT_FOUND: 2026-04-08.md"
+cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null && echo "---EOF---" || echo "FILE_NOT_FOUND: 2026-04-07.md"`,
           },
         },
       ],

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -56,6 +56,9 @@ const KIMI_PREFIX_FUNCTION_STYLE_TOOL_TEXT = `(read "/Users/guoshuyi/.openclaw/w
 const KIMI_JSON_TOOL_CALLS_TEXT = `I'll run my startup sequence now. Let me read the required files first.\`\`\`json
 {"tool_calls": [{"id": "read_SOUL", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/SOUL.md\\"}"}}, {"id": "read_USER", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/USER.md\\"}"}}, {"id": "read_MEMORY", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/MEMORY.md\\"}"}}, {"id": "read_memory_today", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md\\"}"}}, {"id": "read_memory_yesterday", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md\\"}"}}]}]}
 \`\`\``;
+const KIMI_DECORATED_FUNCTION_ID_TOOL_TEXT = `让我用 shell 读取这些文件。
+
+<i class="ml-2">functions.exec:4 <i class="ml-2">{"command":"cat /Users/guoshuyi/.openclaw/workspace/SOUL.md"}<i class="ml-2">functions.exec:5 <i class="ml-2">{"command":"cat /Users/guoshuyi/.openclaw/workspace/USER.md"}<i class="ml-2">functions.exec:6 <i class="ml-2">{"command":"cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md 2>/dev/null || echo \\"FILE_NOT_FOUND\\""}<i class="ml-2">functions.exec:7 <i class="ml-2">{"command":"cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null || echo \\"FILE_NOT_FOUND\\""}`;
 
 describe("kimi tool-call markup wrapper", () => {
   it("converts tagged Kimi tool-call text into structured tool calls", async () => {
@@ -589,6 +592,67 @@ cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null && echo
           id: "read_memory_yesterday",
           name: "read",
           arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md" },
+        },
+      ],
+      stopReason: "toolUse",
+    });
+  });
+
+  it("extracts decorated function ids with inline json arguments", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: KIMI_DECORATED_FUNCTION_ID_TOOL_TEXT }],
+      stopReason: "stop",
+    };
+    const baseStreamFn: StreamFn = () =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }) as ReturnType<StreamFn>;
+
+    const wrapped = createKimiToolCallMarkupWrapper(baseStreamFn);
+    const stream = wrapped(
+      { api: "anthropic-messages", provider: "kimi", id: "k2p5" } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    ) as FakeStream;
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "让我用 shell 读取这些文件。\n\n",
+        },
+        {
+          type: "toolCall",
+          id: "functions.exec:4",
+          name: "functions.exec",
+          arguments: { command: "cat /Users/guoshuyi/.openclaw/workspace/SOUL.md" },
+        },
+        {
+          type: "toolCall",
+          id: "functions.exec:5",
+          name: "functions.exec",
+          arguments: { command: "cat /Users/guoshuyi/.openclaw/workspace/USER.md" },
+        },
+        {
+          type: "toolCall",
+          id: "functions.exec:6",
+          name: "functions.exec",
+          arguments: {
+            command:
+              'cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md 2>/dev/null || echo "FILE_NOT_FOUND"',
+          },
+        },
+        {
+          type: "toolCall",
+          id: "functions.exec:7",
+          name: "functions.exec",
+          arguments: {
+            command:
+              'cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null || echo "FILE_NOT_FOUND"',
+          },
         },
       ],
       stopReason: "toolUse",

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -48,6 +48,11 @@ read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md"})
 read({"file_path": "/Users/guoshuyi/.openclaw/workspace/MEMORY.md"})`;
 const KIMI_MIXED_FUNCTION_STYLE_TOOL_TEXT = `I'll do my startup sequence now. Reading today's and yesterday's memory, plus confirming my core files. read(memory/2026-04-08.md) read(memory/2026-04-07.md) read(MEMORY.md) read(SOUL.md) read(USER.md)
 Oops, let me do that properly with the tool. read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/MEMORY.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/SOUL.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/USER.md"})`;
+const KIMI_PREFIX_FUNCTION_STYLE_TOOL_TEXT = `(read "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md")
+(read "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md")
+(read "/Users/guoshuyi/.openclaw/workspace/MEMORY.md")
+(read "/Users/guoshuyi/.openclaw/workspace/SOUL.md")
+(read "/Users/guoshuyi/.openclaw/workspace/USER.md")`;
 
 describe("kimi tool-call markup wrapper", () => {
   it("converts tagged Kimi tool-call text into structured tool calls", async () => {
@@ -461,6 +466,63 @@ cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null && echo
         {
           type: "toolCall",
           id: "read:9",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/USER.md" },
+        },
+      ],
+      stopReason: "toolUse",
+    });
+  });
+
+  it("extracts prefix function style tool calls", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: KIMI_PREFIX_FUNCTION_STYLE_TOOL_TEXT }],
+      stopReason: "stop",
+    };
+    const baseStreamFn: StreamFn = () =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }) as ReturnType<StreamFn>;
+
+    const wrapped = createKimiToolCallMarkupWrapper(baseStreamFn);
+    const stream = wrapped(
+      { api: "anthropic-messages", provider: "kimi", id: "k2p5" } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    ) as FakeStream;
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "read:0",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:1",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:2",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/MEMORY.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:3",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/SOUL.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:4",
           name: "read",
           arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/USER.md" },
         },

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -41,6 +41,11 @@ const KIMI_XML_TOOL_TEXT = `I'll read the required memory files first. Let me ch
 const KIMI_EXEC_TOOL_TEXT = `Let me check the memory files for today and yesterday. I'll use the shell to read them since the read tool isn't available in this runtime.
 <exec>cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md 2>/dev/null && echo "---EOF---" || echo "FILE_NOT_FOUND: 2026-04-08.md"
 cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null && echo "---EOF---" || echo "FILE_NOT_FOUND: 2026-04-07.md"</exec>`;
+const KIMI_FUNCTION_STYLE_TOOL_TEXT = `read({"file_path": "/Users/guoshuyi/.openclaw/workspace/SOUL.md"})
+read({"file_path": "/Users/guoshuyi/.openclaw/workspace/USER.md"})
+read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md"})
+read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md"})
+read({"file_path": "/Users/guoshuyi/.openclaw/workspace/MEMORY.md"})`;
 
 describe("kimi tool-call markup wrapper", () => {
   it("converts tagged Kimi tool-call text into structured tool calls", async () => {
@@ -304,6 +309,63 @@ describe("kimi tool-call markup wrapper", () => {
             command: `cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md 2>/dev/null && echo "---EOF---" || echo "FILE_NOT_FOUND: 2026-04-08.md"
 cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null && echo "---EOF---" || echo "FILE_NOT_FOUND: 2026-04-07.md"`,
           },
+        },
+      ],
+      stopReason: "toolUse",
+    });
+  });
+
+  it("extracts line-oriented function style tool calls", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: KIMI_FUNCTION_STYLE_TOOL_TEXT }],
+      stopReason: "stop",
+    };
+    const baseStreamFn: StreamFn = () =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }) as ReturnType<StreamFn>;
+
+    const wrapped = createKimiToolCallMarkupWrapper(baseStreamFn);
+    const stream = wrapped(
+      { api: "anthropic-messages", provider: "kimi", id: "k2p5" } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    ) as FakeStream;
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "toolCall",
+          id: "read:0",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/SOUL.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:1",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/USER.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:2",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:3",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:4",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/MEMORY.md" },
         },
       ],
       stopReason: "toolUse",

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -28,6 +28,16 @@ const KIMI_TOOL_TEXT =
   ' <|tool_calls_section_begin|> <|tool_call_begin|> functions.read:0 <|tool_call_argument_begin|> {"file_path":"./package.json"} <|tool_call_end|> <|tool_calls_section_end|>';
 const KIMI_MULTI_TOOL_TEXT =
   ' <|tool_calls_section_begin|> <|tool_call_begin|> functions.read:0 <|tool_call_argument_begin|> {"file_path":"./package.json"} <|tool_call_end|> <|tool_call_begin|> functions.write:1 <|tool_call_argument_begin|> {"file_path":"./out.txt","content":"done"} <|tool_call_end|> <|tool_calls_section_end|>';
+const KIMI_XML_TOOL_TEXT = `I'll read the required memory files first. Let me check today's and yesterday's daily notes.
+
+<function_calls>
+<invoke name="read">
+<parameter name="path">/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md</parameter>
+</invoke>
+<invoke name="read">
+<parameter name="path">/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md</parameter>
+</invoke>
+</function_calls>`;
 
 describe("kimi tool-call markup wrapper", () => {
   it("converts tagged Kimi tool-call text into structured tool calls", async () => {
@@ -204,6 +214,53 @@ describe("kimi tool-call markup wrapper", () => {
           id: "functions.write:1",
           name: "functions.write",
           arguments: { file_path: "./out.txt", content: "done" },
+        },
+      ],
+      stopReason: "toolUse",
+    });
+  });
+
+  it("extracts XML function_calls blocks while preserving surrounding text", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: KIMI_XML_TOOL_TEXT }],
+      stopReason: "stop",
+    };
+    const baseStreamFn: StreamFn = () =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }) as ReturnType<StreamFn>;
+
+    const wrapped = createKimiToolCallMarkupWrapper(baseStreamFn);
+    const stream = wrapped(
+      { api: "anthropic-messages", provider: "kimi", id: "k2p5" } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    ) as FakeStream;
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "I'll read the required memory files first. Let me check today's and yesterday's daily notes.\n\n",
+        },
+        {
+          type: "toolCall",
+          id: "read:0",
+          name: "read",
+          arguments: {
+            path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md",
+          },
+        },
+        {
+          type: "toolCall",
+          id: "read:1",
+          name: "read",
+          arguments: {
+            path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md",
+          },
         },
       ],
       stopReason: "toolUse",

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -1,5 +1,6 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
+import { createAnthropicToolPayloadCompatibilityWrapper } from "openclaw/plugin-sdk/provider-stream";
 import { describe, expect, it } from "vitest";
 import { createKimiToolCallMarkupWrapper, wrapKimiProviderStream } from "./stream.js";
 
@@ -242,5 +243,64 @@ describe("kimi tool-call markup wrapper", () => {
       ],
       stopReason: "toolUse",
     });
+  });
+
+  it("keeps Kimi anthropic tool payloads native even if an upstream compat wrapper leaked in", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        tools: [
+          {
+            name: "read",
+            description: "Read file",
+            input_schema: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+        tool_choice: { type: "tool", name: "read" },
+      };
+      options?.onPayload?.(payload, _model);
+      payloads.push(payload);
+      return createFakeStream({
+        events: [],
+        resultMessage: { role: "assistant", content: [], stopReason: "stop" },
+      }) as ReturnType<StreamFn>;
+    };
+
+    const wrapped = wrapKimiProviderStream({
+      streamFn: createAnthropicToolPayloadCompatibilityWrapper(baseStreamFn),
+    } as never);
+    void wrapped(
+      {
+        api: "anthropic-messages",
+        provider: "kimi",
+        id: "k2p5",
+        compat: {
+          requiresOpenAiAnthropicToolPayload: true,
+        },
+      } as unknown as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(payloads).toEqual([
+      {
+        tools: [
+          {
+            name: "read",
+            description: "Read file",
+            input_schema: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+        tool_choice: { type: "tool", name: "read" },
+      },
+    ]);
   });
 });

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -53,6 +53,9 @@ const KIMI_PREFIX_FUNCTION_STYLE_TOOL_TEXT = `(read "/Users/guoshuyi/.openclaw/w
 (read "/Users/guoshuyi/.openclaw/workspace/MEMORY.md")
 (read "/Users/guoshuyi/.openclaw/workspace/SOUL.md")
 (read "/Users/guoshuyi/.openclaw/workspace/USER.md")`;
+const KIMI_JSON_TOOL_CALLS_TEXT = `I'll run my startup sequence now. Let me read the required files first.\`\`\`json
+{"tool_calls": [{"id": "read_SOUL", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/SOUL.md\\"}"}}, {"id": "read_USER", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/USER.md\\"}"}}, {"id": "read_MEMORY", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/MEMORY.md\\"}"}}, {"id": "read_memory_today", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md\\"}"}}, {"id": "read_memory_yesterday", "type": "read", "function": {"name": "read", "arguments": "{\\"file_path\\": \\"/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md\\"}"}}]}]}
+\`\`\``;
 
 describe("kimi tool-call markup wrapper", () => {
   it("converts tagged Kimi tool-call text into structured tool calls", async () => {
@@ -525,6 +528,67 @@ cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null && echo
           id: "read:4",
           name: "read",
           arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/USER.md" },
+        },
+      ],
+      stopReason: "toolUse",
+    });
+  });
+
+  it("extracts fenced json tool_calls while preserving surrounding prose", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: KIMI_JSON_TOOL_CALLS_TEXT }],
+      stopReason: "stop",
+    };
+    const baseStreamFn: StreamFn = () =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }) as ReturnType<StreamFn>;
+
+    const wrapped = createKimiToolCallMarkupWrapper(baseStreamFn);
+    const stream = wrapped(
+      { api: "anthropic-messages", provider: "kimi", id: "k2p5" } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    ) as FakeStream;
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "I'll run my startup sequence now. Let me read the required files first.",
+        },
+        {
+          type: "toolCall",
+          id: "read_SOUL",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/SOUL.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read_USER",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/USER.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read_MEMORY",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/MEMORY.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read_memory_today",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read_memory_yesterday",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md" },
         },
       ],
       stopReason: "toolUse",

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -46,6 +46,8 @@ read({"file_path": "/Users/guoshuyi/.openclaw/workspace/USER.md"})
 read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md"})
 read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md"})
 read({"file_path": "/Users/guoshuyi/.openclaw/workspace/MEMORY.md"})`;
+const KIMI_MIXED_FUNCTION_STYLE_TOOL_TEXT = `I'll do my startup sequence now. Reading today's and yesterday's memory, plus confirming my core files. read(memory/2026-04-08.md) read(memory/2026-04-07.md) read(MEMORY.md) read(SOUL.md) read(USER.md)
+Oops, let me do that properly with the tool. read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/MEMORY.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/SOUL.md"}) read({"file_path": "/Users/guoshuyi/.openclaw/workspace/USER.md"})`;
 
 describe("kimi tool-call markup wrapper", () => {
   it("converts tagged Kimi tool-call text into structured tool calls", async () => {
@@ -366,6 +368,101 @@ cat /Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md 2>/dev/null && echo
           id: "read:4",
           name: "read",
           arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/MEMORY.md" },
+        },
+      ],
+      stopReason: "toolUse",
+    });
+  });
+
+  it("extracts inline shorthand and JSON function style tool calls while preserving prose", async () => {
+    const finalMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: KIMI_MIXED_FUNCTION_STYLE_TOOL_TEXT }],
+      stopReason: "stop",
+    };
+    const baseStreamFn: StreamFn = () =>
+      createFakeStream({
+        events: [],
+        resultMessage: finalMessage,
+      }) as ReturnType<StreamFn>;
+
+    const wrapped = createKimiToolCallMarkupWrapper(baseStreamFn);
+    const stream = wrapped(
+      { api: "anthropic-messages", provider: "kimi", id: "k2p5" } as Model<"anthropic-messages">,
+      { messages: [] } as Context,
+      {},
+    ) as FakeStream;
+
+    await expect(stream.result()).resolves.toEqual({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: "I'll do my startup sequence now. Reading today's and yesterday's memory, plus confirming my core files. ",
+        },
+        {
+          type: "toolCall",
+          id: "read:0",
+          name: "read",
+          arguments: { file_path: "memory/2026-04-08.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:1",
+          name: "read",
+          arguments: { file_path: "memory/2026-04-07.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:2",
+          name: "read",
+          arguments: { file_path: "MEMORY.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:3",
+          name: "read",
+          arguments: { file_path: "SOUL.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:4",
+          name: "read",
+          arguments: { file_path: "USER.md" },
+        },
+        {
+          type: "text",
+          text: "\nOops, let me do that properly with the tool. ",
+        },
+        {
+          type: "toolCall",
+          id: "read:5",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-08.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:6",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/memory/2026-04-07.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:7",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/MEMORY.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:8",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/SOUL.md" },
+        },
+        {
+          type: "toolCall",
+          id: "read:9",
+          name: "read",
+          arguments: { file_path: "/Users/guoshuyi/.openclaw/workspace/USER.md" },
         },
       ],
       stopReason: "toolUse",

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -352,6 +352,127 @@ function parseKimiFunctionStyleToolCallsInText(text: string): KimiParsedTextBloc
   return { content, changed };
 }
 
+function parseKimiPrefixFunctionStyleArguments(
+  name: string,
+  rawArgs: string,
+): Record<string, unknown> | null {
+  const trimmedArgs = rawArgs.trim();
+  if (!trimmedArgs) {
+    return null;
+  }
+
+  const quotedMatch = /^(["'])([\s\S]*)\1$/u.exec(trimmedArgs);
+  if (quotedMatch) {
+    const value = quotedMatch[2] ?? "";
+    if (name === "read") {
+      return { file_path: value };
+    }
+    if (name === "exec") {
+      return { command: value };
+    }
+  }
+
+  return parseKimiFunctionStyleArguments(name, trimmedArgs);
+}
+
+function findMatchingPrefixFunctionStyleClose(text: string, openParenIndex: number): number {
+  let depth = 1;
+  let quoteChar: '"' | "'" | null = null;
+  let isEscaped = false;
+
+  for (let index = openParenIndex + 1; index < text.length; index += 1) {
+    const char = text[index];
+    if (quoteChar !== null) {
+      if (isEscaped) {
+        isEscaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        isEscaped = true;
+        continue;
+      }
+      if (char === quoteChar) {
+        quoteChar = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quoteChar = char;
+      continue;
+    }
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+    if (char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function parseKimiPrefixFunctionStyleToolCallsInText(text: string): KimiParsedTextBlock | null {
+  const callStartRe = /\(([A-Za-z_][A-Za-z0-9_.-]*)\s+/g;
+  const content: Array<KimiToolCallBlock | { type: "text"; text: string }> = [];
+  let lastIndex = 0;
+  let changed = false;
+  let toolCallCount = 0;
+  let match: RegExpExecArray | null = null;
+
+  while ((match = callStartRe.exec(text)) !== null) {
+    const name = match[1]?.trim() ?? "";
+    if (!name) {
+      continue;
+    }
+    const openParenIndex = match.index ?? 0;
+    const closeParenIndex = findMatchingPrefixFunctionStyleClose(text, openParenIndex);
+    if (closeParenIndex < 0) {
+      continue;
+    }
+
+    const parsedArgs = parseKimiPrefixFunctionStyleArguments(
+      name,
+      text.slice(match.index + match[0].length, closeParenIndex),
+    );
+    if (!parsedArgs) {
+      callStartRe.lastIndex = openParenIndex + 1;
+      continue;
+    }
+
+    const before = text.slice(lastIndex, openParenIndex);
+    if (before) {
+      content.push({ type: "text", text: before });
+    }
+
+    content.push({
+      type: "toolCall",
+      id: `${name}:${toolCallCount}`,
+      name,
+      arguments: parsedArgs,
+    });
+    toolCallCount += 1;
+    changed = true;
+    lastIndex = closeParenIndex + 1;
+    callStartRe.lastIndex = closeParenIndex + 1;
+  }
+
+  if (!changed) {
+    return null;
+  }
+
+  const after = text.slice(lastIndex);
+  if (after) {
+    content.push({ type: "text", text: after });
+  }
+
+  return { content, changed };
+}
+
 function parseKimiToolCallsInText(text: string): KimiParsedTextBlock | null {
   const tagged = parseKimiTaggedToolCalls(text);
   if (tagged) {
@@ -365,7 +486,11 @@ function parseKimiToolCallsInText(text: string): KimiParsedTextBlock | null {
   if (simpleTagged) {
     return simpleTagged;
   }
-  return parseKimiFunctionStyleToolCallsInText(text);
+  const functionStyle = parseKimiFunctionStyleToolCallsInText(text);
+  if (functionStyle) {
+    return functionStyle;
+  }
+  return parseKimiPrefixFunctionStyleToolCallsInText(text);
 }
 
 function rewriteKimiTaggedToolCallsInMessage(message: unknown): void {

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -15,8 +15,27 @@ type KimiToolCallBlock = {
   arguments: Record<string, unknown>;
 };
 
+type KimiParsedTextBlock = {
+  content: Array<KimiToolCallBlock | { type: "text"; text: string }>;
+  changed: boolean;
+};
+
 function stripTaggedToolCallCounter(value: string): string {
   return value.trim().replace(/:\d+$/, "");
+}
+
+function decodeXmlText(value: string): string {
+  return value
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#34;", '"')
+    .replaceAll("&apos;", "'")
+    .replaceAll("&#39;", "'")
+    .replaceAll("&lt;", "<")
+    .replaceAll("&#60;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&#62;", ">")
+    .replaceAll("&amp;", "&")
+    .replaceAll("&#38;", "&");
 }
 
 function parseKimiTaggedToolCalls(text: string): KimiToolCallBlock[] | null {
@@ -87,6 +106,91 @@ function parseKimiTaggedToolCalls(text: string): KimiToolCallBlock[] | null {
   return toolCalls.length > 0 ? toolCalls : null;
 }
 
+function parseKimiXmlToolCalls(xml: string): KimiToolCallBlock[] | null {
+  const invokeRe = /<invoke\s+name=(["'])([^"']+)\1\s*>([\s\S]*?)<\/invoke>/gi;
+  const parameterRe = /<parameter\s+name=(["'])([^"']+)\1\s*>([\s\S]*?)<\/parameter>/gi;
+  const toolCalls: KimiToolCallBlock[] = [];
+  let invokeMatch: RegExpExecArray | null = null;
+
+  while ((invokeMatch = invokeRe.exec(xml)) !== null) {
+    const rawName = decodeXmlText(invokeMatch[2] ?? "").trim();
+    if (!rawName) {
+      return null;
+    }
+
+    const invokeBody = invokeMatch[3] ?? "";
+    const argumentsRecord: Record<string, unknown> = {};
+    let sawParameter = false;
+    let parameterMatch: RegExpExecArray | null = null;
+    parameterRe.lastIndex = 0;
+
+    while ((parameterMatch = parameterRe.exec(invokeBody)) !== null) {
+      const paramName = decodeXmlText(parameterMatch[2] ?? "").trim();
+      if (!paramName) {
+        return null;
+      }
+      argumentsRecord[paramName] = decodeXmlText(parameterMatch[3] ?? "").trim();
+      sawParameter = true;
+    }
+
+    if (!sawParameter) {
+      return null;
+    }
+
+    toolCalls.push({
+      type: "toolCall",
+      id: `${rawName}:${toolCalls.length}`,
+      name: rawName,
+      arguments: argumentsRecord,
+    });
+  }
+
+  return toolCalls.length > 0 ? toolCalls : null;
+}
+
+function parseKimiXmlToolCallsInText(text: string): KimiParsedTextBlock | null {
+  const functionCallsRe = /<function_calls\b[^>]*>([\s\S]*?)<\/function_calls>/gi;
+  const content: Array<KimiToolCallBlock | { type: "text"; text: string }> = [];
+  let lastIndex = 0;
+  let changed = false;
+  let match: RegExpExecArray | null = null;
+
+  while ((match = functionCallsRe.exec(text)) !== null) {
+    const before = text.slice(lastIndex, match.index);
+    if (before) {
+      content.push({ type: "text", text: before });
+    }
+
+    const parsed = parseKimiXmlToolCalls(match[1] ?? "");
+    if (!parsed) {
+      return null;
+    }
+
+    content.push(...parsed);
+    changed = true;
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (!changed) {
+    return null;
+  }
+
+  const after = text.slice(lastIndex);
+  if (after) {
+    content.push({ type: "text", text: after });
+  }
+
+  return { content, changed };
+}
+
+function parseKimiToolCallsInText(text: string): KimiParsedTextBlock | null {
+  const tagged = parseKimiTaggedToolCalls(text);
+  if (tagged) {
+    return { content: tagged, changed: true };
+  }
+  return parseKimiXmlToolCallsInText(text);
+}
+
 function rewriteKimiTaggedToolCallsInMessage(message: unknown): void {
   if (!message || typeof message !== "object") {
     return;
@@ -110,14 +214,19 @@ function rewriteKimiTaggedToolCallsInMessage(message: unknown): void {
       continue;
     }
 
-    const parsed = parseKimiTaggedToolCalls(typedBlock.text);
+    const parsed = parseKimiToolCallsInText(typedBlock.text);
     if (!parsed) {
       nextContent.push(block);
       continue;
     }
 
-    nextContent.push(...parsed);
-    changed = true;
+    for (const nextBlock of parsed.content) {
+      if (nextBlock.type === "text" && !nextBlock.text) {
+        continue;
+      }
+      nextContent.push(nextBlock);
+    }
+    changed = changed || parsed.changed;
   }
 
   if (!changed) {

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -183,6 +183,161 @@ function parseKimiXmlToolCallsInText(text: string): KimiParsedTextBlock | null {
   return { content, changed };
 }
 
+function findBalancedJsonObject(text: string): string | null {
+  const startIndex = text.indexOf("{");
+  if (startIndex < 0) {
+    return null;
+  }
+
+  let depth = 0;
+  let quoteChar: '"' | "'" | null = null;
+  let isEscaped = false;
+  for (let index = startIndex; index < text.length; index += 1) {
+    const char = text[index];
+    if (quoteChar !== null) {
+      if (isEscaped) {
+        isEscaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        isEscaped = true;
+        continue;
+      }
+      if (char === quoteChar) {
+        quoteChar = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quoteChar = char;
+      continue;
+    }
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return text.slice(startIndex, index + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+function parseKimiJsonToolCalls(payload: string): KimiToolCallBlock[] | null {
+  const jsonObject = findBalancedJsonObject(payload);
+  if (!jsonObject) {
+    return null;
+  }
+
+  let parsedPayload: unknown;
+  try {
+    parsedPayload = JSON.parse(jsonObject);
+  } catch {
+    return null;
+  }
+  if (!parsedPayload || typeof parsedPayload !== "object" || Array.isArray(parsedPayload)) {
+    return null;
+  }
+
+  const toolCallsRaw = (parsedPayload as { tool_calls?: unknown }).tool_calls;
+  if (!Array.isArray(toolCallsRaw)) {
+    return null;
+  }
+
+  const toolCalls: KimiToolCallBlock[] = [];
+  for (let index = 0; index < toolCallsRaw.length; index += 1) {
+    const entry = toolCallsRaw[index];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return null;
+    }
+
+    const entryRecord = entry as Record<string, unknown>;
+    const functionRecord =
+      entryRecord.function &&
+      typeof entryRecord.function === "object" &&
+      !Array.isArray(entryRecord.function)
+        ? (entryRecord.function as Record<string, unknown>)
+        : undefined;
+    const nameCandidate =
+      typeof functionRecord?.name === "string"
+        ? functionRecord.name
+        : typeof entryRecord.name === "string"
+          ? entryRecord.name
+          : typeof entryRecord.type === "string"
+            ? entryRecord.type
+            : "";
+    const name = nameCandidate.trim();
+    if (!name) {
+      return null;
+    }
+
+    let parsedArgs: unknown = functionRecord?.arguments;
+    if (typeof parsedArgs === "string") {
+      try {
+        parsedArgs = JSON.parse(parsedArgs);
+      } catch {
+        return null;
+      }
+    }
+    if (!parsedArgs || typeof parsedArgs !== "object" || Array.isArray(parsedArgs)) {
+      return null;
+    }
+
+    const idCandidate =
+      typeof entryRecord.id === "string" && entryRecord.id.trim()
+        ? entryRecord.id.trim()
+        : `${name}:${index}`;
+    toolCalls.push({
+      type: "toolCall",
+      id: idCandidate,
+      name,
+      arguments: parsedArgs as Record<string, unknown>,
+    });
+  }
+
+  return toolCalls.length > 0 ? toolCalls : null;
+}
+
+function parseKimiJsonToolCallsInText(text: string): KimiParsedTextBlock | null {
+  const fencedJsonRe = /```(?:json)?\s*([\s\S]*?)```/gi;
+  const content: Array<KimiToolCallBlock | { type: "text"; text: string }> = [];
+  let lastIndex = 0;
+  let changed = false;
+  let match: RegExpExecArray | null = null;
+
+  while ((match = fencedJsonRe.exec(text)) !== null) {
+    const before = text.slice(lastIndex, match.index);
+    if (before) {
+      content.push({ type: "text", text: before });
+    }
+
+    const parsed = parseKimiJsonToolCalls(match[1] ?? "");
+    if (!parsed) {
+      return null;
+    }
+
+    content.push(...parsed);
+    changed = true;
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (!changed) {
+    return null;
+  }
+
+  const after = text.slice(lastIndex);
+  if (after) {
+    content.push({ type: "text", text: after });
+  }
+
+  return { content, changed };
+}
+
 function parseKimiSimpleTaggedToolCallsInText(text: string): KimiParsedTextBlock | null {
   const simpleToolRe = /<exec>([\s\S]*?)<\/exec>/gi;
   const content: Array<KimiToolCallBlock | { type: "text"; text: string }> = [];
@@ -481,6 +636,10 @@ function parseKimiToolCallsInText(text: string): KimiParsedTextBlock | null {
   const xml = parseKimiXmlToolCallsInText(text);
   if (xml) {
     return xml;
+  }
+  const json = parseKimiJsonToolCallsInText(text);
+  if (json) {
+    return json;
   }
   const simpleTagged = parseKimiSimpleTaggedToolCallsInText(text);
   if (simpleTagged) {

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -183,12 +183,56 @@ function parseKimiXmlToolCallsInText(text: string): KimiParsedTextBlock | null {
   return { content, changed };
 }
 
+function parseKimiSimpleTaggedToolCallsInText(text: string): KimiParsedTextBlock | null {
+  const simpleToolRe = /<exec>([\s\S]*?)<\/exec>/gi;
+  const content: Array<KimiToolCallBlock | { type: "text"; text: string }> = [];
+  let lastIndex = 0;
+  let changed = false;
+  let match: RegExpExecArray | null = null;
+
+  while ((match = simpleToolRe.exec(text)) !== null) {
+    const before = text.slice(lastIndex, match.index);
+    if (before) {
+      content.push({ type: "text", text: before });
+    }
+
+    const command = decodeXmlText(match[1] ?? "").trim();
+    if (!command) {
+      return null;
+    }
+
+    content.push({
+      type: "toolCall",
+      id: `exec:${content.filter((entry) => entry.type === "toolCall").length}`,
+      name: "exec",
+      arguments: { command },
+    });
+    changed = true;
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (!changed) {
+    return null;
+  }
+
+  const after = text.slice(lastIndex);
+  if (after) {
+    content.push({ type: "text", text: after });
+  }
+
+  return { content, changed };
+}
+
 function parseKimiToolCallsInText(text: string): KimiParsedTextBlock | null {
   const tagged = parseKimiTaggedToolCalls(text);
   if (tagged) {
     return { content: tagged, changed: true };
   }
-  return parseKimiXmlToolCallsInText(text);
+  const xml = parseKimiXmlToolCallsInText(text);
+  if (xml) {
+    return xml;
+  }
+  return parseKimiSimpleTaggedToolCallsInText(text);
 }
 
 function rewriteKimiTaggedToolCallsInMessage(message: unknown): void {

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -223,44 +223,121 @@ function parseKimiSimpleTaggedToolCallsInText(text: string): KimiParsedTextBlock
   return { content, changed };
 }
 
+function parseKimiFunctionStyleArguments(
+  name: string,
+  rawArgs: string,
+): Record<string, unknown> | null {
+  const trimmedArgs = rawArgs.trim();
+  if (!trimmedArgs) {
+    return null;
+  }
+
+  if (trimmedArgs.startsWith("{")) {
+    try {
+      const parsedArgs = JSON.parse(trimmedArgs);
+      if (parsedArgs && typeof parsedArgs === "object" && !Array.isArray(parsedArgs)) {
+        return parsedArgs as Record<string, unknown>;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  if (name === "read") {
+    return { file_path: trimmedArgs };
+  }
+  if (name === "exec") {
+    return { command: trimmedArgs };
+  }
+
+  return null;
+}
+
+function findMatchingFunctionStyleClose(text: string, openParenIndex: number): number {
+  let depth = 1;
+  let quoteChar: '"' | "'" | null = null;
+  let isEscaped = false;
+
+  for (let index = openParenIndex + 1; index < text.length; index += 1) {
+    const char = text[index];
+    if (quoteChar !== null) {
+      if (isEscaped) {
+        isEscaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        isEscaped = true;
+        continue;
+      }
+      if (char === quoteChar) {
+        quoteChar = null;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quoteChar = char;
+      continue;
+    }
+    if (char === "(") {
+      depth += 1;
+      continue;
+    }
+    if (char === ")") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+
+  return -1;
+}
+
 function parseKimiFunctionStyleToolCallsInText(text: string): KimiParsedTextBlock | null {
-  const lineRe = /^([A-Za-z_][A-Za-z0-9_.-]*)\((\{.*\})\)\s*$/gm;
+  const callStartRe = /([A-Za-z_][A-Za-z0-9_.-]*)\(/g;
   const content: Array<KimiToolCallBlock | { type: "text"; text: string }> = [];
   let lastIndex = 0;
   let changed = false;
   let toolCallCount = 0;
   let match: RegExpExecArray | null = null;
 
-  while ((match = lineRe.exec(text)) !== null) {
+  while ((match = callStartRe.exec(text)) !== null) {
+    const name = match[1]?.trim() ?? "";
+    if (!name) {
+      continue;
+    }
+    const openParenIndex = (match.index ?? 0) + name.length;
+    const closeParenIndex = findMatchingFunctionStyleClose(text, openParenIndex);
+    if (closeParenIndex < 0) {
+      continue;
+    }
+
+    const parsedArgs = parseKimiFunctionStyleArguments(
+      name,
+      text.slice(openParenIndex + 1, closeParenIndex),
+    );
+    if (!parsedArgs) {
+      callStartRe.lastIndex = openParenIndex + 1;
+      continue;
+    }
+
     const before = text.slice(lastIndex, match.index);
     if (before) {
       content.push({ type: "text", text: before });
-    }
-
-    const name = match[1]?.trim() ?? "";
-    if (!name) {
-      return null;
-    }
-
-    let parsedArgs: unknown;
-    try {
-      parsedArgs = JSON.parse(match[2] ?? "");
-    } catch {
-      return null;
-    }
-    if (!parsedArgs || typeof parsedArgs !== "object" || Array.isArray(parsedArgs)) {
-      return null;
     }
 
     content.push({
       type: "toolCall",
       id: `${name}:${toolCallCount}`,
       name,
-      arguments: parsedArgs as Record<string, unknown>,
+      arguments: parsedArgs,
     });
     toolCallCount += 1;
     changed = true;
-    lastIndex = match.index + match[0].length;
+    lastIndex = closeParenIndex + 1;
+    callStartRe.lastIndex = closeParenIndex + 1;
   }
 
   if (!changed) {

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -131,6 +131,29 @@ function rewriteKimiTaggedToolCallsInMessage(message: unknown): void {
   }
 }
 
+function stripKimiAnthropicToolPayloadCompat<TModel extends { api?: unknown; compat?: unknown }>(
+  model: TModel,
+): TModel {
+  if (model.api !== "anthropic-messages") {
+    return model;
+  }
+  if (!model.compat || typeof model.compat !== "object" || Array.isArray(model.compat)) {
+    return model;
+  }
+
+  const compat = model.compat as Record<string, unknown>;
+  if (compat.requiresOpenAiAnthropicToolPayload !== true) {
+    return model;
+  }
+
+  const nextCompat = { ...compat };
+  delete nextCompat.requiresOpenAiAnthropicToolPayload;
+  return {
+    ...model,
+    compat: Object.keys(nextCompat).length > 0 ? nextCompat : undefined,
+  } as TModel;
+}
+
 function wrapKimiTaggedToolCalls(
   stream: ReturnType<typeof streamSimple>,
 ): ReturnType<typeof streamSimple> {
@@ -173,7 +196,7 @@ function wrapKimiTaggedToolCalls(
 export function createKimiToolCallMarkupWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   return (model, context, options) => {
-    const maybeStream = underlying(model, context, options);
+    const maybeStream = underlying(stripKimiAnthropicToolPayloadCompat(model), context, options);
     if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
       return Promise.resolve(maybeStream).then((stream) => wrapKimiTaggedToolCalls(stream));
     }

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -223,6 +223,58 @@ function parseKimiSimpleTaggedToolCallsInText(text: string): KimiParsedTextBlock
   return { content, changed };
 }
 
+function parseKimiFunctionStyleToolCallsInText(text: string): KimiParsedTextBlock | null {
+  const lineRe = /^([A-Za-z_][A-Za-z0-9_.-]*)\((\{.*\})\)\s*$/gm;
+  const content: Array<KimiToolCallBlock | { type: "text"; text: string }> = [];
+  let lastIndex = 0;
+  let changed = false;
+  let toolCallCount = 0;
+  let match: RegExpExecArray | null = null;
+
+  while ((match = lineRe.exec(text)) !== null) {
+    const before = text.slice(lastIndex, match.index);
+    if (before) {
+      content.push({ type: "text", text: before });
+    }
+
+    const name = match[1]?.trim() ?? "";
+    if (!name) {
+      return null;
+    }
+
+    let parsedArgs: unknown;
+    try {
+      parsedArgs = JSON.parse(match[2] ?? "");
+    } catch {
+      return null;
+    }
+    if (!parsedArgs || typeof parsedArgs !== "object" || Array.isArray(parsedArgs)) {
+      return null;
+    }
+
+    content.push({
+      type: "toolCall",
+      id: `${name}:${toolCallCount}`,
+      name,
+      arguments: parsedArgs as Record<string, unknown>,
+    });
+    toolCallCount += 1;
+    changed = true;
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (!changed) {
+    return null;
+  }
+
+  const after = text.slice(lastIndex);
+  if (after) {
+    content.push({ type: "text", text: after });
+  }
+
+  return { content, changed };
+}
+
 function parseKimiToolCallsInText(text: string): KimiParsedTextBlock | null {
   const tagged = parseKimiTaggedToolCalls(text);
   if (tagged) {
@@ -232,7 +284,11 @@ function parseKimiToolCallsInText(text: string): KimiParsedTextBlock | null {
   if (xml) {
     return xml;
   }
-  return parseKimiSimpleTaggedToolCallsInText(text);
+  const simpleTagged = parseKimiSimpleTaggedToolCallsInText(text);
+  if (simpleTagged) {
+    return simpleTagged;
+  }
+  return parseKimiFunctionStyleToolCallsInText(text);
 }
 
 function rewriteKimiTaggedToolCallsInMessage(message: unknown): void {
@@ -265,7 +321,7 @@ function rewriteKimiTaggedToolCallsInMessage(message: unknown): void {
     }
 
     for (const nextBlock of parsed.content) {
-      if (nextBlock.type === "text" && !nextBlock.text) {
+      if (nextBlock.type === "text" && !nextBlock.text.trim()) {
         continue;
       }
       nextContent.push(nextBlock);

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -189,6 +189,14 @@ function findBalancedJsonObject(text: string): string | null {
     return null;
   }
 
+  return findBalancedJsonObjectAt(text, startIndex);
+}
+
+function findBalancedJsonObjectAt(text: string, startIndex: number): string | null {
+  if (text[startIndex] !== "{") {
+    return null;
+  }
+
   let depth = 0;
   let quoteChar: '"' | "'" | null = null;
   let isEscaped = false;
@@ -226,6 +234,25 @@ function findBalancedJsonObject(text: string): string | null {
   }
 
   return null;
+}
+
+function skipKimiDecorativeMarkup(text: string, startIndex: number): number {
+  let index = startIndex;
+  while (index < text.length) {
+    while (index < text.length && /\s/.test(text[index] ?? "")) {
+      index += 1;
+    }
+    const tagMatch = /^<\/?i\b[^>]*>/i.exec(text.slice(index));
+    if (!tagMatch) {
+      break;
+    }
+    index += tagMatch[0].length;
+  }
+  return index;
+}
+
+function isKimiDecorativeMarkupOnly(text: string): boolean {
+  return text.replaceAll(/<\/?i\b[^>]*>/gi, "").trim().length === 0;
 }
 
 function parseKimiJsonToolCalls(payload: string): KimiToolCallBlock[] | null {
@@ -332,6 +359,64 @@ function parseKimiJsonToolCallsInText(text: string): KimiParsedTextBlock | null 
 
   const after = text.slice(lastIndex);
   if (after) {
+    content.push({ type: "text", text: after });
+  }
+
+  return { content, changed };
+}
+
+function parseKimiDecoratedJsonIdToolCallsInText(text: string): KimiParsedTextBlock | null {
+  const callStartRe = /(?:<\/?i\b[^>]*>\s*)*([A-Za-z_][A-Za-z0-9_.-]*:\d+)/g;
+  const content: Array<KimiToolCallBlock | { type: "text"; text: string }> = [];
+  let lastIndex = 0;
+  let changed = false;
+  let match: RegExpExecArray | null = null;
+
+  while ((match = callStartRe.exec(text)) !== null) {
+    const rawId = match[1]?.trim() ?? "";
+    const name = stripTaggedToolCallCounter(rawId);
+    if (!rawId || !name) {
+      continue;
+    }
+
+    const argsStart = skipKimiDecorativeMarkup(text, match.index + match[0].length);
+    const rawArgs = findBalancedJsonObjectAt(text, argsStart);
+    if (!rawArgs) {
+      continue;
+    }
+
+    let parsedArgs: unknown;
+    try {
+      parsedArgs = JSON.parse(rawArgs);
+    } catch {
+      continue;
+    }
+    if (!parsedArgs || typeof parsedArgs !== "object" || Array.isArray(parsedArgs)) {
+      continue;
+    }
+
+    const before = text.slice(lastIndex, match.index);
+    if (before && !isKimiDecorativeMarkupOnly(before)) {
+      content.push({ type: "text", text: before });
+    }
+
+    content.push({
+      type: "toolCall",
+      id: rawId,
+      name,
+      arguments: parsedArgs as Record<string, unknown>,
+    });
+    changed = true;
+    lastIndex = argsStart + rawArgs.length;
+    callStartRe.lastIndex = lastIndex;
+  }
+
+  if (!changed) {
+    return null;
+  }
+
+  const after = text.slice(lastIndex);
+  if (after && !isKimiDecorativeMarkupOnly(after)) {
     content.push({ type: "text", text: after });
   }
 
@@ -640,6 +725,10 @@ function parseKimiToolCallsInText(text: string): KimiParsedTextBlock | null {
   const json = parseKimiJsonToolCallsInText(text);
   if (json) {
     return json;
+  }
+  const decoratedJsonIds = parseKimiDecoratedJsonIdToolCallsInText(text);
+  if (decoratedJsonIds) {
+    return decoratedJsonIds;
   }
   const simpleTagged = parseKimiSimpleTaggedToolCallsInText(text);
   if (simpleTagged) {


### PR DESCRIPTION
## Summary

- Problem: Kimi tool calls are leaking into assistant text in current releases across multiple downgraded formats: legacy tagged tool-call markers, XML `<function_calls>` / `<invoke>` blocks, and raw `<exec>...</exec>` tags.
- Why it matters: instead of executing tools, Kimi replies with plain-text tool markup and stops the task.
- What changed: harden the Kimi wrapper in three ways: strip leaked `compat.requiresOpenAiAnthropicToolPayload` before dispatch, parse inline XML `function_calls` blocks into structured `toolCall` blocks while preserving surrounding prose, and parse downgraded `<exec>` tags into real `exec` tool calls with `arguments.command`.
- What did NOT change (scope boundary): no non-Kimi provider behavior, no generic Anthropic compat behavior, and no transport/runtime refactor.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #60059
- Related #60391
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Kimi currently has multiple downgrade paths on the wrapper seam in `extensions/kimi-coding/stream.ts`: leaked Anthropic compat metadata can force OpenAI-style payload rewriting again, and newer Kimi responses can emit plain-text tool markup in formats the existing parser did not recognize.
- Missing detection / guardrail: there were no regression tests covering leaked compat state, inline XML `function_calls` mixed with prose, or downgraded `<exec>` tags.
- Contributing context (if known): the provider wrapper refactor on April 4, 2026 moved Kimi to the context-based `wrapKimiProviderStream(...)` seam, so the fix needs to be owned by the Kimi wrapper itself.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/kimi-coding/stream.test.ts`
- Scenario the test should lock in: Kimi must preserve native Anthropic payloads on the wrapper path, and Kimi plain-text downgraded tool markup must be converted into structured `toolCall` blocks for the known legacy tagged, XML `function_calls`, and `<exec>` forms.
- Why this is the smallest reliable guardrail: it exercises the exact Kimi-owned wrapper seam that composes payload handling and message rewriting without needing live Kimi credentials.
- Existing test that already covers this (if any): existing Kimi stream tests originally covered only legacy tagged tool-call parsing.
- If no new test is added, why not:

## User-visible / Behavior Changes

Kimi tool calls no longer stay in plain text when the provider emits legacy tagged tool markers, XML `function_calls`, or downgraded `<exec>` tags; the wrapper converts them back into executable tool calls.

## Diagram (if applicable)

```text
Before:
[Kimi assistant text] -> [legacy tags or XML/function tag downgrade] -> [wrapper misses format or leaked compat state] -> [raw tool markup shown to user]

After:
[Kimi assistant text] -> [Kimi wrapper strips leaked compat + parses known downgraded tags] -> [structured toolCall blocks] -> [tool executes]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local workspace
- Model/provider: Kimi / `anthropic-messages`
- Integration/channel (if any): Kimi provider plugin
- Relevant config (redacted): N/A

### Steps

1. Produce a Kimi reply that includes normal prose plus downgraded plain-text tool markup.
2. Run that reply through `wrapKimiProviderStream(...)`.
3. Inspect the rewritten assistant message content.

### Expected

- Prose stays as text and the downgraded tool markup becomes structured `toolCall` blocks.

### Actual

- Before this change, the markup stayed in the text block and the tool was never executed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test extensions/kimi-coding/stream.test.ts`; `pnpm build`
- Edge cases checked: compat-wrapped upstream stream plus `compat.requiresOpenAiAnthropicToolPayload=true`; inline XML `function_calls` with surrounding prose and multiple `read` invocations; downgraded `<exec>` tags with multiline shell commands
- What you did **not** verify: live Kimi requests against the released binary

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Kimi could emit another unsupported plain-text tool encoding beyond the known legacy tagged, XML, and `<exec>` forms.
  - Mitigation: this PR adds explicit coverage for each observed encoding and keeps the parsing isolated to the Kimi wrapper.
