### PR TITLE
fix(cron): repair nextRunAtMs=0 on non-schedule edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Daemon/gateway install: preserve safe custom service env vars on forced reinstall, merge prior custom PATH segments behind the managed service PATH, and stop removed managed env keys from persisting as custom carryover. (#63136) Thanks @WarrenJones.
 - Config validation: surface the actual offending field for strict-schema union failures in bindings, including top-level unexpected keys on the matching ACP branch. (#40841) Thanks @Hollychou924.
 - QQBot/security: replace raw `fetch()` in the image-size probe with SSRF-guarded `fetchRemoteMedia`, fix `resolveRepoRoot()` to walk up to `.git` instead of hardcoding two parent levels, and refresh the raw-fetch allowlist to match the corrected scan. (#63495) Thanks @dims.
+- Cron/scheduling: treat `nextRunAtMs <= 0` as invalid across cron update, maintenance, timer, and stale-delivery paths so corrupted zero timestamps self-heal instead of causing immediate runs or skipped deliveries. (#63507) Thanks @WarrenJones.
 
 ## 2026.4.9
 

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -422,6 +422,26 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.deliveryAttempted).toBe(true);
   });
 
+  it("falls back to runStartedAt when nextRunAtMs=0", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-18T17:00:00.000Z"));
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+    vi.mocked(deliverOutboundPayloads).mockResolvedValue([{ ok: true } as never]);
+
+    const params = makeBaseParams({ synthesizedText: "Long running report finished." });
+    params.runStartedAt = Date.now() - (3 * 60 * 60_000 + 1);
+    (params.job as { state?: { nextRunAtMs?: number } }).state = {
+      nextRunAtMs: 0,
+    };
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(state.delivered).toBe(true);
+    expect(state.deliveryAttempted).toBe(true);
+  });
+
   it("cleans up the direct cron session after a silent reply when deleteAfterRun is enabled", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -17,6 +17,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
+import { hasScheduledNextRunAtMs } from "../service/jobs.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { pickSummaryFromOutput } from "./helpers.js";
@@ -190,9 +191,7 @@ function pruneCompletedDirectCronDeliveries(now: number) {
 
 function resolveCronDeliveryScheduledAtMs(params: { job: CronJob; runStartedAt: number }): number {
   const scheduledAt = params.job.state?.nextRunAtMs;
-  return typeof scheduledAt === "number" && Number.isFinite(scheduledAt)
-    ? scheduledAt
-    : params.runStartedAt;
+  return hasScheduledNextRunAtMs(scheduledAt) ? scheduledAt : params.runStartedAt;
 }
 
 function resolveCronDeliveryStartDelayMs(params: { job: CronJob; runStartedAt: number }): number {

--- a/src/cron/service.issue-13992-regression.test.ts
+++ b/src/cron/service.issue-13992-regression.test.ts
@@ -98,6 +98,22 @@ describe("issue #13992 regression - cron jobs skip execution", () => {
     expect(job.state.nextRunAtMs).toBeGreaterThan(now);
   });
 
+  it("should repair nextRunAtMs=0 during maintenance", () => {
+    const now = Date.now();
+
+    const job = createCronSystemEventJob(now, {
+      state: {
+        nextRunAtMs: 0,
+      },
+    });
+
+    const state = createMockCronStateForJobs({ jobs: [job], nowMs: now });
+    recomputeNextRunsForMaintenance(state);
+
+    expect(typeof job.state.nextRunAtMs).toBe("number");
+    expect(job.state.nextRunAtMs).toBeGreaterThan(now);
+  });
+
   it("should clear nextRunAtMs for disabled jobs during maintenance", () => {
     const now = Date.now();
     const futureTime = now + 3600_000;

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -43,6 +43,10 @@ function isFiniteTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+export function hasScheduledNextRunAtMs(value: unknown): value is number {
+  return isFiniteTimestamp(value) && value > 0;
+}
+
 function resolveStableCronOffsetMs(jobId: string, staggerMs: number) {
   if (staggerMs <= 1) {
     return 0;
@@ -372,7 +376,7 @@ function normalizeJobTickState(params: { state: CronServiceState; job: CronJob; 
     return { changed, skip: true };
   }
 
-  if (!isFiniteTimestamp(job.state.nextRunAtMs) && job.state.nextRunAtMs !== undefined) {
+  if (!hasScheduledNextRunAtMs(job.state.nextRunAtMs) && job.state.nextRunAtMs !== undefined) {
     job.state.nextRunAtMs = undefined;
     changed = true;
   }
@@ -442,7 +446,7 @@ export function recomputeNextRuns(state: CronServiceState): boolean {
     // Preserving a still-future nextRunAtMs avoids accidentally advancing
     // a job that hasn't fired yet (e.g. during restart recovery).
     const nextRun = job.state.nextRunAtMs;
-    const isDueOrMissing = !isFiniteTimestamp(nextRun) || now >= nextRun;
+    const isDueOrMissing = !hasScheduledNextRunAtMs(nextRun) || now >= nextRun;
     if (isDueOrMissing) {
       if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
         changed = true;
@@ -468,8 +472,7 @@ export function recomputeNextRunsForMaintenance(
     state,
     ({ job, nowMs: now }) => {
       let changed = false;
-      if (!isFiniteTimestamp(job.state.nextRunAtMs)) {
-        // Missing or invalid nextRunAtMs is always repaired.
+      if (!hasScheduledNextRunAtMs(job.state.nextRunAtMs)) {
         if (recomputeJobNextRunAtMs({ state, job, nowMs: now })) {
           changed = true;
         }
@@ -496,17 +499,17 @@ export function recomputeNextRunsForMaintenance(
 
 export function nextWakeAtMs(state: CronServiceState) {
   const jobs = state.store?.jobs ?? [];
-  const enabled = jobs.filter((j) => j.enabled && isFiniteTimestamp(j.state.nextRunAtMs));
+  const enabled = jobs.filter((j) => j.enabled && hasScheduledNextRunAtMs(j.state.nextRunAtMs));
   if (enabled.length === 0) {
     return undefined;
   }
   const first = enabled[0]?.state.nextRunAtMs;
-  if (!isFiniteTimestamp(first)) {
+  if (!hasScheduledNextRunAtMs(first)) {
     return undefined;
   }
   return enabled.reduce((min, j) => {
     const next = j.state.nextRunAtMs;
-    return isFiniteTimestamp(next) ? Math.min(min, next) : min;
+    return hasScheduledNextRunAtMs(next) ? Math.min(min, next) : min;
   }, first);
 }
 
@@ -840,7 +843,9 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
     return true;
   }
   return (
-    isJobEnabled(job) && typeof job.state.nextRunAtMs === "number" && nowMs >= job.state.nextRunAtMs
+    isJobEnabled(job) &&
+    hasScheduledNextRunAtMs(job.state.nextRunAtMs) &&
+    nowMs >= job.state.nextRunAtMs
   );
 }
 

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -5,7 +5,7 @@ import * as taskExecutor from "../../tasks/task-executor.js";
 import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
 import { setupCronServiceSuite, writeCronStoreSnapshot } from "../service.test-harness.js";
 import type { CronJob } from "../types.js";
-import { run, start, stop } from "./ops.js";
+import { run, start, stop, update } from "./ops.js";
 import { createCronServiceState } from "./state.js";
 
 const { logger, makeStorePath } = setupCronServiceSuite({
@@ -245,6 +245,84 @@ describe("cron service ops seam coverage", () => {
       process.env.OPENCLAW_STATE_DIR = originalStateDir;
     }
     resetTaskRegistryForTests();
+  });
+
+  it("non-schedule edit preserves nextRunAtMs (#63499)", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-04-09T08:00:00.000Z");
+    const originalNextRunAtMs = Date.parse("2026-04-10T09:00:00.000Z");
+
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [
+        {
+          id: "daily-report",
+          name: "daily report",
+          enabled: true,
+          createdAtMs: now - 86_400_000,
+          updatedAtMs: now - 3_600_000,
+          schedule: { kind: "cron", expr: "0 9 * * *", tz: "Asia/Shanghai" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "daily" },
+          state: { nextRunAtMs: originalNextRunAtMs },
+        },
+      ],
+    });
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    const updated = await update(state, "daily-report", { description: "edited" });
+
+    expect(updated.description).toBe("edited");
+    expect(updated.state.nextRunAtMs).toBe(originalNextRunAtMs);
+  });
+
+  it("repairs nextRunAtMs=0 on non-schedule edit (#63499)", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-04-09T08:00:00.000Z");
+
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [
+        {
+          id: "broken-job",
+          name: "broken",
+          enabled: true,
+          createdAtMs: now - 86_400_000,
+          updatedAtMs: now - 3_600_000,
+          schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "test" },
+          state: { nextRunAtMs: 0 },
+        },
+      ],
+    });
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    const updated = await update(state, "broken-job", { description: "fixed" });
+
+    expect(updated.description).toBe("fixed");
+    expect(updated.state.nextRunAtMs).toBeGreaterThan(0);
+    expect(updated.state.nextRunAtMs).toBeGreaterThan(now);
   });
 
   it("records startup catch-up timeouts as timed_out in the shared task registry", async () => {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -13,6 +13,7 @@ import {
   computeJobNextRunAtMs,
   createJob,
   findJobOrThrow,
+  hasScheduledNextRunAtMs,
   isJobEnabled,
   isJobDue,
   nextWakeAtMs,
@@ -327,13 +328,8 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
         job.state.nextRunAtMs = undefined;
         job.state.runningAtMs = undefined;
       }
-    } else if (isJobEnabled(job)) {
-      // Non-schedule edits should not mutate other jobs, but still repair a
-      // missing/corrupt/zero nextRunAtMs for the updated job.
-      const nextRun = job.state.nextRunAtMs;
-      if (typeof nextRun !== "number" || !Number.isFinite(nextRun) || nextRun <= 0) {
-        job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
-      }
+    } else if (isJobEnabled(job) && !hasScheduledNextRunAtMs(job.state.nextRunAtMs)) {
+      job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
     }
 
     await persist(state);

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -329,9 +329,9 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
       }
     } else if (isJobEnabled(job)) {
       // Non-schedule edits should not mutate other jobs, but still repair a
-      // missing/corrupt nextRunAtMs for the updated job.
+      // missing/corrupt/zero nextRunAtMs for the updated job.
       const nextRun = job.state.nextRunAtMs;
-      if (typeof nextRun !== "number" || !Number.isFinite(nextRun)) {
+      if (typeof nextRun !== "number" || !Number.isFinite(nextRun) || nextRun <= 0) {
         job.state.nextRunAtMs = computeJobNextRunAtMs(job, now);
       }
     }

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -22,6 +22,7 @@ import type {
 import {
   computeJobPreviousRunAtMs,
   computeJobNextRunAtMs,
+  hasScheduledNextRunAtMs,
   isJobEnabled,
   nextWakeAtMs,
   recomputeNextRunsForMaintenance,
@@ -606,12 +607,8 @@ export function armTimer(state: CronServiceState) {
     const jobCount = state.store?.jobs.length ?? 0;
     const enabledCount = state.store?.jobs.filter((j) => j.enabled).length ?? 0;
     const withNextRun =
-      state.store?.jobs.filter(
-        (j) =>
-          j.enabled &&
-          typeof j.state.nextRunAtMs === "number" &&
-          Number.isFinite(j.state.nextRunAtMs),
-      ).length ?? 0;
+      state.store?.jobs.filter((j) => j.enabled && hasScheduledNextRunAtMs(j.state.nextRunAtMs))
+        .length ?? 0;
     state.deps.log.debug(
       { jobCount, enabledCount, withNextRun },
       "cron: armTimer skipped - no jobs with nextRunAtMs",
@@ -865,15 +862,10 @@ function isRunnableJob(params: {
     return false;
   }
   const next = job.state.nextRunAtMs;
-  if (typeof next === "number" && Number.isFinite(next) && nowMs >= next) {
+  if (hasScheduledNextRunAtMs(next) && nowMs >= next) {
     return true;
   }
-  if (
-    typeof next === "number" &&
-    Number.isFinite(next) &&
-    next > nowMs &&
-    isErrorBackoffPending(job, nowMs)
-  ) {
+  if (hasScheduledNextRunAtMs(next) && next > nowMs && isErrorBackoffPending(job, nowMs)) {
     // Respect active retry backoff windows on restart, but allow missed-slot
     // replay once the backoff window has elapsed.
     return false;


### PR DESCRIPTION
Closes #63499

## Summary
- treat `nextRunAtMs <= 0` as invalid during non-schedule cron job updates
- editing metadata fields like `--description` now recomputes `nextRunAtMs` instead of silently keeping a corrupt/zero value
- add two regression tests covering both the preservation case and the repair case

## Root cause
The `update()` function in `src/cron/service/ops.ts` only repaired `nextRunAtMs` when it was `undefined` or non-finite. A value of `0` passed both guards (`typeof 0 === "number"` and `Number.isFinite(0)`), so it was silently preserved. Once `nextRunAtMs` became `0` (from any source — initialization bug, concurrent write, or store corruption), every subsequent non-schedule edit would keep it at `0`, causing the cron scheduler to treat the job as stale and skip delivery.

## Test plan
- `node scripts/run-vitest.mjs run --config vitest.cron.config.ts src/cron/service/ops.test.ts` — 7 passed (including 2 new)