### PR TITLE
build: block legacy plugin sdk imports in xai

### DIFF
--- a/extensions/xai/api.ts
+++ b/extensions/xai/api.ts
@@ -8,7 +8,7 @@ import {
   applyXaiModelCompat,
   resolveXaiModelCompatPatch,
 } from "@openclaw/plugin-sdk/provider-tools";
-import { readStringValue } from "openclaw/plugin-sdk/text-runtime";
+import { readStringValue } from "@openclaw/plugin-sdk/text-runtime";
 
 export { buildXaiProvider } from "./provider-catalog.js";
 export { applyXaiConfig, applyXaiProviderConfig } from "./onboard.js";

--- a/extensions/xai/code-execution.test.ts
+++ b/extensions/xai/code-execution.test.ts
@@ -1,4 +1,4 @@
-import { withFetchPreconnect } from "openclaw/plugin-sdk/testing";
+import { withFetchPreconnect } from "@openclaw/plugin-sdk/testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createCodeExecutionTool } from "./code-execution.js";
 

--- a/extensions/xai/code-execution.ts
+++ b/extensions/xai/code-execution.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
-import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/config-runtime";
-import { jsonResult, readStringParam } from "openclaw/plugin-sdk/provider-web-search";
+import { getRuntimeConfigSnapshot } from "@openclaw/plugin-sdk/config-runtime";
+import { jsonResult, readStringParam } from "@openclaw/plugin-sdk/provider-web-search";
 import {
   buildXaiCodeExecutionPayload,
   requestXaiCodeExecution,

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -1,7 +1,7 @@
 import { Type } from "@sinclair/typebox";
-import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
-import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
-import { jsonResult, readProviderEnvValue } from "openclaw/plugin-sdk/provider-web-search";
+import { defineSingleProviderPluginEntry } from "@openclaw/plugin-sdk/provider-entry";
+import { buildProviderReplayFamilyHooks } from "@openclaw/plugin-sdk/provider-model-shared";
+import { jsonResult, readProviderEnvValue } from "@openclaw/plugin-sdk/provider-web-search";
 import {
   applyXaiModelCompat,
   normalizeXaiModelId,

--- a/extensions/xai/model-definitions.ts
+++ b/extensions/xai/model-definitions.ts
@@ -1,5 +1,5 @@
-import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
-import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
+import type { ModelDefinitionConfig } from "@openclaw/plugin-sdk/provider-model-shared";
+import { normalizeOptionalLowercaseString } from "@openclaw/plugin-sdk/text-runtime";
 
 export const XAI_BASE_URL = "https://api.x.ai/v1";
 export const XAI_DEFAULT_MODEL_ID = "grok-4";

--- a/extensions/xai/onboard.test.ts
+++ b/extensions/xai/onboard.test.ts
@@ -1,7 +1,7 @@
 import {
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
-} from "openclaw/plugin-sdk/provider-onboard";
+} from "@openclaw/plugin-sdk/provider-onboard";
 import { describe, expect, it } from "vitest";
 import {
   createConfigWithFallbacks,

--- a/extensions/xai/provider-models.ts
+++ b/extensions/xai/provider-models.ts
@@ -1,9 +1,9 @@
 import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
-} from "openclaw/plugin-sdk/plugin-entry";
-import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-model-shared";
-import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
+} from "@openclaw/plugin-sdk/plugin-entry";
+import { normalizeModelCompat } from "@openclaw/plugin-sdk/provider-model-shared";
+import { normalizeOptionalLowercaseString } from "@openclaw/plugin-sdk/text-runtime";
 import { applyXaiModelCompat } from "./api.js";
 import { resolveXaiCatalogEntry, XAI_BASE_URL } from "./model-definitions.js";
 

--- a/extensions/xai/src/tool-auth-shared.test.ts
+++ b/extensions/xai/src/tool-auth-shared.test.ts
@@ -1,4 +1,4 @@
-import { NON_ENV_SECRETREF_MARKER } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { NON_ENV_SECRETREF_MARKER } from "@openclaw/plugin-sdk/provider-auth-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   isXaiToolEnabled,

