### PR TITLE
fix(fireworks): disable FirePass Kimi reasoning leak

### DIFF
--- a/extensions/fireworks/index.test.ts
+++ b/extensions/fireworks/index.test.ts
@@ -74,7 +74,7 @@ describe("fireworks provider plugin", () => {
     expect(catalog.provider.baseUrl).toBe(FIREWORKS_BASE_URL);
     expect(catalog.provider.models?.map((model) => model.id)).toEqual([FIREWORKS_DEFAULT_MODEL_ID]);
     expect(catalog.provider.models?.[0]).toMatchObject({
-      reasoning: true,
+      reasoning: false,
       input: ["text", "image"],
       contextWindow: FIREWORKS_DEFAULT_CONTEXT_WINDOW,
       maxTokens: FIREWORKS_DEFAULT_MAX_TOKENS,
@@ -110,6 +110,36 @@ describe("fireworks provider plugin", () => {
       api: "openai-completions",
       baseUrl: FIREWORKS_BASE_URL,
       reasoning: true,
+    });
+  });
+
+  it("disables reasoning metadata for Fireworks Kimi dynamic models", async () => {
+    const provider = await registerSingleProviderPlugin(fireworksPlugin);
+    const resolved = provider.resolveDynamicModel?.(
+      createDynamicContext({
+        provider: "fireworks",
+        modelId: "accounts/fireworks/models/kimi-k2p5",
+        models: [
+          {
+            id: FIREWORKS_DEFAULT_MODEL_ID,
+            name: FIREWORKS_DEFAULT_MODEL_ID,
+            provider: "fireworks",
+            api: "openai-completions",
+            baseUrl: FIREWORKS_BASE_URL,
+            reasoning: false,
+            input: ["text", "image"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: FIREWORKS_DEFAULT_CONTEXT_WINDOW,
+            maxTokens: FIREWORKS_DEFAULT_MAX_TOKENS,
+          },
+        ],
+      }),
+    );
+
+    expect(resolved).toMatchObject({
+      provider: "fireworks",
+      id: "accounts/fireworks/models/kimi-k2p5",
+      reasoning: false,
     });
   });
 });

--- a/extensions/fireworks/index.test.ts
+++ b/extensions/fireworks/index.test.ts
@@ -142,4 +142,34 @@ describe("fireworks provider plugin", () => {
       reasoning: false,
     });
   });
+
+  it("disables reasoning metadata for Fireworks Kimi k2.5 aliases", async () => {
+    const provider = await registerSingleProviderPlugin(fireworksPlugin);
+    const resolved = provider.resolveDynamicModel?.(
+      createDynamicContext({
+        provider: "fireworks",
+        modelId: "accounts/fireworks/routers/kimi-k2.5-turbo",
+        models: [
+          {
+            id: FIREWORKS_DEFAULT_MODEL_ID,
+            name: FIREWORKS_DEFAULT_MODEL_ID,
+            provider: "fireworks",
+            api: "openai-completions",
+            baseUrl: FIREWORKS_BASE_URL,
+            reasoning: false,
+            input: ["text", "image"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: FIREWORKS_DEFAULT_CONTEXT_WINDOW,
+            maxTokens: FIREWORKS_DEFAULT_MAX_TOKENS,
+          },
+        ],
+      }),
+    );
+
+    expect(resolved).toMatchObject({
+      provider: "fireworks",
+      id: "accounts/fireworks/routers/kimi-k2.5-turbo",
+      reasoning: false,
+    });
+  });
 });

