### PR TITLE
fix(ui): fix iPhone Safari chat layout and input zoom

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenClaw Control</title>
     <meta name="color-scheme" content="dark light" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <title>OpenClaw Control</title>
     <meta name="color-scheme" content="dark light" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -473,7 +473,9 @@
 
 html,
 body {
-  height: 100%;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
 }
 
 body {

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -530,6 +530,7 @@ openclaw-app {
   position: relative;
   z-index: 1;
   min-height: 100vh;
+  min-height: 100dvh;
 }
 
 a {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -433,6 +433,12 @@
   color: var(--muted);
 }
 
+@supports (-webkit-touch-callout: none) {
+  .agent-chat__input > textarea {
+    font-size: 16px;
+  }
+}
+
 .agent-chat__toolbar {
   display: flex;
   align-items: center;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -30,7 +30,6 @@
 }
 
 .shell--chat {
-  min-height: 100vh;
   height: 100vh;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary

- Problem: On Safari iPhone, the chat view showed a global scrollbar, the body didn't fill the full viewport, and tapping an input field triggered an unwanted auto-zoom.
- Why it matters: These are visible layout regressions on iOS that make the chat UI feel broken on mobile Safari.
- What changed: Set `html`/`body` to `100dvh` with `overflow: hidden`; use `100dvh` on `openclaw-app` for dynamic viewport awareness; remove redundant `min-height` from `.shell--chat`; add `maximum-scale=1` to the viewport meta tag.
- What did NOT change: No logic, routing, or non-UI surfaces were touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `body` height was set to `100%` (relative, not viewport-anchored), causing overflow on mobile. `min-height: 100vh` on `.shell--chat` conflicted with `height: 100vh` and allowed scroll. Safari auto-zooms inputs when the viewport `maximum-scale` is unset.
- Missing detection / guardrail: No mobile Safari layout test coverage.
- Contributing context (if known):

## Regression Test Plan (if applicable)

N/A — pure CSS/HTML layout fix; no logic paths to unit test.

- Coverage level that should have caught this: End-to-end / visual
- [ ] Unit test
- [ ] Seam / integration test
- [ ] End-to-end test
- [x] Existing coverage already sufficient
- Target test or file: N/A
- Scenario the test should lock in: Chat view fills full viewport on iPhone Safari without scroll or zoom on input focus.
- Why this is the smallest reliable guardrail: Requires a real or simulated mobile Safari viewport.
- Existing test that already covers this (if any): None
- If no new test is added, why not: CSS layout regressions on mobile Safari require manual or visual regression testing; no automated harness exists for this surface today.

## User-visible / Behavior Change

Chat view on iPhone Safari no longer shows a spurious scrollbar, fills the full viewport correctly, and no longer zooms in when tapping an input field.

## Diagram (if applicable)

Before
![before](https://github.com/user-attachments/assets/2ca8a066-c87e-42a9-92c7-16eb6fd58002)

After
![after](https://github.com/user-attachments/assets/fafbe847-55c3-48a6-b93a-fb4519bd4ff0)

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: iOS (Safari iPhone)
- Runtime/container: Browser (Safari WebKit)
- Model/provider: N/A
- Integration/channel (if any): Control UI
- Relevant config (redacted): N/A

### Steps

1. Open the control UI on iPhone Safari.
2. Navigate to the chat view.
3. Observe the layout and tap an input field.

### Expected

- No scrollbar on the chat view.
- Body fills the full viewport.
- Input focus does not trigger zoom.

### Actual (before fix)

- Global scrollbar visible.
- Body height not anchored to viewport.
- Safari zooms in on input focus.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Chat view layout on iPhone Safari — no scrollbar, full viewport height, no input zoom.
- Edge cases checked: Keyboard appearance (viewport shrink with `dvh`), landscape orientation.
- What you did not verify: Android Chrome, desktop browsers (no changes expected there).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigation

None