### PR TITLE
fix(slack): move outbound payload test harness off contract-api entrypoint

### DIFF
--- a/extensions/slack/contract-api.ts
+++ b/extensions/slack/contract-api.ts
@@ -3,7 +3,6 @@ export {
   collectRuntimeConfigAssignments,
   secretTargetRegistryEntries,
 } from "./src/secret-contract.js";
-export { createSlackOutboundPayloadHarness } from "./src/outbound-payload-harness.js";
 export type {
   SlackInteractiveHandlerContext,
   SlackInteractiveHandlerRegistration,

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -1,6 +1,6 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { describe, expect, it } from "vitest";
-import { createSlackOutboundPayloadHarness } from "../contract-api.js";
+import { createSlackOutboundPayloadHarness } from "../test-api.js";
 
 function createHarness(params: {
   payload: ReplyPayload;

--- a/extensions/slack/test-api.ts
+++ b/extensions/slack/test-api.ts
@@ -6,4 +6,5 @@ export { createSlackActions } from "./src/channel-actions.js";
 export { prepareSlackMessage } from "./src/monitor/message-handler/prepare.js";
 export { createInboundSlackTestContext } from "./src/monitor/message-handler/prepare.test-helpers.js";
 export { slackOutbound } from "./src/outbound-adapter.js";
+export { createSlackOutboundPayloadHarness } from "./src/outbound-payload-harness.js";
 export { sendMessageSlack } from "./src/send.js";

--- a/test/helpers/channels/outbound-payload-contract.ts
+++ b/test/helpers/channels/outbound-payload-contract.ts
@@ -1,5 +1,5 @@
 import { beforeEach, expect, it, type Mock, vi } from "vitest";
-import { createSlackOutboundPayloadHarness } from "../../../extensions/slack/contract-api.js";
+import { createSlackOutboundPayloadHarness } from "../../../extensions/slack/test-api.js";
 import { whatsappOutbound } from "../../../extensions/whatsapp/test-api.js";
 import {
   chunkTextForOutbound as chunkZaloTextForOutbound,


### PR DESCRIPTION
Resubmitting #63363 (auto-closed by the PR-cap bot).

## Summary

- `extensions/slack/contract-api.ts` re-exported `createSlackOutboundPayloadHarness`, which transitively imports `vi` from `vitest` plus other test-only helpers. That pulled the vitest harness into the production plugin-contract bundle.
- At runtime, `resolvePluginDoctorContracts` loads `dist/extensions/slack/contract-api.js` via `jiti` to read `legacyConfigRules`. The nested relative ESM imports don't resolve under jiti, so the live binding for `legacyConfigRules` ends up `undefined`, and the compiled getter throws `TypeError: Cannot read properties of undefined (reading 't')`. Config loading aborts for every command, including `openclaw tui`.
- Moves `createSlackOutboundPayloadHarness` to `extensions/slack/test-api.ts` (matching how `matrix` and other plugins keep test helpers out of the contract entrypoint) and updates the single in-tree consumer.

Fixes #63360

## Reproduction backtrace

Running `openclaw tui` against any config that exercises the slack plugin contract:

```
Failed to read config at /home/<user>/.openclaw/openclaw.json TypeError: Cannot read properties of undefined (reading 't')
    at Object.get [as legacyConfigRules] (.../openclaw/dist/extensions/slack/contract-api.js:1:647)
    at resolvePluginDoctorContracts (.../openclaw/dist/config-DMMR1XE_.js:220:52)
    at listPluginDoctorLegacyConfigRules (.../openclaw/dist/config-DMMR1XE_.js:233:9)
    at resolveLegacyConfigForRead (.../openclaw/dist/config-DMMR1XE_.js:19138:82)
    at Object.loadConfig (.../openclaw/dist/config-DMMR1XE_.js:19203:29)
    at loadPinnedRuntimeConfig (.../openclaw/dist/runtime-snapshot-BVfF9E0s.js:42:17)
    at loadConfig (.../openclaw/dist/config-DMMR1XE_.js:19669:9)
    at primeConfiguredContextWindows (.../openclaw/dist/context-CIaFOK75.js:119:39)
    at ensureContextWindowCacheLoaded (.../openclaw/dist/context-CIaFOK75.js:137:15)
```

The literal `'t'` is the minified re-export name for `legacyConfigRules` in `doctor-contract-Byp5_Sbd.js` — when jiti fails to resolve that nested chunk, the live binding is `undefined` and the compiled getter blows up.

## Test plan

- [ ] Build succeeds
- [ ] `outbound-payload-contract` tests still pass
- [ ] After publish, `openclaw tui` starts cleanly with a config containing a `channels.slack` block
- [ ] `dist/extensions/slack/contract-api.js` no longer imports `vitest` / `testing-*` chunks