### PR TITLE
fix(gateway): stabilize inter-session completion wake prompts

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -933,6 +933,66 @@ describe("gateway agent handler", () => {
     );
   });
 
+  it("does not add group chat context for channel completion wakes", async () => {
+    primeMainAgentRun();
+    mockMainSessionEntry({
+      chatType: "channel",
+      channel: "telegram",
+      subject: "Release Updates",
+      lastChannel: "discord",
+      lastTo: "channel:c3",
+      lastAccountId: "acct-1",
+      origin: {
+        provider: "telegram",
+        surface: "discord",
+        chatType: "channel",
+        to: "channel:c3",
+        accountId: "acct-1",
+      },
+    });
+    mocks.agentCommand.mockClear();
+
+    await invokeAgent({
+      message: "child finished",
+      sessionKey: "agent:main:main",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:main:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "fix the cache bug",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Patched and tested.",
+          replyInstruction: "Reply in your normal assistant voice now.",
+        },
+      ],
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:subagent:child",
+        sourceChannel: "internal",
+        sourceTool: "subagent_announce",
+      },
+      idempotencyKey: "inter-session-context-channel",
+    });
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      extraSystemPrompt?: string;
+    };
+    expect(callArgs.extraSystemPrompt).toContain("## Inbound Context (trusted metadata)");
+    expect(callArgs.extraSystemPrompt).toContain('"chat_type": "channel"');
+    expect(callArgs.extraSystemPrompt).toContain('"provider": "discord"');
+    expect(callArgs.extraSystemPrompt).not.toContain(
+      'You are in the Discord group chat "Release Updates".',
+    );
+    expect(callArgs.extraSystemPrompt).not.toContain(
+      "Your replies are automatically sent to this group chat.",
+    );
+  });
+
   it("keeps explicit extraSystemPrompt on inter-session completion wakes", async () => {
     primeMainAgentRun();
     mockMainSessionEntry({

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -873,6 +873,111 @@ describe("gateway agent handler", () => {
     expect(findTaskByRunId("music-generation-event-inter-session")).toBeUndefined();
   });
 
+  it("rebuilds persisted session context for inter-session completion wakes", async () => {
+    primeMainAgentRun();
+    mockMainSessionEntry({
+      chatType: "group",
+      channel: "discord",
+      subject: "Release Squad",
+      lastChannel: "discord",
+      lastTo: "channel:c3",
+      lastAccountId: "acct-1",
+      origin: {
+        provider: "discord",
+        surface: "discord",
+        chatType: "group",
+        to: "channel:c3",
+        accountId: "acct-1",
+      },
+    });
+    mocks.agentCommand.mockClear();
+
+    await invokeAgent({
+      message: "child finished",
+      sessionKey: "agent:main:main",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:main:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "fix the cache bug",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Patched and tested.",
+          replyInstruction: "Reply in your normal assistant voice now.",
+        },
+      ],
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:subagent:child",
+        sourceChannel: "internal",
+        sourceTool: "subagent_announce",
+      },
+      idempotencyKey: "inter-session-context-rebuild",
+    });
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      extraSystemPrompt?: string;
+    };
+    expect(callArgs.extraSystemPrompt).toContain("## Inbound Context (trusted metadata)");
+    expect(callArgs.extraSystemPrompt).toContain('"chat_id": "channel:c3"');
+    expect(callArgs.extraSystemPrompt).toContain('"account_id": "acct-1"');
+    expect(callArgs.extraSystemPrompt).toContain('"channel": "discord"');
+    expect(callArgs.extraSystemPrompt).toContain('"chat_type": "group"');
+    expect(callArgs.extraSystemPrompt).toContain(
+      'You are in the Discord group chat "Release Squad".',
+    );
+  });
+
+  it("keeps explicit extraSystemPrompt on inter-session completion wakes", async () => {
+    primeMainAgentRun();
+    mockMainSessionEntry({
+      chatType: "group",
+      channel: "discord",
+      subject: "Release Squad",
+      lastChannel: "discord",
+      lastTo: "channel:c3",
+      lastAccountId: "acct-1",
+    });
+    mocks.agentCommand.mockClear();
+
+    await invokeAgent({
+      message: "child finished",
+      sessionKey: "agent:main:main",
+      extraSystemPrompt: "Caller-provided context.",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:main:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "fix the cache bug",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Patched and tested.",
+          replyInstruction: "Reply in your normal assistant voice now.",
+        },
+      ],
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:subagent:child",
+        sourceChannel: "internal",
+        sourceTool: "subagent_announce",
+      },
+      idempotencyKey: "inter-session-context-explicit",
+    });
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      extraSystemPrompt?: string;
+    };
+    expect(callArgs.extraSystemPrompt).toBe("Caller-provided context.");
+  });
+
   it("only forwards workspaceDir for spawned sessions with stored workspace inheritance", async () => {
     primeMainAgentRun();
     mockMainSessionEntry({

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -877,13 +877,13 @@ describe("gateway agent handler", () => {
     primeMainAgentRun();
     mockMainSessionEntry({
       chatType: "group",
-      channel: "discord",
+      channel: "telegram",
       subject: "Release Squad",
       lastChannel: "discord",
       lastTo: "channel:c3",
       lastAccountId: "acct-1",
       origin: {
-        provider: "discord",
+        provider: "telegram",
         surface: "discord",
         chatType: "group",
         to: "channel:c3",
@@ -926,6 +926,7 @@ describe("gateway agent handler", () => {
     expect(callArgs.extraSystemPrompt).toContain('"chat_id": "channel:c3"');
     expect(callArgs.extraSystemPrompt).toContain('"account_id": "acct-1"');
     expect(callArgs.extraSystemPrompt).toContain('"channel": "discord"');
+    expect(callArgs.extraSystemPrompt).toContain('"provider": "discord"');
     expect(callArgs.extraSystemPrompt).toContain('"chat_type": "group"');
     expect(callArgs.extraSystemPrompt).toContain(
       'You are in the Discord group chat "Release Squad".',

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -993,6 +993,43 @@ describe("gateway agent handler", () => {
     );
   });
 
+  it("skips synthesized wake context for metadata-free sessions", async () => {
+    primeMainAgentRun();
+    mocks.agentCommand.mockClear();
+
+    await invokeAgent({
+      message: "child finished",
+      sessionKey: "agent:main:main",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:main:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "fix the cache bug",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Patched and tested.",
+          replyInstruction: "Reply in your normal assistant voice now.",
+        },
+      ],
+      inputProvenance: {
+        kind: "inter_session",
+        sourceSessionKey: "agent:main:subagent:child",
+        sourceChannel: "internal",
+        sourceTool: "subagent_announce",
+      },
+      idempotencyKey: "inter-session-context-metadata-free",
+    });
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      extraSystemPrompt?: string;
+    };
+    expect(callArgs.extraSystemPrompt).toBeUndefined();
+  });
+
   it("keeps explicit extraSystemPrompt on inter-session completion wakes", async () => {
     primeMainAgentRun();
     mockMainSessionEntry({

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -198,6 +198,27 @@ function hasTaskCompletionInternalEvent(events?: AgentInternalEvent[]): boolean 
   return Array.isArray(events) && events.some((event) => event.type === "task_completion");
 }
 
+function hasPersistedCompletionWakeDeliveryMetadata(entry: SessionEntry): boolean {
+  if (normalizeOptionalString(entry.lastChannel) || normalizeOptionalString(entry.lastTo)) {
+    return true;
+  }
+  const origin = entry.origin;
+  if (!origin) {
+    return false;
+  }
+  return Boolean(
+    normalizeOptionalString(origin.provider) ||
+    normalizeOptionalString(origin.surface) ||
+    normalizeOptionalString(origin.to) ||
+    normalizeOptionalString(origin.from) ||
+    normalizeOptionalString(origin.accountId) ||
+    normalizeOptionalString(origin.chatType) ||
+    normalizeOptionalString(origin.nativeChannelId) ||
+    normalizeOptionalString(origin.nativeDirectUserId) ||
+    (origin.threadId != null ? String(origin.threadId) : undefined),
+  );
+}
+
 function buildPersistedCompletionWakeExtraSystemPrompt(
   entry: SessionEntry | undefined,
   inputProvenance: InputProvenance | undefined,
@@ -211,7 +232,8 @@ function buildPersistedCompletionWakeExtraSystemPrompt(
   if (
     inputProvenance?.kind !== "inter_session" ||
     !hasTaskCompletionInternalEvent(events) ||
-    !entry
+    !entry ||
+    !hasPersistedCompletionWakeDeliveryMetadata(entry)
   ) {
     return undefined;
   }

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -5,7 +5,10 @@ import {
   normalizeSpawnedRunMetadata,
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
+import { buildGroupChatContext } from "../../auto-reply/reply/groups.js";
+import { buildInboundMetaSystemPrompt } from "../../auto-reply/reply/inbound-meta.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
+import type { TemplateContext } from "../../auto-reply/templating.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -189,6 +192,51 @@ function emitSessionsChanged(
     connIds,
     { dropIfSlow: true },
   );
+}
+
+function hasTaskCompletionInternalEvent(events?: AgentInternalEvent[]): boolean {
+  return Array.isArray(events) && events.some((event) => event.type === "task_completion");
+}
+
+function buildPersistedCompletionWakeExtraSystemPrompt(
+  entry: SessionEntry | undefined,
+  inputProvenance: InputProvenance | undefined,
+  events: AgentInternalEvent[] | undefined,
+  existingExtraSystemPrompt: string | undefined,
+): string | undefined {
+  const explicitExtraSystemPrompt = normalizeOptionalString(existingExtraSystemPrompt);
+  if (explicitExtraSystemPrompt) {
+    return explicitExtraSystemPrompt;
+  }
+  if (
+    inputProvenance?.kind !== "inter_session" ||
+    !hasTaskCompletionInternalEvent(events) ||
+    !entry
+  ) {
+    return undefined;
+  }
+
+  const sessionCtx: TemplateContext = {
+    AccountId: entry.lastAccountId ?? entry.origin?.accountId,
+    OriginatingTo: entry.lastTo ?? entry.origin?.to,
+    OriginatingChannel: entry.lastChannel ?? entry.origin?.provider ?? entry.channel,
+    Provider: entry.channel ?? entry.origin?.provider ?? entry.lastChannel,
+    Surface: entry.origin?.surface,
+    ChatType: entry.chatType ?? entry.origin?.chatType,
+    GroupSubject: entry.subject,
+    GroupChannel: entry.groupChannel,
+    GroupSpace: entry.space,
+  };
+
+  const groupChatContext =
+    sessionCtx.ChatType === "group" || sessionCtx.ChatType === "channel"
+      ? buildGroupChatContext({ sessionCtx })
+      : "";
+
+  const parts = [buildInboundMetaSystemPrompt(sessionCtx), groupChatContext]
+    .map((part) => normalizeOptionalString(part))
+    .filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join("\n\n") : undefined;
 }
 
 function dispatchAgentRunFromGateway(params: {
@@ -623,7 +671,7 @@ export const agentHandlers: GatewayRequestHandlers = {
           store[primaryKey] = merged;
           return merged;
         });
-        sessionEntry = persisted;
+        sessionEntry = persisted ?? sessionEntry;
       }
       if (canonicalSessionKey === mainSessionKey || canonicalSessionKey === "global") {
         context.addChatRun(idem, {
@@ -796,6 +844,12 @@ export const agentHandlers: GatewayRequestHandlers = {
     }
 
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
+    const extraSystemPrompt = buildPersistedCompletionWakeExtraSystemPrompt(
+      sessionEntry,
+      inputProvenance,
+      request.internalEvents,
+      request.extraSystemPrompt,
+    );
 
     dispatchAgentRunFromGateway({
       ingressOpts: {
@@ -830,7 +884,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         messageChannel: originMessageChannel,
         runId,
         lane: request.lane,
-        extraSystemPrompt: request.extraSystemPrompt,
+        extraSystemPrompt,
         bootstrapContextMode: request.bootstrapContextMode,
         bootstrapContextRunKind: request.bootstrapContextRunKind,
         internalEvents: request.internalEvents,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -220,7 +220,7 @@ function buildPersistedCompletionWakeExtraSystemPrompt(
     AccountId: entry.lastAccountId ?? entry.origin?.accountId,
     OriginatingTo: entry.lastTo ?? entry.origin?.to,
     OriginatingChannel: entry.lastChannel ?? entry.origin?.provider ?? entry.channel,
-    Provider: entry.channel ?? entry.origin?.provider ?? entry.lastChannel,
+    Provider: entry.lastChannel ?? entry.channel ?? entry.origin?.provider,
     Surface: entry.origin?.surface,
     ChatType: entry.chatType ?? entry.origin?.chatType,
     GroupSubject: entry.subject,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -229,9 +229,7 @@ function buildPersistedCompletionWakeExtraSystemPrompt(
   };
 
   const groupChatContext =
-    sessionCtx.ChatType === "group" || sessionCtx.ChatType === "channel"
-      ? buildGroupChatContext({ sessionCtx })
-      : "";
+    sessionCtx.ChatType === "group" ? buildGroupChatContext({ sessionCtx }) : "";
 
   const parts = [buildInboundMetaSystemPrompt(sessionCtx), groupChatContext]
     .map((part) => normalizeOptionalString(part))


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: inter-session `task_completion` wakes sent through the gateway `agent` path did not rebuild the session-backed `Inbound Context` / `Group Chat Context` suffix that normal chat turns include.
- Why it matters: the volatile system-prompt suffix changed on ACP/subagent completion notifications, which busted Anthropic prompt cache reuse and caused expensive cache rewrites.
- What changed: `src/gateway/server-methods/agent.ts` now synthesizes persisted session context for inter-session completion wakes when no explicit `extraSystemPrompt` is provided, and preserves explicit caller-provided prompt context when it is present.
- What did NOT change (scope boundary): no gateway protocol/schema changes, no changes to the normal inbound chat prompt path, and no changes to internal event formatting beyond using the existing session metadata to rebuild prompt context.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63030
- Related #43148
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the completion-wake path entered through gateway `agent` with `inputProvenance.kind="inter_session"` and `task_completion` internal events, but unlike the normal chat path it did not reconstruct the session-derived `extraSystemPrompt` sections that contain `Inbound Context` and `Group Chat Context`.
- Missing detection / guardrail: there was no gateway-seam regression test asserting that inter-session completion wakes preserve the same session-derived prompt context as ordinary chat turns.
- Contributing context (if known): these sections live below the cache boundary and above `## Runtime`, so missing them changes the system prompt digest even when session state and transcript history are otherwise unchanged.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/agent.test.ts`
- Scenario the test should lock in: an inter-session `task_completion` wake for an existing session should rebuild persisted inbound/group prompt context when `extraSystemPrompt` is omitted, and should preserve explicit `extraSystemPrompt` when one is provided.
- Why this is the smallest reliable guardrail: the bug lives at the gateway `agent` ingress seam, where session metadata, provenance, and internal events are combined before the run is dispatched.
- Existing test that already covers this (if any): `does not create task rows for inter-session completion wakes` covers adjacent routing behavior, but not prompt-context reconstruction.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- ACP/subagent completion notifications routed through the gateway now reuse the same persisted session context shaping as normal chat turns.
- For affected Anthropic sessions, completion wakes should stop causing unnecessary prompt-cache invalidation from missing session-derived suffix sections.
- No config, CLI, or protocol behavior changed.

## Diagram (if applicable)

```text
Before:
[child task completes]
  -> [gateway agent wake with inter_session provenance]
  -> [internal events only]
  -> [system prompt misses inbound/group context]
  -> [systemDigest changes] -> [prompt cache bust]

After:
[child task completes]
  -> [gateway agent wake with inter_session provenance]
  -> [rebuild persisted inbound/group context from session entry]
  -> [system prompt matches normal session shaping]
  -> [stable systemDigest] -> [prompt cache reused]
