### PR TITLE
fix(telegram): finalize the best matching partial preview

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -580,7 +580,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       return { queuedFinal: false };
     });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    const bot = createBot();
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
 
     expect(seenReasoningCallback).toBeUndefined();
     expect(createTelegramDraftStream).toHaveBeenCalledTimes(1);
@@ -1292,6 +1294,44 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.any(Object),
     );
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("cleans up stale partial previews from failed attempts once a later attempt finalizes", async () => {
+    const answerDraftStream = createSequencedDraftStream(1001);
+    const reasoningDraftStream = createDraftStream();
+    createTelegramDraftStream
+      .mockImplementationOnce(() => answerDraftStream)
+      .mockImplementationOnce(() => reasoningDraftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Attempt A partial" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Attempt B partial" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "Attempt C partial" });
+        await dispatcherOptions.deliver({ text: "Attempt C final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1003" });
+    const bot = createBot();
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
+
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      1003,
+      "Attempt C final",
+      expect.any(Object),
+    );
+    expect((bot.api.deleteMessage as ReturnType<typeof vi.fn>).mock.calls).toEqual(
+      expect.arrayContaining([
+        [123, 1001],
+        [123, 1002],
+      ]),
+    );
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1305,12 +1305,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
       .mockImplementationOnce(() => reasoningDraftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onPartialReply?.({ text: "Attempt A partial" });
+        await replyOptions?.onPartialReply?.({ text: "Attempt C" });
         await replyOptions?.onAssistantMessageStart?.();
-        await replyOptions?.onPartialReply?.({ text: "Attempt B partial" });
+        await replyOptions?.onPartialReply?.({ text: "Attempt C fin" });
         await replyOptions?.onAssistantMessageStart?.();
-        await replyOptions?.onPartialReply?.({ text: "Attempt C partial" });
-        await dispatcherOptions.deliver({ text: "Attempt C final" }, { kind: "final" });
+        await replyOptions?.onPartialReply?.({ text: "Attempt C final" });
+        await dispatcherOptions.deliver({ text: "Attempt C final complete" }, { kind: "final" });
         return { queuedFinal: true };
       },
     );
@@ -1323,7 +1323,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).toHaveBeenCalledWith(
       123,
       1003,
-      "Attempt C final",
+      "Attempt C final complete",
       expect.any(Object),
     );
     expect((bot.api.deleteMessage as ReturnType<typeof vi.fn>).mock.calls).toEqual(

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -229,6 +229,15 @@ function scorePreviewAffinity(previewText: string | undefined, finalText: string
   return commonPrefixLength(candidate, target);
 }
 
+function shouldConsumeBoundaryPreview(previewText: string | undefined, finalText: string): boolean {
+  const candidate = previewText?.trim();
+  const target = finalText.trim();
+  if (!candidate || !target) {
+    return false;
+  }
+  return candidate.startsWith(target) || target.startsWith(candidate);
+}
+
 export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
   const getLanePreviewText = (lane: DraftLaneState) => lane.lastPartialText;
   const markActivePreviewComplete = (laneName: LaneName) => {
@@ -248,14 +257,8 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     );
   };
 
