### PR TITLE
fix(memory-core): add missing idempotencyKey to dreaming narrative subagent call

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -10,6 +10,7 @@ type SubagentSurface = {
     message: string;
     extraSystemPrompt?: string;
     deliver?: boolean;
+    idempotencyKey?: string;
   }) => Promise<{ runId: string }>;
   waitForRun: (params: {
     runId: string;
@@ -435,6 +436,7 @@ export async function generateAndAppendDreamNarrative(params: {
       message,
       extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
       deliver: false,
+      idempotencyKey: sessionKey,
     });
 
     const result = await params.subagent.waitForRun({


### PR DESCRIPTION
## Bug
memory-core dreaming narrative generation fails with 'must have required property idempotencyKey' in 2026.4.8

## Root Cause
The `subagent.run()` call in `dreaming-narrative.ts` `generateAndAppendDreamNarrative` was missing the `idempotencyKey` parameter which is now required in `AgentParamsSchema\'. This caused both light and REM phase narrative generation to fail on every dreaming run.

## Fix
Add `idempotencyKey: sessionKey` to the `subagent.run()` call (2 lines changed).

## Testing
Manual verification: patched the built `dist/dreaming-looUjKfS.js` on a live 2026.4.8 gateway, restarted, and confirmed narrative generation now executes (98ms vs 1ms before the fix). No more `idempotencyKey` errors in logs.

---

**Original issue**: GitHub #63214
**Original PR** (closed without merge): #63245