### PR TITLE
fix(config): strip legacy installs/plugins from channel configs before validation

### DIFF
--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -240,6 +240,43 @@ describe("FeishuConfigSchema actions", () => {
   });
 });
 
+describe("FeishuConfigSchema legacy field rejection (issue #63101)", () => {
+  it("rejects config with legacy installs field before migration", () => {
+    const result = FeishuConfigSchema.safeParse({
+      appId: "cli_test",
+      appSecret: "secret_test", // pragma: allowlist secret
+      installs: [{ source: "npm", spec: "@openclaw/plugin-feishu@4.5.0" }],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages.some((m) => /unrecognized/i.test(m))).toBe(true);
+    }
+  });
+
+  it("rejects config with legacy plugins field before migration", () => {
+    const result = FeishuConfigSchema.safeParse({
+      appId: "cli_test",
+      appSecret: "secret_test", // pragma: allowlist secret
+      plugins: { allow: ["@openclaw/plugin-feishu"] },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects config with both legacy installs and plugins fields before migration", () => {
+    const result = FeishuConfigSchema.safeParse({
+      appId: "cli_test",
+      appSecret: "secret_test", // pragma: allowlist secret
+      installs: [{ source: "npm", spec: "@openclaw/plugin-feishu@4.5.0" }],
+      plugins: { allow: ["@openclaw/plugin-feishu"] },
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("FeishuConfigSchema defaultAccount", () => {
   it("accepts defaultAccount when it matches an account key", () => {
     const result = FeishuConfigSchema.safeParse({

--- a/src/config/legacy-migrate.test.ts
+++ b/src/config/legacy-migrate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { migrateLegacyConfig } from "./legacy-migrate.js";
+import { applyLegacyMigrations } from "./legacy.js";
 
 describe("legacy migrate audio transcription", () => {
   it("does not rewrite removed routing.transcribeAudio migrations", () => {
@@ -327,5 +328,114 @@ describe("legacy migrate controlUi.allowedOrigins seed (issue #29385)", () => {
       "http://localhost:18789",
       "http://127.0.0.1:18789",
     ]);
+  });
+});
+
+describe("legacy migrate stale channel keys (issue #63101)", () => {
+  it("strips installs from channels.feishu", () => {
+    const { next, changes } = applyLegacyMigrations({
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test", // pragma: allowlist secret
+          installs: [{ source: "npm", spec: "@openclaw/plugin-feishu@4.5.0" }],
+        },
+      },
+    });
+
+    expect(next).not.toBeNull();
+    expect(changes.length).toBeGreaterThan(0);
+    expect(changes.some((c) => c.includes("channels.feishu.installs"))).toBe(true);
+    const feishu = (next?.channels as Record<string, Record<string, unknown>>)?.feishu;
+    expect(feishu).toBeDefined();
+    expect(Object.prototype.hasOwnProperty.call(feishu, "installs")).toBe(false);
+    expect(feishu?.appId).toBe("cli_test");
+  });
+
+  it("strips plugins from channels.feishu", () => {
+    const { next, changes } = applyLegacyMigrations({
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test", // pragma: allowlist secret
+          plugins: { allow: ["@openclaw/plugin-feishu"] },
+        },
+      },
+    });
+
+    expect(next).not.toBeNull();
+    expect(changes.some((c) => c.includes("channels.feishu.plugins"))).toBe(true);
+    const feishu = (next?.channels as Record<string, Record<string, unknown>>)?.feishu;
+    expect(Object.prototype.hasOwnProperty.call(feishu, "plugins")).toBe(false);
+  });
+
+  it("strips both installs and plugins from channels.feishu", () => {
+    const { next, changes } = applyLegacyMigrations({
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test", // pragma: allowlist secret
+          installs: [{ source: "npm", spec: "@openclaw/plugin-feishu@4.5.0" }],
+          plugins: { allow: ["@openclaw/plugin-feishu"] },
+        },
+      },
+    });
+
+    expect(next).not.toBeNull();
+    expect(changes.filter((c) => c.includes("channels.feishu")).length).toBe(2);
+    const feishu = (next?.channels as Record<string, Record<string, unknown>>)?.feishu;
+    expect(Object.prototype.hasOwnProperty.call(feishu, "installs")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(feishu, "plugins")).toBe(false);
+  });
+
+  it("does not modify channel config without stale keys", () => {
+    const { next, changes } = applyLegacyMigrations({
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test", // pragma: allowlist secret
+        },
+      },
+    });
+
+    expect(next).toBeNull();
+    expect(changes).toHaveLength(0);
+  });
+
+  it("strips stale keys from other channels too", () => {
+    const { next, changes } = applyLegacyMigrations({
+      channels: {
+        slack: {
+          botToken: "xoxb-test",
+          installs: [{ source: "npm", spec: "@openclaw/plugin-slack@4.5.0" }],
+        },
+      },
+    });
+
+    expect(next).not.toBeNull();
+    expect(changes.some((c) => c.includes("channels.slack.installs"))).toBe(true);
+  });
+
+  it("strips stale keys from nested account configs", () => {
+    const { next, changes } = applyLegacyMigrations({
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test", // pragma: allowlist secret
+          accounts: {
+            main: {
+              appId: "cli_main",
+              plugins: { allow: ["@openclaw/plugin-feishu"] },
+            },
+          },
+        },
+      },
+    });
+
+    expect(next).not.toBeNull();
+    expect(changes.some((c) => c.includes("channels.feishu.accounts.main.plugins"))).toBe(true);
+    const accounts = (next?.channels as Record<string, Record<string, unknown>>)?.feishu
+      ?.accounts as Record<string, Record<string, unknown>>;
+    expect(Object.prototype.hasOwnProperty.call(accounts?.main, "plugins")).toBe(false);
   });
 });

--- a/src/config/legacy.migrations.channels.ts
+++ b/src/config/legacy.migrations.channels.ts
@@ -82,7 +82,93 @@ const THREAD_BINDING_RULES: LegacyConfigRule[] = [
   },
 ];
 
+/** Fields that were never valid inside a channel config block but could appear
+ *  in v4.5-era configs due to top-level key nesting.  Stripping them before
+ *  schema validation restores a safe v4.5 → v4.8 upgrade path (issue #63101). */
+const CHANNEL_LEVEL_STALE_KEYS = ["installs", "plugins"] as const;
+
+function hasStaleChannelKeys(channelValue: unknown): boolean {
+  const entry = getRecord(channelValue);
+  return entry !== null && CHANNEL_LEVEL_STALE_KEYS.some((key) => hasOwnKey(entry, key));
+}
+
+/**
+ * Strip stale top-level keys (`installs`, `plugins`) from every channel entry
+ * and its nested `accounts.<id>` entries.
+ * Returns `true` if at least one key was removed.
+ */
+function stripStaleChannelKeys(params: {
+  entry: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+}): boolean {
+  let removed = false;
+  for (const key of CHANNEL_LEVEL_STALE_KEYS) {
+    if (hasOwnKey(params.entry, key)) {
+      delete params.entry[key];
+      params.changes.push(
+        `Removed ${params.pathPrefix}.${key} (not a valid channel property; auto-stripped for upgrade compatibility).`,
+      );
+      removed = true;
+    }
+  }
+
+  const accounts = getRecord(params.entry.accounts);
+  if (accounts) {
+    for (const [accountId, accountRaw] of Object.entries(accounts)) {
+      const account = getRecord(accountRaw);
+      if (!account) {
+        continue;
+      }
+      for (const key of CHANNEL_LEVEL_STALE_KEYS) {
+        if (hasOwnKey(account, key)) {
+          delete account[key];
+          params.changes.push(
+            `Removed ${params.pathPrefix}.accounts.${accountId}.${key} (not a valid channel property; auto-stripped for upgrade compatibility).`,
+          );
+          removed = true;
+        }
+      }
+    }
+  }
+  return removed;
+}
+
+const STALE_CHANNEL_KEY_RULES: LegacyConfigRule[] = [
+  {
+    path: ["channels", "feishu"],
+    message:
+      'channels.feishu contains legacy "installs" or "plugins" keys that are not valid channel properties (auto-removed on load).',
+    match: (value) => hasStaleChannelKeys(value),
+  },
+];
+
 export const LEGACY_CONFIG_MIGRATIONS_CHANNELS: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "channels.*.stale-top-level-keys",
+    describe:
+      "Strip legacy installs/plugins keys from channel configs (not valid channel properties)",
+    legacyRules: STALE_CHANNEL_KEY_RULES,
+    apply: (raw, changes) => {
+      const channels = getRecord(raw.channels);
+      if (!channels) {
+        return;
+      }
+      for (const [channelId, channelRaw] of Object.entries(channels)) {
+        const channel = getRecord(channelRaw);
+        if (!channel) {
+          continue;
+        }
+        stripStaleChannelKeys({
+          entry: channel,
+          pathPrefix: `channels.${channelId}`,
+          changes,
+        });
+        channels[channelId] = channel;
+      }
+      raw.channels = channels;
+    },
+  }),
   defineLegacyConfigMigration({
     id: "thread-bindings.ttlHours->idleHours",
     describe:


### PR DESCRIPTION
## Summary

Fixes #63101

After upgrading from v4.5 to v4.8, `openclaw gateway restart` fails with:

```
channels.feishu: invalid config: must NOT have additional properties
```

when legacy `installs` and `plugins` fields are present under `channels.feishu`.

## Root Cause

The Feishu channel config schema (`FeishuConfigSchema`) uses Zod `.strict()` mode, which rejects any properties not explicitly declared in the schema. The `installs` and `plugins` fields were never valid channel-level properties but could appear in v4.5-era configs due to top-level key nesting.

## Fix

Add a legacy config migration (`channels.*.stale-top-level-keys`) that auto-strips `installs` and `plugins` from every `channels.*` entry (including nested `accounts.*`) **before** schema validation runs. The migration:

- Logs a clear change message so operators know the fields were removed
- Applies generically to all channels (not just Feishu) since these fields are never valid at the channel level
- Includes a legacy rule that triggers a warning for `channels.feishu` specifically

## Tests

- 6 regression tests for the migration in `src/config/legacy-migrate.test.ts`
- 3 schema-level rejection tests in `extensions/feishu/src/config-schema.test.ts`

All 51 tests pass.