### PR TITLE
fix(memory-core): limit dreaming narrative fallback to request-scoped subagent runtime errors

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -153,6 +153,56 @@ async function startNarrativeRunOrFallback(params: {
   }
 }
 
+function buildRequestScopedFallbackNarrative(data: NarrativePhaseData): string {
+  return (
+    data.snippets.map((value) => value.trim()).find((value) => value.length > 0) ??
+    (data.promotions ?? []).map((value) => value.trim()).find((value) => value.length > 0) ??
+    "A memory trace surfaced, but details were unavailable in this run."
+  );
+}
+
+async function startNarrativeRunOrFallback(params: {
+  subagent: SubagentSurface;
+  sessionKey: string;
+  message: string;
+  data: NarrativePhaseData;
+  workspaceDir: string;
+  nowMs: number;
+  timezone?: string;
+  logger: Logger;
+}): Promise<string | null> {
+  try {
+    const run = await params.subagent.run({
+      idempotencyKey: params.sessionKey,
+      sessionKey: params.sessionKey,
+      message: params.message,
+      extraSystemPrompt: NARRATIVE_SYSTEM_PROMPT,
+      deliver: false,
+    });
+    return run.runId;
+  } catch (runErr) {
+    if (!isRequestScopedSubagentRuntimeError(runErr)) {
+      throw runErr;
+    }
+    try {
+      await appendNarrativeEntry({
+        workspaceDir: params.workspaceDir,
+        narrative: buildRequestScopedFallbackNarrative(params.data),
+        nowMs: params.nowMs,
+        timezone: params.timezone,
+      });
+      params.logger.warn(
+        `memory-core: narrative generation used fallback for ${params.data.phase} phase because subagent runtime is request-scoped [workspace=${params.workspaceDir}].`,
+      );
+    } catch (fallbackErr) {
+      params.logger.warn(
+        `memory-core: narrative fallback failed for ${params.data.phase} phase: ${formatErrorMessage(fallbackErr)}`,
+      );
+    }
+    return null;
+  }
+}
+
 // ── Prompt building ────────────────────────────────────────────────────
 
 export function buildNarrativePrompt(data: NarrativePhaseData): string {


### PR DESCRIPTION
## Summary

- Problem: scheduled Dreaming can hit request-scoped subagent runtime errors and skip diary output.
- Why it matters: we should preserve `DREAMS.md` output for that specific scheduled/runtime mismatch.
- What changed: fallback is now limited to the canonical request-scoped runtime error, with shared constant wiring across throw/check sites.
- What did NOT change: non-request-scope `subagent.run` failures still follow existing best-effort warning behavior (no fallback diary write).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #63832
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: scheduled Dreaming used a subagent runtime path that can be request-scoped only.
- Missing guardrail: narrative fallback path was not scoped tightly to that specific runtime-unavailable condition.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-core/src/dreaming-narrative.test.ts`
- Scenario locked in: request-scoped runtime error triggers fallback diary write; other run failures do not.

## User-visible / Behavior Changes

- Scheduled Dreaming now writes fallback diary text only for request-scoped subagent runtime unavailability.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification (required)

- Verified scenarios: request-scoped fallback path, non-request failure path, existing narrative flow tests.
- Edge case checked: nested `cause` text no longer triggers fallback path.
- Not verified in this PR: live cron run on a real gateway instance.

## Risks and Mitigations

- Risk: request-scoped discriminator drift across boundaries.
  - Mitigation: shared exported constant (`SUBAGENT_RUNTIME_REQUEST_SCOPE_ERROR_MESSAGE`) used by both runtime throw and memory-core check.
- Risk: diary writes through symlinked `DREAMS.md`.
  - Mitigation: `appendNarrativeEntry` now uses guarded atomic write path.
