### PR TITLE
fix(discord): propagate blockquote context across chunk boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Skills: rename the repo-local Codex closeout review skill and helper to `autoreview` while preserving the Codex-first fallback behavior.
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.
 - Browser: surface pending and recently handled modal dialogs in snapshots, return `blockedByDialog` when an action opens a modal, and allow `browser dialog --dialog-id` to answer pending dialogs.
+- Discord: preserve blockquote prefixes when long quoted lines split across chunk boundaries without adding empty quoted paragraphs on line-limit splits.
 - Codex app-server: scope OpenClaw prompt guidance by runtime surface so native Codex keeps Codex-owned base/personality instructions while OpenClaw contributes only runtime context, delivery guidance, and explicitly scoped command hints. (#83454) Thanks @100yenadmin.
 - Agents/tools: shorten built-in tool descriptions and schema hints across media, messaging, sessions, cron, Gateway, web, image/PDF, TTS, nodes, and plan tools while preserving routing guardrails.
 - Skills: add node inspector debugging, fused diagram generation, and throwaway spike workflow skills.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Discord: preserve blockquote prefixes when long quoted lines spill across chunk boundaries without regressing Unicode-safe split points or adding empty quoted paragraphs on line-limit splits.
 - Web UI/i18n: add Spanish (`es`) locale support in the Control UI, including locale detection, lazy loading, and language picker labels across supported locales. (#35038) Thanks @DaoPromociones.
 - Discord/allowBots mention gating: add `allowBots: "mentions"` to only accept bot-authored messages that mention the bot. Thanks @thewilloftheshadow.
 - Docs/Web search: remove outdated Brave free-tier wording and replace prescriptive AI ToS guidance with neutral compliance language in Brave setup docs. (#26860) Thanks @HenryLoenwind.

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -1,46 +1,150 @@
-import { describe, expect, it, vi } from "vitest";
-
-vi.mock("openclaw/plugin-sdk/reply-chunking", () => ({
-  chunkMarkdownTextWithMode: (text: string) => [text],
-}));
-
-const { chunkDiscordText } = await import("./chunk.js");
+import { countLines, hasBalancedFences } from "openclaw/plugin-sdk/testing";
+import { describe, expect, it } from "vitest";
+import { chunkDiscordText, chunkDiscordTextWithMode } from "./chunk.js";
 
 describe("chunkDiscordText", () => {
-  it("re-seeds blockquote context when splitting a long quoted line by chars", () => {
-    const chunks = chunkDiscordText(`> ${"a".repeat(18)}`, {
-      maxChars: 12,
-      maxLines: 10,
-    });
+  it("splits tall messages even when under 2000 chars", () => {
+    const text = Array.from({ length: 45 }, (_, i) => `line-${i + 1}`).join("\n");
+    expect(text.length).toBeLessThan(2000);
 
-    expect(chunks).toEqual(["> aaaaaaaaa", "> aaaaaaaaa"]);
+    const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 20 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(countLines(chunk)).toBeLessThanOrEqual(20);
+    }
   });
 
-  it("does not add an empty quoted line when splitting on line limits", () => {
-    const chunks = chunkDiscordText(["> first", "> second", "> third"].join("\n"), {
-      maxChars: 100,
-      maxLines: 2,
-    });
+  it("keeps fenced code blocks balanced across chunks", () => {
+    const body = Array.from({ length: 30 }, (_, i) => `console.log(${i});`).join("\n");
+    const text = `Here is code:\n\n\`\`\`js\n${body}\n\`\`\`\n\nDone.`;
 
-    expect(chunks).toEqual(["> first\n> second", "> third"]);
-    expect(chunks[1]).not.toContain("> \n");
+    const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 10 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (const chunk of chunks) {
+      expect(hasBalancedFences(chunk)).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(2000);
+    }
+
+    expect(chunks[0]).toContain("```js");
+    expect(chunks.at(-1)).toContain("Done.");
   });
 
-  it("leaves non-blockquote content unchanged when chunking by lines", () => {
-    const chunks = chunkDiscordText(["alpha", "beta", "gamma"].join("\n"), {
-      maxChars: 100,
-      maxLines: 2,
+  it("keeps fenced blocks intact when chunkMode is newline", () => {
+    const text = "```js\nconst a = 1;\nconst b = 2;\n```\nAfter";
+    const chunks = chunkDiscordTextWithMode(text, {
+      maxChars: 2000,
+      maxLines: 50,
+      chunkMode: "newline",
     });
-
-    expect(chunks).toEqual(["alpha\nbeta", "gamma"]);
+    expect(chunks).toEqual([text]);
   });
 
-  it("preserves nested blockquote prefixes across character splits", () => {
-    const chunks = chunkDiscordText(`>> ${"b".repeat(20)}`, {
-      maxChars: 12,
-      maxLines: 10,
-    });
+  it("reserves space for closing fences when chunking", () => {
+    const body = "a".repeat(120);
+    const text = `\`\`\`txt\n${body}\n\`\`\``;
 
-    expect(chunks).toEqual([">> bbbbbbb", ">> bbbbbbbbbbbbb"]);
+    const chunks = chunkDiscordText(text, { maxChars: 50, maxLines: 50 });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(50);
+      expect(hasBalancedFences(chunk)).toBe(true);
+    }
+  });
+
+  it("preserves whitespace when splitting long lines", () => {
+    const text = Array.from({ length: 40 }, () => "word").join(" ");
+    const chunks = chunkDiscordText(text, { maxChars: 20, maxLines: 50 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("preserves mixed whitespace across chunk boundaries", () => {
+    const text = "alpha  beta\tgamma   delta epsilon  zeta";
+    const chunks = chunkDiscordText(text, { maxChars: 12, maxLines: 50 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("keeps leading whitespace when splitting long lines", () => {
+    const text = "    indented line with words that force splits";
+    const chunks = chunkDiscordText(text, { maxChars: 14, maxLines: 50 });
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("keeps reasoning italics balanced across chunks", () => {
+    const body = Array.from({ length: 25 }, (_, i) => `${i + 1}. line`).join("\n");
+    const text = `Reasoning:\n_${body}_`;
+
+    const chunks = chunkDiscordText(text, { maxLines: 10, maxChars: 2000 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (const chunk of chunks) {
+      // Each chunk should have balanced italics markers (even count).
+      const count = (chunk.match(/_/g) || []).length;
+      expect(count % 2).toBe(0);
+    }
+
+    // Ensure italics reopen on subsequent chunks
+    expect(chunks[0]).toContain("_1. line");
+    // Second chunk should reopen italics at the start
+    expect(chunks[1].trimStart().startsWith("_")).toBe(true);
+  });
+
+  it("keeps reasoning italics balanced when chunks split by char limit", () => {
+    const longLine = "This is a very long reasoning line that forces char splits.";
+    const body = Array.from({ length: 5 }, () => longLine).join("\n");
+    const text = `Reasoning:\n_${body}_`;
+
+    const chunks = chunkDiscordText(text, { maxChars: 80, maxLines: 50 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    for (const chunk of chunks) {
+      const underscoreCount = (chunk.match(/_/g) || []).length;
+      expect(underscoreCount % 2).toBe(0);
+    }
+  });
+
+  it("reopens italics while preserving leading whitespace on following chunk", () => {
+    const body = [
+      "1. line",
+      "2. line",
+      "3. line",
+      "4. line",
+      "5. line",
+      "6. line",
+      "7. line",
+      "8. line",
+      "9. line",
+      "10. line",
+      "  11. indented line",
+      "12. line",
+    ].join("\n");
+    const text = `Reasoning:\n_${body}_`;
+
+    const chunks = chunkDiscordText(text, { maxLines: 10, maxChars: 2000 });
+    expect(chunks.length).toBeGreaterThan(1);
+
+    const second = chunks[1];
+    expect(second.startsWith("_")).toBe(true);
+    expect(second).toContain("  11. indented line");
+  });
+
+  it("preserves blockquote context across character-split chunks", () => {
+    const text = `> ${"quoted text ".repeat(40)}`.trimEnd();
+
+    const chunks = chunkDiscordText(text, { maxChars: 120, maxLines: 10 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.startsWith("> "))).toBe(true);
+  });
+
+  it("does not add an empty blockquote line on line-limit splits", () => {
+    const text = ["> first quoted line", "> second quoted line", "> third quoted line"].join("\n");
+
+    const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 2 });
+
+    expect(chunks).toEqual(["> first quoted line\n> second quoted line", "> third quoted line"]);
   });
 });

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openclaw/plugin-sdk/reply-chunking", () => ({
+  chunkMarkdownTextWithMode: (text: string) => [text],
+}));
+
+const { chunkDiscordText } = await import("./chunk.js");
+
+describe("chunkDiscordText", () => {
+  it("re-seeds blockquote context when splitting a long quoted line by chars", () => {
+    const chunks = chunkDiscordText(`> ${"a".repeat(18)}`, {
+      maxChars: 12,
+      maxLines: 10,
+    });
+
+    expect(chunks).toEqual(["> aaaaaaaaa", "> aaaaaaaaa"]);
+  });
+
+  it("does not add an empty quoted line when splitting on line limits", () => {
+    const chunks = chunkDiscordText(["> first", "> second", "> third"].join("\n"), {
+      maxChars: 100,
+      maxLines: 2,
+    });
+
+    expect(chunks).toEqual(["> first\n> second", "> third"]);
+    expect(chunks[1]).not.toContain("> \n");
+  });
+
+  it("leaves non-blockquote content unchanged when chunking by lines", () => {
+    const chunks = chunkDiscordText(["alpha", "beta", "gamma"].join("\n"), {
+      maxChars: 100,
+      maxLines: 2,
+    });
+
+    expect(chunks).toEqual(["alpha\nbeta", "gamma"]);
+  });
+
+  it("preserves nested blockquote prefixes across character splits", () => {
+    const chunks = chunkDiscordText(`>> ${"b".repeat(20)}`, {
+      maxChars: 12,
+      maxLines: 10,
+    });
+
+    expect(chunks).toEqual([">> bbbbbbb", ">> bbbbbbbbbbbbb"]);
+  });
+});

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -154,4 +154,22 @@ describe("chunkDiscordText", () => {
     expect(second.startsWith("_")).toBe(true);
     expect(second).toContain("  11. indented line");
   });
+
+  it("preserves blockquote context across character-split chunks", () => {
+    const text = `> ${"quoted text ".repeat(40)}`.trimEnd();
+
+    const chunks = chunkDiscordText(text, { maxChars: 120, maxLines: 10 });
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => chunk.startsWith("> "))).toBe(true);
+    expect(chunks.every((chunk) => chunk.length <= 120)).toBe(true);
+  });
+
+  it("does not add an empty blockquote line on line-limit splits", () => {
+    const text = ["> first quoted line", "> second quoted line", "> third quoted line"].join("\n");
+
+    const chunks = chunkDiscordText(text, { maxChars: 2000, maxLines: 2 });
+
+    expect(chunks).toEqual(["> first quoted line\n> second quoted line", "> third quoted line"]);
+  });
 });

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -1,14 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { countLines, hasBalancedFences } from "../../../src/test-utils/chunk-test-helpers.js";
 import { chunkDiscordText, chunkDiscordTextWithMode } from "./chunk.js";
-
-function countLines(text: string) {
-  return text === "" ? 0 : text.split(/\r?\n/).length;
-}
-
-function hasBalancedFences(text: string) {
-  const fenceMatches = text.match(/(^|\n)( {0,3})(`{3,}|~{3,})/g);
-  return (fenceMatches?.length ?? 0) % 2 === 0;
-}
 
 describe("chunkDiscordText", () => {
   it("splits tall messages even when under 2000 chars", () => {

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -1,6 +1,14 @@
-import { countLines, hasBalancedFences } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { chunkDiscordText, chunkDiscordTextWithMode } from "./chunk.js";
+
+function countLines(text: string) {
+  return text === "" ? 0 : text.split(/\r?\n/).length;
+}
+
+function hasBalancedFences(text: string) {
+  const fenceMatches = text.match(/(^|\n)( {0,3})(`{3,}|~{3,})/g);
+  return (fenceMatches?.length ?? 0) % 2 === 0;
+}
 
 describe("chunkDiscordText", () => {
   it("splits tall messages even when under 2000 chars", () => {

--- a/extensions/discord/src/chunk.test.ts
+++ b/extensions/discord/src/chunk.test.ts
@@ -1,4 +1,4 @@
-import { countLines, hasBalancedFences } from "openclaw/plugin-sdk/testing";
+import { countLines, hasBalancedFences } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { chunkDiscordText, chunkDiscordTextWithMode } from "./chunk.js";
 
@@ -73,6 +73,30 @@ describe("chunkDiscordText", () => {
     expect(chunks.join("")).toBe(text);
   });
 
+  it("uses CJK punctuation as a safe long-line split point", () => {
+    const text = "一二三四五。六七八九十。甲乙丙丁戊。";
+    const chunks = chunkDiscordText(text, { maxChars: 10, maxLines: 50 });
+
+    expect(chunks).toEqual(["一二三四五。", "六七八九十。", "甲乙丙丁戊。"]);
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("still prefers whitespace before CJK punctuation", () => {
+    const text = "alpha beta。gamma delta";
+    const chunks = chunkDiscordText(text, { maxChars: 13, maxLines: 50 });
+
+    expect(chunks[0]).toBe("alpha");
+    expect(chunks.join("")).toBe(text);
+  });
+
+  it("does not split surrogate pairs at hard fallback boundaries", () => {
+    const text = "ab😀cd😀ef";
+    const chunks = chunkDiscordText(text, { maxChars: 3, maxLines: 50 });
+
+    expect(chunks).toEqual(["ab", "😀c", "d😀", "ef"]);
+    expect(chunks.join("")).toBe(text);
+  });
+
   it("keeps reasoning italics balanced across chunks", () => {
     const body = Array.from({ length: 25 }, (_, i) => `${i + 1}. line`).join("\n");
     const text = `Reasoning:\n_${body}_`;
@@ -81,14 +105,11 @@ describe("chunkDiscordText", () => {
     expect(chunks.length).toBeGreaterThan(1);
 
     for (const chunk of chunks) {
-      // Each chunk should have balanced italics markers (even count).
       const count = (chunk.match(/_/g) || []).length;
       expect(count % 2).toBe(0);
     }
 
-    // Ensure italics reopen on subsequent chunks
     expect(chunks[0]).toContain("_1. line");
-    // Second chunk should reopen italics at the start
     expect(chunks[1].trimStart().startsWith("_")).toBe(true);
   });
 

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -22,7 +22,7 @@ type OpenFence = {
 const DEFAULT_MAX_CHARS = 2000;
 const DEFAULT_MAX_LINES = 17;
 const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
-const BLOCKQUOTE_RE = /^(>{1,})\s?/;
+const BLOCKQUOTE_RE = /^(\s*(?:>\s*)+)/;
 
 function countLines(text: string) {
   if (!text) {
@@ -46,6 +46,10 @@ function parseFenceLine(line: string): OpenFence | null {
   };
 }
 
+function getBlockquotePrefix(line: string): string | null {
+  return BLOCKQUOTE_RE.exec(line)?.[1] ?? null;
+}
+
 function closeFenceLine(openFence: OpenFence) {
   return `${openFence.indent}${openFence.markerChar.repeat(openFence.markerLen)}`;
 }
@@ -64,15 +68,6 @@ function closeFenceIfNeeded(text: string, openFence: OpenFence | null) {
   return `${text}${closeLine}`;
 }
 
-/**
- * Extract the blockquote prefix from a line (e.g. "> " or ">> ").
- * Returns empty string if the line is not a blockquote continuation.
- */
-function getBlockquotePrefix(line: string): string {
-  const match = line.match(BLOCKQUOTE_RE);
-  return match ? match[0] : "";
-}
-
 function splitLongLine(
   line: string,
   maxChars: number,
@@ -88,23 +83,24 @@ function splitLongLine(
     if (opts.preserveWhitespace) {
       out.push(remaining.slice(0, limit));
       remaining = remaining.slice(limit);
-    } else {
-      const window = remaining.slice(0, limit + 1);
-      let splitAt = -1;
-      for (let i = window.length - 1; i >= 0; i--) {
-        if (window[i] === " ") {
-          splitAt = i;
-          break;
-        }
-      }
-      if (splitAt <= 0) {
-        splitAt = limit;
-      }
-      out.push(remaining.slice(0, splitAt).trimEnd());
-      remaining = remaining.slice(splitAt).trimStart();
+      continue;
     }
+    const window = remaining.slice(0, limit);
+    let breakIdx = -1;
+    for (let i = window.length - 1; i >= 0; i--) {
+      if (/\s/.test(window[i])) {
+        breakIdx = i;
+        break;
+      }
+    }
+    if (breakIdx <= 0) {
+      breakIdx = limit;
+    }
+    out.push(remaining.slice(0, breakIdx));
+    // Keep the separator for the next segment so words don't get glued together.
+    remaining = remaining.slice(breakIdx);
   }
-  if (remaining.length > 0) {
+  if (remaining.length) {
     out.push(remaining);
   }
   return out;
@@ -112,7 +108,7 @@ function splitLongLine(
 
 /**
  * Chunks outbound Discord text by both character count and (soft) line count,
- * while keeping fenced code blocks and blockquote contexts balanced across chunks.
+ * while keeping fenced code blocks balanced across chunks.
  */
 export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string[] {
   const maxChars = Math.max(1, Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS));
@@ -134,10 +130,9 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
   let current = "";
   let currentLines = 0;
   let openFence: OpenFence | null = null;
-  // Track current blockquote prefix so continuation chunks re-open it.
-  let openBlockquote = "";
+  let openBlockquote: string | null = null;
 
-  const flush = (opts?: { continueBlockquote?: boolean }) => {
+  const flush = (options?: { preserveBlockquote?: boolean }) => {
     if (!current) {
       return;
     }
@@ -150,10 +145,9 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     if (openFence) {
       current = openFence.openLine;
       currentLines = 1;
+      return;
     }
-    // Re-open blockquote context on next chunk so Discord keeps rendering
-    // continuation lines inside the quote block.
-    if (opts?.continueBlockquote && openBlockquote && !openFence) {
+    if (options?.preserveBlockquote && openBlockquote) {
       current = openBlockquote;
       currentLines = 1;
     }
@@ -162,6 +156,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
   for (const originalLine of lines) {
     const fenceInfo = parseFenceLine(originalLine);
     const wasInsideFence = openFence !== null;
+    const blockquotePrefix = getBlockquotePrefix(originalLine);
     let nextOpenFence: OpenFence | null = openFence;
     if (fenceInfo) {
       if (!openFence) {
@@ -174,13 +169,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       }
     }
 
-    // Track blockquote context (only when not inside a fenced code block).
-    if (!openFence && !nextOpenFence) {
-      const bqPrefix = getBlockquotePrefix(originalLine);
-      // Update openBlockquote: set when entering/continuing a blockquote,
-      // clear when the line is not a blockquote line.
-      openBlockquote = bqPrefix || "";
-    }
+    openBlockquote = blockquotePrefix;
 
     const reserveChars = nextOpenFence ? closeFenceLine(nextOpenFence).length + 1 : 0;
     const reserveLines = nextOpenFence ? 1 : 0;
@@ -206,7 +195,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       const wouldExceedLines = nextLines > lineLimit;
 
       if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
-        flush({ continueBlockquote: isLineContinuation });
+        flush({ preserveBlockquote: isLineContinuation });
       }
 
       if (current.length > 0) {
@@ -221,6 +210,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     }
 
     openFence = nextOpenFence;
+    openBlockquote = blockquotePrefix;
   }
 
   if (current.length) {

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -137,7 +137,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
   // Track current blockquote prefix so continuation chunks re-open it.
   let openBlockquote = "";
 
-  const flush = () => {
+  const flush = (opts?: { continueBlockquote?: boolean }) => {
     if (!current) {
       return;
     }
@@ -153,7 +153,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     }
     // Re-open blockquote context on next chunk so Discord keeps rendering
     // continuation lines inside the quote block.
-    if (openBlockquote && !openFence) {
+    if (opts?.continueBlockquote && openBlockquote && !openFence) {
       current = openBlockquote;
       currentLines = 1;
     }
@@ -206,7 +206,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       const wouldExceedLines = nextLines > lineLimit;
 
       if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
-        flush();
+        flush({ continueBlockquote: isLineContinuation });
       }
 
       if (current.length > 0) {

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -1,0 +1,302 @@
+import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
+
+export type ChunkDiscordTextOpts = {
+  /** Max characters per Discord message. Default: 2000. */
+  maxChars?: number;
+  /**
+   * Soft max line count per message. Default: 17.
+   *
+   * Discord clients can clip/collapse very tall messages in the UI; splitting
+   * by lines keeps long multi-paragraph replies readable.
+   */
+  maxLines?: number;
+};
+
+type OpenFence = {
+  indent: string;
+  markerChar: string;
+  markerLen: number;
+  openLine: string;
+};
+
+const DEFAULT_MAX_CHARS = 2000;
+const DEFAULT_MAX_LINES = 17;
+const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+const BLOCKQUOTE_RE = /^(>{1,})\s?/;
+
+function countLines(text: string) {
+  if (!text) {
+    return 0;
+  }
+  return text.split("\n").length;
+}
+
+function parseFenceLine(line: string): OpenFence | null {
+  const match = line.match(FENCE_RE);
+  if (!match) {
+    return null;
+  }
+  const indent = match[1] ?? "";
+  const marker = match[2] ?? "";
+  return {
+    indent,
+    markerChar: marker[0] ?? "`",
+    markerLen: marker.length,
+    openLine: line,
+  };
+}
+
+function closeFenceLine(openFence: OpenFence) {
+  return `${openFence.indent}${openFence.markerChar.repeat(openFence.markerLen)}`;
+}
+
+function closeFenceIfNeeded(text: string, openFence: OpenFence | null) {
+  if (!openFence) {
+    return text;
+  }
+  const closeLine = closeFenceLine(openFence);
+  if (!text) {
+    return closeLine;
+  }
+  if (!text.endsWith("\n")) {
+    return `${text}\n${closeLine}`;
+  }
+  return `${text}${closeLine}`;
+}
+
+/**
+ * Extract the blockquote prefix from a line (e.g. "> " or ">> ").
+ * Returns empty string if the line is not a blockquote continuation.
+ */
+function getBlockquotePrefix(line: string): string {
+  const match = line.match(BLOCKQUOTE_RE);
+  return match ? match[0] : "";
+}
+
+function splitLongLine(
+  line: string,
+  maxChars: number,
+  opts: { preserveWhitespace: boolean },
+): string[] {
+  const limit = Math.max(1, Math.floor(maxChars));
+  if (line.length <= limit) {
+    return [line];
+  }
+  const out: string[] = [];
+  let remaining = line;
+  while (remaining.length > limit) {
+    if (opts.preserveWhitespace) {
+      out.push(remaining.slice(0, limit));
+      remaining = remaining.slice(limit);
+    } else {
+      const window = remaining.slice(0, limit + 1);
+      let splitAt = -1;
+      for (let i = window.length - 1; i >= 0; i--) {
+        if (window[i] === " ") {
+          splitAt = i;
+          break;
+        }
+      }
+      if (splitAt <= 0) {
+        splitAt = limit;
+      }
+      out.push(remaining.slice(0, splitAt).trimEnd());
+      remaining = remaining.slice(splitAt).trimStart();
+    }
+  }
+  if (remaining.length > 0) {
+    out.push(remaining);
+  }
+  return out;
+}
+
+/**
+ * Chunks outbound Discord text by both character count and (soft) line count,
+ * while keeping fenced code blocks and blockquote contexts balanced across chunks.
+ */
+export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string[] {
+  const maxChars = Math.max(1, Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS));
+  const maxLines = Math.max(1, Math.floor(opts.maxLines ?? DEFAULT_MAX_LINES));
+
+  const body = text ?? "";
+  if (!body) {
+    return [];
+  }
+
+  const alreadyOk = body.length <= maxChars && countLines(body) <= maxLines;
+  if (alreadyOk) {
+    return [body];
+  }
+
+  const lines = body.split("\n");
+  const chunks: string[] = [];
+
+  let current = "";
+  let currentLines = 0;
+  let openFence: OpenFence | null = null;
+  // Track current blockquote prefix so continuation chunks re-open it.
+  let openBlockquote = "";
+
+  const flush = () => {
+    if (!current) {
+      return;
+    }
+    const payload = closeFenceIfNeeded(current, openFence);
+    if (payload.trim().length) {
+      chunks.push(payload);
+    }
+    current = "";
+    currentLines = 0;
+    if (openFence) {
+      current = openFence.openLine;
+      currentLines = 1;
+    }
+    // Re-open blockquote context on next chunk so Discord keeps rendering
+    // continuation lines inside the quote block.
+    if (openBlockquote && !openFence) {
+      current = openBlockquote;
+      currentLines = 1;
+    }
+  };
+
+  for (const originalLine of lines) {
+    const fenceInfo = parseFenceLine(originalLine);
+    const wasInsideFence = openFence !== null;
+    let nextOpenFence: OpenFence | null = openFence;
+    if (fenceInfo) {
+      if (!openFence) {
+        nextOpenFence = fenceInfo;
+      } else if (
+        openFence.markerChar === fenceInfo.markerChar &&
+        fenceInfo.markerLen >= openFence.markerLen
+      ) {
+        nextOpenFence = null;
+      }
+    }
+
+    // Track blockquote context (only when not inside a fenced code block).
+    if (!openFence && !nextOpenFence) {
+      const bqPrefix = getBlockquotePrefix(originalLine);
+      // Update openBlockquote: set when entering/continuing a blockquote,
+      // clear when the line is not a blockquote line.
+      openBlockquote = bqPrefix || "";
+    }
+
+    const reserveChars = nextOpenFence ? closeFenceLine(nextOpenFence).length + 1 : 0;
+    const reserveLines = nextOpenFence ? 1 : 0;
+    const effectiveMaxChars = maxChars - reserveChars;
+    const effectiveMaxLines = maxLines - reserveLines;
+    const charLimit = effectiveMaxChars > 0 ? effectiveMaxChars : maxChars;
+    const lineLimit = effectiveMaxLines > 0 ? effectiveMaxLines : maxLines;
+    const prefixLen = current.length > 0 ? current.length + 1 : 0;
+    const segmentLimit = Math.max(1, charLimit - prefixLen);
+    const segments = splitLongLine(originalLine, segmentLimit, {
+      preserveWhitespace: wasInsideFence,
+    });
+
+    for (let segIndex = 0; segIndex < segments.length; segIndex++) {
+      const segment = segments[segIndex];
+      const isLineContinuation = segIndex > 0;
+      const delimiter = isLineContinuation ? "" : current.length > 0 ? "\n" : "";
+      const addition = `${delimiter}${segment}`;
+      const nextLen = current.length + addition.length;
+      const nextLines = currentLines + (isLineContinuation ? 0 : 1);
+
+      const wouldExceedChars = nextLen > charLimit;
+      const wouldExceedLines = nextLines > lineLimit;
+
+      if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
+        flush();
+      }
+
+      if (current.length > 0) {
+        current += addition;
+        if (!isLineContinuation) {
+          currentLines += 1;
+        }
+      } else {
+        current = segment;
+        currentLines = 1;
+      }
+    }
+
+    openFence = nextOpenFence;
+  }
+
+  if (current.length) {
+    const payload = closeFenceIfNeeded(current, openFence);
+    if (payload.trim().length) {
+      chunks.push(payload);
+    }
+  }
+
+  return rebalanceReasoningItalics(text, chunks);
+}
+
+export function chunkDiscordTextWithMode(
+  text: string,
+  opts: ChunkDiscordTextOpts & { chunkMode?: ChunkMode },
+): string[] {
+  const chunkMode = opts.chunkMode ?? "length";
+  if (chunkMode !== "newline") {
+    return chunkDiscordText(text, opts);
+  }
+  const lineChunks = chunkMarkdownTextWithMode(
+    text,
+    Math.max(1, Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS)),
+    "newline",
+  );
+  const chunks: string[] = [];
+  for (const line of lineChunks) {
+    const nested = chunkDiscordText(line, opts);
+    if (!nested.length && line) {
+      chunks.push(line);
+      continue;
+    }
+    chunks.push(...nested);
+  }
+  return chunks;
+}
+
+// Keep italics intact for reasoning payloads that are wrapped once with `_…_`.
+// When Discord chunking splits the message, we close italics at the end of
+// each chunk and reopen at the start of the next so every chunk renders
+// consistently.
+function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
+  if (chunks.length <= 1) {
+    return chunks;
+  }
+
+  const opensWithReasoningItalics =
+    source.startsWith("Reasoning:\n_") && source.trimEnd().endsWith("_");
+  if (!opensWithReasoningItalics) {
+    return chunks;
+  }
+
+  const adjusted = [...chunks];
+  for (let i = 0; i < adjusted.length; i++) {
+    const isLast = i === adjusted.length - 1;
+    const current = adjusted[i];
+
+    // Ensure current chunk closes italics so Discord renders it italicized.
+    const needsClosing = !current.trimEnd().endsWith("_");
+    if (needsClosing) {
+      adjusted[i] = `${current}_`;
+    }
+
+    if (isLast) {
+      break;
+    }
+
+    // Re-open italics on the next chunk if needed.
+    const next = adjusted[i + 1];
+    const leadingWhitespaceLen = next.length - next.trimStart().length;
+    const leadingWhitespace = next.slice(0, leadingWhitespaceLen);
+    const nextBody = next.slice(leadingWhitespaceLen);
+    if (!nextBody.startsWith("_")) {
+      adjusted[i + 1] = `${leadingWhitespace}_${nextBody}`;
+    }
+  }
+
+  return adjusted;
+}

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -1,6 +1,6 @@
 import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 
-type ChunkDiscordTextOpts = {
+export type ChunkDiscordTextOpts = {
   /** Max characters per Discord message. Default: 2000. */
   maxChars?: number;
   /**
@@ -22,6 +22,7 @@ type OpenFence = {
 const DEFAULT_MAX_CHARS = 2000;
 const DEFAULT_MAX_LINES = 17;
 const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+const BLOCKQUOTE_RE = /^(\s*(?:>\s*)+)/;
 const CJK_PUNCTUATION_BREAK_AFTER_RE = /[、。，．！？；：）］｝〉》」』】〕〗〙]/u;
 
 function countLines(text: string) {
@@ -44,6 +45,10 @@ function parseFenceLine(line: string): OpenFence | null {
     markerLen: marker.length,
     openLine: line,
   };
+}
+
+function getBlockquotePrefix(line: string): string | null {
+  return BLOCKQUOTE_RE.exec(line)?.[1] ?? null;
 }
 
 function closeFenceLine(openFence: OpenFence) {
@@ -88,7 +93,6 @@ function clampToCodePointBoundary(text: string, index: number) {
 function findWhitespaceBreak(window: string) {
   for (let i = window.length - 1; i >= 0; i--) {
     if (/\s/.test(window[i])) {
-      // Return the separator index so whitespace stays with the next segment.
       return i;
     }
   }
@@ -101,7 +105,6 @@ function findCjkPunctuationBreak(window: string) {
     const start = isLowSurrogate(code) && end > 1 ? end - 2 : end - 1;
     const char = window.slice(start, end);
     if (start > 0 && CJK_PUNCTUATION_BREAK_AFTER_RE.test(char)) {
-      // Return the exclusive end so CJK punctuation stays with the current segment.
       return end;
     }
     end = start;
@@ -136,7 +139,6 @@ function splitLongLine(
       breakIdx = clampToCodePointBoundary(remaining, limit);
     }
     out.push(remaining.slice(0, breakIdx));
-    // Keep the separator for the next segment so words don't get glued together.
     remaining = remaining.slice(breakIdx);
   }
   if (remaining.length) {
@@ -145,10 +147,6 @@ function splitLongLine(
   return out;
 }
 
-/**
- * Chunks outbound Discord text by both character count and (soft) line count,
- * while keeping fenced code blocks balanced across chunks.
- */
 export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string[] {
   const maxChars = Math.max(1, Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS));
   const maxLines = Math.max(1, Math.floor(opts.maxLines ?? DEFAULT_MAX_LINES));
@@ -169,8 +167,9 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
   let current = "";
   let currentLines = 0;
   let openFence: OpenFence | null = null;
+  let openBlockquote: string | null = null;
 
-  const flush = () => {
+  const flush = (options?: { preserveBlockquote?: boolean }) => {
     if (!current) {
       return;
     }
@@ -183,12 +182,18 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     if (openFence) {
       current = openFence.openLine;
       currentLines = 1;
+      return;
+    }
+    if (options?.preserveBlockquote && openBlockquote) {
+      current = openBlockquote;
+      currentLines = 1;
     }
   };
 
   for (const originalLine of lines) {
     const fenceInfo = parseFenceLine(originalLine);
     const wasInsideFence = openFence !== null;
+    const blockquotePrefix = getBlockquotePrefix(originalLine);
     let nextOpenFence: OpenFence | null = openFence;
     if (fenceInfo) {
       if (!openFence) {
@@ -201,6 +206,8 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       }
     }
 
+    openBlockquote = blockquotePrefix;
+
     const reserveChars = nextOpenFence ? closeFenceLine(nextOpenFence).length + 1 : 0;
     const reserveLines = nextOpenFence ? 1 : 0;
     const effectiveMaxChars = maxChars - reserveChars;
@@ -208,7 +215,8 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     const charLimit = effectiveMaxChars > 0 ? effectiveMaxChars : maxChars;
     const lineLimit = effectiveMaxLines > 0 ? effectiveMaxLines : maxLines;
     const prefixLen = current.length > 0 ? current.length + 1 : 0;
-    const segmentLimit = Math.max(1, charLimit - prefixLen);
+    const continuationPrefixLen = !nextOpenFence && blockquotePrefix ? blockquotePrefix.length : 0;
+    const segmentLimit = Math.max(1, charLimit - prefixLen - continuationPrefixLen);
     const segments = splitLongLine(originalLine, segmentLimit, {
       preserveWhitespace: wasInsideFence,
     });
@@ -225,7 +233,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       const wouldExceedLines = nextLines > lineLimit;
 
       if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
-        flush();
+        flush({ preserveBlockquote: isLineContinuation });
       }
 
       if (current.length > 0) {
@@ -240,6 +248,7 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     }
 
     openFence = nextOpenFence;
+    openBlockquote = blockquotePrefix;
   }
 
   if (current.length) {
@@ -277,10 +286,6 @@ export function chunkDiscordTextWithMode(
   return chunks;
 }
 
-// Keep italics intact for reasoning payloads that are wrapped once with `_…_`.
-// When Discord chunking splits the message, we close italics at the end of
-// each chunk and reopen at the start of the next so every chunk renders
-// consistently.
 function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
   if (chunks.length <= 1) {
     return chunks;
@@ -297,7 +302,6 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
     const isLast = i === adjusted.length - 1;
     const current = adjusted[i];
 
-    // Ensure current chunk closes italics so Discord renders it italicized.
     const needsClosing = !current.trimEnd().endsWith("_");
     if (needsClosing) {
       adjusted[i] = `${current}_`;
@@ -307,7 +311,6 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
       break;
     }
 
-    // Re-open italics on the next chunk if needed.
     const next = adjusted[i + 1];
     const leadingWhitespaceLen = next.length - next.trimStart().length;
     const leadingWhitespace = next.slice(0, leadingWhitespaceLen);

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -1,4 +1,4 @@
-import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
+import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
 
 export type ChunkDiscordTextOpts = {
   /** Max characters per Discord message. Default: 2000. */

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -1,4 +1,4 @@
-import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-runtime";
+import { chunkMarkdownTextWithMode, type ChunkMode } from "../../../src/auto-reply/chunk.js";
 
 export type ChunkDiscordTextOpts = {
   /** Max characters per Discord message. Default: 2000. */

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -23,6 +23,7 @@ const DEFAULT_MAX_CHARS = 2000;
 const DEFAULT_MAX_LINES = 17;
 const FENCE_RE = /^( {0,3})(`{3,}|~{3,})(.*)$/;
 const BLOCKQUOTE_RE = /^(\s*(?:>\s*)+)/;
+const CJK_PUNCTUATION_BREAK_AFTER_RE = /[、。，．！？；：）］｝〉》」』】〕〗〙]/u;
 
 function countLines(text: string) {
   if (!text) {
@@ -68,6 +69,49 @@ function closeFenceIfNeeded(text: string, openFence: OpenFence | null) {
   return `${text}${closeLine}`;
 }
 
+function isHighSurrogate(code: number) {
+  return code >= 0xd800 && code <= 0xdbff;
+}
+
+function isLowSurrogate(code: number) {
+  return code >= 0xdc00 && code <= 0xdfff;
+}
+
+function clampToCodePointBoundary(text: string, index: number) {
+  const boundary = Math.min(Math.max(0, index), text.length);
+  if (boundary <= 0 || boundary >= text.length) {
+    return boundary;
+  }
+  const previous = text.charCodeAt(boundary - 1);
+  const next = text.charCodeAt(boundary);
+  if (isHighSurrogate(previous) && isLowSurrogate(next)) {
+    return boundary > 1 ? boundary - 1 : boundary + 1;
+  }
+  return boundary;
+}
+
+function findWhitespaceBreak(window: string) {
+  for (let i = window.length - 1; i >= 0; i--) {
+    if (/\s/.test(window[i])) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function findCjkPunctuationBreak(window: string) {
+  for (let end = window.length; end > 0; ) {
+    const code = window.charCodeAt(end - 1);
+    const start = isLowSurrogate(code) && end > 1 ? end - 2 : end - 1;
+    const char = window.slice(start, end);
+    if (start > 0 && CJK_PUNCTUATION_BREAK_AFTER_RE.test(char)) {
+      return end;
+    }
+    end = start;
+  }
+  return -1;
+}
+
 function splitLongLine(
   line: string,
   maxChars: number,
@@ -81,23 +125,20 @@ function splitLongLine(
   let remaining = line;
   while (remaining.length > limit) {
     if (opts.preserveWhitespace) {
-      out.push(remaining.slice(0, limit));
-      remaining = remaining.slice(limit);
+      const breakIdx = clampToCodePointBoundary(remaining, limit);
+      out.push(remaining.slice(0, breakIdx));
+      remaining = remaining.slice(breakIdx);
       continue;
     }
     const window = remaining.slice(0, limit);
-    let breakIdx = -1;
-    for (let i = window.length - 1; i >= 0; i--) {
-      if (/\s/.test(window[i])) {
-        breakIdx = i;
-        break;
-      }
+    let breakIdx = findWhitespaceBreak(window);
+    if (breakIdx <= 0) {
+      breakIdx = findCjkPunctuationBreak(window);
     }
     if (breakIdx <= 0) {
-      breakIdx = limit;
+      breakIdx = clampToCodePointBoundary(remaining, limit);
     }
     out.push(remaining.slice(0, breakIdx));
-    // Keep the separator for the next segment so words don't get glued together.
     remaining = remaining.slice(breakIdx);
   }
   if (remaining.length) {
@@ -106,10 +147,6 @@ function splitLongLine(
   return out;
 }
 
-/**
- * Chunks outbound Discord text by both character count and (soft) line count,
- * while keeping fenced code blocks balanced across chunks.
- */
 export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}): string[] {
   const maxChars = Math.max(1, Math.floor(opts.maxChars ?? DEFAULT_MAX_CHARS));
   const maxLines = Math.max(1, Math.floor(opts.maxLines ?? DEFAULT_MAX_LINES));
@@ -248,10 +285,6 @@ export function chunkDiscordTextWithMode(
   return chunks;
 }
 
-// Keep italics intact for reasoning payloads that are wrapped once with `_…_`.
-// When Discord chunking splits the message, we close italics at the end of
-// each chunk and reopen at the start of the next so every chunk renders
-// consistently.
 function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
   if (chunks.length <= 1) {
     return chunks;
@@ -268,7 +301,6 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
     const isLast = i === adjusted.length - 1;
     const current = adjusted[i];
 
-    // Ensure current chunk closes italics so Discord renders it italicized.
     const needsClosing = !current.trimEnd().endsWith("_");
     if (needsClosing) {
       adjusted[i] = `${current}_`;
@@ -278,7 +310,6 @@ function rebalanceReasoningItalics(source: string, chunks: string[]): string[] {
       break;
     }
 
-    // Re-open italics on the next chunk if needed.
     const next = adjusted[i + 1];
     const leadingWhitespaceLen = next.length - next.trimStart().length;
     const leadingWhitespace = next.slice(0, leadingWhitespaceLen);


### PR DESCRIPTION
## Summary

Fixes #63409

When `chunkDiscordText()` flushed a chunk in the middle of a blockquote, the next chunk started without the leading `>` prefix. Discord renders each message independently, so continuation lines appeared as plain text outside the quote block.

## Root cause

The chunker already tracks fenced code block state (`openFence`) and re-seeds the next chunk with the opening fence line on flush. The same treatment was never applied to blockquote prefixes.

## Fix

Track the current blockquote prefix (`openBlockquote`) using the same pattern:

```ts
// On flush, re-seed the next chunk with the blockquote prefix
if (openBlockquote && !openFence) {
  current = openBlockquote;
  currentLines = 1;
}
```

A `BLOCKQUOTE_RE` helper extracts the prefix including nested levels (`> `, `>> `, etc.). The prefix is updated on each line and cleared when a non-blockquote line is encountered.

## Real behavior proof
A minimal reproduction is a long Discord quote whose single quoted line is forced to split across two outgoing messages.

Before this patch, the split output looks like:

```text
chunk 1: > very long quoted text that reaches the limit ...
chunk 2: continuation of the same quoted line
```

Discord renders `chunk 2` as plain text because each message is interpreted independently and the continuation no longer starts with `>`.

With this patch, the split output becomes:

```text
chunk 1: > very long quoted text that reaches the limit ...
chunk 2: > continuation of the same quoted line
```

So the continuation remains inside the quote block after the boundary. The same prefix carry-over also preserves nested quotes like `>> `, while fenced-code behavior stays on the existing `openFence` path.

## Behaviour

| Case | Before | After |
|------|--------|-------|
| Multi-line `>` blockquote split at chunk boundary | Continuation lines render as plain text | All lines render inside the quote block |
| Nested `>>` blockquote split at boundary | Same problem | Nested level preserved |
| Fenced code block inside blockquote | Unchanged | Unchanged |
| Non-blockquote content | Unchanged | Unchanged |
