### PR TITLE
fix: flush debounced messages before closing WhatsApp socket

### DIFF
--- a/extensions/bluebubbles/src/monitor-debounce.ts
+++ b/extensions/bluebubbles/src/monitor-debounce.ts
@@ -32,6 +32,7 @@ function sanitizeDebounceEntry(entry: BlueBubblesDebounceEntry): BlueBubblesDebo
 export type BlueBubblesDebouncer = {
   enqueue: (item: BlueBubblesDebounceEntry) => Promise<void>;
   flushKey: (key: string) => Promise<void>;
+  flushAll: () => Promise<void>;
 };
 
 export type BlueBubblesDebounceRegistry = {
@@ -218,6 +219,7 @@ export function createBlueBubblesDebounceRegistry(params: {
           await baseDebouncer.enqueue(sanitizeDebounceEntry(item));
         },
         flushKey: (key) => baseDebouncer.flushKey(key),
+        flushAll: () => baseDebouncer.flushAll(),
       };
 
       targetDebouncers.set(target, debouncer);

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -206,6 +206,7 @@ function installTimingAwareInboundDebouncer(core: PluginRuntime) {
       flushKey: vi.fn(async (key: string) => {
         await flush(key);
       }),
+      flushAll: vi.fn(async () => {}),
     };
   }) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
 }

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -678,6 +678,7 @@ describe("Feishu inbound debounce regressions", () => {
             params.onError?.(new Error("dispatch failed"), [item]);
           },
           flushKey: async () => {},
+          flushAll: async () => {},
         }),
       }),
     );

--- a/extensions/feishu/src/monitor.test-mocks.ts
+++ b/extensions/feishu/src/monitor.test-mocks.ts
@@ -18,6 +18,7 @@ export function createFeishuRuntimeMockModule(): {
         createInboundDebouncer: () => {
           enqueue: () => Promise<void>;
           flushKey: () => Promise<void>;
+          flushAll: () => Promise<void>;
         };
       };
       text: {
@@ -34,6 +35,7 @@ export function createFeishuRuntimeMockModule(): {
           createInboundDebouncer: () => ({
             enqueue: async () => {},
             flushKey: async () => {},
+            flushAll: async () => {},
           }),
         },
         text: {

--- a/extensions/feishu/src/test-support/lifecycle-test-support.ts
+++ b/extensions/feishu/src/test-support/lifecycle-test-support.ts
@@ -86,6 +86,7 @@ export function createImmediateInboundDebounce() {
         }
       },
       flushKey: async () => {},
+      flushAll: async () => {},
     }),
   };
 }

--- a/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
+++ b/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../../../src/channels/inbound-debounce-policy.js", () => ({
         await params.onFlush([entry]);
       },
       flushKey: async (_key: string) => {},
+      flushAll: async () => {},
     },
   }),
 }));

--- a/extensions/slack/src/monitor/message-handler.test.ts
+++ b/extensions/slack/src/monitor/message-handler.test.ts
@@ -18,6 +18,7 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
       debouncer: {
         enqueue: (entry: unknown) => enqueueMock(entry),
         flushKey: (key: string) => flushKeyMock(key),
+        flushAll: async () => {},
       },
     }),
     shouldDebounceTextInbound: ({ hasMedia }: { hasMedia?: boolean }) => !hasMedia,

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -559,8 +559,8 @@ export async function monitorWebInbox(options: {
     close: async () => {
       try {
         detachMessagesUpsert();
-        await debouncer.flushAll();
         detachConnectionUpdate();
+        await debouncer.flushAll();
         closeInboundMonitorSocket(sock);
       } catch (err) {
         logVerbose(`Socket close failed: ${String(err)}`);

--- a/extensions/whatsapp/src/inbound/monitor.ts
+++ b/extensions/whatsapp/src/inbound/monitor.ts
@@ -559,6 +559,7 @@ export async function monitorWebInbox(options: {
     close: async () => {
       try {
         detachMessagesUpsert();
+        await debouncer.flushAll();
         detachConnectionUpdate();
         closeInboundMonitorSocket(sock);
       } catch (err) {

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -231,5 +231,12 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     scheduleFlush(key, buffer);
   };
 
-  return { enqueue, flushKey };
+  const flushAll = async () => {
+    const keys = Array.from(buffers.keys());
+    for (const key of keys) {
+      await flushKey(key);
+    }
+  };
+
+  return { enqueue, flushKey, flushAll };
 }

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -233,9 +233,7 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
 
   const flushAll = async () => {
     const keys = Array.from(buffers.keys());
-    for (const key of keys) {
-      await flushKey(key);
-    }
+    await Promise.all(keys.map((key) => flushKey(key)));
   };
 
   return { enqueue, flushKey, flushAll };

--- a/test/helpers/plugins/plugin-runtime-mock.ts
+++ b/test/helpers/plugins/plugin-runtime-mock.ts
@@ -324,6 +324,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
               await params.onFlush([item]);
             },
             flushKey: vi.fn(),
+            flushAll: vi.fn(),
           }),
         ) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"],
         resolveInboundDebounceMs: vi.fn(


### PR DESCRIPTION
## Problem

When the WhatsApp connection closes (disconnect, watchdog timeout, or graceful shutdown), messages sitting in the inbound debounce window are silently dropped. This happens because:

1. The socket is closed immediately in the `close()` handler
2. Pending debounce timers fire after the socket is already dead
3. Reply callbacks (`msg.reply`, `msg.sendMedia`) fail silently on the closed socket

This affects deployments with `messages.inbound.debounceMs > 0` configured — rapid consecutive messages from the same sender may be lost during connection transitions.

## Fix

**`src/auto-reply/inbound-debounce.ts`**: Add a `flushAll()` method that iterates all buffered keys and flushes them using the existing `flushKey()` logic (which properly clears timers, releases keyed execution slots, and calls `onFlush`).

**`extensions/whatsapp/src/inbound/monitor.ts`**: Call `debouncer.flushAll()` in the `close()` handler, sequenced between:
- `detachMessagesUpsert()` — stop accepting new messages
- `debouncer.flushAll()` — process buffered messages while socket is still alive
- `closeInboundMonitorSocket(sock)` — close the socket

This ordering ensures buffered messages are processed and replies sent before the socket is torn down.

## Testing

- Existing debouncer tests (1019 lines in `inbound.test.ts`) cover `flushKey` behavior
- `flushAll` delegates to `flushKey` per-key, inheriting the same guarantees