### PR TITLE
CLI: add --all flag to models status --probe for per-model health check

### DIFF
--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -50,6 +50,7 @@ export function registerModelsCli(program: Command) {
       false,
     )
     .option("--probe", "Probe configured provider auth (live)", false)
+    .option("--all", "Probe every configured model, not just one per provider", false)
     .option("--probe-provider <name>", "Only probe a single provider")
     .option(
       "--probe-profile <id>",
@@ -78,6 +79,7 @@ export function registerModelsCli(program: Command) {
             plain: Boolean(opts.plain),
             check: Boolean(opts.check),
             probe: Boolean(opts.probe),
+            probeAll: Boolean(opts.all),
             probeProvider: opts.probeProvider as string | undefined,
             probeProfile: opts.probeProfile as string | string[] | undefined,
             probeTimeout: opts.probeTimeout as string | undefined,

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -50,7 +50,11 @@ export function registerModelsCli(program: Command) {
       false,
     )
     .option("--probe", "Probe configured provider auth (live)", false)
-    .option("--all", "Probe every configured model, not just one per provider", false)
+    .option(
+      "--all",
+      "Probe every configured model, not just one per provider (requires --probe)",
+      false,
+    )
     .option("--probe-provider <name>", "Only probe a single provider")
     .option(
       "--probe-profile <id>",

--- a/src/cli/program/route-args.test.ts
+++ b/src/cli/program/route-args.test.ts
@@ -202,9 +202,38 @@ describe("route-args", () => {
       plain: true,
       check: true,
       probe: true,
+      probeAll: false,
     });
     expect(
       parseModelsStatusRouteArgs(["node", "openclaw", "models", "status", "--probe-profile"]),
     ).toBeNull();
+  });
+
+  it("parses --probe --all combined with --probe-provider and --json", () => {
+    expect(
+      parseModelsStatusRouteArgs([
+        "node",
+        "openclaw",
+        "models",
+        "status",
+        "--probe",
+        "--all",
+        "--probe-provider",
+        "anthropic",
+        "--json",
+      ]),
+    ).toEqual({
+      probeProvider: "anthropic",
+      probeTimeout: undefined,
+      probeConcurrency: undefined,
+      probeMaxTokens: undefined,
+      agent: undefined,
+      probeProfile: undefined,
+      json: true,
+      plain: false,
+      check: false,
+      probe: true,
+      probeAll: true,
+    });
   });
 });

--- a/src/cli/program/route-args.ts
+++ b/src/cli/program/route-args.ts
@@ -240,6 +240,7 @@ export function parseModelsStatusRouteArgs(argv: string[]) {
     plain: hasFlag(argv, "--plain"),
     check: hasFlag(argv, "--check"),
     probe: hasFlag(argv, "--probe"),
+    probeAll: hasFlag(argv, "--all"),
   };
 }
 

--- a/src/commands/models/list.probe.targets.test.ts
+++ b/src/commands/models/list.probe.targets.test.ts
@@ -323,3 +323,102 @@ describe("buildProbeTargets reason codes", () => {
     });
   });
 });
