### PR TITLE
fix: clear persistent main CI typecheck and lint failures

### DIFF
--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -1141,7 +1141,7 @@ describe("createFollowupRunner messaging tool dedupe", () => {
               agents: {
                 defaults: {
                   cliBackends: {
-                    anthropic: {},
+                    anthropic: { command: "anthropic" },
                   },
                 },
               },

--- a/ui/src/ui/chat-model-ref.ts
+++ b/ui/src/ui/chat-model-ref.ts
@@ -276,13 +276,6 @@ export function buildChatModelOptionFromLookup(
   displayLookup: ChatModelDisplayLookup,
 ): { value: string; label: string } {
   const provider = entry.provider?.trim();
-  const value = (() => {
-    if (!provider) {
-      return entry.id;
-    }
-    const providerPrefix = `${provider.toLowerCase()}/`;
-    return entry.id.toLowerCase().startsWith(providerPrefix) ? entry.id : `${provider}/${entry.id}`;
-  })();
   return {
     value: buildQualifiedChatModelValue(entry.id, provider),
     label: formatCatalogEntryDisplay(entry, displayLookup),


### PR DESCRIPTION
## Summary
- fix a strict TypeScript config fixture in `followup-runner.test.ts` by providing a valid `CliBackendConfig` (`command`) for `cliBackends.anthropic`
- remove an unused local variable in `ui/src/ui/chat-model-ref.ts` that was failing lint on `main`
- keep behavior unchanged while unblocking recurrent `check`/`tsgo` and lint failures on `main`

## Test plan
- [x] `pnpm check`
- [x] `pnpm test src/auto-reply/reply/followup-runner.test.ts ui/src/ui/chat-model-ref.test.ts`

Made with [Cursor](https://cursor.com)