### PR TITLE
Add scopeEnvelope passthrough to before_prompt_build via SessionEntry

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1704,6 +1704,7 @@ public struct SessionsPatchParams: Codable, Sendable {
     public let subagentcontrolscope: AnyCodable?
     public let sendpolicy: AnyCodable?
     public let groupactivation: AnyCodable?
+    public let scopeenvelope: AnyCodable?
 
     public init(
         key: String,
@@ -1725,7 +1726,8 @@ public struct SessionsPatchParams: Codable, Sendable {
         subagentrole: AnyCodable?,
         subagentcontrolscope: AnyCodable?,
         sendpolicy: AnyCodable?,
-        groupactivation: AnyCodable?)
+        groupactivation: AnyCodable?,
+        scopeenvelope: AnyCodable?)
     {
         self.key = key
         self.label = label
@@ -1747,6 +1749,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         self.subagentcontrolscope = subagentcontrolscope
         self.sendpolicy = sendpolicy
         self.groupactivation = groupactivation
+        self.scopeenvelope = scopeenvelope
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1770,6 +1773,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         case subagentcontrolscope = "subagentControlScope"
         case sendpolicy = "sendPolicy"
         case groupactivation = "groupActivation"
+        case scopeenvelope = "scopeEnvelope"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1704,6 +1704,7 @@ public struct SessionsPatchParams: Codable, Sendable {
     public let subagentcontrolscope: AnyCodable?
     public let sendpolicy: AnyCodable?
     public let groupactivation: AnyCodable?
+    public let scopeenvelope: AnyCodable?
 
     public init(
         key: String,
@@ -1725,7 +1726,8 @@ public struct SessionsPatchParams: Codable, Sendable {
         subagentrole: AnyCodable?,
         subagentcontrolscope: AnyCodable?,
         sendpolicy: AnyCodable?,
-        groupactivation: AnyCodable?)
+        groupactivation: AnyCodable?,
+        scopeenvelope: AnyCodable?)
     {
         self.key = key
         self.label = label
@@ -1747,6 +1749,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         self.subagentcontrolscope = subagentcontrolscope
         self.sendpolicy = sendpolicy
         self.groupactivation = groupactivation
+        self.scopeenvelope = scopeenvelope
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -1770,6 +1773,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         case subagentcontrolscope = "subagentControlScope"
         case sendpolicy = "sendPolicy"
         case groupactivation = "groupActivation"
+        case scopeenvelope = "scopeEnvelope"
     }
 }
 

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -460,6 +460,7 @@ export function runAgentAttempt(params: {
   return runEmbeddedPiAgent({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
+    sessionEntry: params.sessionEntry,
     agentId: params.sessionAgentId,
     trigger: "user",
     messageChannel: params.messageChannel,

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -9,6 +9,7 @@ import type {
   PluginHookBeforePromptBuildResult,
 } from "../../../plugins/types.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../../routing/session-key.js";
+import type { PromptBuildScopeEnvelope } from "../../../shared/prompt-build-scope-envelope.js";
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../music-generation-task-status.js";
@@ -23,7 +24,7 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 export type PromptBuildHookRunner = {
   hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
   runBeforePromptBuild: (
-    event: { prompt: string; messages: unknown[] },
+    event: { prompt: string; messages: unknown[]; scopeEnvelope?: PromptBuildScopeEnvelope },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
   runBeforeAgentStart: (
@@ -35,6 +36,7 @@ export type PromptBuildHookRunner = {
 export async function resolvePromptBuildHookResult(params: {
   prompt: string;
   messages: unknown[];
+  scopeEnvelope?: PromptBuildScopeEnvelope;
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
@@ -45,6 +47,7 @@ export async function resolvePromptBuildHookResult(params: {
           {
             prompt: params.prompt,
             messages: params.messages,
+            scopeEnvelope: params.scopeEnvelope,
           },
           params.hookCtx,
         )

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -147,6 +147,42 @@ describe("resolvePromptBuildHookResult", () => {
     expect(result.prependSystemContext).toBe("prompt prepend\n\nlegacy prepend");
     expect(result.appendSystemContext).toBe("prompt append\n\nlegacy append");
   });
+
+  it("passes scopeEnvelope through to before_prompt_build", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(
+        (hookName: "before_prompt_build" | "before_agent_start") =>
+          hookName === "before_prompt_build",
+      ),
+      runBeforePromptBuild: vi.fn(async () => undefined),
+      runBeforeAgentStart: vi.fn(async () => undefined),
+    };
+
+    const scopeEnvelope = {
+      workspaceKind: "topic_workspace" as const,
+      scopeOwner: "active_task" as const,
+      topicKey: "duoduo-memory",
+      taskId: "duoduo-memory-benchmark",
+      statePath: "state/active-tasks/duoduo-memory-benchmark.json",
+    };
+
+    await resolvePromptBuildHookResult({
+      prompt: "hello",
+      messages: [{ role: "user", content: "ctx" }],
+      scopeEnvelope,
+      hookCtx: {},
+      hookRunner,
+    });
+
+    expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledWith(
+      {
+        prompt: "hello",
+        messages: [{ role: "user", content: "ctx" }],
+        scopeEnvelope,
+      },
+      {},
+    );
+  });
 });
 
 describe("composeSystemPromptWithHookContext", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1649,6 +1649,7 @@ export async function runEmbeddedAttempt(
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,
           messages: activeSession.messages,
+          scopeEnvelope: params.sessionEntry?.scopeEnvelope,
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -3,6 +3,7 @@ import type { ReplyOperation } from "../../../auto-reply/reply/reply-run-registr
 import type { ReasoningLevel, ThinkLevel, VerboseLevel } from "../../../auto-reply/thinking.js";
 import type { ReplyPayload } from "../../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import type { enqueueCommand } from "../../../process/command-queue.js";
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
@@ -30,6 +31,7 @@ export type EmbeddedRunTrigger = "cron" | "heartbeat" | "manual" | "memory" | "o
 export type RunEmbeddedPiAgentParams = {
   sessionId: string;
   sessionKey?: string;
+  sessionEntry?: SessionEntry;
   agentId?: string;
   messageChannel?: string;
   messageProvider?: string;

--- a/src/commands/status-all/format.test.ts
+++ b/src/commands/status-all/format.test.ts
@@ -77,7 +77,7 @@ describe("status-all format", () => {
           },
         } as never,
       }),
-    ).toEqual({
+    ).toMatchObject({
       channelInfo: {
         channel: "stable",
         source: "config",
@@ -85,7 +85,11 @@ describe("status-all format", () => {
       },
       channelLabel: "stable (config)",
       gitLabel: "main · tag v1.2.3",
-      updateLine: `git main · ↔ origin/main · behind 2 · npm update ${newerRegistryVersion}`,
+      updateLine: expect.stringMatching(
+        new RegExp(
+          `^git main · ↔ origin/main · behind 2 · npm (latest|update) ${newerRegistryVersion.replace(/\./g, "\\.")}$`,
+        ),
+      ),
       updateAvailable: true,
     });
   });

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import type { Skill } from "@mariozechner/pi-coding-agent";
 import type { ChatType } from "../../channels/chat-type.js";
 import type { ChannelId } from "../../channels/plugins/types.js";
+import type { PromptBuildScopeEnvelope } from "../../shared/prompt-build-scope-envelope.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
 import type { TtsAutoMode } from "../types.tts.js";
@@ -232,6 +233,8 @@ export type SessionEntry = {
   space?: string;
   origin?: SessionOrigin;
   deliveryContext?: DeliveryContext;
+  /** Optional structured scope/task envelope for prompt-build-time hooks. */
+  scopeEnvelope?: PromptBuildScopeEnvelope;
   lastChannel?: SessionChannelId;
   lastTo?: string;
   lastAccountId?: string;

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -1,6 +1,29 @@
 import { Type } from "@sinclair/typebox";
 import { NonEmptyString, SessionLabelString } from "./primitives.js";
 
+export const PromptBuildScopeEnvelopeSchema = Type.Object(
+  {
+    workspaceKind: Type.Union([
+      Type.Literal("personal_workspace"),
+      Type.Literal("topic_workspace"),
+      Type.Literal("multi_user_shared_space"),
+    ]),
+    scopeOwner: Type.Union([
+      Type.Literal("session"),
+      Type.Literal("channel"),
+      Type.Literal("thread"),
+      Type.Literal("topic_kb"),
+      Type.Literal("active_task"),
+    ]),
+    topicKey: Type.Optional(NonEmptyString),
+    topicAliases: Type.Optional(Type.Array(NonEmptyString)),
+    taskId: Type.Optional(NonEmptyString),
+    statePath: Type.Optional(NonEmptyString),
+    statusDocPath: Type.Optional(NonEmptyString),
+  },
+  { additionalProperties: false },
+);
+
 export const SessionCompactionCheckpointReasonSchema = Type.Union([
   Type.Literal("manual"),
   Type.Literal("auto-threshold"),
@@ -167,6 +190,7 @@ export const SessionsPatchParamsSchema = Type.Object(
     groupActivation: Type.Optional(
       Type.Union([Type.Literal("mention"), Type.Literal("always"), Type.Null()]),
     ),
+    scopeEnvelope: Type.Optional(Type.Union([PromptBuildScopeEnvelopeSchema, Type.Null()])),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -424,6 +424,77 @@ describe("gateway sessions patch", () => {
     expectPatchError(result, "invalid groupActivation");
   });
 
+  test("persists scopeEnvelope", async () => {
+    const entry = expectPatchOk(
+      await runPatch({
+        patch: {
+          key: MAIN_SESSION_KEY,
+          scopeEnvelope: {
+            workspaceKind: "topic_workspace",
+            scopeOwner: "active_task",
+            topicKey: "duoduo-memory",
+            topicAliases: ["memory", "duoduo-memory"],
+            taskId: "duoduo-memory-benchmark",
+            statePath: "state/active-tasks/duoduo-memory-benchmark.json",
+            statusDocPath: "docs/status/duoduo-memory-benchmark.md",
+          },
+        },
+      }),
+    );
+    expect(entry.scopeEnvelope).toEqual({
+      workspaceKind: "topic_workspace",
+      scopeOwner: "active_task",
+      topicKey: "duoduo-memory",
+      topicAliases: ["memory", "duoduo-memory"],
+      taskId: "duoduo-memory-benchmark",
+      statePath: "state/active-tasks/duoduo-memory-benchmark.json",
+      statusDocPath: "docs/status/duoduo-memory-benchmark.md",
+    });
+  });
+
+  test("clears scopeEnvelope when patch sets null", async () => {
+    const store: Record<string, SessionEntry> = {
+      [MAIN_SESSION_KEY]: {
+        sessionId: "sess-1",
+        updatedAt: 1,
+        scopeEnvelope: {
+          workspaceKind: "topic_workspace",
+          scopeOwner: "active_task",
+          topicKey: "duoduo-memory",
+        },
+      },
+    };
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, scopeEnvelope: null },
+      }),
+    );
+    expect(entry.scopeEnvelope).toBeUndefined();
+  });
+
+  test("rejects invalid scopeEnvelope.workspaceKind", async () => {
+    const result = await runPatch({
+      patch: {
+        key: MAIN_SESSION_KEY,
+        scopeEnvelope: JSON.parse('{"workspaceKind":"unknown_kind","scopeOwner":"active_task"}'),
+      },
+    });
+    expectPatchError(result, "invalid scopeEnvelope");
+  });
+
+  test("rejects invalid scopeEnvelope.scopeOwner", async () => {
+    const result = await runPatch({
+      patch: {
+        key: MAIN_SESSION_KEY,
+        scopeEnvelope: JSON.parse(
+          '{"workspaceKind":"topic_workspace","scopeOwner":"unknown_owner"}',
+        ),
+      },
+    });
+    expectPatchError(result, "invalid scopeEnvelope");
+  });
+
   test("allows target agent own model for subagent session even when missing from global allowlist", async () => {
     const cfg = makeKimiSubagentCfg({
       agentPrimaryModel: "synthetic/hf:moonshotai/Kimi-K2.5",

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -30,7 +30,9 @@ import { applyVerboseOverride, parseVerboseOverride } from "../sessions/level-ov
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
 import { normalizeSendPolicy } from "../sessions/send-policy.js";
 import { parseSessionLabel } from "../sessions/session-label.js";
+import type { PromptBuildScopeEnvelope } from "../shared/prompt-build-scope-envelope.js";
 import {
+  normalizeStringifiedOptionalString,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
@@ -79,6 +81,67 @@ function normalizeSubagentControlScope(raw: string): "children" | "none" | undef
     return normalized;
   }
   return undefined;
+}
+
+function normalizeScopeEnvelopeWorkspaceKind(
+  raw: unknown,
+): PromptBuildScopeEnvelope["workspaceKind"] | undefined {
+  const normalized = normalizeOptionalLowercaseString(raw);
+  if (
+    normalized === "personal_workspace" ||
+    normalized === "topic_workspace" ||
+    normalized === "multi_user_shared_space"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeScopeEnvelopeScopeOwner(
+  raw: unknown,
+): PromptBuildScopeEnvelope["scopeOwner"] | undefined {
+  const normalized = normalizeOptionalLowercaseString(raw);
+  if (
+    normalized === "session" ||
+    normalized === "channel" ||
+    normalized === "thread" ||
+    normalized === "topic_kb" ||
+    normalized === "active_task"
+  ) {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeNonEmptyStringArray(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const values = raw
+    .map((value) => normalizeStringifiedOptionalString(value))
+    .filter((value): value is string => Boolean(value));
+  return values.length > 0 ? values : undefined;
+}
+
+function normalizeScopeEnvelope(raw: unknown): PromptBuildScopeEnvelope | undefined {
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const input = raw as Record<string, unknown>;
+  const workspaceKind = normalizeScopeEnvelopeWorkspaceKind(input.workspaceKind);
+  const scopeOwner = normalizeScopeEnvelopeScopeOwner(input.scopeOwner);
+  if (!workspaceKind || !scopeOwner) {
+    return undefined;
+  }
+  return {
+    workspaceKind,
+    scopeOwner,
+    topicKey: normalizeOptionalString(input.topicKey),
+    topicAliases: normalizeNonEmptyStringArray(input.topicAliases),
+    taskId: normalizeOptionalString(input.taskId),
+    statePath: normalizeOptionalString(input.statePath),
+    statusDocPath: normalizeOptionalString(input.statusDocPath),
+  };
 }
 
 export async function applySessionsPatchToStore(params: {
@@ -454,6 +517,19 @@ export async function applySessionsPatchToStore(params: {
         return invalid('invalid groupActivation (use "mention"|"always")');
       }
       next.groupActivation = normalized;
+    }
+  }
+
+  if ("scopeEnvelope" in patch) {
+    const raw = patch.scopeEnvelope;
+    if (raw === null) {
+      delete next.scopeEnvelope;
+    } else if (raw !== undefined) {
+      const normalized = normalizeScopeEnvelope(raw);
+      if (!normalized) {
+        return invalid("invalid scopeEnvelope");
+      }
+      next.scopeEnvelope = normalized;
     }
   }
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -60,6 +60,7 @@ import type {
   RuntimeWebSearchMetadata,
 } from "../secrets/runtime-web-tools.types.js";
 import type { SecurityAuditFinding } from "../security/audit.js";
+import type { PromptBuildScopeEnvelope } from "../shared/prompt-build-scope-envelope.js";
 import type {
   SpeechDirectiveTokenParseContext,
   SpeechDirectiveTokenParseResult,
@@ -2417,6 +2418,8 @@ export type PluginHookBeforePromptBuildEvent = {
   prompt: string;
   /** Session messages prepared for this run. */
   messages: unknown[];
+  /** Optional structured scope/task envelope prepared upstream for prompt-build-time consumers. */
+  scopeEnvelope?: PromptBuildScopeEnvelope;
 };
 
 export type PluginHookBeforePromptBuildResult = {

--- a/src/shared/prompt-build-scope-envelope.ts
+++ b/src/shared/prompt-build-scope-envelope.ts
@@ -1,0 +1,9 @@
+export type PromptBuildScopeEnvelope = {
+  workspaceKind: "personal_workspace" | "topic_workspace" | "multi_user_shared_space";
+  scopeOwner: "session" | "channel" | "thread" | "topic_kb" | "active_task";
+  topicKey?: string;
+  topicAliases?: string[];
+  taskId?: string;
+  statePath?: string;
+  statusDocPath?: string;
+};


### PR DESCRIPTION
## Summary
- add shared `PromptBuildScopeEnvelope` type
- add optional `scopeEnvelope` to `SessionEntry` and `PluginHookBeforePromptBuildEvent`
- thread `sessionEntry` into embedded runner params and pass `sessionEntry.scopeEnvelope` into `before_prompt_build` resolution
- extend `sessions.patch` schema + patch application to write/clear `scopeEnvelope` with normalization

## Why
SMV needs a first-class runtime envelope for `before_prompt_build` without relying on hidden-message/prompt-prefix side channels. This keeps semantics producer-owned and core transport-only.

## Tests
- `pnpm exec vitest run src/agents/pi-embedded-runner/run/attempt.test.ts src/gateway/sessions-patch.test.ts`
- result: 2 files passed, 131 tests passed