### PR TITLE
fix(acp): fail fast on dead spawns and recover stale disconnects

### DIFF
--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -499,6 +499,14 @@ Two ways to start an ACP session:
     - `--cwd <absolute-path>`
     - `--label <name>`
 
+    After the backend creates the runtime session, OpenClaw runs an
+    immediate status check before it binds or persists the spawned
+    session. If the backend reports the session as unavailable, such as
+    `dead` or `no-session`, or the Gateway connection is already stale,
+    the spawn fails and OpenClaw cleans up the partial session instead
+    of leaving the conversation bound to a broken ACP runtime. Run
+    `/acp doctor` when this happens repeatedly.
+
     See [Slash commands](/tools/slash-commands).
 
   </Tab>

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -88,6 +88,7 @@ const ACP_TURN_TIMEOUT_CLEANUP_GRACE_MS = 2_000;
 const ACP_TURN_TIMEOUT_REASON = "turn-timeout";
 const ACP_BACKGROUND_TASK_TEXT_MAX_LENGTH = 160;
 const ACP_BACKGROUND_TASK_PROGRESS_MAX_LENGTH = 240;
+const RECOVERABLE_GATEWAY_DISCONNECT_CLOSE_CODES = new Set(["1000", "1001", "1006", "1012"]);
 
 function summarizeBackgroundTaskText(text: string): string {
   const normalized = normalizeText(text) ?? "ACP background task";
@@ -1775,10 +1776,10 @@ export class AcpSessionManager {
 
   private isRecoverableGatewayDisconnectError(message: string): boolean {
     const normalized = message.trim();
-    return (
-      /^gateway disconnected:\s*\d{3,4}\b/i.test(normalized) ||
-      /^gateway closed\s*\(\d{3,4}\)/i.test(normalized)
-    );
+    const closeCode =
+      normalized.match(/^gateway disconnected:\s*(\d{3,4})(?::|\b)/i)?.[1] ??
+      normalized.match(/^gateway closed\s*\((\d{3,4})(?:\b|\))/i)?.[1];
+    return closeCode ? RECOVERABLE_GATEWAY_DISCONNECT_CLOSE_CODES.has(closeCode) : false;
   }
 
   private isRecoverableMissingPersistentSessionError(message: string): boolean {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1166,11 +1166,36 @@ export class AcpSessionManager {
           reason: params.reason,
         });
       }
-      await withAcpRuntimeErrorBoundary({
-        run: async () => await activeTurn.cancelPromise!,
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "ACP cancel failed before completion.",
-      });
+      try {
+        await withAcpRuntimeErrorBoundary({
+          run: async () => await activeTurn.cancelPromise!,
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "ACP cancel failed before completion.",
+        });
+      } catch (error) {
+        const acpError = toAcpRuntimeError({
+          error,
+          fallbackCode: "ACP_TURN_FAILED",
+          fallbackMessage: "ACP cancel failed before completion.",
+        });
+        if (
+          this.isRecoverableAcpxExitError(acpError.message) ||
+          this.isRecoverableGatewayDisconnectError(acpError.message)
+        ) {
+          this.clearCachedRuntimeStateIfHandleMatches({
+            sessionKey,
+            handle: activeTurn.handle,
+          });
+          await this.setSessionState({
+            cfg: params.cfg,
+            sessionKey,
+            state: "error",
+            lastError: acpError.message,
+          });
+          return;
+        }
+        throw acpError;
+      }
       return;
     }
 
@@ -1207,6 +1232,22 @@ export class AcpSessionManager {
           fallbackCode: "ACP_TURN_FAILED",
           fallbackMessage: "ACP cancel failed before completion.",
         });