+
+describe("buildProbeTargets probeAll flag", () => {
+  beforeEach(() => {
+    mockStore = {
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "token",
+          provider: "anthropic",
+          tokenRef: { source: "env", provider: "default", id: "ANTHROPIC_TOKEN" },
+          expires: Number.MAX_SAFE_INTEGER,
+        },
+      },
+      order: {
+        anthropic: ["anthropic:default"],
+      },
+    };
+    mockAllowedProfiles = ["anthropic:default"];
+    loadModelCatalogMock.mockReset();
+    loadModelCatalogMock.mockResolvedValue([]);
+    resolveAuthProfileOrderMock.mockClear();
+    resolveAuthProfileEligibilityMock.mockClear();
+    resolveSecretRefStringMock.mockReset();
+    resolveSecretRefStringMock.mockResolvedValue("resolved-secret");
+    resolveAuthProfileEligibilityMock.mockReturnValue({
+      eligible: true,
+    } as unknown as { eligible: boolean; reasonCode: "invalid_expires" });
+  });
+
+  it("defaults to the first configured candidate when probeAll is omitted (backward compat)", async () => {
+    const plan = await buildProbeTargets({
+      cfg: {
+        auth: { order: { anthropic: ["anthropic:default"] } },
+      } as OpenClawConfig,
+      providers: ["anthropic"],
+      modelCandidates: [
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-opus-4-7",
+        "anthropic/claude-haiku-4-5",
+      ],
+      options: {
+        timeoutMs: 5_000,
+        concurrency: 1,
+        maxTokens: 16,
+      },
+    });
+
+    const anthropicTargets = plan.targets.filter((t) => t.provider === "anthropic");
+    expect(anthropicTargets.map((t) => t.model?.model)).toEqual(["claude-sonnet-4-6"]);
+  });
+
+  it("expands to every configured candidate when probeAll is true", async () => {
+    const plan = await buildProbeTargets({
+      cfg: {
+        auth: { order: { anthropic: ["anthropic:default"] } },
+      } as OpenClawConfig,
+      providers: ["anthropic"],
+      modelCandidates: [
+        "anthropic/claude-sonnet-4-6",
+        "anthropic/claude-opus-4-7",
+        "anthropic/claude-haiku-4-5",
+      ],
+      options: {
+        timeoutMs: 5_000,
+        concurrency: 1,
+        maxTokens: 16,
+        probeAll: true,
+      },
+    });
+
+    const anthropicTargets = plan.targets.filter((t) => t.provider === "anthropic");
+    const anthropicModels = anthropicTargets
+      .map((t) => t.model?.model)
+      .toSorted((a, b) => (a ?? "").localeCompare(b ?? ""));
+    expect(anthropicModels).toEqual(["claude-haiku-4-5", "claude-opus-4-7", "claude-sonnet-4-6"]);
+  });
+
+  it("falls back to selectProbeModel when probeAll is true but no candidates are configured", async () => {
+    loadModelCatalogMock.mockResolvedValueOnce([
+      { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    ]);
+    const plan = await buildProbeTargets({
+      cfg: {
+        auth: { order: { anthropic: ["anthropic:default"] } },
+      } as OpenClawConfig,
+      providers: ["anthropic"],
+      modelCandidates: [],
+      options: {
+        timeoutMs: 5_000,
+        concurrency: 1,
+        maxTokens: 16,
+        probeAll: true,
+      },
+    });
+
+    const anthropicTargets = plan.targets.filter((t) => t.provider === "anthropic");
+    expect(anthropicTargets.map((t) => t.model?.model)).toEqual(["claude-sonnet-4-6"]);
+  });
+});

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -101,6 +101,7 @@ export type AuthProbeOptions = {
   timeoutMs: number;
   concurrency: number;
   maxTokens: number;
+  probeAll?: boolean;
 };
 
 export function mapFailoverReasonToProbeStatus(reason?: string | null): AuthProbeStatus {
@@ -270,11 +271,19 @@ export async function buildProbeTargets(params: {
       continue;
     }
 
-    const model = selectProbeModel({
-      provider: providerKey,
-      candidates,
-      catalog,
-    });
+    const models: Array<{ provider: string; model: string } | null> = [];
+    if (options.probeAll) {
+      const providerModels = candidates.get(providerKey);
+      if (providerModels && providerModels.length > 0) {
+        for (const m of providerModels) {
+          models.push({ provider: providerKey, model: m });
+        }
+      } else {
+        models.push(selectProbeModel({ provider: providerKey, candidates, catalog }));
+      }
+    } else {
+      models.push(selectProbeModel({ provider: providerKey, candidates, catalog }));
+    }
 
     const profileIds = listProfilesForProvider(store, providerKey);
     const explicitOrder = (() => {
@@ -297,10 +306,11 @@ export async function buildProbeTargets(params: {
         const mode = profile?.type;
         const label = resolveAuthProfileDisplayLabel({ cfg, store, profileId });
         if (explicitOrder && !explicitOrder.includes(profileId)) {
+          const firstModel = models[0];
           results.push({
             provider: providerKey,
             profileId,
-            model: model ? `${model.provider}/${model.model}` : undefined,
+            model: firstModel ? `${firstModel.provider}/${firstModel.model}` : undefined,
             label,
             source: "profile",
             mode,
@@ -318,9 +328,10 @@ export async function buildProbeTargets(params: {
             profileId,
           });
           const reasonCode = mapEligibilityReasonToProbeReasonCode(eligibility.reasonCode);
+          const firstModel = models[0];
           results.push({
             provider: providerKey,
-            model: model ? `${model.provider}/${model.model}` : undefined,
+            model: firstModel ? `${firstModel.provider}/${firstModel.model}` : undefined,
             profileId,
             label,
             source: "profile",
@@ -337,9 +348,10 @@ export async function buildProbeTargets(params: {
           cache: refResolveCache,
         });
         if (unresolvedRefIssue) {
+          const firstModel = models[0];
           results.push({
             provider: providerKey,
-            model: model ? `${model.provider}/${model.model}` : undefined,
+            model: firstModel ? `${firstModel.provider}/${firstModel.model}` : undefined,
             profileId,
             label,
             source: "profile",
@@ -350,7 +362,10 @@ export async function buildProbeTargets(params: {
           });
           continue;
         }
-        if (!model) {
+        const validModels = models.filter(
+          (m): m is { provider: string; model: string } => m !== null,
+        );
+        if (validModels.length === 0) {
           results.push({
             provider: providerKey,
             model: undefined,
@@ -364,14 +379,16 @@ export async function buildProbeTargets(params: {
           });
           continue;
         }
-        targets.push({
-          provider: providerKey,
-          model,
-          profileId,
-          label,
-          source: "profile",
-          mode,
-        });
+        for (const model of validModels) {
+          targets.push({
+            provider: providerKey,
+            model,
+            profileId,
+            label,
+            source: "profile",
+            mode,
+          });
+        }
       }
       continue;
     }
@@ -390,7 +407,10 @@ export async function buildProbeTargets(params: {
     const source = envKey ? "env" : "models.json";
     const mode = envKey?.source.includes("OAUTH_TOKEN") ? "oauth" : "api_key";
 
-    if (!model) {
+    const validModels = models.filter(
+      (m): m is { provider: string; model: string } => m !== null,
+    );
+    if (validModels.length === 0) {
       results.push({
         provider: providerKey,
         model: undefined,
@@ -404,13 +424,15 @@ export async function buildProbeTargets(params: {
       continue;
     }
 
-    targets.push({
-      provider: providerKey,
-      model,
-      label,
-      source,
-      mode,
-    });
+    for (const model of validModels) {
+      targets.push({
+        provider: providerKey,
+        model,
+        label,
+        source,
+        mode,
+      });
+    }
   }
 
   return { targets, results };

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -407,9 +407,7 @@ export async function buildProbeTargets(params: {
     const source = envKey ? "env" : "models.json";
     const mode = envKey?.source.includes("OAUTH_TOKEN") ? "oauth" : "api_key";
 
-    const validModels = models.filter(
-      (m): m is { provider: string; model: string } => m !== null,
-    );
+    const validModels = models.filter((m): m is { provider: string; model: string } => m !== null);
     if (validModels.length === 0) {
       results.push({
         provider: providerKey,

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -159,7 +159,9 @@ export async function modelsStatusCommand(
     throw new Error("--probe cannot be used with --plain output.");
   }
   if (opts.probeAll && !opts.probe) {
-    runtime.error("Warning: --all has no effect without --probe. Add --probe to enable per-model health checks.");
+    runtime.error(
+      "Warning: --all has no effect without --probe. Add --probe to enable per-model health checks.",
+    );
   }
   const configPath = createConfigIO().configPath;
   const cfg = await loadModelsConfig({ commandName: "models status", runtime });

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -144,6 +144,7 @@ export async function modelsStatusCommand(
     plain?: boolean;
     check?: boolean;
     probe?: boolean;
+    probeAll?: boolean;
     probeProvider?: string;
     probeProfile?: string | string[];
     probeTimeout?: string;
@@ -380,6 +381,7 @@ export async function modelsStatusCommand(
             timeoutMs: probeTimeoutMs,
             concurrency: probeConcurrency,
             maxTokens: probeMaxTokens,
+            probeAll: Boolean(opts.probeAll),
           },
           onProgress: update,
         });

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -158,6 +158,9 @@ export async function modelsStatusCommand(
   if (opts.plain && opts.probe) {
     throw new Error("--probe cannot be used with --plain output.");
   }
+  if (opts.probeAll && !opts.probe) {
+    runtime.error("Warning: --all has no effect without --probe. Add --probe to enable per-model health checks.");
+  }
   const configPath = createConfigIO().configPath;
   const cfg = await loadModelsConfig({ commandName: "models status", runtime });
   const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent });


### PR DESCRIPTION
## Summary
- Add `--all` flag to `openclaw models status --probe` that probes every configured model individually, not just one per provider
- Catches deprecated/renamed model IDs that pass auth-only validation because the API key is valid

## Problem
`models status --probe` validates provider auth by picking one representative model per provider via `selectProbeModel()`. This means:
- Deprecated models (e.g., `openai/gpt-5.4` on OpenRouter) sit in config returning 400s undetected
- Fallback chain health is invisible — broken fallback models only surface when the primary fails
- Users with 10-15+ models across tiers have no pre-flight check for the full config

## Changes
- `src/cli/models-cli.ts`: Register `--all` flag, pass `probeAll` to command handler
- `src/commands/models/list.status-command.ts`: Pass `probeAll` through to `runAuthProbes` options
- `src/commands/models/list.probe.ts`: Add `probeAll` to `AuthProbeOptions`; when set, iterate all candidate models for each provider instead of picking one via `selectProbeModel()`
- `src/commands/models/list.probe.targets.test.ts`: 3 new vitest cases asserting probeAll behavior at the `buildProbeTargets` boundary

## Usage
```bash
# Probe every configured model
openclaw models status --probe --all

# Probe all models under a specific provider
openclaw models status --probe --all --probe-provider openrouter

# Existing behavior unchanged
openclaw models status --probe
```

## Backward compatibility
- `--probe` without `--all` behaves exactly as before (one model per provider)
- `--all` without `--probe` is a no-op (probing must be enabled)
- All existing CLI flags (`--probe-provider`, `--probe-timeout`, `--probe-concurrency`, `--probe-max-tokens`) work with `--all`

## Test plan
- [x] `openclaw models status --probe` — unchanged output: asserted in `list.probe.targets.test.ts::"defaults to the first configured candidate when probeAll is omitted"`. Given 3 configured anthropic models, `probeAll` absent → exactly 1 target emitted (the first candidate, asserted by model id, not just count).
- [x] `openclaw models status --probe --all` — every configured model surfaces: asserted in `list.probe.targets.test.ts::"expands to every configured candidate when probeAll is true"`. Given 3 configured anthropic models + `probeAll: true`, all 3 targets emitted (exact model id list asserted via sorted `toEqual`).
- [x] Fallback when no explicit candidates but catalog has one: asserted in `list.probe.targets.test.ts::"falls back to selectProbeModel when probeAll is true but no candidates are configured"` — catalog entry is used, exact model id asserted.
- [ ] `openclaw models status --probe --all --probe-provider anthropic` — filters to one provider: CLI-surface test, not covered by the probe-targets unit test. Manual repro: works because `buildProbeTargets` has always honored the `provider` filter; this PR only adds the `probeAll` expansion within an already-filtered provider.
- [ ] `openclaw models status --probe --all --json` — JSON output includes all model results: CLI-surface test, not covered by the probe-targets unit test. Manual repro: `runAuthProbes` returns the full target array which the JSON renderer already iterates; no code path added here.
- [ ] Deprecated model IDs show `error` / `no_model` status: behavioral test requires live provider auth and catalog. The `probeAll` code path exposes every candidate to the existing probe-and-classify logic; the `error`/`no_model` classification itself is unchanged in this PR.

```
$ pnpm exec vitest run src/commands/models/list.probe.targets.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)  (6 pre-existing + 3 new)
```

The last 3 items in the test plan remain manual CLI-integration checks (flag-level, JSON renderer, live-auth deprecated-model behavior). The core behavior this PR adds — `probeAll` expanding one-per-provider to every-candidate — is now CI-verified at the `buildProbeTargets` boundary with exact model-id assertions.

Implements #63145.
