### PR TITLE
fix(slack): move outbound payload test harness off contract-api entrypoint

### DIFF
--- a/extensions/slack/contract-api.ts
+++ b/extensions/slack/contract-api.ts
@@ -3,7 +3,6 @@ export {
   collectRuntimeConfigAssignments,
   secretTargetRegistryEntries,
 } from "./src/secret-contract.js";
-export { createSlackOutboundPayloadHarness } from "./src/outbound-payload-harness.js";
 export type {
   SlackInteractiveHandlerContext,
   SlackInteractiveHandlerRegistration,

--- a/extensions/slack/test-api.ts
+++ b/extensions/slack/test-api.ts
@@ -6,4 +6,5 @@ export { createSlackActions } from "./src/channel-actions.js";
 export { prepareSlackMessage } from "./src/monitor/message-handler/prepare.js";
 export { createInboundSlackTestContext } from "./src/monitor/message-handler/prepare.test-helpers.js";
 export { slackOutbound } from "./src/outbound-adapter.js";
+export { createSlackOutboundPayloadHarness } from "./src/outbound-payload-harness.js";
 export { sendMessageSlack } from "./src/send.js";

--- a/test/helpers/channels/outbound-payload-contract.ts
+++ b/test/helpers/channels/outbound-payload-contract.ts
@@ -1,5 +1,5 @@
 import { expect, it, type Mock, vi } from "vitest";
-import { createSlackOutboundPayloadHarness } from "../../../extensions/slack/contract-api.js";
+import { createSlackOutboundPayloadHarness } from "../../../extensions/slack/test-api.js";
 import { whatsappOutbound } from "../../../extensions/whatsapp/test-api.js";
 import {
   chunkTextForOutbound as chunkZaloTextForOutbound,


### PR DESCRIPTION
## Summary

- `extensions/slack/contract-api.ts` re-exported `createSlackOutboundPayloadHarness`, which transitively imports `vi` from `vitest` plus other test-only helpers. That pulled the vitest harness into the production plugin-contract bundle.
- At runtime, `resolvePluginDoctorContracts` loads `dist/extensions/slack/contract-api.js` via `jiti` to read `legacyConfigRules`. The nested relative ESM imports don't resolve under jiti, so the live binding for `legacyConfigRules` ends up `undefined`, and the compiled getter throws `TypeError: Cannot read properties of undefined (reading 't')`. Config loading aborts for every command, including `openclaw tui`.
- Moves `createSlackOutboundPayloadHarness` to `extensions/slack/test-api.ts` (matching how `matrix` and other plugins keep test helpers out of the contract entrypoint) and updates the single in-tree consumer (`test/helpers/channels/outbound-payload-contract.ts`).

Fixes #63360

## Test plan

- [ ] Build succeeds
- [ ] `outbound-payload-contract` tests still pass
- [ ] After publish, `openclaw tui` starts cleanly with a config containing a `channels.slack` block
- [ ] `dist/extensions/slack/contract-api.js` no longer imports `vitest` / `testing-*` chunks