--- a/extensions/xai/src/tool-config-shared.ts
+++ b/extensions/xai/src/tool-config-shared.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "openclaw/plugin-sdk/text-runtime";
+import { isRecord } from "@openclaw/plugin-sdk/text-runtime";
 import { normalizeXaiModelId } from "../model-id.js";
 
 export { isRecord };

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -4,54 +4,54 @@
     "rootDir": ".",
     "paths": {
       "openclaw/extension-api": ["../../src/extensionAPI.ts"],
-      "openclaw/plugin-sdk": ["../../dist/plugin-sdk/src/plugin-sdk/index.d.ts"],
-      "openclaw/plugin-sdk/*": ["../../dist/plugin-sdk/src/plugin-sdk/*.d.ts"],
-      "openclaw/plugin-sdk/account-id": ["../../dist/plugin-sdk/src/plugin-sdk/account-id.d.ts"],
+      "openclaw/plugin-sdk": ["./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"],
+      "openclaw/plugin-sdk/*": ["./.boundary-stubs/forbidden-openclaw-plugin-sdk-*.d.ts"],
+      "openclaw/plugin-sdk/account-id": ["./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"],
       "openclaw/plugin-sdk/channel-entry-contract": [
-        "../../dist/plugin-sdk/src/plugin-sdk/channel-entry-contract.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/browser-maintenance": [
-        "../../dist/plugin-sdk/src/plugin-sdk/browser-maintenance.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/browser-config-runtime": [
-        "../../dist/plugin-sdk/src/plugin-sdk/browser-config-runtime.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/browser-node-runtime": [
-        "../../dist/plugin-sdk/src/plugin-sdk/browser-node-runtime.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/browser-setup-tools": [
-        "../../dist/plugin-sdk/src/plugin-sdk/browser-setup-tools.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/browser-security-runtime": [
-        "../../dist/plugin-sdk/src/plugin-sdk/browser-security-runtime.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/channel-secret-runtime": [
-        "../../dist/plugin-sdk/src/plugin-sdk/channel-secret-runtime.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/channel-streaming": [
-        "../../dist/plugin-sdk/src/plugin-sdk/channel-streaming.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
-      "openclaw/plugin-sdk/cli-runtime": ["../../dist/plugin-sdk/src/plugin-sdk/cli-runtime.d.ts"],
+      "openclaw/plugin-sdk/cli-runtime": ["./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"],
       "openclaw/plugin-sdk/error-runtime": [
-        "../../dist/plugin-sdk/src/plugin-sdk/error-runtime.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/provider-catalog-shared": [
-        "../../dist/plugin-sdk/src/plugin-sdk/provider-catalog-shared.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/provider-env-vars": [
-        "../../dist/plugin-sdk/src/plugin-sdk/provider-env-vars.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/provider-entry": [
-        "../../dist/plugin-sdk/src/plugin-sdk/provider-entry.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/provider-web-search-contract": [
-        "../../dist/plugin-sdk/src/plugin-sdk/provider-web-search-contract.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/secret-ref-runtime": [
-        "../../dist/plugin-sdk/src/plugin-sdk/secret-ref-runtime.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "openclaw/plugin-sdk/ssrf-runtime": [
-        "../../dist/plugin-sdk/src/plugin-sdk/ssrf-runtime.d.ts"
+        "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts"
       ],
       "@openclaw/*.js": ["../../packages/plugin-sdk/dist/extensions/*.d.ts", "../*"],
       "@openclaw/*": ["../*"],

--- a/extensions/xai/video-generation-provider.ts
+++ b/extensions/xai/video-generation-provider.ts
@@ -1,17 +1,17 @@
-import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
-import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { isProviderApiKeyConfigured } from "@openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "@openclaw/plugin-sdk/provider-auth-runtime";
 import {
   assertOkOrThrowHttpError,
   fetchWithTimeout,
   postJsonRequest,
   resolveProviderHttpRequestConfig,
-} from "openclaw/plugin-sdk/provider-http";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+} from "@openclaw/plugin-sdk/provider-http";
+import { normalizeOptionalString } from "@openclaw/plugin-sdk/text-runtime";
 import type {
   GeneratedVideoAsset,
   VideoGenerationProvider,
   VideoGenerationRequest,
-} from "openclaw/plugin-sdk/video-generation";
+} from "@openclaw/plugin-sdk/video-generation";
 
 const DEFAULT_XAI_VIDEO_BASE_URL = "https://api.x.ai/v1";
 const DEFAULT_XAI_VIDEO_MODEL = "grok-imagine-video";

--- a/extensions/xai/web-search-contract-api.ts
+++ b/extensions/xai/web-search-contract-api.ts
@@ -1,7 +1,7 @@
 import {
   createWebSearchProviderContractFields,
   type WebSearchProviderPlugin,
-} from "openclaw/plugin-sdk/provider-web-search-config-contract";
+} from "@openclaw/plugin-sdk/provider-web-search-config-contract";
 
 export function createXaiWebSearchProvider(): WebSearchProviderPlugin {
   const credentialPath = "plugins.entries.xai.config.webSearch.apiKey";

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -1,6 +1,6 @@
-import { NON_ENV_SECRETREF_MARKER } from "openclaw/plugin-sdk/provider-auth-runtime";
-import { createNonExitingRuntime } from "openclaw/plugin-sdk/runtime-env";
-import { withEnv } from "openclaw/plugin-sdk/testing";
+import { NON_ENV_SECRETREF_MARKER } from "@openclaw/plugin-sdk/provider-auth-runtime";
+import { createNonExitingRuntime } from "@openclaw/plugin-sdk/runtime-env";
+import { withEnv } from "@openclaw/plugin-sdk/testing";
 import { describe, expect, it, vi } from "vitest";
 import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import { resolveXaiCatalogEntry } from "./model-definitions.js";

--- a/extensions/xai/web-search.ts
+++ b/extensions/xai/web-search.ts
@@ -18,7 +18,7 @@ import {
   type WebSearchProviderSetupContext,
   type WebSearchProviderPlugin,
   writeCache,
-} from "openclaw/plugin-sdk/provider-web-search";
+} from "@openclaw/plugin-sdk/provider-web-search";
 import {
   buildXaiWebSearchPayload,
   extractXaiWebSearchContent,

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -1,4 +1,4 @@
-import { withFetchPreconnect } from "openclaw/plugin-sdk/testing";
+import { withFetchPreconnect } from "@openclaw/plugin-sdk/testing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createXSearchTool } from "./x-search.js";
 

--- a/extensions/xai/x-search.ts
+++ b/extensions/xai/x-search.ts
@@ -1,4 +1,4 @@
-import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/config-runtime";
+import { getRuntimeConfigSnapshot } from "@openclaw/plugin-sdk/config-runtime";
 import {
   jsonResult,
   readCache,
@@ -7,7 +7,7 @@ import {
   resolveCacheTtlMs,
   resolveTimeoutSeconds,
   writeCache,
-} from "openclaw/plugin-sdk/provider-web-search";
+} from "@openclaw/plugin-sdk/provider-web-search";
 import { isXaiToolEnabled, resolveXaiToolApiKey } from "./src/tool-auth-shared.js";
 import { resolveEffectiveXSearchConfig } from "./src/x-search-config.js";
 import {

--- a/scripts/check-extension-package-tsc-boundary.mjs
+++ b/scripts/check-extension-package-tsc-boundary.mjs
@@ -28,6 +28,9 @@ const COMPILE_INPUT_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts", ".js", 
 const ROOTDIR_BOUNDARY_CANARY_IMPORT_PATH =
   "../../src/plugins/contracts/rootdir-boundary-canary.ts";
 const ROOTDIR_BOUNDARY_CANARY_OUTPUT_HINT = "src/plugins/contracts/rootdir-boundary-canary.ts";
+const LEGACY_PLUGIN_SDK_CANARY_IMPORT_PATH = "openclaw/plugin-sdk/provider-entry";
+const LEGACY_PLUGIN_SDK_CANARY_OUTPUT_HINT = "openclaw/plugin-sdk/provider-entry";
+const XAI_LEGACY_PLUGIN_SDK_FORBIDDEN_HINT = "forbidden-openclaw-plugin-sdk";
 
 function parseMode(argv) {
   const modeArg = argv.find((arg) => arg.startsWith("--mode="));
@@ -172,6 +175,16 @@ function resolveExtensionTsconfigPath(extensionId) {
 
 function readExtensionTsconfig(extensionId) {
   return readJsonFile(resolveExtensionTsconfigPath(extensionId));
+}
+
+function hasLegacyPluginSdkPoison(tsconfig) {
+  const legacyPath = tsconfig?.compilerOptions?.paths?.["openclaw/plugin-sdk"];
+  return (
+    Array.isArray(legacyPath) &&
+    legacyPath.some(
+      (entry) => typeof entry === "string" && entry.includes(XAI_LEGACY_PLUGIN_SDK_FORBIDDEN_HINT),
+    )
+  );
 }
 
 function collectOptInExtensionIds() {
@@ -666,6 +679,7 @@ async function runCanaryCheck(extensionIds) {
   await Promise.all(
     extensionIds.map(async (extensionId, index) => {
       const { canaryPath, tsconfigPath } = resolveCanaryArtifactPaths(extensionId);
+      const extensionTsconfig = readExtensionTsconfig(extensionId);
 
       cleanupCanaryArtifacts(extensionId);
       process.stdout.write(`[${index + 1}/${extensionIds.length}] ${extensionId} canary\n`);
@@ -709,6 +723,43 @@ async function runCanaryCheck(extensionIds) {
             : String(error);
         if (!output.includes("TS6059") || !output.includes(ROOTDIR_BOUNDARY_CANARY_OUTPUT_HINT)) {
           throw error;
+        }
+
+        if (hasLegacyPluginSdkPoison(extensionTsconfig)) {
+          writeFileSync(
+            canaryPath,
+            [
+              `import { defineSingleProviderPluginEntry } from "${LEGACY_PLUGIN_SDK_CANARY_IMPORT_PATH}";`,
+              "void defineSingleProviderPluginEntry;",
+              "export {};",
+              "",
+            ].join("\n"),
+            "utf8",
+          );
+
+          try {
+            const legacyResult = await runNodeStepAsync(
+              `${extensionId} legacy-plugin-sdk canary`,
+              [tscBin, "-p", tsconfigPath, "--noEmit"],
+              120_000,
+            );
+            throw new Error(
+              `${extensionId} legacy-plugin-sdk canary unexpectedly passed\n${legacyResult.stdout}${legacyResult.stderr}`,
+            );
+          } catch (legacyError) {
+            const legacyOutput =
+              legacyError instanceof Error && typeof legacyError.fullOutput === "string"
+                ? legacyError.fullOutput
+                : String(legacyError);
+            if (
+              !legacyOutput.includes(LEGACY_PLUGIN_SDK_CANARY_OUTPUT_HINT) ||
+              (!legacyOutput.includes("TS2307") &&
+                !legacyOutput.includes("Cannot find module") &&
+                !legacyOutput.includes("TS2305"))
+            ) {
+              throw legacyError;
+            }
+          }
         }
       } finally {
         cleanupCanaryArtifacts(extensionId);

--- a/scripts/check-extension-package-tsc-boundary.mjs
+++ b/scripts/check-extension-package-tsc-boundary.mjs
@@ -743,9 +743,10 @@ async function runCanaryCheck(extensionIds) {
               [tscBin, "-p", tsconfigPath, "--noEmit"],
               120_000,
             );
-            throw new Error(
-              `${extensionId} legacy-plugin-sdk canary unexpectedly passed\n${legacyResult.stdout}${legacyResult.stderr}`,
-            );
+        throw new Error(
+          `${extensionId} legacy-plugin-sdk canary unexpectedly passed\n${legacyResult.stdout}${legacyResult.stderr}`,
+          { cause: error },
+        );
           } catch (legacyError) {
             const legacyOutput =
               legacyError instanceof Error && typeof legacyError.fullOutput === "string"

--- a/scripts/lib/extension-package-boundary.ts
+++ b/scripts/lib/extension-package-boundary.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { join, posix, resolve } from "node:path";
+import { join, resolve } from "node:path";
 
 export const EXTENSION_PACKAGE_BOUNDARY_BASE_CONFIG =
   "extensions/tsconfig.package-boundary.base.json" as const;
@@ -65,46 +65,36 @@ export const EXTENSION_PACKAGE_BOUNDARY_BASE_PATHS = {
   "@openclaw/plugin-sdk/*": ["../dist/plugin-sdk/src/plugin-sdk/*.d.ts"],
 } as const;
 
-function prefixExtensionPackageBoundaryPaths(
-  paths: Record<string, readonly string[]>,
-  prefix: string,
-): Record<string, readonly string[]> {
-  return Object.fromEntries(
-    Object.entries(paths).map(([key, values]) => [
-      key,
-      values.map((value) => posix.join(prefix, value)),
-    ]),
-  );
-}
+const XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH = [
+  "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts",
+] as const;
+const XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_WILDCARD_PATH = [
+  "./.boundary-stubs/forbidden-openclaw-plugin-sdk-*.d.ts",
+] as const;
 
 export const EXTENSION_PACKAGE_BOUNDARY_XAI_PATHS = {
-  ...prefixExtensionPackageBoundaryPaths(
-    (({
-      "openclaw/plugin-sdk/channel-secret-basic-runtime": _omitBasic,
-      "openclaw/plugin-sdk/channel-secret-tts-runtime": _omitTts,
-      ...rest
-    }) => rest)(EXTENSION_PACKAGE_BOUNDARY_BASE_PATHS),
-    "../",
-  ),
-  "openclaw/plugin-sdk/channel-entry-contract": [
-    "../../dist/plugin-sdk/src/plugin-sdk/channel-entry-contract.d.ts",
-  ],
-  "openclaw/plugin-sdk/browser-maintenance": [
-    "../../dist/plugin-sdk/src/plugin-sdk/browser-maintenance.d.ts",
-  ],
-  "openclaw/plugin-sdk/cli-runtime": ["../../dist/plugin-sdk/src/plugin-sdk/cli-runtime.d.ts"],
-  "openclaw/plugin-sdk/provider-catalog-shared": [
-    "../../dist/plugin-sdk/src/plugin-sdk/provider-catalog-shared.d.ts",
-  ],
-  "openclaw/plugin-sdk/provider-env-vars": [
-    "../../dist/plugin-sdk/src/plugin-sdk/provider-env-vars.d.ts",
-  ],
-  "openclaw/plugin-sdk/provider-entry": [
-    "../../dist/plugin-sdk/src/plugin-sdk/provider-entry.d.ts",
-  ],
+  "openclaw/extension-api": ["../../src/extensionAPI.ts"],
+  "openclaw/plugin-sdk": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/*": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_WILDCARD_PATH],
+  "openclaw/plugin-sdk/account-id": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/channel-entry-contract": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/browser-maintenance": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/browser-config-runtime": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/browser-node-runtime": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/browser-setup-tools": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/browser-security-runtime": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/channel-secret-runtime": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/channel-streaming": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/cli-runtime": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/error-runtime": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/provider-catalog-shared": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/provider-env-vars": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/provider-entry": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
   "openclaw/plugin-sdk/provider-web-search-contract": [
-    "../../dist/plugin-sdk/src/plugin-sdk/provider-web-search-contract.d.ts",
+    ...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH,
   ],
+  "openclaw/plugin-sdk/secret-ref-runtime": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
+  "openclaw/plugin-sdk/ssrf-runtime": [...XAI_FORBIDDEN_LEGACY_PLUGIN_SDK_EXACT_PATH],
   "@openclaw/*.js": ["../../packages/plugin-sdk/dist/extensions/*.d.ts", "../*"],
   "@openclaw/*": ["../*"],
   "@openclaw/plugin-sdk/*": ["../../dist/plugin-sdk/src/plugin-sdk/*.d.ts"],

--- a/scripts/lib/extension-package-boundary.ts
+++ b/scripts/lib/extension-package-boundary.ts
@@ -108,7 +108,7 @@ export type ExtensionPackageBoundaryTsConfigJson = {
   extends?: unknown;
   compilerOptions?: {
     rootDir?: unknown;
-    paths?: unknown;
+    paths?: Record<string, readonly string[]>;
   };
   include?: unknown;
   exclude?: unknown;

--- a/src/plugins/contracts/extension-package-project-boundaries.test.ts
+++ b/src/plugins/contracts/extension-package-project-boundaries.test.ts
@@ -86,6 +86,15 @@ describe("opt-in extension package boundaries", () => {
   it("keeps xai's boundary-specific path overrides derived from the shared package boundary map", () => {
     const tsconfig = readExtensionPackageBoundaryTsconfig("xai", REPO_ROOT);
     expect(tsconfig.compilerOptions?.paths).toEqual(EXTENSION_PACKAGE_BOUNDARY_XAI_PATHS);
+    expect(tsconfig.compilerOptions?.paths?.["openclaw/plugin-sdk"]).toEqual([
+      "./.boundary-stubs/forbidden-openclaw-plugin-sdk.d.ts",
+    ]);
+    expect(tsconfig.compilerOptions?.paths?.["openclaw/plugin-sdk/*"]).toEqual([
+      "./.boundary-stubs/forbidden-openclaw-plugin-sdk-*.d.ts",
+    ]);
+    expect(tsconfig.compilerOptions?.paths?.["@openclaw/plugin-sdk/*"]).toEqual([
+      "../../dist/plugin-sdk/src/plugin-sdk/*.d.ts",
+    ]);
   });
 
   it("keeps plugin-sdk package types generated from the package build, not a hand-maintained types bridge", () => {

--- a/src/plugins/contracts/extension-package-project-boundaries.test.ts
+++ b/src/plugins/contracts/extension-package-project-boundaries.test.ts
@@ -22,7 +22,7 @@ const EXTENSION_PACKAGE_BOUNDARY_BASE_CONFIG =
 type TsConfigJson = {
   extends?: unknown;
   compilerOptions?: {
-    paths?: unknown;
+    paths?: Record<string, readonly string[]>;
     rootDir?: unknown;
     outDir?: unknown;
     declaration?: unknown;

--- a/src/plugins/contracts/extension-package-project-boundaries.test.ts
+++ b/src/plugins/contracts/extension-package-project-boundaries.test.ts
@@ -56,7 +56,7 @@ function collectFilesBySuffix(rootPath: string, suffix: string): string[] {
     }
   }
 
-  return files.sort();
+  return files.toSorted();
 }
 
 describe("opt-in extension package boundaries", () => {

--- a/src/plugins/contracts/extension-package-project-boundaries.test.ts
+++ b/src/plugins/contracts/extension-package-project-boundaries.test.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   collectExtensionsWithTsconfig,
@@ -40,6 +40,23 @@ type PackageJson = {
 
 function readJsonFile<T>(relativePath: string): T {
   return JSON.parse(readFileSync(resolve(REPO_ROOT, relativePath), "utf8")) as T;
+}
+
+function collectFilesBySuffix(rootPath: string, suffix: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
+    const entryPath = join(rootPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFilesBySuffix(entryPath, suffix));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(suffix)) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort();
 }
 
 describe("opt-in extension package boundaries", () => {
@@ -95,6 +112,18 @@ describe("opt-in extension package boundaries", () => {
     expect(tsconfig.compilerOptions?.paths?.["@openclaw/plugin-sdk/*"]).toEqual([
       "../../dist/plugin-sdk/src/plugin-sdk/*.d.ts",
     ]);
+  });
+
+  it("keeps xai tests on the scoped plugin-sdk package name", () => {
+    const xaiRoot = resolve(REPO_ROOT, "extensions/xai");
+    const testFiles = collectFilesBySuffix(xaiRoot, ".test.ts");
+
+    expect(testFiles.length).toBeGreaterThan(0);
+
+    for (const filePath of testFiles) {
+      const contents = readFileSync(filePath, "utf8");
+      expect(contents).not.toContain('"openclaw/plugin-sdk/');
+    }
   });
 
   it("keeps plugin-sdk package types generated from the package build, not a hand-maintained types bridge", () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `extensions/xai/tsconfig.json` still had local `paths` entries that resolved legacy `openclaw/plugin-sdk/*` imports, so the package boundary did not fail closed for old import style.
- Why it matters: other follow-up edits could silently reintroduce the legacy SDK path inside xAI without a hard TypeScript failure, which is exactly what happened after the earlier isolation work merged.
- What changed: I migrated xAI production code to `@openclaw/plugin-sdk/*`, poisoned xAI's local `openclaw/plugin-sdk*` aliases, and extended the boundary canary to assert that the legacy package name fails for hardened packages.
- What did NOT change (scope boundary): I did not remove legacy `openclaw/plugin-sdk*` mappings from the shared extension boundary base, and I did not migrate the rest of the opted-in extensions in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #61548
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the xAI-local boundary config was changed after the original canary landed so legacy `openclaw/plugin-sdk*` specifiers resolved to generated `.d.ts` files instead of failing. That let old imports compile again.
- Missing detection / guardrail: the boundary canary only checked relative `../../src/...` escape imports, not legacy package-name imports.
- Contributing context (if known): the shared extension boundary config is now used by many extensions, so permissive legacy mappings added there or re-added locally can quietly soften the xAI-only isolation unless xAI explicitly forbids them.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `scripts/check-extension-package-tsc-boundary.mjs`, `src/plugins/contracts/extension-package-project-boundaries.test.ts`
- Scenario the test should lock in: xAI fails both when it imports `../../src/...` and when it imports `openclaw/plugin-sdk/provider-entry`, while `@openclaw/plugin-sdk/*` remains the allowed surface.
- Why this is the smallest reliable guardrail: the regression lives in TypeScript path resolution and package-local project wiring, so the package-boundary canary is the direct place to prove the failure mode.
- Existing test that already covers this (if any): `test/extension-package-tsc-boundary.test.ts` covers the boundary canary wrapper.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
xai file -> openclaw/plugin-sdk/* -> local tsconfig paths -> generated d.ts -> compiles

After:
xai file -> openclaw/plugin-sdk/* -> poisoned local tsconfig alias -> TS failure
xai file -> @openclaw/plugin-sdk/* -> generated d.ts -> compiles
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Bun / local checkout
- Model/provider: N/A
- Integration/channel (if any): xAI plugin package boundary
- Relevant config (redacted): default repo checkout

### Steps

1. In `extensions/xai`, add a legacy import like `import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";`.
2. Run the extension package boundary canary.
3. Observe that the xAI canary fails for the legacy package import while `@openclaw/plugin-sdk/*` remains the supported path.

### Expected

- Legacy `openclaw/plugin-sdk/*` imports fail for xAI.
- `@openclaw/plugin-sdk/*` remains the allowed package surface.

### Actual

- With this change, the dedicated xAI boundary canary fails the legacy import as intended.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: I ran `bun scripts/check-extension-package-tsc-boundary.mjs --mode=canary` and verified it passed with the new legacy-import check enabled for xAI.
- Edge cases checked: I confirmed the regression in git blame/history, migrated xAI production imports to `@openclaw/plugin-sdk/*`, and locked the poisoned xAI `paths` map in `src/plugins/contracts/extension-package-project-boundaries.test.ts`.
- What you did **not** verify: I did not fully clean up unrelated `origin/main` typecheck drift outside this narrow boundary slice.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: xAI still depends on the generated `@openclaw/plugin-sdk/*` declaration surface, so future missing subpath exports can break the hardened package.
  - Mitigation: the xAI boundary canary now asserts the allowed package name and the forbidden legacy package name separately, and the contract test locks the poisoned local path map.
