### PR TITLE
fix(slack): preserve thread context for Agents & Assistants DM root messages

### DIFF
--- a/extensions/slack/src/threading.test.ts
+++ b/extensions/slack/src/threading.test.ts
@@ -88,6 +88,26 @@ describe("resolveSlackThreadTargets", () => {
     expect(context.replyToId).toBe("123");
   });
 
+  it("sets messageThreadId for thread-root messages regardless of replyToMode", () => {
+    for (const replyToMode of ["off", "first", "batched"] as const) {
+      const context = resolveSlackThreadContext({
+        replyToMode,
+        message: {
+          type: "message",
+          channel: "C1",
+          ts: "123",
+          thread_ts: "123",
+        },
+      });
+
+      expect(context.isThreadReply).toBe(false);
+      // thread_ts == ts: Agents & Assistants DM root — preserve thread context
+      // so tool calls (subagent results) thread correctly regardless of mode.
+      expect(context.messageThreadId).toBe("123");
+      expect(context.replyToId).toBe("123");
+    }
+  });
+
   it("prefers thread_ts as messageThreadId for replies", () => {
     const context = resolveSlackThreadContext({
       replyToMode: "off",

--- a/extensions/slack/src/threading.ts
+++ b/extensions/slack/src/threading.ts
@@ -20,11 +20,19 @@ export function resolveSlackThreadContext(params: {
   const isThreadReply =
     hasThreadTs && (incomingThreadTs !== messageTs || Boolean(params.message.parent_user_id));
   const replyToId = incomingThreadTs ?? messageTs;
+  // Preserve thread context for thread replies AND for thread-root messages
+  // (e.g. Slack Agents & Assistants DMs where thread_ts == ts on the initial
+  // message). Without this, tool calls that run during the same turn (subagent
+  // results) lose the thread identifier after the first reply because
+  // hasRepliedRef gets marked true, causing subsequent sendMessage calls to fall
+  // through to the top-level channel.
   const messageThreadId = isThreadReply
     ? incomingThreadTs
-    : params.replyToMode === "all"
-      ? messageTs
-      : undefined;
+    : hasThreadTs
+      ? incomingThreadTs
+      : params.replyToMode === "all"
+        ? messageTs
+        : undefined;
   return {
     incomingThreadTs,
     messageTs,


### PR DESCRIPTION
## Summary

- Fix `resolveSlackThreadContext` to preserve `messageThreadId` for thread-root messages where `thread_ts == ts` (Slack Agents & Assistants DM pattern)
- Without this fix, subagent tool calls running in the same turn lose thread context after the first reply, causing `sendMessage` to fall through to the top-level channel
- Add test coverage for the new behavior across all `replyToMode` values

Closes #63659

---
> This PR was developed with AI assistance (Claude). Built with [islo.dev](https://islo.dev)