### PR TITLE
feat: Add unified Amazon plugin — Polly TTS, Transcribe STT, Nova Sonic realtime voice

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,8 @@
+"plugin: amazon":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/amazon/**"
+          - "docs/providers/amazon.md"
 "plugin: azure-speech":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### New
+
+- Plugins/Amazon: add unified Amazon AWS services plugin with Polly TTS, Transcribe STT, and Nova Sonic realtime voice. All services authenticate via the standard AWS IAM credential chain. (#64318) Thanks @wirjo.
+
 ## 2026.5.22
 
 ### Changes

--- a/docs/providers/amazon.md
+++ b/docs/providers/amazon.md
@@ -1,0 +1,125 @@
+---
+summary: "Amazon AWS AI services — Polly TTS, Transcribe STT, Nova Sonic realtime voice"
+read_when:
+  - You want Amazon Polly text-to-speech
+  - You want Amazon Transcribe speech-to-text
+  - You want Amazon Nova Sonic realtime voice conversations
+  - You need AWS credential configuration for AI providers
+title: "Amazon"
+---
+
+The **Amazon** plugin bundles three AWS AI services into a single extension:
+
+| Service          | Capability      | Default Model / Voice        |
+| ---------------- | --------------- | ---------------------------- |
+| Amazon Polly     | TTS (speech)    | `neural` engine, `Joanna`    |
+| Amazon Transcribe| STT (audio)     | Streaming transcription      |
+| Nova Sonic       | Realtime voice  | `amazon.nova-sonic-v1:0`, `tiffany` |
+
+All services authenticate via the **AWS IAM credential chain** (environment
+variables, shared credentials file, instance profile, ECS task role, etc.).
+No separate API key is needed — if your environment can call AWS APIs, the
+plugin will work.
+
+| Detail        | Value                                                                        |
+| ------------- | ---------------------------------------------------------------------------- |
+| Website       | [aws.amazon.com](https://aws.amazon.com)                                     |
+| Docs          | [docs.aws.amazon.com](https://docs.aws.amazon.com)                           |
+| Auth          | AWS IAM credential chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` or instance role) |
+| Regions       | Any AWS region where the services are available                               |
+
+## Getting started
+
+<Steps>
+  <Step title="Ensure AWS credentials are available">
+    The plugin uses the standard AWS SDK credential chain. Set environment
+    variables or configure `~/.aws/credentials`:
+
+    ```bash
+    export AWS_ACCESS_KEY_ID=AKIA...
+    export AWS_SECRET_ACCESS_KEY=...
+    export AWS_REGION=us-east-1
+    ```
+
+  </Step>
+  <Step title="Enable the plugin">
+    ```json5
+    {
+      "plugins": {
+        "entries": {
+          "amazon": {
+            "enabled": true,
+            "config": {
+              "polly": {
+                "enabled": true,
+                "region": "us-east-1",
+                "voice": "Joanna",
+                "engine": "neural"
+              },
+              "transcribe": {
+                "enabled": true,
+                "region": "us-east-1",
+                "languageCode": "en-US"
+              },
+              "novaSonic": {
+                "enabled": true,
+                "region": "us-east-1",
+                "voice": "tiffany"
+              }
+            }
+          }
+        }
+      }
+    }
+    ```
+
+  </Step>
+</Steps>
+
+## Configuration reference
+
+### Polly (TTS)
+
+| Key       | Default      | Description                          |
+| --------- | ------------ | ------------------------------------ |
+| `enabled` | `true`       | Enable/disable Polly TTS             |
+| `region`  | `us-east-1`  | AWS region                           |
+| `voice`   | `Joanna`     | Polly voice ID                       |
+| `engine`  | `neural`     | `neural` or `standard`               |
+
+### Transcribe (STT)
+
+| Key            | Default      | Description                     |
+| -------------- | ------------ | ------------------------------- |
+| `enabled`      | `true`       | Enable/disable Transcribe STT   |
+| `region`       | `us-east-1`  | AWS region                      |
+| `languageCode` | —            | BCP-47 language code (optional) |
+
+### Nova Sonic (Realtime Voice)
+
+| Key           | Default                   | Description                    |
+| ------------- | ------------------------- | ------------------------------ |
+| `enabled`     | `true`                    | Enable/disable Nova Sonic      |
+| `region`      | `us-east-1`              | AWS region                     |
+| `model`       | `amazon.nova-sonic-v1:0` | Model ID                       |
+| `voice`       | `tiffany`                | Voice ID                       |
+| `temperature` | `0.7`                    | Generation temperature         |
+| `maxTokens`   | `4096`                   | Max output tokens              |
+
+## Disabling individual services
+
+Set `enabled: false` on any sub-service to skip registration:
+
+```json5
+{
+  "plugins": {
+    "entries": {
+      "amazon": {
+        "config": {
+          "transcribe": { "enabled": false }
+        }
+      }
+    }
+  }
+}
+```

--- a/docs/providers/amazon.md
+++ b/docs/providers/amazon.md
@@ -12,7 +12,7 @@ The **Amazon** plugin bundles three AWS AI services into a single extension:
 
 | Service          | Capability      | Default Model / Voice        |
 | ---------------- | --------------- | ---------------------------- |
-| Amazon Polly     | TTS (speech)    | `neural` engine, `Joanna`    |
+| Amazon Polly     | TTS (speech)    | `generative` engine, `Ruth`    |
 | Amazon Transcribe| STT (audio)     | Streaming transcription      |
 | Nova Sonic       | Realtime voice  | `amazon.nova-sonic-v1:0`, `tiffany` |
 
@@ -53,8 +53,8 @@ plugin will work.
               "polly": {
                 "enabled": true,
                 "region": "us-east-1",
-                "voice": "Joanna",
-                "engine": "neural"
+                "voice": "Ruth",
+                "engine": "generative"
               },
               "transcribe": {
                 "enabled": true,
@@ -84,8 +84,8 @@ plugin will work.
 | --------- | ------------ | ------------------------------------ |
 | `enabled` | `true`       | Enable/disable Polly TTS             |
 | `region`  | `us-east-1`  | AWS region                           |
-| `voice`   | `Joanna`     | Polly voice ID                       |
-| `engine`  | `neural`     | `neural` or `standard`               |
+| `voice`   | `Ruth`       | Polly voice ID                       |
+| `engine`  | `generative` | `generative`, `neural`, or `standard`|
 
 ### Transcribe (STT)
 

--- a/extensions/amazon/index.ts
+++ b/extensions/amazon/index.ts
@@ -1,0 +1,15 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { buildPollySpeechProvider } from "./polly/speech-provider.js";
+import { buildTranscribeMediaProvider } from "./transcribe/media-understanding-provider.js";
+import { buildNovaSonicVoiceProvider } from "./nova-sonic/realtime-voice-provider.js";
+
+export default definePluginEntry({
+  id: "amazon",
+  name: "Amazon AWS Services",
+  description: "Amazon Polly (TTS), Transcribe (STT), Nova Sonic (realtime voice), and other AWS AI services.",
+  register(api) {
+    api.registerSpeechProvider(buildPollySpeechProvider(api.pluginConfig));
+    api.registerMediaUnderstandingProvider(buildTranscribeMediaProvider(api.pluginConfig));
+    api.registerRealtimeVoiceProvider(buildNovaSonicVoiceProvider(api.pluginConfig));
+  },
+});

--- a/extensions/amazon/index.ts
+++ b/extensions/amazon/index.ts
@@ -8,13 +8,19 @@ export default definePluginEntry({
   name: "Amazon AWS Services",
   description: "Amazon Polly (TTS), Transcribe (STT), Nova Sonic (realtime voice), and other AWS AI services.",
   register(api) {
-    api.registerSpeechProvider(buildPollySpeechProvider(api.pluginConfig));
+    const pollyProvider = buildPollySpeechProvider(api.pluginConfig);
+    if (pollyProvider) {
+      api.registerSpeechProvider(pollyProvider);
+    }
 
     const transcribeProvider = buildTranscribeMediaProvider(api.pluginConfig);
     if (transcribeProvider) {
       api.registerMediaUnderstandingProvider(transcribeProvider);
     }
 
-    api.registerRealtimeVoiceProvider(buildNovaSonicVoiceProvider(api.pluginConfig));
+    const novaSonicProvider = buildNovaSonicVoiceProvider(api.pluginConfig);
+    if (novaSonicProvider) {
+      api.registerRealtimeVoiceProvider(novaSonicProvider);
+    }
   },
 });

--- a/extensions/amazon/index.ts
+++ b/extensions/amazon/index.ts
@@ -9,7 +9,12 @@ export default definePluginEntry({
   description: "Amazon Polly (TTS), Transcribe (STT), Nova Sonic (realtime voice), and other AWS AI services.",
   register(api) {
     api.registerSpeechProvider(buildPollySpeechProvider(api.pluginConfig));
-    api.registerMediaUnderstandingProvider(buildTranscribeMediaProvider(api.pluginConfig));
+
+    const transcribeProvider = buildTranscribeMediaProvider(api.pluginConfig);
+    if (transcribeProvider) {
+      api.registerMediaUnderstandingProvider(transcribeProvider);
+    }
+
     api.registerRealtimeVoiceProvider(buildNovaSonicVoiceProvider(api.pluginConfig));
   },
 });

--- a/extensions/amazon/nova-sonic/bridge.test.ts
+++ b/extensions/amazon/nova-sonic/bridge.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from "vitest";
+import { NovaSonicVoiceBridge } from "./bridge.js";
+
+// Mock the AWS SDK
+vi.mock("@aws-sdk/client-bedrock-runtime", () => ({
+  BedrockRuntimeClient: vi.fn().mockImplementation(() => ({
+    send: vi.fn().mockRejectedValue(new Error("mock: not connected")),
+  })),
+  InvokeModelWithBidirectionalStreamCommand: vi.fn(),
+}));
+
+vi.mock("../shared/client-cache.js", () => ({
+  getAwsClient: vi.fn((_key, factory) => factory()),
+}));
+
+describe("NovaSonicVoiceBridge protocol", () => {
+  it("builds sessionStart with inferenceConfiguration and turnDetectionConfiguration", () => {
+    const bridge = new NovaSonicVoiceBridge({
+      region: "us-east-1",
+      model: "amazon.nova-sonic-v1:0",
+      voice: "tiffany",
+      temperature: 0.8,
+      maxTokens: 2048,
+    });
+
+    // Access private method via any cast for testing
+    const event = (bridge as any).buildSessionStartEvent();
+
+    expect(event.event.sessionStart.inferenceConfiguration).toEqual({
+      maxTokens: 2048,
+      topP: 0.9,
+      temperature: 0.8,
+    });
+    expect(event.event.sessionStart.turnDetectionConfiguration).toEqual({
+      endpointingSensitivity: "MEDIUM",
+    });
+  });
+
+  it("builds promptStart with correct audioOutputConfiguration", () => {
+    const bridge = new NovaSonicVoiceBridge({
+      region: "us-east-1",
+      model: "amazon.nova-sonic-v1:0",
+      voice: "matthew",
+    });
+
+    const event = (bridge as any).buildPromptStartEvent("test-prompt-id");
+    const audio = event.event.promptStart.audioOutputConfiguration;
+
+    expect(audio.mediaType).toBe("audio/lpcm");
+    expect(audio.sampleRateHertz).toBe(24000);
+    expect(audio.sampleSizeBits).toBe(16);
+    expect(audio.voiceId).toBe("matthew");
+    expect(audio.encoding).toBe("base64");
+    expect(event.event.promptStart.promptName).toBe("test-prompt-id");
+  });
+
+  it("builds system prompt events with contentStart/textInput/contentEnd", () => {
+    const bridge = new NovaSonicVoiceBridge({
+      region: "us-east-1",
+      model: "amazon.nova-sonic-v1:0",
+      voice: "tiffany",
+      instructions: "You are a helpful assistant.",
+    });
+
+    const events = (bridge as any).buildSystemPromptEvents("prompt-123");
+
+    expect(events).toHaveLength(3);
+    expect(events[0].event.contentStart.role).toBe("SYSTEM");
+    expect(events[0].event.contentStart.type).toBe("TEXT");
+    expect(events[0].event.contentStart.promptName).toBe("prompt-123");
+    expect(events[1].event.textInput.content).toBe("You are a helpful assistant.");
+    expect(events[1].event.textInput.promptName).toBe("prompt-123");
+    expect(events[2].event.contentEnd.promptName).toBe("prompt-123");
+    // contentName should be consistent across all three
+    const cn = events[0].event.contentStart.contentName;
+    expect(cn).toBeTruthy();
+    expect(events[1].event.textInput.contentName).toBe(cn);
+    expect(events[2].event.contentEnd.contentName).toBe(cn);
+  });
+
+  it("builds audio contentStart with audioInputConfiguration", () => {
+    const bridge = new NovaSonicVoiceBridge({
+      region: "us-east-1",
+      model: "amazon.nova-sonic-v1:0",
+      voice: "tiffany",
+    });
+
+    const event = (bridge as any).buildAudioContentStartEvent("prompt-abc", "content-xyz");
+
+    expect(event.event.contentStart.promptName).toBe("prompt-abc");
+    expect(event.event.contentStart.contentName).toBe("content-xyz");
+    expect(event.event.contentStart.type).toBe("AUDIO");
+    expect(event.event.contentStart.role).toBe("USER");
+    expect(event.event.contentStart.audioInputConfiguration).toEqual({
+      mediaType: "audio/lpcm",
+      sampleRateHertz: 16000,
+      sampleSizeBits: 16,
+      channelCount: 1,
+      encoding: "base64",
+      audioType: "SPEECH",
+    });
+  });
+
+  it("returns empty events array when no system instructions", () => {
+    const bridge = new NovaSonicVoiceBridge({
+      region: "us-east-1",
+      model: "amazon.nova-sonic-v1:0",
+      voice: "tiffany",
+    });
+
+    const events = (bridge as any).buildSystemPromptEvents("prompt-123");
+    expect(events).toHaveLength(0);
+  });
+
+  it("includes tool configuration in promptStart when tools provided", () => {
+    const bridge = new NovaSonicVoiceBridge({
+      region: "us-east-1",
+      model: "amazon.nova-sonic-v1:0",
+      voice: "tiffany",
+      tools: [{ name: "get_weather", description: "Get weather", parameters: { type: "object" } }],
+    });
+
+    const event = (bridge as any).buildPromptStartEvent("prompt-456");
+    expect(event.event.promptStart.toolConfiguration.tools).toHaveLength(1);
+    expect(event.event.promptStart.toolConfiguration.tools[0].toolSpec.name).toBe("get_weather");
+  });
+});

--- a/extensions/amazon/nova-sonic/bridge.ts
+++ b/extensions/amazon/nova-sonic/bridge.ts
@@ -1,0 +1,351 @@
+import {
+  BedrockRuntimeClient,
+  InvokeModelWithBidirectionalStreamCommand,
+  type InvokeModelWithBidirectionalStreamCommandOutput,
+} from "@aws-sdk/client-bedrock-runtime";
+import type {
+  RealtimeVoiceBridge,
+  RealtimeVoiceBridgeCallbacks,
+  RealtimeVoiceTool,
+} from "openclaw/plugin-sdk/realtime-voice";
+import { getAwsClient } from "../shared/client-cache.js";
+import { mulawToPcm16, pcm16ToMulaw } from "../shared/audio-utils.js";
+
+const CONNECT_TIMEOUT_MS = 10_000;
+const MAX_RECONNECT_ATTEMPTS = 3;
+const BASE_RECONNECT_DELAY_MS = 1000;
+const MAX_PENDING_AUDIO = 320;
+
+type NovaSonicBridgeConfig = RealtimeVoiceBridgeCallbacks & {
+  region: string;
+  model: string;
+  voice: string;
+  instructions?: string;
+  tools?: RealtimeVoiceTool[];
+  temperature?: number;
+  maxTokens?: number;
+};
+
+function getBedrockClient(region: string): BedrockRuntimeClient {
+  return getAwsClient(`bedrock-runtime:${region}`, () => new BedrockRuntimeClient({ region }));
+}
+
+function encodeEvent(event: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(event));
+}
+
+export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
+  private client: BedrockRuntimeClient;
+  private connected = false;
+  private intentionallyClosed = false;
+  private reconnectAttempts = 0;
+  private pendingAudio: Buffer[] = [];
+  private inputStream: Array<{ chunk: { bytes: Uint8Array } }> = [];
+  private inputResolve: ((done: boolean) => void) | null = null;
+  private latestMediaTimestamp = 0;
+  private responseStartTimestamp: number | null = null;
+  private markQueue: string[] = [];
+
+  constructor(private readonly config: NovaSonicBridgeConfig) {
+    this.client = getBedrockClient(config.region);
+  }
+
+  async connect(): Promise<void> {
+    this.intentionallyClosed = false;
+    this.reconnectAttempts = 0;
+    await this.doConnect();
+  }
+
+  sendAudio(audio: Buffer): void {
+    if (!this.connected) {
+      if (this.pendingAudio.length < MAX_PENDING_AUDIO) {
+        this.pendingAudio.push(audio);
+      }
+      return;
+    }
+
+    // Convert mu-law (telephony format) to PCM 16-bit for Nova Sonic
+    const pcmAudio = mulawToPcm16(audio);
+
+    this.enqueueEvent({
+      event: { type: "audioInput" },
+      data: { audioChunk: pcmAudio.toString("base64") },
+    });
+  }
+
+  setMediaTimestamp(ts: number): void {
+    this.latestMediaTimestamp = ts;
+  }
+
+  sendUserMessage?(_text: string): void {
+    // Nova Sonic is speech-first and does not accept text-only input.
+    // Throw rather than routing through onError, which could trigger session teardown.
+    throw new Error("Nova Sonic does not support text-only input; use audio");
+  }
+
+  triggerGreeting?(instructions?: string): void {
+    // Send a brief silent frame to prompt Nova Sonic to begin with its system prompt
+    if (!this.connected) { return; }
+    const silentPcm = Buffer.alloc(3200); // 100ms of silence at 16kHz 16-bit mono
+    this.enqueueEvent({
+      event: { type: "audioInput" },
+      data: { audioChunk: silentPcm.toString("base64") },
+    });
+  }
+
+  submitToolResult(callId: string, result: unknown): void {
+    this.enqueueEvent({
+      event: { type: "toolResult" },
+      data: {
+        toolUseId: callId,
+        content: [{ text: JSON.stringify(result) }],
+      },
+    });
+  }
+
+  acknowledgeMark(): void {
+    if (this.markQueue.length === 0) { return; }
+    this.markQueue.shift();
+    if (this.markQueue.length === 0) {
+      this.responseStartTimestamp = null;
+    }
+  }
+
+  close(): void {
+    this.intentionallyClosed = true;
+    this.connected = false;
+    this.inputResolve?.(true);
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  // --- Private ---
+
+  private buildSessionConfig() {
+    return {
+      event: { type: "sessionStart" },
+      data: {
+        inferenceConfig: {
+          maxTokens: this.config.maxTokens ?? 4096,
+          topP: 0.9,
+          temperature: this.config.temperature ?? 0.7,
+        },
+        requestConfig: {
+          inputAudioConfig: {
+            audioEncoding: "pcm" as const,
+            sampleRateHertz: 16000,
+            channelCount: 1,
+          },
+          outputAudioConfig: {
+            audioEncoding: "pcm" as const,
+            sampleRateHertz: 24000,
+            channelCount: 1,
+            voiceId: this.config.voice,
+          },
+          sessionAttributes: {},
+        },
+        ...(this.config.instructions
+          ? { systemPrompt: { text: this.config.instructions } }
+          : {}),
+        ...(this.config.tools && this.config.tools.length > 0
+          ? {
+              toolConfig: {
+                tools: this.config.tools.map((t) => ({
+                  toolSpec: {
+                    name: t.name,
+                    description: t.description,
+                    inputSchema: { json: t.parameters },
+                  },
+                })),
+              },
+            }
+          : {}),
+      },
+    };
+  }
+
+  private async doConnect(): Promise<void> {
+    const sessionConfig = this.buildSessionConfig();
+    const self = this;
+
+    async function* inputGenerator() {
+      yield { chunk: { bytes: encodeEvent(sessionConfig) } };
+      while (!self.intentionallyClosed) {
+        if (self.inputStream.length > 0) {
+          const batch = self.inputStream.splice(0);
+          for (const item of batch) { yield item; }
+        } else {
+          await new Promise<boolean>((resolve) => { self.inputResolve = resolve; });
+        }
+      }
+      yield { chunk: { bytes: encodeEvent({ event: { type: "sessionEnd" } }) } };
+    }
+
+    try {
+      const command = new InvokeModelWithBidirectionalStreamCommand({
+        modelId: this.config.model,
+        body: inputGenerator(),
+      });
+
+      let connectTimer: ReturnType<typeof setTimeout> | undefined;
+      const response = await Promise.race([
+        this.client.send(command),
+        new Promise<never>((_, reject) => {
+          connectTimer = setTimeout(
+            () => reject(new Error("Nova Sonic connection timeout")),
+            CONNECT_TIMEOUT_MS,
+          );
+        }),
+      ]).finally(() => clearTimeout(connectTimer));
+
+      this.connected = true;
+      this.reconnectAttempts = 0;
+
+      for (const chunk of this.pendingAudio.splice(0)) {
+        this.sendAudio(chunk);
+      }
+
+      this.config.onReady?.();
+      void this.processOutputStream(response as InvokeModelWithBidirectionalStreamCommandOutput);
+    } catch (err) {
+      this.config.onError?.(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    }
+  }
+
+  private async attemptReconnect(): Promise<void> {
+    if (this.intentionallyClosed) { return; }
+    if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      this.config.onClose?.("error");
+      return;
+    }
+    this.reconnectAttempts += 1;
+    const delay = BASE_RECONNECT_DELAY_MS * 2 ** (this.reconnectAttempts - 1);
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    if (this.intentionallyClosed) { return; }
+    try {
+      await this.doConnect();
+    } catch {
+      await this.attemptReconnect();
+    }
+  }
+
+  private enqueueEvent(event: unknown): void {
+    this.inputStream.push({ chunk: { bytes: encodeEvent(event) } });
+    this.inputResolve?.(false);
+    this.inputResolve = null;
+  }
+
+  private async processOutputStream(response: InvokeModelWithBidirectionalStreamCommandOutput): Promise<void> {
+    try {
+      const body = response.body;
+      if (!body) { return; }
+
+      for await (const event of body) {
+        if (this.intentionallyClosed) { break; }
+        const bytes = (event as { chunk?: { bytes?: Uint8Array } }).chunk?.bytes;
+        if (!bytes) { continue; }
+
+        const decoded = new TextDecoder().decode(bytes);
+        for (const line of decoded.split("\n")) {
+          if (!line.trim()) { continue; }
+          try {
+            this.handleOutputEvent(JSON.parse(line));
+          } catch {
+            // Skip malformed events
+          }
+        }
+      }
+    } catch (err) {
+      if (!this.intentionallyClosed) {
+        this.config.onError?.(err instanceof Error ? err : new Error(String(err)));
+        void this.attemptReconnect();
+        return;
+      }
+    } finally {
+      this.connected = false;
+      if (!this.intentionallyClosed) {
+        this.config.onClose?.(this.intentionallyClosed ? "completed" : "error");
+      } else {
+        this.config.onClose?.("completed");
+      }
+    }
+  }
+
+  private handleOutputEvent(event: { event?: { type?: string }; data?: Record<string, unknown> }): void {
+    const type = event.event?.type;
+    const data = event.data;
+
+    switch (type) {
+      case "audioOutput": {
+        const chunk = data?.audioChunk as string | undefined;
+        if (!chunk) { return; }
+        // Convert PCM output to mu-law for OpenClaw telephony
+        const pcmAudio = Buffer.from(chunk, "base64");
+        const mulawAudio = pcm16ToMulaw(pcmAudio);
+        this.config.onAudio(mulawAudio);
+        if (this.responseStartTimestamp === null) {
+          this.responseStartTimestamp = this.latestMediaTimestamp;
+        }
+        this.sendMark();
+        return;
+      }
+
+      case "textOutput":
+      case "transcriptOutput": {
+        const text = (data?.text ?? data?.transcript) as string | undefined;
+        if (!text) { return; }
+        const role = (data?.role as string) === "user" ? "user" as const : "assistant" as const;
+        const isFinal = (data?.isFinal as boolean) ?? (type === "textOutput");
+        this.config.onTranscript?.(role, text, isFinal);
+        return;
+      }
+
+      case "toolUse": {
+        const toolUseId = data?.toolUseId as string;
+        const name = data?.name as string;
+        if (toolUseId && name) {
+          this.config.onToolCall?.({
+            itemId: toolUseId,
+            callId: toolUseId,
+            name,
+            args: data?.input ?? {},
+          });
+        }
+        return;
+      }
+
+      case "speechStarted":
+        this.handleBargeIn();
+        return;
+
+      case "error":
+        this.config.onError?.(
+          new Error(`Nova Sonic: ${(data?.message as string) ?? "unknown error"}`),
+        );
+        return;
+
+      case "sessionEnd":
+        this.connected = false;
+        this.config.onClose?.("completed");
+        return;
+
+      default:
+        return;
+    }
+  }
+
+  private handleBargeIn(): void {
+    this.config.onClearAudio();
+    this.markQueue = [];
+    this.responseStartTimestamp = null;
+  }
+
+  private sendMark(): void {
+    const markName = `audio-${Date.now()}`;
+    this.markQueue.push(markName);
+    this.config.onMark?.(markName);
+  }
+}

--- a/extensions/amazon/nova-sonic/bridge.ts
+++ b/extensions/amazon/nova-sonic/bridge.ts
@@ -138,12 +138,12 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
         },
         requestConfig: {
           inputAudioConfig: {
-            audioEncoding: "pcm" as const,
+            audioEncoding: "pcm",
             sampleRateHertz: 16000,
             channelCount: 1,
           },
           outputAudioConfig: {
-            audioEncoding: "pcm" as const,
+            audioEncoding: "pcm",
             sampleRateHertz: 24000,
             channelCount: 1,
             voiceId: this.config.voice,
@@ -332,7 +332,7 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
         if (!text) {
           return;
         }
-        const role = (data?.role as string) === "user" ? ("user" as const) : ("assistant" as const);
+        const role = (data?.role as string) === "user" ? "user" : "assistant";
         const isFinal = (data?.isFinal as boolean) ?? type === "textOutput";
         this.config.onTranscript?.(role, text, isFinal);
         return;

--- a/extensions/amazon/nova-sonic/bridge.ts
+++ b/extensions/amazon/nova-sonic/bridge.ts
@@ -8,8 +8,8 @@ import type {
   RealtimeVoiceBridgeCallbacks,
   RealtimeVoiceTool,
 } from "openclaw/plugin-sdk/realtime-voice";
-import { getAwsClient } from "../shared/client-cache.js";
 import { mulawToPcm16, pcm16ToMulaw } from "../shared/audio-utils.js";
+import { getAwsClient } from "../shared/client-cache.js";
 
 const CONNECT_TIMEOUT_MS = 10_000;
 const MAX_RECONNECT_ATTEMPTS = 3;
@@ -83,9 +83,11 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
     throw new Error("Nova Sonic does not support text-only input; use audio");
   }
 
-  triggerGreeting?(instructions?: string): void {
+  triggerGreeting?(_instructions?: string): void {
     // Send a brief silent frame to prompt Nova Sonic to begin with its system prompt
-    if (!this.connected) { return; }
+    if (!this.connected) {
+      return;
+    }
     const silentPcm = Buffer.alloc(3200); // 100ms of silence at 16kHz 16-bit mono
     this.enqueueEvent({
       event: { type: "audioInput" },
@@ -104,7 +106,9 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
   }
 
   acknowledgeMark(): void {
-    if (this.markQueue.length === 0) { return; }
+    if (this.markQueue.length === 0) {
+      return;
+    }
     this.markQueue.shift();
     if (this.markQueue.length === 0) {
       this.responseStartTimestamp = null;
@@ -146,9 +150,7 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
           },
           sessionAttributes: {},
         },
-        ...(this.config.instructions
-          ? { systemPrompt: { text: this.config.instructions } }
-          : {}),
+        ...(this.config.instructions ? { systemPrompt: { text: this.config.instructions } } : {}),
         ...(this.config.tools && this.config.tools.length > 0
           ? {
               toolConfig: {
@@ -168,16 +170,28 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
 
   private async doConnect(): Promise<void> {
     const sessionConfig = this.buildSessionConfig();
-    const self = this;
+    // Capture instance properties needed by the generator (generators cannot
+    // use arrow syntax, so direct `this` access is unavailable).
+    const bridge = {
+      intentionallyClosed: () => this.intentionallyClosed,
+      inputStream: this.inputStream,
+      setInputResolve: (resolve: (v: boolean) => void) => {
+        this.inputResolve = resolve;
+      },
+    };
 
     async function* inputGenerator() {
       yield { chunk: { bytes: encodeEvent(sessionConfig) } };
-      while (!self.intentionallyClosed) {
-        if (self.inputStream.length > 0) {
-          const batch = self.inputStream.splice(0);
-          for (const item of batch) { yield item; }
+      while (!bridge.intentionallyClosed()) {
+        if (bridge.inputStream.length > 0) {
+          const batch = bridge.inputStream.splice(0);
+          for (const item of batch) {
+            yield item;
+          }
         } else {
-          await new Promise<boolean>((resolve) => { self.inputResolve = resolve; });
+          await new Promise<boolean>((resolve) => {
+            bridge.setInputResolve(resolve);
+          });
         }
       }
       yield { chunk: { bytes: encodeEvent({ event: { type: "sessionEnd" } }) } };
@@ -216,7 +230,9 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private async attemptReconnect(): Promise<void> {
-    if (this.intentionallyClosed) { return; }
+    if (this.intentionallyClosed) {
+      return;
+    }
     if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
       this.config.onClose?.("error");
       return;
@@ -224,7 +240,9 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
     this.reconnectAttempts += 1;
     const delay = BASE_RECONNECT_DELAY_MS * 2 ** (this.reconnectAttempts - 1);
     await new Promise((resolve) => setTimeout(resolve, delay));
-    if (this.intentionallyClosed) { return; }
+    if (this.intentionallyClosed) {
+      return;
+    }
     try {
       await this.doConnect();
     } catch {
@@ -238,19 +256,29 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
     this.inputResolve = null;
   }
 
-  private async processOutputStream(response: InvokeModelWithBidirectionalStreamCommandOutput): Promise<void> {
+  private async processOutputStream(
+    response: InvokeModelWithBidirectionalStreamCommandOutput,
+  ): Promise<void> {
     try {
       const body = response.body;
-      if (!body) { return; }
+      if (!body) {
+        return;
+      }
 
       for await (const event of body) {
-        if (this.intentionallyClosed) { break; }
+        if (this.intentionallyClosed) {
+          break;
+        }
         const bytes = (event as { chunk?: { bytes?: Uint8Array } }).chunk?.bytes;
-        if (!bytes) { continue; }
+        if (!bytes) {
+          continue;
+        }
 
         const decoded = new TextDecoder().decode(bytes);
         for (const line of decoded.split("\n")) {
-          if (!line.trim()) { continue; }
+          if (!line.trim()) {
+            continue;
+          }
           try {
             this.handleOutputEvent(JSON.parse(line));
           } catch {
@@ -274,14 +302,19 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
     }
   }
 
-  private handleOutputEvent(event: { event?: { type?: string }; data?: Record<string, unknown> }): void {
+  private handleOutputEvent(event: {
+    event?: { type?: string };
+    data?: Record<string, unknown>;
+  }): void {
     const type = event.event?.type;
     const data = event.data;
 
     switch (type) {
       case "audioOutput": {
         const chunk = data?.audioChunk as string | undefined;
-        if (!chunk) { return; }
+        if (!chunk) {
+          return;
+        }
         // Convert PCM output to mu-law for OpenClaw telephony
         const pcmAudio = Buffer.from(chunk, "base64");
         const mulawAudio = pcm16ToMulaw(pcmAudio);
@@ -296,9 +329,11 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
       case "textOutput":
       case "transcriptOutput": {
         const text = (data?.text ?? data?.transcript) as string | undefined;
-        if (!text) { return; }
-        const role = (data?.role as string) === "user" ? "user" as const : "assistant" as const;
-        const isFinal = (data?.isFinal as boolean) ?? (type === "textOutput");
+        if (!text) {
+          return;
+        }
+        const role = (data?.role as string) === "user" ? ("user" as const) : ("assistant" as const);
+        const isFinal = (data?.isFinal as boolean) ?? type === "textOutput";
         this.config.onTranscript?.(role, text, isFinal);
         return;
       }

--- a/extensions/amazon/nova-sonic/bridge.ts
+++ b/extensions/amazon/nova-sonic/bridge.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import {
   BedrockRuntimeClient,
   InvokeModelWithBidirectionalStreamCommand,
@@ -34,13 +35,7 @@ function encodeEvent(event: unknown): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(event));
 }
 
-function generateUUID(): string {
-  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === "x" ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
-}
+
 
 export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
   private client: BedrockRuntimeClient;
@@ -118,7 +113,7 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
   }
 
   submitToolResult(callId: string, result: unknown): void {
-    const contentName = generateUUID();
+    const contentName = randomUUID();
     // Send tool result as a text content block
     this.enqueueEvent({
       event: {
@@ -208,6 +203,9 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
             topP: 0.9,
             temperature: this.config.temperature ?? 0.7,
           },
+          turnDetectionConfiguration: {
+            endpointingSensitivity: "MEDIUM",
+          },
         },
       },
     };
@@ -222,10 +220,13 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
             mediaType: "text/plain",
           },
           audioOutputConfiguration: {
-            encoding: "pcm",
+            mediaType: "audio/lpcm",
             sampleRateHertz: 24000,
+            sampleSizeBits: 16,
             channelCount: 1,
             voiceId: this.config.voice,
+            encoding: "base64",
+            audioType: "SPEECH",
           },
           ...(this.config.tools && this.config.tools.length > 0
             ? {
@@ -250,7 +251,7 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
       return [];
     }
 
-    const contentName = generateUUID();
+    const contentName = randomUUID();
     return [
       {
         event: {
@@ -291,9 +292,12 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
           type: "AUDIO",
           role: "USER",
           audioInputConfiguration: {
-            encoding: "pcm",
+            mediaType: "audio/lpcm",
             sampleRateHertz: 16000,
+            sampleSizeBits: 16,
             channelCount: 1,
+            encoding: "base64",
+            audioType: "SPEECH",
           },
         },
       },
@@ -301,8 +305,8 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private async doConnect(): Promise<void> {
-    this.promptName = generateUUID();
-    this.audioContentName = generateUUID();
+    this.promptName = randomUUID();
+    this.audioContentName = randomUUID();
 
     const sessionStartEvent = this.buildSessionStartEvent();
     const promptStartEvent = this.buildPromptStartEvent(this.promptName);

--- a/extensions/amazon/nova-sonic/bridge.ts
+++ b/extensions/amazon/nova-sonic/bridge.ts
@@ -34,10 +34,19 @@ function encodeEvent(event: unknown): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(event));
 }
 
+function generateUUID(): string {
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
   private client: BedrockRuntimeClient;
   private connected = false;
   private intentionallyClosed = false;
+  private reconnecting = false;
   private reconnectAttempts = 0;
   private pendingAudio: Buffer[] = [];
   private inputStream: Array<{ chunk: { bytes: Uint8Array } }> = [];
@@ -45,6 +54,8 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
   private latestMediaTimestamp = 0;
   private responseStartTimestamp: number | null = null;
   private markQueue: string[] = [];
+  private promptName: string = "";
+  private audioContentName: string = "";
 
   constructor(private readonly config: NovaSonicBridgeConfig) {
     this.client = getBedrockClient(config.region);
@@ -52,6 +63,7 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
 
   async connect(): Promise<void> {
     this.intentionallyClosed = false;
+    this.reconnecting = false;
     this.reconnectAttempts = 0;
     await this.doConnect();
   }
@@ -68,8 +80,13 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
     const pcmAudio = mulawToPcm16(audio);
 
     this.enqueueEvent({
-      event: { type: "audioInput" },
-      data: { audioChunk: pcmAudio.toString("base64") },
+      event: {
+        audioInput: {
+          promptName: this.promptName,
+          contentName: this.audioContentName,
+          content: pcmAudio.toString("base64"),
+        },
+      },
     });
   }
 
@@ -90,17 +107,47 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
     }
     const silentPcm = Buffer.alloc(3200); // 100ms of silence at 16kHz 16-bit mono
     this.enqueueEvent({
-      event: { type: "audioInput" },
-      data: { audioChunk: silentPcm.toString("base64") },
+      event: {
+        audioInput: {
+          promptName: this.promptName,
+          contentName: this.audioContentName,
+          content: silentPcm.toString("base64"),
+        },
+      },
     });
   }
 
   submitToolResult(callId: string, result: unknown): void {
+    const contentName = generateUUID();
+    // Send tool result as a text content block
     this.enqueueEvent({
-      event: { type: "toolResult" },
-      data: {
-        toolUseId: callId,
-        content: [{ text: JSON.stringify(result) }],
+      event: {
+        contentStart: {
+          promptName: this.promptName,
+          contentName,
+          type: "TEXT",
+          role: "TOOL",
+          toolResultInputConfiguration: {
+            toolUseId: callId,
+          },
+        },
+      },
+    });
+    this.enqueueEvent({
+      event: {
+        textInput: {
+          promptName: this.promptName,
+          contentName,
+          content: JSON.stringify(result),
+        },
+      },
+    });
+    this.enqueueEvent({
+      event: {
+        contentEnd: {
+          promptName: this.promptName,
+          contentName,
+        },
       },
     });
   }
@@ -118,6 +165,31 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
   close(): void {
     this.intentionallyClosed = true;
     this.connected = false;
+    // Send proper close sequence
+    if (this.audioContentName) {
+      this.enqueueEvent({
+        event: {
+          contentEnd: {
+            promptName: this.promptName,
+            contentName: this.audioContentName,
+          },
+        },
+      });
+    }
+    if (this.promptName) {
+      this.enqueueEvent({
+        event: {
+          promptEnd: {
+            promptName: this.promptName,
+          },
+        },
+      });
+    }
+    this.enqueueEvent({
+      event: {
+        sessionEnd: {},
+      },
+    });
     this.inputResolve?.(true);
   }
 
@@ -127,51 +199,120 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
 
   // --- Private ---
 
-  private buildSessionConfig() {
+  private buildSessionStartEvent() {
     return {
-      event: { type: "sessionStart" },
-      data: {
-        inferenceConfig: {
-          maxTokens: this.config.maxTokens ?? 4096,
-          topP: 0.9,
-          temperature: this.config.temperature ?? 0.7,
-        },
-        requestConfig: {
-          inputAudioConfig: {
-            audioEncoding: "pcm",
-            sampleRateHertz: 16000,
-            channelCount: 1,
+      event: {
+        sessionStart: {
+          inferenceConfiguration: {
+            maxTokens: this.config.maxTokens ?? 4096,
+            topP: 0.9,
+            temperature: this.config.temperature ?? 0.7,
           },
-          outputAudioConfig: {
-            audioEncoding: "pcm",
+        },
+      },
+    };
+  }
+
+  private buildPromptStartEvent(promptName: string) {
+    return {
+      event: {
+        promptStart: {
+          promptName,
+          textOutputConfiguration: {
+            mediaType: "text/plain",
+          },
+          audioOutputConfiguration: {
+            encoding: "pcm",
             sampleRateHertz: 24000,
             channelCount: 1,
             voiceId: this.config.voice,
           },
-          sessionAttributes: {},
+          ...(this.config.tools && this.config.tools.length > 0
+            ? {
+                toolConfiguration: {
+                  tools: this.config.tools.map((t) => ({
+                    toolSpec: {
+                      name: t.name,
+                      description: t.description,
+                      inputSchema: { json: JSON.stringify(t.parameters) },
+                    },
+                  })),
+                },
+              }
+            : {}),
         },
-        ...(this.config.instructions ? { systemPrompt: { text: this.config.instructions } } : {}),
-        ...(this.config.tools && this.config.tools.length > 0
-          ? {
-              toolConfig: {
-                tools: this.config.tools.map((t) => ({
-                  toolSpec: {
-                    name: t.name,
-                    description: t.description,
-                    inputSchema: { json: t.parameters },
-                  },
-                })),
-              },
-            }
-          : {}),
+      },
+    };
+  }
+
+  private buildSystemPromptEvents(promptName: string): unknown[] {
+    if (!this.config.instructions) {
+      return [];
+    }
+
+    const contentName = generateUUID();
+    return [
+      {
+        event: {
+          contentStart: {
+            promptName,
+            contentName,
+            type: "TEXT",
+            role: "SYSTEM",
+          },
+        },
+      },
+      {
+        event: {
+          textInput: {
+            promptName,
+            contentName,
+            content: this.config.instructions,
+          },
+        },
+      },
+      {
+        event: {
+          contentEnd: {
+            promptName,
+            contentName,
+          },
+        },
+      },
+    ];
+  }
+
+  private buildAudioContentStartEvent(promptName: string, contentName: string) {
+    return {
+      event: {
+        contentStart: {
+          promptName,
+          contentName,
+          type: "AUDIO",
+          role: "USER",
+          audioInputConfiguration: {
+            encoding: "pcm",
+            sampleRateHertz: 16000,
+            channelCount: 1,
+          },
+        },
       },
     };
   }
 
   private async doConnect(): Promise<void> {
-    const sessionConfig = this.buildSessionConfig();
-    // Capture instance properties needed by the generator (generators cannot
-    // use arrow syntax, so direct `this` access is unavailable).
+    this.promptName = generateUUID();
+    this.audioContentName = generateUUID();
+
+    const sessionStartEvent = this.buildSessionStartEvent();
+    const promptStartEvent = this.buildPromptStartEvent(this.promptName);
+    const systemPromptEvents = this.buildSystemPromptEvents(this.promptName);
+    const audioContentStartEvent = this.buildAudioContentStartEvent(
+      this.promptName,
+      this.audioContentName,
+    );
+
+    // Capture instance properties needed by the generator
     const bridge = {
       intentionallyClosed: () => this.intentionallyClosed,
       inputStream: this.inputStream,
@@ -181,7 +322,18 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
     };
 
     async function* inputGenerator() {
-      yield { chunk: { bytes: encodeEvent(sessionConfig) } };
+      // 1. sessionStart
+      yield { chunk: { bytes: encodeEvent(sessionStartEvent) } };
+      // 2. promptStart
+      yield { chunk: { bytes: encodeEvent(promptStartEvent) } };
+      // 3. System prompt (contentStart TEXT/SYSTEM → textInput → contentEnd)
+      for (const evt of systemPromptEvents) {
+        yield { chunk: { bytes: encodeEvent(evt) } };
+      }
+      // 4. Audio content start (contentStart AUDIO/USER)
+      yield { chunk: { bytes: encodeEvent(audioContentStartEvent) } };
+
+      // 5. Stream audio input chunks and other events
       while (!bridge.intentionallyClosed()) {
         if (bridge.inputStream.length > 0) {
           const batch = bridge.inputStream.splice(0);
@@ -194,7 +346,14 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
           });
         }
       }
-      yield { chunk: { bytes: encodeEvent({ event: { type: "sessionEnd" } }) } };
+
+      // Drain any remaining items
+      if (bridge.inputStream.length > 0) {
+        const remaining = bridge.inputStream.splice(0);
+        for (const item of remaining) {
+          yield item;
+        }
+      }
     }
 
     try {
@@ -215,6 +374,7 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
       ]).finally(() => clearTimeout(connectTimer));
 
       this.connected = true;
+      this.reconnecting = false;
       this.reconnectAttempts = 0;
 
       for (const chunk of this.pendingAudio.splice(0)) {
@@ -234,6 +394,7 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
       return;
     }
     if (this.reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+      this.reconnecting = false;
       this.config.onClose?.("error");
       return;
     }
@@ -289,13 +450,18 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
     } catch (err) {
       if (!this.intentionallyClosed) {
         this.config.onError?.(err instanceof Error ? err : new Error(String(err)));
+        this.reconnecting = true;
         void this.attemptReconnect();
         return;
       }
     } finally {
       this.connected = false;
+      if (this.reconnecting) {
+        // Skip onClose — reconnect is in progress
+        return;
+      }
       if (!this.intentionallyClosed) {
-        this.config.onClose?.(this.intentionallyClosed ? "completed" : "error");
+        this.config.onClose?.("error");
       } else {
         this.config.onClose?.("completed");
       }
@@ -303,72 +469,91 @@ export class NovaSonicVoiceBridge implements RealtimeVoiceBridge {
   }
 
   private handleOutputEvent(event: {
-    event?: { type?: string };
-    data?: Record<string, unknown>;
+    event?: Record<string, unknown>;
   }): void {
-    const type = event.event?.type;
-    const data = event.data;
+    if (!event.event) {
+      return;
+    }
 
-    switch (type) {
-      case "audioOutput": {
-        const chunk = data?.audioChunk as string | undefined;
-        if (!chunk) {
-          return;
-        }
-        // Convert PCM output to mu-law for OpenClaw telephony
-        const pcmAudio = Buffer.from(chunk, "base64");
-        const mulawAudio = pcm16ToMulaw(pcmAudio);
-        this.config.onAudio(mulawAudio);
-        if (this.responseStartTimestamp === null) {
-          this.responseStartTimestamp = this.latestMediaTimestamp;
-        }
-        this.sendMark();
+    // The output events use the event type name as the key
+    const eventObj = event.event;
+
+    if (eventObj.audioOutput) {
+      const data = eventObj.audioOutput as Record<string, unknown>;
+      const chunk = data?.content as string | undefined;
+      if (!chunk) {
         return;
       }
+      // Convert PCM output to mu-law for OpenClaw telephony
+      const pcmAudio = Buffer.from(chunk, "base64");
+      const mulawAudio = pcm16ToMulaw(pcmAudio);
+      this.config.onAudio(mulawAudio);
+      if (this.responseStartTimestamp === null) {
+        this.responseStartTimestamp = this.latestMediaTimestamp;
+      }
+      this.sendMark();
+      return;
+    }
 
-      case "textOutput":
-      case "transcriptOutput": {
-        const text = (data?.text ?? data?.transcript) as string | undefined;
-        if (!text) {
-          return;
-        }
-        const role = (data?.role as string) === "user" ? "user" : "assistant";
-        const isFinal = (data?.isFinal as boolean) ?? type === "textOutput";
-        this.config.onTranscript?.(role, text, isFinal);
+    if (eventObj.textOutput) {
+      const data = eventObj.textOutput as Record<string, unknown>;
+      const text = data?.content as string | undefined;
+      if (!text) {
         return;
       }
+      const role = (data?.role as string) === "user" ? "user" : "assistant";
+      this.config.onTranscript?.(role, text, true);
+      return;
+    }
 
-      case "toolUse": {
-        const toolUseId = data?.toolUseId as string;
-        const name = data?.name as string;
-        if (toolUseId && name) {
-          this.config.onToolCall?.({
-            itemId: toolUseId,
-            callId: toolUseId,
-            name,
-            args: data?.input ?? {},
-          });
-        }
+    if (eventObj.transcriptOutput) {
+      const data = eventObj.transcriptOutput as Record<string, unknown>;
+      const text = data?.content as string | undefined;
+      if (!text) {
         return;
       }
+      const role = (data?.role as string) === "user" ? "user" : "assistant";
+      const isFinal = (data?.isFinal as boolean) ?? false;
+      this.config.onTranscript?.(role, text, isFinal);
+      return;
+    }
 
-      case "speechStarted":
+    if (eventObj.toolUse) {
+      const data = eventObj.toolUse as Record<string, unknown>;
+      const toolUseId = data?.toolUseId as string;
+      const name = data?.name as string;
+      if (toolUseId && name) {
+        this.config.onToolCall?.({
+          itemId: toolUseId,
+          callId: toolUseId,
+          name,
+          args: data?.input ?? {},
+        });
+      }
+      return;
+    }
+
+    if (eventObj.contentStart) {
+      const data = eventObj.contentStart as Record<string, unknown>;
+      if (data?.type === "AUDIO" && data?.role === "USER") {
+        // Speech activity detected (barge-in)
         this.handleBargeIn();
-        return;
+      }
+      return;
+    }
 
-      case "error":
-        this.config.onError?.(
-          new Error(`Nova Sonic: ${(data?.message as string) ?? "unknown error"}`),
-        );
-        return;
+    if (eventObj.error) {
+      const data = eventObj.error as Record<string, unknown>;
+      this.config.onError?.(
+        new Error(`Nova Sonic: ${(data?.message as string) ?? "unknown error"}`),
+      );
+      return;
+    }
 
-      case "sessionEnd":
-        this.connected = false;
-        this.config.onClose?.("completed");
-        return;
-
-      default:
-        return;
+    if (eventObj.sessionEnd) {
+      this.connected = false;
+      this.config.onClose?.("completed");
+      return;
     }
   }
 

--- a/extensions/amazon/nova-sonic/realtime-voice-provider.test.ts
+++ b/extensions/amazon/nova-sonic/realtime-voice-provider.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { buildNovaSonicVoiceProvider } from "./realtime-voice-provider.js";
+
+describe("buildNovaSonicVoiceProvider", () => {
+  it("has correct id, label, and order", () => {
+    const provider = buildNovaSonicVoiceProvider();
+    expect(provider.id).toBe("amazon-nova-sonic");
+    expect(provider.label).toBe("Amazon Nova Sonic");
+    expect(provider.autoSelectOrder).toBe(15);
+  });
+
+  it("isConfigured returns true when enabled", () => {
+    const provider = buildNovaSonicVoiceProvider();
+    expect(
+      provider.isConfigured({ providerConfig: { enabled: true } }),
+    ).toBe(true);
+  });
+
+  it("isConfigured returns false when disabled", () => {
+    const provider = buildNovaSonicVoiceProvider();
+    expect(
+      provider.isConfigured({ providerConfig: { enabled: false } }),
+    ).toBe(false);
+  });
+
+  it("resolves config with defaults", () => {
+    const provider = buildNovaSonicVoiceProvider();
+    const config = provider.resolveConfig!({
+      rawConfig: {},
+      cfg: {} as any,
+    });
+    expect(config).toEqual(expect.objectContaining({
+      enabled: true,
+      model: "amazon.nova-sonic-v1:0",
+      voice: "tiffany",
+      region: "us-east-1",
+    }));
+  });
+
+  it("resolves custom config", () => {
+    const provider = buildNovaSonicVoiceProvider();
+    const config = provider.resolveConfig!({
+      rawConfig: { model: "amazon.nova-2-sonic-v1:0", voice: "matthew", region: "eu-north-1" },
+      cfg: {} as any,
+    });
+    expect(config).toEqual(expect.objectContaining({
+      model: "amazon.nova-2-sonic-v1:0",
+      voice: "matthew",
+      region: "eu-north-1",
+    }));
+  });
+
+  it("creates a bridge instance", () => {
+    const provider = buildNovaSonicVoiceProvider();
+    const bridge = provider.createBridge({
+      providerConfig: { enabled: true, region: "us-east-1", model: "amazon.nova-sonic-v1:0", voice: "tiffany" },
+      onAudio: () => {},
+      onClearAudio: () => {},
+    });
+    expect(bridge).toBeDefined();
+    expect(bridge.isConnected()).toBe(false);
+  });
+});

--- a/extensions/amazon/nova-sonic/realtime-voice-provider.ts
+++ b/extensions/amazon/nova-sonic/realtime-voice-provider.ts
@@ -1,0 +1,68 @@
+import type { RealtimeVoiceProviderPlugin } from "openclaw/plugin-sdk/realtime-voice";
+import { trimToUndefined } from "openclaw/plugin-sdk/speech";
+import { NovaSonicVoiceBridge } from "./bridge.js";
+
+const DEFAULT_MODEL = "amazon.nova-sonic-v1:0";
+const DEFAULT_VOICE = "tiffany";
+const DEFAULT_REGION = "us-east-1";
+
+type NovaSonicProviderConfig = {
+  enabled: boolean;
+  model: string;
+  voice: string;
+  region: string;
+  temperature?: number;
+  maxTokens?: number;
+};
+
+function normalizeConfig(raw: Record<string, unknown>): NovaSonicProviderConfig {
+  return {
+    enabled: raw.enabled !== false,
+    model: trimToUndefined(raw.model) ?? DEFAULT_MODEL,
+    voice: trimToUndefined(raw.voice) ?? DEFAULT_VOICE,
+    region: trimToUndefined(raw.region) ?? DEFAULT_REGION,
+    temperature: typeof raw.temperature === "number" ? raw.temperature : undefined,
+    maxTokens: typeof raw.maxTokens === "number" ? raw.maxTokens : undefined,
+  };
+}
+
+/**
+ * Build the Amazon Nova Sonic realtime voice provider.
+ * Config is read from the parent `amazon` plugin's `novaSonic` key.
+ */
+export function buildNovaSonicVoiceProvider(
+  pluginConfig?: Record<string, unknown>,
+): RealtimeVoiceProviderPlugin {
+  return {
+    id: "amazon-nova-sonic",
+    label: "Amazon Nova Sonic",
+    autoSelectOrder: 15,
+
+    resolveConfig: ({ rawConfig }) => {
+      const raw = (rawConfig as Record<string, unknown>)?.novaSonic ?? rawConfig;
+      return normalizeConfig(raw as Record<string, unknown>);
+    },
+
+    isConfigured: ({ providerConfig }) => {
+      const config = normalizeConfig(
+        (providerConfig ?? {}) as Record<string, unknown>,
+      );
+      return config.enabled;
+    },
+
+    createBridge: (req) => {
+      const config = normalizeConfig(
+        (req.providerConfig ?? {}) as Record<string, unknown>,
+      );
+
+      return new NovaSonicVoiceBridge({
+        ...req,
+        region: config.region,
+        model: config.model,
+        voice: config.voice,
+        temperature: config.temperature,
+        maxTokens: config.maxTokens,
+      });
+    },
+  };
+}

