### PR TITLE
fix(dreaming): require admin for persistent toggle

### DIFF
--- a/extensions/memory-core/src/dreaming-command.test.ts
+++ b/extensions/memory-core/src/dreaming-command.test.ts
@@ -52,13 +52,17 @@ function createHarness(initialConfig: OpenClawConfig = {}) {
   };
 }
 
-function createCommandContext(args?: string): PluginCommandContext {
+function createCommandContext(
+  args?: string,
+  overrides?: Partial<Pick<PluginCommandContext, "gatewayClientScopes">>,
+): PluginCommandContext {
   return {
     channel: "webchat",
     isAuthorizedSender: true,
     commandBody: args ? `/dreaming ${args}` : "/dreaming",
     args,
     config: {},
+    gatewayClientScopes: overrides?.gatewayClientScopes,
     requestConversationBinding: async () => ({ status: "error", message: "unsupported" }),
     detachConversationBinding: async () => ({ removed: false }),
     getCurrentConversationBinding: async () => null,
@@ -113,6 +117,35 @@ describe("memory-core /dreaming command", () => {
       frequency: "0 */6 * * *",
     });
     expect(result.text).toContain("Dreaming disabled.");
+  });
+
+  it("blocks write-scoped gateway callers from persisting dreaming config", async () => {
+    const { command, runtime } = createHarness();
+
+    const result = await command.handler(
+      createCommandContext("off", {
+        gatewayClientScopes: ["operator.write"],
+      }),
+    );
+
+    expect(result.text).toContain("requires operator.admin");
+    expect(runtime.config.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("allows admin-scoped gateway callers to persist dreaming config", async () => {
+    const { command, runtime, getRuntimeConfig } = createHarness();
+
+    const result = await command.handler(
+      createCommandContext("on", {
+        gatewayClientScopes: ["operator.admin"],
+      }),
+    );
+
+    expect(runtime.config.writeConfigFile).toHaveBeenCalledTimes(1);
+    expect(resolveStoredDreaming(getRuntimeConfig())).toMatchObject({
+      enabled: true,
+    });
+    expect(result.text).toContain("Dreaming enabled.");
   });
 
   it("returns status without mutating config", async () => {

--- a/extensions/memory-core/src/dreaming-command.ts
+++ b/extensions/memory-core/src/dreaming-command.ts
@@ -75,6 +75,13 @@ function formatUsage(includeStatus: string): string {
   ].join("\n");
 }
 
+function requiresAdminToMutateDreaming(gatewayClientScopes?: readonly string[]): boolean {
+  if (!Array.isArray(gatewayClientScopes)) {
+    return false;
+  }
+  return !gatewayClientScopes.includes("operator.admin");
+}
+
 export function registerDreamingCommand(api: OpenClawPluginApi): void {
   api.registerCommand({
     name: "dreaming",
@@ -102,6 +109,13 @@ export function registerDreamingCommand(api: OpenClawPluginApi): void {
       }
 
       if (firstToken === "on" || firstToken === "off") {
+        // Gateway callers can override the visible channel, so gateway scopes
+        // are the authoritative signal for internal admin-only persistence.
+        if (requiresAdminToMutateDreaming(ctx.gatewayClientScopes)) {
+          return {
+            text: "⚠️ /dreaming on|off requires operator.admin for gateway clients.",
+          };
+        }
         const enabled = firstToken === "on";
         const nextConfig = updateDreamingEnabledInConfig(currentConfig, enabled);
         await api.runtime.config.writeConfigFile(nextConfig);

--- a/extensions/memory-core/src/dreaming-command.ts
+++ b/extensions/memory-core/src/dreaming-command.ts
@@ -75,7 +75,7 @@ function formatUsage(includeStatus: string): string {
   ].join("\n");
 }
 
-function requiresAdminToMutateDreaming(gatewayClientScopes?: readonly string[]): boolean {
+function isBlockedFromMutatingDreaming(gatewayClientScopes?: readonly string[]): boolean {
   if (!Array.isArray(gatewayClientScopes)) {
     return false;
   }
@@ -111,7 +111,7 @@ export function registerDreamingCommand(api: OpenClawPluginApi): void {
       if (firstToken === "on" || firstToken === "off") {
         // Gateway callers can override the visible channel, so gateway scopes
         // are the authoritative signal for internal admin-only persistence.
-        if (requiresAdminToMutateDreaming(ctx.gatewayClientScopes)) {
+        if (isBlockedFromMutatingDreaming(ctx.gatewayClientScopes)) {
           return {
             text: "⚠️ /dreaming on|off requires operator.admin for gateway clients.",
           };


### PR DESCRIPTION
## Summary
- Require `operator.admin` before gateway-scoped callers can persist `/dreaming on|off` changes
- Keep `/dreaming status` and non-gateway command behavior unchanged

## Changes
- Added a gateway-scope check in `extensions/memory-core/src/dreaming-command.ts` before writing `plugins.entries["memory-core"].config.dreaming.enabled`
- Added regression coverage for write-scoped denial and admin-scoped allow in `extensions/memory-core/src/dreaming-command.test.ts`

## Validation
- Ran `corepack pnpm test extensions/memory-core/src/dreaming-command.test.ts`
- Rebased onto current `origin/main` and re-ran the targeted test file
- Attempted local agentic review via `claude -p "/review"`; the tool requested PR-context instead of producing findings, so no local review feedback required changes

## Notes
- This is a narrow command-local guard around persistent config mutation; it does not change `/dreaming status` behavior
- Residual hardening follow-up, if desired: move plugin config persistence behind a shared admin-aware helper for bundled plugins