### PR TITLE
fix(feishu): serialise startup bot-info probes across concurrent accounts

### DIFF
--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -313,4 +313,51 @@ describe("Feishu startup probe queue serialisation (#63475)", () => {
     expect(results).toEqual([{}, {}]);
     expect(order).toEqual([]);
   });
+
+  it("aborted account escapes the queue without waiting for the in-flight probe", async () => {
+    let releaseAlpha!: () => void;
+    const alphaGate = new Promise<void>((resolve) => {
+      releaseAlpha = resolve;
+    });
+    const order: string[] = [];
+
+    probeFeishuMock.mockImplementation(async (account: { accountId: string }) => {
+      order.push(account.accountId);
+      if (account.accountId === "alpha") {
+        await alphaGate;
+      }
+      return { ok: true, botOpenId: `bot_${account.accountId}` };
+    });
+
+    const accounts = ["alpha", "beta"].map((id) => ({
+      accountId: id,
+      appId: `cli_${id}`,
+      appSecret: `secret_${id}`,
+    }));
+
+    const betaAbort = new AbortController();
+
+    // Start both concurrently — alpha enters the probe, beta queues behind it.
+    const alphaPromise = fetchBotIdentityForMonitor(accounts[0] as never);
+    const betaPromise = fetchBotIdentityForMonitor(accounts[1] as never, {
+      abortSignal: betaAbort.signal,
+    });
+
+    // Wait for alpha to be in-flight.
+    await vi.waitFor(() => expect(order).toEqual(["alpha"]));
+
+    // Abort beta while it is still queued behind alpha's long probe.
+    betaAbort.abort();
+    const betaResult = await betaPromise;
+
+    // Beta must return immediately with an empty identity — NOT wait for alpha.
+    expect(betaResult).toEqual({});
+    // Alpha is still running (not released yet).
+    expect(order).toEqual(["alpha"]);
+
+    // Release alpha and let the queue drain cleanly.
+    releaseAlpha();
+    const alphaResult = await alphaPromise;
+    expect(alphaResult).toEqual({ botOpenId: "bot_alpha" });
+  });
 });

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createNonExitingRuntimeEnv } from "../../../test/helpers/plugins/runtime-env.js";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
+import { fetchBotIdentityForMonitor, resetStartupProbeQueueForTest } from "./monitor.startup.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
 
