### PR TITLE
fix(cli): avoid false downgrade prompt for latest tag

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1358,6 +1358,28 @@ describe("update-cli", () => {
     ).toBe(shouldRunPackageUpdate);
   });
 
+  it("does not treat unresolved latest tag lookups as downgrade risk", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    setTty(false);
+    readPackageVersion.mockResolvedValue("2026.3.23");
+    mockPackageInstallStatus(tempDir);
+    vi.mocked(fetchNpmTagVersion).mockResolvedValue({
+      tag: "latest",
+      version: null,
+      error: "HTTP 404",
+    });
+
+    await updateCommand({ tag: "latest" });
+
+    expect(
+      vi
+        .mocked(defaultRuntime.error)
+        .mock.calls.some((call) => String(call[0]).includes("Downgrade confirmation required.")),
+    ).toBe(false);
+    expect(vi.mocked(defaultRuntime.exit).mock.calls.some((call) => call[0] === 1)).toBe(false);
+    expectPackageInstallSpec("openclaw@latest");
+  });
+
   it("updateWizardCommand offers dev checkout and forwards selections", async () => {
     const tempDir = createCaseDir("openclaw-update-wizard");
     await withEnvAsync({ OPENCLAW_GIT_DIR: tempDir }, async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1380,6 +1380,31 @@ describe("update-cli", () => {
     expectPackageInstallSpec("openclaw@latest");
   });
 
+  it("preserves downgrade confirmation for unresolved non-latest dist-tags", async () => {
+    const tempDir = createCaseDir("openclaw-update");
+    setTty(false);
+    readPackageVersion.mockResolvedValue("2026.3.23");
+    mockPackageInstallStatus(tempDir);
+    vi.mocked(fetchNpmTagVersion).mockResolvedValue({
+      tag: "next",
+      version: null,
+      error: "HTTP 404",
+    });
+
+    await updateCommand({ tag: "next" });
+
+    expect(
+      vi
+        .mocked(defaultRuntime.error)
+        .mock.calls.some((call) => String(call[0]).includes("Downgrade confirmation required.")),
+    ).toBe(true);
+    expect(vi.mocked(defaultRuntime.exit).mock.calls.some((call) => call[0] === 1)).toBe(true);
+    expect(runCommandWithTimeout).not.toHaveBeenCalledWith(
+      ["npm", "i", "-g", "openclaw@next", "--no-fund", "--no-audit", "--loglevel=error"],
+      expect.any(Object),
+    );
+  });
+
   it("updateWizardCommand offers dev checkout and forwards selections", async () => {
     const tempDir = createCaseDir("openclaw-update-wizard");
     await withEnvAsync({ OPENCLAW_GIT_DIR: tempDir }, async () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -829,7 +829,8 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       canResolveRegistryVersionForPackageTarget(tag) &&
       !fallbackToLatest &&
       currentVersion != null &&
-      (targetVersion == null || (cmp != null && cmp > 0));
+      cmp != null &&
+      cmp > 0;
     packageInstallSpec = resolveGlobalInstallSpec({
       packageName: DEFAULT_PACKAGE_NAME,
       tag,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -40,6 +40,7 @@ import { runGatewayUpdate, type UpdateRunResult } from "../../infra/update-runne
 import { syncPluginsForUpdateChannel, updateNpmInstalledPlugins } from "../../plugins/update.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
+import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { stylePromptMessage } from "../../terminal/prompt-style.js";
 import { theme } from "../../terminal/theme.js";
 import { pathExists } from "../../utils.js";
@@ -813,6 +814,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   let packageInstallSpec: string | null = null;
 
   if (updateInstallKind !== "git") {
+    const normalizedTag = normalizeLowercaseStringOrEmpty(tag);
     currentVersion = switchToPackage ? null : await readPackageVersion(root);
     if (explicitTag) {
       targetVersion = await resolveTargetVersion(tag, timeoutMs);
@@ -829,8 +831,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       canResolveRegistryVersionForPackageTarget(tag) &&
       !fallbackToLatest &&
       currentVersion != null &&
-      cmp != null &&
-      cmp > 0;
+      ((targetVersion == null && normalizedTag !== "latest") || (cmp != null && cmp > 0));
     packageInstallSpec = resolveGlobalInstallSpec({
       packageName: DEFAULT_PACKAGE_NAME,
       tag,


### PR DESCRIPTION
## Summary

- Problem: `openclaw update` could treat `latest` as a downgrade target when the current installed version was a date-style release and the tag lookup did not resolve to a concrete version.
- Why it matters: this blocks or misleads users on older installs when they try to update to the latest published package.
- What changed: the downgrade confirmation path now only triggers when there is an actual comparable target version and it is older than the installed version; added a regression test for `--tag latest` with an unresolved lookup.
- What did NOT change (scope boundary): no change to real downgrade handling when both current and target versions are known and comparable.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the package update path treated `targetVersion == null` as downgrade risk for registry-backed targets, so unresolved dist-tags like `latest` were flagged as downgrades.
- Missing detection / guardrail: no regression test covered `--tag latest` when the registry lookup fails to return a concrete version.
- Contributing context (if known): date-style release versions make the prompt especially confusing because the user expects `latest` to move forward, not backward.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/update-cli.test.ts`
- Scenario the test should lock in: `openclaw update --tag latest` should proceed without downgrade confirmation when the `latest` lookup does not resolve to a concrete version.
- Why this is the smallest reliable guardrail: the bug is in update-cli downgrade gating logic and is already covered with mocks in the unit test harness.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Users updating with `--tag latest` no longer get a false downgrade confirmation when the tag lookup is unresolved.

## Diagram (if applicable)

```text
Before:
[user runs openclaw update --tag latest] -> [latest lookup unresolved] -> [false downgrade prompt]

After:
[user runs openclaw update --tag latest] -> [latest lookup unresolved] -> [normal update flow]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v25.8.0 local dev shell
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Start from a package install on an older date-style version.
2. Run `openclaw update --tag latest` with a `latest` lookup that does not resolve to a concrete version.
3. Observe whether the CLI asks for downgrade confirmation.

### Expected

- No downgrade confirmation is shown unless the target version is known and actually older.

### Actual

- Before the fix, unresolved `latest` could be treated as a downgrade target.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran the focused regression test covering downgrade gating and unresolved latest-tag lookup.
- Edge cases checked: existing non-interactive downgrade tests still pass in the focused run; real downgrade prompting remains gated on comparable versions only.
- What you did **not** verify: full `pnpm test` wrapper path in this environment, because this shell does not have a standalone `pnpm` binary on `PATH`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a truly older resolved version might skip the warning if comparison inputs are not semver-comparable.
  - Mitigation: this PR preserves the existing behavior for comparable versions and narrows the change to unresolved-target cases only.
