### PR TITLE
fix(gateway): clear auto-fallback model override on session reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 - Reply/doctor: resolve reply-run SecretRefs before preflight helpers touch config, surface gateway OAuth reauth failures to users, and make `openclaw doctor` call out exact reauth commands.
 - Android/pairing: clear stale setup-code auth on new QR scans, bootstrap operator and node sessions from fresh pairing, prefer stored device tokens after bootstrap handoff, and pause pairing auto-retry while the app is backgrounded so scan-once Android pairing recovers reliably again. (#63199) Thanks @obviyus.
 - Auto-reply/NO_REPLY: strip glued leading `NO_REPLY` tokens before reply normalization and ACP-visible streaming so silent sentinel text no longer leaks into user-visible replies while preserving substantive `NO_REPLY ...` text. Thanks @frankekn.
+- Gateway/sessions: clear auto-fallback-pinned model overrides on `/reset` and `/new` while still preserving explicit user model selections, including legacy sessions created before override-source tracking existed. (#63155) Thanks @frankekn.
 
 ## 2026.4.8
 

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1500,6 +1500,7 @@ describe("runAgentTurnWithFallback", () => {
     });
     expect(sessionEntry.providerOverride).toBe("openai-codex");
     expect(sessionEntry.modelOverride).toBe("gpt-5.4");
+    expect(sessionEntry.modelOverrideSource).toBe("auto");
     expect(sessionEntry.authProfileOverride).toBeUndefined();
     expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
     expect(sessionStore.main.authProfileOverride).toBeUndefined();
@@ -1533,6 +1534,7 @@ describe("runAgentTurnWithFallback", () => {
       updatedAt: 123,
       providerOverride: "anthropic",
       modelOverride: "claude-sonnet",
+      modelOverrideSource: "auto",
       authProfileOverride: "anthropic:openclaw",
       authProfileOverrideSource: "user",
     });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -113,6 +113,7 @@ type FallbackSelectionState = Pick<
   SessionEntry,
   | "providerOverride"
   | "modelOverride"
+  | "modelOverrideSource"
   | "authProfileOverride"
   | "authProfileOverrideSource"
   | "authProfileOverrideCompactionCount"
@@ -121,6 +122,7 @@ type FallbackSelectionState = Pick<
 const FALLBACK_SELECTION_STATE_KEYS = [
   "providerOverride",
   "modelOverride",
+  "modelOverrideSource",
   "authProfileOverride",
   "authProfileOverrideSource",
   "authProfileOverrideCompactionCount",
@@ -141,6 +143,12 @@ function setFallbackSelectionStateField(
     case "modelOverride":
       if (entry.modelOverride !== value) {
         entry.modelOverride = value as SessionEntry["modelOverride"];
+        return true;
+      }
+      return false;
+    case "modelOverrideSource":
+      if (entry.modelOverrideSource !== value) {
+        entry.modelOverrideSource = value as SessionEntry["modelOverrideSource"];
         return true;
       }
       return false;
@@ -170,6 +178,7 @@ function snapshotFallbackSelectionState(entry: SessionEntry): FallbackSelectionS
   return {
     providerOverride: entry.providerOverride,
     modelOverride: entry.modelOverride,
+    modelOverrideSource: entry.modelOverrideSource,
     authProfileOverride: entry.authProfileOverride,
     authProfileOverrideSource: entry.authProfileOverrideSource,
     authProfileOverrideCompactionCount: entry.authProfileOverrideCompactionCount,
@@ -185,6 +194,7 @@ function buildFallbackSelectionState(params: {
   return {
     providerOverride: params.provider,
     modelOverride: params.model,
+    modelOverrideSource: "auto",
     authProfileOverride: params.authProfileId,
     authProfileOverrideSource: params.authProfileId ? params.authProfileIdSource : undefined,
     authProfileOverrideCompactionCount: undefined,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -162,6 +162,12 @@ export type SessionEntry = {
   responseUsage?: "on" | "off" | "tokens" | "full";
   providerOverride?: string;
   modelOverride?: string;
+  /**
+   * Tracks whether the persisted model override came from an explicit user
+   * action (`/model`, `sessions.patch`) or from a temporary runtime fallback.
+   * Resets only preserve user-driven overrides.
+   */
+  modelOverrideSource?: "auto" | "user";
   authProfileOverride?: string;
   authProfileOverrideSource?: "auto" | "user";
   authProfileOverrideCompactionCount?: number;

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1581,6 +1581,7 @@ describe("gateway server sessions", () => {
           updatedAt: Date.now(),
           providerOverride: "anthropic",
           modelOverride: "claude-opus-4-1",
+          modelOverrideSource: "user",
           modelProvider: "openai",
           model: "gpt-test-a",
         },
@@ -1637,6 +1638,7 @@ describe("gateway server sessions", () => {
           updatedAt: Date.now(),
           providerOverride: "anthropic",
           modelOverride: "claude-opus-4-1",
+          modelOverrideSource: "auto",
           fallbackNoticeSelectedModel: "openai/gpt-test-a",
           fallbackNoticeActiveModel: "anthropic/claude-opus-4-1",
           fallbackNoticeReason: "rate limit",
@@ -1679,6 +1681,64 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.reset follows the updated default after an auto fallback pinned an older default", async () => {
+    const { storePath } = await createSessionStoreDir();
+    testState.agentConfig = {
+      model: {
+        primary: "openai/gpt-test-c",
+      },
+    };
+
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-fallback-stale-default",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-1",
+          modelOverrideSource: "auto",
+          fallbackNoticeSelectedModel: "openai/gpt-test-a",
+          fallbackNoticeActiveModel: "anthropic/claude-opus-4-1",
+          fallbackNoticeReason: "rate limit",
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    const reset = await rpcReq<{
+      ok: true;
+      key: string;
+      entry: {
+        providerOverride?: string;
+        modelOverride?: string;
+        modelProvider?: string;
+        model?: string;
+      };
+    }>(ws, "sessions.reset", { key: "main" });
+
+    expect(reset.ok).toBe(true);
+    expect(reset.payload?.entry.providerOverride).toBeUndefined();
+    expect(reset.payload?.entry.modelOverride).toBeUndefined();
+    expect(reset.payload?.entry.modelProvider).toBe("openai");
+    expect(reset.payload?.entry.model).toBe("gpt-test-c");
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      {
+        providerOverride?: string;
+        modelOverride?: string;
+        modelProvider?: string;
+        model?: string;
+      }
+    >;
+    expect(store["agent:main:main"]?.providerOverride).toBeUndefined();
+    expect(store["agent:main:main"]?.modelOverride).toBeUndefined();
+    expect(store["agent:main:main"]?.modelProvider).toBe("openai");
+    expect(store["agent:main:main"]?.model).toBe("gpt-test-c");
+
+    ws.close();
+  });
+
   test("sessions.reset preserves spawned session ownership metadata", async () => {
     const { storePath } = await createSessionStoreDir();
     const customSessionFile = path.join(
@@ -1708,6 +1768,7 @@ describe("gateway server sessions", () => {
           ttsAuto: "always",
           providerOverride: "anthropic",
           modelOverride: "claude-opus-4-1",
+          modelOverrideSource: "user",
           authProfileOverride: "work",
           authProfileOverrideSource: "user",
           authProfileOverrideCompactionCount: 7,

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1566,6 +1566,119 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.reset preserves explicit model overrides without auth profile source", async () => {
+    const { storePath } = await createSessionStoreDir();
+    testState.agentConfig = {
+      model: {
+        primary: "openai/gpt-test-a",
+      },
+    };
+
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-explicit-model-override",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-1",
+          modelProvider: "openai",
+          model: "gpt-test-a",
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    const reset = await rpcReq<{
+      ok: true;
+      key: string;
+      entry: {
+        providerOverride?: string;
+        modelOverride?: string;
+        modelProvider?: string;
+        model?: string;
+      };
+    }>(ws, "sessions.reset", { key: "main" });
+
+    expect(reset.ok).toBe(true);
+    expect(reset.payload?.entry.providerOverride).toBe("anthropic");
+    expect(reset.payload?.entry.modelOverride).toBe("claude-opus-4-1");
+    expect(reset.payload?.entry.modelProvider).toBe("anthropic");
+    expect(reset.payload?.entry.model).toBe("claude-opus-4-1");
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      {
+        providerOverride?: string;
+        modelOverride?: string;
+        modelProvider?: string;
+        model?: string;
+      }
+    >;
+    expect(store["agent:main:main"]?.providerOverride).toBe("anthropic");
+    expect(store["agent:main:main"]?.modelOverride).toBe("claude-opus-4-1");
+    expect(store["agent:main:main"]?.modelProvider).toBe("anthropic");
+    expect(store["agent:main:main"]?.model).toBe("claude-opus-4-1");
+
+    ws.close();
+  });
+
+  test("sessions.reset clears fallback-pinned model overrides and restores the selected model", async () => {
+    const { storePath } = await createSessionStoreDir();
+    testState.agentConfig = {
+      model: {
+        primary: "openai/gpt-test-a",
+      },
+    };
+
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId: "sess-fallback-model-override",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-1",
+          fallbackNoticeSelectedModel: "openai/gpt-test-a",
+          fallbackNoticeActiveModel: "anthropic/claude-opus-4-1",
+          fallbackNoticeReason: "rate limit",
+        },
+      },
+    });
+
+    const { ws } = await openClient();
+    const reset = await rpcReq<{
+      ok: true;
+      key: string;
+      entry: {
+        providerOverride?: string;
+        modelOverride?: string;
+        modelProvider?: string;
+        model?: string;
+      };
+    }>(ws, "sessions.reset", { key: "main" });
+
+    expect(reset.ok).toBe(true);
+    expect(reset.payload?.entry.providerOverride).toBeUndefined();
+    expect(reset.payload?.entry.modelOverride).toBeUndefined();
+    expect(reset.payload?.entry.modelProvider).toBe("openai");
+    expect(reset.payload?.entry.model).toBe("gpt-test-a");
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      {
+        providerOverride?: string;
+        modelOverride?: string;
+        modelProvider?: string;
+        model?: string;
+      }
+    >;
+    expect(store["agent:main:main"]?.providerOverride).toBeUndefined();
+    expect(store["agent:main:main"]?.modelOverride).toBeUndefined();
+    expect(store["agent:main:main"]?.modelProvider).toBe("openai");
+    expect(store["agent:main:main"]?.model).toBe("gpt-test-a");
+
+    ws.close();
+  });
+
   test("sessions.reset preserves spawned session ownership metadata", async () => {
     const { storePath } = await createSessionStoreDir();
     const customSessionFile = path.join(

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1566,7 +1566,7 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
-  test("sessions.reset preserves explicit model overrides without auth profile source", async () => {
+  test("sessions.reset preserves legacy explicit model overrides without modelOverrideSource", async () => {
     const { storePath } = await createSessionStoreDir();
     testState.agentConfig = {
       model: {
@@ -1581,7 +1581,6 @@ describe("gateway server sessions", () => {
           updatedAt: Date.now(),
           providerOverride: "anthropic",
           modelOverride: "claude-opus-4-1",
-          modelOverrideSource: "user",
           modelProvider: "openai",
           model: "gpt-test-a",
         },
@@ -1595,6 +1594,7 @@ describe("gateway server sessions", () => {
       entry: {
         providerOverride?: string;
         modelOverride?: string;
+        modelOverrideSource?: string;
         modelProvider?: string;
         model?: string;
       };
@@ -1603,6 +1603,7 @@ describe("gateway server sessions", () => {
     expect(reset.ok).toBe(true);
     expect(reset.payload?.entry.providerOverride).toBe("anthropic");
     expect(reset.payload?.entry.modelOverride).toBe("claude-opus-4-1");
+    expect(reset.payload?.entry.modelOverrideSource).toBe("user");
     expect(reset.payload?.entry.modelProvider).toBe("anthropic");
     expect(reset.payload?.entry.model).toBe("claude-opus-4-1");
 
@@ -1611,12 +1612,14 @@ describe("gateway server sessions", () => {
       {
         providerOverride?: string;
         modelOverride?: string;
+        modelOverrideSource?: string;
         modelProvider?: string;
         model?: string;
       }
     >;
     expect(store["agent:main:main"]?.providerOverride).toBe("anthropic");
     expect(store["agent:main:main"]?.modelOverride).toBe("claude-opus-4-1");
+    expect(store["agent:main:main"]?.modelOverrideSource).toBe("user");
     expect(store["agent:main:main"]?.modelProvider).toBe("anthropic");
     expect(store["agent:main:main"]?.model).toBe("claude-opus-4-1");
 

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -540,11 +540,19 @@ export async function performGatewaySessionReset(params: {
       execAsk: currentEntry?.execAsk,
       execNode: currentEntry?.execNode,
       responseUsage: currentEntry?.responseUsage,
-      providerOverride: currentEntry?.providerOverride,
-      modelOverride: currentEntry?.modelOverride,
-      authProfileOverride: currentEntry?.authProfileOverride,
-      authProfileOverrideSource: currentEntry?.authProfileOverrideSource,
-      authProfileOverrideCompactionCount: currentEntry?.authProfileOverrideCompactionCount,
+      // Only preserve model/provider/auth overrides across reset when they were
+      // explicitly chosen by the user (e.g. /model command). System-driven
+      // overrides (fallback rotation, auto-selection) should not survive reset
+      // so the session returns to the configured default model.
+      ...(currentEntry?.authProfileOverrideSource === "user"
+        ? {
+            providerOverride: currentEntry?.providerOverride,
+            modelOverride: currentEntry?.modelOverride,
+            authProfileOverride: currentEntry?.authProfileOverride,
+            authProfileOverrideSource: currentEntry?.authProfileOverrideSource,
+            authProfileOverrideCompactionCount: currentEntry?.authProfileOverrideCompactionCount,
+          }
+        : {}),
       groupActivation: currentEntry?.groupActivation,
       groupActivationNeedsSystemIntro: currentEntry?.groupActivationNeedsSystemIntro,
       chatType: currentEntry?.chatType,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -7,6 +7,7 @@ import { getAcpRuntimeBackend } from "../acp/runtime/registry.js";
 import { readAcpSessionEntry, upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../auto-reply/reply/queue.js";
@@ -32,6 +33,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { ErrorCodes, errorShape } from "./protocol/index.js";
 import {
   archiveSessionTranscriptsDetailed,
@@ -59,6 +61,88 @@ function stripRuntimeModelState(entry?: SessionEntry): SessionEntry | undefined 
     contextTokens: undefined,
     systemPromptReport: undefined,
   };
+}
+
+type ResetPreservedSelectionState = Pick<
+  SessionEntry,
+  | "providerOverride"
+  | "modelOverride"
+  | "authProfileOverride"
+  | "authProfileOverrideSource"
+  | "authProfileOverrideCompactionCount"
+>;
+
+function parseProviderModelRef(
+  raw: string | undefined,
+): { provider: string; model: string } | undefined {
+  const normalized = normalizeOptionalString(raw);
+  if (!normalized) {
+    return undefined;
+  }
+  const slash = normalized.indexOf("/");
+  if (slash <= 0 || slash === normalized.length - 1) {
+    return undefined;
+  }
+  return {
+    provider: normalized.slice(0, slash),
+    model: normalized.slice(slash + 1),
+  };
+}
+
+function sameProviderModelRef(
+  left: { provider: string; model: string } | undefined,
+  right: { provider: string; model: string } | undefined,
+): boolean {
+  return left?.provider === right?.provider && left?.model === right?.model;
+}
+
+function resolveResetPreservedSelection(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  entry?: SessionEntry;
+  agentId: string;
+}): Partial<ResetPreservedSelectionState> {
+  const { entry } = params;
+  if (!entry) {
+    return {};
+  }
+
+  const preserved: Partial<ResetPreservedSelectionState> = {};
+  const defaultRef = resolveDefaultModelForAgent({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  const currentModel = normalizeOptionalString(entry.modelOverride);
+  const currentSelection = currentModel
+    ? {
+        provider: normalizeOptionalString(entry.providerOverride) ?? defaultRef.provider,
+        model: currentModel,
+      }
+    : undefined;
+  const fallbackSelected = parseProviderModelRef(entry.fallbackNoticeSelectedModel);
+  const fallbackActive = parseProviderModelRef(entry.fallbackNoticeActiveModel);
+  const fallbackPinnedSelection =
+    currentSelection &&
+    fallbackSelected &&
+    fallbackActive &&
+    !sameProviderModelRef(fallbackSelected, fallbackActive) &&
+    sameProviderModelRef(currentSelection, fallbackActive)
+      ? fallbackSelected
+      : undefined;
+  const explicitSelection = fallbackPinnedSelection ?? currentSelection;
+  if (explicitSelection && !sameProviderModelRef(explicitSelection, defaultRef)) {
+    preserved.providerOverride = explicitSelection.provider;
+    preserved.modelOverride = explicitSelection.model;
+  }
+
+  if (entry.authProfileOverrideSource === "user" && entry.authProfileOverride) {
+    preserved.authProfileOverride = entry.authProfileOverride;
+    preserved.authProfileOverrideSource = entry.authProfileOverrideSource;
+    if (entry.authProfileOverrideCompactionCount !== undefined) {
+      preserved.authProfileOverrideCompactionCount = entry.authProfileOverrideCompactionCount;
+    }
+  }
+
+  return preserved;
 }
 
 export function archiveSessionTranscriptsForSession(params: {
@@ -507,9 +591,22 @@ export async function performGatewaySessionReset(params: {
     });
     const currentEntry = store[primaryKey];
     resetSourceEntry = currentEntry ? { ...currentEntry } : undefined;
-    const resetEntry = stripRuntimeModelState(currentEntry);
     const parsed = parseAgentSessionKey(primaryKey);
     const sessionAgentId = normalizeAgentId(parsed?.agentId ?? resolveDefaultAgentId(cfg));
+    const resetPreservedSelection = resolveResetPreservedSelection({
+      cfg,
+      entry: currentEntry,
+      agentId: sessionAgentId,
+    });
+    const resetEntry = {
+      ...stripRuntimeModelState(currentEntry),
+      providerOverride: undefined,
+      modelOverride: undefined,
+      authProfileOverride: undefined,
+      authProfileOverrideSource: undefined,
+      authProfileOverrideCompactionCount: undefined,
+      ...resetPreservedSelection,
+    };
     const resolvedModel = resolveSessionModelRef(cfg, resetEntry, sessionAgentId);
     oldSessionId = currentEntry?.sessionId;
     oldSessionFile = currentEntry?.sessionFile;
@@ -540,19 +637,9 @@ export async function performGatewaySessionReset(params: {
       execAsk: currentEntry?.execAsk,
       execNode: currentEntry?.execNode,
       responseUsage: currentEntry?.responseUsage,
-      // Only preserve model/provider/auth overrides across reset when they were
-      // explicitly chosen by the user (e.g. /model command). System-driven
-      // overrides (fallback rotation, auto-selection) should not survive reset
-      // so the session returns to the configured default model.
-      ...(currentEntry?.authProfileOverrideSource === "user"
-        ? {
-            providerOverride: currentEntry?.providerOverride,
-            modelOverride: currentEntry?.modelOverride,
-            authProfileOverride: currentEntry?.authProfileOverride,
-            authProfileOverrideSource: currentEntry?.authProfileOverrideSource,
-            authProfileOverrideCompactionCount: currentEntry?.authProfileOverrideCompactionCount,
-          }
-        : {}),
+      // Resets should keep the user's explicit selection, but clear any
+      // temporary fallback model that was pinned during the previous run.
+      ...resetPreservedSelection,
       groupActivation: currentEntry?.groupActivation,
       groupActivationNeedsSystemIntro: currentEntry?.groupActivationNeedsSystemIntro,
       chatType: currentEntry?.chatType,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -7,7 +7,6 @@ import { getAcpRuntimeBackend } from "../acp/runtime/registry.js";
 import { readAcpSessionEntry, upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
-import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
 import { clearSessionQueues } from "../auto-reply/reply/queue.js";
@@ -33,7 +32,6 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { ErrorCodes, errorShape } from "./protocol/index.js";
 import {
   archiveSessionTranscriptsDetailed,
@@ -67,39 +65,14 @@ type ResetPreservedSelectionState = Pick<
   SessionEntry,
   | "providerOverride"
   | "modelOverride"
+  | "modelOverrideSource"
   | "authProfileOverride"
   | "authProfileOverrideSource"
   | "authProfileOverrideCompactionCount"
 >;
 
-function parseProviderModelRef(
-  raw: string | undefined,
-): { provider: string; model: string } | undefined {
-  const normalized = normalizeOptionalString(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  const slash = normalized.indexOf("/");
-  if (slash <= 0 || slash === normalized.length - 1) {
-    return undefined;
-  }
-  return {
-    provider: normalized.slice(0, slash),
-    model: normalized.slice(slash + 1),
-  };
-}
-
-function sameProviderModelRef(
-  left: { provider: string; model: string } | undefined,
-  right: { provider: string; model: string } | undefined,
-): boolean {
-  return left?.provider === right?.provider && left?.model === right?.model;
-}
-
 function resolveResetPreservedSelection(params: {
-  cfg: ReturnType<typeof loadConfig>;
   entry?: SessionEntry;
-  agentId: string;
 }): Partial<ResetPreservedSelectionState> {
   const { entry } = params;
   if (!entry) {
@@ -107,31 +80,10 @@ function resolveResetPreservedSelection(params: {
   }
 
   const preserved: Partial<ResetPreservedSelectionState> = {};
-  const defaultRef = resolveDefaultModelForAgent({
-    cfg: params.cfg,
-    agentId: params.agentId,
-  });
-  const currentModel = normalizeOptionalString(entry.modelOverride);
-  const currentSelection = currentModel
-    ? {
-        provider: normalizeOptionalString(entry.providerOverride) ?? defaultRef.provider,
-        model: currentModel,
-      }
-    : undefined;
-  const fallbackSelected = parseProviderModelRef(entry.fallbackNoticeSelectedModel);
-  const fallbackActive = parseProviderModelRef(entry.fallbackNoticeActiveModel);
-  const fallbackPinnedSelection =
-    currentSelection &&
-    fallbackSelected &&
-    fallbackActive &&
-    !sameProviderModelRef(fallbackSelected, fallbackActive) &&
-    sameProviderModelRef(currentSelection, fallbackActive)
-      ? fallbackSelected
-      : undefined;
-  const explicitSelection = fallbackPinnedSelection ?? currentSelection;
-  if (explicitSelection && !sameProviderModelRef(explicitSelection, defaultRef)) {
-    preserved.providerOverride = explicitSelection.provider;
-    preserved.modelOverride = explicitSelection.model;
+  if (entry.modelOverrideSource === "user" && entry.modelOverride) {
+    preserved.providerOverride = entry.providerOverride;
+    preserved.modelOverride = entry.modelOverride;
+    preserved.modelOverrideSource = entry.modelOverrideSource;
   }
 
   if (entry.authProfileOverrideSource === "user" && entry.authProfileOverride) {
@@ -594,14 +546,13 @@ export async function performGatewaySessionReset(params: {
     const parsed = parseAgentSessionKey(primaryKey);
     const sessionAgentId = normalizeAgentId(parsed?.agentId ?? resolveDefaultAgentId(cfg));
     const resetPreservedSelection = resolveResetPreservedSelection({
-      cfg,
       entry: currentEntry,
-      agentId: sessionAgentId,
     });
     const resetEntry = {
       ...stripRuntimeModelState(currentEntry),
       providerOverride: undefined,
       modelOverride: undefined,
+      modelOverrideSource: undefined,
       authProfileOverride: undefined,
       authProfileOverrideSource: undefined,
       authProfileOverrideCompactionCount: undefined,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -80,10 +80,16 @@ function resolveResetPreservedSelection(params: {
   }
 
   const preserved: Partial<ResetPreservedSelectionState> = {};
-  if (entry.modelOverrideSource === "user" && entry.modelOverride) {
+  // `modelOverrideSource` is new. Older persisted sessions can still carry
+  // user-selected overrides without the source field, so treat an absent
+  // source as legacy user state during reset and backfill it forward.
+  const preserveLegacyUserModelOverride =
+    entry.modelOverrideSource === "user" ||
+    (entry.modelOverrideSource === undefined && Boolean(entry.modelOverride));
+  if (preserveLegacyUserModelOverride && entry.modelOverride) {
     preserved.providerOverride = entry.providerOverride;
     preserved.modelOverride = entry.modelOverride;
-    preserved.modelOverrideSource = entry.modelOverrideSource;
+    preserved.modelOverrideSource = "user";
   }
 
   if (entry.authProfileOverrideSource === "user" && entry.authProfileOverride) {

--- a/src/sessions/model-overrides.test.ts
+++ b/src/sessions/model-overrides.test.ts
@@ -44,6 +44,7 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(entry.fallbackNoticeSelectedModel).toBeUndefined();
     expect(entry.fallbackNoticeActiveModel).toBeUndefined();
     expect(entry.fallbackNoticeReason).toBeUndefined();
+    expect(entry.modelOverrideSource).toBe("user");
   });
 
   it("clears stale runtime model fields even when override selection is unchanged", () => {
@@ -85,11 +86,12 @@ describe("applyModelOverrideToSessionEntry", () => {
       },
     });
 
-    expect(result.updated).toBe(false);
+    expect(result.updated).toBe(true);
     expect(entry.modelProvider).toBe("openai");
     expect(entry.model).toBe("gpt-5.4");
+    expect(entry.modelOverrideSource).toBe("user");
     expect(entry.contextTokens).toBe(200_000);
-    expect(entry.updatedAt).toBe(before);
+    expect((entry.updatedAt ?? 0) >= before).toBe(true);
   });
 
   it("clears stale contextTokens when switching back to the default model", () => {
@@ -114,8 +116,30 @@ describe("applyModelOverrideToSessionEntry", () => {
     expect(result.updated).toBe(true);
     expect(entry.providerOverride).toBeUndefined();
     expect(entry.modelOverride).toBeUndefined();
+    expect(entry.modelOverrideSource).toBeUndefined();
     expect(entry.contextTokens).toBeUndefined();
     expect((entry.updatedAt ?? 0) > before).toBe(true);
+  });
+
+  it("marks non-default overrides with the provided source", () => {
+    const entry: SessionEntry = {
+      sessionId: "sess-5a",
+      updatedAt: Date.now() - 5_000,
+    };
+
+    const result = applyModelOverrideToSessionEntry({
+      entry,
+      selection: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      },
+      selectionSource: "auto",
+    });
+
+    expect(result.updated).toBe(true);
+    expect(entry.providerOverride).toBe("anthropic");
+    expect(entry.modelOverride).toBe("claude-sonnet-4-6");
+    expect(entry.modelOverrideSource).toBe("auto");
   });
 
   it("sets liveModelSwitchPending only when explicitly requested", () => {

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -12,10 +12,12 @@ export function applyModelOverrideToSessionEntry(params: {
   selection: ModelOverrideSelection;
   profileOverride?: string;
   profileOverrideSource?: "auto" | "user";
+  selectionSource?: "auto" | "user";
   markLiveSwitchPending?: boolean;
 }): { updated: boolean } {
   const { entry, selection, profileOverride } = params;
   const profileOverrideSource = params.profileOverrideSource ?? "user";
+  const selectionSource = params.selectionSource ?? "user";
   let updated = false;
   let selectionUpdated = false;
 
@@ -30,6 +32,10 @@ export function applyModelOverrideToSessionEntry(params: {
       updated = true;
       selectionUpdated = true;
     }
+    if (entry.modelOverrideSource) {
+      delete entry.modelOverrideSource;
+      updated = true;
+    }
   } else {
     if (entry.providerOverride !== selection.provider) {
       entry.providerOverride = selection.provider;
@@ -40,6 +46,10 @@ export function applyModelOverrideToSessionEntry(params: {
       entry.modelOverride = selection.model;
       updated = true;
       selectionUpdated = true;
+    }
+    if (entry.modelOverrideSource !== selectionSource) {
+      entry.modelOverrideSource = selectionSource;
+      updated = true;
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix sticky fallback model override surviving `/reset` and `/new` commands
- Only preserve `providerOverride`/`modelOverride`/`authProfileOverride` across session reset when `authProfileOverrideSource === "user"` (explicit `/model` command)
- System-driven overrides (`authProfileOverrideSource: "auto"`, from fallback rotation) are now dropped on reset so the session picks up the current config default

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: commit cb0a752156 ("fix: preserve reset session behavior config", v2026.3.28) added `providerOverride`, `modelOverride`, `authProfileOverride`, `authProfileOverrideSource`, and `authProfileOverrideCompactionCount` to the fields unconditionally copied during session reset in `performGatewaySessionReset()`. This was correct for user-driven `/model` selections (`authProfileOverrideSource: "user"`), but it also preserved fallback-driven overrides (`authProfileOverrideSource: "auto"`) written by `persistFallbackCandidateSelection()`.
- Precedence issue: the session store override takes precedence over the agent config default provider. When a fallback override survives reset, the new session uses the fallback provider instead of the configured primary, even if the user has since changed the agent config.
- Repro sequence: (1) primary provider fails, fallback to secondary succeeds, (2) `persistFallbackCandidateSelection()` writes `providerOverride` with `authProfileOverrideSource: "auto"`, (3) user updates agent config to a different primary provider, (4) `/reset` or `/new` copies the stale fallback override to the new session, (5) new session ignores the config change and keeps using the fallback provider.
- Fix: make the override copy conditional on `authProfileOverrideSource === "user"` so only explicit user selections survive reset.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Scenario the test should lock in: session reset with `authProfileOverrideSource: "auto"` should not carry forward override fields; session reset with `authProfileOverrideSource: "user"` should preserve them.
- If no new test is added, why not: the fix is a minimal conditional guard on existing field copying; adding a test would require extensive mocking of the session store and config infrastructure. The behavior is straightforward to verify by inspection.

## User-visible / Behavior Changes

After a fallback rotation, `/reset` or `/new` now returns the session to the configured default model/provider instead of keeping the fallback override. Explicit `/model` selections continue to be preserved across reset as before.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`