### PR TITLE
fix: don't persist fallback model to session when channel override is active

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1284,4 +1284,67 @@ describe("runAgentTurnWithFallback", () => {
     expect(sessionStore.main.providerOverride).toBe("zai");
     expect(sessionStore.main.modelOverride).toBe("glm-5");
   });
+
+  // Regression test for https://github.com/openclaw/openclaw/issues/63712
+  // When a channel-level model override is active (no session-level override),
+  // a successful fallback must NOT pin modelOverride/providerOverride to the session.
+  // If it did, the next turn would see hasSessionModelOverride=true and skip the
+  // channel override gate, permanently locking the session on the fallback model.
+  it("does not persist fallback selection to session when channel model override is active", async () => {
+    state.runWithModelFallbackMock.mockImplementation(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await params.run("openai", "gpt-5.4"),
+        provider: "openai",
+        model: "gpt-5.4",
+        attempts: [{ provider: "anthropic", model: "claude-opus-4-6", error: "rate_limit" }],
+      }),
+    );
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "fallback reply" }],
+      meta: {},
+    });
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      // No modelOverride / providerOverride — model was selected by a channel override
+    };
+    const sessionStore = { main: { ...sessionEntry } };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "discord",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => sessionEntry,
+      activeSessionStore: sessionStore,
+      resolvedVerboseLevel: "off",
+      hasChannelModelOverride: true,
+    });
+
+    expect(result.kind).toBe("success");
+    // The fallback ran (gpt-5.4) but must NOT have been written to the session entry.
+    // On the next turn, hasSessionModelOverride will remain false so the channel override
+    // can be re-evaluated cleanly.
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionStore.main.modelOverride).toBeUndefined();
+    expect(sessionStore.main.providerOverride).toBeUndefined();
+  });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -483,6 +483,10 @@ export async function runAgentTurnWithFallback(params: {
   activeSessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   resolvedVerboseLevel: VerboseLevel;
+  /** When true, the active model was selected by a channel-level override (not by the user).
+   * Fallback selection is not persisted to the session in this case so the channel override
+   * remains authoritative on subsequent turns. */
+  hasChannelModelOverride?: boolean;
 }): Promise<AgentRunLoopResult> {
   const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
   let didLogHeartbeatStrip = false;
@@ -531,7 +535,14 @@ export async function runAgentTurnWithFallback(params: {
     if (
       !params.sessionKey ||
       !params.activeSessionStore ||
-      (provider === params.followupRun.run.provider && model === params.followupRun.run.model)
+      (provider === params.followupRun.run.provider && model === params.followupRun.run.model) ||
+      // Don't pin the fallback to the session when the primary model was selected by a
+      // channel-level override. Persisting would set modelOverride/providerOverride on the
+      // session entry, which permanently shadows the channel override on subsequent turns
+      // (because channel overrides are gated by !hasSessionModelOverride). By skipping
+      // persistence here the fallback runs once, but the channel override is re-evaluated
+      // cleanly on the very next turn. See: https://github.com/openclaw/openclaw/issues/63712
+      params.hasChannelModelOverride
     ) {
       return;
     }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -105,6 +105,7 @@ export async function runReplyAgent(params: {
   typingMode: TypingMode;
   resetTriggered?: boolean;
   replyOperation?: ReplyOperation;
+  hasChannelModelOverride?: boolean;
 }): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const {
     commandBody,
@@ -134,6 +135,7 @@ export async function runReplyAgent(params: {
     typingMode,
     resetTriggered,
     replyOperation: providedReplyOperation,
+    hasChannelModelOverride,
   } = params;
 
   let activeSessionEntry = sessionEntry;
@@ -464,6 +466,7 @@ export async function runReplyAgent(params: {
       activeSessionStore,
       storePath,
       resolvedVerboseLevel,
+      hasChannelModelOverride,
     });
 
     if (runOutcome.kind === "final") {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -109,6 +109,7 @@ type RunPreparedReplyParams = {
   modelState: Awaited<ReturnType<typeof createModelSelectionState>>;
   provider: string;
   model: string;
+  hasChannelModelOverride?: boolean;
   perMessageQueueMode?: InlineDirectives["queueMode"];
   perMessageQueueOptions?: {
     debounceMs?: number;
@@ -156,6 +157,7 @@ export async function runPreparedReply(
     modelState,
     provider,
     model,
+    hasChannelModelOverride,
     perMessageQueueMode,
     perMessageQueueOptions,
     typing,
@@ -616,5 +618,6 @@ export async function runPreparedReply(
     shouldInjectGroupIntro,
     typingMode,
     resetTriggered,
+    hasChannelModelOverride,
   });
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -289,7 +289,12 @@ export async function getReplyFromConfig(
   const hasSessionModelOverride = Boolean(
     sessionEntry.modelOverride?.trim() || sessionEntry.providerOverride?.trim(),
   );
-  if (!hasResolvedHeartbeatModelOverride && !hasSessionModelOverride && channelModelOverride) {
+  // True when the channel-level model override (not a session/user override) is active.
+  // Used downstream to avoid pinning a transient fallback to the session, which would
+  // permanently shadow the channel override on subsequent turns.
+  const hasChannelModelOverride =
+    !hasResolvedHeartbeatModelOverride && !hasSessionModelOverride && Boolean(channelModelOverride);
+  if (hasChannelModelOverride) {
     const resolved = resolveModelRefFromString({
       raw: channelModelOverride.model,
       defaultProvider,
@@ -497,6 +502,7 @@ export async function getReplyFromConfig(
     modelState,
     provider,
     model,
+    hasChannelModelOverride,
     perMessageQueueMode,
     perMessageQueueOptions,
     typing,


### PR DESCRIPTION
## Summary

When a channel-level model override (channels.modelByChannel) is active, the fallback model was being incorrectly persisted to the session. This fix prevents that.

Closes #63712

## Testing
- Relevant tests pass

---
> This PR was developed with AI assistance (Claude). All code has been reviewed and tested.
> Built with [islo.dev](https://islo.dev)