### PR TITLE
fix(qa-lab): catch missing qa scenario pack in discovery refs init

### DIFF
--- a/extensions/qa-lab/src/discovery-eval.ts
+++ b/extensions/qa-lab/src/discovery-eval.ts
@@ -1,17 +1,21 @@
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { readQaScenarioExecutionConfig } from "./scenario-catalog.js";
 
+const DEFAULT_DISCOVERY_REFS = [
+  "repo/qa/scenarios/index.md",
+  "repo/extensions/qa-lab/src/suite.ts",
+  "repo/docs/help/testing.md",
+];
+
 function readRequiredDiscoveryRefs() {
-  const config = readQaScenarioExecutionConfig("source-docs-discovery-report") as
-    | { requiredFiles?: string[] }
-    | undefined;
-  return (
-    config?.requiredFiles ?? [
-      "repo/qa/scenarios/index.md",
-      "repo/extensions/qa-lab/src/suite.ts",
-      "repo/docs/help/testing.md",
-    ]
-  );
+  try {
+    const config = readQaScenarioExecutionConfig("source-docs-discovery-report") as
+      | { requiredFiles?: string[] }
+      | undefined;
+    return config?.requiredFiles ?? DEFAULT_DISCOVERY_REFS;
+  } catch {
+    return DEFAULT_DISCOVERY_REFS;
+  }
 }
 
 const REQUIRED_DISCOVERY_REFS = readRequiredDiscoveryRefs();


### PR DESCRIPTION
Closes #63510

## Summary
- wrap `readRequiredDiscoveryRefs()` in try/catch so the existing fallback array is reachable when `qa/scenarios/index.md` is not shipped in the npm package
- prevents `openclaw completion --write-state` and `openclaw update` from crashing on module-level constant initialization

## Root cause
`REQUIRED_DISCOVERY_REFS` is evaluated at import time. Its initializer calls through `readQaScenarioExecutionConfig` → `readQaScenarioById` → `readQaScenarioPack`, which throws when `qa/scenarios/index.md` is missing. The existing `?.` and `??` fallback never executes because the exception is thrown before the return.

## Test plan
- verified the fix matches the suggested approach in the issue
- the change is a defensive try/catch around an existing function; no behavioral change when `qa/scenarios/` is present