### PR TITLE
fix(compaction): guard malformed token estimation

### DIFF
--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ToolResultMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
+  estimateMessageTokens,
   estimateMessagesTokens,
   pruneHistoryForContextShare,
   splitMessagesByTokenShare,
@@ -59,6 +60,121 @@ function pruneLargeSimpleHistory() {
   });
   return { messages, pruned, maxContextTokens };
 }
+
+describe("estimateMessageTokens", () => {
+  it("falls back to guarded estimation for malformed assistant blocks", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        null,
+        { type: "text" },
+        { type: "text", text: "abcd" },
+        { type: "input_text", text: "gh" },
+        { type: "output_text", text: "ij" },
+        { type: "thinking" },
+        { type: "thinking", thinking: "ef" },
+        { type: "toolCall", id: "call_1", name: "read", arguments: { path: "x" } },
+      ],
+      timestamp: 1,
+    } as unknown as AgentMessage;
+
+    expect(() => estimateMessageTokens(message)).not.toThrow();
+    expect(estimateMessageTokens(message)).toBe(
+      Math.ceil(
+        ("abcd".length +
+          "gh".length +
+          "ij".length +
+          "ef".length +
+          "read".length +
+          JSON.stringify({ path: "x" }).length) /
+          4,
+      ),
+    );
+  });
+
+  it("counts provider-specific tool-call payloads in the fallback estimator", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text" },
+        { type: "toolUse", id: "call_2", name: "read", input: { path: "IDENTITY.md" } },
+        { type: "functionCall", id: "call_3", name: "bash", arguments: { command: "pwd" } },
+        { type: "tool_use", id: "call_4", name: "search", input: { q: "openclaw" } },
+        { type: "tool_call", id: "call_5", name: "write", arguments: { path: "out.txt" } },
+        { type: "function_call", id: "call_6", name: "exec", arguments: { cmd: "pwd" } },
+        {
+          type: "toolCall",
+          id: "call_7",
+          name: "stream",
+          arguments: {},
+          partialJson: '{"path":"x"}',
+        },
+        {
+          type: "toolUse",
+          id: "call_8",
+          name: "delta",
+          input: undefined,
+          arguments: {},
+          partialArgs: '{"cmd":"ls"}',
+        },
+      ],
+      timestamp: 1,
+    } as unknown as AgentMessage;
+
+    expect(estimateMessageTokens(message)).toBe(
+      Math.ceil(
+        ("read".length +
+          JSON.stringify({ path: "IDENTITY.md" }).length +
+          "bash".length +
+          JSON.stringify({ command: "pwd" }).length +
+          "search".length +
+          JSON.stringify({ q: "openclaw" }).length +
+          "write".length +
+          JSON.stringify({ path: "out.txt" }).length +
+          "exec".length +
+          JSON.stringify({ cmd: "pwd" }).length +
+          "stream".length +
+          JSON.stringify('{"path":"x"}').length +
+          "delta".length +
+          JSON.stringify('{"cmd":"ls"}').length) /
+          4,
+      ),
+    );
+  });
+
+  it("returns zero for assistant messages missing content arrays", () => {
+    const message = {
+      role: "assistant",
+      timestamp: 1,
+    } as unknown as AgentMessage;
+
+    expect(() => estimateMessageTokens(message)).not.toThrow();
+    expect(estimateMessageTokens(message)).toBe(0);
+    expect(estimateMessagesTokens([message])).toBe(0);
+  });
+
+  it("counts input_image blocks in the fallback estimator", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        null,
+        { type: "text" },
+        { type: "input_text", text: "describe this" },
+        {
+          type: "input_image",
+          source: {
+            type: "base64",
+            media_type: "image/png",
+            data: "aGVsbG8=",
+          },
+        },
+      ],
+      timestamp: 1,
+    } as unknown as AgentMessage;
+
+    expect(estimateMessageTokens(message)).toBe(Math.ceil(("describe this".length + 4800) / 4));
+  });
+});
 
 describe("splitMessagesByTokenShare", () => {
   it("splits messages into two non-empty parts", () => {

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -70,12 +70,22 @@ describe("compaction token accounting sanitization", () => {
           toolCallId: "call_2",
           content: "legacy inline tool output",
         },
+        {
+          type: "tool_result",
+          toolUseId: "call_3",
+          content: [{ type: "text", text: "snake case inline tool output" }],
+        },
       ],
       timestamp: 1,
     } as unknown as AgentMessage;
 
     expect(estimateMessageTokens(message)).toBe(
-      Math.ceil(("inline tool output".length + "legacy inline tool output".length) / 4),
+      Math.ceil(
+        ("inline tool output".length +
+          "legacy inline tool output".length +
+          "snake case inline tool output".length) /
+          4,
+      ),
     );
   });
 

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -17,9 +17,68 @@ vi.mock("@mariozechner/pi-coding-agent", async () => {
   };
 });
 
