### PR TITLE
fix: exec tool workdir should expand ~ and throw on invalid path

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1560,7 +1560,7 @@ export function createExecTool(
         workdir = explicitWorkdir;
       } else {
         const rawWorkdir = explicitWorkdir ?? defaultWorkdir ?? process.cwd();
-        workdir = resolveWorkdir(rawWorkdir, warnings);
+        workdir = resolveWorkdir(rawWorkdir);
       }
       rejectExecApprovalShellCommand(params.command);
 

--- a/src/agents/bash-tools.shared.test.ts
+++ b/src/agents/bash-tools.shared.test.ts
@@ -1,8 +1,8 @@
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveSandboxWorkdir } from "./bash-tools.shared.js";
+import { resolveSandboxWorkdir, resolveWorkdir } from "./bash-tools.shared.js";
 
 async function withTempDir(run: (dir: string) => Promise<void>) {
   const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-bash-workdir-"));
@@ -72,6 +72,41 @@ describe("resolveSandboxWorkdir", () => {
       expect(resolved.hostWorkdir).toBe(nested);
       expect(resolved.containerWorkdir).toBe("/sandbox-root/project");
       expect(warnings).toEqual([]);
+    });
+  });
+});
+
+describe("resolveWorkdir", () => {
+  it("returns the workdir unchanged when not starting with ~", async () => {
+    await withTempDir(async (dir) => {
+      const resolved = resolveWorkdir(dir);
+      expect(resolved).toBe(dir);
+    });
+  });
+
+  it("expands ~ to the home directory", async () => {
+    const homeDir = os.homedir();
+    const resolved = resolveWorkdir("~");
+    expect(resolved).toBe(homeDir);
+  });
+
+  it("expands ~/subdir to home directory with subdir", async () => {
+    const home = os.homedir();
+    const resolved = resolveWorkdir("~");
+    expect(resolved).toBe(home);
+  });
+
+  it("throws error when workdir does not exist", async () => {
+    expect(() => resolveWorkdir("/nonexistent/path/to/dir")).toThrow(
+      'workdir "/nonexistent/path/to/dir" does not exist',
+    );
+  });
+
+  it("throws error when workdir is a file, not a directory", async () => {
+    await withTempDir(async (dir) => {
+      const filePath = path.join(dir, "file.txt");
+      await writeFile(filePath, "");
+      expect(() => resolveWorkdir(filePath)).toThrow(`workdir "${filePath}" is not a directory`);
     });
   });
 });

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -1,6 +1,6 @@
 import { existsSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
-import { homedir } from "node:os";
+import os from "node:os";
 import path from "node:path";
 import { sliceUtf16Safe } from "../utils.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
@@ -168,28 +168,21 @@ function normalizeContainerPath(input: string): string {
   return path.posix.normalize(normalized);
 }
 
-export function resolveWorkdir(workdir: string, warnings: string[]) {
-  const current = safeCwd();
-  const fallback = current ?? homedir();
-  try {
-    const stats = statSync(workdir);
-    if (stats.isDirectory()) {
-      return workdir;
-    }
-  } catch {
-    // ignore, fallback below
-  }
-  warnings.push(`Warning: workdir "${workdir}" is unavailable; using "${fallback}".`);
-  return fallback;
-}
+export function resolveWorkdir(workdir: string): string {
+  // Expand ~ to the home directory
+  const expandedWorkdir = workdir.startsWith("~")
+    ? path.join(os.homedir(), workdir.slice(1))
+    : workdir;
 
-function safeCwd() {
-  try {
-    const cwd = process.cwd();
-    return existsSync(cwd) ? cwd : null;
-  } catch {
-    return null;
+  // Validate that the workdir exists and is a directory
+  if (!existsSync(expandedWorkdir)) {
+    throw new Error(`workdir "${workdir}" does not exist`);
   }
+  const stats = statSync(expandedWorkdir);
+  if (!stats.isDirectory()) {
+    throw new Error(`workdir "${workdir}" is not a directory`);
+  }
+  return expandedWorkdir;
 }
 
 /**


### PR DESCRIPTION
This PR fixes issue #63742 where the exec tool's workdir parameter did not expand ~ to the home directory (unlike the read tool), and would silently fall back to the home directory when the workdir was invalid instead of throwing an error.

## Changes

### src/agents/bash-tools.shared.ts
- Modified resolveWorkdir to expand ~ using path.join(os.homedir(), workdir.slice(1))
- Changed behavior to throw an error when workdir is invalid instead of silently falling back

### src/agents/bash-tools.exec.ts
- Updated the call to resolveWorkdir to use the new signature

### src/agents/bash-tools.shared.test.ts
- Added tests for resolveWorkdir covering ~ expansion and error cases

fix #63742