### PR TITLE
fix(image): mixed-source image input for vision-capable models

### DIFF
--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -13,6 +13,9 @@ import {
   splitPromptAndAttachmentRefs,
 } from "./images.js";
 
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+
 function expectNoPromptImages(result: { detectedRefs: unknown[]; images: unknown[] }) {
   expect(result.detectedRefs).toHaveLength(0);
   expect(result.images).toHaveLength(0);
@@ -77,10 +80,11 @@ describe("detectImageReferences", () => {
       1. /home/user/photo1.png
       2. https://mysite.com/photo2.jpg
     `,
-      1,
+      2,
     );
 
     expect(refs.some((r) => r.type === "path")).toBe(true);
+    expect(refs.some((r) => r.type === "remote-url")).toBe(true);
   });
 
   it("handles various image extensions", () => {
@@ -164,15 +168,30 @@ what about these images?`,
     expect(ref?.resolved).toContain("IMG_6430.jpeg");
   });
 
-  it("ignores remote URLs entirely (local-only)", () => {
+  it("detects explicit remote HTTP(S) image urls alongside local paths", () => {
     const refs = expectImageReferenceCount(
       `To send an image: MEDIA:https://example.com/image.jpg
 Here is my actual image: /path/to/real.png
 Also https://cdn.mysite.com/img.jpg`,
-      1,
+      3,
     );
 
-    expect(refs[0]?.raw).toBe("/path/to/real.png");
+    expect(refs).toContainEqual({
+      raw: "/path/to/real.png",
+      resolved: "/path/to/real.png",
+      type: "path",
+    });
+    expect(refs.filter((ref) => ref.type === "remote-url")).toHaveLength(2);
+  });
+
+  it("trims trailing punctuation from explicit remote urls", () => {
+    const ref = expectSingleImageReference("https://example.com/image.png, describe the image");
+
+    expect(ref).toEqual({
+      raw: "https://example.com/image.png",
+      resolved: "https://example.com/image.png",
+      type: "remote-url",
+    });
   });
 
   it("handles single file format with URL (no index)", () => {
@@ -289,6 +308,53 @@ describe("detectAndLoadPromptImages", () => {
     });
 
     expectNoPromptImages(result);
+  });
+
+  it("loads explicit remote image urls into the same native vision payload as inline images", async () => {
+    const originalFetch = globalThis.fetch;
+    const tinyPngBuffer = Buffer.from(TINY_PNG_BASE64, "base64");
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url !== "https://example.com/image.png") {
+        throw new Error(`unexpected url: ${url}`);
+      }
+      return new Response(tinyPngBuffer, {
+        status: 200,
+        headers: {
+          "content-type": "image/png",
+          "content-length": String(tinyPngBuffer.length),
+        },
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await detectAndLoadPromptImages({
+        prompt: "https://example.com/image.png, 这两张图片里有什么",
+        workspaceDir: "/tmp",
+        model: { input: ["text", "image"] },
+        existingImages: [{ type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" }],
+      });
+
+      expect(result.detectedRefs).toEqual([
+        {
+          raw: "https://example.com/image.png",
+          resolved: "https://example.com/image.png",
+          type: "remote-url",
+        },
+      ]);
+      expect(result.loadedCount).toBe(1);
+      expect(result.skippedCount).toBe(0);
+      expect(result.images).toHaveLength(2);
+      expect(result.images[0]).toEqual({
+        type: "image",
+        data: TINY_PNG_BASE64,
+        mimeType: "image/png",
+      });
+      expect(result.images[1]?.type).toBe("image");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   it("preserves attachment order when offloaded refs and inline images are mixed", async () => {

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -39,6 +39,7 @@ const MEDIA_ATTACHED_PATH_REGEX_SOURCE =
 const MESSAGE_IMAGE_REGEX_SOURCE =
   "\\[Image:\\s*source:\\s*([^\\]]+\\.(?:" + IMAGE_EXTENSION_PATTERN + "))\\]";
 const FILE_URL_REGEX_SOURCE = "file://[^\\s<>\"'`\\]]+\\.(?:" + IMAGE_EXTENSION_PATTERN + ")";
+const HTTP_URL_REGEX_SOURCE = "https?://[^\\s<>\"'`\\]，。！？；：、]+";
 const PATH_REGEX_SOURCE =
   "(?:^|\\s|[\"'`(])((\\.\\.?/|[~/])[^\\s\"'`()\\[\\]]*\\.(?:" + IMAGE_EXTENSION_PATTERN + "))";
 
@@ -75,7 +76,7 @@ export interface DetectedImageRef {
   /** The raw matched string from the prompt */
   raw: string;
   /** The type of reference */
-  type: "path" | "media-uri";
+  type: "path" | "media-uri" | "remote-url";
   /** The resolved/normalized path, or the raw media URI for media-uri type */
   resolved: string;
 }
@@ -90,6 +91,22 @@ function isImageExtension(filePath: string): boolean {
 
 function normalizeRefForDedupe(raw: string): string {
   return process.platform === "win32" ? normalizeLowercaseStringOrEmpty(raw) : raw;
+}
+
+function normalizeHttpUrlRef(raw: string): string | null {
+  let candidate = raw.trim();
+  while (candidate.length > 0) {
+    try {
+      const parsed = new URL(candidate);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        return parsed.toString();
+      }
+      return null;
+    } catch {
+      candidate = candidate.slice(0, -1).trimEnd();
+    }
+  }
+  return null;
 }
 
 export function mergePromptAttachmentImages(params: {
@@ -215,6 +232,7 @@ async function sanitizeImagesWithLog(
  * - Relative paths: ./image.png, ../images/photo.jpg
  * - Home paths: ~/Pictures/screenshot.png
  * - file:// URLs: file:///path/to/image.png
+ * - Explicit HTTP(S) URLs written in the prompt
  * - Message attachments: [Image: source: /path/to/image.jpg]
  * - Gateway claim-check URIs: [media attached: media://inbound/<id>]
  *
@@ -248,6 +266,19 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     refs.push({ raw: trimmed, type: "path", resolved });
   };
 
+  const addRemoteUrlRef = (raw: string) => {
+    const resolved = normalizeHttpUrlRef(raw);
+    if (!resolved) {
+      return;
+    }
+    const dedupeKey = normalizeRefForDedupe(resolved);
+    if (seen.has(dedupeKey)) {
+      return;
+    }
+    seen.add(dedupeKey);
+    refs.push({ raw: resolved, type: "remote-url", resolved });
+  };
+
   // Pattern for [media attached: path (type) | url] or [media attached N/M: path (type) | url] format
   // Each bracket = ONE file. The | separates path from URL, not multiple files.
   // Multi-file format uses separate brackets on separate lines.
@@ -255,6 +286,8 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
   const mediaAttachedPathPattern = new RegExp(MEDIA_ATTACHED_PATH_REGEX_SOURCE, "i");
   const messageImagePattern = new RegExp(MESSAGE_IMAGE_REGEX_SOURCE, "gi");
   const fileUrlPattern = new RegExp(FILE_URL_REGEX_SOURCE, "gi");
+  const remoteHttpUrlPattern = new RegExp(HTTP_URL_REGEX_SOURCE, "i");
+  const httpUrlPattern = new RegExp(HTTP_URL_REGEX_SOURCE, "gi");
   const pathPattern = new RegExp(PATH_REGEX_SOURCE, "gi");
   let match: RegExpExecArray | null;
   while ((match = mediaAttachedPattern.exec(prompt)) !== null) {
@@ -287,6 +320,17 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     if (pathMatch?.[1]) {
       addPathRef(pathMatch[1].trim());
     }
+
+    const bracketRemoteUrl = normalizeHttpUrlRef(content.match(remoteHttpUrlPattern)?.[0] ?? "");
+    if (bracketRemoteUrl) {
+      const dedupeKey = normalizeRefForDedupe(bracketRemoteUrl);
+      if (!pathMatch?.[1] && !seen.has(dedupeKey)) {
+        seen.add(dedupeKey);
+        refs.push({ raw: bracketRemoteUrl, type: "remote-url", resolved: bracketRemoteUrl });
+      } else {
+        seen.add(dedupeKey);
+      }
+    }
   }
 
   // Pattern for [Image: source: /path/...] format from messaging systems
@@ -297,7 +341,15 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
     }
   }
 
-  // Remote HTTP(S) URLs are intentionally ignored. Native image injection is local-only.
+  // Explicit remote URLs are loaded into native vision up front so mixed
+  // attachment + URL turns do not depend on the model deciding to call the
+  // fallback image tool later.
+  while ((match = httpUrlPattern.exec(prompt)) !== null) {
+    const raw = match[0];
+    if (raw) {
+      addRemoteUrlRef(raw);
+    }
+  }
 
   // Pattern for file:// URLs - treat as paths since loadWebMedia handles them
   while ((match = fileUrlPattern.exec(prompt)) !== null) {
@@ -383,6 +435,24 @@ export async function loadImageFromRef(
       log.debug(
         `Native image: failed to load media-uri ${ref.resolved}: ${formatErrorMessage(err)}`,
       );
+      return null;
+    }
+  }
+
+  if (ref.type === "remote-url") {
+    try {
+      const media = await loadWebMedia(ref.resolved, {
+        maxBytes: options?.maxBytes,
+      });
+      if (media.kind !== "image") {
+        log.debug(`Native image: remote URL is not an image: ${ref.resolved}`);
+        return null;
+      }
+      const mimeType = media.contentType ?? "image/jpeg";
+      const data = media.buffer.toString("base64");
+      return { type: "image", data, mimeType };
+    } catch (err) {
+      log.debug(`Native image: failed to load ${ref.resolved}: ${formatErrorMessage(err)}`);
       return null;
     }
   }

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -93,13 +93,29 @@ function normalizeRefForDedupe(raw: string): string {
   return process.platform === "win32" ? normalizeLowercaseStringOrEmpty(raw) : raw;
 }
 
-function normalizeHttpUrlRef(raw: string): string | null {
+const TRAILING_HTTP_URL_PUNCTUATION_RE = /[,.;!，。！？；：、]+$/u;
+
+function trimTrailingHttpUrlPunctuation(raw: string): string {
   let candidate = raw.trim();
+  while (candidate.length > 0) {
+    const trimmed = candidate.replace(TRAILING_HTTP_URL_PUNCTUATION_RE, "").trimEnd();
+    if (trimmed === candidate) {
+      return candidate;
+    }
+    candidate = trimmed;
+  }
+  return candidate;
+}
+
+function normalizeHttpUrlRef(raw: string): string | null {
+  // Prompts often place a remote image URL next to sentence punctuation.
+  // Trim that punctuation so the native vision preload fetches the real URL.
+  let candidate = trimTrailingHttpUrlPunctuation(raw);
   while (candidate.length > 0) {
     try {
       const parsed = new URL(candidate);
       if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-        return parsed.toString();
+        return trimTrailingHttpUrlPunctuation(parsed.toString());
       }
       return null;
     } catch {


### PR DESCRIPTION
## Summary

- Problem: In WebUI, when a prompt mixes an uploaded inline image with an explicit HTTP(S) image URL, only the inline image is included in the first native vision request. The HTTP(S) URL remains plain text and is effectively ignored unless the model later calls the fallback `image` tool.
- Why it matters: Mixed-source image prompts behave inconsistently. URL-only prompts can appear to work, but once an inline image is also present the remote image is silently dropped from native vision input.
- What changed: `detectImageReferences()` now recognizes explicit HTTP(S) image URLs as prompt image refs, `detectAndLoadPromptImages()` preloads them through `loadWebMedia(...)`, and the runtime merges them into the same native `images` payload as inline/offloaded images for vision-capable models. Focused regression coverage was also added in `src/agents/pi-embedded-runner/run/images.test.ts`.
- What did NOT change (scope boundary): This PR does not change fallback `image` tool exposure, non-vision model behavior, non-WebUI channels, or local-path/sandbox access rules. It also does not add new user-facing error messaging when a referenced image fails to load.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #62514
- Related #62514
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `detectImageReferences()` only handled local paths, `file://` URLs, and `media://inbound/...` claim-check refs. Explicit HTTP(S) image URLs were intentionally ignored, so mixed turns preloaded only inline/offloaded attachments into native vision input.
- Missing detection / guardrail: We did not have focused coverage asserting that a mixed inline + HTTP(S) URL prompt produces a single first-turn native vision payload containing both images.
- Contributing context (if known): HTTP(S)-only prompts could still work when the runtime later fell back to the `image` tool, which masked the issue and made the behavior look model-dependent.

## User-visible / Behavior Changes

- WebUI prompts that mix uploaded inline images with explicit HTTP(S) image URLs now send both images to the first native vision request for vision-capable models.
- Explicit HTTP(S) image URLs no longer depend on the model deciding to call the fallback `image` tool when other image sources are present.
- Existing behavior for non-vision models and the fallback tool path is unchanged.

## Repro + Verification

### Steps

1. Open WebUI and select a vision-capable model.
2. Upload an inline image and include an explicit HTTP(S) image URL in the same prompt.
3. Ask the model to describe both images.

### Expected

- Both the uploaded inline image and the explicit HTTP(S) image URL are available to the same first native vision request.

### Actual

- Before this change, only the inline image was included in the first native vision request.
- The HTTP(S) URL stayed as plain text and was ignored unless the model later called the fallback `image` tool.

## Evidence

![img_v3_0210j_08150ab9-cec6-4536-b968-da852653febg](https://github.com/user-attachments/assets/d1f89d69-fa63-469b-a1cf-95262f2b4fad)

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: WebUI with a vision-capable model using mixed inline + HTTP(S) image inputs; HTTP(S)-only image prompts; non-vision model behavior remains unchanged.
- Edge cases checked: duplicate refs are deduped; explicit remote URLs are preloaded together with inline/offloaded images; non-image remote responses are skipped instead of being forwarded as images.
- What you did **not** verify: non-WebUI channels / other chat entry points.

## Diagram

### Before

```mermaid
flowchart TD
  A["Vision model<br/>single URL image"] --> B["image-tools"]
  B --> C["default image model"]
  C --> D["vision model"]
  D --> E["2 model calls"]

  F["Vision model<br/>inline image + URL image"] --> G["first native vision request"]
  G --> H["inline image goes into<br/>native images"]
  G --> I["URL image stays as<br/>plain text"]
  I --> J["URL image is ignored"]
  H --> K["vision model gets<br/>incomplete image context"]
  J --> K
```

### After

```mermaid
flowchart TD
  A["Vision model<br/>single URL image"] --> B["extract URL image"]
  B --> C["put into native image input"]
  C --> D["vision model"]
  D --> E["1 model call<br/>no tool path"]

  F["Vision model<br/>inline image + URL image"] --> G["extract URL image"]
  G --> H["merge URL image with<br/>inline image"]
  H --> I["put into native images"]
  I --> J["vision model sees<br/>all images"]
```
