### PR TITLE
fix: don't persist fallback model to session when channel override is active

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1710,4 +1710,59 @@ describe("runAgentTurnWithFallback", () => {
       authProfileOverrideSource: "user",
     });
   });
+
+  // Regression test for https://github.com/openclaw/openclaw/issues/63712
+  it("does not persist fallback selection to session when channel model override is active", async () => {
+    state.runWithModelFallbackMock.mockImplementation(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+        result: await params.run("openai", "gpt-5.4"),
+        provider: "openai",
+        model: "gpt-5.4",
+        attempts: [{ provider: "anthropic", model: "claude-opus-4-6", error: "rate_limit" }],
+      }),
+    );
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "fallback reply" }],
+      meta: {},
+    });
+
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: { ...sessionEntry } };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "discord",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {},
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => sessionEntry,
+      activeSessionStore: sessionStore,
+      resolvedVerboseLevel: "off",
+      hasChannelModelOverride: true,
+    });
+
+    expect(result.kind).toBe("success");
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionStore.main.modelOverride).toBeUndefined();
+    expect(sessionStore.main.providerOverride).toBeUndefined();
+  });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -576,6 +576,10 @@ export async function runAgentTurnWithFallback(params: {
   activeSessionStore?: Record<string, SessionEntry>;
   storePath?: string;
   resolvedVerboseLevel: VerboseLevel;
+  /** When true, the active model was selected by a channel-level override (not by the user).
+   * Fallback selection is not persisted to the session in this case so the channel override
+   * remains authoritative on subsequent turns. */
+  hasChannelModelOverride?: boolean;
 }): Promise<AgentRunLoopResult> {
   const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
   let didLogHeartbeatStrip = false;
@@ -632,7 +636,14 @@ export async function runAgentTurnWithFallback(params: {
     if (
       !params.sessionKey ||
       !params.activeSessionStore ||
-      (provider === params.followupRun.run.provider && model === params.followupRun.run.model)
+      (provider === params.followupRun.run.provider && model === params.followupRun.run.model) ||
+      // Don't pin the fallback to the session when the primary model was selected by a
+      // channel-level override. Persisting would set modelOverride/providerOverride on the
+      // session entry, which permanently shadows the channel override on subsequent turns
+      // (because channel overrides are gated by !hasSessionModelOverride). By skipping
+      // persistence here the fallback runs once, but the channel override is re-evaluated
+      // cleanly on the very next turn. See: https://github.com/openclaw/openclaw/issues/63712
+      params.hasChannelModelOverride
     ) {
       return;
     }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -136,6 +136,7 @@ export async function runReplyAgent(params: {
   typingMode: TypingMode;
   resetTriggered?: boolean;
   replyOperation?: ReplyOperation;
+  hasChannelModelOverride?: boolean;
 }): Promise<ReplyPayload | ReplyPayload[] | undefined> {
   const {
     commandBody,
@@ -165,6 +166,7 @@ export async function runReplyAgent(params: {
     typingMode,
     resetTriggered,
     replyOperation: providedReplyOperation,
+    hasChannelModelOverride,
   } = params;
 
   let activeSessionEntry = sessionEntry;
@@ -439,6 +441,7 @@ export async function runReplyAgent(params: {
       activeSessionStore,
       storePath,
       resolvedVerboseLevel,
+      hasChannelModelOverride,
     });
 
     if (runOutcome.kind === "final") {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -138,6 +138,7 @@ type RunPreparedReplyParams = {
   modelState: Awaited<ReturnType<typeof createModelSelectionState>>;
   provider: string;
   model: string;
+  hasChannelModelOverride?: boolean;
   perMessageQueueMode?: InlineDirectives["queueMode"];
   perMessageQueueOptions?: {
     debounceMs?: number;
@@ -185,6 +186,7 @@ export async function runPreparedReply(
     modelState,
     provider,
     model,
+    hasChannelModelOverride,
     perMessageQueueMode,
     perMessageQueueOptions,
     typing,
@@ -659,5 +661,6 @@ export async function runPreparedReply(
     shouldInjectGroupIntro,
     typingMode,
     resetTriggered,
+    hasChannelModelOverride,
   });
 }

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -319,7 +319,12 @@ export async function getReplyFromConfig(
     normalizeOptionalString(sessionEntry.modelOverride) ||
     normalizeOptionalString(sessionEntry.providerOverride),
   );
-  if (!hasResolvedHeartbeatModelOverride && !hasSessionModelOverride && channelModelOverride) {
+  // True when the channel-level model override (not a session/user override) is active.
+  // Used downstream to avoid pinning a transient fallback to the session, which would
+  // permanently shadow the channel override on subsequent turns.
+  const hasChannelModelOverride =
+    !hasResolvedHeartbeatModelOverride && !hasSessionModelOverride && Boolean(channelModelOverride);
+  if (hasChannelModelOverride) {
     const resolved = resolveModelRefFromString({
       raw: channelModelOverride.model,
       defaultProvider,
@@ -603,6 +608,7 @@ export async function getReplyFromConfig(
     modelState,
     provider,
     model,
+    hasChannelModelOverride,
     perMessageQueueMode,
     perMessageQueueOptions,
     typing,


### PR DESCRIPTION
## Summary

When a channel-level model override is active and the primary model fails, the fallback model selection was persisted to the session entry (`modelOverride`/`providerOverride`). This permanently shadowed the channel override on subsequent turns because channel overrides are gated by `!hasSessionModelOverride`.

Closes #63712

## Changes

- Added `hasChannelModelOverride` parameter through the reply chain (`get-reply.ts` → `get-reply-run.ts` → `agent-runner.ts` → `agent-runner-execution.ts`)
- Skip fallback persistence when `hasChannelModelOverride` is true
- Added regression test verifying fallback doesn't pin to session under channel override

## Testing

- New test: `does not persist fallback selection to session when channel model override is active`

---
> This PR was developed with AI assistance (Claude). Built with [islo.dev](https://islo.dev)