### PR TITLE
feat: add Databricks serving provider plugin

### DIFF
--- a/extensions/databricks/api.ts
+++ b/extensions/databricks/api.ts
@@ -1,0 +1,1 @@
+export { DATABRICKS_DEFAULT_MODEL_REF } from "./onboard.js";

--- a/extensions/databricks/index.test.ts
+++ b/extensions/databricks/index.test.ts
@@ -1,6 +1,6 @@
+import { type ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import plugin from "./index.js";
-import { type ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -45,20 +45,30 @@ describe("Databricks plugin", () => {
         temperature: 0.7,
       } as any;
 
-      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
-        new Response(
-          new ReadableStream({
-            start(controller) {
-              const encoder = new TextEncoder();
-              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"role":"assistant","content":"Hi! "},"finish_reason":null}]}\n'));
-              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"How can I help?"},"finish_reason":"stop"}]}\n'));
-              controller.enqueue(encoder.encode('data: [DONE]\n'));
-              controller.close();
-            }
-          }),
-          { status: 200, statusText: "OK" }
-        )
-      ));
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                const encoder = new TextEncoder();
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"role":"assistant","content":"Hi! "},"finish_reason":null}]}\n',
+                  ),
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"content":"How can I help?"},"finish_reason":"stop"}]}\n',
+                  ),
+                );
+                controller.enqueue(encoder.encode("data: [DONE]\n"));
+                controller.close();
+              },
+            }),
+            { status: 200, statusText: "OK" },
+          ),
+        ),
+      );
 
       const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
       const eventStream = await streamFn(model, context, options);
@@ -75,16 +85,18 @@ describe("Databricks plugin", () => {
           init: expect.objectContaining({
             method: "POST",
             headers: expect.objectContaining({
-              "Authorization": "Bearer test-token",
+              Authorization: "Bearer test-token",
               "Content-Type": "application/json",
-              "Accept": "text/event-stream",
+              Accept: "text/event-stream",
             }),
           }),
-        })
+        }),
       );
 
       expect(events).toContainEqual(expect.objectContaining({ type: "text_delta", delta: "Hi! " }));
-      expect(events).toContainEqual(expect.objectContaining({ type: "text_delta", delta: "How can I help?" }));
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "text_delta", delta: "How can I help?" }),
+      );
       expect(events).toContainEqual(expect.objectContaining({ type: "done", reason: "stop" }));
     });
 
@@ -97,24 +109,38 @@ describe("Databricks plugin", () => {
       const providerReg = api.registerProvider.mock.calls[0][0];
       const wrapStreamFn = providerReg.wrapStreamFn;
 
-      const model = { id: "test-model", baseUrl: "https://my-databricks.cloud.databricks.com", api: "openai-completions" } as any;
+      const model = {
+        id: "test-model",
+        baseUrl: "https://my-databricks.cloud.databricks.com",
+        api: "openai-completions",
+      } as any;
       const context = { messages: [{ role: "user", content: "use a tool" }] } as any;
       const options = { apiKey: "test-token" } as any;
 
-      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
-        new Response(
-          new ReadableStream({
-            start(controller) {
-              const encoder = new TextEncoder();
-              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"id":"call_1","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Lo"}}]},"finish_reason":null}]}\n'));
-              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"ndon\\"}"}}]},"finish_reason":"tool_calls"}]}\n'));
-              controller.enqueue(encoder.encode('data: [DONE]\n'));
-              controller.close();
-            }
-          }),
-          { status: 200 }
-        )
-      ));
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                const encoder = new TextEncoder();
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"tool_calls":[{"id":"call_1","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Lo"}}]},"finish_reason":null}]}\n',
+                  ),
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"ndon\\"}"}}]},"finish_reason":"tool_calls"}]}\n',
+                  ),
+                );
+                controller.enqueue(encoder.encode("data: [DONE]\n"));
+                controller.close();
+              },
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
 
       const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
       const eventStream = await streamFn(model, context, options);
@@ -126,8 +152,12 @@ describe("Databricks plugin", () => {
       }
 
       expect(events).toContainEqual(expect.objectContaining({ type: "toolcall_start" }));
-      expect(events).toContainEqual(expect.objectContaining({ type: "toolcall_delta", delta: '{"city":"Lo' }));
-      expect(events).toContainEqual(expect.objectContaining({ type: "toolcall_delta", delta: 'ndon"}' }));
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "toolcall_delta", delta: '{"city":"Lo' }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "toolcall_delta", delta: 'ndon"}' }),
+      );
       expect(events).toContainEqual(expect.objectContaining({ type: "done", reason: "toolUse" }));
     });
 
@@ -140,26 +170,44 @@ describe("Databricks plugin", () => {
       const context = { messages: [{ role: "user", content: "parallel tools" }] } as any;
       const options = { apiKey: "token" } as any;
 
-      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
-        new Response(
-          new ReadableStream({
-            start(controller) {
-              const encoder = new TextEncoder();
-              // Start Tool 0
-              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c0","function":{"name":"f0","arguments":""}}]},"finish_reason":null}]}\n'));
-              // Start Tool 1
-              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"c1","function":{"name":"f1","arguments":""}}]},"finish_reason":null}]}\n'));
-              // Delta for Tool 0
-              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"a\\":1}"}}]},"finish_reason":null}]}\n'));
-              // Delta for Tool 1
-              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\\"b\\":2}"}}]},"finish_reason":null}]}\n'));
-              controller.enqueue(encoder.encode('data: [DONE]\n'));
-              controller.close();
-            }
-          }),
-          { status: 200 }
-        )
-      ));
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                const encoder = new TextEncoder();
+                // Start Tool 0
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c0","function":{"name":"f0","arguments":""}}]},"finish_reason":null}]}\n',
+                  ),
+                );
+                // Start Tool 1
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"c1","function":{"name":"f1","arguments":""}}]},"finish_reason":null}]}\n',
+                  ),
+                );
+                // Delta for Tool 0
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"a\\":1}"}}]},"finish_reason":null}]}\n',
+                  ),
+                );
+                // Delta for Tool 1
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\\"b\\":2}"}}]},"finish_reason":null}]}\n',
+                  ),
+                );
+                controller.enqueue(encoder.encode("data: [DONE]\n"));
+                controller.close();
+              },
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
 
       const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
       const eventStream = await streamFn(model, context, options);
@@ -170,12 +218,12 @@ describe("Databricks plugin", () => {
         events.push(event);
       }
 
-      const toolStartEvents = events.filter(e => e.type === "toolcall_start");
+      const toolStartEvents = events.filter((e) => e.type === "toolcall_start");
       expect(toolStartEvents).toHaveLength(2);
       expect(toolStartEvents[0].contentIndex).toBe(0);
       expect(toolStartEvents[1].contentIndex).toBe(1);
 
-      const toolDeltaEvents = events.filter(e => e.type === "toolcall_delta");
+      const toolDeltaEvents = events.filter((e) => e.type === "toolcall_delta");
       expect(toolDeltaEvents).toHaveLength(2);
       // Tool 0 delta
       expect(toolDeltaEvents[0].contentIndex).toBe(0);
@@ -190,21 +238,30 @@ describe("Databricks plugin", () => {
       await plugin.register(api);
       const wrapStreamFn = api.registerProvider.mock.calls[0][0].wrapStreamFn;
 
-      const model = { id: "test", baseUrl: "https://test.com", api: "openai-completions", headers: { "X-Model-Header": "foo" } } as any;
+      const model = {
+        id: "test",
+        baseUrl: "https://test.com",
+        api: "openai-completions",
+        headers: { "X-Model-Header": "foo" },
+      } as any;
       const context = {
         systemPrompt: "You are a helpful assistant",
         messages: [
           { role: "user", content: "call tool" },
-          { role: "assistant", content: null, toolCalls: [{ id: "call_1", function: { name: "t1", arguments: "{}" } }] },
-          { role: "toolResult", toolCallId: "call_1", content: "result" }
+          {
+            role: "assistant",
+            content: null,
+            toolCalls: [{ id: "call_1", function: { name: "t1", arguments: "{}" } }],
+          },
+          { role: "toolResult", toolCallId: "call_1", content: "result" },
         ],
-        tools: [{ name: "t1", description: "d1", parameters: {} }]
+        tools: [{ name: "t1", description: "d1", parameters: {} }],
       } as any;
       const options = { apiKey: "token", headers: { "X-Options-Header": "bar" } } as any;
 
-      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
-        new Response("data: [DONE]\n", { status: 200 })
-      ));
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(new Response("data: [DONE]\n", { status: 200 })),
+      );
 
       const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
       await streamFn(model, context, options);
@@ -214,11 +271,13 @@ describe("Databricks plugin", () => {
           init: expect.objectContaining({
             headers: expect.objectContaining({
               "X-Model-Header": "foo",
-              "X-Options-Header": "bar"
+              "X-Options-Header": "bar",
             }),
-            body: expect.stringContaining('"role":"system","content":"You are a helpful assistant"'),
+            body: expect.stringContaining(
+              '"role":"system","content":"You are a helpful assistant"',
+            ),
           }),
-        })
+        }),
       );
 
       const callInit = fetchWithSsrFGuardMock.mock.calls[0][0].init;