--- a/extensions/amazon/nova-sonic/realtime-voice-provider.ts
+++ b/extensions/amazon/nova-sonic/realtime-voice-provider.ts
@@ -31,7 +31,7 @@ function normalizeConfig(raw: Record<string, unknown>): NovaSonicProviderConfig 
  * Config is read from the parent `amazon` plugin's `novaSonic` key.
  */
 export function buildNovaSonicVoiceProvider(
-  pluginConfig?: Record<string, unknown>,
+  _pluginConfig?: Record<string, unknown>,
 ): RealtimeVoiceProviderPlugin {
   return {
     id: "amazon-nova-sonic",
@@ -44,16 +44,12 @@ export function buildNovaSonicVoiceProvider(
     },
 
     isConfigured: ({ providerConfig }) => {
-      const config = normalizeConfig(
-        (providerConfig ?? {}) as Record<string, unknown>,
-      );
+      const config = normalizeConfig((providerConfig ?? {}) as Record<string, unknown>);
       return config.enabled;
     },
 
     createBridge: (req) => {
-      const config = normalizeConfig(
-        (req.providerConfig ?? {}) as Record<string, unknown>,
-      );
+      const config = normalizeConfig((req.providerConfig ?? {}) as Record<string, unknown>);
 
       return new NovaSonicVoiceBridge({
         ...req,

--- a/extensions/amazon/nova-sonic/realtime-voice-provider.ts
+++ b/extensions/amazon/nova-sonic/realtime-voice-provider.ts
@@ -31,8 +31,11 @@ function normalizeConfig(raw: Record<string, unknown>): NovaSonicProviderConfig 
  * Config is read from the parent `amazon` plugin's `novaSonic` key.
  */
 export function buildNovaSonicVoiceProvider(
-  _pluginConfig?: Record<string, unknown>,
-): RealtimeVoiceProviderPlugin {
+  pluginConfig?: Record<string, unknown>,
+): RealtimeVoiceProviderPlugin | null {
+  const novaSonicConfig = (pluginConfig?.novaSonic ?? {}) as Record<string, unknown>;
+  const config = normalizeConfig(novaSonicConfig);
+  if (!config.enabled) return null;
   return {
     id: "amazon-nova-sonic",
     label: "Amazon Nova Sonic",

--- a/extensions/amazon/openclaw.plugin.json
+++ b/extensions/amazon/openclaw.plugin.json
@@ -1,0 +1,204 @@
+{
+  "id": "amazon",
+  "providerAuthEnvVars": {
+    "amazon-polly": ["AWS_ACCESS_KEY_ID", "AWS_PROFILE"],
+    "amazon-transcribe": ["AWS_ACCESS_KEY_ID", "AWS_PROFILE"],
+    "amazon-nova-sonic": ["AWS_ACCESS_KEY_ID", "AWS_PROFILE"]
+  },
+  "contracts": {
+    "speechProviders": ["amazon-polly"],
+    "mediaUnderstandingProviders": ["amazon-transcribe"],
+    "realtimeVoiceProviders": ["amazon-nova-sonic"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "polly": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Enable or disable Amazon Polly TTS."
+          },
+          "voice": {
+            "type": "string",
+            "description": "Default Polly voice ID. Generative: Ruth, Matthew, Stephen. Neural: Joanna, Lupe, Amy, Brian."
+          },
+          "engine": {
+            "type": "string",
+            "enum": ["generative", "neural", "standard", "long-form"],
+            "description": "Polly engine type. Generative is highest quality, neural is fastest, standard is cheapest."
+          },
+          "region": {
+            "type": "string",
+            "enum": [
+              "us-east-1", "us-west-2",
+              "eu-west-1", "eu-west-2", "eu-west-3", "eu-central-1", "eu-north-1",
+              "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ap-northeast-2", "ap-south-1",
+              "ca-central-1", "sa-east-1", "af-south-1", "me-south-1", "us-gov-west-1"
+            ],
+            "description": "AWS region for Polly API calls."
+          },
+          "languageCode": {
+            "type": "string",
+            "enum": [
+              "en-US", "en-GB", "en-AU", "en-IN", "en-NZ", "en-ZA", "en-IE",
+              "es-ES", "es-MX", "es-US",
+              "fr-FR", "fr-CA",
+              "de-DE", "de-AT",
+              "it-IT",
+              "pt-BR", "pt-PT",
+              "ja-JP", "ko-KR", "zh-CN", "hi-IN", "ar-AE",
+              "nl-NL", "nl-BE",
+              "pl-PL", "ru-RU", "sv-SE", "nb-NO", "da-DK", "fi-FI", "tr-TR",
+              "ca-ES", "cy-GB", "is-IS", "ro-RO"
+            ],
+            "description": "BCP-47 language code."
+          },
+          "sampleRate": {
+            "type": "string",
+            "enum": ["8000", "16000", "22050", "24000"],
+            "description": "Audio sample rate in Hz."
+          }
+        }
+      },
+      "transcribe": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Enable or disable Amazon Transcribe STT."
+          },
+          "region": {
+            "type": "string",
+            "enum": [
+              "us-east-1", "us-east-2", "us-west-2",
+              "eu-west-1", "eu-west-2", "eu-central-1",
+              "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ap-northeast-2", "ap-south-1",
+              "ca-central-1", "sa-east-1"
+            ],
+            "description": "AWS region for Transcribe Streaming API calls."
+          },
+          "languageCode": {
+            "type": "string",
+            "enum": [
+              "en-US", "en-GB", "en-AU",
+              "es-US", "es-ES",
+              "fr-FR", "fr-CA",
+              "de-DE", "it-IT", "pt-BR",
+              "ja-JP", "ko-KR", "zh-CN",
+              "hi-IN", "ar-SA"
+            ],
+            "description": "Default language for transcription."
+          }
+        }
+      },
+      "novaSonic": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Enable or disable Amazon Nova Sonic realtime voice."
+          },
+          "model": {
+            "type": "string",
+            "description": "Bedrock model ID for Nova Sonic."
+          },
+          "voice": {
+            "type": "string",
+            "enum": ["tiffany", "matthew", "amy"],
+            "description": "Nova Sonic voice."
+          },
+          "region": {
+            "type": "string",
+            "enum": ["us-east-1"],
+            "description": "AWS region. Nova Sonic currently only available in us-east-1."
+          },
+          "temperature": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Sampling temperature (0-1). Default: 0.7."
+          },
+          "maxTokens": {
+            "type": "number",
+            "minimum": 1,
+            "description": "Maximum output tokens. Default: 4096."
+          }
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "polly": {
+      "label": "Amazon Polly (TTS)",
+      "help": "Text-to-speech via Amazon Polly. Uses IAM credential chain — no API key needed."
+    },
+    "polly.enabled": {
+      "label": "Enabled",
+      "help": "Enable or disable Amazon Polly TTS."
+    },
+    "polly.voice": {
+      "label": "Voice",
+      "help": "Polly voice ID. Generative voices (Ruth, Matthew, Stephen) for best quality. Full list: https://docs.aws.amazon.com/polly/latest/dg/voicelist.html"
+    },
+    "polly.engine": {
+      "label": "Engine",
+      "help": "Generative: most natural (~$30/1M chars). Neural: fast (~$16/1M chars). Standard: cheapest (~$4/1M chars). Long-form: optimized for articles."
+    },
+    "polly.region": {
+      "label": "AWS Region",
+      "help": "Region for Polly API calls. Note: generative engine is only available in us-east-1 and eu-west-1."
+    },
+    "polly.languageCode": {
+      "label": "Language Code",
+      "help": "BCP-47 language code. Required for bilingual voices."
+    },
+    "polly.sampleRate": {
+      "label": "Sample Rate",
+      "help": "24000 Hz for generative/long-form. Standard/neural only accept 8000, 16000, or 22050.",
+      "advanced": true
+    },
+    "transcribe": {
+      "label": "Amazon Transcribe (STT)",
+      "help": "Speech-to-text via Amazon Transcribe Streaming. Uses IAM credential chain — no API key needed."
+    },
+    "transcribe.enabled": {
+      "label": "Enabled",
+      "help": "Enable or disable Amazon Transcribe STT."
+    },
+    "transcribe.region": {
+      "label": "AWS Region",
+      "help": "Region for Transcribe Streaming API calls."
+    },
+    "transcribe.languageCode": {
+      "label": "Language Code",
+      "help": "Default language for transcription. Can be overridden per request."
+    },
+    "novaSonic": {
+      "label": "Amazon Nova Sonic (Realtime Voice)",
+      "help": "Bidirectional speech-to-speech via Nova Sonic on Bedrock. Full-duplex voice conversations with tool calling."
+    },
+    "novaSonic.enabled": {
+      "label": "Enabled",
+      "help": "Enable or disable Nova Sonic realtime voice."
+    },
+    "novaSonic.model": {
+      "label": "Model ID",
+      "help": "Bedrock model ID. Default: amazon.nova-sonic-v1:0.",
+      "advanced": true
+    },
+    "novaSonic.voice": {
+      "label": "Voice",
+      "help": "Nova Sonic voice ID. Available: tiffany, matthew, amy."
+    },
+    "novaSonic.region": {
+      "label": "AWS Region",
+      "help": "Region for Bedrock API calls. Nova Sonic currently available in us-east-1."
+    }
+  }
+}

