### PR TITLE
fix(cli): stage local media before gateway send #63461

### DIFF
--- a/src/infra/outbound/message-gateway-media.test.ts
+++ b/src/infra/outbound/message-gateway-media.test.ts
@@ -1,0 +1,85 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const saveMediaSourceMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../media/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../media/store.js")>();
+  return {
+    ...actual,
+    saveMediaSource: saveMediaSourceMock,
+  };
+});
+
+import { stageLocalMediaPathsForGatewayRpc } from "./message-gateway-media.js";
+
+describe("stageLocalMediaPathsForGatewayRpc", () => {
+  afterEach(() => {
+    saveMediaSourceMock.mockReset();
+  });
+
+  it("copies arbitrary absolute paths into managed media via saveMediaSource", async () => {
+    const outside = path.join(os.tmpdir(), `openclaw-63461-${Date.now()}.bin`);
+    await fs.writeFile(outside, Buffer.from("x"), { mode: 0o600 });
+
+    saveMediaSourceMock.mockResolvedValue({
+      path: "/state/media/outbound/staged.bin",
+      id: "staged.bin",
+      contentType: "application/octet-stream",
+      size: 1,
+    });
+
+    await expect(
+      stageLocalMediaPathsForGatewayRpc({
+        cfg: {},
+        mediaUrl: outside,
+      }),
+    ).resolves.toEqual({
+      mediaUrl: "/state/media/outbound/staged.bin",
+      mediaUrls: undefined,
+    });
+
+    expect(saveMediaSourceMock).toHaveBeenCalledWith(outside, undefined, "outbound");
+    await fs.unlink(outside).catch(() => {});
+  });
+
+  it("does not call saveMediaSource when the path is already under allowed roots", async () => {
+    const rootsModule = await import("../../media/local-roots.js");
+    const roots = rootsModule.getAgentScopedMediaLocalRoots({}, undefined);
+    const root = roots[0];
+    if (!root) {
+      throw new Error("expected default media local roots");
+    }
+    const inside = path.join(root, `nested-${Date.now()}.txt`);
+    await fs.mkdir(path.dirname(inside), { recursive: true }).catch(() => {});
+    await fs.writeFile(inside, Buffer.from("ok"), { mode: 0o600 });
+
+    await expect(
+      stageLocalMediaPathsForGatewayRpc({
+        cfg: {},
+        mediaUrl: inside,
+      }),
+    ).resolves.toEqual({
+      mediaUrl: inside,
+      mediaUrls: undefined,
+    });
+
+    expect(saveMediaSourceMock).not.toHaveBeenCalled();
+    await fs.unlink(inside).catch(() => {});
+  });
+
+  it("passes through https URLs without staging", async () => {
+    await expect(
+      stageLocalMediaPathsForGatewayRpc({
+        cfg: {},
+        mediaUrl: "https://example.com/a.png",
+      }),
+    ).resolves.toEqual({
+      mediaUrl: "https://example.com/a.png",
+      mediaUrls: undefined,
+    });
+    expect(saveMediaSourceMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/infra/outbound/message-gateway-media.ts
+++ b/src/infra/outbound/message-gateway-media.ts
@@ -1,0 +1,118 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
+import type { OpenClawConfig } from "../../config/config.js";
+import { expandHomePrefix } from "../../infra/home-dir.js";
+import { isPathInside } from "../../infra/path-guards.js";
+import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import { saveMediaSource } from "../../media/store.js";
+
+const HTTP_URL_RE = /^https?:\/\//i;
+const FILE_URL_RE = /^file:\/\//i;
+const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
+/** Non-file schemes (e.g. media://) that must pass through unchanged. */
+const OPAQUE_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+function isUnderAnyMediaRoot(target: string, roots: readonly string[]): boolean {
+  const resolvedTarget = path.resolve(target);
+  for (const root of roots) {
+    if (isPathInside(path.resolve(root), resolvedTarget)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveOutboundLocalFilesystemPath(raw: string): string {
+  const trimmed = raw.trim();
+  if (FILE_URL_RE.test(trimmed)) {
+    return path.resolve(fileURLToPath(trimmed));
+  }
+  const expanded = trimmed.startsWith("~") ? expandHomePrefix(trimmed) : trimmed;
+  if (path.isAbsolute(expanded)) {
+    return path.resolve(expanded);
+  }
+  return path.resolve(process.cwd(), expanded);
+}
+
+function shouldPassThroughUnstaged(media: string): boolean {
+  const t = media.trim();
+  if (!t) {
+    return true;
+  }
+  if (HTTP_URL_RE.test(t)) {
+    return true;
+  }
+  if (FILE_URL_RE.test(t)) {
+    return false;
+  }
+  if (WINDOWS_DRIVE_RE.test(t)) {
+    return false;
+  }
+  if (OPAQUE_SCHEME_RE.test(t)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Gateway RPC only carries media URL strings; the gateway process must read the
+ * bytes from paths under {@link getAgentScopedMediaLocalRoots}. CLI users often
+ * pass arbitrary absolute paths (e.g. ~/Downloads/x.ogg) that are outside those
+ * roots. Copy into the managed media cache on the CLI host before invoking the
+ * gateway so delivery matches the agent path (which uses `saveMediaSource`).
+ */
+export async function stageLocalMediaPathsForGatewayRpc(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  mediaUrl?: string;
+  mediaUrls?: string[];
+}): Promise<{ mediaUrl?: string; mediaUrls?: string[] }> {
+  const urls = resolveOutboundMediaUrls({
+    mediaUrl: params.mediaUrl,
+    mediaUrls: params.mediaUrls,
+  });
+  if (urls.length === 0) {
+    return { mediaUrl: params.mediaUrl, mediaUrls: params.mediaUrls };
+  }
+
+  const roots = getAgentScopedMediaLocalRoots(params.cfg, params.agentId);
+  const staged: string[] = [];
+
+  for (const raw of urls) {
+    const trimmed = raw.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (shouldPassThroughUnstaged(trimmed)) {
+      staged.push(trimmed);
+      continue;
+    }
+
+    const absolutePath = resolveOutboundLocalFilesystemPath(trimmed);
+    if (isUnderAnyMediaRoot(absolutePath, roots)) {
+      staged.push(absolutePath);
+      continue;
+    }
+
+    const saved = await saveMediaSource(absolutePath, undefined, "outbound");
+    staged.push(saved.path);
+  }
+
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+  for (const entry of staged) {
+    if (!seen.has(entry)) {
+      seen.add(entry);
+      deduped.push(entry);
+    }
+  }
+
+  if (deduped.length === 0) {
+    return { mediaUrl: undefined, mediaUrls: undefined };
+  }
+  if (deduped.length === 1) {
+    return { mediaUrl: deduped[0], mediaUrls: undefined };
+  }
+  return { mediaUrl: undefined, mediaUrls: deduped };
+}

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -15,6 +15,7 @@ import {
   type OutboundDeliveryResult,
   type OutboundSendDeps,
 } from "./deliver.js";
+import { stageLocalMediaPathsForGatewayRpc } from "./message-gateway-media.js";
 import type { OutboundMirror } from "./mirror.js";
 import { normalizeReplyPayloadsForDelivery } from "./payloads.js";
 import { buildOutboundSessionContext } from "./session-context.js";
@@ -236,7 +237,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
   const mirrorMediaUrls = normalizedPayloads.flatMap(
     (payload) => resolveSendableOutboundReplyParts(payload).mediaUrls,
   );
-  const primaryMediaUrl = mirrorMediaUrls[0] ?? params.mediaUrl ?? null;
+  let primaryMediaUrl = mirrorMediaUrls[0] ?? params.mediaUrl ?? null;
 
   if (params.dryRun) {
     return {
@@ -302,14 +303,24 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     };
   }
 
+  const stagedMedia = await stageLocalMediaPathsForGatewayRpc({
+    cfg,
+    agentId: params.agentId,
+    mediaUrl: params.mediaUrl,
+    mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : params.mediaUrls,
+  });
+  const stagedMediaUrls =
+    stagedMedia.mediaUrls ?? (stagedMedia.mediaUrl ? [stagedMedia.mediaUrl] : undefined);
+  primaryMediaUrl = stagedMediaUrls?.[0] ?? stagedMedia.mediaUrl ?? primaryMediaUrl;
+
   const result = await callMessageGateway<{ messageId: string }>({
     gateway: params.gateway,
     method: "send",
     params: {
       to: params.to,
       message: params.content,
-      mediaUrl: params.mediaUrl,
-      mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : params.mediaUrls,
+      mediaUrl: stagedMedia.mediaUrl,
+      mediaUrls: stagedMedia.mediaUrls,
       gifPlayback: params.gifPlayback,
       accountId: params.accountId,
       agentId: params.agentId,
@@ -324,7 +335,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     to: params.to,
     via: "gateway",
     mediaUrl: primaryMediaUrl,
-    mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : undefined,
+    mediaUrls: stagedMediaUrls,
     result,
   };
 }


### PR DESCRIPTION
## Summary

- Problem: `openclaw message send --channel whatsapp --media <path>` reported success but only text was delivered (`hasMedia: false`), because WhatsApp outbound uses `deliveryMode: "gateway"` and the CLI only sent raw filesystem path strings over the gateway RPC. The gateway only reads local media under agent-scoped roots; arbitrary paths (e.g. under home or `/tmp`) were not loadable.
- Why it matters: Users expect CLI sends to behave like agent-driven sends, which persist media via `saveMediaSource` into managed storage first.
- What changed: Before `callMessageGateway` for `send`, local paths outside allowed roots are copied with `saveMediaSource(..., "outbound")` on the CLI host; `http(s)` and opaque refs (e.g. `media:`) are unchanged; paths already under `getAgentScopedMediaLocalRoots` are not duplicated. New helper: `src/infra/outbound/message-gateway-media.ts`; wired from `src/infra/outbound/message.ts`. Tests in `src/infra/outbound/message-gateway-media.test.ts`.
- What did NOT change (scope boundary): Gateway wire protocol, WhatsApp plugin outbound adapter, remote-gateway / cross-machine file transfer (still path-string only over RPC).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

Fixes #63461
Related #51347

## User-visible / Behavior Changes

- CLI `message send` for channels whose outbound uses gateway delivery (including WhatsApp) now stages out-of-root local `--media` paths into the managed media directory before invoking the gateway, so attachments can be read and sent when CLI and gateway run on the same host with a normal filesystem.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No** (same CLI flags; behavior for valid sends improves)
- Data access scope changed? **No** (still reads only user-supplied paths; staging uses existing `saveMediaSource` / size limits)

## Repro + Verification

### Environment

- OS: Linux (dev); behavior intended same on macOS/Windows for local gateway
- Runtime: Node 22+
- Channel: WhatsApp (gateway delivery mode)

### Steps

1. Place a media file outside default media roots (e.g. under home or a non–OpenClaw tmp path).
2. Run: `openclaw message send --channel whatsapp --target <jid-or-e164> --media /path/to/file -m "test"` (with gateway running locally as usual for your setup).

### Expected

- Message delivers with media attachment (not text-only).

### Actual (before fix)

- Text delivered; logs showed no effective media / `hasMedia: false` style behavior for disallowed paths.

## Evidence

- [x] Unit tests: `pnpm test src/infra/outbound/message-gateway-media.test.ts` (and `src/infra/outbound/message.test.ts` as part of local gate)

## Human Verification (required)

- Verified scenarios: Logic review + unit tests for staging vs pass-through vs in-root paths.
- Edge cases checked: HTTPS passthrough; Windows drive paths not misclassified as opaque schemes (code path).
- What I did **not** verify: End-to-end WhatsApp Web send with real account (requires live gateway + WhatsApp session).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

- Revert the commit touching `src/infra/outbound/message.ts` and remove `message-gateway-media.ts` / test file.

## Risks and Mitigations

- Risk: Extra disk write and brief copy for large files within existing media size limits.
  - Mitigation: Same `saveMediaSource` path as other tooling; skips copy when already under allowed roots.