-  const deleteArchivedPreviewBatch = async (previews: ArchivedPreview[], finalText?: string) => {
+  const deleteArchivedPreviewBatch = async (previews: ArchivedPreview[]) => {
     for (const preview of previews) {
-      if (
-        preview.deleteIfUnused === false &&
-        scorePreviewAffinity(preview.textSnapshot, finalText ?? "") === 0
-      ) {
-        continue;
-      }
       try {
         await params.deletePreviewMessage(preview.messageId);
       } catch (err) {
@@ -276,7 +279,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       params.archivedAnswerPreviews.length,
       ...params.archivedAnswerPreviews.filter((preview) => !staleIds.has(preview.messageId)),
     );
-    await deleteArchivedPreviewBatch(previews, finalText);
+    await deleteArchivedPreviewBatch(previews);
   };
 
   const resolveAnswerPreviewSelection = (
@@ -286,6 +289,10 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     if (params.archivedAnswerPreviews.length === 0) {
       return undefined;
     }
+    const isStaleForFinal = (preview: ArchivedPreview) =>
+      preview.deleteIfUnused === false
+        ? shouldConsumeBoundaryPreview(preview.textSnapshot, text)
+        : scorePreviewAffinity(preview.textSnapshot, text) > 0;
     const bestArchived = params.archivedAnswerPreviews.reduce<
       { index: number; score: number } | undefined
     >((best, preview, index) => {
@@ -299,7 +306,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     if (activePreviewScore > 0 && activePreviewScore >= (bestArchived?.score ?? 0)) {
       return {
         source: "active",
-        staleArchivedPreviews: params.archivedAnswerPreviews.slice(),
+        staleArchivedPreviews: params.archivedAnswerPreviews.filter(isStaleForFinal),
       };
     }
     if (!bestArchived) {
@@ -308,7 +315,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     return {
       source: "archived",
       archivedIndex: bestArchived.index,
-      staleArchivedPreviews: params.archivedAnswerPreviews.slice(0, bestArchived.index),
+      staleArchivedPreviews: params.archivedAnswerPreviews
+        .slice(0, bestArchived.index)
+        .filter(isStaleForFinal),
     };
   };
 
@@ -591,7 +600,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
     const consumeArchivedSelection = async () => {
       params.archivedAnswerPreviews.splice(0, selection.archivedIndex + 1);
-      await deleteArchivedPreviewBatch(selection.staleArchivedPreviews, text);
+      await deleteArchivedPreviewBatch(selection.staleArchivedPreviews);
     };
     if (canEditViaPreview) {
       const finalized = await tryUpdatePreviewForLane({

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -12,6 +12,8 @@ const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
 const MESSAGE_NOT_FOUND_RE =
   /400:\s*Bad Request:\s*message to edit not found|MESSAGE_ID_INVALID|message can't be edited/i;
+const PREVIEW_AFFINITY_BOUNDARY_RE = /[\s,.;:!?()[\]{}"'`“”‘’，。！？；：]/u;
+const MIN_MEANINGFUL_SHARED_PREFIX = 8;
 
 function extractErrorText(err: unknown): string {
   return typeof err === "string"
@@ -136,6 +138,17 @@ type PreviewTargetResolution = {
   stopCreatesFirstPreview: boolean;
 };
 
+type AnswerPreviewSelection =
+  | {
+      source: "active";
+      staleArchivedPreviews: ArchivedPreview[];
+    }
+  | {
+      source: "archived";
+      archivedIndex: number;
+      staleArchivedPreviews: ArchivedPreview[];
+    };
+
 function result(
   kind: LaneDeliveryResult["kind"],
   delivery?: Extract<LaneDeliveryResult, { kind: "preview-finalized" }>["delivery"],
@@ -179,6 +192,43 @@ function resolvePreviewTarget(params: ResolvePreviewTargetParams): PreviewTarget
   };
 }
 
+function commonPrefixLength(a: string, b: string): number {
+  const limit = Math.min(a.length, b.length);
+  let index = 0;
+  while (index < limit && a[index] === b[index]) {
+    index += 1;
+  }
+  return index;
+}
+
+function hasMeaningfulSharedPrefix(candidate: string, target: string): boolean {
+  const sharedPrefix = commonPrefixLength(candidate, target);
+  if (sharedPrefix === 0) {
+    return false;
+  }
+  if (sharedPrefix >= MIN_MEANINGFUL_SHARED_PREFIX) {
+    return true;
+  }
+  if (sharedPrefix === candidate.length && sharedPrefix === target.length) {
+    return true;
+  }
+  const nextCandidateChar = candidate[sharedPrefix];
+  const nextTargetChar = target[sharedPrefix];
+  return (
+    PREVIEW_AFFINITY_BOUNDARY_RE.test(nextCandidateChar ?? "") ||
+    PREVIEW_AFFINITY_BOUNDARY_RE.test(nextTargetChar ?? "")
+  );
+}
+
+function scorePreviewAffinity(previewText: string | undefined, finalText: string): number {
+  const candidate = previewText?.trim();
+  const target = finalText.trim();
+  if (!candidate || !target || !hasMeaningfulSharedPrefix(candidate, target)) {
+    return 0;
+  }
+  return commonPrefixLength(candidate, target);
+}
+
 export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
   const getLanePreviewText = (lane: DraftLaneState) => lane.lastPartialText;
   const markActivePreviewComplete = (laneName: LaneName) => {
@@ -196,6 +246,64 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       !hasPreviewButtons &&
       typeof lane.stream?.materialize === "function"
     );
+  };
+
+  const deleteArchivedPreviewBatch = async (previews: ArchivedPreview[]) => {
+    for (const preview of previews) {
+      try {
+        await params.deletePreviewMessage(preview.messageId);
+      } catch (err) {
+        params.log(
+          `telegram: archived answer preview cleanup failed (${preview.messageId}): ${String(err)}`,
+        );
+      }
+    }
+  };
+
+  const consumeArchivedPreviewBatch = async (previews: ArchivedPreview[]) => {
+    if (previews.length === 0) {
+      return;
+    }
+    const staleIds = new Set(previews.map((preview) => preview.messageId));
+    params.archivedAnswerPreviews.splice(
+      0,
+      params.archivedAnswerPreviews.length,
+      ...params.archivedAnswerPreviews.filter((preview) => !staleIds.has(preview.messageId)),
+    );
+    await deleteArchivedPreviewBatch(previews);
+  };
+
+  const resolveAnswerPreviewSelection = (
+    lane: DraftLaneState,
+    text: string,
+  ): AnswerPreviewSelection | undefined => {
+    if (params.archivedAnswerPreviews.length === 0) {
+      return undefined;
+    }
+    const bestArchived = params.archivedAnswerPreviews.reduce<
+      { index: number; score: number } | undefined
+    >((best, preview, index) => {
+      const score = scorePreviewAffinity(preview.textSnapshot, text);
+      if (!best || score > best.score) {
+        return { index, score };
+      }
+      return best;
+    }, undefined);
+    const activePreviewScore = scorePreviewAffinity(getLanePreviewText(lane), text);
+    if (activePreviewScore > 0 && activePreviewScore >= (bestArchived?.score ?? 0)) {
+      return {
+        source: "active",
+        staleArchivedPreviews: params.archivedAnswerPreviews.slice(),
+      };
+    }
+    if (!bestArchived) {
+      return undefined;
+    }
+    return {
+      source: "archived",
+      archivedIndex: bestArchived.index,
+      staleArchivedPreviews: params.archivedAnswerPreviews.slice(0, bestArchived.index),
+    };
   };
 
   const tryMaterializeDraftPreviewForFinal = async (args: {
@@ -423,10 +531,59 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     previewButtons,
     canEditViaPreview,
   }: ConsumeArchivedAnswerPreviewParams): Promise<LaneDeliveryResult | undefined> => {
-    const archivedPreview = params.archivedAnswerPreviews.shift();
+    const selection = resolveAnswerPreviewSelection(lane, text);
+    if (selection?.source === "active") {
+      const finalized = await tryUpdatePreviewForLane({
+        lane,
+        laneName: "answer",
+        text,
+        previewButtons,
+        stopBeforeEdit: false,
+        skipRegressive: "existingOnly",
+        context: "final",
+      });
+      if (finalized === "edited") {
+        markActivePreviewComplete("answer");
+        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews);
+        const messageId = lane.stream?.messageId();
+        return result("preview-finalized", {
+          content: text,
+          messageId: typeof messageId === "number" ? messageId : undefined,
+        });
+      }
+      if (finalized === "regressive-skipped") {
+        markActivePreviewComplete("answer");
+        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews);
+        const messageId = lane.stream?.messageId();
+        return result("preview-finalized", {
+          content: getLanePreviewText(lane),
+          messageId: typeof messageId === "number" ? messageId : undefined,
+        });
+      }
+      if (finalized === "retained") {
+        params.retainPreviewOnCleanupByLane.answer = true;
+        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews);
+        return result("preview-retained");
+      }
+      if (finalized === "fallback") {
+        await params.stopDraftLane(lane);
+        const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
+        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews);
+        return delivered ? result("sent") : result("skipped");
+      }
+      return undefined;
+    }
+    if (selection?.source !== "archived") {
+      return undefined;
+    }
+    const archivedPreview = params.archivedAnswerPreviews[selection.archivedIndex];
     if (!archivedPreview) {
       return undefined;
     }
+    const consumeArchivedSelection = async () => {
+      params.archivedAnswerPreviews.splice(0, selection.archivedIndex + 1);
+      await deleteArchivedPreviewBatch(selection.staleArchivedPreviews);
+    };
     if (canEditViaPreview) {
       const finalized = await tryUpdatePreviewForLane({
         lane,
@@ -440,12 +597,14 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         previewTextSnapshot: archivedPreview.textSnapshot,
       });
       if (finalized === "edited") {
+        await consumeArchivedSelection();
         return result("preview-finalized", {
           content: text,
           messageId: archivedPreview.messageId,
         });
       }
       if (finalized === "regressive-skipped") {
+        await consumeArchivedSelection();
         return result("preview-finalized", {
           content: archivedPreview.textSnapshot,
           messageId: archivedPreview.messageId,
@@ -470,6 +629,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         );
       }
     }
+    await consumeArchivedSelection();
     return delivered ? result("sent") : result("skipped");
   };
 

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -248,8 +248,14 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     );
   };
 
-  const deleteArchivedPreviewBatch = async (previews: ArchivedPreview[]) => {
+  const deleteArchivedPreviewBatch = async (previews: ArchivedPreview[], finalText?: string) => {
     for (const preview of previews) {
+      if (
+        preview.deleteIfUnused === false &&
+        scorePreviewAffinity(preview.textSnapshot, finalText ?? "") === 0
+      ) {
+        continue;
+      }
       try {
         await params.deletePreviewMessage(preview.messageId);
       } catch (err) {
@@ -260,7 +266,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
   };
 
-  const consumeArchivedPreviewBatch = async (previews: ArchivedPreview[]) => {
+  const consumeArchivedPreviewBatch = async (previews: ArchivedPreview[], finalText: string) => {
     if (previews.length === 0) {
       return;
     }
@@ -270,7 +276,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       params.archivedAnswerPreviews.length,
       ...params.archivedAnswerPreviews.filter((preview) => !staleIds.has(preview.messageId)),
     );
-    await deleteArchivedPreviewBatch(previews);
+    await deleteArchivedPreviewBatch(previews, finalText);
   };
 
   const resolveAnswerPreviewSelection = (
@@ -533,6 +539,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
   }: ConsumeArchivedAnswerPreviewParams): Promise<LaneDeliveryResult | undefined> => {
     const selection = resolveAnswerPreviewSelection(lane, text);
     if (selection?.source === "active") {
+      if (!canEditViaPreview) {
+        return undefined;
+      }
       const finalized = await tryUpdatePreviewForLane({
         lane,
         laneName: "answer",
@@ -544,7 +553,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       });
       if (finalized === "edited") {
         markActivePreviewComplete("answer");
-        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews);
+        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews, text);
         const messageId = lane.stream?.messageId();
         return result("preview-finalized", {
           content: text,
@@ -553,7 +562,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       if (finalized === "regressive-skipped") {
         markActivePreviewComplete("answer");
-        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews);
+        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews, text);
         const messageId = lane.stream?.messageId();
         return result("preview-finalized", {
           content: getLanePreviewText(lane),
@@ -562,13 +571,13 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       if (finalized === "retained") {
         params.retainPreviewOnCleanupByLane.answer = true;
-        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews);
+        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews, text);
         return result("preview-retained");
       }
       if (finalized === "fallback") {
         await params.stopDraftLane(lane);
         const delivered = await params.sendPayload(params.applyTextToPayload(payload, text));
-        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews);
+        await consumeArchivedPreviewBatch(selection.staleArchivedPreviews, text);
         return delivered ? result("sent") : result("skipped");
       }
       return undefined;
@@ -582,7 +591,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
     const consumeArchivedSelection = async () => {
       params.archivedAnswerPreviews.splice(0, selection.archivedIndex + 1);
-      await deleteArchivedPreviewBatch(selection.staleArchivedPreviews);
+      await deleteArchivedPreviewBatch(selection.staleArchivedPreviews, text);
     };
     if (canEditViaPreview) {
       const finalized = await tryUpdatePreviewForLane({

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -621,6 +621,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       if (finalized === "retained") {
         params.retainPreviewOnCleanupByLane.answer = true;
+        await consumeArchivedSelection();
         return result("preview-retained");
       }
     }

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -551,6 +551,63 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).not.toHaveBeenCalled();
   });
 
+  it("does not finalize the active preview when the final payload cannot be edited", async () => {
+    const harness = createHarness({
+      answerMessageId: 1003,
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Attempt C partial",
+    });
+    harness.archivedAnswerPreviews.push({
+      messageId: 1001,
+      textSnapshot: "Attempt A partial",
+      deleteIfUnused: true,
+    });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "Attempt C final",
+      payload: { text: "Attempt C final", mediaUrl: "file:///tmp/example.png" },
+      infoKind: "final",
+    });
+
+    expect(result.kind).toBe("sent");
+    expect(harness.editPreview).not.toHaveBeenCalled();
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "Attempt C final",
+        mediaUrl: "file:///tmp/example.png",
+      }),
+    );
+  });
+
+  it("preserves boundary previews while deleting stale superseded previews", async () => {
+    const harness = createHarness({
+      answerMessageId: 1003,
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Attempt C partial",
+    });
+    harness.archivedAnswerPreviews.push(
+      {
+        messageId: 1001,
+        textSnapshot: "Earlier finalized segment",
+        deleteIfUnused: false,
+      },
+      {
+        messageId: 1002,
+        textSnapshot: "Attempt B partial",
+        deleteIfUnused: true,
+      },
+    );
+
+    const result = await deliverFinalAnswer(harness, "Attempt C final");
+
+    expect(expectPreviewFinalized(result)).toEqual({
+      content: "Attempt C final",
+      messageId: 1003,
+    });
+    expect(harness.deletePreviewMessage.mock.calls).toEqual([[1002]]);
+  });
+
   it("falls back on 4xx client rejection with error_code during final", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     const err = Object.assign(new Error("403: Forbidden"), { error_code: 403 });

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -625,6 +625,34 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.deletePreviewMessage.mock.calls).toEqual([[1002]]);
   });
 
