### PR TITLE
fix(anthropic): replace `|| 1024` fallback with safe `budget_tokens` guard

### DIFF
--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -526,10 +526,19 @@ function buildAnthropicParams(
           params.output_config = { effort: options.effort };
         }
       } else {
-        params.thinking = {
-          type: "enabled",
-          budget_tokens: options.thinkingBudgetTokens || 1024,
-        };
+        // Use nullish coalescing so an explicit 0 budget (produced by
+        // adjustMaxTokensForThinking when the token envelope is too small)
+        // is not coerced to 1024 by the falsy || operator.
+        // When the resolved budget is 0 the API would reject budget_tokens:0
+        // with a 400, so we skip the thinking block entirely — thinking
+        // cannot be meaningfully enabled in this token envelope.
+        const budgetTokens = options.thinkingBudgetTokens ?? 1024;
+        if (budgetTokens > 0) {
+          params.thinking = {
+            type: "enabled",
+            budget_tokens: budgetTokens,
+          };
+        }
       }
     } else if (options?.thinkingEnabled === false) {
       params.thinking = { type: "disabled" };


### PR DESCRIPTION
## Problem — issue #63016

In `buildAnthropicParams` (`src/agents/anthropic-transport-stream.ts`), the legacy budget-based thinking block was built with:

```ts
params.thinking = {
  type: "enabled",
  budget_tokens: options.thinkingBudgetTokens || 1024,
};
```

The `||` operator coerces **any falsy value** — including the legitimate `0` produced by `adjustMaxTokensForThinking` when `maxTokens` is too small — to `1024`. This silently activates deprecated `type: "enabled"` thinking with a non-zero budget on every API call, even trivial ones (file reads, short messages), wasting tokens and bypassing user intent.

A secondary problem: when `adjustMaxTokensForThinking` returns `thinkingBudget: 0`, sending `budget_tokens: 0` to the Anthropic API results in a HTTP 400 error.

## Fix

Two-line change in `buildAnthropicParams`:

```ts
// Before
params.thinking = {
  type: "enabled",
  budget_tokens: options.thinkingBudgetTokens || 1024,
};

// After
const budgetTokens = options.thinkingBudgetTokens ?? 1024;
if (budgetTokens > 0) {
  params.thinking = {
    type: "enabled",
    budget_tokens: budgetTokens,
  };
}
```

1. **`?? 1024`** — nullish coalescing preserves an explicit `0` instead of coercing it to `1024`.
2. **`if (budgetTokens > 0)`** — when the token envelope is too small for thinking (budget = 0), the `thinking` block is omitted entirely rather than sending an API-rejecting `budget_tokens: 0`.

All well-formed thinking configurations (explicit positive budgets, resolved non-zero budgets) are unaffected.