### PR TITLE
fix: preserve proxy routing and control-ui bootstrap on v2026.4.9

### DIFF
--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -215,6 +215,26 @@ describe("buildOpenAIProvider", () => {
     });
   });
 
+  it("preserves configured proxy baseUrl for GPT-5.4 forward-compat models", () => {
+    const provider = buildOpenAIProvider();
+
+    const model = provider.resolveDynamicModel?.({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      providerConfig: {
+        baseUrl: "https://apiqd.com/v1",
+      },
+      modelRegistry: { find: () => null },
+    } as never);
+
+    expect(model).toMatchObject({
+      provider: "openai",
+      id: "gpt-5.4",
+      api: "openai-responses",
+      baseUrl: "https://apiqd.com/v1",
+    });
+  });
+
   it("keeps modern live selection on OpenAI 5.2+ and Codex 5.2+", () => {
     const provider = buildOpenAIProvider();
     const codexProvider = buildOpenAICodexProviderPlugin();

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -70,6 +70,7 @@ const OPENAI_MODERN_MODEL_IDS = [
 const OPENAI_DIRECT_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const SUPPRESSED_SPARK_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
 const OPENAI_RESPONSES_STREAM_HOOKS = buildProviderStreamFamilyHooks("openai-responses-defaults");
+const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 
 function shouldUseOpenAIResponsesTransport(params: {
   provider: string;
@@ -103,6 +104,11 @@ function normalizeOpenAITransport(model: ProviderRuntimeModel): ProviderRuntimeM
   };
 }
 
+function resolveForwardCompatBaseUrl(ctx: ProviderResolveDynamicModelContext): string {
+  const configuredBaseUrl = ctx.providerConfig?.baseUrl?.trim();
+  return configuredBaseUrl || OPENAI_DEFAULT_BASE_URL;
+}
+
 function resolveOpenAIGpt54ForwardCompatModel(
   ctx: ProviderResolveDynamicModelContext,
 ): ProviderRuntimeModel | undefined {
@@ -115,7 +121,7 @@ function resolveOpenAIGpt54ForwardCompatModel(
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveForwardCompatBaseUrl(ctx),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_COST,
@@ -127,7 +133,7 @@ function resolveOpenAIGpt54ForwardCompatModel(
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveForwardCompatBaseUrl(ctx),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_PRO_COST,
@@ -139,7 +145,7 @@ function resolveOpenAIGpt54ForwardCompatModel(
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveForwardCompatBaseUrl(ctx),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_MINI_COST,
@@ -151,7 +157,7 @@ function resolveOpenAIGpt54ForwardCompatModel(
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveForwardCompatBaseUrl(ctx),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_NANO_COST,

--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -284,6 +284,38 @@ describe("bot-native-command-menu", () => {
     await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(2));
   });
 
+  it("treats deleteMyCommands 404 as idempotent success for empty menus", async () => {
+    const deleteMyCommands = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("404: Not Found"))
+      .mockResolvedValue(undefined);
+    const setMyCommands = vi.fn(async () => undefined);
+    const runtimeLog = vi.fn();
+    const accountId = `test-empty-delete-404-${Date.now()}`;
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+    await vi.waitFor(() => expect(deleteMyCommands).toHaveBeenCalledTimes(1));
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      runtimeLog,
+      commandsToRegister: [],
+      accountId,
+      botIdentity: "bot-a",
+    });
+
+    expect(deleteMyCommands).toHaveBeenCalledTimes(1);
+    expect(setMyCommands).not.toHaveBeenCalled();
+  });
+
   it("retries with fewer commands on BOT_COMMANDS_TOO_MUCH", async () => {
     const deleteMyCommands = vi.fn(async () => undefined);
     const setMyCommands = vi

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -123,6 +123,10 @@ function isBotCommandsTooMuchError(err: unknown): boolean {
   return false;
 }
 
+function isTelegramNotFoundError(err: unknown): boolean {
+  return /404:\s*Not Found/i.test(String(err));
+}
+
 function formatTelegramCommandRetrySuccessLog(params: {
   initialCount: number;
   acceptedCount: number;
@@ -282,10 +286,21 @@ export function syncTelegramMenuCommands(params: {
       deleteSucceeded = await withTelegramApiErrorLogging({
         operation: "deleteMyCommands",
         runtime,
+        shouldLog: (err) => !isTelegramNotFoundError(err),
         fn: () => bot.api.deleteMyCommands(),
       })
         .then(() => true)
-        .catch(() => false);
+        .catch((err) => {
+          if (isTelegramNotFoundError(err)) {
+            if (process.env.OPENCLAW_DEBUG_TELEGRAM_ROUTE === "1") {
+              runtime.log?.(
+                "telegram: deleteMyCommands returned 404; assuming command menu is already empty",
+              );
+            }
+            return true;
+          }
+          return false;
+        });
     }
 
     if (commandsToRegister.length === 0) {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -255,6 +255,48 @@ describe("TelegramPollingSession", () => {
     expect(sleepWithAbortMock).toHaveBeenCalledTimes(1);
   });
 
+  it("treats deleteWebhook 404 as idempotent during polling startup", async () => {
+    const abort = new AbortController();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => {
+          throw new Error("404: Not Found");
+        }),
+        getUpdates: vi.fn(async () => []),
+        config: { use: vi.fn() },
+      },
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValue(bot);
+    runMock.mockReturnValue({
+      task: async () => {
+        abort.abort();
+      },
+      stop: vi.fn(async () => undefined),
+      isRunning: () => false,
+    });
+
+    const session = new TelegramPollingSession({
+      token: "tok",
+      config: {},
+      accountId: "default",
+      runtime: undefined,
+      proxyFetch: undefined,
+      abortSignal: abort.signal,
+      runnerOptions: {},
+      getLastUpdateId: () => null,
+      persistUpdateId: async () => undefined,
+      log: () => undefined,
+      telegramTransport: undefined,
+    });
+
+    await session.runUntilAbort();
+
+    expect(runMock).toHaveBeenCalledTimes(1);
+    expect(computeBackoffMock).not.toHaveBeenCalled();
+    expect(sleepWithAbortMock).not.toHaveBeenCalled();
+  });
+
   it("forces a restart when polling stalls without getUpdates activity", async () => {
     const abort = new AbortController();
     const botStop = vi.fn(async () => undefined);

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -23,6 +23,10 @@ const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
 
+function isTelegramDiagEnabled(): boolean {
+  return process.env.OPENCLAW_DEBUG_TELEGRAM_ROUTE === "1";
+}
+
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -176,11 +180,21 @@ export class TelegramPollingSession {
       await withTelegramApiErrorLogging({
         operation: "deleteWebhook",
         runtime: this.opts.runtime,
+        shouldLog: (err) => !/404:\s*Not Found/i.test(String(err)),
         fn: () => bot.api.deleteWebhook({ drop_pending_updates: false }),
       });
       this.#webhookCleared = true;
       return "ready";
     } catch (err) {
+      if (/404:\s*Not Found/i.test(String(err))) {
+        if (isTelegramDiagEnabled()) {
+          this.opts.runtime?.log?.(
+            "Telegram deleteWebhook returned 404 during polling startup; assuming no webhook is configured.",
+          );
+        }
+        this.#webhookCleared = true;
+        return "ready";
+      }
       const shouldRetry = await this.#waitBeforeRetryOnRecoverableSetupError(
         err,
         "Telegram webhook cleanup failed",
@@ -385,9 +399,11 @@ export class TelegramPollingSession {
           ? "unhandled network error"
           : "runner stopped (maxRetryTime exceeded or graceful stop)";
       this.#forceRestarted = false;
-      this.opts.log(
-        `[telegram][diag] polling cycle finished reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${String(lastGetUpdatesError)}` : ""}`,
-      );
+      if (isTelegramDiagEnabled()) {
+        this.opts.log(
+          `[telegram][diag] polling cycle finished reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${String(lastGetUpdatesError)}` : ""}`,
+        );
+      }
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram polling runner stopped (${reason}); restarting in ${delay}.`,
       );
@@ -410,9 +426,11 @@ export class TelegramPollingSession {
       }
       const reason = isConflict ? "getUpdates conflict" : "network error";
       const errMsg = formatErrorMessage(err);
-      this.opts.log(
-        `[telegram][diag] polling cycle error reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"} err=${errMsg}${lastGetUpdatesError ? ` lastGetUpdatesError=${String(lastGetUpdatesError)}` : ""}`,
-      );
+      if (isTelegramDiagEnabled()) {
+        this.opts.log(
+          `[telegram][diag] polling cycle error reason=${reason} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"} err=${errMsg}${lastGetUpdatesError ? ` lastGetUpdatesError=${String(lastGetUpdatesError)}` : ""}`,
+        );
+      }
       const shouldRestart = await this.#waitBeforeRestart(
         (delay) => `Telegram ${reason}: ${errMsg}; retrying in ${delay}.`,
       );

--- a/extensions/telegram/src/polling-transport-state.ts
+++ b/extensions/telegram/src/polling-transport-state.ts
@@ -1,5 +1,9 @@
 import type { TelegramTransport } from "./fetch.js";
 
+function isTelegramDiagEnabled(): boolean {
+  return process.env.OPENCLAW_DEBUG_TELEGRAM_ROUTE === "1";
+}
+
 type TelegramPollingTransportStateOpts = {
   log: (line: string) => void;
   initialTransport?: TelegramTransport;
@@ -23,7 +27,7 @@ export class TelegramPollingTransportState {
     const nextTransport = shouldCreateTransport
       ? (this.opts.createTelegramTransport?.() ?? this.#telegramTransport)
       : this.#telegramTransport;
-    if (this.#transportDirty && nextTransport) {
+    if (this.#transportDirty && nextTransport && isTelegramDiagEnabled()) {
       this.opts.log("[telegram][diag] rebuilding transport for next polling cycle");
     }
     this.#telegramTransport = nextTransport;

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
   DEFAULT_AGENTS_FILENAME,
@@ -171,6 +171,21 @@ describe("ensureAgentWorkspace", () => {
       "utf-8",
     );
     expect(persisted).toContain('"setupCompletedAt": "2026-03-15T02:30:00.000Z"');
+  });
+
+  it("pre-creates today and yesterday daily memory notes", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-07T22:52:00Z"));
+
+    try {
+      await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await expect(fs.access(path.join(tempDir, "memory", "2026-04-07.md"))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(tempDir, "memory", "2026-04-06.md"))).resolves.toBeUndefined();
   });
 });
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -204,6 +204,22 @@ async function fileExists(filePath: string): Promise<boolean> {
   }
 }
 
+function formatLocalDateStamp(value: Date): string {
+  const year = String(value.getFullYear());
+  const month = String(value.getMonth() + 1).padStart(2, "0");
+  const day = String(value.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+async function ensureDailyMemoryNotes(dir: string, now = new Date()): Promise<void> {
+  const memoryDir = path.join(dir, "memory");
+  const yesterday = new Date(now);
+  yesterday.setDate(now.getDate() - 1);
+  await fs.mkdir(memoryDir, { recursive: true });
+  await writeFileIfMissing(path.join(memoryDir, `${formatLocalDateStamp(now)}.md`), "");
+  await writeFileIfMissing(path.join(memoryDir, `${formatLocalDateStamp(yesterday)}.md`), "");
+}
+
 function resolveWorkspaceStatePath(dir: string): string {
   return path.join(dir, WORKSPACE_STATE_DIRNAME, WORKSPACE_STATE_FILENAME);
 }
@@ -448,6 +464,7 @@ export async function ensureAgentWorkspace(params?: {
   if (stateDirty) {
     await writeWorkspaceSetupState(statePath, state);
   }
+  await ensureDailyMemoryNotes(dir);
   await ensureGitRepo(dir, isBrandNewWorkspace);
 
   return {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -41,7 +41,7 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { buildReplyPromptBodies } from "./prompt-prelude.js";
 import { resolveActiveRunQueueAction } from "./queue-policy.js";
 import { resolveQueueSettings } from "./queue/settings.js";
-import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+import { buildBareSessionResetPrompt, buildBareSessionResetReply } from "./session-reset-prompt.js";
 import { drainFormattedSystemEvents } from "./session-system-events.js";
 import { resolveTypingMode } from "./typing-mode.js";
 import { resolveRunTypingPolicy } from "./typing-policy.js";
@@ -282,6 +282,13 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
+  if (isBareNewOrReset && isBareSessionReset) {
+    await typing.onReplyStart();
+    typing.cleanup();
+    return {
+      text: buildBareSessionResetReply(),
+    };
+  }
   const baseBodyFinal = isBareSessionReset ? buildBareSessionResetPrompt(cfg) : baseBody;
   const envelopeOptions = resolveEnvelopeFormatOptions(cfg);
   const inboundUserContext = buildInboundUserContextPrefix(

--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
-import { buildBareSessionResetPrompt } from "./session-reset-prompt.js";
+import { buildBareSessionResetPrompt, buildBareSessionResetReply } from "./session-reset-prompt.js";
 
 describe("buildBareSessionResetPrompt", () => {
   it("includes the core session startup instruction", () => {
@@ -31,5 +31,9 @@ describe("buildBareSessionResetPrompt", () => {
     const nowMs = Date.UTC(2026, 2, 3, 14, 0, 0);
     const prompt = buildBareSessionResetPrompt(undefined, nowMs);
     expect(prompt).toContain("Current time:");
+  });
+
+  it("returns a fixed fast reply for bare reset commands", () => {
+    expect(buildBareSessionResetReply()).toBe("新会话已开始。请直接告诉我你要做什么。");
   });
 });

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -2,7 +2,8 @@ import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
 
 const BARE_SESSION_RESET_PROMPT_BASE =
-  "A new session was started via /new or /reset. Run your Session Startup sequence - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+  "A new session was started via /new or /reset. Before responding, read SESSION_STARTUP.md if it exists and follow it exactly. Only if it does not exist, run the normal Session Startup sequence. Then greet the user in your configured persona, if one is provided. Be yourself. Keep it to 1-2 short sentences and ask what they want to do. Do not mention internal steps, files, tools, or reasoning.";
+const BARE_SESSION_RESET_REPLY = "新会话已开始。请直接告诉我你要做什么。";
 
 /**
  * Build the bare session reset prompt, appending the current date/time so agents
@@ -15,6 +16,10 @@ export function buildBareSessionResetPrompt(cfg?: OpenClawConfig, nowMs?: number
     cfg ?? {},
     nowMs ?? Date.now(),
   );
+}
+
+export function buildBareSessionResetReply(): string {
+  return BARE_SESSION_RESET_REPLY;
 }
 
 /** @deprecated Use buildBareSessionResetPrompt(cfg) instead */

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -133,4 +133,49 @@ describe("cron service store seam coverage", () => {
     expect(raw.jobs[0]?.jobId).toBe("repro-stable-id");
     expect(raw.jobs[0]?.id).toBeUndefined();
   });
+
+  it("normalizes missing job state in memory for legacy stored jobs", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              id: "missing-state",
+              name: "missing state",
+              enabled: false,
+              createdAtMs: now - 60_000,
+              updatedAtMs: now - 60_000,
+              schedule: { kind: "every", everyMs: 60_000 },
+              sessionTarget: "isolated",
+              wakeMode: "now",
+              payload: { kind: "agentTurn", message: "ping" },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeatNow: vi.fn(),
+      runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+    });
+
+    await ensureLoaded(state);
+
+    expect(state.store?.jobs[0]?.state).toEqual({});
+  });
 });

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -49,6 +49,9 @@ export async function ensureLoaded(
     if (typeof job.enabled !== "boolean") {
       job.enabled = true;
     }
+    if (!job.state || typeof job.state !== "object") {
+      job.state = {};
+    }
   }
   state.store = {
     version: 1,

--- a/src/gateway/control-ui-contract.ts
+++ b/src/gateway/control-ui-contract.ts
@@ -4,4 +4,5 @@ export type ControlUiBootstrapConfig = {
   basePath: string;
   assistantName: string;
   assistantAvatar: string;
+  authToken?: string;
 };

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -27,6 +27,7 @@ describe("handleControlUiHttpRequest", () => {
       basePath: string;
       assistantName: string;
       assistantAvatar: string;
+      authToken?: string;
     };
   }
 
@@ -195,10 +196,44 @@ describe("handleControlUiHttpRequest", () => {
         expect(parsed.basePath).toBe("");
         expect(parsed.assistantName).toBe("</script><script>alert(1)//");
         expect(parsed.assistantAvatar).toBe("/avatar/main");
+        expect(parsed.authToken).toBeUndefined();
         expect(parsed).not.toHaveProperty("assistantAgentId");
         expect(parsed).not.toHaveProperty("serverVersion");
       },
     });
+  });
+
+  it("includes auth token for loopback bootstrap requests", async () => {
+    const previous = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "loopback-token-123";
+    try {
+      await withControlUiRoot({
+        fn: async (tmp) => {
+          const { res, end } = makeMockHttpResponse();
+          const handled = handleControlUiHttpRequest(
+            {
+              url: CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
+              method: "GET",
+              socket: { remoteAddress: "127.0.0.1" },
+            } as IncomingMessage,
+            res,
+            {
+              root: { kind: "resolved", path: tmp },
+              config: { agents: { defaults: { workspace: tmp } } },
+            },
+          );
+          expect(handled).toBe(true);
+          const parsed = parseBootstrapPayload(end);
+          expect(parsed.authToken).toBe("loopback-token-123");
+        },
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      } else {
+        process.env.OPENCLAW_GATEWAY_TOKEN = previous;
+      }
+    }
   });
 
   it("serves bootstrap config JSON under basePath", async () => {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { execFileSync } from "node:child_process";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
@@ -109,6 +110,43 @@ export type ControlUiAvatarResolution =
 type ControlUiAvatarMeta = {
   avatarUrl: string | null;
 };
+
+function isLoopbackRemoteAddress(value: string | undefined): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(value);
+  return (
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "::ffff:127.0.0.1" ||
+    normalized.startsWith("127.")
+  );
+}
+
+function readGatewayTokenFromKeychain(): string {
+  try {
+    return execFileSync("/usr/bin/security", ["find-generic-password", "-w", "-s", "openclaw/gateway/token"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function resolveLocalControlUiAuthToken(req: IncomingMessage, config?: OpenClawConfig): string {
+  if (!isLoopbackRemoteAddress(req.socket?.remoteAddress)) {
+    return "";
+  }
+  const runtimeToken = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() ?? "";
+  if (runtimeToken) {
+    return runtimeToken;
+  }
+  const configToken = config?.gateway?.auth?.token;
+  const normalizedConfigToken = typeof configToken === "string" ? configToken.trim() : "";
+  if (normalizedConfigToken && !/^\$\{[A-Z0-9_]+\}$/.test(normalizedConfigToken)) {
+    return normalizedConfigToken;
+  }
+  return readGatewayTokenFromKeychain();
+}
 
 function applyControlUiSecurityHeaders(res: ServerResponse) {
   res.setHeader("X-Frame-Options", "DENY");
@@ -365,6 +403,9 @@ export function handleControlUiHttpRequest(
       basePath,
       assistantName: identity.name,
       assistantAvatar: avatarValue ?? identity.avatar,
+      ...(resolveLocalControlUiAuthToken(req, config)
+        ? { authToken: resolveLocalControlUiAuthToken(req, config) }
+        : {}),
     } satisfies ControlUiBootstrapConfig);
     return true;
   }

--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -12,8 +12,9 @@ import {
 } from "./transcript.js";
 
 // Avoid calling the embedded Pi agent (global command lane); keep this unit test deterministic.
+const generateSlugViaLLMMock = vi.fn().mockResolvedValue("simple-math");
 vi.mock("../../llm-slug-generator.js", () => ({
-  generateSlugViaLLM: vi.fn().mockResolvedValue("simple-math"),
+  generateSlugViaLLM: generateSlugViaLLMMock,
 }));
 
 let handler: typeof import("./handler.js").default;
@@ -186,6 +187,27 @@ function expectMemoryConversation(params: {
 }
 
 describe("session-memory hook", () => {
+  it("falls back quickly when llm slug generation exceeds the latency budget", async () => {
+    generateSlugViaLLMMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve("slow-slug"), 5_000);
+        }),
+    );
+    const startedAt = Date.now();
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Start a fresh session quickly" },
+      { role: "assistant", content: "Keep this reset fast" },
+    ]);
+
+    const { files } = await runNewWithPreviousSession({ sessionContent });
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(files.length).toBe(1);
+    expect(files[0]).toMatch(/^\d{4}-\d{2}-\d{2}-\d{4}\.md$/);
+    expect(elapsedMs).toBeLessThan(3_000);
+  });
+
   it("skips non-command events", async () => {
     const tempDir = await createCaseWorkspace("workspace");
 

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -27,6 +27,7 @@ import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } from "./transcript.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
+const DEFAULT_LLM_SLUG_TIMEOUT_MS = 1200;
 
 function resolveDisplaySessionKey(params: {
   cfg?: OpenClawConfig;
@@ -152,8 +153,22 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
       if (sessionContent && cfg && allowLlmSlug) {
         log.debug("Calling generateSlugViaLLM...");
-        // Use LLM to generate a descriptive slug
-        slug = await generateSlugViaLLM({ sessionContent, cfg });
+        const slugTimeoutMs =
+          typeof hookConfig?.llmSlugTimeoutMs === "number" && hookConfig.llmSlugTimeoutMs >= 0
+            ? hookConfig.llmSlugTimeoutMs
+            : DEFAULT_LLM_SLUG_TIMEOUT_MS;
+        // /new should reply quickly; bound slug generation and fall back to timestamp.
+        slug = await Promise.race([
+          generateSlugViaLLM({ sessionContent, cfg }),
+          new Promise<null>((resolve) => {
+            setTimeout(() => {
+              log.debug("LLM slug generation timed out; using fallback slug", {
+                timeoutMs: slugTimeoutMs,
+              });
+              resolve(null);
+            }, slugTimeoutMs);
+          }),
+        ]);
         log.debug("Generated slug", { slug });
       }
     }

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -18,6 +18,7 @@ import {
 } from "./app-settings.ts";
 import { loadControlUiBootstrapConfig } from "./controllers/control-ui-bootstrap.ts";
 import type { Tab } from "./navigation.ts";
+import type { UiSettings } from "./storage.ts";
 
 type LifecycleHost = {
   basePath: string;
@@ -40,6 +41,8 @@ type LifecycleHost = {
   logsEntries: unknown[];
   popStateHandler: () => void;
   topbarObserver: ResizeObserver | null;
+  settings: UiSettings;
+  applySettings: (next: UiSettings) => void;
 };
 
 export function handleConnected(host: LifecycleHost) {

--- a/ui/src/ui/controllers/control-ui-bootstrap.ts
+++ b/ui/src/ui/controllers/control-ui-bootstrap.ts
@@ -11,6 +11,8 @@ export type ControlUiBootstrapState = {
   assistantAvatar: string | null;
   assistantAgentId: string | null;
   serverVersion: string | null;
+  settings: { token: string; gatewayUrl: string };
+  applySettings: (next: ControlUiBootstrapState["settings"]) => void;
 };
 
 export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapState) {
@@ -42,6 +44,10 @@ export async function loadControlUiBootstrapConfig(state: ControlUiBootstrapStat
     });
     state.assistantName = normalized.name;
     state.assistantAvatar = normalized.avatar;
+    const authToken = typeof parsed.authToken === "string" ? parsed.authToken.trim() : "";
+    if (authToken && authToken !== state.settings.token) {
+      state.applySettings({ ...state.settings, token: authToken });
+    }
   } catch {
     // Ignore bootstrap failures; UI will update identity after connecting.
   }

--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -74,6 +74,16 @@ describe("loadSettings default gateway URL derivation", () => {
     expect(loadSettings().gatewayUrl).toBe(expectedGatewayUrl("/apps/openclaw"));
   });
 
+  it("treats /web/control-ui as a hosted page path, not a gateway websocket base path", async () => {
+    setTestLocation({
+      protocol: "http:",
+      host: "127.0.0.1:18789",
+      pathname: "/web/control-ui",
+    });
+
+    expect(loadSettings().gatewayUrl).toBe(expectedGatewayUrl(""));
+  });
+
   it("skips node sessionStorage accessors that warn without a storage file", async () => {
     vi.unstubAllGlobals();
     vi.stubGlobal("localStorage", createStorageMock());
@@ -139,6 +149,23 @@ describe("loadSettings default gateway URL derivation", () => {
       },
     });
     expect(sessionStorage.length).toBe(0);
+  });
+
+  it("migrates persisted hosted control-ui websocket URLs back to the gateway root", async () => {
+    setTestLocation({
+      protocol: "http:",
+      host: "127.0.0.1:18789",
+      pathname: "/web/control-ui",
+    });
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({
+        gatewayUrl: "ws://127.0.0.1:18789/web/control-ui",
+        sessionKey: "main",
+      }),
+    );
+
+    expect(loadSettings().gatewayUrl).toBe(expectedGatewayUrl(""));
   });
 
   it("loads the current-tab token from sessionStorage", async () => {

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -77,15 +77,44 @@ function deriveDefaultGatewayUrl(): { pageUrl: string; effectiveUrl: string } {
   const configured =
     typeof window !== "undefined" &&
     normalizeOptionalString(window.__OPENCLAW_CONTROL_UI_BASE_PATH__);
-  const basePath = configured
+  const inferredBasePath = configured
     ? normalizeBasePath(configured)
     : inferBasePathFromPathname(location.pathname);
+  const basePath =
+    inferredBasePath === "/web/control-ui" || inferredBasePath.startsWith("/web/control-ui/")
+      ? ""
+      : inferredBasePath;
   const pageUrl = `${proto}://${location.host}${basePath}`;
   if (!isViteDevPage()) {
     return { pageUrl, effectiveUrl: pageUrl };
   }
   const effectiveUrl = `${proto}://${formatHostWithPort(location.hostname, "18789")}`;
   return { pageUrl, effectiveUrl };
+}
+
+function normalizeLegacyHostedControlUiGatewayUrl(rawGatewayUrl: string, defaultGatewayUrl: string) {
+  const normalized = normalizeOptionalString(rawGatewayUrl) ?? "";
+  if (!normalized || typeof location === "undefined") {
+    return normalized;
+  }
+  const hostedControlUiPath = "/web/control-ui";
+  if (
+    location.pathname !== hostedControlUiPath &&
+    !location.pathname.startsWith(`${hostedControlUiPath}/`)
+  ) {
+    return normalized;
+  }
+  try {
+    const parsed = new URL(normalized, `${location.protocol}//${location.host}/`);
+    const expectedProtocol = location.protocol === "https:" ? "wss:" : "ws:";
+    const normalizedPath = parsed.pathname.replace(/\/+$/, "") || "/";
+    if (parsed.host === location.host && parsed.protocol === expectedProtocol && normalizedPath === hostedControlUiPath) {
+      return defaultGatewayUrl;
+    }
+  } catch {
+    // Preserve the original value when it cannot be parsed.
+  }
+  return normalized;
 }
 
 function getSessionStorage(): Storage | null {
@@ -208,7 +237,10 @@ export function loadSettings(): UiSettings {
       return defaults;
     }
     const parsed = JSON.parse(raw) as PersistedUiSettings;
-    const parsedGatewayUrl = normalizeOptionalString(parsed.gatewayUrl) ?? defaults.gatewayUrl;
+    const parsedGatewayUrl = normalizeLegacyHostedControlUiGatewayUrl(
+      normalizeOptionalString(parsed.gatewayUrl) ?? defaults.gatewayUrl,
+      defaults.gatewayUrl,
+    );
     const gatewayUrl = parsedGatewayUrl === pageDerivedUrl ? defaultUrl : parsedGatewayUrl;
     const scopedSessionSelection = resolveScopedSessionSelection(gatewayUrl, parsed, defaults);
     const { theme, mode } = parseThemeSelection(


### PR DESCRIPTION
## Summary
- preserve proxy-aware OpenAI routing for gpt-5.4 and avoid forcing websocket transport for proxied responses
- harden Telegram runtime by treating delete webhook/command 404s as idempotent and gating polling diagnostics
- keep control-ui bootstrap, hosted base-path migration, cron state loading, session reset, and session-memory behavior stable after the v2026.4.9 upgrade
- create daily memory files during workspace setup to avoid startup noise from expected missing files

## Testing
- local source-build install into the live runtime
- healthcheck ok on the upgraded runtime
- control UI bootstrap endpoint returns JSON with auth token on localhost
- /cron returns 200 from the upgraded gateway
- targeted vitest suite running locally for the touched areas
