### PR TITLE
fix: fail fast on qa live auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/gateway: wait for Matrix sync readiness before marking startup successful, keep Matrix background handler failures contained, and route fatal Matrix sync stops through channel-level restart handling instead of crashing the whole gateway. (#62779) Thanks @gumadeiras.
 - Browser/security: re-run blocked-destination safety checks after interaction-driven main-frame navigations from click, evaluate, hook-triggered click, and batched action flows, so browser interactions cannot bypass the SSRF quarantine when they land on forbidden URLs. (#63226) Thanks @eleqtrizit.
 - Providers/Ollama: allow Ollama models using the native `api: "ollama"` path to optionally display thinking output when `/think` is set to a non-off level. (#62712) Thanks @hoyyeva.
+- QA/live auth: fail fast when live QA scenarios hit classified auth or runtime failure replies, including raw scenario wait paths, and sanitize missing-key guidance so gateway auth problems surface as actionable errors instead of timeouts. (#63333) Thanks @shakkernerd.
 
 ## 2026.4.8
 

--- a/extensions/qa-lab/src/reply-failure.test.ts
+++ b/extensions/qa-lab/src/reply-failure.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { extractQaFailureReplyText } from "./reply-failure.js";
+
+describe("extractQaFailureReplyText", () => {
+  it("returns undefined for normal assistant replies", () => {
+    expect(
+      extractQaFailureReplyText("Yes, precious. The build is green and a little cursed."),
+    ).toBe(undefined);
+  });
+
+  it("classifies the generic external fallback reply as a failure", () => {
+    expect(
+      extractQaFailureReplyText(
+        "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.",
+      ),
+    ).toContain("Something went wrong while processing your request.");
+  });
+
+  it("classifies explicit provider auth guidance as a failure", () => {
+    expect(
+      extractQaFailureReplyText(
+        '⚠️ No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.',
+      ),
+    ).toContain('No API key found for provider "openai".');
+  });
+});

--- a/extensions/qa-lab/src/reply-failure.test.ts
+++ b/extensions/qa-lab/src/reply-failure.test.ts
@@ -23,4 +23,12 @@ describe("extractQaFailureReplyText", () => {
       ),
     ).toContain('No API key found for provider "openai".');
   });
+
+  it("classifies curated missing-key guidance as a failure", () => {
+    expect(
+      extractQaFailureReplyText(
+        "⚠️ Missing API key for OpenAI on the gateway. Use `openai-codex/gpt-5.4` for OAuth, or set `OPENAI_API_KEY`, then try again.",
+      ),
+    ).toContain("Missing API key for OpenAI on the gateway.");
+  });
 });

