### PR TITLE
fix(memory-core): auto-generate idempotencyKey in gateway subagent runtime

### DIFF
--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -336,7 +336,7 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
           ...(allowOverride && params.model && { model: params.model }),
           ...(params.extraSystemPrompt && { extraSystemPrompt: params.extraSystemPrompt }),
           ...(params.lane && { lane: params.lane }),
-          ...(params.idempotencyKey && { idempotencyKey: params.idempotencyKey }),
+          idempotencyKey: params.idempotencyKey ?? randomUUID(),
         },
         {
           allowSyntheticModelOverride,


### PR DESCRIPTION
## Fix #63214

**Bug:** dreaming narrative generation fails with `must have required property idempotencyKey` in 2026.4.8

**Root cause:** `AgentParamsSchema` made `idempotencyKey` a required field (2026.4.8 regression), but `createGatewaySubagentRuntime().run()` in `server-plugins.ts` only passed it when explicitly provided. Dreaming code paths call `subagent.run()` without `idempotencyKey`, triggering JSON schema validation failure.

**Fix:** auto-generate `idempotencyKey` via `randomUUID()` when not provided, so all plugin subagent call sites continue working without modification.

**Files changed:** `src/gateway/server-plugins.ts` (1 line)