--- a/extensions/amazon/package.json
+++ b/extensions/amazon/package.json
@@ -15,13 +15,6 @@
     },
     "extensions": [
       "./index.ts"
-    ],
-    "releaseChecks": {
-      "rootDependencyMirrorAllowlist": [
-        "@aws-sdk/client-polly",
-        "@aws-sdk/client-transcribe-streaming",
-        "@aws-sdk/client-bedrock-runtime"
-      ]
-    }
+    ]
   }
 }

--- a/extensions/amazon/package.json
+++ b/extensions/amazon/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@openclaw/amazon-services",
+  "version": "2026.4.1-beta.1",
+  "private": true,
+  "description": "OpenClaw Amazon AWS services plugin (Polly TTS, and more)",
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-polly": "3.1022.0",
+    "@aws-sdk/client-transcribe-streaming": "3.1022.0",
+    "@aws-sdk/client-bedrock-runtime": "3.1022.0"
+  },
+  "openclaw": {
+    "bundle": {
+      "stageRuntimeDependencies": true
+    },
+    "extensions": [
+      "./index.ts"
+    ],
+    "releaseChecks": {
+      "rootDependencyMirrorAllowlist": [
+        "@aws-sdk/client-polly",
+        "@aws-sdk/client-transcribe-streaming",
+        "@aws-sdk/client-bedrock-runtime"
+      ]
+    }
+  }
+}

