### PR TITLE
fix(qqbot): add stream config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Sessions/model selection: preserve catalog-backed session model labels and keep already-qualified session model refs stable when catalog metadata is unavailable, so Control UI model selection survives reloads without bogus provider-prefixed values. (#61382) Thanks @Mule-ME.
 - Gateway/startup: keep WebSocket RPC available while channels and plugin sidecars start, hold `chat.history` unavailable until startup sidecars finish so synchronous history reads cannot stall startup (reported in #63450), refresh advertised gateway methods after deferred plugin reloads, and enforce the pre-auth WebSocket upgrade budget before the no-handler 503 path so upgrade floods cannot bypass connection limits during that window. (#63480) Thanks @neeravmakwana.
 - Gateway/tailscale: start Tailscale exposure and the gateway update check before awaiting channel and plugin sidecar startup so remote operators are not locked out when startup sidecars stall.
+- QQBot/streaming: make block streaming configurable per QQ bot account via `streaming.mode` (`"partial"` | `"off"`, default `"partial"`) instead of hardcoding it off, so responses can be delivered incrementally. (#63746)
 
 ## 2026.4.9
 

--- a/extensions/qqbot/openclaw.plugin.json
+++ b/extensions/qqbot/openclaw.plugin.json
@@ -100,6 +100,17 @@
           "upgradeMode": {
             "type": "string",
             "enum": ["doc", "hot-reload"]
+          },
+          "streaming": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["off", "partial"],
+                "default": "partial"
+              }
+            }
           }
         }
       }
@@ -128,6 +139,17 @@
       "upgradeMode": {
         "type": "string",
         "enum": ["doc", "hot-reload"]
+      },
+      "streaming": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": ["off", "partial"],
+            "default": "partial"
+          }
+        }
       },
       "accounts": {
         "type": "object",

--- a/extensions/qqbot/src/config-schema.ts
+++ b/extensions/qqbot/src/config-schema.ts
@@ -41,6 +41,14 @@ const QQBotSttSchema = z
   .strict()
   .optional();
 
+const QQBotStreamingSchema = z
+  .object({
+    /** "partial" (default) enables block streaming; "off" disables it. */
+    mode: z.enum(["off", "partial"]).default("partial"),
+  })
+  .strict()
+  .optional();
+
 const QQBotAccountSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -56,6 +64,7 @@ const QQBotAccountSchema = z
     urlDirectUpload: z.boolean().optional(),
     upgradeUrl: z.string().optional(),
     upgradeMode: z.enum(["doc", "hot-reload"]).optional(),
+    streaming: QQBotStreamingSchema,
   })
   .strict();
 

--- a/extensions/qqbot/src/gateway.ts
+++ b/extensions/qqbot/src/gateway.ts
@@ -1151,7 +1151,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                 },
               },
               replyOptions: {
-                disableBlockStreaming: true,
+                disableBlockStreaming: account.config.streaming?.mode === "off",
               },
             });
 

--- a/extensions/qqbot/src/types.ts
+++ b/extensions/qqbot/src/types.ts
@@ -57,6 +57,14 @@ export interface QQBotAccountConfig {
    * - "hot-reload": run an in-place npm update flow
    */
   upgradeMode?: "doc" | "hot-reload";
+  /**
+   * Block streaming configuration.
+   * - mode "partial" (default): enable block streaming for incremental delivery.
+   * - mode "off": buffer the full response before sending.
+   */
+  streaming?: {
+    mode?: "off" | "partial";
+  };
 }
 
 /** Audio format policy controlling which formats can skip transcoding. */


### PR DESCRIPTION
## Summary

- **Problem:** QQ bot gateway hardcodes `disableBlockStreaming: true`, preventing any streaming delivery of responses.
- **Why it matters:** Users may want incremental (block-streaming) replies for faster perceived response time; a hardcoded `true` removes that choice entirely.
- **What changed:** Added a `streaming.mode` config option (`"off"` | `"partial"`, default `"partial"`) to each QQ bot account. `disableBlockStreaming` now reads from `account.config.streaming?.mode === "off"` instead of always `true`.
- **What did NOT change (scope boundary):** No changes to the streaming engine itself, message formatting, or any other channel. Only the QQ bot config surface and its single callsite.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `disableBlockStreaming` was hardcoded to `true` in `gateway.ts:1154` with no config escape hatch.
- Missing detection / guardrail: No config schema existed for streaming behavior, so no way for users to override.
- Contributing context (if known): Block streaming was likely disabled during early QQ bot development due to instability, but never re-enabled as a configurable option.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/qqbot/src/gateway.test.ts`
- Scenario the test should lock in: When `streaming.mode` is `"partial"` (or unset), `disableBlockStreaming` should be `false`; when `"off"`, it should be `true`.
- Why this is the smallest reliable guardrail: A unit test on the `replyOptions` construction directly validates the config→behavior mapping.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: Manual verification via live QQ bot interaction.

## User-visible / Behavior Changes

- Block streaming is now **enabled by default** for QQ bot accounts (was disabled).
- Users can set `streaming.mode: "off"` in their QQ bot account config to restore the old buffered behavior.

## Diagram (if applicable)

```text
Before:
[QQ message] -> [agent reply] -> [disableBlockStreaming: true (hardcoded)] -> [full buffered response]

After:
[QQ message] -> [agent reply] -> [streaming.mode config check] -> "partial" -> [incremental block streaming]
                                                                -> "off"     -> [full buffered response]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js via pnpm
- Model/provider: N/A
- Integration/channel: QQ Bot (qqbot)
- Relevant config: `channels.qqbot.accounts.<id>.streaming.mode: "partial" | "off"`

### Steps

1. Set `streaming.mode` to `"partial"` (or omit it) in QQ bot account config.
2. Start gateway, send a message to the QQ bot.
3. Observe response is delivered incrementally (block streaming).
4. Set `streaming.mode` to `"off"`, restart gateway, send another message.
5. Observe response is delivered as a single buffered message.

### Expected

- Default (`"partial"`): incremental delivery.
- `"off"`: full buffered delivery.

### Actual

- Confirmed via live QQ bot testing.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Default config (streaming enabled), explicit `"off"` (streaming disabled).
- Edge cases checked: Missing `streaming` key entirely (should default to `"partial"`); missing `mode` key (should default to `"partial"`).
- What you did **not** verify: High-concurrency streaming under heavy QQ bot traffic.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — default behavior changes from buffered to streaming, but users can restore old behavior with `streaming.mode: "off"`.
- Config/env changes? `Yes` — new optional `streaming` object in QQ bot account config.
- Migration needed? `No` — existing configs without `streaming` key will default to `"partial"`.
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Default behavior change — existing users who relied on buffered responses will now get streaming.
  - Mitigation: Default is `"partial"` which is the intended production behavior; users can opt out with `streaming.mode: "off"`.