### PR TITLE
Ensure ACPX plugin-tools bridge honors before_tool_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@ Docs: https://docs.openclaw.ai
 - Hooks/security: mark agent hook system events as untrusted and sanitize hook display names before cron metadata reuse. (#64372) Thanks @eleqtrizit.
 - Media/security: honor sender-scoped `toolsBySender` policy for outbound host-media reads so denied senders cannot trigger host file disclosure via attachment hydration. (#64459) Thanks @eleqtrizit.
 - Browser/security: reject strict-policy hostname navigation unless the hostname is an explicit allowlist exception or IP literal, and route CDP HTTP discovery through the pinned SSRF fetch path. (#64367) Thanks @eleqtrizit.
+- Plugins/ACPX: wrap plugin tools on the MCP bridge with the shared `before_tool_call` handler so block and approval hooks fire consistently across all execution paths. (#63886) Thanks @eleqtrizit.
 
 ## 2026.4.9
 

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -2,6 +2,11 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AnyAgentTool } from "../agents/tools/common.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
 import { createPluginToolsMcpServer } from "./plugin-tools-serve.js";
 
 async function connectPluginToolsServer(tools: AnyAgentTool[]) {
@@ -21,6 +26,7 @@ async function connectPluginToolsServer(tools: AnyAgentTool[]) {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  resetGlobalHookRunner();
 });
 
 describe("plugin tools MCP server", () => {
@@ -73,9 +79,14 @@ describe("plugin tools MCP server", () => {
         name: "memory_store",
         arguments: { text: "remember this" },
       });
-      expect(execute).toHaveBeenCalledWith(expect.stringMatching(/^mcp-\d+$/), {
-        text: "remember this",
-      });
+      expect(execute).toHaveBeenCalledWith(
+        expect.stringMatching(/^mcp-\d+$/),
+        {
+          text: "remember this",
+        },
+        undefined,
+        undefined,
+      );
       expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
     } finally {
       await session.close();
@@ -105,6 +116,84 @@ describe("plugin tools MCP server", () => {
       });
       expect(failed.isError).toBe(true);
       expect(failed.content).toEqual([{ type: "text", text: "Tool error: boom" }]);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("blocks tool execution when before_tool_call requires approval on the MCP bridge", async () => {
+    let hookCalls = 0;
+    const execute = vi.fn().mockResolvedValue({
+      content: "Stored.",
+    });
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "before_tool_call",
+          handler: async () => {
+            hookCalls += 1;
+            return {
+              requireApproval: {
+                pluginId: "test-plugin",
+                title: "Approval required",
+                description: "Approval required",
+              },
+            };
+          },
+        },
+      ]),
+    );
+    const tool = {
+      name: "memory_store",
+      description: "Store memory",
+      parameters: { type: "object", properties: {} },
+      execute,
+    } as unknown as AnyAgentTool;
+
+    const session = await connectPluginToolsServer([tool]);
+    try {
+      const result = await session.client.callTool({
+        name: "memory_store",
+        arguments: { text: "remember this" },
+      });
+      expect(hookCalls).toBe(1);
+      expect(execute).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        { type: "text", text: "Tool error: Plugin approval required (gateway unavailable)" },
+      ]);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("still executes plugin tools on the MCP bridge when no before_tool_call hook is registered", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      content: "Stored.",
+    });
+    const tool = {
+      name: "memory_store",
+      description: "Store memory",
+      parameters: { type: "object", properties: {} },
+      execute,
+    } as unknown as AnyAgentTool;
+
+    const session = await connectPluginToolsServer([tool]);
+    try {
+      const result = await session.client.callTool({
+        name: "memory_store",
+        arguments: { text: "remember this" },
+      });
+      expect(execute).toHaveBeenCalledWith(
+        expect.stringMatching(/^mcp-\d+$/),
+        {
+          text: "remember this",
+        },
+        undefined,
+        undefined,
+      );
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toEqual([{ type: "text", text: "Stored." }]);
     } finally {
       await session.close();
     }

--- a/src/mcp/plugin-tools-serve.ts
+++ b/src/mcp/plugin-tools-serve.ts
@@ -10,6 +10,10 @@ import { pathToFileURL } from "node:url";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import {
+  isToolWrappedWithBeforeToolCallHook,
+  wrapToolWithBeforeToolCallHook,
+} from "../agents/pi-tools.before-tool-call.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadConfig } from "../config/config.js";
@@ -41,7 +45,14 @@ export function createPluginToolsMcpServer(
   } = {},
 ): Server {
   const cfg = params.config ?? loadConfig();
-  const tools = params.tools ?? resolveTools(cfg);
+  const tools = (params.tools ?? resolveTools(cfg)).map((tool) => {
+    if (isToolWrappedWithBeforeToolCallHook(tool)) {
+      return tool;
+    }
+    // The ACPX MCP bridge should enforce the same pre-execution hook boundary
+    // as the agent and HTTP tool execution paths.
+    return wrapToolWithBeforeToolCallHook(tool);
+  });
 
   const toolMap = new Map<string, AnyAgentTool>();
   for (const tool of tools) {


### PR DESCRIPTION
## Summary
- align the ACPX `openclaw-plugin-tools` MCP bridge with the same `before_tool_call` handling used by the main agent and HTTP tool execution paths

## Changes
- wrap plugin tools exposed by `src/mcp/plugin-tools-serve.ts` with the shared `before_tool_call` wrapper unless they are already wrapped
- add MCP bridge regression coverage for approval-required calls and the unchanged no-hook execution path
- preserve existing MCP response behavior for unknown tools and tool errors

## Validation
- ran `pnpm test src/mcp/plugin-tools-serve.test.ts`
- ran `pnpm check`
- ran `pnpm build`
- attempted local agentic review via `claude -p "/review"`, but the tool immediately requested approval to run `gh pr list`, so that review step was blocked in this environment

## Notes
- behavior change is limited to the ACPX plugin-tools MCP bridge path when a plugin registers `before_tool_call`; normal bridge execution without hooks is unchanged
- incorporated the existing GHSA-private fix approach and preserved co-author credit in the commit
