### PR TITLE
feat(ui): add dreaming diary controls and navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/provider-auth: let provider manifests declare `providerAuthAliases` so provider variants can share env vars, auth profiles, config-backed auth, and API-key onboarding choices without core-specific wiring.
 - Memory/dreaming: add a grounded REM backfill lane with historical `rem-harness --path`, diary commit, and reset flows so old daily notes can be replayed safely into `DREAMS.md`. Thanks @mbelinky.
 - Memory/dreaming: harden grounded diary extraction so `What Happened`, `Reflections`, and durable candidates suppress operational noise and preserve more atomic lasting facts. Thanks @mbelinky.
+- Control UI/dreaming: add a structured diary view with timeline navigation, backfill/reset controls, and traceable dreaming summaries. Thanks @mbelinky.
 
 ### Fixes
 

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -15,6 +15,9 @@ const resolveMemorySearchConfig = vi.hoisted(() =>
   })),
 );
 const getMemorySearchManager = vi.hoisted(() => vi.fn());
+const previewGroundedRemMarkdown = vi.hoisted(() => vi.fn());
+const writeBackfillDiaryEntries = vi.hoisted(() => vi.fn());
+const removeBackfillDiaryEntries = vi.hoisted(() => vi.fn());
 
 vi.mock("../../config/config.js", () => ({
   loadConfig,
@@ -31,6 +34,15 @@ vi.mock("../../agents/memory-search.js", () => ({
 
 vi.mock("../../plugins/memory-runtime.js", () => ({
   getActiveMemorySearchManager: getMemorySearchManager,
+}));
+
+vi.mock("../../../extensions/memory-core/src/rem-evidence.js", () => ({
+  previewGroundedRemMarkdown,
+}));
+
+vi.mock("../../../extensions/memory-core/src/dreaming-narrative.js", () => ({
+  writeBackfillDiaryEntries,
+  removeBackfillDiaryEntries,
 }));
 
 import { doctorHandlers } from "./doctor.js";
@@ -60,6 +72,28 @@ const invokeDoctorMemoryStatus = async (
 
 const invokeDoctorMemoryDreamDiary = async (respond: ReturnType<typeof vi.fn>) => {
   await doctorHandlers["doctor.memory.dreamDiary"]({
+    req: {} as never,
+    params: {} as never,
+    respond: respond as never,
+    context: {} as never,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+};
+
+const invokeDoctorMemoryBackfillDreamDiary = async (respond: ReturnType<typeof vi.fn>) => {
+  await doctorHandlers["doctor.memory.backfillDreamDiary"]({
+    req: {} as never,
+    params: {} as never,
+    respond: respond as never,
+    context: {} as never,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+};
+
+const invokeDoctorMemoryResetDreamDiary = async (respond: ReturnType<typeof vi.fn>) => {
+  await doctorHandlers["doctor.memory.resetDreamDiary"]({
     req: {} as never,
     params: {} as never,
     respond: respond as never,
@@ -123,6 +157,9 @@ describe("doctor.memory.status", () => {
           phaseSignalCount: 0,
           promotedTotal: 0,
           promotedToday: 0,
+          shortTermEntries: [],
+          signalEntries: [],
+          promotedEntries: [],
           phases: expect.objectContaining({
             deep: expect.objectContaining({
               managedCronPresent: false,
@@ -208,13 +245,20 @@ describe("doctor.memory.status", () => {
           entries: {
             "memory:memory/2026-04-03.md:1:2": {
               path: "memory/2026-04-03.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Emma prefers shorter, lower-pressure check-ins.",
               source: "memory",
               recallCount: 2,
               dailyCount: 1,
+              lastRecalledAt: recentIso,
               promotedAt: undefined,
             },
             "memory:memory/2026-04-02.md:1:2": {
               path: "memory/2026-04-02.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Use the Happy Together calendar for flights.",
               source: "memory",
               recallCount: 9,
               dailyCount: 5,
@@ -236,6 +280,9 @@ describe("doctor.memory.status", () => {
           entries: {
             "memory:memory/2026-04-01.md:1:2": {
               path: "memory/2026-04-01.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Bunji lives in London.",
               source: "memory",
               recallCount: 7,
               dailyCount: 4,
@@ -243,6 +290,9 @@ describe("doctor.memory.status", () => {
             },
             "memory:memory/2026-04-04.md:1:2": {
               path: "memory/2026-04-04.md",
+              startLine: 1,
+              endLine: 2,
+              snippet: "Always book the covered valet option at Park & Greet BCN.",
               source: "memory",
               recallCount: 8,
               dailyCount: 3,
@@ -378,6 +428,36 @@ describe("doctor.memory.status", () => {
             remPhaseHitCount: 3,
             promotedTotal: 3,
             promotedToday: 2,
+            shortTermEntries: [
+              expect.objectContaining({
+                path: "memory/2026-04-03.md",
+                snippet: "Emma prefers shorter, lower-pressure check-ins.",
+                totalSignalCount: 3,
+                lightHits: 2,
+                remHits: 3,
+                phaseHitCount: 5,
+              }),
+            ],
+            signalEntries: [
+              expect.objectContaining({
+                path: "memory/2026-04-03.md",
+                totalSignalCount: 3,
+              }),
+            ],
+            promotedEntries: expect.arrayContaining([
+              expect.objectContaining({
+                path: "memory/2026-04-04.md",
+                promotedAt: recentIso,
+              }),
+              expect.objectContaining({
+                path: "memory/2026-04-02.md",
+                promotedAt: recentIso,
+              }),
+              expect.objectContaining({
+                path: "memory/2026-04-01.md",
+                promotedAt: olderIso,
+              }),
+            ]),
             phases: expect.objectContaining({
               deep: expect.objectContaining({
                 cron: "0 */4 * * *",
@@ -629,6 +709,9 @@ describe("doctor.memory.dreamDiary", () => {
     loadConfig.mockClear();
     resolveDefaultAgentId.mockClear();
     resolveAgentWorkspaceDir.mockReset().mockReturnValue("/tmp/openclaw");
+    previewGroundedRemMarkdown.mockReset();
+    writeBackfillDiaryEntries.mockReset();
+    removeBackfillDiaryEntries.mockReset();
   });
 
   it("reads DREAMS.md when present", async () => {
@@ -669,6 +752,7 @@ describe("doctor.memory.dreamDiary", () => {
         expect.objectContaining({
           agentId: "main",
           found: true,
+          path: "DREAMS.md",
           content: "lowercase diary\n",
           updatedAtMs: expect.any(Number),
         }),
@@ -694,6 +778,78 @@ describe("doctor.memory.dreamDiary", () => {
           agentId: "main",
           found: false,
           path: "DREAMS.md",
+        }),
+        undefined,
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("backfills the dream diary from workspace memory files", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-dream-diary-backfill-"));
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "memory", "2026-02-19.md"), "source\n", "utf-8");
+    await fs.writeFile(path.join(workspaceDir, "DREAMS.md"), "# Dream Diary\n", "utf-8");
+    resolveAgentWorkspaceDir.mockReturnValue(workspaceDir);
+    previewGroundedRemMarkdown.mockResolvedValue({
+      scannedFiles: 1,
+      files: [
+        {
+          path: path.join(workspaceDir, "memory", "2026-02-19.md"),
+          renderedMarkdown: "What Happened\n1. Bunji — partner\n",
+        },
+      ],
+    });
+    writeBackfillDiaryEntries.mockResolvedValue({
+      dreamsPath: path.join(workspaceDir, "DREAMS.md"),
+      written: 1,
+      replaced: 1,
+    });
+    const respond = vi.fn();
+
+    try {
+      await invokeDoctorMemoryBackfillDreamDiary(respond);
+      expect(previewGroundedRemMarkdown).toHaveBeenCalledWith({
+        workspaceDir,
+        inputPaths: [path.join(workspaceDir, "memory", "2026-02-19.md")],
+      });
+      expect(writeBackfillDiaryEntries).toHaveBeenCalled();
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          agentId: "main",
+          action: "backfill",
+          scannedFiles: 1,
+          written: 1,
+          replaced: 1,
+        }),
+        undefined,
+      );
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resets only backfilled dream diary entries", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "doctor-dream-diary-reset-"));
+    await fs.writeFile(path.join(workspaceDir, "DREAMS.md"), "# Dream Diary\n", "utf-8");
+    resolveAgentWorkspaceDir.mockReturnValue(workspaceDir);
+    removeBackfillDiaryEntries.mockResolvedValue({
+      dreamsPath: path.join(workspaceDir, "DREAMS.md"),
+      removed: 3,
+    });
+    const respond = vi.fn();
+
+    try {
+      await invokeDoctorMemoryResetDreamDiary(respond);
+      expect(removeBackfillDiaryEntries).toHaveBeenCalledWith({ workspaceDir });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          agentId: "main",
+          action: "reset",
+          removedEntries: 3,
         }),
         undefined,
       );

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -1,5 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import {
+  removeBackfillDiaryEntries,
+  writeBackfillDiaryEntries,
+} from "../../../extensions/memory-core/src/dreaming-narrative.js";
+import { previewGroundedRemMarkdown } from "../../../extensions/memory-core/src/rem-evidence.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -13,7 +18,6 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "../../memory-host-sdk/dreaming.js";
 import { getActiveMemorySearchManager } from "../../plugins/memory-runtime.js";
-import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import { formatError } from "../server-utils.js";
 import { asRecord, normalizeTrimmedString } from "./record-shared.js";
 import type { GatewayRequestHandlers } from "./types.js";
@@ -52,6 +56,22 @@ type DoctorMemoryRemDreamingPayload = DoctorMemoryDreamingPhasePayload & {
   minPatternStrength: number;
 };
 
+type DoctorMemoryDreamingEntryPayload = {
+  key: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  snippet: string;
+  recallCount: number;
+  dailyCount: number;
+  totalSignalCount: number;
+  lightHits: number;
+  remHits: number;
+  phaseHitCount: number;
+  promotedAt?: string;
+  lastRecalledAt?: string;
+};
+
 type DoctorMemoryDreamingPayload = {
   enabled: boolean;
   timezone?: string;
@@ -72,6 +92,9 @@ type DoctorMemoryDreamingPayload = {
   lastPromotedAt?: string;
   storeError?: string;
   phaseSignalError?: string;
+  shortTermEntries: DoctorMemoryDreamingEntryPayload[];
+  signalEntries: DoctorMemoryDreamingEntryPayload[];
+  promotedEntries: DoctorMemoryDreamingEntryPayload[];
   phases: {
     light: DoctorMemoryLightDreamingPayload;
     deep: DoctorMemoryDeepDreamingPayload;
@@ -96,6 +119,45 @@ export type DoctorMemoryDreamDiaryPayload = {
   content?: string;
   updatedAtMs?: number;
 };
+
+export type DoctorMemoryDreamDiaryActionPayload = {
+  agentId: string;
+  path: string;
+  action: "backfill" | "reset";
+  found: boolean;
+  scannedFiles?: number;
+  written?: number;
+  replaced?: number;
+  removedEntries?: number;
+};
+
+function extractIsoDayFromPath(filePath: string): string | null {
+  const match = filePath.replaceAll("\\", "/").match(/(\d{4}-\d{2}-\d{2})\.md$/i);
+  return match?.[1] ?? null;
+}
+
+function groundedMarkdownToDiaryLines(markdown: string): string[] {
+  return markdown
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line, index, lines) => line.length > 0 || (index > 0 && lines[index - 1]?.length > 0));
+}
+
+async function listWorkspaceDailyFiles(memoryDir: string): Promise<string[]> {
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(memoryDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+  return entries
+    .filter((name) => /^\d{4}-\d{2}-\d{2}\.md$/i.test(name))
+    .map((name) => path.join(memoryDir, name))
+    .toSorted((left, right) => left.localeCompare(right));
+}
 
 function resolveDreamingConfig(
   cfg: OpenClawConfig,
@@ -138,6 +200,9 @@ function resolveDreamingConfig(
     verboseLogging: resolved.verboseLogging,
     storageMode: resolved.storage.mode,
     separateReports: resolved.storage.separateReports,
+    shortTermEntries: [],
+    signalEntries: [],
+    promotedEntries: [],
     phases: {
       light: {
         enabled: light.enabled,
@@ -204,7 +269,12 @@ type DreamingStoreStats = Pick<
   | "lastPromotedAt"
   | "storeError"
   | "phaseSignalError"
+  | "shortTermEntries"
+  | "signalEntries"
+  | "promotedEntries"
 >;
+
+const DREAMING_ENTRY_LIST_LIMIT = 8;
 
 function toNonNegativeInt(value: unknown): number {
   const num = Number(value);
@@ -212,6 +282,77 @@ function toNonNegativeInt(value: unknown): number {
     return 0;
   }
   return Math.max(0, Math.floor(num));
+}
+
+function parseEntryRangeFromKey(
+  key: string,
+  fallbackStartLine: unknown,
+  fallbackEndLine: unknown,
+): { startLine: number; endLine: number } {
+  const startLine = toNonNegativeInt(fallbackStartLine);
+  const endLine = toNonNegativeInt(fallbackEndLine);
+  if (startLine > 0 && endLine > 0) {
+    return { startLine, endLine };
+  }
+  const match = key.match(/:(\d+):(\d+)$/);
+  if (match) {
+    return {
+      startLine: Math.max(1, toNonNegativeInt(match[1])),
+      endLine: Math.max(1, toNonNegativeInt(match[2])),
+    };
+  }
+  return { startLine: 1, endLine: 1 };
+}
+
+function compareDreamingEntryByRecency(
+  a: DoctorMemoryDreamingEntryPayload,
+  b: DoctorMemoryDreamingEntryPayload,
+): number {
+  const aMs = a.lastRecalledAt ? Date.parse(a.lastRecalledAt) : Number.NEGATIVE_INFINITY;
+  const bMs = b.lastRecalledAt ? Date.parse(b.lastRecalledAt) : Number.NEGATIVE_INFINITY;
+  if (Number.isFinite(aMs) || Number.isFinite(bMs)) {
+    if (bMs !== aMs) {
+      return bMs - aMs;
+    }
+  }
+  if (b.totalSignalCount !== a.totalSignalCount) {
+    return b.totalSignalCount - a.totalSignalCount;
+  }
+  return a.path.localeCompare(b.path);
+}
+
+function compareDreamingEntryBySignals(
+  a: DoctorMemoryDreamingEntryPayload,
+  b: DoctorMemoryDreamingEntryPayload,
+): number {
+  if (b.totalSignalCount !== a.totalSignalCount) {
+    return b.totalSignalCount - a.totalSignalCount;
+  }
+  if (b.phaseHitCount !== a.phaseHitCount) {
+    return b.phaseHitCount - a.phaseHitCount;
+  }
+  return compareDreamingEntryByRecency(a, b);
+}
+
+function compareDreamingEntryByPromotion(
+  a: DoctorMemoryDreamingEntryPayload,
+  b: DoctorMemoryDreamingEntryPayload,
+): number {
+  const aMs = a.promotedAt ? Date.parse(a.promotedAt) : Number.NEGATIVE_INFINITY;
+  const bMs = b.promotedAt ? Date.parse(b.promotedAt) : Number.NEGATIVE_INFINITY;
+  if (Number.isFinite(aMs) || Number.isFinite(bMs)) {
+    if (bMs !== aMs) {
+      return bMs - aMs;
+    }
+  }
+  return compareDreamingEntryBySignals(a, b);
+}
+
+function trimDreamingEntries(
+  entries: DoctorMemoryDreamingEntryPayload[],
+  compare: (a: DoctorMemoryDreamingEntryPayload, b: DoctorMemoryDreamingEntryPayload) => number,
+): DoctorMemoryDreamingEntryPayload[] {
+  return entries.toSorted(compare).slice(0, DREAMING_ENTRY_LIST_LIMIT);
 }
 
 async function loadDreamingStoreStats(
@@ -238,6 +379,9 @@ async function loadDreamingStoreStats(
     let latestPromotedAtMs = Number.NEGATIVE_INFINITY;
     let latestPromotedAt: string | undefined;
     const activeKeys = new Set<string>();
+    const activeEntries = new Map<string, DoctorMemoryDreamingEntryPayload>();
+    const shortTermEntries: DoctorMemoryDreamingEntryPayload[] = [];
+    const promotedEntries: DoctorMemoryDreamingEntryPayload[] = [];
 
     for (const [entryKey, value] of Object.entries(entries)) {
       const entry = asRecord(value);
@@ -249,18 +393,45 @@ async function loadDreamingStoreStats(
       if (source !== "memory" || !entryPath || !isShortTermMemoryPath(entryPath)) {
         continue;
       }
+      const range = parseEntryRangeFromKey(entryKey, entry.startLine, entry.endLine);
+      const recallCount = toNonNegativeInt(entry.recallCount);
+      const dailyCount = toNonNegativeInt(entry.dailyCount);
+      const totalEntrySignalCount = recallCount + dailyCount;
+      const snippet =
+        normalizeTrimmedString(entry.snippet) ??
+        normalizeTrimmedString(entry.summary) ??
+        normalizeMemoryPath(entryPath);
+      const lastRecalledAt = normalizeTrimmedString(entry.lastRecalledAt);
+      const detail: DoctorMemoryDreamingEntryPayload = {
+        key: entryKey,
+        path: normalizeMemoryPath(entryPath),
+        startLine: range.startLine,
+        endLine: Math.max(range.startLine, range.endLine),
+        snippet,
+        recallCount,
+        dailyCount,
+        totalSignalCount: totalEntrySignalCount,
+        lightHits: 0,
+        remHits: 0,
+        phaseHitCount: 0,
+        ...(lastRecalledAt ? { lastRecalledAt } : {}),
+      };
       const promotedAt = normalizeTrimmedString(entry.promotedAt);
       if (!promotedAt) {
         shortTermCount += 1;
         activeKeys.add(entryKey);
-        const recallCount = toNonNegativeInt(entry.recallCount);
-        const dailyCount = toNonNegativeInt(entry.dailyCount);
         recallSignalCount += recallCount;
         dailySignalCount += dailyCount;
-        totalSignalCount += recallCount + dailyCount;
+        totalSignalCount += totalEntrySignalCount;
+        shortTermEntries.push(detail);
+        activeEntries.set(entryKey, detail);
         continue;
       }
       promotedTotal += 1;
+      promotedEntries.push({
+        ...detail,
+        promotedAt,
+      });
       const promotedAtMs = Date.parse(promotedAt);
       if (Number.isFinite(promotedAtMs) && isSameMemoryDreamingDay(promotedAtMs, nowMs, timezone)) {
         promotedToday += 1;
@@ -287,6 +458,12 @@ async function loadDreamingStoreStats(
         lightPhaseHitCount += lightHits;
         remPhaseHitCount += remHits;
         phaseSignalCount += lightHits + remHits;
+        const detail = activeEntries.get(key);
+        if (detail) {
+          detail.lightHits = lightHits;
+          detail.remHits = remHits;
+          detail.phaseHitCount = lightHits + remHits;
+        }
       }
     } catch (err) {
       const code = (err as NodeJS.ErrnoException | undefined)?.code;
@@ -307,6 +484,9 @@ async function loadDreamingStoreStats(
       promotedToday,
       storePath,
       phaseSignalPath,
+      shortTermEntries: trimDreamingEntries(shortTermEntries, compareDreamingEntryByRecency),
+      signalEntries: trimDreamingEntries(shortTermEntries, compareDreamingEntryBySignals),
+      promotedEntries: trimDreamingEntries(promotedEntries, compareDreamingEntryByPromotion),
       ...(latestPromotedAt ? { lastPromotedAt: latestPromotedAt } : {}),
       ...(phaseSignalError ? { phaseSignalError } : {}),
     };
@@ -325,6 +505,9 @@ async function loadDreamingStoreStats(
         promotedToday: 0,
         storePath,
         phaseSignalPath,
+        shortTermEntries: [],
+        signalEntries: [],
+        promotedEntries: [],
       };
     }
     return {
@@ -339,6 +522,9 @@ async function loadDreamingStoreStats(
       promotedToday: 0,
       storePath,
       phaseSignalPath,
+      shortTermEntries: [],
+      signalEntries: [],
+      promotedEntries: [],
       storeError: formatError(err),
     };
   }
@@ -360,6 +546,9 @@ function mergeDreamingStoreStats(stats: DreamingStoreStats[]): DreamingStoreStat
   const phaseSignalPaths = new Set<string>();
   const storeErrors: string[] = [];
   const phaseSignalErrors: string[] = [];
+  const shortTermEntries: DoctorMemoryDreamingEntryPayload[] = [];
+  const signalEntries: DoctorMemoryDreamingEntryPayload[] = [];
+  const promotedEntries: DoctorMemoryDreamingEntryPayload[] = [];
 
   for (const stat of stats) {
     shortTermCount += stat.shortTermCount;
@@ -383,6 +572,9 @@ function mergeDreamingStoreStats(stats: DreamingStoreStats[]): DreamingStoreStat
     if (stat.phaseSignalError) {
       phaseSignalErrors.push(stat.phaseSignalError);
     }
+    shortTermEntries.push(...stat.shortTermEntries);
+    signalEntries.push(...stat.signalEntries);
+    promotedEntries.push(...stat.promotedEntries);
     const promotedAtMs = stat.lastPromotedAt ? Date.parse(stat.lastPromotedAt) : Number.NaN;
     if (Number.isFinite(promotedAtMs) && promotedAtMs > latestPromotedAtMs) {
       latestPromotedAtMs = promotedAtMs;
@@ -400,6 +592,9 @@ function mergeDreamingStoreStats(stats: DreamingStoreStats[]): DreamingStoreStat
     remPhaseHitCount,
     promotedTotal,
     promotedToday,
+    shortTermEntries: trimDreamingEntries(shortTermEntries, compareDreamingEntryByRecency),
+    signalEntries: trimDreamingEntries(signalEntries, compareDreamingEntryBySignals),
+    promotedEntries: trimDreamingEntries(promotedEntries, compareDreamingEntryByPromotion),
     ...(storePaths.size === 1 ? { storePath: [...storePaths][0] } : {}),
     ...(phaseSignalPaths.size === 1 ? { phaseSignalPath: [...phaseSignalPaths][0] } : {}),
     ...(lastPromotedAt ? { lastPromotedAt } : {}),
@@ -438,7 +633,7 @@ function isManagedDreamingJob(
     return true;
   }
   const name = normalizeTrimmedString(job.name);
-  const payloadKind = normalizeOptionalLowercaseString(job.payload?.kind);
+  const payloadKind = normalizeTrimmedString(job.payload?.kind)?.toLowerCase();
   const payloadText = normalizeTrimmedString(job.payload?.text);
   return (
     name === params.name && payloadKind === "systemevent" && payloadText === params.payloadText
@@ -646,6 +841,65 @@ export const doctorHandlers: GatewayRequestHandlers = {
     const payload: DoctorMemoryDreamDiaryPayload = {
       agentId,
       ...dreamDiary,
+    };
+    respond(true, payload, undefined);
+  },
+  "doctor.memory.backfillDreamDiary": async ({ respond }) => {
+    const cfg = loadConfig();
+    const agentId = resolveDefaultAgentId(cfg);
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    const memoryDir = path.join(workspaceDir, "memory");
+    const sourceFiles = await listWorkspaceDailyFiles(memoryDir);
+    const grounded = await previewGroundedRemMarkdown({
+      workspaceDir,
+      inputPaths: sourceFiles,
+    });
+    const remConfig = resolveMemoryRemDreamingConfig({
+      pluginConfig: resolveMemoryDreamingPluginConfig(cfg),
+      cfg,
+    });
+    const entries = grounded.files
+      .map((file) => {
+        const isoDay = extractIsoDayFromPath(file.path);
+        if (!isoDay) {
+          return null;
+        }
+        return {
+          isoDay,
+          sourcePath: file.path,
+          bodyLines: groundedMarkdownToDiaryLines(file.renderedMarkdown),
+        };
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+    const written = await writeBackfillDiaryEntries({
+      workspaceDir,
+      entries,
+      timezone: remConfig.timezone,
+    });
+    const dreamDiary = await readDreamDiary(workspaceDir);
+    const payload: DoctorMemoryDreamDiaryActionPayload = {
+      agentId,
+      path: dreamDiary.path,
+      action: "backfill",
+      found: dreamDiary.found,
+      scannedFiles: grounded.scannedFiles,
+      written: written.written,
+      replaced: written.replaced,
+    };
+    respond(true, payload, undefined);
+  },
+  "doctor.memory.resetDreamDiary": async ({ respond }) => {
+    const cfg = loadConfig();
+    const agentId = resolveDefaultAgentId(cfg);
+    const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+    const removed = await removeBackfillDiaryEntries({ workspaceDir });
+    const dreamDiary = await readDreamDiary(workspaceDir);
+    const payload: DoctorMemoryDreamDiaryActionPayload = {
+      agentId,
+      path: dreamDiary.path,
+      action: "reset",
+      found: dreamDiary.found,
+      removedEntries: removed.removed,
     };
     respond(true, payload, undefined);
   },

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -2,9 +2,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   removeBackfillDiaryEntries,
+  previewGroundedRemMarkdown,
   writeBackfillDiaryEntries,
-} from "../../../extensions/memory-core/src/dreaming-narrative.js";
-import { previewGroundedRemMarkdown } from "../../../extensions/memory-core/src/rem-evidence.js";
+} from "../../../extensions/memory-core/api.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/config.js";

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -290,10 +290,24 @@ export const en: TranslationMap = {
       promotedSuffix: "promoted",
       nextSweepPrefix: "next sweep",
     },
+    scene: {
+      backfill: "Backfill",
+      reset: "Reset",
+      working: "Working…",
+    },
     stats: {
       shortTerm: "Short-term",
       signals: "Signals",
+      promoted: "Promoted",
       phaseHits: "Phase Hits",
+    },
+    trace: {
+      shortTerm: "Short-term",
+      signals: "Signals",
+      promoted: "Promoted",
+      emptyShortTerm: "No active short-term items.",
+      emptySignals: "No active signals.",
+      emptyPromoted: "Nothing promoted yet today.",
     },
     diary: {
       title: "Dream Diary",

--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -6,6 +6,8 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-height: 0;
+  overflow: hidden;
 }
 
 /* ---- Sub-tab bar ---- */
@@ -314,6 +316,94 @@
   background: var(--border);
 }
 
+.dreams__trace {
+  width: min(900px, calc(100% - 40px));
+  margin-top: 28px;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  z-index: 1;
+  user-select: text;
+}
+
+.dreams__trace-section {
+  background: color-mix(in oklab, var(--panel) 82%, transparent);
+  border: 1px solid color-mix(in oklab, var(--border) 78%, transparent);
+  border-radius: 16px;
+  padding: 12px;
+  min-height: 180px;
+  backdrop-filter: blur(14px);
+}
+
+.dreams__trace-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
+
+.dreams__trace-title {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+}
+
+.dreams__trace-count {
+  min-width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in oklab, var(--accent-subtle) 85%, transparent);
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.dreams__trace-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dreams__trace-item {
+  padding: 10px;
+  border-radius: 12px;
+  background: color-mix(in oklab, var(--panel-raised) 88%, transparent);
+  border: 1px solid color-mix(in oklab, var(--border) 72%, transparent);
+}
+
+.dreams__trace-snippet {
+  font-size: 13px;
+  line-height: 1.35;
+  color: var(--text);
+}
+
+.dreams__trace-source,
+.dreams__trace-meta,
+.dreams__trace-empty {
+  margin-top: 6px;
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--muted);
+}
+
+.dreams__trace-source {
+  font-family: var(--mono);
+}
+
+@media (max-width: 980px) {
+  .dreams__trace {
+    grid-template-columns: 1fr;
+    width: min(680px, calc(100% - 32px));
+  }
+}
+
 /* ---- Dreaming on/off toggle (header bar) ---- */
 
 .dreams__phase-toggle {
@@ -397,6 +487,13 @@
   color: var(--ok-muted);
 }
 
+.dreams__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 14px;
+}
+
 .dreams__status-dot {
   width: 6px;
   height: 6px;
@@ -444,6 +541,8 @@
   padding: 48px 24px 64px;
   flex: 1;
   min-height: 320px;
+  min-width: 0;
+  overflow: auto;
   background: linear-gradient(
     180deg,
     var(--bg) 0%,
@@ -490,6 +589,7 @@
   max-width: 520px;
   position: relative;
   z-index: 1;
+  flex-shrink: 0;
 }
 
 .dreams-diary__title {
@@ -554,7 +654,12 @@
   width: 100%;
   padding: 0 0 0 20px;
   z-index: 1;
+  flex-shrink: 0;
   animation: diary-entry-reveal 1.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.dreams-diary__entry--structured {
+  max-width: 1180px;
 }
 
 @keyframes diary-entry-reveal {
@@ -607,6 +712,220 @@
   font-weight: 400;
   margin-bottom: 16px;
   opacity: 0.8;
+}
+
+.dreams-diary__navigator {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 0 20px;
+  position: relative;
+  z-index: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  flex-shrink: 0;
+}
+
+.dreams-diary__navigator::-webkit-scrollbar {
+  display: none;
+}
+
+.dreams-diary__navigator-content {
+  width: max-content;
+  min-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.dreams-diary__timeline {
+  --dreams-diary-step: 44px;
+  --dreams-diary-gap: 8px;
+  width: max-content;
+  min-width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 0 2px 2px;
+  margin: 0;
+}
+
+.dreams-diary__timeline-months,
+.dreams-diary__timeline-days,
+.dreams-diary__heatmap {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: var(--dreams-diary-step);
+  gap: var(--dreams-diary-gap);
+  width: max-content;
+  min-width: 100%;
+}
+
+.dreams-diary__timeline-month {
+  font-size: 11px;
+  line-height: 1;
+  color: var(--muted);
+  opacity: 0.65;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  min-height: 12px;
+}
+
+.dreams-diary__timeline-month--ghost {
+  opacity: 0;
+}
+
+.dreams-diary__day-chip {
+  width: 100%;
+  min-width: 0;
+  padding: 6px 0;
+  border-radius: 999px;
+  border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  background: color-mix(in oklab, var(--panel) 84%, transparent);
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  text-align: center;
+}
+
+.dreams-diary__day-chip--active {
+  border-color: color-mix(in oklab, var(--accent) 44%, transparent);
+  background: color-mix(in oklab, var(--accent-subtle) 88%, transparent);
+  color: var(--text);
+}
+
+.dreams-diary__heatmap {
+  align-items: center;
+}
+
+.dreams-diary__heatmap-cell {
+  width: 100%;
+  min-width: 0;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+}
+
+.dreams-diary__heatmap-pill {
+  width: 14px;
+  aspect-ratio: 1;
+  border: 1px solid color-mix(in oklab, var(--border) 55%, transparent);
+  border-radius: 4px;
+  background: color-mix(in oklab, var(--panel) 88%, transparent);
+}
+
+.dreams-diary__heatmap-cell[data-intensity="2"] .dreams-diary__heatmap-pill {
+  background: color-mix(in oklab, var(--accent-subtle) 70%, var(--panel));
+}
+
+.dreams-diary__heatmap-cell[data-intensity="3"] .dreams-diary__heatmap-pill {
+  background: color-mix(in oklab, var(--accent) 18%, var(--panel));
+}
+
+.dreams-diary__heatmap-cell[data-intensity="4"] .dreams-diary__heatmap-pill {
+  background: color-mix(in oklab, var(--accent) 32%, var(--panel));
+}
+
+.dreams-diary__heatmap-cell--active .dreams-diary__heatmap-pill {
+  border-color: color-mix(in oklab, var(--accent-2) 60%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in oklab, var(--accent-2) 32%, transparent);
+}
+
+.dreams-diary__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.dreams-diary__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 100%;
+  padding: 18px 18px 16px;
+  border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  border-radius: 16px;
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--bg-elevated, var(--bg)) 88%, #0d0818) 0%,
+      color-mix(in oklab, var(--bg) 92%, #0d0818) 100%
+    );
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.dreams-diary__panel-title {
+  margin: 0;
+  font-size: 11px;
+  line-height: 1.3;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent-muted);
+}
+
+.dreams-diary__panel-subtitle {
+  margin-top: 2px;
+  font-size: 10px;
+  line-height: 1.3;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in oklab, var(--muted) 82%, var(--accent));
+}
+
+.dreams-diary__panel-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dreams-diary__panel-list--points {
+  gap: 0;
+}
+
+.dreams-diary__point {
+  display: grid;
+  grid-template-columns: 10px 1fr;
+  gap: 10px;
+  align-items: start;
+  padding: 10px 0;
+  border-top: 1px solid color-mix(in oklab, var(--border) 58%, transparent);
+  animation: diary-text-stream 1.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.dreams-diary__point:first-child {
+  padding-top: 0;
+  border-top: none;
+}
+
+.dreams-diary__point-bullet {
+  width: 6px;
+  height: 6px;
+  margin-top: 8px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 70%, var(--text));
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent-subtle) 75%, transparent);
+}
+
+.dreams-diary__item {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.6;
+  color: color-mix(in oklab, var(--text) 88%, var(--muted));
+}
+
+.dreams-diary__item--reflection {
+  color: color-mix(in oklab, var(--text) 78%, var(--accent));
+}
+
+.dreams-diary__item--update {
+  color: color-mix(in oklab, var(--text) 86%, var(--accent-2));
 }
 
 .dreams-diary__prose {
@@ -707,5 +1026,9 @@
 
   .dreams-diary__entry {
     padding-left: 16px;
+  }
+
+  .dreams-diary__grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -66,8 +66,10 @@ import {
   rotateDeviceToken,
 } from "./controllers/devices.ts";
 import {
+  backfillDreamDiary,
   loadDreamDiary,
   loadDreamingStatus,
+  resetDreamDiary,
   resolveConfiguredDreaming,
   updateDreamingEnabled,
 } from "./controllers/dreaming.ts";
@@ -101,19 +103,14 @@ import {
   updateSkillEnabled,
 } from "./controllers/skills.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
-import { icons } from "./icons.ts";
 import "./components/dashboard-header.ts";
+import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
 import {
   buildAgentMainSessionKey,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "./session-key.ts";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-  normalizeStringifiedOptionalString,
-} from "./string-coerce.ts";
 import { agentLogoUrl } from "./views/agents-utils.ts";
 import {
   resolveAgentConfig,
@@ -125,6 +122,7 @@ import {
 import { renderChat } from "./views/chat.ts";
 import { renderCommandPalette } from "./views/command-palette.ts";
 import { renderConfig } from "./views/config.ts";
+import { renderDreaming } from "./views/dreaming.ts";
 import { renderExecApprovalPrompt } from "./views/exec-approval.ts";
 import { renderGatewayUrlConfirmation } from "./views/gateway-url-confirmation.ts";
 import { renderLoginGate } from "./views/login-gate.ts";
@@ -162,7 +160,6 @@ const lazyLogs = createLazy(() => import("./views/logs.ts"));
 const lazyNodes = createLazy(() => import("./views/nodes.ts"));
 const lazySessions = createLazy(() => import("./views/sessions.ts"));
 const lazySkills = createLazy(() => import("./views/skills.ts"));
-const lazyDreamingView = createLazy(() => import("./views/dreaming.ts"));
 
 function formatDreamNextCycle(nextRunAtMs: number | undefined): string | null {
   if (typeof nextRunAtMs !== "number" || !Number.isFinite(nextRunAtMs)) {
@@ -212,7 +209,7 @@ function isHttpUrl(value: string): boolean {
 }
 
 function normalizeSuggestionValue(value: unknown): string {
-  return normalizeOptionalString(value) ?? "";
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function uniquePreserveOrder(values: string[]): string[] {
@@ -223,7 +220,7 @@ function uniquePreserveOrder(values: string[]): string[] {
     if (!normalized) {
       continue;
     }
-    const key = normalizeLowercaseStringOrEmpty(normalized);
+    const key = normalized.toLowerCase();
     if (seen.has(key)) {
       continue;
     }
@@ -412,7 +409,9 @@ export function renderApp(state: AppViewState) {
     new Set(
       [
         ...(state.agentsList?.agents?.map((entry) => entry.id.trim()) ?? []),
-        ...state.cronJobs.map((job) => normalizeOptionalString(job.agentId) ?? "").filter(Boolean),
+        ...state.cronJobs
+          .map((job) => (typeof job.agentId === "string" ? job.agentId.trim() : ""))
+          .filter(Boolean),
       ].filter(Boolean),
     ),
   );
@@ -426,7 +425,7 @@ export function renderApp(state: AppViewState) {
             if (job.payload.kind !== "agentTurn" || typeof job.payload.model !== "string") {
               return "";
             }
-            return normalizeOptionalString(job.payload.model) ?? "";
+            return job.payload.model.trim();
           })
           .filter(Boolean),
       ].filter(Boolean),
@@ -1291,7 +1290,7 @@ export function renderApp(state: AppViewState) {
                   const entry = Array.isArray(list)
                     ? (list[index] as { skills?: unknown })
                     : undefined;
-                  const normalizedSkill = normalizeOptionalString(skillName) ?? "";
+                  const normalizedSkill = skillName.trim();
                   if (!normalizedSkill) {
                     return;
                   }
@@ -1299,9 +1298,7 @@ export function renderApp(state: AppViewState) {
                     state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
                     [];
                   const existing = Array.isArray(entry?.skills)
-                    ? entry.skills
-                        .map((name) => normalizeStringifiedOptionalString(name) ?? "")
-                        .filter(Boolean)
+                    ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
                     : undefined;
                   const base = existing ?? allSkills;
                   const next = new Set(base);
@@ -2118,29 +2115,33 @@ export function renderApp(state: AppViewState) {
             )
           : nothing}
         ${state.tab === "dreams"
-          ? lazyRender(lazyDreamingView, (m) =>
-              m.renderDreaming({
-                active: dreamingOn,
-                shortTermCount: state.dreamingStatus?.shortTermCount ?? 0,
-                totalSignalCount: state.dreamingStatus?.totalSignalCount ?? 0,
-                phaseSignalCount: state.dreamingStatus?.phaseSignalCount ?? 0,
-                promotedCount: state.dreamingStatus?.promotedToday ?? 0,
-                dreamingOf: null,
-                nextCycle: dreamingNextCycle,
-                timezone: state.dreamingStatus?.timezone ?? null,
-                statusLoading: state.dreamingStatusLoading,
-                statusError: state.dreamingStatusError,
-                modeSaving: state.dreamingModeSaving,
-                dreamDiaryLoading: state.dreamDiaryLoading,
-                dreamDiaryError: state.dreamDiaryError,
-                dreamDiaryPath: state.dreamDiaryPath,
-                dreamDiaryContent: state.dreamDiaryContent,
-                onRefresh: refreshDreaming,
-                onRefreshDiary: () => loadDreamDiary(state),
-                onToggleEnabled: applyDreamingEnabled,
-                onRequestUpdate: requestHostUpdate,
-              }),
-            )
+          ? renderDreaming({
+              active: dreamingOn,
+              shortTermCount: state.dreamingStatus?.shortTermCount ?? 0,
+              totalSignalCount: state.dreamingStatus?.totalSignalCount ?? 0,
+              promotedCount: state.dreamingStatus?.promotedToday ?? 0,
+              phaseSignalCount: state.dreamingStatus?.phaseSignalCount ?? 0,
+              shortTermEntries: state.dreamingStatus?.shortTermEntries ?? [],
+              signalEntries: state.dreamingStatus?.signalEntries ?? [],
+              promotedEntries: state.dreamingStatus?.promotedEntries ?? [],
+              dreamingOf: null,
+              nextCycle: dreamingNextCycle,
+              timezone: state.dreamingStatus?.timezone ?? null,
+              statusLoading: state.dreamingStatusLoading,
+              statusError: state.dreamingStatusError,
+              modeSaving: state.dreamingModeSaving,
+              dreamDiaryLoading: state.dreamDiaryLoading,
+              dreamDiaryActionLoading: state.dreamDiaryActionLoading,
+              dreamDiaryError: state.dreamDiaryError,
+              dreamDiaryPath: state.dreamDiaryPath,
+              dreamDiaryContent: state.dreamDiaryContent,
+              onRefresh: refreshDreaming,
+              onRefreshDiary: () => loadDreamDiary(state),
+              onBackfillDiary: () => backfillDreamDiary(state),
+              onResetDiary: () => resetDreamDiary(state),
+              onToggleEnabled: applyDreamingEnabled,
+              onRequestUpdate: requestHostUpdate,
+            })
           : nothing}
       </main>
       ${renderExecApprovalPrompt(state)} ${renderGatewayUrlConfirmation(state)} ${nothing}

--- a/ui/src/ui/app-settings.test.ts
+++ b/ui/src/ui/app-settings.test.ts
@@ -158,6 +158,7 @@ const createHost = (tab: Tab): SettingsHost => ({
   dreamingStatus: null,
   dreamingModeSaving: false,
   dreamDiaryLoading: false,
+  dreamDiaryActionLoading: false,
   dreamDiaryError: null,
   dreamDiaryPath: null,
   dreamDiaryContent: null,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -126,6 +126,7 @@ export type AppViewState = {
   dreamingStatus: import("./controllers/dreaming.js").DreamingStatus | null;
   dreamingModeSaving: boolean;
   dreamDiaryLoading: boolean;
+  dreamDiaryActionLoading: boolean;
   dreamDiaryError: string | null;
   dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -72,7 +72,6 @@ import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import { resolveAgentIdFromSessionKey } from "./session-key.ts";
 import { loadSettings, type UiSettings } from "./storage.ts";
-import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.ts";
 import { VALID_THEME_NAMES, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
 import type {
   AgentsListResult,
@@ -119,7 +118,7 @@ function resolveOnboardingMode(): boolean {
   if (!raw) {
     return false;
   }
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
+  const normalized = raw.trim().toLowerCase();
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
@@ -227,6 +226,7 @@ export class OpenClawApp extends LitElement {
   @state() dreamingStatus: DreamingStatus | null = null;
   @state() dreamingModeSaving = false;
   @state() dreamDiaryLoading = false;
+  @state() dreamDiaryActionLoading = false;
   @state() dreamDiaryError: string | null = null;
   @state() dreamDiaryPath: string | null = null;
   @state() dreamDiaryContent: string | null = null;
@@ -737,7 +737,7 @@ export class OpenClawApp extends LitElement {
     if (!nextGatewayUrl) {
       return;
     }
-    const nextToken = normalizeOptionalString(this.pendingGatewayToken) ?? "";
+    const nextToken = this.pendingGatewayToken?.trim() || "";
     this.pendingGatewayUrl = null;
     this.pendingGatewayToken = null;
     applySettingsInternal(this as unknown as Parameters<typeof applySettingsInternal>[0], {

--- a/ui/src/ui/controllers/dreaming.test.ts
+++ b/ui/src/ui/controllers/dreaming.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  backfillDreamDiary,
   loadDreamDiary,
   loadDreamingStatus,
+  resetDreamDiary,
   resolveConfiguredDreaming,
   updateDreamingEnabled,
   type DreamingState,
@@ -21,6 +23,7 @@ function createState(): { state: DreamingState; request: ReturnType<typeof vi.fn
     dreamingStatus: null,
     dreamingModeSaving: false,
     dreamDiaryLoading: false,
+    dreamDiaryActionLoading: false,
     dreamDiaryError: null,
     dreamDiaryPath: null,
     dreamDiaryContent: null,
@@ -55,6 +58,53 @@ describe("dreaming controller", () => {
         remPhaseHitCount: 4,
         promotedTotal: 21,
         promotedToday: 2,
+        shortTermEntries: [
+          {
+            key: "memory:memory/2026-04-05.md:1:2",
+            path: "memory/2026-04-05.md",
+            startLine: 1,
+            endLine: 2,
+            snippet: "Emma prefers shorter, lower-pressure check-ins.",
+            recallCount: 2,
+            dailyCount: 1,
+            totalSignalCount: 3,
+            lightHits: 1,
+            remHits: 2,
+            phaseHitCount: 3,
+            lastRecalledAt: "2026-04-05T01:02:03.000Z",
+          },
+        ],
+        signalEntries: [
+          {
+            key: "memory:memory/2026-04-05.md:1:2",
+            path: "memory/2026-04-05.md",
+            startLine: 1,
+            endLine: 2,
+            snippet: "Emma prefers shorter, lower-pressure check-ins.",
+            recallCount: 2,
+            dailyCount: 1,
+            totalSignalCount: 3,
+            lightHits: 1,
+            remHits: 2,
+            phaseHitCount: 3,
+          },
+        ],
+        promotedEntries: [
+          {
+            key: "memory:memory/2026-04-04.md:4:5",
+            path: "memory/2026-04-04.md",
+            startLine: 4,
+            endLine: 5,
+            snippet: "Use the Happy Together calendar for flights.",
+            recallCount: 3,
+            dailyCount: 2,
+            totalSignalCount: 5,
+            lightHits: 0,
+            remHits: 0,
+            phaseHitCount: 0,
+            promotedAt: "2026-04-05T04:00:00.000Z",
+          },
+        ],
         phases: {
           light: {
             enabled: true,
@@ -99,6 +149,18 @@ describe("dreaming controller", () => {
         totalSignalCount: 20,
         phaseSignalCount: 11,
         promotedToday: 2,
+        shortTermEntries: [
+          expect.objectContaining({
+            snippet: "Emma prefers shorter, lower-pressure check-ins.",
+            totalSignalCount: 3,
+            phaseHitCount: 3,
+          }),
+        ],
+        promotedEntries: [
+          expect.objectContaining({
+            snippet: "Use the Happy Together calendar for flights.",
+          }),
+        ],
         phases: expect.objectContaining({
           deep: expect.objectContaining({
             minScore: 0.8,
@@ -339,5 +401,98 @@ describe("dreaming controller", () => {
 
     expect(state.dreamDiaryError).toContain("dream diary read failed");
     expect(state.dreamDiaryLoading).toBe(false);
+  });
+
+  it("backfills and reloads dream diary state", async () => {
+    const { state, request } = createState();
+    request.mockImplementation(async (method: string) => {
+      if (method === "doctor.memory.backfillDreamDiary") {
+        return { action: "backfill", written: 79, replaced: 79 };
+      }
+      if (method === "doctor.memory.dreamDiary") {
+        return { found: true, path: "DREAMS.md", content: "backfilled diary" };
+      }
+      if (method === "doctor.memory.status") {
+        return {
+          dreaming: {
+            enabled: true,
+            shortTermCount: 1,
+            recallSignalCount: 0,
+            dailySignalCount: 0,
+            totalSignalCount: 1,
+            phaseSignalCount: 0,
+            lightPhaseHitCount: 0,
+            remPhaseHitCount: 0,
+            promotedTotal: 0,
+            promotedToday: 0,
+            shortTermEntries: [],
+            signalEntries: [],
+            promotedEntries: [],
+            phases: {
+              light: {
+                enabled: false,
+                cron: "",
+                managedCronPresent: false,
+                lookbackDays: 0,
+                limit: 0,
+              },
+              deep: {
+                enabled: false,
+                cron: "",
+                managedCronPresent: false,
+                limit: 0,
+                minScore: 0,
+                minRecallCount: 0,
+                minUniqueQueries: 0,
+                recencyHalfLifeDays: 0,
+              },
+              rem: {
+                enabled: false,
+                cron: "",
+                managedCronPresent: false,
+                lookbackDays: 0,
+                limit: 0,
+                minPatternStrength: 0,
+              },
+            },
+          },
+        };
+      }
+      return {};
+    });
+
+    const ok = await backfillDreamDiary(state);
+
+    expect(ok).toBe(true);
+    expect(request).toHaveBeenCalledWith("doctor.memory.backfillDreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
+    expect(state.dreamDiaryContent).toBe("backfilled diary");
+    expect(state.dreamDiaryActionLoading).toBe(false);
+  });
+
+  it("resets and reloads dream diary state", async () => {
+    const { state, request } = createState();
+    request.mockImplementation(async (method: string) => {
+      if (method === "doctor.memory.resetDreamDiary") {
+        return { action: "reset", removedEntries: 79 };
+      }
+      if (method === "doctor.memory.dreamDiary") {
+        return { found: false, path: "DREAMS.md" };
+      }
+      if (method === "doctor.memory.status") {
+        return { dreaming: null };
+      }
+      return {};
+    });
+
+    const ok = await resetDreamDiary(state);
+
+    expect(ok).toBe(true);
+    expect(request).toHaveBeenCalledWith("doctor.memory.resetDreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.dreamDiary", {});
+    expect(request).toHaveBeenCalledWith("doctor.memory.status", {});
+    expect(state.dreamDiaryContent).toBeNull();
+    expect(state.dreamDiaryActionLoading).toBe(false);
   });
 });

--- a/ui/src/ui/controllers/dreaming.ts
+++ b/ui/src/ui/controllers/dreaming.ts
@@ -1,5 +1,4 @@
 import type { GatewayBrowserClient } from "../gateway.ts";
-import { normalizeOptionalLowercaseString } from "../string-coerce.ts";
 import type { ConfigSnapshot } from "../types.ts";
 
 export type DreamingPhaseId = "light" | "deep" | "rem";
@@ -33,6 +32,22 @@ type RemDreamingStatus = DreamingPhaseStatusBase & {
   minPatternStrength: number;
 };
 
+export type DreamingEntry = {
+  key: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  snippet: string;
+  recallCount: number;
+  dailyCount: number;
+  totalSignalCount: number;
+  lightHits: number;
+  remHits: number;
+  phaseHitCount: number;
+  promotedAt?: string;
+  lastRecalledAt?: string;
+};
+
 export type DreamingStatus = {
   enabled: boolean;
   timezone?: string;
@@ -52,6 +67,9 @@ export type DreamingStatus = {
   phaseSignalPath?: string;
   storeError?: string;
   phaseSignalError?: string;
+  shortTermEntries: DreamingEntry[];
+  signalEntries: DreamingEntry[];
+  promotedEntries: DreamingEntry[];
   phases: {
     light: LightDreamingStatus;
     deep: DeepDreamingStatus;
@@ -69,6 +87,13 @@ type DoctorMemoryDreamDiaryPayload = {
   content?: unknown;
 };
 
+type DoctorMemoryDreamDiaryActionPayload = {
+  action?: unknown;
+  removedEntries?: unknown;
+  written?: unknown;
+  replaced?: unknown;
+};
+
 export type DreamingState = {
   client: GatewayBrowserClient | null;
   connected: boolean;
@@ -79,6 +104,7 @@ export type DreamingState = {
   dreamingStatus: DreamingStatus | null;
   dreamingModeSaving: boolean;
   dreamDiaryLoading: boolean;
+  dreamDiaryActionLoading: boolean;
   dreamDiaryError: string | null;
   dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;
@@ -119,7 +145,7 @@ function normalizeFiniteScore(value: unknown, fallback = 0): number {
 }
 
 function normalizeStorageMode(value: unknown): DreamingStatus["storageMode"] {
-  const normalized = normalizeOptionalLowercaseString(normalizeTrimmedString(value));
+  const normalized = normalizeTrimmedString(value)?.toLowerCase();
   if (normalized === "inline" || normalized === "separate" || normalized === "both") {
     return normalized;
   }
@@ -145,7 +171,7 @@ function resolveDreamingPluginId(configValue: Record<string, unknown> | null): s
   const plugins = asRecord(configValue?.plugins);
   const slots = asRecord(plugins?.slots);
   const configuredSlot = normalizeTrimmedString(slots?.memory);
-  if (configuredSlot && normalizeOptionalLowercaseString(configuredSlot) !== "none") {
+  if (configuredSlot && configuredSlot.toLowerCase() !== "none") {
     return configuredSlot;
   }
   return DEFAULT_DREAMING_PLUGIN_ID;
@@ -167,6 +193,41 @@ export function resolveConfiguredDreaming(configValue: Record<string, unknown> |
   };
 }
 
+function normalizeDreamingEntry(raw: unknown): DreamingEntry | null {
+  const record = asRecord(raw);
+  const key = normalizeTrimmedString(record?.key);
+  const path = normalizeTrimmedString(record?.path);
+  const snippet = normalizeTrimmedString(record?.snippet);
+  if (!key || !path || !snippet) {
+    return null;
+  }
+  const promotedAt = normalizeTrimmedString(record?.promotedAt);
+  const lastRecalledAt = normalizeTrimmedString(record?.lastRecalledAt);
+  return {
+    key,
+    path,
+    startLine: Math.max(1, normalizeFiniteInt(record?.startLine, 1)),
+    endLine: Math.max(1, normalizeFiniteInt(record?.endLine, 1)),
+    snippet,
+    recallCount: normalizeFiniteInt(record?.recallCount, 0),
+    dailyCount: normalizeFiniteInt(record?.dailyCount, 0),
+    totalSignalCount: normalizeFiniteInt(record?.totalSignalCount, 0),
+    lightHits: normalizeFiniteInt(record?.lightHits, 0),
+    remHits: normalizeFiniteInt(record?.remHits, 0),
+    phaseHitCount: normalizeFiniteInt(record?.phaseHitCount, 0),
+    ...(promotedAt ? { promotedAt } : {}),
+    ...(lastRecalledAt ? { lastRecalledAt } : {}),
+  };
+}
+
+function normalizeDreamingEntries(raw: unknown): DreamingEntry[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  return raw
+    .map((entry) => normalizeDreamingEntry(entry))
+    .filter((entry): entry is DreamingEntry => entry !== null);
+}
 function normalizeDreamingStatus(raw: unknown): DreamingStatus | null {
   const record = asRecord(raw);
   if (!record) {
@@ -201,6 +262,9 @@ function normalizeDreamingStatus(raw: unknown): DreamingStatus | null {
     ...(phaseSignalPath ? { phaseSignalPath } : {}),
     ...(storeError ? { storeError } : {}),
     ...(phaseSignalError ? { phaseSignalError } : {}),
+    shortTermEntries: normalizeDreamingEntries(record.shortTermEntries),
+    signalEntries: normalizeDreamingEntries(record.signalEntries),
+    promotedEntries: normalizeDreamingEntries(record.promotedEntries),
     phases: {
       light: {
         ...normalizePhaseStatusBase(lightRecord),
@@ -272,6 +336,39 @@ export async function loadDreamDiary(state: DreamingState): Promise<void> {
   } finally {
     state.dreamDiaryLoading = false;
   }
+}
+
+async function runDreamDiaryAction(
+  state: DreamingState,
+  method: "doctor.memory.backfillDreamDiary" | "doctor.memory.resetDreamDiary",
+): Promise<boolean> {
+  if (!state.client || !state.connected || state.dreamDiaryActionLoading) {
+    return false;
+  }
+  state.dreamDiaryActionLoading = true;
+  state.dreamingStatusError = null;
+  state.dreamDiaryError = null;
+  try {
+    await state.client.request<DoctorMemoryDreamDiaryActionPayload>(method, {});
+    await loadDreamDiary(state);
+    await loadDreamingStatus(state);
+    return true;
+  } catch (err) {
+    const message = String(err);
+    state.dreamingStatusError = message;
+    state.lastError = message;
+    return false;
+  } finally {
+    state.dreamDiaryActionLoading = false;
+  }
+}
+
+export async function backfillDreamDiary(state: DreamingState): Promise<boolean> {
+  return runDreamDiaryAction(state, "doctor.memory.backfillDreamDiary");
+}
+
+export async function resetDreamDiary(state: DreamingState): Promise<boolean> {
+  return runDreamDiaryAction(state, "doctor.memory.resetDreamDiary");
 }
 
 async function writeDreamingPatch(

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -92,6 +92,71 @@ describe("control UI routing", () => {
     expect(dreamsLink).not.toBeNull();
   });
 
+  it("renders the dreaming view on the /dreaming route", async () => {
+    const app = mountApp("/dreaming");
+    app.dreamingStatus = {
+      enabled: true,
+      timezone: "Europe/Madrid",
+      verboseLogging: false,
+      storageMode: "inline",
+      separateReports: false,
+      shortTermCount: 2,
+      recallSignalCount: 1,
+      dailySignalCount: 1,
+      totalSignalCount: 2,
+      phaseSignalCount: 0,
+      lightPhaseHitCount: 0,
+      remPhaseHitCount: 0,
+      promotedTotal: 1,
+      promotedToday: 1,
+      shortTermEntries: [],
+      signalEntries: [],
+      promotedEntries: [],
+      phases: {
+        light: { enabled: true, cron: "", managedCronPresent: false, lookbackDays: 7, limit: 20 },
+        deep: {
+          enabled: true,
+          cron: "",
+          managedCronPresent: false,
+          limit: 20,
+          minScore: 0.75,
+          minRecallCount: 3,
+          minUniqueQueries: 2,
+          recencyHalfLifeDays: 7,
+        },
+        rem: {
+          enabled: true,
+          cron: "",
+          managedCronPresent: false,
+          lookbackDays: 7,
+          limit: 20,
+          minPatternStrength: 0.6,
+        },
+      },
+    };
+    app.dreamDiaryPath = "DREAMS.md";
+    app.dreamDiaryContent = [
+      "# Dream Diary",
+      "",
+      "<!-- openclaw:dreaming:diary:start -->",
+      "",
+      "---",
+      "",
+      "*January 1, 2026*",
+      "",
+      "What Happened",
+      "1. Stable operator rule surfaced.",
+      "",
+      "<!-- openclaw:dreaming:diary:end -->",
+    ].join("\n");
+    app.requestUpdate();
+    await app.updateComplete;
+
+    expect(app.tab).toBe("dreams");
+    expect(app.querySelector(".dreams__tab")).not.toBeNull();
+    expect(app.querySelector(".dreams__lobster")).not.toBeNull();
+  });
+
   it("renders the refreshed top navigation shell", async () => {
     const app = mountApp("/chat");
     await app.updateComplete;

--- a/ui/src/ui/views/dreaming.test.ts
+++ b/ui/src/ui/views/dreaming.test.ts
@@ -9,8 +9,54 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     active: true,
     shortTermCount: 47,
     totalSignalCount: 182,
-    phaseSignalCount: 29,
     promotedCount: 12,
+    phaseSignalCount: 29,
+    shortTermEntries: [
+      {
+        key: "memory:memory/2026-04-05.md:1:2",
+        path: "memory/2026-04-05.md",
+        startLine: 1,
+        endLine: 2,
+        snippet: "Emma prefers shorter, lower-pressure check-ins.",
+        recallCount: 2,
+        dailyCount: 1,
+        totalSignalCount: 3,
+        lightHits: 1,
+        remHits: 1,
+        phaseHitCount: 2,
+      },
+    ],
+    signalEntries: [
+      {
+        key: "memory:memory/2026-04-05.md:1:2",
+        path: "memory/2026-04-05.md",
+        startLine: 1,
+        endLine: 2,
+        snippet: "Emma prefers shorter, lower-pressure check-ins.",
+        recallCount: 2,
+        dailyCount: 1,
+        totalSignalCount: 3,
+        lightHits: 1,
+        remHits: 1,
+        phaseHitCount: 2,
+      },
+    ],
+    promotedEntries: [
+      {
+        key: "memory:memory/2026-04-04.md:4:5",
+        path: "memory/2026-04-04.md",
+        startLine: 4,
+        endLine: 5,
+        snippet: "Use the Happy Together calendar for flights.",
+        recallCount: 3,
+        dailyCount: 2,
+        totalSignalCount: 5,
+        lightHits: 0,
+        remHits: 0,
+        phaseHitCount: 0,
+        promotedAt: "2026-04-05T04:00:00.000Z",
+      },
+    ],
     dreamingOf: null,
     nextCycle: "4:00 AM",
     timezone: "America/Los_Angeles",
@@ -18,12 +64,15 @@ function buildProps(overrides?: Partial<DreamingProps>): DreamingProps {
     statusError: null,
     modeSaving: false,
     dreamDiaryLoading: false,
+    dreamDiaryActionLoading: false,
     dreamDiaryError: null,
     dreamDiaryPath: "DREAMS.md",
     dreamDiaryContent:
       "# Dream Diary\n\n<!-- openclaw:dreaming:diary:start -->\n\n---\n\n*April 5, 2026, 3:00 AM*\n\nThe repository whispered of forgotten endpoints tonight.\n\n<!-- openclaw:dreaming:diary:end -->",
     onRefresh: () => {},
     onRefreshDiary: () => {},
+    onBackfillDiary: () => {},
+    onResetDiary: () => {},
     onToggleEnabled: () => {},
     ...overrides,
   };
@@ -65,7 +114,33 @@ describe("dreaming view", () => {
     expect(values.length).toBe(3);
     expect(values[0]?.textContent).toBe("47");
     expect(values[1]?.textContent).toBe("182");
-    expect(values[2]?.textContent).toBe("29");
+    expect(values[2]?.textContent).toBe("12");
+  });
+
+  it("renders short-term, signals, and promoted detail sections", () => {
+    const container = renderInto(buildProps());
+    const titles = [...container.querySelectorAll(".dreams__trace-title")].map((node) =>
+      node.textContent?.trim(),
+    );
+    expect(titles).toEqual(["Short-term", "Signals", "Promoted"]);
+    expect(
+      container.querySelector('[data-kind="shortTerm"] .dreams__trace-snippet')?.textContent,
+    ).toContain("Emma prefers shorter");
+    expect(
+      container.querySelector('[data-kind="signals"] .dreams__trace-meta')?.textContent,
+    ).toContain("3 signals");
+    expect(
+      container.querySelector('[data-kind="promoted"] .dreams__trace-source')?.textContent,
+    ).toContain("memory/2026-04-04.md:4-5");
+  });
+
+  it("renders scene backfill and reset controls", () => {
+    const container = renderInto(buildProps());
+    const buttons = [...container.querySelectorAll("button")].map((node) =>
+      node.textContent?.trim(),
+    );
+    expect(buttons).toContain("Backfill");
+    expect(buttons).toContain("Reset");
   });
 
   it("shows dream bubble when active", () => {
@@ -134,6 +209,97 @@ describe("dreaming view", () => {
     expect(date?.textContent).toContain("April 5, 2026");
     const body = container.querySelector(".dreams-diary__para");
     expect(body?.textContent).toContain("forgotten endpoints");
+    setDreamSubTab("scene");
+  });
+
+  it("renders structured backfill diary entries as three panels", () => {
+    setDreamSubTab("diary");
+    const container = renderInto(
+      buildProps({
+        dreamDiaryContent: [
+          "# Dream Diary",
+          "",
+          "<!-- openclaw:dreaming:diary:start -->",
+          "",
+          "---",
+          "",
+          "*January 1, 2026*",
+          "",
+          "<!-- openclaw:dreaming:backfill-entry day=2026-01-01 source=memory/2026-01-01.md -->",
+          "",
+          "What Happened",
+          "1. Always use Happy Together for flights.",
+          "",
+          "Reflections",
+          "1. Stable preferences were made explicit.",
+          "",
+          "Candidates",
+          "- likely_durable: Happy Together rule",
+          "",
+          "Possible Lasting Updates",
+          "- Use Happy Together for flights.",
+          "",
+          "<!-- openclaw:dreaming:diary:end -->",
+        ].join("\n"),
+      }),
+    );
+    const panelTitles = [...container.querySelectorAll(".dreams-diary__panel-title")].map((node) =>
+      node.textContent?.trim(),
+    );
+    expect(panelTitles).toEqual([
+      "What Happened",
+      "Reflections",
+      "Candidates + Possible Lasting Updates",
+    ]);
+    expect(container.querySelector(".dreams-diary__panel-subtitle")?.textContent).toContain(
+      "Candidates",
+    );
+    expect(container.querySelector(".dreams-diary__item--reflection")?.textContent).toContain(
+      "Stable preferences were made explicit",
+    );
+    expect(container.querySelector(".dreams-diary__item--update")?.textContent).toContain(
+      "Use Happy Together for flights",
+    );
+    setDreamSubTab("scene");
+  });
+
+  it("renders diary day navigation and a density map", () => {
+    setDreamSubTab("diary");
+    const container = renderInto(
+      buildProps({
+        dreamDiaryContent: [
+          "# Dream Diary",
+          "",
+          "<!-- openclaw:dreaming:diary:start -->",
+          "",
+          "---",
+          "",
+          "*January 1, 2026*",
+          "",
+          "What Happened",
+          "1. First durable fact.",
+          "",
+          "---",
+          "",
+          "*January 2, 2026*",
+          "",
+          "What Happened",
+          "1. Second durable fact.",
+          "",
+          "Candidates",
+          "- candidate",
+          "",
+          "<!-- openclaw:dreaming:diary:end -->",
+        ].join("\n"),
+      }),
+    );
+    expect(container.querySelectorAll(".dreams-diary__day-chip").length).toBe(2);
+    expect(container.querySelectorAll(".dreams-diary__heatmap-cell").length).toBe(2);
+    expect(container.querySelector(".dreams-diary__timeline-month")?.textContent).toContain("Jan");
+    const labels = [...container.querySelectorAll(".dreams-diary__day-chip")].map((node) =>
+      node.textContent?.replace(/\s+/g, "").trim(),
+    );
+    expect(labels.filter(Boolean).some((label) => /^\d+\/\d+$/.test(label ?? ""))).toBe(true);
     setDreamSubTab("scene");
   });
 

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -8,6 +8,21 @@ type DiaryEntry = {
   body: string;
 };
 
+type DiaryEntryNav = {
+  date: string;
+  body: string;
+  page: number;
+  timestamp: number | null;
+  signalWeight: number;
+};
+
+type StructuredDiaryEntry = {
+  whatHappened: string[];
+  reflections: string[];
+  candidates: string[];
+  lastingUpdates: string[];
+};
+
 const DIARY_START_RE = /<!--\s*openclaw:dreaming:diary:start\s*-->/;
 const DIARY_END_RE = /<!--\s*openclaw:dreaming:diary:end\s*-->/;
 
@@ -53,12 +68,244 @@ function parseDiaryEntries(raw: string): DiaryEntry[] {
   return entries;
 }
 
+function parseDiaryTimestamp(date: string): number | null {
+  const parsed = Date.parse(date);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatDiaryChipLabel(date: string): string {
+  const parsed = parseDiaryTimestamp(date);
+  if (parsed === null) {
+    return date;
+  }
+  const value = new Date(parsed);
+  return `${value.getMonth() + 1}/${value.getDate()}`;
+}
+
+function formatDiaryMonthLabel(date: string): string {
+  const parsed = parseDiaryTimestamp(date);
+  if (parsed === null) {
+    return date;
+  }
+  return new Date(parsed).toLocaleDateString([], {
+    month: "short",
+  });
+}
+
+function normalizeStructuredDiaryItem(line: string): string {
+  return line
+    .replace(/^(?:\d+\.\s+|-\s+(?:\[[^\]]+\]\s+)?(?:[a-z_]+:\s+)?|\[[^\]]+\]\s+)/i, "")
+    .replace(/^(?:likely_durable|likely_situational|unclear):\s+/i, "")
+    .trim();
+}
+
+function parseStructuredDiaryEntry(body: string): StructuredDiaryEntry | null {
+  const lines = body
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return null;
+  }
+  const sections: StructuredDiaryEntry = {
+    whatHappened: [],
+    reflections: [],
+    candidates: [],
+    lastingUpdates: [],
+  };
+  let current: keyof StructuredDiaryEntry | null = null;
+  for (const line of lines) {
+    if (line === "What Happened") {
+      current = "whatHappened";
+      continue;
+    }
+    if (line === "Reflections") {
+      current = "reflections";
+      continue;
+    }
+    if (line === "Candidates") {
+      current = "candidates";
+      continue;
+    }
+    if (line === "Possible Lasting Updates") {
+      current = "lastingUpdates";
+      continue;
+    }
+    if (!current) {
+      continue;
+    }
+    sections[current].push(normalizeStructuredDiaryItem(line));
+  }
+  if (
+    sections.whatHappened.length === 0 &&
+    sections.reflections.length === 0 &&
+    sections.candidates.length === 0 &&
+    sections.lastingUpdates.length === 0
+  ) {
+    return null;
+  }
+  return sections;
+}
+
+function scoreStructuredDiaryEntry(entry: StructuredDiaryEntry | null): number {
+  if (!entry) {
+    return 1;
+  }
+  return Math.max(
+    1,
+    entry.whatHappened.length +
+      entry.reflections.length +
+      entry.candidates.length * 2 +
+      entry.lastingUpdates.length * 3,
+  );
+}
+
+function buildDiaryNavigation(entries: DiaryEntry[]): DiaryEntryNav[] {
+  const reversed = [...entries].toReversed();
+  return reversed.map((entry, page) => ({
+    ...entry,
+    page,
+    timestamp: parseDiaryTimestamp(entry.date),
+    signalWeight: scoreStructuredDiaryEntry(parseStructuredDiaryEntry(entry.body)),
+  }));
+}
+
+const DIARY_LABEL_INTERVAL = 7;
+
+function shouldShowDiaryLabel(
+  entries: DiaryEntryNav[],
+  index: number,
+  activePage: number,
+): boolean {
+  if (index === activePage || index === 0 || index % DIARY_LABEL_INTERVAL === 0) {
+    return true;
+  }
+  const previous = entries[index - 1];
+  return (
+    formatDiaryMonthLabel(previous?.date ?? "") !==
+    formatDiaryMonthLabel(entries[index]?.date ?? "")
+  );
+}
+
+function renderDiaryNavigator(
+  entries: DiaryEntryNav[],
+  activePage: number,
+  requestUpdate?: () => void,
+) {
+  return html`
+    <div class="dreams-diary__timeline" aria-label="Diary day browser">
+      <div class="dreams-diary__timeline-months">
+        ${entries.map((entry, index) => {
+          const previous = entries[index - 1];
+          const showLabel =
+            index === 0 ||
+            formatDiaryMonthLabel(previous?.date ?? "") !== formatDiaryMonthLabel(entry.date);
+          return html`
+            <span
+              class="dreams-diary__timeline-month ${showLabel
+                ? ""
+                : "dreams-diary__timeline-month--ghost"}"
+            >
+              ${showLabel ? formatDiaryMonthLabel(entry.date) : ""}
+            </span>
+          `;
+        })}
+      </div>
+      <div class="dreams-diary__timeline-days">
+        ${entries.map(
+          (entry, index) => html`
+            <button
+              class="dreams-diary__day-chip ${entry.page === activePage
+                ? "dreams-diary__day-chip--active"
+                : ""}"
+              @click=${() => {
+                setDiaryPage(entry.page);
+                requestUpdate?.();
+              }}
+              title=${entry.date}
+            >
+              ${shouldShowDiaryLabel(entries, index, activePage)
+                ? formatDiaryChipLabel(entry.date)
+                : html`<span aria-hidden="true">&nbsp;</span>`}
+            </button>
+          `,
+        )}
+      </div>
+      <div class="dreams-diary__heatmap" aria-label="Diary activity map">
+        ${entries.map((entry) => {
+          const intensity = Math.min(4, Math.max(1, entry.signalWeight));
+          return html`
+            <button
+              class="dreams-diary__heatmap-cell ${entry.page === activePage
+                ? "dreams-diary__heatmap-cell--active"
+                : ""}"
+              data-intensity=${String(intensity)}
+              @click=${() => {
+                setDiaryPage(entry.page);
+                requestUpdate?.();
+              }}
+              title=${`${entry.date} · ${entry.signalWeight} signals`}
+            >
+              <span class="dreams-diary__heatmap-pill"></span>
+            </button>
+          `;
+        })}
+      </div>
+    </div>
+  `;
+}
+
 export type DreamingProps = {
   active: boolean;
   shortTermCount: number;
   totalSignalCount: number;
-  phaseSignalCount: number;
   promotedCount: number;
+  phaseSignalCount: number;
+  shortTermEntries: {
+    key: string;
+    path: string;
+    startLine: number;
+    endLine: number;
+    snippet: string;
+    recallCount: number;
+    dailyCount: number;
+    totalSignalCount: number;
+    lightHits: number;
+    remHits: number;
+    phaseHitCount: number;
+    promotedAt?: string;
+    lastRecalledAt?: string;
+  }[];
+  signalEntries: {
+    key: string;
+    path: string;
+    startLine: number;
+    endLine: number;
+    snippet: string;
+    recallCount: number;
+    dailyCount: number;
+    totalSignalCount: number;
+    lightHits: number;
+    remHits: number;
+    phaseHitCount: number;
+    promotedAt?: string;
+    lastRecalledAt?: string;
+  }[];
+  promotedEntries: {
+    key: string;
+    path: string;
+    startLine: number;
+    endLine: number;
+    snippet: string;
+    recallCount: number;
+    dailyCount: number;
+    totalSignalCount: number;
+    lightHits: number;
+    remHits: number;
+    phaseHitCount: number;
+    promotedAt?: string;
+    lastRecalledAt?: string;
+  }[];
   dreamingOf: string | null;
   nextCycle: string | null;
   timezone: string | null;
@@ -66,11 +313,14 @@ export type DreamingProps = {
   statusError: string | null;
   modeSaving: boolean;
   dreamDiaryLoading: boolean;
+  dreamDiaryActionLoading: boolean;
   dreamDiaryError: string | null;
   dreamDiaryPath: string | null;
   dreamDiaryContent: string | null;
   onRefresh: () => void;
   onRefreshDiary: () => void;
+  onBackfillDiary: () => void;
+  onResetDiary: () => void;
   onToggleEnabled: (enabled: boolean) => void;
   onRequestUpdate?: () => void;
 };
@@ -278,6 +528,25 @@ function renderScene(props: DreamingProps, idle: boolean, dreamText: string) {
         </div>
       </div>
 
+      <div class="dreams__actions">
+        <button
+          class="btn btn--subtle btn--sm"
+          ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
+          @click=${() => props.onBackfillDiary()}
+        >
+          ${props.dreamDiaryActionLoading
+            ? t("dreaming.scene.working")
+            : t("dreaming.scene.backfill")}
+        </button>
+        <button
+          class="btn btn--subtle btn--sm"
+          ?disabled=${props.modeSaving || props.dreamDiaryActionLoading}
+          @click=${() => props.onResetDiary()}
+        >
+          ${t("dreaming.scene.reset")}
+        </button>
+      </div>
+
       <div class="dreams__stats">
         <div class="dreams__stat">
           <span class="dreams__stat-value" style="color: var(--text-strong);"
@@ -295,15 +564,113 @@ function renderScene(props: DreamingProps, idle: boolean, dreamText: string) {
         <div class="dreams__stat-divider"></div>
         <div class="dreams__stat">
           <span class="dreams__stat-value" style="color: var(--accent-2);"
-            >${props.phaseSignalCount}</span
+            >${props.promotedCount}</span
           >
-          <span class="dreams__stat-label">${t("dreaming.stats.phaseHits")}</span>
+          <span class="dreams__stat-label">${t("dreaming.stats.promoted")}</span>
         </div>
+      </div>
+
+      <div class="dreams__trace">
+        ${renderTraceSection("shortTerm", props.shortTermEntries, {
+          count: props.shortTermCount,
+          emptyKey: "dreaming.trace.emptyShortTerm",
+          meta: (entry) =>
+            [
+              entry.recallCount > 0
+                ? `${entry.recallCount} recall${entry.recallCount === 1 ? "" : "s"}`
+                : null,
+              entry.dailyCount > 0 ? `${entry.dailyCount} daily` : null,
+              entry.phaseHitCount > 0
+                ? `${entry.phaseHitCount} phase hit${entry.phaseHitCount === 1 ? "" : "s"}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" · "),
+        })}
+        ${renderTraceSection("signals", props.signalEntries, {
+          count: props.totalSignalCount,
+          emptyKey: "dreaming.trace.emptySignals",
+          meta: (entry) =>
+            [
+              `${entry.totalSignalCount} signal${entry.totalSignalCount === 1 ? "" : "s"}`,
+              entry.phaseHitCount > 0
+                ? `${entry.phaseHitCount} phase hit${entry.phaseHitCount === 1 ? "" : "s"}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" · "),
+        })}
+        ${renderTraceSection("promoted", props.promotedEntries, {
+          count: props.promotedCount,
+          emptyKey: "dreaming.trace.emptyPromoted",
+          meta: (entry) =>
+            [
+              entry.promotedAt ? formatCompactDateTime(entry.promotedAt) : null,
+              entry.totalSignalCount > 0
+                ? `${entry.totalSignalCount} signal${entry.totalSignalCount === 1 ? "" : "s"} before promote`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" · "),
+        })}
       </div>
 
       ${props.statusError
         ? html`<div class="dreams__controls-error">${props.statusError}</div>`
         : nothing}
+    </section>
+  `;
+}
+
+function formatRange(path: string, startLine: number, endLine: number): string {
+  return startLine === endLine ? `${path}:${startLine}` : `${path}:${startLine}-${endLine}`;
+}
+
+function formatCompactDateTime(value: string): string {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    return value;
+  }
+  return new Date(parsed).toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function renderTraceSection(
+  kind: "shortTerm" | "signals" | "promoted",
+  entries: DreamingProps["shortTermEntries"],
+  options: {
+    count: number;
+    emptyKey: string;
+    meta: (entry: DreamingProps["shortTermEntries"][number]) => string;
+  },
+) {
+  return html`
+    <section class="dreams__trace-section">
+      <div class="dreams__trace-header">
+        <span class="dreams__trace-title">${t(`dreaming.trace.${kind}`)}</span>
+        <span class="dreams__trace-count">${options.count}</span>
+      </div>
+      ${entries.length === 0
+        ? html`<div class="dreams__trace-empty">${t(options.emptyKey)}</div>`
+        : html`
+            <div class="dreams__trace-list">
+              ${entries.map(
+                (entry) => html`
+                  <article class="dreams__trace-item" data-kind=${kind} data-key=${entry.key}>
+                    <div class="dreams__trace-snippet">${entry.snippet}</div>
+                    <div class="dreams__trace-source">
+                      ${formatRange(entry.path, entry.startLine, entry.endLine)}
+                    </div>
+                    <div class="dreams__trace-meta">${options.meta(entry)}</div>
+                  </article>
+                `,
+              )}
+            </div>
+          `}
     </section>
   `;
 }
@@ -361,13 +728,13 @@ function renderDiarySection(props: DreamingProps) {
     `;
   }
 
-  // Show most recent entries first (reverse chronological).
-  const reversed = [...entries].toReversed();
+  const reversed = buildDiaryNavigation(entries);
   // Clamp page.
   const page = Math.max(0, Math.min(_diaryPage, reversed.length - 1));
   const entry = reversed[page];
   const hasPrev = page > 0;
   const hasNext = page < reversed.length - 1;
+  const structured = parseStructuredDiaryEntry(entry.body);
 
   return html`
     <section class="dreams-diary">
@@ -410,19 +777,109 @@ function renderDiarySection(props: DreamingProps) {
         </button>
       </div>
 
-      <article class="dreams-diary__entry" key="${page}">
+      <div class="dreams-diary__navigator">
+        <div class="dreams-diary__navigator-content">
+          ${renderDiaryNavigator(reversed, page, props.onRequestUpdate)}
+        </div>
+      </div>
+
+      <article
+        class="dreams-diary__entry ${structured ? "dreams-diary__entry--structured" : ""}"
+        key="${page}"
+      >
         <div class="dreams-diary__accent"></div>
         ${entry.date ? html`<time class="dreams-diary__date">${entry.date}</time>` : nothing}
-        <div class="dreams-diary__prose">
-          ${entry.body
-            .split("\n")
-            .map(
-              (para, i) =>
-                html`<p class="dreams-diary__para" style="animation-delay: ${0.3 + i * 0.15}s;">
-                  ${para}
-                </p>`,
-            )}
-        </div>
+        ${structured
+          ? html`
+              <div class="dreams-diary__grid">
+                <section class="dreams-diary__panel">
+                  <h3 class="dreams-diary__panel-title">What Happened</h3>
+                  <div class="dreams-diary__panel-list dreams-diary__panel-list--points">
+                    ${structured.whatHappened.map(
+                      (item, i) => html`
+                        <div
+                          class="dreams-diary__point"
+                          style="animation-delay: ${0.2 + i * 0.06}s;"
+                        >
+                          <span class="dreams-diary__point-bullet"></span>
+                          <p class="dreams-diary__item">${item}</p>
+                        </div>
+                      `,
+                    )}
+                  </div>
+                </section>
+                <section class="dreams-diary__panel">
+                  <h3 class="dreams-diary__panel-title">Reflections</h3>
+                  <div class="dreams-diary__panel-list dreams-diary__panel-list--points">
+                    ${structured.reflections.map(
+                      (item, i) => html`
+                        <div
+                          class="dreams-diary__point"
+                          style="animation-delay: ${0.26 + i * 0.06}s;"
+                        >
+                          <span class="dreams-diary__point-bullet"></span>
+                          <p class="dreams-diary__item dreams-diary__item--reflection">${item}</p>
+                        </div>
+                      `,
+                    )}
+                  </div>
+                </section>
+                <section class="dreams-diary__panel">
+                  <h3 class="dreams-diary__panel-title">Candidates + Possible Lasting Updates</h3>
+                  ${structured.candidates.length > 0
+                    ? html`
+                        <div class="dreams-diary__panel-subtitle">Candidates</div>
+                        <div class="dreams-diary__panel-list dreams-diary__panel-list--points">
+                          ${structured.candidates.map(
+                            (item, i) => html`
+                              <div
+                                class="dreams-diary__point"
+                                style="animation-delay: ${0.32 + i * 0.06}s;"
+                              >
+                                <span class="dreams-diary__point-bullet"></span>
+                                <p class="dreams-diary__item">${item}</p>
+                              </div>
+                            `,
+                          )}
+                        </div>
+                      `
+                    : nothing}
+                  ${structured.lastingUpdates.length > 0
+                    ? html`
+                        <div class="dreams-diary__panel-subtitle">Possible Lasting Updates</div>
+                        <div class="dreams-diary__panel-list dreams-diary__panel-list--points">
+                          ${structured.lastingUpdates.map(
+                            (item, i) => html`
+                              <div
+                                class="dreams-diary__point"
+                                style="animation-delay: ${0.38 + i * 0.06}s;"
+                              >
+                                <span class="dreams-diary__point-bullet"></span>
+                                <p class="dreams-diary__item dreams-diary__item--update">${item}</p>
+                              </div>
+                            `,
+                          )}
+                        </div>
+                      `
+                    : nothing}
+                </section>
+              </div>
+            `
+          : html`
+              <div class="dreams-diary__prose">
+                ${entry.body
+                  .split("\n")
+                  .map(
+                    (para, i) =>
+                      html`<p
+                        class="dreams-diary__para"
+                        style="animation-delay: ${0.3 + i * 0.15}s;"
+                      >
+                        ${para}
+                      </p>`,
+                  )}
+              </div>
+            `}
       </article>
     </section>
   `;


### PR DESCRIPTION
## Summary

- Problem: the grounded diary/backfill lane was only inspectable via raw markdown and the existing Dreams UI made it hard to browse days, inspect grounded output, or trigger rebuild/reset flows.
- Why it matters: we need a usable review surface before deciding which grounded candidate truths should feed the live dreaming evidence lane.
- What changed: added diary navigation, three-column grounded diary presentation, scene-level backfill/reset controls, and the gateway doctor surface those controls need.
- What did NOT change (scope boundary): this PR does not change grounded extraction logic and does not wire grounded candidates into live promotion.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX
- [x] Memory / storage
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Integrations
- [ ] API / contracts
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #63273
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: the backfill lane had no usable control surface or browseable diary presentation.
- Missing detection / guardrail: we had no focused UI/controller tests for grounded diary actions and rendering.
- Prior context (`git blame`, prior PR, issue, or refactor if known): UI follow-up on top of #63273.
- Why this regressed now: N/A
- If unknown, what was ruled out: N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-methods/doctor.test.ts`, `ui/src/ui/controllers/dreaming.test.ts`, `ui/src/ui/views/dreaming.test.ts`, `ui/src/ui/navigation.browser.test.ts`
- Scenario the test should lock in: diary action RPCs, diary render layout/data, and browser navigation behavior.
- Why this is the smallest reliable guardrail: these seams cover the full UI control loop without requiring a live gateway/browser E2E.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Dreams Diary gets a timeline/heatmap navigator and a three-column grounded layout.
- Scene gets `Backfill` and `Reset` controls for the diary backfill lane.
- grounded diary content is easier to inspect day by day.

## Diagram (if applicable)

```text
Before:
[user opens Dreams] -> [summary card + raw/weak diary inspection]

After:
[user opens Dreams] -> [timeline + heatmap + 3-column diary]
                     -> [Backfill / Reset controls]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: the UI can now trigger grounded diary backfill/reset through the doctor gateway surface. The server-side actions remain workspace-local and marker-scoped; reset only removes backfilled diary entries.

## Repro + Verification

### Environment

- OS: macOS authoring, `mb-server` for gates
- Runtime/container: Node 22 / Vitest 4
- Model/provider: N/A
- Integration/channel (if any): Control UI / gateway doctor RPC
- Relevant config (redacted): default memory workspace layout

### Steps

1. Open Dreams.
2. Navigate the diary with the timeline/heatmap.
3. Trigger `Backfill` and `Reset` from Scene.

### Expected

- diary renders in 3 columns with navigation
- controls call the right gateway methods and reload state

### Actual

- Matches expected in focused UI/gateway tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: diary navigation/rendering, scene action control loop, doctor action endpoints.
- Edge cases checked: loading state, navigation token warnings already covered by existing browser tests.
- What you did **not** verify: manual screenshot attachment in this draft.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: UI and doctor action surface could drift from the grounded backfill lane if the CLI side changes later.
  - Mitigation: this PR is stacked directly on the backfill foundation PR and has focused controller/server tests for the action loop.

