### PR TITLE
fix(message): hydrate send action media for plugin channels

### DIFF
--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -652,6 +652,13 @@ export type ChannelMessageActionAdapter = {
     action: ChannelMessageActionName;
     toolContext?: ChannelThreadingToolContext;
   }) => boolean;
+  /**
+   * Set this only for `send` handlers that consume the shared hydrated
+   * attachment fields (`buffer`, `contentType`, `filename`) directly.
+   * Most handlers should leave media as URL/path hints and load it inside
+   * the channel runtime so core/gateway sends do not prefetch media bytes.
+   */
+  preloadSendMedia?: boolean;
   extractToolSend?: (params: { args: Record<string, unknown> }) => ChannelToolSend | null;
   /**
    * Prefer this for channel-specific poll semantics or extra poll parameters.

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import * as webMedia from "../../media/web-media.js";
 import {
   hydrateAttachmentParamsForAction,
   normalizeSandboxMediaList,
@@ -12,6 +13,10 @@ import {
 
 const cfg = {} as OpenClawConfig;
 const maybeIt = process.platform === "win32" ? it.skip : it;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("message action media helpers", () => {
   it("prefers sandbox media policy when sandbox roots are non-blank", () => {
@@ -152,6 +157,36 @@ describe("message action media helpers", () => {
     });
 
     expect(args.filename).toBe("attachment");
+  });
+
+  it("hydrates send actions when media is provided via the media field", async () => {
+    const loadSpy = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      buffer: Buffer.from("remote-image"),
+      contentType: "image/png",
+      kind: "image",
+      fileName: "photo.png",
+    });
+    const args: Record<string, unknown> = {
+      media: "https://example.com/photo.png",
+      message: "hello",
+    };
+
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "discord",
+      args,
+      action: "send",
+      mediaPolicy: { mode: "host" },
+    });
+
+    expect(loadSpy).toHaveBeenCalledWith(
+      "https://example.com/photo.png",
+      expect.objectContaining({}),
+    );
+    expect(args.buffer).toBe(Buffer.from("remote-image").toString("base64"));
+    expect(args.contentType).toBe("image/png");
+    expect(args.filename).toBe("photo.png");
+    expect(args.caption).toBe("hello");
   });
 });
 

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -159,7 +159,7 @@ describe("message action media helpers", () => {
     expect(args.filename).toBe("attachment");
   });
 
-  it("hydrates send actions when media is provided via the media field", async () => {
+  it("does not hydrate send actions unless the caller opts in", async () => {
     const loadSpy = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
       buffer: Buffer.from("remote-image"),
       contentType: "image/png",
@@ -177,6 +177,34 @@ describe("message action media helpers", () => {
       args,
       action: "send",
       mediaPolicy: { mode: "host" },
+    });
+
+    expect(loadSpy).not.toHaveBeenCalled();
+    expect(args).toEqual({
+      media: "https://example.com/photo.png",
+      message: "hello",
+    });
+  });
+
+  it("hydrates send actions when media is provided and hydration is requested", async () => {
+    const loadSpy = vi.spyOn(webMedia, "loadWebMedia").mockResolvedValue({
+      buffer: Buffer.from("remote-image"),
+      contentType: "image/png",
+      kind: "image",
+      fileName: "photo.png",
+    });
+    const args: Record<string, unknown> = {
+      media: "https://example.com/photo.png",
+      message: "hello",
+    };
+
+    await hydrateAttachmentParamsForAction({
+      cfg,
+      channel: "discord",
+      args,
+      action: "send",
+      mediaPolicy: { mode: "host" },
+      hydrateSendMedia: true,
     });
 
     expect(loadSpy).toHaveBeenCalledWith(

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -312,10 +312,14 @@ export async function hydrateAttachmentParamsForAction(params: {
   mediaPolicy: AttachmentMediaPolicy;
 }): Promise<void> {
   const shouldHydrateUploadFile = params.action === "upload-file";
+  const shouldHydrateSend =
+    params.action === "send" &&
+    Boolean(readAttachmentMediaHint(params.args) ?? readAttachmentFileHint(params.args));
   if (
     params.action !== "sendAttachment" &&
     params.action !== "setGroupIcon" &&
-    !shouldHydrateUploadFile
+    !shouldHydrateUploadFile &&
+    !shouldHydrateSend
   ) {
     return;
   }
@@ -326,7 +330,8 @@ export async function hydrateAttachmentParamsForAction(params: {
     args: params.args,
     dryRun: params.dryRun,
     mediaPolicy: params.mediaPolicy,
-    allowMessageCaptionFallback: params.action === "sendAttachment" || shouldHydrateUploadFile,
+    allowMessageCaptionFallback:
+      params.action === "sendAttachment" || shouldHydrateUploadFile || shouldHydrateSend,
   });
 }
 

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -310,9 +310,11 @@ export async function hydrateAttachmentParamsForAction(params: {
   action: ChannelMessageActionName;
   dryRun?: boolean;
   mediaPolicy: AttachmentMediaPolicy;
+  hydrateSendMedia?: boolean;
 }): Promise<void> {
   const shouldHydrateUploadFile = params.action === "upload-file";
   const shouldHydrateSend =
+    params.hydrateSendMedia === true &&
     params.action === "send" &&
     Boolean(readAttachmentMediaHint(params.args) ?? readAttachmentFileHint(params.args));
   if (

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -4,12 +4,30 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { runMessageAction } from "./message-action-runner.js";
 
+const loadWebMediaMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../media/web-media.js", async () => {
+  const actual = await vi.importActual<typeof import("../../media/web-media.js")>(
+    "../../media/web-media.js",
+  );
+  return {
+    ...actual,
+    loadWebMedia: (...args: unknown[]) => loadWebMediaMock(...args),
+  };
+});
+
 describe("runMessageAction core send routing", () => {
   afterEach(() => {
     setActivePluginRegistry(createTestRegistry([]));
+    loadWebMediaMock.mockReset();
   });
 
   it("promotes caption to message for media sends when message is empty", async () => {
+    loadWebMediaMock.mockResolvedValue({
+      buffer: Buffer.from("cat"),
+      contentType: "image/png",
+      fileName: "cat.png",
+    });
     const sendMedia = vi.fn().mockResolvedValue({
       channel: "testchat",
       messageId: "m1",
@@ -65,6 +83,11 @@ describe("runMessageAction core send routing", () => {
   });
 
   it("does not misclassify send as poll when zero-valued poll params are present", async () => {
+    loadWebMediaMock.mockResolvedValue({
+      buffer: Buffer.from("hello"),
+      contentType: "text/plain",
+      fileName: "file.txt",
+    });
     const sendMedia = vi.fn().mockResolvedValue({
       channel: "testchat",
       messageId: "m2",

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { jsonResult } from "../../agents/tools/common.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
@@ -23,11 +25,6 @@ describe("runMessageAction core send routing", () => {
   });
 
   it("promotes caption to message for media sends when message is empty", async () => {
-    loadWebMediaMock.mockResolvedValue({
-      buffer: Buffer.from("cat"),
-      contentType: "image/png",
-      fileName: "cat.png",
-    });
     const sendMedia = vi.fn().mockResolvedValue({
       channel: "testchat",
       messageId: "m1",
@@ -80,14 +77,10 @@ describe("runMessageAction core send routing", () => {
         mediaUrl: "https://example.com/cat.png",
       }),
     );
+    expect(loadWebMediaMock).not.toHaveBeenCalled();
   });
 
   it("does not misclassify send as poll when zero-valued poll params are present", async () => {
-    loadWebMediaMock.mockResolvedValue({
-      buffer: Buffer.from("hello"),
-      contentType: "text/plain",
-      fileName: "file.txt",
-    });
     const sendMedia = vi.fn().mockResolvedValue({
       channel: "testchat",
       messageId: "m2",
@@ -145,5 +138,140 @@ describe("runMessageAction core send routing", () => {
         mediaUrl: "https://example.com/file.txt",
       }),
     );
+    expect(loadWebMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("does not preload media for plugin send handlers unless they opt in", async () => {
+    const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>
+      jsonResult({
+        ok: true,
+        media: params.media,
+        buffer: params.buffer ?? null,
+      }),
+    );
+    const plugin: ChannelPlugin = {
+      id: "pluginchat",
+      meta: {
+        id: "pluginchat",
+        label: "Plugin Chat",
+        selectionLabel: "Plugin Chat",
+        docsPath: "/channels/pluginchat",
+        blurb: "Plugin chat test channel.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        handleAction,
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "pluginchat", source: "test", plugin }]),
+    );
+
+    const result = await runMessageAction({
+      cfg: {
+        channels: {
+          pluginchat: {
+            enabled: true,
+          },
+        },
+      } as OpenClawConfig,
+      action: "send",
+      params: {
+        channel: "pluginchat",
+        target: "channel:abc",
+        media: "https://example.com/cat.png",
+        message: "hello",
+      },
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(result.handledBy).toBe("plugin");
+    expect(result.payload).toMatchObject({
+      ok: true,
+      media: "https://example.com/cat.png",
+      buffer: null,
+    });
+    expect(loadWebMediaMock).not.toHaveBeenCalled();
+  });
+
+  it("preloads media for plugin send handlers that opt in", async () => {
+    loadWebMediaMock.mockResolvedValue({
+      buffer: Buffer.from("cat"),
+      contentType: "image/png",
+      kind: "image",
+      fileName: "cat.png",
+    });
+    const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>
+      jsonResult({
+        ok: true,
+        buffer: params.buffer,
+        filename: params.filename,
+        contentType: params.contentType,
+      }),
+    );
+    const plugin: ChannelPlugin = {
+      id: "bufferchat",
+      meta: {
+        id: "bufferchat",
+        label: "Buffer Chat",
+        selectionLabel: "Buffer Chat",
+        docsPath: "/channels/bufferchat",
+        blurb: "Buffer chat test channel.",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => ["default"],
+        resolveAccount: () => ({ enabled: true }),
+        isConfigured: () => true,
+      },
+      actions: {
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
+        preloadSendMedia: true,
+        handleAction,
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "bufferchat", source: "test", plugin }]),
+    );
+
+    const result = await runMessageAction({
+      cfg: {
+        channels: {
+          bufferchat: {
+            enabled: true,
+          },
+        },
+      } as OpenClawConfig,
+      action: "send",
+      params: {
+        channel: "bufferchat",
+        target: "channel:abc",
+        media: "https://example.com/cat.png",
+        message: "hello",
+      },
+      dryRun: false,
+    });
+
+    expect(loadWebMediaMock).toHaveBeenCalledWith(
+      "https://example.com/cat.png",
+      expect.objectContaining({}),
+    );
+    expect(result.kind).toBe("send");
+    expect(result.handledBy).toBe("plugin");
+    expect(result.payload).toMatchObject({
+      ok: true,
+      buffer: Buffer.from("cat").toString("base64"),
+      filename: "cat.png",
+      contentType: "image/png",
+    });
   });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -789,6 +789,7 @@ export async function runMessageAction(
     action,
     dryRun,
     mediaPolicy,
+    hydrateSendMedia: shouldPreloadSendMedia({ channel, action }),
   });
 
   const resolvedTarget = await resolveActionTarget({
@@ -855,4 +856,18 @@ export async function runMessageAction(
     agentId: resolvedAgentId,
     abortSignal: input.abortSignal,
   });
+}
+
+function shouldPreloadSendMedia(params: {
+  channel: ChannelId;
+  action: ChannelMessageActionName;
+}): boolean {
+  if (params.action !== "send") {
+    return false;
+  }
+  const actions = getChannelPlugin(params.channel)?.actions;
+  if (!actions?.handleAction || actions.preloadSendMedia !== true) {
+    return false;
+  }
+  return actions.supportsAction ? actions.supportsAction({ action: params.action }) : true;
 }


### PR DESCRIPTION
## Summary
Hydrate attachment payloads for plugin-handled `send` actions when callers provide `media`, `path`, `filePath`, `mediaUrl`, or `fileUrl`.

## Changes
- allow `hydrateAttachmentParamsForAction()` to hydrate `send` actions when attachment hints are present
- preserve existing caption fallback behavior for media sends
- add a regression test proving `send` now materializes `buffer`, `contentType`, and `filename`

## Test Plan
- `pnpm --dir /Users/wentao/Desktop/openclaw exec vitest run src/infra/outbound/message-action-params.test.ts`