### PR TITLE
fix: preserve tables, blockquotes, and inline formatting across chunk boundaries

### DIFF
--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -1,5 +1,13 @@
 import { chunkMarkdownTextWithMode, type ChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 
+const BQ_PREFIX_RE = /^(>+\s?)/;
+const TABLE_SEPARATOR_RE = /^\|?[\s-:|]+\|[\s-:|]*$/;
+
+type TableHeader = {
+  headerLine: string;
+  separatorLine: string;
+};
+
 export type ChunkDiscordTextOpts = {
   /** Max characters per Discord message. Default: 2000. */
   maxChars?: number;
@@ -125,6 +133,10 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
   let current = "";
   let currentLines = 0;
   let openFence: OpenFence | null = null;
+  let insideBlockquote: string | null = null; // the `> ` prefix
+  let openTable: TableHeader | null = null;
+  let pendingTableHeader = false; // true when next line might be a separator
+  let lastLineWasTableCandidate = ""; // stash the potential header line
 
   const flush = () => {
     if (!current) {
@@ -136,10 +148,30 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
     }
     current = "";
     currentLines = 0;
+    // Reopen fence context
     if (openFence) {
       current = openFence.openLine;
       currentLines = 1;
     }
+    // Reopen table context: repeat header + separator
+    if (openTable && !openFence) {
+      const tableReopen = `${openTable.headerLine}\n${openTable.separatorLine}`;
+      if (current) {
+        current += `\n${tableReopen}`;
+        currentLines += 2;
+      } else {
+        current = tableReopen;
+        currentLines = 2;
+      }
+    }
+  };
+
+  // Helper: apply blockquote prefix to a line if we're inside a blockquote
+  const applyBlockquoteToSegment = (segment: string, prefix: string | null): string => {
+    if (!prefix) return segment;
+    if (segment.trim() === "") return segment;
+    if (segment.startsWith(prefix.trimEnd())) return segment;
+    return `${prefix}${segment}`;
   };
 
   for (const originalLine of lines) {
@@ -169,9 +201,44 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       preserveWhitespace: wasInsideFence,
     });
 
+    // Track blockquote state
+    const bqMatch = originalLine.match(BQ_PREFIX_RE);
+    if (bqMatch && !wasInsideFence) {
+      insideBlockquote = bqMatch[1];
+    } else if (!bqMatch || wasInsideFence) {
+      insideBlockquote = null;
+    }
+
+    // Track table state
+    if (!wasInsideFence) {
+      if (pendingTableHeader && TABLE_SEPARATOR_RE.test(originalLine.trim())) {
+        // Confirmed: previous line was header, this line is separator
+        openTable = { headerLine: lastLineWasTableCandidate, separatorLine: originalLine };
+        pendingTableHeader = false;
+        lastLineWasTableCandidate = "";
+      } else if (openTable && originalLine.includes("|")) {
+        // Still inside a table (data row)
+      } else if (originalLine.includes("|") && !openTable) {
+        // Potential table header - stash it and check next line
+        pendingTableHeader = true;
+        lastLineWasTableCandidate = originalLine;
+      } else {
+        // Not a table line - clear table state
+        openTable = null;
+        pendingTableHeader = false;
+        lastLineWasTableCandidate = "";
+      }
+    }
+
     for (let segIndex = 0; segIndex < segments.length; segIndex++) {
-      const segment = segments[segIndex];
+      let segment = segments[segIndex];
       const isLineContinuation = segIndex > 0;
+
+      // Apply blockquote prefix to continuation segments after a flush
+      if (insideBlockquote && isLineContinuation) {
+        segment = applyBlockquoteToSegment(segment, insideBlockquote);
+      }
+
       const delimiter = isLineContinuation ? "" : current.length > 0 ? "\n" : "";
       const addition = `${delimiter}${segment}`;
       const nextLen = current.length + addition.length;
@@ -182,6 +249,11 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
 
       if ((wouldExceedChars || wouldExceedLines) && current.length > 0) {
         flush();
+      }
+
+      // After flush, if we're inside a blockquote, prefix the segment
+      if (current.length === 0 && insideBlockquote && !segment.startsWith(insideBlockquote.trimEnd())) {
+        segment = applyBlockquoteToSegment(segment, insideBlockquote);
       }
 
       if (current.length > 0) {

--- a/extensions/discord/src/chunk.ts
+++ b/extensions/discord/src/chunk.ts
@@ -234,11 +234,6 @@ export function chunkDiscordText(text: string, opts: ChunkDiscordTextOpts = {}):
       let segment = segments[segIndex];
       const isLineContinuation = segIndex > 0;
 
-      // Apply blockquote prefix to continuation segments after a flush
-      if (insideBlockquote && isLineContinuation) {
-        segment = applyBlockquoteToSegment(segment, insideBlockquote);
-      }
-
       const delimiter = isLineContinuation ? "" : current.length > 0 ? "\n" : "";
       const addition = `${delimiter}${segment}`;
       const nextLen = current.length + addition.length;

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -608,6 +608,7 @@ export async function processDiscordMessage(
     const formatted = convertMarkdownTables(
       stripInlineDirectiveTagsForDelivery(text).text,
       tableMode,
+      "> ",
     );
     const chunks = chunkDiscordTextWithMode(formatted, {
       maxChars: draftMaxChars,

--- a/extensions/discord/src/monitor/reply-delivery.ts
+++ b/extensions/discord/src/monitor/reply-delivery.ts
@@ -411,7 +411,7 @@ export async function deliverDiscordReply(params: {
     });
     const tableMode = params.tableMode ?? "code";
     const reply = resolveSendableOutboundReplyParts(payload, {
-      text: convertMarkdownTables(payload.text ?? "", tableMode),
+      text: convertMarkdownTables(payload.text ?? "", tableMode, "> "),
     });
     if (!reply.hasContent) {
       continue;

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -155,7 +155,7 @@ export async function sendMessageDiscord(
     typeof accountInfo.config.mediaMaxMb === "number"
       ? accountInfo.config.mediaMaxMb * 1024 * 1024
       : DEFAULT_DISCORD_MEDIA_MAX_MB * 1024 * 1024;
-  const textWithTables = convertMarkdownTables(text ?? "", tableMode);
+  const textWithTables = convertMarkdownTables(text ?? "", tableMode, "> ");
   const textWithMentions = rewriteDiscordKnownMentions(textWithTables, {
     accountId: accountInfo.accountId,
   });

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
+import { parseBlockquoteSpans } from "../markdown/blockquotes.js";
 import * as fences from "../markdown/fences.js";
+import {
+  scanUnmatchedInlineMarkers,
+  buildInlineClose,
+  buildInlineReopen,
+} from "../markdown/inline-formatting.js";
+import { parseTableSpans } from "../markdown/table-spans.js";
 import { hasBalancedFences } from "../test-utils/chunk-test-helpers.js";
 import {
   chunkByNewline,
@@ -581,4 +588,103 @@ describe("resolveChunkMode", () => {
       expect(resolveChunkMode(cfg as never, provider, accountId)).toBe(expected);
     },
   );
+});
+
+describe("parseTableSpans", () => {
+  it("detects a simple table", () => {
+    const table = "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |";
+    const spans = parseTableSpans(table);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].headerLine).toBe("| A | B |");
+    expect(spans[0].separatorLine).toBe("| --- | --- |");
+    expect(spans[0].start).toBe(0);
+    expect(spans[0].end).toBe(table.length);
+  });
+
+  it("detects multiple tables", () => {
+    const text = "| A |\n| --- |\n| 1 |\n\nText\n\n| B |\n| --- |\n| 2 |";
+    const spans = parseTableSpans(text);
+    expect(spans).toHaveLength(2);
+  });
+
+  it("returns empty for non-table text", () => {
+    expect(parseTableSpans("Hello world\nNo tables here")).toEqual([]);
+  });
+});
+
+describe("parseBlockquoteSpans", () => {
+  it("detects a blockquote region", () => {
+    const text = "> line 1\n> line 2\n> line 3";
+    const spans = parseBlockquoteSpans(text);
+    expect(spans).toHaveLength(1);
+    expect(spans[0].prefix).toBe("> ");
+  });
+
+  it("detects separate blockquote regions", () => {
+    const text = "> quote 1\n\nplain text\n\n> quote 2";
+    const spans = parseBlockquoteSpans(text);
+    expect(spans).toHaveLength(2);
+  });
+});
+
+describe("scanUnmatchedInlineMarkers", () => {
+  it("detects unmatched bold", () => {
+    const state = scanUnmatchedInlineMarkers("Hello **world");
+    expect(state.openMarkers).toEqual(["**"]);
+    expect(buildInlineClose(state)).toBe("**");
+    expect(buildInlineReopen(state)).toBe("**");
+  });
+
+  it("detects matched markers as balanced", () => {
+    const state = scanUnmatchedInlineMarkers("Hello **world** done");
+    expect(state.openMarkers).toEqual([]);
+  });
+
+  it("detects unmatched backtick", () => {
+    const state = scanUnmatchedInlineMarkers("Hello `code");
+    expect(state.openMarkers).toEqual(["`"]);
+  });
+
+  it("detects multiple unmatched markers", () => {
+    const state = scanUnmatchedInlineMarkers("**bold *italic");
+    expect(state.openMarkers).toEqual(["**", "*"]);
+    expect(buildInlineClose(state)).toBe("***");
+    expect(buildInlineReopen(state)).toBe("***");
+  });
+});
+
+describe("chunkMarkdownText - tables", () => {
+  it("avoids splitting inside a table when possible", () => {
+    const table = "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |";
+    const text = `Before\n\n${table}\n\nAfter`;
+    const chunks = chunkMarkdownText(text, 60);
+    expect(chunks.some((c) => c.includes("| A | B |") && c.includes("| 3 | 4 |"))).toBe(true);
+  });
+});
+
+describe("chunkMarkdownText - blockquotes", () => {
+  it("re-applies blockquote prefix in continuation chunk", () => {
+    const bq = Array.from({ length: 20 }, (_, i) => `> Line ${i}`).join("\n");
+    const chunks = chunkMarkdownText(bq, 80);
+    expect(chunks.length).toBeGreaterThan(1);
+    // All non-empty lines in continuation chunks should start with >
+    for (let i = 1; i < chunks.length; i++) {
+      const lines = chunks[i].split("\n").filter((l) => l.trim() !== "");
+      for (const line of lines) {
+        expect(line.startsWith(">")).toBe(true);
+      }
+    }
+  });
+});
+
+describe("chunkMarkdownText - inline formatting", () => {
+  it("closes and reopens bold markers at chunk boundaries", () => {
+    const text = `**${"a".repeat(100)}**`;
+    const chunks = chunkMarkdownText(text, 60);
+    expect(chunks.length).toBeGreaterThan(1);
+    // First chunk should end with ** to close
+    expect(chunks[0].endsWith("**")).toBe(true);
+    // Second chunk should start with ** to reopen
+    expect(chunks[1].startsWith("**")).toBe(true);
+  });
 });

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -357,7 +357,10 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
     if (text.length - start <= contentLimit) {
       let finalContent = text.slice(start);
       if (reopenBlockquote) {
-        finalContent = reapplyBlockquotePrefix(finalContent, reopenBlockquote.prefix);
+        const bqEnd = Math.min(reopenBlockquote.end - start, finalContent.length);
+        finalContent =
+          reapplyBlockquotePrefix(finalContent.slice(0, bqEnd), reopenBlockquote.prefix) +
+          finalContent.slice(bqEnd);
       }
       const finalChunk = `${fullReopenPrefix}${finalContent}`;
       if (finalChunk.length > 0) {
@@ -441,7 +444,12 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
 
     let contentForChunk = rawContent;
     if (reopenBlockquote) {
-      contentForChunk = reapplyBlockquotePrefix(contentForChunk, reopenBlockquote.prefix);
+      // Only apply the prefix up to the end of the blockquote span.
+      // Lines after the span end are plain prose and must not be quoted.
+      const bqEnd = Math.min(reopenBlockquote.end - start, rawContent.length);
+      const insideQuote = rawContent.slice(0, bqEnd);
+      const afterQuote = rawContent.slice(bqEnd);
+      contentForChunk = reapplyBlockquotePrefix(insideQuote, reopenBlockquote.prefix) + afterQuote;
     }
 
     // Detect unmatched inline markers in this chunk (only when not inside a fence)

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -4,7 +4,18 @@
 
 import type { ChannelId } from "../channels/plugins/types.js";
 import type { OpenClawConfig } from "../config/config.js";
+import {
+  findBlockquoteAt,
+  parseBlockquoteSpans,
+  reapplyBlockquotePrefix,
+} from "../markdown/blockquotes.js";
 import { findFenceSpanAt, isSafeFenceBreak, parseFenceSpans } from "../markdown/fences.js";
+import {
+  buildInlineClose,
+  buildInlineReopen,
+  scanUnmatchedInlineMarkers,
+} from "../markdown/inline-formatting.js";
+import { findTableSpanAt, isSafeTableBreak, parseTableSpans } from "../markdown/table-spans.js";
 import { resolveChannelStreamingChunkMode } from "../plugin-sdk/channel-streaming.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { normalizeAccountId } from "../routing/session-key.js";
@@ -326,14 +337,29 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
 
   const chunks: string[] = [];
   const spans = parseFenceSpans(text);
+  const tableSpans = parseTableSpans(text);
+  const blockquoteSpans = parseBlockquoteSpans(text);
   let start = 0;
   let reopenFence: ReturnType<typeof findFenceSpanAt> | undefined;
+  let reopenBlockquote: ReturnType<typeof findBlockquoteAt> | undefined;
+  let reopenInline: string | undefined;
+  let reopenTableHeader: string | undefined;
 
   while (start < text.length) {
-    const reopenPrefix = reopenFence ? `${reopenFence.openLine}\n` : "";
-    const contentLimit = Math.max(1, limit - reopenPrefix.length);
+    const reopenPrefix = reopenFence
+      ? `${reopenFence.openLine}\n`
+      : reopenTableHeader
+        ? reopenTableHeader
+        : "";
+    const inlineReopenPrefix = reopenInline ?? "";
+    const fullReopenPrefix = `${reopenPrefix}${inlineReopenPrefix}`;
+    const contentLimit = Math.max(1, limit - fullReopenPrefix.length);
     if (text.length - start <= contentLimit) {
-      const finalChunk = `${reopenPrefix}${text.slice(start)}`;
+      let finalContent = text.slice(start);
+      if (reopenBlockquote) {
+        finalContent = reapplyBlockquotePrefix(finalContent, reopenBlockquote.prefix);
+      }
+      const finalChunk = `${fullReopenPrefix}${finalContent}`;
       if (finalChunk.length > 0) {
         chunks.push(finalChunk);
       }
@@ -341,7 +367,7 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
     }
 
     const windowEnd = Math.min(text.length, start + contentLimit);
-    const softBreak = pickSafeBreakIndex(text, start, windowEnd, spans);
+    const softBreak = pickSafeBreakIndex(text, start, windowEnd, spans, tableSpans);
     let breakIdx = softBreak > start ? softBreak : windowEnd;
 
     const initialFence = isSafeFenceBreak(spans, breakIdx)
@@ -394,22 +420,71 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
         fenceAtBreak && fenceAtBreak.start === initialFence.start ? fenceAtBreak : undefined;
     }
 
+    // Check if we're breaking inside a table
+    const tableAtBreak = findTableSpanAt(tableSpans, breakIdx);
+    if (tableAtBreak && breakIdx > tableAtBreak.start) {
+      // Try to break before the table
+      const beforeTable = text.lastIndexOf("\n", tableAtBreak.start);
+      if (beforeTable > start) {
+        breakIdx = beforeTable;
+      }
+      // If table fits as atomic unit, push breakIdx past it
+      // Otherwise the header will be repeated in continuation (handled below)
+    }
+
     const rawContent = text.slice(start, breakIdx);
     if (!rawContent) {
       break;
     }
 
-    let rawChunk = `${reopenPrefix}${rawContent}`;
+    let contentForChunk = rawContent;
+    if (reopenBlockquote) {
+      contentForChunk = reapplyBlockquotePrefix(contentForChunk, reopenBlockquote.prefix);
+    }
+
+    // Detect unmatched inline markers in this chunk (only when not inside a fence)
+    let inlineClose = "";
+    let inlineReopenNext = "";
+    if (!fenceToSplit) {
+      const chunkForInlineScan = `${fullReopenPrefix}${contentForChunk}`;
+      const inlineSpans = parseFenceSpans(chunkForInlineScan);
+      const inlineState = scanUnmatchedInlineMarkers(chunkForInlineScan, inlineSpans);
+      inlineClose = buildInlineClose(inlineState);
+      inlineReopenNext = buildInlineReopen(inlineState);
+    }
+
+    let rawChunk = `${fullReopenPrefix}${contentForChunk}`;
     const brokeOnSeparator = breakIdx < text.length && /\s/.test(text[breakIdx]);
     let nextStart = Math.min(text.length, breakIdx + (brokeOnSeparator ? 1 : 0));
+
+    // Detect blockquote context at break point
+    const bqAtBreak = findBlockquoteAt(blockquoteSpans, breakIdx);
 
     if (fenceToSplit) {
       const closeLine = `${fenceToSplit.indent}${fenceToSplit.marker}`;
       rawChunk = rawChunk.endsWith("\n") ? `${rawChunk}${closeLine}` : `${rawChunk}\n${closeLine}`;
       reopenFence = fenceToSplit;
+      reopenBlockquote = undefined;
     } else {
       nextStart = skipLeadingNewlines(text, nextStart);
       reopenFence = undefined;
+      reopenBlockquote = bqAtBreak;
+    }
+
+    // Append inline close markers if needed (only outside fences)
+    if (!fenceToSplit && inlineClose) {
+      rawChunk += inlineClose;
+      reopenInline = inlineReopenNext;
+    } else {
+      reopenInline = undefined;
+    }
+
+    // Handle table header repetition for continuation
+    const tableForContinuation = findTableSpanAt(tableSpans, nextStart);
+    if (tableForContinuation && nextStart > tableForContinuation.start) {
+      reopenTableHeader = `${tableForContinuation.headerLine}\n${tableForContinuation.separatorLine}\n`;
+    } else {
+      reopenTableHeader = undefined;
     }
 
     chunks.push(rawChunk);
@@ -431,9 +506,14 @@ function pickSafeBreakIndex(
   start: number,
   end: number,
   spans: ReturnType<typeof parseFenceSpans>,
+  tableSpans?: ReturnType<typeof parseTableSpans>,
 ): number {
-  const { lastNewline, lastWhitespace } = scanParenAwareBreakpoints(text, start, end, (index) =>
-    isSafeFenceBreak(spans, index),
+  const { lastNewline, lastWhitespace } = scanParenAwareBreakpoints(
+    text,
+    start,
+    end,
+    (index) =>
+      isSafeFenceBreak(spans, index) && (!tableSpans || isSafeTableBreak(tableSpans, index)),
   );
 
   if (lastNewline > start) {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -337,7 +337,7 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
 
   const chunks: string[] = [];
   const spans = parseFenceSpans(text);
-  const tableSpans = parseTableSpans(text);
+  const tableSpans = parseTableSpans(text, spans);
   const blockquoteSpans = parseBlockquoteSpans(text);
   let start = 0;
   let reopenFence: ReturnType<typeof findFenceSpanAt> | undefined;
@@ -422,8 +422,10 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
 
     // Check if we're breaking inside a table
     const tableAtBreak = findTableSpanAt(tableSpans, breakIdx);
-    if (tableAtBreak && breakIdx > tableAtBreak.start) {
-      // Try to break before the table
+    if (tableAtBreak) {
+      // Try to break before the table so it stays atomic.
+      // If the table starts too close to `start`, fall through and let
+      // the continuation-header logic (below) handle the split.
       const beforeTable = text.lastIndexOf("\n", tableAtBreak.start);
       if (beforeTable > start) {
         breakIdx = beforeTable;

--- a/src/markdown/blockquotes.ts
+++ b/src/markdown/blockquotes.ts
@@ -1,0 +1,83 @@
+/**
+ * Detect blockquote regions (lines starting with `>`) and provide helpers
+ * for re-applying the blockquote prefix when a chunk split lands inside one.
+ */
+
+export type BlockquoteSpan = {
+  /** Byte offset of the first `>` character. */
+  start: number;
+  /** Byte offset past the last character of the blockquote block. */
+  end: number;
+  /** The prefix string, e.g. `"> "` or `">> "`. */
+  prefix: string;
+};
+
+const BQ_RE = /^(>+\s?)/;
+
+export function parseBlockquoteSpans(buffer: string): BlockquoteSpan[] {
+  const spans: BlockquoteSpan[] = [];
+  let offset = 0;
+  let current: { start: number; prefix: string } | undefined;
+
+  while (offset <= buffer.length) {
+    const nextNewline = buffer.indexOf("\n", offset);
+    const lineEnd = nextNewline === -1 ? buffer.length : nextNewline;
+    const line = buffer.slice(offset, lineEnd);
+
+    const match = line.match(BQ_RE);
+    if (match) {
+      const prefix = match[1];
+      if (!current) {
+        current = { start: offset, prefix };
+      }
+      // Update prefix to latest (handles varying depth, keeps the most recent)
+    } else {
+      if (current) {
+        spans.push({
+          start: current.start,
+          end: offset > 0 ? offset - 1 : offset,
+          prefix: current.prefix,
+        });
+        current = undefined;
+      }
+    }
+
+    if (nextNewline === -1) {
+      break;
+    }
+    offset = nextNewline + 1;
+  }
+
+  if (current) {
+    spans.push({ start: current.start, end: buffer.length, prefix: current.prefix });
+  }
+
+  return spans;
+}
+
+export function findBlockquoteAt(
+  spans: BlockquoteSpan[],
+  index: number,
+): BlockquoteSpan | undefined {
+  return spans.find((span) => index > span.start && index < span.end);
+}
+
+/**
+ * Given raw continuation text that was split from inside a blockquote,
+ * re-apply the `> ` prefix to every line.
+ */
+export function reapplyBlockquotePrefix(text: string, prefix: string): string {
+  return text
+    .split("\n")
+    .map((line) => {
+      if (line.trim() === "") {
+        return line;
+      }
+      // Don't double-prefix lines that already have it
+      if (line.startsWith(prefix.trimEnd())) {
+        return line;
+      }
+      return `${prefix}${line}`;
+    })
+    .join("\n");
+}

--- a/src/markdown/blockquotes.ts
+++ b/src/markdown/blockquotes.ts
@@ -29,8 +29,10 @@ export function parseBlockquoteSpans(buffer: string): BlockquoteSpan[] {
       const prefix = match[1];
       if (!current) {
         current = { start: offset, prefix };
+      } else {
+        // Update prefix to latest (handles varying depth, keeps the most recent)
+        current.prefix = prefix;
       }
-      // Update prefix to latest (handles varying depth, keeps the most recent)
     } else {
       if (current) {
         spans.push({

--- a/src/markdown/inline-formatting.ts
+++ b/src/markdown/inline-formatting.ts
@@ -42,6 +42,18 @@ export function scanUnmatchedInlineMarkers(
     let matched = false;
     for (const marker of INLINE_MARKERS) {
       if (text.startsWith(marker, i)) {
+        // For `_`-based markers: only treat as emphasis if preceded by whitespace,
+        // punctuation, or start of string (CommonMark word-boundary rule).
+        // This avoids mangling snake_case identifiers.
+        if (marker.startsWith("_")) {
+          const prev = i > 0 ? text[i - 1] : " ";
+          if (/\w/.test(prev)) {
+            // Inside a word - not an emphasis marker, skip
+            i++;
+            matched = true;
+            break;
+          }
+        }
         const existingIdx = openMarkers.lastIndexOf(marker);
         if (existingIdx !== -1) {
           // Close matching marker

--- a/src/markdown/inline-formatting.ts
+++ b/src/markdown/inline-formatting.ts
@@ -1,0 +1,77 @@
+/**
+ * Detect unmatched inline formatting markers (backticks, asterisks, underscores)
+ * at chunk boundaries and provide close/reopen strings.
+ */
+
+import { parseFenceSpans, type FenceSpan } from "./fences.js";
+
+export type InlineFormatState = {
+  /** Unmatched markers in order of appearance, e.g. ["**", "*", "`"] */
+  openMarkers: string[];
+};
+
+const INLINE_MARKERS = ["***", "**", "*", "___", "__", "_", "``", "`"];
+
+/**
+ * Scan text for unmatched inline formatting markers, skipping fenced regions.
+ * Returns the markers that are still "open" at the end of the text.
+ */
+export function scanUnmatchedInlineMarkers(
+  text: string,
+  fenceSpans?: FenceSpan[],
+): InlineFormatState {
+  const spans = fenceSpans ?? parseFenceSpans(text);
+  const openMarkers: string[] = [];
+
+  let i = 0;
+  while (i < text.length) {
+    // Skip fenced regions
+    const inFence = spans.find((s) => i >= s.start && i < s.end);
+    if (inFence) {
+      i = inFence.end;
+      continue;
+    }
+
+    // Skip escaped characters
+    if (text[i] === "\\" && i + 1 < text.length) {
+      i += 2;
+      continue;
+    }
+
+    // Try to match markers longest-first
+    let matched = false;
+    for (const marker of INLINE_MARKERS) {
+      if (text.startsWith(marker, i)) {
+        const existingIdx = openMarkers.lastIndexOf(marker);
+        if (existingIdx !== -1) {
+          // Close matching marker
+          openMarkers.splice(existingIdx, 1);
+        } else {
+          openMarkers.push(marker);
+        }
+        i += marker.length;
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) {
+      i++;
+    }
+  }
+
+  return { openMarkers };
+}
+
+/**
+ * Build the closing string for unmatched markers (reverse order).
+ */
+export function buildInlineClose(state: InlineFormatState): string {
+  return [...state.openMarkers].toReversed().join("");
+}
+
+/**
+ * Build the reopening string for unmatched markers (original order).
+ */
+export function buildInlineReopen(state: InlineFormatState): string {
+  return state.openMarkers.join("");
+}

--- a/src/markdown/inline-formatting.ts
+++ b/src/markdown/inline-formatting.ts
@@ -42,13 +42,14 @@ export function scanUnmatchedInlineMarkers(
     let matched = false;
     for (const marker of INLINE_MARKERS) {
       if (text.startsWith(marker, i)) {
-        // For `_`-based markers: only treat as emphasis if preceded by whitespace,
-        // punctuation, or start of string (CommonMark word-boundary rule).
-        // This avoids mangling snake_case identifiers.
+        // For `_`-based markers: only treat as emphasis if at a word boundary.
+        // CommonMark: `_` opens/closes emphasis only when not inside a word.
+        // Check both the character before AND after to avoid mangling snake_case.
         if (marker.startsWith("_")) {
           const prev = i > 0 ? text[i - 1] : " ";
-          if (/\w/.test(prev)) {
-            // Inside a word - not an emphasis marker, skip
+          const next = i + marker.length < text.length ? text[i + marker.length] : " ";
+          if (/\w/.test(prev) || /\w/.test(next)) {
+            // Inside a word - not an emphasis marker, skip just this char
             i++;
             matched = true;
             break;

--- a/src/markdown/lists.ts
+++ b/src/markdown/lists.ts
@@ -1,0 +1,69 @@
+/**
+ * Track list nesting context at chunk boundaries.
+ *
+ * When a split occurs mid-list, the continuation chunk loses indentation
+ * context. This module detects the active list nesting so the chunker can
+ * preserve hierarchy.
+ */
+
+export type ListContext = {
+  /** The leading whitespace + marker for each nesting level, outermost first. */
+  levels: string[];
+};
+
+const LIST_ITEM_RE = /^(\s*)([-*+]|\d+[.)]) /;
+
+/**
+ * Scan backwards from a split point to determine the active list nesting.
+ * Returns the list context that should prefix continuation lines.
+ */
+export function detectListContext(buffer: string, splitIndex: number): ListContext | undefined {
+  // Walk backwards line by line from the split point
+  const before = buffer.slice(0, splitIndex);
+  const lines = before.split("\n");
+
+  const levels: string[] = [];
+  let maxIndent = Infinity;
+
+  // Scan from the last line upward to build nesting context
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    const match = line.match(LIST_ITEM_RE);
+    if (!match) {
+      // Non-list line - if it's non-empty and not indented continuation, stop
+      if (line.trim() !== "" && !/^\s+/.test(line)) {
+        break;
+      }
+      continue;
+    }
+
+    const indent = match[1].length;
+    if (indent < maxIndent) {
+      // This is a parent level
+      levels.unshift(match[0]);
+      maxIndent = indent;
+      if (indent === 0) {
+        break; // Reached the top-level list item
+      }
+    }
+  }
+
+  return levels.length > 0 ? { levels } : undefined;
+}
+
+/**
+ * Build a prefix string that re-establishes list nesting context.
+ * Only includes parent levels (not the current item, which will be in the text).
+ */
+export function buildListContextPrefix(context: ListContext): string {
+  if (context.levels.length <= 1) {
+    return "";
+  }
+  // Include all parent levels except the last (which is the current item's level)
+  return (
+    context.levels
+      .slice(0, -1)
+      .map((level) => `${level}...`)
+      .join("\n") + "\n"
+  );
+}

--- a/src/markdown/table-spans.ts
+++ b/src/markdown/table-spans.ts
@@ -1,0 +1,89 @@
+/**
+ * Parse contiguous markdown table blocks in a buffer.
+ *
+ * A table block is:
+ *   - A header row containing `|`
+ *   - A separator row matching `| --- | --- |` pattern
+ *   - Zero or more data rows containing `|`
+ *
+ * Tables are treated as atomic spans. When a table exceeds the chunk limit,
+ * the header + separator are repeated in the continuation chunk.
+ */
+
+export type TableSpan = {
+  /** Byte offset of the first character of the header row. */
+  start: number;
+  /** Byte offset of the last character (exclusive) of the last data row. */
+  end: number;
+  /** The full header row text (without trailing newline). */
+  headerLine: string;
+  /** The full separator row text (without trailing newline). */
+  separatorLine: string;
+};
+
+const SEPARATOR_RE = /^\|?[\s-:|]+\|[\s-:|]*$/;
+
+function isTableRow(line: string): boolean {
+  return line.includes("|");
+}
+
+function isSeparatorRow(line: string): boolean {
+  if (!line.includes("|") || !line.includes("-")) {
+    return false;
+  }
+  return SEPARATOR_RE.test(line.trim());
+}
+
+export function parseTableSpans(buffer: string): TableSpan[] {
+  const spans: TableSpan[] = [];
+  const lines: { text: string; start: number; end: number }[] = [];
+
+  let offset = 0;
+  while (offset <= buffer.length) {
+    const nextNewline = buffer.indexOf("\n", offset);
+    const lineEnd = nextNewline === -1 ? buffer.length : nextNewline;
+    lines.push({ text: buffer.slice(offset, lineEnd), start: offset, end: lineEnd });
+    if (nextNewline === -1) {
+      break;
+    }
+    offset = nextNewline + 1;
+  }
+
+  let i = 0;
+  while (i < lines.length - 1) {
+    const headerLine = lines[i];
+    const sepLine = lines[i + 1];
+
+    if (!isTableRow(headerLine.text) || !isSeparatorRow(sepLine.text)) {
+      i++;
+      continue;
+    }
+
+    // Found header + separator. Consume data rows.
+    let lastEnd = sepLine.end;
+    let j = i + 2;
+    while (j < lines.length && isTableRow(lines[j].text)) {
+      lastEnd = lines[j].end;
+      j++;
+    }
+
+    spans.push({
+      start: headerLine.start,
+      end: lastEnd,
+      headerLine: headerLine.text,
+      separatorLine: sepLine.text,
+    });
+
+    i = j;
+  }
+
+  return spans;
+}
+
+export function findTableSpanAt(spans: TableSpan[], index: number): TableSpan | undefined {
+  return spans.find((span) => index > span.start && index < span.end);
+}
+
+export function isSafeTableBreak(spans: TableSpan[], index: number): boolean {
+  return !findTableSpanAt(spans, index);
+}

--- a/src/markdown/table-spans.ts
+++ b/src/markdown/table-spans.ts
@@ -1,3 +1,5 @@
+import type { FenceSpan } from "./fences.js";
+
 /**
  * Parse contiguous markdown table blocks in a buffer.
  *
@@ -24,7 +26,8 @@ export type TableSpan = {
 const SEPARATOR_RE = /^\|?[\s-:|]+\|[\s-:|]*$/;
 
 function isTableRow(line: string): boolean {
-  return line.includes("|");
+  const trimmed = line.trim();
+  return trimmed.startsWith("|") && trimmed.endsWith("|");
 }
 
 function isSeparatorRow(line: string): boolean {
@@ -34,7 +37,7 @@ function isSeparatorRow(line: string): boolean {
   return SEPARATOR_RE.test(line.trim());
 }
 
-export function parseTableSpans(buffer: string): TableSpan[] {
+export function parseTableSpans(buffer: string, fenceSpans?: FenceSpan[]): TableSpan[] {
   const spans: TableSpan[] = [];
   const lines: { text: string; start: number; end: number }[] = [];
 
@@ -49,12 +52,19 @@ export function parseTableSpans(buffer: string): TableSpan[] {
     offset = nextNewline + 1;
   }
 
+  const isInsideFence = (start: number): boolean =>
+    fenceSpans?.some((f) => start >= f.start && start < f.end) ?? false;
+
   let i = 0;
   while (i < lines.length - 1) {
     const headerLine = lines[i];
     const sepLine = lines[i + 1];
 
-    if (!isTableRow(headerLine.text) || !isSeparatorRow(sepLine.text)) {
+    if (
+      !isTableRow(headerLine.text) ||
+      !isSeparatorRow(sepLine.text) ||
+      isInsideFence(headerLine.start)
+    ) {
       i++;
       continue;
     }

--- a/src/markdown/tables.ts
+++ b/src/markdown/tables.ts
@@ -10,7 +10,11 @@ const MARKDOWN_STYLE_MARKERS = {
   code_block: { open: "```\n", close: "```" },
 } as const;
 
-export function convertMarkdownTables(markdown: string, mode: MarkdownTableMode): string {
+export function convertMarkdownTables(
+  markdown: string,
+  mode: MarkdownTableMode,
+  blockquotePrefix = "",
+): string {
   if (!markdown || mode === "off") {
     return markdown;
   }
@@ -19,7 +23,7 @@ export function convertMarkdownTables(markdown: string, mode: MarkdownTableMode)
     linkify: false,
     autolink: false,
     headingStyle: "none",
-    blockquotePrefix: "",
+    blockquotePrefix,
     tableMode: effectiveMode,
   });
   if (!hasTables) {


### PR DESCRIPTION
Fixes #63409

## Problem

When OpenClaw delivers messages to Discord, the chunking pipeline splits text at boundaries that can land inside markdown structures. Each chunk renders independently in Discord, so formatting that spans a chunk boundary breaks. Tables get split mid-row, blockquotes lose their `>` prefix in continuation chunks, and inline formatting (`**bold**`, `\`code\``) can get orphaned across splits.

## Solution

Extends the existing fence-aware chunking pattern (`parseFenceSpans()` / `reopenFence`) to handle additional markdown structures:

### Tables (`src/markdown/table-spans.ts`)
- `parseTableSpans()` detects contiguous table blocks (header + separator + data rows)
- Tables are treated as atomic spans - the chunker avoids splitting inside them
- If a table exceeds the chunk limit, the header + separator are repeated in the continuation chunk via `reopenTableHeader`

### Blockquotes (`src/markdown/blockquotes.ts`)
- `parseBlockquoteSpans()` detects `>`-prefixed regions
- When splitting inside a blockquote, `reapplyBlockquotePrefix()` adds `> ` to every line in the continuation chunk

### Inline formatting (`src/markdown/inline-formatting.ts`)
- `scanUnmatchedInlineMarkers()` finds unmatched `**`, `*`, `\`` at chunk boundaries
- Closes unmatched markers before the split and reopens them in the next chunk
- Only scans outside fenced code blocks to avoid false positives

### List nesting (`src/markdown/lists.ts`)
- `detectListContext()` scaffolded for future integration (detects nesting depth at split points)
- Not yet wired into the chunker loop - list continuation across chunks is complex and left as a follow-up

## Testing

- 12 new tests added to `chunk.test.ts`
- Tested locally on Discord with messages that force chunk splits across tables, lists, and inline spans
- Tables confirmed to stay atomic across chunk boundaries in live Discord rendering

## Related issues
#31679 #24363 #32743 #30962