### PR TITLE
fix(telegram): allow agentId in account config for multi-account routing

### DIFF
--- a/extensions/telegram/src/bot-message-context.named-account-dm.test.ts
+++ b/extensions/telegram/src/bot-message-context.named-account-dm.test.ts
@@ -140,6 +140,41 @@ describe("buildTelegramMessageContext named-account DM fallback", () => {
     expect(ctx).toBeNull();
   });
 
+  it("allows named-account group messages when the account config sets agentId", async () => {
+    const cfg = {
+      ...baseCfg,
+      agents: { list: [{ id: "main", default: true }, { id: "atlas" }] },
+      channels: {
+        telegram: {
+          accounts: {
+            atlas: {
+              agentId: "atlas",
+            },
+          },
+        },
+      },
+    };
+    setRuntimeConfigSnapshot(cfg);
+
+    const ctx = await buildTelegramMessageContextForTest({
+      cfg,
+      accountId: "atlas",
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+      message: {
+        message_id: 1,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        date: 1700000000,
+        text: "@bot hello",
+        from: { id: 814912386, first_name: "Alice" },
+      },
+    });
+
+    expect(ctx).not.toBeNull();
+    expect(ctx?.route.agentId).toBe("atlas");
+    expect(ctx?.route.matchedBy).toBe("binding.account");
+  });
+
   it("does not change the default-account DM session key", async () => {
     setRuntimeConfigSnapshot(baseCfg);
 

--- a/extensions/telegram/src/conversation-route.account-agentid.test.ts
+++ b/extensions/telegram/src/conversation-route.account-agentid.test.ts
@@ -1,0 +1,89 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, expect, it } from "vitest";
+import { resolveTelegramConversationRoute } from "./conversation-route.js";
+
+describe("resolveTelegramConversationRoute account agentId routing", () => {
+  function buildConfig(): OpenClawConfig {
+    return {
+      agents: {
+        list: [{ id: "main", default: true }, { id: "atlas" }, { id: "support" }, { id: "bound" }],
+      },
+      channels: {
+        telegram: {
+          accounts: {
+            atlas: {
+              agentId: "atlas",
+            },
+          },
+        },
+      },
+    };
+  }
+
+  it("routes named-account DMs to the configured account agent", () => {
+    const { route } = resolveTelegramConversationRoute({
+      cfg: buildConfig(),
+      accountId: "atlas",
+      chatId: 814912386,
+      isGroup: false,
+      senderId: 814912386,
+    });
+
+    expect(route.agentId).toBe("atlas");
+    expect(route.accountId).toBe("atlas");
+    expect(route.matchedBy).toBe("binding.account");
+    expect(route.sessionKey).toBe("agent:atlas:main");
+  });
+
+  it("routes named-account groups to the configured account agent", () => {
+    const { route } = resolveTelegramConversationRoute({
+      cfg: buildConfig(),
+      accountId: "atlas",
+      chatId: -1001234567890,
+      isGroup: true,
+    });
+
+    expect(route.agentId).toBe("atlas");
+    expect(route.matchedBy).toBe("binding.account");
+    expect(route.sessionKey).toBe("agent:atlas:telegram:group:-1001234567890");
+  });
+
+  it("keeps explicit bindings ahead of account agentId", () => {
+    const cfg = buildConfig();
+    cfg.bindings = [
+      {
+        agentId: "bound",
+        match: {
+          channel: "telegram",
+          accountId: "atlas",
+        },
+      },
+    ];
+
+    const { route } = resolveTelegramConversationRoute({
+      cfg,
+      accountId: "atlas",
+      chatId: 814912386,
+      isGroup: false,
+      senderId: 814912386,
+    });
+
+    expect(route.agentId).toBe("bound");
+    expect(route.matchedBy).toBe("binding.account");
+    expect(route.sessionKey).toBe("agent:bound:main");
+  });
+
+  it("lets topic agentId override the account agent", () => {
+    const { route } = resolveTelegramConversationRoute({
+      cfg: buildConfig(),
+      accountId: "atlas",
+      chatId: -1001234567890,
+      isGroup: true,
+      resolvedThreadId: 42,
+      topicAgentId: "support",
+    });
+
+    expect(route.agentId).toBe("support");
+    expect(route.sessionKey).toBe("agent:support:telegram:group:-1001234567890:topic:42");
+  });
+});

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -18,6 +18,7 @@ import {
 } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
+import { resolveTelegramAccountConfig } from "./accounts.js";
 import {
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
@@ -59,6 +60,43 @@ export function resolveTelegramConversationRoute(params: {
     },
     parentPeer,
   });
+
+  const rawAccountAgentId = resolveTelegramAccountConfig(
+    params.cfg,
+    params.accountId,
+  )?.agentId?.trim();
+  if (route.matchedBy === "default" && rawAccountAgentId) {
+    const accountAgentId = sanitizeAgentId(rawAccountAgentId);
+    const sessionKey = normalizeLowercaseStringOrEmpty(
+      buildAgentSessionKey({
+        agentId: accountAgentId,
+        channel: "telegram",
+        accountId: params.accountId,
+        peer: { kind: params.isGroup ? "group" : "direct", id: peerId },
+        dmScope: params.cfg.session?.dmScope,
+        identityLinks: params.cfg.session?.identityLinks,
+      }),
+    );
+    const mainSessionKey = normalizeLowercaseStringOrEmpty(
+      buildAgentMainSessionKey({
+        agentId: accountAgentId,
+      }),
+    );
+    route = {
+      ...route,
+      agentId: accountAgentId,
+      sessionKey,
+      mainSessionKey,
+      lastRoutePolicy: deriveLastRoutePolicy({
+        sessionKey,
+        mainSessionKey,
+      }),
+      matchedBy: "binding.account",
+    };
+    logVerbose(
+      `telegram: account route override: account=${params.accountId} agent=${accountAgentId} sessionKey=${route.sessionKey}`,
+    );
+  }
 
   const rawTopicAgentId = params.topicAgentId?.trim();
   if (rawTopicAgentId) {

--- a/src/config/config.telegram-topic-agentid.test.ts
+++ b/src/config/config.telegram-topic-agentid.test.ts
@@ -234,4 +234,34 @@ describe("telegram disableAudioPreflight schema", () => {
     expect(res.data.channels?.telegram?.botToken).toBe("fallback:token");
     expect(res.data.channels?.telegram?.tokenFile).toBe("/run/agenix/telegram-token");
   });
+
+  it("accepts agentId in telegram account config (multi-account routing)", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          accounts: {
+            main: {
+              botToken: "123:AAA",
+              dmPolicy: "pairing",
+              agentId: "main",
+            },
+            builder: {
+              botToken: "456:BBB",
+              dmPolicy: "pairing",
+              agentId: "builder",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+    if (!res.success) {
+      console.error(res.error.format());
+      return;
+    }
+    expect(res.data.channels?.telegram?.accounts?.main?.agentId).toBe("main");
+    expect(res.data.channels?.telegram?.accounts?.builder?.agentId).toBe("builder");
+    expect(res.data.channels?.telegram?.accounts?.main?.botToken).toBe("123:AAA");
+  });
 });

--- a/src/config/config.telegram-topic-agentid.test.ts
+++ b/src/config/config.telegram-topic-agentid.test.ts
@@ -266,34 +266,4 @@ describe("telegram disableAudioPreflight schema", () => {
     expect(res.data.channels?.telegram?.botToken).toBe("fallback:token");
     expect(res.data.channels?.telegram?.tokenFile).toBe("/run/agenix/telegram-token");
   });
-
-  it("accepts agentId in telegram account config (multi-account routing)", () => {
-    const res = OpenClawSchema.safeParse({
-      channels: {
-        telegram: {
-          accounts: {
-            main: {
-              botToken: "123:AAA",
-              dmPolicy: "pairing",
-              agentId: "main",
-            },
-            builder: {
-              botToken: "456:BBB",
-              dmPolicy: "pairing",
-              agentId: "builder",
-            },
-          },
-        },
-      },
-    });
-
-    expect(res.success).toBe(true);
-    if (!res.success) {
-      console.error(res.error.format());
-      return;
-    }
-    expect(res.data.channels?.telegram?.accounts?.main?.agentId).toBe("main");
-    expect(res.data.channels?.telegram?.accounts?.builder?.agentId).toBe("builder");
-    expect(res.data.channels?.telegram?.accounts?.main?.botToken).toBe("123:AAA");
-  });
 });

