### PR TITLE
feat(ios): add background alive beacon support

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -18,6 +18,22 @@ private struct GatewayRelayIdentityResponse: Decodable {
     let publicKey: String
 }
 
+private struct NodePresenceAlivePayload: Encodable, Sendable {
+    let displayName: String
+    let version: String
+    let platform: String
+    let deviceFamily: String
+    let modelIdentifier: String
+    let trigger: String
+    let pushTransport: String
+    let sentAtMs: Int
+}
+
+private struct NodeEventRequestPayload: Encodable, Sendable {
+    let event: String
+    let payloadJSON: String?
+}
+
 // Ensures notification requests return promptly even if the system prompt blocks.
 private final class NotificationInvokeLatch<T: Sendable>: @unchecked Sendable {
     private let lock = NSLock()
@@ -607,6 +623,9 @@ final class NodeAppModel {
     private static let apnsDeviceTokenUserDefaultsKey = "push.apns.deviceTokenHex"
     private static let deepLinkKeyUserDefaultsKey = "deeplink.agent.key"
     private static let canvasUnattendedDeepLinkKey: String = NodeAppModel.generateDeepLinkKey()
+    private static let backgroundAliveBeaconLastSuccessAtMsKey = "gateway.backgroundAlive.lastSuccessAtMs"
+    private static let backgroundAliveBeaconLastTriggerKey = "gateway.backgroundAlive.lastTrigger"
+    private static let backgroundAliveBeaconMinimumIntervalMs = 10 * 60 * 1000
 
     private func refreshBrandingFromGateway() async {
         do {
@@ -3097,7 +3116,9 @@ extension NodeAppModel {
             return handled
         }
 
-        let result = await self.reconnectGatewaySessionsForSilentPushIfNeeded(wakeId: wakeId)
+        let result = await self.performBackgroundAliveBeaconIfNeeded(
+            wakeId: wakeId,
+            trigger: pushKind)
         let outcomeMessage =
             "Silent push outcome wakeId=\(wakeId) "
             + "applied=\(result.applied) "
@@ -3115,7 +3136,9 @@ extension NodeAppModel {
             + "backgrounded=\(self.isBackgrounded) "
             + "autoReconnect=\(self.gatewayAutoReconnectEnabled)"
         self.pushWakeLogger.info("\(receivedMessage, privacy: .public)")
-        let result = await self.reconnectGatewaySessionsForSilentPushIfNeeded(wakeId: wakeId)
+        let result = await self.performBackgroundAliveBeaconIfNeeded(
+            wakeId: wakeId,
+            trigger: trigger)
         let outcomeMessage =
             "Background refresh wake outcome wakeId=\(wakeId) "
             + "applied=\(result.applied) "
@@ -3151,7 +3174,9 @@ extension NodeAppModel {
             + "backgrounded=\(self.isBackgrounded) "
             + "autoReconnect=\(self.gatewayAutoReconnectEnabled)"
         self.locationWakeLogger.info("\(beginMessage, privacy: .public)")
-        let result = await self.reconnectGatewaySessionsForSilentPushIfNeeded(wakeId: wakeId)
+        let result = await self.performBackgroundAliveBeaconIfNeeded(
+            wakeId: wakeId,
+            trigger: "significant_location")
         let triggerMessage =
             "Location wake trigger wakeId=\(wakeId) "
             + "applied=\(result.applied) "
@@ -3740,10 +3765,79 @@ extension NodeAppModel {
         return await self.waitForOperatorConnection(timeoutMs: timeoutMs, pollMs: 250)
     }
 
-    private func reconnectGatewaySessionsForSilentPushIfNeeded(
-        wakeId: String
+    private func publishBackgroundAliveBeacon(trigger: String, wakeId: String) async -> Bool {
+        let normalizedTrigger = trigger.trimmingCharacters(in: .whitespacesAndNewlines)
+        let beaconTrigger = normalizedTrigger.isEmpty ? "background" : normalizedTrigger
+        let displayName = NodeDisplayName.resolve(
+            existing: UserDefaults.standard.string(forKey: "node.displayName"),
+            deviceName: UIDevice.current.name,
+            interfaceIdiom: UIDevice.current.userInterfaceIdiom)
+        let usesRelayTransport = await self.pushRegistrationManager.usesRelayTransport
+        let payload = NodePresenceAlivePayload(
+            displayName: displayName,
+            version: DeviceInfoHelper.appVersion(),
+            platform: DeviceInfoHelper.platformString(),
+            deviceFamily: DeviceInfoHelper.deviceFamily(),
+            modelIdentifier: DeviceInfoHelper.modelIdentifier(),
+            trigger: beaconTrigger,
+            pushTransport: usesRelayTransport ? PushTransportMode.relay.rawValue : PushTransportMode.direct.rawValue,
+            sentAtMs: Int(Date().timeIntervalSince1970 * 1000))
+
+        do {
+            let payloadJSON = try Self.encodePayload(payload)
+            let requestJSON = try Self.encodePayload(NodeEventRequestPayload(
+                event: "node.presence.alive",
+                payloadJSON: payloadJSON))
+            _ = try await self.nodeGateway.request(
+                method: "node.event",
+                paramsJSON: requestJSON,
+                timeoutSeconds: 8)
+            self.pushWakeLogger.info(
+                "Wake alive beacon acknowledged wakeId=\(wakeId, privacy: .public) trigger=\(beaconTrigger, privacy: .public)")
+            return true
+        } catch {
+            self.pushWakeLogger.error(
+                "Wake alive beacon failed wakeId=\(wakeId, privacy: .public) trigger=\(beaconTrigger, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            return false
+        }
+    }
+
+    private func recordBackgroundAliveBeaconSuccess(trigger: String, nowMs: Int) {
+        let normalizedTrigger = trigger.trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaults = UserDefaults.standard
+        defaults.set(nowMs, forKey: Self.backgroundAliveBeaconLastSuccessAtMsKey)
+        defaults.set(normalizedTrigger.isEmpty ? "background" : normalizedTrigger, forKey: Self.backgroundAliveBeaconLastTriggerKey)
+    }
+
+    nonisolated private static func shouldThrottleBackgroundAliveBeacon(
+        lastSuccessAtMs: Int?,
+        nowMs: Int,
+        minimumIntervalMs: Int) -> Bool
+    {
+        guard let lastSuccessAtMs else { return false }
+        guard nowMs >= lastSuccessAtMs else { return false }
+        return nowMs - lastSuccessAtMs < minimumIntervalMs
+    }
+
+    nonisolated private static func shouldSkipBackgroundAliveBeaconBecauseOfRecentSuccess(
+        lastSuccessAtMs: Int?,
+        nowMs: Int,
+        minimumIntervalMs: Int,
+        gatewayConnected: Bool) -> Bool
+    {
+        gatewayConnected && self.shouldThrottleBackgroundAliveBeacon(
+            lastSuccessAtMs: lastSuccessAtMs,
+            nowMs: nowMs,
+            minimumIntervalMs: minimumIntervalMs)
+    }
+
+    private func performBackgroundAliveBeaconIfNeeded(
+        wakeId: String,
+        trigger: String
     ) async -> SilentPushWakeAttemptResult {
         let startedAt = Date()
+        let normalizedTrigger = trigger.trimmingCharacters(in: .whitespacesAndNewlines)
+        let beaconTrigger = normalizedTrigger.isEmpty ? "background" : normalizedTrigger
         let makeResult: (Bool, String) -> SilentPushWakeAttemptResult = { applied, reason in
             let durationMs = Int(Date().timeIntervalSince(startedAt) * 1000)
             return SilentPushWakeAttemptResult(
@@ -3765,18 +3859,48 @@ extension NodeAppModel {
             return makeResult(false, "no_active_gateway_config")
         }
 
-        self.pushWakeLogger.info(
-            "Wake reconnect begin wakeId=\(wakeId, privacy: .public) stableID=\(cfg.stableID, privacy: .public)")
-        self.grantBackgroundReconnectLease(seconds: 30, reason: "wake_\(wakeId)")
-        await self.operatorGateway.disconnect()
-        await self.nodeGateway.disconnect()
-        self.operatorConnected = false
-        self.gatewayConnected = false
-        self.gatewayStatusText = "Reconnecting…"
-        self.talkMode.updateGatewayConnected(false)
-        self.applyGatewayConnectConfig(cfg)
-        self.pushWakeLogger.info("Wake reconnect trigger applied wakeId=\(wakeId, privacy: .public)")
-        return makeResult(true, "reconnect_triggered")
+        let nowMs = Int(Date().timeIntervalSince1970 * 1000)
+        let lastSuccessAtMs = UserDefaults.standard.object(forKey: Self.backgroundAliveBeaconLastSuccessAtMsKey) as? Int
+        let gatewayConnected = await self.isGatewayConnected()
+        if Self.shouldSkipBackgroundAliveBeaconBecauseOfRecentSuccess(
+            lastSuccessAtMs: lastSuccessAtMs,
+            nowMs: nowMs,
+            minimumIntervalMs: Self.backgroundAliveBeaconMinimumIntervalMs,
+            gatewayConnected: gatewayConnected)
+        {
+            self.pushWakeLogger.info(
+                "Wake no-op wakeId=\(wakeId, privacy: .public): recent alive beacon already succeeded trigger=\(beaconTrigger, privacy: .public)")
+            return makeResult(false, "recent_success")
+        }
+
+        if !gatewayConnected {
+            self.pushWakeLogger.info(
+                "Wake reconnect begin wakeId=\(wakeId, privacy: .public) stableID=\(cfg.stableID, privacy: .public) trigger=\(beaconTrigger, privacy: .public)")
+            self.grantBackgroundReconnectLease(seconds: 30, reason: "wake_\(wakeId)")
+            await self.operatorGateway.disconnect()
+            await self.nodeGateway.disconnect()
+            self.operatorConnected = false
+            self.gatewayConnected = false
+            self.gatewayStatusText = "Reconnecting…"
+            self.talkMode.updateGatewayConnected(false)
+            self.applyGatewayConnectConfig(cfg)
+            self.pushWakeLogger.info("Wake reconnect trigger applied wakeId=\(wakeId, privacy: .public)")
+
+            let connected = await self.waitForGatewayConnection(timeoutMs: 12_000, pollMs: 250)
+            guard connected else {
+                self.pushWakeLogger.info(
+                    "Wake reconnect timeout wakeId=\(wakeId, privacy: .public) trigger=\(beaconTrigger, privacy: .public)")
+                return makeResult(false, "reconnect_timeout")
+            }
+        } else {
+            self.grantBackgroundReconnectLease(seconds: 15, reason: "wake_connected_\(wakeId)")
+        }
+
+        guard await self.publishBackgroundAliveBeacon(trigger: beaconTrigger, wakeId: wakeId) else {
+            return makeResult(false, "beacon_failed")
+        }
+        self.recordBackgroundAliveBeaconSuccess(trigger: beaconTrigger, nowMs: nowMs)
+        return makeResult(true, "beacon_acknowledged")
     }
 }
 
@@ -4126,6 +4250,15 @@ extension NodeAppModel {
         self.gatewayConnected = connected
     }
 
+    func _test_setBackgrounded(_ backgrounded: Bool) {
+        self.isBackgrounded = backgrounded
+    }
+
+    func _test_performBackgroundAliveBeacon(trigger: String, wakeId: String) async -> Bool {
+        let result = await self.performBackgroundAliveBeaconIfNeeded(wakeId: wakeId, trigger: trigger)
+        return result.applied
+    }
+
     func _test_applyPendingForegroundNodeActions(
         _ actions: [(id: String, command: String, paramsJSON: String?)]) async
     {
@@ -4246,6 +4379,30 @@ extension NodeAppModel {
             bootstrapToken: bootstrapToken,
             password: password,
             hasStoredOperatorToken: hasStoredOperatorToken)
+    }
+
+    nonisolated static func _test_shouldThrottleBackgroundAliveBeacon(
+        lastSuccessAtMs: Int?,
+        nowMs: Int,
+        minimumIntervalMs: Int) -> Bool
+    {
+        self.shouldThrottleBackgroundAliveBeacon(
+            lastSuccessAtMs: lastSuccessAtMs,
+            nowMs: nowMs,
+            minimumIntervalMs: minimumIntervalMs)
+    }
+
+    nonisolated static func _test_shouldSkipBackgroundAliveBeaconBecauseOfRecentSuccess(
+        lastSuccessAtMs: Int?,
+        nowMs: Int,
+        minimumIntervalMs: Int,
+        gatewayConnected: Bool) -> Bool
+    {
+        self.shouldSkipBackgroundAliveBeaconBecauseOfRecentSuccess(
+            lastSuccessAtMs: lastSuccessAtMs,
+            nowMs: nowMs,
+            minimumIntervalMs: minimumIntervalMs,
+            gatewayConnected: gatewayConnected)
     }
 
     nonisolated static func _test_shouldRequestOperatorApprovalScope(

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -3121,11 +3121,12 @@ extension NodeAppModel {
             trigger: pushKind)
         let outcomeMessage =
             "Silent push outcome wakeId=\(wakeId) "
+            + "handled=\(result.handled) "
             + "applied=\(result.applied) "
             + "reason=\(result.reason) "
             + "durationMs=\(result.durationMs)"
         self.pushWakeLogger.info("\(outcomeMessage, privacy: .public)")
-        return result.applied
+        return result.handled
     }
 
     func handleBackgroundRefreshWake(trigger: String = "bg_app_refresh") async -> Bool {
@@ -3141,11 +3142,12 @@ extension NodeAppModel {
             trigger: trigger)
         let outcomeMessage =
             "Background refresh wake outcome wakeId=\(wakeId) "
+            + "handled=\(result.handled) "
             + "applied=\(result.applied) "
             + "reason=\(result.reason) "
             + "durationMs=\(result.durationMs)"
         self.pushWakeLogger.info("\(outcomeMessage, privacy: .public)")
-        return result.applied
+        return result.handled
     }
 
     func handleSignificantLocationWakeIfNeeded() async {
@@ -3179,6 +3181,7 @@ extension NodeAppModel {
             trigger: "significant_location")
         let triggerMessage =
             "Location wake trigger wakeId=\(wakeId) "
+            + "handled=\(result.handled) "
             + "applied=\(result.applied) "
             + "reason=\(result.reason) "
             + "durationMs=\(result.durationMs)"
@@ -3602,6 +3605,7 @@ extension NodeAppModel {
     }
 
     private struct SilentPushWakeAttemptResult {
+        var handled: Bool
         var applied: Bool
         var reason: String
         var durationMs: Int
@@ -3831,6 +3835,13 @@ extension NodeAppModel {
             minimumIntervalMs: minimumIntervalMs)
     }
 
+    nonisolated private static func shouldTreatBackgroundAliveWakeAsHandled(
+        applied: Bool,
+        reason: String) -> Bool
+    {
+        applied || reason == "recent_success"
+    }
+
     private func performBackgroundAliveBeaconIfNeeded(
         wakeId: String,
         trigger: String
@@ -3841,6 +3852,7 @@ extension NodeAppModel {
         let makeResult: (Bool, String) -> SilentPushWakeAttemptResult = { applied, reason in
             let durationMs = Int(Date().timeIntervalSince(startedAt) * 1000)
             return SilentPushWakeAttemptResult(
+                handled: Self.shouldTreatBackgroundAliveWakeAsHandled(applied: applied, reason: reason),
                 applied: applied,
                 reason: reason,
                 durationMs: max(0, durationMs))
@@ -4403,6 +4415,13 @@ extension NodeAppModel {
             nowMs: nowMs,
             minimumIntervalMs: minimumIntervalMs,
             gatewayConnected: gatewayConnected)
+    }
+
+    nonisolated static func _test_shouldTreatBackgroundAliveWakeAsHandled(
+        applied: Bool,
+        reason: String) -> Bool
+    {
+        self.shouldTreatBackgroundAliveWakeAsHandled(applied: applied, reason: reason)
     }
 
     nonisolated static func _test_shouldRequestOperatorApprovalScope(

--- a/apps/ios/Tests/NodeBackgroundAliveBeaconTests.swift
+++ b/apps/ios/Tests/NodeBackgroundAliveBeaconTests.swift
@@ -1,0 +1,56 @@
+import Testing
+@testable import OpenClaw
+
+@Suite struct NodeBackgroundAliveBeaconTests {
+    @Test func doesNotThrottleWithoutPriorSuccess() {
+        #expect(
+            NodeAppModel._test_shouldThrottleBackgroundAliveBeacon(
+                lastSuccessAtMs: nil,
+                nowMs: 10_000,
+                minimumIntervalMs: 60_000) == false)
+    }
+
+    @Test func throttlesWithinMinimumInterval() {
+        #expect(
+            NodeAppModel._test_shouldThrottleBackgroundAliveBeacon(
+                lastSuccessAtMs: 100_000,
+                nowMs: 120_000,
+                minimumIntervalMs: 60_000))
+    }
+
+    @Test func doesNotThrottleAtBoundaryOrAfter() {
+        #expect(
+            NodeAppModel._test_shouldThrottleBackgroundAliveBeacon(
+                lastSuccessAtMs: 100_000,
+                nowMs: 160_000,
+                minimumIntervalMs: 60_000) == false)
+        #expect(
+            NodeAppModel._test_shouldThrottleBackgroundAliveBeacon(
+                lastSuccessAtMs: 100_000,
+                nowMs: 200_000,
+                minimumIntervalMs: 60_000) == false)
+    }
+
+    @Test func doesNotThrottleWhenClockMovesBackward() {
+        #expect(
+            NodeAppModel._test_shouldThrottleBackgroundAliveBeacon(
+                lastSuccessAtMs: 200_000,
+                nowMs: 100_000,
+                minimumIntervalMs: 60_000) == false)
+    }
+
+    @Test func recentSuccessDoesNotSkipReconnectWhenGatewayIsDisconnected() {
+        #expect(
+            NodeAppModel._test_shouldSkipBackgroundAliveBeaconBecauseOfRecentSuccess(
+                lastSuccessAtMs: 100_000,
+                nowMs: 120_000,
+                minimumIntervalMs: 60_000,
+                gatewayConnected: false) == false)
+        #expect(
+            NodeAppModel._test_shouldSkipBackgroundAliveBeaconBecauseOfRecentSuccess(
+                lastSuccessAtMs: 100_000,
+                nowMs: 120_000,
+                minimumIntervalMs: 60_000,
+                gatewayConnected: true))
+    }
+}

--- a/apps/ios/Tests/NodeBackgroundAliveBeaconTests.swift
+++ b/apps/ios/Tests/NodeBackgroundAliveBeaconTests.swift
@@ -53,4 +53,15 @@ import Testing
                 minimumIntervalMs: 60_000,
                 gatewayConnected: true))
     }
+
+    @Test func recentSuccessCountsAsHandledWake() {
+        #expect(
+            NodeAppModel._test_shouldTreatBackgroundAliveWakeAsHandled(
+                applied: false,
+                reason: "recent_success"))
+        #expect(
+            NodeAppModel._test_shouldTreatBackgroundAliveWakeAsHandled(
+                applied: false,
+                reason: "beacon_failed") == false)
+    }
 }

