### PR TITLE
CLI: align profile state dir with OPENCLAW_HOME

### DIFF
--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -123,7 +123,7 @@ describe("applyCliProfileEnv", () => {
     expect(env.OPENCLAW_CONFIG_PATH).toBe(path.join("/custom", "openclaw.json"));
   });
 
-  it("uses OPENCLAW_HOME when deriving profile state dir", () => {
+  it("skips profile suffix under OPENCLAW_HOME for daemon/CLI path parity", () => {
     const env: Record<string, string | undefined> = {
       OPENCLAW_HOME: "/srv/openclaw-home",
       HOME: "/home/other",
@@ -135,10 +135,9 @@ describe("applyCliProfileEnv", () => {
     });
 
     const resolvedHome = path.resolve("/srv/openclaw-home");
-    expect(env.OPENCLAW_STATE_DIR).toBe(path.join(resolvedHome, ".openclaw-work"));
-    expect(env.OPENCLAW_CONFIG_PATH).toBe(
-      path.join(resolvedHome, ".openclaw-work", "openclaw.json"),
-    );
+    const stateDir = path.join(resolvedHome, ".openclaw");
+    expect(env.OPENCLAW_STATE_DIR).toBe(stateDir);
+    expect(env.OPENCLAW_CONFIG_PATH).toBe(path.join(stateDir, "openclaw.json"));
   });
 });
 

--- a/src/cli/profile.test.ts
+++ b/src/cli/profile.test.ts
@@ -139,6 +139,36 @@ describe("applyCliProfileEnv", () => {
     expect(env.OPENCLAW_STATE_DIR).toBe(stateDir);
     expect(env.OPENCLAW_CONFIG_PATH).toBe(path.join(stateDir, "openclaw.json"));
   });
+
+  it("skips profile suffix for dev profile under OPENCLAW_HOME, still sets dev port", () => {
+    const env: Record<string, string | undefined> = {
+      OPENCLAW_HOME: "/srv/openclaw-home",
+    };
+    applyCliProfileEnv({
+      profile: "dev",
+      env,
+      homedir: () => "/home/fallback",
+    });
+
+    const stateDir = path.join(path.resolve("/srv/openclaw-home"), ".openclaw");
+    expect(env.OPENCLAW_STATE_DIR).toBe(stateDir);
+    expect(env.OPENCLAW_GATEWAY_PORT).toBe("19001");
+  });
+
+  it("does not skip profile suffix when OPENCLAW_HOME is a string sentinel", () => {
+    const env: Record<string, string | undefined> = {
+      OPENCLAW_HOME: "undefined",
+      HOME: "/home/other",
+    };
+    applyCliProfileEnv({
+      profile: "work",
+      env,
+      homedir: () => "/home/fallback",
+    });
+
+    const stateDir = path.join(path.resolve("/home/other"), ".openclaw-work");
+    expect(env.OPENCLAW_STATE_DIR).toBe(stateDir);
+  });
 });
 
 describe("formatCliCommand", () => {

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -87,6 +87,13 @@ function resolveProfileStateDir(
   env: Record<string, string | undefined>,
   homedir: () => string,
 ): string {
+  // When OPENCLAW_HOME is explicitly set, the user has already established physical
+  // isolation at the root level. Appending a profile suffix would create a mismatch
+  // between the CLI path (<OPENCLAW_HOME>/.openclaw-<profile>) and the daemon path
+  // (<OPENCLAW_HOME>/.openclaw), so we skip the suffix in this case.
+  if (env.OPENCLAW_HOME?.trim()) {
+    return path.join(resolveRequiredHomeDir(env as NodeJS.ProcessEnv, homedir), ".openclaw");
+  }
   const suffix = normalizeLowercaseStringOrEmpty(profile) === "default" ? "" : `-${profile}`;
   return path.join(resolveRequiredHomeDir(env as NodeJS.ProcessEnv, homedir), `.openclaw${suffix}`);
 }

--- a/src/cli/profile.ts
+++ b/src/cli/profile.ts
@@ -1,7 +1,10 @@
 import os from "node:os";
 import path from "node:path";
 import { FLAG_TERMINATOR } from "../infra/cli-root-options.js";
-import { resolveRequiredHomeDir } from "../infra/home-dir.js";
+import {
+  isOpenClawHomeEnvExplicit,
+  resolveRequiredHomeDir,
+} from "../infra/home-dir.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -91,7 +94,7 @@ function resolveProfileStateDir(
   // isolation at the root level. Appending a profile suffix would create a mismatch
   // between the CLI path (<OPENCLAW_HOME>/.openclaw-<profile>) and the daemon path
   // (<OPENCLAW_HOME>/.openclaw), so we skip the suffix in this case.
-  if (env.OPENCLAW_HOME?.trim()) {
+  if (isOpenClawHomeEnvExplicit(env as NodeJS.ProcessEnv)) {
     return path.join(resolveRequiredHomeDir(env as NodeJS.ProcessEnv, homedir), ".openclaw");
   }
   const suffix = normalizeLowercaseStringOrEmpty(profile) === "default" ? "" : `-${profile}`;

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -65,6 +65,11 @@ function normalizeSafe(homedir: () => string): string | undefined {
   }
 }
 
+/** True when `OPENCLAW_HOME` is a non-empty, non-sentinel value (matches `resolveRawHomeDir` semantics). */
+export function isOpenClawHomeEnvExplicit(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(normalize(env.OPENCLAW_HOME));
+}
+
 export function resolveRequiredHomeDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,


### PR DESCRIPTION
### Problem
When both `OPENCLAW_HOME` (physical isolation) and `--profile` / `OPENCLAW_PROFILE` are used, the daemon resolves state under `$OPENCLAW_HOME/.openclaw`, but the CLI forced `$OPENCLAW_HOME/.openclaw-<profile>`, so CLI commands could not reach the running gateway.

### Change
In `resolveProfileStateDir`, skip appending the profile suffix when `OPENCLAW_HOME` is set, matching daemon path resolution.

### Tests
Updated `src/cli/profile.test.ts` to expect `.openclaw` (no profile suffix) when `OPENCLAW_HOME` is set.

Made with [Cursor](https://cursor.com)