### PR TITLE
fix(agents): pass run timeoutMs to OpenAI SDK HTTP client

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -48,6 +48,9 @@ type BaseStreamOptions = {
   sessionId?: string;
   onPayload?: (payload: unknown, model: Model<Api>) => unknown;
   headers?: Record<string, string>;
+  /** HTTP-level timeout in milliseconds passed to the OpenAI SDK client constructor.
+   * Overrides the SDK's built-in 10-minute default. Derived from the run's timeoutMs. */
+  httpTimeoutMs?: number;
 };
 
 type OpenAIResponsesOptions = BaseStreamOptions & {
@@ -619,6 +622,7 @@ function createOpenAIResponsesClient(
   apiKey: string,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  httpTimeoutMs?: number,
 ) {
   return new OpenAI({
     apiKey,
@@ -626,6 +630,7 @@ function createOpenAIResponsesClient(
     dangerouslyAllowBrowser: true,
     defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders),
     fetch: buildGuardedModelFetch(model),
+    ...(httpTimeoutMs !== undefined ? { timeout: httpTimeoutMs } : {}),
   });
 }
 
@@ -665,6 +670,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           apiKey,
           options?.headers,
           turnState?.headers,
+          (options as BaseStreamOptions | undefined)?.httpTimeoutMs,
         );
         let params = buildOpenAIResponsesParams(
           model,
@@ -819,6 +825,7 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
           apiKey,
           options?.headers,
           turnState?.headers,
+          (options as BaseStreamOptions | undefined)?.httpTimeoutMs,
         );
         const deploymentName = resolveAzureDeploymentName(model);
         let params = buildAzureOpenAIResponsesParams(
@@ -881,6 +888,7 @@ function createAzureOpenAIClient(
   apiKey: string,
   optionHeaders?: Record<string, string>,
   turnHeaders?: Record<string, string>,
+  httpTimeoutMs?: number,
 ) {
   return new AzureOpenAI({
     apiKey,
@@ -889,6 +897,7 @@ function createAzureOpenAIClient(
     defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders, turnHeaders),
     baseURL: normalizeAzureBaseUrl(model.baseUrl),
     fetch: buildGuardedModelFetch(model),
+    ...(httpTimeoutMs !== undefined ? { timeout: httpTimeoutMs } : {}),
   });
 }
 
@@ -918,6 +927,7 @@ function createOpenAICompletionsClient(
   context: Context,
   apiKey: string,
   optionHeaders?: Record<string, string>,
+  httpTimeoutMs?: number,
 ) {
   return new OpenAI({
     apiKey,
@@ -925,6 +935,7 @@ function createOpenAICompletionsClient(
     dangerouslyAllowBrowser: true,
     defaultHeaders: buildOpenAIClientHeaders(model, context, optionHeaders),
     fetch: buildGuardedModelFetch(model),
+    ...(httpTimeoutMs !== undefined ? { timeout: httpTimeoutMs } : {}),
   });
 }
 
@@ -952,7 +963,13 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
       };
       try {
         const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-        const client = createOpenAICompletionsClient(model, context, apiKey, options?.headers);
+        const client = createOpenAICompletionsClient(
+          model,
+          context,
+          apiKey,
+          options?.headers,
+          (options as BaseStreamOptions | undefined)?.httpTimeoutMs,
+        );
         let params = buildOpenAICompletionsParams(
           model as OpenAIModeModel,
           context,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -998,6 +998,7 @@ export async function runEmbeddedAttempt(
         model: params.model,
         resolvedApiKey: params.resolvedApiKey,
         authStorage: params.authStorage,
+        httpTimeoutMs: params.timeoutMs,
       });
 
       const { effectiveExtraParams } = applyExtraParamsToAgent(

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -70,6 +70,8 @@ export function resolveEmbeddedAgentStreamFn(params: {
   model: EmbeddedRunAttemptParams["model"];
   resolvedApiKey?: string;
   authStorage?: { getApiKey(provider: string): Promise<string | undefined> };
+  /** HTTP-level timeout to inject into stream options for OpenAI-compatible transports. */
+  httpTimeoutMs?: number;
 }): StreamFn {
   if (params.providerStreamFn) {
     const inner = params.providerStreamFn;
@@ -84,7 +86,7 @@ export function resolveEmbeddedAgentStreamFn(params: {
     // so keep injecting the resolved runtime apiKey for streamSimple-compatible
     // transports that still read credentials from options.apiKey.
     if (params.authStorage || params.resolvedApiKey) {
-      const { authStorage, model, resolvedApiKey } = params;
+      const { authStorage, httpTimeoutMs, model, resolvedApiKey } = params;
       return async (m, context, options) => {
         const apiKey = await resolveEmbeddedAgentApiKey({
           provider: model.provider,
@@ -94,11 +96,23 @@ export function resolveEmbeddedAgentStreamFn(params: {
         return inner(m, normalizeContext(context), {
           ...options,
           apiKey: apiKey ?? options?.apiKey,
+          ...(httpTimeoutMs !== undefined ? { httpTimeoutMs } : {}),
         });
       };
     }
+    if (params.httpTimeoutMs !== undefined) {
+      const { httpTimeoutMs } = params;
+      return (m, context, options) =>
+        inner(m, normalizeContext(context), { ...options, httpTimeoutMs });
+    }
     return (m, context, options) => inner(m, normalizeContext(context), options);
   }
+
+  const { httpTimeoutMs } = params;
+  const wrapWithTimeout = (fn: StreamFn): StreamFn => {
+    if (httpTimeoutMs === undefined) return fn;
+    return (m, context, options) => fn(m, context, { ...options, httpTimeoutMs });
+  };
 
   const currentStreamFn = params.currentStreamFn ?? streamSimple;
   if (params.shouldUseWebSocketTransport) {
@@ -116,9 +130,9 @@ export function resolveEmbeddedAgentStreamFn(params: {
   if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {
     const boundaryAwareStreamFn = createBoundaryAwareStreamFnForModel(params.model);
     if (boundaryAwareStreamFn) {
-      return boundaryAwareStreamFn;
+      return wrapWithTimeout(boundaryAwareStreamFn);
     }
   }
 
-  return currentStreamFn;
+  return wrapWithTimeout(currentStreamFn);
 }


### PR DESCRIPTION
## Summary

The OpenAI SDK defaults to a 600s HTTP timeout that silently terminates long-running agent runs. This fix passes the configured run timeoutMs to the SDK HTTP client to override the default.

Closes #63663

## Testing
- Relevant tests pass

---
> This PR was developed with AI assistance (Claude). All code has been reviewed and tested.
> Built with [islo.dev](https://islo.dev)