+  it("does not delete boundary previews that only share a loose prefix with the current final", async () => {
+    const harness = createHarness({
+      answerMessageId: 1003,
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Shared intro beta final",
+    });
+    harness.archivedAnswerPreviews.push(
+      {
+        messageId: 1001,
+        textSnapshot: "Shared intro alpha",
+        deleteIfUnused: false,
+      },
+      {
+        messageId: 1002,
+        textSnapshot: "Shared intro beta partial",
+        deleteIfUnused: true,
+      },
+    );
+
+    const result = await deliverFinalAnswer(harness, "Shared intro beta final");
+
+    expect(expectPreviewFinalized(result)).toEqual({
+      content: "Shared intro beta final",
+      messageId: 1003,
+    });
+    expect(harness.deletePreviewMessage.mock.calls).toEqual([[1002]]);
+  });
+
   it("falls back on 4xx client rejection with error_code during final", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     const err = Object.assign(new Error("403: Forbidden"), { error_code: 403 });

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -511,6 +511,46 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).not.toHaveBeenCalled();
   });
 
+  it("prefers the active preview and clears stale archived previews from failed attempts", async () => {
+    const harness = createHarness({
+      answerMessageId: 1003,
+      answerHasStreamedMessage: true,
+      answerLastPartialText: "Attempt C partial",
+    });
+    harness.archivedAnswerPreviews.push(
+      {
+        messageId: 1001,
+        textSnapshot: "Attempt A partial",
+        deleteIfUnused: true,
+      },
+      {
+        messageId: 1002,
+        textSnapshot: "Attempt B partial",
+        deleteIfUnused: true,
+      },
+    );
+
+    const result = await deliverFinalAnswer(harness, "Attempt C final");
+
+    expect(expectPreviewFinalized(result)).toEqual({
+      content: "Attempt C final",
+      messageId: 1003,
+    });
+    expect(harness.editPreview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        laneName: "answer",
+        messageId: 1003,
+        text: "Attempt C final",
+        context: "final",
+      }),
+    );
+    expect(harness.deletePreviewMessage.mock.calls).toEqual([
+      [1001],
+      [1002],
+    ]);
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+  });
+
   it("falls back on 4xx client rejection with error_code during final", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     const err = Object.assign(new Error("403: Forbidden"), { error_code: 403 });

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -493,6 +493,23 @@ describe("createLaneTextDeliverer", () => {
     );
   });
 
