### PR TITLE
fix: read packed refs for git commit metadata

### DIFF
--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -16,6 +16,7 @@ async function makeFakeGitRepo(
   root: string,
   options: {
     head: string;
+    packedRefs?: Record<string, string>;
     refs?: Record<string, string>;
     gitdir?: string;
     commondir?: string;
@@ -30,13 +31,23 @@ async function makeFakeGitRepo(
   }
   await fs.mkdir(gitdir, { recursive: true });
   await fs.writeFile(path.join(gitdir, "HEAD"), options.head, "utf-8");
+  const refsBase = options.commondir ? path.resolve(gitdir, options.commondir) : gitdir;
+  await fs.mkdir(refsBase, { recursive: true });
   if (options.commondir) {
     await fs.writeFile(path.join(gitdir, "commondir"), options.commondir, "utf-8");
   }
   for (const [refPath, commit] of Object.entries(options.refs ?? {})) {
-    const targetPath = path.join(gitdir, refPath);
+    const targetPath = path.join(refsBase, refPath);
     await fs.mkdir(path.dirname(targetPath), { recursive: true });
     await fs.writeFile(targetPath, `${commit}\n`, "utf-8");
+  }
+  const packedRefsEntries = Object.entries(options.packedRefs ?? {});
+  if (packedRefsEntries.length > 0) {
+    const packedRefsContents = [
+      "# pack-refs with: peeled fully-peeled sorted",
+      ...packedRefsEntries.map(([refPath, commit]) => `${commit} ${refPath}`),
+    ].join("\n");
+    await fs.writeFile(path.join(refsBase, "packed-refs"), `${packedRefsContents}\n`, "utf-8");
   }
 }
 
@@ -229,6 +240,24 @@ describe("git commit resolution", () => {
     expect(resolveCommitHash({ cwd: repoA, env: {} })).toBe("0123456");
     expect(resolveCommitHash({ cwd: repoB, env: {} })).toBe("89abcde");
     expect(resolveCommitHash({ cwd: repoA, env: {} })).toBe("0123456");
+  });
+
+  it("reads packed refs from the common git dir for worktree-style checkouts", async () => {
+    const temp = await makeTempDir("git-commit-packed-refs");
+    const checkoutRoot = path.join(temp, "checkout");
+    const commonGitDir = path.join(temp, "git-common");
+    const worktreeGitDir = path.join(commonGitDir, "worktrees", "checkout");
+
+    await makeFakeGitRepo(checkoutRoot, {
+      gitdir: worktreeGitDir,
+      commondir: "../..",
+      head: "ref: refs/heads/main\n",
+      packedRefs: {
+        "refs/heads/main": "0123456789abcdef0123456789abcdef01234567",
+      },
+    });
+
+    expect(resolveCommitHash({ cwd: checkoutRoot, env: {} })).toBe("0123456");
   });
 
   it("caches deterministic null results per resolved search directory", async () => {

--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -100,12 +100,20 @@ const readCommitFromGit = (
   }
   if (head.startsWith("ref:")) {
     const ref = head.replace(/^ref:\s*/i, "").trim();
-    const refPath = resolveRefPath(headPath, ref);
+    const refsBase = resolveGitRefsBase(headPath);
+    const refPath = resolveRefPath(refsBase, ref);
     if (!refPath) {
       return null;
     }
-    const refHash = safeReadFilePrefix(refPath).trim();
-    return formatCommit(refHash);
+    try {
+      const refHash = safeReadFilePrefix(refPath).trim();
+      return formatCommit(refHash);
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
+      }
+    }
+    return readCommitFromPackedRefs(refsBase, ref);
   }
   return formatCommit(head);
 };
@@ -126,8 +134,29 @@ const resolveGitRefsBase = (headPath: string) => {
   return gitDir;
 };
 
+const readCommitFromPackedRefs = (refsBase: string, ref: string) => {
+  try {
+    const packedRefs = fs.readFileSync(path.join(refsBase, "packed-refs"), "utf-8");
+    for (const line of packedRefs.split("\n")) {
+      if (!line || line.startsWith("#") || line.startsWith("^")) {
+        continue;
+      }
+      const [commit, packedRef] = line.trim().split(/\s+/, 2);
+      if (packedRef === ref) {
+        return formatCommit(commit);
+      }
+    }
+    return null;
+  } catch (error) {
+    if (!isMissingPathError(error)) {
+      throw error;
+    }
+    return null;
+  }
+};
+
 /** Safely resolve a git ref path, rejecting traversal attacks from a crafted HEAD file. */
-const resolveRefPath = (headPath: string, ref: string) => {
+const resolveRefPath = (refsBase: string, ref: string) => {
   if (!ref.startsWith("refs/")) {
     return null;
   }
@@ -137,7 +166,6 @@ const resolveRefPath = (headPath: string, ref: string) => {
   if (ref.split(/[/]/).includes("..")) {
     return null;
   }
-  const refsBase = resolveGitRefsBase(headPath);
   const resolved = path.resolve(refsBase, ref);
   const rel = path.relative(refsBase, resolved);
   if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) {


### PR DESCRIPTION
## Summary

- Problem: `src/infra/git-commit.ts` only resolved loose git ref files, so commit metadata lookup could return `null` or baked metadata when `HEAD` pointed at a branch stored only in `.git/packed-refs`.
- Why it matters: this repo uses worktrees and packed refs regularly, and the CLI/version metadata path should still resolve live git commit information in those checkouts.
- What changed: added a packed-refs fallback in the common git dir and added a deterministic worktree-style regression test in `src/infra/git-commit.test.ts`.
- What did NOT change (scope boundary): no CLI output format changes, no git root discovery refactor, and no broader lint/type cleanup outside this focused fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: commit resolution followed `HEAD -> refs/...` by opening only the loose ref path, but Git can store branch refs exclusively in `.git/packed-refs`, especially in worktree-heavy repos.
- Missing detection / guardrail: the existing tests did not include a synthetic worktree checkout whose branch ref existed only in `packed-refs`.
- Contributing context (if known): detached `origin/main` checkouts can pass because `HEAD` contains a direct commit SHA, so the blind spot only shows up in branch-based checkout states.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/git-commit.test.ts`
- Scenario the test should lock in: a worktree-style checkout with `commondir` set and a branch ref present only in `packed-refs` still resolves live commit metadata.
- Why this is the smallest reliable guardrail: it exercises the exact ref-resolution seam without depending on the host repository's current ref storage layout.
- Existing test that already covers this (if any): none deterministically covered the packed-ref-only branch case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
HEAD -> refs/heads/main -> loose ref missing -> null or baked metadata fallback

After:
HEAD -> refs/heads/main -> loose ref missing -> packed-refs lookup -> live commit hash
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.17.0, pnpm 10.32.1
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): checkout state where `HEAD` points at a branch ref stored only in `.git/packed-refs`

### Steps

1. Use a checkout or worktree where `HEAD` is `ref: refs/heads/<branch>` and that branch exists only in `packed-refs`.
2. Run `pnpm test -- src/infra/git-commit.test.ts`.
3. Run `pnpm build`.

### Expected

- `resolveCommitHash()` returns the live git commit instead of `null` or baked build/package metadata.
- The targeted regression test passes.
- Build stays green.

### Actual

- Before this change, packed-ref-only branch states could fail to resolve the live commit hash.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted `src/infra/git-commit.test.ts` passes with the new synthetic packed-ref worktree case; `pnpm build` passes after the fix.
- Edge cases checked: detached `origin/main` still passes; branch/worktree lookup still uses the common git dir; loose refs continue to work unchanged.
- What you did **not** verify: full `pnpm check` remains red on unrelated existing `origin/main` lint/type issues under `extensions/*`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: parsing `packed-refs` could accidentally match the wrong ref if lookup were fuzzy.
  - Mitigation: the implementation only accepts exact ref matches after the existing `refs/` path validation.