--- a/extensions/fireworks/index.ts
+++ b/extensions/fireworks/index.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_CONTEXT_TOKENS,
   normalizeModelCompat,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import { isFireworksKimiModelId } from "./model-id.js";
 import { applyFireworksConfig, FIREWORKS_DEFAULT_MODEL_REF } from "./onboard.js";
 import {
   buildFireworksProvider,
@@ -14,6 +15,7 @@ import {
   FIREWORKS_DEFAULT_MAX_TOKENS,
   FIREWORKS_DEFAULT_MODEL_ID,
 } from "./provider-catalog.js";
+import { wrapFireworksProviderStream } from "./stream.js";
 
 const PROVIDER_ID = "fireworks";
 const OPENAI_COMPATIBLE_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
@@ -34,6 +36,7 @@ function resolveFireworksDynamicModel(ctx: ProviderResolveDynamicModelContext) {
       ctx,
       patch: {
         provider: PROVIDER_ID,
+        reasoning: !isFireworksKimiModelId(modelId),
       },
     }) ??
     normalizeModelCompat({
@@ -42,7 +45,7 @@ function resolveFireworksDynamicModel(ctx: ProviderResolveDynamicModelContext) {
       provider: PROVIDER_ID,
       api: "openai-completions",
       baseUrl: FIREWORKS_BASE_URL,
-      reasoning: true,
+      reasoning: !isFireworksKimiModelId(modelId),
       input: ["text", "image"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: FIREWORKS_DEFAULT_CONTEXT_WINDOW,
@@ -77,6 +80,7 @@ export default defineSingleProviderPluginEntry({
       allowExplicitBaseUrl: true,
     },
     ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
+    wrapStreamFn: wrapFireworksProviderStream,
     resolveDynamicModel: (ctx) => resolveFireworksDynamicModel(ctx),
     isModernModelRef: () => true,
   },

--- a/extensions/fireworks/model-id.ts
+++ b/extensions/fireworks/model-id.ts
@@ -1,0 +1,3 @@
+export function isFireworksKimiModelId(modelId: string): boolean {
+  return modelId.trim().toLowerCase().includes("kimi-k2p5");
+}

--- a/extensions/fireworks/model-id.ts
+++ b/extensions/fireworks/model-id.ts
@@ -1,3 +1,5 @@
 export function isFireworksKimiModelId(modelId: string): boolean {
-  return modelId.trim().toLowerCase().includes("kimi-k2p5");
+  const normalized = modelId.trim().toLowerCase();
+  const lastSegment = normalized.split("/").pop() ?? normalized;
+  return /^kimi-k2(?:p5|\.5)(?:[-_].+)?$/.test(lastSegment);
 }

--- a/extensions/fireworks/provider-catalog.ts
+++ b/extensions/fireworks/provider-catalog.ts
@@ -2,7 +2,6 @@ import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
-import { isFireworksKimiModelId } from "./model-id.js";
 
 export const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 export const FIREWORKS_DEFAULT_MODEL_ID = "accounts/fireworks/routers/kimi-k2p5-turbo";
@@ -21,7 +20,7 @@ export function buildFireworksCatalogModels(): ModelDefinitionConfig[] {
     {
       id: FIREWORKS_DEFAULT_MODEL_ID,
       name: "Kimi K2.5 Turbo (Fire Pass)",
-      reasoning: !isFireworksKimiModelId(FIREWORKS_DEFAULT_MODEL_ID),
+      reasoning: false, // Kimi K2.5 can expose reasoning in visible content on FirePass.
       input: ["text", "image"],
       cost: ZERO_COST,
       contextWindow: FIREWORKS_DEFAULT_CONTEXT_WINDOW,

--- a/extensions/fireworks/provider-catalog.ts
+++ b/extensions/fireworks/provider-catalog.ts
@@ -2,6 +2,7 @@ import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import { isFireworksKimiModelId } from "./model-id.js";
 
 export const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
 export const FIREWORKS_DEFAULT_MODEL_ID = "accounts/fireworks/routers/kimi-k2p5-turbo";
@@ -20,7 +21,7 @@ export function buildFireworksCatalogModels(): ModelDefinitionConfig[] {
     {
       id: FIREWORKS_DEFAULT_MODEL_ID,
       name: "Kimi K2.5 Turbo (Fire Pass)",
-      reasoning: true,
+      reasoning: !isFireworksKimiModelId(FIREWORKS_DEFAULT_MODEL_ID),
       input: ["text", "image"],
       cost: ZERO_COST,
       contextWindow: FIREWORKS_DEFAULT_CONTEXT_WINDOW,

--- a/extensions/fireworks/stream.test.ts
+++ b/extensions/fireworks/stream.test.ts
@@ -1,7 +1,10 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { createFireworksKimiThinkingDisabledWrapper } from "./stream.js";
+import {
+  createFireworksKimiThinkingDisabledWrapper,
+  wrapFireworksProviderStream,
+} from "./stream.js";
 
 function capturePayload(params: {
   provider: string;
@@ -57,23 +60,74 @@ describe("createFireworksKimiThinkingDisabledWrapper", () => {
     expect(payload).toEqual({ thinking: { type: "disabled" } });
   });
 
-  it("does not affect non-Kimi Fireworks models", () => {
-    expect(
-      capturePayload({
-        provider: "fireworks",
+  it("reapplies the hardening after caller onPayload hooks run", () => {
+    let captured: Record<string, unknown> = {};
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload = {};
+      options?.onPayload?.(payload, _model);
+      captured = payload;
+      return {} as ReturnType<StreamFn>;
+    };
+
+    const wrapped = createFireworksKimiThinkingDisabledWrapper(baseStreamFn);
+    void wrapped(
+      {
         api: "openai-completions",
-        modelId: "accounts/fireworks/models/qwen3.6-plus",
-      }),
-    ).toEqual({});
+        provider: "fireworks",
+        id: "accounts/fireworks/routers/kimi-k2p5-turbo",
+      } as Model<"openai-completions">,
+      { messages: [] } as Context,
+      {
+        onPayload: (payload) => {
+          const payloadObj = payload as Record<string, unknown>;
+          payloadObj.reasoning_effort = "high";
+          payloadObj.reasoning = { effort: "high" };
+          payloadObj.thinking = { type: "enabled" };
+        },
+      },
+    );
+
+    expect(captured).toEqual({ thinking: { type: "disabled" } });
   });
 
-  it("does not affect non-Fireworks providers", () => {
+  it("returns no provider wrapper for non-target Fireworks requests", () => {
     expect(
-      capturePayload({
+      wrapFireworksProviderStream({
+        provider: "fireworks",
+        modelId: "accounts/fireworks/models/qwen3.6-plus",
+        model: {
+          api: "openai-completions",
+          provider: "fireworks",
+          id: "accounts/fireworks/models/qwen3.6-plus",
+        } as Model<"openai-completions">,
+        streamFn: undefined,
+      } as never),
+    ).toBeUndefined();
+
+    expect(
+      wrapFireworksProviderStream({
+        provider: "fireworks",
+        modelId: "accounts/fireworks/routers/kimi-k2p5-turbo",
+        model: {
+          api: "openai-responses",
+          provider: "fireworks",
+          id: "accounts/fireworks/routers/kimi-k2p5-turbo",
+        } as Model<"openai-responses">,
+        streamFn: undefined,
+      } as never),
+    ).toBeUndefined();
+
+    expect(
+      wrapFireworksProviderStream({
         provider: "openai",
-        api: "openai-completions",
         modelId: "gpt-5.4",
-      }),
-    ).toEqual({});
+        model: {
+          api: "openai-completions",
+          provider: "openai",
+          id: "gpt-5.4",
+        } as Model<"openai-completions">,
+        streamFn: undefined,
+      } as never),
+    ).toBeUndefined();
   });
 });

--- a/extensions/fireworks/stream.test.ts
+++ b/extensions/fireworks/stream.test.ts
@@ -1,0 +1,79 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { createFireworksKimiThinkingDisabledWrapper } from "./stream.js";
+
+function capturePayload(params: {
+  provider: string;
+  api: string;
+  modelId: string;
+  initialPayload?: Record<string, unknown>;
+}): Record<string, unknown> {
+  let captured: Record<string, unknown> = {};
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    const payload = { ...params.initialPayload };
+    options?.onPayload?.(payload, _model);
+    captured = payload;
+    return {} as ReturnType<StreamFn>;
+  };
+
+  const wrapped = createFireworksKimiThinkingDisabledWrapper(baseStreamFn);
+  void wrapped(
+    {
+      api: params.api,
+      provider: params.provider,
+      id: params.modelId,
+    } as Model<"openai-completions">,
+    { messages: [] } as Context,
+    {},
+  );
+
+  return captured;
+}
+
+describe("createFireworksKimiThinkingDisabledWrapper", () => {
+  it("forces thinking disabled for Fireworks Kimi models", () => {
+    expect(
+      capturePayload({
+        provider: "fireworks",
+        api: "openai-completions",
+        modelId: "accounts/fireworks/routers/kimi-k2p5-turbo",
+      }),
+    ).toMatchObject({ thinking: { type: "disabled" } });
+  });
+
+  it("strips reasoning fields when disabling Fireworks Kimi thinking", () => {
+    const payload = capturePayload({
+      provider: "fireworks",
+      api: "openai-completions",
+      modelId: "accounts/fireworks/models/kimi-k2p5",
+      initialPayload: {
+        reasoning_effort: "low",
+        reasoning: { effort: "low" },
+        reasoningEffort: "low",
+      },
+    });
+
+    expect(payload).toEqual({ thinking: { type: "disabled" } });
+  });
+
+  it("does not affect non-Kimi Fireworks models", () => {
+    expect(
+      capturePayload({
+        provider: "fireworks",
+        api: "openai-completions",
+        modelId: "accounts/fireworks/models/qwen3.6-plus",
+      }),
+    ).toEqual({});
+  });
+
+  it("does not affect non-Fireworks providers", () => {
+    expect(
+      capturePayload({
+        provider: "openai",
+        api: "openai-completions",
+        modelId: "gpt-5.4",
+      }),
+    ).toEqual({});
+  });
+});

--- a/extensions/fireworks/stream.test.ts
+++ b/extensions/fireworks/stream.test.ts
@@ -70,12 +70,14 @@ describe("createFireworksKimiThinkingDisabledWrapper", () => {
     expect(payload).toEqual({ thinking: { type: "disabled" } });
   });
 
-  it("reapplies the hardening after caller onPayload hooks run", () => {
-    let captured: Record<string, unknown> = {};
+  it("passes sanitized payloads to caller onPayload hooks", () => {
+    let callbackPayload: Record<string, unknown> = {};
     const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload = {};
+      const payload = {
+        reasoning_effort: "high",
+        reasoning: { effort: "high" },
+      };
       options?.onPayload?.(payload, _model);
-      captured = payload;
       return {} as ReturnType<StreamFn>;
     };
 
@@ -89,15 +91,12 @@ describe("createFireworksKimiThinkingDisabledWrapper", () => {
       { messages: [] } as Context,
       {
         onPayload: (payload) => {
-          const payloadObj = payload as Record<string, unknown>;
-          payloadObj.reasoning_effort = "high";
-          payloadObj.reasoning = { effort: "high" };
-          payloadObj.thinking = { type: "enabled" };
+          callbackPayload = payload as Record<string, unknown>;
         },
       },
     );
 
-    expect(captured).toEqual({ thinking: { type: "disabled" } });
+    expect(callbackPayload).toEqual({ thinking: { type: "disabled" } });
   });
 
   it("returns no provider wrapper for non-target Fireworks requests", () => {
@@ -126,6 +125,19 @@ describe("createFireworksKimiThinkingDisabledWrapper", () => {
         streamFn: undefined,
       } as never),
     ).toBeUndefined();
+
+    expect(
+      wrapFireworksProviderStream({
+        provider: "fireworks-ai",
+        modelId: "accounts/fireworks/routers/kimi-k2p5-turbo",
+        model: {
+          api: "openai-completions",
+          provider: "fireworks-ai",
+          id: "accounts/fireworks/routers/kimi-k2p5-turbo",
+        } as Model<"openai-completions">,
+        streamFn: undefined,
+      } as never),
+    ).toBeTypeOf("function");
 
     expect(
       wrapFireworksProviderStream({

--- a/extensions/fireworks/stream.test.ts
+++ b/extensions/fireworks/stream.test.ts
@@ -45,6 +45,16 @@ describe("createFireworksKimiThinkingDisabledWrapper", () => {
     ).toMatchObject({ thinking: { type: "disabled" } });
   });
 
+  it("forces thinking disabled for Fireworks Kimi k2.5 aliases", () => {
+    expect(
+      capturePayload({
+        provider: "fireworks",
+        api: "openai-completions",
+        modelId: "accounts/fireworks/routers/kimi-k2.5-turbo",
+      }),
+    ).toMatchObject({ thinking: { type: "disabled" } });
+  });
+
   it("strips reasoning fields when disabling Fireworks Kimi thinking", () => {
     const payload = capturePayload({
       provider: "fireworks",

--- a/extensions/fireworks/stream.ts
+++ b/extensions/fireworks/stream.ts
@@ -1,8 +1,14 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import { streamWithPayloadPatch } from "openclaw/plugin-sdk/provider-stream-shared";
 import { isFireworksKimiModelId } from "./model-id.js";
+
+function isFireworksProviderId(providerId: string): boolean {
+  const normalized = normalizeProviderId(providerId);
+  return normalized === "fireworks" || normalized === "fireworks-ai";
+}
 
 export function createFireworksKimiThinkingDisabledWrapper(
   baseStreamFn: StreamFn | undefined,
@@ -23,7 +29,7 @@ export function wrapFireworksProviderStream(
   ctx: ProviderWrapStreamFnContext,
 ): StreamFn | undefined {
   if (
-    ctx.provider !== "fireworks" ||
+    !isFireworksProviderId(ctx.provider) ||
     ctx.model?.api !== "openai-completions" ||
     !isFireworksKimiModelId(ctx.modelId)
   ) {

--- a/extensions/fireworks/stream.ts
+++ b/extensions/fireworks/stream.ts
@@ -1,0 +1,33 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { streamWithPayloadPatch } from "openclaw/plugin-sdk/provider-stream-shared";
+import { isFireworksKimiModelId } from "./model-id.js";
+
+export function createFireworksKimiThinkingDisabledWrapper(
+  baseStreamFn: StreamFn | undefined,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    if (
+      model.provider !== "fireworks" ||
+      model.api !== "openai-completions" ||
+      !isFireworksKimiModelId(String(model.id))
+    ) {
+      return underlying(model, context, options);
+    }
+
+    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+      // Fireworks Kimi can emit chain-of-thought in visible `content` unless
+      // the Anthropic-style thinking toggle is explicitly disabled.
+      payloadObj.thinking = { type: "disabled" };
+      delete payloadObj.reasoning;
+      delete payloadObj.reasoning_effort;
+      delete payloadObj.reasoningEffort;
+    });
+  };
+}
+
+export function wrapFireworksProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn {
+  return createFireworksKimiThinkingDisabledWrapper(ctx.streamFn);
+}

--- a/extensions/fireworks/stream.ts
+++ b/extensions/fireworks/stream.ts
@@ -8,16 +8,8 @@ export function createFireworksKimiThinkingDisabledWrapper(
   baseStreamFn: StreamFn | undefined,
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
-  return (model, context, options) => {
-    if (
-      model.provider !== "fireworks" ||
-      model.api !== "openai-completions" ||
-      !isFireworksKimiModelId(String(model.id))
-    ) {
-      return underlying(model, context, options);
-    }
-
-    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
+  return (model, context, options) =>
+    streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
       // Fireworks Kimi can emit chain-of-thought in visible `content` unless
       // the Anthropic-style thinking toggle is explicitly disabled.
       payloadObj.thinking = { type: "disabled" };
@@ -25,9 +17,17 @@ export function createFireworksKimiThinkingDisabledWrapper(
       delete payloadObj.reasoning_effort;
       delete payloadObj.reasoningEffort;
     });
-  };
 }
 
-export function wrapFireworksProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn {
+export function wrapFireworksProviderStream(
+  ctx: ProviderWrapStreamFnContext,
+): StreamFn | undefined {
+  if (
+    ctx.provider !== "fireworks" ||
+    ctx.model?.api !== "openai-completions" ||
+    !isFireworksKimiModelId(ctx.modelId)
+  ) {
+    return undefined;
+  }
   return createFireworksKimiThinkingDisabledWrapper(ctx.streamFn);
 }

--- a/src/agents/pi-embedded-runner/stream-payload-utils.ts
+++ b/src/agents/pi-embedded-runner/stream-payload-utils.ts
@@ -11,11 +11,10 @@ export function streamWithPayloadPatch(
   return underlying(model, context, {
     ...options,
     onPayload: (payload) => {
-      const result = originalOnPayload?.(payload, model);
       if (payload && typeof payload === "object") {
         patchPayload(payload as Record<string, unknown>);
       }
-      return result;
+      return originalOnPayload?.(payload, model);
     },
   });
 }

--- a/src/agents/pi-embedded-runner/stream-payload-utils.ts
+++ b/src/agents/pi-embedded-runner/stream-payload-utils.ts
@@ -11,10 +11,11 @@ export function streamWithPayloadPatch(
   return underlying(model, context, {
     ...options,
     onPayload: (payload) => {
+      const result = originalOnPayload?.(payload, model);
       if (payload && typeof payload === "object") {
         patchPayload(payload as Record<string, unknown>);
       }
-      return originalOnPayload?.(payload, model);
+      return result;
     },
   });
 }


### PR DESCRIPTION
## Summary

- Problem: FirePass Kimi K2.5 can emit full reasoning in visible `content` when OpenClaw sends the normal OpenAI-compatible payload.
- Why it matters: users can see the model's internal reasoning text even when OpenClaw should keep thinking hidden.
- What changed: Fireworks Kimi K2.5 now defaults to `reasoning: false`, and the Fireworks provider wrapper forces `thinking: { type: "disabled" }` while stripping reasoning fields before the request is sent.
- What did NOT change (scope boundary): no shared OpenAI transport/parser changes and no behavior changes for non-Fireworks or non-Kimi models.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Fireworks Pass Kimi can return reasoning in visible `content` unless `thinking` is explicitly disabled, while the bundled Fireworks provider still advertised Kimi as reasoning-enabled and forwarded reasoning settings.
- Missing detection / guardrail: there was no Fireworks-owned provider wrapper that normalized Kimi requests away from reasoning mode.
- Contributing context (if known): Fireworks' OpenClaw setup script already writes `reasoning: false`, but the bundled provider catalog and dynamic-model path had drifted from that expectation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/fireworks/stream.test.ts`, `extensions/fireworks/index.test.ts`
- Scenario the test should lock in: Fireworks Kimi requests force `thinking: { type: "disabled" }`, strip reasoning fields, and do not mark Kimi models as reasoning-enabled.
- Why this is the smallest reliable guardrail: the leak is provider-specific request shaping, so the provider seam is the narrowest place that can catch it deterministically.
- Existing test that already covers this (if any): `src/agents/pi-embedded-runner/minimax-stream-wrappers.test.ts` covers the adjacent hidden-thinking wrapper pattern.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- FirePass Kimi K2.5 no longer runs with OpenClaw reasoning enabled by default.
- OpenClaw now sends Fireworks Kimi requests with `thinking: { type: "disabled" }` to prevent visible reasoning leakage.

## Diagram (if applicable)

```text
Before:
[user prompt] -> [Fireworks Kimi with reasoning-capable payload] -> [reasoning may appear in visible content]

After:
[user prompt] -> [Fireworks Kimi with thinking disabled] -> [normal visible answer only]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: Fireworks Pass `accounts/fireworks/routers/kimi-k2p5-turbo`
- Integration/channel (if any): OpenAI-compatible provider transport
- Relevant config (redacted): Fireworks API key via env only

### Steps

1. Send a Fireworks Pass Kimi request without explicitly disabling thinking.
2. Observe Fireworks can return reasoning in visible `content`.
3. Apply the provider wrapper and rerun the same request path.

### Expected

- Visible response text should contain only the answer.

### Actual

- Before the fix, reasoning could appear in visible `content`.
- After the fix, the same path returns only visible answer text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused provider tests passed; live Fireworks Pass replay returned visible text only and no thinking text.
- Edge cases checked: non-Kimi Fireworks models stay untouched; non-Fireworks providers stay untouched; pre-existing MiniMax wrapper tests still pass.
- What you did **not** verify: full repo `pnpm build` / full-suite gate in this worktree.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a future Fireworks Kimi model id variant may not match the current helper.
  - Mitigation: matching is isolated in `extensions/fireworks/model-id.ts` and covered by focused tests.
