### PR TITLE
fix: resolve qa-lab type-aware linting

### DIFF
--- a/extensions/qa-lab/src/bus-state.ts
+++ b/extensions/qa-lab/src/bus-state.ts
@@ -31,12 +31,38 @@ const DEFAULT_BOT_ID = "openclaw";
 const DEFAULT_BOT_NAME = "OpenClaw QA";
 
 type QaBusEventSeed =
-  | Omit<Extract<QaBusEvent, { kind: "inbound-message" }>, "cursor">
-  | Omit<Extract<QaBusEvent, { kind: "outbound-message" }>, "cursor">
-  | Omit<Extract<QaBusEvent, { kind: "thread-created" }>, "cursor">
-  | Omit<Extract<QaBusEvent, { kind: "message-edited" }>, "cursor">
-  | Omit<Extract<QaBusEvent, { kind: "message-deleted" }>, "cursor">
-  | Omit<Extract<QaBusEvent, { kind: "reaction-added" }>, "cursor">;
+  | {
+      kind: "inbound-message";
+      accountId: string;
+      message: QaBusMessage;
+    }
+  | {
+      kind: "outbound-message";
+      accountId: string;
+      message: QaBusMessage;
+    }
+  | {
+      kind: "thread-created";
+      accountId: string;
+      thread: QaBusThread;
+    }
+  | {
+      kind: "message-edited";
+      accountId: string;
+      message: QaBusMessage;
+    }
+  | {
+      kind: "message-deleted";
+      accountId: string;
+      message: QaBusMessage;
+    }
+  | {
+      kind: "reaction-added";
+      accountId: string;
+      message: QaBusMessage;
+      emoji: string;
+      senderId: string;
+    };
 
 export function createQaBusState() {
   const conversations = new Map<string, QaBusConversation>();

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -47,6 +47,14 @@
         "../dist/plugin-sdk/src/plugin-sdk/secret-ref-runtime.d.ts"
       ],
       "openclaw/plugin-sdk/ssrf-runtime": ["../dist/plugin-sdk/src/plugin-sdk/ssrf-runtime.d.ts"],
+      "@openclaw/qa-channel/*.js": [
+        "../dist/plugin-sdk/extensions/qa-channel/*.d.ts",
+        "../extensions/qa-channel/*"
+      ],
+      "@openclaw/qa-channel/*": [
+        "../dist/plugin-sdk/extensions/qa-channel/*.d.ts",
+        "../extensions/qa-channel/*"
+      ],
       "@openclaw/*.js": ["../packages/plugin-sdk/dist/extensions/*.d.ts", "../extensions/*"],
       "@openclaw/*": ["../packages/plugin-sdk/dist/extensions/*", "../extensions/*"],
       "@openclaw/plugin-sdk/*": ["../dist/plugin-sdk/src/plugin-sdk/*.d.ts"]


### PR DESCRIPTION
## Summary

- Problem: `pnpm check` failed in `qa-lab` because the QA bus event seed union triggered duplicate-constituent lint errors and the bundled-extension package-boundary paths could not resolve the nested `@openclaw/qa-channel/api.js` types referenced by the generated plugin-sdk facade.
- Why it matters: unrelated PR prep and landing work was blocked on a baseline-red repo gate.
- What changed: made `QaBusEventSeed` explicit in `extensions/qa-lab/src/bus-state.ts` and added narrow `@openclaw/qa-channel/*` path mappings in `extensions/tsconfig.package-boundary.paths.json` so bundled extensions can resolve the generated qa-channel declaration subpath.
- What did NOT change (scope boundary): no runtime behavior, API contract, or QA scenario flow was changed beyond the typing/linting surface.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/qa-lab/src/bus-state.ts` used an `Omit<Extract<...>>` union that collapsed into duplicate constituents under type-aware oxlint, and bundled-extension package-boundary paths did not cover nested `@openclaw/qa-channel/*` subpaths used by the generated `openclaw/plugin-sdk/qa-channel` declarations.
- Missing detection / guardrail: the repo gate surfaced the problem, but the path mapping gap made the type failures look like unrelated `any`-type fallout inside `qa-lab` instead of a resolver issue.
- Contributing context (if known): these failures started surfacing after bundled extension linting began covering the QA lab surfaces.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `extensions/qa-lab/src/bus-state.ts`, `extensions/tsconfig.package-boundary.paths.json`, and the existing `pnpm check` gate.
- Scenario the test should lock in: type-aware linting and package-boundary type resolution for `qa-lab` stay green when consuming QA channel plugin-sdk types.
- Why this is the smallest reliable guardrail: this regression is in lint/type resolution, so the reliable guardrail is the existing type-aware lint/typecheck gate rather than a new runtime assertion.
- Existing test that already covers this (if any): `OPENCLAW_LOCAL_CHECK=0 pnpm check` and `OPENCLAW_LOCAL_CHECK=0 pnpm test extensions/qa-lab/src/bus-state.test.ts`.
- If no new test is added, why not: runtime behavior was unchanged; the failure mode is static analysis, and the existing repo gate is the correct detector.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): QA Channel / qa-lab
- Relevant config (redacted): `OPENCLAW_LOCAL_CHECK=0` for verification to avoid an unrelated local heavy-check lock

### Steps

1. Run `pnpm exec oxlint --type-aware --tsconfig tsconfig.oxlint.json extensions/qa-lab/src/bus-waiters.ts extensions/qa-lab/src/bus-state.ts extensions/qa-lab/src/runtime-api.ts`.
2. Run `pnpm exec tsc -p extensions/qa-lab/tsconfig.json --noEmit`.
3. Run `OPENCLAW_LOCAL_CHECK=0 pnpm check` and `OPENCLAW_LOCAL_CHECK=0 pnpm test extensions/qa-lab/src/bus-state.test.ts`.

### Expected

- The QA-lab lint/type failures are gone and the repo gate is green.

### Actual

- All listed verification commands passed locally.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted type-aware oxlint for the affected QA-lab files, package-local `tsc --noEmit`, full `pnpm check`, and `extensions/qa-lab/src/bus-state.test.ts`.
- Edge cases checked: resolver coverage for nested `@openclaw/qa-channel/*` declarations and discriminated event seed variants for every QA bus event kind.
- What you did **not** verify: broader QA-lab test files beyond the focused bus-state test.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the package-boundary path mapping is narrowly tailored to `qa-channel` and could miss other nested bundled-extension subpaths in the future.
  - Mitigation: keep the mapping scoped for this fix and rely on the existing repo gate to surface any other unresolved nested subpaths.
