### PR TITLE
feat(memory): harden grounded REM extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - iOS: pin release versioning to an explicit CalVer in `apps/ios/version.json`, keep TestFlight iteration on the same short version until maintainers intentionally promote the next gateway version, and add the documented `pnpm ios:version:pin -- --from-gateway` workflow for release trains. (#63001) Thanks @ngutman.
 - Plugins/provider-auth: let provider manifests declare `providerAuthAliases` so provider variants can share env vars, auth profiles, config-backed auth, and API-key onboarding choices without core-specific wiring.
 - Memory/dreaming: add a grounded REM backfill lane with historical `rem-harness --path`, diary commit, and reset flows so old daily notes can be replayed safely into `DREAMS.md`. Thanks @mbelinky.
+- Memory/dreaming: harden grounded diary extraction so `What Happened`, `Reflections`, and durable candidates suppress operational noise and preserve more atomic lasting facts. Thanks @mbelinky.
 
 ### Fixes
 

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1212,7 +1212,7 @@ describe("memory cli", () => {
       const file = payload?.grounded?.files?.[0];
       const rendered = file?.renderedMarkdown ?? "";
       expect(rendered).toContain(
-        "1. People mentioned with context: Bunji — partner, Surrealist Ball Sat 28 Feb w/ Maga",
+        "People mentioned with context: Bunji — partner, Surrealist Ball Sat 28 Feb w/ Maga",
       );
       expect(rendered).toContain("Bex — girlfriend, date weekend Fri-Sun London, Chateau Denmark");
       expect(rendered).toContain("Bunji — partner");

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1217,7 +1217,7 @@ describe("memory cli", () => {
       expect(rendered).toContain("Bex — girlfriend, date weekend Fri-Sun London, Chateau Denmark");
       expect(rendered).toContain("Bunji — partner");
       expect(rendered).toContain("Bex — girlfriend");
-      expect(rendered).toContain("Bunji — Surrealist Ball Sat 28 Feb w/ Maga");
+      expect(rendered).not.toContain("Bunji — Surrealist Ball Sat 28 Feb w/ Maga [");
       expect(rendered).not.toContain("Bex — date weekend Fri-Sun London, Chateau Denmark");
       expect(
         file?.reflections?.some((item) =>

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1074,6 +1074,165 @@ describe("memory cli", () => {
     });
   });
 
+  it("prefers persistence-relevant evidence over narrated operational logs in grounded what happened", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const historyDir = path.join(workspaceDir, "history");
+      await fs.mkdir(historyDir, { recursive: true });
+      const historyPath = path.join(historyDir, "2025-03-30.md");
+      await fs.writeFile(
+        historyPath,
+        [
+          "## OpenClaw / runtime / workflow preferences and corrections",
+          "- Mariano explicitly said that when he tells Razor there has been an error, the default interpretation should be that he wants it fixed, not merely diagnosed or acknowledged.",
+          "- Mariano clarified that the problem with cron output is overlapping, independently unreasonable crons converging into dumb sludge.",
+          "",
+          "## Versions / machine state and update work",
+          "- MB Server repo updated but the active installed runtime is still old.",
+          "- jpclawhq updated and running.",
+          "",
+          "## Other context and user preferences reinforced in this session",
+          "- Mariano prefers short, punk, high-signal copy for social posts.",
+          "- He explicitly wants the assistant to treat ADHD as a reason to reduce clutter and noise, not to produce more summaries.",
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli(["rem-harness", "--json", "--grounded", "--path", historyPath]);
+
+      const payload = firstWrittenJsonArg<{
+        grounded?: {
+          files?: Array<{
+            renderedMarkdown?: string;
+          }>;
+        } | null;
+      }>(writeJson);
+      const rendered = payload?.grounded?.files?.[0]?.renderedMarkdown ?? "";
+      expect(rendered).toContain("prefers short, punk, high-signal copy");
+      expect(rendered).not.toContain(
+        "MB Server repo updated but the active installed runtime is still old",
+      );
+      expect(rendered).not.toContain("jpclawhq updated and running");
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("suppresses monitoring-heavy operational days instead of promoting alert sludge", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const historyDir = path.join(workspaceDir, "history");
+      await fs.mkdir(historyDir, { recursive: true });
+      const historyPath = path.join(historyDir, "2025-02-17.md");
+      await fs.writeFile(
+        historyPath,
+        [
+          "## Heartbeat checks",
+          "- 04:17 (Europe/Madrid) heartbeat run.",
+          "- Ariston check returned warning/error:",
+          "  - Pressure LOW: 1.1 bar",
+          "- Action: alert Mariano on this heartbeat.",
+          "",
+          "## 07:15 life-context sync (travel + now)",
+          "- mariano@tpmcap.com calendar access failed (invalid_grant: token expired/revoked).",
+          "- memory/email-tracker.json checkpoint at 2025-02-17T07:03:53+01:00.",
+          "- memory/travel.md updated.",
+          "",
+          "## Heartbeat checks (07:18)",
+          "- Ariston check again reports low pressure: 1.1 bar.",
+          "- collect-temps.sh completed OK (exit 0).",
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli(["rem-harness", "--json", "--grounded", "--path", historyPath]);
+
+      const payload = firstWrittenJsonArg<{
+        grounded?: {
+          files?: Array<{
+            renderedMarkdown?: string;
+          }>;
+        } | null;
+      }>(writeJson);
+      const rendered = payload?.grounded?.files?.[0]?.renderedMarkdown ?? "";
+      expect(rendered).toContain("No grounded facts were extracted.");
+      expect(rendered).toContain("mostly as monitoring and operational state");
+      expect(rendered).not.toContain("Pressure LOW");
+      expect(rendered).not.toContain("invalid_grant");
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
+  it("splits multi-fact person lines into atomic grounded candidates", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const historyDir = path.join(workspaceDir, "history");
+      await fs.mkdir(historyDir, { recursive: true });
+      const historyPath = path.join(historyDir, "2025-02-19.md");
+      await fs.writeFile(
+        historyPath,
+        [
+          "## People mentioned with context",
+          "- Bunji — partner, Surrealist Ball Sat 28 Feb w/ Maga",
+          "- Bex — girlfriend, date weekend Fri-Sun London, Chateau Denmark",
+          "",
+          "## Process improvements",
+          "- Routed several inbound requests into different workflows.",
+          "- Important context was written into notes and memory surfaces.",
+        ].join("\n") + "\n",
+        "utf-8",
+      );
+
+      const close = vi.fn(async () => {});
+      mockManager({
+        status: () => makeMemoryStatus({ workspaceDir }),
+        close,
+      });
+
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      await runMemoryCli(["rem-harness", "--json", "--grounded", "--path", historyPath]);
+
+      const payload = firstWrittenJsonArg<{
+        grounded?: {
+          files?: Array<{
+            renderedMarkdown?: string;
+          }>;
+        } | null;
+      }>(writeJson);
+      const file = payload?.grounded?.files?.[0];
+      const rendered = file?.renderedMarkdown ?? "";
+      expect(rendered).toContain(
+        "1. People mentioned with context: Bunji — partner, Surrealist Ball Sat 28 Feb w/ Maga",
+      );
+      expect(rendered).toContain("Bex — girlfriend, date weekend Fri-Sun London, Chateau Denmark");
+      expect(rendered).toContain("Bunji — partner");
+      expect(rendered).toContain("Bex — girlfriend");
+      expect(rendered).toContain("Bunji — Surrealist Ball Sat 28 Feb w/ Maga");
+      expect(rendered).not.toContain("Bex — date weekend Fri-Sun London, Chateau Denmark");
+      expect(
+        file?.reflections?.some((item) =>
+          item.text.includes("More than one active relationship thread"),
+        ),
+      ).toBe(true);
+      expect(
+        file?.reflections?.some((item) =>
+          item.text.includes("converting messy inbound information into routed workflows"),
+        ),
+      ).toBe(false);
+      expect(close).toHaveBeenCalled();
+    });
+  });
+
   it("rolls back grounded rem backfill entries from DREAMS.md", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const dreamsPath = path.join(workspaceDir, "DREAMS.md");

--- a/extensions/memory-core/src/rem-evidence.ts
+++ b/extensions/memory-core/src/rem-evidence.ts
@@ -48,6 +48,8 @@ const REM_STABLE_PERSON_SIGNAL_RE =
   /\b(partner|wife|husband|boyfriend|girlfriend|relationship interest|lives in)\b/i;
 const REM_EXPLICIT_PREFERENCE_SIGNAL_RE =
   /\b(explicitly|wants?|does not want|don't want|default .* should|should default to|likes?|dislikes?|treat .* as|prefers?)\b/i;
+const REM_MONITORING_SIGNAL_RE =
+  /\b(heartbeat|ariston|collect-temps|low pressure|exit code|invalid[_-]?grant|token expired|token revoked|warning\/error|warning|alert(?:ing)?|checkpoint at|daily note file already existed|header creation|local time verified|calendar access failed|gmail .* failed|no proactive .* sent|silent log only|gateway restarted successfully|still no response|no reply yet|blocked\b|passkey|credential|password in bws|working correctly|catchup completed)\b/i;
 const REM_SPECIFICITY_BURDEN_RE =
   /\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)\b|€|\$\d|→|\b\d{1,2}:\d{2}\b|\+\d{6,}/i;
 const REM_TIME_PREFIX_RE = /^\d{1,2}:\d{2}\s*-\s*/;
@@ -388,10 +390,27 @@ function compactCandidateTitle(title: string): string {
 
 function compactCandidateSnippetText(text: string, title: string): string {
   const normalized = normalizeWhitespace(text);
+  if (REM_MONITORING_SIGNAL_RE.test(`${title} ${normalized}`)) {
+    return normalized
+      .replace(/\b(?:local time verified[^.;]*[.;]?\s*)/gi, "")
+      .replace(/\b(?:daily note file already existed[^.;]*[.;]?\s*)/gi, "")
+      .replace(/\b(?:header creation[^.;]*[.;]?\s*)/gi, "")
+      .trim();
+  }
   if (REM_STABLE_PERSON_SIGNAL_RE.test(`${title} ${normalized}`)) {
     return (normalized.split(/(?<=[.?!])\s+/)[0] ?? normalized).trim();
   }
   return normalized;
+}
+
+function isDurableSignalSnippet(text: string, title: string): boolean {
+  return (
+    REM_MEMORY_SIGNAL_RE.test(text) ||
+    REM_PERSISTENCE_SIGNAL_RE.test(text) ||
+    REM_EXPLICIT_PREFERENCE_SIGNAL_RE.test(text) ||
+    REM_STABLE_PERSON_SIGNAL_RE.test(`${title} ${text}`) ||
+    REM_PERSON_PATTERN_SIGNAL_RE.test(text)
+  );
 }
 
 function scoreCandidateSnippet(text: string, title: string): number {
@@ -428,6 +447,9 @@ function scoreCandidateSnippet(text: string, title: string): number {
   }
   if (REM_TOOLING_META_SIGNAL_RE.test(text) && !REM_STABLE_PERSON_SIGNAL_RE.test(text)) {
     score -= 2.1;
+  }
+  if (REM_MONITORING_SIGNAL_RE.test(`${title} ${text}`) && !REM_MEMORY_SIGNAL_RE.test(text)) {
+    score -= 4.2;
   }
   if (REM_TRAVEL_DECISION_SIGNAL_RE.test(text)) {
     score -= 2.6;
@@ -473,6 +495,11 @@ function chooseFactSnippets(
         scoreCandidateSnippet(text, section.title) + (REM_MEMORY_SIGNAL_RE.test(text) ? 0.6 : 0);
       return { snippet: { ...snippet, text }, score };
     })
+    .filter(
+      (entry) =>
+        !REM_MONITORING_SIGNAL_RE.test(`${section.title} ${entry.snippet.text}`) ||
+        isDurableSignalSnippet(entry.snippet.text, section.title),
+    )
     .filter((entry) => entry.snippet.text.length >= 18 && entry.score >= 1.4)
     .toSorted((left, right) => {
       if (right.score !== left.score) {
@@ -511,9 +538,21 @@ function chooseCandidateSnippets(
   return [...snippets]
     .map((snippet) => {
       const text = compactCandidateSnippetText(snippet.text, section.title);
-      const score = scoreCandidateSnippet(text, section.title);
+      const claimScores = atomizeClaimText(text).map((claim) =>
+        scoreCandidateSnippet(claim, section.title),
+      );
+      const score = Math.max(
+        scoreCandidateSnippet(text, section.title),
+        ...claimScores,
+        Number.NEGATIVE_INFINITY,
+      );
       return { snippet: { ...snippet, text }, score };
     })
+    .filter(
+      (entry) =>
+        !REM_MONITORING_SIGNAL_RE.test(`${section.title} ${entry.snippet.text}`) ||
+        isDurableSignalSnippet(entry.snippet.text, section.title),
+    )
     .filter((entry) => entry.snippet.text.length >= 18 && entry.score >= 1.8)
     .toSorted((left, right) => {
       if (right.score !== left.score) {
@@ -528,6 +567,75 @@ function chooseCandidateSnippets(
 
 function buildCandidateSnippetText(title: string, text: string): string {
   return buildFactText(title, text);
+}
+
+function findTopLevelDelimiter(text: string, delimiter: string): number {
+  let roundDepth = 0;
+  let squareDepth = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "(") {
+      roundDepth += 1;
+    } else if (char === ")") {
+      roundDepth = Math.max(0, roundDepth - 1);
+    } else if (char === "[") {
+      squareDepth += 1;
+    } else if (char === "]") {
+      squareDepth = Math.max(0, squareDepth - 1);
+    } else if (char === delimiter && roundDepth === 0 && squareDepth === 0) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function splitTopLevelClauses(text: string, delimiter: string): string[] {
+  const parts: string[] = [];
+  let rest = text;
+  while (rest.length > 0) {
+    const splitAt = findTopLevelDelimiter(rest, delimiter);
+    if (splitAt < 0) {
+      parts.push(rest);
+      break;
+    }
+    parts.push(rest.slice(0, splitAt));
+    rest = rest.slice(splitAt + 1);
+  }
+  return parts.map((part) => normalizeWhitespace(part)).filter(Boolean);
+}
+
+function splitSubjectLeadClaim(text: string): string[] {
+  const match = /^(?<subject>.+?(?:—|–|-))\s*(?<rest>.+)$/u.exec(text);
+  if (!match?.groups) {
+    return [text];
+  }
+  const subject = normalizeWhitespace(match.groups.subject);
+  const rest = normalizeWhitespace(match.groups.rest);
+  if (!subject || !rest) {
+    return [text];
+  }
+  const commaIndex = findTopLevelDelimiter(rest, ",");
+  if (commaIndex < 0) {
+    return [text];
+  }
+  const first = normalizeWhitespace(rest.slice(0, commaIndex));
+  const remainder = normalizeWhitespace(rest.slice(commaIndex + 1));
+  if (first.length < 3 || remainder.length < 6) {
+    return [text];
+  }
+  return [`${subject} ${first}`, `${subject} ${remainder}`];
+}
+
+function atomizeClaimText(text: string): string[] {
+  const normalized = normalizeWhitespace(text);
+  if (!normalized) {
+    return [];
+  }
+  const atomic = splitTopLevelClauses(normalized, ";")
+    .flatMap((part) => splitSubjectLeadClaim(part))
+    .map((part) => normalizeWhitespace(part))
+    .filter(Boolean);
+  return Array.from(new Set(atomic)).slice(0, 3);
 }
 
 function classifyCandidateLeanFromText(text: string, title: string): GroundedRemCandidate["lean"] {
@@ -575,6 +683,13 @@ function previewGroundedRemForFile(params: {
     section,
     snippets: sectionToSnippets(section),
   }));
+  const monitoringSignal = sectionScores.reduce(
+    (sum, { section, snippets }) =>
+      sum +
+      countMatchingSnippets(snippets, REM_MONITORING_SIGNAL_RE) +
+      (REM_MONITORING_SIGNAL_RE.test(section.title) ? 1 : 0),
+    0,
+  );
   const summaries = sectionScores
     .map(({ section }) => summarizeSection(params.relPath, section))
     .filter((summary): summary is SectionSummary => summary !== null);
@@ -610,18 +725,20 @@ function previewGroundedRemForFile(params: {
     if (snippets.length === 0) {
       return [];
     }
-    return chooseCandidateSnippets(section, snippets)
-      .map((snippet) => {
-        const score = scoreCandidateSnippet(snippet.text, section.title);
-        const text = buildCandidateSnippetText(section.title, snippet.text);
-        return {
-          text,
-          refs: [makeRef(params.relPath, snippet.line)],
-          lean: classifyCandidateLeanFromText(snippet.text, section.title),
-          score,
-        };
-      })
-      .filter((candidate) => candidate.text.length >= 12 && candidate.score >= 1.8);
+    return chooseCandidateSnippets(section, snippets).flatMap((snippet) =>
+      atomizeClaimText(snippet.text)
+        .map((claim) => {
+          const score = scoreCandidateSnippet(claim, section.title);
+          const text = buildCandidateSnippetText(section.title, claim);
+          return {
+            text,
+            refs: [makeRef(params.relPath, snippet.line)],
+            lean: classifyCandidateLeanFromText(claim, section.title),
+            score,
+          };
+        })
+        .filter((candidate) => candidate.text.length >= 12 && candidate.score >= 1.8),
+    );
   });
 
   const candidates = candidateSnippets
@@ -679,7 +796,7 @@ function previewGroundedRemForFile(params: {
       break;
     }
   }
-  if (facts.length === 0) {
+  if (facts.length === 0 && monitoringSignal < 3) {
     const bestFor = (metric: keyof SectionSummary["scores"]) =>
       summaries
         .filter((summary) => summary.scores[metric] > 0)
@@ -712,6 +829,8 @@ function previewGroundedRemForFile(params: {
 
   const reflections: GroundedRemPreviewItem[] = [];
   const seenReflections = new Set<string>();
+  const relationshipFacts = facts.filter((item) => REM_STABLE_PERSON_SIGNAL_RE.test(item.text));
+  const multiRelationshipContext = relationshipFacts.length >= 2;
   const buildSignal = summaries.reduce((sum, item) => sum + item.scores.build, 0);
   const incidentSignal = summaries.reduce((sum, item) => sum + item.scores.incident, 0);
   const logisticsSignal = summaries.reduce((sum, item) => sum + item.scores.logistics, 0);
@@ -735,6 +854,20 @@ function previewGroundedRemForFile(params: {
     .filter((summary) => summary.scores.externalization > 0)
     .toSorted((left, right) => right.scores.overall - left.scores.overall)[0];
 
+  if (facts.length === 0 && monitoringSignal >= 3) {
+    addReflection(
+      reflections,
+      seenReflections,
+      "This day reads mostly as monitoring and operational state, not as durable memory. It should be treated as current-state exhaust unless a clearer rule or preference appears.",
+      [
+        makeRef(
+          params.relPath,
+          sections[0]?.startLine ?? 1,
+          sections[sections.length - 1]?.endLine ?? 1,
+        ),
+      ],
+    );
+  }
   if (effectiveMemoryImplications.length > 0) {
     addReflection(
       reflections,
@@ -743,7 +876,21 @@ function previewGroundedRemForFile(params: {
       effectiveMemoryImplications.flatMap((item) => item.refs).slice(0, 3),
     );
   }
-  if (facts.length > 0 && routingSignal >= 2 && strongestRoutingSummary && buildSignal >= incidentSignal) {
+  if (multiRelationshipContext) {
+    addReflection(
+      reflections,
+      seenReflections,
+      "More than one active relationship thread appears in the same day, which means person-memory matters operationally: who each person is should be kept separate from the transient date or venue details attached to them.",
+      relationshipFacts.flatMap((item) => item.refs).slice(0, 3),
+    );
+  }
+  if (
+    !multiRelationshipContext &&
+    facts.length > 0 &&
+    routingSignal >= 2 &&
+    strongestRoutingSummary &&
+    buildSignal >= incidentSignal
+  ) {
     addReflection(
       reflections,
       seenReflections,
@@ -751,7 +898,12 @@ function previewGroundedRemForFile(params: {
       strongestRoutingSummary.refs,
     );
   }
-  if (facts.length > 0 && externalizationSignal >= 2 && strongestExternalizationSummary) {
+  if (
+    !multiRelationshipContext &&
+    facts.length > 0 &&
+    externalizationSignal >= 2 &&
+    strongestExternalizationSummary
+  ) {
     addReflection(
       reflections,
       seenReflections,
@@ -759,7 +911,7 @@ function previewGroundedRemForFile(params: {
       strongestExternalizationSummary.refs,
     );
   }
-  if (facts.length > 0 && buildSignal >= 2) {
+  if (!multiRelationshipContext && facts.length > 0 && buildSignal >= 2) {
     const buildRefs = facts
       .filter((item) => REM_BUILD_SIGNAL_RE.test(item.text))
       .flatMap((item) => item.refs)
@@ -783,7 +935,7 @@ function previewGroundedRemForFile(params: {
       strongestIncidentSummary.refs,
     );
   }
-  if (facts.length > 0 && logisticsSignal >= 2) {
+  if (!multiRelationshipContext && facts.length > 0 && logisticsSignal >= 2) {
     const logisticsRefs = facts
       .filter((item) => REM_LOGISTICS_SIGNAL_RE.test(item.text))
       .flatMap((item) => item.refs)
@@ -812,7 +964,13 @@ function previewGroundedRemForFile(params: {
     );
   }
 
-  const visibleReflections = reflections.slice(0, REM_SUMMARY_REFLECTION_LIMIT);
+  const reflectionLimit =
+    facts.length === 0
+      ? 1
+      : facts.length === 1
+        ? 2
+        : Math.min(REM_SUMMARY_REFLECTION_LIMIT, facts.length + 1);
+  const visibleReflections = reflections.slice(0, reflectionLimit);
 
   const renderedLines: string[] = [];
   renderedLines.push("## What Happened");


### PR DESCRIPTION
## Summary

- Problem: the grounded backfill lane still over-read noisy technical days and kept some multi-fact person lines as bundled memory candidates.
- Why it matters: without stricter extraction, the diary/backfill output stays too loggy to trust as future warm-memory evidence.
- What changed: tightened grounded `What Happened` selection, suppressed monitoring sludge, split durable subfacts out of multi-fact candidate lines, and made reflections more relationship-aware when that is the real signal.
- What did NOT change (scope boundary): this PR does not change the live promotion lane yet and does not add UI.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Memory / storage
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #63273
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the base backfill lane extracted grounded summaries, but it still treated some monitoring/logistics residue and bundled person lines as if they were equally memory-worthy.
- Missing detection / guardrail: the initial lane had no targeted tests for noisy operational days or multi-fact relationship lines.
- Prior context (`git blame`, prior PR, issue, or refactor if known): follow-up hardening on top of #63273.
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/cli.test.ts`
- Scenario the test should lock in: persistence-shaped fact selection, monitoring-day suppression, and atomic durable-candidate extraction from mixed person lines.
- Why this is the smallest reliable guardrail: the grounded extractor behavior is exercised directly through the CLI preview path.
- Existing test that already covers this (if any): base backfill tests live in #63273.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `What Happened` prefers more persistence-shaped grounded facts.
- monitoring-heavy days stop surfacing alert sludge as memory facts.
- `Candidates` and `Possible Lasting Updates` can split durable subfacts out of mixed person lines.
- reflections become less generic on relationship-heavy days.

## Diagram (if applicable)

```text
Before:
[daily note] -> [grounded backfill] -> [bundled/noisy facts]

After:
[daily note] -> [grounded backfill] -> [durable facts + cleaner candidates + sharper reflections]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS authoring, `mb-server` for gates
- Runtime/container: Node 22 / Vitest 4
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default memory workspace layout

### Steps

1. Run `openclaw memory rem-harness --json --grounded --path <history-dir>` on noisy and relationship-heavy day files.
2. Inspect `What Happened`, `Reflections`, and `Candidates`.

### Expected

- noisy operational days stay sparse
- durable relationship facts survive without dragging transient venue/travel details into memory candidates

### Actual

- Matches expected on the focused gate scenarios.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: noisy monitoring day suppression, persistence-weighted fact selection, atomic durable-candidate extraction.
- Edge cases checked: multi-fact relationship lines, ordering-insensitive durable candidate assertions.
- What you did **not** verify: UI rendering; that remains in a separate stacked PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: overly strict extraction could under-surface one-off but real facts.
  - Mitigation: this ships as a focused stacked hardening PR on top of the reversible backfill foundation, so we can tune it further before feeding live promotion.

