### PR TITLE
fix(build): prune stale bundled plugin node_modules

### DIFF
--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -2,9 +2,11 @@
 // Runs after install to restore bundled extension runtime deps.
 // Installed builds can lazy-load bundled plugin code through root dist chunks,
 // so runtime dependencies declared in dist/extensions/*/package.json must also
-// resolve from the package root node_modules. Skip source checkouts.
+// resolve from the package root node_modules. Source checkouts resolve bundled
+// plugin deps from the workspace root, so stale plugin-local node_modules must
+// not linger under extensions/* and shadow the root graph.
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveNpmRunner } from "./npm-runner.mjs";
@@ -102,7 +104,7 @@ export function createNestedNpmInstallEnv(env = process.env) {
   return nextEnv;
 }
 
-function isSourceCheckoutRoot(params) {
+export function isSourceCheckoutRoot(params) {
   const pathExists = params.existsSync ?? existsSync;
   return (
     pathExists(join(params.packageRoot, ".git")) &&
@@ -111,14 +113,35 @@ function isSourceCheckoutRoot(params) {
   );
 }
 
+export function pruneBundledPluginSourceNodeModules(params = {}) {
+  const extensionsDir = params.extensionsDir ?? join(DEFAULT_PACKAGE_ROOT, "extensions");
+  const pathExists = params.existsSync ?? existsSync;
+  const readDir = params.readdirSync ?? readdirSync;
+  const removePath = params.rmSync ?? rmSync;
+
+  if (!pathExists(extensionsDir)) {
+    return;
+  }
+
+  for (const entry of readDir(extensionsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const pluginDir = join(extensionsDir, entry.name);
+    if (!pathExists(join(pluginDir, "package.json"))) {
+      continue;
+    }
+
+    removePath(join(pluginDir, "node_modules"), { recursive: true, force: true });
+  }
+}
+
 function shouldRunBundledPluginPostinstall(params) {
   if (params.env?.[DISABLE_POSTINSTALL_ENV]?.trim()) {
     return false;
   }
   if (!params.existsSync(params.extensionsDir)) {
-    return false;
-  }
-  if (isSourceCheckoutRoot({ packageRoot: params.packageRoot, existsSync: params.existsSync })) {
     return false;
   }
   return true;
@@ -139,6 +162,13 @@ export function runBundledPluginPostinstall(params = {}) {
       existsSync: pathExists,
     })
   ) {
+    return;
+  }
+  if (isSourceCheckoutRoot({ packageRoot, existsSync: pathExists })) {
+    pruneBundledPluginSourceNodeModules({
+      extensionsDir: join(packageRoot, "extensions"),
+      existsSync: pathExists,
+    });
     return;
   }
   const runtimeDeps =

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -124,7 +124,7 @@ export function pruneBundledPluginSourceNodeModules(params = {}) {
   }
 
   for (const entry of readDir(extensionsDir, { withFileTypes: true })) {
-    if (!entry.isDirectory()) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
       continue;
     }
 
@@ -154,6 +154,19 @@ export function runBundledPluginPostinstall(params = {}) {
   const spawn = params.spawnSync ?? spawnSync;
   const pathExists = params.existsSync ?? existsSync;
   const log = params.log ?? console;
+  if (isSourceCheckoutRoot({ packageRoot, existsSync: pathExists })) {
+    try {
+      pruneBundledPluginSourceNodeModules({
+        extensionsDir: join(packageRoot, "extensions"),
+        existsSync: pathExists,
+        readdirSync: params.readdirSync,
+        rmSync: params.rmSync,
+      });
+    } catch (e) {
+      log.warn(`[postinstall] could not prune bundled plugin source node_modules: ${String(e)}`);
+    }
+    return;
+  }
   if (
     !shouldRunBundledPluginPostinstall({
       env,
@@ -162,13 +175,6 @@ export function runBundledPluginPostinstall(params = {}) {
       existsSync: pathExists,
     })
   ) {
-    return;
-  }
-  if (isSourceCheckoutRoot({ packageRoot, existsSync: pathExists })) {
-    pruneBundledPluginSourceNodeModules({
-      extensionsDir: join(packageRoot, "extensions"),
-      existsSync: pathExists,
-    });
     return;
   }
   const runtimeDeps =

--- a/scripts/postinstall-bundled-plugins.mjs
+++ b/scripts/postinstall-bundled-plugins.mjs
@@ -154,6 +154,9 @@ export function runBundledPluginPostinstall(params = {}) {
   const spawn = params.spawnSync ?? spawnSync;
   const pathExists = params.existsSync ?? existsSync;
   const log = params.log ?? console;
+  if (env?.[DISABLE_POSTINSTALL_ENV]?.trim()) {
+    return;
+  }
   if (isSourceCheckoutRoot({ packageRoot, existsSync: pathExists })) {
     try {
       pruneBundledPluginSourceNodeModules({

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -60,9 +60,6 @@ function pruneSourceCheckoutBundledPluginNodeModules() {
   });
 }
 
-pruneSourceCheckoutBundledPluginNodeModules();
-pruneStaleRuntimeSymlinks();
-
 function findFatalUnresolvedImport(lines) {
   for (const line of lines) {
     if (!UNRESOLVED_IMPORT_RE.test(line)) {
@@ -112,6 +109,8 @@ function isMainModule() {
 }
 
 if (isMainModule()) {
+  pruneSourceCheckoutBundledPluginNodeModules();
+  pruneStaleRuntimeSymlinks();
   const invocation = resolveTsdownBuildInvocation();
   const result = spawnSync(invocation.command, invocation.args, invocation.options);
 

--- a/scripts/tsdown-build.mjs
+++ b/scripts/tsdown-build.mjs
@@ -6,6 +6,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { BUNDLED_PLUGIN_PATH_PREFIX } from "./lib/bundled-plugin-paths.mjs";
 import { resolvePnpmRunner } from "./pnpm-runner.mjs";
+import {
+  isSourceCheckoutRoot,
+  pruneBundledPluginSourceNodeModules,
+} from "./postinstall-bundled-plugins.mjs";
 
 const logLevel = process.env.OPENCLAW_BUILD_VERBOSE ? "info" : "warn";
 const extraArgs = process.argv.slice(2);
@@ -43,6 +47,20 @@ function pruneStaleRuntimeSymlinks() {
   removeDistPluginNodeModulesSymlinks(path.join(cwd, "dist-runtime"));
 }
 
+function pruneSourceCheckoutBundledPluginNodeModules() {
+  const cwd = process.cwd();
+  if (!isSourceCheckoutRoot({ packageRoot: cwd, existsSync: fs.existsSync })) {
+    return;
+  }
+  pruneBundledPluginSourceNodeModules({
+    extensionsDir: path.join(cwd, "extensions"),
+    existsSync: fs.existsSync,
+    readdirSync: fs.readdirSync,
+    rmSync: fs.rmSync,
+  });
+}
+
+pruneSourceCheckoutBundledPluginNodeModules();
 pruneStaleRuntimeSymlinks();
 
 function findFatalUnresolvedImport(lines) {

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -121,15 +121,40 @@ describe("bundled plugin postinstall", () => {
 
     runBundledPluginPostinstall({
       env: { HOME: "/tmp/home" },
-      extensionsDir,
       packageRoot,
       spawnSync,
+      log: { log: vi.fn(), warn: vi.fn() },
     });
 
     await expect(fs.stat(path.join(extensionsDir, "acpx", "node_modules"))).rejects.toMatchObject({
       code: "ENOENT",
     });
     expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  it("keeps source-checkout prune non-fatal", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-source-checkout-prune-error-");
+    const extensionsDir = path.join(packageRoot, "extensions");
+    await fs.mkdir(path.join(packageRoot, ".git"), { recursive: true });
+    await fs.mkdir(path.join(packageRoot, "src"), { recursive: true });
+    await fs.mkdir(path.join(extensionsDir, "acpx"), { recursive: true });
+    await fs.writeFile(path.join(extensionsDir, "acpx", "package.json"), "{}\n");
+    const warn = vi.fn();
+
+    expect(() =>
+      runBundledPluginPostinstall({
+        env: { HOME: "/tmp/home" },
+        packageRoot,
+        rmSync: vi.fn(() => {
+          throw new Error("locked");
+        }),
+        log: { log: vi.fn(), warn },
+      }),
+    ).not.toThrow();
+
+    expect(warn).toHaveBeenCalledWith(
+      "[postinstall] could not prune bundled plugin source node_modules: Error: locked",
+    );
   });
 
   it("runs nested local installs with sanitized env when the sentinel package is missing", async () => {
@@ -353,5 +378,24 @@ describe("bundled plugin postinstall", () => {
     await expect(
       fs.stat(path.join(extensionsDir, "fixtures", "node_modules")),
     ).resolves.toBeTruthy();
+  });
+
+  it("skips symlink entries when pruning source-checkout bundled plugin node_modules", () => {
+    const removePath = vi.fn();
+
+    pruneBundledPluginSourceNodeModules({
+      extensionsDir: "/repo/extensions",
+      existsSync: vi.fn((value) => value === "/repo/extensions"),
+      readdirSync: vi.fn(() => [
+        {
+          name: "acpx",
+          isDirectory: () => true,
+          isSymbolicLink: () => true,
+        },
+      ]),
+      rmSync: removePath,
+    });
+
+    expect(removePath).not.toHaveBeenCalled();
   });
 });

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -157,6 +157,23 @@ describe("bundled plugin postinstall", () => {
     );
   });
 
+  it("honors disable env before source-checkout pruning", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-source-checkout-disabled-");
+    const extensionsDir = path.join(packageRoot, "extensions");
+    await fs.mkdir(path.join(packageRoot, ".git"), { recursive: true });
+    await fs.mkdir(path.join(packageRoot, "src"), { recursive: true });
+    await fs.mkdir(path.join(extensionsDir, "acpx", "node_modules"), { recursive: true });
+    await fs.writeFile(path.join(extensionsDir, "acpx", "package.json"), "{}\n");
+
+    runBundledPluginPostinstall({
+      env: { OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL: "1" },
+      packageRoot,
+      log: { log: vi.fn(), warn: vi.fn() },
+    });
+
+    await expect(fs.stat(path.join(extensionsDir, "acpx", "node_modules"))).resolves.toBeTruthy();
+  });
+
   it("runs nested local installs with sanitized env when the sentinel package is missing", async () => {
     const extensionsDir = await createExtensionsDir();
     const packageRoot = path.dirname(path.dirname(extensionsDir));

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   createNestedNpmInstallEnv,
   discoverBundledPluginRuntimeDeps,
+  pruneBundledPluginSourceNodeModules,
   runBundledPluginPostinstall,
 } from "../../scripts/postinstall-bundled-plugins.mjs";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -98,6 +99,37 @@ describe("bundled plugin postinstall", () => {
     });
 
     expect(spawnSync).toHaveBeenCalled();
+  });
+
+  it("prunes source-checkout bundled plugin node_modules", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-source-checkout-");
+    const extensionsDir = path.join(packageRoot, "extensions");
+    await fs.mkdir(path.join(packageRoot, ".git"), { recursive: true });
+    await fs.mkdir(path.join(packageRoot, "src"), { recursive: true });
+    await fs.mkdir(extensionsDir, { recursive: true });
+    await writePluginPackage(extensionsDir, "acpx", {
+      dependencies: {
+        acpx: "0.5.2",
+      },
+    });
+    await fs.mkdir(path.join(extensionsDir, "acpx", "node_modules", "acpx"), { recursive: true });
+    await fs.writeFile(
+      path.join(extensionsDir, "acpx", "node_modules", "acpx", "package.json"),
+      JSON.stringify({ name: "acpx", version: "0.4.1" }),
+    );
+    const spawnSync = vi.fn();
+
+    runBundledPluginPostinstall({
+      env: { HOME: "/tmp/home" },
+      extensionsDir,
+      packageRoot,
+      spawnSync,
+    });
+
+    await expect(fs.stat(path.join(extensionsDir, "acpx", "node_modules"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(spawnSync).not.toHaveBeenCalled();
   });
 
   it("runs nested local installs with sanitized env when the sentinel package is missing", async () => {
@@ -301,5 +333,25 @@ describe("bundled plugin postinstall", () => {
     });
 
     expectNpmInstallSpawn(spawnSync, packageRoot, ["grammy@1.38.4"]);
+  });
+
+  it("prunes only bundled plugin package node_modules in source checkouts", async () => {
+    const packageRoot = await createTempDirAsync("openclaw-source-prune-");
+    const extensionsDir = path.join(packageRoot, "extensions");
+    await fs.mkdir(path.join(extensionsDir, "acpx", "node_modules"), { recursive: true });
+    await fs.mkdir(path.join(extensionsDir, "fixtures", "node_modules"), { recursive: true });
+    await fs.writeFile(
+      path.join(extensionsDir, "acpx", "package.json"),
+      JSON.stringify({ name: "@openclaw/acpx" }),
+    );
+
+    pruneBundledPluginSourceNodeModules({ extensionsDir });
+
+    await expect(fs.stat(path.join(extensionsDir, "acpx", "node_modules"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(
+      fs.stat(path.join(extensionsDir, "fixtures", "node_modules")),
+    ).resolves.toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- prune bundled plugin-local `node_modules` in source checkouts during postinstall
- enforce the same invariant before tsdown builds so stale ACPX installs cannot shadow root deps
- add regression coverage for the ACPX stale-shadow case and scoped pruning behavior

## Testing
- pnpm test test/scripts/postinstall-bundled-plugins.test.ts
- pnpm build