### PR TITLE
fix(signal): preserve uuid allowlist entries for command auth

### DIFF
--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -69,6 +69,43 @@ describe("signal sender identity", () => {
   });
 });
 
+describe("signal allowFrom normalization", () => {
+  it("preserves uuid sender ids for shared allowlist formatting", () => {
+    expect(
+      signalPlugin.config.formatAllowFrom?.({
+        cfg: {} as never,
+        accountId: "default",
+        allowFrom: [
+          " signal:uuid:ABCDEF12-3456-7890-ABCD-EF1234567890 ",
+          " +1 (555) 555-0123 ",
+          "*",
+        ],
+      }),
+    ).toEqual(["uuid:abcdef12-3456-7890-abcd-ef1234567890", "+15555550123", "*"]);
+  });
+
+  it("uses the same uuid normalization for DM policy auth", () => {
+    const resolveDmPolicy = signalPlugin.security?.resolveDmPolicy;
+    const dmPolicy = resolveDmPolicy?.({
+      cfg: { channels: { signal: {} } } as never,
+      accountId: "default",
+      account: {
+        accountId: "default",
+        config: {
+          allowFrom: ["uuid:ABCDEF12-3456-7890-ABCD-EF1234567890"],
+          dmPolicy: "allowlist",
+          groupPolicy: "allowlist",
+        },
+      } as never,
+    });
+
+    expect(dmPolicy?.normalizeEntry?.("signal:uuid:ABCDEF12-3456-7890-ABCD-EF1234567890")).toBe(
+      "uuid:abcdef12-3456-7890-abcd-ef1234567890",
+    );
+    expect(dmPolicy?.normalizeEntry?.("+1 (555) 555-0123")).toBe("+15555550123");
+  });
+});
+
 describe("probeSignal", () => {
   it("falls back to the direct probe helper when runtime is not initialized", async () => {
     clearSignalRuntime();

--- a/extensions/signal/src/shared.ts
+++ b/extensions/signal/src/shared.ts
@@ -17,7 +17,9 @@ import {
   type ResolvedSignalAccount,
 } from "./accounts.js";
 import { SignalChannelConfigSchema } from "./config-schema.js";
+import { normalizeSignalMessagingTarget } from "./normalize.js";
 import { createSignalSetupWizardProxy } from "./setup-core.js";
+import { looksLikeUuid } from "./uuid.js";
 
 export const SIGNAL_CHANNEL = "signal" as const;
 
@@ -29,6 +31,27 @@ export const signalSetupWizard = createSignalSetupWizardProxy(
   async () => (await loadSignalChannelRuntime()).signalSetupWizard,
 );
 
+function normalizeSignalAllowEntry(raw: string | number): string | undefined {
+  const entry = normalizeStringifiedOptionalString(raw);
+  if (!entry) {
+    return undefined;
+  }
+  if (entry === "*") {
+    return "*";
+  }
+
+  const normalized = normalizeSignalMessagingTarget(entry);
+  if (!normalized || normalized.startsWith("group:") || normalized.startsWith("username:")) {
+    return undefined;
+  }
+  if (looksLikeUuid(normalized)) {
+    return `uuid:${normalized}`;
+  }
+
+  const e164 = normalizeE164(normalized);
+  return e164.length > 1 ? e164 : undefined;
+}
+
 export const signalConfigAdapter = createScopedChannelConfigAdapter<ResolvedSignalAccount>({
   sectionKey: SIGNAL_CHANNEL,
   listAccountIds: (cfg) => listSignalAccountIds(cfg),
@@ -38,10 +61,8 @@ export const signalConfigAdapter = createScopedChannelConfigAdapter<ResolvedSign
   resolveAllowFrom: (account: ResolvedSignalAccount) => account.config.allowFrom,
   formatAllowFrom: (allowFrom) =>
     allowFrom
-      .map((entry) => normalizeStringifiedOptionalString(entry))
-      .filter((entry): entry is string => Boolean(entry))
-      .map((entry) => (entry === "*" ? "*" : normalizeE164(entry.replace(/^signal:/i, ""))))
-      .filter(Boolean),
+      .map((entry) => normalizeSignalAllowEntry(entry))
+      .filter((entry): entry is string => Boolean(entry)),
   resolveDefaultTo: (account: ResolvedSignalAccount) => account.config.defaultTo,
 });
 
@@ -56,7 +77,7 @@ export const signalSecurityAdapter = createRestrictSendersChannelSecurity<Resolv
   groupAllowFromPath: "channels.signal.groupAllowFrom",
   mentionGated: false,
   policyPathSuffix: "dmPolicy",
-  normalizeDmEntry: (raw) => normalizeE164(raw.replace(/^signal:/i, "").trim()),
+  normalizeDmEntry: (raw) => normalizeSignalAllowEntry(raw) ?? "",
 });
 
 export function createSignalPluginBase(params: {


### PR DESCRIPTION
This fixes a Signal command-authorization regression for paired senders stored as `uuid:...`.\n\nSignal text commands such as `/help` and `/status` already existed, and UUID-based Signal sender support already existed. The regression was introduced in the shared Signal config/security adapter, which normalized all `allowFrom` entries as E.164 phone numbers. That broke command auth and DM-policy normalization for UUID-based paired senders.\n\nThis change adds Signal-specific allowlist normalization that:\n\n- preserves `uuid:` sender ids\n- still normalizes phone numbers as E.164\n- uses the same normalization for both shared config formatting and DM-policy normalization\n\nValidation:\n\n- `vitest run extensions/signal/src/core.test.ts`\n- passed with `33` tests