### PR TITLE
fix openrouter model picker refs

### DIFF
--- a/ui/src/ui/chat-model-ref.test.ts
+++ b/ui/src/ui/chat-model-ref.test.ts
@@ -35,6 +35,37 @@ describe("chat-model-ref helpers", () => {
     );
   });
 
+  it("prefixes provider-native model ids that already contain slashes", () => {
+    expect(
+      buildChatModelOption({
+        id: "google/gemma-4-26b-a4b-it",
+        provider: "openrouter",
+      } as never),
+    ).toEqual({
+      value: "openrouter/google/gemma-4-26b-a4b-it",
+      label: "google/gemma-4-26b-a4b-it · openrouter",
+    });
+    expect(
+      resolvePreferredServerChatModel("Google/Gemma-4-26b-a4b-it", "openrouter", [
+        { id: "google/gemma-4-26b-a4b-it", provider: "openrouter" } as never,
+      ]),
+    ).toEqual({
+      value: "openrouter/google/gemma-4-26b-a4b-it",
+      source: "server",
+    });
+  });
+
+  it("reuses already-qualified catalog ids without double-prefixing them", () => {
+    expect(
+      resolvePreferredServerChatModel("OpenAI/GPT-4O", "openai", [
+        { id: "openai/gpt-4o", provider: "openai" } as never,
+      ]),
+    ).toEqual({
+      value: "openai/gpt-4o",
+      source: "server",
+    });
+  });
+
   it("normalizes raw overrides when the catalog match is unique", () => {
     expect(normalizeChatModelOverrideValue(createChatModelOverride("gpt-5-mini"), catalog)).toBe(
       "openai/gpt-5-mini",
@@ -102,7 +133,6 @@ describe("chat-model-ref helpers", () => {
     ).toEqual({
       value: "openai/gpt-5-mini",
       source: "server",
-      reason: "ambiguous",
     });
   });
 });

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -113,6 +113,20 @@ export function resolvePreferredServerChatModel(
   if (!trimmedModel) {
     return { value: "", source: "empty", reason: "empty" };
   }
+  const trimmedProvider = provider?.trim();
+  if (trimmedProvider) {
+    const providerMatch = catalog.find(
+      (entry) =>
+        entry.provider?.trim().toLowerCase() === trimmedProvider.toLowerCase() &&
+        entry.id.trim().toLowerCase() === trimmedModel.toLowerCase(),
+    );
+    if (providerMatch) {
+      return {
+        value: buildChatModelOption(providerMatch).value,
+        source: "server",
+      };
+    }
+  }
 
   const overrideResolution = resolveChatModelOverride(
     createChatModelOverride(trimmedModel),
@@ -151,8 +165,15 @@ export function formatChatModelDisplay(value: string): string {
 
 export function buildChatModelOption(entry: ModelCatalogEntry): { value: string; label: string } {
   const provider = entry.provider?.trim();
+  const value = (() => {
+    if (!provider) {
+      return entry.id;
+    }
+    const providerPrefix = `${provider.toLowerCase()}/`;
+    return entry.id.toLowerCase().startsWith(providerPrefix) ? entry.id : `${provider}/${entry.id}`;
+  })();
   return {
-    value: buildQualifiedChatModelValue(entry.id, provider),
+    value,
     label: provider ? `${entry.id} · ${provider}` : entry.id,
   };
 }

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -359,6 +359,37 @@ describe("executeSlashCommand directives", () => {
     });
   });
 
+  it("keeps openrouter-prefixed refs when patched model ids include slashes", async () => {
+    const request = vi.fn(async (method: string, _payload?: unknown) => {
+      if (method === "sessions.patch") {
+        return createResolvedModelPatch("google/gemma-4-26b-a4b-it", "openrouter");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "main",
+      "model",
+      "google/gemma-4-26b-a4b-it",
+      {
+        chatModelCatalog: [
+          {
+            id: "google/gemma-4-26b-a4b-it",
+            name: "Gemma 4 26B",
+            provider: "openrouter",
+          },
+        ],
+      },
+    );
+
+    expect(result.sessionPatch?.modelOverride).toEqual({
+      kind: "qualified",
+      value: "openrouter/google/gemma-4-26b-a4b-it",
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to the patched server provider when catalog lookup fails", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {
       if (method === "sessions.patch") {


### PR DESCRIPTION
## Summary

fixes `Failed to set model:GatewayRequestError model not allowed` UI bug

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #49379

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: 

  - OpenRouter exposes many model ids like google/gemma-4-26b-a4b-it.
  - The picker incorrectly treated that as already qualified and built the option value as google/gemma-4-26b-a4b-it
    instead of openrouter/google/gemma-4-26b-a4b-it.
  - If OpenRouter was already the default/active provider, the UI also had server session data with
    modelProvider=openrouter, so it could surface the correct fully qualified ref as the current/default value and
    partially mask the bug.
  - If OpenRouter was only an additional provider, there was no active/default session value to repair it, so the dropdown
    only had the malformed catalog value, and selecting it failed allowlist validation.
