### PR TITLE
fix: surface context overflow error when stop reason is model_context_window_exceeded

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -264,6 +264,36 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     );
   });
 
+  it("detects context overflow from model_context_window_exceeded stop reason (no promptError)", async () => {
+    // Some providers (e.g. ZhipuAI/GLM) return model_context_window_exceeded as a
+    // stop reason rather than an error-coded stop. Without detection, payloads=0
+    // and the UI shows an infinite spinner instead of an error message (#63661).
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        promptError: null,
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          api: "openai-responses" as const,
+          provider: "openai",
+          model: "glm-4.5-air",
+          usage: { input: 0, output: 0, total: 0 },
+          timestamp: 0,
+          stopReason: "model_context_window_exceeded",
+          errorMessage: "Unhandled stop reason: model_context_window_exceeded",
+          content: [],
+        },
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    // The overflow should be detected and an error payload surfaced to the user.
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("Context overflow");
+    expect(result.meta.error?.kind).toBe("context_overflow");
+  });
+
   it("guards thrown engine-owned overflow compaction attempts", async () => {
     mockedContextEngine.info.ownsCompaction = true;
     mockedGlobalHookRunner.hasHooks.mockImplementation(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -799,6 +799,17 @@ export async function runEmbeddedPiAgent(
                     source: "assistantError" as const,
                   };
                 }
+                // Some providers (e.g. ZhipuAI/GLM) surface context overflow via
+                // a dedicated stop reason (model_context_window_exceeded) rather
+                // than an error-coded stop with an errorMessage. Detect those here
+                // so the standard overflow recovery path applies.
+                const rawStopReason = lastAssistant?.stopReason;
+                if (rawStopReason && isLikelyContextOverflowError(rawStopReason)) {
+                  return {
+                    text: lastAssistant?.errorMessage?.trim() || rawStopReason,
+                    source: "assistantError" as const,
+                  };
+                }
                 return null;
               })()
             : null;


### PR DESCRIPTION
## Summary

- Extends `contextOverflowError` to also check `lastAssistant.stopReason` directly via `isLikelyContextOverflowError`
- Fixes providers like ZhipuAI/GLM that surface context overflow via a dedicated `model_context_window_exceeded` stop reason instead of an error-coded stop with `errorMessage`
- Without this fix, the turn returned 0 payloads, causing an infinite spinner instead of the expected error message

Closes #63661

---
> This PR was developed with AI assistance (Claude). Built with [islo.dev](https://islo.dev)