### PR TITLE
fix(gateway): short-circuit repeated device-required probes in probeGateway

### DIFF
--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -63,13 +63,16 @@ vi.mock("../infra/device-identity.js", () => ({
   },
 }));
 
-const { clampProbeTimeoutMs, probeGateway } = await import("./probe.js");
+const { __resetDeviceRequiredCacheForTests, clampProbeTimeoutMs, probeGateway } = await import(
+  "./probe.js"
+);
 
 describe("probeGateway", () => {
   beforeEach(() => {
     deviceIdentityState.throwOnLoad = false;
     gatewayClientState.startMode = "hello";
     gatewayClientState.close = { code: 1008, reason: "pairing required" };
+    __resetDeviceRequiredCacheForTests();
   });
 
   it("clamps probe timeout to timer-safe bounds", () => {
@@ -200,5 +203,114 @@ describe("probeGateway", () => {
       close: { code: 1008, reason: "pairing required" },
     });
     expect(gatewayClientState.requests).toEqual([]);
+  });
+
+  describe("device-required short-circuit cache (#63427)", () => {
+    const makeDeviceRequiredProbe = () =>
+      probeGateway({
+        url: "ws://127.0.0.1:18789",
+        timeoutMs: 1_000,
+        includeDetails: false,
+      });
+
+    beforeEach(() => {
+      gatewayClientState.startMode = "close";
+      gatewayClientState.close = { code: 1008, reason: "device identity required" };
+    });
+
+    it("opens a WebSocket for the first three device-required rejections", async () => {
+      for (let i = 0; i < 3; i += 1) {
+        const result = await makeDeviceRequiredProbe();
+        expect(result.ok).toBe(false);
+        expect(result.close).toMatchObject({ code: 1008, reason: "device identity required" });
+        // First 3 attempts must actually hit the mock GatewayClient
+        expect(gatewayClientState.options).not.toBeNull();
+      }
+    });
+
+    it("short-circuits the 4th probe without creating a GatewayClient", async () => {
+      for (let i = 0; i < 3; i += 1) {
+        await makeDeviceRequiredProbe();
+      }
+      // Mark the mock as "has not been re-created" by nulling the options seen.
+      gatewayClientState.options = null;
+
+      const fourth = await makeDeviceRequiredProbe();
+
+      expect(fourth.ok).toBe(false);
+      expect(fourth.close?.code).toBe(1008);
+      expect(fourth.close?.reason).toBe("device identity required");
+      expect(fourth.close?.hint).toContain("short-circuited");
+      // Crucially: no new GatewayClient was constructed.
+      expect(gatewayClientState.options).toBeNull();
+    });
+
+    it("does not populate the cache on non-device-required closes", async () => {
+      gatewayClientState.close = { code: 1008, reason: "pairing required" };
+      for (let i = 0; i < 5; i += 1) {
+        await probeGateway({
+          url: "ws://127.0.0.1:18789",
+          timeoutMs: 1_000,
+          includeDetails: false,
+        });
+      }
+      // After 5 "pairing required" failures the cache must still be empty,
+      // so a 6th probe goes through the real mock client path.
+      gatewayClientState.options = null;
+      await probeGateway({
+        url: "ws://127.0.0.1:18789",
+        timeoutMs: 1_000,
+        includeDetails: false,
+      });
+      expect(gatewayClientState.options).not.toBeNull();
+    });
+
+    it("clears the cache entry when the same URL eventually succeeds", async () => {
+      for (let i = 0; i < 3; i += 1) {
+        await makeDeviceRequiredProbe();
+      }
+      // Switch the mock to successful hello and probe the same URL —
+      // a successful probe must reset the cache.
+      gatewayClientState.startMode = "hello";
+      const success = await probeGateway({
+        url: "ws://127.0.0.1:18789",
+        timeoutMs: 1_000,
+        includeDetails: false,
+      });
+      expect(success.ok).toBe(true);
+
+      // Flip back to rejection and confirm the next probe is NOT short-
+      // circuited — the cache must have been cleared by the success.
+      gatewayClientState.startMode = "close";
+      gatewayClientState.close = { code: 1008, reason: "device identity required" };
+      gatewayClientState.options = null;
+      const afterReset = await makeDeviceRequiredProbe();
+      expect(afterReset.ok).toBe(false);
+      expect(afterReset.close?.hint).toBeUndefined();
+      // Real mock client path was taken — options populated again.
+      expect(gatewayClientState.options).not.toBeNull();
+    });
+
+    it("keeps per-URL caches independent across different gateway URLs", async () => {
+      for (let i = 0; i < 3; i += 1) {
+        await probeGateway({
+          url: "ws://127.0.0.1:18789",
+          timeoutMs: 1_000,
+          includeDetails: false,
+        });
+      }
+
+      // A different URL must NOT be short-circuited just because 127.0.0.1
+      // exceeded its threshold.
+      gatewayClientState.options = null;
+      const other = await probeGateway({
+        url: "ws://127.0.0.1:28789",
+        timeoutMs: 1_000,
+        includeDetails: false,
+      });
+      expect(other.ok).toBe(false);
+      // Real mock was used for the second URL.
+      expect(gatewayClientState.options).not.toBeNull();
+    });
   });
 });

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -40,6 +40,90 @@ function formatProbeCloseError(close: GatewayProbeClose): string {
   return `gateway closed (${close.code}): ${close.reason}`;
 }
 
