### PR TITLE
Require operator.admin for /dreaming persistence

### DIFF
--- a/extensions/memory-core/src/dreaming-command.test.ts
+++ b/extensions/memory-core/src/dreaming-command.test.ts
@@ -132,6 +132,32 @@ describe("memory-core /dreaming command", () => {
     expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
   });
 
+  it("blocks unscoped gateway callers from persisting dreaming config", async () => {
+    const { command, runtime } = createHarness();
+
+    const result = await command.handler(
+      createCommandContext("off", {
+        gatewayClientScopes: [],
+      }),
+    );
+
+    expect(result.text).toContain("requires operator.admin");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("allows write-scoped gateway callers to use /dreaming status", async () => {
+    const { command, runtime } = createHarness();
+
+    const result = await command.handler(
+      createCommandContext("status", {
+        gatewayClientScopes: ["operator.write"],
+      }),
+    );
+
+    expect(result.text).toContain("Dreaming status:");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+
   it("allows admin-scoped gateway callers to persist dreaming config", async () => {
     const { command, runtime, getRuntimeConfig } = createHarness();
 

--- a/extensions/memory-core/src/dreaming-command.test.ts
+++ b/extensions/memory-core/src/dreaming-command.test.ts
@@ -52,13 +52,17 @@ function createHarness(initialConfig: OpenClawConfig = {}) {
   };
 }
 
-function createCommandContext(args?: string): PluginCommandContext {
+function createCommandContext(
+  args?: string,
+  overrides?: Partial<Pick<PluginCommandContext, "gatewayClientScopes">>,
+): PluginCommandContext {
   return {
     channel: "webchat",
     isAuthorizedSender: true,
     commandBody: args ? `/dreaming ${args}` : "/dreaming",
     args,
     config: {},
+    gatewayClientScopes: overrides?.gatewayClientScopes,
     requestConversationBinding: async () => ({ status: "error", message: "unsupported" }),
     detachConversationBinding: async () => ({ removed: false }),
     getCurrentConversationBinding: async () => null,
@@ -113,6 +117,35 @@ describe("memory-core /dreaming command", () => {
       frequency: "0 */6 * * *",
     });
     expect(result.text).toContain("Dreaming disabled.");
+  });
+
+  it("blocks write-scoped gateway callers from persisting dreaming config", async () => {
+    const { command, runtime } = createHarness();
+
+    const result = await command.handler(
+      createCommandContext("off", {
+        gatewayClientScopes: ["operator.write"],
+      }),
+    );
+
+    expect(result.text).toContain("requires operator.admin");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("allows admin-scoped gateway callers to persist dreaming config", async () => {
+    const { command, runtime, getRuntimeConfig } = createHarness();
+
+    const result = await command.handler(
+      createCommandContext("on", {
+        gatewayClientScopes: ["operator.admin"],
+      }),
+    );
+
+    expect(runtime.config.writeConfigFile).toHaveBeenCalledTimes(1);
+    expect(resolveStoredDreaming(getRuntimeConfig())).toMatchObject({
+      enabled: true,
+    });
+    expect(result.text).toContain("Dreaming enabled.");
   });
 
   it("returns status without mutating config", async () => {

--- a/extensions/memory-core/src/dreaming-command.ts
+++ b/extensions/memory-core/src/dreaming-command.ts
@@ -74,6 +74,13 @@ function formatUsage(includeStatus: string): string {
   ].join("\n");
 }
 
+function requiresAdminToMutateDreaming(gatewayClientScopes?: readonly string[]): boolean {
+  if (!Array.isArray(gatewayClientScopes)) {
+    return false;
+  }
+  return !gatewayClientScopes.includes("operator.admin");
+}
+
 export function registerDreamingCommand(api: OpenClawPluginApi): void {
   api.registerCommand({
     name: "dreaming",
@@ -101,6 +108,13 @@ export function registerDreamingCommand(api: OpenClawPluginApi): void {
       }
 
       if (firstToken === "on" || firstToken === "off") {
+        // Gateway callers can override the visible channel, so gateway scopes
+        // are the authoritative signal for internal admin-only persistence.
+        if (requiresAdminToMutateDreaming(ctx.gatewayClientScopes)) {
+          return {
+            text: "⚠️ /dreaming on|off requires operator.admin for gateway clients.",
+          };
+        }
         const enabled = firstToken === "on";
         const nextConfig = updateDreamingEnabledInConfig(currentConfig, enabled);
         await api.runtime.config.writeConfigFile(nextConfig);

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1664,7 +1664,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         SenderId: clientInfo?.id,
         SenderName: clientInfo?.displayName,
         SenderUsername: clientInfo?.displayName,
-        GatewayClientScopes: client?.connect?.scopes,
+        GatewayClientScopes: client?.connect?.scopes ?? [],
       };
 
       const agentId = resolveSessionAgentId({


### PR DESCRIPTION
## Summary
- Requires `operator.admin` before `/dreaming on|off` persists config for scoped gateway callers
- Keeps `/dreaming status` and non-gateway command behavior unchanged

## Changes
- Added a gateway-scope guard in the `memory-core` dreaming command before writing config
- Added regression coverage for write-scoped gateway callers and admin-scoped gateway callers

## Validation
- Ran `pnpm test extensions/memory-core/src/dreaming-command.test.ts`
- Ran `pnpm check`
- Ran `pnpm build`

## Notes
- The local `claude -p "/review"` step was attempted but blocked in this environment because the tool requested interactive approval to inspect PR state
