### PR TITLE
feat: add local coding agent bootstrap and selftests

### DIFF
--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -9,6 +9,7 @@ import * as commandTextModule from "openclaw/plugin-sdk/text-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.js";
+import * as routeModule from "./native-command-route.js";
 import { createModelsProviderData as createBaseModelsProviderData } from "./model-picker.test-utils.js";
 import { replyWithDiscordModelPickerProviders } from "./native-command-ui.js";
 import {
@@ -244,6 +245,72 @@ function createBoundThreadBindingManager(params: {
   };
 }
 
+function createUnboundRouteState(params: {
+  sessionKey: string;
+  agentId?: string;
+  accountId?: string;
+}) {
+  return {
+    route: {
+      agentId: params.agentId ?? "main",
+      channel: "discord",
+      accountId: params.accountId ?? "default",
+      sessionKey: params.sessionKey,
+      mainSessionKey: `agent:${params.agentId ?? "main"}:main`,
+      lastRoutePolicy: "session",
+      matchedBy: "default",
+    },
+    effectiveRoute: {
+      agentId: params.agentId ?? "main",
+      channel: "discord",
+      accountId: params.accountId ?? "default",
+      sessionKey: params.sessionKey,
+      mainSessionKey: `agent:${params.agentId ?? "main"}:main`,
+      lastRoutePolicy: "session",
+      matchedBy: "default",
+    },
+    boundSessionKey: undefined,
+    configuredRoute: null,
+    configuredBinding: null,
+    bindingReadiness: null,
+  } satisfies Awaited<
+    ReturnType<typeof import("./native-command-route.js").resolveDiscordNativeInteractionRouteState>
+  >;
+}
+
+function createBoundRouteState(params: {
+  sessionKey: string;
+  agentId?: string;
+  accountId?: string;
+}) {
+  return {
+    route: {
+      agentId: params.agentId ?? "main",
+      channel: "discord",
+      accountId: params.accountId ?? "default",
+      sessionKey: params.sessionKey,
+      mainSessionKey: `agent:${params.agentId ?? "main"}:main`,
+      lastRoutePolicy: "session",
+      matchedBy: "binding.channel",
+    },
+    effectiveRoute: {
+      agentId: params.agentId ?? "main",
+      channel: "discord",
+      accountId: params.accountId ?? "default",
+      sessionKey: params.sessionKey,
+      mainSessionKey: `agent:${params.agentId ?? "main"}:main`,
+      lastRoutePolicy: "session",
+      matchedBy: "binding.channel",
+    },
+    boundSessionKey: params.sessionKey,
+    configuredRoute: null,
+    configuredBinding: null,
+    bindingReadiness: { ok: true } as const,
+  } satisfies Awaited<
+    ReturnType<typeof import("./native-command-route.js").resolveDiscordNativeInteractionRouteState>
+  >;
+}
+
 function createDispatchSpy() {
   const dispatchSpy = vi
     .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
@@ -259,10 +326,27 @@ describe("Discord model picker interactions", () => {
     nativeCommandTesting.setDispatchReplyWithDispatcher(
       dispatcherModule.dispatchReplyWithDispatcher,
     );
+    nativeCommandTesting.setResolveDiscordNativeInteractionRouteState(async (params) =>
+      params.threadBinding
+        ? createBoundRouteState({
+            sessionKey: params.threadBinding.targetSessionKey,
+            agentId: params.threadBinding.agentId,
+            accountId: params.accountId,
+          })
+        : createUnboundRouteState({
+            sessionKey: params.isDirectMessage
+              ? `agent:main:discord:dm:${params.directUserId ?? "owner"}`
+              : `agent:main:discord:channel:${params.conversationId}`,
+            accountId: params.accountId,
+          }),
+    );
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    nativeCommandTesting.setResolveDiscordNativeInteractionRouteState(
+      routeModule.resolveDiscordNativeInteractionRouteState,
+    );
   });
 
   it("registers distinct fallback ids for button and select handlers", () => {

--- a/package.json
+++ b/package.json
@@ -1192,6 +1192,8 @@
     "qa:lab:up": "node --import tsx scripts/qa-lab-up.ts",
     "qa:lab:up:fast": "node --import tsx scripts/qa-lab-up.ts --use-prebuilt-image --bind-ui-dist --skip-ui-build",
     "qa:lab:watch": "vite build --watch --config extensions/qa-lab/web/vite.config.ts",
+    "qa:local-agents:bootstrap": "node scripts/dev/bootstrap-local-coding-agents.mjs",
+    "qa:local-agents:selftest": "bash scripts/dev/local-coding-agents-selftest.sh",
     "release:check": "pnpm check:base-config-schema && pnpm check:bundled-channel-config-metadata && pnpm config:docs:check && pnpm plugin-sdk:check-exports && pnpm plugin-sdk:api:check && node --import tsx scripts/release-check.ts",
     "release:openclaw:npm:check": "node --import tsx scripts/openclaw-npm-release-check.ts",
     "release:openclaw:npm:verify-published": "node --import tsx scripts/openclaw-npm-postpublish-verify.ts",

--- a/qa/README.md
+++ b/qa/README.md
@@ -6,10 +6,14 @@ Files:
 
 - `scenarios.md` - canonical QA scenario pack, kickoff mission, and operator identity.
 - `frontier-harness-plan.md` - big-model bakeoff and tuning loop for harness work.
+- `local-coding-agents.md` - local OpenClaw coding-agent bootstrap and selftest workflow.
+- `seed-scenarios.json` - repo-backed baseline QA scenarios.
 
 Key workflow:
 
 - `qa suite` is the executable frontier subset / regression loop.
 - `qa manual` is the scoped personality and style probe after the executable subset is green.
+- `pnpm qa:local-agents:bootstrap` upserts the local coding-agent profiles into `~/.openclaw`.
+- `pnpm qa:local-agents:selftest` runs the local end-to-end coding stack check, with optional GitHub and WhatsApp live verification.
 
 Keep this folder in git. Add new scenarios here before wiring them into automation.

--- a/qa/local-coding-agents.md
+++ b/qa/local-coding-agents.md
@@ -1,0 +1,111 @@
+# Local Coding Agents
+
+This repo can bootstrap a small local OpenClaw coding setup for development and QA.
+
+The goal is narrow:
+
+- create stable local agent profiles for repo work
+- make those profiles reproducible instead of ad hoc
+- provide a single selftest entrypoint for the core local coding paths
+
+## Files
+
+- `scripts/dev/bootstrap-local-coding-agents.mjs`
+  - upserts local coding agent profiles into `~/.openclaw/openclaw.json`
+  - updates `tools.agentToAgent.allow`
+  - extends `main.subagents.allowAgents`
+  - writes a timestamped backup of the original config
+- `scripts/dev/local-coding-agents-selftest.sh`
+  - validates `exec`, `read`, `patch`, and optional GitHub/WhatsApp live checks
+
+## Agent Profiles
+
+The bootstrap creates:
+
+- `oc-builder`
+  - workspace: this repo
+  - purpose: local code execution, repo reads, patching
+- `oc-github`
+  - workspace: this repo
+  - purpose: `gh`-based repository work
+
+Default model:
+
+- `openai-codex/gpt-5.3-codex-spark`
+
+Override it when needed:
+
+```bash
+OPENCLAW_LOCAL_AGENT_MODEL=google-gemini/gemini-2.0-flash \
+pnpm qa:local-agents:bootstrap
+```
+
+## Commands
+
+Bootstrap the local coding profiles:
+
+```bash
+pnpm qa:local-agents:bootstrap
+```
+
+Run the end-to-end selftest:
+
+```bash
+PATH="${OPENCLAW_SELFTEST_NODE_BIN:-$HOME/.node22/current/bin}:$PATH" \
+pnpm qa:local-agents:selftest
+```
+
+The explicit `PATH` export is only needed when your shell resolves `openclaw`
+through an older Node runtime than the installed CLI accepts.
+
+## What the Selftest Verifies
+
+Always:
+
+- `exec` through `oc-builder`
+- repo file reads through `oc-builder`
+- repo patching through `oc-builder`
+
+When available:
+
+- GitHub CLI access through `oc-github`
+- live WhatsApp self-delivery through `main`
+
+By default, GitHub and WhatsApp are skipped when the local environment is not
+ready for them. Make them hard requirements with:
+
+```bash
+OPENCLAW_SELFTEST_REQUIRE_GITHUB=1 \
+OPENCLAW_SELFTEST_REQUIRE_WHATSAPP=1 \
+pnpm qa:local-agents:selftest
+```
+
+## Real Task Examples
+
+Read repo data through the builder agent:
+
+```bash
+PATH="${OPENCLAW_SELFTEST_NODE_BIN:-$HOME/.node22/current/bin}:$PATH" \
+openclaw agent --agent oc-builder \
+  --message "Nutze read, lies package.json und antworte mit dem lokalen Agent-Selftest-Scriptnamen." \
+  --json
+```
+
+Run GitHub repo inspection:
+
+```bash
+PATH="${OPENCLAW_SELFTEST_NODE_BIN:-$HOME/.node22/current/bin}:$PATH" \
+openclaw agent --agent oc-github \
+  --message "Nutze exec und führe 'gh repo view --json nameWithOwner,isFork,url' aus." \
+  --json
+```
+
+## Expected Local Side Effects
+
+Bootstrap writes only to local OpenClaw state:
+
+- `~/.openclaw/openclaw.json`
+- `~/.openclaw/openclaw.json.bak.local-coding-agents-*`
+
+The scripts do not publish or push anything. Live checks only touch the services
+you explicitly have available in the local environment.

--- a/scripts/dev/bootstrap-local-coding-agents.mjs
+++ b/scripts/dev/bootstrap-local-coding-agents.mjs
@@ -60,7 +60,9 @@ async function readConfig() {
   try {
     config = JSON.parse(rawConfig);
   } catch (error) {
-    throw new Error(`OpenClaw config must be valid JSON at ${configPath}: ${String(error)}`);
+    throw new Error(`OpenClaw config must be valid JSON at ${configPath}: ${String(error)}`, {
+      cause: error,
+    });
   }
   if (!config || typeof config !== "object") {
     throw new Error(`Invalid OpenClaw config object at ${configPath}`);
@@ -132,8 +134,8 @@ function upsertAgent(list, nextAgent) {
     ...list[index],
     ...nextAgent,
     identity: {
-      ...(list[index].identity ?? {}),
-      ...(nextAgent.identity ?? {}),
+      ...list[index].identity,
+      ...nextAgent.identity,
     },
   };
 }

--- a/scripts/dev/bootstrap-local-coding-agents.mjs
+++ b/scripts/dev/bootstrap-local-coding-agents.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..");
+const homeDir = os.homedir();
+const stateDir = resolveHomePath(process.env.OPENCLAW_STATE_DIR ?? path.join(homeDir, ".openclaw"));
+const configPath = resolveHomePath(process.env.OPENCLAW_CONFIG_PATH ?? path.join(stateDir, "openclaw.json"));
+const defaultModel = process.env.OPENCLAW_LOCAL_AGENT_MODEL ?? "openai-codex/gpt-5.3-codex-spark";
+const agentIds = {
+  builder: process.env.OPENCLAW_LOCAL_BUILDER_ID ?? "oc-builder",
+  github: process.env.OPENCLAW_LOCAL_GITHUB_ID ?? "oc-github",
+};
+
+await ensureExists(path.dirname(configPath), "OpenClaw config directory");
+const { config, rawConfig } = await readConfig();
+const backupPath = await backupConfig(rawConfig);
+mutateConfig(config);
+await fs.writeFile(configPath, JSON.stringify(config, null, 2) + "\n", "utf8");
+
+console.log(
+  JSON.stringify(
+    {
+      configPath,
+      backupPath,
+      repoRoot,
+      agents: Object.values(agentIds),
+      model: defaultModel,
+    },
+    null,
+    2,
+  ),
+);
+
+function resolveHomePath(value) {
+  if (!value.startsWith("~")) {
+    return path.resolve(value);
+  }
+  if (value === "~") {
+    return homeDir;
+  }
+  return path.join(homeDir, value.slice(2));
+}
+
+async function ensureExists(targetPath, label) {
+  try {
+    await fs.access(targetPath);
+  } catch {
+    throw new Error(`${label} not found: ${targetPath}`);
+  }
+}
+
+async function readConfig() {
+  const rawConfig = await fs.readFile(configPath, "utf8");
+  let config;
+  try {
+    config = JSON.parse(rawConfig);
+  } catch (error) {
+    throw new Error(`OpenClaw config must be valid JSON at ${configPath}: ${String(error)}`);
+  }
+  if (!config || typeof config !== "object") {
+    throw new Error(`Invalid OpenClaw config object at ${configPath}`);
+  }
+  return { config, rawConfig };
+}
+
+async function backupConfig(rawConfig) {
+  const backupPath = `${configPath}.bak.local-coding-agents-${Date.now()}`;
+  await fs.writeFile(backupPath, rawConfig, "utf8");
+  return backupPath;
+}
+
+function mutateConfig(config) {
+  config.agents ??= {};
+  config.agents.list = Array.isArray(config.agents.list) ? config.agents.list : [];
+  config.tools ??= {};
+  config.tools.agentToAgent ??= {};
+
+  const desiredAgents = [
+    {
+      id: agentIds.builder,
+      name: "OpenClaw Builder",
+      workspace: repoRoot,
+      model: defaultModel,
+      skills: ["coding-agent", "github", "session-logs"],
+      identity: {
+        name: "OpenClaw Builder",
+        theme: "Local code execution and patching",
+        emoji: "🛠️",
+      },
+    },
+    {
+      id: agentIds.github,
+      name: "OpenClaw GitHub",
+      workspace: repoRoot,
+      model: defaultModel,
+      skills: ["github", "session-logs"],
+      identity: {
+        name: "OpenClaw GitHub",
+        theme: "Repository and PR operations",
+        emoji: "🐙",
+      },
+    },
+  ];
+
+  for (const agent of desiredAgents) {
+    upsertAgent(config.agents.list, agent);
+  }
+
+  const allow = Array.isArray(config.tools.agentToAgent.allow) ? config.tools.agentToAgent.allow : [];
+  config.tools.agentToAgent.allow = uniqueStrings([...allow, agentIds.builder, agentIds.github]);
+
+  const mainAgent = config.agents.list.find((entry) => entry && entry.id === "main");
+  if (mainAgent) {
+    mainAgent.subagents ??= {};
+    const allowAgents = Array.isArray(mainAgent.subagents.allowAgents) ? mainAgent.subagents.allowAgents : [];
+    mainAgent.subagents.allowAgents = uniqueStrings([...allowAgents, agentIds.builder, agentIds.github]);
+  }
+}
+
+function upsertAgent(list, nextAgent) {
+  const index = list.findIndex((entry) => entry && entry.id === nextAgent.id);
+  if (index === -1) {
+    list.push(nextAgent);
+    return;
+  }
+  list[index] = {
+    ...list[index],
+    ...nextAgent,
+    identity: {
+      ...(list[index].identity ?? {}),
+      ...(nextAgent.identity ?? {}),
+    },
+  };
+}
+
+function uniqueStrings(values) {
+  return [...new Set(values.filter((value) => typeof value === "string" && value.trim().length > 0))];
+}

--- a/scripts/dev/local-coding-agents-selftest.sh
+++ b/scripts/dev/local-coding-agents-selftest.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+STATE_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+GATEWAY_LOG="$STATE_DIR/logs/gateway.log"
+NODE22_BIN="${OPENCLAW_SELFTEST_NODE_BIN:-$HOME/.node22/current/bin}"
+BUILDER_ID="${OPENCLAW_LOCAL_BUILDER_ID:-oc-builder}"
+GITHUB_ID="${OPENCLAW_LOCAL_GITHUB_ID:-oc-github}"
+SELFTEST_ROOT="$(mktemp -d "$REPO_ROOT/.local-agent-selftest.XXXXXX")"
+EXEC_JSON="$SELFTEST_ROOT/exec.json"
+READ_JSON="$SELFTEST_ROOT/read.json"
+PATCH_JSON="$SELFTEST_ROOT/patch.json"
+GITHUB_JSON="$SELFTEST_ROOT/github.json"
+WA_JSON="$SELFTEST_ROOT/whatsapp.json"
+READ_PROOF="$SELFTEST_ROOT/read-proof.txt"
+PATCH_TARGET="$SELFTEST_ROOT/patch-target.txt"
+
+cleanup() {
+  rm -rf "$SELFTEST_ROOT"
+}
+trap cleanup EXIT
+
+if [[ -d "$NODE22_BIN" ]]; then
+  PATH="$NODE22_BIN:$PATH"
+  export PATH
+fi
+
+json_payload_text() {
+  local json_path="$1"
+  python3 - <<'PY' "$json_path"
+import json, sys
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as handle:
+    raw = handle.read()
+start = raw.find("{")
+if start < 0:
+    raise SystemExit(f"{path}: missing JSON payload")
+payload = json.loads(raw[start:])
+print(payload["result"]["payloads"][0]["text"])
+PY
+}
+
+run_json_assert() {
+  local json_path="$1"
+  local expected="$2"
+  local actual
+  actual="$(json_payload_text "$json_path")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "$json_path: unexpected text '$actual' != '$expected'" >&2
+    exit 1
+  fi
+}
+
+latest_session_jsonl() {
+  local agent_id="$1"
+  python3 - <<'PY' "$STATE_DIR" "$agent_id"
+import pathlib, sys
+state_dir, agent_id = sys.argv[1], sys.argv[2]
+session_dir = pathlib.Path(state_dir) / "agents" / agent_id / "sessions"
+files = sorted(session_dir.glob("*.jsonl"), key=lambda item: item.stat().st_mtime, reverse=True)
+print(files[0] if files else "")
+PY
+}
+
+assert_tool_call() {
+  local agent_id="$1"
+  local pattern="$2"
+  local session_file
+  session_file="$(latest_session_jsonl "$agent_id")"
+  if [[ -z "$session_file" || ! -f "$session_file" ]]; then
+    echo "missing session log for $agent_id" >&2
+    exit 1
+  fi
+  if ! rg -q "$pattern" "$session_file"; then
+    echo "expected pattern $pattern in $session_file" >&2
+    exit 1
+  fi
+}
+
+echo "== bootstrap local coding agents =="
+node "$REPO_ROOT/scripts/dev/bootstrap-local-coding-agents.mjs" >/dev/null
+
+echo "== gateway health =="
+openclaw gateway health
+
+echo "== exec proof =="
+EXEC_EXPECTED="EXEC_OK:$(cd "$REPO_ROOT" && pwd)"
+openclaw agent --agent "$BUILDER_ID" --message "Nutze exec, führe 'pwd' aus und antworte exakt mit $EXEC_EXPECTED." --json >"$EXEC_JSON"
+run_json_assert "$EXEC_JSON" "$EXEC_EXPECTED"
+assert_tool_call "$BUILDER_ID" '"name":"exec"'
+
+echo "== read proof =="
+READ_EXPECTED="READ_OK_$(date +%s)"
+printf '%s\n' "$READ_EXPECTED" >"$READ_PROOF"
+openclaw agent --agent "$BUILDER_ID" --message "Nutze read, lies $READ_PROOF und antworte exakt mit dem Inhalt." --json >"$READ_JSON"
+run_json_assert "$READ_JSON" "$READ_EXPECTED"
+assert_tool_call "$BUILDER_ID" '"name":"read"'
+
+echo "== patch proof =="
+PATCH_EXPECTED="PATCH_OK_$(date +%s)"
+printf 'before\n' >"$PATCH_TARGET"
+openclaw agent --agent "$BUILDER_ID" --message "Nutze apply_patch oder edit, ändere $PATCH_TARGET so dass die Datei exakt '$PATCH_EXPECTED' enthält. Antworte exakt mit PATCH_DONE." --json >"$PATCH_JSON"
+run_json_assert "$PATCH_JSON" "PATCH_DONE"
+ACTUAL_PATCH="$(tr -d '\r' <"$PATCH_TARGET" | tr -d '\n')"
+if [[ "$ACTUAL_PATCH" != "$PATCH_EXPECTED" ]]; then
+  echo "patch proof failed: $ACTUAL_PATCH != $PATCH_EXPECTED" >&2
+  exit 1
+fi
+assert_tool_call "$BUILDER_ID" '"name":"apply_patch"|"name":"edit"|"name":"write"'
+
+echo "== github proof =="
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  GITHUB_REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+  GITHUB_EXPECTED="GITHUB_OK:$GITHUB_REPO"
+  openclaw agent --agent "$GITHUB_ID" --message "Nutze exec und führe 'gh repo view --json nameWithOwner,isFork,url' aus. Antworte exakt mit $GITHUB_EXPECTED." --json >"$GITHUB_JSON"
+  run_json_assert "$GITHUB_JSON" "$GITHUB_EXPECTED"
+  assert_tool_call "$GITHUB_ID" '"name":"exec"'
+else
+  echo "SKIP github proof (gh missing or unauthenticated)"
+  if [[ "${OPENCLAW_SELFTEST_REQUIRE_GITHUB:-0}" == "1" ]]; then
+    echo "github proof required but unavailable" >&2
+    exit 1
+  fi
+fi
+
+echo "== whatsapp reply proof =="
+WHATSAPP_STATUS_RAW="$(openclaw channels status --json)"
+WHATSAPP_SELF_E164="$(printf '%s' "$WHATSAPP_STATUS_RAW" | python3 -c 'import json, sys; raw=sys.stdin.read(); start=raw.find("{"); assert start >= 0, raw; payload=json.loads(raw[start:]); channel=payload.get("channels", {}).get("whatsapp", {}); print(channel.get("self", {}).get("e164", ""))')"
+WHATSAPP_LINKED="$(printf '%s' "$WHATSAPP_STATUS_RAW" | python3 -c 'import json, sys; raw=sys.stdin.read(); start=raw.find("{"); assert start >= 0, raw; payload=json.loads(raw[start:]); print("1" if payload.get("channels", {}).get("whatsapp", {}).get("linked") else "0")')"
+if [[ -n "$WHATSAPP_SELF_E164" && "$WHATSAPP_LINKED" == "1" ]]; then
+  WA_EXPECTED="WA_SELFTEST_$(date +%s)"
+  if [[ ! -f "$GATEWAY_LOG" ]]; then
+    echo "missing gateway log at $GATEWAY_LOG" >&2
+    exit 1
+  fi
+  WA_LOG_MARKER="$(wc -c <"$GATEWAY_LOG")"
+  openclaw agent --agent main --channel whatsapp --to "$WHATSAPP_SELF_E164" --deliver --message "Antworte exakt: $WA_EXPECTED" --json >"$WA_JSON"
+  run_json_assert "$WA_JSON" "$WA_EXPECTED"
+  python3 - <<'PY' "$GATEWAY_LOG" "$WA_LOG_MARKER" "$WA_EXPECTED"
+import sys
+log_path = sys.argv[1]
+offset = int(sys.argv[2])
+expected = sys.argv[3]
+with open(log_path, "rb") as handle:
+    handle.seek(offset)
+    tail = handle.read().decode("utf-8", errors="replace")
+if expected not in tail or "Sent message" not in tail:
+    raise SystemExit(f"whatsapp delivery proof missing token or sent marker for {expected!r}")
+print(expected)
+PY
+else
+  echo "SKIP whatsapp proof (channel not linked)"
+  if [[ "${OPENCLAW_SELFTEST_REQUIRE_WHATSAPP:-0}" == "1" ]]; then
+    echo "whatsapp proof required but unavailable" >&2
+    exit 1
+  fi
+fi
+
+echo "== all local coding agent selftests passed =="


### PR DESCRIPTION
## Summary
- add a small local bootstrap script for reproducible coding-agent profiles in `~/.openclaw/openclaw.json`
- add a local selftest entrypoint for `exec`, `read`, `patch`, plus optional GitHub and WhatsApp live checks
- document the workflow under `qa/local-coding-agents.md`

## Notes
- this branch is intentionally the upstream-safe split of a larger machine-local setup
- it does **not** include the fork-local `claw-code` integration layer
- GitHub and WhatsApp checks auto-skip when the local environment is not ready; set `OPENCLAW_SELFTEST_REQUIRE_GITHUB=1` and/or `OPENCLAW_SELFTEST_REQUIRE_WHATSAPP=1` to make them mandatory

## Verification
- `PATH="${OPENCLAW_SELFTEST_NODE_BIN:-$HOME/.node22/current/bin}:$PATH" pnpm qa:local-agents:selftest`
