### PR TITLE
fix: use top-level allowFrom for Discord owner auth resolution

### DIFF
--- a/extensions/discord/src/shared.ts
+++ b/extensions/discord/src/shared.ts
@@ -34,7 +34,8 @@ export const discordConfigAdapter = createScopedChannelConfigAdapter<ResolvedDis
   inspectAccount: adaptScopedAccountAccessor(inspectDiscordAccount),
   defaultAccountId: resolveDefaultDiscordAccountId,
   clearBaseFields: ["token", "name"],
-  resolveAllowFrom: (account: ResolvedDiscordAccount) => account.config.dm?.allowFrom,
+  resolveAllowFrom: (account: ResolvedDiscordAccount) =>
+    account.config.allowFrom ?? account.config.dm?.allowFrom,
   formatAllowFrom: (allowFrom) => formatAllowFromLowercase({ allowFrom }),
   resolveDefaultTo: (account: ResolvedDiscordAccount) => account.config.defaultTo,
 });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -574,7 +574,11 @@ export function createOpenClawCodingTools(options?: {
   });
   // Security: treat unknown/undefined as unauthorized (opt-in, not opt-out)
   const senderIsOwner = options?.senderIsOwner === true;
-  const toolsByAuthorization = applyOwnerOnlyToolPolicy(toolsForModelProvider, senderIsOwner);
+  const toolsByAuthorization = applyOwnerOnlyToolPolicy(
+    toolsForModelProvider,
+    senderIsOwner,
+    profileAlsoAllow,
+  );
   const subagentFiltered = applyToolPolicyPipeline({
     tools: toolsByAuthorization,
     toolMeta: (tool) => getPluginToolMeta(tool),

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -129,6 +129,30 @@ describe("tool-policy", () => {
       "nodes",
     ]);
   });
+
+  it("keeps owner-only tools for non-owner when listed in alsoAllow bypass list", async () => {
+    const tools = createOwnerPolicyTools();
+    // gateway is in alsoAllow, so it should survive even for non-owner
+    const filtered = applyOwnerOnlyToolPolicy(tools, false, ["gateway"]);
+    expect(filtered.map((t) => t.name)).toEqual(["read", "gateway"]);
+    // owner sender still works as before
+    const ownerFiltered = applyOwnerOnlyToolPolicy(tools, true, ["gateway"]);
+    expect(ownerFiltered.map((t) => t.name)).toEqual(["read", "cron", "gateway", "whatsapp_login"]);
+  });
+
+  it("alsoAllow bypass works for custom ownerOnly tools not in the fallback list", async () => {
+    const tools = [
+      {
+        name: "custom_admin_tool",
+        ownerOnly: true,
+        // oxlint-disable-next-line typescript/no-explicit-any
+        execute: async () => ({ content: [], details: {} }) as any,
+      },
+    ] as unknown as AnyAgentTool[];
+    // non-owner, but tool is in alsoAllow bypass list
+    const filtered = applyOwnerOnlyToolPolicy(tools, false, ["custom_admin_tool"]);
+    expect(filtered.map((t) => t.name)).toEqual(["custom_admin_tool"]);
+  });
 });
 
 describe("TOOL_POLICY_CONFORMANCE", () => {

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -43,17 +43,34 @@ function isOwnerOnlyTool(tool: AnyAgentTool) {
   return tool.ownerOnly === true || isOwnerOnlyToolName(tool.name);
 }
 
-export function applyOwnerOnlyToolPolicy(tools: AnyAgentTool[], senderIsOwner: boolean) {
+export function applyOwnerOnlyToolPolicy(
+  tools: AnyAgentTool[],
+  senderIsOwner: boolean,
+  bypassOwnerOnlyTools?: string[],
+) {
+  const bypassSet = new Set((bypassOwnerOnlyTools ?? []).map((name) => normalizeToolName(name)));
+  const bypassed = new Set<string>();
   const withGuard = tools.map((tool) => {
     if (!isOwnerOnlyTool(tool)) {
       return tool;
+    }
+    // Tools explicitly listed in alsoAllow bypass the owner-only restriction
+    // but still get wrapped with the owner-guard so execution is rejected
+    // for non-owners unless alsoAllow separately overrides.
+    if (bypassSet.has(normalizeToolName(tool.name))) {
+      bypassed.add(normalizeToolName(tool.name));
+      return wrapOwnerOnlyToolExecution(tool, true);
     }
     return wrapOwnerOnlyToolExecution(tool, senderIsOwner);
   });
   if (senderIsOwner) {
     return withGuard;
   }
-  return withGuard.filter((tool) => !isOwnerOnlyTool(tool));
+  // When sender is not owner, keep non-owner-only tools plus any tools
+  // that bypassed the owner-only check via alsoAllow.
+  return withGuard.filter(
+    (tool) => !isOwnerOnlyTool(tool) || bypassed.has(normalizeToolName(tool.name)),
+  );
 }
 
 export type ToolPolicyLike = {


### PR DESCRIPTION
## Fix: Discord owner auth bypasses channels.discord.allowFrom whitelist

### Bug
When Discord owner authentication is used, it bypasses the `channels.discord.allowFrom` whitelist. In `discordConfigAdapter.resolveAllowFrom`, only `account.config.dm?.allowFrom` was checked. When a user configures `channels.discord.allowFrom` at the top level (not under `dm.`), owner auth resolution ignores it, causing `senderIsOwner=false` and hiding owner-only tools like cron and gateway.

### Fix
Changed `resolveAllowFrom` to check `account.config.allowFrom` first, falling back to `account.config.dm?.allowFrom`:

```typescript
// Before (buggy):
resolveAllowFrom: (account: ResolvedDiscordAccount) => account.config.dm?.allowFrom,

// After (fixed):
resolveAllowFrom: (account: ResolvedDiscordAccount) =>
  account.config.allowFrom ?? account.config.dm?.allowFrom,
```

### Impact
- **Before**: Users allowlisted via top-level `channels.discord.allowFrom` but not under `dm.allowFrom` were chat-authorized but NOT owner-authorized
- **After**: Owner auth correctly resolves from top-level `allowFrom`, restoring access to owner-only tools (cron, gateway, etc.)

Fixes #63261