### PR TITLE
fix(slack): defer token resolution on plugin register path

### DIFF
--- a/extensions/slack/src/http/plugin-routes.test.ts
+++ b/extensions/slack/src/http/plugin-routes.test.ts
@@ -1,0 +1,103 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import { describe, expect, it, vi } from "vitest";
+import { registerSlackPluginHttpRoutes } from "./plugin-routes.js";
+
+type RegisterHttpRouteCall = Parameters<OpenClawPluginApi["registerHttpRoute"]>[0];
+
+function makeMockApi(cfg: Record<string, unknown>): {
+  api: OpenClawPluginApi;
+  registerHttpRoute: ReturnType<typeof vi.fn<[RegisterHttpRouteCall], void>>;
+} {
+  const registerHttpRoute = vi.fn<[RegisterHttpRouteCall], void>();
+  const api = {
+    config: cfg,
+    registerHttpRoute,
+  } as unknown as OpenClawPluginApi;
+  return { api, registerHttpRoute };
+}
+
+describe("registerSlackPluginHttpRoutes (#63937)", () => {
+  it("registers the default webhook path when slack config is absent", () => {
+    const { api, registerHttpRoute } = makeMockApi({});
+
+    expect(() => registerSlackPluginHttpRoutes(api)).not.toThrow();
+    expect(registerHttpRoute).toHaveBeenCalledTimes(1);
+    expect(registerHttpRoute.mock.calls[0]?.[0]).toMatchObject({
+      path: "/slack/events",
+      auth: "plugin",
+    });
+  });
+
+  it("does not resolve SecretRef tokens at register time (#63937)", () => {
+    // Regression: previously `registerSlackPluginHttpRoutes` called
+    // `resolveSlackAccount`, which eagerly ran `resolveSlackBotToken`
+    // on the merged config. When `botToken` is a `SecretRef` object
+    // (e.g. `file:local:/SLACK_BOT_TOKEN`) and the caller is the CLI
+    // (no gateway runtime snapshot), that threw "unresolved SecretRef"
+    // and crashed every `openclaw agents` subcommand. The fix swaps
+    // to the token-free `mergeSlackAccountConfig` helper.
+    const { api, registerHttpRoute } = makeMockApi({
+      channels: {
+        slack: {
+          accounts: {
+            default: {
+              botToken: {
+                source: "file",
+                provider: "local",
+                id: "/SLACK_BOT_TOKEN",
+              },
+              appToken: {
+                source: "file",
+                provider: "local",
+                id: "/SLACK_APP_TOKEN",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(() => registerSlackPluginHttpRoutes(api)).not.toThrow();
+    expect(registerHttpRoute).toHaveBeenCalled();
+    expect(registerHttpRoute.mock.calls[0]?.[0]?.path).toBe("/slack/events");
+  });
+
+  it("registers a custom webhookPath from config without touching tokens", () => {
+    const { api, registerHttpRoute } = makeMockApi({
+      channels: {
+        slack: {
+          accounts: {
+            default: {
+              webhookPath: "/hooks/slack",
+              botToken: {
+                source: "file",
+                provider: "local",
+                id: "/SLACK_BOT_TOKEN",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(() => registerSlackPluginHttpRoutes(api)).not.toThrow();
+    const paths = registerHttpRoute.mock.calls.map((call) => call[0]?.path);
+    expect(paths).toContain("/hooks/slack");
+  });
+
+  it("deduplicates webhook paths across multiple accounts with the same path", () => {
+    const { api, registerHttpRoute } = makeMockApi({
+      channels: {
+        slack: {
+          accounts: {
+            default: { webhookPath: "/slack/events" },
+            secondary: { webhookPath: "/slack/events" },
+          },
+        },
+      },
+    });
+
+    expect(() => registerSlackPluginHttpRoutes(api)).not.toThrow();
+    expect(registerHttpRoute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/slack/src/http/plugin-routes.ts
+++ b/extensions/slack/src/http/plugin-routes.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
-import { listSlackAccountIds, resolveSlackAccount } from "../accounts.js";
+import { listSlackAccountIds, mergeSlackAccountConfig } from "../accounts.js";
 import { normalizeSlackWebhookPath } from "./paths.js";
 
 let slackHttpHandlerRuntimePromise: Promise<typeof import("./handler.runtime.js")> | null = null;
@@ -13,9 +13,18 @@ async function loadSlackHttpHandlerRuntime() {
 export function registerSlackPluginHttpRoutes(api: OpenClawPluginApi): void {
   const accountIds = new Set<string>([DEFAULT_ACCOUNT_ID, ...listSlackAccountIds(api.config)]);
   const registeredPaths = new Set<string>();
-  for (const accountId of accountIds) {
-    const account = resolveSlackAccount({ cfg: api.config, accountId });
-    registeredPaths.add(normalizeSlackWebhookPath(account.config.webhookPath));
+  for (const rawAccountId of accountIds) {
+    // Use mergeSlackAccountConfig (the token-free surface) instead of
+    // resolveSlackAccount here. The register path only needs `webhookPath`
+    // to register an HTTP route — it has no business resolving bot/app/user
+    // tokens, and doing so crashes the CLI when tokens are stored as
+    // SecretRef objects because the CLI has no gateway runtime snapshot to
+    // resolve secrets against. Token resolution still happens at request
+    // time inside handleSlackHttpRequest, which runs under the gateway
+    // runtime where secrets are resolvable (#63937).
+    const accountId = normalizeAccountId(rawAccountId);
+    const merged = mergeSlackAccountConfig(api.config, accountId);
+    registeredPaths.add(normalizeSlackWebhookPath(merged.webhookPath));
   }
   if (registeredPaths.size === 0) {
     registeredPaths.add(normalizeSlackWebhookPath());


### PR DESCRIPTION
## Summary

`registerSlackPluginHttpRoutes()` in `extensions/slack/src/http/plugin-routes.ts` used to call `resolveSlackAccount()` on every configured account for the sole purpose of reading `config.webhookPath`. `resolveSlackAccount()` eagerly runs `resolveSlackBotToken/AppToken/UserToken` on the merged config (`extensions/slack/src/accounts.ts:61-72`). When any of those tokens are stored as a `SecretRef` object — the default for `file:local`-provided secrets — token resolution throws \`\"unresolved SecretRef\"\` and crashes the register path.

The CLI runs plugin registration with `throwOnLoadError: true`, so every `openclaw agents ...` subcommand (which forces `loadPlugins: \"always\"`) fails with a fatal `PluginLoadFailureError` before any agent command can execute. The running gateway process is unaffected because it holds a resolved in-memory runtime snapshot, but the CLI is a separate process that reads raw `openclaw.json` and has no access to that snapshot.

Fixes #63937

## Reproducer (from the issue)

```json
{
  \"channels\": {
    \"slack\": {
      \"accounts\": {
        \"default\": {
          \"botToken\": { \"source\": \"file\", \"provider\": \"local\", \"id\": \"/SLACK_BOT_TOKEN\" },
          \"appToken\": { \"source\": \"file\", \"provider\": \"local\", \"id\": \"/SLACK_APP_TOKEN\" }
        }
      }
    }
  }
}
```

```
$ openclaw agents list
[plugins] slack failed during register from .../extensions/slack/index.js:
  Error: channels.slack.accounts.default.botToken: unresolved SecretRef \"file:local:/SLACK_BOT_TOKEN\".
  Resolve this command against an active gateway runtime snapshot before reading it.

[openclaw] Failed to start CLI: PluginLoadFailureError: plugin load failed: slack: ...
```

Every workaround the reporter tried fails:
- `SLACK_BOT_TOKEN` env var → `accounts.js` evaluates the `SecretRef` from config before the env fallback
- `channels.slack.enabled: false` → `registerSlackPluginHttpRoutes` iterates `DEFAULT_ACCOUNT_ID` unconditionally
- Removing `\"slack\"` from `plugins.allow` → also triggered by the `channels.slack` config block
- `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` → invalidates the entire config

## Fix

Swap `resolveSlackAccount(...).config.webhookPath` for `mergeSlackAccountConfig(...).webhookPath`. `mergeSlackAccountConfig()` is the already-exported token-free surface — it's what `resolveSlackAccount()` itself calls internally (`accounts.ts:54`), without the subsequent token-resolution steps.

The merge helper is already used idiomatically throughout the Slack extension for exactly this pattern:
- `extensions/slack/src/group-policy.ts:23`
- `extensions/slack/src/directory-config.ts:15`
- `extensions/slack/src/account-inspect.ts:77`

Token resolution continues to happen at request time inside `handleSlackHttpRequest`, which runs under the gateway runtime where secrets are resolvable. No change to the request path, no change to token storage, no change to the outbound send path.

### Diff sketch

\`\`\`diff
- import { DEFAULT_ACCOUNT_ID } from \"openclaw/plugin-sdk/account-id\";
+ import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from \"openclaw/plugin-sdk/account-id\";
  import type { OpenClawPluginApi } from \"openclaw/plugin-sdk/core\";
- import { listSlackAccountIds, resolveSlackAccount } from \"../accounts.js\";
+ import { listSlackAccountIds, mergeSlackAccountConfig } from \"../accounts.js\";
  ...
  export function registerSlackPluginHttpRoutes(api: OpenClawPluginApi): void {
    const accountIds = new Set<string>([DEFAULT_ACCOUNT_ID, ...listSlackAccountIds(api.config)]);
    const registeredPaths = new Set<string>();
-   for (const accountId of accountIds) {
-     const account = resolveSlackAccount({ cfg: api.config, accountId });
-     registeredPaths.add(normalizeSlackWebhookPath(account.config.webhookPath));
+   for (const rawAccountId of accountIds) {
+     const accountId = normalizeAccountId(rawAccountId);
+     const merged = mergeSlackAccountConfig(api.config, accountId);
+     registeredPaths.add(normalizeSlackWebhookPath(merged.webhookPath));
    }
\`\`\`

The explicit `normalizeAccountId` call preserves the normalization that `resolveSlackAccount` used to apply internally (`accounts.ts:50-52`).

## Tests

Added `extensions/slack/src/http/plugin-routes.test.ts` with 4 regression cases:

1. **Empty config** still registers the default `/slack/events` path (smoke test)
2. **SecretRef tokens in config** do NOT throw during registration (the #63937 regression guard — would fail on main before this patch)
3. **Custom webhookPath** from config is honored without touching tokens
4. **Duplicate paths across accounts** are deduplicated

All tests use a plain mock `OpenClawPluginApi` with `registerHttpRoute: vi.fn()`, no real gateway runtime needed. Validates that register-time token resolution is gone.

## Scope

- **Files**: `extensions/slack/src/http/plugin-routes.ts` (-3 +8), `extensions/slack/src/http/plugin-routes.test.ts` (+103)
- **Production LOC**: ~5 real lines changed
- **No changes** to `accounts.ts`, `token.js`, request path, send path, or any upstream config schema
- **oxlint clean**

cc @Takhoffman — Slack channel ownership. Credit to @oliviercp for the complete call-chain RCA in #63937.