### PR TITLE
fix(hooks): send messages pushed via event.messages in message:received hooks

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -495,15 +495,38 @@ export async function dispatchReplyFromConfig(params: {
 
   // Bridge to internal hooks (HOOK.md discovery system) - refs #8807
   if (sessionKey) {
-    fireAndForgetHook(
-      triggerInternalHook(
-        createInternalHookEvent("message", "received", sessionKey, {
-          ...toInternalMessageReceivedContext(hookContext),
-          timestamp,
-        }),
-      ),
-      "dispatch-from-config: message_received internal hook failed",
-    );
+    const hookEvent = createInternalHookEvent("message", "received", sessionKey, {
+      ...toInternalMessageReceivedContext(hookContext),
+      timestamp,
+    });
+    try {
+      await triggerInternalHook(hookEvent);
+    } catch (err) {
+      logVerbose(`dispatch-from-config: message_received internal hook failed: ${String(err)}`);
+    }
+    // Send any messages pushed by the hook back to the user
+    if (hookEvent.messages.length > 0) {
+      const replyChannel = originatingChannel ?? currentSurface;
+      const replyTo = originatingTo ?? ctx.From ?? ctx.To;
+      if (replyChannel && replyTo) {
+        const result = await routeReplyRuntime.routeReply({
+          payload: { text: hookEvent.messages.join("\n\n") },
+          channel: replyChannel,
+          to: replyTo,
+          sessionKey,
+          accountId: ctx.AccountId,
+          threadId: routeThreadId,
+          cfg,
+          isGroup,
+          groupId,
+        });
+        if (!result.ok) {
+          logVerbose(
+            `dispatch-from-config: message_received hook reply failed: ${result.error ?? "unknown error"}`,
+          );
+        }
+      }
+    }
   }
 
   markProcessing();


### PR DESCRIPTION
## Summary

Closes #63601

- When a `message:received` hook replies via `event.messages.push(...)`, those messages are now forwarded to the routing layer as expected — previously only messages from the hook's `return` value were sent.

---

> This PR was developed with AI assistance (Claude). Built with [islo.dev](https://islo.dev)