### PR TITLE
fix(ci): repair protocol drift and audit failures

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2837,6 +2837,7 @@ public struct ModelChoice: Codable, Sendable {
     public let id: String
     public let name: String
     public let provider: String
+    public let alias: String?
     public let contextwindow: Int?
     public let reasoning: Bool?
 
@@ -2844,12 +2845,14 @@ public struct ModelChoice: Codable, Sendable {
         id: String,
         name: String,
         provider: String,
+        alias: String?,
         contextwindow: Int?,
         reasoning: Bool?)
     {
         self.id = id
         self.name = name
         self.provider = provider
+        self.alias = alias
         self.contextwindow = contextwindow
         self.reasoning = reasoning
     }
@@ -2858,6 +2861,7 @@ public struct ModelChoice: Codable, Sendable {
         case id
         case name
         case provider
+        case alias
         case contextwindow = "contextWindow"
         case reasoning
     }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2837,6 +2837,7 @@ public struct ModelChoice: Codable, Sendable {
     public let id: String
     public let name: String
     public let provider: String
+    public let alias: String?
     public let contextwindow: Int?
     public let reasoning: Bool?
 
@@ -2844,12 +2845,14 @@ public struct ModelChoice: Codable, Sendable {
         id: String,
         name: String,
         provider: String,
+        alias: String?,
         contextwindow: Int?,
         reasoning: Bool?)
     {
         self.id = id
         self.name = name
         self.provider = provider
+        self.alias = alias
         self.contextwindow = contextwindow
         self.reasoning = reasoning
     }
@@ -2858,6 +2861,7 @@ public struct ModelChoice: Codable, Sendable {
         case id
         case name
         case provider
+        case alias
         case contextwindow = "contextWindow"
         case reasoning
     }

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -19,9 +19,6 @@
       "optional": true
     }
   },
-  "overrides": {
-    "axios": "1.15.0"
-  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -19,6 +19,9 @@
       "optional": true
     }
   },
