### PR TITLE
fix(workspace): surface cross-OS migration hint on ENOENT mkdir failure

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
+  buildCrossOsWorkspaceMigrationHint,
   DEFAULT_AGENTS_FILENAME,
   DEFAULT_BOOTSTRAP_FILENAME,
   DEFAULT_IDENTITY_FILENAME,
@@ -26,6 +27,63 @@ describe("resolveDefaultAgentWorkspaceDir", () => {
     } as NodeJS.ProcessEnv);
 
     expect(dir).toBe(path.join(path.resolve("/srv/openclaw-home"), ".openclaw", "workspace"));
+  });
+});
+
+describe("buildCrossOsWorkspaceMigrationHint (#63572)", () => {
+  it("flags a Linux home prefix on a macOS host", () => {
+    const hint = buildCrossOsWorkspaceMigrationHint(
+      "/home/alice/.openclaw/workspace",
+      "/Users/alice",
+    );
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("/home/alice");
+    expect(hint).toContain("macOS");
+    expect(hint).toContain("agents.defaults.workspace");
+  });
+
+  it("flags a macOS home prefix on a Linux host", () => {
+    const hint = buildCrossOsWorkspaceMigrationHint(
+      "/Users/bob/.openclaw/workspace",
+      "/home/bob",
+    );
+    expect(hint).not.toBeNull();
+    expect(hint).toContain("/Users/bob");
+    expect(hint).toContain("Linux");
+    expect(hint).toContain("agents.defaults.workspace");
+  });
+
+  it("returns null when the workspace is already under the current home", () => {
+    expect(
+      buildCrossOsWorkspaceMigrationHint("/Users/alice/.openclaw/workspace", "/Users/alice"),
+    ).toBeNull();
+    expect(
+      buildCrossOsWorkspaceMigrationHint("/home/alice/.openclaw/workspace", "/home/alice"),
+    ).toBeNull();
+  });
+
+  it("returns null for paths that do not match a cross-OS home prefix", () => {
+    // Bespoke workspace location outside any home tree is not a cross-OS
+    // migration issue — the mkdir failure is probably a permissions bug.
+    expect(
+      buildCrossOsWorkspaceMigrationHint("/srv/shared/openclaw/workspace", "/Users/alice"),
+    ).toBeNull();
+    expect(
+      buildCrossOsWorkspaceMigrationHint("/opt/openclaw/workspace", "/home/alice"),
+    ).toBeNull();
+  });
+
+  it("returns null when either input is empty", () => {
+    expect(buildCrossOsWorkspaceMigrationHint("", "/Users/alice")).toBeNull();
+    expect(buildCrossOsWorkspaceMigrationHint("/home/alice/ws", "")).toBeNull();
+  });
+
+  it("does not false-positive on /home paths on a Linux host", () => {
+    // Same-OS but a different user — this could be an intentional shared
+    // workspace, not a migration artifact. Skip the hint so we don't mislead.
+    expect(
+      buildCrossOsWorkspaceMigrationHint("/home/shared/workspace", "/home/alice"),
+    ).toBeNull();
   });
 });
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -322,6 +322,53 @@ async function ensureGitRepo(dir: string, isBrandNewWorkspace: boolean) {
   }
 }
 
