### PR TITLE
fix: apply cache_control to conversation messages on OpenRouter path

### DIFF
--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyAnthropicEphemeralCacheControlMarkers,
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
@@ -223,5 +224,60 @@ describe("anthropic payload policy", () => {
         text: "Stable prefix\nDynamic lab suffix",
       },
     ]);
+  });
+});
+
+describe("applyAnthropicEphemeralCacheControlMarkers", () => {
+  it("marks the last user message with ephemeral cache_control", () => {
+    const payload = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+        { role: "user", content: [{ type: "text", text: "world" }] },
+      ],
+    };
+    applyAnthropicEphemeralCacheControlMarkers(payload);
+    const lastUser = payload.messages[2] as { content: Array<Record<string, unknown>> };
+    expect(lastUser.content[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  it("skips when the last message is assistant", () => {
+    const payload = {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+        { role: "assistant", content: [{ type: "text", text: "hi" }] },
+      ],
+    };
+    applyAnthropicEphemeralCacheControlMarkers(payload);
+    const lastAssistant = payload.messages[1] as { content: Array<Record<string, unknown>> };
+    expect(lastAssistant.content[0].cache_control).toBeUndefined();
+  });
+
+  it("marks system/developer content with ephemeral cache_control", () => {
+    const payload = {
+      messages: [
+        { role: "system", content: "you are helpful" },
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+      ],
+    };
+    applyAnthropicEphemeralCacheControlMarkers(payload);
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "you are helpful", cache_control: { type: "ephemeral" } },
+    ]);
+  });
+
+  it("strips cache_control from thinking blocks", () => {
+    const payload = {
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "thinking", text: "hmm", cache_control: { type: "ephemeral" } }],
+        },
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+      ],
+    };
+    applyAnthropicEphemeralCacheControlMarkers(payload);
+    const assistant = payload.messages[0] as { content: Array<Record<string, unknown>> };
+    expect(assistant.content[0].cache_control).toBeUndefined();
   });
 });

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -258,4 +258,5 @@ export function applyAnthropicEphemeralCacheControlMarkers(
       }
     }
   }
+  applyAnthropicCacheControlToMessages(messages, { type: "ephemeral" });
 }

--- a/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.openrouter-cache-control.test.ts
@@ -43,7 +43,9 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
     expect(payload.messages[0].content).toEqual([
       { type: "text", text: "You are a helpful assistant.", cache_control: { type: "ephemeral" } },
     ]);
-    expect(payload.messages[1].content).toBe("Hello");
+    expect(payload.messages[1].content).toEqual([
+      { type: "text", text: "Hello", cache_control: { type: "ephemeral" } },
+    ]);
   });
 
   it("adds cache_control to last content block when system message is already array", () => {
@@ -80,14 +82,16 @@ describe("extra-params: OpenRouter Anthropic cache_control", () => {
     expect(payload.messages[0].content).toBe("You are a helpful assistant.");
   });
 
-  it("leaves payload unchanged when no system message exists", () => {
+  it("marks last user message with ephemeral cache_control when no system message exists", () => {
     const payload = {
       messages: [{ role: "user", content: "Hello" }],
     };
 
     runOpenRouterPayload(payload, "anthropic/claude-opus-4-6");
 
-    expect(payload.messages[0].content).toBe("Hello");
+    expect(payload.messages[0].content).toEqual([
+      { type: "text", text: "Hello", cache_control: { type: "ephemeral" } },
+    ]);
   });
 
   it("does not inject cache_control into thinking blocks", () => {


### PR DESCRIPTION
## Summary

The OpenRouter code path (`applyAnthropicEphemeralCacheControlMarkers`) only applies `cache_control` markers to system/developer messages. Conversation messages (user/assistant) are never marked. This means on OpenRouter, only the system prompt is cached — the entire conversation history is re-sent uncached on every turn.

The direct Anthropic path (`applyAnthropicPayloadPolicyToParams`) correctly marks both system prompt AND the last user message via `applyAnthropicCacheControlToMessages`.

## Fix

One line added at the end of `applyAnthropicEphemeralCacheControlMarkers`:

```typescript
applyAnthropicCacheControlToMessages(messages, { type: "ephemeral" });
```

This reuses the existing function from the direct Anthropic path to mark the last user message with `cache_control: { type: "ephemeral" }`, enabling the full conversation prefix to be cached.

## Test Results

Before patch:
- Agent A (80K context): **14% cache hit rate**, $0.30/turn
- Agent B (170K context): **12% cache hit rate**, $0.90/turn

After patch:
- Agent A (80K context): **86% cache hit rate**, $0.03/turn
- **10× cost reduction** on OpenRouter fallback

## Impact

| Session Context | Pre-patch Cache | Post-patch Cache | Cost Reduction |
|----------------|----------------|-----------------|---------------|
| 80K (Agent A) | 14% | 86% | 10× |
| 170K (Agent B) | 12% | ~85% (estimated) | ~10× |
| 15K (subagent) | 70-89% | 70-89% (no change) | — |

Subagents were unaffected because system prompt dominates their total context. Main sessions with large conversation history benefit dramatically.

Fixes #63034