### PR TITLE
fix(diffs): reuse shared secret comparison helper for artifact token

### DIFF
--- a/extensions/diffs/src/store.ts
+++ b/extensions/diffs/src/store.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import { safeEqualSecret } from "openclaw/plugin-sdk/browser-security-runtime";
 import type { PluginLogger } from "../api.js";
 import type { DiffArtifactContext, DiffArtifactMeta, DiffOutputFormat } from "./types.js";
 
@@ -88,7 +89,7 @@ export class DiffArtifactStore {
     if (!meta) {
       return null;
     }
-    if (meta.token !== token) {
+    if (!safeEqualSecret(meta.token, token)) {
       return null;
     }
     if (isExpired(meta)) {


### PR DESCRIPTION
## Summary

- Reuses the shared `safeEqualSecret` helper for diff artifact token comparison, bringing `extensions/diffs` in line with the rest of the codebase
- Replaces the remaining ad hoc `!==` comparison in the diffs artifact store

## Changes

- Swapped the diff artifact token check in `DiffArtifactStore.getArtifact` to `safeEqualSecret` (from `openclaw/plugin-sdk/browser-security-runtime`)
- Kept the change scoped to the single audited call site

## Rationale

`safeEqualSecret` is the shared constant-time secret comparison helper already used by:

- `src/gateway/server-http.ts:500` for hook token validation
- `extensions/browser/src/browser/http-auth.ts:46,53,58` for browser plugin auth
- `extensions/bluebubbles/src/monitor.ts:126` for webhook secret comparison

`extensions/diffs/src/store.ts` was the only remaining token comparison that still used a plain `!==`. This PR restores parity with the established pattern, matching the hardening direction of #58432.

The diff artifact token is a 24-byte random value (48 hex chars) that gates HTTP access to `/plugins/diffs/view/:id/:token`. Loopback traffic skips the viewer rate limiter entirely (`http.ts:63-72`), so using the shared helper here keeps the extension consistent with the rest of the gateway.

## Validation

- Verified no other ad hoc token comparisons remain in `extensions/diffs/`
- `safeEqualSecret` has identical return semantics for equal strings; behavior is unchanged for legitimate callers

## AI assistance

This PR was drafted with Claude Code assistance. The change is a drop-in replacement of an existing `!==` comparison with a shared helper that has identical return semantics for equal strings, mirroring the pattern in #58432.

- [x] Mark as AI-assisted
- [x] Lightly tested (drop-in replacement, identical semantics)
- [x] Confirm understanding of the change