@@ -239,25 +298,29 @@ describe("Databricks plugin", () => {
       const providerReg = api.registerProvider.mock.calls[0][0];
       const catalogRun = providerReg.catalog.run;
 
-      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
-        new Response(JSON.stringify({
-          endpoints: [
-            { name: "chat-model", task: "llm/v1/chat" },
-            { name: "legacy-model", task: "llm/v1/completions" },
-            { name: "embedding-model", task: "llm/v1/embeddings" },
-          ]
-        }))
-      ));
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(
+          new Response(
+            JSON.stringify({
+              endpoints: [
+                { name: "chat-model", task: "llm/v1/chat" },
+                { name: "legacy-model", task: "llm/v1/completions" },
+                { name: "embedding-model", task: "llm/v1/embeddings" },
+              ],
+            }),
+          ),
+        ),
+      );
 
       const ctx = {
         resolveProviderApiKey: () => ({ apiKey: "test-token" }),
         config: {
           models: {
             providers: {
-              databricks: { baseUrl: "https://my-databricks.cloud.databricks.com" }
-            }
-          }
-        }
+              databricks: { baseUrl: "https://my-databricks.cloud.databricks.com" },
+            },
+          },
+        },
       } as any;
 
       const result = await catalogRun(ctx);
@@ -289,9 +352,9 @@ describe("Databricks plugin", () => {
       } as any;
       const options = { apiKey: "token" } as any;
 
-      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
-        new Response("data: [DONE]\n", { status: 200 })
-      ));
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(new Response("data: [DONE]\n", { status: 200 })),
+      );
 
       const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
       await streamFn(model, context, options);
@@ -300,7 +363,9 @@ describe("Databricks plugin", () => {
       const roles = sentBody.messages.map((m: { role: string }) => m.role);
       // The synthetic stub should be inserted between assistant and user
       expect(roles).toContain("tool");
-      const toolMsg = sentBody.messages.find((m: { role: string; tool_call_id?: string }) => m.role === "tool");
+      const toolMsg = sentBody.messages.find(
+        (m: { role: string; tool_call_id?: string }) => m.role === "tool",
+      );
       expect(toolMsg?.tool_call_id).toBe("call_x");
     });
 
@@ -325,9 +390,9 @@ describe("Databricks plugin", () => {
       } as any;
       const options = { apiKey: "token" } as any;
 
-      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
-        new Response("data: [DONE]\n", { status: 200 })
-      ));
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(new Response("data: [DONE]\n", { status: 200 })),
+      );
 
       const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
       await streamFn(model, context, options);
@@ -336,6 +401,104 @@ describe("Databricks plugin", () => {
       const assistantMsg = sentBody.messages.find((m: { role: string }) => m.role === "assistant");
       // Content should not contain any thinking-type objects
       expect(assistantMsg?.content).not.toMatch(/thinking/i);
+    });
+
+    it("flattens tool-result content blocks to text", async () => {
+      const api = { registerProvider: vi.fn() } as any;
+      await plugin.register(api);
+      const wrapStreamFn = api.registerProvider.mock.calls[0][0].wrapStreamFn;
+
+      const model = { id: "test", baseUrl: "https://test.com", api: "openai-completions" } as any;
+      const context = {
+        messages: [
+          { role: "user", content: "call tool" },
+          {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call_1", name: "search", arguments: {} }],
+            stopReason: "toolUse",
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            content: [
+              { type: "text", text: "first line" },
+              { type: "image", data: "base64data" },
+              { type: "text", text: " second line" },
+            ],
+          },
+          { role: "user", content: "continue" },
+        ],
+      } as any;
+      const options = { apiKey: "token" } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(new Response("data: [DONE]\n", { status: 200 })),
+      );
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      await streamFn(model, context, options);
+
+      const sentBody = JSON.parse(fetchWithSsrFGuardMock.mock.calls[0][0].init.body);
+      const toolMsg = sentBody.messages.find((m: { role: string }) => m.role === "tool");
+      // Content should be a flattened text string, not an array
+      expect(typeof toolMsg?.content).toBe("string");
+      expect(toolMsg?.content).toBe("first line second line");
+    });
+  });
+
+  describe("SSE resilience", () => {
+    it("skips malformed JSON lines without aborting the stream", async () => {
+      const api = { registerProvider: vi.fn() } as any;
+      await plugin.register(api);
+      const wrapStreamFn = api.registerProvider.mock.calls[0][0].wrapStreamFn;
+
+      const model = { id: "test", baseUrl: "https://test.com", api: "openai-completions" } as any;
+      const context = { messages: [{ role: "user", content: "hello" }] } as any;
+      const options = { apiKey: "token" } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                const encoder = new TextEncoder();
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n',
+                  ),
+                );
+                controller.enqueue(encoder.encode("data: {INVALID_JSON\n"));
+                controller.enqueue(
+                  encoder.encode(
+                    'data: {"choices":[{"delta":{"content":" World"},"finish_reason":"stop"}]}\n',
+                  ),
+                );
+                controller.enqueue(encoder.encode("data: [DONE]\n"));
+                controller.close();
+              },
+            }),
+            { status: 200 },
+          ),
+        ),
+      );
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      const eventStream = await streamFn(model, context, options);
+
+      const iterableStream = eventStream as AsyncIterable<Record<string, unknown>>;
+      const events: Record<string, unknown>[] = [];
+      for await (const event of iterableStream) {
+        events.push(event);
+      }
+
+      // The stream should continue past the malformed line
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "text_delta", delta: "Hello" }),
+      );
+      expect(events).toContainEqual(
+        expect.objectContaining({ type: "text_delta", delta: " World" }),
+      );
+      expect(events).toContainEqual(expect.objectContaining({ type: "done", reason: "stop" }));
     });
   });
 });

--- a/extensions/databricks/index.test.ts
+++ b/extensions/databricks/index.test.ts
@@ -446,6 +446,39 @@ describe("Databricks plugin", () => {
       // Non-text blocks (like image) should be filtered out
       expect(toolMsg?.content).not.toContain("base64data");
     });