+        if (
+          this.isRecoverableAcpxExitError(acpError.message) ||
+          this.isRecoverableGatewayDisconnectError(acpError.message)
+        ) {
+          this.clearCachedRuntimeStateIfHandleMatches({
+            sessionKey,
+            handle,
+          });
+          await this.setSessionState({
+            cfg: params.cfg,
+            sessionKey,
+            state: "error",
+            lastError: acpError.message,
+          });
+          return;
+        }
         await this.setSessionState({
           cfg: params.cfg,
           sessionKey,
@@ -1299,7 +1340,8 @@ export class AcpSessionManager {
               (input.discardPersistentState && acpError.code === "ACP_SESSION_INIT_FAILED") ||
               (input.discardPersistentState &&
                 acpError.code === "ACP_BACKEND_UNSUPPORTED_CONTROL") ||
-              this.isRecoverableAcpxExitError(acpError.message))
+              this.isRecoverableAcpxExitError(acpError.message) ||
+              this.isRecoverableGatewayDisconnectError(acpError.message))
           ) {
             if (input.discardPersistentState) {
               const configuredBackend = (meta.backend || input.cfg.acp?.backend || "").trim();
@@ -1683,7 +1725,10 @@ export class AcpSessionManager {
     if (params.attempt > 0 || params.sawTurnOutput) {
       return false;
     }
-    if (this.isRecoverableAcpxExitError(params.error.message)) {
+    if (
+      this.isRecoverableAcpxExitError(params.error.message) ||
+      this.isRecoverableGatewayDisconnectError(params.error.message)
+    ) {
       this.clearCachedRuntimeState(params.sessionKey);
       logVerbose(
         `acp-manager: retrying ${params.sessionKey} with a fresh runtime handle after early turn failure: ${params.error.message}`,
@@ -1726,6 +1771,14 @@ export class AcpSessionManager {
 
   private isRecoverableAcpxExitError(message: string): boolean {
     return /^acpx exited with (code \d+|signal [a-z0-9]+)/i.test(message.trim());
+  }
+
+  private isRecoverableGatewayDisconnectError(message: string): boolean {
+    const normalized = message.trim();
+    return (
+      /^gateway disconnected:\s*\d{3,4}\b/i.test(normalized) ||
+      /^gateway closed\s*\(\d{3,4}\)/i.test(normalized)
+    );
   }
 
   private isRecoverableMissingPersistentSessionError(message: string): boolean {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1579,6 +1579,47 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
   });
 
+  it("does not swallow non-stale gateway closure errors during close", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.close.mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: {
+          ...readySessionMeta(),
+          runtimeSessionName: `runtime:${sessionKey}`,
+        },
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-a",
+      text: "first",
+      mode: "prompt",
+      requestId: "r1",
+    });
+
+    await expect(
+      manager.closeSession({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-a",
+        reason: "manual-close",
+        allowBackendUnavailable: true,
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_TURN_FAILED",
+      message: "gateway closed (1008): pairing required",
+    });
+  });
+
   it("treats stale session init failures as recoverable during discard resets", async () => {
     const runtimeState = createRuntime();
     runtimeState.ensureSession.mockRejectedValueOnce(
@@ -2108,6 +2149,46 @@ describe("AcpSessionManager", () => {
     expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
   });
 
+  it("does not swallow non-stale gateway closure errors during cancel", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.cancel.mockRejectedValueOnce(new Error("gateway closed (1008): pairing required"));
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: {
+          ...readySessionMeta(),
+          runtimeSessionName: `runtime:${sessionKey}`,
+        },
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: baseCfg,
+      sessionKey: "agent:codex:acp:session-a",
+      text: "first",
+      mode: "prompt",
+      requestId: "r1",
+    });
+
+    await expect(
+      manager.cancelSession({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-a",
+        reason: "manual-cancel",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_TURN_FAILED",
+      message: "gateway closed (1008): pairing required",
+    });
+  });
+
   it("cleans actor-tail bookkeeping after session turns complete", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
@@ -2345,6 +2426,46 @@ describe("AcpSessionManager", () => {
     expect(states).toContain("running");
     expect(states).toContain("idle");
     expect(states).not.toContain("error");
+  });
+
+  it("does not retry early turns for non-stale gateway closures", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn.mockImplementationOnce(async function* () {
+      yield {
+        type: "error" as const,
+        message: "Gateway disconnected: 1008: pairing required",
+      };
+    });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-1",
+      }),
+    ).rejects.toMatchObject({
+      code: "ACP_TURN_FAILED",
+      message: "Gateway disconnected: 1008: pairing required",
+    });
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(1);
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states).toContain("error");
+    expect(states.at(-1)).toBe("error");
   });
 
   it("retries once with a fresh persistent session after an early missing-session turn failure", async () => {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1522,6 +1522,63 @@ describe("AcpSessionManager", () => {
     }
   });
 
+  it("drops cached runtime handles when close sees a stale gateway disconnect error", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.close.mockRejectedValueOnce(
+      new Error("Gateway disconnected: 1006: connection lost"),
+    );
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: {
+          ...readySessionMeta(),
+          runtimeSessionName: `runtime:${sessionKey}`,
+        },
+      };
+    });
+    const limitedCfg = {
+      acp: {
+        ...baseCfg.acp,
+        maxConcurrentSessions: 1,
+      },
+    } as OpenClawConfig;
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: limitedCfg,
+      sessionKey: "agent:codex:acp:session-a",
+      text: "first",
+      mode: "prompt",
+      requestId: "r1",
+    });
+
+    const closeResult = await manager.closeSession({
+      cfg: limitedCfg,
+      sessionKey: "agent:codex:acp:session-a",
+      reason: "manual-close",
+      allowBackendUnavailable: true,
+    });
+    expect(closeResult.runtimeClosed).toBe(false);
+    expect(closeResult.runtimeNotice).toBe("Gateway disconnected: 1006: connection lost");
+
+    await expect(
+      manager.runTurn({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-b",
+        text: "second",
+        mode: "prompt",
+        requestId: "r2",
+      }),
+    ).resolves.toBeUndefined();
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+  });
+
   it("treats stale session init failures as recoverable during discard resets", async () => {
     const runtimeState = createRuntime();
     runtimeState.ensureSession.mockRejectedValueOnce(
@@ -1995,6 +2052,62 @@ describe("AcpSessionManager", () => {
     expect(states).not.toContain("error");
   });
 
+  it("treats stale gateway disconnect errors as recoverable during cancel", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.cancel.mockRejectedValueOnce(
+      new Error("Gateway disconnected: 1006: connection lost"),
+    );
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: {
+          ...readySessionMeta(),
+          runtimeSessionName: `runtime:${sessionKey}`,
+        },
+      };
+    });
+    const limitedCfg = {
+      acp: {
+        ...baseCfg.acp,
+        maxConcurrentSessions: 1,
+      },
+    } as OpenClawConfig;
+
+    const manager = new AcpSessionManager();
+    await manager.runTurn({
+      cfg: limitedCfg,
+      sessionKey: "agent:codex:acp:session-a",
+      text: "first",
+      mode: "prompt",
+      requestId: "r1",
+    });
+
+    await expect(
+      manager.cancelSession({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-a",
+        reason: "manual-cancel",
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      manager.runTurn({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-b",
+        text: "second",
+        mode: "prompt",
+        requestId: "r2",
+      }),
+    ).resolves.toBeUndefined();
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+  });
+
   it("cleans actor-tail bookkeeping after session turns complete", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
@@ -2191,6 +2304,47 @@ describe("AcpSessionManager", () => {
       expect(states, message).not.toContain("error");
       resetAcpSessionManagerForTests();
     }
+  });
+
+  it("retries once with a fresh runtime handle after an early gateway disconnect", async () => {
+    const runtimeState = createRuntime();
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:codex:acp:session-1",
+      storeSessionKey: "agent:codex:acp:session-1",
+      acp: readySessionMeta(),
+    });
+    runtimeState.runTurn
+      .mockImplementationOnce(async function* () {
+        yield {
+          type: "error" as const,
+          message: "Gateway disconnected: 1006: connection lost",
+        };
+      })
+      .mockImplementationOnce(async function* () {
+        yield { type: "done" as const };
+      });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:session-1",
+        text: "do work",
+        mode: "prompt",
+        requestId: "run-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
+    const states = extractStatesFromUpserts();
+    expect(states).toContain("running");
+    expect(states).toContain("idle");
+    expect(states).not.toContain("error");
   });
 
   it("retries once with a fresh persistent session after an early missing-session turn failure", async () => {

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -2093,6 +2093,84 @@ describe("AcpSessionManager", () => {
     expect(states).not.toContain("error");
   });
 
+  it("drops cached runtime handles when active-turn cancel sees a stale gateway disconnect", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.cancel.mockRejectedValueOnce(
+      new Error("Gateway disconnected: 1006: connection lost"),
+    );
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+      const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey ?? "";
+      return {
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: {
+          ...readySessionMeta(),
+          runtimeSessionName: `runtime:${sessionKey}`,
+        },
+      };
+    });
+    const limitedCfg = {
+      acp: {
+        ...baseCfg.acp,
+        maxConcurrentSessions: 1,
+      },
+    } as OpenClawConfig;
+
+    let enteredRun = false;
+    runtimeState.runTurn.mockImplementationOnce(async function* (input: { signal?: AbortSignal }) {
+      enteredRun = true;
+      await new Promise<void>((resolve) => {
+        if (input.signal?.aborted) {
+          resolve();
+          return;
+        }
+        input.signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      yield { type: "done" as const, stopReason: "cancel" };
+    });
+
+    const manager = new AcpSessionManager();
+    const runPromise = manager.runTurn({
+      cfg: limitedCfg,
+      sessionKey: "agent:codex:acp:session-a",
+      text: "long task",
+      mode: "prompt",
+      requestId: "r1",
+    });
+    await vi.waitFor(
+      () => {
+        expect(enteredRun).toBe(true);
+      },
+      { interval: 1 },
+    );
+
+    await expect(
+      manager.cancelSession({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-a",
+        reason: "manual-cancel",
+      }),
+    ).resolves.toBeUndefined();
+    await runPromise;
+
+    await expect(
+      manager.runTurn({
+        cfg: limitedCfg,
+        sessionKey: "agent:codex:acp:session-b",
+        text: "second",
+        mode: "prompt",
+        requestId: "r2",
+      }),
+    ).resolves.toBeUndefined();
+    expect(runtimeState.cancel).toHaveBeenCalledTimes(1);
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+    expect(extractStatesFromUpserts()).toContain("error");
+  });
+
   it("treats stale gateway disconnect errors as recoverable during cancel", async () => {
     const runtimeState = createRuntime();
     runtimeState.cancel.mockRejectedValueOnce(

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1134,6 +1134,25 @@ describe("/acp command", () => {
     expect(seededWithoutEntry?.runtimeSessionName).toContain(":runtime");
   });
 
+  it("fails spawn when immediate post-init status checks detect gateway disconnect", async () => {
+    hoisted.getStatusMock.mockRejectedValueOnce(
+      new AcpRuntimeError("ACP_TURN_FAILED", "Gateway disconnected: 1006: connection lost"),
+    );
+
+    const result = await runDiscordAcpCommand("/acp spawn codex --bind here");
+
+    expect(result?.reply?.text).toContain(
+      "ACP error (ACP_TURN_FAILED): Gateway disconnected: 1006: connection lost",
+    );
+    expect(hoisted.sessionBindingBindMock).not.toHaveBeenCalled();
+    expect(hoisted.closeMock).toHaveBeenCalled();
+    expect(hoisted.callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.delete",
+      }),
+    );
+  });
+
   it("persists ACP spawn labels without a nested gateway self-call", async () => {
     const params = createDiscordParams("/acp spawn codex --bind here --label inbox");
 

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1154,6 +1154,44 @@ describe("/acp command", () => {
     );
   });
 
+  it.each([
+    [
+      "dead details status",
+      {
+        summary: "status=alive sessionId=sid-1 pid=1234",
+        details: { status: "dead", sessionId: "sid-1", pid: 1234 },
+      },
+      "status=dead",
+    ],
+    [
+      "no-session summary status",
+      {
+        summary: "status=no-session session missing",
+        details: {},
+      },
+      "status=no-session",
+    ],
+  ])(
+    "fails spawn when immediate post-init status checks report %s",
+    async (_label, status, message) => {
+      hoisted.getStatusMock.mockResolvedValueOnce(status);
+
+      const result = await runDiscordAcpCommand("/acp spawn codex --bind here");
+
+      expect(result?.reply?.text).toContain(
+        `ACP error (ACP_TURN_FAILED): ACP session failed health checks immediately after spawn: ${message}`,
+      );
+      expect(hoisted.getStatusMock).toHaveBeenCalledTimes(1);
+      expect(hoisted.sessionBindingBindMock).not.toHaveBeenCalled();
+      expect(hoisted.closeMock).toHaveBeenCalled();
+      expect(hoisted.callGatewayMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: "sessions.delete",
+        }),
+      );
+    },
+  );
+
   it("does not fail spawn when runtime capability lookup would fail after init", async () => {
     hoisted.getCapabilitiesMock.mockRejectedValueOnce(new Error("capability probe failed"));
 

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1144,6 +1144,7 @@ describe("/acp command", () => {
     expect(result?.reply?.text).toContain(
       "ACP error (ACP_TURN_FAILED): Gateway disconnected: 1006: connection lost",
     );
+    expect(hoisted.getStatusMock).toHaveBeenCalledTimes(1);
     expect(hoisted.sessionBindingBindMock).not.toHaveBeenCalled();
     expect(hoisted.closeMock).toHaveBeenCalled();
     expect(hoisted.callGatewayMock).toHaveBeenCalledWith(
@@ -1151,6 +1152,18 @@ describe("/acp command", () => {
         method: "sessions.delete",
       }),
     );
+  });
+
+  it("does not fail spawn when runtime capability lookup would fail after init", async () => {
+    hoisted.getCapabilitiesMock.mockRejectedValueOnce(new Error("capability probe failed"));
+
+    const result = await runDiscordAcpCommand("/acp spawn codex --bind here");
+
+    expect(result?.reply?.text).toContain("Bound this conversation to");
+    expect(hoisted.getStatusMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.getCapabilitiesMock).not.toHaveBeenCalled();
+    expect(hoisted.sessionBindingBindMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.closeMock).not.toHaveBeenCalled();
   });
 
   it("persists ACP spawn labels without a nested gateway self-call", async () => {

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -11,10 +11,12 @@ import {
   resolveAcpDispatchPolicyError,
   resolveAcpDispatchPolicyMessage,
 } from "../../../acp/policy.js";
+import { AcpRuntimeError } from "../../../acp/runtime/errors.js";
 import {
   resolveAcpSessionCwd,
   resolveAcpThreadSessionDetailLines,
 } from "../../../acp/runtime/session-identifiers.js";
+import type { AcpRuntimeStatus } from "../../../acp/runtime/types.js";
 import { resolveAcpSpawnRuntimePolicyError } from "../../../agents/acp-spawn.js";
 import { getChannelPlugin, normalizeChannelId } from "../../../channels/plugins/index.js";
 import {
@@ -136,6 +138,23 @@ function buildSpawnedAcpBindingMetadata(params: {
       }),
     }),
   };
+}
+
+function resolveRuntimeStatusToken(status: AcpRuntimeStatus | undefined): string | undefined {
+  if (!status) {
+    return undefined;
+  }
+  const detailsStatus = normalizeOptionalString(status.details?.status)?.toLowerCase();
+  if (detailsStatus) {
+    return detailsStatus;
+  }
+  const summaryStatus = status.summary?.match(/\bstatus=([^\s]+)/i)?.[1];
+  return normalizeOptionalString(summaryStatus)?.toLowerCase();
+}
+
+function isUnhealthyRuntimeStatus(status: AcpRuntimeStatus | undefined): boolean {
+  const statusToken = resolveRuntimeStatusToken(status);
+  return statusToken === "dead" || statusToken === "no-session";
 }
 
 async function bindSpawnedAcpSession(params: {
@@ -525,7 +544,7 @@ export async function handleAcpSpawnAction(
         runtime: {
           getStatus?: (params: {
             handle: { sessionKey: string; backend: string; runtimeSessionName: string };
-          }) => Promise<unknown>;
+          }) => Promise<AcpRuntimeStatus | undefined>;
         };
         handle: { sessionKey: string; backend: string; runtimeSessionName: string };
       }
@@ -560,9 +579,15 @@ export async function handleAcpSpawnAction(
 
   try {
     if (initializedStatusProbe?.runtime.getStatus) {
-      await initializedStatusProbe.runtime.getStatus({
+      const status = await initializedStatusProbe.runtime.getStatus({
         handle: initializedStatusProbe.handle,
       });
+      if (isUnhealthyRuntimeStatus(status)) {
+        throw new AcpRuntimeError(
+          "ACP_TURN_FAILED",
+          `ACP session failed health checks immediately after spawn: status=${resolveRuntimeStatusToken(status)}`,
+        );
+      }
     }
   } catch (err) {
     await cleanupFailedSpawn({

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -544,6 +544,27 @@ export async function handleAcpSpawnAction(
     );
   }
 
+  try {
+    await acpManager.getSessionStatus({
+      cfg: params.cfg,
+      sessionKey,
+    });
+  } catch (err) {
+    await cleanupFailedSpawn({
+      cfg: params.cfg,
+      sessionKey,
+      shouldDeleteSession: true,
+      initializedRuntime,
+    });
+    return stopWithText(
+      collectAcpErrorText({
+        error: err,
+        fallbackCode: "ACP_TURN_FAILED",
+        fallbackMessage: "ACP session failed health checks immediately after spawn.",
+      }),
+    );
+  }
+
   let binding: SessionBindingRecord | null = null;
   if (spawn.bind !== "off") {
     const bound = await bindSpawnedAcpSessionToCurrentConversation({

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -520,6 +520,16 @@ export async function handleAcpSpawnAction(
   let initializedBackend = "";
   let initializedMeta: SessionAcpMeta | undefined;
   let initializedRuntime: AcpSpawnRuntimeCloseHandle | undefined;
+  let initializedStatusProbe:
+    | {
+        runtime: {
+          getStatus?: (params: {
+            handle: { sessionKey: string; backend: string; runtimeSessionName: string };
+          }) => Promise<unknown>;
+        };
+        handle: { sessionKey: string; backend: string; runtimeSessionName: string };
+      }
+    | undefined;
   try {
     const initialized = await acpManager.initializeSession({
       cfg: params.cfg,
@@ -529,6 +539,10 @@ export async function handleAcpSpawnAction(
       cwd: spawn.cwd,
     });
     initializedRuntime = {
+      runtime: initialized.runtime,
+      handle: initialized.handle,
+    };
+    initializedStatusProbe = {
       runtime: initialized.runtime,
       handle: initialized.handle,
     };
@@ -545,10 +559,11 @@ export async function handleAcpSpawnAction(
   }
 
   try {
-    await acpManager.getSessionStatus({
-      cfg: params.cfg,
-      sessionKey,
-    });
+    if (initializedStatusProbe?.runtime.getStatus) {
+      await initializedStatusProbe.runtime.getStatus({
+        handle: initializedStatusProbe.handle,
+      });
+    }
   } catch (err) {
     await cleanupFailedSpawn({
       cfg: params.cfg,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: ACP sessions could report a successful `/acp spawn` even when the newly initialized runtime handle was already unusable, and stale gateway disconnects could leave cancel/close/early-turn recovery stuck on a bad cached handle.
- Why it matters: Operators can see contradictory UX (`Spawned` followed by immediate `ACP_TURN_FAILED`) and then lose reliable recovery controls for the affected ACP session.
- What changed: Probe the freshly initialized runtime status before reporting spawn success; clean up failed post-spawn sessions; treat explicit stale gateway disconnect close codes as recoverable for close, cancel, active-turn cancel, and early-turn retry.
- What did NOT change (scope boundary): No ACP protocol/schema changes, no new public commands, no auth/provider changes, no gateway restart policy changes, and no broad retry policy for non-stale gateway errors.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (none)
- Related #63656
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Spawn success was emitted after `initializeSession` without verifying the new runtime handle could answer an immediate status check, and the ACP manager only treated `acpx exited ...` as a stale runtime-handle recovery signal.
- Missing detection / guardrail: There was no spawn-time liveliness guard, no regression for gateway-disconnect stale-handle recovery, and no active-turn cancel test for stale disconnect cleanup.
- Contributing context (if known): ACP transport disconnects surface as `Gateway disconnected: 1006` or `gateway closed (...)`; some close codes indicate stale transport, while others such as `1008` represent real authorization/pairing failures.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/acp/control-plane/manager.test.ts`
  - `src/auto-reply/reply/commands-acp.test.ts`
- Scenario the test should lock in:
  - `/acp spawn` fails and cleans up when the immediate status probe reports `Gateway disconnected: 1006`.
  - Spawn health checks call direct runtime status and do not depend on capability lookup.
  - Close, passive cancel, active-turn cancel, and early-turn retry recover known stale gateway disconnect close codes.
  - Non-stale gateway closures such as `1008 pairing required` are surfaced instead of swallowed.
- Why this is the smallest reliable guardrail: The behavior is localized to ACP command lifecycle and `AcpSessionManager` runtime-handle recovery, so mocked runtime tests can deterministically exercise every branch without a live ACP backend.
- Existing test that already covers this (if any): Existing ACP manager tests covered equivalent `acpx exited ...` recovery and normal active-turn cancel; this PR extends that pattern to gateway disconnect errors and post-spawn health checks.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- `/acp spawn` no longer reports success when the freshly initialized ACP runtime immediately fails status with a gateway disconnect; it returns the ACP error and cleans up the failed session.
- `/acp cancel` and `/acp close` can recover stale gateway-disconnected runtime handles for explicit stale/disconnect close codes.
- First ACP turns that fail immediately with a stale gateway disconnect get one fresh-handle retry.

## Diagram (if applicable)

```text
Before:
/acp spawn -> initializeSession OK -> "Spawned" -> first prompt -> ACP_TURN_FAILED
           -> cancel/close can stay stuck on stale cached handle

After:
/acp spawn -> initializeSession OK -> direct runtime status probe
            -> fail? cleanup + ACP error
            -> pass? bind/report spawn success

stale gateway disconnect during close/cancel/early first turn
  -> clear cached handle -> recover or retry once
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node.js via repo `pnpm` lanes
- Model/provider: ACP runtime mocked in regression tests
- Integration/channel (if any): ACP slash command lifecycle
- Relevant config (redacted): ACP enabled with `acpx` backend

### Steps

1. Spawn an ACP session while the freshly initialized runtime status path fails with `Gateway disconnected: 1006`.
2. Attempt cancel/close against an ACP session whose cached runtime handle is stale from a gateway disconnect.
3. Attempt an early first turn that fails before output with `Gateway disconnected: 1006`.

### Expected

- Spawn fails immediately with cleanup instead of reporting false success.
- Recoverable stale disconnects clear the cached handle and allow recovery/fresh-handle retry.
- Non-stale gateway errors remain visible.

### Actual

- Before this fix, spawn could report success before immediate turn failure, and stale gateway disconnects were not covered by the existing stale-runtime recovery handling.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation:

- `node scripts/run-vitest.mjs run --config vitest.config.ts src/acp/control-plane/manager.test.ts src/auto-reply/reply/commands-acp.test.ts`
  - `3` files passed, `166` tests passed.
- `pnpm check:changed`
  - Stopped during the final broad e2e shard because the local changed-gate plan selected 293 targets. Completed before stop: core typecheck, core test typecheck, lint, import-cycle checks, gateway shard (`91` files / `990` tests), auto-reply shard (`38` files / `494` tests), agents shard (`41` files / `746` tests), and the smaller ACP/plugin/CLI/commands shards shown in local output.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Spawn-health failure returns the ACP error, avoids binding, closes the runtime, and deletes the failed session.
  - Spawn-health success path does not call capability lookup.
  - Stale gateway disconnect recovery clears cached handles for close, passive cancel, active-turn cancel, and early-turn retry.
- Edge cases checked:
  - Recoverable gateway disconnects are limited to explicit stale/disconnect close codes.
  - `1008 pairing required` is not treated as recoverable.
- What you did **not** verify:
  - Full live ACP backend replay in this PR cycle.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A post-spawn status probe can reject a session that is already unstable immediately after initialization.
  - Mitigation: This is intentional fail-fast behavior to avoid false-success spawns; failed sessions are cleaned up.
- Risk: Gateway disconnect recovery could hide real gateway failures if classified too broadly.
  - Mitigation: Recovery is limited to an explicit stale/disconnect close-code allowlist, with negative tests for `1008 pairing required`.
