### PR TITLE
[codex] finish android release handoff

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,169 @@
+name: Android Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build (e.g. v2026.4.6)
+        required: true
+        type: string
+
+concurrency:
+  group: android-release-${{ inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  build-release-bundles:
+    runs-on: blacksmith-16vcpu-ubuntu-2404
+    timeout-minutes: 30
+    permissions:
+      contents: write
+    steps:
+      - name: Validate tag format
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]{4}\.[1-9][0-9]*\.[1-9][0-9]*((-beta\.[1-9][0-9]*)|(-[1-9][0-9]*))?$ ]]; then
+            echo "Invalid release tag format: ${RELEASE_TAG}"
+            exit 1
+          fi
+
+      - name: Checkout tag
+        uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ inputs.tag }}
+          persist-credentials: false
+          submodules: false
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Android SDK cmdline-tools
+        run: |
+          set -euo pipefail
+          ANDROID_SDK_ROOT="$HOME/.android-sdk"
+          CMDLINE_TOOLS_VERSION="12266719"
+          ARCHIVE="commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+          URL="https://dl.google.com/android/repository/${ARCHIVE}"
+
+          mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+          curl -fsSL "$URL" -o "/tmp/${ARCHIVE}"
+          rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+          unzip -q "/tmp/${ARCHIVE}" -d "$ANDROID_SDK_ROOT/cmdline-tools"
+          mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+
+          echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
+          echo "ANDROID_HOME=$ANDROID_SDK_ROOT" >> "$GITHUB_ENV"
+          echo "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin" >> "$GITHUB_PATH"
+          echo "$ANDROID_SDK_ROOT/platform-tools" >> "$GITHUB_PATH"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
+        with:
+          gradle-version: 8.11.1
+
+      - name: Install Android SDK packages
+        run: |
+          yes | sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null
+          sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --install \
+            "platform-tools" \
+            "platforms;android-36" \
+            "build-tools;36.0.0"
+
+      - name: Decode signing keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYSTORE_PATH="$RUNNER_TEMP/upload-keystore.jks"
+          echo "$KEYSTORE_BASE64" | base64 -d > "$KEYSTORE_PATH"
+
+          mkdir -p "$HOME/.gradle"
+          cat > "$HOME/.gradle/gradle.properties" <<PROPS
+          OPENCLAW_ANDROID_STORE_FILE=$KEYSTORE_PATH
+          OPENCLAW_ANDROID_STORE_PASSWORD=$KEYSTORE_PASSWORD
+          OPENCLAW_ANDROID_KEY_ALIAS=$KEY_ALIAS
+          OPENCLAW_ANDROID_KEY_PASSWORD=$KEY_PASSWORD
+          PROPS
+
+      - name: Run Android unit tests
+        working-directory: apps/android
+        run: ./gradlew --no-daemon :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest
+
+      - name: Run Android ktlint
+        working-directory: apps/android
+        run: ./gradlew --no-daemon :app:ktlintCheck :benchmark:ktlintCheck
+
+      - name: Run Android release lint
+        working-directory: apps/android
+        run: ./gradlew --no-daemon :app:lintVitalPlayRelease :app:lintVitalThirdPartyRelease
+
+      - name: Build Play release AAB
+        working-directory: apps/android
+        run: ./gradlew --no-daemon :app:bundlePlayRelease
+
+      - name: Build ThirdParty release AAB
+        working-directory: apps/android
+        run: ./gradlew --no-daemon :app:bundleThirdPartyRelease
+
+      - name: Verify signatures
+        working-directory: apps/android
+        run: |
+          set -euo pipefail
+          jarsigner -verify app/build/outputs/bundle/playRelease/app-play-release.aab
+          jarsigner -verify app/build/outputs/bundle/thirdPartyRelease/app-thirdParty-release.aab
+          echo "Both AABs verified successfully"
+
+      - name: Compute checksums
+        working-directory: apps/android
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.tag }}"
+          VERSION="${VERSION#v}"
+          mkdir -p build/release-bundles
+
+          cp app/build/outputs/bundle/playRelease/app-play-release.aab \
+             "build/release-bundles/openclaw-${VERSION}-play-release.aab"
+          cp app/build/outputs/bundle/thirdPartyRelease/app-thirdParty-release.aab \
+             "build/release-bundles/openclaw-${VERSION}-thirdParty-release.aab"
+
+          cd build/release-bundles
+          sha256sum *.aab > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Upload AABs to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        working-directory: apps/android/build/release-bundles
+        run: |
+          set -euo pipefail
+          gh release upload "$RELEASE_TAG" \
+            *.aab \
+            SHA256SUMS.txt \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+      - name: Summary
+        run: |
+          VERSION="${{ inputs.tag }}"
+          VERSION="${VERSION#v}"
+          echo "## Android Release Bundles" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Play**: \`openclaw-${VERSION}-play-release.aab\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **ThirdParty**: \`openclaw-${VERSION}-thirdParty-release.aab\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Next Steps" >> "$GITHUB_STEP_SUMMARY"
+          echo "1. Download \`openclaw-${VERSION}-play-release.aab\` from the release" >> "$GITHUB_STEP_SUMMARY"
+          echo "2. Upload to Google Play Console → Production track" >> "$GITHUB_STEP_SUMMARY"
+          echo "3. Submit for review" >> "$GITHUB_STEP_SUMMARY"

--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -46,7 +46,7 @@ cd apps/android
 `bun run android:bundle:release` auto-bumps Android `versionName`/`versionCode` in `apps/android/app/build.gradle.kts`, then builds two signed release bundles:
 
 - Play build: `apps/android/build/release-bundles/openclaw-<version>-play-release.aab`
-- Third-party build: `apps/android/build/release-bundles/openclaw-<version>-third-party-release.aab`
+- Third-party build: `apps/android/build/release-bundles/openclaw-<version>-thirdParty-release.aab`
 
 Flavor-specific direct Gradle tasks:
 
@@ -55,6 +55,16 @@ cd apps/android
 ./gradlew :app:bundlePlayRelease
 ./gradlew :app:bundleThirdPartyRelease
 ```
