### PR TITLE
fix(session): prefer exact key match over freshest-updatedAt match

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -400,8 +400,19 @@ export function loadSessionEntry(sessionKey: string) {
     store,
   });
   const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(store, target.storeKeys);
-  const legacyKey = freshestMatch?.key !== canonicalKey ? freshestMatch?.key : undefined;
-  return { cfg, storePath, store, entry: freshestMatch?.entry, canonicalKey, legacyKey };
+  // Prefer an exact key match over the freshest-updatedAt match. Without this,
+  // clicking an archived compound-key session (e.g. agent:main:main:<oldId>)
+  // returns the NEW primary-key session because it has a newer updatedAt.
+  const trimmedKey = sessionKey.trim();
+  const exactEntry = store[trimmedKey] ?? store[canonicalKey];
+  const resolvedEntry = exactEntry ?? freshestMatch?.entry;
+  const resolvedKey = exactEntry
+    ? store[trimmedKey]
+      ? trimmedKey
+      : canonicalKey
+    : freshestMatch?.key;
+  const legacyKey = resolvedKey !== canonicalKey ? resolvedKey : undefined;
+  return { cfg, storePath, store, entry: resolvedEntry, canonicalKey, legacyKey };
 }
 
 export function resolveFreshestSessionStoreMatchFromStoreKeys(


### PR DESCRIPTION
## Summary
Fixed a bug where clicking an archived/compound-key session in the sidebar would load the new primary session instead. `loadSessionEntry` now checks for exact key match first, falling back to freshest-updatedAt match only when no exact entry exists.

## Problem
`resolveFreshestSessionStoreMatchFromStoreKeys` always returned the entry with the highest `updatedAt`, even when the exact requested compound key existed. This broke sidebar history navigation — clicking old sessions loaded the current primary session instead.

## Solution
Priority-based lookup in `loadSessionEntry`:
1. **First:** Check exact match on `sessionKey` or `canonicalKey` (O(1) store lookup)
2. **Fallback:** Only use freshest-match if no exact entry found

## Changes
- `src/gateway/session-utils.ts` — +13/-2 lines

## Test Plan
- [x] Exact match on compound key → loads compound entry ✅
- [x] Exact match on canonical key → loads canonical entry ✅
- [x] No exact match → fallback to freshest (existing behavior) ✅
- [x] Key normalization (trim) handles edge cases ✅

## Backward Compatibility
✅ Fully backward compatible — return type unchanged, existing callers see same or better results

See detailed proposal: references/github-contribute/PR-2-SESSION-KEY-MATCHING.md