### PR TITLE
fix(agents): initialize hook runner for runtime loads #63018

### DIFF
--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -2,10 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   resolveRuntimePluginRegistry: vi.fn(),
+  getGlobalHookRunner: vi.fn(),
+  initializeGlobalHookRunner: vi.fn(),
 }));
 
 vi.mock("../plugins/loader.js", () => ({
   resolveRuntimePluginRegistry: hoisted.resolveRuntimePluginRegistry,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: hoisted.getGlobalHookRunner,
+  initializeGlobalHookRunner: hoisted.initializeGlobalHookRunner,
 }));
 
 describe("ensureRuntimePluginsLoaded", () => {
@@ -14,6 +21,9 @@ describe("ensureRuntimePluginsLoaded", () => {
   beforeEach(async () => {
     hoisted.resolveRuntimePluginRegistry.mockReset();
     hoisted.resolveRuntimePluginRegistry.mockReturnValue(undefined);
+    hoisted.getGlobalHookRunner.mockReset();
+    hoisted.getGlobalHookRunner.mockReturnValue(null);
+    hoisted.initializeGlobalHookRunner.mockReset();
     vi.resetModules();
     ({ ensureRuntimePluginsLoaded } = await import("./runtime-plugins.js"));
   });
@@ -28,6 +38,7 @@ describe("ensureRuntimePluginsLoaded", () => {
     });
 
     expect(hoisted.resolveRuntimePluginRegistry).toHaveBeenCalledTimes(1);
+    expect(hoisted.initializeGlobalHookRunner).toHaveBeenCalledTimes(1);
   });
 
   it("resolves runtime plugins through the shared runtime helper", async () => {
@@ -44,5 +55,30 @@ describe("ensureRuntimePluginsLoaded", () => {
         allowGatewaySubagentBinding: true,
       },
     });
+  });
+
+  it("initializes the global hook runner when a registry is returned", async () => {
+    const registry = {} as never;
+    hoisted.resolveRuntimePluginRegistry.mockReturnValue(registry);
+    hoisted.getGlobalHookRunner.mockReturnValue(null);
+
+    ensureRuntimePluginsLoaded({
+      config: {} as never,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(hoisted.initializeGlobalHookRunner).toHaveBeenCalledWith(registry);
+  });
+
+  it("does not reinitialize the hook runner when one already exists", async () => {
+    hoisted.resolveRuntimePluginRegistry.mockReturnValue({} as never);
+    hoisted.getGlobalHookRunner.mockReturnValue({} as never);
+
+    ensureRuntimePluginsLoaded({
+      config: {} as never,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(hoisted.initializeGlobalHookRunner).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import { getGlobalHookRunner, initializeGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { resolveRuntimePluginRegistry } from "../plugins/loader.js";
 import { resolveUserPath } from "../utils.js";
 
@@ -20,5 +21,11 @@ export function ensureRuntimePluginsLoaded(params: {
         }
       : undefined,
   };
-  resolveRuntimePluginRegistry(loadOptions);
+  const registry = resolveRuntimePluginRegistry(loadOptions);
+  if (registry && !getGlobalHookRunner()) {
+    // Runtime/plugin helper callers can load a compatible registry snapshot without
+    // activating the global hook runner (for example in embedded-runner-only flows).
+    // Ensure hooks like agent_end are available once a registry exists.
+    initializeGlobalHookRunner(registry);
+  }
 }


### PR DESCRIPTION
## Summary

- Problem: Feishu webhook / embedded-runner flows can load a runtime plugin registry without activating the global hook runner, so lifecycle hooks like `agent_end` may never fire.
- Why it matters: Memory and session plugins that depend on `agent_end` (and related lifecycle phases) miss end-of-turn notifications on Feishu, causing silent feature gaps.
- What changed: When `ensureRuntimePluginsLoaded(...)` returns a registry and there is no global hook runner yet, initialize it so `agent_end` and other hooks are available.
- What did NOT change (scope boundary): No Feishu-specific pipeline changes; no new hook types; no changes to hook payload schemas.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #63018

## User-visible / Behavior Changes

Feishu (and other embedded-runner runtime flows) will now reliably trigger `agent_end` hooks once a runtime plugin registry is loaded, enabling memory/session plugins that rely on end-of-turn lifecycle.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node (repo default)
- Integration/channel (if any): Feishu (webhook / embedded-runner paths)
- Relevant config (redacted): N/A

### Steps

1. Ensure runtime plugins are loaded via `ensureRuntimePluginsLoaded(...)`.
2. Run an embedded agent turn that expects `agent_end` hooks to be available.
3. Observe `agent_end` hook handlers firing after the turn completes.

### Expected

- `agent_end` hooks run when a runtime plugin registry exists.

### Actual (before)

- Some runtime/embedded-runner flows had a registry but no global hook runner, so `agent_end` hooks were skipped.

## Evidence

- [x] Passing test: `pnpm test src/agents/runtime-plugins.test.ts`

## Human Verification (required)

- Verified scenarios: unit-level behavior that hook runner initializes when a registry is returned and no runner exists; no re-init when runner already exists.
- Edge cases checked: runner already initialized; registry missing/undefined.
- What you did **not** verify: end-to-end Feishu webhook integration run (requires external Feishu setup).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the commit touching `src/agents/runtime-plugins.ts`.
- Known bad symptoms reviewers should watch for: unexpected hook runner initialization timing in unusual test harnesses.

## Risks and Mitigations

- Risk: initializing the global hook runner earlier than before in some runtime-only processes.
  - Mitigation: only initializes when a registry is successfully returned and no runner exists; includes unit coverage for both branches.