+
+Export the current Play upload certificate PEM from the configured keystore:
+
+```bash
+pnpm android:export-upload-cert
+```
+
+Default output:
+
+- `apps/android/build/release-bundles/openclaw-upload-cert.pem`
 
 ## Kotlin Lint + Format
 
@@ -237,6 +247,69 @@ Reference links:
 - [Background location policy](https://support.google.com/googleplay/android-developer/answer/9799150)
 - [AccessibilityService policy](https://support.google.com/googleplay/android-developer/answer/10964491?hl=en-GB)
 - [Photo and Video Permissions policy](https://support.google.com/googleplay/android-developer/answer/14594990)
+
+## Release Handoff
+
+Local release signing reads these properties from `~/.gradle/gradle.properties`:
+
+- `OPENCLAW_ANDROID_STORE_FILE`
+- `OPENCLAW_ANDROID_STORE_PASSWORD`
+- `OPENCLAW_ANDROID_KEY_ALIAS`
+- `OPENCLAW_ANDROID_KEY_PASSWORD`
+
+Local release flow:
+
+```bash
+pnpm android:test
+pnpm android:test:third-party
+pnpm android:lint
+cd apps/android
+./gradlew :app:lintVitalPlayRelease :app:lintVitalThirdPartyRelease
+cd ../..
+pnpm android:bundle:release
+pnpm android:export-upload-cert
+```
+
+Artifacts written locally:
+
+- Play bundle: `apps/android/build/release-bundles/openclaw-<version>-play-release.aab`
+- Third-party bundle: `apps/android/build/release-bundles/openclaw-<version>-thirdParty-release.aab`
+- Upload certificate PEM: `apps/android/build/release-bundles/openclaw-upload-cert.pem`
+
+GitHub Actions release workflow:
+
+- Workflow file: `.github/workflows/android-release.yml`
+- Trigger: manual `workflow_dispatch`
+- Input: release tag such as `v2026.4.6`
+- CI checks before upload:
+  - `:app:testPlayDebugUnitTest`
+  - `:app:testThirdPartyDebugUnitTest`
+  - `:app:ktlintCheck`
+  - `:benchmark:ktlintCheck`
+  - `:app:lintVitalPlayRelease`
+  - `:app:lintVitalThirdPartyRelease`
+- Uploaded release assets:
+  - `openclaw-<version>-play-release.aab`
+  - `openclaw-<version>-thirdParty-release.aab`
+  - `SHA256SUMS.txt`
+
+GitHub repository secrets required for the workflow:
+
+| Secret | Value |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | Base64 contents of the upload keystore |
+| `ANDROID_KEYSTORE_PASSWORD` | Keystore password |
+| `ANDROID_KEY_ALIAS` | Upload key alias |
+| `ANDROID_KEY_PASSWORD` | Upload key password |
+
+Google Play Console handoff:
+
+1. Go to `Release > Production` or the track you are promoting from.
+2. Create a new release and upload `openclaw-<version>-play-release.aab`.
+3. If Google Play rejects the upload because the upload key changed, open `Setup > App signing`, request an upload key reset, and submit `apps/android/build/release-bundles/openclaw-upload-cert.pem`.
+4. After the upload key reset is approved, upload the Play AAB again and submit for review.
+
+`thirdParty` remains the sideload flavor and should not be uploaded to Google Play.
 
 ## Integration Capability Test (Preconditioned)
 

--- a/apps/android/scripts/build-release-aab.ts
+++ b/apps/android/scripts/build-release-aab.ts
@@ -16,7 +16,7 @@ const releaseVariants = [
     bundlePath: join(androidDir, "app", "build", "outputs", "bundle", "playRelease", "app-play-release.aab"),
   },
   {
-    flavorName: "third-party",
+    flavorName: "thirdParty",
     gradleTask: ":app:bundleThirdPartyRelease",
     bundlePath: join(
       androidDir,

--- a/apps/android/scripts/export-upload-cert.sh
+++ b/apps/android/scripts/export-upload-cert.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+android_dir="$(cd "${script_dir}/.." && pwd -P)"
+output_path="${android_dir}/build/release-bundles/openclaw-upload-cert.pem"
+
+usage() {
+  echo "Usage: bash apps/android/scripts/export-upload-cert.sh [--output <pem-path>]"
+}
+
+resolve_output_path() {
+  local raw_path="$1"
+
+  if [[ "${raw_path}" = /* ]]; then
+    printf '%s\n' "${raw_path}"
+    return
+  fi
+
+  printf '%s\n' "$(pwd -P)/${raw_path}"
+}
+
+read_gradle_property() {
+  local property_name="$1"
+  local properties_path="${HOME}/.gradle/gradle.properties"
+
+  awk -F'[:=]' -v key="${property_name}" '
+    $0 !~ /^[[:space:]]*#/ && $0 !~ /^[[:space:]]*!/ {
+      current_key = $1
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", current_key)
+      if (current_key == key) {
+        sub(/^[^:=]+[:=][[:space:]]*/, "", $0)
+        print $0
+        exit
+      }
+    }
+  ' "${properties_path}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --output)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value after --output" >&2
+        exit 1
+      fi
+      output_path="$(resolve_output_path "$2")"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+store_file="${OPENCLAW_ANDROID_STORE_FILE:-$(read_gradle_property OPENCLAW_ANDROID_STORE_FILE)}"
+store_password="${OPENCLAW_ANDROID_STORE_PASSWORD:-$(read_gradle_property OPENCLAW_ANDROID_STORE_PASSWORD)}"
+key_alias="${OPENCLAW_ANDROID_KEY_ALIAS:-$(read_gradle_property OPENCLAW_ANDROID_KEY_ALIAS)}"
+
+if [[ -z "${store_file}" || -z "${store_password}" || -z "${key_alias}" ]]; then
+  echo "Missing Android signing config. Set OPENCLAW_ANDROID_STORE_FILE, OPENCLAW_ANDROID_STORE_PASSWORD, and OPENCLAW_ANDROID_KEY_ALIAS in env or ~/.gradle/gradle.properties." >&2
+  exit 1
+fi
+
+if [[ "${store_file}" == "~/"* ]]; then
+  store_file="${HOME}/${store_file#"~/"}"
+fi
+
+mkdir -p "$(dirname "${output_path}")"
+
+if ! export_output="$(
+  keytool -exportcert -rfc \
+    -alias "${key_alias}" \
+    -keystore "${store_file}" \
+    -storepass "${store_password}" \
+    -file "${output_path}" \
+    2>&1
+)"; then
+  printf '%s\n' "${export_output}" >&2
+  exit 1
+fi
+
+echo "Upload certificate PEM: ${output_path}"
+keytool -printcert -file "${output_path}" \
+  | awk '/^[[:space:]]*(Owner|Issuer|Serial number|Valid from|SHA1|SHA256):/ { sub(/^[[:space:]]+/, "", $0); print }'

--- a/package.json
+++ b/package.json
@@ -1064,6 +1064,7 @@
     "android:assemble": "cd apps/android && ./gradlew :app:assemblePlayDebug",
     "android:assemble:third-party": "cd apps/android && ./gradlew :app:assembleThirdPartyDebug",
     "android:bundle:release": "bun apps/android/scripts/build-release-aab.ts",
+    "android:export-upload-cert": "bash apps/android/scripts/export-upload-cert.sh",
     "android:format": "cd apps/android && ./gradlew :app:ktlintFormat :benchmark:ktlintFormat",
     "android:install": "cd apps/android && ./gradlew :app:installPlayDebug",
     "android:install:third-party": "cd apps/android && ./gradlew :app:installThirdPartyDebug",


### PR DESCRIPTION
## What changed

This finishes the Android release handoff so the release process is reproducible from the repo instead of relying on chat history.

- add a manual GitHub Actions workflow to build signed Android release AABs and upload them to a GitHub release
- document the Android release handoff, required GitHub secrets, and Play Console upload-key-reset flow
- add a helper script to export the Play upload certificate PEM from the configured local keystore
- align the local sideload bundle artifact name with the workflow artifact naming

## Why

The Android release work was completed locally, but the repo still lacked the durable CI/docs handoff needed for the next release and for Play Console key-reset follow-up.

## Validation

- `bash apps/android/scripts/export-upload-cert.sh --output /tmp/openclaw-upload-cert.pem`
- `./gradlew --dry-run :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest :app:ktlintCheck :benchmark:ktlintCheck :app:lintVitalPlayRelease :app:lintVitalThirdPartyRelease`
- `git diff --check -- .github/workflows/android-release.yml apps/android/README.md apps/android/scripts/export-upload-cert.sh apps/android/scripts/build-release-aab.ts package.json`

## Notes

A repo-wide pre-commit hook failed because of an unrelated untracked file: `src/gateway/server-constants.test.ts`. The Android release changes themselves were validated directly before commit.
