### PR TITLE
fix(memory): stabilize corpus supplement ordering for prompt-cache and performance stability

### DIFF
--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -220,6 +220,30 @@ describe("memory plugin state", () => {
     ).resolves.toEqual([{ corpus: "wiki", path: "sources/alpha.md", score: 1, snippet: "x" }]);
   });
 
+  it("listMemoryCorpusSupplements returns supplements in pluginId order regardless of registration order", () => {
+    const makeSupp = () => ({ search: async () => [], get: async () => null });
+
+    // Register in reverse alphabetical order
+    registerMemoryCorpusSupplement("plugin-z", makeSupp());
+    registerMemoryCorpusSupplement("plugin-a", makeSupp());
+    registerMemoryCorpusSupplement("plugin-m", makeSupp());
+
+    const ids = listMemoryCorpusSupplements().map((s) => s.pluginId);
+    expect(ids).toEqual(["plugin-a", "plugin-m", "plugin-z"]);
+  });
+
+  it("listMemoryCorpusSupplements order is stable when re-registering the same plugin", () => {
+    const makeSupp = () => ({ search: async () => [], get: async () => null });
+
+    registerMemoryCorpusSupplement("plugin-b", makeSupp());
+    registerMemoryCorpusSupplement("plugin-a", makeSupp());
+    // Re-register plugin-b (simulates plugin reload)
+    registerMemoryCorpusSupplement("plugin-b", makeSupp());
+
+    const ids = listMemoryCorpusSupplements().map((s) => s.pluginId);
+    expect(ids).toEqual(["plugin-a", "plugin-b"]);
+  });
+
   it("uses the registered flush plan resolver", () => {
     registerMemoryFlushPlanResolver(() => ({
       softThresholdTokens: 1,

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -184,7 +184,10 @@ export function getMemoryCapabilityRegistration(): MemoryPluginCapabilityRegistr
 }
 
 export function listMemoryCorpusSupplements(): MemoryCorpusSupplementRegistration[] {
-  return [...memoryPluginState.corpusSupplements];
+  // Keep supplement order stable even if plugin registration order changes.
+  return [...memoryPluginState.corpusSupplements].toSorted((a, b) =>
+    a.pluginId.localeCompare(b.pluginId),
+  );
 }
 
 /** @deprecated Use registerMemoryCapability(pluginId, { promptBuilder }) instead. */


### PR DESCRIPTION
## Summary

  - **Problem:** `listMemoryCorpusSupplements()` returned supplements in insertion order, which varies with plugin load sequence across restarts.
  - **Why it matters:** Non-deterministic ordering has two concrete effects:
    1. `getMemoryCorpusSupplementResult` iterates supplements sequentially and returns the first hit — if two supplements can serve the same path, registration order silently decides which one wins, making behavior inconsistent across restarts.
    2. `loader.ts` snapshots and restores the corpus supplement list for cache/rollback paths — an unstable order means cache hits can restore a different list than the live run produced.
    The parallel `promptSupplements` path already has an explicit `.toSorted()` with a comment explaining this exact concern; `corpusSupplements` was missing the same guard.
  - **What changed:** Added `.toSorted((a, b) => a.pluginId.localeCompare(b.pluginId))` to `listMemoryCorpusSupplements()` — matching the existing pattern in the same file.
  - **What did NOT change:** Registration mutation logic, supplement content, search result ordering (search uses score-based sort regardless), or any other part of `memory-state.ts`.

  ## Change Type (select all)

  - [x] Bug fix

  ## Scope (select all touched areas)

  - [x] Memory / storage

  ## Linked Issue/PR

  - [ ] This PR fixes a bug or regression

  ## Root Cause (if applicable)

  - Root cause: `promptSupplements` was sorted when `corpusSupplements` was added later; the sort was not applied consistently.
  - Missing detection / guardrail: No test asserted that `listMemoryCorpusSupplements` returns a stable order regardless of registration sequence.
  - Contributing context (if known): The existing `promptSupplements` sort already has an explanatory comment; `corpusSupplements` was a copy without the guard.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
  - Target test or file: `src/plugins/memory-state.test.ts`
  - Scenario the test should lock in: reverse-alphabetical registration order produces alphabetical output; re-registering the same plugin does not duplicate or reorder entries.
  - Why this is the smallest reliable guardrail: The function is pure state; a unit test with controlled registration order is the fastest and most direct proof.
  - Existing test that already covers this (if any): None (added in this PR).

  ## User-visible / Behavior Changes

  None — `corpusSupplements` are consumed internally for memory search assembly; users do not see ordering directly. The fix eliminates silent prompt-cache invalidation.

  ## Diagram (if applicable)

  ```text
  Before:
  [plugins register in any order] -> listMemoryCorpusSupplements() -> insertion order (non-deterministic)

  After:
  [plugins register in any order] -> listMemoryCorpusSupplements() -> sorted by pluginId (stable)

  Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  Repro + Verification

  Steps

  1. Register two corpus supplements with IDs "plugin-z" and "plugin-a" (in that order).
  2. Call listMemoryCorpusSupplements().
  3. Before fix: order was ["plugin-z", "plugin-a"]. After fix: ["plugin-a", "plugin-z"].

  Expected

  Alphabetical order regardless of registration sequence.

  Actual (before fix)

  Insertion order.

  Evidence

  - Failing test/log before + passing after

  Two new tests in src/plugins/memory-state.test.ts — both pass after the fix, both would fail against the old implementation. Full suite: 13/13 green.

  Human Verification (required)

  - Verified scenarios: out-of-order registration, re-registration of existing plugin ID.
  - Edge cases checked: single supplement (trivially stable), re-registration replaces existing entry.
  - What you did not verify: live multi-plugin startup with real plugin packages.

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  Risks and Mitigations

  - Risk: Any caller that depended on insertion order would observe a different sequence.
    - Mitigation: No public contract documents an insertion-order guarantee; the parallel promptSupplements path already sorts. No known callers depend on insertion order.