### PR TITLE
fix(memory-core): add missing idempotencyKey to dreaming narrative subagent call

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -10,6 +10,7 @@ type SubagentSurface = {
     message: string;
     extraSystemPrompt?: string;
     deliver?: boolean;
+    idempotencyKey?: string;
   }) => Promise<{ runId: string }>;
   waitForRun: (params: {
     runId: string;
@@ -247,6 +248,7 @@ export async function generateAndAppendDreamNarrative(params: {
       message,
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
       deliver: false,
+      idempotencyKey: sessionKey,
     });
 
     const result = await params.subagent.waitForRun({


### PR DESCRIPTION
Fixes regression in 2026.4.8 where dreaming narrative generation fails with 'must have required property idempotencyKey'.

Issue: #63214