### PR TITLE
feat: add Multipass runner for qa suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Memory/Active Memory: add a new optional Active Memory plugin that gives OpenClaw a dedicated memory sub-agent right before the main reply, so ongoing chats can automatically pull in relevant preferences, context, and past details without making users remember to manually say "remember this" or "search memory" first. Includes configurable message/recent/full context modes, live `/verbose` inspection, advanced prompt/thinking overrides for tuning, and opt-in transcript persistence for debugging.
 - macOS/Talk: add an experimental local MLX speech provider for Talk Mode, with explicit provider selection, local utterance playback, interruption handling, and system-voice fallback. (#63539) Thanks @ImLukeF.
 - Docs i18n: chunk raw doc translation, reject truncated tagged outputs, avoid ambiguous body-only wrapper unwrapping, and recover from terminated Pi translation sessions without changing the default `openai/gpt-5.4` path. (#62969, #63808) Thanks @hxy91819.
+- QA/testing: add a `--runner multipass` lane for `openclaw qa suite` so repo-backed QA scenarios can run inside a disposable Linux VM and write back the usual report, summary, and VM logs. (#63426) Thanks @shakkernerd.
 
 ### Fixes
 

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -52,6 +52,18 @@ pnpm qa:lab:watch
 rebuilds that bundle on change, and the browser auto-reloads when the QA Lab
 asset hash changes.
 
+For a disposable Linux VM lane without bringing Docker into the QA path, run:
+
+```bash
+pnpm openclaw qa suite --runner multipass --scenario channel-chat-baseline
+```
+
+This boots a fresh Multipass guest, installs dependencies, builds OpenClaw
+inside the guest, runs `qa suite` on the mock-openai lane, then copies the
+normal QA report and summary back into `.artifacts/qa-e2e/...` on the host.
+It reuses the same scenario-selection behavior as `qa suite` on the host and
+only changes where that suite runs.
+
 ## Repo-backed seeds
 
 Seed assets live in `qa/`:

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -59,10 +59,13 @@ pnpm openclaw qa suite --runner multipass --scenario channel-chat-baseline
 ```
 
 This boots a fresh Multipass guest, installs dependencies, builds OpenClaw
-inside the guest, runs `qa suite` on the mock-openai lane, then copies the
-normal QA report and summary back into `.artifacts/qa-e2e/...` on the host.
-It reuses the same scenario-selection behavior as `qa suite` on the host and
-only changes where that suite runs.
+inside the guest, runs `qa suite`, then copies the normal QA report and
+summary back into `.artifacts/qa-e2e/...` on the host.
+It reuses the same scenario-selection behavior as `qa suite` on the host.
+Live runs forward the supported QA auth inputs that are practical for the
+guest: env-based provider keys, the QA live provider config path, and
+`CODEX_HOME` when present. Keep `--output-dir` under the repo root so the guest
+can write back through the mounted workspace.
 
 ## Repo-backed seeds
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -51,7 +51,12 @@ These commands sit beside the main test suites when you need QA-lab realism:
 - `pnpm openclaw qa suite --runner multipass`
   - Runs the same QA suite inside a disposable Multipass Linux VM.
   - Keeps the same scenario-selection behavior as `qa suite` on the host.
-  - Reuses the same provider/model selection flags as `qa suite`; the runner only changes where the suite executes.
+  - Reuses the same provider/model selection flags as `qa suite`.
+  - Live runs forward the supported QA auth inputs that are practical for the guest:
+    env-based provider keys, the QA live provider config path, and `CODEX_HOME`
+    when present.
+  - Output dirs must stay under the repo root so the guest can write back through
+    the mounted workspace.
   - Writes the normal QA report + summary plus Multipass logs under
     `.artifacts/qa-e2e/...`.
 - `pnpm qa:lab:up`

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -28,6 +28,7 @@ Most days:
 - Direct file targeting now routes extension/channel paths too: `pnpm test extensions/discord/src/monitor/message-handler.preflight.test.ts`
 - Prefer targeted runs first when you are iterating on a single failure.
 - Docker-backed QA site: `pnpm qa:lab:up`
+- Linux VM-backed QA lane: `pnpm openclaw qa suite --runner multipass --scenario channel-chat-baseline`
 
 When you touch tests or want extra confidence:
 
@@ -40,6 +41,21 @@ When debugging real providers/models (requires real creds):
 - Target one live file quietly: `pnpm test:live -- src/agents/models.profiles.live.test.ts`
 
 Tip: when you only need one failing case, prefer narrowing live tests via the allowlist env vars described below.
+
+## QA-specific runners
+
+These commands sit beside the main test suites when you need QA-lab realism:
+
+- `pnpm openclaw qa suite`
+  - Runs repo-backed QA scenarios directly on the host.
+- `pnpm openclaw qa suite --runner multipass`
+  - Runs the same QA suite inside a disposable Multipass Linux VM.
+  - Keeps the same scenario-selection behavior as `qa suite` on the host.
+  - Reuses the same provider/model selection flags as `qa suite`; the runner only changes where the suite executes.
+  - Writes the normal QA report + summary plus Multipass logs under
+    `.artifacts/qa-e2e/...`.
+- `pnpm qa:lab:up`
+  - Starts the Docker-backed QA site for operator-style QA work.
 
 ## Test suites (what runs where)
 

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -5,6 +5,7 @@ const {
   runQaManualLane,
   runQaSuite,
   runQaCharacterEval,
+  runQaMultipass,
   startQaLabServer,
   writeQaDockerHarnessFiles,
   buildQaDockerHarnessImage,
@@ -13,6 +14,7 @@ const {
   runQaManualLane: vi.fn(),
   runQaSuite: vi.fn(),
   runQaCharacterEval: vi.fn(),
+  runQaMultipass: vi.fn(),
   startQaLabServer: vi.fn(),
   writeQaDockerHarnessFiles: vi.fn(),
   buildQaDockerHarnessImage: vi.fn(),
@@ -29,6 +31,10 @@ vi.mock("./suite.js", () => ({
 
 vi.mock("./character-eval.js", () => ({
   runQaCharacterEval,
+}));
+
+vi.mock("./multipass.runtime.js", () => ({
+  runQaMultipass,
 }));
 
 vi.mock("./lab-server.js", () => ({
@@ -62,6 +68,7 @@ describe("qa cli runtime", () => {
     runQaSuite.mockReset();
     runQaCharacterEval.mockReset();
     runQaManualLane.mockReset();
+    runQaMultipass.mockReset();
     startQaLabServer.mockReset();
     writeQaDockerHarnessFiles.mockReset();
     buildQaDockerHarnessImage.mockReset();
@@ -80,6 +87,16 @@ describe("qa cli runtime", () => {
       waited: { status: "ok" },
       reply: "done",
       watchUrl: "http://127.0.0.1:43124",
+    });
+    runQaMultipass.mockResolvedValue({
+      outputDir: "/tmp/multipass",
+      reportPath: "/tmp/multipass/qa-suite-report.md",
+      summaryPath: "/tmp/multipass/qa-suite-summary.json",
+      hostLogPath: "/tmp/multipass/multipass-host.log",
+      bootstrapLogPath: "/tmp/multipass/multipass-guest-bootstrap.log",
+      guestScriptPath: "/tmp/multipass/multipass-guest-run.sh",
+      vmName: "openclaw-qa-test",
+      scenarioIds: ["channel-chat-baseline"],
     });
     startQaLabServer.mockResolvedValue({
       baseUrl: "http://127.0.0.1:58000",
@@ -265,6 +282,68 @@ describe("qa cli runtime", () => {
       message: "read qa kickoff and reply short",
       timeoutMs: 45_000,
     });
+  });
+
+  it("routes suite runs through multipass when the runner is selected", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      outputDir: ".artifacts/qa-multipass",
+      runner: "multipass",
+      providerMode: "mock-openai",
+      scenarioIds: ["channel-chat-baseline"],
+      image: "lts",
+      cpus: 2,
+      memory: "4G",
+      disk: "24G",
+    });
+
+    expect(runQaMultipass).toHaveBeenCalledWith({
+      repoRoot: path.resolve("/tmp/openclaw-repo"),
+      outputDir: path.resolve("/tmp/openclaw-repo", ".artifacts/qa-multipass"),
+      providerMode: "mock-openai",
+      primaryModel: undefined,
+      alternateModel: undefined,
+      fastMode: undefined,
+      scenarioIds: ["channel-chat-baseline"],
+      image: "lts",
+      cpus: 2,
+      memory: "4G",
+      disk: "24G",
+    });
+    expect(runQaSuite).not.toHaveBeenCalled();
+  });
+
+  it("passes live suite selection through to the multipass runner", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      runner: "multipass",
+      providerMode: "live-frontier",
+      primaryModel: "openai/gpt-5.4",
+      alternateModel: "openai/gpt-5.4",
+      fastMode: true,
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expect(runQaMultipass).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoRoot: path.resolve("/tmp/openclaw-repo"),
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.4",
+        alternateModel: "openai/gpt-5.4",
+        fastMode: true,
+        scenarioIds: ["channel-chat-baseline"],
+      }),
+    );
+  });
+
+  it("rejects multipass-only suite flags on the host runner", async () => {
+    await expect(
+      runQaSuiteCommand({
+        repoRoot: "/tmp/openclaw-repo",
+        runner: "host",
+        image: "lts",
+      }),
+    ).rejects.toThrow("--image, --cpus, --memory, and --disk require --runner multipass.");
   });
 
   it("defaults manual mock runs onto the mock-openai model lane", async () => {

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -5,6 +5,7 @@ import { runQaDockerUp } from "./docker-up.runtime.js";
 import { startQaLabServer } from "./lab-server.js";
 import { runQaManualLane } from "./manual-lane.runtime.js";
 import { startQaMockOpenAiServer } from "./mock-openai-server.js";
+import { runQaMultipass } from "./multipass.runtime.js";
 import { normalizeQaThinkingLevel, type QaThinkingLevel } from "./qa-gateway-config.js";
 import {
   defaultQaModelForMode,
@@ -193,14 +194,53 @@ export async function runQaLabSelfCheckCommand(opts: { repoRoot?: string; output
 export async function runQaSuiteCommand(opts: {
   repoRoot?: string;
   outputDir?: string;
+  runner?: string;
   providerMode?: QaProviderModeInput;
   primaryModel?: string;
   alternateModel?: string;
   fastMode?: boolean;
   scenarioIds?: string[];
+  image?: string;
+  cpus?: number;
+  memory?: string;
+  disk?: string;
 }) {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const runner = (opts.runner ?? "host").trim().toLowerCase();
+  if (runner !== "host" && runner !== "multipass") {
+    throw new Error(`--runner must be one of host or multipass, got "${opts.runner}".`);
+  }
   const providerMode = normalizeQaProviderMode(opts.providerMode);
+  if (
+    runner === "host" &&
+    (opts.image !== undefined ||
+      opts.cpus !== undefined ||
+      opts.memory !== undefined ||
+      opts.disk !== undefined)
+  ) {
+    throw new Error("--image, --cpus, --memory, and --disk require --runner multipass.");
+  }
+  if (runner === "multipass") {
+    const result = await runQaMultipass({
+      repoRoot,
+      outputDir: opts.outputDir ? path.resolve(repoRoot, opts.outputDir) : undefined,
+      providerMode,
+      primaryModel: opts.primaryModel,
+      alternateModel: opts.alternateModel,
+      fastMode: opts.fastMode,
+      scenarioIds: opts.scenarioIds,
+      image: opts.image,
+      cpus: parseQaPositiveIntegerOption("--cpus", opts.cpus),
+      memory: opts.memory,
+      disk: opts.disk,
+    });
+    process.stdout.write(`QA Multipass dir: ${result.outputDir}\n`);
+    process.stdout.write(`QA Multipass report: ${result.reportPath}\n`);
+    process.stdout.write(`QA Multipass summary: ${result.summaryPath}\n`);
+    process.stdout.write(`QA Multipass host log: ${result.hostLogPath}\n`);
+    process.stdout.write(`QA Multipass bootstrap log: ${result.bootstrapLogPath}\n`);
+    return;
+  }
   const result = await runQaSuite({
     repoRoot,
     outputDir: opts.outputDir ? path.resolve(repoRoot, opts.outputDir) : undefined,

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -23,6 +23,11 @@ async function runQaSuite(opts: {
   alternateModel?: string;
   fastMode?: boolean;
   scenarioIds?: string[];
+  runner?: string;
+  image?: string;
+  cpus?: number;
+  memory?: string;
+  disk?: string;
 }) {
   const runtime = await loadQaLabCliRuntime();
   await runtime.runQaSuiteCommand(opts);
@@ -138,6 +143,7 @@ export function registerQaLabCli(program: Command) {
     .description("Run repo-backed QA scenarios against the QA gateway lane")
     .option("--repo-root <path>", "Repository root to target when running from a neutral cwd")
     .option("--output-dir <path>", "Suite artifact directory")
+    .option("--runner <kind>", "Execution runner: host or multipass", "host")
     .option(
       "--provider-mode <mode>",
       "Provider mode: mock-openai or live-frontier (legacy live-openai still works)",
@@ -147,24 +153,38 @@ export function registerQaLabCli(program: Command) {
     .option("--alt-model <ref>", "Alternate provider/model ref")
     .option("--scenario <id>", "Run only the named QA scenario (repeatable)", collectString, [])
     .option("--fast", "Enable provider fast mode where supported", false)
+    .option("--image <alias>", "Multipass image alias")
+    .option("--cpus <count>", "Multipass vCPU count", (value: string) => Number(value))
+    .option("--memory <size>", "Multipass memory size")
+    .option("--disk <size>", "Multipass disk size")
     .action(
       async (opts: {
         repoRoot?: string;
         outputDir?: string;
+        runner?: string;
         providerMode?: QaProviderModeInput;
         model?: string;
         altModel?: string;
         scenario?: string[];
         fast?: boolean;
+        image?: string;
+        cpus?: number;
+        memory?: string;
+        disk?: string;
       }) => {
         await runQaSuite({
           repoRoot: opts.repoRoot,
           outputDir: opts.outputDir,
+          runner: opts.runner,
           providerMode: opts.providerMode,
           primaryModel: opts.model,
           alternateModel: opts.altModel,
           fastMode: opts.fast,
           scenarioIds: opts.scenario,
+          image: opts.image,
+          cpus: opts.cpus,
+          memory: opts.memory,
+          disk: opts.disk,
         });
       },
     );

--- a/extensions/qa-lab/src/multipass.runtime.test.ts
+++ b/extensions/qa-lab/src/multipass.runtime.test.ts
@@ -1,0 +1,72 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQaMultipassPlan, renderQaMultipassGuestScript } from "./multipass.runtime.js";
+
+describe("qa multipass runtime", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reuses suite scenario semantics and resolves mounted artifact paths", () => {
+    const repoRoot = process.cwd();
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "multipass-test");
+    const plan = createQaMultipassPlan({
+      repoRoot,
+      outputDir,
+    });
+
+    expect(plan.outputDir).toBe(outputDir);
+    expect(plan.scenarioIds).toEqual([]);
+    expect(plan.qaCommand).not.toContain("--scenario");
+    expect(plan.guestOutputDir).toBe("/workspace/openclaw-host/.artifacts/qa-e2e/multipass-test");
+    expect(plan.reportPath).toBe(path.join(outputDir, "qa-suite-report.md"));
+    expect(plan.summaryPath).toBe(path.join(outputDir, "qa-suite-summary.json"));
+  });
+
+  it("renders a guest script that runs the mock qa suite with explicit scenarios", () => {
+    const plan = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-test"),
+      scenarioIds: ["channel-chat-baseline", "thread-follow-up"],
+    });
+
+    const script = renderQaMultipassGuestScript(plan);
+
+    expect(script).toContain("pnpm install --frozen-lockfile");
+    expect(script).toContain("pnpm build");
+    expect(script).toContain("'pnpm' 'openclaw' 'qa' 'suite' '--provider-mode' 'mock-openai'");
+    expect(script).toContain("'--scenario' 'channel-chat-baseline'");
+    expect(script).toContain("'--scenario' 'thread-follow-up'");
+    expect(script).toContain("/workspace/openclaw-host/.artifacts/qa-e2e/multipass-test");
+  });
+
+  it("carries live suite flags and forwarded auth env into the guest command", () => {
+    vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+    const plan = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-live-test"),
+      providerMode: "live-frontier",
+      primaryModel: "openai/gpt-5.4",
+      alternateModel: "openai/gpt-5.4",
+      fastMode: true,
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    const script = renderQaMultipassGuestScript(plan);
+
+    expect(plan.qaCommand).toEqual(
+      expect.arrayContaining([
+        "--provider-mode",
+        "live-frontier",
+        "--model",
+        "openai/gpt-5.4",
+        "--alt-model",
+        "openai/gpt-5.4",
+        "--fast",
+      ]),
+    );
+    expect(plan.forwardedEnv.OPENAI_API_KEY).toBe("test-openai-key");
+    expect(script).toContain("OPENAI_API_KEY='test-openai-key'");
+    expect(script).toContain("'pnpm' 'openclaw' 'qa' 'suite' '--provider-mode' 'live-frontier'");
+  });
+});

--- a/extensions/qa-lab/src/multipass.runtime.test.ts
+++ b/extensions/qa-lab/src/multipass.runtime.test.ts
@@ -7,6 +7,15 @@ describe("qa multipass runtime", () => {
     vi.unstubAllEnvs();
   });
 
+  it("rejects output directories outside the mounted repo root", () => {
+    expect(() =>
+      createQaMultipassPlan({
+        repoRoot: process.cwd(),
+        outputDir: "/tmp/qa-out",
+      }),
+    ).toThrow("qa suite --runner multipass requires --output-dir to stay under the repo root");
+  });
+
   it("reuses suite scenario semantics and resolves mounted artifact paths", () => {
     const repoRoot = process.cwd();
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "multipass-test");

--- a/extensions/qa-lab/src/multipass.runtime.test.ts
+++ b/extensions/qa-lab/src/multipass.runtime.test.ts
@@ -1,10 +1,32 @@
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { createQaMultipassPlan, renderQaMultipassGuestScript } from "./multipass.runtime.js";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    execFile: execFileMock,
+  };
+});
+
+import {
+  createQaMultipassPlan,
+  renderQaMultipassGuestScript,
+  runQaMultipass,
+} from "./multipass.runtime.js";
 
 describe("qa multipass runtime", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
+    vi.restoreAllMocks();
   });
 
   it("rejects output directories outside the mounted repo root", () => {
@@ -14,6 +36,32 @@ describe("qa multipass runtime", () => {
         outputDir: "/tmp/qa-out",
       }),
     ).toThrow("qa suite --runner multipass requires --output-dir to stay under the repo root");
+  });
+
+  it("rejects repo-local symlink output directories that escape the repo root", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-multipass-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const outsideRoot = path.join(tempRoot, "outside");
+    const symlinkPath = path.join(repoRoot, "artifacts-link");
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.mkdirSync(outsideRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(repoRoot, "package.json"),
+      JSON.stringify({ packageManager: "pnpm@10.32.1" }),
+      "utf8",
+    );
+    fs.symlinkSync(outsideRoot, symlinkPath);
+
+    try {
+      expect(() =>
+        createQaMultipassPlan({
+          repoRoot,
+          outputDir: path.join(symlinkPath, "qa-out"),
+        }),
+      ).toThrow("qa suite --runner multipass requires --output-dir to stay under the repo root");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("reuses suite scenario semantics and resolves mounted artifact paths", () => {
@@ -43,6 +91,7 @@ describe("qa multipass runtime", () => {
 
     expect(script).toContain("pnpm install --frozen-lockfile");
     expect(script).toContain("pnpm build");
+    expect(script).toContain("corepack prepare 'pnpm@10.32.1' --activate");
     expect(script).toContain("'pnpm' 'openclaw' 'qa' 'suite' '--provider-mode' 'mock-openai'");
     expect(script).toContain("'--scenario' 'channel-chat-baseline'");
     expect(script).toContain("'--scenario' 'thread-follow-up'");
@@ -77,5 +126,130 @@ describe("qa multipass runtime", () => {
     expect(plan.forwardedEnv.OPENAI_API_KEY).toBe("test-openai-key");
     expect(script).toContain("OPENAI_API_KEY='test-openai-key'");
     expect(script).toContain("'pnpm' 'openclaw' 'qa' 'suite' '--provider-mode' 'live-frontier'");
+  });
+
+  it("redacts forwarded live secrets in the persisted artifact script", () => {
+    vi.stubEnv("OPENAI_API_KEY", "test-openai-key");
+    const plan = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-live-test"),
+      providerMode: "live-frontier",
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    const redactedScript = renderQaMultipassGuestScript(plan, { redactSecrets: true });
+
+    expect(redactedScript).toContain("OPENAI_API_KEY='<redacted>'");
+    expect(redactedScript).not.toContain("OPENAI_API_KEY='test-openai-key'");
+  });
+
+  it("forwards live key list and numbered key env shapes", () => {
+    vi.stubEnv("OPENCLAW_LIVE_ANTHROPIC_KEYS", "anthropic-a anthropic-b");
+    vi.stubEnv("OPENAI_API_KEY_1", "openai-one");
+    vi.stubEnv("GEMINI_API_KEY_2", "gemini-two");
+    const plan = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-live-test"),
+      providerMode: "live-frontier",
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expect(plan.forwardedEnv.OPENCLAW_LIVE_ANTHROPIC_KEYS).toBe("anthropic-a anthropic-b");
+    expect(plan.forwardedEnv.OPENAI_API_KEY_1).toBe("openai-one");
+    expect(plan.forwardedEnv.GEMINI_API_KEY_2).toBe("gemini-two");
+  });
+
+  it("skips stale CODEX_HOME values that do not exist on the host", () => {
+    vi.stubEnv("CODEX_HOME", "/tmp/does-not-exist-openclaw-codex-home");
+    const plan = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-live-test"),
+      providerMode: "live-frontier",
+    });
+
+    expect(plan.forwardedEnv.CODEX_HOME).toBeUndefined();
+    expect(plan.hostCodexHomePath).toBeUndefined();
+    expect(plan.guestCodexHomePath).toBeUndefined();
+  });
+
+  it("falls back to os.homedir() when HOME is unset for CODEX_HOME discovery", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-multipass-home-"));
+    const fakeHome = path.join(tempRoot, "home");
+    const fakeCodexHome = path.join(fakeHome, ".codex");
+    fs.mkdirSync(fakeCodexHome, { recursive: true });
+    vi.stubEnv("HOME", "");
+    vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+
+    try {
+      const plan = createQaMultipassPlan({
+        repoRoot: process.cwd(),
+        outputDir: path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-live-test"),
+        providerMode: "live-frontier",
+      });
+
+      expect(plan.forwardedEnv.CODEX_HOME).toBe(fakeCodexHome);
+      expect(plan.hostCodexHomePath).toBe(fakeCodexHome);
+      expect(plan.guestCodexHomePath).toBe("/workspace/openclaw-codex-home");
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not leave a temp guest transfer script behind when multipass is missing", async () => {
+    const outputDir = path.join(process.cwd(), ".artifacts", "qa-e2e", "multipass-missing-test");
+    vi.spyOn(Date, "now").mockReturnValue(1_717_171_717_171);
+    vi.spyOn(Math, "random").mockReturnValue(0.123456789);
+    (execFileMock as unknown as Mock).mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as (error: Error | null, stdout: string, stderr: string) => void;
+      const error = new Error("spawn multipass ENOENT") as NodeJS.ErrnoException;
+      error.code = "ENOENT";
+      callback(error, "", "");
+    });
+
+    const expectedVmName = createQaMultipassPlan({
+      repoRoot: process.cwd(),
+      outputDir,
+      scenarioIds: ["channel-chat-baseline"],
+    }).vmName;
+    const expectedTransferDir = path.join(os.tmpdir(), `${expectedVmName}-qa-suite-`);
+
+    await expect(
+      runQaMultipass({
+        repoRoot: process.cwd(),
+        outputDir,
+        scenarioIds: ["channel-chat-baseline"],
+      }),
+    ).rejects.toThrow("Multipass is not installed on this host.");
+
+    const tempEntries = fs
+      .readdirSync(os.tmpdir())
+      .filter((entry) => entry.startsWith(path.basename(expectedTransferDir)));
+    expect(tempEntries).toEqual([]);
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it("preserves non-install multipass probe failures", async () => {
+    const outputDir = path.join(
+      process.cwd(),
+      ".artifacts",
+      "qa-e2e",
+      "multipass-probe-error-test",
+    );
+    (execFileMock as unknown as Mock).mockImplementation((...args: unknown[]) => {
+      const callback = args[3] as (error: Error | null, stdout: string, stderr: string) => void;
+      const error = new Error("multipassd is not running") as NodeJS.ErrnoException;
+      error.code = "EACCES";
+      callback(error, "", "multipassd is not running");
+    });
+
+    await expect(
+      runQaMultipass({
+        repoRoot: process.cwd(),
+        outputDir,
+        scenarioIds: ["channel-chat-baseline"],
+      }),
+    ).rejects.toThrow("Unable to verify Multipass availability: multipassd is not running.");
+
+    fs.rmSync(outputDir, { recursive: true, force: true });
   });
 });

--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -234,7 +234,9 @@ function createQaMultipassOutputDir(repoRoot: string) {
 function resolveGuestMountedPath(repoRoot: string, hostPath: string) {
   const relativePath = path.relative(repoRoot, hostPath);
   if (relativePath.startsWith("..") || path.isAbsolute(relativePath) || relativePath.length === 0) {
-    throw new Error(`unable to resolve Multipass mounted path for ${hostPath}`);
+    throw new Error(
+      `qa suite --runner multipass requires --output-dir to stay under the repo root (${repoRoot}), got ${hostPath}.`,
+    );
   }
   return path.posix.join(MULTIPASS_MOUNTED_REPO_PATH, ...relativePath.split(path.sep));
 }

--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -25,6 +25,8 @@ const MULTIPASS_REPO_SYNC_EXCLUDES = [
   "coverage",
   "*.heapsnapshot",
 ] as const;
+const MULTIPASS_EXEC_MAX_BUFFER = 64 * 1024 * 1024;
+const MULTIPASS_GUEST_RUN_TIMEOUT_MS = 60 * 60 * 1000;
 
 const QA_LIVE_ENV_ALIASES = Object.freeze([
   {
@@ -64,6 +66,11 @@ const QA_LIVE_ALLOWED_ENV_VARS = Object.freeze([
   "OPENCLAW_CONFIG_PATH",
   "VOYAGE_API_KEY",
 ]);
+const QA_LIVE_ALLOWED_ENV_PATTERNS = Object.freeze([
+  /^[A-Z0-9_]+_API_KEYS$/u,
+  /^[A-Z0-9_]+_API_KEY_[0-9]+$/u,
+  /^OPENCLAW_LIVE_[A-Z0-9_]+_KEYS$/u,
+]);
 
 export const qaMultipassDefaultResources = {
   image: "lts",
@@ -75,6 +82,14 @@ export const qaMultipassDefaultResources = {
 type ExecResult = {
   stdout: string;
   stderr: string;
+};
+
+type ExecFileError = Error & {
+  code?: string;
+};
+
+type ExecFileOptions = {
+  timeoutMs?: number;
 };
 
 export type QaMultipassPlan = {
@@ -120,6 +135,10 @@ export type QaMultipassRunResult = {
   scenarioIds: string[];
 };
 
+type RenderGuestScriptOptions = {
+  redactSecrets?: boolean;
+};
+
 function shellQuote(value: string) {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
@@ -136,17 +155,76 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function execFileAsync(file: string, args: string[]) {
+function execFileAsync(file: string, args: string[], options: ExecFileOptions = {}) {
   return new Promise<ExecResult>((resolve, reject) => {
-    execFile(file, args, { encoding: "utf8" }, (error, stdout, stderr) => {
-      if (error) {
-        const message = stderr.trim() || stdout.trim() || error.message;
-        reject(new Error(message));
-        return;
-      }
-      resolve({ stdout, stderr });
-    });
+    execFile(
+      file,
+      args,
+      {
+        encoding: "utf8",
+        maxBuffer: MULTIPASS_EXEC_MAX_BUFFER,
+        timeout: options.timeoutMs,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const message = stderr.trim() || stdout.trim() || error.message;
+          const wrappedError = new Error(message, { cause: error }) as ExecFileError;
+          wrappedError.code = (error as NodeJS.ErrnoException).code;
+          reject(wrappedError);
+          return;
+        }
+        resolve({ stdout, stderr });
+      },
+    );
   });
+}
+
+function resolveRealPath(value: string) {
+  return fs.realpathSync.native?.(value) ?? fs.realpathSync(value);
+}
+
+function resolveExistingPath(value: string) {
+  let currentPath = value;
+  while (!fs.existsSync(currentPath)) {
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) {
+      throw new Error(`unable to resolve existing path for ${value}`);
+    }
+    currentPath = parentPath;
+  }
+  return currentPath;
+}
+
+function isPathInside(parentPath: string, childPath: string) {
+  const relativePath = path.relative(parentPath, childPath);
+  return !relativePath.startsWith("..") && !path.isAbsolute(relativePath);
+}
+
+function validatePnpmVersion(version: string) {
+  if (!/^[0-9A-Za-z.+_-]+$/u.test(version)) {
+    throw new Error(`unsupported pnpm version in packageManager: ${version}`);
+  }
+  return version;
+}
+
+function resolveMountedOutputPath(repoRoot: string, hostPath: string) {
+  const relativePath = path.relative(repoRoot, hostPath);
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath) || relativePath.length === 0) {
+    throw new Error(
+      `qa suite --runner multipass requires --output-dir to stay under the repo root (${repoRoot}), got ${hostPath}.`,
+    );
+  }
+
+  const realRepoRoot = resolveRealPath(repoRoot);
+  const existingHostPath = resolveExistingPath(hostPath);
+  const realExistingHostPath = resolveRealPath(existingHostPath);
+  if (!isPathInside(realRepoRoot, realExistingHostPath) && realExistingHostPath !== realRepoRoot) {
+    throw new Error(
+      `qa suite --runner multipass requires --output-dir to stay under the repo root (${repoRoot}), got ${hostPath}.`,
+    );
+  }
+
+  return path.posix.join(MULTIPASS_MOUNTED_REPO_PATH, ...relativePath.split(path.sep));
 }
 
 function resolvePnpmVersion(repoRoot: string) {
@@ -196,20 +274,24 @@ function resolveLiveProviderConfigPath(env: NodeJS.ProcessEnv = process.env) {
 function resolveQaLiveCliAuthEnv(baseEnv: NodeJS.ProcessEnv) {
   const configuredCodexHome = baseEnv.CODEX_HOME?.trim();
   if (configuredCodexHome) {
-    return { CODEX_HOME: resolveUserPath(configuredCodexHome, baseEnv) };
+    const codexHome = resolveUserPath(configuredCodexHome, baseEnv);
+    return fs.existsSync(codexHome) ? { CODEX_HOME: codexHome } : {};
   }
-  const hostHome = baseEnv.HOME?.trim();
-  if (!hostHome) {
-    return {};
-  }
+  const hostHome = baseEnv.HOME?.trim() || os.homedir();
   const codexHome = path.join(hostHome, ".codex");
   return fs.existsSync(codexHome) ? { CODEX_HOME: codexHome } : {};
 }
 
 function resolveForwardedLiveEnv(baseEnv: NodeJS.ProcessEnv = process.env) {
   const forwarded: Record<string, string> = {};
-  for (const key of QA_LIVE_ALLOWED_ENV_VARS) {
-    const value = baseEnv[key]?.trim();
+  for (const [key, rawValue] of Object.entries(baseEnv)) {
+    if (
+      !QA_LIVE_ALLOWED_ENV_VARS.includes(key) &&
+      !QA_LIVE_ALLOWED_ENV_PATTERNS.some((pattern) => pattern.test(key))
+    ) {
+      continue;
+    }
+    const value = rawValue?.trim();
     if (value) {
       forwarded[key] = value;
     }
@@ -232,13 +314,7 @@ function createQaMultipassOutputDir(repoRoot: string) {
 }
 
 function resolveGuestMountedPath(repoRoot: string, hostPath: string) {
-  const relativePath = path.relative(repoRoot, hostPath);
-  if (relativePath.startsWith("..") || path.isAbsolute(relativePath) || relativePath.length === 0) {
-    throw new Error(
-      `qa suite --runner multipass requires --output-dir to stay under the repo root (${repoRoot}), got ${hostPath}.`,
-    );
-  }
-  return path.posix.join(MULTIPASS_MOUNTED_REPO_PATH, ...relativePath.split(path.sep));
+  return resolveMountedOutputPath(repoRoot, hostPath);
 }
 
 function appendScenarioArgs(command: string[], scenarioIds: string[]) {
@@ -304,7 +380,7 @@ export function createQaMultipassPlan(params: {
     cpus: params.cpus ?? qaMultipassDefaultResources.cpus,
     memory: params.memory ?? qaMultipassDefaultResources.memory,
     disk: params.disk ?? qaMultipassDefaultResources.disk,
-    pnpmVersion: resolvePnpmVersion(params.repoRoot),
+    pnpmVersion: validatePnpmVersion(resolvePnpmVersion(params.repoRoot)),
     providerMode,
     primaryModel: params.primaryModel,
     alternateModel: params.alternateModel,
@@ -326,7 +402,11 @@ export function createQaMultipassPlan(params: {
   } satisfies QaMultipassPlan;
 }
 
-export function renderQaMultipassGuestScript(plan: QaMultipassPlan) {
+export function renderQaMultipassGuestScript(
+  plan: QaMultipassPlan,
+  options: RenderGuestScriptOptions = {},
+) {
+  const redactSecrets = options.redactSecrets ?? false;
   const rsyncCommand = [
     "rsync -a --delete",
     ...MULTIPASS_REPO_SYNC_EXCLUDES.flatMap((value) => ["--exclude", shellQuote(value)]),
@@ -341,7 +421,7 @@ export function renderQaMultipassGuestScript(plan: QaMultipassPlan) {
           key !== "OPENCLAW_CONFIG_PATH" &&
           key !== "OPENCLAW_QA_LIVE_PROVIDER_CONFIG_PATH",
       )
-      .map(([key, value]) => `${key}=${shellQuote(value)}`),
+      .map(([key, value]) => `${key}=${shellQuote(redactSecrets ? "<redacted>" : value)}`),
     ...(plan.guestCodexHomePath ? [`CODEX_HOME=${shellQuote(plan.guestCodexHomePath)}`] : []),
     ...(plan.guestLiveProviderConfigPath
       ? [
@@ -355,7 +435,7 @@ export function renderQaMultipassGuestScript(plan: QaMultipassPlan) {
   const lines = [
     "#!/usr/bin/env bash",
     "set -euo pipefail",
-    "trap 'status=$?; echo \"guest failure: ${BASH_COMMAND} (exit ${status})\" >&2; exit ${status}' ERR",
+    "trap 'status=$?; echo \"guest failure (exit ${status})\" >&2; exit ${status}' ERR",
     "",
     "export DEBIAN_FRONTEND=noninteractive",
     `BOOTSTRAP_LOG=${shellQuote(plan.guestBootstrapLogPath)}`,
@@ -406,7 +486,7 @@ export function renderQaMultipassGuestScript(plan: QaMultipassPlan) {
     "",
     "ensure_pnpm() {",
     '  sudo env PATH="/usr/local/bin:/usr/bin:/bin" corepack enable >>"$BOOTSTRAP_LOG" 2>&1',
-    `  sudo env PATH="/usr/local/bin:/usr/bin:/bin" corepack prepare pnpm@${plan.pnpmVersion} --activate >>"$BOOTSTRAP_LOG" 2>&1`,
+    `  sudo env PATH="/usr/local/bin:/usr/bin:/bin" corepack prepare ${shellQuote(`pnpm@${plan.pnpmVersion}`)} --activate >>"$BOOTSTRAP_LOG" 2>&1`,
     "}",
     "",
     'command -v sudo >/dev/null || { echo "missing sudo in guest" >&2; exit 1; }',
@@ -435,9 +515,9 @@ async function appendMultipassLog(logPath: string, message: string) {
   await appendFile(logPath, message, "utf8");
 }
 
-async function runMultipassCommand(logPath: string, args: string[]) {
+async function runMultipassCommand(logPath: string, args: string[], options: ExecFileOptions = {}) {
   await appendMultipassLog(logPath, `$ ${["multipass", ...args].join(" ")}\n`);
-  const result = await execFileAsync("multipass", args);
+  const result = await execFileAsync("multipass", args, options);
   if (result.stdout.trim()) {
     await appendMultipassLog(logPath, `${result.stdout.trim()}\n`);
   }
@@ -562,15 +642,38 @@ export async function runQaMultipass(params: {
     `# OpenClaw QA Multipass host log\nvmName=${plan.vmName}\noutputDir=${plan.outputDir}\n\n`,
     "utf8",
   );
-  await writeFile(plan.hostGuestScriptPath, renderQaMultipassGuestScript(plan), "utf8");
+  await writeFile(
+    plan.hostGuestScriptPath,
+    renderQaMultipassGuestScript(plan, { redactSecrets: true }),
+    {
+      encoding: "utf8",
+      mode: 0o600,
+    },
+  );
 
   try {
     await execFileAsync("multipass", ["version"]);
-  } catch {
+  } catch (error) {
+    if ((error as ExecFileError).code !== "ENOENT") {
+      throw new Error(
+        `Unable to verify Multipass availability: ${error instanceof Error ? error.message : String(error)}.`,
+        { cause: error },
+      );
+    }
     throw new Error(
       `Multipass is not installed on this host. Install it with '${resolveMultipassInstallHint()}', then rerun 'pnpm openclaw qa suite --runner multipass'.`,
+      { cause: error },
     );
   }
+
+  const hostTransferDirPath = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), `${plan.vmName}-qa-suite-`),
+  );
+  const hostTransferScriptPath = path.join(hostTransferDirPath, "guest-run.sh");
+  await writeFile(hostTransferScriptPath, renderQaMultipassGuestScript(plan), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
 
   let launched = false;
   try {
@@ -595,7 +698,7 @@ export async function runQaMultipass(params: {
     await transferLiveProviderConfig(plan);
     await runMultipassCommand(plan.hostLogPath, [
       "transfer",
-      plan.hostGuestScriptPath,
+      hostTransferScriptPath,
       `${plan.vmName}:${plan.guestScriptPath}`,
     ]);
     await runMultipassCommand(plan.hostLogPath, [
@@ -606,7 +709,9 @@ export async function runQaMultipass(params: {
       "+x",
       plan.guestScriptPath,
     ]);
-    await runMultipassCommand(plan.hostLogPath, ["exec", plan.vmName, "--", plan.guestScriptPath]);
+    await runMultipassCommand(plan.hostLogPath, ["exec", plan.vmName, "--", plan.guestScriptPath], {
+      timeoutMs: MULTIPASS_GUEST_RUN_TIMEOUT_MS,
+    });
     await tryCopyGuestBootstrapLog(plan);
   } catch (error) {
     if (launched) {
@@ -617,6 +722,7 @@ export async function runQaMultipass(params: {
       { cause: error },
     );
   } finally {
+    await fs.promises.rm(hostTransferDirPath, { recursive: true, force: true });
     if (launched) {
       try {
         await runMultipassCommand(plan.hostLogPath, ["delete", "--purge", plan.vmName]);

--- a/extensions/qa-lab/src/multipass.runtime.ts
+++ b/extensions/qa-lab/src/multipass.runtime.ts
@@ -1,0 +1,643 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { access, appendFile, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+const MULTIPASS_MOUNTED_REPO_PATH = "/workspace/openclaw-host";
+const MULTIPASS_GUEST_REPO_PATH = "/workspace/openclaw";
+const MULTIPASS_GUEST_CODEX_HOME_PATH = "/workspace/openclaw-codex-home";
+const MULTIPASS_GUEST_PACKAGES = [
+  "build-essential",
+  "ca-certificates",
+  "curl",
+  "pkg-config",
+  "python3",
+  "rsync",
+  "xz-utils",
+] as const;
+const MULTIPASS_REPO_SYNC_EXCLUDES = [
+  ".git",
+  "node_modules",
+  ".artifacts",
+  ".tmp",
+  ".turbo",
+  "coverage",
+  "*.heapsnapshot",
+] as const;
+
+const QA_LIVE_ENV_ALIASES = Object.freeze([
+  {
+    liveVar: "OPENCLAW_LIVE_OPENAI_KEY",
+    providerVar: "OPENAI_API_KEY",
+  },
+  {
+    liveVar: "OPENCLAW_LIVE_ANTHROPIC_KEY",
+    providerVar: "ANTHROPIC_API_KEY",
+  },
+  {
+    liveVar: "OPENCLAW_LIVE_GEMINI_KEY",
+    providerVar: "GEMINI_API_KEY",
+  },
+]);
+
+const QA_LIVE_ALLOWED_ENV_VARS = Object.freeze([
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_OAUTH_TOKEN",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_BEARER_TOKEN_BEDROCK",
+  "AWS_REGION",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "GEMINI_API_KEY",
+  "GEMINI_API_KEYS",
+  "GOOGLE_API_KEY",
+  "MISTRAL_API_KEY",
+  "OPENAI_API_KEY",
+  "OPENAI_API_KEYS",
+  "OPENAI_BASE_URL",
+  "OPENCLAW_LIVE_ANTHROPIC_KEY",
+  "OPENCLAW_LIVE_ANTHROPIC_KEYS",
+  "OPENCLAW_LIVE_GEMINI_KEY",
+  "OPENCLAW_LIVE_OPENAI_KEY",
+  "OPENCLAW_QA_LIVE_PROVIDER_CONFIG_PATH",
+  "OPENCLAW_CONFIG_PATH",
+  "VOYAGE_API_KEY",
+]);
+
+export const qaMultipassDefaultResources = {
+  image: "lts",
+  cpus: 2,
+  memory: "4G",
+  disk: "24G",
+} as const;
+
+type ExecResult = {
+  stdout: string;
+  stderr: string;
+};
+
+export type QaMultipassPlan = {
+  repoRoot: string;
+  outputDir: string;
+  reportPath: string;
+  summaryPath: string;
+  hostLogPath: string;
+  hostBootstrapLogPath: string;
+  hostGuestScriptPath: string;
+  vmName: string;
+  image: string;
+  cpus: number;
+  memory: string;
+  disk: string;
+  pnpmVersion: string;
+  providerMode: "mock-openai" | "live-frontier";
+  primaryModel?: string;
+  alternateModel?: string;
+  fastMode?: boolean;
+  scenarioIds: string[];
+  forwardedEnv: Record<string, string>;
+  hostCodexHomePath?: string;
+  guestCodexHomePath?: string;
+  hostLiveProviderConfigPath?: string;
+  guestLiveProviderConfigPath?: string;
+  guestMountedRepoPath: string;
+  guestRepoPath: string;
+  guestOutputDir: string;
+  guestScriptPath: string;
+  guestBootstrapLogPath: string;
+  qaCommand: string[];
+};
+
+export type QaMultipassRunResult = {
+  outputDir: string;
+  reportPath: string;
+  summaryPath: string;
+  hostLogPath: string;
+  bootstrapLogPath: string;
+  guestScriptPath: string;
+  vmName: string;
+  scenarioIds: string[];
+};
+
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function createOutputStamp() {
+  return new Date().toISOString().replaceAll(":", "").replaceAll(".", "").replace("T", "-");
+}
+
+function createVmSuffix() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function execFileAsync(file: string, args: string[]) {
+  return new Promise<ExecResult>((resolve, reject) => {
+    execFile(file, args, { encoding: "utf8" }, (error, stdout, stderr) => {
+      if (error) {
+        const message = stderr.trim() || stdout.trim() || error.message;
+        reject(new Error(message));
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function resolvePnpmVersion(repoRoot: string) {
+  const packageJsonPath = path.join(repoRoot, "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
+    packageManager?: string;
+  };
+  const packageManager = packageJson.packageManager ?? "";
+  const match = /^pnpm@(.+)$/.exec(packageManager);
+  if (!match?.[1]) {
+    throw new Error(`unable to resolve pnpm version from packageManager in ${packageJsonPath}`);
+  }
+  return match[1];
+}
+
+function resolveMultipassInstallHint() {
+  if (process.platform === "darwin") {
+    return "brew install --cask multipass";
+  }
+  if (process.platform === "win32") {
+    return "winget install Canonical.Multipass";
+  }
+  if (process.platform === "linux") {
+    return "sudo snap install multipass";
+  }
+  return "https://multipass.run/install";
+}
+
+function resolveUserPath(value: string, env: NodeJS.ProcessEnv = process.env) {
+  if (value === "~") {
+    return env.HOME ?? os.homedir();
+  }
+  if (value.startsWith("~/")) {
+    return path.join(env.HOME ?? os.homedir(), value.slice(2));
+  }
+  return path.resolve(value);
+}
+
+function resolveLiveProviderConfigPath(env: NodeJS.ProcessEnv = process.env) {
+  const explicit =
+    env.OPENCLAW_QA_LIVE_PROVIDER_CONFIG_PATH?.trim() || env.OPENCLAW_CONFIG_PATH?.trim();
+  return explicit
+    ? { path: resolveUserPath(explicit, env), explicit: true }
+    : { path: path.join(os.homedir(), ".openclaw", "openclaw.json"), explicit: false };
+}
+
+function resolveQaLiveCliAuthEnv(baseEnv: NodeJS.ProcessEnv) {
+  const configuredCodexHome = baseEnv.CODEX_HOME?.trim();
+  if (configuredCodexHome) {
+    return { CODEX_HOME: resolveUserPath(configuredCodexHome, baseEnv) };
+  }
+  const hostHome = baseEnv.HOME?.trim();
+  if (!hostHome) {
+    return {};
+  }
+  const codexHome = path.join(hostHome, ".codex");
+  return fs.existsSync(codexHome) ? { CODEX_HOME: codexHome } : {};
+}
+
+function resolveForwardedLiveEnv(baseEnv: NodeJS.ProcessEnv = process.env) {
+  const forwarded: Record<string, string> = {};
+  for (const key of QA_LIVE_ALLOWED_ENV_VARS) {
+    const value = baseEnv[key]?.trim();
+    if (value) {
+      forwarded[key] = value;
+    }
+  }
+  for (const { liveVar, providerVar } of QA_LIVE_ENV_ALIASES) {
+    const liveValue = forwarded[liveVar]?.trim();
+    if (liveValue && !forwarded[providerVar]?.trim()) {
+      forwarded[providerVar] = liveValue;
+    }
+  }
+  const liveCliAuth = resolveQaLiveCliAuthEnv(baseEnv);
+  if (liveCliAuth.CODEX_HOME) {
+    forwarded.CODEX_HOME = liveCliAuth.CODEX_HOME;
+  }
+  return forwarded;
+}
+
+function createQaMultipassOutputDir(repoRoot: string) {
+  return path.join(repoRoot, ".artifacts", "qa-e2e", `multipass-${createOutputStamp()}`);
+}
+
+function resolveGuestMountedPath(repoRoot: string, hostPath: string) {
+  const relativePath = path.relative(repoRoot, hostPath);
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath) || relativePath.length === 0) {
+    throw new Error(`unable to resolve Multipass mounted path for ${hostPath}`);
+  }
+  return path.posix.join(MULTIPASS_MOUNTED_REPO_PATH, ...relativePath.split(path.sep));
+}
+
+function appendScenarioArgs(command: string[], scenarioIds: string[]) {
+  for (const scenarioId of scenarioIds) {
+    command.push("--scenario", scenarioId);
+  }
+  return command;
+}
+
+export function createQaMultipassPlan(params: {
+  repoRoot: string;
+  outputDir?: string;
+  providerMode?: "mock-openai" | "live-frontier";
+  primaryModel?: string;
+  alternateModel?: string;
+  fastMode?: boolean;
+  scenarioIds?: string[];
+  image?: string;
+  cpus?: number;
+  memory?: string;
+  disk?: string;
+}) {
+  const outputDir = params.outputDir ?? createQaMultipassOutputDir(params.repoRoot);
+  const scenarioIds = [...new Set(params.scenarioIds ?? [])];
+  const providerMode = params.providerMode ?? "mock-openai";
+  const forwardedEnv = providerMode === "live-frontier" ? resolveForwardedLiveEnv() : {};
+  const hostCodexHomePath = forwardedEnv.CODEX_HOME;
+  const liveProviderConfig =
+    providerMode === "live-frontier" ? resolveLiveProviderConfigPath() : undefined;
+  const hostLiveProviderConfigPath =
+    liveProviderConfig && fs.existsSync(liveProviderConfig.path)
+      ? liveProviderConfig.path
+      : undefined;
+  const vmName = `openclaw-qa-${createVmSuffix()}`;
+  const guestOutputDir = resolveGuestMountedPath(params.repoRoot, outputDir);
+  const qaCommand = appendScenarioArgs(
+    [
+      "pnpm",
+      "openclaw",
+      "qa",
+      "suite",
+      "--provider-mode",
+      providerMode,
+      "--output-dir",
+      guestOutputDir,
+      ...(params.primaryModel ? ["--model", params.primaryModel] : []),
+      ...(params.alternateModel ? ["--alt-model", params.alternateModel] : []),
+      ...(params.fastMode ? ["--fast"] : []),
+    ],
+    scenarioIds,
+  );
+
+  return {
+    repoRoot: params.repoRoot,
+    outputDir,
+    reportPath: path.join(outputDir, "qa-suite-report.md"),
+    summaryPath: path.join(outputDir, "qa-suite-summary.json"),
+    hostLogPath: path.join(outputDir, "multipass-host.log"),
+    hostBootstrapLogPath: path.join(outputDir, "multipass-guest-bootstrap.log"),
+    hostGuestScriptPath: path.join(outputDir, "multipass-guest-run.sh"),
+    vmName,
+    image: params.image ?? qaMultipassDefaultResources.image,
+    cpus: params.cpus ?? qaMultipassDefaultResources.cpus,
+    memory: params.memory ?? qaMultipassDefaultResources.memory,
+    disk: params.disk ?? qaMultipassDefaultResources.disk,
+    pnpmVersion: resolvePnpmVersion(params.repoRoot),
+    providerMode,
+    primaryModel: params.primaryModel,
+    alternateModel: params.alternateModel,
+    fastMode: params.fastMode,
+    scenarioIds,
+    forwardedEnv,
+    hostCodexHomePath,
+    guestCodexHomePath: hostCodexHomePath ? MULTIPASS_GUEST_CODEX_HOME_PATH : undefined,
+    hostLiveProviderConfigPath,
+    guestLiveProviderConfigPath: hostLiveProviderConfigPath
+      ? `/tmp/${vmName}-live-provider-config.json`
+      : undefined,
+    guestMountedRepoPath: MULTIPASS_MOUNTED_REPO_PATH,
+    guestRepoPath: MULTIPASS_GUEST_REPO_PATH,
+    guestOutputDir,
+    guestScriptPath: `/tmp/${vmName}-qa-suite.sh`,
+    guestBootstrapLogPath: `/tmp/${vmName}-bootstrap.log`,
+    qaCommand,
+  } satisfies QaMultipassPlan;
+}
+
+export function renderQaMultipassGuestScript(plan: QaMultipassPlan) {
+  const rsyncCommand = [
+    "rsync -a --delete",
+    ...MULTIPASS_REPO_SYNC_EXCLUDES.flatMap((value) => ["--exclude", shellQuote(value)]),
+    shellQuote(`${plan.guestMountedRepoPath}/`),
+    shellQuote(`${plan.guestRepoPath}/`),
+  ].join(" ");
+  const qaCommand = [
+    ...Object.entries(plan.forwardedEnv)
+      .filter(
+        ([key]) =>
+          key !== "CODEX_HOME" &&
+          key !== "OPENCLAW_CONFIG_PATH" &&
+          key !== "OPENCLAW_QA_LIVE_PROVIDER_CONFIG_PATH",
+      )
+      .map(([key, value]) => `${key}=${shellQuote(value)}`),
+    ...(plan.guestCodexHomePath ? [`CODEX_HOME=${shellQuote(plan.guestCodexHomePath)}`] : []),
+    ...(plan.guestLiveProviderConfigPath
+      ? [
+          `OPENCLAW_CONFIG_PATH=${shellQuote(plan.guestLiveProviderConfigPath)}`,
+          `OPENCLAW_QA_LIVE_PROVIDER_CONFIG_PATH=${shellQuote(plan.guestLiveProviderConfigPath)}`,
+        ]
+      : []),
+    plan.qaCommand.map(shellQuote).join(" "),
+  ].join(" ");
+
+  const lines = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "trap 'status=$?; echo \"guest failure: ${BASH_COMMAND} (exit ${status})\" >&2; exit ${status}' ERR",
+    "",
+    "export DEBIAN_FRONTEND=noninteractive",
+    `BOOTSTRAP_LOG=${shellQuote(plan.guestBootstrapLogPath)}`,
+    ': > "$BOOTSTRAP_LOG"',
+    "",
+    "ensure_guest_packages() {",
+    '  sudo -E apt-get update >>"$BOOTSTRAP_LOG" 2>&1',
+    "  sudo -E apt-get install -y \\",
+    ...MULTIPASS_GUEST_PACKAGES.map((value, index) =>
+      index === MULTIPASS_GUEST_PACKAGES.length - 1
+        ? `    ${value} >>"$BOOTSTRAP_LOG" 2>&1`
+        : `    ${value} \\`,
+    ),
+    "}",
+    "",
+    "ensure_node() {",
+    "  if command -v node >/dev/null; then",
+    "    local node_major",
+    '    node_major="$(node -p \'process.versions.node.split(".")[0]\' 2>/dev/null || echo 0)"',
+    '    if [ "${node_major}" -ge 22 ]; then',
+    "      return 0",
+    "    fi",
+    "  fi",
+    "  local node_arch",
+    '  case "$(uname -m)" in',
+    '    x86_64) node_arch="x64" ;;',
+    '    aarch64|arm64) node_arch="arm64" ;;',
+    '    *) echo "unsupported guest architecture for node bootstrap: $(uname -m)" >&2; return 1 ;;',
+    "  esac",
+    "  local node_tmp_dir tarball_name extract_dir base_url",
+    '  node_tmp_dir="$(mktemp -d)"',
+    "  trap 'rm -rf \"${node_tmp_dir}\"' RETURN",
+    '  base_url="https://nodejs.org/dist/latest-v22.x"',
+    '  curl -fsSL "${base_url}/SHASUMS256.txt" -o "${node_tmp_dir}/SHASUMS256.txt" >>"$BOOTSTRAP_LOG" 2>&1',
+    '  tarball_name="$(awk \'/linux-\'"${node_arch}"\'\\.tar\\.xz$/ { print $2; exit }\' "${node_tmp_dir}/SHASUMS256.txt")"',
+    '  [ -n "${tarball_name}" ] || { echo "unable to resolve node tarball for ${node_arch}" >&2; return 1; }',
+    '  curl -fsSL "${base_url}/${tarball_name}" -o "${node_tmp_dir}/${tarball_name}" >>"$BOOTSTRAP_LOG" 2>&1',
+    '  (cd "${node_tmp_dir}" && grep " ${tarball_name}$" SHASUMS256.txt | sha256sum -c -) >>"$BOOTSTRAP_LOG" 2>&1',
+    '  extract_dir="${tarball_name%.tar.xz}"',
+    '  sudo mkdir -p /usr/local/lib/nodejs >>"$BOOTSTRAP_LOG" 2>&1',
+    '  sudo rm -rf "/usr/local/lib/nodejs/${extract_dir}" >>"$BOOTSTRAP_LOG" 2>&1',
+    '  sudo tar -xJf "${node_tmp_dir}/${tarball_name}" -C /usr/local/lib/nodejs >>"$BOOTSTRAP_LOG" 2>&1',
+    '  sudo ln -sf "/usr/local/lib/nodejs/${extract_dir}/bin/node" /usr/local/bin/node >>"$BOOTSTRAP_LOG" 2>&1',
+    '  sudo ln -sf "/usr/local/lib/nodejs/${extract_dir}/bin/npm" /usr/local/bin/npm >>"$BOOTSTRAP_LOG" 2>&1',
+    '  sudo ln -sf "/usr/local/lib/nodejs/${extract_dir}/bin/npx" /usr/local/bin/npx >>"$BOOTSTRAP_LOG" 2>&1',
+    '  sudo ln -sf "/usr/local/lib/nodejs/${extract_dir}/bin/corepack" /usr/local/bin/corepack >>"$BOOTSTRAP_LOG" 2>&1',
+    "}",
+    "",
+    "ensure_pnpm() {",
+    '  sudo env PATH="/usr/local/bin:/usr/bin:/bin" corepack enable >>"$BOOTSTRAP_LOG" 2>&1',
+    `  sudo env PATH="/usr/local/bin:/usr/bin:/bin" corepack prepare pnpm@${plan.pnpmVersion} --activate >>"$BOOTSTRAP_LOG" 2>&1`,
+    "}",
+    "",
+    'command -v sudo >/dev/null || { echo "missing sudo in guest" >&2; exit 1; }',
+    "ensure_guest_packages",
+    "ensure_node",
+    "ensure_pnpm",
+    'command -v node >/dev/null || { echo "missing node after guest bootstrap" >&2; exit 1; }',
+    'command -v pnpm >/dev/null || { echo "missing pnpm after guest bootstrap" >&2; exit 1; }',
+    'command -v rsync >/dev/null || { echo "missing rsync after guest bootstrap" >&2; exit 1; }',
+    "",
+    `mkdir -p ${shellQuote(path.posix.dirname(plan.guestRepoPath))}`,
+    `rm -rf ${shellQuote(plan.guestRepoPath)}`,
+    `mkdir -p ${shellQuote(plan.guestRepoPath)}`,
+    `mkdir -p ${shellQuote(plan.guestOutputDir)}`,
+    rsyncCommand,
+    `cd ${shellQuote(plan.guestRepoPath)}`,
+    'pnpm install --frozen-lockfile >>"$BOOTSTRAP_LOG" 2>&1',
+    'pnpm build >>"$BOOTSTRAP_LOG" 2>&1',
+    qaCommand,
+    "",
+  ];
+  return lines.join("\n");
+}
+
+async function appendMultipassLog(logPath: string, message: string) {
+  await appendFile(logPath, message, "utf8");
+}
+
+async function runMultipassCommand(logPath: string, args: string[]) {
+  await appendMultipassLog(logPath, `$ ${["multipass", ...args].join(" ")}\n`);
+  const result = await execFileAsync("multipass", args);
+  if (result.stdout.trim()) {
+    await appendMultipassLog(logPath, `${result.stdout.trim()}\n`);
+  }
+  if (result.stderr.trim()) {
+    await appendMultipassLog(logPath, `${result.stderr.trim()}\n`);
+  }
+  await appendMultipassLog(logPath, "\n");
+  return result;
+}
+
+async function waitForGuestReady(logPath: string, vmName: string) {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 12; attempt += 1) {
+    try {
+      await runMultipassCommand(logPath, ["exec", vmName, "--", "bash", "-lc", "echo guest-ready"]);
+      return;
+    } catch (error) {
+      lastError = error;
+      await appendMultipassLog(
+        logPath,
+        `guest-ready retry ${attempt}/12: ${error instanceof Error ? error.message : String(error)}\n\n`,
+      );
+      if (attempt < 12) {
+        await sleep(2_000);
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function mountRepo(logPath: string, repoRoot: string, vmName: string) {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    try {
+      await runMultipassCommand(logPath, [
+        "mount",
+        repoRoot,
+        `${vmName}:${MULTIPASS_MOUNTED_REPO_PATH}`,
+      ]);
+      return;
+    } catch (error) {
+      lastError = error;
+      await appendMultipassLog(
+        logPath,
+        `mount retry ${attempt}/5: ${error instanceof Error ? error.message : String(error)}\n\n`,
+      );
+      if (attempt < 5) {
+        await sleep(2_000);
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function mountCodexHome(logPath: string, hostCodexHomePath: string, vmName: string) {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 5; attempt += 1) {
+    try {
+      await runMultipassCommand(logPath, [
+        "mount",
+        hostCodexHomePath,
+        `${vmName}:${MULTIPASS_GUEST_CODEX_HOME_PATH}`,
+      ]);
+      return;
+    } catch (error) {
+      lastError = error;
+      await appendMultipassLog(
+        logPath,
+        `codex-home mount retry ${attempt}/5: ${error instanceof Error ? error.message : String(error)}\n\n`,
+      );
+      if (attempt < 5) {
+        await sleep(2_000);
+      }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+async function transferLiveProviderConfig(plan: QaMultipassPlan) {
+  if (!plan.hostLiveProviderConfigPath || !plan.guestLiveProviderConfigPath) {
+    return;
+  }
+  await runMultipassCommand(plan.hostLogPath, [
+    "transfer",
+    plan.hostLiveProviderConfigPath,
+    `${plan.vmName}:${plan.guestLiveProviderConfigPath}`,
+  ]);
+}
+
+async function tryCopyGuestBootstrapLog(plan: QaMultipassPlan) {
+  try {
+    await runMultipassCommand(plan.hostLogPath, [
+      "transfer",
+      `${plan.vmName}:${plan.guestBootstrapLogPath}`,
+      plan.hostBootstrapLogPath,
+    ]);
+  } catch (error) {
+    await appendMultipassLog(
+      plan.hostLogPath,
+      `bootstrap log transfer skipped: ${error instanceof Error ? error.message : String(error)}\n\n`,
+    );
+  }
+}
+
+export async function runQaMultipass(params: {
+  repoRoot: string;
+  outputDir?: string;
+  providerMode?: "mock-openai" | "live-frontier";
+  primaryModel?: string;
+  alternateModel?: string;
+  fastMode?: boolean;
+  scenarioIds?: string[];
+  image?: string;
+  cpus?: number;
+  memory?: string;
+  disk?: string;
+}) {
+  const plan = createQaMultipassPlan(params);
+  await mkdir(plan.outputDir, { recursive: true });
+  await writeFile(
+    plan.hostLogPath,
+    `# OpenClaw QA Multipass host log\nvmName=${plan.vmName}\noutputDir=${plan.outputDir}\n\n`,
+    "utf8",
+  );
+  await writeFile(plan.hostGuestScriptPath, renderQaMultipassGuestScript(plan), "utf8");
+
+  try {
+    await execFileAsync("multipass", ["version"]);
+  } catch {
+    throw new Error(
+      `Multipass is not installed on this host. Install it with '${resolveMultipassInstallHint()}', then rerun 'pnpm openclaw qa suite --runner multipass'.`,
+    );
+  }
+
+  let launched = false;
+  try {
+    await runMultipassCommand(plan.hostLogPath, [
+      "launch",
+      "--name",
+      plan.vmName,
+      "--cpus",
+      String(plan.cpus),
+      "--memory",
+      plan.memory,
+      "--disk",
+      plan.disk,
+      plan.image,
+    ]);
+    launched = true;
+    await waitForGuestReady(plan.hostLogPath, plan.vmName);
+    await mountRepo(plan.hostLogPath, plan.repoRoot, plan.vmName);
+    if (plan.hostCodexHomePath) {
+      await mountCodexHome(plan.hostLogPath, plan.hostCodexHomePath, plan.vmName);
+    }
+    await transferLiveProviderConfig(plan);
+    await runMultipassCommand(plan.hostLogPath, [
+      "transfer",
+      plan.hostGuestScriptPath,
+      `${plan.vmName}:${plan.guestScriptPath}`,
+    ]);
+    await runMultipassCommand(plan.hostLogPath, [
+      "exec",
+      plan.vmName,
+      "--",
+      "chmod",
+      "+x",
+      plan.guestScriptPath,
+    ]);
+    await runMultipassCommand(plan.hostLogPath, ["exec", plan.vmName, "--", plan.guestScriptPath]);
+    await tryCopyGuestBootstrapLog(plan);
+  } catch (error) {
+    if (launched) {
+      await tryCopyGuestBootstrapLog(plan);
+    }
+    throw new Error(
+      `QA Multipass run failed: ${error instanceof Error ? error.message : String(error)}. See ${plan.hostLogPath}.`,
+      { cause: error },
+    );
+  } finally {
+    if (launched) {
+      try {
+        await runMultipassCommand(plan.hostLogPath, ["delete", "--purge", plan.vmName]);
+      } catch (error) {
+        await appendMultipassLog(
+          plan.hostLogPath,
+          `cleanup error: ${error instanceof Error ? error.message : String(error)}\n\n`,
+        );
+      }
+    }
+  }
+
+  await access(plan.reportPath);
+  await access(plan.summaryPath);
+
+  return {
+    outputDir: plan.outputDir,
+    reportPath: plan.reportPath,
+    summaryPath: plan.summaryPath,
+    hostLogPath: plan.hostLogPath,
+    bootstrapLogPath: plan.hostBootstrapLogPath,
+    guestScriptPath: plan.hostGuestScriptPath,
+    vmName: plan.vmName,
+    scenarioIds: plan.scenarioIds,
+  } satisfies QaMultipassRunResult;
+}


### PR DESCRIPTION
## Summary

- Problem: QA can run on the host today, but there is no disposable Linux VM runner for the same `qa suite` flow.
- Why it matters: we need a VM-backed QA lane without inventing a separate testing system or changing how contributors already use `qa suite`.
- What changed: adds `--runner multipass` to `pnpm openclaw qa suite`, so the existing suite can run inside a fresh Multipass VM and export the normal QA report and summary back to the host, along with Multipass host/bootstrap logs.
- What did NOT change (scope boundary): this does not introduce a new QA command, a new QA model, or a general backend framework. Docker flows and the normal host `qa suite` path stay as they are.

## Change Type

- [x] Feature
- [x] Docs

## User-visible / Behavior Changes

- New runner option:
  - `pnpm openclaw qa suite --runner multipass --scenario channel-chat-baseline`
- Host remains the default:
  - `pnpm openclaw qa suite ...`
- Multipass writes these artifacts on the host:
  - `qa-suite-report.md`
  - `qa-suite-summary.json`
  - `multipass-host.log`
  - `multipass-guest-bootstrap.log`
  - `multipass-guest-run.sh`

## Notes

- Multipass is a runner for `qa suite`, not a separate QA command.
- Current live support forwards the supported QA auth inputs that are practical for the guest:
  - env-based provider keys
  - QA live provider config path
  - `CODEX_HOME` when present
- `--output-dir` must stay under the repo root so the guest can write back through the mounted workspace.

## Verification

- `pnpm test extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/multipass.runtime.test.ts`
- `pnpm build`
- `pnpm check:docs`
- `pnpm openclaw qa suite --runner multipass --scenario channel-chat-baseline`
- `pnpm openclaw qa suite --runner multipass --provider-mode live-frontier --model openai/gpt-5.4 --alt-model openai/gpt-5.4 --scenario channel-chat-baseline`

## Example Artifact Bundle

A real mock Multipass run produced:

- `.artifacts/qa-e2e/multipass-2026-04-08-232729699Z/qa-suite-report.md`
- `.artifacts/qa-e2e/multipass-2026-04-08-232729699Z/qa-suite-summary.json`
- `.artifacts/qa-e2e/multipass-2026-04-08-232729699Z/multipass-host.log`
- `.artifacts/qa-e2e/multipass-2026-04-08-232729699Z/multipass-guest-bootstrap.log`

With summary:

```json
{
  "counts": {
    "total": 1,
    "passed": 1,
    "failed": 0
  }
}
```

## Risks and Mitigations

- Risk: Multipass live runs cannot automatically reproduce every possible host auth/state shape inside the guest.
- Mitigation: docs state the supported forwarded auth inputs explicitly instead of claiming full equivalence.

- Risk: arbitrary external output dirs do not work with the mounted repo writeback model.
- Mitigation: the runner validates this up front and errors clearly when `--output-dir` is outside the repo root.
