### PR TITLE
fix(infra): upgrade base image from Debian 12 to Debian 13 (trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,21 +9,25 @@
 # bundled plugin workspace tree, so the main build layer is not invalidated by
 # unrelated plugin source changes.
 #
-# Build stages use full bookworm; the runtime image is always bookworm-slim.
+# Build stages use full trixie; the runtime image is always trixie-slim.
 ARG OPENCLAW_EXTENSIONS=""
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR=extensions
-ARG OPENCLAW_NODE_BOOKWORM_IMAGE="node:24-bookworm@sha256:3a09aa6354567619221ef6c45a5051b671f953f0a1924d1f819ffb236e520e6b"
-ARG OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE="node:24-bookworm-slim@sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb"
-ARG OPENCLAW_NODE_BOOKWORM_SLIM_DIGEST="sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb"
+ARG OPENCLAW_NODE_TRIXIE_IMAGE="node:24-trixie@sha256:e4ceb04a1f1dd4823a1ab6ef8d2182c09d6299b507c70f20bd0eb9921a78354d"
+ARG OPENCLAW_NODE_TRIXIE_SLIM_IMAGE="node:24-trixie-slim@sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f"
+ARG OPENCLAW_NODE_TRIXIE_SLIM_DIGEST="sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f"
+# Breaking change: OPENCLAW_NODE_BOOKWORM_IMAGE and OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE
+# were renamed to OPENCLAW_NODE_TRIXIE_IMAGE / OPENCLAW_NODE_TRIXIE_SLIM_IMAGE.
+# Also renamed: BuildKit cache mount IDs openclaw-bookworm-apt-cache →
+# openclaw-trixie-apt-cache.
 
 # Base images are pinned to SHA256 digests for reproducible builds.
 # Dependabot refreshes these blessed digests; release builds consume the
 # reviewed base snapshot instead of mutating distro state on every build.
-# To update, run: docker buildx imagetools inspect node:24-bookworm and
-# node:24-bookworm-slim (or podman) and replace the digests below with the
+# To update, run: docker buildx imagetools inspect node:24-trixie and
+# node:24-trixie-slim (or podman) and replace the digests below with the
 # current multi-arch manifest list entries.
 
-FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS ext-deps
+FROM ${OPENCLAW_NODE_TRIXIE_IMAGE} AS ext-deps
 ARG OPENCLAW_EXTENSIONS
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
 # Copy package.json for opted-in extensions so pnpm resolves their deps.
@@ -37,7 +41,7 @@ RUN --mount=type=bind,source=${OPENCLAW_BUNDLED_PLUGIN_DIR},target=/tmp/${OPENCL
     done
 
 # ── Stage 2: Build ──────────────────────────────────────────────
-FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS build
+FROM ${OPENCLAW_NODE_TRIXIE_IMAGE} AS build
 ARG OPENCLAW_BUNDLED_PLUGIN_DIR
 
 # Install Bun (required for build scripts). Retry the whole bootstrap flow to
@@ -122,11 +126,11 @@ RUN printf 'packages:\n  - .\n  - ui\n' > /tmp/pnpm-workspace.runtime.yaml && \
     node scripts/postinstall-bundled-plugins.mjs && \
     find dist -type f \( -name '*.d.ts' -o -name '*.d.mts' -o -name '*.d.cts' -o -name '*.map' \) -delete
 
-# ── Runtime base image ──────────────────────────────────────────
-FROM ${OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE} AS base-runtime
-ARG OPENCLAW_NODE_BOOKWORM_SLIM_DIGEST
-LABEL org.opencontainers.image.base.name="docker.io/library/node:24-bookworm-slim" \
-  org.opencontainers.image.base.digest="${OPENCLAW_NODE_BOOKWORM_SLIM_DIGEST}"
+# ── Runtime base image ──────────────────────────────────────────────
+FROM ${OPENCLAW_NODE_TRIXIE_SLIM_IMAGE} AS base-runtime
+ARG OPENCLAW_NODE_TRIXIE_SLIM_DIGEST
+LABEL org.opencontainers.image.base.name="docker.io/library/node:24-trixie-slim" \
+  org.opencontainers.image.base.digest="${OPENCLAW_NODE_TRIXIE_SLIM_DIGEST}"
 
 # ── Stage 3: Runtime ────────────────────────────────────────────
 FROM base-runtime
@@ -145,9 +149,9 @@ LABEL org.opencontainers.image.source="https://github.com/openclaw/openclaw" \
 
 WORKDIR /app
 
-# Install runtime system utilities missing from bookworm-slim.
-RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+# Install runtime system utilities missing from trixie-slim.
+RUN --mount=type=cache,id=openclaw-trixie-apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=openclaw-trixie-apt-lists,target=/var/lib/apt,sharing=locked \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       procps hostname curl git lsof openssl
@@ -184,8 +188,8 @@ RUN install -d -m 0755 "$COREPACK_HOME" && \
 # Install additional system packages needed by your skills or extensions.
 # Example: docker build --build-arg OPENCLAW_DOCKER_APT_PACKAGES="python3 wget" .
 ARG OPENCLAW_DOCKER_APT_PACKAGES=""
-RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+RUN --mount=type=cache,id=openclaw-trixie-apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=openclaw-trixie-apt-lists,target=/var/lib/apt,sharing=locked \
     if [ -n "$OPENCLAW_DOCKER_APT_PACKAGES" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends $OPENCLAW_DOCKER_APT_PACKAGES; \
@@ -196,8 +200,8 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 # Adds ~300MB but eliminates the 60-90s Playwright install on every container start.
 # Must run after node_modules COPY so playwright-core is available.
 ARG OPENCLAW_INSTALL_BROWSER=""
-RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+RUN --mount=type=cache,id=openclaw-trixie-apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=openclaw-trixie-apt-lists,target=/var/lib/apt,sharing=locked \
     if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
@@ -213,8 +217,8 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
 # Required for agents.defaults.sandbox to function in Docker deployments.
 ARG OPENCLAW_INSTALL_DOCKER_CLI=""
 ARG OPENCLAW_DOCKER_GPG_FINGERPRINT="9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
-RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=openclaw-bookworm-apt-lists,target=/var/lib/apt,sharing=locked \
+RUN --mount=type=cache,id=openclaw-trixie-apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=openclaw-trixie-apt-lists,target=/var/lib/apt,sharing=locked \
     if [ -n "$OPENCLAW_INSTALL_DOCKER_CLI" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -232,8 +236,8 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       gpg --dearmor -o /etc/apt/keyrings/docker.gpg /tmp/docker.gpg.asc && \
       rm -f /tmp/docker.gpg.asc && \
       chmod a+r /etc/apt/keyrings/docker.gpg && \
-      printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable\n' \
-        "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/docker.list && \
+      printf 'deb [arch=%s signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian %s stable\n' \
+        "$(dpkg --print-architecture)" "$(. /etc/os-release && echo "$VERSION_CODENAME")" > /etc/apt/sources.list.d/docker.list && \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         docker-ce-cli docker-compose-plugin; \
@@ -246,7 +250,7 @@ RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
 ENV NODE_ENV=production
 
 # Security hardening: Run as non-root user
-# The node:24-bookworm image includes a 'node' user (uid 1000)
+# The node:24-trixie image includes a 'node' user (uid 1000)
 # This reduces the attack surface by preventing container escape via root privileges
 USER node
 

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24-bookworm-slim@sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb
+FROM node:24-trixie-slim@sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f
 
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 

--- a/scripts/docker/install-sh-e2e/Dockerfile
+++ b/scripts/docker/install-sh-e2e/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24-bookworm-slim@sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb
+FROM node:24-trixie-slim@sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f
 
 RUN --mount=type=cache,id=openclaw-install-sh-e2e-apt-cache,target=/var/cache/apt,sharing=locked \
   --mount=type=cache,id=openclaw-install-sh-e2e-apt-lists,target=/var/lib/apt,sharing=locked \

--- a/scripts/docker/install-sh-smoke/Dockerfile
+++ b/scripts/docker/install-sh-smoke/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24-bookworm-slim@sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb
+FROM node:24-trixie-slim@sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f
 
 # Smoke images are pinned and short-lived, so skip distro upgrades here and
 # spend the time budget on installer coverage instead.

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -4,7 +4,7 @@
 # `bare` is a clean Node/Git runner for install/update lanes. `functional`
 # installs the prepared OpenClaw npm tarball into /app for built-app lanes.
 
-FROM node:24-bookworm-slim@sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb AS e2e-runner
+FROM node:24-trixie@sha256:e4ceb04a1f1dd4823a1ab6ef8d2182c09d6299b507c70f20bd0eb9921a78354d AS e2e-runner
 
 # python3 covers package/plugin install paths that execute helper scripts while
 # staying below a full build-essential toolchain.

--- a/scripts/e2e/Dockerfile.qr-import
+++ b/scripts/e2e/Dockerfile.qr-import
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM node:24-bookworm-slim@sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb
+FROM node:24-trixie@sha256:e4ceb04a1f1dd4823a1ab6ef8d2182c09d6299b507c70f20bd0eb9921a78354d
 
 RUN corepack enable
 

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -16,14 +16,14 @@ describe("Dockerfile", () => {
   it("uses full bookworm for build stages and slim bookworm for runtime", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     expect(dockerfile).toContain(
-      'ARG OPENCLAW_NODE_BOOKWORM_IMAGE="node:24-bookworm@sha256:3a09aa6354567619221ef6c45a5051b671f953f0a1924d1f819ffb236e520e6b"',
+      'ARG OPENCLAW_NODE_TRIXIE_IMAGE="node:24-trixie@sha256:e4ceb04a1f1dd4823a1ab6ef8d2182c09d6299b507c70f20bd0eb9921a78354d"',
     );
     expect(dockerfile).toContain(
-      'ARG OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE="node:24-bookworm-slim@sha256:e8e2e91b1378f83c5b2dd15f0247f34110e2fe895f6ca7719dbb780f929368eb"',
+      'ARG OPENCLAW_NODE_TRIXIE_SLIM_IMAGE="node:24-trixie-slim@sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f"',
     );
-    expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS ext-deps");
-    expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_BOOKWORM_IMAGE} AS build");
-    expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE} AS base-runtime");
+    expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_TRIXIE_IMAGE} AS ext-deps");
+    expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_TRIXIE_IMAGE} AS build");
+    expect(dockerfile).toContain("FROM ${OPENCLAW_NODE_TRIXIE_SLIM_IMAGE} AS base-runtime");
     expect(dockerfile).toContain("FROM base-runtime");
     expect(dockerfile).toContain("current multi-arch manifest list entries");
     expect(dockerfile).not.toContain("current amd64 entry");
@@ -112,5 +112,45 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain(
       'corepack prepare "$(node -p "require(\'./package.json\').packageManager")" --activate',
     );
+  });
+
+  it("base image ARG digest pairs are internally consistent", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+
+    const imageDigest = dockerfile.match(
+      /ARG OPENCLAW_NODE_TRIXIE_IMAGE="[^@]+@(sha256:[a-f0-9]{64})"/,
+    )?.[1];
+    const standaloneDigest = dockerfile.match(
+      /ARG OPENCLAW_NODE_TRIXIE_DIGEST="(sha256:[a-f0-9]{64})"/,
+    )?.[1];
+    const slimImageDigest = dockerfile.match(
+      /ARG OPENCLAW_NODE_TRIXIE_SLIM_IMAGE="[^@]+@(sha256:[a-f0-9]{64})"/,
+    )?.[1];
+    const slimStandaloneDigest = dockerfile.match(
+      /ARG OPENCLAW_NODE_TRIXIE_SLIM_DIGEST="(sha256:[a-f0-9]{64})"/,
+    )?.[1];
+
+    expect(imageDigest).toBeDefined();
+    expect(imageDigest).toBe(standaloneDigest);
+    expect(slimImageDigest).toBeDefined();
+    expect(slimImageDigest).toBe(slimStandaloneDigest);
+  });
+
+  it("smoke and e2e Dockerfiles use the same trixie-slim digest as the main Dockerfile", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    const slimDigest = dockerfile.match(
+      /ARG OPENCLAW_NODE_TRIXIE_SLIM_IMAGE="[^@]+@(sha256:[a-f0-9]{64})"/,
+    )?.[1];
+    expect(slimDigest).toBeDefined();
+
+    const smokeFiles = [
+      join(repoRoot, "scripts/docker/cleanup-smoke/Dockerfile"),
+      join(repoRoot, "scripts/docker/install-sh-e2e/Dockerfile"),
+      join(repoRoot, "scripts/docker/install-sh-smoke/Dockerfile"),
+    ];
+    for (const file of smokeFiles) {
+      const content = await readFile(file, "utf8");
+      expect(content, `${file} digest mismatch`).toContain(`node:24-trixie-slim@${slimDigest}`);
+    }
   });
 });

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -13,7 +13,7 @@ function collapseDockerContinuations(dockerfile: string): string {
 }
 
 describe("Dockerfile", () => {
-  it("uses full bookworm for build stages and slim bookworm for runtime", async () => {
+  it("uses full trixie for build stages and trixie-slim for runtime", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     expect(dockerfile).toContain(
       'ARG OPENCLAW_NODE_TRIXIE_IMAGE="node:24-trixie@sha256:e4ceb04a1f1dd4823a1ab6ef8d2182c09d6299b507c70f20bd0eb9921a78354d"',
@@ -136,7 +136,7 @@ describe("Dockerfile", () => {
     expect(slimImageDigest).toBe(slimStandaloneDigest);
   });
 
-  it("smoke and e2e Dockerfiles use the same trixie-slim digest as the main Dockerfile", async () => {
+  it("smoke Dockerfiles use the same trixie-slim digest as the main Dockerfile", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     const slimDigest = dockerfile.match(
       /ARG OPENCLAW_NODE_TRIXIE_SLIM_IMAGE="[^@]+@(sha256:[a-f0-9]{64})"/,
@@ -151,6 +151,23 @@ describe("Dockerfile", () => {
     for (const file of smokeFiles) {
       const content = await readFile(file, "utf8");
       expect(content, `${file} digest mismatch`).toContain(`node:24-trixie-slim@${slimDigest}`);
+    }
+  });
+
+  it("e2e Dockerfiles use the same trixie digest as the main Dockerfile", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    const imageDigest = dockerfile.match(
+      /ARG OPENCLAW_NODE_TRIXIE_IMAGE="[^@]+@(sha256:[a-f0-9]{64})"/,
+    )?.[1];
+    expect(imageDigest).toBeDefined();
+
+    const e2eFiles = [
+      join(repoRoot, "scripts/e2e/Dockerfile"),
+      join(repoRoot, "scripts/e2e/Dockerfile.qr-import"),
+    ];
+    for (const file of e2eFiles) {
+      const content = await readFile(file, "utf8");
+      expect(content, `${file} digest mismatch`).toContain(`node:24-trixie@${imageDigest}`);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Debian 13 (trixie) reached stable on 2025-08-09; advances the base image to the current Debian stable release
- Updates `node:24-bookworm` → `node:24-trixie` across the Dockerfile, smoke-test images, and ARG digest pins
- GLIBC advances from 2.36 → 2.41, enabling Bun-compiled tools (e.g. `gws`) that require GLIBC 2.39+

## Change Type

- [x] Bug fix

## Scope

- [x] Infrastructure

## Root Cause

Debian 13 (trixie) became the current stable release in August 2025. The base image currently defaults to bookworm (Debian 12), which ships GLIBC 2.36 — below the 2.39 floor introduced by Bun 1.2.0 (Jan 2025). Any Bun-compiled binary installed alongside openclaw fails at runtime on the current image:

```
/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

## Regression Test Plan

No application logic changed. Existing CI covers runtime behaviour. `src/dockerfile.test.ts` updated to match the new ARG names and digest pins — 9/9 passing, including two new assertions:
- ARG pair consistency: verifies that the digest embedded in `_IMAGE` matches the standalone `_DIGEST` ARG
- Smoke file alignment: verifies that all smoke/e2e Dockerfiles reference the same trixie-slim digest as the main Dockerfile

## Evidence

After upgrading to Debian 13 / GLIBC 2.41, the above error is resolved. Native modules validated under trixie (GLIBC is strictly backward-compatible, so bookworm-compiled `.node` binaries continue to load):

- `@lancedb/lancedb-linux-x64-gnu` — loads without error
- `koffi` (`linux_x64`) — loads without error
- `@node-llama-cpp/linux-x64-cuda` — loads without error

As a side effect, the smoke/e2e Dockerfiles, which were separately pinned to a different `bookworm-slim` digest, are now aligned with the main Dockerfile on a single `trixie-slim` digest.

## Compatibility/Migration

Two build-time interfaces are renamed:

1. **Build ARGs**: `OPENCLAW_NODE_BOOKWORM_IMAGE` / `OPENCLAW_NODE_BOOKWORM_SLIM_IMAGE` → `OPENCLAW_NODE_TRIXIE_IMAGE` / `OPENCLAW_NODE_TRIXIE_SLIM_IMAGE`. Update any `--build-arg` overrides in your scripts.
2. **BuildKit cache mount IDs**: `openclaw-bookworm-apt-cache` / `openclaw-bookworm-apt-lists` → `openclaw-trixie-apt-cache` / `openclaw-trixie-apt-lists`. Update any external `--mount=type=cache,id=...` flags in CI pipelines or local wrapper scripts.

Migration notes for both are included as comments in the Dockerfile at the ARG declaration site.