--- a/extensions/qa-lab/src/reply-failure.ts
+++ b/extensions/qa-lab/src/reply-failure.ts
@@ -10,6 +10,7 @@ const FAILURE_REPLY_PREFIXES = [
   "⚠️ model login failed on the gateway",
   "⚠️ agent failed before reply:",
   "⚠️ no api key found for provider ",
+  "⚠️ missing api key for ",
 ];
 
 export function extractQaFailureReplyText(text: string): string | undefined {

--- a/extensions/qa-lab/src/reply-failure.ts
+++ b/extensions/qa-lab/src/reply-failure.ts
@@ -1,0 +1,25 @@
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
+
+const FAILURE_REPLY_PREFIXES = [
+  "⚠️ something went wrong while processing your request.",
+  "⚠️ session history got out of sync.",
+  "⚠️ session history was corrupted.",
+  "⚠️ context overflow",
+  "⚠️ message ordering conflict.",
+  "⚠️ model login expired on the gateway",
+  "⚠️ model login failed on the gateway",
+  "⚠️ agent failed before reply:",
+  "⚠️ no api key found for provider ",
+];
+
+export function extractQaFailureReplyText(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const lower = normalizeLowercaseStringOrEmpty(trimmed);
+  if (FAILURE_REPLY_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+    return trimmed;
+  }
+  return undefined;
+}

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -64,4 +64,52 @@ describe("qa suite failure reply handling", () => {
 
     await expect(pending).rejects.toThrow('No API key found for provider "openai".');
   });
+
+  it("fails raw scenario waitForCondition calls even when mixed traffic already exists", async () => {
+    const state = createQaBusState();
+    state.addInboundMessage({
+      conversation: { id: "qa-operator", kind: "direct" },
+      senderId: "alice",
+      senderName: "Alice",
+      text: "hello",
+    });
+    state.addOutboundMessage({
+      to: "dm:qa-operator",
+      text: "working on it",
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+    });
+    state.addInboundMessage({
+      conversation: { id: "qa-operator", kind: "direct" },
+      senderId: "alice",
+      senderName: "Alice",
+      text: "ok do it",
+    });
+
+    const waitForCondition = qaSuiteTesting.createScenarioWaitForCondition(state);
+    const pending = waitForCondition(
+      () =>
+        state
+          .getSnapshot()
+          .messages.slice(3)
+          .filter(
+            (message) =>
+              message.direction === "outbound" &&
+              message.conversation.id === "qa-operator" &&
+              message.text.includes("mission"),
+          )
+          .at(-1),
+      150,
+      10,
+    );
+
+    state.addOutboundMessage({
+      to: "dm:qa-operator",
+      text: '⚠️ No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.',
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+    });
+
+    await expect(pending).rejects.toThrow('No API key found for provider "openai".');
+  });
 });

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { qaSuiteTesting } from "./suite.js";
+
+describe("qa suite failure reply handling", () => {
+  it("detects classified failure replies before a success-only outbound predicate matches", async () => {
+    const state = createQaBusState();
+    state.addOutboundMessage({
+      to: "dm:qa-operator",
+      text: "⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.",
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+    });
+
+    const message = qaSuiteTesting.findFailureOutboundMessage(state);
+    expect(message?.text).toContain("Something went wrong while processing your request.");
+  });
+
+  it("fails success-only waitForOutboundMessage calls when a classified failure reply arrives first", async () => {
+    const state = createQaBusState();
+    const pending = qaSuiteTesting.waitForOutboundMessage(
+      state,
+      (candidate) =>
+        candidate.conversation.id === "qa-operator" &&
+        candidate.text.includes("Remembered ALPHA-7."),
+      5_000,
+    );
+
+    state.addOutboundMessage({
+      to: "dm:qa-operator",
+      text: '⚠️ No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.',
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+    });
+
+    await expect(pending).rejects.toThrow('No API key found for provider "openai".');
+  });
+
+  it("fails raw scenario waitForCondition calls when a classified failure reply arrives", async () => {
+    const state = createQaBusState();
+    const waitForCondition = qaSuiteTesting.createScenarioWaitForCondition(state);
+
+    const pending = waitForCondition(
+      () =>
+        state
+          .getSnapshot()
+          .messages.filter(
+            (message) =>
+              message.direction === "outbound" &&
+              message.conversation.id === "qa-operator" &&
+              message.text.includes("ALPHA-7"),
+          )
+          .at(-1),
+      5_000,
+      10,
+    );
+
+    state.addOutboundMessage({
+      to: "dm:qa-operator",
+      text: '⚠️ No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.',
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+    });
+
+    await expect(pending).rejects.toThrow('No API key found for provider "openai".');
+  });
+});

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -34,6 +34,7 @@ import {
 } from "./model-selection.js";
 import { hasModelSwitchContinuityEvidence } from "./model-switch-eval.js";
 import type { QaThinkingLevel } from "./qa-gateway-config.js";
+import { extractQaFailureReplyText } from "./reply-failure.js";
 import { renderQaMarkdownReport, type QaReportCheck, type QaReportScenario } from "./report.js";
 import { qaChannelPlugin, type QaBusMessage } from "./runtime-api.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
