### PR TITLE
Pass outbound session identity into message_sending and surface guarded gateway send denial

### DIFF
--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { ErrorCodes } from "../protocol/index.js";
 import type { GatewayRequestContext } from "./types.js";
 
 type ResolveOutboundTarget = typeof import("../../infra/outbound/targets.js").resolveOutboundTarget;
@@ -506,6 +507,49 @@ describe("gateway send mirroring", () => {
         mirror: expect.objectContaining({
           sessionKey: "agent:main:main",
         }),
+      }),
+    );
+  });
+
+  it("surfaces explicit guarded denial when message_sending cancels delivery", async () => {
+    mocks.deliverOutboundPayloads.mockImplementation(async (params) => {
+      params.onMessageSendingCancelled?.({
+        channel: "slack",
+        to: "resolved",
+        accountId: undefined,
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        reason: "guard blocked outbound send",
+      });
+      return [];
+    });
+
+    const { respond } = await runSend({
+      to: "channel:C1",
+      message: "hi",
+      channel: "slack",
+      idempotencyKey: "idem-guarded-cancel",
+      sessionKey: "agent:main:main",
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.UNAVAILABLE,
+        message: "guard blocked outbound send",
+        details: expect.objectContaining({
+          reason: "MESSAGE_SENDING_CANCELLED",
+          hook: "message_sending",
+          channel: "slack",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+        }),
+      }),
+      expect.objectContaining({
+        channel: "slack",
+        guarded: true,
+        hook: "message_sending",
       }),
     );
   });

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -345,6 +345,13 @@ export const sendHandlers: GatewayRequestHandlers = {
           agentId: effectiveAgentId,
           sessionKey: outboundSessionKey,
         });