+// Device-required rejections happen when the CLI probe connects to a gateway
+// that is configured to require device pairing but the calling process has no
+// device identity (e.g. `openclaw status` invoked by a short-lived cron session,
+// or any script that re-spawns the CLI repeatedly). Each new CLI process starts
+// a fresh `GatewayClient` instance which cannot learn from prior rejections, so
+// upstream observers see tight bursts of `handshake failed cause=device-required`
+// log entries (see #63427 — 1127 rejections in 24h from 73 sessions).
+//
+// To dampen the log noise without changing the reachability semantics, track
+// recent device-required rejections per URL at module scope. Once a URL has
+// been rejected `DEVICE_REQUIRED_FAILURE_THRESHOLD` times within
+// `DEVICE_REQUIRED_TTL_MS`, subsequent probes for the same URL short-circuit
+// with a synthetic rejected result for the rest of the TTL window instead of
+// opening another WebSocket. Any successful probe clears the cache entry so a
+// newly-paired gateway reverts to normal probing immediately.
+const DEVICE_REQUIRED_FAILURE_THRESHOLD = 3;
+const DEVICE_REQUIRED_TTL_MS = 5 * 60_000;
+
+type DeviceRequiredCacheEntry = {
+  failures: number;
+  firstFailureAt: number;
+};
+
+const deviceRequiredCache = new Map<string, DeviceRequiredCacheEntry>();
+
+function isDeviceRequiredClose(close: GatewayProbeClose | null): boolean {
+  if (!close || close.code !== 1008) {
+    return false;
+  }
+  return close.reason.includes("device identity");
+}
+
+function noteDeviceRequiredFailure(url: string, now: number): void {
+  const existing = deviceRequiredCache.get(url);
+  if (!existing || now - existing.firstFailureAt >= DEVICE_REQUIRED_TTL_MS) {
+    deviceRequiredCache.set(url, { failures: 1, firstFailureAt: now });
+    return;
+  }
+  existing.failures += 1;
+}
+
+function shouldSkipProbeForDeviceRequired(url: string, now: number): boolean {
+  const entry = deviceRequiredCache.get(url);
+  if (!entry) {
+    return false;
+  }
+  if (now - entry.firstFailureAt >= DEVICE_REQUIRED_TTL_MS) {
+    deviceRequiredCache.delete(url);
+    return false;
+  }
+  return entry.failures >= DEVICE_REQUIRED_FAILURE_THRESHOLD;
+}
+
+function clearDeviceRequiredCacheFor(url: string): void {
+  deviceRequiredCache.delete(url);
+}
+
+/**
+ * Test-only helper: reset the module-level device-required cache so tests can
+ * run in isolation without carrying state across suites.
+ */
+export function __resetDeviceRequiredCacheForTests(): void {
+  deviceRequiredCache.clear();
+}
+
+function makeDeviceRequiredShortCircuitResult(url: string): GatewayProbeResult {
+  return {
+    ok: false,
+    url,
+    connectLatencyMs: null,
+    error:
+      "gateway closed (1008): device identity required (cached short-circuit — retry after pairing)",
+    close: {
+      code: 1008,
+      reason: "device identity required",
+      hint: "probe short-circuited by recent device-required rejections",
+    },
+    health: null,
+    status: null,
+    presence: null,
+    configSnapshot: null,
+  };
+}
+
 export async function probeGateway(opts: {
   url: string;
   auth?: GatewayProbeAuth;
@@ -49,6 +133,11 @@ export async function probeGateway(opts: {
   tlsFingerprint?: string;
 }): Promise<GatewayProbeResult> {
   const startedAt = Date.now();
+  // Short-circuit repeated device-required rejections to dampen CLI log noise
+  // when many short-lived processes probe the same unpaired gateway in a burst.
+  if (shouldSkipProbeForDeviceRequired(opts.url, startedAt)) {
+    return makeDeviceRequiredShortCircuitResult(opts.url);
+  }
   const instanceId = randomUUID();
   let connectLatencyMs: number | null = null;
   let connectError: string | null = null;
@@ -98,6 +187,15 @@ export async function probeGateway(opts: {
       settled = true;
       clearProbeTimer();
       client.stop();
+      // Track device-required rejections at the probe boundary so bursts of
+      // CLI probes against an unpaired gateway stop spamming handshake-failed
+      // logs. Any successful probe clears the entry so a newly-paired gateway
+      // resumes normal probing immediately.
+      if (result.ok) {
+        clearDeviceRequiredCacheFor(opts.url);
+      } else if (isDeviceRequiredClose(result.close)) {
+        noteDeviceRequiredFailure(opts.url, Date.now());
+      }
       resolve({ url: opts.url, ...result });
     };
 


### PR DESCRIPTION
## Summary

When many short-lived processes probe the same unpaired gateway in a burst — e.g. `openclaw status` invoked by cron sessions, monitoring scripts, or any wrapper that re-spawns the CLI — each new process starts a fresh `GatewayClient` with no memory of prior rejections. Every probe opens a WebSocket, hits the `DEVICE_IDENTITY_REQUIRED` handshake rejection, and logs a `handshake failed cause=device-required` entry.

Reporter in #63427 observed **1127 rejections in 24h from 73 separate sessions** on a single unpaired gateway.

Fixes #63427

## Caller chain in production

```
openclaw status  (cli/daemon-cli/status.gather.ts:442)
  -> inspectGatewayRestart
     -> inspectGatewayPortHealth
        -> confirmGatewayReachable  (restart-health.ts:72)
           -> probeGateway          (gateway/probe.ts:43)
```

`GatewayClient` itself already has exponential backoff AND pauses reconnect on `DEVICE_IDENTITY_REQUIRED`, but each probe creates a **fresh** `GatewayClient` instance, so the backoff never accumulates across invocations. That's what makes this invisible to single-client logic.

## Fix

Track recent device-required rejections per URL at module scope in `src/gateway/probe.ts`:

- `DEVICE_REQUIRED_FAILURE_THRESHOLD = 3`
- `DEVICE_REQUIRED_TTL_MS = 5 * 60_000` (5 min window)

After 3 device-required rejections within the TTL window, subsequent probes for the same URL short-circuit with a synthetic rejected result (same `code: 1008`, `reason: \"device identity required\"`, plus a `hint` explaining the short-circuit) without creating another WebSocket. Any successful probe clears the cache entry so a newly-paired gateway resumes normal probing immediately.

The cache layer sits inside `probeGateway()` itself, so every caller (`restart-health.ts`, `lifecycle.ts`, and any future callers) gets the same protection without duplicating the logic.

### Why at this layer (not in `confirmGatewayReachable`)

An alternative would be to add `\"device\"` to the `looksLikeAuthClose` keyword list in `restart-health.ts` so `device-required` closes are treated as \"reachable but unauthenticated\". That fixes the semantic issue but does **not** reduce log noise — each probe still opens a WebSocket and still trips the server-side `handshake failed` log. The noise is the actual user pain in #63427, so the cache has to live at the probe boundary.

## Tests

Added a `describe(\"device-required short-circuit cache (#63427)\")` block in `src/gateway/probe.test.ts` with 5 cases:

1. **First 3 device-required probes** hit the real `GatewayClient` mock (no premature short-circuit).
2. **4th probe short-circuits** without constructing a client — asserted by `gatewayClientState.options === null` after reset.
3. **Non-device-required closes** (e.g. `\"pairing required\"`) do NOT populate the cache even after 5 rejections — the 6th probe still hits the real client.
4. **A successful probe clears the cache** so the next rejection cycle starts fresh on the same URL.
5. **Per-URL caches are independent** — one unpaired gateway does not block probes to another.

Test helper `__resetDeviceRequiredCacheForTests()` is exported to reset the module-level cache between cases. It's namespaced with `__` to mark it as internal / test-only.

## Notes

- Credit to @djimit for the detailed RCA in the issue and follow-up comment; the updated RCA (\"each cron session creates a fresh `GatewayClient`\") is exactly right and drove this fix.
- Reporter's patched `dist/probe-tkuAqDVF.js` is the compiled output of `src/gateway/probe.ts` — this PR fixes it at source.
- The reporter's \"bonus suggestion\" of an unauthenticated `/health` HTTP endpoint is out of scope for this PR; the cache alone removes the log-noise pain without broadening the gateway attack surface.