### PR TITLE
[codex] fix cron telegram final announce delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 - Memory/lancedb: accept `dreaming` config when `memory-lancedb` owns the memory slot so Dreaming surfaces can read slot-owner settings without schema rejection. (#63874) Thanks @mbelinky.
 - Heartbeats/sessions: remove stale accumulated isolated heartbeat session keys when the next tick converges them back to the canonical sibling, so repaired sessions stop showing orphaned `:heartbeat:heartbeat` variants in session listings. (#59606) Thanks @rogerdigital.
 - Control UI/dreaming: keep the Dreaming trace area contained and scrollable so overlays no longer cover tabs or blow out the page layout.
+- Cron/Telegram: collapse isolated announce delivery to the final assistant-visible text only for Telegram targets, while preserving existing multi-message direct delivery semantics for other channels. (#63228) Thanks @welfo-beo.
 
 ## 2026.4.9
 
@@ -75,7 +76,6 @@ Docs: https://docs.openclaw.ai
 - Slack/media: preserve bearer auth across same-origin `files.slack.com` redirects while still stripping it on cross-origin Slack CDN hops, so `url_private_download` image attachments load again. (#62960) Thanks @vincentkoc.
 - Reply/doctor: use the active runtime snapshot for queued reply runs, resolve reply-run SecretRefs before preflight helpers touch config, surface gateway OAuth reauth failures to users, and make `openclaw doctor` call out exact reauth commands. (#62693, #63217) Thanks @mbelinky.
 - Control UI: guard stale session-history reloads during fast session switches so the selected session and rendered transcript stay in sync. (#62975) Thanks @scoootscooob.
-<<<<<<< HEAD
 - Gateway/chat: suppress exact and streamed `ANNOUNCE_SKIP` / `REPLY_SKIP` control replies across live chat updates and history sanitization so internal agent-to-agent control tokens no longer leak into user-facing gateway chat surfaces. (#51739) Thanks @Pinghuachiu.
 - Auto-reply/NO_REPLY: strip glued leading `NO_REPLY` tokens before reply normalization and ACP-visible streaming so silent sentinel text no longer leaks into user-visible replies while preserving substantive `NO_REPLY ...` text. Thanks @frankekn.
 - Sessions/routing: preserve established external routes on inter-session announce traffic so `sessions_send` follow-ups do not steal delivery from Telegram, Discord, or other external channels. (#58013) Thanks @duqaXxX.
@@ -101,7 +101,6 @@ Docs: https://docs.openclaw.ai
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
 - Wizard/plugin config: coerce integer-typed plugin config fields from interactive text input so integer schema values persist as numbers instead of failing validation. (#63346) Thanks @jalehman.
-- Cron/Telegram: collapse isolated announce delivery to the final assistant-visible text only for Telegram targets, while preserving existing multi-message direct delivery semantics for other channels. (#63228) Thanks @welfo-beo.
 
 ## 2026.4.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Docs: https://docs.openclaw.ai
 - Slack/media: preserve bearer auth across same-origin `files.slack.com` redirects while still stripping it on cross-origin Slack CDN hops, so `url_private_download` image attachments load again. (#62960) Thanks @vincentkoc.
 - Reply/doctor: use the active runtime snapshot for queued reply runs, resolve reply-run SecretRefs before preflight helpers touch config, surface gateway OAuth reauth failures to users, and make `openclaw doctor` call out exact reauth commands. (#62693, #63217) Thanks @mbelinky.
 - Control UI: guard stale session-history reloads during fast session switches so the selected session and rendered transcript stay in sync. (#62975) Thanks @scoootscooob.
+<<<<<<< HEAD
 - Gateway/chat: suppress exact and streamed `ANNOUNCE_SKIP` / `REPLY_SKIP` control replies across live chat updates and history sanitization so internal agent-to-agent control tokens no longer leak into user-facing gateway chat surfaces. (#51739) Thanks @Pinghuachiu.
 - Auto-reply/NO_REPLY: strip glued leading `NO_REPLY` tokens before reply normalization and ACP-visible streaming so silent sentinel text no longer leaks into user-visible replies while preserving substantive `NO_REPLY ...` text. Thanks @frankekn.
 - Sessions/routing: preserve established external routes on inter-session announce traffic so `sessions_send` follow-ups do not steal delivery from Telegram, Discord, or other external channels. (#58013) Thanks @duqaXxX.
@@ -100,6 +101,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/models: preserve provider-qualified refs for OpenRouter catalog models whose ids already contain slashes so picker selections submit allowlist-compatible model refs instead of dropping the `openrouter/` prefix. (#63416) Thanks @sallyom.
 - Plugin SDK/command auth: split command status builders onto the lightweight `openclaw/plugin-sdk/command-status` subpath while preserving deprecated `command-auth` compatibility exports, so auth-only plugin imports no longer pull status/context warmup into CLI onboarding paths. (#63174) Thanks @hxy91819.
 - Wizard/plugin config: coerce integer-typed plugin config fields from interactive text input so integer schema values persist as numbers instead of failing validation. (#63346) Thanks @jalehman.
+- Cron/Telegram: collapse isolated announce delivery to the final assistant-visible text only for Telegram targets, while preserving existing multi-message direct delivery semantics for other channels. (#63228) Thanks @welfo-beo.
 
 ## 2026.4.8
 

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -78,6 +78,7 @@ import { createFailoverDecisionLogger } from "./run/failover-observation.js";
 import { mergeRetryFailoverReason, resolveRunFailoverDecision } from "./run/failover-policy.js";
 import {
   buildErrorAgentMeta,
+  resolveFinalAssistantVisibleText,
   buildUsageAgentMetaFields,
   createCompactionDiagId,
   resolveActiveErrorContext,
@@ -1410,6 +1411,7 @@ export async function runEmbeddedPiAgent(
             promptTokens: usageMeta.promptTokens,
             compactionCount: autoCompactionCount > 0 ? autoCompactionCount : undefined,
           };
+          const finalAssistantVisibleText = resolveFinalAssistantVisibleText(lastAssistant);
 
           const payloads = buildEmbeddedRunPayloads({
             assistantTexts: attempt.assistantTexts,
@@ -1451,6 +1453,7 @@ export async function runEmbeddedPiAgent(
                 agentMeta,
                 aborted,
                 systemPromptReport: attempt.systemPromptReport,
+                finalAssistantVisibleText,
               },
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
               didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
@@ -1542,6 +1545,7 @@ export async function runEmbeddedPiAgent(
                 agentMeta,
                 aborted,
                 systemPromptReport: attempt.systemPromptReport,
+                finalAssistantVisibleText,
               },
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
               didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
@@ -1575,6 +1579,7 @@ export async function runEmbeddedPiAgent(
               agentMeta,
               aborted,
               systemPromptReport: attempt.systemPromptReport,
+              finalAssistantVisibleText,
               // Handle client tool calls (OpenResponses hosted tools)
               // Propagate the LLM stop reason so callers (lifecycle events,
               // ACP bridge) can distinguish end_turn from max_tokens.

--- a/src/agents/pi-embedded-runner/run/helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.test.ts
@@ -1,0 +1,52 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { resolveFinalAssistantVisibleText } from "./helpers.js";
+
+function makeAssistantMessage(
+  content: AssistantMessage["content"],
+  phase?: string,
+): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    timestamp: Date.now(),
+    stopReason: "end_turn",
+    ...(phase ? { phase } : {}),
+  } as AssistantMessage;
+}
+
+describe("resolveFinalAssistantVisibleText", () => {
+  it("prefers final_answer text over commentary blocks", () => {
+    const lastAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "Working...",
+        textSignature: JSON.stringify({ v: 1, id: "item_commentary", phase: "commentary" }),
+      },
+      {
+        type: "text",
+        text: "Section 1\nSection 2",
+        textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+      },
+    ]);
+
+    expect(resolveFinalAssistantVisibleText(lastAssistant)).toBe("Section 1\nSection 2");
+  });
+
+  it("returns undefined when the final visible text is empty", () => {
+    const lastAssistant = makeAssistantMessage([
+      {
+        type: "text",
+        text: "Working...",
+        textSignature: JSON.stringify({ v: 1, id: "item_commentary", phase: "commentary" }),
+      },
+      {
+        type: "text",
+        text: "   ",
+        textSignature: JSON.stringify({ v: 1, id: "item_final", phase: "final_answer" }),
+      },
+    ]);
+
+    expect(resolveFinalAssistantVisibleText(lastAssistant)).toBeUndefined();
+  });
+});

--- a/src/agents/pi-embedded-runner/run/helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.test.ts
@@ -7,12 +7,23 @@ function makeAssistantMessage(
   phase?: string,
 ): AssistantMessage {
   return {
+    api: "responses",
+    provider: "openai",
+    model: "gpt-5.4",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
     role: "assistant",
     content,
     timestamp: Date.now(),
-    stopReason: "end_turn",
+    stopReason: "stop",
     ...(phase ? { phase } : {}),
-  } as AssistantMessage;
+  };
 }
 
 describe("resolveFinalAssistantVisibleText", () => {

--- a/src/agents/pi-embedded-runner/run/helpers.ts
+++ b/src/agents/pi-embedded-runner/run/helpers.ts
@@ -1,5 +1,7 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { generateSecureToken } from "../../../infra/secure-random.js";
+import { extractAssistantVisibleText } from "../../pi-embedded-utils.js";
 import { derivePromptTokens, normalizeUsage } from "../../usage.js";
 import type { EmbeddedPiAgentMeta } from "../types.js";
 import { toLastCallUsage, toNormalizedUsage, type UsageAccumulator } from "../usage-accumulator.js";
@@ -134,4 +136,14 @@ export function buildErrorAgentMeta(params: {
     ...(usageMeta.lastCallUsage ? { lastCallUsage: usageMeta.lastCallUsage } : {}),
     ...(usageMeta.promptTokens ? { promptTokens: usageMeta.promptTokens } : {}),
   };
+}
+
+export function resolveFinalAssistantVisibleText(
+  lastAssistant: AssistantMessage | undefined,
+): string | undefined {
+  if (!lastAssistant) {
+    return undefined;
+  }
+  const visibleText = extractAssistantVisibleText(lastAssistant).trim();
+  return visibleText || undefined;
 }

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -36,6 +36,7 @@ export type EmbeddedPiRunMeta = {
   agentMeta?: EmbeddedPiAgentMeta;
   aborted?: boolean;
   systemPromptReport?: SessionSystemPromptReport;
+  finalAssistantVisibleText?: string;
   error?: {
     kind:
       | "context_overflow"

--- a/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-core-channels.test.ts
@@ -207,5 +207,47 @@ describe("runCronIsolatedAgentTurn core-channel direct delivery", () => {
         );
       });
     });
+
+    it(`preserves multi-payload text-only announce delivery for ${testCase.name} even when final assistant text exists`, async () => {
+      await withTempCronHome(async (home) => {
+        const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+        const deps = createCliDeps();
+        mockAgentPayloads([{ text: "Working on it..." }, { text: "Final weather summary" }], {
+          meta: {
+            durationMs: 5,
+            agentMeta: { sessionId: "s", provider: "p", model: "m" },
+            finalAssistantVisibleText: "Final weather summary",
+          },
+        });
+
+        const res = await runExplicitAnnounceTurn({
+          home,
+          storePath,
+          deps,
+          channel: testCase.channel,
+          to: testCase.to,
+        });
+
+        expect(res.status).toBe("ok");
+        expect(res.delivered).toBe(true);
+        expect(res.deliveryAttempted).toBe(true);
+        expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+        const sendFn = deps[testCase.sendKey];
+        expect(sendFn).toHaveBeenCalledTimes(2);
+        expect(sendFn).toHaveBeenNthCalledWith(
+          1,
+          testCase.expectedTo,
+          "Working on it...",
+          expect.any(Object),
+        );
+        expect(sendFn).toHaveBeenNthCalledWith(
+          2,
+          testCase.expectedTo,
+          "Final weather summary",
+          expect.any(Object),
+        );
+      });
+    });
   }
 });

--- a/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
+++ b/src/cron/isolated-agent.direct-delivery-forum-topics.test.ts
@@ -10,6 +10,14 @@ import {
 import { withTempCronHome, writeSessionStore } from "./isolated-agent.test-harness.js";
 import { setupIsolatedAgentTurnMocks } from "./isolated-agent.test-setup.js";
 
+function makeRunMeta(finalAssistantVisibleText: string) {
+  return {
+    durationMs: 5,
+    agentMeta: { sessionId: "s", provider: "p", model: "m" },
+    finalAssistantVisibleText,
+  };
+}
+
 describe("runCronIsolatedAgentTurn forum topic delivery", () => {
   beforeEach(() => {
     setupIsolatedAgentTurnMocks();
@@ -39,15 +47,18 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
     });
   });
 
-  it("delivers all successful text chunks to forum-topic telegram targets", async () => {
+  it("delivers only the final assistant-visible text to forum-topic telegram targets", async () => {
     await withTempCronHome(async (home) => {
       const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
       const deps = createCliDeps();
-      mockAgentPayloads([
-        { text: "section 1" },
-        { text: "temporary error", isError: true },
-        { text: "section 2" },
-      ]);
+      mockAgentPayloads(
+        [
+          { text: "section 1" },
+          { text: "temporary error", isError: true },
+          { text: "section 2" },
+        ],
+        { meta: makeRunMeta("section 1\nsection 2") },
+      );
 
       const res = await runTelegramAnnounceTurn({
         home,
@@ -59,19 +70,11 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
       expect(res.status).toBe("ok");
       expect(res.delivered).toBe(true);
       expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
-      expect(deps.sendMessageTelegram).toHaveBeenCalledTimes(2);
-      expect(deps.sendMessageTelegram).toHaveBeenNthCalledWith(
-        1,
-        "123",
-        "section 1",
-        expect.objectContaining({ messageThreadId: 42 }),
-      );
-      expect(deps.sendMessageTelegram).toHaveBeenNthCalledWith(
-        2,
-        "123",
-        "section 2",
-        expect.objectContaining({ messageThreadId: 42 }),
-      );
+      expectDirectTelegramDelivery(deps, {
+        chatId: "123",
+        text: "section 1\nsection 2",
+        messageThreadId: 42,
+      });
     });
   });
 
@@ -94,6 +97,32 @@ describe("runCronIsolatedAgentTurn forum topic delivery", () => {
       expectDirectTelegramDelivery(deps, {
         chatId: "123",
         text: "plain message",
+      });
+    });
+  });
+
+  it("delivers only the final assistant-visible text to plain telegram targets", async () => {
+    await withTempCronHome(async (home) => {
+      const storePath = await writeSessionStore(home, { lastProvider: "webchat", lastTo: "" });
+      const deps = createCliDeps();
+      mockAgentPayloads(
+        [{ text: "Working on it..." }, { text: "Final weather summary" }],
+        { meta: makeRunMeta("Final weather summary") },
+      );
+
+      const plainRes = await runTelegramAnnounceTurn({
+        home,
+        storePath,
+        deps,
+        delivery: { mode: "announce", channel: "telegram", to: "123" },
+      });
+
+      expect(plainRes.status).toBe("ok");
+      expect(plainRes.delivered).toBe(true);
+      expect(runSubagentAnnounceFlow).not.toHaveBeenCalled();
+      expectDirectTelegramDelivery(deps, {
+        chatId: "123",
+        text: "Final weather summary",
       });
     });
   });

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -60,7 +60,7 @@ describe("resolveCronPayloadOutcome", () => {
     expect(String(result.summary ?? "")).toMatch(/…$/);
   });
 
-  it("preserves all successful deliverable payloads for announce delivery", () => {
+  it("preserves all successful deliverable payloads when no final assistant text is available", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [
         { text: "line 1" },
@@ -73,15 +73,35 @@ describe("resolveCronPayloadOutcome", () => {
     expect(result.deliveryPayload).toEqual({ text: "line 2" });
   });
 
+  it("prefers finalAssistantVisibleText for text-only announce delivery", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "section 1" },
+        { text: "temporary error", isError: true },
+        { text: "section 2" },
+      ],
+      finalAssistantVisibleText: "section 1\nsection 2",
+    });
+
+    expect(result.summary).toBe("section 1\nsection 2");
+    expect(result.outputText).toBe("section 1\nsection 2");
+    expect(result.synthesizedText).toBe("section 1\nsection 2");
+    expect(result.deliveryPayloads).toEqual([{ text: "section 1\nsection 2" }]);
+    expect(result.deliveryPayload).toEqual({ text: "section 2" });
+  });
+
   it("keeps structured-content detection scoped to the last delivery payload", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ mediaUrl: "https://example.com/report.png" }, { text: "final text" }],
+      finalAssistantVisibleText: "full final report",
     });
 
     expect(result.deliveryPayloads).toEqual([
       { mediaUrl: "https://example.com/report.png" },
       { text: "final text" },
     ]);
+    expect(result.outputText).toBe("final text");
+    expect(result.synthesizedText).toBe("final text");
     expect(result.deliveryPayloadHasStructuredContent).toBe(false);
   });
 
@@ -91,8 +111,10 @@ describe("resolveCronPayloadOutcome", () => {
         { text: "first error", isError: true },
         { text: "last error", isError: true },
       ],
+      finalAssistantVisibleText: "Recovered final answer",
     });
 
+    expect(result.outputText).toBe("last error");
     expect(result.deliveryPayloads).toEqual([{ text: "last error", isError: true }]);
     expect(result.deliveryPayload).toEqual({ text: "last error", isError: true });
   });

--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -81,6 +81,7 @@ describe("resolveCronPayloadOutcome", () => {
         { text: "section 2" },
       ],
       finalAssistantVisibleText: "section 1\nsection 2",
+      preferFinalAssistantVisibleText: true,
     });
 
     expect(result.summary).toBe("section 1\nsection 2");
@@ -94,6 +95,7 @@ describe("resolveCronPayloadOutcome", () => {
     const result = resolveCronPayloadOutcome({
       payloads: [{ mediaUrl: "https://example.com/report.png" }, { text: "final text" }],
       finalAssistantVisibleText: "full final report",
+      preferFinalAssistantVisibleText: true,
     });
 
     expect(result.deliveryPayloads).toEqual([
@@ -112,10 +114,24 @@ describe("resolveCronPayloadOutcome", () => {
         { text: "last error", isError: true },
       ],
       finalAssistantVisibleText: "Recovered final answer",
+      preferFinalAssistantVisibleText: true,
     });
 
     expect(result.outputText).toBe("last error");
     expect(result.deliveryPayloads).toEqual([{ text: "last error", isError: true }]);
     expect(result.deliveryPayload).toEqual({ text: "last error", isError: true });
+  });
+
+  it("keeps multi-payload direct delivery when finalAssistantVisibleText is not preferred", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "Working on it..." }, { text: "Final weather summary" }],
+      finalAssistantVisibleText: "Final weather summary",
+    });
+
+    expect(result.outputText).toBe("Final weather summary");
+    expect(result.deliveryPayloads).toEqual([
+      { text: "Working on it..." },
+      { text: "Final weather summary" },
+    ]);
   });
 });

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -81,6 +81,18 @@ function isDeliverablePayload(payload: DeliveryPayload | null | undefined): bool
   return hasOutboundReplyContent(payload, { trimText: true }) || hasInteractive || hasChannelData;
 }
 
+function payloadHasStructuredDeliveryContent(payload: DeliveryPayload | null | undefined): boolean {
+  if (!payload) {
+    return false;
+  }
+  return (
+    payload.mediaUrl !== undefined ||
+    (payload.mediaUrls?.length ?? 0) > 0 ||
+    (payload.interactive?.blocks?.length ?? 0) > 0 ||
+    Object.keys(payload.channelData ?? {}).length > 0
+  );
+}
+
 export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
   for (let i = payloads.length - 1; i >= 0; i--) {
     if (payloads[i]?.isError) {
@@ -125,24 +137,14 @@ export function resolveHeartbeatAckMaxChars(agentCfg?: { heartbeat?: { ackMaxCha
 export function resolveCronPayloadOutcome(params: {
   payloads: DeliveryPayload[];
   runLevelError?: unknown;
+  finalAssistantVisibleText?: string;
 }): CronPayloadOutcome {
   const firstText = params.payloads[0]?.text ?? "";
-  const summary = pickSummaryFromPayloads(params.payloads) ?? pickSummaryFromOutput(firstText);
-  const outputText = pickLastNonEmptyTextFromPayloads(params.payloads);
-  const synthesizedText = normalizeOptionalString(outputText) ?? normalizeOptionalString(summary);
+  const fallbackSummary = pickSummaryFromPayloads(params.payloads) ?? pickSummaryFromOutput(firstText);
+  const fallbackOutputText = pickLastNonEmptyTextFromPayloads(params.payloads);
   const deliveryPayload = pickLastDeliverablePayload(params.payloads);
   const selectedDeliveryPayloads = pickDeliverablePayloads(params.payloads);
-  const resolvedDeliveryPayloads =
-    selectedDeliveryPayloads.length > 0
-      ? selectedDeliveryPayloads
-      : synthesizedText
-        ? [{ text: synthesizedText }]
-        : [];
-  const deliveryPayloadHasStructuredContent =
-    deliveryPayload?.mediaUrl !== undefined ||
-    (deliveryPayload?.mediaUrls?.length ?? 0) > 0 ||
-    (deliveryPayload?.interactive?.blocks?.length ?? 0) > 0 ||
-    Object.keys(deliveryPayload?.channelData ?? {}).length > 0;
+  const deliveryPayloadHasStructuredContent = payloadHasStructuredDeliveryContent(deliveryPayload);
   const hasErrorPayload = params.payloads.some((payload) => payload?.isError === true);
   const lastErrorPayloadIndex = params.payloads.findLastIndex(
     (payload) => payload?.isError === true,
@@ -154,6 +156,32 @@ export function resolveCronPayloadOutcome(params: {
       .slice(lastErrorPayloadIndex + 1)
       .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
   const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
+  const normalizedFinalAssistantVisibleText = normalizeOptionalString(
+    params.finalAssistantVisibleText,
+  );
+  const hasStructuredDeliveryPayloads = selectedDeliveryPayloads.some((payload) =>
+    payloadHasStructuredDeliveryContent(payload),
+  );
+  // Keep structured/media announce payloads intact. Only collapse purely textual
+  // cron announce output to the final assistant-visible answer.
+  const shouldUseFinalAssistantVisibleText =
+    normalizedFinalAssistantVisibleText !== undefined &&
+    !hasFatalErrorPayload &&
+    !hasStructuredDeliveryPayloads;
+  const summary = shouldUseFinalAssistantVisibleText
+    ? pickSummaryFromOutput(normalizedFinalAssistantVisibleText) ?? fallbackSummary
+    : fallbackSummary;
+  const outputText = shouldUseFinalAssistantVisibleText
+    ? normalizedFinalAssistantVisibleText
+    : fallbackOutputText;
+  const synthesizedText = normalizeOptionalString(outputText) ?? normalizeOptionalString(summary);
+  const resolvedDeliveryPayloads = shouldUseFinalAssistantVisibleText
+    ? [{ text: normalizedFinalAssistantVisibleText }]
+    : selectedDeliveryPayloads.length > 0
+      ? selectedDeliveryPayloads
+      : synthesizedText
+        ? [{ text: synthesizedText }]
+        : [];
   const lastErrorPayloadText = [...params.payloads]
     .toReversed()
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -138,9 +138,11 @@ export function resolveCronPayloadOutcome(params: {
   payloads: DeliveryPayload[];
   runLevelError?: unknown;
   finalAssistantVisibleText?: string;
+  preferFinalAssistantVisibleText?: boolean;
 }): CronPayloadOutcome {
   const firstText = params.payloads[0]?.text ?? "";
-  const fallbackSummary = pickSummaryFromPayloads(params.payloads) ?? pickSummaryFromOutput(firstText);
+  const fallbackSummary =
+    pickSummaryFromPayloads(params.payloads) ?? pickSummaryFromOutput(firstText);
   const fallbackOutputText = pickLastNonEmptyTextFromPayloads(params.payloads);
   const deliveryPayload = pickLastDeliverablePayload(params.payloads);
   const selectedDeliveryPayloads = pickDeliverablePayloads(params.payloads);
@@ -165,11 +167,12 @@ export function resolveCronPayloadOutcome(params: {
   // Keep structured/media announce payloads intact. Only collapse purely textual
   // cron announce output to the final assistant-visible answer.
   const shouldUseFinalAssistantVisibleText =
+    params.preferFinalAssistantVisibleText === true &&
     normalizedFinalAssistantVisibleText !== undefined &&
     !hasFatalErrorPayload &&
     !hasStructuredDeliveryPayloads;
   const summary = shouldUseFinalAssistantVisibleText
-    ? pickSummaryFromOutput(normalizedFinalAssistantVisibleText) ?? fallbackSummary
+    ? (pickSummaryFromOutput(normalizedFinalAssistantVisibleText) ?? fallbackSummary)
     : fallbackSummary;
   const outputText = shouldUseFinalAssistantVisibleText
     ? normalizedFinalAssistantVisibleText

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -308,6 +308,7 @@ export async function executeCronRun(params: {
       payloads: interimPayloads,
       runLevelError: runResult.meta?.error,
       finalAssistantVisibleText: runResult.meta?.finalAssistantVisibleText,
+      preferFinalAssistantVisibleText: params.resolvedDelivery.channel === "telegram",
     });
     const interimText = interimOutputText?.trim() ?? "";
     const shouldRetryInterimAck =

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -307,6 +307,7 @@ export async function executeCronRun(params: {
     } = resolveCronPayloadOutcome({
       payloads: interimPayloads,
       runLevelError: runResult.meta?.error,
+      finalAssistantVisibleText: runResult.meta?.finalAssistantVisibleText,
     });
     const interimText = interimOutputText?.trim() ?? "";
     const shouldRetryInterimAck =

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -562,6 +562,7 @@ async function finalizeCronRun(params: {
   } = resolveCronPayloadOutcome({
     payloads,
     runLevelError: finalRunResult.meta?.error,
+    finalAssistantVisibleText: finalRunResult.meta?.finalAssistantVisibleText,
   });
   const resolveRunOutcome = (result?: { delivered?: boolean; deliveryAttempted?: boolean }) =>
     prepared.withRunSession({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -563,6 +563,7 @@ async function finalizeCronRun(params: {
     payloads,
     runLevelError: finalRunResult.meta?.error,
     finalAssistantVisibleText: finalRunResult.meta?.finalAssistantVisibleText,
+    preferFinalAssistantVisibleText: prepared.resolvedDelivery.channel === "telegram",
   });
   const resolveRunOutcome = (result?: { delivered?: boolean; deliveryAttempted?: boolean }) =>
     prepared.withRunSession({


### PR DESCRIPTION
## Summary

- Problem: isolated cron `announce` deliveries to Telegram could leak intermediate assistant chunks and narration because cron preserved every successful text payload after the embedded runner accumulated chunked/intermediate `assistantTexts`.
- Why it matters: Telegram chats and forum topics became noisy regressions in 2026.4.1, with one cron run producing many external messages instead of one final update.
- What changed: added `finalAssistantVisibleText` to embedded run metadata, taught isolated cron payload resolution to prefer that final visible answer for text-only announce delivery, and updated Telegram regressions to lock in single-message final delivery.
- What did NOT change (scope boundary): no Telegram outbound adapter changes, no new streaming config/override, and no changes to structured/media delivery behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #60331
- Related #13812
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the embedded runner's `assistantTexts` can include both true intermediate assistant messages and chunked pieces of the final answer; after #57322, isolated cron announce delivery preserved all successful text payloads, so Telegram external delivery emitted all of them.
- Missing detection / guardrail: cron announce delivery had no final-answer-specific collapse step for text-only external delivery, even though the runner already knew how to extract assistant-visible final text.
- Contributing context (if known): Telegram topic delivery made the regression especially visible because direct outbound delivery sent each preserved payload as a separate message.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/helpers.test.ts`, `src/cron/isolated-agent.helpers.test.ts`, `src/cron/isolated-agent.direct-delivery-forum-topics.test.ts`
- Scenario the test should lock in: text-only cron announce delivery to Telegram uses the final assistant-visible answer as a single outbound message for both plain chats and forum topics, while structured/media payload behavior stays unchanged.
- Why this is the smallest reliable guardrail: the helper test locks in final-answer extraction, and the isolated cron tests verify the exact payload collapse plus Telegram delivery path without requiring a full live integration.
- Existing test that already covers this (if any): existing isolated cron Telegram delivery tests already covered the routing path and were updated to assert the corrected behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Isolated cron `announce` delivery to Telegram now sends one final assistant-visible message instead of streaming intermediate assistant text/narration.
- Telegram forum topics and plain Telegram targets both follow the same final-only behavior for text-only announce runs.
- Structured/media announce payloads keep their previous routing behavior.

## Diagram (if applicable)

```text
Before:
[cron isolated run] -> [assistantTexts contains interim + final chunks] -> [preserve all text payloads] -> [Telegram receives multiple messages]

After:
[cron isolated run] -> [extract finalAssistantVisibleText] -> [collapse text-only announce payloads to final answer] -> [Telegram receives one final message]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node 24 / local checkout
- Model/provider: mocked embedded runner payloads
- Integration/channel (if any): Telegram announce delivery (plain target + forum topic)
- Relevant config (redacted): isolated cron `delivery.mode=announce`, Telegram channel configured, runner returns final assistant-visible text in metadata

### Steps

1. Run an isolated cron announce flow whose embedded runner emits intermediate assistant text and a final answer.
2. Target either a Telegram chat or a Telegram forum topic.
3. Observe the outbound payloads selected for direct delivery.

### Expected

- Telegram receives only the final assistant-visible answer for text-only announce runs.

### Actual

- Before this change, Telegram could receive intermediate text chunks/narration as separate messages.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted tests for final-answer extraction, cron payload collapse, Telegram forum topic announce, and plain Telegram announce final-only delivery.
- Edge cases checked: structured/media payloads still bypass final-text collapse; fatal error payload fallback remains unchanged.
- What you did **not** verify: a live Telegram bot conversation against a real remote channel.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: collapsing text-only announce payloads could accidentally hide intended multi-message behavior outside the Telegram cron regression.
  - Mitigation: the collapse only applies when a final assistant-visible answer exists and the delivery payloads are text-only; structured/media delivery remains on the previous path, and Telegram routing regressions are covered by tests.