+        let guardedCancellation:
+          | {
+              reason?: string;
+              agentId?: string;
+              sessionKey?: string;
+            }
+          | undefined;
         const results = await deliverOutboundPayloads({
           cfg,
           channel: outboundChannel,
@@ -356,6 +363,13 @@ export const sendHandlers: GatewayRequestHandlers = {
           threadId: threadId ?? null,
           deps: outboundDeps,
           gatewayClientScopes: client?.connect?.scopes ?? [],
+          onMessageSendingCancelled: (info) => {
+            guardedCancellation = {
+              reason: info.reason,
+              agentId: info.agentId,
+              sessionKey: info.sessionKey,
+            };
+          },
           mirror: outboundSessionKey
             ? {
                 sessionKey: outboundSessionKey,
@@ -369,6 +383,32 @@ export const sendHandlers: GatewayRequestHandlers = {
 
         const result = results.at(-1);
         if (!result) {
+          if (guardedCancellation) {
+            const error = errorShape(
+              ErrorCodes.UNAVAILABLE,
+              guardedCancellation.reason ??
+                "delivery cancelled by message_sending hook before outbound send",
+              {
+                details: {
+                  reason: "MESSAGE_SENDING_CANCELLED",
+                  hook: "message_sending",
+                  channel,
+                  agentId: guardedCancellation.agentId,
+                  sessionKey: guardedCancellation.sessionKey,
+                },
+              },
+            );
+            cacheGatewayDedupeFailure({ context, dedupeKey, error });
+            return {
+              ok: false,
+              error,
+              meta: {
+                channel,
+                guarded: true,
+                hook: "message_sending",
+              },
+            };
+          }
           throw new Error("No delivery result");
         }
         const payload = buildGatewayDeliveryPayload({ runId: idem, channel, result });

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -263,4 +263,27 @@ describe("message hook mappers", () => {
       groupId: "demo-chat:chat:456",
     });
   });
+
+  it("adds outbound session identity to plugin message context when provided", () => {
+    const canonical = buildCanonicalSentMessageHookContext({
+      to: "demo-chat:chat:456",
+      content: "reply",
+      success: true,
+      channelId: "demo-chat",
+      accountId: "acc-1",
+    });
+
+    expect(
+      toPluginMessageContext(canonical, {
+        agentId: "main",
+        sessionKey: "agent:main:demo-chat:chat:456",
+      }),
+    ).toEqual({
+      channelId: "demo-chat",
+      accountId: "acc-1",
+      conversationId: "demo-chat:chat:456",
+      agentId: "main",
+      sessionKey: "agent:main:demo-chat:chat:456",
+    });
+  });
 });

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -157,11 +157,17 @@ export function buildCanonicalSentMessageHookContext(params: {
 
 export function toPluginMessageContext(
   canonical: CanonicalInboundMessageHookContext | CanonicalSentMessageHookContext,
+  overrides?: {
+    agentId?: string;
+    sessionKey?: string;
+  },
 ): PluginHookMessageContext {
   return {
     channelId: canonical.channelId,
     accountId: canonical.accountId,
     conversationId: canonical.conversationId,
+    agentId: overrides?.agentId,
+    sessionKey: overrides?.sessionKey,
   };
 }
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -842,6 +842,70 @@ describe("deliverOutboundPayloads", () => {
     expect(hookMocks.runner.runMessageSent).not.toHaveBeenCalled();
   });
 
+  it("passes outbound session identity to message_sending hook context", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name?: string) => name === "message_sending");
+    hookMocks.runner.runMessageSending.mockResolvedValue(undefined);
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { whatsapp: sendWhatsApp },
+      session: {
+        agentId: "main",
+        key: "agent:main:whatsapp:+1555",
+      },
+    });
+
+    expect(hookMocks.runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "+1555",
+        content: "hello",
+      }),
+      expect.objectContaining({
+        channelId: "whatsapp",
+        agentId: "main",
+        sessionKey: "agent:main:whatsapp:+1555",
+      }),
+    );
+  });
+
+  it("reports message_sending cancellations through the delivery callback", async () => {
+    hookMocks.runner.hasHooks.mockImplementation((name?: string) => name === "message_sending");
+    hookMocks.runner.runMessageSending.mockResolvedValue({
+      cancel: true,
+      content: "blocked by guard",
+    });
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const onMessageSendingCancelled = vi.fn();
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "hello" }],
+      deps: { whatsapp: sendWhatsApp },
+      session: {
+        agentId: "main",
+        key: "agent:main:whatsapp:+1555",
+      },
+      onMessageSendingCancelled,
+    });
+
+    expect(results).toEqual([]);
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(onMessageSendingCancelled).toHaveBeenCalledWith({
+      channel: "whatsapp",
+      to: "+1555",
+      accountId: undefined,
+      agentId: "main",
+      sessionKey: "agent:main:whatsapp:+1555",
+      reason: "blocked by guard",
+    });
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -294,6 +294,14 @@ type DeliverOutboundPayloadsCoreParams = {
   bestEffort?: boolean;
   onError?: (err: unknown, payload: NormalizedOutboundPayload) => void;
   onPayload?: (payload: NormalizedOutboundPayload) => void;
+  onMessageSendingCancelled?: (params: {
+    channel: Exclude<OutboundChannel, "none">;
+    to: string;
+    accountId?: string;
+    agentId?: string;
+    sessionKey?: string;
+    reason?: string;
+  }) => void;
   /** Session/agent context used for hooks and media local-root scoping. */
   session?: OutboundSessionContext;
   mirror?: DeliveryMirror;
@@ -444,10 +452,12 @@ async function applyMessageSendingHook(params: {
   to: string;
   channel: Exclude<OutboundChannel, "none">;
   accountId?: string;
+  session?: OutboundSessionContext;
 }): Promise<{
   cancelled: boolean;
   payload: ReplyPayload;
   payloadSummary: NormalizedOutboundPayload;
+  cancelReason?: string;
 }> {
   if (!params.enabled) {
     return {
@@ -467,16 +477,30 @@ async function applyMessageSendingHook(params: {
           mediaUrls: params.payloadSummary.mediaUrls,
         },
       },
-      {
-        channelId: params.channel,
-        accountId: params.accountId ?? undefined,
-      },
+      toPluginMessageContext(
+        buildCanonicalSentMessageHookContext({
+          to: params.to,
+          content: params.payloadSummary.text,
+          success: false,
+          channelId: params.channel,
+          accountId: params.accountId,
+          conversationId: params.to,
+        }),
+        {
+          agentId: params.session?.agentId,
+          sessionKey: params.session?.key,
+        },
+      ),
     );
     if (sendingResult?.cancel) {
       return {
         cancelled: true,
         payload: params.payload,
         payloadSummary: params.payloadSummary,
+        cancelReason:
+          typeof sendingResult.content === "string" && sendingResult.content.trim().length > 0
+            ? sendingResult.content
+            : undefined,
       };
     }
     if (sendingResult?.content == null) {
@@ -687,8 +711,17 @@ async function deliverOutboundPayloadsCore(
         to,
         channel,
         accountId,
+        session: params.session,
       });
       if (hookResult.cancelled) {
+        params.onMessageSendingCancelled?.({
+          channel,
+          to,
+          accountId,
+          agentId: params.session?.agentId,
+          sessionKey: params.session?.key,
+          reason: hookResult.cancelReason,
+        });
         continue;
       }
       const effectivePayload = hookResult.payload;

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2552,6 +2552,8 @@ export type PluginHookMessageContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  agentId?: string;
+  sessionKey?: string;
 };
 
 export type PluginHookInboundClaimContext = PluginHookMessageContext & {


### PR DESCRIPTION
## Summary

Make `gateway call send` sufficient for one truthful guarded outbound message path.

This patch:
- passes outbound session identity into `message_sending` hook context when available
- includes `agentId` and `sessionKey` additively and backwards-compatibly
- surfaces guarded delivery cancellation explicitly instead of collapsing it to `No delivery result`

## Why

Today `gateway call send` reaches the shared outbound delivery path and fires `message_sending`, but the hook context drops outbound identity. That makes guard plugins unable to make agent-scoped decisions, and the gateway then hides the real cancellation behind a generic `No delivery result`.

This patch keeps the route narrow:
- it does not unify direct CLI send paths
- it only fixes the gateway send path so one canonical guarded/audited outbound path is usable

## What changed

- add optional `agentId` / `sessionKey` to plugin message hook context
- pass outbound session identity from delivery into `message_sending`
- add an additive cancellation callback on outbound delivery
- have gateway send surface guarded cancellation explicitly

## Tests

- gateway send path reaches `message_sending` with agent identity
- guarded cancellation is surfaced explicitly
- successful delivery path still returns a delivery result

## Live verification

Verified on a real standard-local runtime with Telegram:
1. no credential -> blocked with explicit guarded denial
2. granted credential -> delivered with real provider result
3. revoked credential -> blocked again with explicit guarded denial
