### PR TITLE
fix(doctor): detect stale cross-OS workspace paths (#63572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/startup: keep WebSocket RPC available while channels and plugin sidecars start, hold `chat.history` unavailable until startup sidecars finish so synchronous history reads cannot stall startup (reported in #63450), refresh advertised gateway methods after deferred plugin reloads, and enforce the pre-auth WebSocket upgrade budget before the no-handler 503 path so upgrade floods cannot bypass connection limits during that window. (#63480) Thanks @neeravmakwana.
 - Gateway/tailscale: start Tailscale exposure and the gateway update check before awaiting channel and plugin sidecar startup so remote operators are not locked out when startup sidecars stall.
 - QQBot/streaming: make block streaming configurable per QQ bot account via `streaming.mode` (`"partial"` | `"off"`, default `"partial"`) instead of hardcoding it off, so responses can be delivered incrementally. (#63746)
+- Doctor/workspace paths: detect stale cross-OS absolute workspace paths in `agents.defaults.workspace` and per-agent `workspace` fields (for example `/home/<user>/.openclaw/workspace` migrated to a macOS host) and offer to rewrite them to `~`-relative form so the config travels between machines. (#63572)
 
 ## 2026.4.9
 

--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -90,6 +90,10 @@ Custom profiles use `~/.openclaw-<profile>/` or a path set via `OPENCLAW_STATE_D
     Ensure the state directory and workspace are owned by the user running the gateway.
   </Accordion>
 
+  <Accordion title="Cross-OS absolute workspace paths">
+    If your previous install baked an absolute workspace path into `openclaw.json` (for example `/home/<user>/.openclaw/workspace` from Linux or WSL), it will not resolve on a macOS or Windows host. `openclaw doctor` detects stale cross-OS paths in `agents.defaults.workspace` and per-agent `workspace` fields and offers to rewrite them to `~`-relative form so the config travels between machines.
+  </Accordion>
+
   <Accordion title="Remote mode">
     If your UI points at a **remote** gateway, the remote host owns sessions and workspace.
     Migrate the gateway host itself, not your local laptop. See [FAQ](/help/faq#where-things-live-on-disk).

--- a/src/commands/doctor-workspace-paths.test.ts
+++ b/src/commands/doctor-workspace-paths.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { detectStaleWorkspacePaths, type StaleWorkspacePathEnv } from "./doctor-workspace-paths.js";
+
+function makeCfg(
+  workspaces: {
+    defaults?: string;
+    list?: Array<{ id: string; workspace?: string }>;
+  } = {},
+): OpenClawConfig {
+  const agents: Record<string, unknown> = {};
+  if (workspaces.defaults !== undefined) {
+    agents.defaults = { workspace: workspaces.defaults };
+  }
+  if (workspaces.list !== undefined) {
+    agents.list = workspaces.list;
+  }
+  return { agents } as unknown as OpenClawConfig;
+}
+
+function makeEnv(over: Partial<StaleWorkspacePathEnv> = {}): StaleWorkspacePathEnv {
+  return {
+    homedir: "/Users/alice",
+    username: "alice",
+    platform: "darwin",
+    pathExists: () => false,
+    ...over,
+  };
+}
+
+describe("detectStaleWorkspacePaths", () => {
+  it("returns no findings for an empty config", () => {
+    expect(detectStaleWorkspacePaths(makeCfg(), makeEnv())).toEqual([]);
+  });
+
+  it("skips ~-relative defaults.workspace", () => {
+    const cfg = makeCfg({ defaults: "~/.openclaw/workspace" });
+    expect(detectStaleWorkspacePaths(cfg, makeEnv())).toEqual([]);
+  });
+
+  it("skips relative paths", () => {
+    const cfg = makeCfg({ defaults: "./workspace" });
+    expect(detectStaleWorkspacePaths(cfg, makeEnv())).toEqual([]);
+  });
+
+  it("skips absolute paths that exist on the current host", () => {
+    const cfg = makeCfg({ defaults: "/Users/alice/.openclaw/workspace" });
+    const findings = detectStaleWorkspacePaths(cfg, makeEnv({ pathExists: () => true }));
+    expect(findings).toEqual([]);
+  });
+
+  it("flags a Linux-shaped path on a macOS host as stale", () => {
+    const cfg = makeCfg({ defaults: "/home/alice/.openclaw/workspace" });
+    const findings = detectStaleWorkspacePaths(cfg, makeEnv());
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: "stale-home-prefix",
+      location: "agents.defaults.workspace",
+      currentValue: "/home/alice/.openclaw/workspace",
+      proposedRewrite: "~/.openclaw/workspace",
+    });
+  });
+
+  it("flags a macOS-shaped path on a Linux host as stale", () => {
+    const cfg = makeCfg({ defaults: "/Users/alice/.openclaw/ws" });
+    const findings = detectStaleWorkspacePaths(
+      cfg,
+      makeEnv({ platform: "linux", homedir: "/home/alice" }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: "stale-home-prefix",
+      proposedRewrite: "~/.openclaw/ws",
+    });
+  });
+
+  it("flags a Windows-shaped path on a macOS host as stale", () => {
+    const cfg = makeCfg({ defaults: "C:\\Users\\alice\\.openclaw\\ws" });
+    const findings = detectStaleWorkspacePaths(cfg, makeEnv());
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: "stale-home-prefix",
+      proposedRewrite: "~/.openclaw/ws",
+    });
+  });
+
+  it("flags a different-user Linux home as stale even on Linux", () => {
+    const cfg = makeCfg({ defaults: "/home/bob/.openclaw/workspace" });
+    const findings = detectStaleWorkspacePaths(
+      cfg,
+      makeEnv({ platform: "linux", homedir: "/home/alice" }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].kind).toBe("stale-home-prefix");
+  });
+
+  it("flags /root paths as stale for non-root users", () => {
+    const cfg = makeCfg({ defaults: "/root/.openclaw/ws" });
+    const findings = detectStaleWorkspacePaths(
+      cfg,
+      makeEnv({ platform: "linux", homedir: "/home/alice" }),
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: "stale-home-prefix",
+      proposedRewrite: "~/.openclaw/ws",
+    });
+  });
+
+  it("reports non-home absolute paths that don't exist as missing-nonhome without a rewrite", () => {
+    const cfg = makeCfg({ defaults: "/mnt/data/openclaw-ws" });
+    const findings = detectStaleWorkspacePaths(cfg, makeEnv());
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: "missing-nonhome",
+      currentValue: "/mnt/data/openclaw-ws",
+    });
+    expect(findings[0]).not.toHaveProperty("proposedRewrite");
+  });
+
+  it("preserves nested subpaths in the rewrite", () => {
+    const cfg = makeCfg({ defaults: "/home/alice/work/custom/path" });
+    const findings = detectStaleWorkspacePaths(cfg, makeEnv());
+    expect(findings[0].kind).toBe("stale-home-prefix");
+    if (findings[0].kind === "stale-home-prefix") {
+      expect(findings[0].proposedRewrite).toBe("~/work/custom/path");
+    }
+  });
+
+  it("rewrites a bare home root to ~", () => {
+    const cfg = makeCfg({ defaults: "/home/alice" });
+    const findings = detectStaleWorkspacePaths(cfg, makeEnv());
+    expect(findings[0].kind).toBe("stale-home-prefix");
+    if (findings[0].kind === "stale-home-prefix") {
+      expect(findings[0].proposedRewrite).toBe("~");
+    }
+  });
+
+  it("emits findings per stale agent entry and leaves healthy ones alone", () => {
+    const cfg = makeCfg({
+      defaults: "/home/alice/.openclaw/workspace",
+      list: [
+        { id: "ok-tilde", workspace: "~/other-ws" },
+        { id: "ok-local", workspace: "/Users/alice/local-ws" },
+        { id: "stale", workspace: "/home/alice/stale-ws" },
+      ],
+    });
+    const findings = detectStaleWorkspacePaths(
+      cfg,
+      makeEnv({ pathExists: (p) => p === "/Users/alice/local-ws" }),
+    );
+    expect(findings.map((f) => f.location)).toEqual([
+      "agents.defaults.workspace",
+      "agents.list[2].workspace",
+    ]);
+    for (const f of findings) {
+      expect(f.kind).toBe("stale-home-prefix");
+    }
+    const stale = findings.find((f) => f.location === "agents.list[2].workspace");
+    expect(stale).toBeDefined();
+    if (stale && stale.kind === "stale-home-prefix") {
+      expect(stale.agentId).toBe("stale");
+      expect(stale.proposedRewrite).toBe("~/stale-ws");
+    }
+  });
+
+  it("does not flag paths when current user's home is a prefix (local-missing is skipped)", () => {
+    const cfg = makeCfg({ defaults: "/Users/alice/missing-locally" });
+    const findings = detectStaleWorkspacePaths(cfg, makeEnv({ pathExists: () => false }));
+    expect(findings).toEqual([]);
+  });
+});

--- a/src/commands/doctor-workspace-paths.test.ts
+++ b/src/commands/doctor-workspace-paths.test.ts
@@ -169,4 +169,89 @@ describe("detectStaleWorkspacePaths", () => {
     const findings = detectStaleWorkspacePaths(cfg, makeEnv({ pathExists: () => false }));
     expect(findings).toEqual([]);
   });
+
+  describe("Windows case-insensitive home prefix", () => {
+    // Windows treats `C:\Users\Alice` and `c:\users\alice` as the same path,
+    // and `os.userInfo().username` may report either case depending on how the
+    // account was provisioned. Comparisons against win-shaped prefixes must
+    // therefore be case-insensitive, otherwise a perfectly local Windows
+    // workspace gets flagged as a cross-OS stale path.
+
+    it("does not flag a Windows home with mismatched username case", () => {
+      const cfg = makeCfg({ defaults: "C:\\Users\\Alice\\.openclaw\\workspace" });
+      const findings = detectStaleWorkspacePaths(
+        cfg,
+        makeEnv({
+          platform: "win32",
+          homedir: "C:\\Users\\alice",
+          username: "alice",
+          pathExists: () => false,
+        }),
+      );
+      expect(findings).toEqual([]);
+    });
+
+    it("does not flag a Windows home with mismatched homedir case", () => {
+      const cfg = makeCfg({ defaults: "c:\\users\\alice\\.openclaw\\workspace" });
+      const findings = detectStaleWorkspacePaths(
+        cfg,
+        makeEnv({
+          platform: "win32",
+          homedir: "C:\\Users\\Alice",
+          username: "Alice",
+          pathExists: () => false,
+        }),
+      );
+      expect(findings).toEqual([]);
+    });
+
+    it("does not flag a Windows home with mismatched drive-letter case", () => {
+      const cfg = makeCfg({ defaults: "c:\\Users\\alice\\workspace" });
+      const findings = detectStaleWorkspacePaths(
+        cfg,
+        makeEnv({
+          platform: "win32",
+          homedir: "C:\\Users\\alice",
+          username: "alice",
+          pathExists: () => false,
+        }),
+      );
+      expect(findings).toEqual([]);
+    });
+
+    it("still flags a different Windows user even when our username case matches", () => {
+      const cfg = makeCfg({ defaults: "C:\\Users\\Bob\\workspace" });
+      const findings = detectStaleWorkspacePaths(
+        cfg,
+        makeEnv({
+          platform: "win32",
+          homedir: "C:\\Users\\alice",
+          username: "alice",
+          pathExists: () => false,
+        }),
+      );
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({
+        kind: "stale-home-prefix",
+        proposedRewrite: "~/workspace",
+      });
+    });
+
+    it("preserves Linux case sensitivity (Alice and alice are different users)", () => {
+      // Linux filesystems are case-sensitive, so `/home/Alice` on a host
+      // running as `alice` must still be flagged as cross-user stale.
+      const cfg = makeCfg({ defaults: "/home/Alice/workspace" });
+      const findings = detectStaleWorkspacePaths(
+        cfg,
+        makeEnv({
+          platform: "linux",
+          homedir: "/home/alice",
+          username: "alice",
+          pathExists: () => false,
+        }),
+      );
+      expect(findings).toHaveLength(1);
+      expect(findings[0].kind).toBe("stale-home-prefix");
+    });
+  });
 });

--- a/src/commands/doctor-workspace-paths.ts
+++ b/src/commands/doctor-workspace-paths.ts
@@ -189,6 +189,25 @@ export function detectStaleWorkspacePaths(
  * interactive mode, prompt to rewrite them to `~`-relative form. Returns a
  * new config object; callers should assign the result back to `ctx.cfg`.
  */
+function resolveCurrentUsername(): string {
+  // os.userInfo() throws (`SystemError [ERR_SYSTEM_ERROR]: A system error
+  // occurred: uv_os_get_passwd returned ENOENT`) on systems where the
+  // running UID has no /etc/passwd entry — common in containerized or
+  // NSS-restricted environments. Doctor must not crash there, so fall
+  // back to env vars and finally to an empty string. An empty username
+  // is fine for detection: every home-shaped prefix will compare unequal
+  // and the path will be flagged for review rather than auto-skipped.
+  try {
+    const fromUserInfo = os.userInfo().username;
+    if (fromUserInfo) {
+      return fromUserInfo;
+    }
+  } catch {
+    // fall through to env-based fallback
+  }
+  return process.env.USER ?? process.env.LOGNAME ?? process.env.USERNAME ?? "";
+}
+
 export async function maybeRepairStaleWorkspacePaths(
   cfg: OpenClawConfig,
   prompter: DoctorPrompter,
@@ -196,7 +215,7 @@ export async function maybeRepairStaleWorkspacePaths(
 ): Promise<OpenClawConfig> {
   const findings = detectStaleWorkspacePaths(cfg, {
     homedir: os.homedir(),
-    username: os.userInfo().username,
+    username: resolveCurrentUsername(),
     platform: process.platform,
     pathExists: (p) => {
       try {

--- a/src/commands/doctor-workspace-paths.ts
+++ b/src/commands/doctor-workspace-paths.ts
@@ -1,0 +1,293 @@
+import fs from "node:fs";
+import os from "node:os";
+import { formatCliCommand } from "../cli/command-format.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { note } from "../terminal/note.js";
+import type { DoctorPrompter } from "./doctor-prompter.js";
+
+/**
+ * A path-field in openclaw.json that cannot be used on the current host.
+ *
+ * - `stale-home-prefix`: absolute path whose `/home/<user>`, `/Users/<user>`,
+ *   `/root`, or `C:\Users\<user>` prefix does not belong to the current user
+ *   or the current OS. Safe to rewrite to a `~`-relative form.
+ * - `missing-nonhome`: absolute path that does not exist and does not look
+ *   like a home-dir-shaped path (for example `/mnt/data/openclaw-ws`). Reported
+ *   so the operator can fix it manually; we never auto-rewrite these.
+ */
+export type StaleWorkspacePathFinding =
+  | {
+      kind: "stale-home-prefix";
+      location: string;
+      agentId?: string;
+      currentValue: string;
+      proposedRewrite: string;
+    }
+  | {
+      kind: "missing-nonhome";
+      location: string;
+      agentId?: string;
+      currentValue: string;
+    };
+
+export type StaleWorkspacePathEnv = {
+  homedir: string;
+  username: string;
+  platform: NodeJS.Platform;
+  pathExists: (p: string) => boolean;
+};
+
+type HomePrefixKind = "posix" | "win";
+
+// Ordered list of regexes matching a home-directory-shaped prefix.
+// Capture group 1 (when present) is the username segment.
+const HOME_PREFIX_PATTERNS: Array<{ re: RegExp; kind: HomePrefixKind }> = [
+  { re: /^\/home\/([^/]+)(?:\/|$)/, kind: "posix" },
+  { re: /^\/Users\/([^/]+)(?:\/|$)/, kind: "posix" },
+  { re: /^\/root(?:\/|$)/, kind: "posix" },
+  { re: /^[A-Za-z]:[\\/]Users[\\/]([^\\/]+)(?:[\\/]|$)/, kind: "win" },
+];
+
+type HomePrefixMatch = {
+  matchedPrefix: string;
+  extractedUser: string;
+  kind: HomePrefixKind;
+};
+
+function matchHomePrefix(value: string): HomePrefixMatch | null {
+  for (const { re, kind } of HOME_PREFIX_PATTERNS) {
+    const m = value.match(re);
+    if (!m) {
+      continue;
+    }
+    return {
+      matchedPrefix: m[0],
+      extractedUser: m[1] ?? "root",
+      kind,
+    };
+  }
+  return null;
+}
+
+function rewriteToTilde(value: string, match: HomePrefixMatch): string {
+  const rest = value.slice(match.matchedPrefix.length);
+  if (!rest) {
+    return "~";
+  }
+  // Normalize Windows separators into forward slashes for the tilde form.
+  const normalized = match.kind === "win" ? rest.replace(/\\/g, "/") : rest;
+  const stripped = normalized.replace(/^\/+/, "");
+  return stripped ? `~/${stripped}` : "~";
+}
+
+function isAbsolutePath(value: string, platform: NodeJS.Platform): boolean {
+  if (platform === "win32") {
+    if (/^[A-Za-z]:[\\/]/.test(value)) {
+      return true;
+    }
+    if (value.startsWith("\\") || value.startsWith("/")) {
+      return true;
+    }
+    return false;
+  }
+  return value.startsWith("/");
+}
+
+type WorkspaceEntry = {
+  location: string;
+  agentId?: string;
+  value: string;
+};
+
+function collectWorkspaceEntries(cfg: OpenClawConfig): WorkspaceEntry[] {
+  const entries: WorkspaceEntry[] = [];
+  const defaults = cfg.agents?.defaults?.workspace;
+  if (typeof defaults === "string" && defaults.trim()) {
+    entries.push({
+      location: "agents.defaults.workspace",
+      value: defaults.trim(),
+    });
+  }
+  const list = cfg.agents?.list ?? [];
+  list.forEach((agent, index) => {
+    const raw = agent?.workspace;
+    if (typeof raw === "string" && raw.trim()) {
+      entries.push({
+        location: `agents.list[${index}].workspace`,
+        ...(agent.id !== undefined ? { agentId: agent.id } : {}),
+        value: raw.trim(),
+      });
+    }
+  });
+  return entries;
+}
+
+/**
+ * Pure detector: returns findings for stale workspace path fields in `cfg`.
+ * Does not touch the filesystem beyond the injected `pathExists` probe.
+ */
+export function detectStaleWorkspacePaths(
+  cfg: OpenClawConfig,
+  env: StaleWorkspacePathEnv,
+): StaleWorkspacePathFinding[] {
+  const findings: StaleWorkspacePathFinding[] = [];
+  for (const entry of collectWorkspaceEntries(cfg)) {
+    const value = entry.value;
+
+    if (value.startsWith("~")) {
+      continue;
+    }
+
+    // Home-shaped prefixes (`/home/X`, `/Users/X`, `/root`, `C:\Users\X`) are
+    // inspected regardless of the current platform — the whole point of this
+    // check is to flag cross-OS stale paths, so a Windows-shaped path on a
+    // macOS host must still be considered.
+    const prefix = matchHomePrefix(value);
+    if (prefix) {
+      if (env.pathExists(value)) {
+        continue;
+      }
+      const isOurUser = prefix.extractedUser === env.username;
+      const homeMatches = env.homedir.length > 0 && value.startsWith(env.homedir);
+      if (isOurUser && homeMatches) {
+        // Our user, our home root, but the directory is missing locally.
+        // Not a cross-OS stale case — the existing `doctor:workspace-status`
+        // contribution already surfaces missing-dir concerns, so skip here
+        // to avoid duplicate noise.
+        continue;
+      }
+      findings.push({
+        kind: "stale-home-prefix",
+        location: entry.location,
+        ...(entry.agentId !== undefined ? { agentId: entry.agentId } : {}),
+        currentValue: value,
+        proposedRewrite: rewriteToTilde(value, prefix),
+      });
+      continue;
+    }
+
+    // Non-home path: only worth inspecting if it's absolute on the current
+    // platform. Relative paths are resolved by openclaw at load time.
+    if (!isAbsolutePath(value, env.platform)) {
+      continue;
+    }
+    if (env.pathExists(value)) {
+      continue;
+    }
+    findings.push({
+      kind: "missing-nonhome",
+      location: entry.location,
+      ...(entry.agentId !== undefined ? { agentId: entry.agentId } : {}),
+      currentValue: value,
+    });
+  }
+  return findings;
+}
+
+/**
+ * Effectful doctor repair: surface stale workspace path findings and, in
+ * interactive mode, prompt to rewrite them to `~`-relative form. Returns a
+ * new config object; callers should assign the result back to `ctx.cfg`.
+ */
+export async function maybeRepairStaleWorkspacePaths(
+  cfg: OpenClawConfig,
+  prompter: DoctorPrompter,
+  options: { nonInteractive: boolean },
+): Promise<OpenClawConfig> {
+  const findings = detectStaleWorkspacePaths(cfg, {
+    homedir: os.homedir(),
+    username: os.userInfo().username,
+    platform: process.platform,
+    pathExists: (p) => {
+      try {
+        return fs.existsSync(p);
+      } catch {
+        return false;
+      }
+    },
+  });
+
+  if (findings.length === 0) {
+    return cfg;
+  }
+
+  const stale = findings.filter(
+    (f): f is Extract<StaleWorkspacePathFinding, { kind: "stale-home-prefix" }> =>
+      f.kind === "stale-home-prefix",
+  );
+  const untouchable = findings.filter(
+    (f): f is Extract<StaleWorkspacePathFinding, { kind: "missing-nonhome" }> =>
+      f.kind === "missing-nonhome",
+  );
+
+  const lines: string[] = [];
+  if (stale.length > 0) {
+    lines.push(`Found ${stale.length} workspace path(s) referencing a different OS or user home:`);
+    for (const f of stale) {
+      lines.push(`- ${f.location}: ${f.currentValue} -> ${f.proposedRewrite}`);
+    }
+  }
+  if (untouchable.length > 0) {
+    if (lines.length > 0) {
+      lines.push("");
+    }
+    lines.push(
+      `Found ${untouchable.length} workspace path(s) that do not exist and are not home-shaped (doctor will not touch these):`,
+    );
+    for (const f of untouchable) {
+      lines.push(`- ${f.location}: ${f.currentValue}`);
+    }
+    lines.push(
+      `Fix these manually with ${formatCliCommand("openclaw config set ...")} or by editing openclaw.json.`,
+    );
+  }
+  note(lines.join("\n"), "Workspace paths");
+
+  if (stale.length === 0) {
+    return cfg;
+  }
+  if (options.nonInteractive) {
+    note(
+      `Rerun ${formatCliCommand("openclaw doctor")} interactively to apply the rewrites, or edit openclaw.json directly.`,
+      "Workspace paths",
+    );
+    return cfg;
+  }
+
+  const apply = await prompter.confirm({
+    message: `Rewrite ${stale.length} stale workspace path(s) to home-relative form (~/...)?`,
+    initialValue: true,
+  });
+  if (!apply) {
+    return cfg;
+  }
+
+  const nextAgents = cfg.agents
+    ? {
+        ...cfg.agents,
+        defaults: cfg.agents.defaults ? { ...cfg.agents.defaults } : cfg.agents.defaults,
+        list: cfg.agents.list ? cfg.agents.list.map((a) => ({ ...a })) : cfg.agents.list,
+      }
+    : cfg.agents;
+
+  const next: OpenClawConfig = { ...cfg, agents: nextAgents };
+
+  for (const f of stale) {
+    if (f.location === "agents.defaults.workspace") {
+      if (next.agents?.defaults) {
+        next.agents.defaults.workspace = f.proposedRewrite;
+      }
+      continue;
+    }
+    const indexMatch = /^agents\.list\[(\d+)\]\.workspace$/.exec(f.location);
+    if (indexMatch && next.agents?.list) {
+      const idx = Number(indexMatch[1]);
+      const entry = next.agents.list[idx];
+      if (entry) {
+        next.agents.list[idx] = { ...entry, workspace: f.proposedRewrite };
+      }
+    }
+  }
+
+  return next;
+}

--- a/src/commands/doctor-workspace-paths.ts
+++ b/src/commands/doctor-workspace-paths.ts
@@ -40,12 +40,15 @@ export type StaleWorkspacePathEnv = {
 type HomePrefixKind = "posix" | "win";
 
 // Ordered list of regexes matching a home-directory-shaped prefix.
-// Capture group 1 (when present) is the username segment.
+// Capture group 1 (when present) is the username segment. The Windows
+// pattern is case-insensitive because Windows path semantics are
+// case-insensitive (`C:\Users\Alice` and `c:\users\alice` resolve to the
+// same directory) and configs may carry either casing.
 const HOME_PREFIX_PATTERNS: Array<{ re: RegExp; kind: HomePrefixKind }> = [
   { re: /^\/home\/([^/]+)(?:\/|$)/, kind: "posix" },
   { re: /^\/Users\/([^/]+)(?:\/|$)/, kind: "posix" },
   { re: /^\/root(?:\/|$)/, kind: "posix" },
-  { re: /^[A-Za-z]:[\\/]Users[\\/]([^\\/]+)(?:[\\/]|$)/, kind: "win" },
+  { re: /^[A-Za-z]:[\\/]Users[\\/]([^\\/]+)(?:[\\/]|$)/i, kind: "win" },
 ];
 
 type HomePrefixMatch = {
@@ -147,8 +150,14 @@ export function detectStaleWorkspacePaths(
       if (env.pathExists(value)) {
         continue;
       }
-      const isOurUser = prefix.extractedUser === env.username;
-      const homeMatches = env.homedir.length > 0 && value.startsWith(env.homedir);
+      // Windows path semantics are case-insensitive, so when the matched
+      // prefix is win-shaped we lowercase both sides of the username and
+      // homedir-prefix comparisons. Posix prefixes keep strict equality
+      // because Linux filesystems are case-sensitive.
+      const caseFold = (s: string) => (prefix.kind === "win" ? s.toLowerCase() : s);
+      const isOurUser = caseFold(prefix.extractedUser) === caseFold(env.username);
+      const homeMatches =
+        env.homedir.length > 0 && caseFold(value).startsWith(caseFold(env.homedir));
       if (isOurUser && homeMatches) {
         // Our user, our home root, but the directory is missing locally.
         // Not a cross-OS stale case — the existing `doctor:workspace-status`

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -45,6 +45,7 @@ import {
   detectLegacyStateMigrations,
   runLegacyStateMigrations,
 } from "../commands/doctor-state-migrations.js";
+import { maybeRepairStaleWorkspacePaths } from "../commands/doctor-workspace-paths.js";
 import { noteWorkspaceStatus } from "../commands/doctor-workspace-status.js";
 import { MEMORY_SYSTEM_PROMPT, shouldSuggestMemorySystem } from "../commands/doctor-workspace.js";
 import { noteOpenAIOAuthTlsPrerequisites } from "../commands/oauth-tls-preflight.js";
@@ -399,6 +400,12 @@ async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<v
   noteWorkspaceStatus(ctx.cfg);
 }
 
+async function runStaleWorkspacePathsHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  ctx.cfg = await maybeRepairStaleWorkspacePaths(ctx.cfg, ctx.prompter, {
+    nonInteractive: ctx.options.nonInteractive === true,
+  });
+}
+
 async function runBootstrapSizeHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   await noteBootstrapFileSize(ctx.cfg);
 }
@@ -586,6 +593,11 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
       id: "doctor:workspace-status",
       label: "Workspace status",
       run: runWorkspaceStatusHealth,
+    }),
+    createDoctorHealthContribution({
+      id: "doctor:workspace-stale-paths",
+      label: "Workspace path portability",
+      run: runStaleWorkspacePathsHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:bootstrap-size",


### PR DESCRIPTION
## Summary

Closes #63572.

When a user migrates their `~/.openclaw` state directory across OSes (WSL/Linux → macOS, for example), any absolute paths persisted in `openclaw.json` for `agents.defaults.workspace` or per-agent `workspace` fields break silently. `ensureAgentWorkspace` later tries to `mkdir -p` the stale Linux path on a macOS host and fails with `ENOENT`, taking down every channel's agent dispatch with only gateway-log evidence.

This PR adds a new doctor health contribution — `doctor:workspace-stale-paths` — that detects these stale paths and offers to rewrite them to `~`-relative form, which is durable across future migrations.

## What changed

- **New**: `src/commands/doctor-workspace-paths.ts` — pure `detectStaleWorkspacePaths(cfg, env)` detector plus an effectful `maybeRepairStaleWorkspacePaths(cfg, prompter, options)` wrapper that matches the existing `maybeRepairX` pattern used elsewhere in doctor.
- **New**: `src/commands/doctor-workspace-paths.test.ts` — 14 unit tests covering: empty config, tilde passthrough, relative paths, existing-absolute passthrough, Linux→macOS, macOS→Linux, Windows→macOS, different-user same-OS, `/root` for non-root users, non-home absolute as `missing-nonhome`, nested subpath preservation, bare home root → `~`, mixed healthy + stale agent list, and local-missing-same-home skip.
- **Modified**: `src/flows/doctor-health-contributions.ts` — register the new contribution immediately after `doctor:workspace-status` so mutations land before `doctor:write-config` persists.
- **Modified**: `docs/install/migrating.md` — new "Cross-OS absolute workspace paths" accordion under Common Pitfalls pointing at the new check.
- **Modified**: `CHANGELOG.md` — one line at the end of `Unreleased > ### Fixes`.

## Detection rules

| Input | Outcome |
|---|---|
| Empty, missing, or `~`-prefixed | Skip |
| Relative path | Skip |
| Home-shaped absolute path that exists on this host | Skip |
| Home-shaped absolute path, our user, our home matches, but missing locally | Skip — the existing `doctor:workspace-status` already covers local-missing; we avoid duplicate noise |
| Home-shaped absolute path (`/home/X`, `/Users/X`, `/root`, `C:\Users\X`), different user or wrong home root | **Flag `stale-home-prefix`**, propose `~`-relative rewrite |
| Non-home absolute path (`/mnt/data/ws`), doesn't exist | **Report `missing-nonhome`**, never auto-rewrite |

Home-shaped paths are inspected regardless of the current platform — a Windows-shaped path encountered on a macOS host is exactly the cross-OS case we want to catch.

## Behavior

- **Interactive mode**: single confirmation prompt listing all stale paths and their proposed rewrites. On yes, mutates `ctx.cfg`; the existing `doctor:write-config` contribution persists the result on the same pass.
- **Non-interactive mode** (`openclaw doctor --non-interactive`): logs findings and manual-fix instructions, does not mutate.

## Scope boundaries (explicitly out of scope)

- Does not touch `gateway.staticDir`, `sandbox.workspaceRoot`, or any other absolute-path config field. The reporter named only the agent workspace fields and expanding scope risks rewriting intentionally-absolute mounts.
- Does not change `ensureAgentWorkspace` or `resolveAgentWorkspaceDir`. Strict diagnose-and-repair at the doctor layer, matching the CLAUDE.md guidance ("for legacy config specifically, prefer doctor-owned repair paths over startup/load-time core migrations").
- Does not rewrite the migration guide — single accordion addition only.

## Why `~` rather than absolute homedir

The reporter's failure mode is "stale absolute path after migration". Rewriting to another absolute path (for example the current `/Users/me/...`) just pushes the problem to the next migration. Writing `~/.openclaw/...` keeps the config portable.

## Test plan

- [x] `pnpm test src/commands/doctor-workspace-paths.test.ts` — 14/14 passing
- [x] `pnpm test src/commands/doctor` — 116/116 passing across 24 test files in the broader doctor suite, no regressions
- [x] `pnpm format` — clean (no formatting churn in touched files)
- [x] `pnpm lint` scoped to touched files (`src/commands/doctor-workspace-paths*.ts` and `src/flows/doctor-health-contributions.ts`) — 0 errors, 0 warnings
- [x] Pre-commit hook fast lane (`FAST_COMMIT=1`) — clean
- [ ] Manual verification with a synthetic `openclaw.json` containing `/home/<alt-user>/.openclaw/workspace` on a macOS host — happy to do in a follow-up if a reviewer wants a live trace

## Note on `pnpm check`

The full `pnpm check` gate halts on a pre-existing unrelated tsgo error in `src/auto-reply/reply/followup-runner.test.ts:1140` (type cast from a literal config shape to `OpenClawConfig` rejected by the current `CliBackendConfig` index signature). I verified the error is present on `origin/main` with no changes applied, so it does not belong to this PR. My touched files type-check cleanly in isolation. Happy to adjust if a maintainer would prefer the check-gate-green requirement blocks landing here.

Co-Authored-By: Oz <oz-agent@warp.dev>
