### PR TITLE
[codex] Gateway websocket frame hardening

### DIFF
--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -8,6 +8,7 @@ import { createPreauthConnectionBudget } from "./server/preauth-connection-budge
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
+  connectOk,
   createGatewaySuiteHarness,
   installGatewayTestHooks,
   readConnectChallengeNonce,
@@ -160,6 +161,77 @@ describe("gateway pre-auth hardening", () => {
 
       const result = await closed;
       expect(result.code).toBe(1009);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("accepts typed-array pre-auth connect frames", async () => {
+    const harness = await createGatewaySuiteHarness({
+      serverOptions: { auth: { mode: "none" } },
+    });
+    try {
+      const ws = await harness.openWs();
+      const originalSend = ws.send.bind(ws);
+      const textEncoder = new TextEncoder();
+      ws.send = ((data, options, cb) => {
+        if (typeof data === "string") {
+          return originalSend(textEncoder.encode(data), options, cb);
+        }
+        return originalSend(data, options, cb);
+      }) as typeof ws.send;
+
+      await connectOk(ws, { skipDefaultAuth: true });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("closes malformed json before connect as a protocol violation", async () => {
+    const harness = await createGatewaySuiteHarness({
+      serverOptions: { auth: { mode: "none" } },
+    });
+    try {
+      const ws = await harness.openWs();
+      await readConnectChallengeNonce(ws);
+
+      const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+        ws.once("close", (code, reason) => {
+          resolve({ code, reason: reason.toString() });
+        });
+      });
+
+      ws.send("{ invalid json");
+
+      await expect(closed).resolves.toEqual({
+        code: 1008,
+        reason: "invalid json",
+      });
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("closes malformed json after connect as a protocol violation", async () => {
+    const harness = await createGatewaySuiteHarness({
+      serverOptions: { auth: { mode: "none" } },
+    });
+    try {
+      const ws = await harness.openWs();
+      await connectOk(ws, { skipDefaultAuth: true });
+
+      const closed = new Promise<{ code: number; reason: string }>((resolve) => {
+        ws.once("close", (code, reason) => {
+          resolve({ code, reason: reason.toString() });
+        });
+      });
+
+      ws.send("{ still invalid json");
+
+      await expect(closed).resolves.toEqual({
+        code: 1008,
+        reason: "invalid json",
+      });
     } finally {
       await harness.close();
     }

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -33,7 +33,7 @@ import {
 import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../../infra/skills-remote.js";
 import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
-import { rawDataToString } from "../../../infra/ws.js";
+import { rawDataByteLength, rawDataToString } from "../../../infra/ws.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
   resolveBootstrapProfileScopesForRole,
@@ -301,7 +301,7 @@ export function attachGatewayWsMessageHandler(params: {
       return;
     }
 
-    const preauthPayloadBytes = !getClient() ? getRawDataByteLength(data) : undefined;
+    const preauthPayloadBytes = !getClient() ? rawDataByteLength(data) : undefined;
     if (preauthPayloadBytes !== undefined && preauthPayloadBytes > MAX_PREAUTH_PAYLOAD_BYTES) {
       setHandshakeState("failed");
       setCloseCause("preauth-payload-too-large", {
@@ -1437,24 +1437,19 @@ export function attachGatewayWsMessageHandler(params: {
     } catch (err) {
       logGateway.error(`parse/handle error: ${String(err)}`);
       logWs("out", "parse-error", { connId, error: formatForLog(err) });
+      if (err instanceof SyntaxError) {
+        const hadClient = getClient() !== null;
+        setCloseCause(hadClient ? "invalid-json-frame" : "invalid-handshake-json", {
+          parseError: formatForLog(err),
+        });
+        close(1008, "invalid json");
+        return;
+      }
       if (!getClient()) {
         close();
       }
     }
   });
-}
-
-function getRawDataByteLength(data: unknown): number {
-  if (Buffer.isBuffer(data)) {
-    return data.byteLength;
-  }
-  if (Array.isArray(data)) {
-    return data.reduce((total, chunk) => total + chunk.byteLength, 0);
-  }
-  if (data instanceof ArrayBuffer) {
-    return data.byteLength;
-  }
-  return Buffer.byteLength(String(data));
 }
 
 function setSocketMaxPayload(socket: WebSocket, maxPayload: number): void {

--- a/src/infra/ws.test.ts
+++ b/src/infra/ws.test.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import { describe, expect, it } from "vitest";
-import { rawDataToString } from "./ws.js";
+import { rawDataByteLength, rawDataToString } from "./ws.js";
 
 describe("rawDataToString", () => {
   it("returns string input unchanged", () => {
@@ -15,7 +15,29 @@ describe("rawDataToString", () => {
     expect(rawDataToString(Uint8Array.from([104, 101, 108, 108, 111]).buffer)).toBe("hello");
   });
 
-  it("falls back to string coercion for other raw data shapes", () => {
-    expect(rawDataToString(Uint8Array.from([1, 2, 3]) as never)).toBe("1,2,3");
+  it("decodes typed-array views using the underlying bytes", () => {
+    expect(rawDataToString(Uint8Array.from([104, 101, 108, 108, 111]) as never)).toBe("hello");
+    expect(rawDataToString(new DataView(Uint8Array.from([111, 107]).buffer) as never)).toBe("ok");
+  });
+
+  it("falls back to string coercion for other unsupported raw data shapes", () => {
+    expect(rawDataToString({ hello: "world" } as never)).toBe("[object Object]");
+  });
+});
+
+describe("rawDataByteLength", () => {
+  it("counts strings, buffers, arrays, and binary views by byte length", () => {
+    expect(rawDataByteLength("hello" as unknown as Parameters<typeof rawDataByteLength>[0])).toBe(
+      5,
+    );
+    expect(rawDataByteLength(Buffer.from("hello"))).toBe(5);
+    expect(rawDataByteLength([Buffer.from("he"), Buffer.from("llo")])).toBe(5);
+    expect(rawDataByteLength(Uint8Array.from([104, 101, 108, 108, 111]).buffer)).toBe(5);
+    expect(rawDataByteLength(Uint8Array.from([1, 2, 3]) as never)).toBe(3);
+    expect(rawDataByteLength(new DataView(Uint8Array.from([4, 5]).buffer) as never)).toBe(2);
+  });
+
+  it("falls back to string coercion for unsupported raw data shapes", () => {
+    expect(rawDataByteLength({ ok: true } as never)).toBe("[object Object]".length);
   });
 });

--- a/src/infra/ws.ts
+++ b/src/infra/ws.ts
@@ -1,8 +1,16 @@
 import { Buffer } from "node:buffer";
 import type WebSocket from "ws";
 
+function isArrayBufferView(data: unknown): data is ArrayBufferView {
+  return ArrayBuffer.isView(data);
+}
+
+function rawDataViewToBuffer(data: ArrayBufferView): Buffer {
+  return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+}
+
 export function rawDataToString(
-  data: WebSocket.RawData,
+  data: WebSocket.RawData | ArrayBufferView,
   encoding: BufferEncoding = "utf8",
 ): string {
   if (typeof data === "string") {
@@ -17,5 +25,27 @@ export function rawDataToString(
   if (data instanceof ArrayBuffer) {
     return Buffer.from(data).toString(encoding);
   }
+  if (isArrayBufferView(data)) {
+    return rawDataViewToBuffer(data).toString(encoding);
+  }
   return Buffer.from(String(data)).toString(encoding);
+}
+
+export function rawDataByteLength(data: WebSocket.RawData | ArrayBufferView): number {
+  if (typeof data === "string") {
+    return Buffer.byteLength(data);
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.byteLength;
+  }
+  if (Array.isArray(data)) {
+    return data.reduce((total, chunk) => total + chunk.byteLength, 0);
+  }
+  if (data instanceof ArrayBuffer) {
+    return data.byteLength;
+  }
+  if (isArrayBufferView(data)) {
+    return data.byteLength;
+  }
+  return Buffer.byteLength(String(data));
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Gateway WebSocket frame handling did not consistently treat malformed JSON as a protocol violation, and the shared raw-data helpers mishandled typed-array views like `Uint8Array` / `DataView`.
- Why it matters: malformed live frames could stay attached longer than they should, and typed-array payloads could decode or size-check incorrectly on the pre-auth path.
- What changed: close malformed JSON frames with `1008 invalid json`, centralize raw frame byte counting, and teach the shared raw-data helpers to decode/count typed-array views correctly.
- What did NOT change (scope boundary): no auth-policy changes, no new protocol schema, no reconnect/backpressure redesign, and no voice-call socket changes in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Gateway WebSocket handler only logged JSON parse failures instead of closing the socket as a protocol violation, and the shared raw-data helper only modeled `ws`'s narrow `RawData` typings instead of the typed-array views seen at runtime.
- Missing detection / guardrail: there was no regression test for malformed post-connect JSON frames, and no shared helper test covering typed-array view decode/byte-count behavior.
- Contributing context (if known): `@types/ws` exposes a narrower `RawData` union than the runtime shapes we need to harden against, so the helper had to be widened intentionally.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/ws.test.ts`, `src/gateway/server.preauth-hardening.test.ts`
- Scenario the test should lock in: typed-array pre-auth connect frames are accepted, and malformed JSON closes Gateway sockets with `1008 invalid json` both before and after connect.
- Why this is the smallest reliable guardrail: the helper behavior is pure and best covered directly, while the malformed-frame behavior needs the existing Gateway pre-auth harness to exercise the real socket close path.
- Existing test that already covers this (if any): the pre-auth hardening suite already covered adjacent handshake hardening cases.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Malformed Gateway WebSocket JSON frames now close the connection with `1008 invalid json` instead of only being logged.

## Diagram (if applicable)

```text
Before:
[invalid ws frame] -> [parse error logged] -> [socket may stay open]

After:
[invalid ws frame] -> [parse error logged] -> [1008 invalid json] -> [socket closed]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.18.0 via `nvm exec 22.18.0`
- Model/provider: N/A
- Integration/channel (if any): Gateway WebSocket
- Relevant config (redacted): default local gateway test harness, plus `auth.mode=none` for the malformed-frame regression cases

### Steps

1. Open a Gateway WebSocket connection and complete or begin the normal pre-auth flow.
2. Send malformed JSON or send a connect frame as a typed-array view.
3. Observe socket behavior.

### Expected

- Typed-array frames are decoded and sized correctly.
- Malformed JSON closes the socket with `1008 invalid json`.

### Actual

- After this change, the targeted tests confirm that behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm build`; ran `pnpm test src/infra/ws.test.ts src/gateway/server.preauth-hardening.test.ts` under Node 22.18.0.
- Edge cases checked: malformed JSON before connect, malformed JSON after connect, typed-array pre-auth connect frames.
- What you did **not** verify: I did not manually exercise a live Control UI or remote client against a running gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the shared raw-data helper now accepts a wider input shape than the `ws` type definitions advertise.
  - Mitigation: the widening is covered by focused helper tests and only affects decode/byte-count behavior for runtime payloads we intentionally want to accept.
- Risk: local contributor `pnpm check` is currently red on an untouched latest-`origin/main` file: `src/auto-reply/reply/followup-runner.test.ts` (`OpenClawConfig` cast typing issue around line 1140).
  - Mitigation: this PR does not touch that file; I still ran the relevant targeted tests and a full `pnpm build` on this branch.

AI-assisted: yes.
Testing level: lightly tested plus targeted regression coverage.
I understand what the code does and reviewed the changed socket paths directly.