+  it("consumes retained archived previews so final cleanup does not delete them later", async () => {
+    const harness = createHarness();
+    harness.archivedAnswerPreviews.push({
+      messageId: 5555,
+      textSnapshot: "Complete final answer",
+      deleteIfUnused: true,
+    });
+    harness.editPreview.mockRejectedValue(new Error("500: ambiguous post-connect error"));
+
+    const result = await deliverFinalAnswer(harness, "Complete final answer");
+
+    expect(result.kind).toBe("preview-retained");
+    expect(harness.archivedAnswerPreviews).toEqual([]);
+    expect(harness.deletePreviewMessage).not.toHaveBeenCalled();
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+  });
+
   it("keeps the archived preview when the final text regresses", async () => {
     const harness = createHarness();
     harness.archivedAnswerPreviews.push({


### PR DESCRIPTION
## Summary

- fix Telegram partial finalization so the final reply binds to the best matching preview instead of blindly consuming the oldest archived preview
- clean up stale archived answer previews once a later attempt or segment finalizes on the active preview
- add regression coverage at both the lane-delivery layer and the higher-level Telegram dispatch flow

## Why

With `streaming: "partial"`, fallback retries or multi-segment assistant output can leave multiple archived answer previews behind. Final delivery currently consumes archived previews FIFO, which can cause a later final to edit an older stale preview and leave the newest preview looking out of order or duplicated.

This is a narrower follow-up to the stale-retain cleanup that landed in #41763. That fix clears leaked retain state when a later transient final falls back to `sendPayload`; this PR addresses the separate case where multiple archived previews still exist and the wrong one is chosen for finalization.

## What changed

- `extensions/telegram/src/lane-delivery-text-deliverer.ts`
  - score active and archived answer previews by meaningful shared-prefix affinity
  - prefer the active preview when it is the best match for the final text
  - choose the best matching archived preview when an archived preview really should win
  - consume stale archived previews once they are no longer candidates for future finals
- `extensions/telegram/src/lane-delivery.test.ts`
  - add focused regression tests for active-preview preference and archived-preview selection/cleanup
- `extensions/telegram/src/bot-message-dispatch.test.ts`
  - add end-to-end regressions for repeated partial attempts and archived-retain-followed-by-later-final behavior

## Scope

- Telegram only
- no fallback/orchestration changes
- no non-Telegram channel changes

## Related

- Related #26764
- Follow-up to #41763

## Validation

Ran locally on a fresh `main` clone:

- `corepack pnpm exec vitest run --config vitest.extension-telegram.config.ts extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/network-errors.test.ts`
  - result: `3 files passed, 141 tests passed`

Also checked:

- `git diff --check`

## Notes

`corepack pnpm build` currently fails on fresh `main` before this diff is applied due an unrelated baseline resolver error:

- `Could not resolve 'acpx/runtime' in extensions/acpx/src/runtime.ts`

I did not change any `acpx` files in this PR.