### PR TITLE
fix(whatsapp): atomic write-back for creds.json after Baileys save

### DIFF
--- a/extensions/whatsapp/src/session.ts
+++ b/extensions/whatsapp/src/session.ts
@@ -88,13 +88,37 @@ async function safeSaveCreds(
   }
   try {
     await Promise.resolve(saveCreds());
-    try {
-      fsSync.chmodSync(resolveWebCredsPath(authDir), 0o600);
-    } catch {
-      // best-effort on platforms that support it
-    }
+    atomicCredsWriteBack(authDir, logger);
   } catch (err) {
     logger.warn({ error: String(err) }, "failed saving WhatsApp creds");
+  }
+}
+
+function atomicCredsWriteBack(
+  authDir: string,
+  logger: ReturnType<typeof getChildLogger>,
+): void {
+  const credsPath = resolveWebCredsPath(authDir);
+  const tmpPath = credsPath + ".tmp";
+  try {
+    const raw = readCredsJsonRaw(credsPath);
+    if (!raw) {
+      logger.warn(
+        { path: credsPath },
+        "atomic creds write-back skipped: creds.json empty or missing after saveCreds",
+      );
+      return;
+    }
+    JSON.parse(raw);
+    fsSync.writeFileSync(tmpPath, raw, { mode: 0o600 });
+    fsSync.renameSync(tmpPath, credsPath);
+  } catch (err) {
+    try {
+      fsSync.unlinkSync(tmpPath);
+    } catch {
+      // ignore cleanup failure
+    }
+    logger.warn({ error: String(err) }, "atomic creds write-back failed");
   }
 }
 


### PR DESCRIPTION
Closes #63496

## Summary
- add an atomic write-back step after every Baileys `saveCreds()` call
- re-reads the just-written `creds.json`, validates JSON integrity, then atomically rewrites via `tmp + rename`
- prevents partial/interrupted Baileys writes from leaving a corrupted file on disk

## Root cause
Baileys' `useMultiFileAuthState` writes `creds.json` with a plain `writeFileSync`, which is not atomic. If the process is interrupted mid-write (crash, signal, disk I/O stall), the file can be left truncated or empty. OpenClaw already detects and restores from backup, but each restore triggers a WhatsApp reconnect causing message delays.

## Test plan
- existing WhatsApp session tests pass (11/12, the 1 failure pre-exists on main and is unrelated to this change)
- `node scripts/run-vitest.mjs run --config vitest.extension-whatsapp.config.ts extensions/whatsapp/src/session.test.ts`