+  "overrides": {
+    "axios": "1.15.0"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"

--- a/package.json
+++ b/package.json
@@ -1431,7 +1431,7 @@
       "@anthropic-ai/sdk": "0.81.0",
       "hono": "4.12.12",
       "@hono/node-server": "1.19.13",
-      "axios": "1.13.6",
+      "axios": "1.15.0",
       "defu": "6.1.5",
       "fast-xml-parser": "5.5.7",
       "request": "npm:@cypress/request@3.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@anthropic-ai/sdk': 0.81.0
   hono: 4.12.12
   '@hono/node-server': 1.19.13
-  axios: 1.13.6
+  axios: 1.15.0
   defu: 6.1.5
   fast-xml-parser: 5.5.7
   request: npm:@cypress/request@3.0.10
@@ -4277,8 +4277,8 @@ packages:
     resolution: {integrity: sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==}
     engines: {node: '>=6.0.0'}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -8822,7 +8822,7 @@ snapshots:
 
   '@larksuiteoapi/node-sdk@1.60.0':
     dependencies:
-      axios: 1.13.6
+      axios: 1.15.0
       lodash.identity: 3.0.0
       lodash.merge: 4.6.2
       lodash.pickby: 4.6.0
@@ -9032,7 +9032,7 @@ snapshots:
       '@microsoft/teams.api': 2.0.6
       '@microsoft/teams.common': 2.0.6
       '@microsoft/teams.graph': 2.0.6
-      axios: 1.13.6
+      axios: 1.15.0
       cors: 2.8.6
       express: 5.2.1
       jsonwebtoken: 9.0.3
@@ -9046,7 +9046,7 @@ snapshots:
 
   '@microsoft/teams.common@2.0.6':
     dependencies:
-      axios: 1.13.6
+      axios: 1.15.0
     transitivePeerDependencies:
       - debug
 
@@ -9824,7 +9824,7 @@ snapshots:
       '@slack/types': 2.20.1
       '@slack/web-api': 7.15.0
       '@types/express': 5.0.6
-      axios: 1.13.6
+      axios: 1.15.0
       express: 5.2.1
       path-to-regexp: 8.4.0
       raw-body: 3.0.2
@@ -9870,7 +9870,7 @@ snapshots:
       '@slack/types': 2.20.1
       '@types/node': 25.5.2
       '@types/retry': 0.12.0
-      axios: 1.13.6
+      axios: 1.15.0
       eventemitter3: 5.0.4
       form-data: 2.5.4
       is-electron: 2.2.2
@@ -10836,11 +10836,11 @@ snapshots:
 
   await-to-js@3.0.0: {}
 
-  axios@1.13.6:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 2.5.4
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ minimumReleaseAgeExclude:
   - "@typescript/native-preview*"
   - "@oxlint/*"
   - "@oxfmt/*"
-  - "axios"
+  - "axios@1.15.0"
   - "sqlite-vec"
   - "sqlite-vec-*"
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ minimumReleaseAgeExclude:
   - "@typescript/native-preview*"
   - "@oxlint/*"
   - "@oxfmt/*"
+  - "axios"
   - "sqlite-vec"
   - "sqlite-vec-*"
 

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -35,7 +35,14 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
   beforeAll(loadModule);
 
   beforeEach(() => {
-    mocks.assertSandboxPath.mockClear();
+    mocks.assertSandboxPath.mockReset();
+    mocks.assertSandboxPath.mockImplementation(async ({ filePath }: { filePath: string }) => ({
+      resolved:
+        filePath.startsWith("file://") || path.isAbsolute(filePath)
+          ? filePath
+          : path.resolve(root, filePath),
+      relative: "",
+    }));
   });
 
   it("maps container workspace paths to host workspace root", async () => {

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -2,8 +2,13 @@ import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 
+type AssertSandboxPath = typeof import("./sandbox-paths.js").assertSandboxPath;
+
 const mocks = vi.hoisted(() => ({
-  assertSandboxPath: vi.fn(async () => ({ resolved: "/tmp/root", relative: "" })),
+  assertSandboxPath: vi.fn<AssertSandboxPath>(async () => ({
+    resolved: "/tmp/root",
+    relative: "",
+  })),
 }));
 
 vi.mock("./sandbox-paths.js", () => ({
@@ -31,18 +36,19 @@ let wrapToolWorkspaceRootGuardWithOptions: typeof import("./pi-tools.read.js").w
 
 describe("wrapToolWorkspaceRootGuardWithOptions", () => {
   const root = "/tmp/root";
+  const assertSandboxPathImpl: AssertSandboxPath = async ({ filePath }) => ({
+    resolved:
+      filePath.startsWith("file://") || path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(root, filePath),
+    relative: "",
+  });
 
   beforeAll(loadModule);
 
   beforeEach(() => {
     mocks.assertSandboxPath.mockReset();
-    mocks.assertSandboxPath.mockImplementation(async ({ filePath }: { filePath: string }) => ({
-      resolved:
-        filePath.startsWith("file://") || path.isAbsolute(filePath)
-          ? filePath
-          : path.resolve(root, filePath),
-      relative: "",
-    }));
+    mocks.assertSandboxPath.mockImplementation(assertSandboxPathImpl);
   });
 
   it("maps container workspace paths to host workspace root", async () => {


### PR DESCRIPTION
## Summary

- Problem: CI was red on three separate lanes: protocol artifact drift, a stale workspace-root guard unit test, and a production dependency audit failure on `axios` via Feishu's `@larksuiteoapi/node-sdk`
- Why it matters: the branch could not land while `checks-fast-contracts-protocol`, `checks-node-test`, and `security-fast` were failing
- What changed: regenerated the gateway Swift protocol artifacts, fixed the stale `assertSandboxPath` mock in the guard test, and pinned `axios@1.15.0` via root + Feishu overrides with a narrow `minimumReleaseAgeExclude` entry so pnpm can install the patched version
- What did NOT change (scope boundary): no runtime behavior changes outside the generated protocol alias field that was already present in schema/types, and no broader dependency refresh beyond the targeted `axios` patch path

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `ModelChoice.alias` had been added to the typed protocol schema without checking in the regenerated Swift client artifacts; the workspace-root guard test used a fixed `assertSandboxPath` mock that no longer reflected normalized-path behavior; and the Feishu production dependency path started failing audit once the `axios` SSRF advisory applied to the installed version
- Missing detection / guardrail: the protocol gate and audit gate detected the regressions, but the generated files and patched transitive dependency were not committed yet; the unit test had coverage already, but its mock was stale
- Contributing context (if known): the repo's `minimumReleaseAge` policy blocked adopting `axios@1.15.0` until `axios` was explicitly allowlisted for this targeted security update

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/agents/pi-tools.read.workspace-root-guard.test.ts` and the existing `protocol:check` / `pnpm audit --prod --audit-level=high` gates
- Scenario the test should lock in: custom `outPath` params normalize through the same resolved sandbox path the wrapper uses in production, while protocol/client artifacts and the Feishu dependency tree stay in sync with committed sources
- Why this is the smallest reliable guardrail: the failing unit case already covered the path-normalization seam, and the other two failures are best enforced by the existing protocol drift and audit gates
- Existing test that already covers this (if any): `src/agents/pi-tools.read.workspace-root-guard.test.ts`
- If no new test is added, why not: existing coverage was sufficient; the fix was to correct the stale mock and commit generated artifacts / lockfile state

## User-visible / Behavior Changes

None

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 24 / pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): Feishu dependency path and gateway protocol artifacts
- Relevant config (redacted): default repo config with `minimumReleaseAge` enabled

### Steps

1. Open the failing CI run from April 9, 2026 and inspect the linked `checks-fast-contracts-protocol` lane plus the other red lanes on the same run
2. Reproduce the protocol drift with `OPENCLAW_LOCAL_CHECK=0 pnpm protocol:check`, the stale unit assertion with `OPENCLAW_LOCAL_CHECK=0 pnpm test src/agents/pi-tools.read.workspace-root-guard.test.ts`, and the audit failure with `pnpm audit --prod --audit-level=high`
3. Apply the generated artifact, test-mock, and dependency-override fixes and rerun the same gates

### Expected

- Protocol artifacts are already committed
- The workspace-root guard tests pass
- Production audit reports no known vulnerabilities

### Actual

- Before this patch, CI failed on protocol drift, one guard unit test, and the production audit lane

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reran `OPENCLAW_LOCAL_CHECK=0 pnpm protocol:check`, `pnpm audit --prod --audit-level=high`, `OPENCLAW_LOCAL_CHECK=0 pnpm test src/agents/pi-tools.read.workspace-root-guard.test.ts`, and `OPENCLAW_LOCAL_CHECK=0 pnpm test src/plugins/contracts/package-manifest.contract.test.ts`
- Edge cases checked: relative vs absolute sandbox-path normalization in the guard test, and the pnpm release-age policy path for the targeted `axios` security bump
- What you did **not** verify: full repo-wide `pnpm check` was intentionally skipped on the final commit path after equivalent targeted verification for the touched surfaces

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: adding `axios` to `minimumReleaseAgeExclude` could be overused later if we treat it as a general bypass
  - Mitigation: this PR also pins the exact patched version in overrides, so the exclusion is narrowly tied to the security update path
- Risk: protocol client code can drift again when schema fields change
  - Mitigation: this PR restores the generated Swift artifacts and keeps the existing `protocol:check` gate as the guardrail
