### PR TITLE
fix(agents): support media://inbound URIs in image tool #63476

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/image tool: resolve gateway claim-check `media://inbound/<id>` URIs to on-disk inbound media (same guards as native prompt images) and avoid treating the `media:` scheme as a `MEDIA:` path tag. (#63476) Thanks @zhengriu.
+
 ## 2026.4.9-beta.1
 
 ### Changes

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1356,6 +1356,72 @@ describe("image tool MiniMax VLM routing", () => {
   });
 });
 
+describe("image tool gateway media://inbound URIs", () => {
+  const priorFetch = global.fetch;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    global.fetch = priorFetch;
+  });
+
+  it("resolves claim-check media://inbound/<id> to files under OPENCLAW_STATE_DIR", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inbound-media-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
+
+    try {
+      await fs.mkdir(path.join(stateDir, "media", "inbound"), { recursive: true });
+      const mediaId = "claim-check-test.png";
+      await fs.writeFile(
+        path.join(stateDir, "media", "inbound", mediaId),
+        Buffer.from(ONE_PIXEL_PNG_B64, "base64"),
+      );
+
+      installImageUnderstandingProviderStubs();
+      const fetch = stubMinimaxOkFetch();
+
+      await withTempAgentDir(async (agentDir) => {
+        const tool = createRequiredImageTool({
+          config: createMinimaxImageConfig(),
+          agentDir,
+        });
+        await expectImageToolExecOk(tool, `media://inbound/${mediaId}`);
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts MEDIA:media://inbound/<id> the same as bare media://", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inbound-media2-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
+
+    try {
+      await fs.mkdir(path.join(stateDir, "media", "inbound"), { recursive: true });
+      const mediaId = "tagged.png";
+      await fs.writeFile(
+        path.join(stateDir, "media", "inbound", mediaId),
+        Buffer.from(ONE_PIXEL_PNG_B64, "base64"),
+      );
+
+      installImageUnderstandingProviderStubs();
+      stubMinimaxOkFetch();
+
+      await withTempAgentDir(async (agentDir) => {
+        const tool = createRequiredImageTool({
+          config: createMinimaxImageConfig(),
+          agentDir,
+        });
+        await expectImageToolExecOk(tool, `MEDIA:media://inbound/${mediaId}`);
+      });
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("image tool response validation", () => {
   function createAssistantMessage(
     overrides: Partial<{

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -410,9 +410,8 @@ export function createImageTool(options?: {
         // Match `loadWebMedia`: strip optional MEDIA: tag before scheme/path handling.
         // Do not treat the `media:` scheme of gateway claim-check URIs (`media://inbound/...`)
         // as a tagged path — `/^\s*MEDIA\s*:\s*/i` would otherwise consume `media:` and yield `//inbound/...`.
-        const trimmedForNorm = imageRaw.trimStart();
-        const normalizedRef = trimmedForNorm.toLowerCase().startsWith("media://")
-          ? trimmedForNorm
+        const normalizedRef = imageRaw.toLowerCase().startsWith("media://")
+          ? imageRaw
           : imageRaw.replace(/^\s*MEDIA\s*:\s*/i, "");
 
         const inboundMediaMatch = normalizedRef.match(INBOUND_MEDIA_URI_RE);

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -7,6 +7,7 @@ import {
 } from "../../media-understanding/defaults.js";
 import { getMediaUnderstandingProvider } from "../../media-understanding/provider-registry.js";
 import { buildProviderRegistry } from "../../media-understanding/runner.js";
+import { getMediaDir, resolveMediaBufferPath } from "../../media/store.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import {
   describeImageWithModel,
@@ -45,6 +46,10 @@ import {
 
 const DEFAULT_PROMPT = "Describe the image.";
 const DEFAULT_MAX_IMAGES = 20;
+
+/** Gateway claim-check URIs (`media://inbound/<id>`); aligned with `run/images.ts` MEDIA_URI_REGEX. */
+// eslint-disable-next-line no-control-regex -- exclude null bytes in media IDs (same as `run/images.ts`)
+const INBOUND_MEDIA_URI_RE = /^media:\/\/inbound\/([^\]\s/\\\u0000]+)$/i;
 
 const imageToolProviderDeps = {
   buildProviderRegistry,
@@ -402,16 +407,61 @@ export function createImageTool(options?: {
           throw new Error("image required (empty string in array)");
         }
 
+        // Match `loadWebMedia`: strip optional MEDIA: tag before scheme/path handling.
+        // Do not treat the `media:` scheme of gateway claim-check URIs (`media://inbound/...`)
+        // as a tagged path — `/^\s*MEDIA\s*:\s*/i` would otherwise consume `media:` and yield `//inbound/...`.
+        const trimmedForNorm = imageRaw.trimStart();
+        const normalizedRef = trimmedForNorm.toLowerCase().startsWith("media://")
+          ? trimmedForNorm
+          : imageRaw.replace(/^\s*MEDIA\s*:\s*/i, "");
+
+        const inboundMediaMatch = normalizedRef.match(INBOUND_MEDIA_URI_RE);
+        const inboundMediaId = inboundMediaMatch?.[1]?.trim();
+        if (inboundMediaId) {
+          try {
+            const physicalPath = await resolveMediaBufferPath(inboundMediaId, "inbound");
+            const media = await loadWebMedia(physicalPath, {
+              maxBytes,
+              localRoots: [getMediaDir()],
+            });
+            if (media.kind !== "image") {
+              throw new Error(`Unsupported media type: ${media.kind}`);
+            }
+            const mimeType = media.contentType?.trim() || "image/png";
+            loadedImages.push({
+              buffer: media.buffer,
+              mimeType,
+              resolvedImage: normalizedRef,
+            });
+            continue;
+          } catch (err) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Failed to load inbound media (${normalizedRef}): ${
+                    err instanceof Error ? err.message : String(err)
+                  }`,
+                },
+              ],
+              details: {
+                error: "inbound_media_load_failed",
+                image: imageRawInput,
+              },
+            };
+          }
+        }
+
         // The tool accepts file paths, file/data URLs, or http(s) URLs. In some
         // agent/model contexts, images can be referenced as pseudo-URIs like
         // `image:0` (e.g. "first image in the prompt"). We don't have access to a
         // shared image registry here, so fail gracefully instead of attempting to
         // `fs.readFile("image:0")` and producing a noisy ENOENT.
-        const looksLikeWindowsDrivePath = /^[a-zA-Z]:[\\/]/.test(imageRaw);
-        const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(imageRaw);
-        const isFileUrl = /^file:/i.test(imageRaw);
-        const isHttpUrl = /^https?:\/\//i.test(imageRaw);
-        const isDataUrl = /^data:/i.test(imageRaw);
+        const looksLikeWindowsDrivePath = /^[a-zA-Z]:[\\/]/.test(normalizedRef);
+        const hasScheme = /^[a-z][a-z0-9+.-]*:/i.test(normalizedRef);
+        const isFileUrl = /^file:/i.test(normalizedRef);
+        const isHttpUrl = /^https?:\/\//i.test(normalizedRef);
+        const isDataUrl = /^data:/i.test(normalizedRef);
         if (hasScheme && !looksLikeWindowsDrivePath && !isFileUrl && !isHttpUrl && !isDataUrl) {
           return {
             content: [
@@ -433,10 +483,10 @@ export function createImageTool(options?: {
 
         const resolvedImage = (() => {
           if (sandboxConfig) {
-            return imageRaw;
+            return normalizedRef;
           }
-          if (imageRaw.startsWith("~")) {
-            return resolveUserPath(imageRaw);
+          if (normalizedRef.startsWith("~")) {
+            return resolveUserPath(normalizedRef);
           }
           // Resolve relative paths against workspaceDir so agents can reference
           // workspace-relative paths (e.g. "inbox/photo.png") without needing to
@@ -446,12 +496,12 @@ export function createImageTool(options?: {
             !isFileUrl &&
             !isHttpUrl &&
             !looksLikeWindowsDrivePath &&
-            !isAbsolute(imageRaw) &&
+            !isAbsolute(normalizedRef) &&
             options?.workspaceDir
           ) {
-            return resolve(options.workspaceDir, imageRaw);
+            return resolve(options.workspaceDir, normalizedRef);
           }
-          return imageRaw;
+          return normalizedRef;
         })();
         const resolvedPathInfo: { resolved: string; rewrittenFrom?: string } = isDataUrl
           ? { resolved: "" }


### PR DESCRIPTION
## Summary

- **Problem:** With a text-only primary model (e.g. `zai/glm-5-turbo`), inbound images are not passed as multimodal input; agents rely on the `image` tool. Gateway claim-check references use `media://inbound/<id>`, but the tool either rejected them as unsupported schemes or corrupted them when normalizing `MEDIA:`-style prefixes (stripping `media:` from `media://` produced `//inbound/...` and broke local resolution).
- **Why it matters:** Users hitting Telegram (and similar) flows could see vision failures or “no image” behavior even though files exist under the media store.
- **What changed:** Resolve `media://inbound/<id>` via `resolveMediaBufferPath` + `loadWebMedia` with `localRoots: [getMediaDir()]`, aligned with native prompt image loading. Only strip the `MEDIA:` tag when the value is not already a `media://` gateway URI. Added Vitest coverage with `OPENCLAW_STATE_DIR`.
- **What did NOT change:** Sandbox/workspace rules for ordinary paths and URLs; no changes to gateway offload or channel parsers.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #63476

## User-visible / Behavior Changes

The `image` tool now accepts gateway claim-check URIs `media://inbound/<id>` (and `MEDIA:media://inbound/<id>`), resolving them to on-disk inbound media the same way native prompt image loading does.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No** (same tool; additional allowed URI form, still constrained by `resolveMediaBufferPath` and media dir roots)
- Data access scope changed? **No** (only resolves IDs already under the configured inbound media store)

## Repro + Verification

### Environment

- OS: Linux (CI-style); issue originally macOS + Telegram + ZAI
- Runtime: Node 22+ / Vitest
- Model/provider: N/A for automated test (stubbed media-understanding + fetch)
- Integration/channel: N/A in unit tests
- Relevant config (redacted): `OPENCLAW_STATE_DIR` pointing at a temp dir containing `media/inbound/<file>`

### Steps

1. Set `OPENCLAW_STATE_DIR` to a temp directory; create `media/inbound/claim-check-test.png` with a tiny PNG payload.
2. Run `pnpm test -- src/agents/tools/image-tool.test.ts -t "gateway media"`.
3. (Optional) Full file: `pnpm test -- src/agents/tools/image-tool.test.ts`.

### Expected

- Tool executes successfully and returns text result; fetch stub invoked once for the generic image path.

### Actual

- Both tests pass locally; `pnpm build` passes for the tree that includes this change.

## Evidence

- [x] Failing test/log before + passing after (behavior covered by new tests; prior behavior was wrong path / unsupported URI)
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Vitest `image tool gateway media://inbound URIs`; full `src/agents/tools/image-tool.test.ts`; `pnpm build` after the change.
- Edge cases checked: bare `media://inbound/...` vs `MEDIA:media://inbound/...`.
- What I did **not** verify: Live Telegram + ZAI end-to-end (requires external keys and channel).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Failure Recovery (if this breaks)

- Revert the commit touching `src/agents/tools/image-tool.ts` (and tests/changelog if needed).
- Symptoms: `media://inbound/...` might again be rejected or mis-resolved.

## Risks and Mitigations

- **Risk:** Broader interpretation of `media://` inputs.
  - **Mitigation:** Only `media://inbound/<id>` is handled; ID validation matches existing `resolveMediaBufferPath` guards.