### PR TITLE
fix(memory): report missing qmd workspace cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Docs: https://docs.openclaw.ai
 - fix(gateway): clamp unbound websocket auth scopes [AI]. (#77413) Thanks @pgondhi987.
 - Gate zalouser startup name matching [AI]. (#77411) Thanks @pgondhi987.
 - Active Memory: send a bounded latest-message search query to the recall worker so channel/runtime metadata does not become the memory search string. Fixes #65309. Thanks @joeykrug, @westley3601, @pimenov, and @tasi333.
+- Memory/QMD: report missing or invalid agent workspace directories as workspace probe failures in doctor/QMD availability checks instead of sending operators toward binary-install fixes. Fixes #63158. Thanks @sercada.
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.
 - Claude CLI: honor non-off `/think` levels by passing Claude Code's session-scoped `--effort` flag through the CLI backend seam, so chat bridges no longer show an inert thinking control. Fixes #77303. Thanks @Petr1t.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2118,6 +2118,7 @@ Docs: https://docs.openclaw.ai
 - Diffs plugin: accept `defaults.ttlSeconds` as a plugin-wide artifact lifetime default, so LAN-viewable diff links can keep their configured six-hour TTL without doctor quarantining the plugin entry. (#77456) Thanks @VACInc.
 - Gate zalouser startup name matching [AI]. (#77411) Thanks @pgondhi987.
 - Active Memory: send a bounded latest-message search query to the recall worker so channel/runtime metadata does not become the memory search string. Fixes #65309. Thanks @joeykrug, @westley3601, @pimenov, and @tasi333.
+- Memory/QMD: report missing or invalid agent workspace directories as workspace probe failures in doctor/QMD availability checks instead of sending operators toward binary-install fixes. Fixes #63158. Thanks @sercada.
 - fix(device-pair): require pairing scope for pair command [AI]. (#76377) Thanks @pgondhi987.
 - Providers/OpenRouter: keep DeepSeek V4 `reasoning_effort` on OpenRouter-supported values, mapping stale `max` thinking overrides to `xhigh` so `openrouter/deepseek/deepseek-v4-pro` no longer fails with OpenRouter's invalid-effort 400. Fixes #77350. (#77423) Thanks @krllagent, @mushuiyu886, and @sallyom.
 - fix(qqbot): keep private commands off framework surface [AI]. (#77212) Thanks @pgondhi987.

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -272,6 +272,7 @@ describe("getMemorySearchManager caching", () => {
     const cfg = createQmdCfg("missing-qmd");
     checkQmdBinaryAvailability.mockResolvedValueOnce({
       available: false,
+      reason: "binary",
       error: "spawn qmd ENOENT",
     });
 
@@ -506,7 +507,7 @@ describe("getMemorySearchManager caching", () => {
     );
     checkQmdBinaryAvailability
       .mockResolvedValueOnce({ available: true })
-      .mockResolvedValueOnce({ available: false, error: "spawn qmd ENOENT" });
+      .mockResolvedValueOnce({ available: false, reason: "binary", error: "spawn qmd ENOENT" });
 
     const first = await getMemorySearchManager({ cfg: firstCfg, agentId });
     const firstManager = requireManager(first);

--- a/extensions/memory-core/src/memory/search-manager.test.ts
+++ b/extensions/memory-core/src/memory/search-manager.test.ts
@@ -122,6 +122,7 @@ vi.mock("./qmd-manager.js", () => ({
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-qmd", () => ({
   checkQmdBinaryAvailability,
+  resolveQmdBinaryUnavailableReason: (result: { reason?: string }) => result.reason ?? "binary",
 }));
 
 vi.mock("../../manager-runtime.js", () => ({
@@ -351,10 +352,27 @@ describe("getMemorySearchManager caching", () => {
     const cfg = createQmdCfg("missing-qmd");
     checkQmdBinaryAvailability.mockResolvedValueOnce({
       available: false,
+      reason: "binary",
       error: "spawn qmd ENOENT",
     });
 
     const result = await getMemorySearchManager({ cfg, agentId: "missing-qmd" });
+    const manager = requireManager(result);
+    const searchResults = await manager.search("hello");
+
+    expect(createQmdManagerMock).not.toHaveBeenCalled();
+    expect(mockMemoryIndexGet).toHaveBeenCalled();
+    expect(searchResults).toHaveLength(1);
+  });
+
+  it("treats legacy qmd unavailable results without a reason as binary failures", async () => {
+    const cfg = createQmdCfg("missing-qmd-legacy");
+    checkQmdBinaryAvailability.mockResolvedValueOnce({
+      available: false,
+      error: "spawn qmd ENOENT",
+    });
+
+    const result = await getMemorySearchManager({ cfg, agentId: "missing-qmd-legacy" });
     const manager = requireManager(result);
     const searchResults = await manager.search("hello");
 
@@ -606,7 +624,7 @@ describe("getMemorySearchManager caching", () => {
     );
     checkQmdBinaryAvailability
       .mockResolvedValueOnce({ available: true })
-      .mockResolvedValueOnce({ available: false, error: "spawn qmd ENOENT" });
+      .mockResolvedValueOnce({ available: false, reason: "binary", error: "spawn qmd ENOENT" });
 
     const first = await getMemorySearchManager({ cfg: firstCfg, agentId });
     const firstManager = requireManager(first);

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -182,13 +182,15 @@ export async function getMemorySearchManager(params: {
         cwd: workspaceDir,
       });
       if (!qmdBinary.available) {
-        const message = qmdBinary.error ?? "unknown error";
-        log.warn(
-          `qmd binary unavailable (${qmdResolved.command}); falling back to builtin: ${message}`,
-        );
+        const message = qmdBinary.error;
+        const failurePrefix =
+          qmdBinary.reason === "workspace-cwd"
+            ? `qmd workspace unavailable (${workspaceDir})`
+            : `qmd binary unavailable (${qmdResolved.command})`;
+        log.warn(`${failurePrefix}; falling back to builtin: ${message}`);
         return {
           manager: null,
-          failureReason: `qmd binary unavailable (${qmdResolved.command}): ${message}`,
+          failureReason: `${failurePrefix}: ${message}`,
         };
       }
       try {

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -8,7 +8,10 @@ import {
   resolveMemorySearchSyncConfig,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
-import { checkQmdBinaryAvailability } from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
+import {
+  checkQmdBinaryAvailability,
+  resolveQmdBinaryUnavailableReason,
+} from "openclaw/plugin-sdk/memory-core-host-engine-qmd";
 import {
   resolveMemoryBackendConfig,
   type MemoryEmbeddingProbeResult,
@@ -182,13 +185,15 @@ export async function getMemorySearchManager(params: {
         cwd: workspaceDir,
       });
       if (!qmdBinary.available) {
-        const message = qmdBinary.error ?? "unknown error";
-        log.warn(
-          `qmd binary unavailable (${qmdResolved.command}); falling back to builtin: ${message}`,
-        );
+        const message = qmdBinary.error;
+        const failurePrefix =
+          resolveQmdBinaryUnavailableReason(qmdBinary) === "workspace-cwd"
+            ? `qmd workspace unavailable (${workspaceDir})`
+            : `qmd binary unavailable (${qmdResolved.command})`;
+        log.warn(`${failurePrefix}; falling back to builtin: ${message}`);
         return {
           manager: null,
-          failureReason: `qmd binary unavailable (${qmdResolved.command}): ${message}`,
+          failureReason: `${failurePrefix}: ${message}`,
         };
       }
       try {

--- a/packages/memory-host-sdk/src/engine-qmd.ts
+++ b/packages/memory-host-sdk/src/engine-qmd.ts
@@ -27,4 +27,5 @@ export {
   checkQmdBinaryAvailability,
   resolveCliSpawnInvocation,
   runCliCommand,
+  type QmdBinaryAvailability,
 } from "./host/qmd-process.js";

--- a/packages/memory-host-sdk/src/engine-qmd.ts
+++ b/packages/memory-host-sdk/src/engine-qmd.ts
@@ -26,5 +26,9 @@ export {
 export {
   checkQmdBinaryAvailability,
   resolveCliSpawnInvocation,
+  resolveQmdBinaryUnavailableReason,
   runCliCommand,
+  type QmdBinaryAvailability,
+  type QmdBinaryUnavailable,
+  type QmdBinaryUnavailableReason,
 } from "./host/qmd-process.js";

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -146,7 +146,20 @@ describe("checkQmdBinaryAvailability", () => {
 
     await expect(
       checkQmdBinaryAvailability({ command: "qmd", env: process.env, cwd: tempDir }),
-    ).resolves.toEqual({ available: false, error: "spawn qmd ENOENT" });
+    ).resolves.toEqual({ available: false, reason: "binary", error: "spawn qmd ENOENT" });
+  });
+
+  it("returns an explicit workspace error when cwd is missing", async () => {
+    const missingDir = path.join(tempDir, "missing-workspace");
+
+    await expect(
+      checkQmdBinaryAvailability({ command: "qmd", env: process.env, cwd: missingDir }),
+    ).resolves.toEqual({
+      available: false,
+      reason: "workspace-cwd",
+      error: `workspace directory missing: ${missingDir}`,
+    });
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it("does not treat close-before-spawn as a successful availability probe", async () => {
@@ -160,6 +173,6 @@ describe("checkQmdBinaryAvailability", () => {
 
     await expect(
       checkQmdBinaryAvailability({ command: "qmd", env: process.env, cwd: tempDir }),
-    ).resolves.toEqual({ available: false, error: "spawn qmd ENOENT" });
+    ).resolves.toEqual({ available: false, reason: "binary", error: "spawn qmd ENOENT" });
   });
 });

--- a/packages/memory-host-sdk/src/host/qmd-process.test.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.test.ts
@@ -14,7 +14,12 @@ vi.mock("node:child_process", async () => {
   };
 });
 
-import { checkQmdBinaryAvailability, resolveCliSpawnInvocation } from "./qmd-process.js";
+import {
+  checkQmdBinaryAvailability,
+  resolveCliSpawnInvocation,
+  resolveQmdBinaryUnavailableReason,
+  type QmdBinaryAvailability,
+} from "./qmd-process.js";
 
 function createMockChild() {
   const child = new EventEmitter() as EventEmitter & {
@@ -123,6 +128,15 @@ describe("resolveCliSpawnInvocation", () => {
 });
 
 describe("checkQmdBinaryAvailability", () => {
+  it("keeps legacy unavailable probe results source-compatible", () => {
+    const legacyUnavailable: QmdBinaryAvailability = {
+      available: false,
+      error: "spawn qmd ENOENT",
+    };
+
+    expect(resolveQmdBinaryUnavailableReason(legacyUnavailable)).toBe("binary");
+  });
+
   it("returns available when the qmd process spawns successfully", async () => {
     const child = createMockChild();
     spawnMock.mockImplementationOnce(() => {
@@ -147,7 +161,20 @@ describe("checkQmdBinaryAvailability", () => {
 
     await expect(
       checkQmdBinaryAvailability({ command: "qmd", env: process.env, cwd: tempDir }),
-    ).resolves.toEqual({ available: false, error: "spawn qmd ENOENT" });
+    ).resolves.toEqual({ available: false, reason: "binary", error: "spawn qmd ENOENT" });
+  });
+
+  it("returns an explicit workspace error when cwd is missing", async () => {
+    const missingDir = path.join(tempDir, "missing-workspace");
+
+    await expect(
+      checkQmdBinaryAvailability({ command: "qmd", env: process.env, cwd: missingDir }),
+    ).resolves.toEqual({
+      available: false,
+      reason: "workspace-cwd",
+      error: `workspace directory missing: ${missingDir}`,
+    });
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it("does not treat close-before-spawn as a successful availability probe", async () => {
@@ -161,6 +188,6 @@ describe("checkQmdBinaryAvailability", () => {
 
     await expect(
       checkQmdBinaryAvailability({ command: "qmd", env: process.env, cwd: tempDir }),
-    ).resolves.toEqual({ available: false, error: "spawn qmd ENOENT" });
+    ).resolves.toEqual({ available: false, reason: "binary", error: "spawn qmd ENOENT" });
   });
 });

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
 import { materializeWindowsSpawnProgram, resolveWindowsSpawnProgram } from "./windows-spawn.js";
 
 export type CliSpawnInvocation = {
@@ -8,10 +9,9 @@ export type CliSpawnInvocation = {
   windowsHide?: boolean;
 };
 
-export type QmdBinaryAvailability = {
-  available: boolean;
-  error?: string;
-};
+export type QmdBinaryAvailability =
+  | { available: true }
+  | { available: false; reason: "binary" | "workspace-cwd"; error: string };
 
 export function resolveCliSpawnInvocation(params: {
   command: string;
@@ -45,7 +45,13 @@ export async function checkQmdBinaryAvailability(params: {
       packageName: "qmd",
     });
   } catch (err) {
-    return { available: false, error: formatQmdAvailabilityError(err) };
+    return { available: false, reason: "binary", error: formatQmdAvailabilityError(err) };
+  }
+
+  const cwd = params.cwd ?? process.cwd();
+  const cwdError = validateQmdProbeCwd(cwd);
+  if (cwdError) {
+    return cwdError;
   }
 
   return await new Promise((resolve) => {
@@ -64,7 +70,7 @@ export async function checkQmdBinaryAvailability(params: {
 
     const child = spawn(spawnInvocation.command, spawnInvocation.argv, {
       env: params.env,
-      cwd: params.cwd ?? process.cwd(),
+      cwd,
       shell: spawnInvocation.shell,
       windowsHide: spawnInvocation.windowsHide,
       stdio: "ignore",
@@ -73,12 +79,13 @@ export async function checkQmdBinaryAvailability(params: {
       child.kill("SIGKILL");
       finish({
         available: false,
+        reason: "binary",
         error: `spawn ${params.command} timed out after ${params.timeoutMs ?? 2_000}ms`,
       });
     }, params.timeoutMs ?? 2_000);
 
     child.once("error", (err) => {
-      finish({ available: false, error: formatQmdAvailabilityError(err) });
+      finish({ available: false, reason: "binary", error: formatQmdAvailabilityError(err) });
     });
     child.once("spawn", () => {
       didSpawn = true;
@@ -92,6 +99,33 @@ export async function checkQmdBinaryAvailability(params: {
       finish({ available: true });
     });
   });
+}
+
+function validateQmdProbeCwd(cwd: string): QmdBinaryAvailability | null {
+  try {
+    const stat = statSync(cwd);
+    if (!stat.isDirectory()) {
+      return {
+        available: false,
+        reason: "workspace-cwd",
+        error: `workspace directory is not a directory: ${cwd}`,
+      };
+    }
+    return null;
+  } catch (err) {
+    if (typeof err === "object" && err && "code" in err && err.code === "ENOENT") {
+      return {
+        available: false,
+        reason: "workspace-cwd",
+        error: `workspace directory missing: ${cwd}`,
+      };
+    }
+    return {
+      available: false,
+      reason: "workspace-cwd",
+      error: `workspace directory unavailable: ${cwd} (${formatQmdAvailabilityError(err)})`,
+    };
+  }
 }
 
 export async function runCliCommand(params: {

--- a/packages/memory-host-sdk/src/host/qmd-process.ts
+++ b/packages/memory-host-sdk/src/host/qmd-process.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
 import { materializeWindowsSpawnProgram, resolveWindowsSpawnProgram } from "./windows-spawn.js";
 
 export type CliSpawnInvocation = {
@@ -8,10 +9,25 @@ export type CliSpawnInvocation = {
   windowsHide?: boolean;
 };
 
-export type QmdBinaryAvailability = {
-  available: boolean;
-  error?: string;
+export type QmdBinaryUnavailableReason = "binary" | "workspace-cwd";
+
+export type QmdBinaryUnavailable = {
+  available: false;
+  /**
+   * Optional for source compatibility with older plugin SDK callers that
+   * returned only `{ available: false, error }`.
+   */
+  reason?: QmdBinaryUnavailableReason;
+  error: string;
 };
+
+export type QmdBinaryAvailability = { available: true } | QmdBinaryUnavailable;
+
+export function resolveQmdBinaryUnavailableReason(
+  result: QmdBinaryUnavailable,
+): QmdBinaryUnavailableReason {
+  return result.reason ?? "binary";
+}
 
 export function resolveCliSpawnInvocation(params: {
   command: string;
@@ -45,7 +61,13 @@ export async function checkQmdBinaryAvailability(params: {
       packageName: "qmd",
     });
   } catch (err) {
-    return { available: false, error: formatQmdAvailabilityError(err) };
+    return { available: false, reason: "binary", error: formatQmdAvailabilityError(err) };
+  }
+
+  const cwd = params.cwd ?? process.cwd();
+  const cwdError = validateQmdProbeCwd(cwd);
+  if (cwdError) {
+    return cwdError;
   }
 
   return await new Promise((resolve) => {
@@ -64,7 +86,7 @@ export async function checkQmdBinaryAvailability(params: {
 
     const child = spawn(spawnInvocation.command, spawnInvocation.argv, {
       env: params.env,
-      cwd: params.cwd ?? process.cwd(),
+      cwd,
       shell: spawnInvocation.shell,
       windowsHide: spawnInvocation.windowsHide,
       stdio: "ignore",
@@ -73,12 +95,13 @@ export async function checkQmdBinaryAvailability(params: {
       child.kill("SIGKILL");
       finish({
         available: false,
+        reason: "binary",
         error: `spawn ${params.command} timed out after ${params.timeoutMs ?? 2_000}ms`,
       });
     }, params.timeoutMs ?? 2_000);
 
     child.once("error", (err) => {
-      finish({ available: false, error: formatQmdAvailabilityError(err) });
+      finish({ available: false, reason: "binary", error: formatQmdAvailabilityError(err) });
     });
     child.once("spawn", () => {
       didSpawn = true;
@@ -92,6 +115,33 @@ export async function checkQmdBinaryAvailability(params: {
       finish({ available: true });
     });
   });
+}
+
+function validateQmdProbeCwd(cwd: string): QmdBinaryAvailability | null {
+  try {
+    const stat = statSync(cwd);
+    if (!stat.isDirectory()) {
+      return {
+        available: false,
+        reason: "workspace-cwd",
+        error: `workspace directory is not a directory: ${cwd}`,
+      };
+    }
+    return null;
+  } catch (err) {
+    if (typeof err === "object" && err && "code" in err && err.code === "ENOENT") {
+      return {
+        available: false,
+        reason: "workspace-cwd",
+        error: `workspace directory missing: ${cwd}`,
+      };
+    }
+    return {
+      available: false,
+      reason: "workspace-cwd",
+      error: `workspace directory unavailable: ${cwd} (${formatQmdAvailabilityError(err)})`,
+    };
+  }
 }
 
 export async function runCliCommand(params: {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -355,6 +355,7 @@ describe("noteMemorySearchHealth", () => {
     const qmdCfg = { memory: { backend: "qmd", qmd: { command: "qmd" } } } as OpenClawConfig;
     checkQmdBinaryAvailability.mockResolvedValueOnce({
       available: false,
+      reason: "binary",
       error: "spawn qmd ENOENT",
     });
     resolveMemorySearchConfig.mockReturnValue({
@@ -371,6 +372,29 @@ describe("noteMemorySearchHealth", () => {
     expect(message).toContain("spawn qmd ENOENT");
     expect(message).toContain("npm install -g @tobilu/qmd");
     expect(message).toContain("bun install -g @tobilu/qmd");
+  });
+
+  it("warns with a workspace-specific fix when the QMD probe cwd is missing", async () => {
+    const qmdCfg = { memory: { backend: "qmd", qmd: { command: "qmd" } } } as OpenClawConfig;
+    checkQmdBinaryAvailability.mockResolvedValueOnce({
+      available: false,
+      reason: "workspace-cwd",
+      error: "workspace directory missing: /tmp/agent-default/workspace",
+    });
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(qmdCfg, {});
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("agent workspace directory could not be used");
+    expect(message).toContain("workspace directory missing: /tmp/agent-default/workspace");
+    expect(message).toContain("Create the missing workspace directory");
+    expect(message).not.toContain("npm install -g @tobilu/qmd");
   });
 
   it("does not warn when remote apiKey is configured for explicit provider", async () => {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -55,6 +55,7 @@ vi.mock("../plugins/memory-runtime.js", () => ({
 
 vi.mock("../memory-host-sdk/engine-qmd.js", () => ({
   checkQmdBinaryAvailability,
+  resolveQmdBinaryUnavailableReason: (result: { reason?: string }) => result.reason ?? "binary",
 }));
 
 vi.mock("../plugin-sdk/memory-core-engine-runtime.js", () => ({
@@ -431,6 +432,7 @@ describe("noteMemorySearchHealth", () => {
     const qmdCfg = { memory: { backend: "qmd", qmd: { command: "qmd" } } } as OpenClawConfig;
     checkQmdBinaryAvailability.mockResolvedValueOnce({
       available: false,
+      reason: "binary",
       error: "spawn qmd ENOENT",
     });
     resolveMemorySearchConfig.mockReturnValue({
@@ -447,6 +449,51 @@ describe("noteMemorySearchHealth", () => {
     expect(message).toContain("spawn qmd ENOENT");
     expect(message).toContain("npm install -g @tobilu/qmd");
     expect(message).toContain("bun install -g @tobilu/qmd");
+  });
+
+  it("treats legacy QMD unavailable results without a reason as binary failures", async () => {
+    const qmdCfg = { memory: { backend: "qmd", qmd: { command: "qmd" } } } as OpenClawConfig;
+    checkQmdBinaryAvailability.mockResolvedValueOnce({
+      available: false,
+      error: "spawn qmd ENOENT",
+    });
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(qmdCfg, {});
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = firstNoteMessage();
+    expect(message).toContain("qmd binary could not be started");
+    expect(message).toContain("spawn qmd ENOENT");
+    expect(message).toContain("npm install -g @tobilu/qmd");
+    expect(message).not.toContain("agent workspace directory could not be used");
+  });
+
+  it("warns with a workspace-specific fix when the QMD probe cwd is missing", async () => {
+    const qmdCfg = { memory: { backend: "qmd", qmd: { command: "qmd" } } } as OpenClawConfig;
+    checkQmdBinaryAvailability.mockResolvedValueOnce({
+      available: false,
+      reason: "workspace-cwd",
+      error: "workspace directory missing: /tmp/agent-default/workspace",
+    });
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "auto",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(qmdCfg, {});
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("agent workspace directory could not be used");
+    expect(message).toContain("workspace directory missing: /tmp/agent-default/workspace");
+    expect(message).toContain("Create the missing workspace directory");
+    expect(message).not.toContain("npm install -g @tobilu/qmd");
   });
 
   it("does not warn when remote apiKey is configured for explicit provider", async () => {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -349,14 +349,22 @@ export async function noteMemorySearchHealth(
       cwd: resolveAgentWorkspaceDir(cfg, agentId),
     });
     if (!qmdCheck.available) {
+      const workspaceProbeFailed = qmdCheck.reason === "workspace-cwd";
+      const probeError = qmdCheck.error.trim();
       note(
         [
-          `QMD memory backend is configured, but the qmd binary could not be started (${backendConfig.qmd?.command ?? "qmd"}).`,
-          qmdCheck.error ? `Probe error: ${qmdCheck.error}` : null,
+          workspaceProbeFailed
+            ? "QMD memory backend is configured, but the agent workspace directory could not be used for the QMD startup probe."
+            : `QMD memory backend is configured, but the qmd binary could not be started (${backendConfig.qmd?.command ?? "qmd"}).`,
+          probeError ? `Probe error: ${probeError}` : null,
           "",
           "Fix (pick one):",
-          "- Install the supported QMD package: npm install -g @tobilu/qmd (or bun install -g @tobilu/qmd)",
-          `- Set an explicit binary path: ${formatCliCommand("openclaw config set memory.qmd.command /absolute/path/to/qmd")}`,
+          workspaceProbeFailed
+            ? "- Create the missing workspace directory or update the agent workspace path to an existing directory."
+            : "- Install the supported QMD package: npm install -g @tobilu/qmd (or bun install -g @tobilu/qmd)",
+          workspaceProbeFailed
+            ? "- Verify the resolved workspace path for the affected agent before retrying."
+            : `- Set an explicit binary path: ${formatCliCommand("openclaw config set memory.qmd.command /absolute/path/to/qmd")}`,
           `- Or switch back to builtin memory: ${formatCliCommand("openclaw config set memory.backend builtin")}`,
           "",
           `Verify: ${formatCliCommand("openclaw memory status --deep")}`,

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -14,7 +14,10 @@ import {
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { checkQmdBinaryAvailability } from "../memory-host-sdk/engine-qmd.js";
+import {
+  checkQmdBinaryAvailability,
+  resolveQmdBinaryUnavailableReason,
+} from "../memory-host-sdk/engine-qmd.js";
 import { DEFAULT_LOCAL_MODEL } from "../memory-host-sdk/host/embedding-defaults.js";
 import { hasConfiguredMemorySecretInput } from "../memory-host-sdk/secret.js";
 import {
@@ -379,14 +382,22 @@ export async function noteMemorySearchHealth(
       cwd: resolveAgentWorkspaceDir(cfg, agentId),
     });
     if (!qmdCheck.available) {
+      const workspaceProbeFailed = resolveQmdBinaryUnavailableReason(qmdCheck) === "workspace-cwd";
+      const probeError = qmdCheck.error.trim();
       note(
         [
-          `QMD memory backend is configured, but the qmd binary could not be started (${backendConfig.qmd?.command ?? "qmd"}).`,
-          qmdCheck.error ? `Probe error: ${qmdCheck.error}` : null,
+          workspaceProbeFailed
+            ? "QMD memory backend is configured, but the agent workspace directory could not be used for the QMD startup probe."
+            : `QMD memory backend is configured, but the qmd binary could not be started (${backendConfig.qmd?.command ?? "qmd"}).`,
+          probeError ? `Probe error: ${probeError}` : null,
           "",
           "Fix (pick one):",
-          "- Install the supported QMD package: npm install -g @tobilu/qmd (or bun install -g @tobilu/qmd)",
-          `- Set an explicit binary path: ${formatCliCommand("openclaw config set memory.qmd.command /absolute/path/to/qmd")}`,
+          workspaceProbeFailed
+            ? "- Create the missing workspace directory or update the agent workspace path to an existing directory."
+            : "- Install the supported QMD package: npm install -g @tobilu/qmd (or bun install -g @tobilu/qmd)",
+          workspaceProbeFailed
+            ? "- Verify the resolved workspace path for the affected agent before retrying."
+            : `- Set an explicit binary path: ${formatCliCommand("openclaw config set memory.qmd.command /absolute/path/to/qmd")}`,
           `- Or switch back to builtin memory: ${formatCliCommand("openclaw config set memory.backend builtin")}`,
           "",
           `Verify: ${formatCliCommand("openclaw memory status --deep")}`,

--- a/src/memory-host-sdk/engine-qmd.ts
+++ b/src/memory-host-sdk/engine-qmd.ts
@@ -1,1 +1,7 @@
-export { checkQmdBinaryAvailability } from "../../packages/memory-host-sdk/src/engine-qmd.js";
+export {
+  checkQmdBinaryAvailability,
+  resolveQmdBinaryUnavailableReason,
+  type QmdBinaryAvailability,
+  type QmdBinaryUnavailable,
+  type QmdBinaryUnavailableReason,
+} from "../../packages/memory-host-sdk/src/engine-qmd.js";


### PR DESCRIPTION
## Summary
- fail the QMD availability probe early when the configured workspace cwd is missing or invalid
- surface a workspace-specific doctor warning instead of implying the qmd binary itself is missing
- add focused coverage for the low-level probe, doctor message path, and memory-core caller

Closes #63158.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: When the configured QMD workspace cwd was missing, the availability probe could surface misleading qmd-binary guidance instead of identifying the missing workspace path.
- Real environment tested: Local OpenClaw checkout on macOS rebased on current `origin/main` at commit `719506b2eb`, using the repo runner against the actual memory-host SDK, doctor, and memory-core paths.
- Exact steps or command run after this patch: `OPENCLAW_HOME=/tmp/openclaw-doctor-proof-63167-vwA1MX NODE_DISABLE_COMPILE_CACHE=1 node scripts/run-node.mjs doctor --non-interactive`, `node scripts/test-projects.mjs packages/memory-host-sdk/src/host/qmd-process.test.ts src/commands/doctor-memory-search.test.ts extensions/memory-core/src/memory/search-manager.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts`, `node scripts/test-projects.mjs src/tui/tui-last-session.test.ts`, and `git diff --check HEAD~1..HEAD`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from a local OpenClaw source checkout using a temporary `OPENCLAW_HOME` with `memory.backend=qmd` and no agent workspace directory present:

```text
$ OPENCLAW_HOME=/tmp/openclaw-doctor-proof-63167-vwA1MX NODE_DISABLE_COMPILE_CACHE=1 node scripts/run-node.mjs doctor --non-interactive
◇  Memory search
│  QMD memory backend is configured, but the agent workspace directory
│  could not be used for the QMD startup probe.
│  Probe error: workspace directory missing:
│  /tmp/openclaw-doctor-proof-63167-vwA1MX/.openclaw/workspace
│  Fix (pick one):
│  - Create the missing workspace directory or update the agent workspace
│    path to an existing directory.
│  - Verify the resolved workspace path for the affected agent before
│    retrying.
│  - Or switch back to builtin memory: openclaw config set memory.backend
│    builtin
│  Verify: openclaw memory status --deep
Config: /tmp/openclaw-doctor-proof-63167-vwA1MX/.openclaw/openclaw.json
└  Doctor complete.

$ node scripts/test-projects.mjs packages/memory-host-sdk/src/host/qmd-process.test.ts src/commands/doctor-memory-search.test.ts extensions/memory-core/src/memory/search-manager.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts
unit-fast: 1 file passed, 8 tests passed
contracts-plugin: 1 file passed, 17 tests passed
commands: 1 file passed, 43 tests passed
extension-memory: 1 file passed, 34 tests passed
[test] passed 4 Vitest shards in 45.82s

$ node scripts/test-projects.mjs src/tui/tui-last-session.test.ts
[test] passed 1 Vitest shard in 3.93s

$ git diff --check HEAD~1..HEAD
(no output)
```

- Observed result after fix: The real `openclaw doctor --non-interactive` path now reports QMD as unavailable because the resolved agent workspace directory is missing, gives workspace-specific repair guidance, and no longer implies that the qmd binary itself is the problem. The SDK availability result remains source-compatible with legacy `{ available: false, error }` callers by treating a missing `reason` as `binary`; both the package export and the `src/memory-host-sdk/engine-qmd.ts` bridge now expose that helper, and focused host/doctor/memory-core/plugin-SDK tests pass. The previously timed-out unrelated TUI shard also passed locally on the refreshed head.
- What was not tested: No additional gaps in the targeted QMD workspace probe, doctor behavior, and legacy unavailable-result compatibility paths; full repository CI covers build and regression breadth.
- Before evidence (optional but encouraged): Before the patch, the same failure class was mapped through generic QMD availability handling and could imply the qmd binary was missing rather than the workspace cwd.

## Testing
- node scripts/test-projects.mjs packages/memory-host-sdk/src/host/qmd-process.test.ts src/commands/doctor-memory-search.test.ts extensions/memory-core/src/memory/search-manager.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts
- git diff --check HEAD~1..HEAD


