### PR TITLE
fix(cron): replay interrupted one-shot jobs on startup recovery

### DIFF
--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -30,6 +30,52 @@ function createInterruptedMainJob(now: number): CronJob {
   };
 }
 
+function createInterruptedOneShotJob(now: number): CronJob {
+  // One-shot (`kind: "at"`) job that was mid-execution when the gateway
+  // went down: `runningAtMs` is set but `lastStatus` is unset because the
+  // run never reached the settle step. See #63657.
+  return {
+    id: "startup-interrupted-one-shot",
+    name: "startup interrupted one-shot",
+    enabled: true,
+    createdAtMs: now - 86_400_000,
+    updatedAtMs: now - 30 * 60_000,
+    schedule: { kind: "at", at: new Date(now - 60_000).toISOString() },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "one-shot reminder" },
+    state: {
+      nextRunAtMs: now - 60_000,
+      runningAtMs: now - 30 * 60_000,
+    },
+  };
+}
+
+function createCompletedOneShotJob(now: number): CronJob {
+  // One-shot that already settled successfully before the restart. The
+  // `runningAtMs` marker is stale (should have been cleared by timer.ts:408
+  // in the same block that set `lastStatus`), but defensive code should
+  // still treat it as completed and refuse to re-run it.
+  return {
+    id: "startup-completed-one-shot",
+    name: "startup completed one-shot",
+    enabled: true,
+    createdAtMs: now - 86_400_000,
+    updatedAtMs: now - 30 * 60_000,
+    schedule: { kind: "at", at: new Date(now - 3_600_000).toISOString() },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "already delivered" },
+    state: {
+      nextRunAtMs: now - 3_600_000,
+      lastRunAtMs: now - 3_600_000,
+      lastStatus: "ok",
+      // Stale runningAtMs to simulate a crash between marker set and clear.
+      runningAtMs: now - 3_600_000,
+    },
+  };
+}
+
 function createDueIsolatedJob(now: number): CronJob {
   return {
     id: "isolated-timeout",
@@ -113,6 +159,103 @@ describe("cron service ops seam coverage", () => {
     expect(delays.some((delay) => delay > 0)).toBe(true);
 
     timeoutSpy.mockRestore();
+    stop(state);
+  });
+
+  it("replays interrupted one-shot jobs on startup recovery (#63657)", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [createInterruptedOneShotJob(now)],
+    });
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await start(state);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "startup-interrupted-one-shot" }),
+      "cron: clearing stale running marker on startup",
+    );
+    // Interrupted one-shot jobs must now be replayed on first restart —
+    // previously they were silently skipped, losing any reminder or
+    // scheduled delivery that happened to be mid-flight at the restart
+    // moment (#63657).
+    expect(enqueueSystemEvent).toHaveBeenCalled();
+    expect(requestHeartbeatNow).toHaveBeenCalled();
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      jobs: CronJob[];
+    };
+    const job = persisted.jobs[0];
+    expect(job).toBeDefined();
+    expect(job?.state.runningAtMs).toBeUndefined();
+    expect(job?.state.lastStatus).toBe("ok");
+    expect(job?.state.lastRunAtMs).toBe(now);
+
+    stop(state);
+  });
+
+  it("does not re-run a completed one-shot with stale runningAtMs on startup (#63657)", async () => {
+    // Safety guard: if a crash leaves a completed one-shot with a stale
+    // `runningAtMs` marker (e.g. the gateway died between the settle write
+    // and the state flush), the `skipAtIfAlreadyRan` guard in
+    // `runMissedJobs -> isRunnableJob` must still refuse to re-run it
+    // because `lastStatus` is already set. Without this guarantee, fixing
+    // #63657 would regress the #56509 class of one-shot double-delivery
+    // bugs. See timer.ts:850-866.
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeatNow = vi.fn();
+
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [createCompletedOneShotJob(now)],
+    });
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeatNow,
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await start(state);
+
+    // Startup still clears the stale marker.
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "startup-completed-one-shot" }),
+      "cron: clearing stale running marker on startup",
+    );
+    // But the already-delivered one-shot is NOT re-enqueued.
+    expect(enqueueSystemEvent).not.toHaveBeenCalled();
+
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      jobs: CronJob[];
+    };
+    const job = persisted.jobs[0];
+    expect(job).toBeDefined();
+    expect(job?.state.runningAtMs).toBeUndefined();
+    // Completion state is preserved — still "ok", still the original lastRun.
+    expect(job?.state.lastStatus).toBe("ok");
+    expect(job?.state.lastRunAtMs).toBe(now - 3_600_000);
+
     stop(state);
   });
 

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -103,7 +103,6 @@ export async function start(state: CronServiceState) {
     return;
   }
 
