### PR TITLE
feat(ui): add dreaming diary controls and navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - iOS: pin release versioning to an explicit CalVer in `apps/ios/version.json`, keep TestFlight iteration on the same short version until maintainers intentionally promote the next gateway version, and add the documented `pnpm ios:version:pin -- --from-gateway` workflow for release trains. (#63001) Thanks @ngutman.
 - Memory/dreaming: add a grounded REM backfill lane with historical `rem-harness --path`, diary commit, and reset flows so old daily notes can be replayed safely into `DREAMS.md`. Thanks @mbelinky.
+- Control UI/dreaming: add a structured diary view with timeline navigation, backfill/reset controls, and traceable dreaming summaries. Thanks @mbelinky.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - iOS: pin release versioning to an explicit CalVer in `apps/ios/version.json`, keep TestFlight iteration on the same short version until maintainers intentionally promote the next gateway version, and add the documented `pnpm ios:version:pin -- --from-gateway` workflow for release trains. (#63001) Thanks @ngutman.
+- Memory/dreaming: add a grounded REM backfill lane with historical `rem-harness --path`, diary commit, and reset flows so old daily notes can be replayed safely into `DREAMS.md`. Thanks @mbelinky.
 
 ### Fixes
 

--- a/extensions/memory-core/api.ts
+++ b/extensions/memory-core/api.ts
@@ -4,3 +4,8 @@ export type {
   MemoryProviderStatus,
   MemorySyncProgressUpdate,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+export {
+  removeBackfillDiaryEntries,
+  writeBackfillDiaryEntries,
+} from "./src/dreaming-narrative.js";
+export { previewGroundedRemMarkdown } from "./src/rem-evidence.js";

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -4,7 +4,6 @@ import os from "node:os";
 import path from "node:path";
 import { resolveMemoryRemDreamingConfig } from "openclaw/plugin-sdk/memory-core-host-status";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import {
   colorize,
   defaultRuntime,
@@ -31,10 +30,13 @@ import type {
   MemoryCommandOptions,
   MemoryPromoteCommandOptions,
   MemoryPromoteExplainOptions,
+  MemoryRemBackfillOptions,
   MemoryRemHarnessOptions,
   MemorySearchCommandOptions,
 } from "./cli.types.js";
-import { previewRemDreaming } from "./dreaming-phases.js";
+import { previewRemDreaming, seedHistoricalDailyMemorySignals } from "./dreaming-phases.js";
+import { removeBackfillDiaryEntries, writeBackfillDiaryEntries } from "./dreaming-narrative.js";
+import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import { asRecord } from "./dreaming-shared.js";
 import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
 import {
@@ -112,6 +114,78 @@ function emitMemorySecretResolveDiagnostics(
 function resolveMemoryPluginConfig(cfg: OpenClawConfig): Record<string, unknown> {
   const entry = asRecord(cfg.plugins?.entries?.["memory-core"]);
   return asRecord(entry?.config) ?? {};
+}
+
+const DAILY_MEMORY_FILE_NAME_RE = /^(\d{4}-\d{2}-\d{2})\.md$/;
+
+async function listHistoricalDailyFiles(inputPath: string): Promise<string[]> {
+  const resolvedPath = path.resolve(inputPath);
+  const stat = await fs.stat(resolvedPath);
+  if (stat.isFile()) {
+    return DAILY_MEMORY_FILE_NAME_RE.test(path.basename(resolvedPath)) ? [resolvedPath] : [];
+  }
+  if (!stat.isDirectory()) {
+    return [];
+  }
+  const entries = await fs.readdir(resolvedPath, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && DAILY_MEMORY_FILE_NAME_RE.test(entry.name))
+    .map((entry) => path.join(resolvedPath, entry.name))
+    .toSorted((a, b) => path.basename(a).localeCompare(path.basename(b)));
+}
+
+async function createHistoricalRemHarnessWorkspace(params: {
+  inputPath: string;
+  remLimit: number;
+  nowMs: number;
+  timezone?: string;
+}): Promise<{
+  workspaceDir: string;
+  sourceFiles: string[];
+  workspaceSourceFiles: string[];
+  importedFileCount: number;
+  importedSignalCount: number;
+  skippedPaths: string[];
+}> {
+  const sourceFiles = await listHistoricalDailyFiles(params.inputPath);
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rem-harness-"));
+  const memoryDir = path.join(workspaceDir, "memory");
+  await fs.mkdir(memoryDir, { recursive: true });
+  for (const filePath of sourceFiles) {
+    await fs.copyFile(filePath, path.join(memoryDir, path.basename(filePath)));
+  }
+  const workspaceSourceFiles = sourceFiles.map((entry) => path.join(memoryDir, path.basename(entry)));
+  const seeded = await seedHistoricalDailyMemorySignals({
+    workspaceDir,
+    filePaths: workspaceSourceFiles,
+    limit: params.remLimit,
+    nowMs: params.nowMs,
+    timezone: params.timezone,
+  });
+  return {
+    workspaceDir,
+    sourceFiles,
+    workspaceSourceFiles,
+    importedFileCount: seeded.importedFileCount,
+    importedSignalCount: seeded.importedSignalCount,
+    skippedPaths: seeded.skippedPaths,
+  };
+}
+
+async function listWorkspaceDailyFiles(workspaceDir: string, limit: number): Promise<string[]> {
+  const memoryDir = path.join(workspaceDir, "memory");
+  try {
+    const files = await listHistoricalDailyFiles(memoryDir);
+    if (!Number.isFinite(limit) || limit <= 0 || files.length <= limit) {
+      return files;
+    }
+    return files.slice(-limit);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
 }
 
 function formatDreamingSummary(cfg: OpenClawConfig): string {
@@ -208,6 +282,18 @@ function formatExtraPaths(workspaceDir: string, extraPaths: string[]): string[] 
   return normalizeExtraMemoryPaths(workspaceDir, extraPaths).map((entry) => shortenHomePath(entry));
 }
 
+function extractIsoDayFromPath(filePath: string): string | null {
+  const match = path.basename(filePath).match(DAILY_MEMORY_FILE_NAME_RE);
+  return match?.[1] ?? null;
+}
+
+function groundedMarkdownToDiaryLines(markdown: string): string[] {
+  return markdown
+    .split(/\r?\n/)
+    .map((line) => line.replace(/^##\s+/, "").trimEnd())
+    .filter((line, index, lines) => !(line.length === 0 && lines[index - 1]?.length === 0));
+}
+
 function matchesPromotionSelector(
   candidate: {
     key: string;
@@ -216,15 +302,15 @@ function matchesPromotionSelector(
   },
   selector: string,
 ): boolean {
-  const trimmed = normalizeLowercaseStringOrEmpty(selector);
+  const trimmed = selector.trim().toLowerCase();
   if (!trimmed) {
     return false;
   }
   return (
-    normalizeLowercaseStringOrEmpty(candidate.key) === trimmed ||
-    normalizeLowercaseStringOrEmpty(candidate.key).includes(trimmed) ||
-    normalizeLowercaseStringOrEmpty(candidate.path).includes(trimmed) ||
-    normalizeLowercaseStringOrEmpty(candidate.snippet).includes(trimmed)
+    candidate.key.toLowerCase() === trimmed ||
+    candidate.key.toLowerCase().includes(trimmed) ||
+    candidate.path.toLowerCase().includes(trimmed) ||
+    candidate.snippet.toLowerCase().includes(trimmed)
   );
 }
 
@@ -1250,13 +1336,13 @@ export async function runMemoryRemHarness(opts: MemoryRemHarnessOptions) {
     purpose: "status",
     run: async (manager) => {
       const status = manager.status();
-      const workspaceDir = status.workspaceDir?.trim();
+      const managerWorkspaceDir = status.workspaceDir?.trim();
       const pluginConfig = resolveMemoryPluginConfig(cfg);
       const deep = resolveShortTermPromotionDreamingConfig({
         pluginConfig,
         cfg,
       });
-      if (!workspaceDir) {
+      if (!managerWorkspaceDir && !opts.path) {
         defaultRuntime.error("Memory rem-harness requires a resolvable workspace directory.");
         process.exitCode = 1;
         return;
@@ -1266,69 +1352,297 @@ export async function runMemoryRemHarness(opts: MemoryRemHarnessOptions) {
         cfg,
       });
       const nowMs = Date.now();
-      const cutoffMs = nowMs - Math.max(0, remConfig.lookbackDays) * 24 * 60 * 60 * 1000;
-      const recallEntries = (await readShortTermRecallEntries({ workspaceDir, nowMs })).filter(
-        (entry) => Date.parse(entry.lastRecalledAt) >= cutoffMs,
-      );
-      const remPreview = previewRemDreaming({
-        entries: recallEntries,
-        limit: remConfig.limit,
-        minPatternStrength: remConfig.minPatternStrength,
-      });
-      const deepCandidates = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-        includePromoted: Boolean(opts.includePromoted),
-        recencyHalfLifeDays: deep.recencyHalfLifeDays,
-        maxAgeDays: deep.maxAgeDays,
-      });
-
-      if (opts.json) {
-        defaultRuntime.writeJson({
-          workspaceDir,
-          remConfig,
-          deepConfig: {
-            minScore: deep.minScore,
-            minRecallCount: deep.minRecallCount,
-            minUniqueQueries: deep.minUniqueQueries,
-            recencyHalfLifeDays: deep.recencyHalfLifeDays,
-            maxAgeDays: deep.maxAgeDays ?? null,
-          },
-          rem: remPreview,
-          deep: {
-            candidateCount: deepCandidates.length,
-            candidates: deepCandidates,
-          },
+      let workspaceDir = managerWorkspaceDir ?? "";
+      let sourceFiles: string[] = [];
+      let groundedInputPaths: string[] = [];
+      let importedFileCount = 0;
+      let importedSignalCount = 0;
+      let skippedPaths: string[] = [];
+      let cleanupWorkspaceDir: string | null = null;
+      if (opts.path) {
+        const historical = await createHistoricalRemHarnessWorkspace({
+          inputPath: opts.path,
+          remLimit: remConfig.limit,
+          nowMs,
+          timezone: remConfig.timezone,
         });
+        workspaceDir = historical.workspaceDir;
+        cleanupWorkspaceDir = historical.workspaceDir;
+        sourceFiles = historical.sourceFiles;
+        groundedInputPaths = historical.workspaceSourceFiles;
+        importedFileCount = historical.importedFileCount;
+        importedSignalCount = historical.importedSignalCount;
+        skippedPaths = historical.skippedPaths;
+        if (sourceFiles.length === 0) {
+          await fs.rm(historical.workspaceDir, { recursive: true, force: true });
+          defaultRuntime.error(
+            `Memory rem-harness found no YYYY-MM-DD.md files at ${shortenHomePath(path.resolve(opts.path))}.`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+      }
+      if (!workspaceDir) {
+        defaultRuntime.error("Memory rem-harness requires a resolvable workspace directory.");
+        process.exitCode = 1;
+        return;
+      }
+      try {
+        if (groundedInputPaths.length === 0 && opts.grounded) {
+          groundedInputPaths = await listWorkspaceDailyFiles(workspaceDir, remConfig.limit);
+        }
+        const cutoffMs = nowMs - Math.max(0, remConfig.lookbackDays) * 24 * 60 * 60 * 1000;
+        const recallEntries = (await readShortTermRecallEntries({ workspaceDir, nowMs })).filter(
+          (entry) => Date.parse(entry.lastRecalledAt) >= cutoffMs,
+        );
+        const remPreview = previewRemDreaming({
+          entries: recallEntries,
+          limit: remConfig.limit,
+          minPatternStrength: remConfig.minPatternStrength,
+        });
+        const groundedPreview =
+          opts.grounded && groundedInputPaths.length > 0
+            ? await previewGroundedRemMarkdown({
+                workspaceDir,
+                inputPaths: groundedInputPaths,
+              })
+            : null;
+        const deepCandidates = await rankShortTermPromotionCandidates({
+          workspaceDir,
+          minScore: 0,
+          minRecallCount: 0,
+          minUniqueQueries: 0,
+          includePromoted: Boolean(opts.includePromoted),
+          recencyHalfLifeDays: deep.recencyHalfLifeDays,
+          maxAgeDays: deep.maxAgeDays,
+        });
+
+        if (opts.json) {
+          defaultRuntime.writeJson({
+            workspaceDir,
+            sourcePath: opts.path ? path.resolve(opts.path) : null,
+            sourceFiles,
+            historicalImport:
+              opts.path
+                ? {
+                    importedFileCount,
+                    importedSignalCount,
+                    skippedPaths,
+                  }
+                : null,
+            remConfig,
+            deepConfig: {
+              minScore: deep.minScore,
+              minRecallCount: deep.minRecallCount,
+              minUniqueQueries: deep.minUniqueQueries,
+              recencyHalfLifeDays: deep.recencyHalfLifeDays,
+              maxAgeDays: deep.maxAgeDays ?? null,
+            },
+            rem: remPreview,
+            grounded: groundedPreview,
+            deep: {
+              candidateCount: deepCandidates.length,
+              candidates: deepCandidates,
+            },
+          });
+          return;
+        }
+
+        const rich = isRich();
+        const lines = [
+          `${colorize(rich, theme.heading, "REM Harness")} ${colorize(rich, theme.muted, `(${agentId})`)}`,
+          colorize(rich, theme.muted, `workspace=${shortenHomePath(workspaceDir)}`),
+          ...(opts.path
+            ? [
+                colorize(
+                  rich,
+                  theme.muted,
+                  `sourcePath=${shortenHomePath(path.resolve(opts.path))}`,
+                ),
+                colorize(
+                  rich,
+                  theme.muted,
+                  `historicalFiles=${sourceFiles.length} importedFiles=${importedFileCount} importedSignals=${importedSignalCount}`,
+                ),
+                ...(skippedPaths.length > 0
+                  ? [
+                      colorize(
+                        rich,
+                        theme.warn,
+                        `skipped=${skippedPaths.map((entry) => shortenHomePath(entry)).join(", ")}`,
+                      ),
+                    ]
+                  : []),
+              ]
+            : []),
+          ...(opts.grounded
+            ? [
+                colorize(
+                  rich,
+                  theme.muted,
+                  `groundedInputs=${groundedInputPaths.length > 0 ? groundedInputPaths.map((entry) => shortenHomePath(entry)).join(", ") : "none"}`,
+                ),
+              ]
+            : []),
+          colorize(
+            rich,
+            theme.muted,
+            `recentRecallEntries=${recallEntries.length} deepCandidates=${deepCandidates.length}`,
+          ),
+          "",
+          colorize(rich, theme.heading, "REM Preview"),
+          ...remPreview.bodyLines,
+          ...(groundedPreview
+            ? [
+                "",
+                colorize(rich, theme.heading, "Grounded REM"),
+                ...groundedPreview.files.flatMap((file) => [
+                  colorize(rich, theme.label, file.path),
+                  file.renderedMarkdown,
+                  "",
+                ]),
+              ]
+            : []),
+          "",
+          colorize(rich, theme.heading, "Deep Candidates"),
+          ...(deepCandidates.length > 0
+            ? deepCandidates
+                .slice(0, 10)
+                .map(
+                  (candidate) =>
+                    `${candidate.score.toFixed(3)} ${candidate.snippet} [${shortenHomePath(candidate.path)}:${candidate.startLine}-${candidate.endLine}]`,
+                )
+            : ["- No deep candidates."]),
+        ];
+        defaultRuntime.log(lines.join("\n"));
+      } finally {
+        if (cleanupWorkspaceDir) {
+          await fs.rm(cleanupWorkspaceDir, { recursive: true, force: true });
+        }
+      }
+    },
+  });
+}
+
+export async function runMemoryRemBackfill(opts: MemoryRemBackfillOptions) {
+  const { config: cfg, diagnostics } = await loadMemoryCommandConfig("memory rem-backfill");
+  emitMemorySecretResolveDiagnostics(diagnostics, { json: Boolean(opts.json) });
+  const agentId = resolveAgent(cfg, opts.agent);
+
+  await withMemoryManagerForAgent({
+    cfg,
+    agentId,
+    purpose: "status",
+    run: async (manager) => {
+      const status = manager.status();
+      const workspaceDir = status.workspaceDir?.trim();
+      const pluginConfig = resolveMemoryPluginConfig(cfg);
+      const remConfig = resolveMemoryRemDreamingConfig({
+        pluginConfig,
+        cfg,
+      });
+      if (!workspaceDir) {
+        defaultRuntime.error("Memory rem-backfill requires a resolvable workspace directory.");
+        process.exitCode = 1;
         return;
       }
 
-      const rich = isRich();
-      const lines = [
-        `${colorize(rich, theme.heading, "REM Harness")} ${colorize(rich, theme.muted, `(${agentId})`)}`,
-        colorize(rich, theme.muted, `workspace=${shortenHomePath(workspaceDir)}`),
-        colorize(
-          rich,
-          theme.muted,
-          `recentRecallEntries=${recallEntries.length} deepCandidates=${deepCandidates.length}`,
-        ),
-        "",
-        colorize(rich, theme.heading, "REM Preview"),
-        ...remPreview.bodyLines,
-        "",
-        colorize(rich, theme.heading, "Deep Candidates"),
-        ...(deepCandidates.length > 0
-          ? deepCandidates
-              .slice(0, 10)
-              .map(
-                (candidate) =>
-                  `${candidate.score.toFixed(3)} ${candidate.snippet} [${shortenHomePath(candidate.path)}:${candidate.startLine}-${candidate.endLine}]`,
-              )
-          : ["- No deep candidates."]),
-      ];
-      defaultRuntime.log(lines.join("\n"));
+      if (opts.rollback) {
+        const removed = await removeBackfillDiaryEntries({ workspaceDir });
+        if (opts.json) {
+          defaultRuntime.writeJson({
+            workspaceDir,
+            rollback: true,
+            dreamsPath: removed.dreamsPath,
+            removedEntries: removed.removed,
+          });
+          return;
+        }
+        defaultRuntime.log(
+          [
+            `${colorize(isRich(), theme.heading, "REM Backfill")} ${colorize(isRich(), theme.muted, "(rollback)")}`,
+            colorize(isRich(), theme.muted, `workspace=${shortenHomePath(workspaceDir)}`),
+            colorize(isRich(), theme.muted, `dreamsPath=${shortenHomePath(removed.dreamsPath)}`),
+            colorize(isRich(), theme.muted, `removedEntries=${removed.removed}`),
+          ].join("\n"),
+        );
+        return;
+      }
+
+      if (!opts.path) {
+        defaultRuntime.error("Memory rem-backfill requires --path <file-or-dir> unless using --rollback.");
+        process.exitCode = 1;
+        return;
+      }
+
+      const scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rem-backfill-"));
+      try {
+        const sourceFiles = await listHistoricalDailyFiles(opts.path);
+        if (sourceFiles.length === 0) {
+          defaultRuntime.error(
+            `Memory rem-backfill found no YYYY-MM-DD.md files at ${shortenHomePath(path.resolve(opts.path))}.`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+        const scratchMemoryDir = path.join(scratchDir, "memory");
+        await fs.mkdir(scratchMemoryDir, { recursive: true });
+        const workspaceSourceFiles: string[] = [];
+        for (const filePath of sourceFiles) {
+          const dst = path.join(scratchMemoryDir, path.basename(filePath));
+          await fs.copyFile(filePath, dst);
+          workspaceSourceFiles.push(dst);
+        }
+        const grounded = await previewGroundedRemMarkdown({
+          workspaceDir: scratchDir,
+          inputPaths: workspaceSourceFiles,
+        });
+        const entries = grounded.files
+          .map((file) => {
+            const isoDay = extractIsoDayFromPath(file.path);
+            if (!isoDay) {
+              return null;
+            }
+            return {
+              isoDay,
+              sourcePath: file.path,
+              bodyLines: groundedMarkdownToDiaryLines(file.renderedMarkdown),
+            };
+          })
+          .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+
+        const written = await writeBackfillDiaryEntries({
+          workspaceDir,
+          entries,
+          timezone: remConfig.timezone,
+        });
+
+        if (opts.json) {
+          defaultRuntime.writeJson({
+            workspaceDir,
+            sourcePath: path.resolve(opts.path),
+            sourceFiles,
+            groundedFiles: grounded.scannedFiles,
+            writtenEntries: written.written,
+            replacedEntries: written.replaced,
+            dreamsPath: written.dreamsPath,
+          });
+          return;
+        }
+
+        const rich = isRich();
+        defaultRuntime.log(
+          [
+            `${colorize(rich, theme.heading, "REM Backfill")} ${colorize(rich, theme.muted, `(${agentId})`)}`,
+            colorize(rich, theme.muted, `workspace=${shortenHomePath(workspaceDir)}`),
+            colorize(rich, theme.muted, `sourcePath=${shortenHomePath(path.resolve(opts.path))}`),
+            colorize(rich, theme.muted, `historicalFiles=${sourceFiles.length} writtenEntries=${written.written} replacedEntries=${written.replaced}`),
+            colorize(rich, theme.muted, `dreamsPath=${shortenHomePath(written.dreamsPath)}`),
+          ].join("\n"),
+        );
+      } finally {
+        await fs.rm(scratchDir, { recursive: true, force: true });
+      }
     },
   });
 }

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -948,6 +948,177 @@ describe("memory cli", () => {
     });
   });
 
+  it("previews rem harness output from a historical daily file path", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const historyDir = path.join(workspaceDir, "history");
+      await fs.mkdir(historyDir, { recursive: true });
+      const historyPath = path.join(historyDir, "2025-01-01.md");
+      await fs.writeFile(
+        historyPath,
+        [
+          "# Preferences Learned",
+          '- Always use "Happy Together" calendar for flights and reservations.',
+          "- Calendar ID: udolnrooml2f2ha8jaio24v1r8@group.calendar.google.com",
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli(["rem-harness", "--json", "--path", historyPath]);
+
+      const payload = firstWrittenJsonArg<{
+        sourcePath?: string | null;
+        sourceFiles?: string[];
+        historicalImport?: { importedFileCount?: number; importedSignalCount?: number } | null;
+        rem?: { candidateTruths?: Array<{ snippet?: string }> };
+        deep?: { candidates?: Array<{ snippet?: string; path?: string }> };
+      }>(writeJson);
+      expect(payload?.sourcePath).toBe(historyPath);
+      expect(payload?.sourceFiles).toEqual([historyPath]);
+      expect(payload?.historicalImport?.importedFileCount).toBe(1);
+      expect(payload?.historicalImport?.importedSignalCount).toBeGreaterThan(0);
+      expect(Array.isArray(payload?.rem?.candidateTruths)).toBe(true);
+      expect(payload?.deep?.candidates?.[0]?.snippet).toContain("Happy Together");
+      expect(payload?.deep?.candidates?.[0]?.path).toBe("memory/2025-01-01.md");
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("previews grounded rem output from a historical daily file path", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const historyDir = path.join(workspaceDir, "history");
+      await fs.mkdir(historyDir, { recursive: true });
+      const historyPath = path.join(historyDir, "2025-01-01.md");
+      await fs.writeFile(
+        historyPath,
+        [
+          "## Preferences Learned",
+          '- Always use "Happy Together" calendar for flights and reservations.',
+          "- Calendar ID: udolnrooml2f2ha8jaio24v1r8@group.calendar.google.com",
+          "",
+          "## Setup",
+          "- Set up Gmail access via gog.",
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli(["rem-harness", "--json", "--grounded", "--path", historyPath]);
+
+      const payload = firstWrittenJsonArg<{
+        grounded?: {
+          scannedFiles?: number;
+          files?: Array<{
+            path?: string;
+            renderedMarkdown?: string;
+            memoryImplications?: Array<{ text?: string }>;
+          }>;
+        } | null;
+      }>(writeJson);
+      expect(payload?.grounded?.scannedFiles).toBe(1);
+      expect(payload?.grounded?.files?.[0]?.path).toBe("memory/2025-01-01.md");
+      expect(payload?.grounded?.files?.[0]?.renderedMarkdown).toContain("## What Happened");
+      expect(payload?.grounded?.files?.[0]?.renderedMarkdown).toContain("## Reflections");
+      expect(payload?.grounded?.files?.[0]?.renderedMarkdown).toContain(
+        "## Possible Lasting Updates",
+      );
+      expect(payload?.grounded?.files?.[0]?.memoryImplications?.[0]?.text).toContain(
+        'Always use "Happy Together" calendar for flights and reservations',
+      );
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("writes grounded rem backfill entries into DREAMS.md", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const historyDir = path.join(workspaceDir, "history");
+      await fs.mkdir(historyDir, { recursive: true });
+      const historyPath = path.join(historyDir, "2025-01-01.md");
+      await fs.writeFile(
+        historyPath,
+        [
+          "## Preferences Learned",
+          '- Always use "Happy Together" calendar for flights and reservations.',
+          "- Calendar ID: udolnrooml2f2ha8jaio24v1r8@group.calendar.google.com",
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      await runMemoryCli(["rem-backfill", "--path", historyPath]);
+
+      const dreams = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+      expect(dreams).toContain("openclaw:dreaming:backfill-entry");
+      expect(dreams).toContain("January 1, 2025");
+      expect(dreams).toContain("What Happened");
+      expect(dreams).toContain("Possible Lasting Updates");
+      expect(dreams).toContain("Happy Together");
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("rolls back grounded rem backfill entries from DREAMS.md", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const dreamsPath = path.join(workspaceDir, "DREAMS.md");
+      await fs.writeFile(
+        dreamsPath,
+        [
+          "# Dream Diary",
+          "",
+          "<!-- openclaw:dreaming:diary:start -->",
+          "---",
+          "",
+          "*April 5, 2026, 3:00 AM*",
+          "",
+          "Keep this normal dream.",
+          "",
+          "---",
+          "",
+          "*January 1, 2025*",
+          "",
+          "<!-- openclaw:dreaming:backfill-entry day=2025-01-01 source=memory/2025-01-01.md -->",
+          "",
+          "What Happened",
+          "1. Remove this entry.",
+          "",
+          "<!-- openclaw:dreaming:diary:end -->",
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      await runMemoryCli(["rem-backfill", "--rollback"]);
+
+      const dreams = await fs.readFile(dreamsPath, "utf-8");
+      expect(dreams).toContain("Keep this normal dream.");
+      expect(dreams).not.toContain("Remove this entry.");
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
   it("applies top promote candidates into MEMORY.md", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [

--- a/extensions/memory-core/src/cli.ts
+++ b/extensions/memory-core/src/cli.ts
@@ -8,6 +8,7 @@ import type {
   MemoryCommandOptions,
   MemoryPromoteCommandOptions,
   MemoryPromoteExplainOptions,
+  MemoryRemBackfillOptions,
   MemoryRemHarnessOptions,
   MemorySearchCommandOptions,
 } from "./cli.types.js";
@@ -59,6 +60,11 @@ async function runMemoryRemHarness(opts: MemoryRemHarnessOptions) {
   await runtime.runMemoryRemHarness(opts);
 }
 
+async function runMemoryRemBackfill(opts: MemoryRemBackfillOptions) {
+  const runtime = await loadMemoryCliRuntime();
+  await runtime.runMemoryRemBackfill(opts);
+}
+
 export function registerMemoryCli(program: Command) {
   const memory = program
     .command("memory")
@@ -94,6 +100,10 @@ export function registerMemoryCli(program: Command) {
           [
             "openclaw memory rem-harness --json",
             "Preview REM reflections, candidate truths, and deep promotion output.",
+          ],
+          [
+            "openclaw memory rem-backfill --path ./memory",
+            "Write grounded historical REM entries into DREAMS.md for UI review.",
           ],
           ["openclaw memory status --json", "Output machine-readable JSON (good for scripts)."],
         ])}\n\n${theme.muted("Docs:")} ${formatDocsLink("/cli/memory", "docs.openclaw.ai/cli/memory")}\n`,
@@ -177,9 +187,22 @@ export function registerMemoryCli(program: Command) {
     .command("rem-harness")
     .description("Preview REM reflections, candidate truths, and deep promotions without writing")
     .option("--agent <id>", "Agent id (default: default agent)")
+    .option("--path <file-or-dir>", "Seed the harness from historical daily memory file(s)")
+    .option("--grounded", "Also render a grounded day-level REM preview")
     .option("--include-promoted", "Include already promoted deep candidates", false)
     .option("--json", "Print JSON")
     .action(async (opts: MemoryRemHarnessOptions) => {
       await runMemoryRemHarness(opts);
+    });
+
+  memory
+    .command("rem-backfill")
+    .description("Write grounded historical REM summaries into DREAMS.md for UI review")
+    .option("--agent <id>", "Agent id (default: default agent)")
+    .option("--path <file-or-dir>", "Historical daily memory file(s) or directory")
+    .option("--rollback", "Remove previously written grounded REM backfill entries", false)
+    .option("--json", "Print JSON")
+    .action(async (opts: MemoryRemBackfillOptions) => {
+      await runMemoryRemBackfill(opts);
     });
 }

--- a/extensions/memory-core/src/cli.types.ts
+++ b/extensions/memory-core/src/cli.types.ts
@@ -29,4 +29,11 @@ export type MemoryPromoteExplainOptions = MemoryCommandOptions & {
 
 export type MemoryRemHarnessOptions = MemoryCommandOptions & {
   includePromoted?: boolean;
+  path?: string;
+  grounded?: boolean;
+};
+
+export type MemoryRemBackfillOptions = MemoryCommandOptions & {
+  path?: string;
+  rollback?: boolean;
 };

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -3,12 +3,16 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   appendNarrativeEntry,
+  buildBackfillDiaryEntry,
   buildDiaryEntry,
   buildNarrativePrompt,
   extractNarrativeText,
   formatNarrativeDate,
+  formatBackfillDiaryDate,
   generateAndAppendDreamNarrative,
+  removeBackfillDiaryEntries,
   type NarrativePhaseData,
+  writeBackfillDiaryEntries,
 } from "./dreaming-narrative.js";
 import { createMemoryCoreTestHarness } from "./test-helpers.js";
 
@@ -114,6 +118,88 @@ describe("buildDiaryEntry", () => {
     expect(entry).toContain("---");
     expect(entry).toContain("*April 5, 2026, 3:00 AM*");
     expect(entry).toContain("The code drifted gently.");
+  });
+});
+
+describe("backfill diary entries", () => {
+  it("formats a backfill date without time", () => {
+    expect(formatBackfillDiaryDate("2026-01-01", "UTC")).toBe("January 1, 2026");
+  });
+
+  it("builds a marked backfill diary entry", () => {
+    const entry = buildBackfillDiaryEntry({
+      isoDay: "2026-01-01",
+      sourcePath: "memory/2026-01-01.md",
+      bodyLines: ["What Happened", "1. A durable preference appeared."],
+      timezone: "UTC",
+    });
+    expect(entry).toContain("*January 1, 2026*");
+    expect(entry).toContain("openclaw:dreaming:backfill-entry");
+    expect(entry).toContain("What Happened");
+  });
+
+  it("writes and replaces backfill diary entries", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-backfill-");
+    const first = await writeBackfillDiaryEntries({
+      workspaceDir,
+      timezone: "UTC",
+      entries: [
+        {
+          isoDay: "2026-01-01",
+          sourcePath: "memory/2026-01-01.md",
+          bodyLines: ["What Happened", "1. First pass."],
+        },
+      ],
+    });
+    expect(first.written).toBe(1);
+    expect(first.replaced).toBe(0);
+
+    const second = await writeBackfillDiaryEntries({
+      workspaceDir,
+      timezone: "UTC",
+      entries: [
+        {
+          isoDay: "2026-01-02",
+          sourcePath: "memory/2026-01-02.md",
+          bodyLines: ["Reflections", "1. Second pass."],
+        },
+      ],
+    });
+    expect(second.written).toBe(1);
+    expect(second.replaced).toBe(1);
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).not.toContain("First pass.");
+    expect(content).toContain("Second pass.");
+    expect(content.match(/openclaw:dreaming:backfill-entry/g)?.length).toBe(1);
+  });
+
+  it("removes only backfill diary entries", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-backfill-");
+    await appendNarrativeEntry({
+      workspaceDir,
+      narrative: "Keep this real dream.",
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+    });
+    await writeBackfillDiaryEntries({
+      workspaceDir,
+      timezone: "UTC",
+      entries: [
+        {
+          isoDay: "2026-01-01",
+          sourcePath: "memory/2026-01-01.md",
+          bodyLines: ["What Happened", "1. Remove this backfill."],
+        },
+      ],
+    });
+
+    const removed = await removeBackfillDiaryEntries({ workspaceDir });
+    expect(removed.removed).toBe(1);
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("Keep this real dream.");
+    expect(content).not.toContain("Remove this backfill.");
   });
 });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -70,6 +70,7 @@ const NARRATIVE_TIMEOUT_MS = 60_000;
 const DREAMS_FILENAMES = ["DREAMS.md", "dreams.md"] as const;
 const DIARY_START_MARKER = "<!-- openclaw:dreaming:diary:start -->";
 const DIARY_END_MARKER = "<!-- openclaw:dreaming:diary:end -->";
+const BACKFILL_ENTRY_MARKER = "openclaw:dreaming:backfill-entry";
 
 // ── Prompt building ────────────────────────────────────────────────────
 
@@ -165,6 +166,157 @@ async function resolveDreamsPath(workspaceDir: string): Promise<string> {
     }
   }
   return path.join(workspaceDir, DREAMS_FILENAMES[0]);
+}
+
+async function readDreamsFile(dreamsPath: string): Promise<string> {
+  try {
+    return await fs.readFile(dreamsPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return "";
+    }
+    throw err;
+  }
+}
+
+function ensureDiarySection(existing: string): string {
+  if (existing.includes(DIARY_START_MARKER) && existing.includes(DIARY_END_MARKER)) {
+    return existing;
+  }
+  const diarySection = `# Dream Diary\n\n${DIARY_START_MARKER}\n${DIARY_END_MARKER}\n`;
+  if (existing.trim().length === 0) {
+    return diarySection;
+  }
+  return diarySection + "\n" + existing;
+}
+
+function replaceDiaryContent(existing: string, diaryContent: string): string {
+  const ensured = ensureDiarySection(existing);
+  const startIdx = ensured.indexOf(DIARY_START_MARKER);
+  const endIdx = ensured.indexOf(DIARY_END_MARKER);
+  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+    return ensured;
+  }
+  const before = ensured.slice(0, startIdx + DIARY_START_MARKER.length);
+  const after = ensured.slice(endIdx);
+  const normalized = diaryContent.trim().length > 0 ? `\n${diaryContent.trim()}\n` : "\n";
+  return before + normalized + after;
+}
+
+function splitDiaryBlocks(diaryContent: string): string[] {
+  return diaryContent
+    .split(/\n---\n/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0);
+}
+
+function joinDiaryBlocks(blocks: string[]): string {
+  if (blocks.length === 0) {
+    return "";
+  }
+  return blocks.map((block) => `---\n\n${block.trim()}\n`).join("\n");
+}
+
+function stripBackfillDiaryBlocks(existing: string): { updated: string; removed: number } {
+  const ensured = ensureDiarySection(existing);
+  const startIdx = ensured.indexOf(DIARY_START_MARKER);
+  const endIdx = ensured.indexOf(DIARY_END_MARKER);
+  if (startIdx < 0 || endIdx < 0 || endIdx < startIdx) {
+    return { updated: ensured, removed: 0 };
+  }
+  const inner = ensured.slice(startIdx + DIARY_START_MARKER.length, endIdx);
+  const kept: string[] = [];
+  let removed = 0;
+  for (const block of splitDiaryBlocks(inner)) {
+    if (block.includes(BACKFILL_ENTRY_MARKER)) {
+      removed += 1;
+      continue;
+    }
+    kept.push(block);
+  }
+  return {
+    updated: replaceDiaryContent(ensured, joinDiaryBlocks(kept)),
+    removed,
+  };
+}
+
+export function formatBackfillDiaryDate(isoDay: string, timezone?: string): string {
+  const opts: Intl.DateTimeFormatOptions = {
+    timeZone: timezone ?? "UTC",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  const epochMs = Date.parse(`${isoDay}T12:00:00Z`);
+  return new Intl.DateTimeFormat("en-US", opts).format(new Date(epochMs));
+}
+
+export function buildBackfillDiaryEntry(params: {
+  isoDay: string;
+  bodyLines: string[];
+  sourcePath?: string;
+  timezone?: string;
+}): string {
+  const dateStr = formatBackfillDiaryDate(params.isoDay, params.timezone);
+  const marker = `<!-- ${BACKFILL_ENTRY_MARKER} day=${params.isoDay}${params.sourcePath ? ` source=${params.sourcePath}` : ""} -->`;
+  const body = params.bodyLines.map((line) => line.trimEnd()).join("\n").trim();
+  return [`*${dateStr}*`, marker, body].filter((part) => part.length > 0).join("\n\n");
+}
+
+export async function writeBackfillDiaryEntries(params: {
+  workspaceDir: string;
+  entries: Array<{
+    isoDay: string;
+    bodyLines: string[];
+    sourcePath?: string;
+  }>;
+  timezone?: string;
+}): Promise<{ dreamsPath: string; written: number; replaced: number }> {
+  const dreamsPath = await resolveDreamsPath(params.workspaceDir);
+  await fs.mkdir(path.dirname(dreamsPath), { recursive: true });
+  const existing = await readDreamsFile(dreamsPath);
+  const stripped = stripBackfillDiaryBlocks(existing);
+  const startIdx = stripped.updated.indexOf(DIARY_START_MARKER);
+  const endIdx = stripped.updated.indexOf(DIARY_END_MARKER);
+  const inner =
+    startIdx >= 0 && endIdx > startIdx
+      ? stripped.updated.slice(startIdx + DIARY_START_MARKER.length, endIdx)
+      : "";
+  const preservedBlocks = splitDiaryBlocks(inner);
+  const nextBlocks = [
+    ...preservedBlocks,
+    ...params.entries.map((entry) =>
+      buildBackfillDiaryEntry({
+        isoDay: entry.isoDay,
+        bodyLines: entry.bodyLines,
+        sourcePath: entry.sourcePath,
+        timezone: params.timezone,
+      }),
+    ),
+  ];
+  const updated = replaceDiaryContent(stripped.updated, joinDiaryBlocks(nextBlocks));
+  await fs.writeFile(dreamsPath, updated, "utf-8");
+  return {
+    dreamsPath,
+    written: params.entries.length,
+    replaced: stripped.removed,
+  };
+}
+
+export async function removeBackfillDiaryEntries(params: {
+  workspaceDir: string;
+}): Promise<{ dreamsPath: string; removed: number }> {
+  const dreamsPath = await resolveDreamsPath(params.workspaceDir);
+  const existing = await readDreamsFile(dreamsPath);
+  const stripped = stripBackfillDiaryBlocks(existing);
+  if (stripped.removed > 0 || existing.length > 0) {
+    await fs.mkdir(path.dirname(dreamsPath), { recursive: true });
+    await fs.writeFile(dreamsPath, stripped.updated, "utf-8");
+  }
+  return {
+    dreamsPath,
+    removed: stripped.removed,
+  };
 }
 
 export function buildDiaryEntry(narrative: string, dateStr: string): string {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -18,18 +18,9 @@ import {
   type MemoryLightDreamingConfig,
   type MemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
-import {
-  lowercasePreservingWhitespace,
-  normalizeLowercaseStringOrEmpty,
-} from "openclaw/plugin-sdk/text-runtime";
 import { writeDailyDreamingPhaseBlock } from "./dreaming-markdown.js";
 import { generateAndAppendDreamNarrative, type NarrativePhaseData } from "./dreaming-narrative.js";
-import {
-  asRecord,
-  formatErrorMessage,
-  includesSystemEventToken,
-  normalizeTrimmedString,
-} from "./dreaming-shared.js";
+import { asRecord, formatErrorMessage, normalizeTrimmedString } from "./dreaming-shared.js";
 import {
   readShortTermRecallEntries,
   recordDreamingPhaseSignals,
@@ -131,7 +122,7 @@ function isGenericDailyHeading(heading: string): boolean {
   if (!normalized) {
     return true;
   }
-  const lower = normalizeLowercaseStringOrEmpty(normalized);
+  const lower = normalized.toLowerCase();
   if (lower === "today" || lower === "yesterday" || lower === "tomorrow") {
     return true;
   }
@@ -428,7 +419,7 @@ type SessionIngestionCollectionResult = {
 
 function normalizeWorkspaceKey(workspaceDir: string): string {
   const resolved = path.resolve(workspaceDir).replace(/\\/g, "/");
-  return process.platform === "win32" ? lowercasePreservingWhitespace(resolved) : resolved;
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 }
 
 function resolveSessionIngestionStatePath(workspaceDir: string): string {
@@ -1100,13 +1091,117 @@ async function ingestDailyMemorySignals(params: {
   }
 }
 
+export async function seedHistoricalDailyMemorySignals(params: {
+  workspaceDir: string;
+  filePaths: string[];
+  limit: number;
+  nowMs: number;
+  timezone?: string;
+}): Promise<{
+  importedFileCount: number;
+  importedSignalCount: number;
+  skippedPaths: string[];
+}> {
+  const normalizedPaths = [...new Set(params.filePaths.map((entry) => entry.trim()).filter(Boolean))];
+  if (normalizedPaths.length === 0) {
+    return {
+      importedFileCount: 0,
+      importedSignalCount: 0,
+      skippedPaths: [],
+    };
+  }
+
+  const resolved = normalizedPaths
+    .map((filePath) => {
+      const fileName = path.basename(filePath);
+      const match = fileName.match(DAILY_MEMORY_FILENAME_RE);
+      if (!match) {
+        return { filePath, day: null as string | null };
+      }
+      return { filePath, day: match[1] ?? null };
+    })
+    .toSorted((a, b) => {
+      if (a.day && b.day) {
+        return b.day.localeCompare(a.day);
+      }
+      if (a.day) {
+        return -1;
+      }
+      if (b.day) {
+        return 1;
+      }
+      return a.filePath.localeCompare(b.filePath);
+    });
+
+  const valid = resolved.filter((entry): entry is { filePath: string; day: string } => Boolean(entry.day));
+  const skippedPaths = resolved.filter((entry) => !entry.day).map((entry) => entry.filePath);
+  const totalCap = Math.max(20, params.limit * 4);
+  const perFileCap = Math.max(6, Math.ceil(totalCap / Math.max(1, valid.length)));
+  let importedSignalCount = 0;
+  let importedFileCount = 0;
+
+  for (const entry of valid) {
+    if (importedSignalCount >= totalCap) {
+      break;
+    }
+    const raw = await fs.readFile(entry.filePath, "utf-8").catch((err: unknown) => {
+      if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+        skippedPaths.push(entry.filePath);
+        return "";
+      }
+      throw err;
+    });
+    if (!raw) {
+      continue;
+    }
+    const lines = stripManagedDailyDreamingLines(raw.split(/\r?\n/));
+    const chunks = buildDailySnippetChunks(lines, perFileCap);
+    const results: MemorySearchResult[] = [];
+    for (const chunk of chunks) {
+      results.push({
+        path: `memory/${entry.day}.md`,
+        startLine: chunk.startLine,
+        endLine: chunk.endLine,
+        score: DAILY_INGESTION_SCORE,
+        snippet: chunk.snippet,
+        source: "memory",
+      });
+      if (results.length >= perFileCap || importedSignalCount + results.length >= totalCap) {
+        break;
+      }
+    }
+    if (results.length === 0) {
+      continue;
+    }
+    await recordShortTermRecalls({
+      workspaceDir: params.workspaceDir,
+      query: `__dreaming_daily__:${entry.day}`,
+      results,
+      signalType: "daily",
+      dedupeByQueryPerDay: true,
+      dayBucket: entry.day,
+      nowMs: params.nowMs,
+      timezone: params.timezone,
+    });
+    importedSignalCount += results.length;
+    importedFileCount += 1;
+  }
+
+  return {
+    importedFileCount,
+    importedSignalCount,
+    skippedPaths,
+  };
+}
+
 function entryAverageScore(entry: ShortTermRecallEntry): number {
   return entry.recallCount > 0 ? Math.max(0, Math.min(1, entry.totalScore / entry.recallCount)) : 0;
 }
 
 function tokenizeSnippet(snippet: string): Set<string> {
   return new Set(
-    normalizeLowercaseStringOrEmpty(snippet)
+    snippet
+      .toLowerCase()
       .split(/[^a-z0-9]+/i)
       .map((token) => token.trim())
       .filter(Boolean),
@@ -1117,7 +1212,7 @@ function jaccardSimilarity(left: string, right: string): number {
   const leftTokens = tokenizeSnippet(left);
   const rightTokens = tokenizeSnippet(right);
   if (leftTokens.size === 0 || rightTokens.size === 0) {
-    return normalizeLowercaseStringOrEmpty(left) === normalizeLowercaseStringOrEmpty(right) ? 1 : 0;
+    return left.trim().toLowerCase() === right.trim().toLowerCase() ? 1 : 0;
   }
   let intersection = 0;
   for (const token of leftTokens) {
@@ -1529,10 +1624,7 @@ async function runPhaseIfTriggered(params: {
         storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
       });
 }): Promise<{ handled: true; reason: string } | undefined> {
-  if (
-    params.trigger !== "heartbeat" ||
-    !includesSystemEventToken(params.cleanedBody, params.eventText)
-  ) {
+  if (params.trigger !== "heartbeat" || params.cleanedBody.trim() !== params.eventText) {
     return undefined;
   }
   if (!params.config.enabled) {
@@ -1558,10 +1650,7 @@ async function runPhaseIfTriggered(params: {
         await runLightDreaming({
           workspaceDir,
           cfg: params.cfg,
-          config: params.config as MemoryLightDreamingConfig & {
-            timezone?: string;
-            storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
-          },
+          config: params.config,
           logger: params.logger,
           subagent: params.subagent,
         });
@@ -1569,10 +1658,7 @@ async function runPhaseIfTriggered(params: {
         await runRemDreaming({
           workspaceDir,
           cfg: params.cfg,
-          config: params.config as MemoryRemDreamingConfig & {
-            timezone?: string;
-            storage: { mode: "inline" | "separate" | "both"; separateReports: boolean };
-          },
+          config: params.config,
           logger: params.logger,
           subagent: params.subagent,
         });

--- a/extensions/memory-core/src/rem-evidence.ts
+++ b/extensions/memory-core/src/rem-evidence.ts
@@ -1,0 +1,903 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const REM_BLOCKED_SECTION_RE =
+  /\b(morning reminders|tasks? for today|to-?do|pickups?|action items?|next steps?|open questions?|stats|setup tasks?|priority contacts|visitors?|top priority candidates|timeline coverage|action items for morning review|test .* skill|heartbeat checks?|date semantics guardrail|still broken|last message (?:&|and) status|plugin \/ service warning|email triage cron)\b/i;
+const REM_GENERIC_SECTION_RE =
+  /^(setup|session notes?|notes|summary|major accomplishments?|infrastructure|process improvements?)$/i;
+const REM_MEMORY_SIGNAL_RE =
+  /\b(always use|prefers?|preference|preferences|standing rule|rule:|use .* calendar|durable|remember)\b/i;
+const REM_BUILD_SIGNAL_RE =
+  /\b(set up|setup|created|built|rewrite|rewrote|implemented|installed|configured|added|updated|exported|documented)\b/i;
+const REM_INCIDENT_SIGNAL_RE =
+  /\b(fail(?:ed|ing)?|error|issue|problem|auth|expired|broken|unable|missing|required|root cause|consecutive failures?)\b/i;
+const REM_LOGISTICS_SIGNAL_RE =
+  /\b(visitor|arriv(?:e|al|ing)|flight|calendar|reservation|schedule|coordinate|travel|pickup)\b/i;
+const REM_TASK_SIGNAL_RE =
+  /\b(reminder|task|to-?do|action item|next step|need to|follow up|respond to|call\b|check\b)\b/i;
+const REM_ROUTING_SIGNAL_RE =
+  /\b(categor(?:ize|ized|ization)|route|routing|workflow|processor|read later|auto-implement|codex|razor)\b/i;
+const REM_OPERATOR_RULE_SIGNAL_RE = /\b(learned:|rule:|always [a-z])\b/i;
+const REM_EXTERNALIZATION_SIGNAL_RE =
+  /\b(obsidian|memory|tracker|notes captured|committed to memory|updated .*md|documented|file comparison table)\b/i;
+const REM_RETRY_SIGNAL_RE =
+  /\b(repeat(?:ed|edly)?|again|retry|root cause|third attempt|fourth|fifth|consecutive failures?)\b/i;
+const REM_PERSON_PATTERN_SIGNAL_RE =
+  /\b(relationship|who:|patterns?:|failure modes?:|best stance:|space|boundaries|timing|family quick reference)\b/i;
+const REM_SITUATIONAL_SIGNAL_RE =
+  /\b(hotel|address|phone|reservation|check-?in|check-?out|flight|arrival|departure|terminal|price shown|invoice|pending items|screenshot|butler)\b/i;
+const REM_PERSISTENCE_SIGNAL_RE =
+  /\b(always|preference|prefers?|standing rule|best stance|failure modes?|key patterns?|relationship|who:|important .* keep track|people in .* life|partner|wife|husband|boyfriend|girlfriend)\b/i;
+const REM_TRANSIENT_SIGNAL_RE =
+  /\b(today|this session|in progress|installed|booked|confirmed|pending|status:|action pending|open items?|next steps?|issue:|diagnostics|screenshot|source file|insight files|thread\b|ticket|price shown|calendar fix|cron fixes|security audit|updates? this session|bought:|order\b)\b/i;
+const REM_SECTION_PERSISTENCE_TITLE_RE =
+  /\b(preferences? learned|preference|people update|relationship|standing|patterns?|identity|memory)\b/i;
+const REM_SECTION_TRANSIENT_TITLE_RE =
+  /\b(setup|fix|fixes|audit|booked|call|today|session|updates?|file paths|open items?|next steps?|research pipeline|info gathered|calendar|tickets?)\b/i;
+const REM_METADATA_HEAVY_SIGNAL_RE =
+  /\b(address|phone|email|website|google maps|source file|insight files|conversation id|thread has|order\b|reservation\b|price\b|cost\b|ticket|uuid|url:|model:|workspace:|bindings:|accountid|config change|path:)\b/i;
+const REM_PROJECT_META_SIGNAL_RE =
+  /\b(strategy|audit|discussion|research|topic|candidate|north star|pipeline|data dump|export|draft|insights? draft|weekly|analysis|findings)\b/i;
+const REM_PROCESS_FRAME_SIGNAL_RE =
+  /\b(dossier|registry|cadence|framework|facts,\s*timeline|open loops|next actions|auto preference rollups?|insights? draft created)\b/i;
+const REM_TOOLING_META_SIGNAL_RE =
+  /\b(cli|tool|tools\.md|agents\.md|sessionssend|subagents?|spawn|tmux|xurl|bird|codex exec|interactive codex)\b/i;
+const REM_TRAVEL_DECISION_SIGNAL_RE =
+  /\b(routing|cabin|business class|trip brief|departure|arrival|hotel|reservation|tickets?|show tonight|cheaper alternatives?|venue timing)\b/i;
+const REM_STABLE_PERSON_SIGNAL_RE =
+  /\b(partner|wife|husband|boyfriend|girlfriend|relationship interest|lives in)\b/i;
+const REM_EXPLICIT_PREFERENCE_SIGNAL_RE =
+  /\b(explicitly|wants?|does not want|don't want|default .* should|should default to|likes?|dislikes?|treat .* as|prefers?)\b/i;
+const REM_SPECIFICITY_BURDEN_RE =
+  /\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b|€|\$\d|→|\b\d{1,2}:\d{2}\b|\+\d{6,}/i;
+const REM_TIME_PREFIX_RE = /^\d{1,2}:\d{2}\s*-\s*/;
+const REM_CODE_FENCE_RE = /^\s*```/;
+const REM_TABLE_RE = /^\s*\|.*\|\s*$/;
+const REM_TABLE_DIVIDER_RE = /^\s*\|?[\s:-]+\|[\s|:-]*$/;
+const REM_SUMMARY_FACT_LIMIT = 4;
+const REM_SUMMARY_REFLECTION_LIMIT = 4;
+const REM_SUMMARY_MEMORY_LIMIT = 3;
+
+export type GroundedRemPreviewItem = {
+  text: string;
+  refs: string[];
+};
+
+export type GroundedRemCandidate = GroundedRemPreviewItem & {
+  lean: "likely_durable" | "unclear" | "likely_situational";
+};
+
+export type GroundedRemFilePreview = {
+  path: string;
+  facts: GroundedRemPreviewItem[];
+  reflections: GroundedRemPreviewItem[];
+  memoryImplications: GroundedRemPreviewItem[];
+  candidates: GroundedRemCandidate[];
+  renderedMarkdown: string;
+};
+
+export type GroundedRemPreviewResult = {
+  workspaceDir: string;
+  scannedFiles: number;
+  files: GroundedRemFilePreview[];
+};
+
+type CandidateSnippetSummary = GroundedRemCandidate & {
+  score: number;
+};
+
+type ParsedSectionLine = {
+  line: number;
+  text: string;
+};
+
+type ParsedMarkdownSection = {
+  title: string;
+  startLine: number;
+  endLine: number;
+  lines: ParsedSectionLine[];
+};
+
+type SectionSnippet = {
+  text: string;
+  line: number;
+};
+
+type SectionSummary = {
+  title: string;
+  text: string;
+  refs: string[];
+  scores: {
+    preference: number;
+    build: number;
+    incident: number;
+    logistics: number;
+    tasks: number;
+    routing: number;
+    externalization: number;
+    retries: number;
+    overall: number;
+  };
+};
+
+function normalizeWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, " ");
+}
+
+function normalizePath(rawPath: string): string {
+  return rawPath.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+function stripMarkdown(text: string): string {
+  return normalizeWhitespace(
+    text
+      .replace(/!\[[^\]]*]\([^)]*\)/g, "")
+      .replace(/\[([^\]]+)]\([^)]*\)/g, "$1")
+      .replace(/[`*_~>#]/g, "")
+      .replace(/\s+/g, " "),
+  );
+}
+
+function sanitizeSectionTitle(title: string): string {
+  return normalizeWhitespace(stripMarkdown(title).replace(REM_TIME_PREFIX_RE, ""));
+}
+
+function makeRef(pathValue: string, startLine: number, endLine = startLine): string {
+  return startLine === endLine
+    ? `${pathValue}:${startLine}`
+    : `${pathValue}:${startLine}-${endLine}`;
+}
+
+function parseMarkdownSections(content: string): ParsedMarkdownSection[] {
+  const sections: ParsedMarkdownSection[] = [];
+  const lines = content.split(/\r?\n/);
+  let current: ParsedMarkdownSection | null = null;
+  let inCodeFence = false;
+
+  const flush = () => {
+    if (!current) {
+      return;
+    }
+    const meaningfulLines = current.lines.filter(
+      (entry) => normalizeWhitespace(entry.text).length > 0,
+    );
+    if (meaningfulLines.length > 0) {
+      const endLine = meaningfulLines[meaningfulLines.length - 1]?.line ?? current.endLine;
+      sections.push({ ...current, endLine, lines: meaningfulLines });
+    }
+    current = null;
+  };
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const rawLine = lines[index] ?? "";
+    const lineNumber = index + 1;
+    if (REM_CODE_FENCE_RE.test(rawLine)) {
+      inCodeFence = !inCodeFence;
+      continue;
+    }
+    if (inCodeFence) {
+      continue;
+    }
+    const headingMatch = rawLine.match(/^\s{0,3}(#{2,6})\s+(.+)$/);
+    if (headingMatch?.[2]) {
+      flush();
+      current = {
+        title: sanitizeSectionTitle(headingMatch[2]),
+        startLine: lineNumber,
+        endLine: lineNumber,
+        lines: [],
+      };
+      continue;
+    }
+    if (!current) {
+      continue;
+    }
+    current.endLine = lineNumber;
+    const trimmed = rawLine.trim();
+    if (
+      !trimmed ||
+      /^---+$/.test(trimmed) ||
+      REM_TABLE_RE.test(trimmed) ||
+      REM_TABLE_DIVIDER_RE.test(trimmed)
+    ) {
+      continue;
+    }
+    current.lines.push({ line: lineNumber, text: rawLine });
+  }
+
+  flush();
+  return sections;
+}
+
+function sectionToSnippets(section: ParsedMarkdownSection): SectionSnippet[] {
+  const snippets: SectionSnippet[] = [];
+  const seen = new Set<string>();
+  for (const entry of section.lines) {
+    const trimmed = entry.text.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const bulletMatch = trimmed.match(/^(?:[-*+]|\d+\.)\s+(?:\[[ xX]\]\s*)?(.*)$/);
+    const candidateText = bulletMatch?.[1] ?? trimmed;
+    const text = normalizeWhitespace(stripMarkdown(candidateText));
+    if (text.length < 10) {
+      continue;
+    }
+    const dedupeKey = text.toLowerCase();
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+    seen.add(dedupeKey);
+    snippets.push({ text, line: entry.line });
+  }
+  return snippets;
+}
+
+function countMatchingSnippets(snippets: SectionSnippet[], pattern: RegExp): number {
+  let count = 0;
+  for (const snippet of snippets) {
+    if (pattern.test(snippet.text)) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function scoreSection(section: ParsedMarkdownSection, snippets: SectionSnippet[]) {
+  const title = section.title;
+  const titleBonus = (pattern: RegExp) => (pattern.test(title) ? 1 : 0);
+  const preference =
+    countMatchingSnippets(snippets, REM_MEMORY_SIGNAL_RE) + titleBonus(REM_MEMORY_SIGNAL_RE);
+  const build =
+    countMatchingSnippets(snippets, REM_BUILD_SIGNAL_RE) + titleBonus(REM_BUILD_SIGNAL_RE);
+  const incident =
+    countMatchingSnippets(snippets, REM_INCIDENT_SIGNAL_RE) + titleBonus(REM_INCIDENT_SIGNAL_RE);
+  const logistics =
+    countMatchingSnippets(snippets, REM_LOGISTICS_SIGNAL_RE) + titleBonus(REM_LOGISTICS_SIGNAL_RE);
+  const tasks =
+    countMatchingSnippets(snippets, REM_TASK_SIGNAL_RE) + titleBonus(REM_TASK_SIGNAL_RE);
+  const routing =
+    countMatchingSnippets(snippets, REM_ROUTING_SIGNAL_RE) + titleBonus(REM_ROUTING_SIGNAL_RE);
+  const externalization =
+    countMatchingSnippets(snippets, REM_EXTERNALIZATION_SIGNAL_RE) +
+    titleBonus(REM_EXTERNALIZATION_SIGNAL_RE);
+  const retries =
+    countMatchingSnippets(snippets, REM_RETRY_SIGNAL_RE) + titleBonus(REM_RETRY_SIGNAL_RE);
+  const overall =
+    preference * 2 +
+    build * 1.6 +
+    incident * 1.6 +
+    logistics * 1.2 +
+    routing * 1.8 +
+    externalization * 1.4 +
+    Math.min(snippets.length, 3) * 0.3 -
+    (REM_GENERIC_SECTION_RE.test(title) ? 0.8 : 0);
+  return {
+    preference,
+    build,
+    incident,
+    logistics,
+    tasks,
+    routing,
+    externalization,
+    retries,
+    overall,
+  };
+}
+
+function scoreSnippet(text: string, title: string): number {
+  let score = 1;
+  if (REM_MEMORY_SIGNAL_RE.test(text)) {
+    score += 2.2;
+  }
+  if (REM_BUILD_SIGNAL_RE.test(text)) {
+    score += 1.2;
+  }
+  if (REM_INCIDENT_SIGNAL_RE.test(text)) {
+    score += 1.2;
+  }
+  if (REM_LOGISTICS_SIGNAL_RE.test(text)) {
+    score += 0.9;
+  }
+  if (REM_ROUTING_SIGNAL_RE.test(text)) {
+    score += 1.4;
+  }
+  if (REM_EXTERNALIZATION_SIGNAL_RE.test(text)) {
+    score += 1.1;
+  }
+  if (REM_RETRY_SIGNAL_RE.test(text)) {
+    score += 0.9;
+  }
+  if (REM_TASK_SIGNAL_RE.test(text) && !REM_BUILD_SIGNAL_RE.test(text)) {
+    score -= 0.8;
+  }
+  if (title && !REM_GENERIC_SECTION_RE.test(title)) {
+    score += 0.25;
+  }
+  return score;
+}
+
+function chooseSummarySnippets(
+  section: ParsedMarkdownSection,
+  snippets: SectionSnippet[],
+): SectionSnippet[] {
+  const selectionLimit = REM_GENERIC_SECTION_RE.test(section.title) ? 2 : 3;
+  return [...snippets]
+    .toSorted((left, right) => {
+      const scoreDelta =
+        scoreSnippet(right.text, section.title) - scoreSnippet(left.text, section.title);
+      if (scoreDelta !== 0) {
+        return scoreDelta;
+      }
+      return left.line - right.line;
+    })
+    .slice(0, selectionLimit)
+    .toSorted((left, right) => left.line - right.line);
+}
+
+function joinSummaryParts(parts: string[]): string {
+  if (parts.length <= 1) {
+    return parts[0] ?? "";
+  }
+  if (parts.length === 2) {
+    return `${parts[0]} and ${parts[1]}`;
+  }
+  return `${parts.slice(0, -1).join("; ")}; and ${parts[parts.length - 1]}`;
+}
+
+function summarizeSection(
+  pathValue: string,
+  section: ParsedMarkdownSection,
+): SectionSummary | null {
+  if (REM_BLOCKED_SECTION_RE.test(section.title)) {
+    return null;
+  }
+  const snippets = sectionToSnippets(section);
+  if (snippets.length === 0) {
+    return null;
+  }
+  const selected = chooseSummarySnippets(section, snippets);
+  if (selected.length === 0) {
+    return null;
+  }
+  const title = sanitizeSectionTitle(section.title);
+  const body = joinSummaryParts(selected.map((snippet) => snippet.text));
+  const text = !title || REM_GENERIC_SECTION_RE.test(title) ? body : `${title}: ${body}`;
+  return {
+    title,
+    text,
+    refs: selected.map((snippet) => makeRef(pathValue, snippet.line)),
+    scores: scoreSection(section, snippets),
+  };
+}
+
+function compactCandidateTitle(title: string): string {
+  let compact = sanitizeSectionTitle(title)
+    .replace(/\s*\((?:via:|from qmd \+ memory|this session)[^)]+\)\s*/gi, " ")
+    .replace(
+      /\s*[—-]\s*(?:research results.*|in progress.*|working.*|installed.*|booked.*|proposed.*|clarified.*|candidate.*|fixes.*|updates?.*)$/i,
+      "",
+    )
+    .trim();
+  if (/^(?:preferences? learned|candidate facts?)$/i.test(compact)) {
+    return "";
+  }
+  compact = compact.replace(/^preference:\s*/i, "");
+  return compact;
+}
+
+function compactCandidateSnippetText(text: string, title: string): string {
+  const normalized = normalizeWhitespace(text);
+  if (REM_STABLE_PERSON_SIGNAL_RE.test(`${title} ${normalized}`)) {
+    return (normalized.split(/(?<=[.?!])\s+/)[0] ?? normalized).trim();
+  }
+  return normalized;
+}
+
+function scoreCandidateSnippet(text: string, title: string): number {
+  let score = 0;
+  if (REM_PERSISTENCE_SIGNAL_RE.test(text)) {
+    score += 3.2;
+  }
+  if (REM_MEMORY_SIGNAL_RE.test(text)) {
+    score += 2.4;
+  }
+  if (REM_EXPLICIT_PREFERENCE_SIGNAL_RE.test(text)) {
+    score += 1.8;
+  }
+  if (REM_PERSON_PATTERN_SIGNAL_RE.test(text)) {
+    score += 2.3;
+  }
+  if (REM_OPERATOR_RULE_SIGNAL_RE.test(text)) {
+    score += 1.6;
+  }
+  if (REM_SECTION_PERSISTENCE_TITLE_RE.test(title)) {
+    score += 1.2;
+  }
+  if (REM_STABLE_PERSON_SIGNAL_RE.test(text)) {
+    score += 1.5;
+  }
+  if (REM_METADATA_HEAVY_SIGNAL_RE.test(text)) {
+    score -= 2.4;
+  }
+  if (REM_PROJECT_META_SIGNAL_RE.test(`${title} ${text}`)) {
+    score -= 2.2;
+  }
+  if (REM_PROCESS_FRAME_SIGNAL_RE.test(text)) {
+    score -= 2.4;
+  }
+  if (REM_TOOLING_META_SIGNAL_RE.test(text) && !REM_STABLE_PERSON_SIGNAL_RE.test(text)) {
+    score -= 2.1;
+  }
+  if (REM_TRAVEL_DECISION_SIGNAL_RE.test(text)) {
+    score -= 2.6;
+  }
+  if (REM_SPECIFICITY_BURDEN_RE.test(text) && !REM_STABLE_PERSON_SIGNAL_RE.test(text)) {
+    score -= 1.2;
+  }
+  if (REM_SITUATIONAL_SIGNAL_RE.test(text)) {
+    score -= 2.8;
+  }
+  if (REM_TRANSIENT_SIGNAL_RE.test(text)) {
+    score -= 2;
+  }
+  if (REM_INCIDENT_SIGNAL_RE.test(text)) {
+    score -= 1.6;
+  }
+  if (REM_TASK_SIGNAL_RE.test(text)) {
+    score -= 1.2;
+  }
+  if (REM_LOGISTICS_SIGNAL_RE.test(text) && !REM_MEMORY_SIGNAL_RE.test(text)) {
+    score -= 1.4;
+  }
+  if (REM_BUILD_SIGNAL_RE.test(text) && !REM_MEMORY_SIGNAL_RE.test(text)) {
+    score -= 0.8;
+  }
+  if (REM_SECTION_TRANSIENT_TITLE_RE.test(title) && !REM_SECTION_PERSISTENCE_TITLE_RE.test(title)) {
+    score -= 1.2;
+  }
+  if (/[`/]/.test(text) || /https?:\/\//i.test(text)) {
+    score -= 0.8;
+  }
+  return score;
+}
+
+function chooseFactSnippets(
+  section: ParsedMarkdownSection,
+  snippets: SectionSnippet[],
+): SectionSnippet[] {
+  return [...snippets]
+    .map((snippet) => {
+      const text = compactCandidateSnippetText(snippet.text, section.title);
+      const score =
+        scoreCandidateSnippet(text, section.title) + (REM_MEMORY_SIGNAL_RE.test(text) ? 0.6 : 0);
+      return { snippet: { ...snippet, text }, score };
+    })
+    .filter((entry) => entry.snippet.text.length >= 18 && entry.score >= 1.4)
+    .toSorted((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+      return left.snippet.line - right.snippet.line;
+    })
+    .slice(0, 2)
+    .map((entry) => entry.snippet)
+    .toSorted((left, right) => left.line - right.line);
+}
+
+type FactSnippetSummary = GroundedRemPreviewItem & {
+  score: number;
+};
+
+function buildFactText(title: string, text: string): string {
+  const compactTitle = compactCandidateTitle(title);
+  if (!compactTitle) {
+    return text;
+  }
+  if (
+    REM_SECTION_PERSISTENCE_TITLE_RE.test(compactTitle) ||
+    REM_STABLE_PERSON_SIGNAL_RE.test(compactTitle) ||
+    /\b(relationship|people mentioned|people update|identity)\b/i.test(compactTitle)
+  ) {
+    return `${compactTitle}: ${text}`;
+  }
+  return text;
+}
+
+function chooseCandidateSnippets(
+  section: ParsedMarkdownSection,
+  snippets: SectionSnippet[],
+): SectionSnippet[] {
+  return [...snippets]
+    .map((snippet) => {
+      const text = compactCandidateSnippetText(snippet.text, section.title);
+      const score = scoreCandidateSnippet(text, section.title);
+      return { snippet: { ...snippet, text }, score };
+    })
+    .filter((entry) => entry.snippet.text.length >= 18 && entry.score >= 1.8)
+    .toSorted((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+      return left.snippet.line - right.snippet.line;
+    })
+    .slice(0, 2)
+    .map((entry) => entry.snippet)
+    .toSorted((left, right) => left.line - right.line);
+}
+
+function buildCandidateSnippetText(title: string, text: string): string {
+  return buildFactText(title, text);
+}
+
+function classifyCandidateLeanFromText(text: string, title: string): GroundedRemCandidate["lean"] {
+  const score = scoreCandidateSnippet(text, title);
+  if (score >= 4) {
+    return "likely_durable";
+  }
+  if (score <= 0.25 || REM_SITUATIONAL_SIGNAL_RE.test(text) || REM_TRANSIENT_SIGNAL_RE.test(text)) {
+    return "likely_situational";
+  }
+  return "unclear";
+}
+
+function addReflection(
+  reflections: GroundedRemPreviewItem[],
+  seen: Set<string>,
+  text: string,
+  refs: string[],
+) {
+  const normalized = normalizeWhitespace(text);
+  const key = normalized.toLowerCase();
+  if (!normalized || seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  reflections.push({ text: normalized, refs });
+}
+
+function isOperatorRuleSummary(summary: SectionSummary): boolean {
+  return (
+    /process improvements?/i.test(summary.title) || REM_OPERATOR_RULE_SIGNAL_RE.test(summary.text)
+  );
+}
+
+function isRoutingSummary(summary: SectionSummary): boolean {
+  return summary.scores.routing > 0 || REM_ROUTING_SIGNAL_RE.test(summary.text);
+}
+
+function previewGroundedRemForFile(params: {
+  relPath: string;
+  content: string;
+}): GroundedRemFilePreview {
+  const sections = parseMarkdownSections(params.content);
+  const sectionScores = sections.map((section) => ({
+    section,
+    snippets: sectionToSnippets(section),
+  }));
+  const summaries = sectionScores
+    .map(({ section }) => summarizeSection(params.relPath, section))
+    .filter((summary): summary is SectionSummary => summary !== null);
+  const factSummaries: FactSnippetSummary[] = sections.flatMap((section) => {
+    if (REM_BLOCKED_SECTION_RE.test(section.title)) {
+      return [];
+    }
+    const snippets = sectionToSnippets(section);
+    if (snippets.length === 0) {
+      return [];
+    }
+    return chooseFactSnippets(section, snippets).map((snippet) => ({
+      text: buildFactText(section.title, snippet.text),
+      refs: [makeRef(params.relPath, snippet.line)],
+      score: scoreCandidateSnippet(snippet.text, section.title),
+    }));
+  });
+
+  const memoryImplications = summaries
+    .filter((summary) => summary.scores.preference > 0 || isOperatorRuleSummary(summary))
+    .map((summary) => ({
+      text: summary.text.replace(/^[^:]+:\s*/, ""),
+      refs: summary.refs,
+    }))
+    .filter((item, index, items) => items.findIndex((entry) => entry.text === item.text) === index)
+    .slice(0, REM_SUMMARY_MEMORY_LIMIT);
+
+  const candidateSnippets: CandidateSnippetSummary[] = sections.flatMap((section) => {
+    if (REM_BLOCKED_SECTION_RE.test(section.title)) {
+      return [];
+    }
+    const snippets = sectionToSnippets(section);
+    if (snippets.length === 0) {
+      return [];
+    }
+    return chooseCandidateSnippets(section, snippets)
+      .map((snippet) => {
+        const score = scoreCandidateSnippet(snippet.text, section.title);
+        const text = buildCandidateSnippetText(section.title, snippet.text);
+        return {
+          text,
+          refs: [makeRef(params.relPath, snippet.line)],
+          lean: classifyCandidateLeanFromText(snippet.text, section.title),
+          score,
+        };
+      })
+      .filter((candidate) => candidate.text.length >= 12 && candidate.score >= 1.8);
+  });
+
+  const candidates = candidateSnippets
+    .toSorted((left, right) => {
+      const leanRank = { likely_durable: 0, unclear: 1, likely_situational: 2 };
+      const leanDelta = leanRank[left.lean] - leanRank[right.lean];
+      if (leanDelta !== 0) {
+        return leanDelta;
+      }
+      return right.score - left.score;
+    })
+    .filter(
+      (candidate, index, items) =>
+        items.findIndex((entry) => entry.text === candidate.text) === index,
+    )
+    .slice(0, 4);
+
+  const durableImplications = candidateSnippets
+    .filter((candidate) => candidate.lean === "likely_durable" || candidate.score >= 4)
+    .filter(
+      (candidate, index, items) =>
+        items.findIndex((entry) => entry.text === candidate.text) === index,
+    )
+    .toSorted((left, right) => right.score - left.score)
+    .slice(0, REM_SUMMARY_MEMORY_LIMIT)
+    .map((candidate) => ({ text: candidate.text, refs: candidate.refs }));
+
+  const candidateDrivenImplications = candidateSnippets
+    .filter((candidate) => candidate.lean !== "likely_situational" && candidate.score >= 2.2)
+    .filter(
+      (candidate, index, items) =>
+        items.findIndex((entry) => entry.text === candidate.text) === index,
+    )
+    .toSorted((left, right) => right.score - left.score)
+    .slice(0, REM_SUMMARY_MEMORY_LIMIT)
+    .map((candidate) => ({ text: candidate.text, refs: candidate.refs }));
+
+  const effectiveMemoryImplications =
+    durableImplications.length > 0
+      ? durableImplications
+      : candidateDrivenImplications.length > 0
+        ? candidateDrivenImplications
+        : memoryImplications;
+
+  const facts: GroundedRemPreviewItem[] = [];
+  const usedFactTexts = new Set<string>();
+  for (const summary of factSummaries.toSorted((left, right) => right.score - left.score)) {
+    const key = summary.text.toLowerCase();
+    if (usedFactTexts.has(key)) {
+      continue;
+    }
+    usedFactTexts.add(key);
+    facts.push({ text: summary.text, refs: summary.refs });
+    if (facts.length >= REM_SUMMARY_FACT_LIMIT) {
+      break;
+    }
+  }
+  if (facts.length === 0) {
+    const bestFor = (metric: keyof SectionSummary["scores"]) =>
+      summaries
+        .filter((summary) => summary.scores[metric] > 0)
+        .toSorted((left, right) => {
+          if (right.scores[metric] !== left.scores[metric]) {
+            return right.scores[metric] - left.scores[metric];
+          }
+          return right.scores.overall - left.scores.overall;
+        })[0];
+    for (const summary of [
+      bestFor("preference"),
+      bestFor("routing"),
+      bestFor("externalization"),
+      ...summaries.toSorted((left, right) => right.scores.overall - left.scores.overall),
+    ]) {
+      if (!summary) {
+        continue;
+      }
+      const key = summary.text.toLowerCase();
+      if (usedFactTexts.has(key)) {
+        continue;
+      }
+      usedFactTexts.add(key);
+      facts.push({ text: summary.text, refs: summary.refs });
+      if (facts.length >= REM_SUMMARY_FACT_LIMIT) {
+        break;
+      }
+    }
+  }
+
+  const reflections: GroundedRemPreviewItem[] = [];
+  const seenReflections = new Set<string>();
+  const buildSignal = summaries.reduce((sum, item) => sum + item.scores.build, 0);
+  const incidentSignal = summaries.reduce((sum, item) => sum + item.scores.incident, 0);
+  const logisticsSignal = summaries.reduce((sum, item) => sum + item.scores.logistics, 0);
+  const routingSignal = summaries.reduce((sum, item) => sum + item.scores.routing, 0);
+  const externalizationSignal = summaries.reduce(
+    (sum, item) => sum + item.scores.externalization,
+    0,
+  );
+  const retrySignal = summaries.reduce((sum, item) => sum + item.scores.retries, 0);
+  const taskSignal = sectionScores.reduce(
+    (sum, { section, snippets }) => sum + scoreSection(section, snippets).tasks,
+    0,
+  );
+  const strongestRoutingSummary = summaries
+    .filter((summary) => isRoutingSummary(summary))
+    .toSorted((left, right) => right.scores.overall - left.scores.overall)[0];
+  const strongestIncidentSummary = summaries
+    .filter((summary) => summary.scores.incident > 0)
+    .toSorted((left, right) => right.scores.overall - left.scores.overall)[0];
+  const strongestExternalizationSummary = summaries
+    .filter((summary) => summary.scores.externalization > 0)
+    .toSorted((left, right) => right.scores.overall - left.scores.overall)[0];
+
+  if (effectiveMemoryImplications.length > 0) {
+    addReflection(
+      reflections,
+      seenReflections,
+      "A stable rule or preference was stated explicitly, which suggests operating choices are being made legible instead of left implicit.",
+      effectiveMemoryImplications.flatMap((item) => item.refs).slice(0, 3),
+    );
+  }
+  if (facts.length > 0 && routingSignal >= 2 && strongestRoutingSummary && buildSignal >= incidentSignal) {
+    addReflection(
+      reflections,
+      seenReflections,
+      "The strongest pattern here is a preference for converting messy inbound information into routed workflows with different downstream actions, instead of handling each case manually.",
+      strongestRoutingSummary.refs,
+    );
+  }
+  if (facts.length > 0 && externalizationSignal >= 2 && strongestExternalizationSummary) {
+    addReflection(
+      reflections,
+      seenReflections,
+      "Important context tends to get externalized quickly into notes, trackers, or memory surfaces, which suggests a preference for explicit systems over holding context informally.",
+      strongestExternalizationSummary.refs,
+    );
+  }
+  if (facts.length > 0 && buildSignal >= 2) {
+    const buildRefs = facts
+      .filter((item) => REM_BUILD_SIGNAL_RE.test(item.text))
+      .flatMap((item) => item.refs)
+      .slice(0, 3);
+    if (buildRefs.length > 0) {
+      addReflection(
+        reflections,
+        seenReflections,
+        "The day leaned toward building operator infrastructure, which suggests the interaction is often used to reshape the system around recurring needs rather than just complete isolated tasks.",
+        buildRefs,
+      );
+    }
+  }
+  if (facts.length > 0 && incidentSignal >= 2 && strongestIncidentSummary) {
+    addReflection(
+      reflections,
+      seenReflections,
+      retrySignal >= 2
+        ? "When something breaks repeatedly, the response is systematic: retries, root-cause narrowing, and preserving enough state to resume once the blocker is fixed."
+        : "A meaningful share of the day went into friction, and the interaction pattern looks pragmatic rather than emotional: diagnose the blocker, preserve state, and move on.",
+      strongestIncidentSummary.refs,
+    );
+  }
+  if (facts.length > 0 && logisticsSignal >= 2) {
+    const logisticsRefs = facts
+      .filter((item) => REM_LOGISTICS_SIGNAL_RE.test(item.text))
+      .flatMap((item) => item.refs)
+      .slice(0, 3);
+    if (logisticsRefs.length > 0) {
+      addReflection(
+        reflections,
+        seenReflections,
+        "Personal logistics and operating-system work are being managed in the same surface, which suggests a preference for one integrated control plane rather than separate personal and technical loops.",
+        logisticsRefs,
+      );
+    }
+  }
+  if (taskSignal >= 3 && reflections.length === 0) {
+    addReflection(
+      reflections,
+      seenReflections,
+      "The raw note is mostly task and current-state material, so it should not be over-read as memory.",
+      [
+        makeRef(
+          params.relPath,
+          sections[0]?.startLine ?? 1,
+          sections[sections.length - 1]?.endLine ?? 1,
+        ),
+      ],
+    );
+  }
+
+  const visibleReflections = reflections.slice(0, REM_SUMMARY_REFLECTION_LIMIT);
+
+  const renderedLines: string[] = [];
+  renderedLines.push("## What Happened");
+  if (facts.length === 0) {
+    renderedLines.push("1. No grounded facts were extracted.");
+  } else {
+    for (const [index, fact] of facts.entries()) {
+      renderedLines.push(`${index + 1}. ${fact.text} [${fact.refs.join(", ")}]`);
+    }
+  }
+  renderedLines.push("");
+  renderedLines.push("## Reflections");
+  if (visibleReflections.length === 0) {
+    renderedLines.push("1. No grounded reflections emerged from this note yet.");
+  } else {
+    for (const [index, reflection] of visibleReflections.entries()) {
+      renderedLines.push(`${index + 1}. ${reflection.text} [${reflection.refs.join(", ")}]`);
+    }
+  }
+  if (candidates.length > 0) {
+    renderedLines.push("");
+    renderedLines.push("## Candidates");
+    for (const candidate of candidates) {
+      renderedLines.push(`- [${candidate.lean}] ${candidate.text} [${candidate.refs.join(", ")}]`);
+    }
+  }
+  if (effectiveMemoryImplications.length > 0) {
+    renderedLines.push("");
+    renderedLines.push("## Possible Lasting Updates");
+    for (const implication of effectiveMemoryImplications) {
+      renderedLines.push(`- ${implication.text} [${implication.refs.join(", ")}]`);
+    }
+  }
+
+  return {
+    path: params.relPath,
+    facts,
+    reflections: visibleReflections,
+    memoryImplications: effectiveMemoryImplications,
+    candidates,
+    renderedMarkdown: renderedLines.join("\n"),
+  };
+}
+
+async function collectMarkdownFiles(inputPaths: string[]): Promise<string[]> {
+  const found = new Set<string>();
+  async function walk(targetPath: string): Promise<void> {
+    const resolved = path.resolve(targetPath);
+    const stat = await fs.stat(resolved);
+    if (stat.isDirectory()) {
+      const entries = await fs.readdir(resolved, { withFileTypes: true });
+      for (const entry of entries) {
+        await walk(path.join(resolved, entry.name));
+      }
+      return;
+    }
+    if (stat.isFile() && resolved.toLowerCase().endsWith(".md")) {
+      found.add(resolved);
+    }
+  }
+  for (const inputPath of inputPaths) {
+    const trimmed = inputPath.trim();
+    if (!trimmed) {
+      continue;
+    }
+    await walk(trimmed);
+  }
+  return Array.from(found).toSorted((left, right) => left.localeCompare(right));
+}
+
+export async function previewGroundedRemMarkdown(params: {
+  workspaceDir: string;
+  inputPaths: string[];
+}): Promise<GroundedRemPreviewResult> {
+  const workspaceDir = params.workspaceDir.trim();
+  const files = await collectMarkdownFiles(params.inputPaths);
+  const previews: GroundedRemFilePreview[] = [];
+  for (const filePath of files) {
+    const content = await fs.readFile(filePath, "utf-8");
+    const relPath = normalizePath(path.relative(workspaceDir, filePath));
+    previews.push(previewGroundedRemForFile({ relPath, content }));
+  }
+  return {
+    workspaceDir,
+    scannedFiles: files.length,
+    files: previews,
+  };
+}

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -15,6 +15,9 @@ const resolveMemorySearchConfig = vi.hoisted(() =>
   })),
 );
 const getMemorySearchManager = vi.hoisted(() => vi.fn());
+const previewGroundedRemMarkdown = vi.hoisted(() => vi.fn());
+const writeBackfillDiaryEntries = vi.hoisted(() => vi.fn());
+const removeBackfillDiaryEntries = vi.hoisted(() => vi.fn());
 
 vi.mock("../../config/config.js", () => ({
   loadConfig,
@@ -31,6 +34,15 @@ vi.mock("../../agents/memory-search.js", () => ({
 
 vi.mock("../../plugins/memory-runtime.js", () => ({
   getActiveMemorySearchManager: getMemorySearchManager,
+}));
+
+vi.mock("../../../extensions/memory-core/src/rem-evidence.js", () => ({
+  previewGroundedRemMarkdown,
+}));
+
+vi.mock("../../../extensions/memory-core/src/dreaming-narrative.js", () => ({
+  writeBackfillDiaryEntries,
+  removeBackfillDiaryEntries,
 }));
 
 import { doctorHandlers } from "./doctor.js";
@@ -60,6 +72,28 @@ const invokeDoctorMemoryStatus = async (
 
 const invokeDoctorMemoryDreamDiary = async (respond: ReturnType<typeof vi.fn>) => {
   await doctorHandlers["doctor.memory.dreamDiary"]({
+    req: {} as never,
+    params: {} as never,
+    respond: respond as never,
+    context: {} as never,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+};
+
+const invokeDoctorMemoryBackfillDreamDiary = async (respond: ReturnType<typeof vi.fn>) => {
+  await doctorHandlers["doctor.memory.backfillDreamDiary"]({
+    req: {} as never,
+    params: {} as never,
+    respond: respond as never,
+    context: {} as never,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+};
+
+const invokeDoctorMemoryResetDreamDiary = async (respond: ReturnType<typeof vi.fn>) => {
+  await doctorHandlers["doctor.memory.resetDreamDiary"]({
     req: {} as never,
     params: {} as never,
     respond: respond as never,
@@ -123,6 +157,9 @@ describe("doctor.memory.status", () => {
           phaseSignalCount: 0,
           promotedTotal: 0,
           promotedToday: 0,
+          shortTermEntries: [],
+          signalEntries: [],
+          promotedEntries: [],
           phases: expect.objectContaining({
             deep: expect.objectContaining({
               managedCronPresent: false,
@@ -208,13 +245,20 @@ describe("doctor.memory.status", () => {
           entries: {
             "memory:memory/2026-04-03.md:1:2": {
               path: "memory/2026-04-03.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Emma prefers shorter, lower-pressure check-ins.",
               source: "memory",
               recallCount: 2,
               dailyCount: 1,
+              lastRecalledAt: recentIso,
               promotedAt: undefined,
             },
             "memory:memory/2026-04-02.md:1:2": {
               path: "memory/2026-04-02.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Use the Happy Together calendar for flights.",
               source: "memory",
               recallCount: 9,
               dailyCount: 5,
@@ -236,6 +280,9 @@ describe("doctor.memory.status", () => {
           entries: {
             "memory:memory/2026-04-01.md:1:2": {
               path: "memory/2026-04-01.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Bunji lives in London.",
               source: "memory",
               recallCount: 7,
               dailyCount: 4,
@@ -243,6 +290,9 @@ describe("doctor.memory.status", () => {
             },
             "memory:memory/2026-04-04.md:1:2": {
               path: "memory/2026-04-04.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Always book the covered valet option at Park & Greet BCN.",
               source: "memory",
               recallCount: 8,
               dailyCount: 3,
@@ -378,6 +428,36 @@ describe("doctor.memory.status", () => {
             remPhaseHitCount: 3,
             promotedTotal: 3,
             promotedToday: 2,
+            shortTermEntries: [
+              expect.objectContaining({
+                path: "memory/2026-04-03.md",
+                snippet: "Emma prefers shorter, lower-pressure check-ins.",
+                totalSignalCount: 3,
+                lightHits: 2,
+                remHits: 3,
+                phaseHitCount: 5,
+              }),
+            ],
+            signalEntries: [
+              expect.objectContaining({
+                path: "memory/2026-04-03.md",
+                totalSignalCount: 3,
+              }),
+            ],
+            promotedEntries: expect.arrayContaining([
+              expect.objectContaining({
+                path: "memory/2026-04-04.md",
+                promotedAt: recentIso,
+              }),
+              expect.objectContaining({
+                path: "memory/2026-04-02.md",
+                promotedAt: recentIso,
+              }),
+              expect.objectContaining({
+                path: "memory/2026-04-01.md",
+                promotedAt: olderIso,
+              }),
+            ]),
             phases: expect.objectContaining({
               deep: expect.objectContaining({
                 cron: "0 */4 * * *",
@@ -629,6 +709,9 @@ describe("doctor.memory.dreamDiary", () => {
     loadConfig.mockClear();
     resolveDefaultAgentId.mockClear();
     resolveAgentWorkspaceDir.mockReset().mockReturnValue("/tmp/openclaw");
+    previewGroundedRemMarkdown.mockReset();
+    writeBackfillDiaryEntries.mockReset();
+    removeBackfillDiaryEntries.mockReset();
   });
 
   it("reads DREAMS.md when present", async () => {
@@ -669,6 +752,7 @@ describe("doctor.memory.dreamDiary", () => {
         expect.objectContaining({
           agentId: "main",
           found: true,
+          path: "DREAMS.md",
           content: "lowercase diary\n",
           updatedAtMs: expect.any(Number),
         }),
@@ -694,6 +778,78 @@ describe("doctor.memory.dreamDiary", () => {
           agentId: "main",
           found: false,
           path: "DREAMS.md",
+        }),
+        undefined,
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("backfills the dream diary from workspace memory files", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-dream-diary-backfill-"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-02-19.md"), "source\n", "utf-8");
+    await fs.writeFile(path.join(workspaceDir, "DREAMS.md"), "# Dream Diary\n", "utf-8");
+    resolveAgentWorkspaceDir.mockReturnValue(workspaceDir);
+    previewGroundedRemMarkdown.mockResolvedValue({
+      scannedFiles: 1,
+      files: [
+        {
+          path: path.join(workspaceDir, "memory", "2026-02-19.md"),
+          renderedMarkdown: "What Happened\n1. Bunji — partner\n",
+        },
+      ],
+    });
+    writeBackfillDiaryEntries.mockResolvedValue({
+      dreamsPath: path.join(workspaceDir, "DREAMS.md"),
+      written: 1,
+      replaced: 1,
+    });
+    const respond = vi.fn();
+
+    try {
+      await invokeDoctorMemoryBackfillDreamDiary(respond);
+      expect(previewGroundedRemMarkdown).toHaveBeenCalledWith({
+        workspaceDir,
+        inputPaths: [path.join(workspaceDir, "memory", "2026-02-19.md")],
+      });
+      expect(writeBackfillDiaryEntries).toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          agentId: "main",
+          action: "backfill",
+          scannedFiles: 1,
+          written: 1,
+          replaced: 1,
+        }),
+        undefined,
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resets only backfilled dream diary entries", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-dream-diary-reset-"));
+    await fs.writeFile(path.join(workspaceDir, "DREAMS.md"), "# Dream Diary\n", "utf-8");
+    resolveAgentWorkspaceDir.mockReturnValue(workspaceDir);
+    removeBackfillDiaryEntries.mockResolvedValue({
+      dreamsPath: path.join(workspaceDir, "DREAMS.md"),
+      removed: 3,
+    });
+    const respond = vi.fn();
+
+    try {
+      await invokeDoctorMemoryResetDreamDiary(respond);
+      expect(removeBackfillDiaryEntries).toHaveBeenCalledWith({ workspaceDir });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          agentId: "main",
+          action: "reset",
+          removedEntries: 3,
         }),
         undefined,
       );

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  removeBackfillDiaryEntries,
+  writeBackfillDiaryEntries,
+} from "../../../extensions/memory-core/src/dreaming-narrative.js";
+import { previewGroundedRemMarkdown } from "../../../extensions/memory-core/src/rem-evidence.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -13,7 +18,6 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "../../memory-host-sdk/dreaming.js";
 import { getActiveMemorySearchManager } from "../../plugins/memory-runtime.js";
-import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import { formatError } from "../server-utils.js";
 import { asRecord, normalizeTrimmedString } from "./record-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -52,6 +56,22 @@ type DoctorMemoryRemDreamingPayload = DoctorMemoryDreamingPhasePayload & {
   minPatternStrength: number;
 };
 
+type DoctorMemoryDreamingEntryPayload = {
+  key: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  snippet: string;
+  recallCount: number;
+  dailyCount: number;
+  totalSignalCount: number;
+  lightHits: number;
+  remHits: number;
+  phaseHitCount: number;
+  promotedAt?: string;
+  lastRecalledAt?: string;
+};
+
 type DoctorMemoryDreamingPayload = {
   enabled: boolean;
   timezone?: string;
@@ -72,6 +92,9 @@ type DoctorMemoryDreamingPayload = {
   lastPromotedAt?: string;
   storeError?: string;
   phaseSignalError?: string;
+  shortTermEntries: DoctorMemoryDreamingEntryPayload[];
+  signalEntries: DoctorMemoryDreamingEntryPayload[];
+  promotedEntries: DoctorMemoryDreamingEntryPayload[];
   phases: {
     light: DoctorMemoryLightDreamingPayload;
     deep: DoctorMemoryDeepDreamingPayload;
@@ -96,6 +119,45 @@ export type DoctorMemoryDreamDiaryPayload = {
   content?: string;
   updatedAtMs?: number;
 };
+
+export type DoctorMemoryDreamDiaryActionPayload = {
+  agentId: string;
+  path: string;
+  action: "backfill" | "reset";
+  found: boolean;
+  scannedFiles?: number;
+  written?: number;
+  replaced?: number;
+  removedEntries?: number;
+};
+
+function extractIsoDayFromPath(filePath: string): string | null {
+  const match = filePath.replaceAll("\\", "/").match(/(\d{4}-\d{2}-\d{2})\.md$/i);
+  return match?.[1] ?? null;
+}
+
+function groundedMarkdownToDiaryLines(markdown: string): string[] {
+  return markdown
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line, index, lines) => line.length > 0 || (index > 0 && lines[index - 1]?.length > 0));
+}
+
+async function listWorkspaceDailyFiles(memoryDir: string): Promise<string[]> {
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(memoryDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+  return entries
+    .filter((name) => /^\d{4}-\d{2}-\d{2}\.md$/i.test(name))
+    .map((name) => path.join(memoryDir, name))
+    .toSorted((left, right) => left.localeCompare(right));
+}
 
 function resolveDreamingConfig(
   cfg: OpenClawConfig,
@@ -138,6 +200,9 @@ function resolveDreamingConfig(
     verboseLogging: resolved.verboseLogging,
     storageMode: resolved.storage.mode,
     separateReports: resolved.storage.separateReports,
+    shortTermEntries: [],
+    signalEntries: [],
+    promotedEntries: [],
     phases: {
       light: {
         enabled: light.enabled,
@@ -204,7 +269,12 @@ type DreamingStoreStats = Pick<
   | "lastPromotedAt"
   | "storeError"
   | "phaseSignalError"
+  | "shortTermEntries"
+  | "signalEntries"
+  | "promotedEntries"
 >;
+
+const DREAMING_ENTRY_LIST_LIMIT = 8;
 
 function toNonNegativeInt(value: unknown): number {
   const num = Number(value);
@@ -212,6 +282,77 @@ function toNonNegativeInt(value: unknown): number {
     return 0;
   }
   return Math.max(0, Math.floor(num));
+}
+
+function parseEntryRangeFromKey(
+  key: string,
+  fallbackStartLine: unknown,
+  fallbackEndLine: unknown,
+): { startLine: number; endLine: number } {
+  const startLine = toNonNegativeInt(fallbackStartLine);
+  const endLine = toNonNegativeInt(fallbackEndLine);
+  if (startLine > 0 && endLine > 0) {
+    return { startLine, endLine };
+  }
+  const match = key.match(/:(\d+):(\d+)$/);
+  if (match) {
+    return {
+      startLine: Math.max(1, toNonNegativeInt(match[1])),
+      endLine: Math.max(1, toNonNegativeInt(match[2])),
+    };
+  }
+  return { startLine: 1, endLine: 1 };
+}
+
+function compareDreamingEntryByRecency(
+  a: DoctorMemoryDreamingEntryPayload,
+  b: DoctorMemoryDreamingEntryPayload,
+): number {
+  const aMs = a.lastRecalledAt ? Date.parse(a.lastRecalledAt) : Number.NEGATIVE_INFINITY;
+  const bMs = b.lastRecalledAt ? Date.parse(b.lastRecalledAt) : Number.NEGATIVE_INFINITY;
+  if (Number.isFinite(aMs) || Number.isFinite(bMs)) {
+    if (bMs !== aMs) {
+      return bMs - aMs;
+    }
+  }
+  if (b.totalSignalCount !== a.totalSignalCount) {
+    return b.totalSignalCount - a.totalSignalCount;
+  }
+  return a.path.localeCompare(b.path);
+}
+
+function compareDreamingEntryBySignals(
+  a: DoctorMemoryDreamingEntryPayload,
+  b: DoctorMemoryDreamingEntryPayload,
+): number {
+  if (b.totalSignalCount !== a.totalSignalCount) {
+    return b.totalSignalCount - a.totalSignalCount;
+  }
+  if (b.phaseHitCount !== a.phaseHitCount) {
+    return b.phaseHitCount - a.phaseHitCount;
+  }
+  return compareDreamingEntryByRecency(a, b);
+}
+
+function compareDreamingEntryByPromotion(
+  a: DoctorMemoryDreamingEntryPayload,
+  b: DoctorMemoryDreamingEntryPayload,
+): number {
+  const aMs = a.promotedAt ? Date.parse(a.promotedAt) : Number.NEGATIVE_INFINITY;
+  const bMs = b.promotedAt ? Date.parse(b.promotedAt) : Number.NEGATIVE_INFINITY;
+  if (Number.isFinite(aMs) || Number.isFinite(bMs)) {
+    if (bMs !== aMs) {
+      return bMs - aMs;
+    }
+  }
+  return compareDreamingEntryBySignals(a, b);
+}
+
+function trimDreamingEntries(
+  entries: DoctorMemoryDreamingEntryPayload[],
+  compare: (a: DoctorMemoryDreamingEntryPayload, b: DoctorMemoryDreamingEntryPayload) => number,
+): DoctorMemoryDreamingEntryPayload[] {
+  return entries.toSorted(compare).slice(0, DREAMING_ENTRY_LIST_LIMIT);
 }
 
 async function loadDreamingStoreStats(
@@ -238,6 +379,9 @@ async function loadDreamingStoreStats(
     let latestPromotedAtMs = Number.NEGATIVE_INFINITY;
     let latestPromotedAt: string | undefined;
     const activeKeys = new Set<string>();
+    const activeEntries = new Map<string, DoctorMemoryDreamingEntryPayload>();
+    const shortTermEntries: DoctorMemoryDreamingEntryPayload[] = [];
+    const promotedEntries: DoctorMemoryDreamingEntryPayload[] = [];
 
     for (const [entryKey, value] of Object.entries(entries)) {
       const entry = asRecord(value);
@@ -249,18 +393,45 @@ async function loadDreamingStoreStats(
       if (source !== "memory" || !entryPath || !isShortTermMemoryPath(entryPath)) {
         continue;
       }
+      const range = parseEntryRangeFromKey(entryKey, entry.startLine, entry.endLine);
+      const recallCount = toNonNegativeInt(entry.recallCount);
+      const dailyCount = toNonNegativeInt(entry.dailyCount);
+      const totalEntrySignalCount = recallCount + dailyCount;
+      const snippet =
+        normalizeTrimmedString(entry.snippet) ??
+        normalizeTrimmedString(entry.summary) ??
+        normalizeMemoryPath(entryPath);
+      const lastRecalledAt = normalizeTrimmedString(entry.lastRecalledAt);
+      const detail: DoctorMemoryDreamingEntryPayload = {
+        key: entryKey,
+        path: normalizeMemoryPath(entryPath),
+        startLine: range.startLine,
+        endLine: Math.max(range.startLine, range.endLine),
+        snippet,
+        recallCount,
+        dailyCount,
+        totalSignalCount: totalEntrySignalCount,
+        lightHits: 0,
+        remHits: 0,
+        phaseHitCount: 0,
+        ...(lastRecalledAt ? { lastRecalledAt } : {}),
+      };
       const promotedAt = normalizeTrimmedString(entry.promotedAt);
       if (!promotedAt) {
         shortTermCount += 1;
         activeKeys.add(entryKey);
-        const recallCount = toNonNegativeInt(entry.recallCount);
-        const dailyCount = toNonNegativeInt(entry.dailyCount);
         recallSignalCount += recallCount;
         dailySignalCount += dailyCount;
-        totalSignalCount += recallCount + dailyCount;
+        totalSignalCount += totalEntrySignalCount;
+        shortTermEntries.push(detail);
+        activeEntries.set(entryKey, detail);
         continue;
       }
       promotedTotal += 1;
+      promotedEntries.push({
+        ...detail,
+        promotedAt,
+      });
       const promotedAtMs = Date.parse(promotedAt);
       if (Number.isFinite(promotedAtMs) && isSameMemoryDreamingDay(promotedAtMs, nowMs, timezone)) {
         promotedToday += 1;
@@ -287,6 +458,12 @@ async function loadDreamingStoreStats(
         lightPhaseHitCount += lightHits;
         remPhaseHitCount += remHits;
         phaseSignalCount += lightHits + remHits;
+        const detail = activeEntries.get(key);
+        if (detail) {
+          detail.lightHits = lightHits;
+          detail.remHits = remHits;
+          detail.phaseHitCount = lightHits + remHits;
+        }
       }
     } catch (err) {
       const code = (err as NodeJS.ErrnoException | undefined)?.code;
@@ -307,6 +484,9 @@ async function loadDreamingStoreStats(
       promotedToday,
       storePath,
       phaseSignalPath,
+      shortTermEntries: trimDreamingEntries(shortTermEntries, compareDreamingEntryByRecency),
+      signalEntries: trimDreamingEntries(shortTermEntries, compareDreamingEntryBySignals),
+      promotedEntries: trimDreamingEntries(promotedEntries, compareDreamingEntryByPromotion),
       ...(latestPromotedAt ? { lastPromotedAt: latestPromotedAt } : {}),
       ...(phaseSignalError ? { phaseSignalError } : {}),
     };
@@ -325,6 +505,9 @@ async function loadDreamingStoreStats(
         promotedToday: 0,
         storePath,
         phaseSignalPath,
+        shortTermEntries: [],
+        signalEntries: [],
+        promotedEntries: [],
       };
     }
     return {
@@ -339,6 +522,9 @@ async function loadDreamingStoreStats(
       promotedToday: 0,
       storePath,
       phaseSignalPath,
+      shortTermEntries: [],
+      signalEntries: [],
+      promotedEntries: [],
       storeError: formatError(err),
     };
   }
@@ -360,6 +546,9 @@ function mergeDreamingStoreStats(stats: DreamingStoreStats[]): DreamingStoreStat
   const phaseSignalPaths = new Set<string>();
   const storeErrors: string[] = [];
   const phaseSignalErrors: string[] = [];
+  const shortTermEntries: DoctorMemoryDreamingEntryPayload[] = [];
+  const signalEntries: DoctorMemoryDreamingEntryPayload[] = [];
+  const promotedEntries: DoctorMemoryDreamingEntryPayload[] = [];
 
   for (const stat of stats) {
     shortTermCount += stat.shortTermCount;
@@ -383,6 +572,9 @@ function mergeDreamingStoreStats(stats: DreamingStoreStats[]): DreamingStoreStat
     if (stat.phaseSignalError) {
       phaseSignalErrors.push(stat.phaseSignalError);
     }
+    shortTermEntries.push(...stat.shortTermEntries);
+    signalEntries.push(...stat.signalEntries);
+    promotedEntries.push(...stat.promotedEntries);
     const promotedAtMs = stat.lastPromotedAt ? Date.parse(stat.lastPromotedAt) : Number.NaN;
     if (Number.isFinite(promotedAtMs) && promotedAtMs > latestPromotedAtMs) {
       latestPromotedAtMs = promotedAtMs;
@@ -400,6 +592,9 @@ function mergeDreamingStoreStats(stats: DreamingStoreStats[]): DreamingStoreStat
     remPhaseHitCount,
     promotedTotal,
     promotedToday,
+    shortTermEntries: trimDreamingEntries(shortTermEntries, compareDreamingEntryByRecency),
+    signalEntries: trimDreamingEntries(signalEntries, compareDreamingEntryBySignals),
+    promotedEntries: trimDreamingEntries(promotedEntries, compareDreamingEntryByPromotion),
     ...(storePaths.size === 1 ? { storePath: [...storePaths][0] } : {}),
     ...(phaseSignalPaths.size === 1 ? { phaseSignalPath: [...phaseSignalPaths][0] } : {}),
     ...(lastPromotedAt ? { lastPromotedAt } : {}),
@@ -438,7 +633,7 @@ function isManagedDreamingJob(
     return true;
   }
   const name = normalizeTrimmedString(job.name);
-  const payloadKind = normalizeOptionalLowercaseString(job.payload?.kind);
+  const payloadKind = normalizeTrimmedString(job.payload?.kind)?.toLowerCase();
   const payloadText = normalizeTrimmedString(job.payload?.text);
   return (
     name === params.name && payloadKind === "systemevent" && payloadText === params.payloadText
@@ -646,6 +841,65 @@ export const doctorHandlers: GatewayRequestHandlers = {
     const payload: DoctorMemoryDreamDiaryPayload = {
       agentId,
       ...dreamDiary,
+    };
+    respond(true, payload, undefined);
+  },
+  "doctor.memory.backfillDreamDiary": async ({ respond }) => {
+    const cfg = loadConfig();
+    const agentId = resolveDefaultAgentId(cfg);
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    const memoryDir = path.join(workspaceDir, "memory");
+    const sourceFiles = await listWorkspaceDailyFiles(memoryDir);
+    const grounded = await previewGroundedRemMarkdown({
+      workspaceDir,
+      inputPaths: sourceFiles,
+    });
+    const remConfig = resolveMemoryRemDreamingConfig({
+      pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
+      cfg,
+    });
+    const entries = grounded.files
+      .map((file) => {
+        const isoDay = extractIsoDayFromPath(file.path);
+        if (!isoDay) {
+          return null;
+        }
+        return {
+          isoDay,
+          sourcePath: file.path,
+          bodyLines: groundedMarkdownToDiaryLines(file.renderedMarkdown),
+        };
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+    const written = await writeBackfillDiaryEntries({
+      workspaceDir,
+      entries,
+      timezone: remConfig.timezone,
+    });
+    const dreamDiary = await readDreamDiary(workspaceDir);
+    const payload: DoctorMemoryDreamDiaryActionPayload = {
+      agentId,
+      path: dreamDiary.path,
+      action: "backfill",
+      found: dreamDiary.found,
+      scannedFiles: grounded.scannedFiles,
+      written: written.written,
+      replaced: written.replaced,
+    };
+    respond(true, payload, undefined);
+  },
+  "doctor.memory.resetDreamDiary": async ({ respond }) => {
+    const cfg = loadConfig();
+    const agentId = resolveDefaultAgentId(cfg);
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    const removed = await removeBackfillDiaryEntries({ workspaceDir });
+    const dreamDiary = await readDreamDiary(workspaceDir);
+    const payload: DoctorMemoryDreamDiaryActionPayload = {
+      agentId,
+      path: dreamDiary.path,
+      action: "reset",
+      found: dreamDiary.found,
+      removedEntries: removed.removed,
     };
     respond(true, payload, undefined);
   },

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -2,9 +2,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   removeBackfillDiaryEntries,
+  previewGroundedRemMarkdown,
   writeBackfillDiaryEntries,
-} from "../../../extensions/memory-core/src/dreaming-narrative.js";
-import { previewGroundedRemMarkdown } from "../../../extensions/memory-core/src/rem-evidence.js";
+} from "../../../extensions/memory-core/api.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/config.js";

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -290,10 +290,24 @@ export const en: TranslationMap = {
       promotedSuffix: "promoted",
       nextSweepPrefix: "next sweep",
     },
+    scene: {
+      backfill: "Backfill",
+      reset: "Reset",
+      working: "Working…",
+    },
     stats: {
       shortTerm: "Short-term",
       signals: "Signals",
+      promoted: "Promoted",
       phaseHits: "Phase Hits",
+    },
+    trace: {
+      shortTerm: "Short-term",
+      signals: "Signals",
+      promoted: "Promoted",
+      emptyShortTerm: "No active short-term items.",
+      emptySignals: "No active signals.",
+      emptyPromoted: "Nothing promoted yet today.",
     },
     diary: {
       title: "Dream Diary",

--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -6,6 +6,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* ---- Sub-tab bar ---- */
@@ -314,6 +316,94 @@
   background: var(--border);
 }
 
+.dreams__trace {
+  width: min(900px, calc(100% - 40px));
+  margin-top: 28px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  z-index: 1;
+  user-select: text;
+}
+
+.dreams__trace-section {
+  background: color-mix(in oklab, var(--panel) 82%, transparent);
+  border: 1px solid color-mix(in oklab, var(--border) 78%, transparent);
+  border-radius: 16px;
+  padding: 12px;
+  min-height: 180px;
+  backdrop-filter: blur(14px);
+}
+
+.dreams__trace-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.dreams__trace-title {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.dreams__trace-count {
+  min-width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklab, var(--accent-subtle) 85%, transparent);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.dreams__trace-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dreams__trace-item {
+  padding: 10px;
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--panel-raised) 88%, transparent);
+  border: 1px solid color-mix(in oklab, var(--border) 72%, transparent);
+}
+
+.dreams__trace-snippet {
+  font-size: 13px;
+  line-height: 1.35;
+  color: var(--text);
+}
+
+.dreams__trace-source,
+.dreams__trace-meta,
+.dreams__trace-empty {
+  margin-top: 6px;
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--muted);
+}
+
+.dreams__trace-source {
+  font-family: var(--mono);
+}
+
+@media (max-width: 980px) {
+  .dreams__trace {
+    grid-template-columns: 1fr;
+    width: min(680px, calc(100% - 32px));
+  }
+}
+
 /* ---- Dreaming on/off toggle (header bar) ---- */
 
 .dreams__phase-toggle {
@@ -397,6 +487,13 @@
   color: var(--ok-muted);
 }
 
+.dreams__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 14px;
+}
+
 .dreams__status-dot {
   width: 6px;
   height: 6px;
@@ -444,6 +541,8 @@
   padding: 48px 24px 64px;
   flex: 1;
   min-height: 320px;
+  min-width: 0;
+  overflow: auto;
   background: linear-gradient(
     180deg,
     var(--bg) 0%,
@@ -490,6 +589,7 @@
   max-width: 520px;
   position: relative;
   z-index: 1;
+  flex-shrink: 0;
 }
 
 .dreams-diary__title {
@@ -554,7 +654,12 @@
   width: 100%;
   padding: 0 0 0 20px;
   z-index: 1;
+  flex-shrink: 0;
   animation: diary-entry-reveal 1.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.dreams-diary__entry--structured {
+  max-width: 1180px;
 }
 
 @keyframes diary-entry-reveal {
@@ -607,6 +712,220 @@
   font-weight: 400;
   margin-bottom: 16px;
   opacity: 0.8;
+}
+
+.dreams-diary__navigator {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 0 20px;
+  position: relative;
+  z-index: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  flex-shrink: 0;
+}
+
+.dreams-diary__navigator::-webkit-scrollbar {
+  display: none;
+}
+
+.dreams-diary__navigator-content {
+  width: max-content;
+  min-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.dreams-diary__timeline {
+  --dreams-diary-step: 44px;
+  --dreams-diary-gap: 8px;
+  width: max-content;
+  min-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 2px 2px;
+  margin: 0;
+}
+
+.dreams-diary__timeline-months,
+.dreams-diary__timeline-days,
+.dreams-diary__heatmap {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: var(--dreams-diary-step);
+  gap: var(--dreams-diary-gap);
+  width: max-content;
+  min-width: 100%;
+}
+
+.dreams-diary__timeline-month {
+  font-size: 11px;
+  line-height: 1;
+  color: var(--muted);
+  opacity: 0.65;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  min-height: 12px;
+}
+
+.dreams-diary__timeline-month--ghost {
+  opacity: 0;
+}
+
+.dreams-diary__day-chip {
+  width: 100%;
+  min-width: 0;
+  padding: 6px 0;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  background: color-mix(in oklab, var(--panel) 84%, transparent);
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  text-align: center;
+}
+
+.dreams-diary__day-chip--active {
+  border-color: color-mix(in oklab, var(--accent) 44%, transparent);
+  background: color-mix(in oklab, var(--accent-subtle) 88%, transparent);
+  color: var(--text);
+}
+
+.dreams-diary__heatmap {
+  align-items: center;
+}
+
+.dreams-diary__heatmap-cell {
+  width: 100%;
+  min-width: 0;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+}
+
+.dreams-diary__heatmap-pill {
+  width: 14px;
+  aspect-ratio: 1;
+  border: 1px solid color-mix(in oklab, var(--border) 55%, transparent);
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--panel) 88%, transparent);
+}
+
+.dreams-diary__heatmap-cell[data-intensity="2"] .dreams-diary__heatmap-pill {
+  background: color-mix(in oklab, var(--accent-subtle) 70%, var(--panel));
+}
+
+.dreams-diary__heatmap-cell[data-intensity="3"] .dreams-diary__heatmap-pill {
+  background: color-mix(in oklab, var(--accent) 18%, var(--panel));
+}
+
+.dreams-diary__heatmap-cell[data-intensity="4"] .dreams-diary__heatmap-pill {
+  background: color-mix(in oklab, var(--accent) 32%, var(--panel));
+}
+
+.dreams-diary__heatmap-cell--active .dreams-diary__heatmap-pill {
+  border-color: color-mix(in oklab, var(--accent-2) 60%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent-2) 32%, transparent);
+}
+
+.dreams-diary__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.dreams-diary__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 100%;
+  padding: 18px 18px 16px;
+  border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  border-radius: 16px;
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--bg-elevated, var(--bg)) 88%, #0d0818) 0%,
+      color-mix(in oklab, var(--bg) 92%, #0d0818) 100%
+    );
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.dreams-diary__panel-title {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.3;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent-muted);
+}
+
+.dreams-diary__panel-subtitle {
+  margin-top: 2px;
+  font-size: 10px;
+  line-height: 1.3;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in oklab, var(--muted) 82%, var(--accent));
+}
+
+.dreams-diary__panel-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dreams-diary__panel-list--points {
+  gap: 0;
+}
+
+.dreams-diary__point {
+  display: grid;
+  grid-template-columns: 10px 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 10px 0;
+  border-top: 1px solid color-mix(in oklab, var(--border) 58%, transparent);
+  animation: diary-text-stream 1.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.dreams-diary__point:first-child {
+  padding-top: 0;
+  border-top: none;
+}
+
+.dreams-diary__point-bullet {
+  width: 6px;
+  height: 6px;
+  margin-top: 8px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 70%, var(--text));
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent-subtle) 75%, transparent);
+}
+
+.dreams-diary__item {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: color-mix(in oklab, var(--text) 88%, var(--muted));
+}
+
+.dreams-diary__item--reflection {
+  color: color-mix(in oklab, var(--text) 78%, var(--accent));
+}
+
+.dreams-diary__item--update {
+  color: color-mix(in oklab, var(--text) 86%, var(--accent-2));
 }
 
 .dreams-diary__prose {
@@ -707,5 +1026,9 @@
 
   .dreams-diary__entry {
     padding-left: 16px;
+  }
+
+  .dreams-diary__grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -66,8 +66,10 @@ import {
   rotateDeviceToken,
 } from "./controllers/devices.ts";
 import {
+  backfillDreamDiary,
   loadDreamDiary,
   loadDreamingStatus,
+  resetDreamDiary,
   resolveConfiguredDreaming,
   updateDreamingEnabled,
 } from "./controllers/dreaming.ts";
@@ -101,19 +103,14 @@ import {
   updateSkillEnabled,
 } from "./controllers/skills.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
-import { icons } from "./icons.ts";
 import "./components/dashboard-header.ts";
+import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
 import {
   buildAgentMainSessionKey,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "./session-key.ts";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-  normalizeStringifiedOptionalString,
-} from "./string-coerce.ts";
 import { agentLogoUrl } from "./views/agents-utils.ts";
 import {
   resolveAgentConfig,
@@ -125,6 +122,7 @@ import {
 import { renderChat } from "./views/chat.ts";
 import { renderCommandPalette } from "./views/command-palette.ts";
 import { renderConfig } from "./views/config.ts";
+import { renderDreaming } from "./views/dreaming.ts";
 import { renderExecApprovalPrompt } from "./views/exec-approval.ts";
 import { renderGatewayUrlConfirmation } from "./views/gateway-url-confirmation.ts";
 import { renderLoginGate } from "./views/login-gate.ts";
@@ -162,7 +160,6 @@ const lazyLogs = createLazy(() => import("./views/logs.ts"));
 const lazyNodes = createLazy(() => import("./views/nodes.ts"));
 const lazySessions = createLazy(() => import("./views/sessions.ts"));
 const lazySkills = createLazy(() => import("./views/skills.ts"));
-const lazyDreamingView = createLazy(() => import("./views/dreaming.ts"));
 
 function formatDreamNextCycle(nextRunAtMs: number | undefined): string | null {
   if (typeof nextRunAtMs !== "number" || !Number.isFinite(nextRunAtMs)) {
@@ -212,7 +209,7 @@ function isHttpUrl(value: string): boolean {
 }
 
 function normalizeSuggestionValue(value: unknown): string {
-  return normalizeOptionalString(value) ?? "";
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function uniquePreserveOrder(values: string[]): string[] {
@@ -223,7 +220,7 @@ function uniquePreserveOrder(values: string[]): string[] {
     if (!normalized) {
       continue;
     }
-    const key = normalizeLowercaseStringOrEmpty(normalized);
+    const key = normalized.toLowerCase();
     if (seen.has(key)) {
       continue;
     }
@@ -412,7 +409,9 @@ export function renderApp(state: AppViewState) {
     new Set(
       [
         ...(state.agentsList?.agents?.map((entry) => entry.id.trim()) ?? []),
-        ...state.cronJobs.map((job) => normalizeOptionalString(job.agentId) ?? "").filter(Boolean),
+        ...state.cronJobs
+          .map((job) => (typeof job.agentId === "string" ? job.agentId.trim() : ""))
+          .filter(Boolean),
       ].filter(Boolean),
     ),
   );
@@ -426,7 +425,7 @@ export function renderApp(state: AppViewState) {
             if (job.payload.kind !== "agentTurn" || typeof job.payload.model !== "string") {
               return "";
             }
-            return normalizeOptionalString(job.payload.model) ?? "";
+            return job.payload.model.trim();
           })
           .filter(Boolean),
       ].filter(Boolean),
@@ -1291,7 +1290,7 @@ export function renderApp(state: AppViewState) {
                   const entry = Array.isArray(list)
                     ? (list[index] as { skills?: unknown })
                     : undefined;
-                  const normalizedSkill = normalizeOptionalString(skillName) ?? "";
+                  const normalizedSkill = skillName.trim();
                   if (!normalizedSkill) {
                     return;
                   }
@@ -1299,9 +1298,7 @@ export function renderApp(state: AppViewState) {
                     state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
                     [];
                   const existing = Array.isArray(entry?.skills)
-                    ? entry.skills
-                        .map((name) => normalizeStringifiedOptionalString(name) ?? "")
-                        .filter(Boolean)
+                    ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
                     : undefined;
                   const base = existing ?? allSkills;
                   const next = new Set(base);
@@ -2118,29 +2115,33 @@ export function renderApp(state: AppViewState) {
             )
           : nothing}
         ${state.tab === "dreams"
-          ? lazyRender(lazyDreamingView, (m) =>
-              m.renderDreaming({
-                active: dreamingOn,
-                shortTermCount: state.dreamingStatus?.shortTermCount ?? 0,
-                totalSignalCount: state.dreamingStatus?.totalSignalCount ?? 0,
-                phaseSignalCount: state.dreamingStatus?.phaseSignalCount ?? 0,
-                promotedCount: state.dreamingStatus?.promotedToday ?? 0,
-                dreamingOf: null,
-                nextCycle: dreamingNextCycle,
-                timezone: state.dreamingStatus?.timezone ?? null,
-                statusLoading: state.dreamingStatusLoading,
-                statusError: state.dreamingStatusError,
-                modeSaving: state.dreamingModeSaving,
-                dreamDiaryLoading: state.dreamDiaryLoading,
-                dreamDiaryError: state.dreamDiaryError,
-                dreamDiaryPath: state.dreamDiaryPath,
-                dreamDiaryContent: state.dreamDiaryContent,
-                onRefresh: refreshDreaming,
-                onRefreshDiary: () => loadDreamDiary(state),
-                onToggleEnabled: applyDreamingEnabled,
-                onRequestUpdate: requestHostUpdate,
-              }),
-            )
+          ? renderDreaming({
+              active: dreamingOn,
+              shortTermCount: state.dreamingStatus?.shortTermCount ?? 0,
+              totalSignalCount: state.dreamingStatus?.totalSignalCount ?? 0,
+              promotedCount: state.dreamingStatus?.promotedToday ?? 0,
+              phaseSignalCount: state.dreamingStatus?.phaseSignalCount ?? 0,
+              shortTermEntries: state.dreamingStatus?.shortTermEntries ?? [],
+              signalEntries: state.dreamingStatus?.signalEntries ?? [],
+              promotedEntries: state.dreamingStatus?.promotedEntries ?? [],
+              dreamingOf: null,
+              nextCycle: dreamingNextCycle,
+              timezone: state.dreamingStatus?.timezone ?? null,
+              statusLoading: state.dreamingStatusLoading,
+              statusError: state.dreamingStatusError,
+              modeSaving: state.dreamingModeSaving,
+              dreamDiaryLoading: state.dreamDiaryLoading,
+              dreamDiaryActionLoading: state.dreamDiaryActionLoading,
+              dreamDiaryError: state.dreamDiaryError,
+              dreamDiaryPath: state.dreamDiaryPath,
+              dreamDiaryContent: state.dreamDiaryContent,
+              onRefresh: refreshDreaming,
+              onRefreshDiary: () => loadDreamDiary(state),
+              onBackfillDiary: () => backfillDreamDiary(state),
+              onResetDiary: () => resetDreamDiary(state),
+              onToggleEnabled: applyDreamingEnabled,
+              onRequestUpdate: requestHostUpdate,
+            })
           : nothing}
       </main>
       ${renderExecApprovalPrompt(state)} ${renderGatewayUrlConfirmation(state)} ${nothing}

--- a/ui/src/ui/app-settings.test.ts
+++ b/ui/src/ui/app-settings.test.ts
@@ -158,6 +158,7 @@ const createHost = (tab: Tab): SettingsHost => ({
   dreamingStatus: null,
   dreamingModeSaving: false,
   dreamDiaryLoading: false,
+  dreamDiaryActionLoading: false,
   dreamDiaryError: null,
   dreamDiaryPath: null,
   dreamDiaryContent: null,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -126,6 +126,7 @@ export type AppViewState = {
   dreamingStatus: import("./controllers/dreaming.js").DreamingStatus | null;
   dreamingModeSaving: boolean;
   dreamDiaryLoading: boolean;
+  dreamDiaryActionLoading: boolean;
   dreamDiaryError: string | null;
   dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -72,7 +72,6 @@ import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import { resolveAgentIdFromSessionKey } from "./session-key.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
-import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
 import { VALID_THEME_NAMES, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
 import type {
   AgentsListResult,
@@ -119,7 +118,7 @@ function resolveOnboardingMode(): boolean {
   if (!raw) {
     return false;
   }
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
+  const normalized = raw.trim().toLowerCase();
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
@@ -227,6 +226,7 @@ export class OpenClawApp extends LitElement {
   @state() dreamingStatus: DreamingStatus | null = null;
   @state() dreamingModeSaving = false;
   @state() dreamDiaryLoading = false;
+  @state() dreamDiaryActionLoading = false;
   @state() dreamDiaryError: string | null = null;
   @state() dreamDiaryPath: string | null = null;
   @state() dreamDiaryContent: string | null = null;
@@ -737,7 +737,7 @@ export class OpenClawApp extends LitElement {
     if (!nextGatewayUrl) {
       return;
     }
-    const nextToken = normalizeOptionalString(this.pendingGatewayToken) ?? "";
+    const nextToken = this.pendingGatewayToken?.trim() || "";
     this.pendingGatewayUrl = null;
     this.pendingGatewayToken = null;
     applySettingsInternal(this as unknown as Parameters<typeof applySettingsInternal>[0], {

--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  backfillDreamDiary,
   loadDreamDiary,
   loadDreamingStatus,
+  resetDreamDiary,
   resolveConfiguredDreaming,
   updateDreamingEnabled,
   type DreamingState,
@@ -21,6 +23,7 @@ function createState(): { state: DreamingState; request: ReturnType<typeof vi.fn
     dreamingStatus: null,
     dreamingModeSaving: false,
     dreamDiaryLoading: false,
+    dreamDiaryActionLoading: false,
     dreamDiaryError: null,
     dreamDiaryPath: null,
     dreamDiaryContent: null,
@@ -55,6 +58,53 @@ describe("dreaming controller", () => {
         remPhaseHitCount: 4,
         promotedTotal: 21,
         promotedToday: 2,
+        shortTermEntries: [
+          {
+            key: "memory:memory/2026-04-05.md:1:2",
+            path: "memory/2026-04-05.md",
+            startLine: 1,
+            endLine: 2,
+            snippet: "Emma prefers shorter, lower-pressure check-ins.",
+            recallCount: 2,
+            dailyCount: 1,
+            totalSignalCount: 3,
+            lightHits: 1,
+            remHits: 2,
+            phaseHitCount: 3,
+            lastRecalledAt: "2026-04-05T01:02:03.000Z",
+          },
+        ],
+        signalEntries: [
+          {
+            key: "memory:memory/2026-04-05.md:1:2",
+            path: "memory/2026-04-05.md",
+            startLine: 1,
+            endLine: 2,
+            snippet: "Emma prefers shorter, lower-pressure check-ins.",
+            recallCount: 2,
+            dailyCount: 1,
+            totalSignalCount: 3,
+            lightHits: 1,
+            remHits: 2,
+            phaseHitCount: 3,
+          },
+        ],
+        promotedEntries: [
+          {
+            key: "memory:memory/2026-04-04.md:4:5",
+            path: "memory/2026-04-04.md",
+            startLine: 4,
+            endLine: 5,
+            snippet: "Use the Happy Together calendar for flights.",
+            recallCount: 3,
+            dailyCount: 2,
+            totalSignalCount: 5,
+            lightHits: 0,
+            remHits: 0,
+            phaseHitCount: 0,
+            promotedAt: "2026-04-05T04:00:00.000Z",
+          },
+        ],
         phases: {
           light: {
             enabled: true,
@@ -99,6 +149,18 @@ describe("dreaming controller", () => {
         totalSignalCount: 20,
         phaseSignalCount: 11,
         promotedToday: 2,
+        shortTermEntries: [
+          expect.objectContaining({
+            snippet: "Emma prefers shorter, lower-pressure check-ins.",
+            totalSignalCount: 3,
+            phaseHitCount: 3,
+          }),
+        ],
+        promotedEntries: [
+          expect.objectContaining({
+            snippet: "Use the Happy Together calendar for flights.",
+          }),
+        ],
         phases: expect.objectContaining({
           deep: expect.objectContaining({
             minScore: 0.8,
@@ -339,5 +401,98 @@ describe("dreaming controller", () => {
 
     expect(state.dreamDiaryError).toContain("dream diary read failed");
     expect(state.dreamDiaryLoading).toBe(false);
+  });
+
+  it("backfills and reloads dream diary state", async () => {
+    const { state, request } = createState();
+    request.mockImplementation(async (method: string) => {
+      if (method === "doctor.memory.backfillDreamDiary") {
+        return { action: "backfill", written: 79, replaced: 79 };
+      }
+      if (method === "doctor.memory.dreamDiary") {
+        return { found: true, path: "DREAMS.md", content: "backfilled diary" };
+      }
+      if (method === "doctor.memory.status") {
+        return {
+          dreaming: {
+            enabled: true,
+            shortTermCount: 1,
+            recallSignalCount: 0,
+            dailySignalCount: 0,
+            totalSignalCount: 1,
+            phaseSignalCount: 0,
+            lightPhaseHitCount: 0,
+            remPhaseHitCount: 0,
+            promotedTotal: 0,
+            promotedToday: 0,
+            shortTermEntries: [],
+            signalEntries: [],
+            promotedEntries: [],
+            phases: {
+              light: {
+                enabled: false,
+                cron: "",
+                managedCronPresent: false,
+                lookbackDays: 0,
+                limit: 0,
+              },
+              deep: {
+                enabled: false,
+                cron: "",
+                managedCronPresent: false,
+                limit: 0,
+                minScore: 0,
+                minRecallCount: 0,
+                minUniqueQueries: 0,
+                recencyHalfLifeDays: 0,
+              },
+              rem: {
+                enabled: false,
+                cron: "",
+                managedCronPresent: false,
+                lookbackDays: 0,
+                limit: 0,
+                minPatternStrength: 0,
+              },
+            },
+          },
+        };
+      }
+      return {};
+    });
+
+    const ok = await backfillDreamDiary(state);
+
+    expect(ok).toBe(true);
+    expect(request).toHaveBeenCalledWith("doctor.memory.backfillDreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
+    expect(state.dreamDiaryContent).toBe("backfilled diary");
+    expect(state.dreamDiaryActionLoading).toBe(false);
+  });
+
+  it("resets and reloads dream diary state", async () => {
+    const { state, request } = createState();
+    request.mockImplementation(async (method: string) => {
+      if (method === "doctor.memory.resetDreamDiary") {
+        return { action: "reset", removedEntries: 79 };
+      }
+      if (method === "doctor.memory.dreamDiary") {
+        return { found: false, path: "DREAMS.md" };
+      }
+      if (method === "doctor.memory.status") {
+        return { dreaming: null };
+      }
+      return {};
+    });
+
+    const ok = await resetDreamDiary(state);
+
+    expect(ok).toBe(true);
+    expect(request).toHaveBeenCalledWith("doctor.memory.resetDreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
+    expect(state.dreamDiaryContent).toBeNull();
+    expect(state.dreamDiaryActionLoading).toBe(false);
   });
 });

--- a/ui/src/ui/controllers/dreaming.ts
+++ b/ui/src/ui/controllers/dreaming.ts
@@ -1,5 +1,4 @@
 import type { GatewayBrowserClient } from "../gateway.ts";
-import { normalizeOptionalLowercaseString } from "../string-coerce.ts";
 import type { ConfigSnapshot } from "../types.ts";
 
 export type DreamingPhaseId = "light" | "deep" | "rem";
@@ -33,6 +32,22 @@ type RemDreamingStatus = DreamingPhaseStatusBase & {
   minPatternStrength: number;
 };
 
+export type DreamingEntry = {
+  key: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  snippet: string;
+  recallCount: number;
+  dailyCount: number;
+  totalSignalCount: number;
+  lightHits: number;
+  remHits: number;
+  phaseHitCount: number;
+  promotedAt?: string;
+  lastRecalledAt?: string;
+};
+
 export type DreamingStatus = {
   enabled: boolean;
   timezone?: string;
@@ -52,6 +67,9 @@ export type DreamingStatus = {
   phaseSignalPath?: string;
   storeError?: string;
   phaseSignalError?: string;
+  shortTermEntries: DreamingEntry[];
+  signalEntries: DreamingEntry[];
+  promotedEntries: DreamingEntry[];
   phases: {
     light: LightDreamingStatus;
     deep: DeepDreamingStatus;
@@ -69,6 +87,13 @@ type DoctorMemoryDreamDiaryPayload = {
   content?: unknown;
 };
 
+type DoctorMemoryDreamDiaryActionPayload = {
+  action?: unknown;
+  removedEntries?: unknown;
+  written?: unknown;
+  replaced?: unknown;
+};
+
 export type DreamingState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
@@ -79,6 +104,7 @@ export type DreamingState = {
   dreamingStatus: DreamingStatus | null;
   dreamingModeSaving: boolean;
   dreamDiaryLoading: boolean;
+  dreamDiaryActionLoading: boolean;
   dreamDiaryError: string | null;
   dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;
@@ -119,7 +145,7 @@ function normalizeFiniteScore(value: unknown, fallback = 0): number {
 }
 
 function normalizeStorageMode(value: unknown): DreamingStatus["storageMode"] {
-  const normalized = normalizeOptionalLowercaseString(normalizeTrimmedString(value));
+  const normalized = normalizeTrimmedString(value)?.toLowerCase();
   if (normalized === "inline" || normalized === "separate" || normalized === "both") {
     return normalized;
   }
@@ -145,7 +171,7 @@ function resolveDreamingPluginId(configValue: Record<string, unknown> | null): s
   const plugins = asRecord(configValue?.plugins);
   const slots = asRecord(plugins?.slots);
   const configuredSlot = normalizeTrimmedString(slots?.memory);
-  if (configuredSlot && normalizeOptionalLowercaseString(configuredSlot) !== "none") {
+  if (configuredSlot && configuredSlot.toLowerCase() !== "none") {
     return configuredSlot;
   }
   return DEFAULT_DREAMING_PLUGIN_ID;
@@ -167,6 +193,41 @@ export function resolveConfiguredDreaming(configValue: Record<string, unknown> |
   };
 }
 
+function normalizeDreamingEntry(raw: unknown): DreamingEntry | null {
+  const record = asRecord(raw);
+  const key = normalizeTrimmedString(record?.key);
+  const path = normalizeTrimmedString(record?.path);
+  const snippet = normalizeTrimmedString(record?.snippet);
+  if (!key || !path || !snippet) {
+    return null;
+  }
+  const promotedAt = normalizeTrimmedString(record?.promotedAt);
+  const lastRecalledAt = normalizeTrimmedString(record?.lastRecalledAt);
+  return {
+    key,
+    path,
+    startLine: Math.max(1, normalizeFiniteInt(record?.startLine, 1)),
+    endLine: Math.max(1, normalizeFiniteInt(record?.endLine, 1)),
+    snippet,
+    recallCount: normalizeFiniteInt(record?.recallCount, 0),
+    dailyCount: normalizeFiniteInt(record?.dailyCount, 0),
+    totalSignalCount: normalizeFiniteInt(record?.totalSignalCount, 0),
+    lightHits: normalizeFiniteInt(record?.lightHits, 0),
+    remHits: normalizeFiniteInt(record?.remHits, 0),
+    phaseHitCount: normalizeFiniteInt(record?.phaseHitCount, 0),
+    ...(promotedAt ? { promotedAt } : {}),
+    ...(lastRecalledAt ? { lastRecalledAt } : {}),
+  };
+}
+
+function normalizeDreamingEntries(raw: unknown): DreamingEntry[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .map((entry) => normalizeDreamingEntry(entry))
+    .filter((entry): entry is DreamingEntry => entry !== null);
+}
 function normalizeDreamingStatus(raw: unknown): DreamingStatus | null {
   const record = asRecord(raw);
   if (!record) {
@@ -201,6 +262,9 @@ function normalizeDreamingStatus(raw: unknown): DreamingStatus | null {
     ...(phaseSignalPath ? { phaseSignalPath } : {}),
     ...(storeError ? { storeError } : {}),
     ...(phaseSignalError ? { phaseSignalError } : {}),
+    shortTermEntries: normalizeDreamingEntries(record.shortTermEntries),
+    signalEntries: normalizeDreamingEntries(record.signalEntries),
+    promotedEntries: normalizeDreamingEntries(record.promotedEntries),
     phases: {
       light: {
         ...normalizePhaseStatusBase(lightRecord),
@@ -272,6 +336,39 @@ export async function loadDreamDiary(state: DreamingState): Promise<void> {
   } finally {
     state.dreamDiaryLoading = false;
   }
+}
+
+async function runDreamDiaryAction(
+  state: DreamingState,
+  method: "doctor.memory.backfillDreamDiary" | "doctor.memory.resetDreamDiary",
+): Promise<boolean> {
+  if (!state.client || !state.connected || state.dreamDiaryActionLoading) {
+    return false;
+  }
+  state.dreamDiaryActionLoading = true;
+  state.dreamingStatusError = null;
+  state.dreamDiaryError = null;
+  try {
+    await state.client.request<DoctorMemoryDreamDiaryActionPayload>(method, {});
+    await loadDreamDiary(state);
+    await loadDreamingStatus(state);
+    return true;
+  } catch (err) {
+    const message = String(err);
+    state.dreamingStatusError = message;
+    state.lastError = message;
+    return false;
+  } finally {
+    state.dreamDiaryActionLoading = false;
+  }
+}
+
+export async function backfillDreamDiary(state: DreamingState): Promise<boolean> {
+  return runDreamDiaryAction(state, "doctor.memory.backfillDreamDiary");
+}
+
+export async function resetDreamDiary(state: DreamingState): Promise<boolean> {
+  return runDreamDiaryAction(state, "doctor.memory.resetDreamDiary");
 }
 
 async function writeDreamingPatch(

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -92,6 +92,71 @@ describe("control UI routing", () => {
     expect(dreamsLink).not.toBeNull();
   });
 
+  it("renders the dreaming view on the /dreaming route", async () => {
+    const app = mountApp("/dreaming");
+    app.dreamingStatus = {
+      enabled: true,
+      timezone: "Europe/Madrid",
+      verboseLogging: false,
+      storageMode: "inline",
+      separateReports: false,
+      shortTermCount: 2,
+      recallSignalCount: 1,
+      dailySignalCount: 1,
+      totalSignalCount: 2,
+      phaseSignalCount: 0,
+      lightPhaseHitCount: 0,
+      remPhaseHitCount: 0,
+      promotedTotal: 1,
+      promotedToday: 1,
+      shortTermEntries: [],
+      signalEntries: [],
+      promotedEntries: [],
+      phases: {
+        light: { enabled: true, cron: "", managedCronPresent: false, lookbackDays: 7, limit: 20 },
+        deep: {
+          enabled: true,
+          cron: "",
+          managedCronPresent: false,
+          limit: 20,
+          minScore: 0.75,
+          minRecallCount: 3,
+          minUniqueQueries: 2,
+          recencyHalfLifeDays: 7,
+        },
+        rem: {
+          enabled: true,
+          cron: "",
+          managedCronPresent: false,
+          lookbackDays: 7,
+          limit: 20,
+          minPatternStrength: 0.6,
+        },
+      },
+    };
+    app.dreamDiaryPath = "DREAMS.md";
+    app.dreamDiaryContent = [
+      "# Dream Diary",
+      "",
+      "<!-- openclaw:dreaming:diary:start -->",
+      "",
+      "---",
+      "",
+      "*January 1, 2026*",
+      "",
+      "What Happened",
+      "1. Stable operator rule surfaced.",
+      "",
+      "<!-- openclaw:dreaming:diary:end -->",
+    ].join("\n");
+    app.requestUpdate();
+    await app.updateComplete;
+
+    expect(app.tab).toBe("dreams");
+    expect(app.querySelector(".dreams__tab")).not.toBeNull();
+    expect(app.querySelector(".dreams__lobster")).not.toBeNull();
+  });
+
   it("renders the refreshed top navigation shell", async () => {
     const app = mountApp("/chat");
     await app.updateComplete;

--- a/ui/src/ui/views/dreaming.test.ts
+++ b/ui/src/ui/views/dreaming.test.ts
@@ -9,8 +9,54 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     active: true,
     shortTermCount: 47,
     totalSignalCount: 182,
-    phaseSignalCount: 29,
     promotedCount: 12,
+    phaseSignalCount: 29,
+    shortTermEntries: [
+      {
+        key: "memory:memory/2026-04-05.md:1:2",
+        path: "memory/2026-04-05.md",
+        startLine: 1,
+        endLine: 2,
+        snippet: "Emma prefers shorter, lower-pressure check-ins.",
+        recallCount: 2,
+        dailyCount: 1,
+        totalSignalCount: 3,
+        lightHits: 1,
+        remHits: 1,
+        phaseHitCount: 2,
+      },
+    ],
+    signalEntries: [
+      {
+        key: "memory:memory/2026-04-05.md:1:2",
+        path: "memory/2026-04-05.md",
+        startLine: 1,
+        endLine: 2,
+        snippet: "Emma prefers shorter, lower-pressure check-ins.",
+        recallCount: 2,
+        dailyCount: 1,
+        totalSignalCount: 3,
+        lightHits: 1,
+        remHits: 1,
+        phaseHitCount: 2,
+      },
+    ],
+    promotedEntries: [
+      {
+        key: "memory:memory/2026-04-04.md:4:5",
+        path: "memory/2026-04-04.md",
+        startLine: 4,
+        endLine: 5,
+        snippet: "Use the Happy Together calendar for flights.",
+        recallCount: 3,
+        dailyCount: 2,
+        totalSignalCount: 5,
+        lightHits: 0,
+        remHits: 0,
+        phaseHitCount: 0,
+        promotedAt: "2026-04-05T04:00:00.000Z",
+      },
+    ],
     dreamingOf: null,
     nextCycle: "4:00 AM",
     timezone: "America/Los_Angeles",
@@ -18,12 +64,15 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     statusError: null,
     modeSaving: false,
     dreamDiaryLoading: false,
+    dreamDiaryActionLoading: false,
     dreamDiaryError: null,
     dreamDiaryPath: "DREAMS.md",
     dreamDiaryContent:
       "# Dream Diary\n\n<!-- openclaw:dreaming:diary:start -->\n\n---\n\n*April 5, 2026, 3:00 AM*\n\nThe repository whispered of forgotten endpoints tonight.\n\n<!-- openclaw:dreaming:diary:end -->",
     onRefresh: () => {},
     onRefreshDiary: () => {},
+    onBackfillDiary: () => {},
+    onResetDiary: () => {},
     onToggleEnabled: () => {},
     ...overrides,
   };
@@ -65,7 +114,33 @@ describe("dreaming view", () => {
     expect(values.length).toBe(3);
     expect(values[0]?.textContent).toBe("47");
     expect(values[1]?.textContent).toBe("182");
-    expect(values[2]?.textContent).toBe("29");
+    expect(values[2]?.textContent).toBe("12");
+  });
+
+  it("renders short-term, signals, and promoted detail sections", () => {
+    const container = renderInto(buildProps());
+    const titles = [...container.querySelectorAll(".dreams__trace-title")].map((node) =>
+      node.textContent?.trim(),
+    );
+    expect(titles).toEqual(["Short-term", "Signals", "Promoted"]);
+    expect(
+      container.querySelector('[data-kind="shortTerm"] .dreams__trace-snippet')?.textContent,
+    ).toContain("Emma prefers shorter");
+    expect(
+      container.querySelector('[data-kind="signals"] .dreams__trace-meta')?.textContent,
+    ).toContain("3 signals");
+    expect(
+      container.querySelector('[data-kind="promoted"] .dreams__trace-source')?.textContent,
+    ).toContain("memory/2026-04-04.md:4-5");
+  });
+
+  it("renders scene backfill and reset controls", () => {
+    const container = renderInto(buildProps());
+    const buttons = [...container.querySelectorAll("button")].map((node) =>
+      node.textContent?.trim(),
+    );
+    expect(buttons).toContain("Backfill");
+    expect(buttons).toContain("Reset");
   });
 
   it("shows dream bubble when active", () => {
@@ -134,6 +209,97 @@ describe("dreaming view", () => {
     expect(date?.textContent).toContain("April 5, 2026");
     const body = container.querySelector(".dreams-diary__para");
     expect(body?.textContent).toContain("forgotten endpoints");
+    setDreamSubTab("scene");
+  });
+
+  it("renders structured backfill diary entries as three panels", () => {
+    setDreamSubTab("diary");
+    const container = renderInto(
+      buildProps({
+        dreamDiaryContent: [
+          "# Dream Diary",
+          "",
+          "<!-- openclaw:dreaming:diary:start -->",
+          "",
+          "---",
+          "",
+          "*January 1, 2026*",
+          "",
+          "<!-- openclaw:dreaming:backfill-entry day=2026-01-01 source=memory/2026-01-01.md -->",
+          "",
+          "What Happened",
+          "1. Always use Happy Together for flights.",
+          "",
+          "Reflections",
+          "1. Stable preferences were made explicit.",
+          "",
+          "Candidates",
+          "- likely_durable: Happy Together rule",
+          "",
+          "Possible Lasting Updates",
+          "- Use Happy Together for flights.",
+          "",
+          "<!-- openclaw:dreaming:diary:end -->",
+        ].join("\n"),
+      }),
+    );
+    const panelTitles = [...container.querySelectorAll(".dreams-diary__panel-title")].map((node) =>
+      node.textContent?.trim(),
+    );
+    expect(panelTitles).toEqual([
+      "What Happened",
+      "Reflections",
+      "Candidates + Possible Lasting Updates",
+    ]);
+    expect(container.querySelector(".dreams-diary__panel-subtitle")?.textContent).toContain(
+      "Candidates",
+    );
+    expect(container.querySelector(".dreams-diary__item--reflection")?.textContent).toContain(
+      "Stable preferences were made explicit",
+    );
+    expect(container.querySelector(".dreams-diary__item--update")?.textContent).toContain(
+      "Use Happy Together for flights",
+    );
+    setDreamSubTab("scene");
+  });
+
+  it("renders diary day navigation and a density map", () => {
+    setDreamSubTab("diary");
+    const container = renderInto(
+      buildProps({
+        dreamDiaryContent: [
+          "# Dream Diary",
+          "",
+          "<!-- openclaw:dreaming:diary:start -->",
+          "",
+          "---",
+          "",
+          "*January 1, 2026*",
+          "",
+          "What Happened",
+          "1. First durable fact.",
+          "",
+          "---",
+          "",
+          "*January 2, 2026*",
+          "",
+          "What Happened",
+          "1. Second durable fact.",
+          "",
+          "Candidates",
+          "- candidate",
+          "",
+          "<!-- openclaw:dreaming:diary:end -->",
+        ].join("\n"),
+      }),
+    );
+    expect(container.querySelectorAll(".dreams-diary__day-chip").length).toBe(2);
+    expect(container.querySelectorAll(".dreams-diary__heatmap-cell").length).toBe(2);
+    expect(container.querySelector(".dreams-diary__timeline-month")?.textContent).toContain("Jan");
+    const labels = [...container.querySelectorAll(".dreams-diary__day-chip")].map((node) =>
+      node.textContent?.replace(/\s+/g, "").trim(),
+    );
+    expect(labels.filter(Boolean).some((label) => /^\d+\/\d+$/.test(label ?? ""))).toBe(true);
     setDreamSubTab("scene");
   });
 

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -8,6 +8,21 @@ type DiaryEntry = {
   body: string;
 };
 
+type DiaryEntryNav = {
+  date: string;
+  body: string;
+  page: number;
+  timestamp: number | null;
+  signalWeight: number;
+};
+
+type StructuredDiaryEntry = {
+  whatHappened: string[];
+  reflections: string[];
+  candidates: string[];
+  lastingUpdates: string[];
+};
+
 const DIARY_START_RE = /<!--\s*openclaw:dreaming:diary:start\s*-->/;
 const DIARY_END_RE = /<!--\s*openclaw:dreaming:diary:end\s*-->/;
 
@@ -53,12 +68,244 @@ function parseDiaryEntries(raw: string): DiaryEntry[] {
   return entries;
 }
 
+function parseDiaryTimestamp(date: string): number | null {
+  const parsed = Date.parse(date);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatDiaryChipLabel(date: string): string {
+  const parsed = parseDiaryTimestamp(date);
+  if (parsed === null) {
+    return date;
+  }
+  const value = new Date(parsed);
+  return `${value.getMonth() + 1}/${value.getDate()}`;
+}
+
+function formatDiaryMonthLabel(date: string): string {
+  const parsed = parseDiaryTimestamp(date);
+  if (parsed === null) {
+    return date;
+  }
+  return new Date(parsed).toLocaleDateString([], {
+    month: "short",
+  });
+}
+
+function normalizeStructuredDiaryItem(line: string): string {
+  return line
+    .replace(/^(?:\d+\.\s+|-\s+(?:\[[^\]]+\]\s+)?(?:[a-z_]+:\s+)?|\[[^\]]+\]\s+)/i, "")
+    .replace(/^(?:likely_durable|likely_situational|unclear):\s+/i, "")
+    .trim();
+}
+
+function parseStructuredDiaryEntry(body: string): StructuredDiaryEntry | null {
+  const lines = body
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return null;
+  }
+  const sections: StructuredDiaryEntry = {
+    whatHappened: [],
+    reflections: [],
+    candidates: [],
+    lastingUpdates: [],
+  };
+  let current: keyof StructuredDiaryEntry | null = null;
+  for (const line of lines) {
+    if (line === "What Happened") {
+      current = "whatHappened";
+      continue;
+    }
+    if (line === "Reflections") {
+      current = "reflections";
+      continue;
+    }
+    if (line === "Candidates") {
+      current = "candidates";
+      continue;
+    }
+    if (line === "Possible Lasting Updates") {
+      current = "lastingUpdates";
+      continue;
+    }
+    if (!current) {
+      continue;
+    }
+    sections[current].push(normalizeStructuredDiaryItem(line));
+  }
+  if (
+    sections.whatHappened.length === 0 &&
+    sections.reflections.length === 0 &&
+    sections.candidates.length === 0 &&
+    sections.lastingUpdates.length === 0
+  ) {
+    return null;
+  }
+  return sections;
+}
+
+function scoreStructuredDiaryEntry(entry: StructuredDiaryEntry | null): number {
+  if (!entry) {
+    return 1;
+  }
+  return Math.max(
+    1,
+    entry.whatHappened.length +
+      entry.reflections.length +
+      entry.candidates.length * 2 +
+      entry.lastingUpdates.length * 3,
+  );
+}
+
+function buildDiaryNavigation(entries: DiaryEntry[]): DiaryEntryNav[] {
+  const reversed = [...entries].toReversed();
+  return reversed.map((entry, page) => ({
+    ...entry,
+    page,
+    timestamp: parseDiaryTimestamp(entry.date),
+    signalWeight: scoreStructuredDiaryEntry(parseStructuredDiaryEntry(entry.body)),
+  }));
+}
+
+const DIARY_LABEL_INTERVAL = 7;
+
+function shouldShowDiaryLabel(
+  entries: DiaryEntryNav[],
+  index: number,
+  activePage: number,
+): boolean {
+  if (index === activePage || index === 0 || index % DIARY_LABEL_INTERVAL === 0) {
+    return true;
+  }
+  const previous = entries[index - 1];
+  return (
+    formatDiaryMonthLabel(previous?.date ?? "") !==
+    formatDiaryMonthLabel(entries[index]?.date ?? "")
+  );
+}
+
+function renderDiaryNavigator(
+  entries: DiaryEntryNav[],
+  activePage: number,
+  requestUpdate?: () => void,
+) {
+  return html`
+    <div class="dreams-diary__timeline" aria-label="Diary day browser">
+      <div class="dreams-diary__timeline-months">
+        ${entries.map((entry, index) => {
+          const previous = entries[index - 1];
+          const showLabel =
+            index === 0 ||
+            formatDiaryMonthLabel(previous?.date ?? "") !== formatDiaryMonthLabel(entry.date);
+          return html`
+            <span
+              class="dreams-diary__timeline-month ${showLabel
+                ? ""
+                : "dreams-diary__timeline-month--ghost"}"
+            >
+              ${showLabel ? formatDiaryMonthLabel(entry.date) : ""}
+            </span>
+          `;
+        })}
+      </div>
+      <div class="dreams-diary__timeline-days">
+        ${entries.map(
+          (entry, index) => html`
+            <button
+              class="dreams-diary__day-chip ${entry.page === activePage
+                ? "dreams-diary__day-chip--active"
+                : ""}"
+              @click=${() => {
+                setDiaryPage(entry.page);
+                requestUpdate?.();
+              }}
+              title=${entry.date}
+            >
+              ${shouldShowDiaryLabel(entries, index, activePage)
+                ? formatDiaryChipLabel(entry.date)
+                : html`<span aria-hidden="true">&nbsp;</span>`}
+            </button>
+          `,
+        )}
+      </div>
+      <div class="dreams-diary__heatmap" aria-label="Diary activity map">
+        ${entries.map((entry) => {
+          const intensity = Math.min(4, Math.max(1, entry.signalWeight));
+          return html`
+            <button
+              class="dreams-diary__heatmap-cell ${entry.page === activePage
+                ? "dreams-diary__heatmap-cell--active"
+                : ""}"
+              data-intensity=${String(intensity)}
+              @click=${() => {
+                setDiaryPage(entry.page);
+                requestUpdate?.();
+              }}
+              title=${`${entry.date} · ${entry.signalWeight} signals`}
+            >
+              <span class="dreams-diary__heatmap-pill"></span>
+            </button>
+          `;
+        })}
+      </div>
+    </div>
+  `;
+}
+
 export type DreamingProps = {
   active: boolean;
   shortTermCount: number;
   totalSignalCount: number;
-  phaseSignalCount: number;
   promotedCount: number;
+  phaseSignalCount: number;
+  shortTermEntries: {
+    key: string;
+    path: string;
+    startLine: number;
+    endLine: number;
+    snippet: string;
+    recallCount: number;
+    dailyCount: number;
+    totalSignalCount: number;
+    lightHits: number;
+    remHits: number;
+    phaseHitCount: number;
+    promotedAt?: string;
+    lastRecalledAt?: string;
+  }[];
+  signalEntries: {
+    key: string;
+    path: string;
+    startLine: number;
+    endLine: number;
+    snippet: string;
+    recallCount: number;
+    dailyCount: number;
+    totalSignalCount: number;
+    lightHits: number;
+    remHits: number;
+    phaseHitCount: number;
+    promotedAt?: string;
+    lastRecalledAt?: string;
+  }[];
+  promotedEntries: {
+    key: string;
+    path: string;
+    startLine: number;
+    endLine: number;
+    snippet: string;
+    recallCount: number;
+    dailyCount: number;
+    totalSignalCount: number;
+    lightHits: number;
+    remHits: number;
+    phaseHitCount: number;
+    promotedAt?: string;
+    lastRecalledAt?: string;
+  }[];
   dreamingOf: string | null;
   nextCycle: string | null;
   timezone: string | null;
@@ -66,11 +313,14 @@ export type DreamingProps = {
   statusError: string | null;
   modeSaving: boolean;
   dreamDiaryLoading: boolean;
+  dreamDiaryActionLoading: boolean;
   dreamDiaryError: string | null;
   dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;
   onRefresh: () => void;
   onRefreshDiary: () => void;
+  onBackfillDiary: () => void;
+  onResetDiary: () => void;
   onToggleEnabled: (enabled: boolean) => void;
   onRequestUpdate?: () => void;
 };
@@ -278,6 +528,25 @@ function renderScene(props: DreamingProps, idle: boolean, dreamText: string) {
         </div>
       </div>
 
+      <div class="dreams__actions">
+        <button
+          class="btn btn--subtle btn--sm"
+          ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
+          @click=${() => props.onBackfillDiary()}
+        >
+          ${props.dreamDiaryActionLoading
+            ? t("dreaming.scene.working")
+            : t("dreaming.scene.backfill")}
+        </button>
+        <button
+          class="btn btn--subtle btn--sm"
+          ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
+          @click=${() => props.onResetDiary()}
+        >
+          ${t("dreaming.scene.reset")}
+        </button>
+      </div>
+
       <div class="dreams__stats">
         <div class="dreams__stat">
           <span class="dreams__stat-value" style="color: var(--text-strong);"
@@ -295,15 +564,113 @@ function renderScene(props: DreamingProps, idle: boolean, dreamText: string) {
         <div class="dreams__stat-divider"></div>
         <div class="dreams__stat">
           <span class="dreams__stat-value" style="color: var(--accent-2);"
-            >${props.phaseSignalCount}</span
+            >${props.promotedCount}</span
           >
-          <span class="dreams__stat-label">${t("dreaming.stats.phaseHits")}</span>
+          <span class="dreams__stat-label">${t("dreaming.stats.promoted")}</span>
         </div>
+      </div>
+
+      <div class="dreams__trace">
+        ${renderTraceSection("shortTerm", props.shortTermEntries, {
+          count: props.shortTermCount,
+          emptyKey: "dreaming.trace.emptyShortTerm",
+          meta: (entry) =>
+            [
+              entry.recallCount > 0
+                ? `${entry.recallCount} recall${entry.recallCount === 1 ? "" : "s"}`
+                : null,
+              entry.dailyCount > 0 ? `${entry.dailyCount} daily` : null,
+              entry.phaseHitCount > 0
+                ? `${entry.phaseHitCount} phase hit${entry.phaseHitCount === 1 ? "" : "s"}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" · "),
+        })}
+        ${renderTraceSection("signals", props.signalEntries, {
+          count: props.totalSignalCount,
+          emptyKey: "dreaming.trace.emptySignals",
+          meta: (entry) =>
+            [
+              `${entry.totalSignalCount} signal${entry.totalSignalCount === 1 ? "" : "s"}`,
+              entry.phaseHitCount > 0
+                ? `${entry.phaseHitCount} phase hit${entry.phaseHitCount === 1 ? "" : "s"}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" · "),
+        })}
+        ${renderTraceSection("promoted", props.promotedEntries, {
+          count: props.promotedCount,
+          emptyKey: "dreaming.trace.emptyPromoted",
+          meta: (entry) =>
+            [
+              entry.promotedAt ? formatCompactDateTime(entry.promotedAt) : null,
+              entry.totalSignalCount > 0
+                ? `${entry.totalSignalCount} signal${entry.totalSignalCount === 1 ? "" : "s"} before promote`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" · "),
+        })}
       </div>
 
       ${props.statusError
         ? html`<div class="dreams__controls-error">${props.statusError}</div>`
         : nothing}
+    </section>
+  `;
+}
+
+function formatRange(path: string, startLine: number, endLine: number): string {
+  return startLine === endLine ? `${path}:${startLine}` : `${path}:${startLine}-${endLine}`;
+}
+
+function formatCompactDateTime(value: string): string {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    return value;
+  }
+  return new Date(parsed).toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function renderTraceSection(
+  kind: "shortTerm" | "signals" | "promoted",
+  entries: DreamingProps["shortTermEntries"],
+  options: {
+    count: number;
+    emptyKey: string;
+    meta: (entry: DreamingProps["shortTermEntries"][number]) => string;
+  },
+) {
+  return html`
+    <section class="dreams__trace-section">
+      <div class="dreams__trace-header">
+        <span class="dreams__trace-title">${t(`dreaming.trace.${kind}`)}</span>
+        <span class="dreams__trace-count">${options.count}</span>
+      </div>
+      ${entries.length === 0
+        ? html`<div class="dreams__trace-empty">${t(options.emptyKey)}</div>`
+        : html`
+            <div class="dreams__trace-list">
+              ${entries.map(
+                (entry) => html`
+                  <article class="dreams__trace-item" data-kind=${kind} data-key=${entry.key}>
+                    <div class="dreams__trace-snippet">${entry.snippet}</div>
+                    <div class="dreams__trace-source">
+                      ${formatRange(entry.path, entry.startLine, entry.endLine)}
+                    </div>
+                    <div class="dreams__trace-meta">${options.meta(entry)}</div>
+                  </article>
+                `,
+              )}
+            </div>
+          `}
     </section>
   `;
 }
@@ -361,13 +728,13 @@ function renderDiarySection(props: DreamingProps) {
     `;
   }
 
-  // Show most recent entries first (reverse chronological).
-  const reversed = [...entries].toReversed();
+  const reversed = buildDiaryNavigation(entries);
   // Clamp page.
   const page = Math.max(0, Math.min(_diaryPage, reversed.length - 1));
   const entry = reversed[page];
   const hasPrev = page > 0;
   const hasNext = page < reversed.length - 1;
+  const structured = parseStructuredDiaryEntry(entry.body);
 
   return html`
     <section class="dreams-diary">
@@ -410,19 +777,109 @@ function renderDiarySection(props: DreamingProps) {
         </button>
       </div>
 
-      <article class="dreams-diary__entry" key="${page}">
+      <div class="dreams-diary__navigator">
+        <div class="dreams-diary__navigator-content">
+          ${renderDiaryNavigator(reversed, page, props.onRequestUpdate)}
+        </div>
+      </div>
+
+      <article
+        class="dreams-diary__entry ${structured ? "dreams-diary__entry--structured" : ""}"
+        key="${page}"
+      >
         <div class="dreams-diary__accent"></div>
         ${entry.date ? html`<time class="dreams-diary__date">${entry.date}</time>` : nothing}
-        <div class="dreams-diary__prose">
-          ${entry.body
-            .split("\n")
-            .map(
-              (para, i) =>
-                html`<p class="dreams-diary__para" style="animation-delay: ${0.3 + i * 0.15}s;">
-                  ${para}
-                </p>`,
-            )}
-        </div>
+        ${structured
+          ? html`
+              <div class="dreams-diary__grid">
+                <section class="dreams-diary__panel">
+                  <h3 class="dreams-diary__panel-title">What Happened</h3>
+                  <div class="dreams-diary__panel-list dreams-diary__panel-list--points">
+                    ${structured.whatHappened.map(
+                      (item, i) => html`
+                        <div
+                          class="dreams-diary__point"
+                          style="animation-delay: ${0.2 + i * 0.06}s;"
+                        >
+                          <span class="dreams-diary__point-bullet"></span>
+                          <p class="dreams-diary__item">${item}</p>
+                        </div>
+                      `,
+                    )}
+                  </div>
+                </section>
+                <section class="dreams-diary__panel">
+                  <h3 class="dreams-diary__panel-title">Reflections</h3>
+                  <div class="dreams-diary__panel-list dreams-diary__panel-list--points">
+                    ${structured.reflections.map(
+                      (item, i) => html`
+                        <div
+                          class="dreams-diary__point"
+                          style="animation-delay: ${0.26 + i * 0.06}s;"
+                        >
+                          <span class="dreams-diary__point-bullet"></span>
+                          <p class="dreams-diary__item dreams-diary__item--reflection">${item}</p>
+                        </div>
+                      `,
+                    )}
+                  </div>
+                </section>
+                <section class="dreams-diary__panel">
+                  <h3 class="dreams-diary__panel-title">Candidates + Possible Lasting Updates</h3>
+                  ${structured.candidates.length > 0
+                    ? html`
+                        <div class="dreams-diary__panel-subtitle">Candidates</div>
+                        <div class="dreams-diary__panel-list dreams-diary__panel-list--points">
+                          ${structured.candidates.map(
+                            (item, i) => html`
+                              <div
+                                class="dreams-diary__point"
+                                style="animation-delay: ${0.32 + i * 0.06}s;"
+                              >
+                                <span class="dreams-diary__point-bullet"></span>
+                                <p class="dreams-diary__item">${item}</p>
+                              </div>
+                            `,
+                          )}
+                        </div>
+                      `
+                    : nothing}
+                  ${structured.lastingUpdates.length > 0
+                    ? html`
+                        <div class="dreams-diary__panel-subtitle">Possible Lasting Updates</div>
+                        <div class="dreams-diary__panel-list dreams-diary__panel-list--points">
+                          ${structured.lastingUpdates.map(
+                            (item, i) => html`
+                              <div
+                                class="dreams-diary__point"
+                                style="animation-delay: ${0.38 + i * 0.06}s;"
+                              >
+                                <span class="dreams-diary__point-bullet"></span>
+                                <p class="dreams-diary__item dreams-diary__item--update">${item}</p>
+                              </div>
+                            `,
+                          )}
+                        </div>
+                      `
+                    : nothing}
+                </section>
+              </div>
+            `
+          : html`
+              <div class="dreams-diary__prose">
+                ${entry.body
+                  .split("\n")
+                  .map(
+                    (para, i) =>
+                      html`<p
+                        class="dreams-diary__para"
+                        style="animation-delay: ${0.3 + i * 0.15}s;"
+                      >
+                        ${para}
+                      </p>`,
+                  )}
+              </div>
+            `}
       </article>
     </section>
   `;


### PR DESCRIPTION
## Summary

- Problem: the grounded diary/backfill lane was only inspectable via raw markdown and the existing Dreams UI made it hard to browse days, inspect grounded output, or trigger rebuild/reset flows.
- Why it matters: we need a usable review surface before deciding which grounded candidate truths should feed the live dreaming evidence lane.
- What changed: added diary navigation, three-column grounded diary presentation, scene-level backfill/reset controls, and the gateway doctor surface those controls need.
- What did NOT change (scope boundary): this PR does not change grounded extraction logic and does not wire grounded candidates into live promotion.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX
- [x] Memory / storage
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Integrations
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #63273
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the backfill lane had no usable control surface or browseable diary presentation.
- Missing detection / guardrail: we had no focused UI/controller tests for grounded diary actions and rendering.
- Prior context (`git blame`, prior PR, issue, or refactor if known): UI follow-up on top of #63273.
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/doctor.test.ts`, `ui/src/ui/controllers/dreaming.test.ts`, `ui/src/ui/views/dreaming.test.ts`, `ui/src/ui/navigation.browser.test.ts`
- Scenario the test should lock in: diary action RPCs, diary render layout/data, and browser navigation behavior.
- Why this is the smallest reliable guardrail: these seams cover the full UI control loop without requiring a live gateway/browser E2E.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Dreams Diary gets a timeline/heatmap navigator and a three-column grounded layout.
- Scene gets `Backfill` and `Reset` controls for the diary backfill lane.
- grounded diary content is easier to inspect day by day.

## Diagram (if applicable)

```text
Before:
[user opens Dreams] -> [summary card + raw/weak diary inspection]

After:
[user opens Dreams] -> [timeline + heatmap + 3-column diary]
                     -> [Backfill / Reset controls]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: the UI can now trigger grounded diary backfill/reset through the doctor gateway surface. The server-side actions remain workspace-local and marker-scoped; reset only removes backfilled diary entries.

## Repro + Verification

### Environment

- OS: macOS authoring, `mb-server` for gates
- Runtime/container: Node 22 / Vitest 4
- Model/provider: N/A
- Integration/channel (if any): Control UI / gateway doctor RPC
- Relevant config (redacted): default memory workspace layout

### Steps

1. Open Dreams.
2. Navigate the diary with the timeline/heatmap.
3. Trigger `Backfill` and `Reset` from Scene.

### Expected

- diary renders in 3 columns with navigation
- controls call the right gateway methods and reload state

### Actual

- Matches expected in focused UI/gateway tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: diary navigation/rendering, scene action control loop, doctor action endpoints.
- Edge cases checked: loading state, navigation token warnings already covered by existing browser tests.
- What you did **not** verify: manual screenshot attachment in this draft.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: UI and doctor action surface could drift from the grounded backfill lane if the CLI side changes later.
  - Mitigation: this PR is stacked directly on the backfill foundation PR and has focused controller/server tests for the action loop.
