### PR TITLE
tools: clarify sessions_send tool description

### DIFF
--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -65,9 +65,14 @@ disk instead of treating `sessions_history` as a raw dump.
 `sessions_send` delivers a message to another session and optionally waits for
 the response:
 
+- Target the destination with **either** `sessionKey` **or** `label`, not both.
+- Use `sessionKey` when you already have an exact key from `sessions_list`.
+- Use `label` when you want OpenClaw to resolve a visible session by label.
 - **Fire-and-forget:** set `timeoutSeconds: 0` to enqueue and return
   immediately.
 - **Wait for reply:** set a timeout and get the response inline.
+
+If both `sessionKey` and `label` are provided, the tool returns an input error.
 
 After the target responds, OpenClaw can run a **reply-back loop** where the
 agents alternate messages (up to 5 turns). The target agent can reply

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -26,7 +26,8 @@ export function describeSessionsHistoryTool(): string {
 
 export function describeSessionsSendTool(): string {
   return [
-    "Send a message into another visible session by sessionKey or label.",
+    "Send a message into another visible session by sessionKey or label (provide only one target mode).",
+    "Prefer sessionKey when you already know the exact target; use label for visible-session lookup.",
     "Use this to delegate follow-up work to an existing session; waits for the target run and returns the updated assistant reply when available.",
   ].join(" ");
 }


### PR DESCRIPTION
## Summary

Clarify the high-level tool description for `sessions_send`.

This updates the tool description preset to make the targeting rules clearer by stating that callers should use only one target mode and prefer `sessionKey` when the exact target is already known.

## Why

PR #63334 was closed as superseded, and PR #63339 focuses on schema field descriptions. This change covers a separate layer: the concise model-facing tool description preset.

That makes the guidance clearer even before a caller inspects individual schema fields.

## Changes

- Updated `src/agents/tool-description-presets.ts`
- Clarified that `sessions_send` should use only one target mode
- Added guidance to prefer `sessionKey` when known
