### PR TITLE
fix: narrow plugin CLI missing-command diagnostic

### DIFF
--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -74,35 +74,75 @@ describe("shouldUseRootHelpFastPath", () => {
 describe("resolveMissingPluginCommandMessage", () => {
   it("explains plugins.allow misses for a bundled plugin command", () => {
     expect(
-      resolveMissingPluginCommandMessage("browser", {
-        plugins: {
-          allow: ["telegram"],
+      resolveMissingPluginCommandMessage(
+        "browser",
+        {
+          plugins: {
+            allow: ["telegram"],
+          },
         },
-      }),
+        ["browser"],
+      ),
     ).toContain('`plugins.allow` excludes "browser"');
   });
 
   it("explains explicit bundled plugin disablement", () => {
     expect(
-      resolveMissingPluginCommandMessage("browser", {
-        plugins: {
-          entries: {
-            browser: {
-              enabled: false,
+      resolveMissingPluginCommandMessage(
+        "browser",
+        {
+          plugins: {
+            entries: {
+              browser: {
+                enabled: false,
+              },
             },
           },
         },
-      }),
+        ["browser"],
+      ),
     ).toContain("plugins.entries.browser.enabled=false");
   });
 
   it("returns null when the bundled plugin command is already allowed", () => {
     expect(
-      resolveMissingPluginCommandMessage("browser", {
-        plugins: {
-          allow: ["browser"],
+      resolveMissingPluginCommandMessage(
+        "browser",
+        {
+          plugins: {
+            allow: ["browser"],
+          },
         },
-      }),
+        ["browser"],
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for unknown primary tokens that are not plugin CLI roots", () => {
+    expect(
+      resolveMissingPluginCommandMessage(
+        "lossless",
+        {
+          plugins: {
+            allow: ["telegram"],
+          },
+        },
+        ["browser"],
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for slash-prefixed tokens", () => {
+    expect(
+      resolveMissingPluginCommandMessage(
+        "/lcm",
+        {
+          plugins: {
+            allow: ["telegram"],
+          },
+        },
+        ["browser"],
+      ),
     ).toBeNull();
   });
 });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -66,9 +66,21 @@ export function shouldUseRootHelpFastPath(argv: string[]): boolean {
 export function resolveMissingPluginCommandMessage(
   pluginId: string,
   config?: OpenClawConfig,
+  knownPluginCliRoots: readonly string[] = [],
 ): string | null {
   const normalizedPluginId = normalizeLowercaseStringOrEmpty(pluginId);
   if (!normalizedPluginId) {
+    return null;
+  }
+  if (normalizedPluginId.startsWith("/")) {
+    return null;
+  }
+  const normalizedPluginCliRoots = new Set(
+    knownPluginCliRoots
+      .map((entry) => normalizeOptionalLowercaseString(entry))
+      .filter((entry): entry is string => Boolean(entry)),
+  );
+  if (!normalizedPluginCliRoots.has(normalizedPluginId)) {
     return null;
   }
   const allow =
@@ -202,7 +214,8 @@ export async function runCli(argv: string[] = process.argv) {
     });
     if (!shouldSkipPluginRegistration) {
       // Register plugin CLI commands before parsing
-      const { registerPluginCliCommandsFromValidatedConfig } = await import("../plugins/cli.js");
+      const { getPluginCliCommandRoots, registerPluginCliCommandsFromValidatedConfig } =
+        await import("../plugins/cli.js");
       const config = await registerPluginCliCommandsFromValidatedConfig(
         program,
         undefined,
@@ -214,7 +227,11 @@ export async function runCli(argv: string[] = process.argv) {
       );
       if (config) {
         if (primary && !program.commands.some((command) => command.name() === primary)) {
-          const missingPluginCommandMessage = resolveMissingPluginCommandMessage(primary, config);
+          const missingPluginCommandMessage = resolveMissingPluginCommandMessage(
+            primary,
+            config,
+            await getPluginCliCommandRoots(config),
+          );
           if (missingPluginCommandMessage) {
             throw new Error(missingPluginCommandMessage);
           }

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -1,10 +1,13 @@
 import type { Command } from "commander";
 import { loadConfig, readConfigFileSnapshot, type OpenClawConfig } from "../config/config.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import {
   createPluginCliLogger,
   loadPluginCliDescriptors,
+  loadPluginCliMetadataRegistryWithContext,
   loadPluginCliRegistrationEntriesWithDefaults,
   type PluginCliLoaderOptions,
+  resolvePluginCliLoadContext,
 } from "./cli-registry-loader.js";
 import { registerPluginCliCommandGroups } from "./register-plugin-cli-command-groups.js";
 import type { OpenClawPluginCliCommandDescriptor } from "./types.js";
@@ -33,6 +36,32 @@ export async function getPluginCliCommandDescriptors(
   loaderOptions?: PluginCliLoaderOptions,
 ): Promise<OpenClawPluginCliCommandDescriptor[]> {
   return loadPluginCliDescriptors({ cfg, env, loaderOptions });
+}
+
+export async function getPluginCliCommandRoots(
+  cfg?: OpenClawConfig,
+  env?: NodeJS.ProcessEnv,
+  loaderOptions?: PluginCliLoaderOptions,
+): Promise<string[]> {
+  try {
+    const logger = createPluginCliLogger();
+    const context = resolvePluginCliLoadContext({
+      cfg,
+      env,
+      logger,
+    });
+    const { registry } = await loadPluginCliMetadataRegistryWithContext(context, loaderOptions);
+    return [
+      ...new Set(
+        registry.cliRegistrars
+          .flatMap((entry) => entry.commands)
+          .map((command) => normalizeOptionalLowercaseString(command))
+          .filter((command): command is string => Boolean(command)),
+      ),
+    ];
+  } catch {
+    return [];
+  }
 }
 
 export async function registerPluginCliCommands(


### PR DESCRIPTION
## What
This PR narrows the root CLI's missing-plugin diagnostic so it only shows `plugins.allow` or `plugins.entries.<id>.enabled=false` guidance for real plugin CLI roots declared through plugin CLI metadata.

## Why
The current root CLI can misdiagnose unknown tokens like `lossless` or `/lcm` as excluded plugin ids when `plugins.allow` is set, which points users at configuration changes that would not fix the problem.

## Changes
- Gate special diagnostics on real CLI roots
- Reuse plugin CLI metadata for lookup
- Ignore bogus unknown tokens like `lossless`
- Let slash-style tokens fall through normally
- Keep browser allowlist behavior covered
- Add regression tests for false hints

## Testing
- `pnpm test src/cli/run-main.test.ts`
- `pnpm check`
