### PR TITLE
fix: preserve content when stripping final tags in SSE streaming

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -869,6 +869,59 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     }
   });
 
+  it("preserves content when upstream emits replace events during final-tag stripping", async () => {
+    const port = enabledPort;
+
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      // Simulate partial <final> tag split across chunks:
+      // Chunk 1: delta contains partial tag remnant "<"
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "<", delta: "<" },
+      });
+      // Chunk 2: tag is fully resolved; upstream sends replace with corrected text
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "Title\nSubtitle\nBody", delta: "", replace: true },
+      });
+      // Chunk 3: normal append delta
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { text: "Title\nSubtitle\nBody more", delta: " more" },
+      });
+      return { payloads: [{ text: "Title\nSubtitle\nBody more" }] };
+    }) as never);
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "tell me" }],
+    });
+    expect(res.status).toBe(200);
+
+    const text = await res.text();
+    const data = parseSseDataLines(text);
+    expect(data[data.length - 1]).toBe("[DONE]");
+
+    const jsonChunks = data
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+    const allContent = jsonChunks
+      .flatMap((c) => (c.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+      .filter((v): v is string => typeof v === "string")
+      .join("");
+    expect(allContent).toContain("Title");
+    expect(allContent).toContain("Subtitle");
+    expect(allContent).toContain("Body more");
+    expect(allContent.split("Title").length - 1).toBe(1);
+  });
+
   it("treats shared-secret bearer callers as owner operators", async () => {
     const port = await getFreePort();
     const server = await startTokenServer(port);

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -560,6 +560,7 @@ export async function handleOpenAiHttpRequest(
   let wroteRole = false;
   let sawAssistantDelta = false;
   let closed = false;
+  let accumulatedSent = "";
   let stopWatchingDisconnect = () => {};
 
   const unsubscribe = onAgentEvent((evt) => {
@@ -571,7 +572,28 @@ export async function handleOpenAiHttpRequest(
     }
 
     if (evt.stream === "assistant") {
-      const content = resolveAssistantStreamDeltaText(evt) ?? "";
+      const fullText = typeof evt.data?.text === "string" ? evt.data.text : "";
+      const delta = resolveAssistantStreamDeltaText(evt) ?? "";
+
+      let content: string;
+      if (fullText) {
+        if (fullText.startsWith(accumulatedSent)) {
+          content = fullText.slice(accumulatedSent.length);
+        } else {
+          let commonLen = 0;
+          const limit = Math.min(accumulatedSent.length, fullText.length);
+          while (commonLen < limit && accumulatedSent[commonLen] === fullText[commonLen]) {
+            commonLen++;
+          }
+          content = fullText.slice(commonLen);
+          accumulatedSent = fullText.slice(0, commonLen);
+        }
+      } else if (delta) {
+        content = delta;
+      } else {
+        content = "";
+      }
+
       if (!content) {
         return;
       }
@@ -582,6 +604,7 @@ export async function handleOpenAiHttpRequest(
       }
 
       sawAssistantDelta = true;
+      accumulatedSent += content;
       writeAssistantContentChunk(res, {
         runId,
         model,


### PR DESCRIPTION
## Summary

The `/v1/chat/completions` SSE streaming path dropped response content when `<final>`/`<think>` tags straddled chunk boundaries. The upstream handler detects cross-boundary tags and emits replace events with corrected full text, but the SSE handler only looked at `delta`, silently discarding replace events with empty deltas.

Closes #63325

## Changes

- Track accumulated sent text via `accumulatedSent` in the SSE streaming handler
- Derive incremental SSE deltas from the authoritative `text` field instead of raw `delta`
- Use common-prefix matching on replace events to avoid duplicating already-sent content
- Added test covering replace events during final-tag stripping

## Testing

- New test: `preserves content when upstream emits replace events during final-tag stripping`
- Verifies no content loss and no duplication on replace events

---
> This PR was developed with AI assistance (Claude). Built with [islo.dev](https://islo.dev)