+
+    it("serializes block-array user content to text instead of null", async () => {
+      const api = { registerProvider: vi.fn() } as any;
+      await plugin.register(api);
+      const wrapStreamFn = api.registerProvider.mock.calls[0][0].wrapStreamFn;
+
+      const model = { id: "test", baseUrl: "https://test.com", api: "openai-completions" } as any;
+      const context = {
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Hello " },
+              { type: "text", text: "World" },
+            ],
+          },
+        ],
+      } as any;
+      const options = { apiKey: "token" } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(new Response("data: [DONE]\n", { status: 200 })),
+      );
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      await streamFn(model, context, options);
+
+      const sentBody = JSON.parse(fetchWithSsrFGuardMock.mock.calls[0][0].init.body);
+      const userMsg = sentBody.messages.find((m: { role: string }) => m.role === "user");
+      // Block-array user content must be flattened to text, not sent as null
+      expect(typeof userMsg?.content).toBe("string");
+      expect(userMsg?.content).toBe("Hello World");
+    });
   });
 
   describe("SSE resilience", () => {

--- a/extensions/databricks/index.test.ts
+++ b/extensions/databricks/index.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import plugin from "./index.js";
+import { type ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchWithSsrFGuardMock,
+}));
+
+/** Helper to wrap a Response in the GuardedFetchResult shape that fetchWithSsrFGuard returns. */
+function mockFetchResult(response: Response): { response: Response; release: () => Promise<void> } {
+  return { response, release: vi.fn(async () => {}) };
+}
+
+describe("Databricks plugin", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("wrapStreamFn", () => {
+    it("rewrites the URL to the invocations endpoint and handles streaming", async () => {
+      const api = {
+        registerProvider: vi.fn(),
+      } as any;
+      await plugin.register(api);
+
+      const providerReg = api.registerProvider.mock.calls[0][0];
+      const wrapStreamFn = providerReg.wrapStreamFn;
+      expect(wrapStreamFn).toBeDefined();
+
+      const model = {
+        id: "test-model",
+        baseUrl: "https://my-databricks.cloud.databricks.com",
+        api: "openai-completions",
+      } as any;
+      const context = {
+        messages: [{ role: "user", content: "hello" }],
+      } as any;
+      const options = {
+        apiKey: "test-token",
+        maxTokens: 100,
+        temperature: 0.7,
+      } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              const encoder = new TextEncoder();
+              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"role":"assistant","content":"Hi! "},"finish_reason":null}]}\n'));
+              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"content":"How can I help?"},"finish_reason":"stop"}]}\n'));
+              controller.enqueue(encoder.encode('data: [DONE]\n'));
+              controller.close();
+            }
+          }),
+          { status: 200, statusText: "OK" }
+        )
+      ));
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      const eventStream = await streamFn(model, context, options);
+
+      const iterableStream = eventStream as AsyncIterable<Record<string, unknown>>;
+      const events: Record<string, unknown>[] = [];
+      for await (const event of iterableStream) {
+        events.push(event);
+      }
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "https://my-databricks.cloud.databricks.com/serving-endpoints/test-model/invocations",
+          init: expect.objectContaining({
+            method: "POST",
+            headers: expect.objectContaining({
+              "Authorization": "Bearer test-token",
+              "Content-Type": "application/json",
+              "Accept": "text/event-stream",
+            }),
+          }),
+        })
+      );
+
+      expect(events).toContainEqual(expect.objectContaining({ type: "text_delta", delta: "Hi! " }));
+      expect(events).toContainEqual(expect.objectContaining({ type: "text_delta", delta: "How can I help?" }));
+      expect(events).toContainEqual(expect.objectContaining({ type: "done", reason: "stop" }));
+    });
+
+    it("handles streamed tool calls", async () => {
+      const api = {
+        registerProvider: vi.fn(),
+      } as any;
+      await plugin.register(api);
+
+      const providerReg = api.registerProvider.mock.calls[0][0];
+      const wrapStreamFn = providerReg.wrapStreamFn;
+
+      const model = { id: "test-model", baseUrl: "https://my-databricks.cloud.databricks.com", api: "openai-completions" } as any;
+      const context = { messages: [{ role: "user", content: "use a tool" }] } as any;
+      const options = { apiKey: "test-token" } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              const encoder = new TextEncoder();
+              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"id":"call_1","function":{"name":"get_weather","arguments":"{\\"city\\":\\"Lo"}}]},"finish_reason":null}]}\n'));
+              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"ndon\\"}"}}]},"finish_reason":"tool_calls"}]}\n'));
+              controller.enqueue(encoder.encode('data: [DONE]\n'));
+              controller.close();
+            }
+          }),
+          { status: 200 }
+        )
+      ));
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      const eventStream = await streamFn(model, context, options);
+
+      const iterableStream = eventStream as AsyncIterable<Record<string, unknown>>;
+      const events: Record<string, unknown>[] = [];
+      for await (const event of iterableStream) {
+        events.push(event);
+      }
+
+      expect(events).toContainEqual(expect.objectContaining({ type: "toolcall_start" }));
+      expect(events).toContainEqual(expect.objectContaining({ type: "toolcall_delta", delta: '{"city":"Lo' }));
+      expect(events).toContainEqual(expect.objectContaining({ type: "toolcall_delta", delta: 'ndon"}' }));
+      expect(events).toContainEqual(expect.objectContaining({ type: "done", reason: "toolUse" }));
+    });
+
+    it("handles interleaved parallel tool calls using index", async () => {
+      const api = { registerProvider: vi.fn() } as any;
+      await plugin.register(api);
+      const wrapStreamFn = api.registerProvider.mock.calls[0][0].wrapStreamFn;
+
+      const model = { id: "test", baseUrl: "https://test.com", api: "openai-completions" } as any;
+      const context = { messages: [{ role: "user", content: "parallel tools" }] } as any;
+      const options = { apiKey: "token" } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              const encoder = new TextEncoder();
+              // Start Tool 0
+              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"c0","function":{"name":"f0","arguments":""}}]},"finish_reason":null}]}\n'));
+              // Start Tool 1
+              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":1,"id":"c1","function":{"name":"f1","arguments":""}}]},"finish_reason":null}]}\n'));
+              // Delta for Tool 0
+              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"a\\":1}"}}]},"finish_reason":null}]}\n'));
+              // Delta for Tool 1
+              controller.enqueue(encoder.encode('data: {"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\\"b\\":2}"}}]},"finish_reason":null}]}\n'));
+              controller.enqueue(encoder.encode('data: [DONE]\n'));
+              controller.close();
+            }
+          }),
+          { status: 200 }
+        )
+      ));
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      const eventStream = await streamFn(model, context, options);
+
+      const iterableStream = eventStream as AsyncIterable<Record<string, unknown>>;
+      const events: Record<string, unknown>[] = [];
+      for await (const event of iterableStream) {
+        events.push(event);
+      }
+
+      const toolStartEvents = events.filter(e => e.type === "toolcall_start");
+      expect(toolStartEvents).toHaveLength(2);
+      expect(toolStartEvents[0].contentIndex).toBe(0);
+      expect(toolStartEvents[1].contentIndex).toBe(1);
+
+      const toolDeltaEvents = events.filter(e => e.type === "toolcall_delta");
+      expect(toolDeltaEvents).toHaveLength(2);
+      // Tool 0 delta
+      expect(toolDeltaEvents[0].contentIndex).toBe(0);
+      expect(toolDeltaEvents[0].delta).toBe('{"a":1}');
+      // Tool 1 delta
+      expect(toolDeltaEvents[1].contentIndex).toBe(1);
+      expect(toolDeltaEvents[1].delta).toBe('{"b":2}');
+    });
+
+    it("includes systemPrompt and maps toolResult role", async () => {
+      const api = { registerProvider: vi.fn() } as any;
+      await plugin.register(api);
+      const wrapStreamFn = api.registerProvider.mock.calls[0][0].wrapStreamFn;
+
+      const model = { id: "test", baseUrl: "https://test.com", api: "openai-completions", headers: { "X-Model-Header": "foo" } } as any;
+      const context = {
+        systemPrompt: "You are a helpful assistant",
+        messages: [
+          { role: "user", content: "call tool" },
+          { role: "assistant", content: null, toolCalls: [{ id: "call_1", function: { name: "t1", arguments: "{}" } }] },
+          { role: "toolResult", toolCallId: "call_1", content: "result" }
+        ],
+        tools: [{ name: "t1", description: "d1", parameters: {} }]
+      } as any;
+      const options = { apiKey: "token", headers: { "X-Options-Header": "bar" } } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
+        new Response("data: [DONE]\n", { status: 200 })
+      ));
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      await streamFn(model, context, options);
+
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          init: expect.objectContaining({
+            headers: expect.objectContaining({
+              "X-Model-Header": "foo",
+              "X-Options-Header": "bar"
+            }),
+            body: expect.stringContaining('"role":"system","content":"You are a helpful assistant"'),
+          }),
+        })
+      );
+
+      const callInit = fetchWithSsrFGuardMock.mock.calls[0][0].init;
+      const body = JSON.parse(callInit.body);
+      expect(body.messages[0].role).toBe("system");
+      expect(body.messages[3].role).toBe("tool"); // toolResult -> tool
+      expect(body.tools[0].type).toBe("function");
+    });
+  });
+
+  describe("catalog", () => {
+    it("filters to chat-capable models and maps to openai-completions api", async () => {
+      const api = {
+        registerProvider: vi.fn(),
+      } as any;
+      await plugin.register(api);
+
+      const providerReg = api.registerProvider.mock.calls[0][0];
+      const catalogRun = providerReg.catalog.run;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
+        new Response(JSON.stringify({
+          endpoints: [
+            { name: "chat-model", task: "llm/v1/chat" },
+            { name: "legacy-model", task: "llm/v1/completions" },
+            { name: "embedding-model", task: "llm/v1/embeddings" },
+          ]
+        }))
+      ));
+
+      const ctx = {
+        resolveProviderApiKey: () => ({ apiKey: "test-token" }),
+        config: {
+          models: {
+            providers: {
+              databricks: { baseUrl: "https://my-databricks.cloud.databricks.com" }
+            }
+          }
+        }
+      } as any;
+
+      const result = await catalogRun(ctx);
+      expect(result.provider.models).toHaveLength(1);
+      expect(result.provider.models[0].name).toBe("chat-model");
+      expect(result.provider.models[0].api).toBe("openai-completions");
+    });
+  });
+
+  describe("replay normalization", () => {
+    it("inserts synthetic tool-result stub for dangling assistant tool call", async () => {
+      const api = { registerProvider: vi.fn() } as any;
+      await plugin.register(api);
+      const wrapStreamFn = api.registerProvider.mock.calls[0][0].wrapStreamFn;
+
+      const model = { id: "test", baseUrl: "https://test.com", api: "openai-completions" } as any;
+      // history: assistant called a tool, but the session was interrupted before toolResult arrived
+      const context = {
+        messages: [
+          { role: "user", content: "use a tool" },
+          {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call_x", name: "search", arguments: {} }],
+            stopReason: "toolUse",
+          },
+          // No toolResult for call_x - this is the dangling case
+          { role: "user", content: "what happened?" },
+        ],
+      } as any;
+      const options = { apiKey: "token" } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
+        new Response("data: [DONE]\n", { status: 200 })
+      ));
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      await streamFn(model, context, options);
+
+      const sentBody = JSON.parse(fetchWithSsrFGuardMock.mock.calls[0][0].init.body);
+      const roles = sentBody.messages.map((m: { role: string }) => m.role);
+      // The synthetic stub should be inserted between assistant and user
+      expect(roles).toContain("tool");
+      const toolMsg = sentBody.messages.find((m: { role: string; tool_call_id?: string }) => m.role === "tool");
+      expect(toolMsg?.tool_call_id).toBe("call_x");
+    });
+
+    it("strips thinking blocks before sending to Databricks", async () => {
+      const api = { registerProvider: vi.fn() } as any;
+      await plugin.register(api);
+      const wrapStreamFn = api.registerProvider.mock.calls[0][0].wrapStreamFn;
+
+      const model = { id: "test", baseUrl: "https://test.com", api: "openai-completions" } as any;
+      const context = {
+        messages: [
+          {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "I should answer carefully.", redacted: false },
+              { type: "text", text: "Here is my answer." },
+            ],
+            stopReason: "stop",
+          },
+          { role: "user", content: "follow-up" },
+        ],
+      } as any;
+      const options = { apiKey: "token" } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(mockFetchResult(
+        new Response("data: [DONE]\n", { status: 200 })
+      ));
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      await streamFn(model, context, options);
+
+      const sentBody = JSON.parse(fetchWithSsrFGuardMock.mock.calls[0][0].init.body);
+      const assistantMsg = sentBody.messages.find((m: { role: string }) => m.role === "assistant");
+      // Content should not contain any thinking-type objects
+      expect(assistantMsg?.content).not.toMatch(/thinking/i);
+    });
+  });
+});