@@ -171,15 +172,21 @@ async function waitForOutboundMessage(
   timeoutMs = 15_000,
   options?: { sinceIndex?: number },
 ) {
-  return await waitForCondition(
-    () =>
-      state
-        .getSnapshot()
-        .messages.filter((message) => message.direction === "outbound")
-        .slice(options?.sinceIndex ?? 0)
-        .find(predicate),
-    timeoutMs,
-  );
+  return await waitForCondition(() => {
+    const match = state
+      .getSnapshot()
+      .messages.filter((message) => message.direction === "outbound")
+      .slice(options?.sinceIndex ?? 0)
+      .find(predicate);
+    if (!match) {
+      return undefined;
+    }
+    const failureReply = extractQaFailureReplyText(match.text);
+    if (failureReply) {
+      throw new Error(failureReply);
+    }
+    return match;
+  }, timeoutMs);
 }
 
 async function waitForNoOutbound(state: QaBusState, timeoutMs = 1_200) {

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -166,12 +166,22 @@ async function waitForCondition<T>(
   throw new Error(`timed out after ${timeoutMs}ms`);
 }
 
-function findFailureOutboundMessage(state: QaBusState, options?: { sinceIndex?: number }) {
-  return state
-    .getSnapshot()
-    .messages.filter((message) => message.direction === "outbound")
-    .slice(options?.sinceIndex ?? 0)
-    .find((message) => Boolean(extractQaFailureReplyText(message.text)));
+function findFailureOutboundMessage(
+  state: QaBusState,
+  options?: { sinceIndex?: number; cursorSpace?: "all" | "outbound" },
+) {
+  const cursorSpace = options?.cursorSpace ?? "outbound";
+  const observedMessages =
+    cursorSpace === "all"
+      ? state.getSnapshot().messages.slice(options?.sinceIndex ?? 0)
+      : state
+          .getSnapshot()
+          .messages.filter((message) => message.direction === "outbound")
+          .slice(options?.sinceIndex ?? 0);
+  return observedMessages.find(
+    (message) =>
+      message.direction === "outbound" && Boolean(extractQaFailureReplyText(message.text)),
+  );
 }
 
 function createScenarioWaitForCondition(state: QaBusState) {
@@ -183,7 +193,10 @@ function createScenarioWaitForCondition(state: QaBusState) {
   ): Promise<T> {
     return await waitForCondition(
       async () => {
-        const failureMessage = findFailureOutboundMessage(state, { sinceIndex });
+        const failureMessage = findFailureOutboundMessage(state, {
+          sinceIndex,
+          cursorSpace: "all",
+        });
         if (failureMessage) {
           throw new Error(extractQaFailureReplyText(failureMessage.text) ?? failureMessage.text);
         }

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -166,6 +166,35 @@ async function waitForCondition<T>(
   throw new Error(`timed out after ${timeoutMs}ms`);
 }
 
+function findFailureOutboundMessage(state: QaBusState, options?: { sinceIndex?: number }) {
+  return state
+    .getSnapshot()
+    .messages.filter((message) => message.direction === "outbound")
+    .slice(options?.sinceIndex ?? 0)
+    .find((message) => Boolean(extractQaFailureReplyText(message.text)));
+}
+
+function createScenarioWaitForCondition(state: QaBusState) {
+  const sinceIndex = state.getSnapshot().messages.length;
+  return async function waitForScenarioCondition<T>(
+    check: () => T | Promise<T | null | undefined> | null | undefined,
+    timeoutMs = 15_000,
+    intervalMs = 100,
+  ): Promise<T> {
+    return await waitForCondition(
+      async () => {
+        const failureMessage = findFailureOutboundMessage(state, { sinceIndex });
+        if (failureMessage) {
+          throw new Error(extractQaFailureReplyText(failureMessage.text) ?? failureMessage.text);
+        }
+        return await check();
+      },
+      timeoutMs,
+      intervalMs,
+    );
+  };
+}
+
 async function waitForOutboundMessage(
   state: QaBusState,
   predicate: (message: QaBusMessage) => boolean,
@@ -173,6 +202,10 @@ async function waitForOutboundMessage(
   options?: { sinceIndex?: number },
 ) {
   return await waitForCondition(() => {
+    const failureMessage = findFailureOutboundMessage(state, options);
+    if (failureMessage) {
+      throw new Error(extractQaFailureReplyText(failureMessage.text) ?? failureMessage.text);
+    }
     const match = state
       .getSnapshot()
       .messages.filter((message) => message.direction === "outbound")
@@ -1034,7 +1067,7 @@ function createScenarioFlowApi(
     sleep,
     randomUUID,
     runScenario,
-    waitForCondition,
+    waitForCondition: createScenarioWaitForCondition(env.lab.state),
     waitForOutboundMessage,
     waitForNoOutbound,
     recentOutboundSummary,
@@ -1092,6 +1125,12 @@ function createScenarioFlowApi(
     },
   };
 }
+
+export const qaSuiteTesting = {
+  createScenarioWaitForCondition,
+  findFailureOutboundMessage,
+  waitForOutboundMessage,
+};
 
 async function runScenarioDefinition(
   env: QaSuiteEnvironment,

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1084,7 +1084,7 @@ describe("runAgentTurnWithFallback", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        '⚠️ No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.',
+        "⚠️ Missing API key for OpenAI on the gateway. Use `openai-codex/gpt-5.4` for OAuth, or set `OPENAI_API_KEY`, then try again.",
       );
     }
   });

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1049,6 +1049,46 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("surfaces direct provider auth guidance for missing API keys", async () => {
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error(
+        'No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4. | No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.',
+      ),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        '⚠️ No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.',
+      );
+    }
+  });
+
   it("falls back to a generic reauth command when the provider in the OAuth error is unsafe", async () => {
     state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
       new Error(

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1089,6 +1089,44 @@ describe("runAgentTurnWithFallback", () => {
     }
   });
 
+  it("falls back to a generic provider message for unsafe missing-key provider ids", async () => {
+    state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
+      new Error('No API key found for provider "openai`\nrm -rf /".'),
+    );
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Missing API key for the selected provider on the gateway. Configure provider auth, then try again.",
+      );
+    }
+  });
+
   it("falls back to a generic reauth command when the provider in the OAuth error is unsafe", async () => {
     state.runEmbeddedPiAgentMock.mockRejectedValueOnce(
       new Error(

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -331,6 +331,8 @@ function collapseRepeatedFailureDetail(message: string): string {
   return message.trim();
 }
 
+const SAFE_MISSING_API_KEY_PROVIDERS = new Set(["anthropic", "google", "openai", "openai-codex"]);
+
 function buildMissingApiKeyFailureText(message: string): string | null {
   const normalizedMessage = collapseRepeatedFailureDetail(message);
   const providerMatch = normalizedMessage.match(/No API key found for provider "([^"]+)"/u);
@@ -341,7 +343,10 @@ function buildMissingApiKeyFailureText(message: string): string | null {
   if (provider === "openai" && normalizedMessage.includes("OpenAI Codex OAuth")) {
     return "⚠️ Missing API key for OpenAI on the gateway. Use `openai-codex/gpt-5.4` for OAuth, or set `OPENAI_API_KEY`, then try again.";
   }
-  return `⚠️ Missing API key for provider "${provider}". Configure the gateway auth for that provider, then try again.`;
+  if (SAFE_MISSING_API_KEY_PROVIDERS.has(provider)) {
+    return `⚠️ Missing API key for provider "${provider}". Configure the gateway auth for that provider, then try again.`;
+  }
+  return "⚠️ Missing API key for the selected provider on the gateway. Configure provider auth, then try again.";
 }
 
 function buildExternalRunFailureText(message: string): string {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -331,13 +331,27 @@ function collapseRepeatedFailureDetail(message: string): string {
   return message.trim();
 }
 
+function buildMissingApiKeyFailureText(message: string): string | null {
+  const normalizedMessage = collapseRepeatedFailureDetail(message);
+  const providerMatch = normalizedMessage.match(/No API key found for provider "([^"]+)"/u);
+  const provider = providerMatch?.[1]?.trim().toLowerCase();
+  if (!provider) {
+    return null;
+  }
+  if (provider === "openai" && normalizedMessage.includes("OpenAI Codex OAuth")) {
+    return "⚠️ Missing API key for OpenAI on the gateway. Use `openai-codex/gpt-5.4` for OAuth, or set `OPENAI_API_KEY`, then try again.";
+  }
+  return `⚠️ Missing API key for provider "${provider}". Configure the gateway auth for that provider, then try again.`;
+}
+
 function buildExternalRunFailureText(message: string): string {
   const normalizedMessage = collapseRepeatedFailureDetail(message);
   if (isToolResultTurnMismatchError(normalizedMessage)) {
     return "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.";
   }
-  if (normalizedMessage.includes('No API key found for provider "')) {
-    return `⚠️ ${normalizedMessage}`;
+  const missingApiKeyFailure = buildMissingApiKeyFailureText(normalizedMessage);
+  if (missingApiKeyFailure) {
+    return missingApiKeyFailure;
   }
   const oauthRefreshFailure = classifyOAuthRefreshFailure(normalizedMessage);
   if (oauthRefreshFailure) {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -320,11 +320,26 @@ function isToolResultTurnMismatchError(message: string): boolean {
   );
 }
 
+function collapseRepeatedFailureDetail(message: string): string {
+  const parts = message
+    .split(/\s+\|\s+/u)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (parts.length >= 2 && parts.every((part) => part === parts[0])) {
+    return parts[0];
+  }
+  return message.trim();
+}
+
 function buildExternalRunFailureText(message: string): string {
-  if (isToolResultTurnMismatchError(message)) {
+  const normalizedMessage = collapseRepeatedFailureDetail(message);
+  if (isToolResultTurnMismatchError(normalizedMessage)) {
     return "⚠️ Session history got out of sync. Please try again, or use /new to start a fresh session.";
   }
-  const oauthRefreshFailure = classifyOAuthRefreshFailure(message);
+  if (normalizedMessage.includes('No API key found for provider "')) {
+    return `⚠️ ${normalizedMessage}`;
+  }
+  const oauthRefreshFailure = classifyOAuthRefreshFailure(normalizedMessage);
   if (oauthRefreshFailure) {
     const loginCommand = buildOAuthRefreshFailureLoginCommand(oauthRefreshFailure.provider);
     if (oauthRefreshFailure.reason) {


### PR DESCRIPTION
## Summary

- Problem: live QA scenario flows could hide real provider auth failures behind long generic timeouts, even when the underlying gateway had already produced an immediate actionable error.
- Why it matters: this made live QA runs much slower to debug and much harder to trust, because provider setup failures looked like scenario timeouts instead of the real root cause.
- What changed: QA now treats known fallback and error replies as terminal failures across both outbound-message waits and raw scenario condition waits, and external missing-API-key failures now preserve direct auth guidance instead of collapsing to the generic fallback reply.
- What did NOT change (scope boundary): this does not change model auth itself; it fixes how QA surfaces those failures in scenario flows.

## Change Type

- [x] Bug fix
- [x] Test

## Root Cause

- Root cause: the live QA scenario path accepted the channel fallback reply as ordinary outbound text, or kept polling success-specific conditions without checking whether a classified failure reply had already arrived.
- Contributing context: the underlying gateway already knew the real error immediately, but the scenario flow surfaced it too late and too generically.

## User-visible Changes

- Live QA suite runs now fail fast when the channel reply is an obvious runtime failure reply.
- That fail-fast wiring now covers both success-specific outbound waits and raw scenario `waitForCondition(...)` checks.
- Missing API key failures now preserve direct provider guidance instead of only showing `Something went wrong while processing your request`.
- Repeated auth failure text like `x | x` is now collapsed into one clean message in the final QA report.

## Why This Matters

This bug was first captured clearly through Kova.

Kova showed a sharp mismatch between two otherwise similar live runs:
- `openai/gpt-5.4` failed after a long timeout
- `openai-codex/gpt-5.4` passed quickly on the same machine

Example Kova evidence from the investigation:

```text
candidate: openai/gpt-5.4
run: kova_20260408_183035268_cc484f
verdict: fail
duration: 380.9s
detail: timed out after 360000ms
```

```text
candidate: openai-codex/gpt-5.4
run: kova_20260408_185441906_df9a53
verdict: pass
duration: 65.0s
judge score: 8.8
```

That made the bug obvious:
- provider auth was not generically broken
- the live QA scenario flow was hiding the real auth failure

## Verification

### Targeted tests

- `pnpm test extensions/qa-lab/src/reply-failure.test.ts extensions/qa-lab/src/suite.test.ts src/auto-reply/reply/agent-runner-execution.test.ts`

### Live repro before the fix

- Direct manual lane already failed fast with the correct auth message:
  - `pnpm openclaw qa manual --provider-mode live-frontier --model openai/gpt-5.4 --message 'Reply exactly: OPENAI_OK' --timeout-ms 30000`
- But the scenario lane could stall and surface a timeout instead of the auth failure.

### Live repro after the fix

- `pnpm openclaw qa suite --provider-mode live-frontier --model openai/gpt-5.4 --alt-model openai/gpt-5.4 --scenario memory-recall --output-dir .artifacts/qa-e2e/repro-auth-timeout-memory-recall`

Result:
- suite finished in about `6.8s`
- scenario failed immediately with:
  - `agent.wait returned error: FailoverError: No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.`

Snippet from the generated QA report:

```text
### Memory recall after context switch

- Status: fail
- Details: agent.wait returned error: FailoverError: No API key found for provider "openai". You are authenticated with OpenAI Codex OAuth. Use openai-codex/gpt-5.4 (OAuth) or set OPENAI_API_KEY to use openai/gpt-5.4.
```

## Files

- `extensions/qa-lab/src/reply-failure.ts`
- `extensions/qa-lab/src/reply-failure.test.ts`
- `extensions/qa-lab/src/suite.ts`
- `extensions/qa-lab/src/suite.test.ts`
- `src/auto-reply/reply/agent-runner-execution.ts`
- `src/auto-reply/reply/agent-runner-execution.test.ts`

## Risks and Mitigations

- Risk: QA could now fail faster on replies that are intentional warning text.
- Mitigation: the failure classifier is intentionally narrow and only matches known runtime fallback and error reply patterns.
