### PR TITLE
fix(net): rename SsrFBlockedError to SsrfBlockedError for consistency

### DIFF
--- a/extensions/browser/src/browser/cdp.test.ts
+++ b/extensions/browser/src/browser/cdp.test.ts
@@ -1,7 +1,7 @@
 import { createServer } from "node:http";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type WebSocket, WebSocketServer } from "ws";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import { rawDataToString } from "../infra/ws.js";
 import { isWebSocketUrl } from "./cdp.helpers.js";
 import { createTargetViaCdp, evaluateJavaScript, normalizeCdpWsUrl, snapshotAria } from "./cdp.js";
@@ -162,7 +162,7 @@ describe("cdp", () => {
           cdpUrl: "ws://127.0.0.1:9222",
           url: "http://127.0.0.1:8080",
         }),
-      ).rejects.toBeInstanceOf(SsrFBlockedError);
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
       // SSRF check happens before any connection attempt
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
@@ -178,7 +178,7 @@ describe("cdp", () => {
           cdpUrl: "http://127.0.0.1:9222",
           url: "http://127.0.0.1:8080",
         }),
-      ).rejects.toBeInstanceOf(SsrFBlockedError);
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
       fetchSpy.mockRestore();
@@ -241,7 +241,7 @@ describe("cdp", () => {
           allowedHostnames: ["127.0.0.1"],
         },
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it("blocks the initial /json/version fetch when the cdpUrl host is outside strict SSRF policy", async () => {
@@ -254,7 +254,7 @@ describe("cdp", () => {
           allowedHostnames: ["127.0.0.1"],
         },
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it("blocks direct websocket cdp urls outside strict SSRF policy", async () => {
@@ -267,7 +267,7 @@ describe("cdp", () => {
           allowedHostnames: ["127.0.0.1"],
         },
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it("evaluates javascript via CDP", async () => {

--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -6,7 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import {
   decorateOpenClawProfile,
   ensureProfileCleanExit,
@@ -357,7 +357,7 @@ describe("browser chrome helpers", () => {
           dangerouslyAllowPrivateNetwork: false,
           allowedHostnames: ["127.0.0.1"],
         }),
-      ).rejects.toBeInstanceOf(SsrFBlockedError);
+      ).rejects.toBeInstanceOf(SsrfBlockedError);
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }

--- a/extensions/browser/src/browser/errors.ts
+++ b/extensions/browser/src/browser/errors.ts
@@ -1,4 +1,4 @@
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 
 export class BrowserError extends Error {
@@ -75,7 +75,7 @@ export function toBrowserErrorResponse(err: unknown): {
   if (err instanceof Error && err.name === "BlockedBrowserTargetError") {
     return { status: 409, message: err.message };
   }
-  if (err instanceof SsrFBlockedError) {
+  if (err instanceof SsrfBlockedError) {
     return { status: 400, message: err.message };
   }
   if (

--- a/extensions/browser/src/browser/navigation-guard.test.ts
+++ b/extensions/browser/src/browser/navigation-guard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SsrFBlockedError, type LookupFn } from "../infra/net/ssrf.js";
+import { SsrfBlockedError, type LookupFn } from "../infra/net/ssrf.js";
 import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationRedirectChainAllowed,
@@ -38,7 +38,7 @@ describe("browser navigation guard", () => {
       assertBrowserNavigationAllowed({
         url: "http://127.0.0.1:8080",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it("allows about:blank", async () => {
@@ -102,7 +102,7 @@ describe("browser navigation guard", () => {
         url: "https://example.com",
         lookupFn,
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it("allows hostnames that resolve to public addresses", async () => {
@@ -154,7 +154,7 @@ describe("browser navigation guard", () => {
         url: "http://private.test",
         lookupFn,
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it("ignores non-network browser-internal final URLs", async () => {
@@ -188,7 +188,7 @@ describe("browser navigation guard", () => {
             : publicLookup(hostname, { all: true }),
         ) as unknown as LookupFn,
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
   });
 
   it("allows redirect chains when every hop is public", async () => {

--- a/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
+++ b/extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
@@ -1,6 +1,6 @@
 import { chromium } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import * as chromeModule from "./chrome.js";
 import { BrowserTabNotFoundError } from "./errors.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
@@ -210,7 +210,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         cdpUrl: "http://127.0.0.1:18792",
         url: "https://93.184.216.34/start",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     expect(pageGoto).toHaveBeenCalledTimes(1);
     expect(pageClose).toHaveBeenCalledTimes(1);
@@ -231,7 +231,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         cdpUrl: "http://127.0.0.1:18792",
         url: "https://93.184.216.34/start",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     expect(pageGoto).toHaveBeenCalledTimes(1);
     expect(pageClose).toHaveBeenCalledTimes(1);
@@ -379,7 +379,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         cdpUrl: "http://127.0.0.1:18792",
         url: "https://93.184.216.34/start",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     const pages = await listPagesViaPlaywright({ cdpUrl: "http://127.0.0.1:18792" });
     expect(pages).toHaveLength(0);
@@ -407,7 +407,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         cdpUrl: "http://127.0.0.1:18792",
         url: "https://93.184.216.34/start",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     await forceDisconnectPlaywrightForTarget({
       cdpUrl: "http://127.0.0.1:18792",
@@ -433,7 +433,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         cdpUrl: "http://127.0.0.1:18792",
         url: "https://93.184.216.34/start",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     const disconnectedHandler = getBrowserDisconnectedHandler();
     expect(disconnectedHandler).toBeTypeOf("function");
@@ -457,7 +457,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         cdpUrl: "http://127.0.0.1:18792",
         url: "https://93.184.216.34/start",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     sessionSend.mockRejectedValueOnce(new Error("Target lookup failed"));
     await expect(
@@ -477,7 +477,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         cdpUrl: "http://127.0.0.1:18792",
         url: "https://93.184.216.34/start",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     sessionSend.mockImplementationOnce(async (method: string) => {
       if (method === "Target.getTargetInfo") {
@@ -543,7 +543,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         timeoutMs: 1000,
         targetId: "MISSING_TARGET",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     await expect(
       getPageForTargetId({
@@ -583,7 +583,7 @@ describe("pw-session createPageViaPlaywright navigation guard", () => {
         timeoutMs: 1000,
         targetId: "TARGET_1",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     await forceDisconnectPlaywrightForTarget({
       cdpUrl: "http://127.0.0.1:18792",

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -10,7 +10,7 @@ import type {
 } from "playwright-core";
 import { chromium } from "playwright-core";
 import { formatErrorMessage } from "../infra/errors.js";
-import { SsrFBlockedError, type SsrFPolicy } from "../infra/net/ssrf.js";
+import { SsrfBlockedError, type SsrFPolicy } from "../infra/net/ssrf.js";
 import { withNoProxyForCdpUrl } from "./cdp-proxy-bypass.js";
 import {
   appendCdpPath,
@@ -694,7 +694,7 @@ function isTopLevelNavigationRequest(page: Page, request: Request): boolean {
 }
 
 function isPolicyDenyNavigationError(err: unknown): boolean {
-  return err instanceof SsrFBlockedError || err instanceof InvalidBrowserNavigationUrlError;
+  return err instanceof SsrfBlockedError || err instanceof InvalidBrowserNavigationUrlError;
 }
 
 async function closeBlockedNavigationTarget(opts: {

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import { InvalidBrowserNavigationUrlError } from "./navigation-guard.js";
 import {
   getPwToolsCoreSessionMocks,
@@ -129,7 +129,7 @@ describe("pw-tools-core.snapshot navigate guard", () => {
       url: vi.fn(() => "https://93.184.216.34/final"),
     });
     getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely.mockRejectedValueOnce(
-      new SsrFBlockedError("Blocked hostname or private/internal/special-use IP address"),
+      new SsrfBlockedError("Blocked hostname or private/internal/special-use IP address"),
     );
 
     await expect(
@@ -137,7 +137,7 @@ describe("pw-tools-core.snapshot navigate guard", () => {
         cdpUrl: "http://127.0.0.1:18792",
         url: "https://93.184.216.34/start",
       }),
-    ).rejects.toBeInstanceOf(SsrFBlockedError);
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
 
     expect(getPwToolsCoreSessionMocks().gotoPageWithNavigationGuard).toHaveBeenCalledTimes(1);
     expect(getPwToolsCoreSessionMocks().assertPageNavigationCompletedSafely).toHaveBeenCalledTimes(

--- a/extensions/browser/src/browser/server-context.ts
+++ b/extensions/browser/src/browser/server-context.ts
@@ -1,4 +1,4 @@
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import { isChromeReachable, resolveOpenClawUserDataDir } from "./chrome.js";
 import type { ResolvedBrowserProfile } from "./config.js";
 import { resolveProfile } from "./config.js";
@@ -229,7 +229,7 @@ export function createBrowserRouteContext(opts: ContextOptions): BrowserRouteCon
     if (browserMapped) {
       return browserMapped;
     }
-    if (err instanceof SsrFBlockedError) {
+    if (err instanceof SsrfBlockedError) {
       return { status: 400, message: err.message };
     }
     if (err instanceof InvalidBrowserNavigationUrlError) {

--- a/extensions/browser/src/infra/net/ssrf.ts
+++ b/extensions/browser/src/infra/net/ssrf.ts
@@ -1,5 +1,5 @@
 export {
-  SsrFBlockedError,
+  SsrfBlockedError,
   isPrivateNetworkAllowedByPolicy,
   resolvePinnedHostnameWithPolicy,
   type LookupFn,

--- a/extensions/tlon/runtime-api.ts
+++ b/extensions/tlon/runtime-api.ts
@@ -14,4 +14,4 @@ export {
   type LookupFn,
   type SsrFPolicy,
 } from "openclaw/plugin-sdk/ssrf-runtime";
-export { SsrFBlockedError } from "openclaw/plugin-sdk/browser-security-runtime";
+export { SsrfBlockedError } from "openclaw/plugin-sdk/browser-security-runtime";

--- a/extensions/tlon/src/urbit/auth.ssrf.test.ts
+++ b/extensions/tlon/src/urbit/auth.ssrf.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { LookupFn } from "../../api.js";
-import { SsrFBlockedError } from "../../api.js";
+import { SsrfBlockedError } from "../../api.js";
 import { authenticate } from "./auth.js";
 
 describe("tlon urbit auth ssrf", () => {
@@ -17,7 +17,7 @@ describe("tlon urbit auth ssrf", () => {
     vi.stubGlobal("fetch", mockFetch);
 
     await expect(authenticate("http://127.0.0.1:8080", "code")).rejects.toBeInstanceOf(
-      SsrFBlockedError,
+      SsrfBlockedError,
     );
     expect(mockFetch).not.toHaveBeenCalled();
   });

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
-import { SsrFBlockedError, type LookupFn } from "../../infra/net/ssrf.js";
+import { SsrfBlockedError, type LookupFn } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchMetadata } from "../../secrets/runtime-web-tools.types.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
@@ -408,7 +408,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       );
     }
   } catch (error) {
-    if (error instanceof SsrFBlockedError) {
+    if (error instanceof SsrfBlockedError) {
       throw error;
     }
     const payload = await maybeFetchProviderWebFetchPayload({

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import { mergeMockedModule } from "../test-utils/vitest-module-mocks.js";
 
 const {
@@ -131,7 +131,7 @@ describe("buildGatewayCronService", () => {
     const cfg = createCronConfig("server-cron-ssrf");
     loadConfigMock.mockReturnValue(cfg);
     fetchWithSsrFGuardMock.mockRejectedValue(
-      new SsrFBlockedError("Blocked: resolves to private/internal/special-use IP address"),
+      new SsrfBlockedError("Blocked: resolves to private/internal/special-use IP address"),
     );
 
     const state = buildGatewayCronService({

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -29,7 +29,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
-import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import { SsrfBlockedError } from "../infra/net/ssrf.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { getChildLogger } from "../logging.js";
@@ -119,7 +119,7 @@ async function postCronWebhook(params: {
     });
     await result.release();
   } catch (err) {
-    if (err instanceof SsrFBlockedError) {
+    if (err instanceof SsrfBlockedError) {
       params.logger.warn(
         {
           ...params.logContext,

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -14,7 +14,7 @@ import {
   resolvePinnedHostnameWithPolicy,
   type LookupFn,
   type PinnedDispatcherPolicy,
-  SsrFBlockedError,
+  SsrfBlockedError,
   type SsrFPolicy,
 } from "./ssrf.js";
 import {
@@ -388,7 +388,7 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
         release: async () => release(dispatcher),
       };
     } catch (err) {
-      if (err instanceof SsrFBlockedError) {
+      if (err instanceof SsrfBlockedError) {
         const context = params.auditContext ?? "url-fetch";
         logWarn(
           `security: blocked URL fetch (${context}) target=${parsedUrl.origin}${parsedUrl.pathname} reason=${err.message}`,

--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -4,7 +4,7 @@ import {
   type LookupFn,
   resolvePinnedHostname,
   resolvePinnedHostnameWithPolicy,
-  SsrFBlockedError,
+  SsrfBlockedError,
 } from "./ssrf.js";
 
 function createPublicLookupMock(): LookupFn {
@@ -159,7 +159,7 @@ describe("ssrf pinning", () => {
     const lookup = createPublicLookupMock();
 
     await expect(resolvePinnedHostnameWithPolicy(hostname, { lookupFn: lookup })).rejects.toThrow(
-      SsrFBlockedError,
+      SsrfBlockedError,
     );
     expect(lookup).not.toHaveBeenCalled();
   });

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -34,6 +34,9 @@ export class SsrfBlockedError extends Error {
   }
 }
 
+/** @deprecated Use {@link SsrfBlockedError} instead. */
+export const SsrFBlockedError = SsrfBlockedError;
+
 export type LookupFn = typeof dnsLookup;
 
 export type SsrFPolicy = {

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -27,10 +27,10 @@ type LookupCallback = (
 
 type LookupResult = LookupAddress | LookupAddress[];
 
-export class SsrFBlockedError extends Error {
+export class SsrfBlockedError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "SsrFBlockedError";
+    this.name = "SsrfBlockedError";
   }
 }
 
@@ -187,7 +187,7 @@ const BLOCKED_RESOLVED_IP_MESSAGE = "Blocked: resolves to private/internal/speci
 
 function assertAllowedHostOrIpOrThrow(hostnameOrIp: string, policy?: SsrFPolicy): void {
   if (isBlockedHostnameOrIp(hostnameOrIp, policy)) {
-    throw new SsrFBlockedError(BLOCKED_HOST_OR_IP_MESSAGE);
+    throw new SsrfBlockedError(BLOCKED_HOST_OR_IP_MESSAGE);
   }
 }
 
@@ -198,7 +198,7 @@ function assertAllowedResolvedAddressesOrThrow(
   for (const entry of results) {
     // Reuse the exact same host/IP classifier as the pre-DNS check to avoid drift.
     if (isBlockedHostnameOrIp(entry.address, policy)) {
-      throw new SsrFBlockedError(BLOCKED_RESOLVED_IP_MESSAGE);
+      throw new SsrfBlockedError(BLOCKED_RESOLVED_IP_MESSAGE);
     }
   }
 }
@@ -332,7 +332,7 @@ export async function resolvePinnedHostnameWithPolicy(
   const skipPrivateNetworkChecks = shouldSkipPrivateNetworkChecks(normalized, params.policy);
 
   if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
-    throw new SsrFBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
+    throw new SsrfBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
   }
 
   if (!skipPrivateNetworkChecks) {

--- a/src/plugin-sdk/browser-security-runtime.ts
+++ b/src/plugin-sdk/browser-security-runtime.ts
@@ -7,7 +7,7 @@ export {
 } from "../infra/fs-safe.js";
 export { hasProxyEnvConfigured } from "../infra/net/proxy-env.js";
 export {
-  SsrFBlockedError,
+  SsrfBlockedError,
   isBlockedHostnameOrIp,
   isPrivateNetworkAllowedByPolicy,
   resolvePinnedHostnameWithPolicy,

--- a/src/plugin-sdk/tlon.ts
+++ b/src/plugin-sdk/tlon.ts
@@ -20,7 +20,7 @@ export type { OpenClawConfig } from "../config/config.js";
 export { createDedupeCache } from "../infra/dedupe.js";
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export type { LookupFn, SsrFPolicy } from "../infra/net/ssrf.js";
-export { isBlockedHostnameOrIp, SsrFBlockedError } from "../infra/net/ssrf.js";
+export { isBlockedHostnameOrIp, SsrfBlockedError } from "../infra/net/ssrf.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 export type { OpenClawPluginApi } from "../plugins/types.js";


### PR DESCRIPTION
The class name `SsrFBlockedError` has inconsistent casing (capital F in the middle). This renames it to `SsrfBlockedError` to match standard acronym casing conventions and avoid confusion in catch blocks.