### PR TITLE
[codex] tests: fix discord CI seam leakage

### DIFF
--- a/extensions/discord/src/monitor/native-command.model-picker.test.ts
+++ b/extensions/discord/src/monitor/native-command.model-picker.test.ts
@@ -3,6 +3,7 @@ import * as commandRegistryModule from "openclaw/plugin-sdk/command-auth";
 import type { ChatCommandDefinition, CommandArgsParsing } from "openclaw/plugin-sdk/command-auth";
 import type { ModelsProviderData } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import * as pluginRuntimeModule from "openclaw/plugin-sdk/plugin-runtime";
 import * as dispatcherModule from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import * as globalsModule from "openclaw/plugin-sdk/runtime-env";
 import * as commandTextModule from "openclaw/plugin-sdk/text-runtime";
@@ -10,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as modelPickerPreferencesModule from "./model-picker-preferences.js";
 import * as modelPickerModule from "./model-picker.js";
 import { createModelsProviderData as createBaseModelsProviderData } from "./model-picker.test-utils.js";
+import * as nativeCommandRouteModule from "./native-command-route.js";
 import { replyWithDiscordModelPickerProviders } from "./native-command-ui.js";
 import {
   __testing as nativeCommandTesting,
@@ -256,8 +258,13 @@ describe("Discord model picker interactions", () => {
   beforeEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    nativeCommandTesting.setMatchPluginCommand(pluginRuntimeModule.matchPluginCommand);
+    nativeCommandTesting.setExecutePluginCommand(pluginRuntimeModule.executePluginCommand);
     nativeCommandTesting.setDispatchReplyWithDispatcher(
       dispatcherModule.dispatchReplyWithDispatcher,
+    );
+    nativeCommandTesting.setResolveDiscordNativeInteractionRouteState(
+      nativeCommandRouteModule.resolveDiscordNativeInteractionRouteState,
     );
   });
 


### PR DESCRIPTION
## Summary

- reset all mutable `native-command.ts` testing seams in `native-command.model-picker.test.ts`
- prevent `native-command.plugin-dispatch.test.ts` from leaking route/plugin dispatch stubs into later Discord model-picker tests under the non-isolated runner
- keep the change test-only and scoped to the Discord CI failure

## Why

`CI / extension-fast (extension-fast-discord, discord)` timed out in `extensions/discord/src/monitor/native-command.model-picker.test.ts`, but the failure only showed up when the full Discord extension lane ran under the non-isolated Vitest runner.

The root cause was incomplete test seam reset. `native-command.ts` stores several `__testing` overrides in module-level mutable state, and `native-command.plugin-dispatch.test.ts` mutates more than just the reply dispatcher. `native-command.model-picker.test.ts` only restored `dispatchReplyWithDispatcher`, so a prior file could leak route/plugin command mocks into the model-picker tests.

## Impact

- fixes the Discord CI-only timeout chain
- does not change product behavior
- keeps the repair localized to test setup

## Validation

- `pnpm test extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts`
- `pnpm test extensions/discord/src/monitor/native-command.model-picker.test.ts`
