### PR TITLE
fix(process): destroy stdio streams on dispose to prevent gateway crash

### DIFF
--- a/src/process/supervisor/adapters/child.test.ts
+++ b/src/process/supervisor/adapters/child.test.ts
@@ -168,6 +168,32 @@ describe("createChildAdapter", () => {
     expect(spawnArgs.fallbacks ?? []).toEqual([]);
   });
 
+  it("dispose destroys stdout/stderr streams so late-arriving data does not fire listeners", async () => {
+    const stub = createStubChild(5555);
+    spawnWithFallbackMock.mockResolvedValue({
+      child: stub.child,
+      usedFallback: false,
+    });
+    const adapter = await createChildAdapter({
+      argv: ["node", "-e", "setTimeout(() => {}, 1000)"],
+      stdinMode: "pipe-open",
+    });
+
+    const stdoutListener = vi.fn();
+    const stderrListener = vi.fn();
+    adapter.onStdout(stdoutListener);
+    adapter.onStderr(stderrListener);
+
+    adapter.dispose();
+
+    // Emitting data after dispose should not reach listeners since streams are destroyed
+    stub.child.stdout?.emit("data", Buffer.from("late stdout"));
+    stub.child.stderr?.emit("data", Buffer.from("late stderr"));
+
+    expect(stdoutListener).not.toHaveBeenCalled();
+    expect(stderrListener).not.toHaveBeenCalled();
+  });
+
   it("keeps inherited env when no override env is provided", async () => {
     await createAdapterHarness({
       pid: 3333,

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -230,6 +230,14 @@ export async function createChildAdapter(params: {
   const dispose = () => {
     clearForceKillWaitFallback();
     child.removeAllListeners();
+    // Destroy stdio streams explicitly — child.removeAllListeners() only removes
+    // listeners from the ChildProcess EventEmitter, not from the separate
+    // child.stdout/child.stderr Readable stream objects. Without this, the
+    // onStdout/onStderr listeners survive dispose() and fire on late-arriving
+    // data, pushing into a disposed agent run context and causing an unhandled
+    // promise rejection that crashes the gateway.
+    child.stdout?.destroy();
+    child.stderr?.destroy();
   };
 
   return {


### PR DESCRIPTION
## Summary

child.removeAllListeners() only removes listeners from the ChildProcess EventEmitter but not from stdio streams. This fix destroys stdio streams on dispose to prevent gateway crashes from dangling stream listeners.

Closes #63699

## Testing
- Relevant tests pass

---
> This PR was developed with AI assistance (Claude). All code has been reviewed and tested.
> Built with [islo.dev](https://islo.dev)