--- a/extensions/databricks/index.test.ts
+++ b/extensions/databricks/index.test.ts
@@ -329,6 +329,27 @@ describe("Databricks plugin", () => {
       expect(result.provider.models[0].name).toBe("chat-model");
       expect(result.provider.models[0].api).toBe("openai-completions");
     });
+
+    it("rejects http:// base URLs to prevent credential exposure", async () => {
+      const api = { registerProvider: vi.fn() } as any;
+      await plugin.register(api);
+      const catalogRun = api.registerProvider.mock.calls[0][0].catalog.run;
+
+      const ctx = {
+        resolveProviderApiKey: () => ({ apiKey: "test-token" }),
+        config: {
+          models: {
+            providers: {
+              databricks: { baseUrl: "http://insecure.databricks.com" },
+            },
+          },
+        },
+      } as any;
+
+      const result = await catalogRun(ctx);
+      expect(result).toBeNull();
+      expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("replay normalization", () => {

--- a/extensions/databricks/index.test.ts
+++ b/extensions/databricks/index.test.ts
@@ -480,6 +480,35 @@ describe("Databricks plugin", () => {
       expect(typeof userMsg?.content).toBe("string");
       expect(userMsg?.content).toBe("Hello World");
     });
+
+    it("preserves plain-string assistant content from older transcripts", async () => {
+      const api = { registerProvider: vi.fn() } as any;
+      await plugin.register(api);
+      const wrapStreamFn = api.registerProvider.mock.calls[0][0].wrapStreamFn;
+
+      const model = { id: "test", baseUrl: "https://test.com", api: "openai-completions" } as any;
+      const context = {
+        messages: [
+          { role: "user", content: "hi" },
+          // Older transcripts / some provider paths store assistant content as a plain string
+          { role: "assistant", content: "Sure, I can help with that.", stopReason: "stop" },
+          { role: "user", content: "thanks" },
+        ],
+      } as any;
+      const options = { apiKey: "token" } as any;
+
+      fetchWithSsrFGuardMock.mockResolvedValue(
+        mockFetchResult(new Response("data: [DONE]\n", { status: 200 })),
+      );
+
+      const streamFn = wrapStreamFn({} as ProviderWrapStreamFnContext);
+      await streamFn(model, context, options);
+
+      const sentBody = JSON.parse(fetchWithSsrFGuardMock.mock.calls[0][0].init.body);
+      const assistantMsg = sentBody.messages.find((m: { role: string }) => m.role === "assistant");
+      // Plain-string content must survive normalization, not become null
+      expect(assistantMsg?.content).toBe("Sure, I can help with that.");
+    });
   });
 
   describe("SSE resilience", () => {

--- a/extensions/databricks/index.test.ts
+++ b/extensions/databricks/index.test.ts
@@ -443,6 +443,8 @@ describe("Databricks plugin", () => {
       // Content should be a flattened text string, not an array
       expect(typeof toolMsg?.content).toBe("string");
       expect(toolMsg?.content).toBe("first line second line");
+      // Non-text blocks (like image) should be filtered out
+      expect(toolMsg?.content).not.toContain("base64data");
     });
   });
 

--- a/extensions/databricks/index.test.ts
+++ b/extensions/databricks/index.test.ts
@@ -1,6 +1,7 @@
 import { type ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import plugin from "./index.js";
+import { normalizeDatabricksBaseUrl } from "./onboard.js";
 
 const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
   fetchWithSsrFGuardMock: vi.fn(),
@@ -534,6 +535,37 @@ describe("Databricks plugin", () => {
         expect.objectContaining({ type: "text_delta", delta: " World" }),
       );
       expect(events).toContainEqual(expect.objectContaining({ type: "done", reason: "stop" }));
+    });
+  });
+
+  describe("normalizeDatabricksBaseUrl", () => {
+    it("returns undefined for empty/whitespace input", () => {
+      expect(normalizeDatabricksBaseUrl(undefined)).toBeUndefined();
+      expect(normalizeDatabricksBaseUrl("")).toBeUndefined();
+      expect(normalizeDatabricksBaseUrl("   ")).toBeUndefined();
+    });
+
+    it("prepends https:// when no scheme is provided", () => {
+      expect(normalizeDatabricksBaseUrl("dbc-xxxx.cloud.databricks.com")).toBe(
+        "https://dbc-xxxx.cloud.databricks.com",
+      );
+    });
+
+    it("preserves https:// URLs", () => {
+      expect(normalizeDatabricksBaseUrl("https://dbc-xxxx.cloud.databricks.com")).toBe(
+        "https://dbc-xxxx.cloud.databricks.com",
+      );
+    });
+
+    it("strips trailing slashes", () => {
+      expect(normalizeDatabricksBaseUrl("https://dbc-xxxx.cloud.databricks.com///")).toBe(
+        "https://dbc-xxxx.cloud.databricks.com",
+      );
+    });
+
+    it("rejects http:// URLs to prevent credential exposure over cleartext", () => {
+      expect(normalizeDatabricksBaseUrl("http://dbc-xxxx.cloud.databricks.com")).toBeUndefined();
+      expect(normalizeDatabricksBaseUrl("http://localhost:8080")).toBeUndefined();
     });
   });
 });

