### PR TITLE
CLI: avoid false plugin allowlist fallback for unknown commands

### DIFF
--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as pluginCliRegistryLoader from "../plugins/cli-registry-loader.js";
 import {
   rewriteUpdateFlagArgv,
   resolveMissingPluginCommandMessage,
   shouldEnsureCliPath,
   shouldUseRootHelpFastPath,
 } from "./run-main.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("rewriteUpdateFlagArgv", () => {
   it("leaves argv unchanged when --update is absent", () => {
@@ -79,7 +84,7 @@ describe("resolveMissingPluginCommandMessage", () => {
           allow: ["telegram"],
         },
       }),
-    ).resolves.toContain('`plugins.allow` excludes "browser"');
+    ).resolves.toContain('`plugins.allow` excludes plugin "browser"');
   });
 
   it("explains explicit bundled plugin disablement", async () => {
@@ -109,6 +114,30 @@ describe("resolveMissingPluginCommandMessage", () => {
   it("returns null for unknown commands under a restrictive plugins.allow", async () => {
     await expect(
       resolveMissingPluginCommandMessage("run", {
+        plugins: {
+          allow: ["telegram"],
+        },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("explains plugins.allow misses for bundled CLI roots whose command differs from plugin id", async () => {
+    await expect(
+      resolveMissingPluginCommandMessage("voicecall", {
+        plugins: {
+          allow: ["telegram"],
+        },
+      }),
+    ).resolves.toContain('`plugins.allow` excludes plugin "voice-call"');
+  });
+
+  it("returns null when bundled CLI root detection throws", async () => {
+    vi.spyOn(pluginCliRegistryLoader, "loadPluginCliMetadataRegistryWithContext").mockRejectedValue(
+      new Error("boom"),
+    );
+
+    await expect(
+      resolveMissingPluginCommandMessage("browser", {
         plugins: {
           allow: ["telegram"],
         },

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -131,6 +131,17 @@ describe("resolveMissingPluginCommandMessage", () => {
     ).resolves.toContain('`plugins.allow` excludes plugin "voice-call"');
   });
 
+  it("ignores plugins.deny while probing bundled CLI roots", async () => {
+    await expect(
+      resolveMissingPluginCommandMessage("voicecall", {
+        plugins: {
+          allow: ["telegram"],
+          deny: ["voice-call"],
+        },
+      }),
+    ).resolves.toContain('`plugins.allow` excludes plugin "voice-call"');
+  });
+
   it("returns null when bundled CLI root detection throws", async () => {
     vi.spyOn(pluginCliRegistryLoader, "loadPluginCliMetadataRegistryWithContext").mockRejectedValue(
       new Error("boom"),

--- a/src/cli/run-main.test.ts
+++ b/src/cli/run-main.test.ts
@@ -72,18 +72,18 @@ describe("shouldUseRootHelpFastPath", () => {
 });
 
 describe("resolveMissingPluginCommandMessage", () => {
-  it("explains plugins.allow misses for a bundled plugin command", () => {
-    expect(
+  it("explains plugins.allow misses for a bundled plugin command", async () => {
+    await expect(
       resolveMissingPluginCommandMessage("browser", {
         plugins: {
           allow: ["telegram"],
         },
       }),
-    ).toContain('`plugins.allow` excludes "browser"');
+    ).resolves.toContain('`plugins.allow` excludes "browser"');
   });
 
-  it("explains explicit bundled plugin disablement", () => {
-    expect(
+  it("explains explicit bundled plugin disablement", async () => {
+    await expect(
       resolveMissingPluginCommandMessage("browser", {
         plugins: {
           entries: {
@@ -93,16 +93,26 @@ describe("resolveMissingPluginCommandMessage", () => {
           },
         },
       }),
-    ).toContain("plugins.entries.browser.enabled=false");
+    ).resolves.toContain("plugins.entries.browser.enabled=false");
   });
 
-  it("returns null when the bundled plugin command is already allowed", () => {
-    expect(
+  it("returns null when the bundled plugin command is already allowed", async () => {
+    await expect(
       resolveMissingPluginCommandMessage("browser", {
         plugins: {
           allow: ["browser"],
         },
       }),
-    ).toBeNull();
+    ).resolves.toBeNull();
+  });
+
+  it("returns null for unknown commands under a restrictive plugins.allow", async () => {
+    await expect(
+      resolveMissingPluginCommandMessage("run", {
+        plugins: {
+          allow: ["telegram"],
+        },
+      }),
+    ).resolves.toBeNull();
   });
 });

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -104,6 +104,7 @@ async function resolveBundledPluginCliRootCommand(
       ...config?.plugins,
       ...(config?.plugins?.enabled === false ? { enabled: true } : {}),
       allow: bundledPluginIds,
+      deny: [],
       entries: detectionEntries,
     },
   };

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -64,17 +64,26 @@ export function shouldUseRootHelpFastPath(argv: string[]): boolean {
   return resolveCliArgvInvocation(argv).isRootHelpInvocation;
 }
 
-async function isBundledPluginCliRootCommand(
-  pluginId: string,
+async function resolveBundledPluginCliRootCommand(
+  commandName: string,
   config?: OpenClawConfig,
-): Promise<boolean> {
+): Promise<string | null> {
+  const normalizedCommandName = normalizeLowercaseStringOrEmpty(commandName);
+  if (!normalizedCommandName) {
+    return null;
+  }
+
   const pluginRegistry = loadPluginManifestRegistry({ config });
-  const hasBundledPluginId = pluginRegistry.plugins.some(
-    (plugin) =>
-      plugin.origin === "bundled" && normalizeLowercaseStringOrEmpty(plugin.id) === pluginId,
+  const bundledPluginIds = Array.from(
+    new Set(
+      pluginRegistry.plugins
+        .filter((plugin) => plugin.origin === "bundled")
+        .map((plugin) => normalizeLowercaseStringOrEmpty(plugin.id))
+        .filter(Boolean),
+    ),
   );
-  if (!hasBundledPluginId) {
-    return false;
+  if (bundledPluginIds.length === 0) {
+    return null;
   }
 
   const {
@@ -82,21 +91,20 @@ async function isBundledPluginCliRootCommand(
     loadPluginCliMetadataRegistryWithContext,
     resolvePluginCliLoadContext,
   } = await import("../plugins/cli-registry-loader.js");
-  const detectedAllow = new Set(config?.plugins?.allow ?? []);
-  detectedAllow.add(pluginId);
+  const detectionEntries = { ...config?.plugins?.entries };
+  for (const pluginId of bundledPluginIds) {
+    detectionEntries[pluginId] = {
+      ...config?.plugins?.entries?.[pluginId],
+      enabled: true,
+    };
+  }
   const detectionConfig: OpenClawConfig = {
     ...config,
     plugins: {
       ...config?.plugins,
       ...(config?.plugins?.enabled === false ? { enabled: true } : {}),
-      allow: [...detectedAllow],
-      entries: {
-        ...config?.plugins?.entries,
-        [pluginId]: {
-          ...config?.plugins?.entries?.[pluginId],
-          enabled: true,
-        },
-      },
+      allow: bundledPluginIds,
+      entries: detectionEntries,
     },
   };
   const context = resolvePluginCliLoadContext({
@@ -104,18 +112,41 @@ async function isBundledPluginCliRootCommand(
     logger: createPluginCliLogger(),
   });
   const { registry } = await loadPluginCliMetadataRegistryWithContext(context);
-  return registry.cliRegistrars.some(
-    (entry) =>
-      normalizeLowercaseStringOrEmpty(entry.pluginId) === pluginId &&
-      entry.commands.some((name) => normalizeLowercaseStringOrEmpty(name) === pluginId),
-  );
+  const matchedPluginId =
+    registry.cliRegistrars.find(
+      (entry) =>
+        bundledPluginIds.includes(normalizeLowercaseStringOrEmpty(entry.pluginId)) &&
+        entry.commands.some(
+          (name) => normalizeLowercaseStringOrEmpty(name) === normalizedCommandName,
+        ),
+    )?.pluginId ?? null;
+  return matchedPluginId ? normalizeLowercaseStringOrEmpty(matchedPluginId) : null;
+}
+
+async function resolveMissingBundledPluginCliRoot(
+  commandName: string,
+  config?: OpenClawConfig,
+): Promise<string | null> {
+  try {
+    return await resolveBundledPluginCliRootCommand(commandName, config);
+  } catch {
+    // Unknown-command handling should degrade gracefully if metadata probing fails.
+    return null;
+  }
 }
 
 export async function resolveMissingPluginCommandMessage(
-  pluginId: string,
+  commandName: string,
   config?: OpenClawConfig,
 ): Promise<string | null> {
-  const normalizedPluginId = normalizeLowercaseStringOrEmpty(pluginId);
+  const normalizedCommandName = normalizeLowercaseStringOrEmpty(commandName);
+  if (!normalizedCommandName) {
+    return null;
+  }
+  const normalizedPluginId = await resolveMissingBundledPluginCliRoot(
+    normalizedCommandName,
+    config,
+  );
   if (!normalizedPluginId) {
     return null;
   }
@@ -131,19 +162,16 @@ export async function resolveMissingPluginCommandMessage(
   if (!blockedByAllowlist && !explicitlyDisabled) {
     return null;
   }
-  if (!(await isBundledPluginCliRootCommand(normalizedPluginId, config))) {
-    return null;
-  }
   if (blockedByAllowlist) {
     return (
-      `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
-      `\`plugins.allow\` excludes "${normalizedPluginId}". Add "${normalizedPluginId}" to ` +
+      `The \`openclaw ${normalizedCommandName}\` command is unavailable because ` +
+      `\`plugins.allow\` excludes plugin "${normalizedPluginId}". Add "${normalizedPluginId}" to ` +
       `\`plugins.allow\` if you want that bundled plugin CLI surface.`
     );
   }
   if (explicitlyDisabled) {
     return (
-      `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
+      `The \`openclaw ${normalizedCommandName}\` command is unavailable because ` +
       `\`plugins.entries.${normalizedPluginId}.enabled=false\`. Re-enable that entry if you want ` +
       "the bundled plugin CLI surface."
     );

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -11,6 +11,7 @@ import { isMainModule } from "../infra/is-main.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { assertSupportedRuntime } from "../infra/runtime-guard.js";
 import { enableConsoleCapture } from "../logging.js";
+import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { hasMemoryRuntime } from "../plugins/memory-state.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -63,10 +64,57 @@ export function shouldUseRootHelpFastPath(argv: string[]): boolean {
   return resolveCliArgvInvocation(argv).isRootHelpInvocation;
 }
 
-export function resolveMissingPluginCommandMessage(
+async function isBundledPluginCliRootCommand(
   pluginId: string,
   config?: OpenClawConfig,
-): string | null {
+): Promise<boolean> {
+  const pluginRegistry = loadPluginManifestRegistry({ config });
+  const hasBundledPluginId = pluginRegistry.plugins.some(
+    (plugin) =>
+      plugin.origin === "bundled" && normalizeLowercaseStringOrEmpty(plugin.id) === pluginId,
+  );
+  if (!hasBundledPluginId) {
+    return false;
+  }
+
+  const {
+    createPluginCliLogger,
+    loadPluginCliMetadataRegistryWithContext,
+    resolvePluginCliLoadContext,
+  } = await import("../plugins/cli-registry-loader.js");
+  const detectedAllow = new Set(config?.plugins?.allow ?? []);
+  detectedAllow.add(pluginId);
+  const detectionConfig: OpenClawConfig = {
+    ...config,
+    plugins: {
+      ...config?.plugins,
+      ...(config?.plugins?.enabled === false ? { enabled: true } : {}),
+      allow: [...detectedAllow],
+      entries: {
+        ...config?.plugins?.entries,
+        [pluginId]: {
+          ...config?.plugins?.entries?.[pluginId],
+          enabled: true,
+        },
+      },
+    },
+  };
+  const context = resolvePluginCliLoadContext({
+    cfg: detectionConfig,
+    logger: createPluginCliLogger(),
+  });
+  const { registry } = await loadPluginCliMetadataRegistryWithContext(context);
+  return registry.cliRegistrars.some(
+    (entry) =>
+      normalizeLowercaseStringOrEmpty(entry.pluginId) === pluginId &&
+      entry.commands.some((name) => normalizeLowercaseStringOrEmpty(name) === pluginId),
+  );
+}
+
+export async function resolveMissingPluginCommandMessage(
+  pluginId: string,
+  config?: OpenClawConfig,
+): Promise<string | null> {
   const normalizedPluginId = normalizeLowercaseStringOrEmpty(pluginId);
   if (!normalizedPluginId) {
     return null;
@@ -78,14 +126,22 @@ export function resolveMissingPluginCommandMessage(
           .map((entry) => normalizeOptionalLowercaseString(entry))
           .filter(Boolean)
       : [];
-  if (allow.length > 0 && !allow.includes(normalizedPluginId)) {
+  const blockedByAllowlist = allow.length > 0 && !allow.includes(normalizedPluginId);
+  const explicitlyDisabled = config?.plugins?.entries?.[normalizedPluginId]?.enabled === false;
+  if (!blockedByAllowlist && !explicitlyDisabled) {
+    return null;
+  }
+  if (!(await isBundledPluginCliRootCommand(normalizedPluginId, config))) {
+    return null;
+  }
+  if (blockedByAllowlist) {
     return (
       `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
       `\`plugins.allow\` excludes "${normalizedPluginId}". Add "${normalizedPluginId}" to ` +
       `\`plugins.allow\` if you want that bundled plugin CLI surface.`
     );
   }
-  if (config?.plugins?.entries?.[normalizedPluginId]?.enabled === false) {
+  if (explicitlyDisabled) {
     return (
       `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
       `\`plugins.entries.${normalizedPluginId}.enabled=false\`. Re-enable that entry if you want ` +
@@ -214,7 +270,10 @@ export async function runCli(argv: string[] = process.argv) {
       );
       if (config) {
         if (primary && !program.commands.some((command) => command.name() === primary)) {
-          const missingPluginCommandMessage = resolveMissingPluginCommandMessage(primary, config);
+          const missingPluginCommandMessage = await resolveMissingPluginCommandMessage(
+            primary,
+            config,
+          );
           if (missingPluginCommandMessage) {
             throw new Error(missingPluginCommandMessage);
           }


### PR DESCRIPTION
## Summary
- scope the `run-main` bundled-plugin fallback to real bundled plugin CLI root commands
- stop treating arbitrary missing primary commands as `plugins.allow` / `plugins.entries.*.enabled` misses
- add a regression test that keeps `openclaw run` from surfacing a bogus plugin allowlist error

## Root cause
`resolveMissingPluginCommandMessage(...)` was checking the raw missing primary command string against `plugins.allow` and `plugins.entries` without first proving that the string mapped to a real bundled plugin CLI root.

That meant a command like `openclaw run` could fail with a misleading message about `plugins.allow` excluding `"run"`, even though `run` is not a bundled plugin CLI root on current `main`.

## Fix
Before emitting the bundled-plugin fallback message, this PR now confirms that the missing primary command matches a real bundled plugin CLI root from the plugin CLI metadata registry, using a detection-only config snapshot that force-enables the candidate plugin for inspection.

If the missing command does not map to a real bundled plugin CLI root, the fallback returns `null` and the CLI continues to the normal unknown-command path.

## Testing
- `OPENCLAW_LOCAL_CHECK=0 pnpm test src/cli/run-main.test.ts src/cli/run-main.exit.test.ts src/cli/run-main.profile-env.test.ts`

Refs #63907