-import { chunkMessagesByMaxTokens, splitMessagesByTokenShare } from "./compaction.js";
+import {
+  chunkMessagesByMaxTokens,
+  estimateMessageTokens,
+  splitMessagesByTokenShare,
+} from "./compaction.js";
 
 describe("compaction token accounting sanitization", () => {
+  it("counts legacy tool-role messages when fallback estimation is used", () => {
+    piCodingAgentMocks.estimateTokens.mockImplementation(() => {
+      throw new TypeError("boom");
+    });
+
+    const message = {
+      role: "tool",
+      content: "legacy tool output",
+      timestamp: 1,
+    } as unknown as AgentMessage;
+
+    expect(estimateMessageTokens(message)).toBe(Math.ceil("legacy tool output".length / 4));
+  });
+
+  it("counts legacy assistant string content when fallback estimation is used", () => {
+    piCodingAgentMocks.estimateTokens.mockImplementation(() => {
+      throw new TypeError("boom");
+    });
+
+    const message = {
+      role: "assistant",
+      content: "legacy assistant text",
+      timestamp: 1,
+    } as unknown as AgentMessage;
+
+    expect(estimateMessageTokens(message)).toBe(Math.ceil("legacy assistant text".length / 4));
+  });
+
+  it("counts inline tool-result blocks when fallback estimation is used", () => {
+    piCodingAgentMocks.estimateTokens.mockImplementation(() => {
+      throw new TypeError("boom");
+    });
+
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "toolResult",
+          toolUseId: "call_1",
+          content: [{ type: "text", text: "inline tool output" }],
+        },
+        {
+          type: "tool",
+          toolCallId: "call_2",
+          content: "legacy inline tool output",
+        },
+      ],
+      timestamp: 1,
+    } as unknown as AgentMessage;
+
+    expect(estimateMessageTokens(message)).toBe(
+      Math.ceil(("inline tool output".length + "legacy inline tool output".length) / 4),
+    );
+  });
+
   it("does not pass toolResult.details into per-message token estimates", () => {
     const messages: AgentMessage[] = [
       {

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -79,7 +79,7 @@ describe("compaction token accounting sanitization", () => {
     );
   });
 
-  it("counts reasoning signatures and redacted thinking payloads when fallback estimation is used", () => {
+  it("counts reasoning signature aliases and redacted thinking payloads when fallback estimation is used", () => {
     piCodingAgentMocks.estimateTokens.mockImplementation(() => {
       throw new TypeError("boom");
     });
@@ -91,6 +91,14 @@ describe("compaction token accounting sanitization", () => {
           type: "thinking",
           thinking: "draft reasoning",
           thinkingSignature: "sig_payload",
+        },
+        {
+          type: "thinking",
+          signature: "legacy_signature_payload",
+        },
+        {
+          type: "thinking",
+          thought_signature: "snake_case_signature_payload",
         },
         {
           type: "redacted_thinking",
@@ -105,6 +113,8 @@ describe("compaction token accounting sanitization", () => {
       Math.ceil(
         ("draft reasoning".length +
           "sig_payload".length +
+          "legacy_signature_payload".length +
+          "snake_case_signature_payload".length +
           "redacted_reasoning_blob".length +
           "sig_redacted".length) /
           4,

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -79,6 +79,39 @@ describe("compaction token accounting sanitization", () => {
     );
   });
 
+  it("counts reasoning signatures and redacted thinking payloads when fallback estimation is used", () => {
+    piCodingAgentMocks.estimateTokens.mockImplementation(() => {
+      throw new TypeError("boom");
+    });
+
+    const message = {
+      role: "assistant",
+      content: [
+        {
+          type: "thinking",
+          thinking: "draft reasoning",
+          thinkingSignature: "sig_payload",
+        },
+        {
+          type: "redacted_thinking",
+          data: "redacted_reasoning_blob",
+          thinkingSignature: "sig_redacted",
+        },
+      ],
+      timestamp: 1,
+    } as unknown as AgentMessage;
+
+    expect(estimateMessageTokens(message)).toBe(
+      Math.ceil(
+        ("draft reasoning".length +
+          "sig_payload".length +
+          "redacted_reasoning_blob".length +
+          "sig_redacted".length) /
+          4,
+      ),
+    );
+  });
+
   it("does not pass toolResult.details into per-message token estimates", () => {
     const messages: AgentMessage[] = [
       {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -1,7 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
-  estimateTokens,
+  estimateTokens as piEstimateTokens,
   generateSummary as piGenerateSummary,
 } from "@mariozechner/pi-coding-agent";
 import type { AgentCompactionIdentifierPolicy } from "../config/types.agent-defaults.js";
@@ -100,10 +100,195 @@ export function buildCompactionSummarizationInstructions(
   return `${identifierPreservation}\n\nAdditional focus:\n${custom}`;
 }
 
+function estimateSafeToolCallChars(block: unknown): number {
+  if (!block || typeof block !== "object") {
+    return 0;
+  }
+  const record = block as {
+    name?: unknown;
+    input?: unknown;
+    arguments?: unknown;
+    partialJson?: unknown;
+    partialArgs?: unknown;
+  };
+  let chars = typeof record.name === "string" ? record.name.length : 0;
+  try {
+    chars += JSON.stringify(
+      record.input ?? record.partialJson ?? record.partialArgs ?? record.arguments ?? {},
+    ).length;
+  } catch {
+    chars += 0;
+  }
+  return chars;
+}
+
+function isFallbackToolCallType(type: unknown): boolean {
+  return (
+    type === "toolCall" ||
+    type === "toolUse" ||
+    type === "functionCall" ||
+    type === "tool_call" ||
+    type === "tool_use" ||
+    type === "function_call"
+  );
+}
+
+function isFallbackTextType(type: unknown): boolean {
+  return type === "text" || type === "input_text" || type === "output_text";
+}
+
+function isFallbackImageType(type: unknown): boolean {
+  return type === "image" || type === "input_image";
+}
+
+function isFallbackToolResultType(type: unknown): boolean {
+  return type === "toolResult" || type === "tool";
+}
+
+function estimateSafeUnknownChars(value: unknown): number {
+  if (typeof value === "string") {
+    return value.length;
+  }
+  if (value === undefined) {
+    return 0;
+  }
+  try {
+    const serialized = JSON.stringify(value);
+    return typeof serialized === "string" ? serialized.length : 0;
+  } catch {
+    return 256;
+  }
+}
+
+function estimateSafeToolResultChars(block: unknown): number {
+  if (!block || typeof block !== "object") {
+    return 0;
+  }
+  const record = block as {
+    content?: unknown;
+    text?: unknown;
+  };
+  if (typeof record.content === "string") {
+    return record.content.length;
+  }
+  if (Array.isArray(record.content)) {
+    return estimateSafeArrayContentChars(record.content);
+  }
+  if (record.content !== undefined) {
+    return estimateSafeUnknownChars(record.content);
+  }
+  if (typeof record.text === "string") {
+    return record.text.length;
+  }
+  return estimateSafeUnknownChars(block);
+}
+
+function estimateSafeArrayContentChars(content: unknown): number {
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+
+  let chars = 0;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as {
+      type?: unknown;
+      text?: unknown;
+      thinking?: unknown;
+    };
+    if (isFallbackTextType(record.type) && typeof record.text === "string") {
+      chars += record.text.length;
+      continue;
+    }
+    if (record.type === "thinking" && typeof record.thinking === "string") {
+      chars += record.thinking.length;
+      continue;
+    }
+    if (isFallbackToolCallType(record.type)) {
+      chars += estimateSafeToolCallChars(block);
+      continue;
+    }
+    if (isFallbackToolResultType(record.type)) {
+      chars += estimateSafeToolResultChars(block);
+      continue;
+    }
+    if (isFallbackImageType(record.type)) {
+      chars += 4800;
+    }
+  }
+  return chars;
+}
+
+function stripToolResultDetailsFromMessage(message: AgentMessage): AgentMessage {
+  if ((message.role !== "toolResult" && message.role !== "tool") || !("details" in message)) {
+    return message;
+  }
+  const sanitized = { ...(message as object) } as { details?: unknown };
+  delete sanitized.details;
+  return sanitized as AgentMessage;
+}
+
+function estimateMalformedMessageTokens(message: AgentMessage): number {
+  if ((message as { role?: unknown }).role === "system") {
+    const content = (message as { content?: unknown }).content;
+    return Math.ceil(
+      (typeof content === "string" ? content.length : estimateSafeArrayContentChars(content)) / 4,
+    );
+  }
+
+  switch (message.role) {
+    case "user": {
+      return Math.ceil(
+        (typeof message.content === "string"
+          ? message.content.length
+          : estimateSafeArrayContentChars(message.content)) / 4,
+      );
+    }
+    case "assistant": {
+      return Math.ceil(
+        (typeof message.content === "string"
+          ? message.content.length
+          : estimateSafeArrayContentChars(message.content)) / 4,
+      );
+    }
+    case "custom":
+    case "tool":
+    case "toolResult": {
+      return Math.ceil(
+        (typeof message.content === "string"
+          ? message.content.length
+          : estimateSafeArrayContentChars(message.content)) / 4,
+      );
+    }
+    case "bashExecution": {
+      const command = typeof message.command === "string" ? message.command.length : 0;
+      const output = typeof message.output === "string" ? message.output.length : 0;
+      return Math.ceil((command + output) / 4);
+    }
+    case "branchSummary":
+    case "compactionSummary": {
+      const summary = typeof message.summary === "string" ? message.summary.length : 0;
+      return Math.ceil(summary / 4);
+    }
+  }
+  return 0;
+}
+
+export function estimateMessageTokens(message: AgentMessage): number {
+  const sanitized = stripToolResultDetailsFromMessage(message);
+  try {
+    return piEstimateTokens(sanitized);
+  } catch {
+    return estimateMalformedMessageTokens(sanitized);
+  }
+}
+
 export function estimateMessagesTokens(messages: AgentMessage[]): number {
   // SECURITY: toolResult.details can contain untrusted/verbose payloads; never include in LLM-facing compaction.
   const safe = stripToolResultDetails(messages);
-  return safe.reduce((sum, message) => sum + estimateTokens(message), 0);
+  return safe.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
 }
 
 function estimateCompactionMessageTokens(message: AgentMessage): number {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -146,7 +146,7 @@ function isFallbackThinkingType(type: unknown): boolean {
 }
 
 function isFallbackToolResultType(type: unknown): boolean {
-  return type === "toolResult" || type === "tool";
+  return type === "toolResult" || type === "tool_result" || type === "tool";
 }
 
 function estimateSafeUnknownChars(value: unknown): number {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -141,6 +141,10 @@ function isFallbackImageType(type: unknown): boolean {
   return type === "image" || type === "input_image";
 }
 
+function isFallbackThinkingType(type: unknown): boolean {
+  return type === "thinking" || type === "redacted_thinking";
+}
+
 function isFallbackToolResultType(type: unknown): boolean {
   return type === "toolResult" || type === "tool";
 }
@@ -183,6 +187,30 @@ function estimateSafeToolResultChars(block: unknown): number {
   return estimateSafeUnknownChars(block);
 }
 
+function estimateSafeThinkingChars(block: unknown): number {
+  if (!block || typeof block !== "object") {
+    return 0;
+  }
+  const record = block as {
+    type?: unknown;
+    thinking?: unknown;
+    thinkingSignature?: unknown;
+    data?: unknown;
+  };
+
+  let chars = 0;
+  if (typeof record.thinking === "string") {
+    chars += record.thinking.length;
+  }
+  if (typeof record.thinkingSignature === "string") {
+    chars += record.thinkingSignature.length;
+  }
+  if (record.type === "redacted_thinking" && typeof record.data === "string") {
+    chars += record.data.length;
+  }
+  return chars;
+}
+
 function estimateSafeArrayContentChars(content: unknown): number {
   if (!Array.isArray(content)) {
     return 0;
@@ -196,14 +224,13 @@ function estimateSafeArrayContentChars(content: unknown): number {
     const record = block as {
       type?: unknown;
       text?: unknown;
-      thinking?: unknown;
     };
     if (isFallbackTextType(record.type) && typeof record.text === "string") {
       chars += record.text.length;
       continue;
     }
-    if (record.type === "thinking" && typeof record.thinking === "string") {
-      chars += record.thinking.length;
+    if (isFallbackThinkingType(record.type)) {
+      chars += estimateSafeThinkingChars(block);
       continue;
     }
     if (isFallbackToolCallType(record.type)) {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -195,6 +195,9 @@ function estimateSafeThinkingChars(block: unknown): number {
     type?: unknown;
     thinking?: unknown;
     thinkingSignature?: unknown;
+    signature?: unknown;
+    thought_signature?: unknown;
+    thoughtSignature?: unknown;
     data?: unknown;
   };
 
@@ -202,8 +205,23 @@ function estimateSafeThinkingChars(block: unknown): number {
   if (typeof record.thinking === "string") {
     chars += record.thinking.length;
   }
-  if (typeof record.thinkingSignature === "string") {
-    chars += record.thinkingSignature.length;
+  const signatureCandidates = [
+    record.thinkingSignature,
+    record.signature,
+    record.thought_signature,
+    record.thoughtSignature,
+  ];
+  const signature = signatureCandidates.reduce<string | undefined>((longest, candidate) => {
+    if (typeof candidate !== "string") {
+      return longest;
+    }
+    if (!longest || candidate.length > longest.length) {
+      return candidate;
+    }
+    return longest;
+  }, undefined);
+  if (signature) {
+    chars += signature.length;
   }
   if (record.type === "redacted_thinking" && typeof record.data === "string") {
     chars += record.data.length;

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -4,7 +4,6 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import {
   createAgentSession,
   DefaultResourceLoader,
-  estimateTokens,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
@@ -51,6 +50,7 @@ import {
   hasMeaningfulConversationContent,
   isRealConversationMessage,
 } from "../compaction-real-conversation.js";
+import { estimateMessageTokens } from "../compaction.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
@@ -272,7 +272,6 @@ function summarizeCompactionMessages(messages: AgentMessage[]): CompactionMessag
   let toolResultChars = 0;
   const contributors: Array<{ role: string; chars: number; tool?: string }> = [];
   let estTokens = 0;
-  let tokenEstimationFailed = false;
 
   for (const msg of messages) {
     const role = typeof msg.role === "string" ? msg.role : "unknown";
@@ -282,20 +281,14 @@ function summarizeCompactionMessages(messages: AgentMessage[]): CompactionMessag
       toolResultChars += chars;
     }
     contributors.push({ role, chars, tool: resolveMessageToolLabel(msg) });
-    if (!tokenEstimationFailed) {
-      try {
-        estTokens += estimateTokens(msg);
-      } catch {
-        tokenEstimationFailed = true;
-      }
-    }
+    estTokens += estimateMessageTokens(msg);
   }
 
   return {
     messages: messages.length,
     historyTextChars,
     toolResultChars,
-    estTokens: tokenEstimationFailed ? undefined : estTokens,
+    estTokens,
     contributors: contributors.toSorted((a, b) => b.chars - a.chars).slice(0, 3),
   };
 }
@@ -940,7 +933,7 @@ export async function compactEmbeddedPiSessionDirect(
             originalMessages,
             currentMessages: session.messages,
             observedTokenCount,
-            estimateTokensFn: estimateTokens,
+            estimateTokensFn: estimateMessageTokens,
           });
           const { hookSessionKey, missingSessionKey } = await runBeforeCompactionHooks({
             hookRunner,
@@ -990,7 +983,10 @@ export async function compactEmbeddedPiSessionDirect(
           // history subset, not the full session.
           let fullSessionTokensBefore = 0;
           try {
-            fullSessionTokensBefore = limited.reduce((sum, msg) => sum + estimateTokens(msg), 0);
+            fullSessionTokensBefore = limited.reduce(
+              (sum, msg) => sum + estimateMessageTokens(msg),
+              0,
+            );
           } catch {
             // If token estimation throws on a malformed message, fall back to 0 so
             // the sanity check below becomes a no-op instead of crashing compaction.
@@ -1041,7 +1037,7 @@ export async function compactEmbeddedPiSessionDirect(
             messagesAfter: session.messages,
             observedTokenCount,
             fullSessionTokensBefore,
-            estimateTokensFn: estimateTokens,
+            estimateTokensFn: estimateMessageTokens,
           });
           const messageCountAfter = session.messages.length;
           const compactedCount = Math.max(0, messageCountCompactionInput - messageCountAfter);

--- a/src/agents/pi-embedded-runner/compact.types.ts
+++ b/src/agents/pi-embedded-runner/compact.types.ts
@@ -62,6 +62,6 @@ export type CompactionMessageMetrics = {
   messages: number;
   historyTextChars: number;
   toolResultChars: number;
-  estTokens?: number;
+  estTokens: number;
   contributors: Array<{ role: string; chars: number; tool?: string }>;
 };

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts
@@ -56,6 +56,37 @@ describe("preemptive-compaction", () => {
     expect(larger).toBeGreaterThan(smaller);
   });
 
+  it("does not throw on malformed replay history during pre-prompt estimation", () => {
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          null,
+          { type: "text" },
+          { type: "thinking" },
+          { type: "text", text: "still usable" },
+        ],
+        timestamp: timestamp++,
+      } as unknown as AgentMessage,
+      {
+        role: "toolResult",
+        toolCallId: `call_${timestamp}`,
+        toolName: "read",
+        content: undefined,
+        isError: false,
+        timestamp: timestamp++,
+      } as unknown as AgentMessage,
+    ];
+
+    expect(() =>
+      estimatePrePromptTokens({
+        messages,
+        systemPrompt: verboseSystem,
+        prompt: verbosePrompt,
+      }),
+    ).not.toThrow();
+  });
+
   it("requests preemptive compaction when the reserve-based prompt budget would be exceeded", () => {
     const result = shouldPreemptivelyCompactBeforePrompt({
       messages: [makeAssistantHistory(verboseHistory)],

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -1,6 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { estimateTokens } from "@mariozechner/pi-coding-agent";
-import { SAFETY_MARGIN, estimateMessagesTokens } from "../../compaction.js";
+import { SAFETY_MARGIN, estimateMessagesTokens, estimateMessageTokens } from "../../compaction.js";
 import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
 
 export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
@@ -33,7 +32,7 @@ export function estimatePrePromptTokens(params: {
 
   const estimated =
     estimateMessagesTokens(messages) +
-    syntheticMessages.reduce((sum, message) => sum + estimateTokens(message), 0);
+    syntheticMessages.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
   return Math.max(0, Math.ceil(estimated * SAFETY_MARGIN));
 }
 


### PR DESCRIPTION
## Summary

- Problem: long-lived `main` sessions could crash before provider dispatch when compaction token estimation hit malformed replay history and `estimateTokens()` read missing `.length` fields.
- Why it matters: once a session contained one malformed history block, every later prompt attempt could fail in pre-prompt compaction, making the session effectively unrecoverable.
- What changed: added a guarded `estimateMessageTokens()` path in `src/agents/compaction.ts` and switched preemptive compaction plus embedded compaction metrics/sanity checks to reuse it.
- What did NOT change (scope boundary): this PR does not redesign replay-history normalization or patch `@mariozechner/pi-coding-agent`; it only hardens OpenClaw’s local compaction estimation path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63612
- This likely also addresses the malformed-history / `reading 'length'` Telegram manifestation discussed in #64053, and may partially reduce the Telegram crash facet mentioned in #64034, but it does not address the broader Discord overflow/lag symptoms tracked there.

- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: compaction-side token estimation assumed replayed message blocks always had fully normalized shapes, but malformed assistant/toolResult blocks could still reach estimation and trigger unchecked `.length` reads.
- Missing detection / guardrail: OpenClaw had replay sanitization and some downstream try/catch sites, but no shared safe estimator for all compaction-related `estimateTokens()` call sites.
- Contributing context (if known): long-lived `main` sessions exercise pre-prompt compaction on every turn, so one malformed history block could repeatedly fail the recovery path itself.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/compaction.test.ts`, `src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts`
- Scenario the test should lock in: malformed assistant/toolResult history blocks do not throw during token estimation or pre-prompt compaction checks.
- Why this is the smallest reliable guardrail: the crash happens in pure estimation logic before provider dispatch, so unit coverage at the estimation and precheck seam is enough to lock in the failure mode.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Long-lived sessions with malformed replay history now fail soft in compaction token estimation instead of crashing before reply generation.

## Diagram (if applicable)

```text
Before:
[new user turn] -> [pre-prompt compaction estimation] -> [throws on malformed block] -> [session cannot reply]

After:
[new user turn] -> [guarded token estimation] -> [invalid block counted as 0/safe fallback] -> [reply flow continues]
```
## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node 22+/pnpm workspace
- Model/provider: N/A for repro; crash occurs before provider dispatch
- Integration/channel (if any): embedded `main` session
- Relevant config (redacted): default compaction path with long-lived session history

### Steps

1. Build or replay a session history containing malformed assistant/toolResult blocks.
2. Trigger a new turn that runs pre-prompt compaction estimation.
3. Observe the behavior before and after the patch.

### Expected

- Token estimation tolerates malformed blocks and the session continues.

### Actual

- Before this fix, estimation could throw `Cannot read properties of undefined (reading 'length')` and abort the reply before provider dispatch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `pnpm test src/agents/compaction.test.ts`, `pnpm test src/agents/pi-embedded-runner/run/preemptive-compaction.test.ts`, and `pnpm check`.
- Edge cases checked: malformed assistant content entries, missing assistant content arrays, malformed toolResult content during pre-prompt estimation.
- What you did **not** verify: no live reproduction against a real damaged long-lived session transcript.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: local fallback token estimation may slightly differ from upstream `estimateTokens()` for malformed messages.
  - Mitigation: fallback is only used on malformed inputs where the previous behavior was to throw; valid messages still use upstream estimation first.