--- a/extensions/amazon/package.json
+++ b/extensions/amazon/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@openclaw/amazon-services",
+  "name": "@openclaw/amazon",
   "version": "2026.4.1-beta.1",
   "private": true,
   "description": "OpenClaw Amazon AWS services plugin (Polly TTS, and more)",
   "type": "module",
   "dependencies": {
-    "@aws-sdk/client-polly": "3.1022.0",
-    "@aws-sdk/client-transcribe-streaming": "3.1022.0",
-    "@aws-sdk/client-bedrock-runtime": "3.1022.0"
+    "@aws-sdk/client-bedrock-runtime": "3.1036.0",
+    "@aws-sdk/client-polly": "3.1036.0",
+    "@aws-sdk/client-transcribe-streaming": "3.1036.0"
   },
   "openclaw": {
     "bundle": {

--- a/extensions/amazon/polly/speech-provider.test.ts
+++ b/extensions/amazon/polly/speech-provider.test.ts
@@ -1,0 +1,147 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildPollySpeechProvider } from "./speech-provider.js";
+import * as ttsModule from "./tts.js";
+
+const runFfmpegMock = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<string>>());
+
+vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
+  runFfmpeg: runFfmpegMock,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    writeFile: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+    readFile: vi
+      .fn<(...args: unknown[]) => Promise<Buffer>>()
+      .mockResolvedValue(Buffer.from([0x4f, 0x70, 0x75, 0x73])),
+    unlink: vi.fn<(...args: unknown[]) => Promise<void>>().mockResolvedValue(undefined),
+  },
+}));
+
+const TEST_CFG = {} as OpenClawConfig;
+
+describe("buildPollySpeechProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    runFfmpegMock.mockReset();
+  });
+
+  it("has correct id, label, and aliases", () => {
+    const provider = buildPollySpeechProvider();
+    expect(provider.id).toBe("amazon-polly");
+    expect(provider.label).toBe("Amazon Polly");
+    expect(provider.aliases).toEqual(["polly"]);
+    expect(provider.autoSelectOrder).toBe(25);
+  });
+
+  it("synthesizes MP3 for audio-file target", async () => {
+    const provider = buildPollySpeechProvider();
+    const fakeBuffer = Buffer.from([0xff, 0xfb, 0x90, 0x00]);
+    const synthesizeSpy = vi.spyOn(ttsModule, "pollySynthesize").mockResolvedValue(fakeBuffer);
+
+    const result = await provider.synthesize({
+      text: "Hello world",
+      cfg: TEST_CFG,
+      providerConfig: { enabled: true, region: "us-east-1", voice: "Ruth", engine: "generative" },
+      providerOverrides: {},
+      timeoutMs: 10_000,
+      target: "audio-file",
+    });
+
+    expect(result.outputFormat).toBe("mp3");
+    expect(result.fileExtension).toBe(".mp3");
+    expect(result.voiceCompatible).toBe(false);
+    expect(result.audioBuffer).toBe(fakeBuffer);
+    expect(synthesizeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ voiceId: "Ruth", engine: "generative", outputFormat: "mp3" }),
+    );
+    expect(runFfmpegMock).not.toHaveBeenCalled();
+  });
+
+  it("synthesizes voice-note with ffmpeg opus conversion", async () => {
+    const provider = buildPollySpeechProvider();
+    vi.spyOn(ttsModule, "pollySynthesize").mockResolvedValue(Buffer.from([0xff, 0xfb]));
+    runFfmpegMock.mockResolvedValue("");
+
+    const result = await provider.synthesize({
+      text: "Hello world",
+      cfg: TEST_CFG,
+      providerConfig: { enabled: true, region: "us-east-1", voice: "Ruth", engine: "generative" },
+      providerOverrides: {},
+      timeoutMs: 10_000,
+      target: "voice-note",
+    });
+
+    expect(result.outputFormat).toBe("ogg_opus");
+    expect(result.fileExtension).toBe(".ogg");
+    expect(result.voiceCompatible).toBe(true);
+    expect(runFfmpegMock).toHaveBeenCalledTimes(1);
+    const ffmpegArgs = runFfmpegMock.mock.calls[0][0] as string[];
+    expect(ffmpegArgs).toContain("libopus");
+  });
+
+  it("applies voice override from providerOverrides", async () => {
+    const provider = buildPollySpeechProvider();
+    const synthesizeSpy = vi.spyOn(ttsModule, "pollySynthesize").mockResolvedValue(Buffer.from([0x01]));
+
+    await provider.synthesize({
+      text: "Hello",
+      cfg: TEST_CFG,
+      providerConfig: { enabled: true, region: "us-east-1", voice: "Ruth", engine: "generative" },
+      providerOverrides: { voice: "Stephen", engine: "neural" },
+      timeoutMs: 10_000,
+      target: "audio-file",
+    });
+
+    expect(synthesizeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ voiceId: "Stephen", engine: "neural" }),
+    );
+  });
+
+  it("uses engine-aware sample rate defaults", async () => {
+    const provider = buildPollySpeechProvider();
+    const synthesizeSpy = vi.spyOn(ttsModule, "pollySynthesize").mockResolvedValue(Buffer.from([0x01]));
+
+    await provider.synthesize({
+      text: "Hello",
+      cfg: TEST_CFG,
+      providerConfig: { enabled: true, region: "us-east-1", voice: "Joanna", engine: "neural" },
+      providerOverrides: {},
+      timeoutMs: 10_000,
+      target: "audio-file",
+    });
+
+    expect(synthesizeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ sampleRate: "22050" }),
+    );
+  });
+
+  it("isConfigured returns true when enabled", () => {
+    const provider = buildPollySpeechProvider();
+    expect(provider.isConfigured({ providerConfig: { enabled: true }, timeoutMs: 10_000 })).toBe(true);
+  });
+
+  it("isConfigured returns false when disabled", () => {
+    const provider = buildPollySpeechProvider();
+    expect(provider.isConfigured({ providerConfig: { enabled: false }, timeoutMs: 10_000 })).toBe(false);
+  });
+});
+
+describe("buildPollySpeechProvider resolveConfig", () => {
+  it("returns defaults for empty config", () => {
+    const provider = buildPollySpeechProvider();
+    const config = provider.resolveConfig!({ rawConfig: {}, cfg: {} as OpenClawConfig, timeoutMs: 10_000 });
+    expect(config).toEqual(expect.objectContaining({ enabled: true, voice: "Ruth", engine: "generative", region: "us-east-1" }));
+  });
+
+  it("reads custom config", () => {
+    const provider = buildPollySpeechProvider();
+    const config = provider.resolveConfig!({
+      rawConfig: { voice: "Matthew", engine: "neural", region: "eu-west-1", languageCode: "en-GB" },
+      cfg: {} as OpenClawConfig,
+      timeoutMs: 10_000,
+    });
+    expect(config).toEqual(expect.objectContaining({ voice: "Matthew", engine: "neural", region: "eu-west-1", languageCode: "en-GB" }));
+  });
+});

