### PR TITLE
fix(cron): clear poisoned system-event deliveryContext from isolated session (#63733)

### DIFF
--- a/src/cron/isolated-agent/session.test.ts
+++ b/src/cron/isolated-agent/session.test.ts
@@ -255,6 +255,33 @@ describe("resolveCronSession", () => {
       });
     });
 
+    it("clears poisoned deliveryContext written by a heartbeat run (regression #63733)", () => {
+      // A heartbeat run on the same session key can write {to: "heartbeat"} into the
+      // session store. When a subsequent isolated cron job reuses that session, it must
+      // not inherit the poisoned delivery context — doing so causes announce deliveries to
+      // fail with "Unknown Channel".
+      const result = resolveWithStoredEntry({
+        entry: {
+          sessionId: "existing-session-id-poisoned",
+          updatedAt: NOW_MS - 1000,
+          systemSent: true,
+          lastChannel: "discord" as never,
+          lastTo: "heartbeat",
+          deliveryContext: {
+            to: "heartbeat",
+          },
+        },
+        fresh: true,
+      });
+
+      // Session should be reused (it is fresh)
+      expect(result.isNewSession).toBe(false);
+      // But the poisoned delivery context must be wiped
+      expect(result.sessionEntry.lastChannel).toBeUndefined();
+      expect(result.sessionEntry.lastTo).toBeUndefined();
+      expect(result.sessionEntry.deliveryContext).toBeUndefined();
+    });
+
     it("creates new sessionId when entry exists but has no sessionId", () => {
       const result = resolveWithStoredEntry({
         entry: {

--- a/src/cron/isolated-agent/session.ts
+++ b/src/cron/isolated-agent/session.ts
@@ -9,6 +9,25 @@ import {
 import { loadSessionStore } from "../../config/sessions/store.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 
+/**
+ * Returns true when the persisted deliveryContext appears to have been written by a
+ * system event (heartbeat / cron-event) rather than a real user interaction.
+ * A heartbeat run uses the literal string "heartbeat" as the delivery `to` target,
+ * and if that value is written into the shared session store it poisons the routing
+ * state for subsequent isolated cron announce deliveries.
+ * See: https://github.com/openclaw/openclaw/issues/63733
+ */
+function isSystemDeliveryContext(
+  ctx: { to?: string | null } | null | undefined,
+): boolean {
+  if (!ctx || typeof ctx !== "object") {
+    return false;
+  }
+  const to = typeof ctx.to === "string" ? ctx.to.trim() : "";
+  // The heartbeat delivery target is the literal string "heartbeat" (no prefix).
+  return to === "heartbeat" || to === "cron-event" || to === "exec-event";
+}
+
 export function resolveCronSession(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
@@ -77,13 +96,17 @@ export function resolveCronSession(params: {
     // replies instead of channel top-level messages.
     // deliveryContext must also be cleared because normalizeSessionEntryDelivery
     // repopulates lastThreadId from deliveryContext.threadId on store writes.
-    ...(isNewSession && {
+    // When the persisted delivery context appears to have been written by a system
+    // event (e.g. a heartbeat run wrote {to: "heartbeat"} into the session store
+    // that this isolated cron job shares), clear it unconditionally to prevent
+    // poisoned routing. See: https://github.com/openclaw/openclaw/issues/63733
+    ...(isNewSession || isSystemDeliveryContext(entry?.deliveryContext) ? {
       lastChannel: undefined,
       lastTo: undefined,
       lastAccountId: undefined,
       lastThreadId: undefined,
       deliveryContext: undefined,
-    }),
+    } : {}),
   };
   return { storePath, store, sessionEntry, systemSent, isNewSession };
 }


### PR DESCRIPTION
## Summary

Fixes #63733

### Root Cause

When a heartbeat or cron-event run executes under the same session key as an isolated cron job, it can write a poisoned `deliveryContext` (e.g. `{to: "heartbeat"}`) into the shared session store.

If the isolated cron job later reuses that session (`isNewSession=false`), it inherits the poisoned context and its announce delivery fails with `Unknown Channel` — even after clean gateway restarts.

The existing cleanup code only cleared `deliveryContext` when `isNewSession=true`, leaving reused sessions vulnerable to this contamination.

### Fix

`resolveCronSession` now detects a system-event delivery context (`to === "heartbeat"`, `"cron-event"`, or `"exec-event"`) via the new `isSystemDeliveryContext` helper, and clears it unconditionally — just as it would for a new session.

Legitimate delivery routing state (e.g. a real Slack channel ID `channel:C0XXXXXXXXX`) is preserved unchanged.

### Testing

Added a regression test covering the poisoned-context scenario. All 11 session tests pass.