### PR TITLE
fix(agents): guard nodes tool outPath against workspace boundary [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- fix(agents): guard nodes tool outPath against workspace boundary [AI-assisted]. (#63551) Thanks @pgondhi987.
 - fix(qqbot): enforce media storage boundary for all outbound local file paths [AI]. (#63271) Thanks @pgondhi987.
 - iMessage/self-chat: distinguish normal DM outbound rows from true self-chat using `destination_caller_id` plus chat participants, while preserving multi-handle self-chat aliases so outbound DM replies stop looping back as inbound messages. (#61619) Thanks @neeravmakwana.
 - fix(browser): auto-generate browser control auth token for none/trusted-proxy modes [AI]. (#63280) Thanks @pgondhi987.

--- a/src/agents/openclaw-tools.nodes-workspace-guard.test.ts
+++ b/src/agents/openclaw-tools.nodes-workspace-guard.test.ts
@@ -3,14 +3,28 @@ import type { AnyAgentTool } from "./tools/common.js";
 
 const mocks = vi.hoisted(() => ({
   assertSandboxPath: vi.fn(async (params: { filePath: string; cwd: string; root: string }) => {
-    const root = params.root.replace(/\/+$/, "");
-    const filePath = params.filePath;
-    const inside = filePath === root || filePath.startsWith(`${root}/`);
-    if (!inside) {
-      throw new Error(`Path escapes sandbox root (${root}): ${filePath}`);
+    const root = `/${params.root.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "")}`;
+    const candidate = params.filePath.replace(/\\/g, "/");
+    const input = candidate.startsWith("/") ? candidate : `${root}/${candidate}`;
+    const segments = input.split("/");
+    const stack: string[] = [];
+    for (const segment of segments) {
+      if (!segment || segment === ".") {
+        continue;
+      }
+      if (segment === "..") {
+        stack.pop();
+        continue;
+      }
+      stack.push(segment);
     }
-    const relative = filePath === root ? "" : filePath.slice(root.length + 1);
-    return { resolved: filePath, relative };
+    const resolved = `/${stack.join("/")}`;
+    const inside = resolved === root || resolved.startsWith(`${root}/`);
+    if (!inside) {
+      throw new Error(`Path escapes sandbox root (${root}): ${params.filePath}`);
+    }
+    const relative = resolved === root ? "" : resolved.slice(root.length + 1);
+    return { resolved, relative };
   }),
   nodesExecute: vi.fn(async () => ({
     content: [{ type: "text", text: "ok" }],
@@ -79,6 +93,29 @@ describe("createOpenClawTools nodes workspace guard", () => {
       root: WORKSPACE_ROOT,
     });
     expect(mocks.nodesExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes relative outPath to an absolute workspace path before execute", async () => {
+    const nodesTool = getNodesTool(true);
+    await nodesTool.execute("call-rel", {
+      action: "screen_record",
+      outPath: "videos/capture.mp4",
+    });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: "videos/capture.mp4",
+      cwd: WORKSPACE_ROOT,
+      root: WORKSPACE_ROOT,
+    });
+    expect(mocks.nodesExecute).toHaveBeenCalledWith(
+      "call-rel",
+      {
+        action: "screen_record",
+        outPath: `${WORKSPACE_ROOT}/videos/capture.mp4`,
+      },
+      undefined,
+      undefined,
+    );
   });
 
   it("rejects outPath outside workspace when workspaceOnly is enabled", async () => {

--- a/src/agents/openclaw-tools.nodes-workspace-guard.test.ts
+++ b/src/agents/openclaw-tools.nodes-workspace-guard.test.ts
@@ -1,0 +1,106 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "./tools/common.js";
+
+const mocks = vi.hoisted(() => ({
+  assertSandboxPath: vi.fn(async (params: { filePath: string; cwd: string; root: string }) => {
+    const root = params.root.replace(/\/+$/, "");
+    const filePath = params.filePath;
+    const inside = filePath === root || filePath.startsWith(`${root}/`);
+    if (!inside) {
+      throw new Error(`Path escapes sandbox root (${root}): ${filePath}`);
+    }
+    const relative = filePath === root ? "" : filePath.slice(root.length + 1);
+    return { resolved: filePath, relative };
+  }),
+  nodesExecute: vi.fn(async () => ({
+    content: [{ type: "text", text: "ok" }],
+  })),
+}));
+
+vi.mock("./sandbox-paths.js", () => ({
+  assertSandboxPath: mocks.assertSandboxPath,
+}));
+
+vi.mock("./tools/nodes-tool.js", () => ({
+  createNodesTool: () =>
+    ({
+      name: "nodes",
+      label: "Nodes",
+      description: "nodes test tool",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+      execute: mocks.nodesExecute,
+    }) as AnyAgentTool,
+}));
+
+let createOpenClawTools: typeof import("./openclaw-tools.js").createOpenClawTools;
+
+const WORKSPACE_ROOT = "/tmp/openclaw-workspace-nodes-guard";
+
+describe("createOpenClawTools nodes workspace guard", () => {
+  beforeAll(async () => {
+    vi.resetModules();
+    ({ createOpenClawTools } = await import("./openclaw-tools.js"));
+  });
+
+  beforeEach(() => {
+    mocks.assertSandboxPath.mockClear();
+    mocks.nodesExecute.mockClear();
+  });
+
+  function getNodesTool(workspaceOnly: boolean): AnyAgentTool {
+    const tools = createOpenClawTools({
+      workspaceDir: WORKSPACE_ROOT,
+      fsPolicy: { workspaceOnly },
+      disablePluginTools: true,
+      disableMessageTool: true,
+    });
+    const nodesTool = tools.find((tool) => tool.name === "nodes");
+    expect(nodesTool).toBeDefined();
+    if (!nodesTool) {
+      throw new Error("missing nodes tool");
+    }
+    return nodesTool;
+  }
+
+  it("guards outPath when workspaceOnly is enabled", async () => {
+    const nodesTool = getNodesTool(true);
+    await nodesTool.execute("call-1", {
+      action: "screen_record",
+      outPath: `${WORKSPACE_ROOT}/videos/capture.mp4`,
+    });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: `${WORKSPACE_ROOT}/videos/capture.mp4`,
+      cwd: WORKSPACE_ROOT,
+      root: WORKSPACE_ROOT,
+    });
+    expect(mocks.nodesExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects outPath outside workspace when workspaceOnly is enabled", async () => {
+    const nodesTool = getNodesTool(true);
+    await expect(
+      nodesTool.execute("call-2", {
+        action: "screen_record",
+        outPath: "/etc/passwd",
+      }),
+    ).rejects.toThrow(/Path escapes sandbox root/);
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledTimes(1);
+    expect(mocks.nodesExecute).not.toHaveBeenCalled();
+  });
+
+  it("does not guard outPath when workspaceOnly is disabled", async () => {
+    const nodesTool = getNodesTool(false);
+    await nodesTool.execute("call-3", {
+      action: "screen_record",
+      outPath: "/etc/passwd",
+    });
+
+    expect(mocks.assertSandboxPath).not.toHaveBeenCalled();
+    expect(mocks.nodesExecute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agents/openclaw-tools.nodes-workspace-guard.test.ts
+++ b/src/agents/openclaw-tools.nodes-workspace-guard.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   }),
   nodesExecute: vi.fn(async () => ({
     content: [{ type: "text", text: "ok" }],
+    details: {},
   })),
 }));
 
@@ -32,7 +33,7 @@ vi.mock("./tools/nodes-tool.js", () => ({
         properties: {},
       },
       execute: mocks.nodesExecute,
-    }) as AnyAgentTool,
+    }) as unknown as AnyAgentTool,
 }));
 
 let createOpenClawTools: typeof import("./openclaw-tools.js").createOpenClawTools;

--- a/src/agents/openclaw-tools.nodes-workspace-guard.test.ts
+++ b/src/agents/openclaw-tools.nodes-workspace-guard.test.ts
@@ -65,10 +65,15 @@ describe("createOpenClawTools nodes workspace guard", () => {
     mocks.nodesExecute.mockClear();
   });
 
-  function getNodesTool(workspaceOnly: boolean): AnyAgentTool {
+  function getNodesTool(
+    workspaceOnly: boolean,
+    options?: { sandboxRoot?: string; sandboxContainerWorkdir?: string },
+  ): AnyAgentTool {
     const tools = createOpenClawTools({
       workspaceDir: WORKSPACE_ROOT,
       fsPolicy: { workspaceOnly },
+      sandboxRoot: options?.sandboxRoot,
+      sandboxContainerWorkdir: options?.sandboxContainerWorkdir,
       disablePluginTools: true,
       disableMessageTool: true,
     });
@@ -109,6 +114,32 @@ describe("createOpenClawTools nodes workspace guard", () => {
     });
     expect(mocks.nodesExecute).toHaveBeenCalledWith(
       "call-rel",
+      {
+        action: "screen_record",
+        outPath: `${WORKSPACE_ROOT}/videos/capture.mp4`,
+      },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("maps sandbox container outPath to host root when containerWorkdir is provided", async () => {
+    const nodesTool = getNodesTool(true, {
+      sandboxRoot: WORKSPACE_ROOT,
+      sandboxContainerWorkdir: "/workspace",
+    });
+    await nodesTool.execute("call-sandbox", {
+      action: "screen_record",
+      outPath: "/workspace/videos/capture.mp4",
+    });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: `${WORKSPACE_ROOT}/videos/capture.mp4`,
+      cwd: WORKSPACE_ROOT,
+      root: WORKSPACE_ROOT,
+    });
+    expect(mocks.nodesExecute).toHaveBeenCalledWith(
+      "call-sandbox",
       {
         action: "screen_record",
         outPath: `${WORKSPACE_ROOT}/videos/capture.mp4`,

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -219,7 +219,7 @@ export function createOpenClawTools(
   const nodesTool =
     options?.fsPolicy?.workspaceOnly === true
       ? wrapToolWorkspaceRootGuardWithOptions(nodesToolBase, options?.sandboxRoot ?? workspaceDir, {
-          pathParamKeys: ["path", "outPath"],
+          pathParamKeys: ["outPath"],
         })
       : nodesToolBase;
   const tools: AnyAgentTool[] = [

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -61,6 +61,7 @@ export function createOpenClawTools(
     agentThreadId?: string | number;
     agentDir?: string;
     sandboxRoot?: string;
+    sandboxContainerWorkdir?: string;
     sandboxFsBridge?: SandboxFsBridge;
     fsPolicy?: ToolFsPolicy;
     sandboxed?: boolean;
@@ -219,6 +220,7 @@ export function createOpenClawTools(
   const nodesTool =
     options?.fsPolicy?.workspaceOnly === true
       ? wrapToolWorkspaceRootGuardWithOptions(nodesToolBase, options?.sandboxRoot ?? workspaceDir, {
+          containerWorkdir: options?.sandboxContainerWorkdir,
           pathParamKeys: ["outPath"],
           normalizeGuardedPathParams: true,
         })

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -220,6 +220,7 @@ export function createOpenClawTools(
     options?.fsPolicy?.workspaceOnly === true
       ? wrapToolWorkspaceRootGuardWithOptions(nodesToolBase, options?.sandboxRoot ?? workspaceDir, {
           pathParamKeys: ["outPath"],
+          normalizeGuardedPathParams: true,
         })
       : nodesToolBase;
   const tools: AnyAgentTool[] = [

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -9,6 +9,7 @@ import {
   collectPresentOpenClawTools,
   isUpdatePlanToolEnabledForOpenClawTools,
 } from "./openclaw-tools.registration.js";
+import { wrapToolWorkspaceRootGuardWithOptions } from "./pi-tools.read.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import type { SpawnedToolContext } from "./spawned-context.js";
 import type { ToolFsPolicy } from "./tool-fs-policy.js";
@@ -205,18 +206,25 @@ export function createOpenClawTools(
         requireExplicitTarget: options?.requireExplicitMessageTarget,
         requesterSenderId: options?.requesterSenderId ?? undefined,
       });
+  const nodesToolBase = createNodesTool({
+    agentSessionKey: options?.agentSessionKey,
+    agentChannel: options?.agentChannel,
+    agentAccountId: options?.agentAccountId,
+    currentChannelId: options?.currentChannelId,
+    currentThreadTs: options?.currentThreadTs,
+    config: options?.config,
+    modelHasVision: options?.modelHasVision,
+    allowMediaInvokeCommands: options?.allowMediaInvokeCommands,
+  });
+  const nodesTool =
+    options?.fsPolicy?.workspaceOnly === true
+      ? wrapToolWorkspaceRootGuardWithOptions(nodesToolBase, options?.sandboxRoot ?? workspaceDir, {
+          pathParamKeys: ["path", "outPath"],
+        })
+      : nodesToolBase;
   const tools: AnyAgentTool[] = [
     createCanvasTool({ config: options?.config }),
-    createNodesTool({
-      agentSessionKey: options?.agentSessionKey,
-      agentChannel: options?.agentChannel,
-      agentAccountId: options?.agentAccountId,
-      currentChannelId: options?.currentChannelId,
-      currentThreadTs: options?.currentThreadTs,
-      config: options?.config,
-      modelHasVision: options?.modelHasVision,
-      allowMediaInvokeCommands: options?.allowMediaInvokeCommands,
-    }),
+    nodesTool,
     createCronTool({
       agentSessionKey: options?.agentSessionKey,
     }),

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -552,6 +552,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
   options?: {
     containerWorkdir?: string;
     pathParamKeys?: readonly string[];
+    normalizeGuardedPathParams?: boolean;
   },
 ): AnyAgentTool {
   const pathParamKeys =
@@ -560,6 +561,7 @@ export function wrapToolWorkspaceRootGuardWithOptions(
     ...tool,
     execute: async (toolCallId, args, signal, onUpdate) => {
       const record = getToolParamsRecord(args);
+      let normalizedRecord: Record<string, unknown> | undefined;
       for (const key of pathParamKeys) {
         const filePath = record?.[key];
         if (typeof filePath !== "string" || !filePath.trim()) {
@@ -570,9 +572,13 @@ export function wrapToolWorkspaceRootGuardWithOptions(
           root,
           containerWorkdir: options?.containerWorkdir,
         });
-        await assertSandboxPath({ filePath: sandboxPath, cwd: root, root });
+        const sandboxResult = await assertSandboxPath({ filePath: sandboxPath, cwd: root, root });
+        if (options?.normalizeGuardedPathParams && record) {
+          normalizedRecord ??= { ...record };
+          normalizedRecord[key] = sandboxResult.resolved;
+        }
       }
-      return tool.execute(toolCallId, args, signal, onUpdate);
+      return tool.execute(toolCallId, normalizedRecord ?? args, signal, onUpdate);
     },
   };
 }

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -551,14 +551,20 @@ export function wrapToolWorkspaceRootGuardWithOptions(
   root: string,
   options?: {
     containerWorkdir?: string;
+    pathParamKeys?: readonly string[];
   },
 ): AnyAgentTool {
+  const pathParamKeys =
+    options?.pathParamKeys && options.pathParamKeys.length > 0 ? options.pathParamKeys : ["path"];
   return {
     ...tool,
     execute: async (toolCallId, args, signal, onUpdate) => {
       const record = getToolParamsRecord(args);
-      const filePath = record?.path;
-      if (typeof filePath === "string" && filePath.trim()) {
+      for (const key of pathParamKeys) {
+        const filePath = record?.[key];
+        if (typeof filePath !== "string" || !filePath.trim()) {
+          continue;
+        }
         const sandboxPath = mapContainerPathToWorkspaceRoot({
           filePath,
           root,

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -140,18 +140,25 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
   });
 
   it("guards custom outPath params when configured", async () => {
-    const { tool } = createToolHarness();
+    const { execute, tool } = createToolHarness();
     const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
       containerWorkdir: "/workspace",
       pathParamKeys: ["outPath"],
+      normalizeGuardedPathParams: true,
     });
 
-    await wrapped.execute("tc-outpath-custom", { outPath: "/workspace/videos/capture.mp4" });
+    await wrapped.execute("tc-outpath-custom", { outPath: "videos/capture.mp4" });
 
     expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
-      filePath: path.resolve(root, "videos", "capture.mp4"),
+      filePath: "videos/capture.mp4",
       cwd: root,
       root,
     });
+    expect(execute).toHaveBeenCalledWith(
+      "tc-outpath-custom",
+      { outPath: path.resolve(root, "videos", "capture.mp4") },
+      undefined,
+      undefined,
+    );
   });
 });

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -127,4 +127,31 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
       root,
     });
   });
+
+  it("does not guard outPath by default", async () => {
+    const { tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/workspace",
+    });
+
+    await wrapped.execute("tc-outpath-default", { outPath: "/workspace/videos/capture.mp4" });
+
+    expect(mocks.assertSandboxPath).not.toHaveBeenCalled();
+  });
+
+  it("guards custom outPath params when configured", async () => {
+    const { tool } = createToolHarness();
+    const wrapped = wrapToolWorkspaceRootGuardWithOptions(tool, root, {
+      containerWorkdir: "/workspace",
+      pathParamKeys: ["outPath"],
+    });
+
+    await wrapped.execute("tc-outpath-custom", { outPath: "/workspace/videos/capture.mp4" });
+
+    expect(mocks.assertSandboxPath).toHaveBeenCalledWith({
+      filePath: path.resolve(root, "videos", "capture.mp4"),
+      cwd: root,
+      root,
+    });
+  });
 });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -532,6 +532,7 @@ export function createOpenClawCodingTools(options?: {
       agentGroupSpace: options?.groupSpace ?? null,
       agentDir: options?.agentDir,
       sandboxRoot,
+      sandboxContainerWorkdir: sandbox?.containerWorkdir,
       sandboxFsBridge,
       fsPolicy,
       workspaceDir: workspaceRoot,


### PR DESCRIPTION
## Summary

- **Problem:** The nodes tool's `screen_record` action accepts an `outPath` parameter from the LLM and writes decoded binary data to it via a raw `fs.writeFile` with no path validation.
- **Why it matters:** When `tools.fs.workspaceOnly: true` hardening is enabled, `read`/`write`/`edit` tools are wrapped with a workspace root guard — but the nodes tool was constructed without that wrapper. Additionally, even if the guard had been applied, it only inspected the `path` parameter key, not `outPath`, so the parameter would evade the check regardless.
- **What changed:** Extended `wrapToolWorkspaceRootGuardWithOptions` to accept a configurable `pathParamKeys` option (defaults to `["path"]` for backwards compatibility), then applied it to the nodes tool in `createOpenClawTools` with `pathParamKeys: ["outPath"]` when `workspaceOnly` is enabled.
- **What did NOT change:** No behaviour change when `workspaceOnly` is false. No changes to the nodes tool schema, gateway protocol, or any other tool's guard logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The nodes tool was instantiated in `openclaw-tools.ts` without going through the same `wrapToolWorkspaceRootGuard` pipeline used for `read`/`write`/`edit` tools. Furthermore, the existing guard only checked `record?.path`, not `record?.outPath`, meaning the nodes tool's `screen_record` output path was doubly unchecked.
- Missing detection / guardrail: No unit test verified that the nodes tool respected `workspaceOnly`; only the read/write/edit tools had guard coverage.
- Contributing context (if known): The `outPath` parameter name diverges from the `path` parameter name that all other guarded tools use, making the gap non-obvious.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openclaw-tools.nodes-workspace-guard.test.ts` (new), `src/agents/pi-tools.read.workspace-root-guard.test.ts` (extended)
- Scenario the test should lock in: nodes tool rejects `outPath` outside workspace root when `workspaceOnly` is enabled; nodes tool passes `outPath` inside workspace root; nodes tool skips the guard when `workspaceOnly` is disabled.
- Why this is the smallest reliable guardrail: Directly tests the guard wire-up at the `createOpenClawTools` level and the `pathParamKeys` extension at the helper level.
- Existing test that already covers this (if any): None — this was the gap.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

When `tools.fs.workspaceOnly: true` is configured: the nodes tool's `screen_record` action now rejects an `outPath` that falls outside the workspace root, consistent with how `write`/`edit` tools already behave. No change when `workspaceOnly` is not enabled.

## Diagram (if applicable)

```text
Before (workspaceOnly=true):
  LLM → nodes(screen_record, outPath=/etc/foo) → raw fs.writeFile("/etc/foo") ✗ no check

After (workspaceOnly=true):
  LLM → nodes(screen_record, outPath=/etc/foo) → assertSandboxPath() → throws ✓ blocked
  LLM → nodes(screen_record, outPath=/workspace/out.mp4) → assertSandboxPath() → passes → fs.writeFile ✓
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — nodes tool `outPath` is now validated against the workspace root when `workspaceOnly` is enabled.
- Data access scope changed? No
- Explanation: This is a tightening of an existing security boundary. Operators who already rely on `workspaceOnly` will now have the nodes tool respect that boundary as expected. No new attack surface is introduced.

## Repro + Verification

### Environment

- OS: Linux (Docker, node:24-bookworm-slim)
- Runtime/container: Node 24, pnpm
- Model/provider: N/A (unit tests only)
- Integration/channel: N/A
- Relevant config: `tools.fs.workspaceOnly: true`

### Steps

1. Run `pnpm test src/agents/openclaw-tools.nodes-workspace-guard.test.ts`
2. Run `pnpm test src/agents/pi-tools.read.workspace-root-guard.test.ts`
3. Confirm all new cases pass; confirm existing cases are unaffected.

### Expected

- Guard fires and rejects `outPath` outside workspace when `workspaceOnly=true`
- Guard passes `outPath` inside workspace when `workspaceOnly=true`
- Guard is not applied when `workspaceOnly=false`

### Actual

- All three scenarios confirmed by new test cases.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test file `openclaw-tools.nodes-workspace-guard.test.ts` provides before/after coverage. Extended `pi-tools.read.workspace-root-guard.test.ts` confirms the `pathParamKeys` extension is backwards-compatible (default `["path"]` unchanged).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Guard correctly blocks out-of-workspace `outPath`; guard correctly passes in-workspace `outPath`; guard is skipped when `workspaceOnly=false`; existing callers of `wrapToolWorkspaceRootGuardWithOptions` without `pathParamKeys` continue to check only `path` (default unchanged).
- Edge cases checked: `sandboxRoot ?? workspaceDir` fallback when `sandboxRoot` is not set; `pathParamKeys` with empty array falls back to default `["path"]`.
- What you did **not** verify: Live gateway run with a real paired node and `screen_record` invocation.

> **AI-assisted:** This fix was generated by OpenAI Codex and reviewed by Claude. No human modifications to source files.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Operators who rely on nodes `screen_record` to write to paths outside the workspace (e.g. a system-wide capture directory) when `workspaceOnly` is enabled will now get an error.
  - Mitigation: This is the intended behaviour of `workspaceOnly`. Operators who need cross-boundary writes should disable `workspaceOnly` or set `sandboxRoot` to cover their target directory.