### PR TITLE
Plugins: keep untrusted workspace channel shadows out of setup-time loads

### DIFF
--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -319,7 +319,15 @@ export function buildChannelUiCatalog(
   return { entries, order, labels, detailLabels, systemImages, byId };
 }
 
-export function listChannelPluginCatalogEntries(
+/**
+ * Raw catalog listing without trust filtering — internal implementation.
+ * Exported for use by trusted-catalog helpers that apply their own filtering.
+ * External callers should use {@link listTrustedChannelPluginCatalogEntries}
+ * from `commands/channel-setup/trusted-catalog` instead.
+ *
+ * @internal
+ */
+export function listChannelPluginCatalogEntriesUnfiltered(
   options: CatalogOptions = {},
 ): ChannelPluginCatalogEntry[] {
   const manifestEntries = listChannelCatalogEntries({
@@ -384,6 +392,18 @@ export function listChannelPluginCatalogEntries(
     });
 }
 
+/**
+ * @deprecated Use {@link listTrustedChannelPluginCatalogEntries} from
+ * `commands/channel-setup/trusted-catalog` for execution-facing paths, or
+ * {@link listChannelPluginCatalogEntriesUnfiltered} for internal plumbing
+ * that applies its own trust filtering.
+ */
+export function listChannelPluginCatalogEntries(
+  options: CatalogOptions = {},
+): ChannelPluginCatalogEntry[] {
+  return listChannelPluginCatalogEntriesUnfiltered(options);
+}
+
 export function getChannelPluginCatalogEntry(
   id: string,
   options: CatalogOptions = {},
@@ -392,5 +412,5 @@ export function getChannelPluginCatalogEntry(
   if (!trimmed) {
     return undefined;
   }
-  return listChannelPluginCatalogEntries(options).find((entry) => entry.id === trimmed);
+  return listChannelPluginCatalogEntriesUnfiltered(options).find((entry) => entry.id === trimmed);
 }

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -1,7 +1,7 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
   getChannelPluginCatalogEntry,
-  listChannelPluginCatalogEntries,
+  listChannelPluginCatalogEntriesUnfiltered,
   type ChannelPluginCatalogEntry,
 } from "../../channels/plugins/catalog.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
@@ -55,7 +55,7 @@ export function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | nu
     return undefined;
   }
   const workspaceDir = cfg ? resolveWorkspaceDir(cfg) : undefined;
-  return listChannelPluginCatalogEntries({ workspaceDir }).find((entry) => {
+  return listChannelPluginCatalogEntriesUnfiltered({ workspaceDir }).find((entry) => {
     if (normalizeOptionalLowercaseString(entry.id) === trimmed) {
       return true;
     }
@@ -104,7 +104,7 @@ function resolveTrustedCatalogEntry(params: {
     if (!trimmed) {
       return undefined;
     }
-    return listChannelPluginCatalogEntries({
+    return listChannelPluginCatalogEntriesUnfiltered({
       workspaceDir: params.workspaceDir,
       excludeWorkspace: true,
     }).find((entry) => {

--- a/src/commands/channel-setup/trusted-catalog.test.ts
+++ b/src/commands/channel-setup/trusted-catalog.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
+
+const listChannelPluginCatalogEntries = vi.hoisted(() =>
+  vi.fn((_opts?: unknown): ChannelPluginCatalogEntry[] => []),
+);
+const getChannelPluginCatalogEntry = vi.hoisted(() =>
+  vi.fn((_id?: unknown, _opts?: unknown): ChannelPluginCatalogEntry | undefined => undefined),
+);
+const applyPluginAutoEnable = vi.hoisted(() =>
+  vi.fn(({ config }: { config: unknown }) => ({
+    config: config as never,
+    changes: [] as string[],
+    autoEnabledReasons: {},
+  })),
+);
+
+vi.mock("../../channels/plugins/catalog.js", () => ({
+  listChannelPluginCatalogEntries: (opts?: unknown) => listChannelPluginCatalogEntries(opts),
+  getChannelPluginCatalogEntry: (id?: unknown, opts?: unknown) =>
+    getChannelPluginCatalogEntry(id, opts),
+}));
+
+vi.mock("../../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable: (args: unknown) =>
+    applyPluginAutoEnable(args as { config: unknown; env?: NodeJS.ProcessEnv }),
+}));
+
+import {
+  getTrustedChannelPluginCatalogEntry,
+  listSetupDiscoveryChannelPluginCatalogEntries,
+  listTrustedChannelPluginCatalogEntries,
+} from "./trusted-catalog.js";
+
+function createCatalogEntry(params: {
+  id: string;
+  pluginId: string;
+  origin?: "workspace" | "bundled";
+}): ChannelPluginCatalogEntry {
+  return {
+    id: params.id,
+    pluginId: params.pluginId,
+    origin: params.origin,
+    meta: {
+      id: params.id,
+      label: params.id,
+      selectionLabel: params.id,
+      docsPath: `/channels/${params.id}`,
+      blurb: `${params.id} channel`,
+    },
+    install: {
+      npmSpec: params.pluginId,
+    },
+  };
+}
+
+describe("trusted catalog helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    applyPluginAutoEnable.mockImplementation(({ config }: { config: unknown }) => ({
+      config: config as never,
+      changes: [] as string[],
+      autoEnabledReasons: {},
+    }));
+  });
+
+  it("falls back to the bundled entry for an untrusted workspace shadow", () => {
+    const workspaceEntry = createCatalogEntry({
+      id: "telegram",
+      pluginId: "evil-telegram-shadow",
+      origin: "workspace",
+    });
+    const bundledEntry = createCatalogEntry({
+      id: "telegram",
+      pluginId: "telegram",
+      origin: "bundled",
+    });
+    getChannelPluginCatalogEntry
+      .mockReturnValueOnce(workspaceEntry)
+      .mockReturnValueOnce(bundledEntry);
+
+    const result = getTrustedChannelPluginCatalogEntry("telegram", {
+      cfg: {} as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result?.pluginId).toBe("telegram");
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(1, "telegram", {
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(2, "telegram", {
+      workspaceDir: "/tmp/workspace",
+      excludeWorkspace: true,
+    });
+  });
+
+  it("keeps trusted workspace overrides eligible", () => {
+    const workspaceEntry = createCatalogEntry({
+      id: "telegram",
+      pluginId: "trusted-telegram-shadow",
+      origin: "workspace",
+    });
+    getChannelPluginCatalogEntry.mockReturnValue(workspaceEntry);
+
+    const result = getTrustedChannelPluginCatalogEntry("telegram", {
+      cfg: {
+        plugins: {
+          enabled: true,
+          allow: ["trusted-telegram-shadow"],
+        },
+      } as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result?.pluginId).toBe("trusted-telegram-shadow");
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits untrusted workspace-only entries from the trusted list", () => {
+    const workspaceOnlyEntry = createCatalogEntry({
+      id: "my-cool-plugin",
+      pluginId: "my-cool-plugin",
+      origin: "workspace",
+    });
+    listChannelPluginCatalogEntries.mockImplementation((opts?: unknown) =>
+      (opts as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
+        ? []
+        : [workspaceOnlyEntry],
+    );
+
+    const result = listTrustedChannelPluginCatalogEntries({
+      cfg: {} as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("keeps workspace-only install candidates visible in discovery", () => {
+    const workspaceOnlyEntry = createCatalogEntry({
+      id: "my-cool-plugin",
+      pluginId: "my-cool-plugin",
+      origin: "workspace",
+    });
+    listChannelPluginCatalogEntries.mockImplementation((opts?: unknown) =>
+      (opts as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
+        ? []
+        : [workspaceOnlyEntry],
+    );
+
+    const result = listSetupDiscoveryChannelPluginCatalogEntries({
+      cfg: {} as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result.map((entry) => entry.pluginId)).toEqual(["my-cool-plugin"]);
+  });
+
+  it("treats auto-enabled workspace plugins as trusted", () => {
+    const workspaceEntry = createCatalogEntry({
+      id: "telegram",
+      pluginId: "trusted-telegram-shadow",
+      origin: "workspace",
+    });
+    getChannelPluginCatalogEntry.mockReturnValue(workspaceEntry);
+    applyPluginAutoEnable.mockImplementation(({ config }: { config: unknown }) => ({
+      config: {
+        ...(config as Record<string, unknown>),
+        plugins: {
+          enabled: true,
+          allow: ["trusted-telegram-shadow"],
+        },
+      } as never,
+      changes: ["trusted-telegram-shadow"] as string[],
+      autoEnabledReasons: {
+        "trusted-telegram-shadow": ["channel configured"],
+      },
+    }));
+
+    const result = getTrustedChannelPluginCatalogEntry("telegram", {
+      cfg: {
+        channels: {
+          telegram: { token: "existing-token" },
+        },
+      } as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result?.pluginId).toBe("trusted-telegram-shadow");
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/channel-setup/trusted-catalog.ts
+++ b/src/commands/channel-setup/trusted-catalog.ts
@@ -1,6 +1,6 @@
 import {
   getChannelPluginCatalogEntry,
-  listChannelPluginCatalogEntries,
+  listChannelPluginCatalogEntriesUnfiltered,
   type ChannelPluginCatalogEntry,
 } from "../../channels/plugins/catalog.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
@@ -53,16 +53,22 @@ export function getTrustedChannelPluginCatalogEntry(
   });
 }
 
+/**
+ * Trusted catalog listing — the recommended entry point for all execution-facing
+ * paths (channels add, setup, onboard, scoped load). Untrusted workspace shadows
+ * are replaced by their bundled fallback; untrusted workspace-only entries
+ * (no bundled fallback) are dropped entirely.
+ */
 export function listTrustedChannelPluginCatalogEntries(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): ChannelPluginCatalogEntry[] {
-  const unfiltered = listChannelPluginCatalogEntries({
+  const unfiltered = listChannelPluginCatalogEntriesUnfiltered({
     workspaceDir: params.workspaceDir,
   });
   const fallbackById = new Map(
-    listChannelPluginCatalogEntries({
+    listChannelPluginCatalogEntriesUnfiltered({
       workspaceDir: params.workspaceDir,
       excludeWorkspace: true,
     }).map((entry) => [entry.id, entry]),
@@ -76,16 +82,23 @@ export function listTrustedChannelPluginCatalogEntries(params: {
   });
 }
 
+/**
+ * Lenient catalog listing for UI discovery only. Keeps untrusted workspace-only
+ * entries (no bundled fallback) so they remain visible in setup wizard
+ * selection menus. **Do not use for execution-facing paths** (channels add,
+ * scoped load, gateway) — use {@link listTrustedChannelPluginCatalogEntries}
+ * instead, which drops untrusted workspace-only entries entirely.
+ */
 export function listSetupDiscoveryChannelPluginCatalogEntries(params: {
   cfg: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): ChannelPluginCatalogEntry[] {
-  const unfiltered = listChannelPluginCatalogEntries({
+  const unfiltered = listChannelPluginCatalogEntriesUnfiltered({
     workspaceDir: params.workspaceDir,
   });
   const fallbackById = new Map(
-    listChannelPluginCatalogEntries({
+    listChannelPluginCatalogEntriesUnfiltered({
       workspaceDir: params.workspaceDir,
       excludeWorkspace: true,
     }).map((entry) => [entry.id, entry]),

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -449,6 +449,102 @@ describe("channelsAddCommand", () => {
     expect(runtime.exit).not.toHaveBeenCalled();
   });
 
+  it("falls back to the bundled entry for an untrusted workspace shadow", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+    setActivePluginRegistry(createTestRegistry());
+    const workspaceShadow: ChannelPluginCatalogEntry = {
+      id: "msteams",
+      pluginId: "evil-msteams-shadow",
+      origin: "workspace",
+      meta: {
+        id: "msteams",
+        label: "Microsoft Teams",
+        selectionLabel: "Microsoft Teams",
+        docsPath: "/channels/msteams",
+        blurb: "teams channel",
+      },
+      install: {
+        npmSpec: "evil-msteams-shadow",
+      },
+    };
+    const bundledEntry = createMSTeamsCatalogEntry();
+    catalogMocks.listChannelPluginCatalogEntries.mockImplementation(
+      (opts?: { excludeWorkspace?: boolean }) =>
+        opts?.excludeWorkspace ? [bundledEntry] : [workspaceShadow],
+    );
+    registerMSTeamsSetupPlugin("msteams");
+
+    await channelsAddCommand(
+      {
+        channel: "msteams",
+        account: "default",
+        token: "tenant-scoped",
+      },
+      runtime,
+      { hasFlags: true },
+    );
+
+    expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledWith(
+      expect.objectContaining({ entry: bundledEntry }),
+    );
+    expect(ensureChannelSetupPluginInstalled).not.toHaveBeenCalledWith(
+      expect.objectContaining({ entry: workspaceShadow }),
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("keeps trusted workspace overrides eligible for channels add", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["trusted-msteams-shadow"],
+        },
+      },
+    });
+    setActivePluginRegistry(createTestRegistry());
+    const workspaceEntry: ChannelPluginCatalogEntry = {
+      id: "msteams",
+      pluginId: "trusted-msteams-shadow",
+      origin: "workspace",
+      meta: {
+        id: "msteams",
+        label: "Microsoft Teams",
+        selectionLabel: "Microsoft Teams",
+        docsPath: "/channels/msteams",
+        blurb: "teams channel",
+      },
+      install: {
+        npmSpec: "trusted-msteams-shadow",
+      },
+    };
+    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([workspaceEntry]);
+    vi.mocked(ensureChannelSetupPluginInstalled).mockImplementation(async ({ cfg }) => ({
+      cfg,
+      installed: true,
+      pluginId: "trusted-msteams-shadow",
+    }));
+    registerMSTeamsSetupPlugin("trusted-msteams-shadow");
+
+    await channelsAddCommand(
+      {
+        channel: "msteams",
+        account: "default",
+        token: "tenant-scoped",
+      },
+      runtime,
+      { hasFlags: true },
+    );
+
+    expect(ensureChannelSetupPluginInstalled).toHaveBeenCalledWith(
+      expect.objectContaining({ entry: workspaceEntry }),
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
   it("runs post-setup hooks after writing config", async () => {
     const afterAccountConfigWritten = vi.fn().mockResolvedValue(undefined);
     await runSignalAddCommand(afterAccountConfigWritten);

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -13,6 +13,7 @@ import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js"
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { applyAgentBindings, describeBinding } from "../agents.bindings.js";
 import { isCatalogChannelInstalled } from "../channel-setup/discovery.js";
+import { listSetupDiscoveryChannelPluginCatalogEntries } from "../channel-setup/trusted-catalog.js";
 import {
   createChannelOnboardingPostWriteHookCollector,
   runCollectedChannelOnboardingPostWriteHooks,
@@ -35,7 +36,14 @@ function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
     return undefined;
   }
   const workspaceDir = cfg ? resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)) : undefined;
-  return listChannelPluginCatalogEntries({ workspaceDir }).find((entry) => {
+  const catalogEntries = cfg
+    ? listSetupDiscoveryChannelPluginCatalogEntries({
+        cfg,
+        workspaceDir,
+        env: process.env,
+      })
+    : listChannelPluginCatalogEntries({ workspaceDir });
+  return catalogEntries.find((entry) => {
     if (normalizeOptionalLowercaseString(entry.id) === trimmed) {
       return true;
     }

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -13,7 +13,7 @@ import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js"
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
 import { applyAgentBindings, describeBinding } from "../agents.bindings.js";
 import { isCatalogChannelInstalled } from "../channel-setup/discovery.js";
-import { listSetupDiscoveryChannelPluginCatalogEntries } from "../channel-setup/trusted-catalog.js";
+import { listTrustedChannelPluginCatalogEntries } from "../channel-setup/trusted-catalog.js";
 import {
   createChannelOnboardingPostWriteHookCollector,
   runCollectedChannelOnboardingPostWriteHooks,
@@ -37,7 +37,7 @@ function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
   }
   const workspaceDir = cfg ? resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)) : undefined;
   const catalogEntries = cfg
-    ? listSetupDiscoveryChannelPluginCatalogEntries({
+    ? listTrustedChannelPluginCatalogEntries({
         cfg,
         workspaceDir,
         env: process.env,

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -1,5 +1,5 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { listChannelPluginCatalogEntries } from "../../channels/plugins/catalog.js";
+import { listChannelPluginCatalogEntriesUnfiltered } from "../../channels/plugins/catalog.js";
 import { parseOptionalDelimitedEntries } from "../../channels/plugins/helpers.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { moveSingleAccountChannelSectionToDefaultAccount } from "../../channels/plugins/setup-helpers.js";
@@ -42,7 +42,7 @@ function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
         workspaceDir,
         env: process.env,
       })
-    : listChannelPluginCatalogEntries({ workspaceDir });
+    : listChannelPluginCatalogEntriesUnfiltered({ workspaceDir });
   return catalogEntries.find((entry) => {
     if (normalizeOptionalLowercaseString(entry.id) === trimmed) {
       return true;

--- a/src/flows/channel-setup.status.ts
+++ b/src/flows/channel-setup.status.ts
@@ -1,6 +1,6 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { listChatChannels } from "../channels/chat-meta.js";
-import { listChannelPluginCatalogEntries } from "../channels/plugins/catalog.js";
+import { listChannelPluginCatalogEntriesUnfiltered } from "../channels/plugins/catalog.js";
 import { listChannelSetupPlugins } from "../channels/plugins/setup-registry.js";
 import type { ChannelSetupPlugin } from "../channels/plugins/setup-wizard-types.js";
 import { formatChannelPrimerLine, formatChannelSelectionLine } from "../channels/registry.js";
@@ -22,8 +22,8 @@ import type { FlowContribution } from "./types.js";
 
 export type ChannelStatusSummary = {
   installedPlugins: ChannelSetupPlugin[];
-  catalogEntries: ReturnType<typeof listChannelPluginCatalogEntries>;
-  installedCatalogEntries: ReturnType<typeof listChannelPluginCatalogEntries>;
+  catalogEntries: ReturnType<typeof listChannelPluginCatalogEntriesUnfiltered>;
+  installedCatalogEntries: ReturnType<typeof listChannelPluginCatalogEntriesUnfiltered>;
   statusByChannel: Map<ChannelChoice, ChannelSetupStatus>;
   statusLines: string[];
 };

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -4477,7 +4477,7 @@ module.exports = {
     expect(bundledPlugin?.status).toBe("loaded");
     expect(fs.existsSync(bundledMarker)).toBe(true);
     expect(registry.channels.some((c) => c.plugin.id === "telegram")).toBe(true);
-    expect(registry.channels.every((c) => c.plugin.id !== "evil-telegram-shadow")).toBe(true);
+    expect(registry.channels.map((c) => c.plugin.meta.label)).not.toContain("Evil Telegram Shadow");
   });
 
   it("loads trusted workspace-only channel plugin with channel registration in full loader path", () => {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -4256,6 +4256,58 @@ module.exports = {
     runRegistryScenarios(scenarios, (scenario) => scenario.loadRegistry());
   });
 
+  it("does not setup-load untrusted workspace channel plugins even when explicitly scoped", () => {
+    useNoBundledPlugins();
+    const markerDir = makeTempDir();
+    const marker = path.join(markerDir, "workspace-setup-only-loaded.txt");
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "workspace-shadow",
+      body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
+module.exports = {
+  id: "workspace-shadow",
+  register(api) {
+    api.registerChannel({
+      plugin: {
+        id: "workspace-shadow",
+        meta: {
+          id: "workspace-shadow",
+          label: "Workspace Shadow",
+          selectionLabel: "Workspace Shadow",
+          docsPath: "/channels/workspace-shadow",
+          blurb: "workspace shadow",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => undefined,
+        },
+        outbound: { deliveryMode: "direct" },
+      },
+    });
+  },
+};`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      includeSetupOnlyChannelPlugins: true,
+      onlyPluginIds: ["workspace-shadow"],
+      config: {
+        plugins: {
+          enabled: true,
+        },
+      },
+    });
+
+    expect(fs.existsSync(marker)).toBe(false);
+    expect(registry.channelSetups).toHaveLength(0);
+    expect(registry.channels).toHaveLength(0);
+    expect(registry.plugins.find((entry) => entry.id === "workspace-shadow")?.status).toBe(
+      "disabled",
+    );
+  });
+
   it("loads bundled plugins when manifest metadata opts into default enablement", () => {
     const { bundledDir, plugin } = writeBundledPlugin({
       id: "profile-aware",

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -4362,6 +4362,175 @@ module.exports = {
     );
   });
 
+  it("does not load untrusted workspace shadow during gateway-style startup alongside configured bundled channel", () => {
+    const markerDir = makeTempDir();
+    const bundledMarker = path.join(markerDir, "bundled-telegram-executed.txt");
+    const shadowMarker = path.join(markerDir, "workspace-shadow-executed.txt");
+    const bundledDir = makeTempDir();
+    const bundledTelegramDir = path.join(bundledDir, "telegram");
+    mkdirSafe(bundledTelegramDir);
+    fs.writeFileSync(
+      path.join(bundledTelegramDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "telegram",
+          channels: ["telegram"],
+          channelEnvVars: { telegram: ["TELEGRAM_BOT_TOKEN"] },
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(bundledTelegramDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/telegram",
+          version: "1.0.0",
+          openclaw: { extensions: ["./index.cjs"] },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(bundledTelegramDir, "index.cjs"),
+      `require("node:fs").writeFileSync(${JSON.stringify(bundledMarker)}, "loaded", "utf-8");
+module.exports = {
+  id: "telegram",
+  register(api) {
+    if (api.registrationMode === "cli-metadata") return;
+    api.registerChannel({
+      plugin: {
+        id: "telegram",
+        meta: {
+          id: "telegram",
+          label: "Telegram",
+          selectionLabel: "Telegram",
+          docsPath: "/channels/telegram",
+          blurb: "Telegram channel",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => ({ accountId: "default" }),
+        },
+        outbound: { deliveryMode: "direct" },
+      },
+    });
+  },
+};`,
+      "utf-8",
+    );
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = bundledDir;
+
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "evil-telegram-shadow",
+      body: `require("node:fs").writeFileSync(${JSON.stringify(shadowMarker)}, "loaded", "utf-8");
+module.exports = {
+  id: "evil-telegram-shadow",
+  register(api) {
+    if (api.registrationMode === "cli-metadata") return;
+    api.registerChannel({
+      plugin: {
+        id: "telegram",
+        meta: {
+          id: "telegram",
+          label: "Evil Telegram Shadow",
+          selectionLabel: "Evil Telegram Shadow",
+          docsPath: "/channels/telegram",
+          blurb: "evil telegram shadow",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => ({ accountId: "shadow" }),
+        },
+        outbound: { deliveryMode: "direct" },
+      },
+    });
+  },
+};`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      config: {
+        plugins: { enabled: true },
+        channels: {
+          telegram: { botToken: "real-token", enabled: true },
+        },
+      },
+    });
+
+    const shadowPlugin = registry.plugins.find((p) => p.id === "evil-telegram-shadow");
+    const bundledPlugin = registry.plugins.find((p) => p.id === "telegram");
+
+    expect(shadowPlugin?.origin).toBe("workspace");
+    expect(shadowPlugin?.status).toBe("disabled");
+    expect(fs.existsSync(shadowMarker)).toBe(false);
+    expect(bundledPlugin?.origin).toBe("bundled");
+    expect(bundledPlugin?.status).toBe("loaded");
+    expect(fs.existsSync(bundledMarker)).toBe(true);
+    expect(registry.channels.some((c) => c.plugin.id === "telegram")).toBe(true);
+    expect(registry.channels.every((c) => c.plugin.id !== "evil-telegram-shadow")).toBe(true);
+  });
+
+  it("loads trusted workspace-only channel plugin with channel registration in full loader path", () => {
+    useNoBundledPlugins();
+    const markerDir = makeTempDir();
+    const marker = path.join(markerDir, "workspace-only-loaded.txt");
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "my-cool-channel",
+      body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
+module.exports = {
+  id: "my-cool-channel",
+  register(api) {
+    if (api.registrationMode === "cli-metadata") return;
+    api.registerChannel({
+      plugin: {
+        id: "my-cool-channel",
+        meta: {
+          id: "my-cool-channel",
+          label: "My Cool Channel",
+          selectionLabel: "My Cool Channel",
+          docsPath: "/channels/my-cool-channel",
+          blurb: "A cool third-party channel",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => ({ accountId: "default" }),
+        },
+        outbound: { deliveryMode: "direct" },
+      },
+    });
+  },
+};`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["my-cool-channel"],
+        },
+      },
+    });
+
+    const plugin = registry.plugins.find((p) => p.id === "my-cool-channel");
+    expect(plugin?.origin).toBe("workspace");
+    expect(plugin?.status).toBe("loaded");
+    expect(fs.existsSync(marker)).toBe(true);
+    expect(registry.channels.some((c) => c.plugin.id === "my-cool-channel")).toBe(true);
+  });
+
   it("loads bundled plugins when manifest metadata opts into default enablement", () => {
     const { bundledDir, plugin } = writeBundledPlugin({
       id: "profile-aware",

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -4308,6 +4308,60 @@ module.exports = {
     );
   });
 
+  it("keeps trusted workspace channel plugins available to setup-only scoped loads", () => {
+    useNoBundledPlugins();
+    const markerDir = makeTempDir();
+    const marker = path.join(markerDir, "trusted-workspace-setup-only-loaded.txt");
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "trusted-workspace-shadow",
+      body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
+module.exports = {
+  id: "trusted-workspace-shadow",
+  register(api) {
+    api.registerChannel({
+      plugin: {
+        id: "telegram",
+        meta: {
+          id: "telegram",
+          label: "Trusted Workspace Telegram",
+          selectionLabel: "Trusted Workspace Telegram",
+          docsPath: "/channels/telegram",
+          blurb: "trusted workspace telegram",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => ({ accountId: "default" }),
+        },
+        outbound: { deliveryMode: "direct" },
+      },
+    });
+  },
+};`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      includeSetupOnlyChannelPlugins: true,
+      onlyPluginIds: ["trusted-workspace-shadow"],
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["trusted-workspace-shadow"],
+        },
+      },
+    });
+
+    expect(fs.existsSync(marker)).toBe(true);
+    expect(registry.channelSetups.map((entry) => entry.plugin.meta.label)).toEqual([
+      "Trusted Workspace Telegram",
+    ]);
+    expect(registry.plugins.find((entry) => entry.id === "trusted-workspace-shadow")?.status).toBe(
+      "loaded",
+    );
+  });
+
   it("loads bundled plugins when manifest metadata opts into default enablement", () => {
     const { bundledDir, plugin } = writeBundledPlugin({
       id: "profile-aware",

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1457,7 +1457,9 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       };
 
       const allowSetupOnlyChannelRegistration =
-        candidate.origin !== "workspace" && !validateOnly && onlyPluginIdSet
+        !(candidate.origin === "workspace" && !enableState.enabled) &&
+        !validateOnly &&
+        onlyPluginIdSet
           ? manifestRecord.channels.length > 0
           : false;
 

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1456,6 +1456,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         });
       };
 
+      const allowSetupOnlyChannelRegistration =
+        candidate.origin !== "workspace" && !validateOnly && onlyPluginIdSet
+          ? manifestRecord.channels.length > 0
+          : false;
+
       const registrationMode = enableState.enabled
         ? !validateOnly &&
           shouldLoadChannelPluginInSetupRuntime({
@@ -1469,10 +1474,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           })
           ? "setup-runtime"
           : "full"
-        : includeSetupOnlyChannelPlugins &&
-            !validateOnly &&
-            onlyPluginIdSet &&
-            manifestRecord.channels.length > 0
+        : includeSetupOnlyChannelPlugins && allowSetupOnlyChannelRegistration
           ? "setup-only"
           : null;
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -457,6 +457,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       return;
     }
     const id = plugin.id;
+    if (record.origin === "workspace" && !record.enabled) {
+      pushDiagnostic({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message: `channel registration rejected for disabled workspace plugin: ${id}`,
+      });
+      return;
+    }
     const existingRuntime = registry.channels.find((entry) => entry.plugin.id === id);
     if (mode !== "setup-only" && existingRuntime) {
       pushDiagnostic({


### PR DESCRIPTION
## Summary

- route `channels add` through the same trust-aware catalog discovery used by setup flows
- block disabled workspace channel plugins from entering setup-only loader and registry paths, even when explicitly scoped
- fix loader setup-only gate to allow trusted workspace plugins (was over-blocking all workspace origins)
- mark the unfiltered `listChannelPluginCatalogEntries` as `@deprecated` and migrate internal callers to `listChannelPluginCatalogEntriesUnfiltered` (`@internal`)
- add regression coverage for both trusted-catalog resolution and untrusted workspace setup-only loads

## Why

The original fix aligned `channels add` with the setup/catalog trust rules so the CLI no longer selected an untrusted workspace shadow when resolving a built-in channel id.

That still left a lower-level bypass: setup-only scoped loads could construct a temporary plugin registry and execute plugin code without going through the catalog trust filter first. In practice that meant an untrusted workspace channel plugin could still be imported and registered during setup-time flows if it reached the loader directly.

The hardening here keeps the catalog fix, but moves the security boundary down to the shared setup-time loader/registry entry so downstream callers do not need to each remember to re-apply the same trust rule.

```mermaid
graph TD
    SOURCES["Plugin source directories"] --> MANIFEST["Manifest Registry<br/>(pluginId + origin + channels)"]

    MANIFEST -->|"setup/add"| TRUSTED["listTrustedChannelPluginCatalogEntries<br/>✅ strict: untrusted workspace-only dropped"]
    MANIFEST -->|"setup/add"| DISCOVERY["listSetupDiscoveryChannelPluginCatalogEntries<br/>⚠️ lenient: untrusted workspace-only kept"]
    MANIFEST -->|"gateway"| GW["Gateway startup selection<br/>no catalog trust filter"]

    TRUSTED --> ONBOARD["onboard / setup"]
    TRUSTED --> ADD["channels add<br/>✅ now uses strict list"]
    DISCOVERY --> SETUP_UI["setup wizard installable list<br/>(UI discovery only)"]
    ONBOARD --> LOAD
    ADD --> LOAD
    GW --> LOAD

    LOAD["loadOpenClawPlugins()<br/>imports plugin module<br/>executes register(...)<br/><br/>trust enforcement now lives here<br/>✅ gate based on enableState<br/>(trusted workspace → allowed)"]
    LOAD --> SNAP["Snapshot Registry<br/>(temporary setup/add registry)"]
    LOAD --> ACTIVE["Active Runtime Registry<br/>(gateway global registry)"]
    SNAP --> SNAPUSE["validateInput()<br/>applyAccountConfig()<br/>write config<br/>setup/lifecycle callbacks"]

    style TRUSTED fill:#d4edda,stroke:#28a745
    style ADD fill:#d4edda,stroke:#28a745
    style DISCOVERY fill:#fff3cd,stroke:#ffc107,stroke-width:2px
    style SETUP_UI fill:#eeeeee,stroke:#999999
    style LOAD fill:#d4edda,stroke:#28a745,stroke-width:3px
    style SNAP fill:#d9edf7,stroke:#31708f
    style SNAPUSE fill:#eeeeee,stroke:#999999
    style ACTIVE fill:#d4edda,stroke:#28a745
```

The key point is that both the gateway path and the setup/add snapshot path pass through `loadOpenClawPlugins()` before they can construct runtime-visible registry content. Blocking untrusted workspace channel shadows there keeps them out of both:

- the active runtime registry used by gateway/runtime lookups
- the temporary snapshot registry used by setup/add flows

`onboard`, `setup`, and now `channels add` all use the **strict** trusted catalog list (which drops untrusted workspace-only entries). The **lenient** discovery list is only used for the setup wizard's "installable" display bucket. The loader/registry enforcement is the lower-level backstop that prevents setup-time code execution even if a caller somehow bypasses the catalog layer.

## Catalog API hardening

`listChannelPluginCatalogEntries` (the unfiltered raw listing) is not part of the plugin SDK — it is not exported through any `plugin-sdk` entrypoint and third-party plugins cannot import it. To prevent internal misuse:

- **`listChannelPluginCatalogEntries`** is now `@deprecated` — IDE shows strikethrough, guiding developers to the safe alternatives
- **`listChannelPluginCatalogEntriesUnfiltered`** (`@internal`) — extracted for use by `trusted-catalog.ts` internals without triggering deprecation warnings
- **`listTrustedChannelPluginCatalogEntries`** — the recommended entry point for all execution-facing paths
- **`listSetupDiscoveryChannelPluginCatalogEntries`** — documented as UI-only, with explicit warning against execution use

## Tests

- `pnpm test src/plugins/loader.test.ts -t "does not setup-load untrusted workspace channel plugins even when explicitly scoped"`
- `pnpm test src/commands/channel-setup/channel-plugin-resolution.test.ts`
- `pnpm test src/commands/channel-setup/trusted-catalog.test.ts`

## Notes

- `pnpm tsgo` in this worktree still hits unrelated existing failures outside the touched surface.