@@ -47,6 +48,7 @@ async function waitForStartedAccount(started: string[], accountId: string) {
 
 afterEach(() => {
   stopFeishuMonitor();
+  resetStartupProbeQueueForTest();
 });
 
 describe("Feishu monitor startup preflight", () => {
@@ -187,5 +189,128 @@ describe("Feishu monitor startup preflight", () => {
     } finally {
       abortController.abort();
     }
+  });
+});
+
+describe("Feishu startup probe queue serialisation (#63475)", () => {
+  it("serialises concurrent fetchBotIdentityForMonitor calls from parallel startAccount", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const order: string[] = [];
+    const gates = new Map<string, () => void>();
+
+    probeFeishuMock.mockImplementation(async (account: { accountId: string }) => {
+      const id = account.accountId;
+      order.push(`enter:${id}`);
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      // Wait until the test explicitly releases this probe.
+      await new Promise<void>((resolve) => {
+        gates.set(id, resolve);
+      });
+      inFlight -= 1;
+      order.push(`exit:${id}`);
+      return { ok: true, botOpenId: `bot_${id}` };
+    });
+
+    const accounts = ["acct1", "acct2", "acct3"].map((id) => ({
+      accountId: id,
+      appId: `cli_${id}`,
+      appSecret: `secret_${id}`,
+    }));
+
+    // Simulate the gateway calling fetchBotIdentityForMonitor concurrently
+    // for each account (same pattern as Promise.all in server-channels.ts).
+    const promises = accounts.map((acct) => fetchBotIdentityForMonitor(acct as never));
+
+    // Allow microtasks to settle — only the first probe should be in-flight.
+    await vi.waitFor(() => expect(gates.size).toBe(1));
+    expect(inFlight).toBe(1);
+    expect(order).toEqual(["enter:acct1"]);
+
+    // Release first probe.
+    gates.get("acct1")!();
+    await vi.waitFor(() => expect(gates.size).toBe(2));
+    expect(order).toEqual(["enter:acct1", "exit:acct1", "enter:acct2"]);
+    expect(inFlight).toBe(1);
+
+    // Release second probe.
+    gates.get("acct2")!();
+    await vi.waitFor(() => expect(gates.size).toBe(3));
+    expect(order).toEqual([
+      "enter:acct1",
+      "exit:acct1",
+      "enter:acct2",
+      "exit:acct2",
+      "enter:acct3",
+    ]);
+    expect(inFlight).toBe(1);
+
+    // Release third probe.
+    gates.get("acct3")!();
+    const results = await Promise.all(promises);
+
+    expect(maxInFlight).toBe(1);
+    expect(results).toEqual([
+      { botOpenId: "bot_acct1" },
+      { botOpenId: "bot_acct2" },
+      { botOpenId: "bot_acct3" },
+    ]);
+  });
+
+  it("does not block subsequent accounts when one probe fails", async () => {
+    const order: string[] = [];
+    probeFeishuMock.mockImplementation(async (account: { accountId: string }) => {
+      order.push(account.accountId);
+      if (account.accountId === "fail") {
+        throw new Error("network error");
+      }
+      return { ok: true, botOpenId: `bot_${account.accountId}` };
+    });
+
+    const accounts = ["fail", "ok1", "ok2"].map((id) => ({
+      accountId: id,
+      appId: `cli_${id}`,
+      appSecret: `secret_${id}`,
+    }));
+
+    const [r1, r2, r3] = await Promise.all(
+      accounts.map((acct) => fetchBotIdentityForMonitor(acct as never)),
+    );
+
+    expect(order).toEqual(["fail", "ok1", "ok2"]);
+    // The failing probe should still return (error is caught internally).
+    expect(r1).toEqual({});
+    expect(r2).toEqual({ botOpenId: "bot_ok1" });
+    expect(r3).toEqual({ botOpenId: "bot_ok2" });
+  });
+
+  it("respects abort signal inside the serialised queue", async () => {
+    const order: string[] = [];
+    const abortController = new AbortController();
+
+    probeFeishuMock.mockImplementation(async (account: { accountId: string }) => {
+      order.push(account.accountId);
+      return { ok: true, botOpenId: `bot_${account.accountId}` };
+    });
+
+    const accounts = ["a", "b"].map((id) => ({
+      accountId: id,
+      appId: `cli_${id}`,
+      appSecret: `secret_${id}`,
+    }));
+
+    // Abort before any probes run.
+    abortController.abort();
+
+    const results = await Promise.all(
+      accounts.map((acct) =>
+        fetchBotIdentityForMonitor(acct as never, { abortSignal: abortController.signal }),
+      ),
+    );
+
+    // Both should return empty since the signal was already aborted.
+    expect(results).toEqual([{}, {}]);
+    expect(order).toEqual([]);
   });
 });

--- a/extensions/feishu/src/monitor.startup.ts
+++ b/extensions/feishu/src/monitor.startup.ts
@@ -86,12 +86,28 @@ export async function fetchBotIdentityForMonitor(
   account: ResolvedFeishuAccount,
   options: FetchBotOpenIdOptions = {},
 ): Promise<FeishuMonitorBotIdentity> {
+  // Short-circuit before joining the queue if already aborted.
+  if (options.abortSignal?.aborted) {
+    return {};
+  }
+
   // Chain onto the shared queue so only one probe is in-flight at a time,
   // regardless of how many concurrent callers exist.
   const ticket = startupProbeQueue.then(() => fetchBotIdentityCore(account, options));
   // Swallow rejections in the queue itself so a failing probe does not block
   // subsequent accounts.
   startupProbeQueue = ticket.catch(() => {});
+
+  // Race the queue wait against the abort signal so a stopped account does not
+  // block behind another account's long probe timeout.
+  if (options.abortSignal) {
+    const signal = options.abortSignal;
+    const abortRace = new Promise<FeishuMonitorBotIdentity>((resolve) => {
+      signal.addEventListener("abort", () => resolve({}), { once: true });
+    });
+    return Promise.race([ticket, abortRace]);
+  }
+
   return ticket;
 }
 

--- a/extensions/feishu/src/monitor.startup.ts
+++ b/extensions/feishu/src/monitor.startup.ts
@@ -42,19 +42,29 @@ function isAbortErrorMessage(message: string | undefined): boolean {
   return normalizeLowercaseStringOrEmpty(message).includes("aborted");
 }
 
