### PR TITLE
fix(plugins): normalize Windows ESM import paths #62980

### DIFF
--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
@@ -75,7 +76,9 @@ describe("doctor-contract-registry getJiti", () => {
     }
 
     expect(mocks.createJiti).toHaveBeenCalledTimes(1);
-    expect(mocks.createJiti.mock.calls[0]?.[0]).toBe(path.join(pluginRoot, "contract-api.js"));
+    expect(mocks.createJiti.mock.calls[0]?.[0]).toBe(
+      pathToFileURL(path.join(pluginRoot, "contract-api.js")).href,
+    );
     expect(mocks.createJiti.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
         tryNative: false,

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -12,6 +12,7 @@ import {
   buildPluginLoaderAliasMap,
   buildPluginLoaderJitiOptions,
   shouldPreferNativeJiti,
+  toSafeImportPath,
 } from "./sdk-alias.js";
 
 const CONTRACT_API_EXTENSIONS = [".js", ".mjs", ".cjs", ".ts", ".mts", ".cts"] as const;
@@ -44,6 +45,7 @@ const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();
 const doctorContractCache = new Map<string, PluginDoctorContractEntry[]>();
 
 function getJiti(modulePath: string) {
+  const safeModulePath = toSafeImportPath(modulePath);
   const aliasMap = buildPluginLoaderAliasMap(modulePath, process.argv[1], import.meta.url);
   const tryNative = shouldPreferNativeJiti(modulePath);
   const cacheKey = JSON.stringify({
@@ -54,7 +56,7 @@ function getJiti(modulePath: string) {
   if (cached) {
     return cached;
   }
-  const loader = createJiti(modulePath, {
+  const loader = createJiti(safeModulePath, {
     ...buildPluginLoaderJitiOptions(aliasMap),
     tryNative,
   });
@@ -207,7 +209,8 @@ function resolvePluginDoctorContracts(params?: {
     }
     let mod: PluginDoctorContractModule;
     try {
-      mod = getJiti(contractSource)(contractSource) as PluginDoctorContractModule;
+      const safeContractSource = toSafeImportPath(contractSource);
+      mod = getJiti(contractSource)(safeContractSource) as PluginDoctorContractModule;
     } catch {
       continue;
     }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -74,6 +74,7 @@ import {
   resolvePluginRuntimeModulePath,
   resolvePluginSdkScopedAliasMap,
   shouldPreferNativeJiti,
+  toSafeImportPath,
 } from "./sdk-alias.js";
 import { hasKind, kindsEqual } from "./slots.js";
 import type {
@@ -188,32 +189,6 @@ export function clearPluginLoaderCache(): void {
 }
 
 const defaultLogger = () => createSubsystemLogger("plugins");
-
-/**
- * On Windows, the Node.js ESM loader requires absolute paths to be expressed
- * as file:// URLs (e.g. file:///C:/Users/...). Raw drive-letter paths like
- * C:\... are rejected with ERR_UNSUPPORTED_ESM_URL_SCHEME because the loader
- * mistakes the drive letter for an unknown URL scheme.
- *
- * This helper converts Windows absolute import specifiers to file:// URLs and
- * leaves everything else unchanged.
- */
-function toSafeImportPath(specifier: string): string {
-  if (process.platform !== "win32") {
-    return specifier;
-  }
-  if (specifier.startsWith("file://")) {
-    return specifier;
-  }
-  if (path.win32.isAbsolute(specifier)) {
-    const normalizedSpecifier = specifier.replaceAll("\\", "/");
-    if (normalizedSpecifier.startsWith("//")) {
-      return new URL(`file:${encodeURI(normalizedSpecifier)}`).href;
-    }
-    return new URL(`file:///${encodeURI(normalizedSpecifier)}`).href;
-  }
-  return specifier;
-}
 
 function createPluginJitiLoader(options: Pick<PluginLoadOptions, "pluginSdkResolution">) {
   const jitiLoaders = new Map<string, ReturnType<typeof createJiti>>();

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -26,6 +26,32 @@ export function normalizeJitiAliasTargetPath(targetPath: string): string {
   return process.platform === "win32" ? targetPath.replace(/\\/g, "/") : targetPath;
 }
 
+/**
+ * On Windows, Node's ESM loader requires absolute paths to be expressed as file:// URLs.
+ * Raw drive-letter paths like C:\... can be misread as an unsupported URL scheme ("c:").
+ */
+export function toSafeImportPath(specifier: string): string {
+  if (process.platform !== "win32") {
+    return specifier;
+  }
+  if (specifier.startsWith("file://")) {
+    return specifier;
+  }
+  if (path.win32.isAbsolute(specifier)) {
+    const normalizedSpecifier = specifier.replaceAll("\\", "/");
+    if (normalizedSpecifier.startsWith("//")) {
+      return new URL(`file:${encodeURI(normalizedSpecifier)}`).href;
+    }
+    // When test environments spoof win32, they may still pass POSIX absolute paths
+    // (e.g. /tmp/foo). Preserve pathToFileURL-style encoding for that case.
+    if (normalizedSpecifier.startsWith("/")) {
+      return new URL(`file://${encodeURI(normalizedSpecifier)}`).href;
+    }
+    return new URL(`file:///${encodeURI(normalizedSpecifier)}`).href;
+  }
+  return specifier;
+}
+
 function resolveLoaderModulePath(params: LoaderModuleResolveParams = {}): string {
   return params.modulePath ?? fileURLToPath(params.moduleUrl ?? import.meta.url);
 }

--- a/src/plugins/setup-registry.test.ts
+++ b/src/plugins/setup-registry.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
@@ -76,7 +77,9 @@ describe("setup-registry getJiti", () => {
     }
 
     expect(mocks.createJiti).toHaveBeenCalledTimes(1);
-    expect(mocks.createJiti.mock.calls[0]?.[0]).toBe(path.join(pluginRoot, "setup-api.js"));
+    expect(mocks.createJiti.mock.calls[0]?.[0]).toBe(
+      pathToFileURL(path.join(pluginRoot, "setup-api.js")).href,
+    );
     expect(mocks.createJiti.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({
         tryNative: false,

--- a/src/plugins/setup-registry.ts
+++ b/src/plugins/setup-registry.ts
@@ -14,6 +14,7 @@ import {
   buildPluginLoaderAliasMap,
   buildPluginLoaderJitiOptions,
   shouldPreferNativeJiti,
+  toSafeImportPath,
 } from "./sdk-alias.js";
 import type {
   CliBackendPlugin,
@@ -80,6 +81,7 @@ export function clearPluginSetupRegistryCache(): void {
 }
 
 function getJiti(modulePath: string) {
+  const safeModulePath = toSafeImportPath(modulePath);
   const aliasMap = buildPluginLoaderAliasMap(modulePath, process.argv[1], import.meta.url);
   const tryNative = shouldPreferNativeJiti(modulePath);
   const cacheKey = JSON.stringify({
@@ -90,7 +92,7 @@ function getJiti(modulePath: string) {
   if (cached) {
     return cached;
   }
-  const loader = createJiti(modulePath, {
+  const loader = createJiti(safeModulePath, {
     ...buildPluginLoaderJitiOptions(aliasMap),
     tryNative,
   });
@@ -293,7 +295,8 @@ export function resolvePluginSetupRegistry(params?: {
 
     let mod: OpenClawPluginModule;
     try {
-      mod = getJiti(setupSource)(setupSource) as OpenClawPluginModule;
+      const safeSetupSource = toSafeImportPath(setupSource);
+      mod = getJiti(setupSource)(safeSetupSource) as OpenClawPluginModule;
     } catch {
       continue;
     }
@@ -416,7 +419,8 @@ export function resolvePluginSetupProvider(params: {
 
   let mod: OpenClawPluginModule;
   try {
-    mod = getJiti(setupSource)(setupSource) as OpenClawPluginModule;
+    const safeSetupSource = toSafeImportPath(setupSource);
+    mod = getJiti(setupSource)(safeSetupSource) as OpenClawPluginModule;
   } catch {
     setupProviderCache.set(cacheKey, null);
     return undefined;
@@ -516,7 +520,8 @@ export function resolvePluginSetupCliBackend(params: {
 
   let mod: OpenClawPluginModule;
   try {
-    mod = getJiti(setupSource)(setupSource) as OpenClawPluginModule;
+    const safeSetupSource = toSafeImportPath(setupSource);
+    mod = getJiti(setupSource)(safeSetupSource) as OpenClawPluginModule;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

- Problem: On Windows, OpenClaw onboarding/setup flows can crash with `ERR_UNSUPPORTED_ESM_URL_SCHEME` when plugin loader paths like `C:\...` are passed through the ESM loader, which interprets `c:` as an unsupported URL scheme.
- Why it matters: This breaks initial onboarding and configuration for Windows users, preventing them from installing and configuring models/providers successfully.
- What changed: Centralized a helper to normalize Windows absolute paths into `file://` URLs and applied it to plugin loader Jiti bases and specifiers used by the setup and doctor contract registries.
- What did NOT change (scope boundary): No behavior changes to plugin discovery, activation rules, config schema validation, or non-Windows platforms; only the way module paths are passed into the loader was adjusted.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (plugin loading/setup)
- [x] API / contracts (plugin loader behavior)
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #62980

## User-visible / Behavior Changes

- Windows users should no longer see `Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: ... Received protocol 'c:'` when running onboarding or plugin-related configuration flows.
- Behavior on non-Windows platforms is unchanged; paths are left as-is.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)  
  No
- Secrets/tokens handling changed? (`Yes/No`)  
  No
- New/changed network calls? (`Yes/No`)  
  No
- Command/tool execution surface changed? (`Yes/No`)  
  No
- Data access scope changed? (`Yes/No`)  
  No
- If any `Yes`, explain risk + mitigation:  
  N/A

## Repro + Verification

### Environment

- OS: Windows 10 (issue reporter), Linux dev environment for this fix
- Runtime/container: Node.js 22+ (as per repo baseline)
- Model/provider: Not required to trigger the loader bug
- Integration/channel: Plugin loader and setup/doctor plugin registries
- Relevant config (redacted): Any config that exercises plugin setup APIs or doctor contracts on Windows

### Steps (original repro from issue)

1. On Windows PowerShell, install and run OpenClaw onboarding:

   ```powershell
   powershell -c "irm https://openclaw.ai/install.ps1 | iex"
   ```

2. Configure a model/provider via onboarding so that plugin setup code runs.

### Expected

- Onboarding and configuration complete without crashes.
- No `ERR_UNSUPPORTED_ESM_URL_SCHEME` from the Node ESM loader.

### Actual (before this fix)

- On Windows, onboarding/setup can fail with:

  ```text
  Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in:
  file, data, and node are supported by the default ESM loader.
  On Windows, absolute paths must be valid file:// URLs.
  Received protocol 'c:'
  ```

### Verification (after this fix)

Locally, on Linux (cannot fully exercise Windows ESM behavior, but we verify the loader wiring and tests that simulate `win32`):

- Targeted tests:

  ```bash
  pnpm test src/plugins/setup-registry.test.ts src/plugins/doctor-contract-registry.test.ts
  ```

  Both files now pass, including the cases that:

  - Force `process.platform === "win32"`.
  - Assert that `createJiti(...)` is called with `file://...` URLs rather than raw paths for setup/contract modules.
- TypeScript + repo checks via the pre-commit hook:

  - `pnpm tsgo` (run inside `scripts/committer`)
  - `pnpm check` (run by `scripts/committer`)

On a real Windows machine, the expected manual verification is:

1. Upgrade to a build containing this fix.
2. Re-run onboarding / plugin configuration steps.
3. Confirm that `ERR_UNSUPPORTED_ESM_URL_SCHEME` no longer appears in logs or CLI output.

## What Changed

- `src/plugins/sdk-alias.ts`
  - Added `toSafeImportPath(specifier: string)` as a shared helper that:
    - On `win32`, converts absolute paths (including drive-letter paths like `C:\...`) to `file://` URLs.
    - Leaves `file://` URLs and non-absolute specifiers unchanged.
  - Kept behavior on non-Windows platforms as a no-op.

- `src/plugins/loader.ts`
  - Switched from a local `toSafeImportPath` implementation to the shared helper in `sdk-alias.ts`, so that all plugin loader paths normalize imports consistently.

- `src/plugins/setup-registry.ts`
  - Updated the internal `getJiti(modulePath)` helper to:
    - Use `toSafeImportPath(modulePath)` when constructing the Jiti base.
  - When loading `setup-api` modules, now:
    - Use the original `setupSource` for alias resolution and cache keys.
    - Pass `toSafeImportPath(setupSource)` as the actual import specifier to Jiti.
  - This ensures Windows absolute paths are always normalized to `file://` URLs before hitting ESM.

- `src/plugins/doctor-contract-registry.ts`
  - Applied the same pattern as `setup-registry`:
    - Normalize the Jiti base with `toSafeImportPath(modulePath)`.
    - Normalize the contract module specifier with `toSafeImportPath(contractSource)`.

- `src/plugins/setup-registry.test.ts`
  - Adjusted expectations to match the new behavior:
    - In the Windows-specific test, assert that `createJiti` is called with `file://...` URLs (using `pathToFileURL(...).href`), not with raw filesystem paths.

- `src/plugins/doctor-contract-registry.test.ts`
  - Same as above for the doctor contract path:
    - Ensure that on simulated `win32`, the Jiti base is a `file://` URL.

## Tests

- `pnpm test src/plugins/setup-registry.test.ts src/plugins/doctor-contract-registry.test.ts`
- `pnpm tsgo`

All of the above passed locally.

## Checklist

- [x] Changes are limited to the plugin loader + setup/doctor registry surfaces and related tests.
- [x] No secrets, tokens, or user-specific data added to code or tests.
- [x] Behavior on non-Windows platforms is unchanged.
- [x] Tests added/updated to cover the Windows path normalization and prevent regressions.