### PR TITLE
fix(memory-lancedb): accept dreaming config for slot-aware dreaming

### DIFF
--- a/extensions/memory-lancedb/config.ts
+++ b/extensions/memory-lancedb/config.ts
@@ -14,6 +14,14 @@ export type MemoryConfig = {
   autoCapture?: boolean;
   autoRecall?: boolean;
   captureMaxChars?: number;
+  /**
+   * Dreaming config is passed through opaquely to the shared dreaming resolver
+   * (`resolveMemoryDreamingConfig`), which reads it from whichever plugin owns
+   * `plugins.slots.memory`. Keeping it as `unknown` here avoids duplicating the
+   * full `MemoryDreamingConfig` type and ensures forward-compatibility as the
+   * dreaming schema evolves in `src/memory-host-sdk/dreaming.ts`.
+   */
+  dreaming?: unknown;
 };
 
 export const MEMORY_CATEGORIES = ["preference", "fact", "decision", "entity", "other"] as const;
@@ -97,7 +105,7 @@ export const memoryConfigSchema = {
     const cfg = value as Record<string, unknown>;
     assertAllowedKeys(
       cfg,
-      ["embedding", "dbPath", "autoCapture", "autoRecall", "captureMaxChars"],
+      ["embedding", "dbPath", "autoCapture", "autoRecall", "captureMaxChars", "dreaming"],
       "memory config",
     );
 
@@ -131,6 +139,7 @@ export const memoryConfigSchema = {
       autoCapture: cfg.autoCapture === true,
       autoRecall: cfg.autoRecall !== false,
       captureMaxChars: captureMaxChars ?? DEFAULT_CAPTURE_MAX_CHARS,
+      dreaming: cfg.dreaming,
     };
   },
   uiHints: {
@@ -175,6 +184,11 @@ export const memoryConfigSchema = {
       help: "Maximum message length eligible for auto-capture",
       advanced: true,
       placeholder: String(DEFAULT_CAPTURE_MAX_CHARS),
+    },
+    dreaming: {
+      label: "Dreaming",
+      help: "Memory dreaming config (consolidation, phases). See memory-core dreaming docs.",
+      advanced: true,
     },
   },
 };

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -187,6 +187,18 @@ describe("memory plugin e2e", () => {
     expect(config?.autoRecall).toBe(true);
   });
 
+  test("config schema accepts dreaming config for slot-aware dreaming", async () => {
+    const dreaming = { enabled: true, frequency: "0 3 * * *" };
+    const config = parseConfig({ dreaming });
+    expect(config?.dreaming).toEqual(dreaming);
+  });
+
+  test("config schema rejects unknown top-level keys", async () => {
+    expect(() => {
+      parseConfig({ unknownKey: true });
+    }).toThrow("memory config has unknown keys: unknownKey");
+  });
+
   test("passes configured dimensions to OpenAI embeddings API", async () => {
     const embeddingsCreate = vi.fn(async () => ({
       data: [{ embedding: [0.1, 0.2, 0.3] }],

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -31,6 +31,7 @@ type MemoryPluginTestConfig = {
   captureMaxChars?: number;
   autoCapture?: boolean;
   autoRecall?: boolean;
+  dreaming?: unknown;
 };
 
 const TEST_RUNTIME_MANIFEST = {

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -81,6 +81,10 @@
         "type": "number",
         "minimum": 100,
         "maximum": 10000
+      },
+      "dreaming": {
+        "type": "object",
+        "description": "Memory dreaming config passed through to the shared dreaming resolver. See memory-core dreaming docs for the full schema."
       }
     },
     "required": ["embedding"]


### PR DESCRIPTION
## Summary

Fixes #63590.

When `plugins.slots.memory = "memory-lancedb"`, the shared dreaming resolver (`resolveMemoryDreamingPluginConfig` in `src/memory-host-sdk/dreaming.ts`) already correctly reads dreaming config from `plugins.entries.memory-lancedb.config.dreaming` — the slot-aware plumbing was already in place. However, `memoryConfigSchema` in the lancedb extension rejected the `dreaming` key as an unknown property, producing a hard validation failure that prevented the gateway from starting:

```
Config invalid at ~/.openclaw/openclaw.json:
  × plugins.entries.memory-lancedb.config: invalid config: must NOT have additional properties
```

This meant users who set `plugins.slots.memory = "memory-lancedb"` (the recommended memory backend) could not configure dreaming at all, even though the runtime was ready to consume it.

## Changes

- `extensions/memory-lancedb/config.ts` — add `dreaming?: unknown` to `MemoryConfig` and `"dreaming"` to the `assertAllowedKeys` allowlist; pass `cfg.dreaming` through in the parsed output
- `extensions/memory-lancedb/index.test.ts` — add test that `dreaming` is accepted and passed through; add test that other unknown keys are still rejected

`dreaming` is typed as `unknown` (rather than importing the full `MemoryDreamingConfig` shape) to avoid cross-package coupling and stay forward-compatible as the dreaming schema evolves.

## Test plan

- [ ] `pnpm vitest run --project extension-memory` passes
- [ ] Config with `plugins.entries.memory-lancedb.config.dreaming.enabled = true` passes `openclaw config validate`
- [ ] Gateway starts without errors
- [ ] Dreaming respects the config (enabled/disabled, frequency) when lancedb owns the memory slot