-export async function fetchBotIdentityForMonitor(
+// Serialise startup probes so concurrent gateway-driven startAccount calls
+// (one per Feishu account via Promise.all) do not burst Feishu's bot-info
+// endpoint from the same IP — which causes rotating timeouts (#63475).
+let startupProbeQueue: Promise<unknown> = Promise.resolve();
+
+async function fetchBotIdentityCore(
   account: ResolvedFeishuAccount,
-  options: FetchBotOpenIdOptions = {},
+  options: FetchBotOpenIdOptions,
 ): Promise<FeishuMonitorBotIdentity> {
   if (options.abortSignal?.aborted) {
     return {};
   }
 
   const timeoutMs = options.timeoutMs ?? FEISHU_STARTUP_BOT_INFO_TIMEOUT_MS;
-  const result = await probeFeishu(account, {
-    timeoutMs,
-    abortSignal: options.abortSignal,
-  });
+  let result;
+  try {
+    result = await probeFeishu(account, {
+      timeoutMs,
+      abortSignal: options.abortSignal,
+    });
+  } catch {
+    return {};
+  }
   if (result.ok) {
     return { botOpenId: result.botOpenId, botName: result.botName };
   }
@@ -70,6 +80,24 @@ export async function fetchBotIdentityForMonitor(
     );
   }
   return {};
+}
+
+export async function fetchBotIdentityForMonitor(
+  account: ResolvedFeishuAccount,
+  options: FetchBotOpenIdOptions = {},
+): Promise<FeishuMonitorBotIdentity> {
+  // Chain onto the shared queue so only one probe is in-flight at a time,
+  // regardless of how many concurrent callers exist.
+  const ticket = startupProbeQueue.then(() => fetchBotIdentityCore(account, options));
+  // Swallow rejections in the queue itself so a failing probe does not block
+  // subsequent accounts.
+  startupProbeQueue = ticket.catch(() => {});
+  return ticket;
+}
+
+/** Reset the startup probe queue (for testing). */
+export function resetStartupProbeQueueForTest(): void {
+  startupProbeQueue = Promise.resolve();
 }
 
 export async function fetchBotOpenIdForMonitor(


### PR DESCRIPTION
## Problem

Fixes #63475

With multiple Feishu accounts configured, the gateway starts all accounts concurrently via `Promise.all()` in `server-channels.ts`. Each account's `startAccount` calls `monitorSingleAccount` without a prefetched bot identity, causing `fetchBotIdentityForMonitor` to fire concurrently for all accounts. This floods Feishu's `/open-apis/bot/v3/info` endpoint from the same IP, causing one account to rotate through timeouts on each restart.

## Root Cause

Two code paths exist for multi-account startup:
1. **Multi-account path** (`monitor.ts:55–93`): probes sequentially via a `for` loop ✅
2. **Per-account path** (`monitor.ts:39–53`): called by the gateway's `startAccount` callback, which runs all accounts in `Promise.all()` — no serialisation ❌

The gateway always uses path 2, so the sequential probing in path 1 is never reached during normal startup.

## Fix

Add a module-level promise-chain queue to `fetchBotIdentityForMonitor` in `monitor.startup.ts`:
- Only one bot-info probe is in-flight at any time, regardless of how many concurrent callers exist
- A failing probe does not block subsequent accounts (rejections are swallowed in the queue chain)
- Defensive `try/catch` added around the `probeFeishu` call for robustness
- Queue is reset between tests via `resetStartupProbeQueueForTest()`

## Changes

| File | Change |
|------|--------|
| `extensions/feishu/src/monitor.startup.ts` | Add serialisation queue around `fetchBotIdentityForMonitor`; extract core logic to `fetchBotIdentityCore`; add `resetStartupProbeQueueForTest` export |
| `extensions/feishu/src/monitor.startup.test.ts` | Add 3 regression tests covering concurrent serialisation, failure isolation, and abort-signal propagation |

## Tests

All 7 tests in `monitor.startup.test.ts` pass (4 existing + 3 new):
- `serialises concurrent fetchBotIdentityForMonitor calls from parallel startAccount`
- `does not block subsequent accounts when one probe fails`
- `respects abort signal inside the serialised queue`

All related test suites (`probe.test.ts`, `channel.test.ts`, `monitor.*.test.ts`) continue to pass.