+/**
+ * Detect absolute workspace paths that appear to have been authored on a
+ * different operating system (e.g. `/home/alice/...` on macOS, or
+ * `/Users/alice/...` on Linux) and return a helpful migration hint.
+ *
+ * Returns `null` when the path is same-OS, already rooted under the current
+ * user's home, or not recognisable as a cross-OS home prefix.
+ *
+ * Exported so #63572 regression tests can exercise the detection logic
+ * without touching the real filesystem.
+ */
+export function buildCrossOsWorkspaceMigrationHint(
+  dir: string,
+  currentHome: string,
+): string | null {
+  if (!dir || !currentHome) {
+    return null;
+  }
+  const normalizedDir = path.normalize(dir);
+  const normalizedHome = path.normalize(currentHome);
+  // Paths already anchored at the current home are not cross-OS stale.
+  if (normalizedDir === normalizedHome || normalizedDir.startsWith(`${normalizedHome}${path.sep}`)) {
+    return null;
+  }
+  // Linux/WSL home prefix used on macOS → `/home/<user>/…`.
+  const linuxMatch = /^\/home\/([^/]+)(?:\/|$)/.exec(normalizedDir);
+  if (linuxMatch && normalizedHome.startsWith("/Users/")) {
+    return (
+      `workspace path ${normalizedDir} references a Linux-style home prefix (/home/${linuxMatch[1]}), ` +
+      `but this host is macOS with home ${normalizedHome}. ` +
+      `Update agents.defaults.workspace (and any per-agent workspace fields) in openclaw.json ` +
+      `to use the current host's home, or re-run openclaw setup to reset it.`
+    );
+  }
+  // macOS home prefix used on Linux → `/Users/<user>/…`.
+  const macMatch = /^\/Users\/([^/]+)(?:\/|$)/.exec(normalizedDir);
+  if (macMatch && normalizedHome.startsWith("/home/")) {
+    return (
+      `workspace path ${normalizedDir} references a macOS-style home prefix (/Users/${macMatch[1]}), ` +
+      `but this host is Linux with home ${normalizedHome}. ` +
+      `Update agents.defaults.workspace (and any per-agent workspace fields) in openclaw.json ` +
+      `to use the current host's home, or re-run openclaw setup to reset it.`
+    );
+  }
+  return null;
+}
+
 export async function ensureAgentWorkspace(params?: {
   dir?: string;
   ensureBootstrapFiles?: boolean;
@@ -337,7 +384,23 @@ export async function ensureAgentWorkspace(params?: {
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
   const dir = resolveUserPath(rawDir);
-  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fs.mkdir(dir, { recursive: true });
+  } catch (err) {
+    // Cross-OS migration (e.g. Linux/WSL state directory copied to macOS)
+    // leaves hardcoded absolute workspace paths like `/home/alice/.openclaw`
+    // in openclaw.json. On the new host, `fs.mkdir(/home/alice/...)` fails
+    // because `/home` is not writable. Surface a targeted hint so the user
+    // knows exactly which config key to update instead of chasing a raw
+    // ENOENT stack trace through the gateway logs.
+    if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") {
+      const hint = buildCrossOsWorkspaceMigrationHint(dir, os.homedir());
+      if (hint) {
+        throw new Error(hint, { cause: err });
+      }
+    }
+    throw err;
+  }
 
   if (!params?.ensureBootstrapFiles) {
     return { dir };


### PR DESCRIPTION
## Summary

When users migrate an OpenClaw state directory between Linux/WSL and macOS (or vice versa), `openclaw.json` still references absolute workspace paths from the original host — commonly `/home/<user>/.openclaw/workspace` on a host where home is actually `/Users/<user>`.

`ensureAgentWorkspace()` calls `fs.mkdir(dir, { recursive: true })` on the stale path and fails with a raw `ENOENT: no such file or directory, mkdir '/home/<user>'` in the gateway error log, because `/home` is not a writable location for non-root users on macOS. **Agents silently fail on every inbound message** with no visible hint that the root cause is a stale absolute path in config.

Fixes #63572

## Reporter's stack trace (from #63572)

```
error gateway/channels/telegram telegram bot error:
  Error: ENOENT: no such file or directory, mkdir '/home/<username>'
    at Object.mkdir (node:internal/fs/promises:852:10)
    at ensureAgentWorkspace (workspace-Q6iYWMyk.js:256:2)
    at getReplyFromConfig (reply-DW8PLbAC.js:3079:130)
    at dispatchReplyFromConfig (dispatch-BvwlsDx2.js:590:23)
    ...
```

The `dist/workspace-Q6iYWMyk.js:256` line corresponds to `src/agents/workspace.ts:340` — the `fs.mkdir(dir, { recursive: true })` call inside `ensureAgentWorkspace`.

## Fix

Catch `ENOENT` from the initial `mkdir` and, if the path pattern looks like a cross-OS home-prefix mismatch (`/home/<user>` on a host with `/Users/...` home, or vice versa), throw a new `Error` that explicitly names:

1. The failing path
2. The current host's home
3. The exact config key (`agents.defaults.workspace`) the user must update
4. The alternative (`openclaw setup` to reset)

The original error is preserved as `cause` for debugging. Non-cross-OS ENOENTs still surface the original error unchanged, so unrelated permission/filesystem failures are not masked.

The detection logic is extracted into an exported pure function `buildCrossOsWorkspaceMigrationHint(dir, home)` so the behaviour can be unit-tested without touching the real filesystem.

## Why error-message, not auto-rewrite

An earlier option considered was to silently rewrite the stale path to the current user's home. Rejected because:

- Could corrupt intentional cross-user or shared workspace setups
- Silent mutation of config files is a trust violation
- A clear, actionable error lets the user decide: update the path, reset via `openclaw setup`, or symlink the directory

## Tests

Added `describe(\"buildCrossOsWorkspaceMigrationHint (#63572)\")` block with 6 cases in `src/agents/workspace.test.ts`:

1. **Linux home prefix on macOS host** → hint emitted, mentions `/home/alice`, \"macOS\", and `agents.defaults.workspace`
2. **macOS home prefix on Linux host** → hint emitted, mentions `/Users/bob`, \"Linux\", and `agents.defaults.workspace`
3. **Workspace already under current home** → `null` (no false-positive on happy path)
4. **Bespoke workspace outside any home tree** (e.g. `/srv/shared/...`, `/opt/...`) → `null` (not a migration issue)
5. **Empty inputs** → `null` (defensive)
6. **Same-OS different-user shared workspace** → `null` (could be intentional, avoid misleading hint)

## Scope

- 2 files touched, +122 / -1
- One new exported helper (`buildCrossOsWorkspaceMigrationHint`) for testability
- One new try/catch around the existing `fs.mkdir` call
- Zero changes to the happy path (workspace creation succeeds unchanged)
- Zero changes to the `ensureBootstrapFiles` logic downstream of `mkdir`

Credit to @davidperjac for the detailed repro and full stack trace in the issue.