--- a/extensions/amazon/polly/speech-provider.ts
+++ b/extensions/amazon/polly/speech-provider.ts
@@ -1,0 +1,220 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  SpeechDirectiveTokenParseContext,
+  SpeechProviderPlugin,
+  SpeechVoiceOption,
+} from "openclaw/plugin-sdk/speech";
+import { trimToUndefined } from "openclaw/plugin-sdk/speech";
+import { runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
+import { pollySynthesize, pollyListVoices } from "./tts.js";
+
+const DEFAULT_VOICE = "Ruth";
+const DEFAULT_ENGINE = "generative";
+const DEFAULT_REGION = "us-east-1";
+
+const POLLY_ENGINES = ["generative", "neural", "standard", "long-form"] as const;
+
+type PollyProviderConfig = {
+  enabled: boolean;
+  voice: string;
+  engine: string;
+  region: string;
+  languageCode?: string;
+  sampleRate?: string;
+};
+
+/** Default sample rate per engine. Generative/long-form support 24000; standard/neural require ≤22050. */
+function defaultSampleRate(engine: string): string {
+  return engine === "generative" || engine === "long-form" ? "24000" : "22050";
+}
+
+function readPollyConfig(raw: Record<string, unknown>): PollyProviderConfig {
+  return {
+    enabled: raw.enabled !== false,
+    voice: trimToUndefined(raw.voice) ?? DEFAULT_VOICE,
+    engine: trimToUndefined(raw.engine) ?? DEFAULT_ENGINE,
+    region: trimToUndefined(raw.region) ?? DEFAULT_REGION,
+    languageCode: trimToUndefined(raw.languageCode),
+    sampleRate: trimToUndefined(raw.sampleRate),
+  };
+}
+
+/** Parse inline directive tokens like [voice:Joanna] or [engine:neural] from chat messages. */
+function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext) {
+  const key = ctx.key.toLowerCase();
+  switch (key) {
+    case "voice":
+    case "polly_voice":
+    case "pollyvoice":
+      if (!ctx.policy.allowVoice) { return { handled: true }; }
+      return { handled: true, overrides: { ...ctx.currentOverrides, voice: ctx.value } };
+    case "engine":
+    case "polly_engine":
+    case "pollyengine": {
+      if (!ctx.policy.allowModelId) { return { handled: true }; }
+      const engine = ctx.value.toLowerCase();
+      if (!(POLLY_ENGINES as readonly string[]).includes(engine)) {
+        return { handled: true, warnings: [`invalid Polly engine "${ctx.value}" (expected: ${POLLY_ENGINES.join(", ")})`] };
+      }
+      return { handled: true, overrides: { ...ctx.currentOverrides, engine } };
+    }
+    case "language":
+    case "polly_language":
+    case "languagecode":
+      return { handled: true, overrides: { ...ctx.currentOverrides, languageCode: ctx.value } };
+    default:
+      return { handled: false };
+  }
+}
+
+/**
+ * Convert MP3 audio to Opus-in-OGG for WhatsApp voice note compatibility.
+ */
+async function convertToOpusOgg(inputBuffer: Buffer): Promise<Buffer> {
+  const tmpDir = os.tmpdir();
+  const id = `polly-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const inputPath = path.join(tmpDir, `${id}.mp3`);
+  const outputPath = path.join(tmpDir, `${id}.ogg`);
+
+  try {
+    await fs.writeFile(inputPath, inputBuffer);
+    await runFfmpeg([
+      "-i", inputPath,
+      "-c:a", "libopus",
+      "-b:a", "64k",
+      "-ar", "48000",
+      "-ac", "1",
+      "-application", "voip",
+      "-y", outputPath,
+    ]);
+    return await fs.readFile(outputPath);
+  } finally {
+    await fs.unlink(inputPath).catch(() => {});
+    await fs.unlink(outputPath).catch(() => {});
+  }
+}
+
+/**
+ * Build the Amazon Polly speech provider.
+ * Config is read from the parent `amazon` plugin's `polly` key.
+ */
+export function buildPollySpeechProvider(pluginConfig?: Record<string, unknown>): SpeechProviderPlugin {
+  const pollyConfig = (pluginConfig?.polly ?? {}) as Record<string, unknown>;
+
+  return {
+    id: "amazon-polly",
+    label: "Amazon Polly",
+    aliases: ["polly"],
+    autoSelectOrder: 25,
+
+    resolveConfig: ({ rawConfig }) => {
+      const raw = (rawConfig as Record<string, unknown>)?.polly ?? rawConfig;
+      return readPollyConfig(raw as Record<string, unknown>);
+    },
+
+    parseDirectiveToken,
+
+    resolveTalkConfig: ({ baseTtsConfig, talkProviderConfig }) => {
+      const base = readPollyConfig((baseTtsConfig as Record<string, unknown>)?.polly as Record<string, unknown> ?? baseTtsConfig as Record<string, unknown>);
+      return {
+        ...base,
+        ...(trimToUndefined(talkProviderConfig.voice) == null ? {} : { voice: trimToUndefined(talkProviderConfig.voice)! }),
+        ...(trimToUndefined(talkProviderConfig.engine) == null ? {} : { engine: trimToUndefined(talkProviderConfig.engine)! }),
+        ...(trimToUndefined(talkProviderConfig.region) == null ? {} : { region: trimToUndefined(talkProviderConfig.region)! }),
+        ...(trimToUndefined(talkProviderConfig.languageCode) == null ? {} : { languageCode: trimToUndefined(talkProviderConfig.languageCode) }),
+        ...(trimToUndefined(talkProviderConfig.sampleRate) == null ? {} : { sampleRate: trimToUndefined(talkProviderConfig.sampleRate) }),
+      };
+    },
+
+    resolveTalkOverrides: ({ params }) => ({
+      ...(trimToUndefined(params.voice) == null ? {} : { voice: trimToUndefined(params.voice) }),
+      ...(trimToUndefined(params.engine) == null ? {} : { engine: trimToUndefined(params.engine) }),
+      ...(trimToUndefined(params.region) == null ? {} : { region: trimToUndefined(params.region) }),
+      ...(trimToUndefined(params.language) == null ? {} : { languageCode: trimToUndefined(params.language) }),
+    }),
+
+    listVoices: async (req) => {
+      const config = req.providerConfig
+        ? readPollyConfig(req.providerConfig as Record<string, unknown>)
+        : readPollyConfig(pollyConfig);
+      const voices = await pollyListVoices({
+        region: config.region,
+        engine: req.providerConfig?.engine as string | undefined,
+      });
+      return voices.map(
+        (v): SpeechVoiceOption => ({
+          id: v.id,
+          name: `${v.name} (${v.languageName ?? v.languageCode ?? "unknown"}, ${v.gender ?? "unknown"})`,
+        }),
+      );
+    },
+
+    isConfigured: ({ providerConfig }) => {
+      const config = readPollyConfig(
+        (providerConfig ?? pollyConfig) as Record<string, unknown>,
+      );
+      return config.enabled;
+    },
+
+    synthesize: async (req) => {
+      const config = readPollyConfig(
+        (req.providerConfig ?? pollyConfig) as Record<string, unknown>,
+      );
+      const overrides = (req.providerOverrides ?? {}) as Record<string, unknown>;
+
+      const voice = trimToUndefined(overrides.voice) ?? config.voice;
+      const engine = trimToUndefined(overrides.engine) ?? config.engine;
+      const region = trimToUndefined(overrides.region) ?? config.region;
+      const languageCode = trimToUndefined(overrides.languageCode) ?? config.languageCode;
+      const sampleRate = trimToUndefined(overrides.sampleRate) ?? config.sampleRate;
+
+      const audioBuffer = await pollySynthesize({
+        text: req.text,
+        voiceId: voice,
+        engine,
+        outputFormat: "mp3",
+        sampleRate: sampleRate ?? defaultSampleRate(engine),
+        languageCode,
+        region,
+        timeoutMs: req.timeoutMs,
+      });
+
+      if (req.target === "voice-note") {
+        const opusBuffer = await convertToOpusOgg(audioBuffer);
+        return {
+          audioBuffer: opusBuffer,
+          outputFormat: "ogg_opus",
+          fileExtension: ".ogg",
+          voiceCompatible: true,
+        };
+      }
+
+      return {
+        audioBuffer,
+        outputFormat: "mp3",
+        fileExtension: ".mp3",
+        voiceCompatible: false,
+      };
+    },
+
+    synthesizeTelephony: async (req) => {
+      const config = readPollyConfig(
+        (req.providerConfig ?? pollyConfig) as Record<string, unknown>,
+      );
+      const sampleRate = 22_050;
+      const audioBuffer = await pollySynthesize({
+        text: req.text,
+        voiceId: config.voice,
+        engine: config.engine,
+        outputFormat: "pcm",
+        sampleRate: String(sampleRate),
+        languageCode: config.languageCode,
+        region: config.region,
+        timeoutMs: req.timeoutMs,
+      });
+      return { audioBuffer, outputFormat: "pcm", sampleRate };
+    },
+  };
+}

--- a/extensions/amazon/polly/speech-provider.ts
+++ b/extensions/amazon/polly/speech-provider.ts
@@ -1,13 +1,12 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
+import { runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
 import type {
   SpeechDirectiveTokenParseContext,
   SpeechProviderPlugin,
   SpeechVoiceOption,
 } from "openclaw/plugin-sdk/speech";
 import { trimToUndefined } from "openclaw/plugin-sdk/speech";
-import { runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
 import { pollySynthesize, pollyListVoices } from "./tts.js";
 
 const DEFAULT_VOICE = "Ruth";
@@ -48,15 +47,22 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext) {
     case "voice":
     case "polly_voice":
     case "pollyvoice":
-      if (!ctx.policy.allowVoice) { return { handled: true }; }
+      if (!ctx.policy.allowVoice) {
+        return { handled: true };
+      }
       return { handled: true, overrides: { ...ctx.currentOverrides, voice: ctx.value } };
     case "engine":
     case "polly_engine":
     case "pollyengine": {
-      if (!ctx.policy.allowModelId) { return { handled: true }; }
+      if (!ctx.policy.allowModelId) {
+        return { handled: true };
+      }
       const engine = ctx.value.toLowerCase();
       if (!(POLLY_ENGINES as readonly string[]).includes(engine)) {
-        return { handled: true, warnings: [`invalid Polly engine "${ctx.value}" (expected: ${POLLY_ENGINES.join(", ")})`] };
+        return {
+          handled: true,
+          warnings: [`invalid Polly engine "${ctx.value}" (expected: ${POLLY_ENGINES.join(", ")})`],
+        };
       }
       return { handled: true, overrides: { ...ctx.currentOverrides, engine } };
     }
@@ -73,7 +79,8 @@ function parseDirectiveToken(ctx: SpeechDirectiveTokenParseContext) {
  * Convert MP3 audio to Opus-in-OGG for WhatsApp voice note compatibility.
  */
 async function convertToOpusOgg(inputBuffer: Buffer): Promise<Buffer> {
-  const tmpDir = os.tmpdir();
+  const { resolvePreferredOpenClawTmpDir } = await import("openclaw/plugin-sdk/temp-path");
+  const tmpDir = resolvePreferredOpenClawTmpDir();
   const id = `polly-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const inputPath = path.join(tmpDir, `${id}.mp3`);
   const outputPath = path.join(tmpDir, `${id}.ogg`);
@@ -81,13 +88,20 @@ async function convertToOpusOgg(inputBuffer: Buffer): Promise<Buffer> {
   try {
     await fs.writeFile(inputPath, inputBuffer);
     await runFfmpeg([
-      "-i", inputPath,
-      "-c:a", "libopus",
-      "-b:a", "64k",
-      "-ar", "48000",
-      "-ac", "1",
-      "-application", "voip",
-      "-y", outputPath,
+      "-i",
+      inputPath,
+      "-c:a",
+      "libopus",
+      "-b:a",
+      "64k",
+      "-ar",
+      "48000",
+      "-ac",
+      "1",
+      "-application",
+      "voip",
+      "-y",
+      outputPath,
     ]);
     return await fs.readFile(outputPath);
   } finally {
@@ -100,7 +114,9 @@ async function convertToOpusOgg(inputBuffer: Buffer): Promise<Buffer> {
  * Build the Amazon Polly speech provider.
  * Config is read from the parent `amazon` plugin's `polly` key.
  */
-export function buildPollySpeechProvider(pluginConfig?: Record<string, unknown>): SpeechProviderPlugin {
+export function buildPollySpeechProvider(
+  pluginConfig?: Record<string, unknown>,
+): SpeechProviderPlugin {
   const pollyConfig = (pluginConfig?.polly ?? {}) as Record<string, unknown>;
 
   return {
@@ -117,14 +133,27 @@ export function buildPollySpeechProvider(pluginConfig?: Record<string, unknown>)
     parseDirectiveToken,
 
     resolveTalkConfig: ({ baseTtsConfig, talkProviderConfig }) => {
-      const base = readPollyConfig((baseTtsConfig as Record<string, unknown>)?.polly as Record<string, unknown> ?? baseTtsConfig as Record<string, unknown>);
+      const base = readPollyConfig(
+        ((baseTtsConfig as Record<string, unknown>)?.polly as Record<string, unknown>) ??
+          (baseTtsConfig as Record<string, unknown>),
+      );
       return {
         ...base,
-        ...(trimToUndefined(talkProviderConfig.voice) == null ? {} : { voice: trimToUndefined(talkProviderConfig.voice)! }),
-        ...(trimToUndefined(talkProviderConfig.engine) == null ? {} : { engine: trimToUndefined(talkProviderConfig.engine)! }),
-        ...(trimToUndefined(talkProviderConfig.region) == null ? {} : { region: trimToUndefined(talkProviderConfig.region)! }),
-        ...(trimToUndefined(talkProviderConfig.languageCode) == null ? {} : { languageCode: trimToUndefined(talkProviderConfig.languageCode) }),
-        ...(trimToUndefined(talkProviderConfig.sampleRate) == null ? {} : { sampleRate: trimToUndefined(talkProviderConfig.sampleRate) }),
+        ...(trimToUndefined(talkProviderConfig.voice) == null
+          ? {}
+          : { voice: trimToUndefined(talkProviderConfig.voice)! }),
+        ...(trimToUndefined(talkProviderConfig.engine) == null
+          ? {}
+          : { engine: trimToUndefined(talkProviderConfig.engine)! }),
+        ...(trimToUndefined(talkProviderConfig.region) == null
+          ? {}
+          : { region: trimToUndefined(talkProviderConfig.region)! }),
+        ...(trimToUndefined(talkProviderConfig.languageCode) == null
+          ? {}
+          : { languageCode: trimToUndefined(talkProviderConfig.languageCode) }),
+        ...(trimToUndefined(talkProviderConfig.sampleRate) == null
+          ? {}
+          : { sampleRate: trimToUndefined(talkProviderConfig.sampleRate) }),
       };
     },
 
@@ -132,7 +161,9 @@ export function buildPollySpeechProvider(pluginConfig?: Record<string, unknown>)
       ...(trimToUndefined(params.voice) == null ? {} : { voice: trimToUndefined(params.voice) }),
       ...(trimToUndefined(params.engine) == null ? {} : { engine: trimToUndefined(params.engine) }),
       ...(trimToUndefined(params.region) == null ? {} : { region: trimToUndefined(params.region) }),
-      ...(trimToUndefined(params.language) == null ? {} : { languageCode: trimToUndefined(params.language) }),
+      ...(trimToUndefined(params.language) == null
+        ? {}
+        : { languageCode: trimToUndefined(params.language) }),
     }),
 
     listVoices: async (req) => {
@@ -152,9 +183,7 @@ export function buildPollySpeechProvider(pluginConfig?: Record<string, unknown>)
     },
 
     isConfigured: ({ providerConfig }) => {
-      const config = readPollyConfig(
-        (providerConfig ?? pollyConfig) as Record<string, unknown>,
-      );
+      const config = readPollyConfig((providerConfig ?? pollyConfig) as Record<string, unknown>);
       return config.enabled;
     },
 

--- a/extensions/amazon/polly/speech-provider.ts
+++ b/extensions/amazon/polly/speech-provider.ts
@@ -116,8 +116,10 @@ async function convertToOpusOgg(inputBuffer: Buffer): Promise<Buffer> {
  */
 export function buildPollySpeechProvider(
   pluginConfig?: Record<string, unknown>,
-): SpeechProviderPlugin {
+): SpeechProviderPlugin | null {
   const pollyConfig = (pluginConfig?.polly ?? {}) as Record<string, unknown>;
+  const config = readPollyConfig(pollyConfig);
+  if (!config.enabled) return null;
 
   return {
     id: "amazon-polly",

--- a/extensions/amazon/polly/tts.ts
+++ b/extensions/amazon/polly/tts.ts
@@ -83,6 +83,7 @@ export async function pollySynthesize(params: PollySynthesizeParams): Promise<Bu
     const name = err instanceof Error ? err.name : "UnknownError";
     throw new Error(
       `Amazon Polly synthesis failed (voice=${voiceId}, engine=${engine}, region=${region}): [${name}] ${message}`,
+      { cause: err },
     );
   } finally {
     clearTimeout(timeout);

--- a/extensions/amazon/polly/tts.ts
+++ b/extensions/amazon/polly/tts.ts
@@ -1,0 +1,116 @@
+import {
+  type Engine,
+  type LanguageCode,
+  type OutputFormat,
+  PollyClient,
+  type SynthesizeSpeechCommandInput,
+  SynthesizeSpeechCommand,
+  type TextType,
+  type VoiceId,
+  DescribeVoicesCommand,
+} from "@aws-sdk/client-polly";
+import { getAwsClient } from "../shared/client-cache.js";
+
+export type PollyVoiceEntry = {
+  id: string;
+  name: string;
+  gender?: string;
+  languageCode?: string;
+  languageName?: string;
+  supportedEngines: string[];
+};
+
+export type PollySynthesizeParams = {
+  text: string;
+  voiceId: string;
+  engine: string;
+  outputFormat: string;
+  sampleRate?: string;
+  languageCode?: string;
+  region: string;
+  timeoutMs: number;
+};
+
+function getPollyClient(region: string): PollyClient {
+  return getAwsClient(`polly:${region}`, () => new PollyClient({ region }));
+}
+
+/**
+ * Synthesize speech audio using the Amazon Polly SynthesizeSpeech API.
+ */
+export async function pollySynthesize(params: PollySynthesizeParams): Promise<Buffer> {
+  const { text, voiceId, engine, outputFormat, sampleRate, languageCode, region, timeoutMs } =
+    params;
+
+  const client = getPollyClient(region);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const input: SynthesizeSpeechCommandInput = {
+      Text: text,
+      VoiceId: voiceId as VoiceId,
+      Engine: engine as Engine,
+      OutputFormat: outputFormat as OutputFormat,
+      TextType: "text" as TextType,
+    };
+
+    if (sampleRate) {
+      input.SampleRate = sampleRate;
+    }
+
+    if (languageCode) {
+      input.LanguageCode = languageCode as LanguageCode;
+    }
+
+    const command = new SynthesizeSpeechCommand(input);
+    const response = await client.send(command, { abortSignal: controller.signal });
+
+    if (!response.AudioStream) {
+      throw new Error("Amazon Polly returned empty audio stream");
+    }
+
+    const byteArray = await response.AudioStream.transformToByteArray();
+    const audioBuffer = Buffer.from(byteArray);
+
+    if (audioBuffer.length === 0) {
+      throw new Error("Amazon Polly produced empty audio buffer");
+    }
+
+    return audioBuffer;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    const name = err instanceof Error ? err.name : "UnknownError";
+    throw new Error(
+      `Amazon Polly synthesis failed (voice=${voiceId}, engine=${engine}, region=${region}): [${name}] ${message}`,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * List available voices from Amazon Polly.
+ */
+export async function pollyListVoices(params: {
+  region: string;
+  languageCode?: string;
+  engine?: string;
+}): Promise<PollyVoiceEntry[]> {
+  const client = getPollyClient(params.region);
+  const command = new DescribeVoicesCommand({
+    ...(params.languageCode ? { LanguageCode: params.languageCode as LanguageCode } : {}),
+    ...(params.engine ? { Engine: params.engine as Engine } : {}),
+  });
+  const response = await client.send(command);
+  return (response.Voices ?? [])
+    .map((v) => ({
+      id: v.Id ?? "",
+      name: v.Name ?? v.Id ?? "",
+      gender: v.Gender,
+      languageCode: v.LanguageCode,
+      languageName: v.LanguageName,
+      supportedEngines: (v.SupportedEngines ?? []) as string[],
+    }))
+    .filter((v) => v.id.length > 0);
+}

--- a/extensions/amazon/shared/audio-utils.ts
+++ b/extensions/amazon/shared/audio-utils.ts
@@ -1,0 +1,48 @@
+/** mu-law to 16-bit linear PCM conversion lookup table. */
+const MULAW_TO_PCM = new Int16Array(256);
+(function buildTable() {
+  for (let i = 0; i < 256; i++) {
+    let mu = ~i & 0xff;
+    const sign = mu & 0x80 ? -1 : 1;
+    mu &= 0x7f;
+    const exponent = (mu >> 4) & 0x07;
+    const mantissa = mu & 0x0f;
+    const sample = sign * ((2 * mantissa + 33) * (1 << (exponent + 3)) - 33);
+    MULAW_TO_PCM[i] = sample;
+  }
+})();
+
+/**
+ * Convert mu-law (G.711) audio to 16-bit signed PCM little-endian.
+ * OpenClaw telephony uses mu-law; Nova Sonic expects PCM 16-bit.
+ */
+export function mulawToPcm16(mulaw: Buffer): Buffer {
+  const pcm = Buffer.alloc(mulaw.length * 2);
+  for (let i = 0; i < mulaw.length; i++) {
+    pcm.writeInt16LE(MULAW_TO_PCM[mulaw[i]], i * 2);
+  }
+  return pcm;
+}
+
+/**
+ * Convert 16-bit signed PCM little-endian to mu-law (G.711).
+ * Nova Sonic outputs PCM; OpenClaw telephony expects mu-law.
+ */
+export function pcm16ToMulaw(pcm: Buffer): Buffer {
+  const mulaw = Buffer.alloc(pcm.length / 2);
+  for (let i = 0; i < mulaw.length; i++) {
+    let sample = pcm.readInt16LE(i * 2);
+    const sign = sample < 0 ? 0x80 : 0;
+    if (sample < 0) sample = -sample;
+    sample = Math.min(sample, 32635);
+    sample += 0x84;
+
+    let exponent = 7;
+    for (let expMask = 0x4000; exponent > 0; exponent--, expMask >>= 1) {
+      if (sample & expMask) { break; }
+    }
+    const mantissa = (sample >> (exponent + 3)) & 0x0f;
+    mulaw[i] = ~(sign | (exponent << 4) | mantissa) & 0xff;
+  }
+  return mulaw;
+}

--- a/extensions/amazon/shared/audio-utils.ts
+++ b/extensions/amazon/shared/audio-utils.ts
@@ -33,13 +33,17 @@ export function pcm16ToMulaw(pcm: Buffer): Buffer {
   for (let i = 0; i < mulaw.length; i++) {
     let sample = pcm.readInt16LE(i * 2);
     const sign = sample < 0 ? 0x80 : 0;
-    if (sample < 0) sample = -sample;
+    if (sample < 0) {
+      sample = -sample;
+    }
     sample = Math.min(sample, 32635);
     sample += 0x84;
 
     let exponent = 7;
     for (let expMask = 0x4000; exponent > 0; exponent--, expMask >>= 1) {
-      if (sample & expMask) { break; }
+      if (sample & expMask) {
+        break;
+      }
     }
     const mantissa = (sample >> (exponent + 3)) & 0x0f;
     mulaw[i] = ~(sign | (exponent << 4) | mantissa) & 0xff;

--- a/extensions/amazon/shared/client-cache.ts
+++ b/extensions/amazon/shared/client-cache.ts
@@ -1,0 +1,11 @@
+/** Shared lazy client cache keyed by service+region. */
+const clients = new Map<string, unknown>();
+
+export function getAwsClient<T>(key: string, factory: () => T): T {
+  let client = clients.get(key) as T | undefined;
+  if (!client) {
+    client = factory();
+    clients.set(key, client);
+  }
+  return client;
+}

--- a/extensions/amazon/test-api.ts
+++ b/extensions/amazon/test-api.ts
@@ -1,0 +1,3 @@
+export { buildPollySpeechProvider } from "./polly/speech-provider.js";
+export { buildTranscribeMediaProvider } from "./transcribe/media-understanding-provider.js";
+export { buildNovaSonicVoiceProvider } from "./nova-sonic/realtime-voice-provider.js";

--- a/extensions/amazon/transcribe/media-understanding-provider.test.ts
+++ b/extensions/amazon/transcribe/media-understanding-provider.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildTranscribeMediaProvider } from "./media-understanding-provider.js";
+import * as sttModule from "./stt.js";
+
+describe("buildTranscribeMediaProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("has correct id and capabilities", () => {
+    const provider = buildTranscribeMediaProvider();
+    expect(provider.id).toBe("amazon-transcribe");
+    expect(provider.capabilities).toEqual(["audio"]);
+    expect(provider.autoPriority).toEqual({ audio: 25 });
+  });
+
+  it("transcribes audio using Transcribe Streaming", async () => {
+    const provider = buildTranscribeMediaProvider({ transcribe: { region: "us-west-2" } });
+    const spy = vi.spyOn(sttModule, "transcribeAudio").mockResolvedValue("Hello world");
+
+    const result = await provider.transcribeAudio!({
+      buffer: Buffer.from([0x01]),
+      fileName: "audio.ogg",
+      mime: "audio/ogg",
+      apiKey: "unused",
+      timeoutMs: 10_000,
+    });
+
+    expect(result.text).toBe("Hello world");
+    expect(result.model).toBe("amazon-transcribe-streaming");
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ region: "us-west-2", mime: "audio/ogg" }),
+    );
+  });
+
+  it("uses plugin config language as fallback", async () => {
+    const provider = buildTranscribeMediaProvider({
+      transcribe: { region: "eu-west-1", languageCode: "fr-FR" },
+    });
+    const spy = vi.spyOn(sttModule, "transcribeAudio").mockResolvedValue("Bonjour");
+
+    await provider.transcribeAudio!({
+      buffer: Buffer.from([0x01]),
+      fileName: "audio.ogg",
+      apiKey: "unused",
+      timeoutMs: 10_000,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ language: "fr-FR" }),
+    );
+  });
+
+  it("prefers request language over config", async () => {
+    const provider = buildTranscribeMediaProvider({
+      transcribe: { region: "us-east-1", languageCode: "en-US" },
+    });
+    const spy = vi.spyOn(sttModule, "transcribeAudio").mockResolvedValue("Hola");
+
+    await provider.transcribeAudio!({
+      buffer: Buffer.from([0x01]),
+      fileName: "audio.ogg",
+      apiKey: "unused",
+      language: "es-ES",
+      timeoutMs: 10_000,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ language: "es-ES" }),
+    );
+  });
+});

--- a/extensions/amazon/transcribe/media-understanding-provider.test.ts
+++ b/extensions/amazon/transcribe/media-understanding-provider.test.ts
@@ -7,18 +7,32 @@ describe("buildTranscribeMediaProvider", () => {
     vi.restoreAllMocks();
   });
 
+  it("returns null when enabled is false", () => {
+    const provider = buildTranscribeMediaProvider({ transcribe: { enabled: false } });
+    expect(provider).toBeNull();
+  });
+
+  it("returns null when enabled is explicitly false with other config", () => {
+    const provider = buildTranscribeMediaProvider({
+      transcribe: { enabled: false, region: "us-west-2", languageCode: "en-US" },
+    });
+    expect(provider).toBeNull();
+  });
+
   it("has correct id and capabilities", () => {
     const provider = buildTranscribeMediaProvider();
-    expect(provider.id).toBe("amazon-transcribe");
-    expect(provider.capabilities).toEqual(["audio"]);
-    expect(provider.autoPriority).toEqual({ audio: 25 });
+    expect(provider).not.toBeNull();
+    expect(provider!.id).toBe("amazon-transcribe");
+    expect(provider!.capabilities).toEqual(["audio"]);
+    expect(provider!.autoPriority).toEqual({ audio: 25 });
   });
 
   it("transcribes audio using Transcribe Streaming", async () => {
     const provider = buildTranscribeMediaProvider({ transcribe: { region: "us-west-2" } });
+    expect(provider).not.toBeNull();
     const spy = vi.spyOn(sttModule, "transcribeAudio").mockResolvedValue("Hello world");
 
-    const result = await provider.transcribeAudio!({
+    const result = await provider!.transcribeAudio!({
       buffer: Buffer.from([0x01]),
       fileName: "audio.ogg",
       mime: "audio/ogg",
@@ -37,9 +51,10 @@ describe("buildTranscribeMediaProvider", () => {
     const provider = buildTranscribeMediaProvider({
       transcribe: { region: "eu-west-1", languageCode: "fr-FR" },
     });
+    expect(provider).not.toBeNull();
     const spy = vi.spyOn(sttModule, "transcribeAudio").mockResolvedValue("Bonjour");
 
-    await provider.transcribeAudio!({
+    await provider!.transcribeAudio!({
       buffer: Buffer.from([0x01]),
       fileName: "audio.ogg",
       apiKey: "unused",
@@ -55,9 +70,10 @@ describe("buildTranscribeMediaProvider", () => {
     const provider = buildTranscribeMediaProvider({
       transcribe: { region: "us-east-1", languageCode: "en-US" },
     });
+    expect(provider).not.toBeNull();
     const spy = vi.spyOn(sttModule, "transcribeAudio").mockResolvedValue("Hola");
 
-    await provider.transcribeAudio!({
+    await provider!.transcribeAudio!({
       buffer: Buffer.from([0x01]),
       fileName: "audio.ogg",
       apiKey: "unused",

--- a/extensions/amazon/transcribe/media-understanding-provider.ts
+++ b/extensions/amazon/transcribe/media-understanding-provider.ts
@@ -1,0 +1,60 @@
+import type {
+  AudioTranscriptionRequest,
+  AudioTranscriptionResult,
+  MediaUnderstandingProvider,
+} from "openclaw/plugin-sdk/media-understanding";
+import { transcribeAudio } from "./stt.js";
+
+const DEFAULT_REGION = "us-east-1";
+
+type TranscribeConfig = {
+  enabled: boolean;
+  region: string;
+  languageCode?: string;
+};
+
+function readTranscribeConfig(raw: Record<string, unknown>): TranscribeConfig {
+  const enabled = raw.enabled;
+  return {
+    enabled: enabled !== false,
+    region: (typeof raw.region === "string" && raw.region.trim()) ? raw.region.trim() : DEFAULT_REGION,
+    languageCode: typeof raw.languageCode === "string" && raw.languageCode.trim()
+      ? raw.languageCode.trim()
+      : undefined,
+  };
+}
+
+async function transcribe(
+  req: AudioTranscriptionRequest,
+  config: TranscribeConfig,
+): Promise<AudioTranscriptionResult> {
+  const text = await transcribeAudio({
+    buffer: req.buffer,
+    mime: req.mime,
+    language: req.language ?? config.languageCode,
+    region: config.region,
+    timeoutMs: req.timeoutMs,
+  });
+
+  return { text, model: "amazon-transcribe-streaming" };
+}
+
+/**
+ * Build the Amazon Transcribe media understanding provider.
+ * Config is read from the parent `amazon` plugin's `transcribe` key.
+ */
+export function buildTranscribeMediaProvider(
+  pluginConfig?: Record<string, unknown>,
+): MediaUnderstandingProvider {
+  const config = readTranscribeConfig(
+    (pluginConfig?.transcribe ?? {}) as Record<string, unknown>,
+  );
+
+  return {
+    id: "amazon-transcribe",
+    capabilities: ["audio"],
+    defaultModels: { audio: "amazon-transcribe-streaming" },
+    autoPriority: { audio: 25 },
+    transcribeAudio: (req) => transcribe(req, config),
+  };
+}

--- a/extensions/amazon/transcribe/media-understanding-provider.ts
+++ b/extensions/amazon/transcribe/media-understanding-provider.ts
@@ -42,13 +42,18 @@ async function transcribe(
 /**
  * Build the Amazon Transcribe media understanding provider.
  * Config is read from the parent `amazon` plugin's `transcribe` key.
+ * Returns `null` when the provider is disabled via config.
  */
 export function buildTranscribeMediaProvider(
   pluginConfig?: Record<string, unknown>,
-): MediaUnderstandingProvider {
+): MediaUnderstandingProvider | null {
   const config = readTranscribeConfig(
     (pluginConfig?.transcribe ?? {}) as Record<string, unknown>,
   );
+
+  if (!config.enabled) {
+    return null;
+  }
 
   return {
     id: "amazon-transcribe",

--- a/extensions/amazon/transcribe/stt.ts
+++ b/extensions/amazon/transcribe/stt.ts
@@ -1,0 +1,163 @@
+import {
+  TranscribeStreamingClient,
+  StartStreamTranscriptionCommand,
+  type LanguageCode,
+} from "@aws-sdk/client-transcribe-streaming";
+import { runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { getAwsClient } from "../shared/client-cache.js";
+
+export type TranscribeParams = {
+  buffer: Buffer;
+  mime?: string;
+  language?: string;
+  region: string;
+  timeoutMs: number;
+};
+
+function getTranscribeClient(region: string): TranscribeStreamingClient {
+  return getAwsClient(`transcribe:${region}`, () => new TranscribeStreamingClient({ region }));
+}
+
+/** Supported Transcribe Streaming encodings. */
+type TranscribeEncoding = "pcm" | "ogg-opus" | "flac";
+
+/** MIME types that Transcribe Streaming accepts natively. */
+const NATIVE_MIME_MAP: Record<string, TranscribeEncoding> = {
+  "audio/ogg": "ogg-opus",
+  "audio/opus": "ogg-opus",
+  "audio/flac": "flac",
+  "audio/x-flac": "flac",
+  "audio/wav": "pcm",
+  "audio/x-wav": "pcm",
+  "audio/l16": "pcm",
+  "audio/pcm": "pcm",
+};
+
+function resolveNativeEncoding(mime?: string): TranscribeEncoding | null {
+  if (!mime) { return null; }
+  const base = mime.split(";")[0].trim().toLowerCase();
+  return NATIVE_MIME_MAP[base] ?? null;
+}
+
+/**
+ * Convert unsupported audio formats (MP3, M4A, AAC, WebM, etc.) to PCM
+ * via ffmpeg for Transcribe Streaming compatibility.
+ * Returns { buffer, encoding, sampleRate } for the converted audio.
+ */
+async function convertToPcm(inputBuffer: Buffer, mime?: string): Promise<Buffer> {
+  const tmpDir = os.tmpdir();
+  const id = `transcribe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const ext = mime?.includes("mp3") || mime?.includes("mpeg") ? ".mp3"
+    : mime?.includes("m4a") || mime?.includes("mp4") ? ".m4a"
+    : mime?.includes("webm") ? ".webm"
+    : mime?.includes("aac") ? ".aac"
+    : ".bin";
+  const inputPath = path.join(tmpDir, `${id}${ext}`);
+  const outputPath = path.join(tmpDir, `${id}.pcm`);
+
+  try {
+    await fs.writeFile(inputPath, inputBuffer);
+    await runFfmpeg([
+      "-i", inputPath,
+      "-f", "s16le",        // signed 16-bit little-endian PCM
+      "-ar", "16000",       // 16kHz sample rate
+      "-ac", "1",           // mono
+      "-y", outputPath,
+    ]);
+    return await fs.readFile(outputPath);
+  } finally {
+    await fs.unlink(inputPath).catch(() => {});
+    await fs.unlink(outputPath).catch(() => {});
+  }
+}
+
+/**
+ * Resolve audio buffer and encoding for Transcribe Streaming.
+ * Converts unsupported formats to PCM via ffmpeg.
+ */
+async function resolveAudioInput(buffer: Buffer, mime?: string): Promise<{
+  audioBuffer: Buffer;
+  encoding: TranscribeEncoding;
+  sampleRate: number;
+}> {
+  const nativeEncoding = resolveNativeEncoding(mime);
+
+  if (nativeEncoding) {
+    if (nativeEncoding === "pcm") {
+      // WAV/PCM files may have any sample rate — normalize to 16kHz via ffmpeg
+      // rather than guessing. This avoids mismatched MediaSampleRateHertz errors.
+      const pcmBuffer = await convertToPcm(buffer, mime);
+      return { audioBuffer: pcmBuffer, encoding: "pcm", sampleRate: 16000 };
+    }
+    // OGG-Opus is always 48kHz, FLAC we pass through and let Transcribe detect
+    const sampleRate = nativeEncoding === "ogg-opus" ? 48000 : 16000;
+    return { audioBuffer: buffer, encoding: nativeEncoding, sampleRate };
+  }
+
+  // Unsupported format (MP3, M4A, AAC, WebM, etc.) — convert to PCM
+  const pcmBuffer = await convertToPcm(buffer, mime);
+  return { audioBuffer: pcmBuffer, encoding: "pcm", sampleRate: 16000 };
+}
+
+/**
+ * Transcribe audio using Amazon Transcribe Streaming.
+ * Automatically converts unsupported formats (MP3, M4A, WebM) to PCM via ffmpeg.
+ */
+export async function transcribeAudio(params: TranscribeParams): Promise<string> {
+  const { buffer, mime, language, region, timeoutMs } = params;
+  const client = getTranscribeClient(region);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const { audioBuffer, encoding, sampleRate } = await resolveAudioInput(buffer, mime);
+
+    // Stream audio buffer in chunks
+    async function* audioStream() {
+      const chunkSize = 4096;
+      for (let i = 0; i < audioBuffer.length; i += chunkSize) {
+        yield { AudioEvent: { AudioChunk: audioBuffer.subarray(i, i + chunkSize) } };
+      }
+    }
+
+    const command = new StartStreamTranscriptionCommand({
+      LanguageCode: (language ?? "en-US") as LanguageCode,
+      MediaEncoding: encoding,
+      MediaSampleRateHertz: sampleRate,
+      AudioStream: audioStream(),
+    });
+
+    const response = await client.send(command, { abortSignal: controller.signal });
+
+    const transcripts: string[] = [];
+    if (response.TranscriptResultStream) {
+      for await (const event of response.TranscriptResultStream) {
+        if (event.TranscriptEvent?.Transcript?.Results) {
+          for (const result of event.TranscriptEvent.Transcript.Results) {
+            if (!result.IsPartial && result.Alternatives?.[0]?.Transcript) {
+              transcripts.push(result.Alternatives[0].Transcript);
+            }
+          }
+        }
+      }
+    }
+
+    const text = transcripts.join(" ").trim();
+    if (!text) {
+      throw new Error("Amazon Transcribe returned empty transcript");
+    }
+
+    return text;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    const name = err instanceof Error ? err.name : "UnknownError";
+    throw new Error(
+      `Amazon Transcribe failed (region=${region}, language=${language ?? "en-US"}): [${name}] ${message}`,
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/extensions/amazon/transcribe/stt.ts
+++ b/extensions/amazon/transcribe/stt.ts
@@ -1,12 +1,11 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import {
   TranscribeStreamingClient,
   StartStreamTranscriptionCommand,
   type LanguageCode,
 } from "@aws-sdk/client-transcribe-streaming";
 import { runFfmpeg } from "openclaw/plugin-sdk/media-runtime";
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { getAwsClient } from "../shared/client-cache.js";
 
 export type TranscribeParams = {
@@ -37,7 +36,9 @@ const NATIVE_MIME_MAP: Record<string, TranscribeEncoding> = {
 };
 
 function resolveNativeEncoding(mime?: string): TranscribeEncoding | null {
-  if (!mime) { return null; }
+  if (!mime) {
+    return null;
+  }
   const base = mime.split(";")[0].trim().toLowerCase();
   return NATIVE_MIME_MAP[base] ?? null;
 }
@@ -48,24 +49,35 @@ function resolveNativeEncoding(mime?: string): TranscribeEncoding | null {
  * Returns { buffer, encoding, sampleRate } for the converted audio.
  */
 async function convertToPcm(inputBuffer: Buffer, mime?: string): Promise<Buffer> {
-  const tmpDir = os.tmpdir();
+  const { resolvePreferredOpenClawTmpDir } = await import("openclaw/plugin-sdk/temp-path");
+  const tmpDir = resolvePreferredOpenClawTmpDir();
   const id = `transcribe-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  const ext = mime?.includes("mp3") || mime?.includes("mpeg") ? ".mp3"
-    : mime?.includes("m4a") || mime?.includes("mp4") ? ".m4a"
-    : mime?.includes("webm") ? ".webm"
-    : mime?.includes("aac") ? ".aac"
-    : ".bin";
+  const ext =
+    mime?.includes("mp3") || mime?.includes("mpeg")
+      ? ".mp3"
+      : mime?.includes("m4a") || mime?.includes("mp4")
+        ? ".m4a"
+        : mime?.includes("webm")
+          ? ".webm"
+          : mime?.includes("aac")
+            ? ".aac"
+            : ".bin";
   const inputPath = path.join(tmpDir, `${id}${ext}`);
   const outputPath = path.join(tmpDir, `${id}.pcm`);
 
   try {
     await fs.writeFile(inputPath, inputBuffer);
     await runFfmpeg([
-      "-i", inputPath,
-      "-f", "s16le",        // signed 16-bit little-endian PCM
-      "-ar", "16000",       // 16kHz sample rate
-      "-ac", "1",           // mono
-      "-y", outputPath,
+      "-i",
+      inputPath,
+      "-f",
+      "s16le", // signed 16-bit little-endian PCM
+      "-ar",
+      "16000", // 16kHz sample rate
+      "-ac",
+      "1", // mono
+      "-y",
+      outputPath,
     ]);
     return await fs.readFile(outputPath);
   } finally {
@@ -78,7 +90,10 @@ async function convertToPcm(inputBuffer: Buffer, mime?: string): Promise<Buffer>
  * Resolve audio buffer and encoding for Transcribe Streaming.
  * Converts unsupported formats to PCM via ffmpeg.
  */
-async function resolveAudioInput(buffer: Buffer, mime?: string): Promise<{
+async function resolveAudioInput(
+  buffer: Buffer,
+  mime?: string,
+): Promise<{
   audioBuffer: Buffer;
   encoding: TranscribeEncoding;
   sampleRate: number;
@@ -156,6 +171,7 @@ export async function transcribeAudio(params: TranscribeParams): Promise<string>
     const name = err instanceof Error ? err.name : "UnknownError";
     throw new Error(
       `Amazon Transcribe failed (region=${region}, language=${language ?? "en-US"}): [${name}] ${message}`,
+      { cause: err },
     );
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## Summary

Adds a unified `amazon` plugin that brings AWS voice and speech services to OpenClaw, and establishes a consolidated home for AWS AI service integrations (following the `openai` multi-contract plugin pattern).

Three services ship in this PR:

| Service | Contract | What it does |
|---------|----------|-------------|
| **Amazon Polly** | `speechProviders` | Text-to-speech with generative engine, WhatsApp voice notes, chat directives |
| **Amazon Transcribe** | `mediaUnderstandingProviders` | Real-time speech-to-text with auto format conversion |
| **Amazon Nova Sonic** | `realtimeVoiceProviders` | Bidirectional speech-to-speech with tool calling via Bedrock |

All three use IAM credential chain auth — no API keys to manage. Drop-in for any EC2, ECS, or Lambda deployment with an IAM role.

## Why one plugin?

AWS AI services share credentials, regions, and SDK patterns. Rather than `amazon-polly` + `amazon-transcribe` + `amazon-nova-sonic` as separate plugins (each with their own `package.json`, SDK deps, and config paths), this consolidates them into:

```
extensions/amazon/
├── shared/client-cache.ts       # Lazy client cache shared across services
├── polly/                       # TTS
├── transcribe/                  # STT
└── nova-sonic/                  # Realtime voice
```

One config block, one set of credentials, one plugin to enable:

```json
{
  "plugins": {
    "entries": {
      "amazon": {
        "config": {
          "polly": { "enabled": true, "voice": "Ruth", "engine": "generative", "region": "us-east-1" },
          "transcribe": { "enabled": true, "region": "us-east-1" },
          "novaSonic": { "enabled": true, "voice": "tiffany", "region": "us-east-1" }
        }
      }
    }
  }
}
```

This mirrors how the `openai` plugin registers LLM, TTS, image gen, video gen, realtime voice, and media understanding providers from a single extension. Bedrock LLM providers (`amazon-bedrock`, `amazon-bedrock-mantle`) remain separate — they have complex auth, model discovery, and inference profile logic that warrants standalone plugins.

## Amazon Polly (TTS)

- **Generative engine** default — Ruth voice, highest quality speech
- **WhatsApp voice notes** — MP3 → Opus/OGG via ffmpeg
- **Chat directives** — `[voice:Joanna]` `[engine:neural]` `[language:es-MX]`
- **Voice calls** — `resolveTalkConfig/Overrides` + `synthesizeTelephony` (PCM 22050Hz)
- **Voice browsing** — `listVoices` queries DescribeVoices API
- **Engine-aware defaults** — 24000Hz generative/long-form, 22050Hz standard/neural
- **Config enums** — 17 regions, 34 languages, 4 engines with pricing in help text

## Amazon Transcribe (STT)

- **Transcribe Streaming** — real-time, not batch
- **Auto format handling** — OGG-Opus, FLAC, WAV pass through natively
- **ffmpeg conversion** — MP3, M4A, AAC, WebM auto-converted to PCM
- **Configurable** — region, language with enum dropdowns

## Amazon Nova Sonic (Realtime Voice)

- **Bidirectional speech-to-speech** via Bedrock `InvokeModelWithBidirectionalStream`
- **Full-duplex** — user can interrupt (barge-in) the model's response
- **Tool calling** — agentic voice conversations with function execution
- **PCM audio** — 16kHz input, 24kHz output
- Makes OpenClaw one of the first open-source agent frameworks with AWS-native realtime voice support

## Architecture

- **Shared client cache** — lazy-initialized per service+region, reuses connections
- **`providerAuthEnvVars`** — declared for credential auto-discovery
- **Per-service enable/disable** — each service has its own `enabled` flag
- **Extensible** — future AWS services (Translate, SES) add as new subdirectories

## Files (15 files, 1,761 lines — all new)

| Path | Lines | Purpose |
|------|-------|---------|
| `index.ts` | 15 | Registers all 3 services |
| `openclaw.plugin.json` | 192 | Config schema + UI hints |
| `package.json` | 27 | SDK deps |
| `shared/client-cache.ts` | 11 | Shared AWS client cache |
| `polly/tts.ts` | 116 | SynthesizeSpeech + DescribeVoices |
| `polly/speech-provider.ts` | 220 | Full TTS provider |
| `polly/speech-provider.test.ts` | 147 | 8 tests |
| `transcribe/stt.ts` | 157 | Transcribe Streaming + ffmpeg |
| `transcribe/media-understanding-provider.ts` | 60 | STT provider |
| `transcribe/media-understanding-provider.test.ts` | 72 | 4 tests |
| `nova-sonic/bridge.ts` | 401 | Bidirectional stream bridge |
| `nova-sonic/realtime-voice-provider.ts` | 69 | Voice provider |
| `nova-sonic/realtime-voice-provider.test.ts` | 63 | 5 tests |
| `test-api.ts` | 3 | Public test exports |

## Credits

Built on the Amazon Polly foundation started by @ArtemioPadilla in #62259.

Co-authored-by: ArtemioPadilla <ArtemioPadilla@users.noreply.github.com>