### PR TITLE
fix(cli): gracefully handle missing qa/scenarios scaffold

### DIFF
--- a/extensions/qa-lab/src/discovery-eval.ts
+++ b/extensions/qa-lab/src/discovery-eval.ts
@@ -14,7 +14,20 @@ function readRequiredDiscoveryRefs() {
   );
 }
 
-const REQUIRED_DISCOVERY_REFS = readRequiredDiscoveryRefs();
+// Guard against missing qa/scenarios/ scaffold in npm/homebrew installs (not bundled in published package).
+// Falls back to hardcoded defaults when scaffold is absent.
+const FALLBACK_DISCOVERY_REFS = [
+  "repo/qa/scenarios/index.md",
+  "repo/extensions/qa-lab/src/suite.ts",
+  "repo/docs/help/testing.md",
+] as const;
+
+let REQUIRED_DISCOVERY_REFS: readonly string[];
+try {
+  REQUIRED_DISCOVERY_REFS = readRequiredDiscoveryRefs();
+} catch {
+  REQUIRED_DISCOVERY_REFS = FALLBACK_DISCOVERY_REFS;
+}
 
 const REQUIRED_DISCOVERY_REFS_LOWER = REQUIRED_DISCOVERY_REFS.map(normalizeLowercaseStringOrEmpty);
 


### PR DESCRIPTION
## Summary

Fixes a startup crash in `openclaw qa` and `openclaw update` commands that was introduced in the 2026.4.9 release (commit a5f32d3a1a).

## Root Cause

The `discovery-eval.ts` module calls `readRequiredDiscoveryRefs()` at **module top-level**:

```typescript
const REQUIRED_DISCOVERY_REFS = readRequiredDiscoveryRefs();
```

This function calls `readQaScenarioExecutionConfig()` → `readQaScenarioById()` → `readQaScenarioPack()`, which reads `qa/scenarios/index.md`. Since this file is not included in the npm/Homebrew package, the call throws on every CLI invocation that imports the module — including the completion cache builder during `openclaw update`.

## Fix

Wrap the top-level call in a try/catch that degrades to the **hardcoded fallback** (the same default paths that `readRequiredDiscoveryRefs()` would return if the config were present).

**Before:**
```typescript
const REQUIRED_DISCOVERY_REFS = readRequiredDiscoveryRefs();
```

**After:**
```typescript
const FALLBACK_DISCOVERY_REFS = [
  "repo/qa/scenarios/index.md",
  "repo/extensions/qa-lab/src/suite.ts",
  "repo/docs/help/testing.md",
] as const;

let REQUIRED_DISCOVERY_REFS: readonly string[];
try {
  REQUIRED_DISCOVERY_REFS = readRequiredDiscoveryRefs();
} catch {
  REQUIRED_DISCOVERY_REFS = FALLBACK_DISCOVERY_REFS;
}
```

## Impact

- `openclaw qa` subcommands are no longer broken for npm/Homebrew installs
- `openclaw update` completion cache no longer crashes
- Non-QA commands unaffected
- Fallback maintains same discovery-ref behavior when scaffold IS present

Fix #63727