### PR TITLE
fix: preserve external routing for group/topic webchat sessions

### DIFF
--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -111,6 +111,37 @@ describe("session delivery direct-session routing overrides", () => {
   );
 
   it.each([
+    {
+      sessionKey: "agent:main:telegram:group:-1003774691294",
+      persistedLastTo: "-1003774691294",
+    },
+    {
+      sessionKey: "agent:main:telegram:group:-1003774691294:topic:47",
+      persistedLastTo: "-1003774691294:topic:47",
+    },
+  ])(
+    "preserves established Telegram group/topic delivery when webchat opens $sessionKey",
+    ({ sessionKey, persistedLastTo }) => {
+      expect(
+        resolveLastChannelRaw({
+          originatingChannelRaw: "webchat",
+          persistedLastChannel: "telegram",
+          sessionKey,
+        }),
+      ).toBe("telegram");
+      expect(
+        resolveLastToRaw({
+          originatingChannelRaw: "webchat",
+          originatingToRaw: "session:dashboard",
+          persistedLastChannel: "telegram",
+          persistedLastTo,
+          sessionKey,
+        }),
+      ).toBe(persistedLastTo);
+    },
+  );
+
+  it.each([
     "agent:main:main:direct",
     "agent:main:cron:job-1:dm",
     "agent:main:subagent:worker:direct:user-1",

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -1,11 +1,7 @@
 import type { SessionEntry } from "../../config/sessions.js";
 import { buildAgentMainSessionKey } from "../../routing/session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "../../shared/string-coerce.js";
+import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import {
   deliveryContextFromSession,
   deliveryContextKey,
@@ -33,58 +29,6 @@ function resolveSessionKeyChannelHint(sessionKey?: string): string | undefined {
     return undefined;
   }
   return normalizeMessageChannel(head);
-}
-
-function isMainSessionKey(sessionKey?: string): boolean {
-  const parsed = parseAgentSessionKey(sessionKey);
-  if (!parsed) {
-    return normalizeLowercaseStringOrEmpty(sessionKey) === "main";
-  }
-  return normalizeLowercaseStringOrEmpty(parsed.rest) === "main";
-}
-
-const DIRECT_SESSION_MARKERS = new Set(["direct", "dm"]);
-const THREAD_SESSION_MARKERS = new Set(["thread", "topic"]);
-
-function hasStrictDirectSessionTail(parts: string[], markerIndex: number): boolean {
-  const peerId = normalizeOptionalString(parts[markerIndex + 1]);
-  if (!peerId) {
-    return false;
-  }
-  const tail = parts.slice(markerIndex + 2);
-  if (tail.length === 0) {
-    return true;
-  }
-  return (
-    tail.length === 2 &&
-    THREAD_SESSION_MARKERS.has(tail[0] ?? "") &&
-    Boolean(normalizeOptionalString(tail[1]))
-  );
-}
-
-function isDirectSessionKey(sessionKey?: string): boolean {
-  const raw = normalizeLowercaseStringOrEmpty(sessionKey);
-  if (!raw) {
-    return false;
-  }
-  const scoped = parseAgentSessionKey(raw)?.rest ?? raw;
-  const parts = scoped.split(":").filter(Boolean);
-  if (parts.length < 2) {
-    return false;
-  }
-  if (DIRECT_SESSION_MARKERS.has(parts[0] ?? "")) {
-    return hasStrictDirectSessionTail(parts, 0);
-  }
-  const channel = normalizeMessageChannel(parts[0]);
-  if (!channel || !isDeliverableMessageChannel(channel)) {
-    return false;
-  }
-  if (DIRECT_SESSION_MARKERS.has(parts[1] ?? "")) {
-    return hasStrictDirectSessionTail(parts, 1);
-  }
-  return Boolean(normalizeOptionalString(parts[1])) && DIRECT_SESSION_MARKERS.has(parts[2] ?? "")
-    ? hasStrictDirectSessionTail(parts, 2)
-    : false;
 }
 
 function isExternalRoutingChannel(channel?: string): channel is string {
@@ -118,11 +62,11 @@ export function resolveLastChannelRaw(params: {
   if (params.isInterSession && hasEstablishedExternalRoute) {
     return persistedChannel || sessionKeyChannelHint;
   }
-  if (
-    originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
-    !hasEstablishedExternalRoute &&
-    (isMainSessionKey(params.sessionKey) || isDirectSessionKey(params.sessionKey))
-  ) {
+  // Allow webchat to own routing only when no external route exists.
+  // Applies to all session types (direct, main, group, topic) so that
+  // group/topic sessions with established Telegram/Discord routes are
+  // not overwritten by webchat/dashboard access.
+  if (originatingChannel === INTERNAL_MESSAGE_CHANNEL && !hasEstablishedExternalRoute) {
     return params.originatingChannelRaw;
   }
   let resolved = params.originatingChannelRaw || params.persistedLastChannel;
@@ -159,11 +103,7 @@ export function resolveLastToRaw(params: {
   if (params.isInterSession && hasEstablishedExternalRouteForTo && params.persistedLastTo) {
     return params.persistedLastTo;
   }
-  if (
-    originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
-    !hasEstablishedExternalRouteForTo &&
-    (isMainSessionKey(params.sessionKey) || isDirectSessionKey(params.sessionKey))
-  ) {
+  if (originatingChannel === INTERNAL_MESSAGE_CHANNEL && !hasEstablishedExternalRouteForTo) {
     return params.originatingToRaw || params.toRaw;
   }
   // When the turn originates from an internal/non-deliverable source, do not

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2559,6 +2559,52 @@ describe("initSessionState internal channel routing preservation", () => {
     expect(result.sessionEntry.deliveryContext?.to).toBe("+1555");
   });
 
+  it.each([
+    {
+      sessionKey: "agent:main:telegram:group:-1003774691294",
+      lastTo: "-1003774691294",
+    },
+    {
+      sessionKey: "agent:main:telegram:group:-1003774691294:topic:47",
+      lastTo: "-1003774691294:topic:47",
+    },
+  ])(
+    "preserves Telegram group/topic delivery when webchat accesses $sessionKey",
+    async ({ sessionKey, lastTo }) => {
+      const storePath = await createStorePath("webchat-group-route-preserve-");
+      await writeSessionStoreFast(storePath, {
+        [sessionKey]: {
+          sessionId: "sess-webchat-group",
+          updatedAt: Date.now(),
+          lastChannel: "telegram",
+          lastTo,
+          deliveryContext: {
+            channel: "telegram",
+            to: lastTo,
+          },
+        },
+      });
+      const cfg = { session: { store: storePath } } as OpenClawConfig;
+
+      const result = await initSessionState({
+        ctx: {
+          Body: "reply from control ui",
+          SessionKey: sessionKey,
+          OriginatingChannel: "webchat",
+          OriginatingTo: "session:dashboard",
+          Surface: "webchat",
+        },
+        cfg,
+        commandAuthorized: true,
+      });
+
+      expect(result.sessionEntry.lastChannel).toBe("telegram");
+      expect(result.sessionEntry.lastTo).toBe(lastTo);
+      expect(result.sessionEntry.deliveryContext?.channel).toBe("telegram");
+      expect(result.sessionEntry.deliveryContext?.to).toBe(lastTo);
+    },
+  );
+
   it("lets direct webchat turns own routing for sessions with no prior external route", async () => {
     // Webchat should still own routing for sessions that were created via webchat
     // (no external channel ever established).


### PR DESCRIPTION
The existing webchat routing guard from PR #58013 only protected inter-session messages. This fix also removes the isMainSessionKey/isDirectSessionKey predicate from the internal-message webchat routing condition so that group and topic session keys with established external routes (Telegram, Discord, etc.) are not overwritten by webchat access. Adds regression tests for group and topic session keys.