### PR TITLE
feat(hooks): respect userTimezone in session-memory timestamps #63454

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Hooks/session-memory: format saved memory filenames and `# Session` headers using `agents.defaults.userTimezone` instead of always using UTC wall time. (#63454)
 - fix(browser): auto-generate browser control auth token for none/trusted-proxy modes [AI]. (#63280) Thanks @pgondhi987.
 - fix(exec): replace TOCTOU check-then-read with atomic pinned-fd open in script preflight [AI]. (#62333) Thanks @pgondhi987.
 - WhatsApp/auto-reply: keep inbound reply, media, and composing sends on the current socket across reconnects, wait through reconnect gaps, and retry timeout-only send failures without dropping the active socket ref. (#62892) Thanks @mcaxtr.

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -166,7 +166,7 @@ openclaw hooks enable <hook-name>
 
 ### session-memory details
 
-Extracts the last 15 user/assistant messages, generates a descriptive filename slug via LLM, and saves to `<workspace>/memory/YYYY-MM-DD-slug.md`. Requires `workspace.dir` to be configured.
+Extracts the last 15 user/assistant messages, generates a descriptive filename slug via LLM, and saves to `<workspace>/memory/YYYY-MM-DD-slug.md`. The dated prefix and `# Session` header use `agents.defaults.userTimezone` when set. Requires `workspace.dir` to be configured.
 
 ### bootstrap-extra-files config
 

--- a/extensions/memory-core/src/flush-plan.ts
+++ b/extensions/memory-core/src/flush-plan.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
+  formatDateStampInTimezone,
   parseNonNegativeByteSize,
   resolveCronStyleNow,
   SILENT_REPLY_TOKEN,
@@ -39,22 +40,6 @@ export const DEFAULT_MEMORY_FLUSH_SYSTEM_PROMPT = [
   MEMORY_FLUSH_APPEND_ONLY_HINT,
   `You may reply, but usually ${SILENT_REPLY_TOKEN} is correct.`,
 ].join(" ");
-
-function formatDateStampInTimezone(nowMs: number, timezone: string): string {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).formatToParts(new Date(nowMs));
-  const year = parts.find((part) => part.type === "year")?.value;
-  const month = parts.find((part) => part.type === "month")?.value;
-  const day = parts.find((part) => part.type === "day")?.value;
-  if (year && month && day) {
-    return `${year}-${month}-${day}`;
-  }
-  return new Date(nowMs).toISOString().slice(0, 10);
-}
 
 function normalizeNonNegativeInt(value: unknown): number | null {
   if (typeof value !== "number" || !Number.isFinite(value)) {

--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -191,3 +191,47 @@ export function formatUserTime(
     return undefined;
   }
 }
+
+/** Calendar date in `YYYY-MM-DD` for the instant in the given IANA time zone. */
+export function formatDateStampInTimezone(nowMs: number, timeZone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(new Date(nowMs));
+    const year = parts.find((part) => part.type === "year")?.value;
+    const month = parts.find((part) => part.type === "month")?.value;
+    const day = parts.find((part) => part.type === "day")?.value;
+    if (year && month && day) {
+      return `${year}-${month}-${day}`;
+    }
+  } catch {
+    // fall through
+  }
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+/** 24-hour wall time `HH:MM:SS` for the instant in the given IANA time zone. */
+export function formatWallClockHmsInTimezone(nowMs: number, timeZone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+      hourCycle: "h23",
+    }).formatToParts(new Date(nowMs));
+    const hour = parts.find((part) => part.type === "hour")?.value;
+    const minute = parts.find((part) => part.type === "minute")?.value;
+    const second = parts.find((part) => part.type === "second")?.value;
+    if (hour != null && minute != null && second != null) {
+      return `${hour}:${minute}:${second}`;
+    }
+  } catch {
+    // fall through
+  }
+  return new Date(nowMs).toISOString().split("T")[1]?.split(".")[0] ?? "00:00:00";
+}

--- a/src/hooks/bundled/session-memory/HOOK.md
+++ b/src/hooks/bundled/session-memory/HOOK.md
@@ -25,14 +25,14 @@ When you run `/new` or `/reset` to start a fresh session:
 1. **Finds the previous session** - Uses the pre-reset session entry to locate the correct transcript
 2. **Extracts conversation** - Reads the last N user/assistant messages from the session (default: 15, configurable)
 3. **Generates descriptive slug** - Uses LLM to create a meaningful filename slug based on conversation content
-4. **Saves to memory** - Creates a new file at `<workspace>/memory/YYYY-MM-DD-slug.md`
+4. **Saves to memory** - Creates a new file at `<workspace>/memory/YYYY-MM-DD-slug.md` (calendar day and header clock use `agents.defaults.userTimezone`, falling back to the host zone or `UTC`)
 
 ## Output Format
 
 Memory files are created with the following format:
 
 ```markdown
-# Session: 2026-01-16 14:30:00 UTC
+# Session: 2026-01-16 09:30:00 America/New_York
 
 - **Session Key**: agent:main:main
 - **Session ID**: abc123def456

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -71,6 +71,8 @@ async function runNewWithPreviousSessionEntry(params: {
   action?: "new" | "reset";
   sessionKey?: string;
   workspaceDirOverride?: string;
+  /** Pin wall time for deterministic filename/header assertions */
+  timestamp?: Date;
 }): Promise<{ files: string[]; memoryContent: string }> {
   const event = createHookEvent(
     "command",
@@ -86,6 +88,9 @@ async function runNewWithPreviousSessionEntry(params: {
       ...(params.workspaceDirOverride ? { workspaceDir: params.workspaceDirOverride } : {}),
     },
   );
+  if (params.timestamp) {
+    event.timestamp = params.timestamp;
+  }
 
   await handler(event);
 
@@ -100,6 +105,7 @@ async function runNewWithPreviousSession(params: {
   sessionContent: string;
   cfg?: (tempDir: string) => OpenClawConfig;
   action?: "new" | "reset";
+  timestamp?: Date;
 }): Promise<{ tempDir: string; files: string[]; memoryContent: string }> {
   const tempDir = await createCaseWorkspace("workspace");
   const sessionsDir = path.join(tempDir, "sessions");
@@ -125,6 +131,7 @@ async function runNewWithPreviousSession(params: {
       sessionId: "test-123",
       sessionFile,
     },
+    timestamp: params.timestamp,
   });
   return { tempDir, files, memoryContent };
 }
@@ -212,6 +219,24 @@ describe("session-memory hook", () => {
     // Memory directory should not be created for other commands
     const memoryDir = path.join(tempDir, "memory");
     await expect(fs.access(memoryDir)).rejects.toThrow();
+  });
+
+  it("uses agents.defaults.userTimezone for filename date and session header", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Jakarta time check" },
+      { role: "assistant", content: "Noted" },
+    ]);
+    const { files, memoryContent } = await runNewWithPreviousSession({
+      sessionContent,
+      cfg: (tempDir) =>
+        ({
+          agents: { defaults: { workspace: tempDir, userTimezone: "Asia/Jakarta" } },
+        }) satisfies OpenClawConfig,
+      timestamp: new Date("2026-04-09T00:44:38.000Z"),
+    });
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/^2026-04-09-.*\.md$/);
+    expect(memoryContent).toMatch(/^# Session: 2026-04-09 07:44:38 Asia\/Jakarta\n/m);
   });
 
   it("creates memory file with session content on /new command", async () => {

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -12,6 +12,11 @@ import {
   resolveAgentIdByWorkspacePath,
   resolveAgentWorkspaceDir,
 } from "../../../agents/agent-scope.js";
+import {
+  formatDateStampInTimezone,
+  formatWallClockHmsInTimezone,
+  resolveUserTimezone,
+} from "../../../agents/date-time.js";
 import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveStateDir } from "../../../config/paths.js";
 import { writeFileWithinRoot } from "../../../infra/fs-safe.js";
@@ -80,9 +85,9 @@ const saveSessionToMemory: HookHandler = async (event) => {
     const memoryDir = path.join(workspaceDir, "memory");
     await fs.mkdir(memoryDir, { recursive: true });
 
-    // Get today's date for filename
-    const now = new Date(event.timestamp);
-    const dateStr = now.toISOString().split("T")[0]; // YYYY-MM-DD
+    const nowMs = event.timestamp.getTime();
+    const userTimezone = resolveUserTimezone(cfg?.agents?.defaults?.userTimezone);
+    const dateStr = formatDateStampInTimezone(nowMs, userTimezone);
 
     // Generate descriptive slug from session using LLM
     // Prefer previousSessionEntry (old session before /new) over current (which may be empty)
@@ -158,9 +163,9 @@ const saveSessionToMemory: HookHandler = async (event) => {
       }
     }
 
-    // If no slug, use timestamp
+    // If no slug, use local wall-clock HHMM in userTimezone (matches filename date semantics)
     if (!slug) {
-      const timeSlug = now.toISOString().split("T")[1].split(".")[0].replace(/:/g, "");
+      const timeSlug = formatWallClockHmsInTimezone(nowMs, userTimezone).replace(/:/g, "");
       slug = timeSlug.slice(0, 4); // HHMM
       log.debug("Using fallback timestamp slug", { slug });
     }
@@ -173,8 +178,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
       path: memoryFilePath.replace(os.homedir(), "~"),
     });
 
-    // Format time as HH:MM:SS UTC
-    const timeStr = now.toISOString().split("T")[1].split(".")[0];
+    const timeStr = formatWallClockHmsInTimezone(nowMs, userTimezone);
 
     // Extract context details
     const sessionId = (sessionEntry.sessionId as string) || "unknown";
@@ -182,7 +186,7 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Build Markdown entry
     const entryParts = [
-      `# Session: ${dateStr} ${timeStr} UTC`,
+      `# Session: ${dateStr} ${timeStr} ${userTimezone}`,
       "",
       `- **Session Key**: ${displaySessionKey}`,
       `- **Session ID**: ${sessionId}`,

--- a/src/memory-host-sdk/runtime-core.ts
+++ b/src/memory-host-sdk/runtime-core.ts
@@ -2,6 +2,7 @@
 
 export type { AnyAgentTool } from "../agents/tools/common.js";
 export { resolveCronStyleNow } from "../agents/current-time.js";
+export { formatDateStampInTimezone } from "../agents/date-time.js";
 export { DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } from "../agents/pi-settings.js";
 export { resolveDefaultAgentId, resolveSessionAgentId } from "../agents/agent-scope.js";
 export { resolveMemorySearchConfig } from "../agents/memory-search.js";

--- a/src/plugin-sdk/memory-core.ts
+++ b/src/plugin-sdk/memory-core.ts
@@ -5,6 +5,7 @@ export { getMemorySearchManager, MemoryIndexManager } from "./memory-core-engine
 export {
   DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
   emptyPluginConfigSchema,
+  formatDateStampInTimezone,
   jsonResult,
   loadConfig,
   parseAgentSessionKey,


### PR DESCRIPTION
## Summary

- Problem: The bundled `session-memory` hook always derived the dated filename prefix and `# Session` header from UTC (`toISOString()`), so users with `agents.defaults.userTimezone` set still saw UTC in saved memory files—misaligned with the system prompt and Issue #63454.
- Why it matters: Operators in non-UTC zones could not line up memory filenames/headers with local conversation time.
- What changed: `session-memory` now uses `resolveUserTimezone` plus shared `formatDateStampInTimezone` / `formatWallClockHmsInTimezone` for the date prefix, header line, and fallback HHMM slug; header ends with the resolved IANA zone id. `formatDateStampInTimezone` is exported via the memory host runtime / `openclaw/plugin-sdk/memory-core` and reused by `extensions/memory-core/src/flush-plan.ts` to avoid duplicate date logic.
- What did NOT change (scope boundary): Pre-compaction memory flush behavior beyond sharing the same date-stamp helper; no new config keys; no gateway protocol or channel changes.

## Change Type (select all)

- [ ]  Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #63454

## User-visible / Behavior Changes

- `session-memory` hook: saved files under `memory/YYYY-MM-DD-<slug>.md` use the calendar day in `agents.defaults.userTimezone` (fallback: host zone or `UTC`). First line is `# Session: <date> <time> <IANA zone>` instead of `... UTC`.
- Plugin SDK: `formatDateStampInTimezone` is now part of the `openclaw/plugin-sdk/memory-core` export surface (additive).

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux (CI / local dev)
- Runtime/container: Node 22+ / Vitest
- Relevant config (redacted): `agents.defaults.userTimezone: "Asia/Jakarta"` (or any valid IANA zone)

### Steps

1. Enable `session-memory` and set `agents.defaults.userTimezone` to a non-UTC zone (e.g. `Asia/Jakarta`).
2. Trigger `/new` or `/reset` so the hook writes a memory file.
3. Open the new file under `memory/`.

### Expected

- Filename date and `# Session` header reflect local wall time in the configured timezone; header suffix matches the IANA zone name.

### Actual (before)

- UTC-based date/time and `UTC` suffix in the header.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

(Add in PR if useful: new Vitest case in `src/hooks/bundled/session-memory/handler.test.ts` pins `2026-04-09T00:44:38.000Z` with `Asia/Jakarta` and asserts `2026-04-09` + `07:44:38` + `Asia/Jakarta`.)

## Human Verification (required)

- Verified scenarios: `pnpm test src/hooks/bundled/session-memory/handler.test.ts`; `pnpm test extensions/memory-core/index.test.ts -t buildMemoryFlushPlan`; `pnpm check` via `scripts/committer` on commit.
- Edge cases checked: invalid/missing timezone falls back via existing `resolveUserTimezone` behavior.
- What I did **not** verify: Full `pnpm