### PR TITLE
fix: pass currentMessageId to applyReplyThreading in followup drain

### DIFF
--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -20,6 +20,7 @@ import { resolveReplyToMode } from "./reply-threading.js";
 export function resolveFollowupDeliveryPayloads(params: {
   cfg: OpenClawConfig;
   payloads: ReplyPayload[];
+  currentMessageId?: string;
   messageProvider?: string;
   originatingAccountId?: string;
   originatingChannel?: string;
@@ -55,6 +56,7 @@ export function resolveFollowupDeliveryPayloads(params: {
     payloads: sanitizedPayloads,
     replyToMode,
     replyToChannel,
+    currentMessageId: params.currentMessageId,
   });
   const dedupedPayloads = filterMessagingToolDuplicates({
     payloads: replyTaggedPayloads,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -332,6 +332,7 @@ export function createFollowupRunner(params: {
       const finalPayloads = resolveFollowupDeliveryPayloads({
         cfg: runtimeConfig,
         payloads: sanitizedPayloads,
+        currentMessageId: queued.messageId,
         messageProvider: run.messageProvider,
         originatingAccountId: queued.originatingAccountId ?? run.agentAccountId,
         originatingChannel: queued.originatingChannel,


### PR DESCRIPTION
## Problem

When queue mode is `followup`, the followup runner calls `applyReplyThreading` without `currentMessageId`, causing `replyToMode: "all"` to produce replies without `replyToId`. This means channel plugins receive `ctx.replyToId = undefined` and cannot quote/reference the triggering message.

The `messageId` is already correctly saved in `FollowupRun` during enqueue but was not forwarded through `resolveFollowupDeliveryPayloads` to `applyReplyThreading`.

## Fix

- Add `currentMessageId` parameter to `resolveFollowupDeliveryPayloads`
- Pass `queued.messageId` from the followup runner
- Forward it to `applyReplyThreading`

3 lines changed, 2 files.

Fixes #54456