### PR TITLE
fix: add @larksuiteoapi/node-sdk to root deps for feishu plugin

### DIFF
--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -51,6 +51,11 @@
     "bundle": {
       "stageRuntimeDependencies": true
     },
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "@larksuiteoapi/node-sdk"
+      ]
+    },
     "release": {
       "publishToClawHub": true,
       "publishToNpm": true

--- a/package.json
+++ b/package.json
@@ -1313,6 +1313,7 @@
     "@aws-sdk/credential-provider-node": "3.972.29",
     "@clack/prompts": "^1.2.0",
     "@homebridge/ciao": "^1.3.6",
+    "@larksuiteoapi/node-sdk": "^1.60.0",
     "@line/bot-sdk": "^11.0.0",
     "@lydell/node-pty": "1.2.0-beta.10",
     "@mariozechner/pi-agent-core": "0.65.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@homebridge/ciao':
         specifier: ^1.3.6
         version: 1.3.6
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@line/bot-sdk':
         specifier: ^11.0.0
         version: 11.0.0


### PR DESCRIPTION
## Fix for Issue #63129

### Problem
Users installing the feishu plugin encounter `Error: Cannot find module '@larksuiteoapi/node-sdk'` because the dependency is not available at the root level.

### Solution
1. Add `@larksuiteoapi/node-sdk` to root `package.json` dependencies so it gets hoisted to root `node_modules`
2. Add `releaseChecks.rootDependencyMirrorAllowlist` to `extensions/feishu/package.json` to allow the dependency to be mirrored at root level during release

### Changes
- `package.json`: Added `@larksuiteoapi/node-sdk: ^1.60.0` to dependencies
- `extensions/feishu/package.json`: Added `releaseChecks.rootDependencyMirrorAllowlist` containing `@larksuiteoapi/node-sdk`

Closes #63129