### PR TITLE
fix(memory-core): use gateway startup cfg

### DIFF
--- a/extensions/memory-core/src/dreaming.test.ts
+++ b/extensions/memory-core/src/dreaming.test.ts
@@ -3,9 +3,16 @@ import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core";
 import { describe, expect, it, vi } from "vitest";
 import {
+  clearInternalHooks,
+  createInternalHookEvent,
+  registerInternalHook,
+  triggerInternalHook,
+} from "../../../src/hooks/internal-hooks.js";
+import {
   __testing,
   reconcileShortTermDreamingCronJob,
   resolveShortTermPromotionDreamingConfig,
+  registerShortTermPromotionDreaming,
   runShortTermDreamingPromotionIfTriggered,
 } from "./dreaming.js";
 import { recordShortTermRecalls } from "./short-term-promotion.js";
@@ -657,6 +664,51 @@ describe("short-term dreaming cron reconciliation", () => {
     expect(result).toEqual({ status: "disabled", removed: 0 });
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("failed to remove managed dreaming cron job job-managed"),
+    );
+  });
+});
+
+describe("gateway startup reconciliation", () => {
+  it("uses the startup cfg when reconciling the managed dreaming cron job", async () => {
+    clearInternalHooks();
+    const logger = createLogger();
+    const harness = createCronHarness();
+    const api = {
+      config: { plugins: { entries: {} } },
+      pluginConfig: {},
+      logger,
+      runtime: {},
+      registerHook: (event: string, handler: Parameters<typeof registerInternalHook>[1]) => {
+        registerInternalHook(event, handler);
+      },
+      on: vi.fn(),
+    } as never;
+
+    registerShortTermPromotionDreaming(api);
+    await triggerInternalHook(
+      createInternalHookEvent("gateway", "startup", "gateway:startup", {
+        cfg: {
+          hooks: { internal: { enabled: true } },
+          plugins: {
+            entries: {
+              "memory-core": {
+                config: {
+                  dreaming: {
+                    enabled: true,
+                    frequency: "0 3 * * *",
+                  },
+                },
+              },
+            },
+          },
+        } as OpenClawConfig,
+        deps: { cron: harness.cron },
+      }),
+    );
+
+    expect(harness.addCalls).toHaveLength(1);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("created managed dreaming cron job"),
     );
   });
 });

--- a/extensions/memory-core/src/dreaming.ts
+++ b/extensions/memory-core/src/dreaming.ts
@@ -584,9 +584,17 @@ export function registerShortTermPromotionDreaming(api: OpenClawPluginApi): void
     "gateway:startup",
     async (event: unknown) => {
       try {
+        const startupEvent = asRecord(event);
+        const startupContext = asRecord(startupEvent?.context);
+        const startupCfg = startupContext?.cfg
+          ? (asRecord(startupContext.cfg) as OpenClawConfig)
+          : api.config;
         const config = resolveShortTermPromotionDreamingConfig({
-          pluginConfig: resolveMemoryCorePluginConfig(api.config) ?? api.pluginConfig,
-          cfg: api.config,
+          pluginConfig:
+            resolveMemoryCorePluginConfig(startupCfg) ??
+            resolveMemoryCorePluginConfig(api.config) ??
+            api.pluginConfig,
+          cfg: startupCfg,
         });
         const cron = resolveCronServiceFromStartupEvent(event);
         if (!cron && config.enabled) {


### PR DESCRIPTION
## Summary\n- Use the gateway startup event cfg when reconciling the managed dreaming cron job\n- Add a regression test covering startup reconciliation with cfg coming from the event context\n\n## Verification\n- node scripts/run-vitest.mjs run --config vitest.unit.config.ts extensions/memory-core/src/dreaming.test.ts src/hooks/bundled/boot-md/handler.gateway-startup.integration.test.ts