### PR TITLE
Prompt: relax skill selection gating

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -446,7 +446,13 @@ describe("buildAgentSystemPrompt", () => {
       "For long waits, avoid rapid poll loops: use Exec with enough yieldMs or process(action=poll, timeout=<ms>).",
     );
     expect(prompt).toContain(
-      "- If exactly one skill clearly applies: read its SKILL.md at <location> with `Read`, then follow it.",
+      "- If one skill is the obvious best fit: read its SKILL.md at <location> with `Read`, then follow it.",
+    );
+    expect(prompt).toContain(
+      "- If the task could reasonably match a small number of skills: read the 1-3 most likely candidates, pick the best fit, and follow only the relevant guidance.",
+    );
+    expect(prompt).toContain(
+      "- Match by the user's desired outcome and constraints, not exact skill names. Users often describe the job without naming the skill.",
     );
     expect(prompt).toContain("OpenClaw docs: /tmp/openclaw/docs");
     expect(prompt).toContain(
@@ -601,8 +607,9 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("## Skills");
     expect(prompt).toContain(
-      "- If exactly one skill clearly applies: read its SKILL.md at <location> with `read`, then follow it.",
+      "- If one skill is the obvious best fit: read its SKILL.md at <location> with `read`, then follow it.",
     );
+    expect(prompt).toContain("do not read unrelated skills or the whole catalog up front.");
   });
 
   it("appends available skills when provided", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -115,11 +115,12 @@ function buildSkillsSection(params: { skillsPrompt?: string; readToolName: strin
   }
   return [
     "## Skills (mandatory)",
-    "Before replying: scan <available_skills> <description> entries.",
-    `- If exactly one skill clearly applies: read its SKILL.md at <location> with \`${params.readToolName}\`, then follow it.`,
-    "- If multiple could apply: choose the most specific one, then read/follow it.",
-    "- If none clearly apply: do not read any SKILL.md.",
-    "Constraints: never read more than one skill up front; only read after selecting.",
+    "Before replying: scan <available_skills> <description> entries for likely matches.",
+    `- If one skill is the obvious best fit: read its SKILL.md at <location> with \`${params.readToolName}\`, then follow it.`,
+    "- If the task could reasonably match a small number of skills: read the 1-3 most likely candidates, pick the best fit, and follow only the relevant guidance.",
+    "- Match by the user's desired outcome and constraints, not exact skill names. Users often describe the job without naming the skill.",
+    "- If no skill still looks relevant after scanning descriptions, do not read any SKILL.md.",
+    "Constraints: keep skill reads targeted; do not read unrelated skills or the whole catalog up front.",
     "- When a skill drives external API writes, assume rate limits: prefer fewer larger writes, avoid tight one-item loops, serialize bursts when possible, and respect 429/Retry-After.",
     trimmed,
     "",


### PR DESCRIPTION
## Summary
- relax the built-in skills prompt so the model can infer skill use from user intent instead of needing an exact skill-name match
- allow reading a small number of likely candidate skills when descriptions are ambiguous, while still keeping reads targeted
- update prompt tests to cover the new guidance

## Testing
- `pnpm test -- src/agents/system-prompt.test.ts`

## Notes
- `scripts/committer` could not be used end-to-end in this checkout because the repo-wide pre-commit check hits unrelated missing dependency/typecheck failures outside this change.
