### PR TITLE
tools: clarify sessions_send schema field guidance

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -65,9 +65,14 @@ disk instead of treating `sessions_history` as a raw dump.
 `sessions_send` delivers a message to another session and optionally waits for
 the response:
 
+- Target the destination with **either** `sessionKey` **or** `label`, not both.
+- Use `sessionKey` when you already have an exact key from `sessions_list`.
+- Use `label` when you want OpenClaw to resolve a visible session by label.
 - **Fire-and-forget:** set `timeoutSeconds: 0` to enqueue and return
   immediately.
 - **Wait for reply:** set a timeout and get the response inline.
+
+If both `sessionKey` and `label` are provided, the tool returns an input error.
 
 After the target responds, OpenClaw can run a **reply-back loop** where the
 agents alternate messages (up to 5 turns). The target agent can reply

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -33,9 +33,25 @@ import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./session
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
 const SessionsSendToolSchema = Type.Object({
-  sessionKey: Type.Optional(Type.String()),
-  label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
-  agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
+  sessionKey: Type.Optional(
+    Type.String({
+      description: "Exact target session key. Preferred when known. Do not also provide label.",
+    }),
+  ),
+  label: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: SESSION_LABEL_MAX_LENGTH,
+      description: "Visible session label to resolve when sessionKey is not available. Do not provide alongside sessionKey.",
+    }),
+  ),
+  agentId: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: 64,
+      description: "Optional agent id hint for label-based resolution.",
+    }),
+  ),
   message: Type.String(),
   timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
 });


### PR DESCRIPTION
## Summary

Clarify the model-facing schema guidance for `sessions_send`.

This adds field descriptions so tool callers are guided to:
- prefer `sessionKey` when known
- use `label` only when `sessionKey` is unavailable
- treat `agentId` as an optional hint for label-based resolution
- avoid sending `sessionKey` and `label` together

## Why

The runtime already rejects payloads that provide both `sessionKey` and `label`, but the schema exposed both fields as independent optionals without enough guidance.

This makes invalid tool calls more likely, especially when a caller knows both the exact key and a human-readable label.

## Changes

- Updated `src/agents/tools/sessions-send-tool.ts`
- Added descriptions for `sessionKey`, `label`, and `agentId`
- Kept runtime behavior unchanged
