### PR TITLE
fix(session-utils): reject stale transcripts with mismatched session header

### DIFF
--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -799,6 +799,37 @@ describe("readLatestSessionUsageFromTranscript", () => {
 
     expect(readLatestSessionUsageFromTranscript(sessionId, storePath)).toBeNull();
   });
+
+  test("returns null when the transcript session header belongs to a different sessionId (stale transcript after reset)", () => {
+    // Simulate the post-reset bug: the old session's transcript file is still
+    // discoverable on disk, but its header carries the old sessionId. The new
+    // session should not inherit usage figures from the previous session.
+    const oldSessionId = "usage-old-session";
+    const newSessionId = "usage-new-session";
+    // Write the transcript under the OLD session's file name so it can be
+    // picked up as a stale candidate when queried with the new sessionId.
+    writeTranscript(tmpDir, oldSessionId, [
+      { type: "session", version: 1, id: oldSessionId },
+      {
+        message: {
+          role: "assistant",
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          usage: { input: 138_000, output: 5_000, cost: { total: 1.23 } },
+        },
+      },
+    ]);
+
+    // Query with the new sessionId but pass the old file as sessionFile so it
+    // lands in the stale-candidate path inside resolveSessionTranscriptCandidates.
+    const oldSessionFile = `${oldSessionId}.jsonl`;
+    const result = readLatestSessionUsageFromTranscript(
+      newSessionId,
+      storePath,
+      oldSessionFile,
+    );
+    expect(result).toBeNull();
+  });
 });
 
 describe("resolveSessionTranscriptCandidates", () => {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -580,6 +580,23 @@ export function readLatestSessionUsageFromTranscript(
       return null;
     }
     const chunk = fs.readFileSync(fd, "utf-8");
+    // Reject transcript if its session header belongs to a different session.
+    // This prevents stale/archived transcripts from being read as the current
+    // session's usage after a reset (which assigns a new sessionId).
+    const newlineIdx = chunk.indexOf("\n");
+    const firstLine = newlineIdx >= 0 ? chunk.slice(0, newlineIdx) : chunk;
+    try {
+      const header = JSON.parse(firstLine) as Record<string, unknown>;
+      if (
+        header?.type === "session" &&
+        typeof header.id === "string" &&
+        header.id !== sessionId
+      ) {
+        return null;
+      }
+    } catch {
+      // No parseable header — proceed and let the usage extractor handle it.
+    }
     return extractLatestUsageFromTranscriptChunk(chunk);
   });
 }


### PR DESCRIPTION
## Problem

After a session reset, `readLatestSessionUsageFromTranscript` could discover the previous session's transcript file on disk (same `storePath`, different `sessionId`) and return its token counts as if they belonged to the new session. This caused false context-usage alerts immediately after reset.

## Fix

`readLatestSessionUsageFromTranscript` now reads the first line of any transcript it finds and checks the `{ type: "session", id }` header. If the header's `id` does not match the requested `sessionId`, the function returns `null`, so the fallback produces no data instead of stale data.

## Test

Adds a regression test (`session-utils.fs.test.ts`) that reproduces the post-reset scenario:
1. Write a transcript for session A with a mismatched session header
2. Call `readLatestSessionUsageFromTranscript` with session B's ID pointing at the same store path
3. Assert the result is `null` (not stale counts from session A)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>