### PR TITLE
fix(msteams): handle fileConsent/invoke callback for bot-to-user file upload (#55386)

### DIFF
--- a/extensions/msteams/src/file-consent-helpers.ts
+++ b/extensions/msteams/src/file-consent-helpers.ts
@@ -11,6 +11,7 @@
 
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
 import { buildFileConsentCard } from "./file-consent.js";
+import { getDefaultPendingUploadFsStore, type PendingUploadFsStore } from "./pending-uploads-fs.js";
 import { storePendingUpload } from "./pending-uploads.js";
 
 export type FileConsentMedia = {
@@ -24,9 +25,31 @@ export type FileConsentActivityResult = {
   uploadId: string;
 };
 
+function buildConsentActivity(params: {
+  filename: string;
+  sizeInBytes: number;
+  description?: string;
+  uploadId: string;
+}): Record<string, unknown> {
+  const consentCard = buildFileConsentCard({
+    filename: params.filename,
+    description: params.description || `File: ${params.filename}`,
+    sizeInBytes: params.sizeInBytes,
+    context: { uploadId: params.uploadId },
+  });
+  return {
+    type: "message",
+    attachments: [consentCard],
+  };
+}
+
 /**
  * Prepare a FileConsentCard activity for large files or non-images in personal chats.
- * Returns the activity object and uploadId - caller is responsible for sending.
+ * Stores the pending upload in the in-process memory store so the in-process
+ * webhook handler can honor the consent callback. Use
+ * `prepareFileConsentActivityFs` for cross-process sends (e.g. the CLI
+ * `message send --media` path) where the invoke webhook lands in a different
+ * process than the sender.
  */
 export function prepareFileConsentActivity(params: {
   media: FileConsentMedia;
@@ -42,17 +65,52 @@ export function prepareFileConsentActivity(params: {
     conversationId,
   });
 
-  const consentCard = buildFileConsentCard({
+  const activity = buildConsentActivity({
     filename: media.filename,
-    description: description || `File: ${media.filename}`,
     sizeInBytes: media.buffer.length,
-    context: { uploadId },
+    description,
+    uploadId,
   });
 
-  const activity: Record<string, unknown> = {
-    type: "message",
-    attachments: [consentCard],
-  };
+  return { activity, uploadId };
+}
+
+/**
+ * Cross-process variant of `prepareFileConsentActivity` backed by the
+ * filesystem store.
+ *
+ * The `openclaw message send --media` CLI sends the consent card from a
+ * short-lived process, but the `fileConsent/invoke` callback lands on the
+ * long-running monitor webhook — a different process. The in-memory
+ * pending-upload Map used by `prepareFileConsentActivity` is invisible across
+ * processes, so the accept handler has nothing to upload.
+ *
+ * This helper persists the file bytes to the msteams state directory so any
+ * process with access to the state dir can honor the consent callback.
+ */
+export async function prepareFileConsentActivityFs(params: {
+  media: FileConsentMedia;
+  conversationId: string;
+  description?: string;
+  /** Override for tests — defaults to the shared on-disk store. */
+  store?: PendingUploadFsStore;
+}): Promise<FileConsentActivityResult> {
+  const { media, conversationId, description } = params;
+  const store = params.store ?? getDefaultPendingUploadFsStore();
+
+  const uploadId = await store.store({
+    buffer: media.buffer,
+    filename: media.filename,
+    contentType: media.contentType,
+    conversationId,
+  });
+
+  const activity = buildConsentActivity({
+    filename: media.filename,
+    sizeInBytes: media.buffer.length,
+    description,
+    uploadId,
+  });
 
   return { activity, uploadId };
 }

--- a/extensions/msteams/src/monitor-handler.ts
+++ b/extensions/msteams/src/monitor-handler.ts
@@ -10,6 +10,7 @@ import type { MSTeamsAdapter } from "./messenger.js";
 import { resolveMSTeamsSenderAccess } from "./monitor-handler/access.js";
 import { createMSTeamsMessageHandler } from "./monitor-handler/message-handler.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
+import { getDefaultPendingUploadFsStore, type PendingUploadFsStore } from "./pending-uploads-fs.js";
 import { getPendingUpload, removePendingUpload } from "./pending-uploads.js";
 import type { MSTeamsPollStore } from "./polls.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
@@ -48,6 +49,13 @@ export type MSTeamsMessageHandlerDeps = {
   conversationStore: MSTeamsConversationStore;
   pollStore: MSTeamsPollStore;
   log: MSTeamsMonitorLogger;
+  /**
+   * Optional override for the cross-process pending-upload store. Falls back
+   * to the process-wide default (which writes under the msteams state dir).
+   * Tests supply a temp-dir-backed store to avoid touching the real state
+   * dir.
+   */
+  pendingUploadFsStore?: PendingUploadFsStore;
 };
 
 function serializeAdaptiveCardActionValue(value: unknown): string | null {
@@ -110,13 +118,115 @@ async function isFeedbackInvokeAuthorized(
   return true;
 }
 
+/** Source of a resolved pending upload, so we remove from the correct store. */
+type PendingUploadSource = "memory" | "fs";
+type ResolvedPendingUpload = {
+  source: PendingUploadSource;
+  filename: string;
+  contentType?: string;
+  conversationId: string;
+  buffer: Buffer;
+};
+
+/**
+ * Look up a pending upload in both the in-memory store and the FS-backed
+ * store. The FS store is the cross-process fallback used by the CLI
+ * `message send --media` path (see #55386), since that sender runs in a
+ * different process than the monitor webhook handler.
+ *
+ * FS store errors are intentionally swallowed (logged at debug): the FS
+ * store is an opportunistic fallback, and a misconfigured state dir or a
+ * transient read error should never prevent the in-memory fast path or
+ * crash the invoke handler.
+ */
+async function resolvePendingUpload(
+  uploadId: string | undefined,
+  fsStore: PendingUploadFsStore,
+  log: MSTeamsMonitorLogger,
+): Promise<ResolvedPendingUpload | undefined> {
+  if (!uploadId) {
+    return undefined;
+  }
+
+  const memoryHit = getPendingUpload(uploadId);
+  if (memoryHit) {
+    return {
+      source: "memory",
+      filename: memoryHit.filename,
+      contentType: memoryHit.contentType,
+      conversationId: memoryHit.conversationId,
+      buffer: memoryHit.buffer,
+    };
+  }
+
+  try {
+    const fsHit = await fsStore.get(uploadId);
+    if (fsHit) {
+      return {
+        source: "fs",
+        filename: fsHit.entry.filename,
+        contentType: fsHit.entry.contentType,
+        conversationId: fsHit.entry.conversationId,
+        buffer: fsHit.buffer,
+      };
+    }
+  } catch (err) {
+    log.debug?.("fs-backed pending upload lookup failed", {
+      uploadId,
+      error: formatUnknownError(err),
+    });
+  }
+
+  return undefined;
+}
+
+async function removeResolvedPendingUpload(
+  uploadId: string | undefined,
+  source: PendingUploadSource | undefined,
+  fsStore: PendingUploadFsStore,
+  log: MSTeamsMonitorLogger,
+): Promise<void> {
+  if (!uploadId) {
+    return;
+  }
+  const safeFsRemove = async () => {
+    try {
+      await fsStore.remove(uploadId);
+    } catch (err) {
+      log.debug?.("fs-backed pending upload removal failed", {
+        uploadId,
+        error: formatUnknownError(err),
+      });
+    }
+  };
+  if (source === "fs") {
+    await safeFsRemove();
+    return;
+  }
+  if (source === "memory") {
+    removePendingUpload(uploadId);
+    return;
+  }
+  // Source unknown (e.g. decline with no prior lookup) — clear both stores so
+  // no stale entry survives either side.
+  removePendingUpload(uploadId);
+  await safeFsRemove();
+}
+
+export type MSTeamsFileConsentInvokeDeps = {
+  log: MSTeamsMonitorLogger;
+  fsStore?: PendingUploadFsStore;
+};
+
 /**
  * Handle fileConsent/invoke activities for large file uploads.
  */
 async function handleFileConsentInvoke(
   context: MSTeamsTurnContext,
-  log: MSTeamsMonitorLogger,
+  deps: MSTeamsFileConsentInvokeDeps,
 ): Promise<boolean> {
+  const { log } = deps;
+  const fsStore = deps.fsStore ?? getDefaultPendingUploadFsStore();
   const expiredUploadMessage =
     "The file upload request has expired. Please try sending the file again.";
   const activity = context.activity;
@@ -134,7 +244,7 @@ async function handleFileConsentInvoke(
     typeof consentResponse.context?.uploadId === "string"
       ? consentResponse.context.uploadId
       : undefined;
-  const pendingFile = getPendingUpload(uploadId);
+  const pendingFile = await resolvePendingUpload(uploadId, fsStore, log);
   if (pendingFile) {
     const pendingConversationId = normalizeMSTeamsConversationId(pendingFile.conversationId);
     const invokeConversationId = normalizeMSTeamsConversationId(activity.conversation?.id ?? "");
@@ -157,6 +267,7 @@ async function handleFileConsentInvoke(
         uploadId,
         filename: pendingFile.filename,
         size: pendingFile.buffer.length,
+        source: pendingFile.source,
       });
 
       try {
@@ -189,7 +300,7 @@ async function handleFileConsentInvoke(
         log.error("file upload failed", { uploadId, error: formatUnknownError(err) });
         await context.sendActivity("File upload failed. Please try again.");
       } finally {
-        removePendingUpload(uploadId);
+        await removeResolvedPendingUpload(uploadId, pendingFile.source, fsStore, log);
       }
     } else {
       log.debug?.("pending file not found for consent", { uploadId });
@@ -198,7 +309,7 @@ async function handleFileConsentInvoke(
   } else {
     // User declined
     log.debug?.("user declined file consent", { uploadId });
-    removePendingUpload(uploadId);
+    await removeResolvedPendingUpload(uploadId, pendingFile?.source, fsStore, log);
   }
 
   return true;
@@ -398,7 +509,11 @@ export function registerMSTeamsHandlers<T extends MSTeamsActivityHandler>(
 
         try {
           await withRevokedProxyFallback({
-            run: async () => await handleFileConsentInvoke(ctx, deps.log),
+            run: async () =>
+              await handleFileConsentInvoke(ctx, {
+                log: deps.log,
+                fsStore: deps.pendingUploadFsStore,
+              }),
             onRevoked: async () => true,
             onRevokedLog: () => {
               deps.log.debug?.(

--- a/extensions/msteams/src/pending-uploads-fs.test.ts
+++ b/extensions/msteams/src/pending-uploads-fs.test.ts
@@ -1,0 +1,359 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig, PluginRuntime, RuntimeEnv } from "../runtime-api.js";
+import { prepareFileConsentActivityFs } from "./file-consent-helpers.js";
+import {
+  registerMSTeamsHandlers,
+  type MSTeamsActivityHandler,
+  type MSTeamsMessageHandlerDeps,
+} from "./monitor-handler.js";
+import {
+  createActivityHandler,
+  createMSTeamsMessageHandlerDeps,
+} from "./monitor-handler.test-helpers.js";
+import {
+  createPendingUploadFsStore,
+  PENDING_UPLOAD_FS_TTL_MS,
+  type PendingUploadFsStore,
+} from "./pending-uploads-fs.js";
+import { clearPendingUploads } from "./pending-uploads.js";
+import { setMSTeamsRuntime } from "./runtime.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+
+const fileConsentMockState = vi.hoisted(() => ({
+  uploadToConsentUrl: vi.fn(),
+}));
+
+vi.mock("./file-consent.js", async () => {
+  const actual = await vi.importActual<typeof import("./file-consent.js")>("./file-consent.js");
+  return {
+    ...actual,
+    uploadToConsentUrl: fileConsentMockState.uploadToConsentUrl,
+  };
+});
+
+const runtimeStub: PluginRuntime = {
+  logging: {
+    shouldLogVerbose: () => false,
+  },
+  channel: {
+    debounce: {
+      resolveInboundDebounceMs: () => 0,
+      createInboundDebouncer: () => ({
+        enqueue: async () => {},
+      }),
+    },
+  },
+} as unknown as PluginRuntime;
+
+describe("msteams fs-backed pending uploads store", () => {
+  let tmpDir: string;
+  let store: PendingUploadFsStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-pending-"));
+    store = createPendingUploadFsStore({ storeDir: tmpDir });
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("persists the buffer and metadata across separate store handles", async () => {
+    const buffer = Buffer.from("file contents for cross-process lookup");
+    const id = await store.store({
+      buffer,
+      filename: "report.pdf",
+      contentType: "application/pdf",
+      conversationId: "conv-abc",
+    });
+
+    // Build a fresh store that only shares the on-disk directory. This
+    // simulates the CLI sender writing the upload and the gateway monitor
+    // reading it back from a separate process.
+    const reader = createPendingUploadFsStore({ storeDir: tmpDir });
+    const hit = await reader.get(id);
+
+    expect(hit).toBeDefined();
+    expect(hit?.entry.filename).toBe("report.pdf");
+    expect(hit?.entry.contentType).toBe("application/pdf");
+    expect(hit?.entry.conversationId).toBe("conv-abc");
+    expect(hit?.entry.size).toBe(buffer.length);
+    expect(hit?.buffer.equals(buffer)).toBe(true);
+  });
+
+  it("returns undefined for unknown and malformed ids", async () => {
+    expect(await store.get(undefined)).toBeUndefined();
+    expect(await store.get("")).toBeUndefined();
+    expect(await store.get("not-a-uuid")).toBeUndefined();
+    // UUID-shaped but nonexistent
+    expect(await store.get("00000000-0000-4000-8000-000000000000")).toBeUndefined();
+  });
+
+  it("remove deletes both the blob and index row", async () => {
+    const id = await store.store({
+      buffer: Buffer.from("bye"),
+      filename: "bye.txt",
+      conversationId: "conv-1",
+    });
+    expect(await store.count()).toBe(1);
+
+    await store.remove(id);
+    expect(await store.count()).toBe(0);
+    expect(await store.get(id)).toBeUndefined();
+
+    const blobFiles = (await fs.promises.readdir(tmpDir)).filter((f) => f.endsWith(".blob"));
+    expect(blobFiles).toHaveLength(0);
+  });
+
+  it("remove is a no-op for undefined and malformed ids", async () => {
+    await store.store({
+      buffer: Buffer.from("keep me"),
+      filename: "k.txt",
+      conversationId: "conv-1",
+    });
+    await expect(store.remove(undefined)).resolves.toBeUndefined();
+    await expect(store.remove("../etc/passwd")).resolves.toBeUndefined();
+    expect(await store.count()).toBe(1);
+  });
+
+  it("prunes expired entries on read and removes their blob files", async () => {
+    const shortTtl = createPendingUploadFsStore({ storeDir: tmpDir, ttlMs: 10 });
+    const id = await shortTtl.store({
+      buffer: Buffer.from("expires"),
+      filename: "e.txt",
+      conversationId: "conv-1",
+    });
+    // Wait past the TTL without depending on fake timers (FS APIs are real)
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(await shortTtl.get(id)).toBeUndefined();
+    expect(await shortTtl.count()).toBe(0);
+
+    const blobFiles = (await fs.promises.readdir(tmpDir)).filter((f) => f.endsWith(".blob"));
+    expect(blobFiles).toHaveLength(0);
+  });
+
+  it("handles missing blob by dropping the stale index entry", async () => {
+    const id = await store.store({
+      buffer: Buffer.from("orphan test"),
+      filename: "orphan.txt",
+      conversationId: "conv-1",
+    });
+
+    // Simulate a corrupted store: blob gone, index still references the id.
+    await fs.promises.unlink(path.join(tmpDir, `${id}.blob`));
+
+    expect(await store.get(id)).toBeUndefined();
+    expect(await store.count()).toBe(0);
+  });
+
+  it("exposes the shared TTL constant", () => {
+    // Sanity check that the public TTL constant matches the documented 5
+    // minute window. Regressions here would silently change cross-process
+    // expiry behavior.
+    expect(PENDING_UPLOAD_FS_TTL_MS).toBe(5 * 60 * 1000);
+  });
+});
+
+function createDeps(pendingUploadFsStore: PendingUploadFsStore): MSTeamsMessageHandlerDeps {
+  const deps = createMSTeamsMessageHandlerDeps({
+    cfg: {} as OpenClawConfig,
+    runtime: { error: vi.fn() } as unknown as RuntimeEnv,
+  });
+  return { ...deps, pendingUploadFsStore };
+}
+
+function createInvokeContext(params: {
+  conversationId: string;
+  uploadId: string;
+  action: "accept" | "decline";
+}): { context: MSTeamsTurnContext; sendActivity: ReturnType<typeof vi.fn> } {
+  const sendActivity = vi.fn(async () => ({ id: "activity-id" }));
+  const uploadInfo =
+    params.action === "accept"
+      ? {
+          name: "report.pdf",
+          uploadUrl: "https://upload.example.com/put",
+          contentUrl: "https://content.example.com/file",
+          uniqueId: "unique-id",
+          fileType: "pdf",
+        }
+      : undefined;
+  return {
+    context: {
+      activity: {
+        type: "invoke",
+        name: "fileConsent/invoke",
+        conversation: { id: params.conversationId },
+        value: {
+          type: "fileUpload",
+          action: params.action,
+          uploadInfo,
+          context: { uploadId: params.uploadId },
+        },
+      },
+      sendActivity,
+      sendActivities: async () => [],
+    } as unknown as MSTeamsTurnContext,
+    sendActivity,
+  };
+}
+
+describe("msteams file consent handler (cross-process fs fallback)", () => {
+  let tmpDir: string;
+  let fsStore: PendingUploadFsStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "openclaw-msteams-fc-"));
+    fsStore = createPendingUploadFsStore({ storeDir: tmpDir });
+    setMSTeamsRuntime(runtimeStub);
+    clearPendingUploads();
+    fileConsentMockState.uploadToConsentUrl.mockReset();
+    fileConsentMockState.uploadToConsentUrl.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("registers a run wrapper that intercepts fileConsent/invoke activities", () => {
+    const handler = createActivityHandler();
+    const originalRun = handler.run;
+    const wrapped = registerMSTeamsHandlers(handler, createDeps(fsStore));
+    expect(wrapped.run).toBeDefined();
+    // registerMSTeamsHandlers should replace the original run with a wrapper
+    // that knows how to intercept invoke activities.
+    expect(wrapped.run).not.toBe(originalRun);
+  });
+
+  it("uploads when the pending file lives only in the fs store (CLI cross-process path)", async () => {
+    // Simulate the CLI sender process: it writes the pending upload to the
+    // shared fs store and then exits. The monitor never saw an in-memory
+    // storePendingUpload call.
+    const { uploadId } = await prepareFileConsentActivityFs({
+      media: {
+        buffer: Buffer.from("file contents"),
+        filename: "report.pdf",
+        contentType: "application/pdf",
+      },
+      conversationId: "19:victim@thread.v2",
+      store: fsStore,
+    });
+
+    const handler = registerMSTeamsHandlers(
+      createActivityHandler(),
+      createDeps(fsStore),
+    ) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+    const { context, sendActivity } = createInvokeContext({
+      conversationId: "19:victim@thread.v2;messageid=abc123",
+      uploadId,
+      action: "accept",
+    });
+
+    await handler.run(context);
+
+    expect(sendActivity).toHaveBeenCalledWith(expect.objectContaining({ type: "invokeResponse" }));
+    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledTimes(1);
+    expect(fileConsentMockState.uploadToConsentUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://upload.example.com/put",
+        contentType: "application/pdf",
+      }),
+    );
+    // After a successful upload the fs store should be drained so repeat
+    // invokes cannot re-trigger the upload.
+    expect(await fsStore.get(uploadId)).toBeUndefined();
+  });
+
+  it("drops the fs-backed pending upload when the user declines", async () => {
+    const { uploadId } = await prepareFileConsentActivityFs({
+      media: {
+        buffer: Buffer.from("file contents"),
+        filename: "report.pdf",
+        contentType: "application/pdf",
+      },
+      conversationId: "19:victim@thread.v2",
+      store: fsStore,
+    });
+    expect(await fsStore.count()).toBe(1);
+
+    const handler = registerMSTeamsHandlers(
+      createActivityHandler(),
+      createDeps(fsStore),
+    ) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+    const { context } = createInvokeContext({
+      conversationId: "19:victim@thread.v2",
+      uploadId,
+      action: "decline",
+    });
+
+    await handler.run(context);
+
+    expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
+    expect(await fsStore.get(uploadId)).toBeUndefined();
+    expect(await fsStore.count()).toBe(0);
+  });
+
+  it("shows an expired message when neither store has a pending upload", async () => {
+    const handler = registerMSTeamsHandlers(
+      createActivityHandler(),
+      createDeps(fsStore),
+    ) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+    const { context, sendActivity } = createInvokeContext({
+      conversationId: "19:victim@thread.v2",
+      // Valid UUID format but never stored in either store.
+      uploadId: "11111111-2222-4333-8444-555555555555",
+      action: "accept",
+    });
+
+    await handler.run(context);
+
+    expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
+    expect(sendActivity).toHaveBeenCalledWith(
+      "The file upload request has expired. Please try sending the file again.",
+    );
+  });
+
+  it("rejects cross-conversation accept for an fs-backed pending upload", async () => {
+    const { uploadId } = await prepareFileConsentActivityFs({
+      media: {
+        buffer: Buffer.from("secret contents"),
+        filename: "secret.pdf",
+        contentType: "application/pdf",
+      },
+      conversationId: "19:victim@thread.v2",
+      store: fsStore,
+    });
+
+    const handler = registerMSTeamsHandlers(
+      createActivityHandler(),
+      createDeps(fsStore),
+    ) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+    const { context, sendActivity } = createInvokeContext({
+      // Attacker tries to accept from a different conversation.
+      conversationId: "19:attacker@thread.v2",
+      uploadId,
+      action: "accept",
+    });
+
+    await handler.run(context);
+
+    expect(fileConsentMockState.uploadToConsentUrl).not.toHaveBeenCalled();
+    expect(sendActivity).toHaveBeenCalledWith(
+      "The file upload request has expired. Please try sending the file again.",
+    );
+    // Pending upload must survive the attempted cross-conversation accept.
+    expect(await fsStore.get(uploadId)).toBeDefined();
+  });
+});

--- a/extensions/msteams/src/pending-uploads-fs.ts
+++ b/extensions/msteams/src/pending-uploads-fs.ts
@@ -1,0 +1,282 @@
+/**
+ * Filesystem-backed storage for files awaiting user consent in the
+ * FileConsentCard flow.
+ *
+ * The in-memory `pending-uploads.ts` store only works when the sender and the
+ * webhook handler live in the same Node.js process. The `openclaw message send
+ * --media` CLI path sends the consent card from a short-lived CLI process, but
+ * the `fileConsent/invoke` callback lands on the long-running gateway/monitor
+ * webhook (a different process). Without a shared store, the invoke handler
+ * cannot find the pending upload and the accept fails.
+ *
+ * This module persists pending uploads to disk so any process with access to
+ * the msteams state directory can honor the consent callback.
+ *
+ * Layout under <stateDir>/msteams-pending-uploads/:
+ *   index.json         — metadata map keyed by upload id
+ *   <uploadId>.blob    — raw file bytes
+ *
+ * Metadata entries are TTL-pruned on read.
+ */
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { resolveMSTeamsStorePath } from "./storage.js";
+import { readJsonFile, withFileLock, writeJsonFile } from "./store-fs.js";
+
+/** TTL for pending uploads: 5 minutes (matches in-memory store) */
+export const PENDING_UPLOAD_FS_TTL_MS = 5 * 60 * 1000;
+
+const STORE_DIRNAME = "msteams-pending-uploads";
+const INDEX_FILENAME = "index.json";
+const BLOB_EXTENSION = ".blob";
+
+export interface PendingUploadFsEntry {
+  id: string;
+  filename: string;
+  contentType?: string;
+  conversationId: string;
+  size: number;
+  createdAt: number;
+}
+
+interface PendingUploadFsIndex {
+  version: 1;
+  entries: Record<string, PendingUploadFsEntry>;
+}
+
+const EMPTY_INDEX: PendingUploadFsIndex = { version: 1, entries: {} };
+
+export interface PendingUploadFsStoreOptions {
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+  stateDir?: string;
+  /** Custom absolute directory that will hold the index + blobs. */
+  storeDir?: string;
+  ttlMs?: number;
+}
+
+export interface PendingUploadFsStore {
+  store: (params: {
+    buffer: Buffer;
+    filename: string;
+    contentType?: string;
+    conversationId: string;
+  }) => Promise<string>;
+  get: (id?: string) => Promise<
+    | {
+        entry: PendingUploadFsEntry;
+        buffer: Buffer;
+      }
+    | undefined
+  >;
+  remove: (id?: string) => Promise<void>;
+  /** Return the current number of entries after pruning expired rows. */
+  count: () => Promise<number>;
+}
+
+function isSafeUploadId(id: string): boolean {
+  // UUIDs are safe; reject anything that could traverse paths.
+  return /^[0-9a-f-]{36}$/i.test(id);
+}
+
+function blobPath(storeDir: string, id: string): string {
+  return path.join(storeDir, `${id}${BLOB_EXTENSION}`);
+}
+
+function pruneExpired(
+  index: PendingUploadFsIndex,
+  nowMs: number,
+  ttlMs: number,
+): { index: PendingUploadFsIndex; expiredIds: string[] } {
+  const kept: Record<string, PendingUploadFsEntry> = {};
+  const expired: string[] = [];
+  for (const [id, entry] of Object.entries(index.entries)) {
+    if (nowMs - entry.createdAt > ttlMs) {
+      expired.push(id);
+      continue;
+    }
+    kept[id] = entry;
+  }
+  return { index: { version: 1, entries: kept }, expiredIds: expired };
+}
+
+async function unlinkBlobIfPresent(storeDir: string, id: string): Promise<void> {
+  try {
+    await fs.promises.unlink(blobPath(storeDir, id));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      throw err;
+    }
+  }
+}
+
+async function ensureStoreDir(storeDir: string): Promise<void> {
+  await fs.promises.mkdir(storeDir, { recursive: true });
+}
+
+function resolveStoreDirLazy(opts?: PendingUploadFsStoreOptions): () => string {
+  if (opts?.storeDir) {
+    const dir = opts.storeDir;
+    return () => dir;
+  }
+  // Defer msteams runtime / state-dir resolution until the first time the
+  // store actually needs to touch disk. Resolving eagerly would throw in
+  // tests (and other bootstrap paths) where the msteams runtime hasn't been
+  // initialized yet, but where the caller only needs a store reference.
+  let cached: string | null = null;
+  return () => {
+    if (cached !== null) {
+      return cached;
+    }
+    const indexPath = resolveMSTeamsStorePath({
+      filename: `${STORE_DIRNAME}/${INDEX_FILENAME}`,
+      env: opts?.env,
+      homedir: opts?.homedir,
+      stateDir: opts?.stateDir,
+    });
+    cached = path.dirname(indexPath);
+    return cached;
+  };
+}
+
+export function createPendingUploadFsStore(
+  opts?: PendingUploadFsStoreOptions,
+): PendingUploadFsStore {
+  const ttlMs = opts?.ttlMs ?? PENDING_UPLOAD_FS_TTL_MS;
+  const getStoreDir = resolveStoreDirLazy(opts);
+  const getIndexPath = () => path.join(getStoreDir(), INDEX_FILENAME);
+
+  const readIndex = async (indexPath: string): Promise<PendingUploadFsIndex> => {
+    const { value } = await readJsonFile(indexPath, EMPTY_INDEX);
+    if (value.version !== 1 || !value.entries || typeof value.entries !== "object") {
+      return EMPTY_INDEX;
+    }
+    return value;
+  };
+
+  const readAndPruneLocked = async (
+    storeDir: string,
+    indexPath: string,
+  ): Promise<PendingUploadFsIndex> => {
+    const current = await readIndex(indexPath);
+    const nowMs = Date.now();
+    const { index, expiredIds } = pruneExpired(current, nowMs, ttlMs);
+    if (expiredIds.length > 0) {
+      await writeJsonFile(indexPath, index);
+      for (const id of expiredIds) {
+        await unlinkBlobIfPresent(storeDir, id);
+      }
+    }
+    return index;
+  };
+
+  const store: PendingUploadFsStore = {
+    async store(params) {
+      const storeDir = getStoreDir();
+      const indexPath = getIndexPath();
+      await ensureStoreDir(storeDir);
+      const id = crypto.randomUUID();
+      // Write the blob FIRST (best-effort crash safety: if we crash between
+      // blob write and index update, a stale blob without an index entry is
+      // just disk litter that the next prune cycle can skip).
+      await fs.promises.writeFile(blobPath(storeDir, id), new Uint8Array(params.buffer));
+      try {
+        await withFileLock(indexPath, EMPTY_INDEX, async () => {
+          const current = await readAndPruneLocked(storeDir, indexPath);
+          const entry: PendingUploadFsEntry = {
+            id,
+            filename: params.filename,
+            contentType: params.contentType,
+            conversationId: params.conversationId,
+            size: params.buffer.length,
+            createdAt: Date.now(),
+          };
+          current.entries[id] = entry;
+          await writeJsonFile(indexPath, current);
+        });
+      } catch (err) {
+        await unlinkBlobIfPresent(storeDir, id).catch(() => {});
+        throw err;
+      }
+      return id;
+    },
+
+    async get(id) {
+      if (!id || !isSafeUploadId(id)) {
+        return undefined;
+      }
+      const storeDir = getStoreDir();
+      const indexPath = getIndexPath();
+      return await withFileLock(indexPath, EMPTY_INDEX, async () => {
+        const current = await readAndPruneLocked(storeDir, indexPath);
+        const entry = current.entries[id];
+        if (!entry) {
+          return undefined;
+        }
+        let buffer: Buffer;
+        try {
+          buffer = await fs.promises.readFile(blobPath(storeDir, id));
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException)?.code === "ENOENT") {
+            // Orphan metadata (blob missing) — drop the index row so we never
+            // return half-written state.
+            delete current.entries[id];
+            await writeJsonFile(indexPath, current);
+            return undefined;
+          }
+          throw err;
+        }
+        return { entry, buffer };
+      });
+    },
+
+    async remove(id) {
+      if (!id || !isSafeUploadId(id)) {
+        return;
+      }
+      const storeDir = getStoreDir();
+      const indexPath = getIndexPath();
+      await withFileLock(indexPath, EMPTY_INDEX, async () => {
+        const current = await readIndex(indexPath);
+        const hadEntry = Object.hasOwn(current.entries, id);
+        if (hadEntry) {
+          delete current.entries[id];
+          await writeJsonFile(indexPath, current);
+        }
+      });
+      await unlinkBlobIfPresent(storeDir, id);
+    },
+
+    async count() {
+      const storeDir = getStoreDir();
+      const indexPath = getIndexPath();
+      return await withFileLock(indexPath, EMPTY_INDEX, async () => {
+        const current = await readAndPruneLocked(storeDir, indexPath);
+        return Object.keys(current.entries).length;
+      });
+    },
+  };
+
+  return store;
+}
+
+/**
+ * Default, lazily-instantiated process-wide FS store.
+ *
+ * Callers that need a dedicated store (tests, alternate state dirs) should
+ * build one via `createPendingUploadFsStore` directly.
+ */
+let defaultStore: PendingUploadFsStore | null = null;
+export function getDefaultPendingUploadFsStore(): PendingUploadFsStore {
+  if (!defaultStore) {
+    defaultStore = createPendingUploadFsStore();
+  }
+  return defaultStore;
+}
+
+/** Test helper — resets the cached default store so later tests see a fresh dir. */
+export function resetDefaultPendingUploadFsStoreForTests(): void {
+  defaultStore = null;
+}

--- a/extensions/msteams/src/send.ts
+++ b/extensions/msteams/src/send.ts
@@ -7,7 +7,7 @@ import {
   formatMSTeamsSendErrorHint,
   formatUnknownError,
 } from "./errors.js";
-import { prepareFileConsentActivity, requiresFileConsent } from "./file-consent-helpers.js";
+import { prepareFileConsentActivityFs, requiresFileConsent } from "./file-consent-helpers.js";
 import { buildTeamsFileInfoCard } from "./graph-chat.js";
 import {
   getDriveItemProperties,
@@ -153,7 +153,10 @@ export async function sendMessageMSTeams(
         thresholdBytes: FILE_CONSENT_THRESHOLD_BYTES,
       })
     ) {
-      const { activity, uploadId } = prepareFileConsentActivity({
+      // Use the FS-backed store so the monitor webhook (typically a
+      // different process than the CLI sender) can honor the accept callback.
+      // See #55386.
+      const { activity, uploadId } = await prepareFileConsentActivityFs({
         media: { buffer: media.buffer, filename: fileName, contentType: media.contentType },
         conversationId,
         description: messageText || undefined,


### PR DESCRIPTION
## Summary

Bot-to-user file uploads via \`openclaw message send --media\` were silently failing because the \`fileConsent/invoke\` callback could not find the pending upload. The root cause was cross-process: the CLI sender registered the pending upload in its own in-memory Map and then exited, but the \`fileConsent/invoke\` callback lands on the long-running monitor webhook in a different process, so the invoke handler always saw an empty store and could not honor \"Accept\".

Fixes #55386.

## Fix

- Add a new filesystem-backed pending upload store (\`pending-uploads-fs.ts\`) that persists the file bytes under the msteams state dir (\`msteams-pending-uploads/<uploadId>.blob\` + \`index.json\`) so any process with access to the state dir can honor the consent callback.
- Add \`prepareFileConsentActivityFs\` helper that writes to the FS store, and route the CLI \`sendMessageMSTeams\` path through it so CLI-originated consent cards survive the process boundary.
- Extend \`handleFileConsentInvoke\` with a fallback lookup: check the in-memory store first (fast path for same-process sends), then the FS store (cross-process CLI path). Removal targets the same store the pending upload was resolved from. FS store errors are logged at debug so a misconfigured state dir never crashes the invoke handler.
- Validate UUID-shaped upload ids before FS operations (defense in depth against path traversal), and prune expired entries plus orphaned blobs on read.

## Relationship to PR #49580

PR #49580 (\`fix/msteams-file-consent-card-update\`) is in flight and updates the consent card *after* a successful upload (calls \`context.updateActivity\`). That PR extends the in-memory \`PendingUpload\` with \`consentCardActivityId\` and teaches the handler to replace the consent card in place. This PR is a separate concern — it fixes the cross-process pending upload lookup so the accept handler actually has a file to upload in the first place. The two changes touch overlapping files (\`monitor-handler.ts\`, \`send.ts\`, \`file-consent-helpers.ts\`) so some manual rebasing may be needed, but the behaviors are compatible: the FS store can persist \`consentCardActivityId\` in a follow-up if needed.

## Test plan

- [x] \`pnpm test extensions/msteams/\` — all 589 msteams tests pass (54 test files)
- [x] New \`pending-uploads-fs.test.ts\` covers: cross-process round trip (two store handles sharing a temp dir), TTL pruning + orphan blob handling, safe upload id validation, handler registration, accept → \`uploadToConsentUrl\` PUT + fs drain, decline → fs drain, missing pending upload → expired message, cross-conversation accept rejected with pending upload preserved
- [x] Existing \`monitor-handler.file-consent.test.ts\` still passes unchanged (in-memory fast path untouched)
- [ ] Manual: \`openclaw message send --channel msteams --media <file>\` to a personal DM, click Accept, confirm the file uploads to OneDrive and the file info card arrives