--- a/apps/ios/Tests/NodeBackgroundAliveE2ETests.swift
+++ b/apps/ios/Tests/NodeBackgroundAliveE2ETests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import OpenClawKit
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized) struct NodeBackgroundAliveE2ETests {
+    private struct NodeListResult: Decodable {
+        var nodes: [NodeSummary]
+    }
+
+    private struct NodeSummary: Decodable {
+        var nodeId: String
+        var clientId: String?
+        var connected: Bool?
+        var lastSeenAtMs: Int?
+        var lastSeenReason: String?
+    }
+
+    private static let enabledEnvKey = "OPENCLAW_IOS_BACKGROUND_ALIVE_E2E"
+    private static let urlEnvKey = "OPENCLAW_IOS_BACKGROUND_ALIVE_E2E_URL"
+
+    @Test @MainActor func reconnectsAndPublishesAliveBeaconAgainstLocalGateway() async throws {
+        guard ProcessInfo.processInfo.environment[Self.enabledEnvKey] == "1" else { return }
+
+        let gatewayURL = URL(
+            string: ProcessInfo.processInfo.environment[Self.urlEnvKey] ?? "ws://127.0.0.1:18789")!
+        let appModel = NodeAppModel()
+        let operatorSession = GatewayNodeSession()
+        defer {
+            appModel.disconnectGateway()
+            Task {
+                await operatorSession.disconnect()
+            }
+        }
+
+        try await operatorSession.connect(
+            url: gatewayURL,
+            token: nil,
+            bootstrapToken: nil,
+            password: nil,
+            connectOptions: GatewayConnectOptions(
+                role: "operator",
+                scopes: ["operator.admin", "operator.read"],
+                caps: [],
+                commands: [],
+                permissions: [:],
+                clientId: "ios-background-alive-e2e-operator",
+                clientMode: "ui",
+                clientDisplayName: "iOS Background Alive E2E"),
+            sessionBox: nil,
+            onConnected: {},
+            onDisconnected: { _ in },
+            onInvoke: { req in
+                BridgeInvokeResponse(
+                    id: req.id,
+                    ok: false,
+                    error: OpenClawNodeError(
+                        code: .invalidRequest,
+                        message: "operator session does not handle node invokes"))
+            })
+
+        let nodeOptions = GatewayConnectOptions(
+            role: "node",
+            scopes: [],
+            caps: [OpenClawCapability.device.rawValue],
+            commands: [OpenClawDeviceCommand.status.rawValue],
+            permissions: [:],
+            clientId: "ios-background-alive-e2e-node",
+            clientMode: "node",
+            clientDisplayName: "iOS Background Alive E2E")
+        appModel.applyGatewayConnectConfig(
+            GatewayConnectConfig(
+                url: gatewayURL,
+                stableID: "ios-background-alive-e2e",
+                tls: nil,
+                token: nil,
+                bootstrapToken: nil,
+                password: nil,
+                nodeOptions: nodeOptions))
+
+        let initialNode = try await Self.waitForNode(
+            operatorSession: operatorSession,
+            clientId: nodeOptions.clientId,
+            timeoutSeconds: 12)
+        let initialLastSeenAtMs = initialNode.lastSeenAtMs ?? 0
+
+        appModel._test_setBackgrounded(true)
+        await appModel.gatewaySession.disconnect()
+        appModel._test_setGatewayConnected(false)
+
+        let applied = await appModel._test_performBackgroundAliveBeacon(
+            trigger: "simulator_e2e",
+            wakeId: "sim-e2e")
+        #expect(applied)
+
+        let updatedNode = try await Self.waitForNode(
+            operatorSession: operatorSession,
+            clientId: nodeOptions.clientId,
+            timeoutSeconds: 12,
+            predicate: { node in
+                node.lastSeenReason == "simulator_e2e" && (node.lastSeenAtMs ?? 0) > initialLastSeenAtMs
+            })
+        #expect(updatedNode.lastSeenReason == "simulator_e2e")
+        #expect((updatedNode.lastSeenAtMs ?? 0) > initialLastSeenAtMs)
+    }
+
+    private static func waitForNode(
+        operatorSession: GatewayNodeSession,
+        clientId: String,
+        timeoutSeconds: Double,
+        predicate: ((NodeSummary) -> Bool)? = nil
+    ) async throws -> NodeSummary {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        while Date() < deadline {
+            let payload = try await operatorSession.request(method: "node.list", paramsJSON: "{}", timeoutSeconds: 8)
+            let decoded = try JSONDecoder().decode(NodeListResult.self, from: payload)
+            if let match = decoded.nodes.first(where: { node in
+                node.clientId == clientId && (predicate?(node) ?? true)
+            }) {
+                return match
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        throw NSError(
+            domain: "NodeBackgroundAliveE2E",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Timed out waiting for node \(clientId)"])
+    }
+}

--- a/src/gateway/node-catalog.test.ts
+++ b/src/gateway/node-catalog.test.ts
@@ -94,6 +94,8 @@ describe("gateway/node-catalog", () => {
           commands: ["system.run"],
           createdAtMs: 1,
           approvedAtMs: 100,
+          lastSeenAtMs: 111,
+          lastSeenReason: "bg_app_refresh",
         },
       ],
       connectedNodes: [
@@ -135,6 +137,8 @@ describe("gateway/node-catalog", () => {
         pathEnv: "/usr/bin:/bin",
         approvedAtMs: 100,
         connectedAtMs,
+        lastSeenAtMs: connectedAtMs,
+        lastSeenReason: "connect",
         paired: true,
         connected: true,
       }),
@@ -173,6 +177,8 @@ describe("gateway/node-catalog", () => {
           commands: ["system.run"],
           createdAtMs: 1,
           approvedAtMs: 123,
+          lastSeenAtMs: 456,
+          lastSeenReason: "silent_push",
         },
       ],
       connectedNodes: [],
@@ -193,6 +199,102 @@ describe("gateway/node-catalog", () => {
         caps: ["system"],
         commands: ["system.run"],
         approvedAtMs: 123,
+        lastSeenAtMs: 456,
+        lastSeenReason: "silent_push",
+        paired: true,
+        connected: false,
+      }),
+    );
+  });
+
+  it("prefers the newest last-seen source consistently", () => {
+    const catalog = createKnownNodeCatalog({
+      pairedDevices: [
+        {
+          deviceId: "ios-1",
+          publicKey: "public-key",
+          displayName: "iPhone",
+          clientId: "openclaw-ios",
+          clientMode: "node",
+          role: "node",
+          roles: ["node"],
+          lastSeenAtMs: 900,
+          lastSeenReason: "silent_push",
+          tokens: {
+            node: {
+              token: "device-token",
+              role: "node",
+              scopes: [],
+              createdAtMs: 1,
+            },
+          },
+          createdAtMs: 1,
+          approvedAtMs: 99,
+        },
+      ],
+      pairedNodes: [
+        {
+          nodeId: "ios-1",
+          token: "node-token",
+          platform: "ios",
+          caps: ["device"],
+          commands: ["device.status"],
+          createdAtMs: 1,
+          approvedAtMs: 123,
+          lastSeenAtMs: 800,
+          lastSeenReason: "bg_app_refresh",
+        },
+      ],
+      connectedNodes: [],
+    });
+
+    expect(getKnownNode(catalog, "ios-1")).toEqual(
+      expect.objectContaining({
+        nodeId: "ios-1",
+        lastSeenAtMs: 900,
+        lastSeenReason: "silent_push",
+        paired: true,
+        connected: false,
+      }),
+    );
+  });
+
+  it("surfaces device-pair last-seen metadata when node pairing is absent", () => {
+    const catalog = createKnownNodeCatalog({
+      pairedDevices: [
+        {
+          deviceId: "ios-1",
+          publicKey: "public-key",
+          displayName: "iPhone",
+          clientId: "openclaw-ios",
+          clientMode: "node",
+          role: "node",
+          roles: ["node"],
+          lastSeenAtMs: 789,
+          lastSeenReason: "background-alive-test",
+          tokens: {
+            node: {
+              token: "device-token",
+              role: "node",
+              scopes: [],
+              createdAtMs: 1,
+            },
+          },
+          createdAtMs: 1,
+          approvedAtMs: 99,
+        },
+      ],
+      pairedNodes: [],
+      connectedNodes: [],
+    });
+
+    expect(getKnownNode(catalog, "ios-1")).toEqual(
+      expect.objectContaining({
+        nodeId: "ios-1",
+        clientId: "openclaw-ios",
+        clientMode: "node",
+        lastSeenAtMs: 789,
+        lastSeenReason: "background-alive-test",
         paired: true,
         connected: false,
       }),

--- a/src/gateway/node-catalog.ts
+++ b/src/gateway/node-catalog.ts
@@ -12,6 +12,8 @@ export type KnownNodeDevicePairingSource = {
   clientMode?: string;
   remoteIp?: string;
   approvedAtMs?: number;
+  lastSeenAtMs?: number;
+  lastSeenReason?: string;
 };
 
 export type KnownNodeApprovedSource = {
@@ -28,6 +30,8 @@ export type KnownNodeApprovedSource = {
   commands: string[];
   permissions?: Record<string, boolean>;
   approvedAtMs?: number;
+  lastSeenAtMs?: number;
+  lastSeenReason?: string;
 };
 
 export type KnownNodeEntry = {
@@ -67,6 +71,8 @@ function buildDevicePairingSource(entry: PairedDevice): KnownNodeDevicePairingSo
     clientMode: entry.clientMode,
     remoteIp: entry.remoteIp,
     approvedAtMs: entry.approvedAtMs,
+    lastSeenAtMs: entry.lastSeenAtMs,
+    lastSeenReason: entry.lastSeenReason,
   };
 }
 
@@ -85,6 +91,41 @@ function buildApprovedNodeSource(entry: NodePairingPairedNode): KnownNodeApprove
     commands: entry.commands ?? [],
     permissions: entry.permissions,
     approvedAtMs: entry.approvedAtMs,
+    lastSeenAtMs: entry.lastSeenAtMs,
+    lastSeenReason: entry.lastSeenReason,
+  };
+}
+
+function resolveEffectiveLastSeen(entry: {
+  devicePairing?: KnownNodeDevicePairingSource;
+  nodePairing?: KnownNodeApprovedSource;
+  live?: NodeSession;
+}): Pick<NodeListNode, "lastSeenAtMs" | "lastSeenReason"> {
+  const { devicePairing, nodePairing, live } = entry;
+  const candidates = [
+    live?.connectedAtMs ? { ts: live.connectedAtMs, reason: "connect" } : null,
+    nodePairing?.lastSeenAtMs
+      ? { ts: nodePairing.lastSeenAtMs, reason: nodePairing.lastSeenReason }
+      : null,
+    devicePairing?.lastSeenAtMs
+      ? { ts: devicePairing.lastSeenAtMs, reason: devicePairing.lastSeenReason }
+      : null,
+  ].filter((candidate) => candidate !== null);
+  const winner = candidates.reduce<{
+    ts: number;
+    reason?: string;
+  } | null>((best, candidate) => {
+    if (!candidate) {
+      return best;
+    }
+    if (!best || candidate.ts > best.ts) {
+      return candidate;
+    }
+    return best;
+  }, null);
+  return {
+    lastSeenAtMs: winner?.ts,
+    lastSeenReason: winner?.reason,
   };
 }
 
@@ -95,6 +136,7 @@ function buildEffectiveKnownNode(entry: {
   live?: NodeSession;
 }): NodeListNode {
   const { nodeId, devicePairing, nodePairing, live } = entry;
+  const { lastSeenAtMs, lastSeenReason } = resolveEffectiveLastSeen(entry);
   return {
     nodeId,
     displayName: live?.displayName ?? nodePairing?.displayName ?? devicePairing?.displayName,
@@ -115,6 +157,8 @@ function buildEffectiveKnownNode(entry: {
     permissions: live?.permissions ?? nodePairing?.permissions,
     connectedAtMs: live?.connectedAtMs,
     approvedAtMs: nodePairing?.approvedAtMs ?? devicePairing?.approvedAtMs,
+    lastSeenAtMs,
+    lastSeenReason,
     paired: Boolean(devicePairing ?? nodePairing),
     connected: Boolean(live),
   };

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -1131,10 +1131,20 @@ export const nodeHandlers: GatewayRequestHandlers = {
         loadGatewayModelCatalog: context.loadGatewayModelCatalog,
         logGateway: { warn: context.logGateway.warn },
       };
-      await handleNodeEvent(nodeContext, nodeId, {
-        event: p.event,
-        payloadJSON,
-      });
+      const nodePairingIds = new Set<string>([nodeId]);
+      const instanceId = normalizeOptionalString(client?.connect?.client?.instanceId) ?? "";
+      if (instanceId) {
+        nodePairingIds.add(instanceId);
+      }
+      await handleNodeEvent(
+        nodeContext,
+        nodeId,
+        {
+          event: p.event,
+          payloadJSON,
+        },
+        { nodePairingIds: [...nodePairingIds] },
+      );
       respond(true, { ok: true }, undefined);
     });
   },

--- a/src/gateway/server-methods/nodes.ts
+++ b/src/gateway/server-methods/nodes.ts
@@ -1131,11 +1131,6 @@ export const nodeHandlers: GatewayRequestHandlers = {
         loadGatewayModelCatalog: context.loadGatewayModelCatalog,
         logGateway: { warn: context.logGateway.warn },
       };
-      const nodePairingIds = new Set<string>([nodeId]);
-      const instanceId = normalizeOptionalString(client?.connect?.client?.instanceId) ?? "";
-      if (instanceId) {
-        nodePairingIds.add(instanceId);
-      }
       await handleNodeEvent(
         nodeContext,
         nodeId,
@@ -1143,7 +1138,7 @@ export const nodeHandlers: GatewayRequestHandlers = {
           event: p.event,
           payloadJSON,
         },
-        { nodePairingIds: [...nodePairingIds] },
+        { deviceId: client?.connect?.device?.id },
       );
       respond(true, { ok: true }, undefined);
     });

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -7,6 +7,8 @@ export { loadConfig } from "../config/config.js";
 export { updateSessionStore } from "../config/sessions.js";
 export { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 export { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
+export { updatePairedDeviceMetadata } from "../infra/device-pairing.js";
+export { updatePairedNodeMetadata } from "../infra/node-pairing.js";
 export { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 export { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 export { resolveOutboundTarget } from "../infra/outbound/targets.js";

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -47,6 +47,8 @@ const loadOrCreateDeviceIdentityMock = vi.hoisted(() =>
     privateKeyPem: "private",
   })),
 );
+const updatePairedDeviceMetadataMock = vi.hoisted(() => vi.fn());
+const updatePairedNodeMetadataMock = vi.hoisted(() => vi.fn());
 const parseMessageWithAttachmentsMock = vi.hoisted(() => vi.fn());
 const normalizeChannelIdMock = vi.hoisted(() =>
   vi.fn((channel?: string | null) => channel ?? null),
@@ -86,6 +88,8 @@ const runtimeMocks = vi.hoisted(() => ({
   ),
   normalizeChannelId: normalizeChannelIdMock,
   normalizeMainKey: vi.fn((key?: string | null) => key?.trim() || "agent:main:main"),
+  updatePairedDeviceMetadata: updatePairedDeviceMetadataMock,
+  updatePairedNodeMetadata: updatePairedNodeMetadataMock,
   normalizeRpcAttachmentsToChatAttachments: vi.fn((attachments?: unknown[]) => attachments ?? []),
   parseMessageWithAttachments: parseMessageWithAttachmentsMock,
   registerApnsRegistration: registerApnsRegistrationMock,
@@ -145,6 +149,8 @@ const updateSessionStoreMock = runtimeMocks.updateSessionStore;
 const loadSessionEntryMock = runtimeMocks.loadSessionEntry;
 const registerApnsRegistrationVi = runtimeMocks.registerApnsRegistration;
 const normalizeChannelIdVi = runtimeMocks.normalizeChannelId;
+const updatePairedDeviceMetadataVi = runtimeMocks.updatePairedDeviceMetadata;
+const updatePairedNodeMetadataVi = runtimeMocks.updatePairedNodeMetadata;
 
 function buildCtx(): NodeEventContext {
   return {
@@ -176,6 +182,8 @@ describe("node exec events", () => {
     registerApnsRegistrationVi.mockClear();
     loadOrCreateDeviceIdentityMock.mockClear();
     normalizeChannelIdVi.mockClear();
+    updatePairedDeviceMetadataVi.mockClear();
+    updatePairedNodeMetadataVi.mockClear();
     normalizeChannelIdVi.mockImplementation((channel?: string | null) => channel ?? null);
   });
 
@@ -439,6 +447,57 @@ describe("node exec events", () => {
     });
 
     expect(registerApnsRegistrationVi).not.toHaveBeenCalled();
+  });
+
+  it("stores durable node last-seen metadata from alive beacons", async () => {
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-alive", {
+      event: "node.presence.alive",
+      payloadJSON: JSON.stringify({
+        displayName: "Sim iPhone",
+        version: "2026.4.8",
+        platform: "iOS 26.0",
+        deviceFamily: "iPhone",
+        modelIdentifier: "iPhone17,1",
+        trigger: "bg_app_refresh",
+        pushTransport: "direct",
+        sentAtMs: 123,
+      }),
+    });
+
+    expect(updatePairedNodeMetadataVi).toHaveBeenCalledTimes(1);
+    expect(updatePairedDeviceMetadataVi).toHaveBeenCalledTimes(1);
+    expect(updatePairedNodeMetadataVi).toHaveBeenCalledWith("node-alive", {
+      lastSeenReason: "bg_app_refresh",
+      lastSeenAtMs: expect.any(Number),
+    });
+    expect(updatePairedDeviceMetadataVi).toHaveBeenCalledWith("node-alive", {
+      lastSeenReason: "bg_app_refresh",
+      lastSeenAtMs: expect.any(Number),
+    });
+  });
+
+  it("updates compatible node pairing aliases for alive beacons", async () => {
+    const ctx = buildCtx();
+    await handleNodeEvent(
+      ctx,
+      "node-alive",
+      {
+        event: "node.presence.alive",
+        payloadJSON: JSON.stringify({ trigger: "silent_push" }),
+      },
+      { nodePairingIds: ["node-alive", "legacy-instance"] },
+    );
+
+    expect(updatePairedNodeMetadataVi).toHaveBeenCalledTimes(2);
+    expect(updatePairedNodeMetadataVi).toHaveBeenNthCalledWith(1, "node-alive", {
+      lastSeenReason: "silent_push",
+      lastSeenAtMs: expect.any(Number),
+    });
+    expect(updatePairedNodeMetadataVi).toHaveBeenNthCalledWith(2, "legacy-instance", {
+      lastSeenReason: "silent_push",
+      lastSeenAtMs: expect.any(Number),
+    });
   });
 });
 

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -451,19 +451,24 @@ describe("node exec events", () => {
 
   it("stores durable node last-seen metadata from alive beacons", async () => {
     const ctx = buildCtx();
-    await handleNodeEvent(ctx, "node-alive", {
-      event: "node.presence.alive",
-      payloadJSON: JSON.stringify({
-        displayName: "Sim iPhone",
-        version: "2026.4.8",
-        platform: "iOS 26.0",
-        deviceFamily: "iPhone",
-        modelIdentifier: "iPhone17,1",
-        trigger: "bg_app_refresh",
-        pushTransport: "direct",
-        sentAtMs: 123,
-      }),
-    });
+    await handleNodeEvent(
+      ctx,
+      "node-alive",
+      {
+        event: "node.presence.alive",
+        payloadJSON: JSON.stringify({
+          displayName: "Sim iPhone",
+          version: "2026.4.8",
+          platform: "iOS 26.0",
+          deviceFamily: "iPhone",
+          modelIdentifier: "iPhone17,1",
+          trigger: "bg_app_refresh",
+          pushTransport: "direct",
+          sentAtMs: 123,
+        }),
+      },
+      { deviceId: "device-alive" },
+    );
 
     expect(updatePairedNodeMetadataVi).toHaveBeenCalledTimes(1);
     expect(updatePairedDeviceMetadataVi).toHaveBeenCalledTimes(1);
@@ -471,33 +476,42 @@ describe("node exec events", () => {
       lastSeenReason: "bg_app_refresh",
       lastSeenAtMs: expect.any(Number),
     });
-    expect(updatePairedDeviceMetadataVi).toHaveBeenCalledWith("node-alive", {
+    expect(updatePairedDeviceMetadataVi).toHaveBeenCalledWith("device-alive", {
       lastSeenReason: "bg_app_refresh",
       lastSeenAtMs: expect.any(Number),
     });
   });
 
-  it("updates compatible node pairing aliases for alive beacons", async () => {
+  it("does not update paired device metadata without an authenticated device id", async () => {
     const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-no-device", {
+      event: "node.presence.alive",
+      payloadJSON: JSON.stringify({ trigger: "silent_push" }),
+    });
+
+    expect(updatePairedNodeMetadataVi).toHaveBeenCalledTimes(1);
+    expect(updatePairedDeviceMetadataVi).not.toHaveBeenCalled();
+  });
+
+  it("throttles repeated alive beacons before persisting again", async () => {
+    const ctx = buildCtx();
+    const payloadJSON = JSON.stringify({ trigger: "bg_app_refresh" });
+
     await handleNodeEvent(
       ctx,
-      "node-alive",
-      {
-        event: "node.presence.alive",
-        payloadJSON: JSON.stringify({ trigger: "silent_push" }),
-      },
-      { nodePairingIds: ["node-alive", "legacy-instance"] },
+      "node-throttle",
+      { event: "node.presence.alive", payloadJSON },
+      { deviceId: "device-throttle" },
+    );
+    await handleNodeEvent(
+      ctx,
+      "node-throttle",
+      { event: "node.presence.alive", payloadJSON },
+      { deviceId: "device-throttle" },
     );
 
-    expect(updatePairedNodeMetadataVi).toHaveBeenCalledTimes(2);
-    expect(updatePairedNodeMetadataVi).toHaveBeenNthCalledWith(1, "node-alive", {
-      lastSeenReason: "silent_push",
-      lastSeenAtMs: expect.any(Number),
-    });
-    expect(updatePairedNodeMetadataVi).toHaveBeenNthCalledWith(2, "legacy-instance", {
-      lastSeenReason: "silent_push",
-      lastSeenAtMs: expect.any(Number),
-    });
+    expect(updatePairedNodeMetadataVi).toHaveBeenCalledTimes(1);
+    expect(updatePairedDeviceMetadataVi).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -20,6 +20,8 @@ import {
   loadSessionEntry,
   migrateAndPruneGatewaySessionStoreKey,
   normalizeChannelId,
+  updatePairedDeviceMetadata,
+  updatePairedNodeMetadata,
   normalizeMainKey,
   normalizeRpcAttachmentsToChatAttachments,
   parseMessageWithAttachments,
@@ -263,7 +265,12 @@ async function sendReceiptAck(params: {
   });
 }
 
-export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt: NodeEvent) => {
+export const handleNodeEvent = async (
+  ctx: NodeEventContext,
+  nodeId: string,
+  evt: NodeEvent,
+  opts?: { nodePairingIds?: readonly string[] },
+) => {
   switch (evt.event) {
     case "voice.transcript": {
       const obj = parsePayloadObject(evt.payloadJSON);
@@ -675,6 +682,35 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         }
       } catch (err) {
         ctx.logGateway.warn(`push apns register failed node=${nodeId}: ${formatForLog(err)}`);
+      }
+      return;
+    }
+    case "node.presence.alive": {
+      const obj = parsePayloadObject(evt.payloadJSON);
+      if (!obj) {
+        return;
+      }
+      const trigger = normalizeOptionalString(obj.trigger) ?? "background";
+      const receivedAtMs = Date.now();
+      const nodePairingIds = new Set<string>(
+        opts?.nodePairingIds?.length ? opts.nodePairingIds : [nodeId],
+      );
+      try {
+        await Promise.all([
+          ...[...nodePairingIds].map(
+            async (pairedNodeId) =>
+              await updatePairedNodeMetadata(pairedNodeId, {
+                lastSeenAtMs: receivedAtMs,
+                lastSeenReason: trigger,
+              }),
+          ),
+          updatePairedDeviceMetadata(nodeId, {
+            lastSeenAtMs: receivedAtMs,
+            lastSeenReason: trigger,
+          }),
+        ]);
+      } catch (err) {
+        ctx.logGateway.warn(`node presence alive failed node=${nodeId}: ${formatForLog(err)}`);
       }
       return;
     }

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -40,8 +40,10 @@ const MAX_EXEC_EVENT_OUTPUT_CHARS = 180;
 const MAX_NOTIFICATION_EVENT_TEXT_CHARS = 120;
 const VOICE_TRANSCRIPT_DEDUPE_WINDOW_MS = 1500;
 const MAX_RECENT_VOICE_TRANSCRIPTS = 200;
+const NODE_PRESENCE_PERSIST_MIN_INTERVAL_MS = 60_000;
 
 const recentVoiceTranscripts = new Map<string, { fingerprint: string; ts: number }>();
+const recentNodePresencePersistAt = new Map<string, number>();
 
 function normalizeFiniteInteger(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? Math.trunc(value) : null;
@@ -269,7 +271,7 @@ export const handleNodeEvent = async (
   ctx: NodeEventContext,
   nodeId: string,
   evt: NodeEvent,
-  opts?: { nodePairingIds?: readonly string[] },
+  opts?: { deviceId?: string },
 ) => {
   switch (evt.event) {
     case "voice.transcript": {
@@ -692,23 +694,27 @@ export const handleNodeEvent = async (
       }
       const trigger = normalizeOptionalString(obj.trigger) ?? "background";
       const receivedAtMs = Date.now();
-      const nodePairingIds = new Set<string>(
-        opts?.nodePairingIds?.length ? opts.nodePairingIds : [nodeId],
-      );
+      const presenceKey = opts?.deviceId ?? nodeId;
+      const lastPersistedAt = recentNodePresencePersistAt.get(presenceKey) ?? 0;
+      if (receivedAtMs - lastPersistedAt < NODE_PRESENCE_PERSIST_MIN_INTERVAL_MS) {
+        return;
+      }
       try {
         await Promise.all([
-          ...[...nodePairingIds].map(
-            async (pairedNodeId) =>
-              await updatePairedNodeMetadata(pairedNodeId, {
-                lastSeenAtMs: receivedAtMs,
-                lastSeenReason: trigger,
-              }),
-          ),
-          updatePairedDeviceMetadata(nodeId, {
+          updatePairedNodeMetadata(nodeId, {
             lastSeenAtMs: receivedAtMs,
             lastSeenReason: trigger,
           }),
+          ...(opts?.deviceId
+            ? [
+                updatePairedDeviceMetadata(opts.deviceId, {
+                  lastSeenAtMs: receivedAtMs,
+                  lastSeenReason: trigger,
+                }),
+              ]
+            : []),
         ]);
+        recentNodePresencePersistAt.set(presenceKey, receivedAtMs);
       } catch (err) {
         ctx.logGateway.warn(`node presence alive failed node=${nodeId}: ${formatForLog(err)}`);
       }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1260,8 +1260,23 @@ export function attachGatewayWsMessageHandler(params: {
           for (const nodeId of nodeIdsForPairing) {
             void updatePairedNodeMetadata(nodeId, {
               lastConnectedAtMs: nodeSession.connectedAtMs,
+              lastSeenAtMs: nodeSession.connectedAtMs,
+              lastSeenReason: "connect",
             }).catch((err) =>
               logGateway.warn(`failed to record last connect for ${nodeId}: ${formatForLog(err)}`),
+            );
+          }
+          if (device?.id) {
+            void updatePairedDeviceMetadata(device.id, {
+              clientId: nodeSession.clientId,
+              clientMode: nodeSession.clientMode,
+              remoteIp: nodeSession.remoteIp,
+              lastSeenAtMs: nodeSession.connectedAtMs,
+              lastSeenReason: "connect",
+            }).catch((err) =>
+              logGateway.warn(
+                `failed to record device last seen for ${device.id}: ${formatForLog(err)}`,
+              ),
             );
           }
           recordRemoteNodeInfo({

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1251,21 +1251,15 @@ export function attachGatewayWsMessageHandler(params: {
           const nodeSession = context.nodeRegistry.register(nextClient, {
             remoteIp: reportedClientIp,
           });
-          const instanceIdRaw = connectParams.client.instanceId;
-          const instanceId = normalizeOptionalString(instanceIdRaw) ?? "";
-          const nodeIdsForPairing = new Set<string>([nodeSession.nodeId]);
-          if (instanceId) {
-            nodeIdsForPairing.add(instanceId);
-          }
-          for (const nodeId of nodeIdsForPairing) {
-            void updatePairedNodeMetadata(nodeId, {
-              lastConnectedAtMs: nodeSession.connectedAtMs,
-              lastSeenAtMs: nodeSession.connectedAtMs,
-              lastSeenReason: "connect",
-            }).catch((err) =>
-              logGateway.warn(`failed to record last connect for ${nodeId}: ${formatForLog(err)}`),
-            );
-          }
+          void updatePairedNodeMetadata(nodeSession.nodeId, {
+            lastConnectedAtMs: nodeSession.connectedAtMs,
+            lastSeenAtMs: nodeSession.connectedAtMs,
+            lastSeenReason: "connect",
+          }).catch((err) =>
+            logGateway.warn(
+              `failed to record last connect for ${nodeSession.nodeId}: ${formatForLog(err)}`,
+            ),
+          );
           if (device?.id) {
             void updatePairedDeviceMetadata(device.id, {
               clientId: nodeSession.clientId,

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -16,6 +16,7 @@ import {
   requestDevicePairing,
   revokeDeviceToken,
   rotateDeviceToken,
+  updatePairedDeviceMetadata,
   verifyDeviceToken,
   type PairedDevice,
   type RotateDeviceTokenResult,
@@ -901,6 +902,50 @@ describe("device pairing tokens", () => {
     await expect(getPairedDevice("device-1", baseDir)).resolves.toBeNull();
 
     await expect(removePairedDevice("device-1", baseDir)).resolves.toBeNull();
+  });
+
+  test("updates paired device metadata using the normalized device id key", async () => {
+    const baseDir = await makeDevicePairingDir();
+    await setupPairedNodeDevice(baseDir);
+
+    await updatePairedDeviceMetadata(
+      "  node-1  ",
+      {
+        lastSeenAtMs: 123_456,
+        lastSeenReason: "bg_app_refresh",
+      },
+      baseDir,
+    );
+
+    await expect(getPairedDevice("node-1", baseDir)).resolves.toEqual(
+      expect.objectContaining({
+        deviceId: "node-1",
+        lastSeenAtMs: 123_456,
+        lastSeenReason: "bg_app_refresh",
+      }),
+    );
+
+    const { pairedPath } = resolvePairingPaths(baseDir, "devices");
+    const pairedByDeviceId = JSON.parse(await readFile(pairedPath, "utf8")) as Record<
+      string,
+      PairedDevice
+    >;
+    expect(Object.keys(pairedByDeviceId)).toEqual(["node-1"]);
+  });
+
+  test("rejects reserved paired device ids for metadata updates", async () => {
+    const baseDir = await makeDevicePairingDir();
+
+    await expect(
+      updatePairedDeviceMetadata(
+        "__proto__",
+        {
+          lastSeenAtMs: 1,
+          lastSeenReason: "connect",
+        },
+        baseDir,
+      ),
+    ).rejects.toThrow("reserved device pairing id");
   });
 
   test("clears paired device state by device id", async () => {

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -78,6 +78,8 @@ export type PairedDevice = {
   tokens?: Record<string, DeviceAuthToken>;
   createdAtMs: number;
   approvedAtMs: number;
+  lastSeenAtMs?: number;
+  lastSeenReason?: string;
 };
 
 export type DevicePairingList = {
@@ -743,6 +745,8 @@ export async function updatePairedDeviceMetadata(
       role: patch.role ?? existing.role,
       roles,
       scopes,
+      lastSeenAtMs: patch.lastSeenAtMs ?? existing.lastSeenAtMs,
+      lastSeenReason: patch.lastSeenReason ?? existing.lastSeenReason,
     };
     await persistState(state, baseDir);
   });

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -97,11 +97,25 @@ type DevicePairingStateFile = {
   pairedByDeviceId: Record<string, PairedDevice>;
 };
 
+const RESERVED_PAIRING_MAP_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 const PENDING_TTL_MS = 5 * 60 * 1000;
 const OPERATOR_ROLE = "operator";
 const OPERATOR_SCOPE_PREFIX = "operator.";
 
 const withLock = createAsyncLock();
+
+function toNullPrototypeRecord<T>(record: Record<string, T> | null | undefined): Record<string, T> {
+  return Object.assign(Object.create(null) as Record<string, T>, record ?? {});
+}
+
+function normalizeDeviceMapKey(deviceId: string): string {
+  const normalized = normalizeDeviceId(deviceId);
+  if (RESERVED_PAIRING_MAP_KEYS.has(normalized)) {
+    throw new Error(`reserved device pairing id: ${normalized}`);
+  }
+  return normalized;
+}
 
 async function loadState(baseDir?: string): Promise<DevicePairingStateFile> {
   const { pendingPath, pairedPath } = resolvePairingPaths(baseDir, "devices");
@@ -110,8 +124,8 @@ async function loadState(baseDir?: string): Promise<DevicePairingStateFile> {
     readJsonFile<Record<string, PairedDevice>>(pairedPath),
   ]);
   const state: DevicePairingStateFile = {
-    pendingById: pending ?? {},
-    pairedByDeviceId: paired ?? {},
+    pendingById: toNullPrototypeRecord(pending),
+    pairedByDeviceId: toNullPrototypeRecord(paired),
   };
   pruneExpiredPending(state.pendingById, Date.now(), PENDING_TTL_MS);
   return state;
@@ -729,13 +743,14 @@ export async function updatePairedDeviceMetadata(
 ): Promise<void> {
   return await withLock(async () => {
     const state = await loadState(baseDir);
-    const existing = state.pairedByDeviceId[normalizeDeviceId(deviceId)];
+    const normalized = normalizeDeviceMapKey(deviceId);
+    const existing = state.pairedByDeviceId[normalized];
     if (!existing) {
       return;
     }
     const roles = mergeRoles(existing.roles, existing.role, patch.role);
     const scopes = mergeScopes(existing.scopes, patch.scopes);
-    state.pairedByDeviceId[deviceId] = {
+    state.pairedByDeviceId[normalized] = {
       ...existing,
       ...patch,
       deviceId: existing.deviceId,

--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -5,6 +5,7 @@ import {
   getPairedNode,
   listNodePairing,
   requestNodePairing,
+  updatePairedNodeMetadata,
   verifyNodeToken,
 } from "./node-pairing.js";
 
@@ -255,6 +256,28 @@ describe("node pairing tokens", () => {
         ],
         paired: [],
       });
+    });
+  });
+
+  test("persists last-seen metadata updates for paired nodes", async () => {
+    await withNodePairingDir(async (baseDir) => {
+      await setupPairedNode(baseDir);
+      await updatePairedNodeMetadata(
+        "node-1",
+        {
+          lastSeenAtMs: 123_456,
+          lastSeenReason: "bg_app_refresh",
+        },
+        baseDir,
+      );
+
+      await expect(getPairedNode("node-1", baseDir)).resolves.toEqual(
+        expect.objectContaining({
+          nodeId: "node-1",
+          lastSeenAtMs: 123_456,
+          lastSeenReason: "bg_app_refresh",
+        }),
+      );
     });
   });
 });

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -50,6 +50,8 @@ export type NodePairingPairedNode = NodeApprovedSurface & {
   createdAtMs: number;
   approvedAtMs: number;
   lastConnectedAtMs?: number;
+  lastSeenAtMs?: number;
+  lastSeenReason?: string;
 };
 
 export type NodePairingList = {
@@ -329,6 +331,8 @@ export async function updatePairedNodeMetadata(
       bins: patch.bins ?? existing.bins,
       permissions: patch.permissions ?? existing.permissions,
       lastConnectedAtMs: patch.lastConnectedAtMs ?? existing.lastConnectedAtMs,
+      lastSeenAtMs: patch.lastSeenAtMs ?? existing.lastSeenAtMs,
+      lastSeenReason: patch.lastSeenReason ?? existing.lastSeenReason,
     };
 
     state.pairedByNodeId[normalized] = next;

--- a/src/infra/node-pairing.ts
+++ b/src/infra/node-pairing.ts
@@ -64,10 +64,16 @@ type NodePairingStateFile = {
   pairedByNodeId: Record<string, NodePairingPairedNode>;
 };
 
+const RESERVED_PAIRING_MAP_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
 const PENDING_TTL_MS = 5 * 60 * 1000;
 const OPERATOR_ROLE = "operator";
 
 const withLock = createAsyncLock();
+
+function toNullPrototypeRecord<T>(record: Record<string, T> | null | undefined): Record<string, T> {
+  return Object.assign(Object.create(null) as Record<string, T>, record ?? {});
+}
 
 function buildPendingNodePairingRequest(params: {
   requestId?: string;
@@ -140,8 +146,8 @@ async function loadState(baseDir?: string): Promise<NodePairingStateFile> {
     readJsonFile<Record<string, NodePairingPairedNode>>(pairedPath),
   ]);
   const state: NodePairingStateFile = {
-    pendingById: pending ?? {},
-    pairedByNodeId: paired ?? {},
+    pendingById: toNullPrototypeRecord(pending),
+    pairedByNodeId: toNullPrototypeRecord(paired),
   };
   pruneExpiredPending(state.pendingById, Date.now(), PENDING_TTL_MS);
   return state;
@@ -156,7 +162,11 @@ async function persistState(state: NodePairingStateFile, baseDir?: string) {
 }
 
 function normalizeNodeId(nodeId: string) {
-  return nodeId.trim();
+  const normalized = nodeId.trim();
+  if (RESERVED_PAIRING_MAP_KEYS.has(normalized)) {
+    throw new Error(`reserved node pairing id: ${normalized}`);
+  }
+  return normalized;
 }
 
 function newToken() {

--- a/src/shared/node-list-types.ts
+++ b/src/shared/node-list-types.ts
@@ -18,6 +18,8 @@ export type NodeListNode = {
   connected?: boolean;
   connectedAtMs?: number;
   approvedAtMs?: number;
+  lastSeenAtMs?: number;
+  lastSeenReason?: string;
 };
 
 export type PendingRequest = {
@@ -47,6 +49,8 @@ export type PairedNode = {
   createdAtMs?: number;
   approvedAtMs?: number;
   lastConnectedAtMs?: number;
+  lastSeenAtMs?: number;
+  lastSeenReason?: string;
 };
 
 export type PairingList = {


### PR DESCRIPTION
## Summary

- Problem: iOS background wakes did not give the gateway a durable, acked way to record that a node was recently alive unless a live websocket reconnect happened.
- Why it matters: operators could not distinguish "currently connected" from "recently seen alive," and iOS background wake opportunities were being spent on reconnect attempts without a durable last-seen signal.
- What changed: added durable `lastSeenAtMs` / `lastSeenReason` metadata, a `node.presence.alive` event path, and iOS background wake logic that reconnects briefly if needed and sends an acked alive beacon.
- What did NOT change (scope boundary): `connected` / `connectedAtMs` still mean live websocket state now; this does not try to keep a persistent background socket alive.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: iOS wake paths only did best-effort reconnect work and the gateway only persisted durable node activity on live connect, so short background wake opportunities had no durable recent-alive breadcrumb.
- Missing detection / guardrail: there was no durable last-seen field or acked node-auth beacon contract for iOS background wakes.
- Contributing context (if known): iOS background execution is OS-controlled, so relying on live websocket state alone misses successful wake opportunities that do not remain connected.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server-node-events.test.ts`
  - `src/gateway/node-catalog.test.ts`
  - `src/infra/node-pairing.test.ts`
  - `apps/ios/Tests/NodeBackgroundAliveBeaconTests.swift`
  - `apps/ios/Tests/NodeBackgroundAliveE2ETests.swift`
- Scenario the test should lock in: durable last-seen persistence/surfacing, connect-derived last-seen updates, and iOS background beacon throttling/reconnect behavior.
- Why this is the smallest reliable guardrail: the gateway contract and iOS wake logic are the narrowest seams that express the bug.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Nodes can now surface durable `lastSeenAtMs` / `lastSeenReason` even when not currently connected.
- iOS background refresh, silent push, and significant location wake paths now try to deliver an acked alive beacon instead of only kicking reconnect work.

## Diagram (if applicable)

```text
Before:
[iOS background wake] -> [best-effort reconnect attempt] -> [maybe live connect] -> [no durable recent-alive signal unless connected]

After:
[iOS background wake] -> [brief reconnect if needed] -> [node.presence.alive ack] -> [gateway persists lastSeen*]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (Yes)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: adds a node-authenticated `node.event` usage for `node.presence.alive`; it does not require operator auth and keeps `connected` semantics unchanged.

## Repro + Verification

### Environment

- OS: macOS 15 + iOS Simulator 18.6
- Runtime/container: Node 24 / pnpm
- Model/provider: N/A
- Integration/channel (if any): local gateway + iOS app
- Relevant config (redacted): local loopback gateway config under `.local/ios-background-alive-e2e/`

### Steps

1. Start a local dev gateway.
2. Connect the iOS app / test node to that gateway.
3. Trigger connect/background-alive paths and inspect `node.list` plus targeted tests.

### Expected

- The gateway preserves live `connected` semantics.
- The gateway also persists durable `lastSeenAtMs` / `lastSeenReason` for recent-alive updates.

### Actual

- Verified as expected via targeted TS tests, local gateway inspection, and iOS logic coverage.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - targeted gateway tests pass for node event + node catalog persistence
  - `xcodebuild test -scheme OpenClawLogicTests ...` passes
  - local gateway `node.list` inspection matches expected last-seen fields
- Edge cases checked:
  - offline node-pair metadata surfacing
  - device-pair fallback surfacing
  - background-beacon throttle helper behavior
- What you did **not** verify:
  - reliable real silent-push wake delivery in Simulator
  - clean app-hosted `OpenClawTests` execution in Simulator (build-for-testing succeeded, but the test runner hung before connecting)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: iOS background execution is best-effort and OS-controlled.
  - Mitigation: the design uses existing wake paths plus acked beacon delivery rather than promising persistent connectivity.
- Risk: Simulator background validation is incomplete for silent push.
  - Mitigation: targeted logic and gateway coverage were added, and local gateway verification was performed.
