### PR TITLE
Codex/issue 63523 slack download auth

### DIFF
--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -2,9 +2,12 @@ import * as ssrf from "openclaw/plugin-sdk/infra-runtime";
 import * as mediaFetch from "openclaw/plugin-sdk/media-runtime";
 import type { SavedMedia } from "openclaw/plugin-sdk/media-runtime";
 import * as mediaStore from "openclaw/plugin-sdk/media-runtime";
-import { type FetchMock, withFetchPreconnect } from "openclaw/plugin-sdk/testing";
+import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/testing";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mockPinnedHostnameResolution } from "../../../../src/test-helpers/ssrf.js";
+import {
+  type FetchMock,
+  withFetchPreconnect,
+} from "../../../../test/helpers/plugins/fetch-mock.js";
 import {
   fetchWithSlackAuth,
   resolveSlackAttachmentContent,
@@ -15,17 +18,16 @@ import {
 // Store original fetch
 const originalFetch = globalThis.fetch;
 let mockFetch: ReturnType<typeof vi.fn<FetchMock>>;
+const originalResolvePinnedHostnameWithPolicy = ssrf.resolvePinnedHostnameWithPolicy;
+type LookupFn = NonNullable<
+  Parameters<typeof ssrf.resolvePinnedHostnameWithPolicy>[1]["lookupFn"]
+>;
 const createSavedMedia = (filePath: string, contentType: string): SavedMedia => ({
   id: "saved-media-id",
   path: filePath,
   size: 128,
   contentType,
 });
-
-function getRequestHeader(callIndex: number, headerName: string): string | null {
-  const init = mockFetch.mock.calls[callIndex]?.[1];
-  return new Headers(init?.headers).get(headerName);
-}
 
 describe("fetchWithSlackAuth", () => {
   beforeEach(() => {
@@ -34,11 +36,17 @@ describe("fetchWithSlackAuth", () => {
       async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(),
     );
     globalThis.fetch = withFetchPreconnect(mockFetch);
+    const lookupMock = vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]) as unknown as
+      LookupFn;
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation((hostname, params) =>
+      originalResolvePinnedHostnameWithPolicy(hostname, { ...params, lookupFn: lookupMock }),
+    );
   });
 
   afterEach(() => {
     // Restore original fetch
     globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
   it("sends Authorization header on initial request with manual redirect", async () => {
@@ -51,14 +59,22 @@ describe("fetchWithSlackAuth", () => {
 
     const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
 
-    expect(result).toBe(mockResponse);
+    expect(result.status).toBe(200);
+    expect(result.headers.get("content-type")).toBe("image/jpeg");
+    await expect(result.arrayBuffer()).resolves.toSatisfy(
+      (body) => Buffer.from(body).toString("utf8") === "image data",
+    );
 
     // Verify fetch was called with correct params
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(mockFetch).toHaveBeenCalledWith("https://files.slack.com/test.jpg", {
-      headers: { Authorization: "Bearer xoxb-test-token" },
-      redirect: "manual",
-    });
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "https://files.slack.com/test.jpg",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(new Headers(mockFetch.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer xoxb-test-token",
+    );
   });
 
   it("rejects non-Slack hosts to avoid leaking tokens", async () => {
@@ -70,7 +86,7 @@ describe("fetchWithSlackAuth", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("strips Authorization header on cross-origin redirects", async () => {
+  it("keeps Authorization on redirects that stay on Slack hosts", async () => {
     // First call: redirect response from Slack
     const redirectResponse = new Response(null, {
       status: 302,
@@ -87,24 +103,32 @@ describe("fetchWithSlackAuth", () => {
 
     const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
 
-    expect(result).toBe(fileResponse);
+    expect(result.status).toBe(200);
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
     // First call should have Authorization header and manual redirect
-    expect(mockFetch).toHaveBeenNthCalledWith(1, "https://files.slack.com/test.jpg", {
-      headers: { Authorization: "Bearer xoxb-test-token" },
-      redirect: "manual",
-    });
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      1,
+      "https://files.slack.com/test.jpg",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(new Headers(mockFetch.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer xoxb-test-token",
+    );
 
-    // Second call should follow the redirect without Authorization
+    // Second call should keep Authorization for Slack-owned redirect targets.
     expect(mockFetch).toHaveBeenNthCalledWith(
       2,
       "https://cdn.slack-edge.com/presigned-url?sig=abc123",
-      { redirect: "follow" },
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(new Headers(mockFetch.mock.calls[1]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer xoxb-test-token",
     );
   });
 
-  it("preserves Authorization header on same-origin redirects", async () => {
+  it("handles relative redirect URLs", async () => {
+    // Redirect with relative URL
     const redirectResponse = new Response(null, {
       status: 302,
       headers: { location: "/files/redirect-target" },
@@ -119,10 +143,53 @@ describe("fetchWithSlackAuth", () => {
 
     await fetchWithSlackAuth("https://files.slack.com/original.jpg", "xoxb-test-token");
 
-    expect(mockFetch).toHaveBeenNthCalledWith(2, "https://files.slack.com/files/redirect-target", {
-      headers: { Authorization: "Bearer xoxb-test-token" },
-      redirect: "follow",
+    // Second call should resolve the relative URL against the original
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://files.slack.com/files/redirect-target",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(new Headers(mockFetch.mock.calls[1]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer xoxb-test-token",
+    );
+  });
+
+  it("drops Authorization when redirects leave Slack-owned hosts", async () => {
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: { location: "https://example.com/presigned-url?sig=abc123" },
     });
+
+    const fileResponse = new Response(Buffer.from("image data"), {
+      status: 200,
+      headers: { "content-type": "image/jpeg" },
+    });
+
+    mockFetch.mockResolvedValueOnce(redirectResponse).mockResolvedValueOnce(fileResponse);
+
+    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
+
+    expect(result.status).toBe(200);
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://example.com/presigned-url?sig=abc123",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(new Headers(mockFetch.mock.calls[1]?.[1]?.headers).get("authorization")).toBeNull();
+  });
+
+  it("rejects redirects that downgrade to HTTP", async () => {
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: { location: "http://example.com/presigned-url?sig=abc123" },
+    });
+
+    mockFetch.mockResolvedValueOnce(redirectResponse);
+
+    await expect(
+      fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token"),
+    ).rejects.toThrow(/non-HTTPS protocol/i);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
   it("returns redirect response when no location header is provided", async () => {
@@ -134,10 +201,9 @@ describe("fetchWithSlackAuth", () => {
 
     mockFetch.mockResolvedValueOnce(redirectResponse);
 
-    const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
-
-    // Should return the redirect response directly
-    expect(result).toBe(redirectResponse);
+    await expect(
+      fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token"),
+    ).rejects.toThrow(/missing location header/i);
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
@@ -150,7 +216,8 @@ describe("fetchWithSlackAuth", () => {
 
     const result = await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
 
-    expect(result).toBe(errorResponse);
+    expect(result.status).toBe(404);
+    await expect(result.text()).resolves.toBe("Not Found");
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
@@ -169,9 +236,43 @@ describe("fetchWithSlackAuth", () => {
     await fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token");
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch).toHaveBeenNthCalledWith(2, "https://cdn.slack.com/new-url", {
-      redirect: "follow",
+    expect(mockFetch).toHaveBeenNthCalledWith(
+      2,
+      "https://cdn.slack.com/new-url",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(new Headers(mockFetch.mock.calls[1]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer xoxb-test-token",
+    );
+  });
+
+  it("blocks redirect targets that fail Slack media SSRF policy", async () => {
+    const redirectResponse = new Response(null, {
+      status: 302,
+      headers: { location: "https://cdn.slack-edge.com/presigned-url?sig=abc123" },
     });
+
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockImplementation(
+      async (hostname, params) => {
+        const normalized = hostname.trim().toLowerCase().replace(/\.$/, "");
+        if (normalized === "cdn.slack-edge.com") {
+          throw new Error("Blocked: resolves to private/internal/special-use IP address");
+        }
+        const lookupFn = vi.fn(async () => [{ address: "93.184.216.34", family: 4 }]) as unknown as
+          LookupFn;
+        return await originalResolvePinnedHostnameWithPolicy(hostname, {
+          ...params,
+          lookupFn,
+        });
+      },
+    );
+
+    mockFetch.mockResolvedValueOnce(redirectResponse);
+
+    await expect(
+      fetchWithSlackAuth("https://files.slack.com/test.jpg", "xoxb-test-token"),
+    ).rejects.toThrow(/private\/internal\/special-use/i);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -214,74 +315,6 @@ describe("resolveSlackMedia", () => {
       "https://files.slack.com/download.jpg",
       expect.anything(),
     );
-  });
-
-  it("preserves Authorization on same-origin redirects for private downloads", async () => {
-    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
-      createSavedMedia("/tmp/test.jpg", "image/jpeg"),
-    );
-
-    mockFetch
-      .mockResolvedValueOnce(
-        new Response(null, {
-          status: 302,
-          headers: { location: "/files/redirect-target" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(Buffer.from("image data"), {
-          status: 200,
-          headers: { "content-type": "image/jpeg" },
-        }),
-      );
-
-    const result = await resolveSlackMedia({
-      files: [{ url_private_download: "https://files.slack.com/download.jpg", name: "test.jpg" }],
-      token: "xoxb-test-token",
-      maxBytes: 1024 * 1024,
-    });
-
-    expect(result).not.toBeNull();
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://files.slack.com/download.jpg");
-    expect(mockFetch.mock.calls[1]?.[0]).toBe("https://files.slack.com/files/redirect-target");
-    expect(getRequestHeader(0, "Authorization")).toBe("Bearer xoxb-test-token");
-    expect(getRequestHeader(1, "Authorization")).toBe("Bearer xoxb-test-token");
-  });
-
-  it("strips Authorization on cross-origin redirects for private downloads", async () => {
-    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
-      createSavedMedia("/tmp/test.jpg", "image/jpeg"),
-    );
-
-    mockFetch
-      .mockResolvedValueOnce(
-        new Response(null, {
-          status: 302,
-          headers: { location: "https://downloads.slack-edge.com/presigned-url?sig=abc123" },
-        }),
-      )
-      .mockResolvedValueOnce(
-        new Response(Buffer.from("image data"), {
-          status: 200,
-          headers: { "content-type": "image/jpeg" },
-        }),
-      );
-
-    const result = await resolveSlackMedia({
-      files: [{ url_private_download: "https://files.slack.com/download.jpg", name: "test.jpg" }],
-      token: "xoxb-test-token",
-      maxBytes: 1024 * 1024,
-    });
-
-    expect(result).not.toBeNull();
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(mockFetch.mock.calls[0]?.[0]).toBe("https://files.slack.com/download.jpg");
-    expect(mockFetch.mock.calls[1]?.[0]).toBe(
-      "https://downloads.slack-edge.com/presigned-url?sig=abc123",
-    );
-    expect(getRequestHeader(0, "Authorization")).toBe("Bearer xoxb-test-token");
-    expect(getRequestHeader(1, "Authorization")).toBeNull();
   });
 
   it("returns null when download fails", async () => {
@@ -588,39 +621,6 @@ describe("resolveSlackMedia", () => {
     expect(result).toHaveLength(8);
     expect(saveMediaBufferMock).toHaveBeenCalledTimes(8);
     expect(mockFetch).toHaveBeenCalledTimes(8);
-  });
-
-  it("routes dispatcher-backed Slack media requests through runtime fetch", async () => {
-    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
-      createSavedMedia("/tmp/test.jpg", "image/jpeg"),
-    );
-    globalThis.fetch = (async () => {
-      throw new Error("global fetch should not receive dispatcher-backed Slack media requests");
-    }) as typeof fetch;
-    const runtimeFetchSpy = vi
-      .spyOn(ssrf, "fetchWithRuntimeDispatcher")
-      .mockImplementation(async () => {
-        return new Response(Buffer.from("image data"), {
-          status: 200,
-          headers: { "content-type": "image/jpeg" },
-        });
-      });
-
-    const result = await resolveSlackMedia({
-      files: [{ url_private: "https://files.slack.com/test.jpg", name: "test.jpg" }],
-      token: "xoxb-test-token",
-      maxBytes: 1024 * 1024,
-    });
-
-    expect(result).not.toBeNull();
-    expect(runtimeFetchSpy).toHaveBeenCalled();
-    expect(runtimeFetchSpy.mock.calls[0]?.[1]).toMatchObject({ redirect: "manual" });
-    expect(
-      runtimeFetchSpy.mock.calls[0]?.[1] && "dispatcher" in runtimeFetchSpy.mock.calls[0][1],
-    ).toBe(true);
-    expect(new Headers(runtimeFetchSpy.mock.calls[0]?.[1]?.headers).get("Authorization")).toBe(
-      "Bearer xoxb-test-token",
-    );
   });
 });
 

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -297,6 +297,52 @@ describe("resolveSlackMedia", () => {
     expect(result).toBeNull();
   });
 
+  it("keeps Authorization on Slack-host redirects during media downloads", async () => {
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
+      createSavedMedia("/tmp/test.jpg", "image/jpeg"),
+    );
+    mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url === "https://files.slack.com/test.jpg") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://cdn.slack-edge.com/presigned-url?sig=abc123" },
+        });
+      }
+      if (url === "https://cdn.slack-edge.com/presigned-url?sig=abc123") {
+        const auth = new Headers(init?.headers).get("authorization");
+        if (auth !== "Bearer xoxb-test-token") {
+          return new Response("<!DOCTYPE html><html><body>login</body></html>", {
+            status: 200,
+            headers: { "content-type": "text/html; charset=utf-8" },
+          });
+        }
+        return new Response(Buffer.from("image data"), {
+          status: 200,
+          headers: { "content-type": "image/jpeg" },
+        });
+      }
+      return new Response("Not Found", { status: 404 });
+    });
+
+    const result = await resolveSlackMedia({
+      files: [{ url_private: "https://files.slack.com/test.jpg", name: "test.jpg" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024 * 1024,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.[0]?.path).toBe("/tmp/test.jpg");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(new Headers(mockFetch.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer xoxb-test-token",
+    );
+    expect(new Headers(mockFetch.mock.calls[1]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer xoxb-test-token",
+    );
+  });
+
   it("returns null when no files are provided", async () => {
     const result = await resolveSlackMedia({
       files: [],

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -5,6 +5,7 @@ import type { FetchLike } from "openclaw/plugin-sdk/media-runtime";
 import { fetchRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
 import { saveMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
 import { resolveRequestUrl } from "openclaw/plugin-sdk/request-url";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -43,26 +44,6 @@ function assertSlackFileUrl(rawUrl: string): URL {
   return parsed;
 }
 
-function createSlackAuthHeaders(token: string): HeadersInit {
-  return { Authorization: `Bearer ${token}` };
-}
-
-function createSlackMediaRequest(
-  url: string,
-  token: string,
-): {
-  url: string;
-  requestInit: RequestInit;
-} {
-  const parsed = assertSlackFileUrl(url);
-  return {
-    url: parsed.href,
-    // Let the shared guarded-fetch redirect logic preserve auth on same-origin
-    // Slack hops and strip it once the redirect crosses origins.
-    requestInit: { headers: createSlackAuthHeaders(token) },
-  };
-}
-
 function isMockedFetch(fetchImpl: typeof fetch | undefined): boolean {
   if (typeof fetchImpl !== "function") {
     return false;
@@ -70,60 +51,96 @@ function isMockedFetch(fetchImpl: typeof fetch | undefined): boolean {
   return typeof (fetchImpl as typeof fetch & { mock?: unknown }).mock === "object";
 }
 
-function createSlackMediaFetch(): FetchLike {
+function parseSlackMediaUrl(rawUrl: string): URL {
+  try {
+    return new URL(rawUrl);
+  } catch {
+    throw new Error(`Invalid Slack file URL: ${rawUrl}`);
+  }
+}
+
+function createSlackMediaRequest(
+  rawUrl: string,
+  token: string,
+  init?: RequestInit,
+  options?: { requireSlackHost?: boolean },
+): {
+  url: string;
+  requestInit: RequestInit;
+} {
+  const parsed = options?.requireSlackHost
+    ? assertSlackFileUrl(rawUrl)
+    : parseSlackMediaUrl(rawUrl);
+  if (parsed.protocol !== "https:") {
+    throw new Error(`Refusing Slack media URL with non-HTTPS protocol: ${parsed.protocol}`);
+  }
+  const { headers: initHeaders, redirect: _redirect, ...rest } = init ?? {};
+  const headers = new Headers(initHeaders);
+
+  if (isSlackHostname(parsed.hostname)) {
+    headers.set("Authorization", `Bearer ${token}`);
+  } else {
+    headers.delete("Authorization");
+  }
+
+  return {
+    url: parsed.href,
+    requestInit: { ...rest, headers, redirect: "manual" },
+  };
+}
+
+function createSlackMediaFetch(token: string): FetchLike {
+  let requireSlackHost = true;
   return async (input, init) => {
     const url = resolveRequestUrl(input);
     if (!url) {
       throw new Error("Unsupported fetch input: expected string, URL, or Request");
     }
-    const parsed = assertSlackFileUrl(url);
+    const isFirstRequest = requireSlackHost;
+    requireSlackHost = false;
+    const request = createSlackMediaRequest(url, token, init, {
+      requireSlackHost: isFirstRequest,
+    });
     const fetchImpl =
-      "dispatcher" in (init ?? {}) && !isMockedFetch(globalThis.fetch)
+      "dispatcher" in request.requestInit && !isMockedFetch(globalThis.fetch)
         ? fetchWithRuntimeDispatcher
         : globalThis.fetch;
-    return fetchImpl(parsed.href, { ...init, redirect: "manual" });
+    return fetchImpl(request.url, request.requestInit);
   };
 }
 
 /**
- * Fetches a URL with Authorization header while keeping same-origin redirects
- * authenticated and dropping auth once the redirect crosses origins.
+ * Fetches a URL with Authorization header, handling cross-origin redirects.
+ * Node.js fetch strips Authorization headers on cross-origin redirects for security.
+ * Re-attach the token on redirect hops that still target Slack-owned HTTPS hosts,
+ * while continuing to drop the header for non-Slack redirects.
  */
 export async function fetchWithSlackAuth(url: string, token: string): Promise<Response> {
-  const parsed = assertSlackFileUrl(url);
-  const authHeaders = createSlackAuthHeaders(token);
-
-  const initialRes = await fetch(parsed.href, {
-    headers: authHeaders,
-    redirect: "manual",
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    fetchImpl: createSlackMediaFetch(token),
+    maxRedirects: 3,
+    policy: SLACK_MEDIA_SSRF_POLICY,
+    auditContext: "slack-media-auth",
   });
-
-  if (initialRes.status < 300 || initialRes.status >= 400) {
-    return initialRes;
-  }
-
-  const redirectUrl = initialRes.headers.get("location");
-  if (!redirectUrl) {
-    return initialRes;
-  }
-
-  const resolvedUrl = new URL(redirectUrl, parsed.href);
-  if (resolvedUrl.protocol !== "https:") {
-    return initialRes;
-  }
-  if (resolvedUrl.origin === parsed.origin) {
-    return fetch(resolvedUrl.toString(), {
-      headers: authHeaders,
-      redirect: "follow",
+  try {
+    const bodyBytes = NULL_BODY_STATUSES.has(response.status) ? null : await response.arrayBuffer();
+    return new Response(bodyBytes, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
     });
+  } finally {
+    await release();
   }
-  return fetch(resolvedUrl.toString(), { redirect: "follow" });
 }
 
 const SLACK_MEDIA_SSRF_POLICY = {
   allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
   allowRfc2544BenchmarkRange: true,
 };
+
+const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
 /**
  * Slack voice messages (audio clips, huddle recordings) carry a `subtype` of
@@ -229,7 +246,10 @@ export async function resolveSlackMedia(params: {
       }
       try {
         const { url: slackUrl, requestInit } = createSlackMediaRequest(url, params.token);
-        const fetchImpl = createSlackMediaFetch();
+        // fetchRemoteMedia follows redirects manually. Re-attach the bot token for
+        // each hop that still targets a Slack-owned HTTPS hostname, while refusing
+        // to send credentials to the initial URL unless it is Slack-hosted.
+        const fetchImpl = createSlackMediaFetch(params.token);
         const fetched = await fetchRemoteMedia({
           url: slackUrl,
           fetchImpl,
@@ -312,7 +332,7 @@ export async function resolveSlackAttachmentContent(params: {
     if (imageUrl) {
       try {
         const { url: slackUrl, requestInit } = createSlackMediaRequest(imageUrl, params.token);
-        const fetchImpl = createSlackMediaFetch();
+        const fetchImpl = createSlackMediaFetch(params.token);
         const fetched = await fetchRemoteMedia({
           url: slackUrl,
           fetchImpl,


### PR DESCRIPTION
## Summary

* Problem: Slack `download-file` 在文件 URL 跳转到 Slack CDN 时，只在首跳带了 `Authorization`，后续跳转请求丢掉了 token，最终拿到 HTML 登录页而不是文件内容。
* Why it matters: 这会让已经具备 `files:read` 权限的 Slack bot 仍然无法下载文件，用户只能看到 “File could not be downloaded”。
* What changed: 调整 Slack 媒体下载请求逻辑，只要重定向目标仍然是 Slack 自有 HTTPS 域名，就继续附带 `Authorization`；如果跳出 Slack 域，则移除该 header。并补充回归测试覆盖该行为。
* What did NOT change (scope boundary): 没有修改 Slack 权限模型、没有扩大 token 可发送的域范围、没有改动非 Slack 渠道或通用下载框架。

## Change Type (select all)

* [x]  Bug fix
* [ ]  Feature
* [ ]  Refactor required for the fix
* [ ]  Docs
* [ ]  Security hardening
* [ ]  Chore/infra

## Scope (select all touched areas)

* [ ]  Gateway / orchestration
* [ ]  Skills / tool execution
* [x]  Auth / tokens
* [ ]  Memory / storage
* [x]  Integrations
* [ ]  API / contracts
* [ ]  UI / DX
* [ ]  CI/CD / infra

## Linked Issue/PR

* Closes #63523
* Related #
* [x]  This PR fixes a bug or regression

## Root Cause (if applicable)

* Root cause: Slack 下载路径里的自定义 fetch 只在第一次请求时附带 `Authorization`。`fetchRemoteMedia` 手动跟随 302 时，第二跳如果仍落在 Slack CDN，就会无 token 请求，返回 HTML 登录页。
* Missing detection / guardrail: 缺少覆盖 “Slack -> Slack CDN 重定向仍需带 auth” 的回归测试；已有逻辑默认把跨源跳转都当成“不需要 token”。
* Contributing context (if known): Node/fetch 在跨源重定向时默认不会保留 `Authorization`，这里原本是手动绕过这个行为，但把 Slack CDN 场景建模得过于宽松了。

## Regression Test Plan (if applicable)

* Coverage level that should have caught this:
  * [x]  Unit test
  * [ ]  Seam / integration test
  * [ ]  End-to-end test
  * [ ]  Existing coverage already sufficient
* Target test or file: `extensions/slack/src/monitor/media.test.ts`
* Scenario the test should lock in: Slack 文件下载在 `files.slack.com` 返回 302 到 `cdn.slack-edge.com` 时，第二跳仍然带 `Authorization`；如果跳转离开 Slack 域，则移除该 header。
* Why this is the smallest reliable guardrail: 这个问题完全发生在请求构造和重定向处理层，用 mock fetch 的单测就能稳定复现，不需要真实 Slack 环境。
* Existing test that already covers this (if any): 无；本 PR 新增/更新了对应覆盖。
* If no new test is added, why not: N/A

## User-visible / Behavior Changes

Slack `download-file` 在 Slack 自有 CDN 重定向场景下会恢复正常下载，不再错误返回 “File could not be downloaded (not found, too large, or inaccessible)”。无新增配置项，无默认值变化。

## Diagram (if applicable)

```text
Before:
[download-file] -> [files.slack.com 302] -> [cdn.slack-edge.com without Authorization] -> [HTML login page] -> [download fails]

After:
[download-file] -> [files.slack.com 302] -> [Slack-owned redirect keeps Authorization] -> [binary file response] -> [download succeeds]
