### PR TITLE
fix(webchat): deliver agent TTS audio from block payloads #63033

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -2819,6 +2819,35 @@ describe("dispatchReplyFromConfig", () => {
     expect(callOrder).toEqual(["queued:The answer is 42", "dispatch:The answer is 42"]);
   });
 
+  it("generates final-mode TTS after block streaming when final replies exist but none were delivered", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeFinalAudio = true;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+
+    // Simulate a final reply being produced, but the channel delivery refusing to queue it.
+    (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mockImplementation(() => false);
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({ text: "Hello from streaming blocks." });
+      // Non-empty replies array, but not delivered due to sendFinalReply=false above.
+      return { text: "" };
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
+
+    const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+    // First call: attempted to send the returned final reply (empty text).
+    // Second call: TTS-only synthetic payload (media only).
+    expect(finalCalls.length).toBeGreaterThanOrEqual(2);
+    const ttsOnlyPayload = finalCalls.at(-1)?.[0] as ReplyPayload | undefined;
+    expect(ttsOnlyPayload?.mediaUrl).toBe("https://example.com/tts-synth.opus");
+    expect(ttsOnlyPayload?.text).toBeUndefined();
+  });
+
   it("forwards payload metadata into onBlockReplyQueued context", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -980,15 +980,10 @@ export async function dispatchReplyFromConfig(params: {
     }
 
     const ttsMode = resolveConfiguredTtsMode(cfg);
-    // Generate TTS-only reply after block streaming completes (when there's no final reply).
+    // Generate TTS-only reply after block streaming completes (when there's no delivered final).
     // This handles the case where block streaming succeeds and drops final payloads,
     // but we still want TTS audio to be generated from the accumulated block content.
-    if (
-      ttsMode === "final" &&
-      replies.length === 0 &&
-      blockCount > 0 &&
-      accumulatedBlockText.trim()
-    ) {
+    if (ttsMode === "final" && !queuedFinal && blockCount > 0 && accumulatedBlockText.trim()) {
       try {
         const ttsSyntheticReply = await maybeApplyTtsToReplyPayload({
           payload: { text: accumulatedBlockText },

--- a/src/gateway/server-methods/chat-webchat-media.test.ts
+++ b/src/gateway/server-methods/chat-webchat-media.test.ts
@@ -36,6 +36,17 @@ describe("buildWebchatAudioContentBlocksFromReplyPayloads", () => {
     );
   });
 
+  it("embeds audio paths provided via mediaUrls arrays", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-webchat-audio-"));
+    const audioPath = path.join(tmpDir, "clip.mp3");
+    fs.writeFileSync(audioPath, Buffer.from([0x03]));
+
+    const blocks = buildWebchatAudioContentBlocksFromReplyPayloads([{ mediaUrls: [audioPath] }]);
+
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { type?: string }).type).toBe("audio");
+  });
+
   it("skips remote URLs", () => {
     const blocks = buildWebchatAudioContentBlocksFromReplyPayloads([
       { mediaUrl: "https://example.com/a.mp3" },

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1827,12 +1827,16 @@ export const chatHandlers: GatewayRequestHandlers = {
               const finalPayloads = deliveredReplies
                 .filter((entry) => entry.kind === "final")
                 .map((entry) => entry.payload);
+              const deliveredPayloads = deliveredReplies.map((entry) => entry.payload);
               const combinedReply = finalPayloads
                 .map((part) => part.text?.trim() ?? "")
                 .filter(Boolean)
                 .join("\n\n")
                 .trim();
-              const audioBlocks = buildWebchatAudioContentBlocksFromReplyPayloads(finalPayloads);
+              // Webchat transcript embedding should include local audio even when it arrived via
+              // streaming/tool block payloads (e.g. embedded pending tool media flushes).
+              const audioBlocks =
+                buildWebchatAudioContentBlocksFromReplyPayloads(deliveredPayloads);
               const assistantContent: Array<Record<string, unknown>> = [];
               if (combinedReply) {
                 assistantContent.push({ type: "text", text: combinedReply });


### PR DESCRIPTION
## Summary

- Problem: Agent-generated TTS audio could be produced on disk but never delivered to webchat when it arrived via `block` payloads (pending tool media flush / streaming paths).
- Why it matters: This fully breaks agent-initiated TTS delivery on webchat, while `/tts audio` continues to work.
- What changed:
  - Webchat post-processing now extracts embeddable local audio from all delivered reply payloads (block + final), while still aggregating text from final-only payloads.
  - The final-mode “accumulated block text → synthetic TTS” fallback now triggers based on whether a final reply was actually delivered, not whether the embedded run produced any final replies.
- What did NOT change (scope boundary):
  - No changes to TTS provider behavior or audio synthesis.
  - No change to text aggregation semantics (still final-only).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #63033

## User-visible / Behavior Changes

- Webchat now delivers agent-generated TTS audio even when the audio reference is emitted via streaming/tool block payloads.
- Final-mode TTS fallback after streaming is more reliable when no final reply was actually delivered.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: Debian/Linux
- Runtime/container: local repo test run
- Integration/channel: webchat (gateway post-processing)

### Steps

1. Have an embedded run emit TTS audio as a pending tool media flush (block-kind payload).
2. Observe webchat post-processing previously only extracted audio from final-kind payloads.
3. Confirm audio is now embedded/delivered in the final webchat message.

### Expected

- Audio is delivered to webchat consistently for agent-initiated TTS.

### Actual (before)

- Audio file exists, but webchat never embeds/delivers it.

## Evidence

- [x] Added/updated unit tests covering:
  - `mediaUrls` array audio embedding for webchat audio blocks
  - Final-mode synthetic TTS triggered after streaming when finals exist but none were delivered

## Human Verification (required)

- Verified scenarios:
  - Targeted tests passing:
    - `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts src/gateway/server-methods/chat-webchat-media.test.ts`
- Edge cases checked:
  - Keep text aggregation final-only while extracting audio from block+final payloads
- What I did **not** verify:
  - End-to-end web UI playback (relies on existing transcript/audio rendering)

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## Risks and Mitigations

- Risk: Duplicated audio embedding if both block and final include the same path.
  - Mitigation: `buildWebchatAudioContentBlocksFromReplyPayloads` already dedupes resolved paths.