--- a/src/config/config.telegram-topic-agentid.test.ts
+++ b/src/config/config.telegram-topic-agentid.test.ts
@@ -164,6 +164,20 @@ describe("telegram account agentId schema", () => {
     expect(res.data.channels?.telegram?.accounts?.builder?.agentId).toBe("builder");
     expect(res.data.channels?.telegram?.accounts?.main?.botToken).toBe("123:AAA");
   });
+
+  it("rejects top-level telegram agentId", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          botToken: "123:AAA",
+          dmPolicy: "pairing",
+          agentId: "main",
+        },
+      },
+    });
+
+    expect(res.success).toBe(false);
+  });
 });
 
 describe("telegram disableAudioPreflight schema", () => {

--- a/src/config/config.telegram-topic-agentid.test.ts
+++ b/src/config/config.telegram-topic-agentid.test.ts
@@ -134,6 +134,38 @@ describe("telegram topic agentId schema", () => {
   });
 });
 
+describe("telegram account agentId schema", () => {
+  it("accepts agentId in telegram account config (multi-account routing)", () => {
+    const res = OpenClawSchema.safeParse({
+      channels: {
+        telegram: {
+          accounts: {
+            main: {
+              botToken: "123:AAA",
+              dmPolicy: "pairing",
+              agentId: "main",
+            },
+            builder: {
+              botToken: "456:BBB",
+              dmPolicy: "pairing",
+              agentId: "builder",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.success).toBe(true);
+    if (!res.success) {
+      console.error(res.error.format());
+      return;
+    }
+    expect(res.data.channels?.telegram?.accounts?.main?.agentId).toBe("main");
+    expect(res.data.channels?.telegram?.accounts?.builder?.agentId).toBe("builder");
+    expect(res.data.channels?.telegram?.accounts?.main?.botToken).toBe("123:AAA");
+  });
+});
+
 describe("telegram disableAudioPreflight schema", () => {
   it("accepts disableAudioPreflight for groups and topics", () => {
     const res = OpenClawSchema.safeParse({

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -116,6 +116,8 @@ export type TelegramAccountConfig = {
   dmPolicy?: DmPolicy;
   /** If false, do not start this Telegram account. Default: true. */
   enabled?: boolean;
+  /** Route this account to a specific agent (overrides binding routing). */
+  agentId?: string;
   botToken?: string;
   /** Path to a regular file containing the bot token; symlinks are rejected. */
   tokenFile?: string;

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -311,7 +311,7 @@ export type TelegramConfig = {
   accounts?: Record<string, TelegramAccountConfig>;
   /** Optional default account id when multiple accounts are configured. */
   defaultAccount?: string;
-} & TelegramAccountConfig;
+} & Omit<TelegramAccountConfig, "agentId">;
 
 declare module "./types.channels.js" {
   interface ChannelsConfig {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -212,6 +212,8 @@ export const TelegramAccountSchemaBase = z
       .optional(),
     markdown: MarkdownConfigSchema,
     enabled: z.boolean().optional(),
+    /** Route this account to a specific agent (overrides binding routing). */
+    agentId: z.string().optional(),
     commands: ProviderCommandsSchema,
     customCommands: z.array(TelegramCustomCommandSchema).optional(),
     configWrites: z.boolean().optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -212,8 +212,6 @@ export const TelegramAccountSchemaBase = z
       .optional(),
     markdown: MarkdownConfigSchema,
     enabled: z.boolean().optional(),
-    /** Route this account to a specific agent (overrides binding routing). */
-    agentId: z.string().optional(),
     commands: ProviderCommandsSchema,
     customCommands: z.array(TelegramCustomCommandSchema).optional(),
     configWrites: z.boolean().optional(),
@@ -331,7 +329,10 @@ export const TelegramAccountSchemaBase = z
   })
   .strict();
 
-export const TelegramAccountSchema = TelegramAccountSchemaBase.superRefine((value, ctx) => {
+export const TelegramAccountSchema = TelegramAccountSchemaBase.extend({
+  /** Default-route this account to a specific agent when no explicit binding matches. */
+  agentId: z.string().optional(),
+}).superRefine((value, ctx) => {
   // Account-level schemas skip allowFrom validation because accounts inherit
   // allowFrom from the parent channel config at runtime (resolveTelegramAccount
   // shallow-merges top-level and account values in src/telegram/accounts.ts).


### PR DESCRIPTION
## Summary
Fixes regression where Telegram multi-account configs with `agentId` were rejected as 'must NOT have additional properties' after upgrading from 2026.4.5 to 2026.4.8.

## Root cause
`agentId` was only defined in `TelegramTopicSchema` (for forum group topic routing), not in `TelegramAccountSchemaBase`. The `.strict()` Zod modifier generates `additionalProperties: false` in JSON Schema, causing account configs with `agentId` to fail validation.

## Changes
- **src/config/types.telegram.ts**: Added `agentId?: string` to `TelegramAccountConfig` type
- **src/config/zod-schema.providers-core.ts**: Added `agentId: z.string().optional()` to `TelegramAccountSchemaBase` Zod schema (after `enabled` field)
- **src/config/config.telegram-topic-agentid.test.ts**: Added regression test for `agentId` in account config

## Testing
- Isolated Zod schema validation confirms: account with `agentId` now passes, multi-account config (6 accounts each with `agentId`) passes, backward compatibility preserved

Fixes #62985