### PR TITLE
fix: 4 bug fixes for feishu, health, models, and skills

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,4 +1,5 @@
 import {
+  buildChannelConfigSchema,
   collectAllowlistProviderRestrictSendersWarnings,
   formatAllowFromLowercase,
   mapAllowFromEntries,
@@ -17,6 +18,7 @@ import {
   listFeishuAccountIds,
   resolveDefaultFeishuAccountId,
 } from "./accounts.js";
+import { FeishuConfigSchema } from "./config-schema.js";
 import {
   listFeishuDirectoryPeers,
   listFeishuDirectoryGroups,
@@ -41,22 +43,6 @@ const meta: ChannelMeta = {
   aliases: ["lark"],
   order: 70,
 };
-
-const secretInputJsonSchema = {
-  oneOf: [
-    { type: "string" },
-    {
-      type: "object",
-      additionalProperties: false,
-      required: ["source", "provider", "id"],
-      properties: {
-        source: { type: "string", enum: ["env", "file", "exec"] },
-        provider: { type: "string", minLength: 1 },
-        id: { type: "string", minLength: 1 },
-      },
-    },
-  ],
-} as const;
 
 function setFeishuNamedAccountEnabled(
   cfg: ClawdbotConfig,
@@ -120,69 +106,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
     stripPatterns: () => ['<at user_id="[^"]*">[^<]*</at>'],
   },
   reload: { configPrefixes: ["channels.feishu"] },
-  configSchema: {
-    schema: {
-      type: "object",
-      additionalProperties: false,
-      properties: {
-        enabled: { type: "boolean" },
-        defaultAccount: { type: "string" },
-        appId: { type: "string" },
-        appSecret: secretInputJsonSchema,
-        encryptKey: secretInputJsonSchema,
-        verificationToken: secretInputJsonSchema,
-        domain: {
-          oneOf: [
-            { type: "string", enum: ["feishu", "lark"] },
-            { type: "string", format: "uri", pattern: "^https://" },
-          ],
-        },
-        connectionMode: { type: "string", enum: ["websocket", "webhook"] },
-        webhookPath: { type: "string" },
-        webhookHost: { type: "string" },
-        webhookPort: { type: "integer", minimum: 1 },
-        dmPolicy: { type: "string", enum: ["open", "pairing", "allowlist"] },
-        allowFrom: { type: "array", items: { oneOf: [{ type: "string" }, { type: "number" }] } },
-        groupPolicy: { type: "string", enum: ["open", "allowlist", "disabled"] },
-        groupAllowFrom: {
-          type: "array",
-          items: { oneOf: [{ type: "string" }, { type: "number" }] },
-        },
-        requireMention: { type: "boolean" },
-        groupSessionScope: {
-          type: "string",
-          enum: ["group", "group_sender", "group_topic", "group_topic_sender"],
-        },
-        topicSessionMode: { type: "string", enum: ["disabled", "enabled"] },
-        replyInThread: { type: "string", enum: ["disabled", "enabled"] },
-        historyLimit: { type: "integer", minimum: 0 },
-        dmHistoryLimit: { type: "integer", minimum: 0 },
-        textChunkLimit: { type: "integer", minimum: 1 },
-        chunkMode: { type: "string", enum: ["length", "newline"] },
-        mediaMaxMb: { type: "number", minimum: 0 },
-        renderMode: { type: "string", enum: ["auto", "raw", "card"] },
-        accounts: {
-          type: "object",
-          additionalProperties: {
-            type: "object",
-            properties: {
-              enabled: { type: "boolean" },
-              name: { type: "string" },
-              appId: { type: "string" },
-              appSecret: secretInputJsonSchema,
-              encryptKey: secretInputJsonSchema,
-              verificationToken: secretInputJsonSchema,
-              domain: { type: "string", enum: ["feishu", "lark"] },
-              connectionMode: { type: "string", enum: ["websocket", "webhook"] },
-              webhookHost: { type: "string" },
-              webhookPath: { type: "string" },
-              webhookPort: { type: "integer", minimum: 1 },
-            },
-          },
-        },
-      },
-    },
-  },
+  configSchema: buildChannelConfigSchema(FeishuConfigSchema),
   config: {
     listAccountIds: (cfg) => listFeishuAccountIds(cfg),
     resolveAccount: (cfg, accountId) => resolveFeishuAccount({ cfg, accountId }),

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -91,12 +91,7 @@ export function normalizeProviderId(provider: string): string {
   if (normalized === "bytedance" || normalized === "doubao") {
     return "volcengine";
   }
-  return normalized;
-}
-
-/** Normalize provider ID for auth lookup. Coding-plan variants share auth with base. */
-export function normalizeProviderIdForAuth(provider: string): string {
-  const normalized = normalizeProviderId(provider);
+  // Coding-plan variants share model catalog with base provider.
   if (normalized === "volcengine-plan") {
     return "volcengine";
   }
@@ -104,6 +99,11 @@ export function normalizeProviderIdForAuth(provider: string): string {
     return "byteplus";
   }
   return normalized;
+}
+
+/** Normalize provider ID for auth lookup. Coding-plan variants share auth with base. */
+export function normalizeProviderIdForAuth(provider: string): string {
+  return normalizeProviderId(provider);
 }
 
 export function findNormalizedProviderValue<T>(

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -211,6 +211,15 @@ function resolveContainedSkillPath(params: {
   if (isPathInside(params.rootRealPath, candidateRealPath)) {
     return candidateRealPath;
   }
+  if (isPathInside(params.rootDir, path.resolve(params.candidatePath))) {
+    skillsLogger.warn("Skill path resolves outside root via symlink; using original path.", {
+      source: params.source,
+      rootDir: params.rootDir,
+      path: path.resolve(params.candidatePath),
+      realPath: candidateRealPath,
+    });
+    return path.resolve(params.candidatePath);
+  }
   warnEscapedSkillPath({
     source: params.source,
     rootDir: params.rootDir,

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -350,7 +350,8 @@ export async function getHealthSnapshot(params?: {
   probe?: boolean;
 }): Promise<HealthSummary> {
   const timeoutMs = params?.timeoutMs;
-  const cfg = loadConfig();
+  const rawCfg = await readBestEffortConfig();
+  const cfg = rawCfg ?? loadConfig();
   const { defaultAgentId, ordered } = resolveAgentOrder(cfg);
   const channelBindings = buildChannelAccountBindings(cfg);
   const sessionCache = new Map<string, HealthSummary["sessions"]>();


### PR DESCRIPTION
## Summary

4 bug fixes addressing stability issues in OpenClaw 2026.4.9.

### 1. fix(feishu): use buildChannelConfigSchema instead of hand-written JSON Schema
- **Problem**: Hand-written JSON Schema only listed 11 properties for accounts, while the Zod schema defines 36+ properties. This caused `must NOT have additional properties` errors when valid config keys like `dmPolicy`, `allowFrom`, etc. were present.
- **Fix**: Switch to `buildChannelConfigSchema(FeishuConfigSchema)` to auto-generate the JSON Schema from the Zod schema, keeping them in sync. This matches the pattern used by all other channel plugins.

### 2. fix(health): use readBestEffortConfig for fresh config in getHealthSnapshot
- **Problem**: `getHealthSnapshot()` used `loadConfig()` which returns a stale `runtimeConfigSnapshot` in the gateway process. This caused health checks to show channels as "not configured" even when the config file had been updated.
- **Fix**: Read directly from file via `await readBestEffortConfig()` with `loadConfig()` as fallback.

### 3. fix(models): normalize volcengine-plan and byteplus-plan in normalizeProviderId
- **Problem**: `normalizeProviderId()` did not normalize `volcengine-plan` to `volcengine` or `byteplus-plan` to `byteplus`, causing `contextWindow` lookups to fail for coding-plan providers.
- **Fix**: Add the normalization mappings to `normalizeProviderId()` and simplify `normalizeProviderIdForAuth()` to delegate to it.

### 4. fix(skills): use original path for symlinked skills instead of skipping
- **Problem**: `resolveContainedSkillPath()` skipped skills when their realpath resolved outside the configured root (e.g. pnpm symlinks, macOS `/var` -> `/private/var`).
- **Fix**: Fall back to the original (unresolved) path when it is inside the root, logging a warning instead of skipping entirely.

## Test plan
- [x] `pnpm build` passes (only pre-existing `global-singleton.ts` error)
- [x] `normalizeProviderId` tests pass
- [x] `normalizeProviderIdForAuth` tests pass
- [x] `context.lookup` tests pass
- [x] `ir.blockquote-spacing` tests pass
