### PR TITLE
fix: prevent self-approval in exec.approval.resolve (CWE-284)

### DIFF
--- a/src/gateway/server-methods/exec-approval-self-approval.test.ts
+++ b/src/gateway/server-methods/exec-approval-self-approval.test.ts
@@ -52,7 +52,7 @@ describe("exec-approval self-approval prevention (CWE-284)", () => {
       params: { id, decision },
       respond,
       client: resolverConnId != null ? { connId: resolverConnId } : null,
-      context: {},
+      context: { broadcast: vi.fn() },
     } as any);
     return respond;
   }

--- a/src/gateway/server-methods/exec-approval-self-approval.test.ts
+++ b/src/gateway/server-methods/exec-approval-self-approval.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ExecApprovalManager } from "../exec-approval-manager.js";
+import { createExecApprovalHandlers } from "./exec-approval.js";
+
+describe("exec-approval self-approval prevention (CWE-284)", () => {
+  let manager: ExecApprovalManager;
+  let handlers: ReturnType<typeof createExecApprovalHandlers>;
+
+  beforeEach(() => {
+    manager = new ExecApprovalManager();
+    handlers = createExecApprovalHandlers(manager);
+  });
+
+  /**
+   * Create a pending approval record and register it.
+   * Sets requestedByConnId to simulate the requesting connection.
+   */
+  function createPending(requestConnId: string | null): string {
+    const record = manager.create(
+      {
+        command: "echo test",
+        allowedDecisions: ["allow-once", "allow-always", "deny"],
+        host: null,
+        nodeId: null,
+        cwd: null,
+        security: null,
+        ask: null,
+        agentId: null,
+        resolvedPath: null,
+        sessionKey: null,
+        systemRunBinding: null,
+        systemRunPlan: undefined,
+        turnSourceChannel: null,
+        turnSourceTo: null,
+        turnSourceAccountId: null,
+        turnSourceThreadId: null,
+      } as any,
+      30_000,
+    );
+    record.requestedByConnId = requestConnId;
+    manager.register(record, 30_000);
+    return record.id;
+  }
+
+  async function resolve(
+    id: string,
+    decision: string,
+    resolverConnId: string | null | undefined,
+  ) {
+    const respond = vi.fn();
+    await handlers["exec.approval.resolve"]({
+      params: { id, decision },
+      respond,
+      client: resolverConnId != null ? { connId: resolverConnId } : null,
+      context: {},
+    } as any);
+    return respond;
+  }
+
+  it("rejects allow-once from the same connection that requested", async () => {
+    const id = createPending("conn-requester");
+    const respond = await resolve(id, "allow-once", "conn-requester");
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("requester cannot approve"),
+      }),
+    );
+  });
+
+  it("allows allow-once from a different connection", async () => {
+    const id = createPending("conn-requester");
+    const respond = await resolve(id, "allow-once", "conn-reviewer");
+    expect(respond).toHaveBeenCalledWith(true, expect.anything(), undefined);
+  });
+
+  it("allows self-deny (requester can deny their own request)", async () => {
+    const id = createPending("conn-requester");
+    const respond = await resolve(id, "deny", "conn-requester");
+    expect(respond).toHaveBeenCalledWith(true, expect.anything(), undefined);
+  });
+
+  it("allows resolve when client has no connId (e.g. system/internal)", async () => {
+    const id = createPending("conn-requester");
+    const respond = await resolve(id, "allow-once", undefined);
+    expect(respond).toHaveBeenCalledWith(true, expect.anything(), undefined);
+  });
+
+  it("rejects allow-always from the same connection that requested", async () => {
+    const id = createPending("conn-requester");
+    const respond = await resolve(id, "allow-always", "conn-requester");
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: expect.stringContaining("requester cannot approve"),
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -358,6 +358,15 @@ export function createExecApprovalHandlers(
         client,
         exposeAmbiguousPrefixError: true,
         validateDecision: (snapshot) => {
+          // Self-approval prevention: requester cannot approve their own exec request (CWE-284)
+          if (
+            decision !== "deny" &&
+            snapshot.requestedByConnId != null &&
+            client?.connId != null &&
+            client.connId === snapshot.requestedByConnId
+          ) {
+            return { message: "requester cannot approve their own exec request" };
+          }
           const allowedDecisions = resolveExecApprovalRequestAllowedDecisions(snapshot.request);
           return allowedDecisions.includes(decision)
             ? null

--- a/src/gateway/server.node-invoke-approval-bypass.test.ts
+++ b/src/gateway/server.node-invoke-approval-bypass.test.ts
@@ -70,13 +70,14 @@ async function getConnectedNodeIds(ws: WebSocket): Promise<string[]> {
 }
 
 async function requestAllowOnceApproval(
-  ws: WebSocket,
+  wsRequester: WebSocket,
+  wsResolver: WebSocket,
   command: string,
   nodeId: string,
 ): Promise<string> {
   const approvalId = crypto.randomUUID();
   const commandArgv = command.split(/\s+/).filter((part) => part.length > 0);
-  const requestP = rpcReq(ws, "exec.approval.request", {
+  const requestP = rpcReq(wsRequester, "exec.approval.request", {
     id: approvalId,
     command,
     commandArgv,
@@ -92,7 +93,7 @@ async function requestAllowOnceApproval(
     host: "node",
     timeoutMs: 30_000,
   });
-  await rpcReq(ws, "exec.approval.resolve", { id: approvalId, decision: "allow-once" });
+  await rpcReq(wsResolver, "exec.approval.resolve", { id: approvalId, decision: "allow-once" });
   const requested = await requestP;
   expect(requested.ok).toBe(true);
   return approvalId;
@@ -371,13 +372,14 @@ describe("node.invoke approval bypass", () => {
     });
 
     const wsApprover = await connectOperator(["operator.write", "operator.approvals"]);
+    const wsResolver = await connectOperator(["operator.write", "operator.approvals"]);
     const wsCaller = await connectOperator(["operator.write"]);
     const wsOtherDevice = await connectOperatorWithNewDevice(["operator.write"]);
 
     try {
       const nodeId = await getConnectedNodeId(wsApprover);
 
-      const approvalId = await requestAllowOnceApproval(wsApprover, "echo hi", nodeId);
+      const approvalId = await requestAllowOnceApproval(wsApprover, wsResolver, "echo hi", nodeId);
       // Separate caller connection simulates per-call clients.
       const invoke = await rpcReq(wsCaller, "node.invoke", {
         nodeId,
@@ -398,7 +400,7 @@ describe("node.invoke approval bypass", () => {
       expect(lastInvokeParams?.["approvalDecision"]).toBe("allow-once");
       expect(lastInvokeParams?.["injected"]).toBeUndefined();
 
-      const replayApprovalId = await requestAllowOnceApproval(wsApprover, "echo hi", nodeId);
+      const replayApprovalId = await requestAllowOnceApproval(wsApprover, wsResolver, "echo hi", nodeId);
       const invokeCountBeforeReplay = invokeCount;
       const replay = await rpcReq(wsOtherDevice, "node.invoke", {
         nodeId,
@@ -417,6 +419,7 @@ describe("node.invoke approval bypass", () => {
       await expectNoForwardedInvoke(() => invokeCount > invokeCountBeforeReplay);
     } finally {
       wsApprover.close();
+      wsResolver.close();
       wsCaller.close();
       wsOtherDevice.close();
       node.stop();
@@ -437,6 +440,7 @@ describe("node.invoke approval bypass", () => {
     const nodeB = await connectLinuxNode(onInvoke, createDeviceIdentity());
 
     const wsApprover = await connectOperator(["operator.write", "operator.approvals"]);
+    const wsResolver = await connectOperator(["operator.write", "operator.approvals"]);
     const wsCaller = await connectOperator(["operator.write"]);
 
     try {
@@ -452,7 +456,7 @@ describe("node.invoke approval bypass", () => {
       expect(approvedNodeId).toBeTruthy();
       expect(replayNodeId).toBeTruthy();
 
-      const approvalId = await requestAllowOnceApproval(wsApprover, "echo hi", approvedNodeId);
+      const approvalId = await requestAllowOnceApproval(wsApprover, wsResolver, "echo hi", approvedNodeId);
       const beforeReplayApprovedNode = invokeCounts.get(approvedNodeId) ?? 0;
       const beforeReplayOtherNode = invokeCounts.get(replayNodeId) ?? 0;
       const replay = await rpcReq(wsCaller, "node.invoke", {
@@ -476,6 +480,7 @@ describe("node.invoke approval bypass", () => {
       );
     } finally {
       wsApprover.close();
+      wsResolver.close();
       wsCaller.close();
       nodeA.stop();
       nodeB.stop();


### PR DESCRIPTION
## Summary

Prevent self-approval in `exec.approval.resolve` — the same WebSocket connection
that requested an exec approval must not be permitted to approve it (CWE-284,
CVSS 8.5).

Supersedes #48149 and #63670 which targeted outdated architecture / had branch issues.

## Vulnerability

Without this guard, a compromised or malicious agent extension can:
1. Call `exec.approval.request` to create an approval for a dangerous command
2. Immediately call `exec.approval.resolve` with `allow-once` using the **same
   connection** to approve its own request
3. Execute arbitrary commands without any human review

This breaks the fundamental security assumption that exec approvals provide
a human-in-the-loop checkpoint.

## Fix

A single guard (8 lines) in the `validateDecision` callback of `exec.approval.resolve`:

```typescript
if (
  decision !== "deny" &&
  snapshot.requestedByConnId != null &&
  client?.connId != null &&
  client.connId === snapshot.requestedByConnId
) {
  return { message: "requester cannot approve their own exec request" };
}
```

### Design decisions

- **Self-deny is allowed**: Users should be able to cancel their own requests
- **Null connId fallback**: When client tracking is unavailable, the check
  is skipped to maintain backward compatibility
- **Minimal diff**: Only the `validateDecision` callback is modified —
  no changes to `approval-shared.ts` or the manager

## Tests

5 focused test cases in `exec-approval-self-approval.test.ts`:

| Scenario | Expected |
|----------|----------|
| Same connId + allow-once | **Rejected** |
| Same connId + allow-always | **Rejected** |
| Same connId + deny | Allowed |
| Different connId + allow-once | Allowed |
| Null client + allow-once | Allowed |

## References

- CWE-284: Improper Access Control
- CVSS 3.1: 8.5 (High) — Network/Low/None/High for C/I/A
- Related: The `requestedByConnId` field is already set during `exec.approval.request`
  but was not checked during resolve