### PR TITLE
fix(slack): preserve thread context for Agents & Assistants DM root messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI/sessions: prune old unreferenced transcript, compaction checkpoint, and trajectory artifacts during normal `sessions cleanup`, so gateway restart or crash orphans do not accumulate indefinitely outside `sessions.json`. Fixes #77608. Thanks @slideshow-dingo.
+- Slack: preserve Agents & Assistants DM root thread context for tool and subagent replies even when Slack omits or misreports `channel_type`, while leaving non-DM self-thread roots top-level. Fixes #63659. Thanks @zozo123.
 - Video generation: wait up to 20 minutes for slow fal/MiniMax queue-backed jobs, stop forwarding unsupported Google Veo generated-audio options, and normalize MiniMax `720P` requests to its supported `768P` resolution with the usual override warning/details instead of failing fallback.
 - Update/restart: probe managed Gateway restarts with the service environment and add a Docker product lane that exercises candidate-owned `openclaw update --yes --json` restarts, so SecretRef-backed local gateway auth cannot regress behind mocked restart checks. Thanks @vincentkoc.
 - Webhooks/Gmail/Windows: resolve `gcloud`, `gog`, and `tailscale` PATH/PATHEXT shims before setup and watcher spawns, using the Windows-safe `.cmd` wrapper for long-lived `gog serve` processes. (#74881, fixes #54470) Thanks @Angfr95.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2635,6 +2635,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/OpenAI: honor `compat.supportsTools: false` for OpenAI Completions models so chat-only compatible endpoints do not receive `tools`, `tool_choice`, or tool-history fallback payloads. Fixes #74664. Thanks @yelog.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
+- Slack: preserve Agents & Assistants DM root thread context for tool and subagent replies even when Slack omits or misreports `channel_type`, while leaving non-DM self-thread roots top-level. Fixes #63659. Thanks @zozo123.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.
 - Gateway/startup: load provider plugins that own explicitly configured image, video, or music generation defaults so generation tools become live after gateway restart instead of remaining catalog-only. Fixes #77244. Thanks @buyuangtampan, @Nikoxx99, and @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2635,7 +2635,6 @@ Docs: https://docs.openclaw.ai
 
 - Agents/OpenAI: honor `compat.supportsTools: false` for OpenAI Completions models so chat-only compatible endpoints do not receive `tools`, `tool_choice`, or tool-history fallback payloads. Fixes #74664. Thanks @yelog.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
-- Slack: preserve Agents & Assistants DM root thread context for tool and subagent replies even when Slack omits or misreports `channel_type`, while leaving non-DM self-thread roots top-level. Fixes #63659. Thanks @zozo123.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.
 - Gateway/startup: load provider plugins that own explicitly configured image, video, or music generation defaults so generation tools become live after gateway restart instead of remaining catalog-only. Fixes #77244. Thanks @buyuangtampan, @Nikoxx99, and @vincentkoc.

--- a/extensions/slack/src/monitor/message-handler/prepare-routing.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-routing.ts
@@ -173,7 +173,7 @@ export function resolveSlackRoutingContext(params: {
 
   const chatType = isDirectMessage ? "direct" : isGroupDm ? "group" : "channel";
   const replyToMode = resolveSlackReplyToMode(account, chatType);
-  const threadContext = resolveSlackThreadContext({ message, replyToMode });
+  const threadContext = resolveSlackThreadContext({ message, replyToMode, isDirectMessage });
   const threadTs = threadContext.incomingThreadTs;
   const isThreadReply = threadContext.isThreadReply;
   // Keep true thread replies thread-scoped, while top-level DMs keep their

--- a/extensions/slack/src/monitor/message-handler/prepare-routing.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-routing.ts
@@ -179,7 +179,7 @@ export function resolveSlackRoutingContext(params: {
 
   const chatType = isDirectMessage ? "direct" : isGroupDm ? "group" : "channel";
   const replyToMode = resolveSlackReplyToMode(account, chatType);
-  const threadContext = resolveSlackThreadContext({ message, replyToMode });
+  const threadContext = resolveSlackThreadContext({ message, replyToMode, isDirectMessage });
   const threadTs = threadContext.incomingThreadTs;
   const isThreadReply = threadContext.isThreadReply;
   // Keep true thread replies thread-scoped, while top-level DMs keep their

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -709,6 +709,39 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expectMainScopedDmClassification(prepared);
   });
 
+  it("preserves MessageThreadId for normalized DM assistant thread roots", async () => {
+    const cases: Array<{
+      name: string;
+      message: SlackMessageEvent;
+    }> = [
+      {
+        name: "raw im",
+        message: createMainScopedDmMessage({ channel_type: "im", thread_ts: "1.000" }),
+      },
+      {
+        name: "wrong channel_type",
+        message: createMainScopedDmMessage({ channel_type: "channel", thread_ts: "1.000" }),
+      },
+      {
+        name: "missing channel_type",
+        message: createMainScopedDmMessage({ thread_ts: "1.000" }),
+      },
+    ];
+    delete cases[2].message.channel_type;
+
+    for (const testCase of cases) {
+      const prepared = await prepareMessageWith(
+        createDmScopeMainSlackCtx(),
+        createSlackAccount(),
+        testCase.message,
+      );
+
+      expectMainScopedDmClassification(prepared, { includeFromCheck: testCase.name !== "raw im" });
+      expect(prepared!.ctxPayload.MessageThreadId).toBe("1.000");
+      expect(prepared!.ctxPayload.ReplyToId).toBe("1.000");
+    }
+  });
+
   it("sets MessageThreadId for top-level messages when replyToMode=all", async () => {
     const prepared = await prepareMessageWith(
       createReplyToAllSlackCtx(),

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1376,6 +1376,39 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     expectMainScopedDmClassification(prepared);
   });
 
+  it("preserves MessageThreadId for normalized DM assistant thread roots", async () => {
+    const cases: Array<{
+      name: string;
+      message: SlackMessageEvent;
+    }> = [
+      {
+        name: "raw im",
+        message: createMainScopedDmMessage({ channel_type: "im", thread_ts: "1.000" }),
+      },
+      {
+        name: "wrong channel_type",
+        message: createMainScopedDmMessage({ channel_type: "channel", thread_ts: "1.000" }),
+      },
+      {
+        name: "missing channel_type",
+        message: createMainScopedDmMessage({ thread_ts: "1.000" }),
+      },
+    ];
+    delete cases[2].message.channel_type;
+
+    for (const testCase of cases) {
+      const prepared = await prepareMessageWith(
+        createDmScopeMainSlackCtx(),
+        createSlackAccount(),
+        testCase.message,
+      );
+
+      expectMainScopedDmClassification(prepared, { includeFromCheck: testCase.name !== "raw im" });
+      expect(prepared!.ctxPayload.MessageThreadId).toBe("1.000");
+      expect(prepared!.ctxPayload.ReplyToId).toBe("1.000");
+    }
+  });
+
   it("sets MessageThreadId for top-level messages when replyToMode=all", async () => {
     const prepared = await prepareMessageWith(
       createReplyToAllSlackCtx(),

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -184,6 +184,7 @@ describe("thread-level session keys", () => {
     });
 
     expect(routing.sessionKey).toBe("agent:main:slack:channel:c123");
+    expect(routing.threadContext.messageThreadId).toBeUndefined();
   });
 
   it("does not seed top-level group DM mentions into thread sessions", () => {
@@ -348,5 +349,47 @@ describe("thread-level session keys", () => {
 
     expect(routing.sessionKey).toBe("agent:main:slack:direct:u3");
     expect(routing.threadContext.messageThreadId).toBe("1770408530.000000");
+  });
+
+  it("preserves distinct MessageThreadIds for concurrent assistant DM roots", () => {
+    const ctx = buildCtx({ replyToMode: "off", dmScope: "per-channel-peer" });
+    const account = buildAccount("off");
+
+    const first = resolveSlackRoutingContext({
+      ctx,
+      account,
+      message: {
+        channel: "D456",
+        channel_type: "channel",
+        user: "U3",
+        text: "first assistant root",
+        ts: "1770408530.000000",
+        thread_ts: "1770408530.000000",
+      } as SlackMessageEvent,
+      isDirectMessage: true,
+      isGroupDm: false,
+      isRoom: false,
+      isRoomish: false,
+    });
+    const second = resolveSlackRoutingContext({
+      ctx,
+      account,
+      message: {
+        channel: "D456",
+        user: "U3",
+        text: "second assistant root",
+        ts: "1770408531.000000",
+        thread_ts: "1770408531.000000",
+      } as SlackMessageEvent,
+      isDirectMessage: true,
+      isGroupDm: false,
+      isRoom: false,
+      isRoomish: false,
+    });
+
+    expect(first.sessionKey).toBe("agent:main:slack:direct:u3");
+    expect(second.sessionKey).toBe(first.sessionKey);
+    expect(first.threadContext.messageThreadId).toBe("1770408530.000000");
+    expect(second.threadContext.messageThreadId).toBe("1770408531.000000");
   });
 });

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -347,6 +347,7 @@ describe("thread-level session keys", () => {
     });
 
     expect(routing.sessionKey).toBe("agent:main:slack:channel:c123");
+    expect(routing.threadContext.messageThreadId).toBeUndefined();
   });
 
   it("does not seed top-level group DM mentions into thread sessions", () => {
@@ -633,5 +634,47 @@ describe("thread-level session keys", () => {
     } finally {
       unregisterSessionBindingAdapter({ channel: "slack", accountId: "default", adapter });
     }
+  });
+
+  it("preserves distinct MessageThreadIds for concurrent assistant DM roots", () => {
+    const ctx = buildCtx({ replyToMode: "off", dmScope: "per-channel-peer" });
+    const account = buildAccount("off");
+
+    const first = resolveSlackRoutingContext({
+      ctx,
+      account,
+      message: {
+        channel: "D456",
+        channel_type: "channel",
+        user: "U3",
+        text: "first assistant root",
+        ts: "1770408530.000000",
+        thread_ts: "1770408530.000000",
+      } as SlackMessageEvent,
+      isDirectMessage: true,
+      isGroupDm: false,
+      isRoom: false,
+      isRoomish: false,
+    });
+    const second = resolveSlackRoutingContext({
+      ctx,
+      account,
+      message: {
+        channel: "D456",
+        user: "U3",
+        text: "second assistant root",
+        ts: "1770408531.000000",
+        thread_ts: "1770408531.000000",
+      } as SlackMessageEvent,
+      isDirectMessage: true,
+      isGroupDm: false,
+      isRoom: false,
+      isRoomish: false,
+    });
+
+    expect(first.sessionKey).toBe("agent:main:slack:direct:u3");
+    expect(second.sessionKey).toBe(first.sessionKey);
+    expect(first.threadContext.messageThreadId).toBe("1770408530.000000");
+    expect(second.threadContext.messageThreadId).toBe("1770408531.000000");
   });
 });

--- a/extensions/slack/src/threading.test.ts
+++ b/extensions/slack/src/threading.test.ts
@@ -88,6 +88,26 @@ describe("resolveSlackThreadTargets", () => {
     expect(context.replyToId).toBe("123");
   });
 
+  it("sets messageThreadId for thread-root messages regardless of replyToMode", () => {
+    for (const replyToMode of ["off", "first", "batched"] as const) {
+      const context = resolveSlackThreadContext({
+        replyToMode,
+        message: {
+          type: "message",
+          channel: "C1",
+          ts: "123",
+          thread_ts: "123",
+        },
+      });
+
+      expect(context.isThreadReply).toBe(false);
+      // thread_ts == ts: Agents & Assistants DM root — preserve thread context
+      // so tool calls (subagent results) thread correctly regardless of mode.
+      expect(context.messageThreadId).toBe("123");
+      expect(context.replyToId).toBe("123");
+    }
+  });
+
   it("prefers thread_ts as messageThreadId for replies", () => {
     const context = resolveSlackThreadContext({
       replyToMode: "off",

--- a/extensions/slack/src/threading.test.ts
+++ b/extensions/slack/src/threading.test.ts
@@ -88,22 +88,44 @@ describe("resolveSlackThreadTargets", () => {
     expect(context.replyToId).toBe("123");
   });
 
-  it("sets messageThreadId for thread-root messages regardless of replyToMode", () => {
+  it("sets messageThreadId for DM assistant thread-root messages regardless of replyToMode", () => {
     for (const replyToMode of ["off", "first", "batched"] as const) {
       const context = resolveSlackThreadContext({
         replyToMode,
         message: {
           type: "message",
-          channel: "C1",
+          channel: "D1",
+          channel_type: "im",
           ts: "123",
           thread_ts: "123",
         },
       });
 
       expect(context.isThreadReply).toBe(false);
-      // thread_ts == ts: Agents & Assistants DM root — preserve thread context
-      // so tool calls (subagent results) thread correctly regardless of mode.
+      // thread_ts == ts in a DM: Agents & Assistants root — preserve thread
+      // context so tool calls (subagent results) thread correctly.
       expect(context.messageThreadId).toBe("123");
+      expect(context.replyToId).toBe("123");
+    }
+  });
+
+  it("does not set messageThreadId for channel thread-root messages with non-all replyToMode", () => {
+    for (const replyToMode of ["off", "first", "batched"] as const) {
+      const context = resolveSlackThreadContext({
+        replyToMode,
+        message: {
+          type: "message",
+          channel: "C1",
+          channel_type: "channel",
+          ts: "123",
+          thread_ts: "123",
+        },
+      });
+
+      expect(context.isThreadReply).toBe(false);
+      // thread_ts == ts in a channel: auto-created top-level thread_ts should
+      // NOT force threaded mode — only DM assistant threads get the override.
+      expect(context.messageThreadId).toBeUndefined();
       expect(context.replyToId).toBe("123");
     }
   });

--- a/extensions/slack/src/threading.test.ts
+++ b/extensions/slack/src/threading.test.ts
@@ -92,6 +92,7 @@ describe("resolveSlackThreadTargets", () => {
     for (const replyToMode of ["off", "first", "batched"] as const) {
       const context = resolveSlackThreadContext({
         replyToMode,
+        isDirectMessage: true,
         message: {
           type: "message",
           channel: "D1",
@@ -109,10 +110,33 @@ describe("resolveSlackThreadTargets", () => {
     }
   });
 
+  it("uses normalized direct-message state for DM assistant thread-root messages", () => {
+    for (const channelType of ["channel", undefined] as const) {
+      const message = {
+        type: "message",
+        channel: "D1",
+        ts: "123",
+        thread_ts: "123",
+        ...(channelType ? { channel_type: channelType } : {}),
+      } as const;
+
+      const context = resolveSlackThreadContext({
+        replyToMode: "off",
+        isDirectMessage: true,
+        message,
+      });
+
+      expect(context.isThreadReply).toBe(false);
+      expect(context.messageThreadId).toBe("123");
+      expect(context.replyToId).toBe("123");
+    }
+  });
+
   it("does not set messageThreadId for channel thread-root messages with non-all replyToMode", () => {
     for (const replyToMode of ["off", "first", "batched"] as const) {
       const context = resolveSlackThreadContext({
         replyToMode,
+        isDirectMessage: false,
         message: {
           type: "message",
           channel: "C1",

--- a/extensions/slack/src/threading.ts
+++ b/extensions/slack/src/threading.ts
@@ -20,11 +20,19 @@ export function resolveSlackThreadContext(params: {
   const isThreadReply =
     hasThreadTs && (incomingThreadTs !== messageTs || Boolean(params.message.parent_user_id));
   const replyToId = incomingThreadTs ?? messageTs;
+  // Preserve thread context for thread replies AND for thread-root messages
+  // (e.g. Slack Agents & Assistants DMs where thread_ts == ts on the initial
+  // message). Without this, tool calls that run during the same turn (subagent
+  // results) lose the thread identifier after the first reply because
+  // hasRepliedRef gets marked true, causing subsequent sendMessage calls to fall
+  // through to the top-level channel.
   const messageThreadId = isThreadReply
     ? incomingThreadTs
-    : params.replyToMode === "all"
-      ? messageTs
-      : undefined;
+    : hasThreadTs
+      ? incomingThreadTs
+      : params.replyToMode === "all"
+        ? messageTs
+        : undefined;
   return {
     incomingThreadTs,
     messageTs,

--- a/extensions/slack/src/threading.ts
+++ b/extensions/slack/src/threading.ts
@@ -12,6 +12,7 @@ type SlackThreadContext = {
 export function resolveSlackThreadContext(params: {
   message: SlackMessageEvent | SlackAppMentionEvent;
   replyToMode: ReplyToMode;
+  isDirectMessage?: boolean;
 }): SlackThreadContext {
   const incomingThreadTs = params.message.thread_ts;
   const eventTs = params.message.event_ts;
@@ -20,21 +21,13 @@ export function resolveSlackThreadContext(params: {
   const isThreadReply =
     hasThreadTs && (incomingThreadTs !== messageTs || Boolean(params.message.parent_user_id));
   const replyToId = incomingThreadTs ?? messageTs;
-  // Preserve thread context for DM assistant thread-root messages
-  // (Slack Agents & Assistants DMs where thread_ts == ts on the initial
-  // message). Without this, tool calls that run during the same turn (subagent
-  // results) lose the thread identifier after the first reply because
-  // hasRepliedRef gets marked true, causing subsequent sendMessage calls to fall
-  // through to the top-level channel.
-  // Only apply for DM (im) channels — in channels/groups, an auto-created
-  // thread_ts == ts must not force threaded mode, since downstream
-  // buildSlackThreadingToolContext treats any MessageThreadId as an explicit
-  // thread target and overrides replyToMode to "all".
-  const isDmAssistantThread =
-    hasThreadTs && !isThreadReply && params.message.channel_type === "im";
-  const messageThreadId = isThreadReply
-    ? incomingThreadTs
-    : isDmAssistantThread
+  // Preserve thread context for Slack Agents & Assistants DM root messages
+  // where thread_ts == ts. Non-DM self-thread roots must stay unset because
+  // downstream tool threading treats MessageThreadId as an explicit thread
+  // target and overrides replyToMode to "all".
+  const isAssistantDmThreadRoot = hasThreadTs && !isThreadReply && params.isDirectMessage === true;
+  const messageThreadId =
+    isThreadReply || isAssistantDmThreadRoot
       ? incomingThreadTs
       : params.replyToMode === "all"
         ? messageTs

--- a/extensions/slack/src/threading.ts
+++ b/extensions/slack/src/threading.ts
@@ -20,15 +20,21 @@ export function resolveSlackThreadContext(params: {
   const isThreadReply =
     hasThreadTs && (incomingThreadTs !== messageTs || Boolean(params.message.parent_user_id));
   const replyToId = incomingThreadTs ?? messageTs;
-  // Preserve thread context for thread replies AND for thread-root messages
-  // (e.g. Slack Agents & Assistants DMs where thread_ts == ts on the initial
+  // Preserve thread context for DM assistant thread-root messages
+  // (Slack Agents & Assistants DMs where thread_ts == ts on the initial
   // message). Without this, tool calls that run during the same turn (subagent
   // results) lose the thread identifier after the first reply because
   // hasRepliedRef gets marked true, causing subsequent sendMessage calls to fall
   // through to the top-level channel.
+  // Only apply for DM (im) channels — in channels/groups, an auto-created
+  // thread_ts == ts must not force threaded mode, since downstream
+  // buildSlackThreadingToolContext treats any MessageThreadId as an explicit
+  // thread target and overrides replyToMode to "all".
+  const isDmAssistantThread =
+    hasThreadTs && !isThreadReply && params.message.channel_type === "im";
   const messageThreadId = isThreadReply
     ? incomingThreadTs
-    : hasThreadTs
+    : isDmAssistantThread
       ? incomingThreadTs
       : params.replyToMode === "all"
         ? messageTs


### PR DESCRIPTION
## Summary

Preserves thread context for Agents & Assistants DM root messages in Slack integration.

Closes #63659

## Testing
- Relevant tests pass

---
> This PR was developed with AI assistance (Claude). All code has been reviewed and tested.
> Built with [islo.dev](https://islo.dev)

## Real behavior proof

- Behavior or issue addressed: Slack Agents & Assistants DM root messages with `thread_ts == ts` now preserve `MessageThreadId` when the message pipeline has normalized the event as a direct message, including cases where Slack omits or misreports raw `channel_type`. Non-DM self-thread roots remain top-level.
- Real environment tested: Local OpenClaw checkout on macOS from PR head `37de7dc8d6`, Node `25.2.1`, pnpm `10.33.2`, running the production Slack routing resolver from this branch.
- Exact steps or command run after this patch: Ran `pnpm exec tsx -e '<script invoking resolveSlackRoutingContext for D-prefix DM roots and a channel self-thread root>'` in the PR worktree.
- Evidence after fix: Console output from the local OpenClaw routing smoke:

```json
{"case":"dm-root-wrong-channel-type","sessionKey":"agent:main:slack:direct:u3","messageThreadId":"1770408530.000000","replyToId":"1770408530.000000"}
{"case":"dm-root-missing-channel-type","sessionKey":"agent:main:slack:direct:u3","messageThreadId":"1770408531.000000","replyToId":"1770408531.000000"}
{"case":"channel-self-thread-root","sessionKey":"agent:main:slack:channel:c123","messageThreadId":null,"replyToId":"1770408532.000000"}
```

- Observed result after fix: Normalized DM root events kept the direct session and preserved the Slack root timestamp as `MessageThreadId`; the channel self-thread root kept channel-session routing and did not set `MessageThreadId`.
- What was not tested: Live Slack workspace delivery was not tested in this environment. Focused Slack Vitest coverage and local `pnpm check:changed` also passed after the smoke.
