### PR TITLE
fix(gateway): start channels before WebSocket handlers (#63450)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Docs: https://docs.openclaw.ai
 - Status: show configured fallback models in `/status` and shared session status cards so per-agent fallback configuration is visible before a live failover happens. (#33111) Thanks @AnCoSONG.
 - Fireworks/FirePass: disable Kimi K2.5 Turbo reasoning output by forcing thinking off on the FirePass path and hardening the provider wrapper so hidden reasoning no longer leaks into visible replies. (#63607) Thanks @frankekn.
 - Sessions/model selection: preserve catalog-backed session model labels and keep already-qualified session model refs stable when catalog metadata is unavailable, so Control UI model selection survives reloads without bogus provider-prefixed values. (#61382) Thanks @Mule-ME.
-- Gateway/startup: start channels and plugin sidecars before attaching WebSocket RPC handlers so slow synchronous `chat.history` work can no longer block channel startup (reported in #63450). (#63480) Thanks @neeravmakwana.
+- Gateway/startup: start channels and plugin sidecars before attaching WebSocket RPC handlers so slow synchronous `chat.history` work can no longer block channel startup (reported in #63450), and enforce the pre-auth WebSocket upgrade budget before the no-handler 503 path so upgrade floods cannot bypass connection limits during that window. (#63480) Thanks @neeravmakwana.
 
 ## 2026.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Status: show configured fallback models in `/status` and shared session status cards so per-agent fallback configuration is visible before a live failover happens. (#33111) Thanks @AnCoSONG.
 - Fireworks/FirePass: disable Kimi K2.5 Turbo reasoning output by forcing thinking off on the FirePass path and hardening the provider wrapper so hidden reasoning no longer leaks into visible replies. (#63607) Thanks @frankekn.
 - Sessions/model selection: preserve catalog-backed session model labels and keep already-qualified session model refs stable when catalog metadata is unavailable, so Control UI model selection survives reloads without bogus provider-prefixed values. (#61382) Thanks @Mule-ME.
+- Gateway/startup: start channels and plugin sidecars before attaching WebSocket RPC handlers so slow synchronous `chat.history` work can no longer block channel startup (reported in #63450). (#63480) Thanks @neeravmakwana.
 
 ## 2026.4.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Docs: https://docs.openclaw.ai
 - Status: show configured fallback models in `/status` and shared session status cards so per-agent fallback configuration is visible before a live failover happens. (#33111) Thanks @AnCoSONG.
 - Fireworks/FirePass: disable Kimi K2.5 Turbo reasoning output by forcing thinking off on the FirePass path and hardening the provider wrapper so hidden reasoning no longer leaks into visible replies. (#63607) Thanks @frankekn.
 - Sessions/model selection: preserve catalog-backed session model labels and keep already-qualified session model refs stable when catalog metadata is unavailable, so Control UI model selection survives reloads without bogus provider-prefixed values. (#61382) Thanks @Mule-ME.
-- Gateway/startup: start channels and plugin sidecars before attaching WebSocket RPC handlers so slow synchronous `chat.history` work can no longer block channel startup (reported in #63450), and enforce the pre-auth WebSocket upgrade budget before the no-handler 503 path so upgrade floods cannot bypass connection limits during that window. (#63480) Thanks @neeravmakwana.
+- Gateway/startup: keep WebSocket RPC available while channels and plugin sidecars start, hold `chat.history` unavailable until startup sidecars finish so synchronous history reads cannot stall startup (reported in #63450), refresh advertised gateway methods after deferred plugin reloads, and enforce the pre-auth WebSocket upgrade budget before the no-handler 503 path so upgrade floods cannot bypass connection limits during that window. (#63480) Thanks @neeravmakwana.
 
 ## 2026.4.9
 

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -265,6 +265,20 @@ function writeUpgradeAuthFailure(
   socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
 }
 
+function writeUpgradeServiceUnavailable(
+  socket: { write: (chunk: string) => void },
+  responseBody: string,
+) {
+  socket.write(
+    "HTTP/1.1 503 Service Unavailable\r\n" +
+      "Connection: close\r\n" +
+      "Content-Type: text/plain; charset=utf-8\r\n" +
+      `Content-Length: ${Buffer.byteLength(responseBody, "utf8")}\r\n` +
+      "\r\n" +
+      responseBody,
+  );
+}
+
 export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
 
 type GatewayHttpRequestStage = {
@@ -1050,32 +1064,15 @@ export function attachGatewayUpgradeHandler(opts: {
         }
       }
       const preauthBudgetKey = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback);
-      // Enforce the pre-auth budget before the no-handler 503 path so upgrade floods
-      // during startup cannot bypass connection limits (handlers attach after sidecars).
+      // Keep startup upgrades inside the pre-auth budget until WS handlers attach.
       if (!preauthConnectionBudget.acquire(preauthBudgetKey)) {
-        const responseBody = "Too many unauthenticated sockets";
-        socket.write(
-          "HTTP/1.1 503 Service Unavailable\r\n" +
-            "Connection: close\r\n" +
-            "Content-Type: text/plain; charset=utf-8\r\n" +
-            `Content-Length: ${Buffer.byteLength(responseBody, "utf8")}\r\n` +
-            "\r\n" +
-            responseBody,
-        );
+        writeUpgradeServiceUnavailable(socket, "Too many unauthenticated sockets");
         socket.destroy();
         return;
       }
       if (wss.listenerCount("connection") === 0) {
         preauthConnectionBudget.release(preauthBudgetKey);
-        const responseBody = "Gateway websocket handlers unavailable";
-        socket.write(
-          "HTTP/1.1 503 Service Unavailable\r\n" +
-            "Connection: close\r\n" +
-            "Content-Type: text/plain; charset=utf-8\r\n" +
-            `Content-Length: ${Buffer.byteLength(responseBody, "utf8")}\r\n` +
-            "\r\n" +
-            responseBody,
-        );
+        writeUpgradeServiceUnavailable(socket, "Gateway websocket handlers unavailable");
         socket.destroy();
         return;
       }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -1050,8 +1050,10 @@ export function attachGatewayUpgradeHandler(opts: {
         }
       }
       const preauthBudgetKey = resolveRequestClientIp(req, trustedProxies, allowRealIpFallback);
-      if (wss.listenerCount("connection") === 0) {
-        const responseBody = "Gateway websocket handlers unavailable";
+      // Enforce the pre-auth budget before the no-handler 503 path so upgrade floods
+      // during startup cannot bypass connection limits (handlers attach after sidecars).
+      if (!preauthConnectionBudget.acquire(preauthBudgetKey)) {
+        const responseBody = "Too many unauthenticated sockets";
         socket.write(
           "HTTP/1.1 503 Service Unavailable\r\n" +
             "Connection: close\r\n" +
@@ -1063,8 +1065,9 @@ export function attachGatewayUpgradeHandler(opts: {
         socket.destroy();
         return;
       }
-      if (!preauthConnectionBudget.acquire(preauthBudgetKey)) {
-        const responseBody = "Too many unauthenticated sockets";
+      if (wss.listenerCount("connection") === 0) {
+        preauthConnectionBudget.release(preauthBudgetKey);
+        const responseBody = "Gateway websocket handlers unavailable";
         socket.write(
           "HTTP/1.1 503 Service Unavailable\r\n" +
             "Connection: close\r\n" +

--- a/src/gateway/server-methods.control-plane-rate-limit.test.ts
+++ b/src/gateway/server-methods.control-plane-rate-limit.test.ts
@@ -131,6 +131,31 @@ describe("gateway control-plane write rate limit", () => {
     expect(handlerCalls).toHaveBeenCalledTimes(4);
   });
 
+  it("blocks startup-gated methods before dispatch", async () => {
+    const handlerCalls = vi.fn();
+    const handler: GatewayRequestHandler = (opts) => {
+      handlerCalls(opts);
+      opts.respond(true, undefined, undefined);
+    };
+    const context = {
+      ...buildContext(),
+      unavailableGatewayMethods: new Set(["chat.history"]),
+    } as Parameters<typeof handleGatewayRequest>[0]["context"];
+    const client = buildClient();
+
+    const blocked = await runRequest({ method: "chat.history", context, client, handler });
+
+    expect(handlerCalls).not.toHaveBeenCalled();
+    expect(blocked).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        retryable: true,
+      }),
+    );
+  });
+
   it("uses connId fallback when both device and client IP are unknown", () => {
     const key = resolveControlPlaneRateLimitKey({
       connect: buildConnect(),

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -106,6 +106,17 @@ export async function handleGatewayRequest(
     respond(false, undefined, authError);
     return;
   }
+  if (context.unavailableGatewayMethods?.has(req.method)) {
+    respond(
+      false,
+      undefined,
+      errorShape(ErrorCodes.UNAVAILABLE, `${req.method} unavailable during gateway startup`, {
+        retryable: true,
+        details: { method: req.method },
+      }),
+    );
+    return;
+  }
   if (CONTROL_PLANE_WRITE_METHODS.has(req.method)) {
     const budget = consumeControlPlaneWriteBudget({ client });
     if (!budget.allowed) {

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -105,6 +105,7 @@ export type GatewayRequestContext = {
     prompter: import("../../wizard/prompts.js").WizardPrompter,
   ) => Promise<void>;
   broadcastVoiceWakeChanged: (triggers: string[]) => void;
+  unavailableGatewayMethods?: ReadonlySet<string>;
 };
 
 export type GatewayRequestOptions = {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1440,6 +1440,35 @@ export async function startGatewayServer(
     // current gateway context without relying on a startup snapshot.
     setFallbackGatewayContextResolver(() => gatewayRequestContext);
 
+    // Start channels and plugin sidecars before WebSocket RPC is enabled. Otherwise a
+    // slow or CPU-heavy `chat.history` (sync session store + transcript reads) can block
+    // the event loop and delay channel startup; upgrades also stay 503 until listeners
+    // attach (see attachGatewayUpgradeHandler).
+    if (!minimalTestGateway) {
+      if (deferredConfiguredChannelPluginIds.length > 0) {
+        ({ pluginRegistry } = reloadDeferredGatewayPlugins({
+          cfg: gatewayPluginConfigAtStart,
+          workspaceDir: defaultWorkspaceDir,
+          log,
+          coreGatewayHandlers,
+          baseMethods,
+          pluginIds: startupPluginIds,
+          logDiagnostics: false,
+        }));
+      }
+      log.info("starting channels and sidecars...");
+      ({ pluginServices } = await startGatewaySidecars({
+        cfg: gatewayPluginConfigAtStart,
+        pluginRegistry,
+        defaultWorkspaceDir,
+        deps,
+        startChannels,
+        log,
+        logHooks,
+        logChannels,
+      }));
+    }
+
     attachGatewayWsHandlers({
       wss,
       clients,
@@ -1498,31 +1527,6 @@ export async function startGatewayServer(
           controlUiBasePath,
           logTailscale,
         });
-
-    if (!minimalTestGateway) {
-      if (deferredConfiguredChannelPluginIds.length > 0) {
-        ({ pluginRegistry } = reloadDeferredGatewayPlugins({
-          cfg: gatewayPluginConfigAtStart,
-          workspaceDir: defaultWorkspaceDir,
-          log,
-          coreGatewayHandlers,
-          baseMethods,
-          pluginIds: startupPluginIds,
-          logDiagnostics: false,
-        }));
-      }
-      log.info("starting channels and sidecars...");
-      ({ pluginServices } = await startGatewaySidecars({
-        cfg: gatewayPluginConfigAtStart,
-        pluginRegistry,
-        defaultWorkspaceDir,
-        deps,
-        startChannels,
-        log,
-        logHooks,
-        logChannels,
-      }));
-    }
 
     // Run gateway_start plugin hook (fire-and-forget)
     if (!minimalTestGateway) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1440,10 +1440,7 @@ export async function startGatewayServer(
     // current gateway context without relying on a startup snapshot.
     setFallbackGatewayContextResolver(() => gatewayRequestContext);
 
-    // Start channels and plugin sidecars before WebSocket RPC is enabled. Otherwise a
-    // slow or CPU-heavy `chat.history` (sync session store + transcript reads) can block
-    // the event loop and delay channel startup; upgrades also stay 503 until listeners
-    // attach (see attachGatewayUpgradeHandler).
+    // Start sidecars before WS RPC so sync history reads cannot stall startup.
     if (!minimalTestGateway) {
       if (deferredConfiguredChannelPluginIds.length > 0) {
         ({ pluginRegistry } = reloadDeferredGatewayPlugins({

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -641,8 +641,14 @@ export async function startGatewayServer(
   const channelRuntimeEnvs = Object.fromEntries(
     Object.entries(channelLogs).map(([id, logger]) => [id, runtimeForLogger(logger)]),
   ) as unknown as Record<ChannelId, RuntimeEnv>;
-  const channelMethods = listChannelPlugins().flatMap((plugin) => plugin.gatewayMethods ?? []);
-  const gatewayMethods = Array.from(new Set([...baseGatewayMethods, ...channelMethods]));
+  const listActiveGatewayMethods = (nextBaseGatewayMethods: string[]) =>
+    Array.from(
+      new Set([
+        ...nextBaseGatewayMethods,
+        ...listChannelPlugins().flatMap((plugin) => plugin.gatewayMethods ?? []),
+      ]),
+    );
+  let gatewayMethods = listActiveGatewayMethods(baseGatewayMethods);
   let pluginServices: PluginServicesHandle | null = null;
   const runtimeConfig = await resolveGatewayRuntimeConfig({
     cfg: cfgAtStart,
@@ -1337,6 +1343,9 @@ export async function startGatewayServer(
 
     const canvasHostServerPort = (canvasHostServer as CanvasHostServer | null)?.port;
 
+    const unavailableGatewayMethods = new Set<string>(
+      minimalTestGateway ? [] : ["chat.history"],
+    );
     const gatewayRequestContext: import("./server-methods/types.js").GatewayRequestContext = {
       deps,
       cron,
@@ -1433,17 +1442,14 @@ export async function startGatewayServer(
       markChannelLoggedOut,
       wizardRunner,
       broadcastVoiceWakeChanged,
+      unavailableGatewayMethods,
     };
 
-    // Register a lazy fallback for plugin subagent dispatch in non-WS paths
-    // (Telegram polling, WhatsApp, etc.) so later runtime swaps can expose the
-    // current gateway context without relying on a startup snapshot.
     setFallbackGatewayContextResolver(() => gatewayRequestContext);
 
-    // Start sidecars before WS RPC so sync history reads cannot stall startup.
     if (!minimalTestGateway) {
       if (deferredConfiguredChannelPluginIds.length > 0) {
-        ({ pluginRegistry } = reloadDeferredGatewayPlugins({
+        ({ pluginRegistry, gatewayMethods: baseGatewayMethods } = reloadDeferredGatewayPlugins({
           cfg: gatewayPluginConfigAtStart,
           workspaceDir: defaultWorkspaceDir,
           log,
@@ -1452,18 +1458,8 @@ export async function startGatewayServer(
           pluginIds: startupPluginIds,
           logDiagnostics: false,
         }));
+        gatewayMethods = listActiveGatewayMethods(baseGatewayMethods);
       }
-      log.info("starting channels and sidecars...");
-      ({ pluginServices } = await startGatewaySidecars({
-        cfg: gatewayPluginConfigAtStart,
-        pluginRegistry,
-        defaultWorkspaceDir,
-        deps,
-        startChannels,
-        log,
-        logHooks,
-        logChannels,
-      }));
     }
 
     attachGatewayWsHandlers({
@@ -1493,6 +1489,21 @@ export async function startGatewayServer(
       broadcast,
       context: gatewayRequestContext,
     });
+
+    if (!minimalTestGateway) {
+      log.info("starting channels and sidecars...");
+      ({ pluginServices } = await startGatewaySidecars({
+        cfg: gatewayPluginConfigAtStart,
+        pluginRegistry,
+        defaultWorkspaceDir,
+        deps,
+        startChannels,
+        log,
+        logHooks,
+        logChannels,
+      }));
+      unavailableGatewayMethods.delete("chat.history");
+    }
     logGatewayStartup({
       cfg: cfgAtStart,
       bindHost,

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -25,7 +25,7 @@ afterEach(async () => {
 });
 
 describe("gateway pre-auth hardening", () => {
-  it("rejects upgrades before websocket handlers attach without consuming pre-auth budget", async () => {
+  it("rejects upgrades before websocket handlers attach (pre-auth budget enforced, then released)", async () => {
     const clients = new Set<GatewayWsClient>();
     const resolvedAuth: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
     const httpServer = createGatewayHttpServer({


### PR DESCRIPTION
## Summary

- Problem: WebSocket RPC (`chat.history`, etc.) was enabled before `startGatewaySidecars` finished. `chat.history` performs large synchronous session-store and transcript reads on the main thread, which can block the event loop and delay Telegram, browser control, and plugin startup (see #63450).
- Why it matters: Operators saw multi-minute gaps after `starting channels and sidecars...` while a pending `chat.history` completed; channels stayed down until then.
- What changed: Run deferred channel-plugin reload (when applicable), then `startGatewaySidecars`, then attach WebSocket handlers. Gateway WebSocket upgrades already return 503 until `wss` connection listeners exist, so clients do not run heavy RPC during this window.
- What did NOT change: Handler implementations, `chat.history` semantics, and Tailscale/update-check ordering after WS attach.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63450
- Related #63450
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Startup ordered WebSocket message handling before channels/sidecars. Synchronous file reads and JSON work in `chat.history` starved the event loop, so async channel startup did not complete until that work finished.
- Missing detection / guardrail: Ordering was not covered by an integration test asserting WS attach vs channel start.
- Contributing context (if known): Regression reported since v2026.4.8; consistent with sync `loadSessionStore` / `readSessionMessages` paths.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/gateway/server.minimal-channel-pin.test.ts`, `src/gateway/server.shared-token-session-rotation.test.ts` (gateway startup smoke).
- Scenario the test should lock in: Full gateway boot completes with channels and WS both healthy.
- Why this is the smallest reliable guardrail: Ordering fix is structural; dedicated timing tests are flaky; existing gateway server tests still pass after reorder.
- Existing test that already covers this (if any): Gateway tests above exercise `startGatewayServer`.
- If no new test is added, why not: Behavior is startup sequencing; no stable hook exposed for a small unit test without refactoring `server.impl.ts` for injection.

## User-visible / Behavior Changes

- WebSocket clients may observe a slightly longer window where the gateway HTTP server is up but WebSocket upgrades return 503 (`Gateway websocket handlers unavailable`) until channels and sidecars have started; then RPC behaves as before.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux/macOS dev (CI covers the rest)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. `pnpm check`
2. `pnpm test src/gateway/server.minimal-channel-pin.test.ts src/gateway/server.shared-token-session-rotation.test.ts`

### Expected

- Tests pass; gateway startup ordering no longer allows WS RPC before channel/sidecar start.

### Actual

- `pnpm check` passed locally; scoped gateway tests passed.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets (repro described in #63450: `chat.history` duration matches channel startup delay)
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Typecheck/lint (`pnpm check`); gateway server smoke tests listed above.
- Edge cases checked: `minimalTestGateway` path unchanged (sidecars still skipped when that env is set).
- What you did **not** verify: Full `pnpm test` suite and `pnpm build` (local `pnpm build` failed on unrelated `acpx/runtime` resolution in this workspace).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Slightly longer period where HTTP is listening but WebSocket upgrades return 503 until sidecars finish.
  - Mitigation: Same 503 behavior existed before `attachGatewayWsHandlers`; this only extends that window to cover channel startup, which is typically short relative to a stuck `chat.history`.