--- a/extensions/databricks/index.ts
+++ b/extensions/databricks/index.ts
@@ -1,0 +1,650 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import {
+  definePluginEntry,
+  type ProviderAuthContext,
+  type ProviderWrapStreamFnContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { DATABRICKS_DEFAULT_MODEL_REF } from "./api.js";
+import { normalizeDatabricksBaseUrl } from "./onboard.js";
+
+const PROVIDER_ID = "databricks";
+
+/** Partial local type for AgentMessage to avoid 'any' in mapping. */
+interface BaseAgentMessage {
+  role: string;
+  content: string | AssistantContentBlock[];
+  toolCalls?: unknown[];
+  toolCallId?: string;
+  name?: string;
+  stopReason?: string;
+}
+
+interface OpenAIChatMessage {
+  role: string;
+  content: string | unknown[] | null;
+  tool_calls?: unknown[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+/**
+ * Represents a content block in an assistant message as stored in replay history.
+ * Covers text, thinking, and toolCall block shapes we need to handle.
+ */
+interface AssistantContentBlock {
+  type: string;
+  text?: string;
+  thinking?: string;
+  redacted?: boolean;
+  id?: string;
+  name?: string;
+  partialArgs?: string;
+  arguments?: unknown;
+}
+
+function mapDatabricksMessages(context: {
+  messages: unknown[];
+  systemPrompt?: string;
+}): OpenAIChatMessage[] {
+  // --- Replay normalization pass ---
+  // Mirrors the essential repairs from core's transport-message-transform:
+  // 1. Strip thinking/redacted blocks (not supported by Databricks/OpenAI wire format).
+  // 2. Insert synthetic tool-result stubs for dangling assistant tool calls that have no
+  //    paired toolResult, so interrupted/resumed sessions don't send invalid turn ordering.
+  interface NormalizedMessage {
+    role: string;
+    content: string | AssistantContentBlock[];
+    toolCalls?: Array<{ id: string; name: string }>;
+    toolCallId?: string;
+    name?: string;
+    stopReason?: string;
+  }
+
+  const normalized: NormalizedMessage[] = [];
+  let pendingToolCalls: Array<{ id: string; name: string }> = [];
+  let seenToolResultIds = new Set<string>();
+
+  for (const m of context.messages) {
+    const msg = m as BaseAgentMessage;
+
+    if (msg.role === "assistant") {
+      // Flush dangling tool calls from previous assistant turn that had no results
+      if (pendingToolCalls.length > 0) {
+        for (const tc of pendingToolCalls) {
+          if (!seenToolResultIds.has(tc.id)) {
+            normalized.push({
+              role: "toolResult",
+              content: "No result provided",
+              toolCallId: tc.id,
+              name: tc.name,
+            });
+          }
+        }
+        pendingToolCalls = [];
+        seenToolResultIds = new Set();
+      }
+
+      // Skip error/aborted assistant turns
+      if (msg.stopReason === "error" || msg.stopReason === "aborted") {
+        continue;
+      }
+
+      // Strip thinking/redacted blocks from assistant content; retain text and toolCall blocks
+      const rawContent = Array.isArray(msg.content) ? msg.content : [];
+      const strippedContent: AssistantContentBlock[] = [];
+      const newToolCalls: Array<{ id: string; name: string }> = [];
+
+      for (const block of rawContent) {
+        if (block.type === "thinking" || block.type === "redacted_thinking") {
+          // Convert non-empty thinking to a text block for context, skip empty/redacted
+          if (!block.redacted && block.thinking && block.thinking.trim()) {
+            strippedContent.push({ type: "text", text: block.thinking });
+          }
+          continue;
+        }
+        if (block.type === "toolCall") {
+          strippedContent.push(block);
+          if (block.id) {
+            newToolCalls.push({ id: block.id, name: block.name ?? "" });
+          }
+          continue;
+        }
+        strippedContent.push(block);
+      }
+
+      pendingToolCalls = newToolCalls;
+      seenToolResultIds = new Set();
+      // Only role, content, and stopReason are relevant for assistant messages in the
+      // normalized form. toolCalls live inside content blocks (type: "toolCall"), and
+      // toolCallId/name are only meaningful on toolResult messages.
+      normalized.push({ role: msg.role, content: strippedContent, stopReason: msg.stopReason });
+      continue;
+    }
+
+    if (msg.role === "toolResult") {
+      const toolCallId = msg.toolCallId ?? "";
+      seenToolResultIds.add(toolCallId);
+      normalized.push(msg as NormalizedMessage);
+      continue;
+    }
+
+    // Flush dangling tool calls before non-assistant, non-toolResult messages (e.g. user)
+    if (pendingToolCalls.length > 0) {
+      for (const tc of pendingToolCalls) {
+        if (!seenToolResultIds.has(tc.id)) {
+          normalized.push({
+            role: "toolResult",
+            content: "No result provided",
+            toolCallId: tc.id,
+            name: tc.name,
+          });
+        }
+      }
+      pendingToolCalls = [];
+      seenToolResultIds = new Set();
+    }
+
+    normalized.push(msg as NormalizedMessage);
+  }
+
+  // --- OpenAI wire-format conversion ---
+  const result: OpenAIChatMessage[] = [];
+  if (context.systemPrompt) {
+    result.push({ role: "system", content: context.systemPrompt });
+  }
+  for (const msg of normalized) {
+    const role = msg.role === "toolResult" ? "tool" : msg.role;
+
+    if (msg.role === "assistant" && Array.isArray(msg.content)) {
+      // Map assistant content blocks to OpenAI tool_calls wire format
+      const contentBlocks = msg.content;
+      const textBlocks = contentBlocks.filter((b) => b.type === "text");
+      const toolCallBlocks = contentBlocks.filter((b) => b.type === "toolCall");
+
+      const textContent = textBlocks.map((b) => b.text ?? "").join("") || null;
+      const tool_calls =
+        toolCallBlocks.length > 0
+          ? toolCallBlocks.map((b, i) => ({
+              id: b.id ?? `call_${i}`,
+              type: "function",
+              function: {
+                name: b.name ?? "",
+                arguments:
+                  typeof b.arguments === "string"
+                    ? b.arguments
+                    : (b.partialArgs ?? JSON.stringify(b.arguments ?? {})),
+              },
+            }))
+          : undefined;
+
+      result.push({
+        role,
+        content: textContent,
+        ...(tool_calls ? { tool_calls } : {}),
+      });
+      continue;
+    }
+
+    result.push({
+      role,
+      content: msg.content as string | unknown[],
+      ...(msg.toolCallId ? { tool_call_id: msg.toolCallId } : {}),
+      ...(msg.name ? { name: msg.name } : {}),
+    });
+  }
+  return result;
+}
+
+function mapDatabricksTools(tools: unknown[] | undefined) {
+  if (!tools || tools.length === 0) {
+    return undefined;
+  }
+  return tools.map((tool) => {
+    const t = tool as Record<string, unknown>;
+    return {
+      type: "function",
+      function: {
+        name: t.name,
+        description: t.description,
+        parameters: t.parameters,
+      },
+    };
+  });
+}
+
+function mapDatabricksStopReason(reason: string | null | undefined): string {
+  if (!reason) {
+    return "stop";
+  }
+  switch (reason) {
+    case "stop":
+    case "end":
+      return "stop";
+    case "length":
+      return "length";
+    case "function_call":
+    case "tool_calls":
+      return "toolUse";
+    case "content_filter":
+      return "error";
+    default:
+      return "stop";
+  }
+}
+
+export default definePluginEntry({
+  id: PROVIDER_ID,
+  name: "Databricks Provider",
+  description: "Bundled Databricks Serving provider plugin",
+  register(api) {
+    const defaultAuth = createProviderApiKeyAuthMethod({
+      providerId: PROVIDER_ID,
+      methodId: "api-key",
+      label: "Databricks API key",
+      hint: "API key or token",
+      optionKey: "databricksApiKey",
+      flagName: "--databricks-api-key",
+      envVar: "DATABRICKS_API_KEY",
+      promptMessage: "Enter Databricks API key",
+      defaultModel: DATABRICKS_DEFAULT_MODEL_REF,
+      wizard: {
+        groupId: "databricks",
+        groupLabel: "Databricks",
+      },
+    });
+
+    const originalRun = defaultAuth.run;
+    defaultAuth.run = async (ctx: ProviderAuthContext) => {
+      const opts = ctx.opts as Record<string, unknown> | undefined;
+      const rawBaseUrl =
+        typeof opts?.databricksBaseUrl === "string" ? opts.databricksBaseUrl : undefined;
+
+      // Prompt for a valid base URL.  If the CLI-provided value normalizes to empty
+      // (e.g. whitespace-only), the user is asked to re-enter so the config is never
+      // left without a baseUrl that would fail at runtime.
+      const promptForBaseUrl = async () =>
+        ctx.prompter.text({
+          message:
+            "Enter Databricks Workspace Base URL (e.g. https://dbc-xxxx.cloud.databricks.com)",
+          validate: (value) =>
+            !normalizeDatabricksBaseUrl(value)
+              ? "Databricks Workspace Base URL is required."
+              : undefined,
+        });
+
+      const normalizedBaseUrl =
+        normalizeDatabricksBaseUrl(rawBaseUrl) ??
+        normalizeDatabricksBaseUrl(await promptForBaseUrl());
+
+      if (!normalizedBaseUrl) {
+        return originalRun(ctx);
+      }
+
+      const result = await originalRun(ctx);
+
+      const existingPatch = result.configPatch ?? {};
+      const providersPatch = existingPatch.models?.providers ?? {};
+      const databricksPatch = providersPatch[PROVIDER_ID] ?? {};
+      result.configPatch = {
+        ...existingPatch,
+        models: {
+          ...existingPatch.models,
+          providers: {
+            ...providersPatch,
+            [PROVIDER_ID]: {
+              ...databricksPatch,
+              baseUrl: normalizedBaseUrl,
+            },
+          },
+        },
+      };
+      return result;
+    };
+
+    const originalRunNonInteractive = defaultAuth.runNonInteractive;
+    defaultAuth.runNonInteractive = async (ctx) => {
+      const opts = ctx.opts as Record<string, unknown> | undefined;
+      const baseUrl = normalizeDatabricksBaseUrl(
+        typeof opts?.databricksBaseUrl === "string" ? opts.databricksBaseUrl : undefined,
+      );
+
+      // Reject incomplete non-interactive setup: baseUrl is required for Databricks to work.
+      // Failing early here prevents an invalid config from being saved and deferring the
+      // error to runtime on the first API call.
+      if (!baseUrl) {
+        return null;
+      }
+
+      const result = await originalRunNonInteractive?.(ctx);
+      if (!result) {
+        return null;
+      }
+
+      const existingPatch = result.models?.providers ?? {};
+      const databricksPatch = existingPatch[PROVIDER_ID] ?? {};
+
+      return {
+        ...result,
+        models: {
+          ...result.models,
+          providers: {
+            ...existingPatch,
+            [PROVIDER_ID]: {
+              ...databricksPatch,
+              baseUrl,
+            },
+          },
+        },
+      };
+    };
+
+    api.registerProvider({
+      id: PROVIDER_ID,
+      label: "Databricks",
+      docsPath: "/providers/databricks",
+      auth: [defaultAuth],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const auth = ctx.resolveProviderApiKey(PROVIDER_ID);
+          if (!auth.apiKey) {
+            return null;
+          }
+
+          const providerConfig = ctx.config.models?.providers?.[PROVIDER_ID];
+          const baseUrl =
+            typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl : undefined;
+          if (!baseUrl) {
+            return null;
+          }
+
+          try {
+            const { response: res, release } = await fetchWithSsrFGuard({
+              url: `${baseUrl.replace(/\/+$/, "")}/api/2.0/serving-endpoints`,
+              init: {
+                headers: {
+                  Authorization: `Bearer ${auth.apiKey}`,
+                },
+              },
+            });
+            try {
+              if (!res.ok) {
+                return null;
+              }
+
+              const data = (await res.json()) as {
+                endpoints?: Array<{ name: string; endpoint_type: string; task: string }>;
+              };
+              if (!data || !Array.isArray(data.endpoints)) {
+                return null;
+              }
+
+              const models = data.endpoints
+                .filter((ep) => ep.task === "llm/v1/chat")
+                .map((ep) => ({
+                  id: ep.name,
+                  name: ep.name,
+                  api: "openai-completions" as const,
+                  reasoning: false,
+                  input: ["text"] as ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 128000,
+                  maxTokens: 4096,
+                }));
+
+              return {
+                provider: {
+                  baseUrl,
+                  api: "openai-completions",
+                  models,
+                },
+              };
+            } finally {
+              await release();
+            }
+          } catch {
+            return null;
+          }
+        },
+      },
+      wrapStreamFn: (_ctx: ProviderWrapStreamFnContext) => {
+        return async (model, context, options) => {
+          const streamOptions = options || {};
+          // Accept both DATABRICKS_API_KEY and DATABRICKS_TOKEN env vars (Databricks PATs are
+          // commonly stored as DATABRICKS_TOKEN in standard Databricks CLI tooling).
+          const apiKey =
+            streamOptions.apiKey ?? process.env.DATABRICKS_API_KEY ?? process.env.DATABRICKS_TOKEN;
+          if (!apiKey) {
+            throw new Error(
+              "Databricks API key not found. Set DATABRICKS_API_KEY or DATABRICKS_TOKEN, or configure it via openclaw auth.",
+            );
+          }
+
+          const baseUrl = normalizeDatabricksBaseUrl(model.baseUrl || "");
+          if (!baseUrl) {
+            throw new Error(
+              "Databricks base URL not found. Please provide it during onboarding or in the configuration.",
+            );
+          }
+
+          const messages = mapDatabricksMessages(context);
+          const tools = mapDatabricksTools(context.tools);
+          const toolChoice = (streamOptions as Record<string, unknown>).toolChoice;
+
+          const extraParams =
+            ((streamOptions as Record<string, unknown>).extraParams as
+              | Record<string, unknown>
+              | undefined) || {};
+          const payload = {
+            messages,
+            model: model.id,
+            stream: true,
+            max_tokens: streamOptions.maxTokens,
+            temperature: streamOptions.temperature,
+            top_p: extraParams.top_p,
+            stop: extraParams.stop,
+            ...(tools ? { tools } : {}),
+            ...(toolChoice ? { tool_choice: toolChoice } : {}),
+            ...(extraParams.response_format
+              ? { response_format: extraParams.response_format }
+              : {}),
+          };
+
+          const eventStream = createAssistantMessageEventStream();
+          const stream = eventStream as { push(event: unknown): void; end(): void };
+          const output: Record<string, unknown> = {
+            role: "assistant",
+            content: [] as unknown[],
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "stop",
+            timestamp: Date.now(),
+          };
+
+          void (async () => {
+            try {
+              const url = `${baseUrl}/serving-endpoints/${model.id}/invocations`;
+              const mergedHeaders = {
+                Authorization: `Bearer ${apiKey}`,
+                "Content-Type": "application/json",
+                Accept: "text/event-stream",
+                ...(model.headers as Record<string, string>),
+                ...(streamOptions.headers as Record<string, string>),
+              };
+
+              const { response, release: releaseStream } = await fetchWithSsrFGuard({
+                url,
+                init: {
+                  method: "POST",
+                  headers: mergedHeaders,
+                  body: JSON.stringify(payload),
+                },
+                signal: streamOptions.signal,
+              });
+
+              if (!response.ok) {
+                await releaseStream();
+                const errorText = await response.text();
+                throw new Error(`Databricks API error (${response.status}): ${errorText}`);
+              }
+
+              const reader = response.body?.getReader();
+              if (!reader) {
+                await releaseStream();
+                throw new Error("Failed to get response reader from Databricks API");
+              }
+
+              try {
+                stream.push({ type: "start", partial: output });
+
+                const decoder = new TextDecoder();
+                let buffer = "";
+                let doneSent = false;
+
+                const toolCallIndexMap = new Map<number, number>();
+
+                while (true) {
+                  const { done, value } = await reader.read();
+                  if (done || doneSent) {
+                    if (doneSent) {
+                      await reader.cancel().catch(() => {});
+                    }
+                    break;
+                  }
+
+                  buffer += decoder.decode(value, { stream: true });
+                  const lines = buffer.split("\n");
+                  buffer = lines.pop() || "";
+
+                  for (const line of lines) {
+                    const trimmed = line.trim();
+                    if (!trimmed || !trimmed.startsWith("data: ")) {
+                      continue;
+                    }
+                    const data = trimmed.slice(6);
+                    if (data === "[DONE]") {
+                      doneSent = true;
+                      break;
+                    }
+
+                    const json = JSON.parse(data);
+                    const choice = json.choices?.[0];
+                    const delta = choice?.delta;
+                    const blockIndex = () => (output.content as Array<unknown>).length - 1;
+
+                    if (delta?.content) {
+                      const contentList = output.content as Array<{ type: string; text: string }>;
+                      if (
+                        contentList.length === 0 ||
+                        contentList[contentList.length - 1].type !== "text"
+                      ) {
+                        contentList.push({ type: "text", text: "" });
+                        stream.push({
+                          type: "text_start",
+                          contentIndex: blockIndex(),
+                          partial: output,
+                        });
+                      }
+                      const textBlock = contentList[contentList.length - 1] as { text: string };
+                      textBlock.text += delta.content;
+                      stream.push({
+                        type: "text_delta",
+                        contentIndex: blockIndex(),
+                        delta: delta.content,
+                        partial: output,
+                      });
+                    }
+
+                    if (delta?.tool_calls) {
+                      for (const toolCall of delta.tool_calls) {
+                        const contentList = output.content as Array<Record<string, unknown>>;
+                        const sseIndex = typeof toolCall.index === "number" ? toolCall.index : 0;
+
+                        let contentIndex = toolCallIndexMap.get(sseIndex);
+                        if (contentIndex === undefined) {
+                          const newBlock = {
+                            type: "toolCall",
+                            id: toolCall.id || "",
+                            name: toolCall.function?.name || "",
+                            arguments: {},
+                            partialArgs: "",
+                          };
+                          contentList.push(newBlock);
+                          contentIndex = contentList.length - 1;
+                          toolCallIndexMap.set(sseIndex, contentIndex);
+                          stream.push({ type: "toolcall_start", contentIndex, partial: output });
+                        }
+
+                        const currentBlock = contentList[contentIndex];
+
+                        if (toolCall.id) {
+                          currentBlock.id = toolCall.id;
+                        }
+                        if (toolCall.function?.name) {
+                          currentBlock.name = toolCall.function.name;
+                        }
+                        if (toolCall.function?.arguments) {
+                          currentBlock.partialArgs =
+                            (currentBlock.partialArgs as string) + toolCall.function.arguments;
+                          stream.push({
+                            type: "toolcall_delta",
+                            contentIndex,
+                            delta: toolCall.function.arguments,
+                            partial: output,
+                          });
+                        }
+                      }
+                    }
+
+                    if (json.usage) {
+                      const usage = output.usage as Record<string, number>;
+                      usage.input = json.usage.prompt_tokens;
+                      usage.output = json.usage.completion_tokens;
+                      usage.totalTokens = json.usage.total_tokens;
+                    }
+
+                    if (choice?.finish_reason) {
+                      output.stopReason = mapDatabricksStopReason(choice.finish_reason);
+                    }
+                  }
+                }
+
+                stream.push({ type: "done", reason: output.stopReason, message: output });
+                stream.end();
+              } finally {
+                await releaseStream();
+              }
+            } catch (e: unknown) {
+              // Preserve aborted stop reason: AbortError means the caller cancelled the
+              // stream intentionally (e.g. user hit stop), so report "aborted" not "error".
+              const isAbort =
+                e instanceof Error && (e.name === "AbortError" || e.name === "TimeoutError");
+              output.stopReason = isAbort ? "aborted" : "error";
+              output.errorMessage = e instanceof Error ? e.message : String(e);
+              stream.push({
+                type: isAbort ? "done" : "error",
+                reason: output.stopReason,
+                ...(isAbort ? { message: output } : { error: output }),
+              });
+              stream.end();
+            }
+          })();
+
+          return eventStream as unknown as ReturnType<StreamFn>;
+        };
+      },
+    });
+  },
+});

--- a/extensions/databricks/index.ts
+++ b/extensions/databricks/index.ts
@@ -299,10 +299,14 @@ export default definePluginEntry({
         ctx.prompter.text({
           message:
             "Enter Databricks Workspace Base URL (e.g. https://dbc-xxxx.cloud.databricks.com)",
-          validate: (value) =>
-            !normalizeDatabricksBaseUrl(value)
+          validate: (value) => {
+            if (value?.trim().startsWith("http://")) {
+              return "HTTPS is required — Databricks URLs must use https://.";
+            }
+            return !normalizeDatabricksBaseUrl(value)
               ? "Databricks Workspace Base URL is required."
-              : undefined,
+              : undefined;
+          },
         });
 
       const normalizedBaseUrl =

--- a/extensions/databricks/index.ts
+++ b/extensions/databricks/index.ts
@@ -296,7 +296,8 @@ export default definePluginEntry({
     defaultAuth.run = async (ctx: ProviderAuthContext) => {
       const opts = ctx.opts as Record<string, unknown> | undefined;
       const rawBaseUrl =
-        typeof opts?.databricksBaseUrl === "string" ? opts.databricksBaseUrl : undefined;
+        (typeof opts?.databricksBaseUrl === "string" ? opts.databricksBaseUrl : undefined) ??
+        process.env.DATABRICKS_BASE_URL;
 
       // Prompt for a valid base URL.  If the CLI-provided value normalizes to empty
       // (e.g. whitespace-only), the user is asked to re-enter so the config is never
@@ -358,6 +359,7 @@ export default definePluginEntry({
         normalizeDatabricksBaseUrl(
           typeof opts?.databricksBaseUrl === "string" ? opts.databricksBaseUrl : undefined,
         ) ??
+        normalizeDatabricksBaseUrl(process.env.DATABRICKS_BASE_URL) ??
         // Fallback to an already-configured base URL so key-rotation/automation flows
         // that omit --databricks-base-url still succeed when the URL is persisted.
         normalizeDatabricksBaseUrl(typeof savedBaseUrl === "string" ? savedBaseUrl : undefined);
@@ -406,15 +408,16 @@ export default definePluginEntry({
           }
 
           const providerConfig = ctx.config.models?.providers?.[PROVIDER_ID];
-          const baseUrl =
-            typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl : undefined;
+          const baseUrl = normalizeDatabricksBaseUrl(
+            typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl : undefined,
+          );
           if (!baseUrl) {
             return null;
           }
 
           try {
             const { response: res, release } = await fetchWithSsrFGuard({
-              url: `${baseUrl.replace(/\/+$/, "")}/api/2.0/serving-endpoints`,
+              url: `${baseUrl}/api/2.0/serving-endpoints`,
               init: {
                 headers: {
                   Authorization: `Bearer ${auth.apiKey}`,

--- a/extensions/databricks/index.ts
+++ b/extensions/databricks/index.ts
@@ -45,6 +45,30 @@ interface AssistantContentBlock {
   arguments?: unknown;
 }
 
+/**
+ * Flatten content to a plain text string for Databricks/OpenAI wire format.
+ * Handles plain strings, block arrays (filtering for text-type blocks), and
+ * unknown shapes by falling back to empty string.
+ */
+function extractTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return (content as Array<{ type?: string; text?: string }>)
+    .filter(
+      (part): part is { type: string; text: string } =>
+        typeof part === "object" &&
+        part !== null &&
+        part.type === "text" &&
+        typeof part.text === "string",
+    )
+    .map((part) => part.text)
+    .join("");
+}
+
 function mapDatabricksMessages(context: {
   messages: unknown[];
   systemPrompt?: string;
@@ -188,9 +212,18 @@ function mapDatabricksMessages(context: {
       continue;
     }
 
+    // For tool-result messages, flatten content block arrays to a text string
+    // so the outbound payload matches the OpenAI/Databricks text-only expectation.
+    let content: string | null;
+    if (role === "tool") {
+      content = extractTextContent(msg.content);
+    } else {
+      content = typeof msg.content === "string" ? msg.content : null;
+    }
+
     result.push({
       role,
-      content: msg.content as string | unknown[],
+      content,
       ...(msg.toolCallId ? { tool_call_id: msg.toolCallId } : {}),
       ...(msg.name ? { name: msg.name } : {}),
     });
@@ -307,9 +340,20 @@ export default definePluginEntry({
     const originalRunNonInteractive = defaultAuth.runNonInteractive;
     defaultAuth.runNonInteractive = async (ctx) => {
       const opts = ctx.opts as Record<string, unknown> | undefined;
-      const baseUrl = normalizeDatabricksBaseUrl(
-        typeof opts?.databricksBaseUrl === "string" ? opts.databricksBaseUrl : undefined,
-      );
+      const configProviders = (
+        ctx.config as Record<string, unknown> & {
+          models?: { providers?: Record<string, { baseUrl?: string }> };
+        }
+      ).models?.providers;
+      const savedBaseUrl = configProviders?.[PROVIDER_ID]?.baseUrl;
+
+      const baseUrl =
+        normalizeDatabricksBaseUrl(
+          typeof opts?.databricksBaseUrl === "string" ? opts.databricksBaseUrl : undefined,
+        ) ??
+        // Fallback to an already-configured base URL so key-rotation/automation flows
+        // that omit --databricks-base-url still succeed when the URL is persisted.
+        normalizeDatabricksBaseUrl(typeof savedBaseUrl === "string" ? savedBaseUrl : undefined);
 
       // Reject incomplete non-interactive setup: baseUrl is required for Databricks to work.
       // Failing early here prevents an invalid config from being saved and deferring the
@@ -511,16 +555,12 @@ export default definePluginEntry({
 
                 const decoder = new TextDecoder();
                 let buffer = "";
-                let doneSent = false;
 
                 const toolCallIndexMap = new Map<number, number>();
 
-                while (true) {
+                outerLoop: while (true) {
                   const { done, value } = await reader.read();
-                  if (done || doneSent) {
-                    if (doneSent) {
-                      await reader.cancel().catch(() => {});
-                    }
+                  if (done) {
                     break;
                   }
 
@@ -535,16 +575,24 @@ export default definePluginEntry({
                     }
                     const data = trimmed.slice(6);
                     if (data === "[DONE]") {
-                      doneSent = true;
-                      break;
+                      await reader.cancel().catch(() => {});
+                      break outerLoop;
                     }
 
-                    const json = JSON.parse(data);
-                    const choice = json.choices?.[0];
-                    const delta = choice?.delta;
+                    let json: Record<string, unknown>;
+                    try {
+                      json = JSON.parse(data);
+                    } catch {
+                      continue;
+                    }
+                    const choice = (
+                      json.choices as Array<Record<string, unknown>> | undefined
+                    )?.[0];
+                    const delta = choice?.delta as Record<string, unknown> | undefined;
                     const blockIndex = () => (output.content as Array<unknown>).length - 1;
 
                     if (delta?.content) {
+                      const deltaContent = delta.content as string;
                       const contentList = output.content as Array<{ type: string; text: string }>;
                       if (
                         contentList.length === 0 ||
@@ -558,17 +606,21 @@ export default definePluginEntry({
                         });
                       }
                       const textBlock = contentList[contentList.length - 1] as { text: string };
-                      textBlock.text += delta.content;
+                      textBlock.text += deltaContent;
                       stream.push({
                         type: "text_delta",
                         contentIndex: blockIndex(),
-                        delta: delta.content,
+                        delta: deltaContent,
                         partial: output,
                       });
                     }
 
                     if (delta?.tool_calls) {
-                      for (const toolCall of delta.tool_calls) {
+                      for (const toolCall of delta.tool_calls as Array<{
+                        index?: number;
+                        id?: string;
+                        function?: { name?: string; arguments?: string };
+                      }>) {
                         const contentList = output.content as Array<Record<string, unknown>>;
                         const sseIndex = typeof toolCall.index === "number" ? toolCall.index : 0;
 
@@ -609,14 +661,15 @@ export default definePluginEntry({
                     }
 
                     if (json.usage) {
+                      const jsonUsage = json.usage as Record<string, number>;
                       const usage = output.usage as Record<string, number>;
-                      usage.input = json.usage.prompt_tokens;
-                      usage.output = json.usage.completion_tokens;
-                      usage.totalTokens = json.usage.total_tokens;
+                      usage.input = jsonUsage.prompt_tokens;
+                      usage.output = jsonUsage.completion_tokens;
+                      usage.totalTokens = jsonUsage.total_tokens;
                     }
 
                     if (choice?.finish_reason) {
-                      output.stopReason = mapDatabricksStopReason(choice.finish_reason);
+                      output.stopReason = mapDatabricksStopReason(choice.finish_reason as string);
                     }
                   }
                 }

--- a/extensions/databricks/index.ts
+++ b/extensions/databricks/index.ts
@@ -116,8 +116,14 @@ function mapDatabricksMessages(context: {
         continue;
       }
 
-      // Strip thinking/redacted blocks from assistant content; retain text and toolCall blocks
-      const rawContent = Array.isArray(msg.content) ? msg.content : [];
+      // Strip thinking/redacted blocks from assistant content; retain text and toolCall blocks.
+      // When content is a plain string (common in older transcripts / some provider paths),
+      // wrap it in a synthetic text block so it survives the block-level filtering below.
+      const rawContent = Array.isArray(msg.content)
+        ? msg.content
+        : typeof msg.content === "string" && msg.content
+          ? [{ type: "text", text: msg.content }]
+          : [];
       const strippedContent: AssistantContentBlock[] = [];
       const newToolCalls: Array<{ id: string; name: string }> = [];
 

--- a/extensions/databricks/index.ts
+++ b/extensions/databricks/index.ts
@@ -212,14 +212,11 @@ function mapDatabricksMessages(context: {
       continue;
     }
 
-    // For tool-result messages, flatten content block arrays to a text string
-    // so the outbound payload matches the OpenAI/Databricks text-only expectation.
-    let content: string | null;
-    if (role === "tool") {
-      content = extractTextContent(msg.content);
-    } else {
-      content = typeof msg.content === "string" ? msg.content : null;
-    }
+    // Flatten content block arrays to a text string for all non-assistant roles
+    // (user, system, tool) so the outbound payload matches the OpenAI/Databricks
+    // text-only expectation. Block-array user messages (e.g. replayed sessions
+    // stored as [{type:"text",text:"..."}]) would otherwise be sent as null.
+    const content = extractTextContent(msg.content) || null;
 
     result.push({
       role,

--- a/extensions/databricks/onboard.ts
+++ b/extensions/databricks/onboard.ts
@@ -8,7 +8,12 @@ export function normalizeDatabricksBaseUrl(url: string | undefined): string | un
   if (!normalized) {
     return undefined;
   }
-  if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+  // Reject http:// — Databricks requests carry bearer tokens in Authorization
+  // headers, so cleartext transport would expose credentials.
+  if (normalized.startsWith("http://")) {
+    return undefined;
+  }
+  if (!normalized.startsWith("https://")) {
     normalized = `https://${normalized}`;
   }
   return normalized.replace(/\/+$/, "");

--- a/extensions/databricks/onboard.ts
+++ b/extensions/databricks/onboard.ts
@@ -1,0 +1,15 @@
+export const DATABRICKS_DEFAULT_MODEL_REF = "databricks/databricks-meta-llama-3-1-70b-instruct";
+
+export function normalizeDatabricksBaseUrl(url: string | undefined): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+  let normalized = url.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+    normalized = `https://${normalized}`;
+  }
+  return normalized.replace(/\/+$/, "");
+}

--- a/extensions/databricks/openclaw.plugin.json
+++ b/extensions/databricks/openclaw.plugin.json
@@ -1,0 +1,45 @@
+{
+  "id": "databricks",
+  "enabledByDefault": true,
+  "providers": ["databricks"],
+  "providerAuthEnvVars": {
+    "databricks": ["DATABRICKS_API_KEY", "DATABRICKS_TOKEN"]
+  },
+  "providerAuthChoices": [
+    {
+      "provider": "databricks",
+      "method": "api-key",
+      "choiceId": "databricks-api-key",
+      "choiceLabel": "Databricks API key",
+      "groupId": "databricks",
+      "groupLabel": "Databricks",
+      "groupHint": "Databricks Serving token",
+      "optionKey": "databricksApiKey",
+      "cliFlag": "--databricks-api-key",
+      "cliOption": "--databricks-api-key <key>",
+      "cliDescription": "Databricks API key"
+    },
+    {
+      "provider": "databricks",
+      "method": "api-key",
+      "choiceId": "databricks-base-url",
+      "assistantVisibility": "manual-only",
+      "optionKey": "databricksBaseUrl",
+      "cliFlag": "--databricks-base-url",
+      "cliOption": "--databricks-base-url <url>",
+      "cliDescription": "Databricks Workspace Base URL"
+    }
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "baseUrl": {
+        "type": "string"
+      }
+    }
+  },
+  "install": {
+    "npmSpec": "@openclaw/databricks"
+  }
+}

--- a/extensions/databricks/openclaw.plugin.json
+++ b/extensions/databricks/openclaw.plugin.json
@@ -18,16 +18,6 @@
       "cliFlag": "--databricks-api-key",
       "cliOption": "--databricks-api-key <key>",
       "cliDescription": "Databricks API key"
-    },
-    {
-      "provider": "databricks",
-      "method": "api-key",
-      "choiceId": "databricks-base-url",
-      "assistantVisibility": "manual-only",
-      "optionKey": "databricksBaseUrl",
-      "cliFlag": "--databricks-base-url",
-      "cliOption": "--databricks-base-url <url>",
-      "cliDescription": "Databricks Workspace Base URL"
     }
   ],
   "configSchema": {

--- a/extensions/databricks/package.json
+++ b/extensions/databricks/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@openclaw/databricks",
+  "version": "2026.4.7",
+  "private": true,
+  "description": "OpenClaw Databricks provider plugin",
+  "type": "module",
+  "dependencies": {
+    "@mariozechner/pi-ai": "0.66.1"
+  },
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,6 +459,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/databricks:
+    dependencies:
+      '@mariozechner/pi-ai':
+        specifier: 0.66.1
+        version: 0.66.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/deepgram:
     devDependencies:
       '@openclaw/plugin-sdk':


### PR DESCRIPTION
Address architectural feedback from the previous PR #62230.

## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem**: OpenClaw lacked native support for Databricks Serving Models. Interacting with Databricks APIs via standard OpenAI proxy setups failed because Databricks requires strict and completely different request URL routing (`/serving-endpoints/<model>/invocations`), and rigidly rejects extraneous parameters (e.g., `store`, `service_tier`) that standard OpenAI completions send.
- **Why it matters**: Databricks users need a seamless, code-free onboarding experience directly through the `openclaw onboarding` CLI to easily map their deployed endpoints and securely use their active workspace directly.
- **What changed**:
  - Implemented a native `databricks` bundled provider plugin using `openclaw/plugin-sdk`.
  - Added dynamic model parsing logic in `catalog.run` that automatically lists active REST endpoints from the workspace's `/api/2.0/serving-endpoints` (filtering for `EXTERNAL_MODEL` and chat endpoints).
  - Used `wrapStreamFn` to dynamically intercept and rewrite internal routing URLs to `<baseUrl>/serving-endpoints/<model>/invocations`, ensuring compatibility with Databricks without touching the core orchestration logic.
  - Added automated payload sanitization to discard Databricks-intolerant OpenAI payload parameters.
- **What did NOT change (scope boundary)**: The core OpenClaw streaming, gateway protocol, and global orchestration loops were untouched. All behavior changes were confined internally to the new Databricks plugin boundary (`extensions/databricks/*`).

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A (This is a net-new plugin)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: N/A
- Why this is the smallest reliable guardrail: N/A
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: General plugin boundaries are fully covered by `plugin-entry-guardrails.test.ts`.

## User-visible / Behavior Changes

- **CLI Setup**: The `openclaw onboarding` command will now prompt users for both their Databricks API Key and their Databricks Workspace Base URL (`--databricks-base-url`).
- **Endpoint Listing**: Users will implicitly see their live Databricks Serving endpoints exposed properly in the model picker UI and system commands.

## Diagram (if applicable)

```text
Before:
[User Configures Proxy] -> [OpenClaw] -> [400 Bad Request (store key rejected) / 404 URL Not Found]

After:
[openclaw onboarding] -> [Databricks Base URL + Token provided]
-> [OpenClaw Catalog Fetches Live Endpoints from /api/2.0/serving-endpoints]
-> [OpenClaw Stream Request] -> [Plugin URL Rewriter & Payload Sanitizer] -> [Valid Databricks /invocations Call]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes`
- New/changed network calls? `Yes`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:
  - **Secrets**: Databricks API tokens are safely ingested utilizing the pre-existing, hardened `createProviderApiKeyAuthMethod` from the core Plugin SDK, keeping secrets compliant with existing OpenClaw Vault and environment hierarchies.
  - **Network calls**: We now send an outbound `GET /api/2.0/serving-endpoints` request on initialization (if the key is provided) to build the model catalog. This correctly passes standard TLS inspection out of the box because it inherits OpenClaw’s standard fetch environment parameters.

## Repro + Verification

### Environment

- OS: Windows 11 / macOS / Linux
- Runtime/container: local Node.js
- Model/provider: Databricks
- Integration/channel (if any): Local Gateway
- Relevant config (redacted): N/A

### Steps

1. Run `openclaw onboarding`
2. Select Databricks provider
3. Insert Databricks Workspace base URL (`https://dbc-xxxx.cloud.databricks.com`) and Valid Serving Token
4. Trigger a generic question message to OpenClaw.

### Expected

- The model catalog correctly lists dynamic endpoints mapped on the Databricks Workspace.
- Invoking the endpoint receives a successful 200 response via standard chat completions, completely bypassing the legacy 400 Bad Request error.

### Actual

- Catalog parses REST dynamically. Model queries complete successfully.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Databricks credential ingestion wizard successfully stores both `databricksApiKey` and `baseUrl` properly partitioned under `models.providers.databricks`.
- Edge cases checked: Discarded unsupported OpenClaw payload headers (`store`, `background`). Checked missing trailing slash appending logic on the Base URL regex so requests wouldn't result in `//api/2.0...` failures.
- What you did **not** verify: Databricks Foundation Model tool-calling with edge-case parameter definitions (due to the scope of this implementation being restricted to making text-completions functionally operational).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` (added `--databricks-base-url`)
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The dynamic REST API fetching could silently fail if the configured Workspace has extremely aggressive Firewalling implementations blocking API discovery paths.
  - Mitigation: The fetching step handles internal REST exceptions gracefully and safely returns `null` instead of panicking or stalling the gateway. OpenClaw just seamlessly ignores registering the sub-catalog.