### PR TITLE
fix: pass cfg to getMemoryEmbeddingProvider in memory-search resolution

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -146,17 +146,18 @@ function mergeConfig(
   defaults: MemorySearchConfig | undefined,
   overrides: MemorySearchConfig | undefined,
   agentId: string,
+  cfg?: OpenClawConfig,
 ): ResolvedMemorySearchConfig {
   const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
   const sessionMemory =
     overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
   const provider = overrides?.provider ?? defaults?.provider ?? "auto";
-  const primaryAdapter = provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider);
+  const primaryAdapter = provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider, cfg);
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
   const fallback = overrides?.fallback ?? defaults?.fallback ?? "none";
   const fallbackAdapter =
-    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback) : undefined;
+    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback, cfg) : undefined;
   const hasRemoteConfig = Boolean(
     overrideRemote?.baseUrl ||
     overrideRemote?.apiKey ||
@@ -382,13 +383,13 @@ export function resolveMemorySearchConfig(
 ): ResolvedMemorySearchConfig | null {
   const defaults = cfg.agents?.defaults?.memorySearch;
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
-  const resolved = mergeConfig(defaults, overrides, agentId);
+  const resolved = mergeConfig(defaults, overrides, agentId, cfg);
   if (!resolved.enabled) {
     return null;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider =
-    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);
+    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider, cfg);
   const builtinMultimodalSupport =
     resolved.provider === "auto"
       ? false


### PR DESCRIPTION
## Summary

- Fixes a bug where `cfg` was not passed to `getMemoryEmbeddingProvider` during memory-search resolution, causing it to fall back to defaults instead of using the configured embedding provider.

Closes #63693

---
> This PR was developed with AI assistance (Claude). Built with [islo.dev](https://islo.dev)