### PR TITLE
fix(gog): correct Gmail search example in skill docs

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -35,7 +35,7 @@ Setup (once)
 Common commands
 
 - Gmail search: `gog gmail search 'newer_than:7d' --max 10`
-- Gmail messages search (per email, ignores threading): `gog gmail messages search "in:inbox from:ryanair.com" --max 20 --account you@example.com`
+- Gmail messages search (per email, ignores threading): `gog gmail search "in:inbox from:ryanair.com" --max 20 --account you@example.com`
 - Gmail send (plain): `gog gmail send --to a@b.com --subject "Hi" --body "Hello"`
 - Gmail send (multi-line): `gog gmail send --to a@b.com --subject "Hi" --body-file ./message.txt`
 - Gmail send (stdin): `gog gmail send --to a@b.com --subject "Hi" --body-file -`


### PR DESCRIPTION
## Summary
- fix the incorrect Gmail example in `skills/gog/SKILL.md`
- change `gog gmail messages search ...` to `gog gmail search ...`
- keep the change scoped to the prebundled skill documentation example only

## Test plan
- not run; documentation-only change