-  const interruptedOneShotIds = new Set<string>();
   let clearedAnyRunningMarker = false;
   await locked(state, async () => {
     await ensureLoaded(state, { skipRecompute: true });
@@ -116,12 +115,6 @@ export async function start(state: CronServiceState) {
         );
         job.state.runningAtMs = undefined;
         clearedAnyRunningMarker = true;
-        // One-shot jobs are not retried after interruption; recurring jobs
-        // (cron/every) are eligible for startup catch-up so they don't
-        // require a second restart to recover (#60495).
-        if (job.schedule.kind === "at") {
-          interruptedOneShotIds.add(job.id);
-        }
       }
     }
     if (clearedAnyRunningMarker) {
@@ -129,9 +122,16 @@ export async function start(state: CronServiceState) {
     }
   });
 
-  await runMissedJobs(state, {
-    skipJobIds: interruptedOneShotIds.size > 0 ? interruptedOneShotIds : undefined,
-  });
+  // Let startup catch-up re-run any job that was interrupted mid-execution,
+  // regardless of schedule kind. Recurring jobs were already eligible via
+  // #60583. One-shot ("at") jobs are now also eligible: an interrupted run
+  // leaves `runningAtMs` set but `lastStatus` unset (timer.ts writes both
+  // atomically on completion), so the existing `skipAtIfAlreadyRan` guard in
+  // `runMissedJobs -> isRunnableJob` (timer.ts:850-866) correctly distinguishes
+  // "never settled" from "already completed" and retries only the former.
+  // This prevents one-shot reminders from silently disappearing when the
+  // gateway restarts mid-delivery (#63657).
+  await runMissedJobs(state);
 
   await locked(state, async () => {
     // Startup catch-up already persisted the latest in-memory store state, and


### PR DESCRIPTION
## Summary

One-shot cron jobs (`schedule.kind === "at"`) that were mid-execution when the gateway restarted were silently lost: `runningAtMs` got cleared but the job was then skipped instead of retried, with 0 runs recorded and no notification delivered. Reminders that happened to fire during a model switch, container restart, or update disappeared without any user-visible signal.

Fixes #63657

## Root cause

In `src/cron/service/ops.ts` `start()`, the startup recovery path used to collect any job with a stale `runningAtMs` marker into a local `interruptedOneShotIds` set and pass that set as `skipJobIds` to `runMissedJobs`, but the collection filter was gated on `schedule.kind === "at"`:

\`\`\`ts
// Before (ops.ts:106-134)
const interruptedOneShotIds = new Set<string>();
// ...
if (typeof job.state.runningAtMs === "number") {
  // ...
  job.state.runningAtMs = undefined;
  // One-shot jobs are not retried after interruption; recurring jobs
  // (cron/every) are eligible for startup catch-up so they don't
  // require a second restart to recover (#60495).
  if (job.schedule.kind === "at") {
    interruptedOneShotIds.add(job.id);
  }
}
// ...
await runMissedJobs(state, {
  skipJobIds: interruptedOneShotIds.size > 0 ? interruptedOneShotIds : undefined,
});
\`\`\`

The existing comment acknowledged recurring jobs are eligible via #60583 and one-shots were deliberately excluded — but the excluded path leaves reminders irrecoverable. A reminder that fires exactly at `docker restart`, `openclaw update`, or a model-switch reload is lost forever with no log line beyond the generic \"clearing stale running marker\".

## Fix

Drop the one-shot skip entirely and let `runMissedJobs` decide. The existing `skipAtIfAlreadyRan` guard in `runMissedJobs -> isRunnableJob` (`src/cron/service/timer.ts:850-866`) already distinguishes \"interrupted before completion\" from \"already completed\" by checking `job.state.lastStatus`:

- `runningAtMs` and `lastStatus` are written **in the same atomic block** at `timer.ts:408-411`. Either both are cleared (successful completion) or neither is touched (crash mid-execution).
- **Interrupted one-shot**: `lastStatus === undefined` → `skipAtIfAlreadyRan` check at timer.ts:850 falls through to the normal `nowMs >= nextRunAtMs` overdue check → retries ✅
- **Completed one-shot** (defensive — e.g. crash between settle and flush leaves stale `runningAtMs`): `lastStatus === \"ok\"` → timer.ts:850-866 returns false → skipped ✅
- **Failed one-shot with retry eligibility**: `lastStatus === \"error\"` + `nextRun > lastRun` → retries per timer.ts:856-864 ✅
- **Failed one-shot without retry**: `lastStatus === \"error\"` + no retry window → skipped ✅

This preserves the invariant protected by PR #56509 (no double-delivery of already-completed one-shots) while fixing the symmetric data-loss bug.

## Tests

Two new cases in `src/cron/service/ops.test.ts`, mirroring the existing `#60495` recurring-interrupted startup test:

1. **`replays interrupted one-shot jobs on startup recovery (#63657)`**
   - Setup: one-shot `at:` job with `runningAtMs` set, `nextRunAtMs` in the past, `lastStatus` unset
   - Action: `start(state)`
   - Asserts: stale marker cleared, `enqueueSystemEvent` called, `lastStatus === \"ok\"`, `lastRunAtMs === now`

2. **`does not re-run a completed one-shot with stale runningAtMs on startup (#63657)`** (the safety guard)
   - Setup: one-shot `at:` job with both `runningAtMs` AND `lastStatus: \"ok\"` (simulates a crash between settle and flush)
   - Action: `start(state)`
   - Asserts: stale marker cleared, `enqueueSystemEvent` NOT called, `lastStatus` and `lastRunAtMs` preserved

The second test is the critical regression guard: it proves the fix doesn't reintroduce the #56509-class of one-shot double-delivery bugs.

## Precedent

- **#60583** (merged, joelnishanth): `fix(cron): resume interrupted recurring jobs on first restart` — the identical fix pattern for recurring jobs. Same catch-up path, same `runMissedJobs` entry point. Referenced in the existing ops.ts comment.
- **#56509** (open, claygeo): `fix(cron): prevent one-shot at jobs from re-triggering after completion` — orthogonal to this PR. #56509 fixes completed one-shots re-triggering from `onTimer`/`runDueJobs` paths that don't pass `skipAtIfAlreadyRan`. This PR works through `runMissedJobs` which DOES pass `skipAtIfAlreadyRan: true` (timer.ts:970), so both fixes coexist.

## Scope

- **Files**: `src/cron/service/ops.ts` (-10, +10), `src/cron/service/ops.test.ts` (+143)
- **LOC**: <20 production changes, no new functions, no new abstractions
- **No changes** to `timer.ts`, to `isRunnableJob`, or to the settle path — the safety comes from existing guards
- **oxlint clean**

cc @steipete — cron service startup recovery, same area as #60583.

Credit to @myradon for the precise RCA in #63657 — the issue body named the exact file, the exact skip logic, and the exact symptom, which made this a ~20 LOC fix with a 143-line test suite.