### PR TITLE
fix(zai): rotate env-backed API keys on rate limit

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-a7612f89b98d04577ec867555e0219bd21659f93879dc127244da0beddb53dae  plugin-sdk-api-baseline.json
-77d138ee00a105cb02c6cb5cdae5348a778b57a3af66551f4bbdc8c03e32f67c  plugin-sdk-api-baseline.jsonl
+bf5d9b6757a8839c502cf9dd50823467d1136d0edecc5b82ae483205e31c8050  plugin-sdk-api-baseline.json
+f4e4e7d24eee1f0c28e60ca165c3ca01b463df4a4d08b697a629d5807b9e9dcc  plugin-sdk-api-baseline.jsonl

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -379,6 +379,7 @@ OpenClaw ships with the pi‑ai catalog. These providers require **no**
 
 - Provider: `zai`
 - Auth: `ZAI_API_KEY`
+- Optional rotation: `ZAI_API_KEYS`, `ZAI_API_KEY_1`, `ZAI_API_KEY_2`, legacy `Z_AI_API_KEY`, plus `OPENCLAW_LIVE_ZAI_KEY` (single override)
 - Example model: `zai/glm-5.1`
 - CLI: `openclaw onboard --auth-choice zai-api-key`
   - Aliases: `z.ai/*` and `z-ai/*` normalize to `zai/*`

--- a/docs/providers/glm.md
+++ b/docs/providers/glm.md
@@ -43,6 +43,10 @@ openclaw onboard --auth-choice zai-cn
 apply the correct base URL automatically. Use the explicit regional choices when
 you want to force a specific Coding Plan or general API surface.
 
+For rate-limit key rotation, OpenClaw also accepts `ZAI_API_KEYS`
+(comma/semicolon list), `ZAI_API_KEY_1`, `ZAI_API_KEY_2`, legacy `Z_AI_API_KEY`,
+and `OPENCLAW_LIVE_ZAI_KEY` as a single override.
+
 ## Current bundled GLM models
 
 OpenClaw currently seeds the bundled `zai` provider with these GLM refs:
@@ -65,4 +69,6 @@ OpenClaw currently seeds the bundled `zai` provider with these GLM refs:
 
 - GLM versions and availability can change; check Z.AI's docs for the latest.
 - Default bundled model ref is `zai/glm-5.1`.
+- When multiple env-backed Z.AI keys are present, gateway runs can rotate to the
+  next key on rate-limit failures.
 - For provider details, see [/providers/zai](/providers/zai).

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -44,6 +44,10 @@ openclaw onboard --auth-choice zai-cn
 apply the correct base URL automatically. Use the explicit regional choices when
 you want to force a specific Coding Plan or general API surface.
 
+For key rotation on rate-limit responses, OpenClaw also supports `ZAI_API_KEYS`
+(comma/semicolon list), `ZAI_API_KEY_1`, `ZAI_API_KEY_2`, legacy `Z_AI_API_KEY`,
+and `OPENCLAW_LIVE_ZAI_KEY` as a single override.
+
 ## Bundled GLM catalog
 
 OpenClaw currently seeds the bundled `zai` provider with:
@@ -71,5 +75,7 @@ OpenClaw currently seeds the bundled `zai` provider with:
   matches the current GLM-5 family shape.
 - `tool_stream` is enabled by default for Z.AI tool-call streaming. Set
   `agents.defaults.models["zai/<model>"].params.tool_stream` to `false` to disable it.
+- When multiple env-backed Z.AI keys are present, gateway runs can rotate to the
+  next key on rate-limit failures.
 - See [/providers/glm](/providers/glm) for the model family overview.
 - Z.AI uses Bearer auth with your API key.

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -360,6 +360,45 @@ describe("zai provider plugin", () => {
 
     const profiles = provider.resolveExternalAuthProfiles?.({
       env: {
+        ZAI_API_KEY: "sk-zai-primary",
+        ZAI_API_KEY_1: "sk-zai-next",
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "zai:default": {
+            type: "api_key",
+            provider: "zai",
+            keyRef: {
+              source: "env",
+              provider: "default",
+              id: "ZAI_API_KEY",
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(profiles).toEqual([
+      {
+        profileId: "zai:runtime-env-1",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-next",
+          displayName: "Z.AI env key 1",
+        },
+      },
+    ]);
+  });
+
+  it("deduplicates keyRef-backed primary env keys before env rotation", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const profiles = provider.resolveExternalAuthProfiles?.({
+      env: {
+        ZAI_API_KEY: "sk-zai-primary",
         ZAI_API_KEY_1: "sk-zai-next",
       },
       store: {

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -354,6 +354,43 @@ describe("zai provider plugin", () => {
     ]);
   });
 
+  it("counts keyRef-backed stored api-key profiles when deciding to emit env rotation", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const profiles = provider.resolveExternalAuthProfiles?.({
+      env: {
+        ZAI_API_KEY_1: "sk-zai-next",
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "zai:default": {
+            type: "api_key",
+            provider: "zai",
+            keyRef: {
+              source: "env",
+              provider: "default",
+              id: "ZAI_API_KEY",
+            },
+          },
+        },
+      },
+    } as never);
+
+    expect(profiles).toEqual([
+      {
+        profileId: "zai:runtime-env-1",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-next",
+          displayName: "Z.AI env key 1",
+        },
+      },
+    ]);
+  });
+
   it("rebuilds the same runtime env profiles when the store already includes them", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -1,9 +1,30 @@
 import { createHash } from "node:crypto";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import plugin from "./index.js";
+
+const detectZaiEndpoint = vi.hoisted(() => vi.fn(async () => undefined));
+const upsertAuthProfile = vi.hoisted(() => vi.fn());
+
+vi.mock("./detect.js", async () => {
+  const actual = await vi.importActual<typeof import("./detect.js")>("./detect.js");
+  return {
+    ...actual,
+    detectZaiEndpoint,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/provider-auth-api-key", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/provider-auth-api-key")>(
+    "openclaw/plugin-sdk/provider-auth-api-key",
+  );
+  return {
+    ...actual,
+    upsertAuthProfile,
+  };
+});
 
 function resolveRuntimeEnvProfileId(apiKey: string): string {
   return `zai:runtime-env-${createHash("sha256").update(apiKey, "utf8").digest("hex").slice(0, 12)}`;
@@ -19,6 +40,12 @@ function resolveProfileApiKey(profile: {
   }
   return profile.credential.key;
 }
+
+beforeEach(() => {
+  detectZaiEndpoint.mockReset();
+  detectZaiEndpoint.mockResolvedValue(undefined);
+  upsertAuthProfile.mockReset();
+});
 
 describe("zai provider plugin", () => {
   it("owns replay policy for OpenAI-compatible Z.ai transports", async () => {
@@ -569,5 +596,84 @@ describe("zai provider plugin", () => {
         ?.map((profile) => [resolveProfileApiKey(profile), profile.profileId] as const)
         .toSorted(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey)),
     );
+  });
+
+  it("keeps ZAI_API_KEYS as an env ref in non-interactive ref mode", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const method = provider.auth.find((entry) => entry.id === "api-key");
+    expect(method?.runNonInteractive).toBeDefined();
+
+    const resolveApiKey = vi.fn(async () => ({ key: "sk-zai-single", source: "profile" as const }));
+    const toApiKeyCredential = vi.fn(({ provider, resolved }) => ({
+      type: "api_key" as const,
+      provider,
+      ...(resolved.source === "env" && resolved.envVarName
+        ? {
+            keyRef: {
+              source: "env" as const,
+              provider: "default",
+              id: resolved.envVarName,
+            },
+          }
+        : { key: resolved.key }),
+    }));
+    const previousZaiApiKeys = process.env.ZAI_API_KEYS;
+    process.env.ZAI_API_KEYS = "sk-zai-single";
+
+    try {
+      const result = await method?.runNonInteractive?.({
+        authChoice: "zai-api-key",
+        config: { agents: { defaults: {} } },
+        baseConfig: { agents: { defaults: {} } },
+        opts: {},
+        runtime: {
+          error: vi.fn(),
+          exit: vi.fn(),
+          log: vi.fn(),
+        } as never,
+        secretInputMode: "ref",
+        resolveApiKey,
+        toApiKeyCredential,
+      } as never);
+
+      expect(resolveApiKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "zai",
+          envVar: "ZAI_API_KEY",
+        }),
+      );
+      expect(toApiKeyCredential).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "zai",
+          resolved: {
+            key: "sk-zai-single",
+            source: "env",
+            envVarName: "ZAI_API_KEYS",
+          },
+        }),
+      );
+      expect(upsertAuthProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          profileId: "zai:default",
+          credential: expect.objectContaining({
+            keyRef: {
+              source: "env",
+              provider: "default",
+              id: "ZAI_API_KEYS",
+            },
+          }),
+        }),
+      );
+      expect(result?.auth?.profiles?.["zai:default"]).toEqual({
+        provider: "zai",
+        mode: "api_key",
+      });
+    } finally {
+      if (previousZaiApiKeys === undefined) {
+        delete process.env.ZAI_API_KEYS;
+      } else {
+        process.env.ZAI_API_KEYS = previousZaiApiKeys;
+      }
+    }
   });
 });

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -1,8 +1,24 @@
+import { createHash } from "node:crypto";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import { registerSingleProviderPlugin } from "../../test/helpers/plugins/plugin-registration.js";
 import plugin from "./index.js";
+
+function resolveRuntimeEnvProfileId(apiKey: string): string {
+  return `zai:runtime-env-${createHash("sha256").update(apiKey, "utf8").digest("hex").slice(0, 12)}`;
+}
+
+function resolveProfileApiKey(profile: {
+  credential: { type: string; key?: string };
+  profileId: string;
+}): string {
+  expect(profile.credential.type).toBe("api_key");
+  if (!profile.credential.key) {
+    throw new Error(`expected api_key credential for ${profile.profileId}`);
+  }
+  return profile.credential.key;
+}
 
 describe("zai provider plugin", () => {
   it("owns replay policy for OpenAI-compatible Z.ai transports", async () => {
@@ -241,7 +257,7 @@ describe("zai provider plugin", () => {
 
     expect(profiles).toEqual([
       {
-        profileId: "zai:runtime-env-1",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-a"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -251,7 +267,7 @@ describe("zai provider plugin", () => {
         },
       },
       {
-        profileId: "zai:runtime-env-2",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-b"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -261,7 +277,7 @@ describe("zai provider plugin", () => {
         },
       },
       {
-        profileId: "zai:runtime-env-3",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-1"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -271,7 +287,7 @@ describe("zai provider plugin", () => {
         },
       },
       {
-        profileId: "zai:runtime-env-4",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-2"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -281,7 +297,7 @@ describe("zai provider plugin", () => {
         },
       },
       {
-        profileId: "zai:runtime-env-5",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-legacy"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -343,7 +359,7 @@ describe("zai provider plugin", () => {
 
     expect(profiles).toEqual([
       {
-        profileId: "zai:runtime-env-1",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-next"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -370,7 +386,7 @@ describe("zai provider plugin", () => {
 
     expect(profiles).toEqual([
       {
-        profileId: "zai:runtime-env-1",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-single"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -408,7 +424,7 @@ describe("zai provider plugin", () => {
 
     expect(profiles).toEqual([
       {
-        profileId: "zai:runtime-env-1",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-next"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -446,7 +462,7 @@ describe("zai provider plugin", () => {
 
     expect(profiles).toEqual([
       {
-        profileId: "zai:runtime-env-1",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-next"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -480,7 +496,7 @@ describe("zai provider plugin", () => {
 
     expect(profiles).toEqual([
       {
-        profileId: "zai:runtime-env-1",
+        profileId: resolveRuntimeEnvProfileId("sk-zai-next"),
         persistence: "runtime-only",
         credential: {
           type: "api_key",
@@ -502,12 +518,12 @@ describe("zai provider plugin", () => {
       store: {
         version: 1,
         profiles: {
-          "zai:runtime-env-1": {
+          [resolveRuntimeEnvProfileId("sk-zai-a")]: {
             type: "api_key",
             provider: "zai",
             key: "sk-zai-a",
           },
-          "zai:runtime-env-2": {
+          [resolveRuntimeEnvProfileId("sk-zai-b")]: {
             type: "api_key",
             provider: "zai",
             key: "sk-zai-b",
@@ -517,8 +533,41 @@ describe("zai provider plugin", () => {
     } as never);
 
     expect(profiles?.map((profile) => profile.profileId)).toEqual([
-      "zai:runtime-env-1",
-      "zai:runtime-env-2",
+      resolveRuntimeEnvProfileId("sk-zai-a"),
+      resolveRuntimeEnvProfileId("sk-zai-b"),
     ]);
+  });
+
+  it("keeps runtime env profile ids stable when env key ordering changes", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const forward = provider.resolveExternalAuthProfiles?.({
+      env: {
+        ZAI_API_KEYS: "sk-zai-a,sk-zai-b",
+      },
+      store: {
+        version: 1,
+        profiles: {},
+      },
+    } as never);
+    const reversed = provider.resolveExternalAuthProfiles?.({
+      env: {
+        ZAI_API_KEYS: "sk-zai-b,sk-zai-a",
+      },
+      store: {
+        version: 1,
+        profiles: {},
+      },
+    } as never);
+
+    expect(
+      forward
+        ?.map((profile) => [resolveProfileApiKey(profile), profile.profileId] as const)
+        .toSorted(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey)),
+    ).toEqual(
+      reversed
+        ?.map((profile) => [resolveProfileApiKey(profile), profile.profileId] as const)
+        .toSorted(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey)),
+    );
   });
 });

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -293,7 +293,7 @@ describe("zai provider plugin", () => {
     ]);
   });
 
-  it("does not create env rotation profiles for a single live override key", async () => {
+  it("creates a runtime auth profile for a single live override key", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 
     const profiles = provider.resolveExternalAuthProfiles?.({
@@ -307,7 +307,51 @@ describe("zai provider plugin", () => {
       },
     } as never);
 
-    expect(profiles).toBeUndefined();
+    expect(profiles).toEqual([
+      {
+        profileId: "zai:default",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-live",
+          displayName: "Z.AI live override",
+        },
+      },
+    ]);
+  });
+
+  it("emits a new runtime profile when one env key complements a persisted key", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const profiles = provider.resolveExternalAuthProfiles?.({
+      env: {
+        ZAI_API_KEY_1: "sk-zai-next",
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "zai:default": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-primary",
+          },
+        },
+      },
+    } as never);
+
+    expect(profiles).toEqual([
+      {
+        profileId: "zai:runtime-env-1",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-next",
+          displayName: "Z.AI env key 1",
+        },
+      },
+    ]);
   });
 
   it("rebuilds the same runtime env profiles when the store already includes them", async () => {

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -309,8 +309,9 @@ describe("zai provider plugin", () => {
 
     expect(profiles).toEqual([
       {
-        profileId: "zai:default",
+        profileId: "zai:runtime-live-override",
         persistence: "runtime-only",
+        selectionPriority: "highest",
         credential: {
           type: "api_key",
           provider: "zai",

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -431,6 +431,40 @@ describe("zai provider plugin", () => {
     ]);
   });
 
+  it("ignores unregistered numbered Z.AI API key env vars beyond the documented pair", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const profiles = provider.resolveExternalAuthProfiles?.({
+      env: {
+        ZAI_API_KEY_1: "sk-zai-next",
+        ZAI_API_KEY_3: "sk-zai-ignored",
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "zai:default": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-primary",
+          },
+        },
+      },
+    } as never);
+
+    expect(profiles).toEqual([
+      {
+        profileId: "zai:runtime-env-1",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-next",
+          displayName: "Z.AI env key 1",
+        },
+      },
+    ]);
+  });
+
   it("rebuilds the same runtime env profiles when the store already includes them", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -215,4 +215,128 @@ describe("zai provider plugin", () => {
 
     expect(capturedPayload).not.toHaveProperty("tool_stream");
   });
+
+  it("exposes runtime-only auth profiles for multiple env API keys", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const profiles = provider.resolveExternalAuthProfiles?.({
+      env: {
+        ZAI_API_KEYS: "sk-zai-a; sk-zai-b",
+        ZAI_API_KEY: "sk-zai-primary",
+        ZAI_API_KEY_2: "sk-zai-2",
+        ZAI_API_KEY_1: "sk-zai-1",
+        Z_AI_API_KEY: "sk-zai-legacy",
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "zai:default": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-primary",
+          },
+        },
+      },
+    } as never);
+
+    expect(profiles).toEqual([
+      {
+        profileId: "zai:runtime-env-1",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-a",
+          displayName: "Z.AI env key 1",
+        },
+      },
+      {
+        profileId: "zai:runtime-env-2",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-b",
+          displayName: "Z.AI env key 2",
+        },
+      },
+      {
+        profileId: "zai:runtime-env-3",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-1",
+          displayName: "Z.AI env key 3",
+        },
+      },
+      {
+        profileId: "zai:runtime-env-4",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-2",
+          displayName: "Z.AI env key 4",
+        },
+      },
+      {
+        profileId: "zai:runtime-env-5",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-legacy",
+          displayName: "Z.AI env key 5",
+        },
+      },
+    ]);
+  });
+
+  it("does not create env rotation profiles for a single live override key", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const profiles = provider.resolveExternalAuthProfiles?.({
+      env: {
+        OPENCLAW_LIVE_ZAI_KEY: "sk-zai-live",
+        ZAI_API_KEYS: "sk-zai-a,sk-zai-b",
+      },
+      store: {
+        version: 1,
+        profiles: {},
+      },
+    } as never);
+
+    expect(profiles).toBeUndefined();
+  });
+
+  it("rebuilds the same runtime env profiles when the store already includes them", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const profiles = provider.resolveExternalAuthProfiles?.({
+      env: {
+        ZAI_API_KEYS: "sk-zai-a,sk-zai-b",
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "zai:runtime-env-1": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-a",
+          },
+          "zai:runtime-env-2": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-b",
+          },
+        },
+      },
+    } as never);
+
+    expect(profiles?.map((profile) => profile.profileId)).toEqual([
+      "zai:runtime-env-1",
+      "zai:runtime-env-2",
+    ]);
+  });
 });

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -355,6 +355,33 @@ describe("zai provider plugin", () => {
     ]);
   });
 
+  it("treats a single-item ZAI_API_KEYS list as usable auth when no stored profile exists", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+
+    const profiles = provider.resolveExternalAuthProfiles?.({
+      env: {
+        ZAI_API_KEYS: "sk-zai-single",
+      },
+      store: {
+        version: 1,
+        profiles: {},
+      },
+    } as never);
+
+    expect(profiles).toEqual([
+      {
+        profileId: "zai:runtime-env-1",
+        persistence: "runtime-only",
+        credential: {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-single",
+          displayName: "Z.AI env key 1",
+        },
+      },
+    ]);
+  });
+
   it("counts keyRef-backed stored api-key profiles when deciding to emit env rotation", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
 

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -676,4 +676,66 @@ describe("zai provider plugin", () => {
       }
     }
   });
+
+  it("persists a single-item ZAI_API_KEYS list when non-interactive auth resolves through profile fallback", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const method = provider.auth.find((entry) => entry.id === "api-key");
+    expect(method?.runNonInteractive).toBeDefined();
+
+    const resolveApiKey = vi.fn(async () => ({ key: "sk-zai-single", source: "profile" as const }));
+    const toApiKeyCredential = vi.fn(({ provider, resolved }) => ({
+      type: "api_key" as const,
+      provider,
+      key: resolved.key,
+    }));
+    const previousZaiApiKeys = process.env.ZAI_API_KEYS;
+    process.env.ZAI_API_KEYS = "sk-zai-single";
+
+    try {
+      const result = await method?.runNonInteractive?.({
+        authChoice: "zai-api-key",
+        config: { agents: { defaults: {} } },
+        baseConfig: { agents: { defaults: {} } },
+        opts: {},
+        runtime: {
+          error: vi.fn(),
+          exit: vi.fn(),
+          log: vi.fn(),
+        } as never,
+        resolveApiKey,
+        toApiKeyCredential,
+      } as never);
+
+      expect(toApiKeyCredential).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "zai",
+          resolved: {
+            key: "sk-zai-single",
+            source: "env",
+            envVarName: "ZAI_API_KEYS",
+          },
+        }),
+      );
+      expect(upsertAuthProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          profileId: "zai:default",
+          credential: {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-single",
+          },
+        }),
+      );
+      expect(result?.auth?.profiles?.["zai:default"]).toEqual({
+        provider: "zai",
+        mode: "api_key",
+      });
+    } finally {
+      if (previousZaiApiKeys === undefined) {
+        delete process.env.ZAI_API_KEYS;
+      } else {
+        process.env.ZAI_API_KEYS = previousZaiApiKeys;
+      }
+    }
+  });
 });

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -77,16 +77,19 @@ function collectPrefixedApiKeys(env: NodeJS.ProcessEnv, prefix: string): string[
   return keys;
 }
 
+function listStoredZaiApiKeyProfileIds(store: AuthProfileStore): string[] {
+  return listProfilesForProvider(store, PROVIDER_ID).filter((profileId) => {
+    if (profileId.startsWith(`${ENV_ROTATION_PROFILE_ID_PREFIX}-`)) {
+      return false;
+    }
+    return store.profiles[profileId]?.type === "api_key";
+  });
+}
+
 function collectExistingZaiApiKeys(store: AuthProfileStore): Set<string> {
   const existing = new Set<string>();
-  for (const profileId of listProfilesForProvider(store, PROVIDER_ID)) {
-    if (profileId.startsWith(`${ENV_ROTATION_PROFILE_ID_PREFIX}-`)) {
-      continue;
-    }
+  for (const profileId of listStoredZaiApiKeyProfileIds(store)) {
     const credential = store.profiles[profileId];
-    if (credential?.type !== "api_key") {
-      continue;
-    }
     const key = normalizeOptionalSecretInput(credential.key);
     if (key) {
       existing.add(key);
@@ -99,11 +102,6 @@ function collectZaiRotationApiKeys(params: {
   env: NodeJS.ProcessEnv;
   store: AuthProfileStore;
 }): string[] {
-  const liveOverride = normalizeOptionalSecretInput(params.env.OPENCLAW_LIVE_ZAI_KEY);
-  if (liveOverride) {
-    return [liveOverride];
-  }
-
   const seen = collectExistingZaiApiKeys(params.store);
   const apiKeys: string[] = [];
   const add = (value?: string) => {
@@ -127,9 +125,30 @@ function collectZaiRotationApiKeys(params: {
   return apiKeys;
 }
 
+function resolveZaiLiveOverrideProfileId(store: AuthProfileStore): string {
+  return listStoredZaiApiKeyProfileIds(store)[0] ?? PROFILE_ID;
+}
+
 function resolveZaiEnvRotationProfiles(ctx: { env: NodeJS.ProcessEnv; store: AuthProfileStore }) {
+  const liveOverride = normalizeOptionalSecretInput(ctx.env.OPENCLAW_LIVE_ZAI_KEY);
+  if (liveOverride) {
+    return [
+      {
+        profileId: resolveZaiLiveOverrideProfileId(ctx.store),
+        persistence: "runtime-only" as const,
+        credential: {
+          type: "api_key" as const,
+          provider: PROVIDER_ID,
+          key: liveOverride,
+          displayName: "Z.AI live override",
+        },
+      },
+    ];
+  }
+
   const apiKeys = collectZaiRotationApiKeys(ctx);
-  if (apiKeys.length < 2) {
+  const existingApiKeyCount = collectExistingZaiApiKeys(ctx.store).size;
+  if (existingApiKeyCount + apiKeys.length < 2) {
     return undefined;
   }
   return apiKeys.map((apiKey, index) => ({

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -90,6 +90,9 @@ function collectExistingZaiApiKeys(store: AuthProfileStore): Set<string> {
   const existing = new Set<string>();
   for (const profileId of listStoredZaiApiKeyProfileIds(store)) {
     const credential = store.profiles[profileId];
+    if (credential?.type !== "api_key") {
+      continue;
+    }
     const key = normalizeOptionalSecretInput(credential.key);
     if (key) {
       existing.add(key);

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   definePluginEntry,
   type ProviderAuthContext,
@@ -131,6 +132,13 @@ function collectZaiRotationApiKeys(params: {
   return apiKeys;
 }
 
+function resolveZaiEnvRotationProfileId(apiKey: string): string {
+  // Keep runtime overlay ids stable per key so persisted cooldown/usage state
+  // does not get reassigned when env list ordering changes between runs.
+  const keyFingerprint = createHash("sha256").update(apiKey, "utf8").digest("hex").slice(0, 12);
+  return `${ENV_ROTATION_PROFILE_ID_PREFIX}-${keyFingerprint}`;
+}
+
 function resolveZaiEnvRotationProfiles(ctx: { env: NodeJS.ProcessEnv; store: AuthProfileStore }) {
   const liveOverride = normalizeOptionalSecretInput(ctx.env.OPENCLAW_LIVE_ZAI_KEY);
   if (liveOverride) {
@@ -158,7 +166,7 @@ function resolveZaiEnvRotationProfiles(ctx: { env: NodeJS.ProcessEnv; store: Aut
     return undefined;
   }
   return apiKeys.map((apiKey, index) => ({
-    profileId: `${ENV_ROTATION_PROFILE_ID_PREFIX}-${index + 1}`,
+    profileId: resolveZaiEnvRotationProfileId(apiKey),
     persistence: "runtime-only" as const,
     credential: {
       type: "api_key" as const,

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -90,14 +90,29 @@ function listStoredZaiApiKeyProfileIds(store: AuthProfileStore): string[] {
   });
 }
 
-function collectExistingZaiApiKeys(store: AuthProfileStore): Set<string> {
+function resolveStoredZaiApiKey(params: {
+  credential: AuthProfileStore["profiles"][string];
+  env: NodeJS.ProcessEnv;
+}): string | undefined {
+  const { credential, env } = params;
+  if (credential?.type !== "api_key") {
+    return undefined;
+  }
+  const inlineKey = normalizeOptionalSecretInput(credential.key);
+  if (inlineKey) {
+    return inlineKey;
+  }
+  if (credential.keyRef?.source === "env" && typeof credential.keyRef.id === "string") {
+    return normalizeOptionalSecretInput(env[credential.keyRef.id]);
+  }
+  return undefined;
+}
+
+function collectExistingZaiApiKeys(store: AuthProfileStore, env: NodeJS.ProcessEnv): Set<string> {
   const existing = new Set<string>();
   for (const profileId of listStoredZaiApiKeyProfileIds(store)) {
     const credential = store.profiles[profileId];
-    if (credential?.type !== "api_key") {
-      continue;
-    }
-    const key = normalizeOptionalSecretInput(credential.key);
+    const key = resolveStoredZaiApiKey({ credential, env });
     if (key) {
       existing.add(key);
     }
@@ -109,7 +124,7 @@ function collectZaiRotationApiKeys(params: {
   env: NodeJS.ProcessEnv;
   store: AuthProfileStore;
 }): string[] {
-  const seen = collectExistingZaiApiKeys(params.store);
+  const seen = collectExistingZaiApiKeys(params.store, params.env);
   const apiKeys: string[] = [];
   const add = (value?: string) => {
     const resolved = normalizeOptionalSecretInput(value);
@@ -374,7 +389,14 @@ export default definePluginEntry({
       label: "Z.AI",
       aliases: ["z-ai", "z.ai"],
       docsPath: "/providers/models",
-      envVars: ["ZAI_API_KEY", "Z_AI_API_KEY"],
+      envVars: [
+        "ZAI_API_KEY",
+        "ZAI_API_KEYS",
+        "ZAI_API_KEY_1",
+        "ZAI_API_KEY_2",
+        "Z_AI_API_KEY",
+        "OPENCLAW_LIVE_ZAI_KEY",
+      ],
       auth: [
         buildZaiApiKeyMethod({
           id: "api-key",

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -307,12 +307,25 @@ async function runZaiApiKeyAuthNonInteractive(
   ctx: ProviderAuthMethodNonInteractiveContext,
   endpoint?: ZaiEndpointId,
 ) {
-  const resolved = await ctx.resolveApiKey({
+  let resolved = await ctx.resolveApiKey({
     provider: PROVIDER_ID,
     flagValue: normalizeOptionalSecretInput(ctx.opts.zaiApiKey),
     flagName: "--zai-api-key",
     envVar: "ZAI_API_KEY",
   });
+  const singleListEnvKey = parseApiKeyList(process.env.ZAI_API_KEYS);
+  if (
+    ctx.secretInputMode === "ref" &&
+    !normalizeOptionalSecretInput(ctx.opts.zaiApiKey) &&
+    (!resolved || resolved.source === "profile") &&
+    singleListEnvKey.length === 1
+  ) {
+    resolved = {
+      key: singleListEnvKey[0] ?? "",
+      source: "env",
+      envVarName: "ZAI_API_KEYS",
+    };
+  }
   if (!resolved) {
     return null;
   }

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -150,7 +150,7 @@ function resolveZaiEnvRotationProfiles(ctx: { env: NodeJS.ProcessEnv; store: Aut
   }
 
   const apiKeys = collectZaiRotationApiKeys(ctx);
-  const existingApiKeyCount = collectExistingZaiApiKeys(ctx.store).size;
+  const existingApiKeyCount = listStoredZaiApiKeyProfileIds(ctx.store).length;
   if (existingApiKeyCount + apiKeys.length < 2) {
     return undefined;
   }

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -33,6 +33,7 @@ const PROVIDER_ID = "zai";
 const GLM5_TEMPLATE_MODEL_ID = "glm-4.7";
 const PROFILE_ID = "zai:default";
 const ENV_ROTATION_PROFILE_ID_PREFIX = "zai:runtime-env";
+const LIVE_OVERRIDE_PROFILE_ID = "zai:runtime-live-override";
 const KEY_SPLIT_RE = /[\s,;]+/g;
 const OPENAI_COMPATIBLE_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
   family: "openai-compatible",
@@ -79,7 +80,10 @@ function collectPrefixedApiKeys(env: NodeJS.ProcessEnv, prefix: string): string[
 
 function listStoredZaiApiKeyProfileIds(store: AuthProfileStore): string[] {
   return listProfilesForProvider(store, PROVIDER_ID).filter((profileId) => {
-    if (profileId.startsWith(`${ENV_ROTATION_PROFILE_ID_PREFIX}-`)) {
+    if (
+      profileId === LIVE_OVERRIDE_PROFILE_ID ||
+      profileId.startsWith(`${ENV_ROTATION_PROFILE_ID_PREFIX}-`)
+    ) {
       return false;
     }
     return store.profiles[profileId]?.type === "api_key";
@@ -128,17 +132,14 @@ function collectZaiRotationApiKeys(params: {
   return apiKeys;
 }
 
-function resolveZaiLiveOverrideProfileId(store: AuthProfileStore): string {
-  return listStoredZaiApiKeyProfileIds(store)[0] ?? PROFILE_ID;
-}
-
 function resolveZaiEnvRotationProfiles(ctx: { env: NodeJS.ProcessEnv; store: AuthProfileStore }) {
   const liveOverride = normalizeOptionalSecretInput(ctx.env.OPENCLAW_LIVE_ZAI_KEY);
   if (liveOverride) {
     return [
       {
-        profileId: resolveZaiLiveOverrideProfileId(ctx.store),
+        profileId: LIVE_OVERRIDE_PROFILE_ID,
         persistence: "runtime-only" as const,
+        selectionPriority: "highest" as const,
         credential: {
           type: "api_key" as const,
           provider: PROVIDER_ID,

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -6,6 +6,7 @@ import {
   type ProviderResolveDynamicModelContext,
   type ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { listProfilesForProvider, type AuthProfileStore } from "openclaw/plugin-sdk/provider-auth";
 import {
   applyAuthProfileConfig,
   buildApiKeyCredential,
@@ -31,10 +32,117 @@ import { applyZaiConfig, applyZaiProviderConfig, ZAI_DEFAULT_MODEL_REF } from ".
 const PROVIDER_ID = "zai";
 const GLM5_TEMPLATE_MODEL_ID = "glm-4.7";
 const PROFILE_ID = "zai:default";
+const ENV_ROTATION_PROFILE_ID_PREFIX = "zai:runtime-env";
+const KEY_SPLIT_RE = /[\s,;]+/g;
 const OPENAI_COMPATIBLE_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
   family: "openai-compatible",
 });
 const ZAI_TOOL_STREAM_HOOKS = buildProviderStreamFamilyHooks("tool-stream-default-on");
+
+function parseApiKeyList(raw?: string): string[] {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(KEY_SPLIT_RE)
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function collectPrefixedApiKeys(env: NodeJS.ProcessEnv, prefix: string): string[] {
+  const entries = Object.entries(env)
+    .filter(([name]) => name.startsWith(prefix) && name.length > prefix.length)
+    .toSorted(([a], [b]) => {
+      const suffixA = a.slice(prefix.length);
+      const suffixB = b.slice(prefix.length);
+      const numberA = Number.parseInt(suffixA, 10);
+      const numberB = Number.parseInt(suffixB, 10);
+      const hasNumberA = Number.isFinite(numberA);
+      const hasNumberB = Number.isFinite(numberB);
+      if (hasNumberA && hasNumberB && numberA !== numberB) {
+        return numberA - numberB;
+      }
+      if (hasNumberA !== hasNumberB) {
+        return hasNumberA ? -1 : 1;
+      }
+      return a.localeCompare(b);
+    });
+  const keys: string[] = [];
+  for (const [, value] of entries) {
+    const resolved = normalizeOptionalSecretInput(value);
+    if (resolved) {
+      keys.push(resolved);
+    }
+  }
+  return keys;
+}
+
+function collectExistingZaiApiKeys(store: AuthProfileStore): Set<string> {
+  const existing = new Set<string>();
+  for (const profileId of listProfilesForProvider(store, PROVIDER_ID)) {
+    if (profileId.startsWith(`${ENV_ROTATION_PROFILE_ID_PREFIX}-`)) {
+      continue;
+    }
+    const credential = store.profiles[profileId];
+    if (credential?.type !== "api_key") {
+      continue;
+    }
+    const key = normalizeOptionalSecretInput(credential.key);
+    if (key) {
+      existing.add(key);
+    }
+  }
+  return existing;
+}
+
+function collectZaiRotationApiKeys(params: {
+  env: NodeJS.ProcessEnv;
+  store: AuthProfileStore;
+}): string[] {
+  const liveOverride = normalizeOptionalSecretInput(params.env.OPENCLAW_LIVE_ZAI_KEY);
+  if (liveOverride) {
+    return [liveOverride];
+  }
+
+  const seen = collectExistingZaiApiKeys(params.store);
+  const apiKeys: string[] = [];
+  const add = (value?: string) => {
+    const resolved = normalizeOptionalSecretInput(value);
+    if (!resolved || seen.has(resolved)) {
+      return;
+    }
+    seen.add(resolved);
+    apiKeys.push(resolved);
+  };
+
+  for (const value of parseApiKeyList(params.env.ZAI_API_KEYS)) {
+    add(value);
+  }
+  add(params.env.ZAI_API_KEY);
+  for (const value of collectPrefixedApiKeys(params.env, "ZAI_API_KEY_")) {
+    add(value);
+  }
+  add(params.env.Z_AI_API_KEY);
+
+  return apiKeys;
+}
+
+function resolveZaiEnvRotationProfiles(ctx: { env: NodeJS.ProcessEnv; store: AuthProfileStore }) {
+  const apiKeys = collectZaiRotationApiKeys(ctx);
+  if (apiKeys.length < 2) {
+    return undefined;
+  }
+  return apiKeys.map((apiKey, index) => ({
+    profileId: `${ENV_ROTATION_PROFILE_ID_PREFIX}-${index + 1}`,
+    persistence: "runtime-only" as const,
+    credential: {
+      type: "api_key" as const,
+      provider: PROVIDER_ID,
+      key: apiKey,
+      displayName: `Z.AI env key ${index + 1}`,
+    },
+  }));
+}
 
 function resolveGlm5ForwardCompatModel(
   ctx: ProviderResolveDynamicModelContext,
@@ -279,6 +387,7 @@ export default definePluginEntry({
           endpoint: "cn",
         }),
       ],
+      resolveExternalAuthProfiles: (ctx) => resolveZaiEnvRotationProfiles(ctx),
       resolveDynamicModel: (ctx) => resolveGlm5ForwardCompatModel(ctx),
       ...OPENAI_COMPATIBLE_REPLAY_HOOKS,
       prepareExtraParams: (ctx) => {

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -50,26 +50,10 @@ function parseApiKeyList(raw?: string): string[] {
     .filter(Boolean);
 }
 
-function collectPrefixedApiKeys(env: NodeJS.ProcessEnv, prefix: string): string[] {
-  const entries = Object.entries(env)
-    .filter(([name]) => name.startsWith(prefix) && name.length > prefix.length)
-    .toSorted(([a], [b]) => {
-      const suffixA = a.slice(prefix.length);
-      const suffixB = b.slice(prefix.length);
-      const numberA = Number.parseInt(suffixA, 10);
-      const numberB = Number.parseInt(suffixB, 10);
-      const hasNumberA = Number.isFinite(numberA);
-      const hasNumberB = Number.isFinite(numberB);
-      if (hasNumberA && hasNumberB && numberA !== numberB) {
-        return numberA - numberB;
-      }
-      if (hasNumberA !== hasNumberB) {
-        return hasNumberA ? -1 : 1;
-      }
-      return a.localeCompare(b);
-    });
+function collectNamedApiKeys(env: NodeJS.ProcessEnv, names: readonly string[]): string[] {
   const keys: string[] = [];
-  for (const [, value] of entries) {
+  for (const name of names) {
+    const value = env[name];
     const resolved = normalizeOptionalSecretInput(value);
     if (resolved) {
       keys.push(resolved);
@@ -139,7 +123,7 @@ function collectZaiRotationApiKeys(params: {
     add(value);
   }
   add(params.env.ZAI_API_KEY);
-  for (const value of collectPrefixedApiKeys(params.env, "ZAI_API_KEY_")) {
+  for (const value of collectNamedApiKeys(params.env, ["ZAI_API_KEY_1", "ZAI_API_KEY_2"])) {
     add(value);
   }
   add(params.env.Z_AI_API_KEY);

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -151,7 +151,10 @@ function resolveZaiEnvRotationProfiles(ctx: { env: NodeJS.ProcessEnv; store: Aut
 
   const apiKeys = collectZaiRotationApiKeys(ctx);
   const existingApiKeyCount = listStoredZaiApiKeyProfileIds(ctx.store).length;
-  if (existingApiKeyCount + apiKeys.length < 2) {
+  if (apiKeys.length === 0) {
+    return undefined;
+  }
+  if (existingApiKeyCount > 0 && existingApiKeyCount + apiKeys.length < 2) {
     return undefined;
   }
   return apiKeys.map((apiKey, index) => ({

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -315,7 +315,6 @@ async function runZaiApiKeyAuthNonInteractive(
   });
   const singleListEnvKey = parseApiKeyList(process.env.ZAI_API_KEYS);
   if (
-    ctx.secretInputMode === "ref" &&
     !normalizeOptionalSecretInput(ctx.opts.zaiApiKey) &&
     (!resolved || resolved.source === "profile") &&
     singleListEnvKey.length === 1

--- a/extensions/zai/openclaw.plugin.json
+++ b/extensions/zai/openclaw.plugin.json
@@ -3,7 +3,14 @@
   "enabledByDefault": true,
   "providers": ["zai"],
   "providerAuthEnvVars": {
-    "zai": ["ZAI_API_KEY", "Z_AI_API_KEY"]
+    "zai": [
+      "ZAI_API_KEY",
+      "ZAI_API_KEYS",
+      "ZAI_API_KEY_1",
+      "ZAI_API_KEY_2",
+      "Z_AI_API_KEY",
+      "OPENCLAW_LIVE_ZAI_KEY"
+    ]
   },
   "providerAuthChoices": [
     {

--- a/extensions/zai/openclaw.plugin.json
+++ b/extensions/zai/openclaw.plugin.json
@@ -5,12 +5,14 @@
   "providerAuthEnvVars": {
     "zai": [
       "ZAI_API_KEY",
-      "ZAI_API_KEYS",
       "ZAI_API_KEY_1",
       "ZAI_API_KEY_2",
       "Z_AI_API_KEY",
       "OPENCLAW_LIVE_ZAI_KEY"
     ]
+  },
+  "providerSecretEnvVars": {
+    "zai": ["ZAI_API_KEYS"]
   },
   "providerAuthChoices": [
     {

--- a/src/agents/auth-profiles.resolve-auth-profile-order.includes-runtime-only-external.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.includes-runtime-only-external.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAuthProfileOrder } from "./auth-profiles.js";
+import type { AuthProfileStore } from "./auth-profiles.js";
+
+const listRuntimeOnlyExternalAuthProfileIdsMock = vi.hoisted(() =>
+  vi.fn<(params: unknown) => string[]>(() => []),
+);
+
+vi.mock("./auth-profiles/external-auth.js", () => ({
+  listRuntimeOnlyExternalAuthProfileIds: (params: unknown) =>
+    listRuntimeOnlyExternalAuthProfileIdsMock(params),
+}));
+
+function createStore(profiles: AuthProfileStore["profiles"]): AuthProfileStore {
+  return {
+    version: 1,
+    profiles,
+  };
+}
+
+describe("resolveAuthProfileOrder runtime-only external profiles", () => {
+  beforeEach(() => {
+    listRuntimeOnlyExternalAuthProfileIdsMock.mockReset();
+  });
+
+  it("appends runtime-only external profiles after configured profile ids", () => {
+    listRuntimeOnlyExternalAuthProfileIdsMock.mockReturnValueOnce(["zai:runtime-env-1"]);
+
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          profiles: {
+            "zai:default": {
+              provider: "zai",
+              mode: "api_key",
+            },
+          },
+        },
+      },
+      store: createStore({
+        "zai:default": {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-default",
+        },
+        "zai:runtime-env-1": {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-runtime",
+        },
+      }),
+      provider: "zai",
+    });
+
+    expect(order).toEqual(["zai:default", "zai:runtime-env-1"]);
+  });
+
+  it("appends runtime-only external profiles after explicit order entries", () => {
+    listRuntimeOnlyExternalAuthProfileIdsMock.mockReturnValueOnce(["zai:runtime-env-1"]);
+
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: {
+            zai: ["zai:work", "zai:default"],
+          },
+          profiles: {
+            "zai:default": {
+              provider: "zai",
+              mode: "api_key",
+            },
+            "zai:work": {
+              provider: "zai",
+              mode: "api_key",
+            },
+          },
+        },
+      },
+      store: createStore({
+        "zai:default": {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-default",
+        },
+        "zai:work": {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-work",
+        },
+        "zai:runtime-env-1": {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-runtime",
+        },
+      }),
+      provider: "zai",
+    });
+
+    expect(order).toEqual(["zai:work", "zai:default", "zai:runtime-env-1"]);
+  });
+});

--- a/src/agents/auth-profiles.resolve-auth-profile-order.includes-runtime-only-external.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.includes-runtime-only-external.test.ts
@@ -2,13 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAuthProfileOrder } from "./auth-profiles.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 
-const listRuntimeOnlyExternalAuthProfileIdsMock = vi.hoisted(() =>
-  vi.fn<(params: unknown) => string[]>(() => []),
+const listRuntimeOnlyExternalAuthProfilesMock = vi.hoisted(() =>
+  vi.fn<
+    (params: unknown) => Array<{ profileId: string; selectionPriority: "default" | "highest" }>
+  >(() => []),
 );
 
 vi.mock("./auth-profiles/external-auth.js", () => ({
-  listRuntimeOnlyExternalAuthProfileIds: (params: unknown) =>
-    listRuntimeOnlyExternalAuthProfileIdsMock(params),
+  listRuntimeOnlyExternalAuthProfiles: (params: unknown) =>
+    listRuntimeOnlyExternalAuthProfilesMock(params),
 }));
 
 function createStore(profiles: AuthProfileStore["profiles"]): AuthProfileStore {
@@ -20,11 +22,13 @@ function createStore(profiles: AuthProfileStore["profiles"]): AuthProfileStore {
 
 describe("resolveAuthProfileOrder runtime-only external profiles", () => {
   beforeEach(() => {
-    listRuntimeOnlyExternalAuthProfileIdsMock.mockReset();
+    listRuntimeOnlyExternalAuthProfilesMock.mockReset();
   });
 
   it("appends runtime-only external profiles after configured profile ids", () => {
-    listRuntimeOnlyExternalAuthProfileIdsMock.mockReturnValueOnce(["zai:runtime-env-1"]);
+    listRuntimeOnlyExternalAuthProfilesMock.mockReturnValueOnce([
+      { profileId: "zai:runtime-env-1", selectionPriority: "default" },
+    ]);
 
     const order = resolveAuthProfileOrder({
       cfg: {
@@ -56,7 +60,9 @@ describe("resolveAuthProfileOrder runtime-only external profiles", () => {
   });
 
   it("appends runtime-only external profiles after explicit order entries", () => {
-    listRuntimeOnlyExternalAuthProfileIdsMock.mockReturnValueOnce(["zai:runtime-env-1"]);
+    listRuntimeOnlyExternalAuthProfilesMock.mockReturnValueOnce([
+      { profileId: "zai:runtime-env-1", selectionPriority: "default" },
+    ]);
 
     const order = resolveAuthProfileOrder({
       cfg: {
@@ -97,5 +103,63 @@ describe("resolveAuthProfileOrder runtime-only external profiles", () => {
     });
 
     expect(order).toEqual(["zai:work", "zai:default", "zai:runtime-env-1"]);
+  });
+
+  it("prioritizes highest-priority runtime-only external profiles ahead of configured ids", () => {
+    listRuntimeOnlyExternalAuthProfilesMock.mockReturnValueOnce([
+      { profileId: "zai:runtime-live-override", selectionPriority: "highest" },
+    ]);
+
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          profiles: {
+            "zai:default": {
+              provider: "zai",
+              mode: "api_key",
+            },
+          },
+        },
+      },
+      store: createStore({
+        "zai:default": {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-default",
+        },
+        "zai:runtime-live-override": {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-live",
+        },
+      }),
+      provider: "zai",
+    });
+
+    expect(order).toEqual(["zai:runtime-live-override", "zai:default"]);
+  });
+
+  it("prioritizes highest-priority runtime-only external profiles without explicit config", () => {
+    listRuntimeOnlyExternalAuthProfilesMock.mockReturnValueOnce([
+      { profileId: "zai:runtime-live-override", selectionPriority: "highest" },
+    ]);
+
+    const order = resolveAuthProfileOrder({
+      store: createStore({
+        "zai:default": {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-default",
+        },
+        "zai:runtime-live-override": {
+          type: "api_key",
+          provider: "zai",
+          key: "sk-zai-live",
+        },
+      }),
+      provider: "zai",
+    });
+
+    expect(order).toEqual(["zai:runtime-live-override", "zai:default"]);
   });
 });

--- a/src/agents/auth-profiles.resolve-auth-profile-order.includes-runtime-only-external.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.includes-runtime-only-external.test.ts
@@ -162,4 +162,85 @@ describe("resolveAuthProfileOrder runtime-only external profiles", () => {
 
     expect(order).toEqual(["zai:runtime-live-override", "zai:default"]);
   });
+
+  it("keeps highest-priority runtime-only external profiles behind available profiles when cooled down", () => {
+    listRuntimeOnlyExternalAuthProfilesMock.mockReturnValueOnce([
+      { profileId: "zai:runtime-live-override", selectionPriority: "highest" },
+    ]);
+
+    const order = resolveAuthProfileOrder({
+      store: {
+        version: 1,
+        profiles: {
+          "zai:default": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-default",
+          },
+          "zai:runtime-live-override": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-live",
+          },
+        },
+        usageStats: {
+          "zai:runtime-live-override": {
+            cooldownUntil: Date.now() + 60_000,
+          },
+        },
+      },
+      provider: "zai",
+    });
+
+    expect(order).toEqual(["zai:default", "zai:runtime-live-override"]);
+  });
+
+  it("keeps cooled-down highest-priority runtime-only external profiles behind available profiles in explicit order mode", () => {
+    listRuntimeOnlyExternalAuthProfilesMock.mockReturnValueOnce([
+      { profileId: "zai:runtime-live-override", selectionPriority: "highest" },
+    ]);
+
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: {
+            zai: ["zai:default", "zai:runtime-live-override"],
+          },
+          profiles: {
+            "zai:default": {
+              provider: "zai",
+              mode: "api_key",
+            },
+            "zai:runtime-live-override": {
+              provider: "zai",
+              mode: "api_key",
+            },
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "zai:default": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-default",
+          },
+          "zai:runtime-live-override": {
+            type: "api_key",
+            provider: "zai",
+            key: "sk-zai-live",
+          },
+        },
+        usageStats: {
+          "zai:runtime-live-override": {
+            cooldownUntil: Date.now() + 60_000,
+          },
+        },
+      },
+      provider: "zai",
+    });
+
+    expect(order).toEqual(["zai:default", "zai:runtime-live-override"]);
+  });
 });

--- a/src/agents/auth-profiles.resolve-auth-profile-order.includes-runtime-only-external.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.includes-runtime-only-external.test.ts
@@ -243,4 +243,43 @@ describe("resolveAuthProfileOrder runtime-only external profiles", () => {
 
     expect(order).toEqual(["zai:default", "zai:runtime-live-override"]);
   });
+
+  it("repairs stale configured profile ids even when a runtime-only overlay is present", () => {
+    listRuntimeOnlyExternalAuthProfilesMock.mockReturnValueOnce([
+      { profileId: "openai-codex:runtime-env-1", selectionPriority: "default" },
+    ]);
+
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          profiles: {
+            "openai-codex:default": {
+              provider: "openai-codex",
+              mode: "oauth",
+            },
+          },
+          order: {
+            "openai-codex": ["openai-codex:default"],
+          },
+        },
+      },
+      store: createStore({
+        "openai-codex:user@example.com": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+        "openai-codex:runtime-env-1": {
+          type: "api_key",
+          provider: "openai-codex",
+          key: "sk-openai-runtime",
+        },
+      }),
+      provider: "openai-codex",
+    });
+
+    expect(order).toEqual(["openai-codex:runtime-env-1", "openai-codex:user@example.com"]);
+  });
 });

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -121,6 +121,22 @@ export function overlayExternalAuthProfiles(
   return next;
 }
 
+export function listRuntimeOnlyExternalAuthProfileIds(params: {
+  store: AuthProfileStore;
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): string[] {
+  return Array.from(
+    resolveExternalAuthProfileMap({
+      store: params.store,
+      agentDir: params.agentDir,
+      env: params.env,
+    }).entries(),
+  )
+    .filter(([, profile]) => profile.persistence !== "persisted")
+    .map(([profileId]) => profileId);
+}
+
 export function shouldPersistExternalAuthProfile(params: {
   store: AuthProfileStore;
   profileId: string;

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -2,7 +2,12 @@ import type { ProviderExternalAuthProfile } from "../../plugins/provider-externa
 import { resolveExternalAuthProfilesWithPlugins } from "../../plugins/provider-runtime.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 
-type ExternalAuthProfileMap = Map<string, ProviderExternalAuthProfile>;
+type NormalizedExternalAuthProfile = ProviderExternalAuthProfile & {
+  persistence: "runtime-only" | "persisted";
+  selectionPriority: "default" | "highest";
+};
+
+type ExternalAuthProfileMap = Map<string, NormalizedExternalAuthProfile>;
 type ResolveExternalAuthProfiles = typeof resolveExternalAuthProfilesWithPlugins;
 
 let resolveExternalAuthProfilesForRuntime: ResolveExternalAuthProfiles | undefined;
@@ -18,13 +23,14 @@ export const __testing = {
 
 function normalizeExternalAuthProfile(
   profile: ProviderExternalAuthProfile,
-): ProviderExternalAuthProfile | null {
+): NormalizedExternalAuthProfile | null {
   if (!profile?.profileId || !profile.credential) {
     return null;
   }
   return {
     ...profile,
     persistence: profile.persistence ?? "runtime-only",
+    selectionPriority: profile.selectionPriority ?? "default",
   };
 }
 
@@ -126,6 +132,14 @@ export function listRuntimeOnlyExternalAuthProfileIds(params: {
   agentDir?: string;
   env?: NodeJS.ProcessEnv;
 }): string[] {
+  return listRuntimeOnlyExternalAuthProfiles(params).map((profile) => profile.profileId);
+}
+
+export function listRuntimeOnlyExternalAuthProfiles(params: {
+  store: AuthProfileStore;
+  agentDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): Array<{ profileId: string; selectionPriority: "default" | "highest" }> {
   return Array.from(
     resolveExternalAuthProfileMap({
       store: params.store,
@@ -134,7 +148,10 @@ export function listRuntimeOnlyExternalAuthProfileIds(params: {
     }).entries(),
   )
     .filter(([, profile]) => profile.persistence !== "persisted")
-    .map(([profileId]) => profileId);
+    .map(([profileId, profile]) => ({
+      profileId,
+      selectionPriority: profile.selectionPriority,
+    }));
 }
 
 export function shouldPersistExternalAuthProfile(params: {

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -79,8 +79,9 @@ function authCredentialMatches(a: AuthProfileCredential, b: AuthProfileCredentia
       a.displayName === b.displayName &&
       a.enterpriseUrl === b.enterpriseUrl &&
       a.projectId === b.projectId &&
-      a.accountId === b.accountId &&
-      a.managedBy === b.managedBy
+      // `managedBy` is persistence/runtime metadata, not credential identity.
+      // Runtime overlays may omit it while synced stored credentials include it.
+      a.accountId === b.accountId
     );
   }
 

--- a/src/agents/auth-profiles/external-auth.ts
+++ b/src/agents/auth-profiles/external-auth.ts
@@ -1,6 +1,6 @@
 import type { ProviderExternalAuthProfile } from "../../plugins/provider-external-auth.types.js";
 import { resolveExternalAuthProfilesWithPlugins } from "../../plugins/provider-runtime.js";
-import type { AuthProfileStore, OAuthCredential } from "./types.js";
+import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
 
 type ExternalAuthProfileMap = Map<string, ProviderExternalAuthProfile>;
 type ResolveExternalAuthProfiles = typeof resolveExternalAuthProfilesWithPlugins;
@@ -58,20 +58,47 @@ function resolveExternalAuthProfileMap(params: {
   return resolved;
 }
 
-function oauthCredentialMatches(a: OAuthCredential, b: OAuthCredential): boolean {
-  return (
-    a.type === b.type &&
-    a.provider === b.provider &&
-    a.access === b.access &&
-    a.refresh === b.refresh &&
-    a.expires === b.expires &&
-    a.clientId === b.clientId &&
-    a.email === b.email &&
-    a.displayName === b.displayName &&
-    a.enterpriseUrl === b.enterpriseUrl &&
-    a.projectId === b.projectId &&
-    a.accountId === b.accountId
-  );
+function authCredentialMatches(a: AuthProfileCredential, b: AuthProfileCredential): boolean {
+  if (a.type !== b.type || a.provider !== b.provider) {
+    return false;
+  }
+
+  if (a.type === "oauth" && b.type === "oauth") {
+    return (
+      a.access === b.access &&
+      a.refresh === b.refresh &&
+      a.expires === b.expires &&
+      a.clientId === b.clientId &&
+      a.email === b.email &&
+      a.displayName === b.displayName &&
+      a.enterpriseUrl === b.enterpriseUrl &&
+      a.projectId === b.projectId &&
+      a.accountId === b.accountId &&
+      a.managedBy === b.managedBy
+    );
+  }
+
+  if (a.type === "api_key" && b.type === "api_key") {
+    return (
+      a.key === b.key &&
+      a.email === b.email &&
+      a.displayName === b.displayName &&
+      JSON.stringify(a.keyRef ?? null) === JSON.stringify(b.keyRef ?? null) &&
+      JSON.stringify(a.metadata ?? null) === JSON.stringify(b.metadata ?? null)
+    );
+  }
+
+  if (a.type === "token" && b.type === "token") {
+    return (
+      a.token === b.token &&
+      a.expires === b.expires &&
+      a.email === b.email &&
+      a.displayName === b.displayName &&
+      JSON.stringify(a.tokenRef ?? null) === JSON.stringify(b.tokenRef ?? null)
+    );
+  }
+
+  return false;
 }
 
 export function overlayExternalAuthProfiles(
@@ -97,7 +124,7 @@ export function overlayExternalAuthProfiles(
 export function shouldPersistExternalAuthProfile(params: {
   store: AuthProfileStore;
   profileId: string;
-  credential: OAuthCredential;
+  credential: AuthProfileCredential;
   agentDir?: string;
   env?: NodeJS.ProcessEnv;
 }): boolean {
@@ -109,7 +136,7 @@ export function shouldPersistExternalAuthProfile(params: {
   if (!external || external.persistence === "persisted") {
     return true;
   }
-  return !oauthCredentialMatches(external.credential, params.credential);
+  return !authCredentialMatches(external.credential, params.credential);
 }
 
 // Compat aliases while file/function naming catches up.

--- a/src/agents/auth-profiles/external-oauth.test.ts
+++ b/src/agents/auth-profiles/external-oauth.test.ts
@@ -230,7 +230,6 @@ describe("auth external oauth helpers", () => {
       profileId: "zai:runtime-live-override",
       credential: runtimeCredential,
     });
-
     expect(shouldPersistPersisted).toBe(true);
     expect(shouldPersistRuntime).toBe(false);
   });

--- a/src/agents/auth-profiles/external-oauth.test.ts
+++ b/src/agents/auth-profiles/external-oauth.test.ts
@@ -2,10 +2,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderExternalAuthProfile } from "../../plugins/types.js";
 import {
   __testing,
+  listRuntimeOnlyExternalAuthProfileIds,
+  listRuntimeOnlyExternalAuthProfiles,
+  overlayExternalAuthProfiles,
   overlayExternalOAuthProfiles,
+  shouldPersistExternalAuthProfile,
   shouldPersistExternalOAuthProfile,
 } from "./external-auth.js";
-import type { AuthProfileStore, OAuthCredential } from "./types.js";
+import type { ApiKeyCredential, AuthProfileStore, OAuthCredential } from "./types.js";
 
 const resolveExternalAuthProfilesWithPluginsMock = vi.fn<
   (params: unknown) => ProviderExternalAuthProfile[]
@@ -22,6 +26,15 @@ function createCredential(overrides: Partial<OAuthCredential> = {}): OAuthCreden
     access: "access-token",
     refresh: "refresh-token",
     expires: 123,
+    ...overrides,
+  };
+}
+
+function createApiKeyCredential(overrides: Partial<ApiKeyCredential> = {}): ApiKeyCredential {
+  return {
+    type: "api_key",
+    provider: "zai",
+    key: "sk-zai-1",
     ...overrides,
   };
 }
@@ -51,6 +64,23 @@ describe("auth external oauth helpers", () => {
       type: "oauth",
       provider: "openai-codex",
       access: "access-token",
+    });
+  });
+
+  it("overlays runtime-only api-key profiles onto the store", () => {
+    resolveExternalAuthProfilesWithPluginsMock.mockReturnValueOnce([
+      {
+        profileId: "zai:runtime-env-1",
+        credential: createApiKeyCredential(),
+      },
+    ]);
+
+    const store = overlayExternalAuthProfiles(createStore());
+
+    expect(store.profiles["zai:runtime-env-1"]).toMatchObject({
+      type: "api_key",
+      provider: "zai",
+      key: "sk-zai-1",
     });
   });
 
@@ -107,5 +137,101 @@ describe("auth external oauth helpers", () => {
     });
 
     expect(shouldPersist).toBe(true);
+  });
+
+  it("omits exact runtime-only api-key overlays from persisted store writes", () => {
+    const credential = createApiKeyCredential();
+    resolveExternalAuthProfilesWithPluginsMock.mockReturnValueOnce([
+      {
+        profileId: "zai:runtime-env-1",
+        credential,
+      },
+    ]);
+
+    const shouldPersist = shouldPersistExternalAuthProfile({
+      store: createStore({ "zai:runtime-env-1": credential }),
+      profileId: "zai:runtime-env-1",
+      credential,
+    });
+
+    expect(shouldPersist).toBe(false);
+  });
+
+  it("lists runtime-only external auth profile ids", () => {
+    resolveExternalAuthProfilesWithPluginsMock.mockReturnValueOnce([
+      {
+        profileId: "zai:runtime-env-1",
+        credential: createApiKeyCredential(),
+      },
+      {
+        profileId: "zai:persisted",
+        credential: createApiKeyCredential({ key: "sk-zai-persisted" }),
+        persistence: "persisted",
+      },
+    ]);
+
+    const profileIds = listRuntimeOnlyExternalAuthProfileIds({
+      store: createStore({
+        "zai:runtime-env-1": createApiKeyCredential(),
+        "zai:persisted": createApiKeyCredential({ key: "sk-zai-persisted" }),
+      }),
+    });
+
+    expect(profileIds).toEqual(["zai:runtime-env-1"]);
+  });
+
+  it("exposes runtime-only external auth profile priority metadata", () => {
+    resolveExternalAuthProfilesWithPluginsMock.mockReturnValueOnce([
+      {
+        profileId: "zai:runtime-live-override",
+        credential: createApiKeyCredential({ key: "sk-zai-live" }),
+        selectionPriority: "highest",
+      },
+    ]);
+
+    const profiles = listRuntimeOnlyExternalAuthProfiles({
+      store: createStore({
+        "zai:runtime-live-override": createApiKeyCredential({ key: "sk-zai-live" }),
+      }),
+    });
+
+    expect(profiles).toEqual([
+      {
+        profileId: "zai:runtime-live-override",
+        selectionPriority: "highest",
+      },
+    ]);
+  });
+
+  it("keeps persisted profiles when a live override uses a separate runtime-only id", () => {
+    const persistedCredential = createApiKeyCredential({ key: "sk-zai-default" });
+    const runtimeCredential = createApiKeyCredential({ key: "sk-zai-live" });
+    resolveExternalAuthProfilesWithPluginsMock.mockReturnValue([
+      {
+        profileId: "zai:runtime-live-override",
+        credential: runtimeCredential,
+        selectionPriority: "highest",
+      },
+    ]);
+
+    const shouldPersistPersisted = shouldPersistExternalAuthProfile({
+      store: createStore({
+        "zai:default": persistedCredential,
+        "zai:runtime-live-override": runtimeCredential,
+      }),
+      profileId: "zai:default",
+      credential: persistedCredential,
+    });
+    const shouldPersistRuntime = shouldPersistExternalAuthProfile({
+      store: createStore({
+        "zai:default": persistedCredential,
+        "zai:runtime-live-override": runtimeCredential,
+      }),
+      profileId: "zai:runtime-live-override",
+      credential: runtimeCredential,
+    });
+
+    expect(shouldPersistPersisted).toBe(true);
+    expect(shouldPersistRuntime).toBe(false);
   });
 });

--- a/src/agents/auth-profiles/external-oauth.test.ts
+++ b/src/agents/auth-profiles/external-oauth.test.ts
@@ -139,6 +139,25 @@ describe("auth external oauth helpers", () => {
     expect(shouldPersist).toBe(true);
   });
 
+  it("omits runtime-only oauth overlays when managedBy is the only difference", () => {
+    const persistedCredential = createCredential({ managedBy: "codex-cli" });
+    const runtimeCredential = createCredential();
+    resolveExternalAuthProfilesWithPluginsMock.mockReturnValueOnce([
+      {
+        profileId: "openai-codex:default",
+        credential: runtimeCredential,
+      },
+    ]);
+
+    const shouldPersist = shouldPersistExternalOAuthProfile({
+      store: createStore({ "openai-codex:default": runtimeCredential }),
+      profileId: "openai-codex:default",
+      credential: persistedCredential,
+    });
+
+    expect(shouldPersist).toBe(false);
+  });
+
   it("omits exact runtime-only api-key overlays from persisted store writes", () => {
     const credential = createApiKeyCredential();
     resolveExternalAuthProfilesWithPluginsMock.mockReturnValueOnce([

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -12,6 +12,9 @@ const loadPluginManifestRegistry = vi.hoisted(() =>
     plugins: [
       {
         id: "fixture-provider",
+        origin: "bundled",
+        enabledByDefault: true,
+        providers: ["fixture-provider"],
         providerAuthAliases: { "fixture-provider-plan": "fixture-provider" },
       },
     ],

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -5,6 +5,7 @@ import {
   evaluateStoredCredentialEligibility,
   type AuthCredentialReasonCode,
 } from "./credential-state.js";
+import { listRuntimeOnlyExternalAuthProfileIds } from "./external-auth.js";
 import { dedupeProfileIds, listProfilesForProvider } from "./profiles.js";
 import type { AuthProfileStore } from "./types.js";
 import {
@@ -89,9 +90,19 @@ export function resolveAuthProfileOrder(params: {
         )
         .map(([profileId]) => profileId)
     : [];
+  const providerStoreProfiles = listProfilesForProvider(store, provider);
+  const runtimeOnlyExternalProfiles =
+    explicitOrder || explicitProfiles.length > 0
+      ? listRuntimeOnlyExternalAuthProfileIds({ store }).filter((profileId) =>
+          providerStoreProfiles.includes(profileId),
+        )
+      : [];
+  const baseCandidates =
+    explicitOrder ?? (explicitProfiles.length > 0 ? explicitProfiles : providerStoreProfiles);
   const baseOrder =
-    explicitOrder ??
-    (explicitProfiles.length > 0 ? explicitProfiles : listProfilesForProvider(store, provider));
+    runtimeOnlyExternalProfiles.length > 0
+      ? dedupeProfileIds([...baseCandidates, ...runtimeOnlyExternalProfiles])
+      : baseCandidates;
   if (baseOrder.length === 0) {
     return [];
   }

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -5,7 +5,7 @@ import {
   evaluateStoredCredentialEligibility,
   type AuthCredentialReasonCode,
 } from "./credential-state.js";
-import { listRuntimeOnlyExternalAuthProfileIds } from "./external-auth.js";
+import { listRuntimeOnlyExternalAuthProfiles } from "./external-auth.js";
 import { dedupeProfileIds, listProfilesForProvider } from "./profiles.js";
 import type { AuthProfileStore } from "./types.js";
 import {
@@ -91,17 +91,24 @@ export function resolveAuthProfileOrder(params: {
         .map(([profileId]) => profileId)
     : [];
   const providerStoreProfiles = listProfilesForProvider(store, provider);
-  const runtimeOnlyExternalProfiles =
-    explicitOrder || explicitProfiles.length > 0
-      ? listRuntimeOnlyExternalAuthProfileIds({ store }).filter((profileId) =>
-          providerStoreProfiles.includes(profileId),
-        )
-      : [];
+  const runtimeOnlyExternalProfiles = listRuntimeOnlyExternalAuthProfiles({ store }).filter(
+    (profile) => providerStoreProfiles.includes(profile.profileId),
+  );
+  const highestPriorityExternalProfiles = runtimeOnlyExternalProfiles
+    .filter((profile) => profile.selectionPriority === "highest")
+    .map((profile) => profile.profileId);
+  const defaultPriorityExternalProfiles = runtimeOnlyExternalProfiles
+    .filter((profile) => profile.selectionPriority !== "highest")
+    .map((profile) => profile.profileId);
   const baseCandidates =
     explicitOrder ?? (explicitProfiles.length > 0 ? explicitProfiles : providerStoreProfiles);
   const baseOrder =
     runtimeOnlyExternalProfiles.length > 0
-      ? dedupeProfileIds([...baseCandidates, ...runtimeOnlyExternalProfiles])
+      ? dedupeProfileIds([
+          ...highestPriorityExternalProfiles,
+          ...baseCandidates,
+          ...defaultPriorityExternalProfiles,
+        ])
       : baseCandidates;
   if (baseOrder.length === 0) {
     return [];
@@ -151,7 +158,10 @@ export function resolveAuthProfileOrder(params: {
       .toSorted((a, b) => a.cooldownUntil - b.cooldownUntil)
       .map((entry) => entry.profileId);
 
-    const ordered = [...available, ...cooldownSorted];
+    const ordered = prioritizeProfiles(
+      [...available, ...cooldownSorted],
+      highestPriorityExternalProfiles,
+    );
 
     // Still put preferredProfile first if specified
     if (preferredProfile && ordered.includes(preferredProfile)) {
@@ -163,13 +173,26 @@ export function resolveAuthProfileOrder(params: {
   // Otherwise, use round-robin: sort by lastUsed (oldest first)
   // preferredProfile goes first if specified (for explicit user choice)
   // lastGood is NOT prioritized - that would defeat round-robin
-  const sorted = orderProfilesByMode(deduped, store);
+  const sorted = prioritizeProfiles(
+    orderProfilesByMode(deduped, store),
+    highestPriorityExternalProfiles,
+  );
 
   if (preferredProfile && sorted.includes(preferredProfile)) {
     return [preferredProfile, ...sorted.filter((e) => e !== preferredProfile)];
   }
 
   return sorted;
+}
+
+function prioritizeProfiles(order: string[], prioritized: string[]): string[] {
+  if (prioritized.length === 0 || order.length === 0) {
+    return order;
+  }
+  const prioritizedSet = new Set(prioritized);
+  const front = prioritized.filter((profileId) => order.includes(profileId));
+  const rest = order.filter((profileId) => !prioritizedSet.has(profileId));
+  return [...front, ...rest];
 }
 
 function orderProfilesByMode(order: string[], store: AuthProfileStore): string[] {

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -126,11 +126,13 @@ export function resolveAuthProfileOrder(params: {
 
   // Repair config/store profile-id drift from older setup flows:
   // if configured profile ids no longer exist in auth-profiles.json, scan the
-  // provider's stored credentials and use any valid entries.
-  const allBaseProfilesMissing = baseOrder.every((profileId) => !store.profiles[profileId]);
-  if (filtered.length === 0 && explicitProfiles.length > 0 && allBaseProfilesMissing) {
+  // provider's stored credentials and use any valid entries. Base candidates
+  // intentionally exclude runtime overlays so those do not mask drift repair.
+  const allBaseCandidatesMissing =
+    baseCandidates.length > 0 && baseCandidates.every((profileId) => !store.profiles[profileId]);
+  if (explicitProfiles.length > 0 && allBaseCandidatesMissing) {
     const storeProfiles = listProfilesForProvider(store, provider);
-    filtered = storeProfiles.filter(isValidProfile);
+    filtered = dedupeProfileIds([...filtered, ...storeProfiles.filter(isValidProfile)]);
   }
 
   const deduped = dedupeProfileIds(filtered);

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -158,10 +158,10 @@ export function resolveAuthProfileOrder(params: {
       .toSorted((a, b) => a.cooldownUntil - b.cooldownUntil)
       .map((entry) => entry.profileId);
 
-    const ordered = prioritizeProfiles(
-      [...available, ...cooldownSorted],
-      highestPriorityExternalProfiles,
-    );
+    const ordered = [
+      ...prioritizeProfiles(available, highestPriorityExternalProfiles),
+      ...cooldownSorted,
+    ];
 
     // Still put preferredProfile first if specified
     if (preferredProfile && ordered.includes(preferredProfile)) {
@@ -173,10 +173,7 @@ export function resolveAuthProfileOrder(params: {
   // Otherwise, use round-robin: sort by lastUsed (oldest first)
   // preferredProfile goes first if specified (for explicit user choice)
   // lastGood is NOT prioritized - that would defeat round-robin
-  const sorted = prioritizeProfiles(
-    orderProfilesByMode(deduped, store),
-    highestPriorityExternalProfiles,
-  );
+  const sorted = orderProfilesByMode(deduped, store, highestPriorityExternalProfiles);
 
   if (preferredProfile && sorted.includes(preferredProfile)) {
     return [preferredProfile, ...sorted.filter((e) => e !== preferredProfile)];
@@ -195,7 +192,11 @@ function prioritizeProfiles(order: string[], prioritized: string[]): string[] {
   return [...front, ...rest];
 }
 
-function orderProfilesByMode(order: string[], store: AuthProfileStore): string[] {
+function orderProfilesByMode(
+  order: string[],
+  store: AuthProfileStore,
+  prioritized: string[] = [],
+): string[] {
   const now = Date.now();
 
   // Partition into available and in-cooldown
@@ -220,16 +221,19 @@ function orderProfilesByMode(order: string[], store: AuthProfileStore): string[]
 
   // Primary sort: type preference (oauth > token > api_key).
   // Secondary sort: lastUsed (oldest first for round-robin within type).
-  const sorted = scored
-    .toSorted((a, b) => {
-      // First by type (oauth > token > api_key)
-      if (a.typeScore !== b.typeScore) {
-        return a.typeScore - b.typeScore;
-      }
-      // Then by lastUsed (oldest first)
-      return a.lastUsed - b.lastUsed;
-    })
-    .map((entry) => entry.profileId);
+  const sorted = prioritizeProfiles(
+    scored
+      .toSorted((a, b) => {
+        // First by type (oauth > token > api_key)
+        if (a.typeScore !== b.typeScore) {
+          return a.typeScore - b.typeScore;
+        }
+        // Then by lastUsed (oldest first)
+        return a.lastUsed - b.lastUsed;
+      })
+      .map((entry) => entry.profileId),
+    prioritized,
+  );
 
   // Append cooldown profiles at the end (sorted by cooldown expiry, soonest first)
   const cooldownSorted = inCooldown

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -415,9 +415,6 @@ export function saveAuthProfileStore(
   const statePath = resolveAuthStatePath(agentDir);
   const runtimeKey = resolveRuntimeStoreKey(agentDir);
   const payload = buildPersistedAuthProfileSecretsStore(store, ({ profileId, credential }) => {
-    if (credential.type !== "oauth") {
-      return true;
-    }
     if (options?.filterExternalAuthProfiles === false) {
       return true;
     }

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -278,6 +278,21 @@ describe("getApiKeyForModel", () => {
     );
   });
 
+  it("resolveEnvApiKey('zai') ignores ZAI_API_KEYS list vars", async () => {
+    await withEnvAsync(
+      {
+        ZAI_API_KEY: undefined,
+        ZAI_API_KEYS: "zai-test-key-1,zai-test-key-2", // pragma: allowlist secret
+        ZAI_API_KEY_1: undefined,
+        ZAI_API_KEY_2: undefined,
+        Z_AI_API_KEY: undefined,
+      },
+      async () => {
+        expect(resolveEnvApiKey("zai")).toBeNull();
+      },
+    );
+  });
+
   it("keeps stored provider auth ahead of env by default", async () => {
     await withEnvAsync({ OPENAI_API_KEY: "env-openai-key" }, async () => {
       const resolved = await resolveApiKeyForProvider({

--- a/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.plugin-providers.ts
@@ -35,6 +35,7 @@ export async function applyNonInteractivePluginProviderChoice(params: {
   opts: OnboardOptions;
   runtime: RuntimeEnv;
   baseConfig: OpenClawConfig;
+  secretInputMode?: "plaintext" | "ref";
   resolveApiKey: (input: ProviderResolveNonInteractiveApiKeyParams) => Promise<{
     key: string;
     source: "profile" | "env" | "flag";
@@ -145,6 +146,7 @@ export async function applyNonInteractivePluginProviderChoice(params: {
     baseConfig: params.baseConfig,
     opts: params.opts as ProviderAuthOptionBag,
     runtime: params.runtime,
+    secretInputMode: params.secretInputMode,
     agentDir,
     workspaceDir,
     resolveApiKey: params.resolveApiKey,

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -134,6 +134,7 @@ export async function applyNonInteractiveAuthChoice(params: {
     opts,
     runtime,
     baseConfig,
+    secretInputMode: requestedSecretInputMode,
     resolveApiKey: (input) =>
       resolveApiKey({
         ...input,

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -382,6 +382,9 @@ describe("loadPluginManifestRegistry", () => {
       providerAuthEnvVars: {
         openai: ["OPENAI_API_KEY"],
       },
+      providerSecretEnvVars: {
+        openai: ["OPENAI_API_KEYS"],
+      },
       providerAuthAliases: {
         "openai-codex": "openai",
       },
@@ -406,6 +409,9 @@ describe("loadPluginManifestRegistry", () => {
 
     expect(registry.plugins[0]?.providerAuthEnvVars).toEqual({
       openai: ["OPENAI_API_KEY"],
+    });
+    expect(registry.plugins[0]?.providerSecretEnvVars).toEqual({
+      openai: ["OPENAI_API_KEYS"],
     });
     expect(registry.plugins[0]?.providerAuthAliases).toEqual({
       "openai-codex": "openai",

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -83,6 +83,7 @@ export type PluginManifestRecord = {
   cliBackends: string[];
   commandAliases?: PluginManifestCommandAlias[];
   providerAuthEnvVars?: Record<string, string[]>;
+  providerSecretEnvVars?: Record<string, string[]>;
   providerAuthAliases?: Record<string, string>;
   channelEnvVars?: Record<string, string[]>;
   providerAuthChoices?: PluginManifest["providerAuthChoices"];
@@ -323,6 +324,7 @@ function buildRecord(params: {
     cliBackends: params.manifest.cliBackends ?? [],
     commandAliases: params.manifest.commandAliases,
     providerAuthEnvVars: params.manifest.providerAuthEnvVars,
+    providerSecretEnvVars: params.manifest.providerSecretEnvVars,
     providerAuthAliases: params.manifest.providerAuthAliases,
     channelEnvVars: params.manifest.channelEnvVars,
     providerAuthChoices: params.manifest.providerAuthChoices,

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -161,6 +161,11 @@ export type PluginManifest = {
   commandAliases?: PluginManifestCommandAlias[];
   /** Cheap provider-auth env lookup without booting plugin runtime. */
   providerAuthEnvVars?: Record<string, string[]>;
+  /**
+   * Additional provider-owned secret env vars that should be scrubbed and
+   * offered for setup flows, but must not be treated as direct auth candidates.
+   */
+  providerSecretEnvVars?: Record<string, string[]>;
   /** Provider ids that should reuse another provider id for auth lookup. */
   providerAuthAliases?: Record<string, string>;
   /** Cheap channel env lookup without booting plugin runtime. */
@@ -668,6 +673,7 @@ export function loadPluginManifest(
   const cliBackends = normalizeTrimmedStringList(raw.cliBackends);
   const commandAliases = normalizeManifestCommandAliases(raw.commandAliases);
   const providerAuthEnvVars = normalizeStringListRecord(raw.providerAuthEnvVars);
+  const providerSecretEnvVars = normalizeStringListRecord(raw.providerSecretEnvVars);
   const providerAuthAliases = normalizeStringRecord(raw.providerAuthAliases);
   const channelEnvVars = normalizeStringListRecord(raw.channelEnvVars);
   const providerAuthChoices = normalizeProviderAuthChoices(raw.providerAuthChoices);
@@ -701,6 +707,7 @@ export function loadPluginManifest(
       cliBackends,
       commandAliases,
       providerAuthEnvVars,
+      providerSecretEnvVars,
       providerAuthAliases,
       channelEnvVars,
       providerAuthChoices,

--- a/src/plugins/provider-external-auth.types.ts
+++ b/src/plugins/provider-external-auth.types.ts
@@ -32,6 +32,12 @@ export type ProviderExternalOAuthProfile = {
   profileId: string;
   credential: AuthProfileCredential;
   persistence?: "runtime-only" | "persisted";
+  /**
+   * Optional auth-selection priority for runtime overlays.
+   * Use `highest` for temporary live overrides that should run before
+   * configured/stored credentials without replacing them on disk.
+   */
+  selectionPriority?: "default" | "highest";
 };
 
 export type ProviderExternalAuthProfile = ProviderExternalOAuthProfile;

--- a/src/plugins/provider-external-auth.types.ts
+++ b/src/plugins/provider-external-auth.types.ts
@@ -1,4 +1,7 @@
-import type { AuthProfileStore, OAuthCredential } from "../agents/auth-profiles/types.js";
+import type {
+  AuthProfileCredential,
+  AuthProfileStore,
+} from "../agents/auth-profiles/types.js";
 import type { ModelProviderAuthMode, ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
@@ -27,7 +30,7 @@ export type ProviderResolveExternalAuthProfilesContext =
 
 export type ProviderExternalOAuthProfile = {
   profileId: string;
-  credential: OAuthCredential;
+  credential: AuthProfileCredential;
   persistence?: "runtime-only" | "persisted";
 };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -297,6 +297,7 @@ export type ProviderAuthMethodNonInteractiveContext = {
   baseConfig: OpenClawConfig;
   opts: ProviderAuthOptionBag;
   runtime: RuntimeEnv;
+  secretInputMode?: SecretInputMode;
   agentDir?: string;
   workspaceDir?: string;
   resolveApiKey: (

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1054,7 +1054,6 @@ export type ProviderModelSelectedContext = {
   agentDir?: string;
   workspaceDir?: string;
 };
-
 export type ProviderDeferSyntheticProfileAuthContext = {
   config?: OpenClawConfig;
   provider: string;

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -74,4 +74,37 @@ describe("provider env vars dynamic manifest metadata", () => {
     expect(mod.getProviderEnvVars("zai")).toEqual(["ZAI_API_KEY", "ZAI_API_KEYS"]);
     expect(mod.listKnownSecretEnvVarNames()).toContain("ZAI_API_KEYS");
   });
+
+  it("preserves plugin secret env vars for core provider ids", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "external-openai",
+          origin: "global",
+          providerAuthEnvVars: {
+            openai: ["OPENAI_ALT_API_KEY"],
+          },
+          providerSecretEnvVars: {
+            openai: ["OPENAI_RESPONSES_KEY"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const mod = await import("./provider-env-vars.js");
+
+    expect(mod.resolveProviderAuthEnvVarCandidates().openai).toEqual([
+      "OPENAI_API_KEY",
+      "OPENAI_ALT_API_KEY",
+    ]);
+    expect(mod.getProviderEnvVars("openai")).toEqual([
+      "OPENAI_API_KEY",
+      "OPENAI_ALT_API_KEY",
+      "OPENAI_RESPONSES_KEY",
+    ]);
+    expect(mod.listKnownSecretEnvVarNames()).toEqual(
+      expect.arrayContaining(["OPENAI_API_KEY", "OPENAI_ALT_API_KEY", "OPENAI_RESPONSES_KEY"]),
+    );
+  });
 });

--- a/src/secrets/provider-env-vars.dynamic.test.ts
+++ b/src/secrets/provider-env-vars.dynamic.test.ts
@@ -5,6 +5,7 @@ type MockManifestRegistry = {
     id: string;
     origin: string;
     providerAuthEnvVars?: Record<string, string[]>;
+    providerSecretEnvVars?: Record<string, string[]>;
     providerAuthAliases?: Record<string, string>;
   }>;
   diagnostics: unknown[];
@@ -48,5 +49,29 @@ describe("provider env vars dynamic manifest metadata", () => {
     expect(mod.getProviderEnvVars("fireworks-plan")).toEqual(["FIREWORKS_ALT_API_KEY"]);
     expect(mod.listKnownProviderAuthEnvVarNames()).toContain("FIREWORKS_ALT_API_KEY");
     expect(mod.listKnownSecretEnvVarNames()).toContain("FIREWORKS_ALT_API_KEY");
+  });
+
+  it("keeps secret-only manifest env vars out of auth candidate resolution", async () => {
+    loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "external-zai",
+          origin: "global",
+          providerAuthEnvVars: {
+            zai: ["ZAI_API_KEY"],
+          },
+          providerSecretEnvVars: {
+            zai: ["ZAI_API_KEYS"],
+          },
+        },
+      ],
+      diagnostics: [],
+    });
+
+    const mod = await import("./provider-env-vars.js");
+
+    expect(mod.resolveProviderAuthEnvVarCandidates().zai).toEqual(["ZAI_API_KEY"]);
+    expect(mod.getProviderEnvVars("zai")).toEqual(["ZAI_API_KEY", "ZAI_API_KEYS"]);
+    expect(mod.listKnownSecretEnvVarNames()).toContain("ZAI_API_KEYS");
   });
 });

--- a/src/secrets/provider-env-vars.test.ts
+++ b/src/secrets/provider-env-vars.test.ts
@@ -63,5 +63,36 @@ describe("provider env vars", () => {
     expect(getProviderEnvVars("openai")).toEqual(["OPENAI_API_KEY"]);
     expect(getProviderEnvVars("anthropic")).toEqual(["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]);
     expect(getProviderEnvVars("fal")).toEqual(["FAL_KEY", "FAL_API_KEY"]);
+    expect(getProviderEnvVars("zai")).toEqual([
+      "ZAI_API_KEY",
+      "ZAI_API_KEYS",
+      "ZAI_API_KEY_1",
+      "ZAI_API_KEY_2",
+      "Z_AI_API_KEY",
+      "OPENCLAW_LIVE_ZAI_KEY",
+    ]);
+  });
+
+  it("includes Z.AI rotation env vars in auth and secret scrub lists", () => {
+    expect(listKnownProviderAuthEnvVarNames()).toEqual(
+      expect.arrayContaining([
+        "ZAI_API_KEY",
+        "ZAI_API_KEYS",
+        "ZAI_API_KEY_1",
+        "ZAI_API_KEY_2",
+        "Z_AI_API_KEY",
+        "OPENCLAW_LIVE_ZAI_KEY",
+      ]),
+    );
+    expect(listKnownSecretEnvVarNames()).toEqual(
+      expect.arrayContaining([
+        "ZAI_API_KEY",
+        "ZAI_API_KEYS",
+        "ZAI_API_KEY_1",
+        "ZAI_API_KEY_2",
+        "Z_AI_API_KEY",
+        "OPENCLAW_LIVE_ZAI_KEY",
+      ]),
+    );
   });
 });

--- a/src/secrets/provider-env-vars.test.ts
+++ b/src/secrets/provider-env-vars.test.ts
@@ -65,11 +65,11 @@ describe("provider env vars", () => {
     expect(getProviderEnvVars("fal")).toEqual(["FAL_KEY", "FAL_API_KEY"]);
     expect(getProviderEnvVars("zai")).toEqual([
       "ZAI_API_KEY",
-      "ZAI_API_KEYS",
       "ZAI_API_KEY_1",
       "ZAI_API_KEY_2",
       "Z_AI_API_KEY",
       "OPENCLAW_LIVE_ZAI_KEY",
+      "ZAI_API_KEYS",
     ]);
   });
 

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -43,6 +43,30 @@ function appendUniqueEnvVarCandidates(
   }
 }
 
+function mergeProviderEnvVarCandidates(
+  ...sources: Array<{
+    candidates: Record<string, readonly string[]>;
+    position?: "append" | "prepend";
+  }>
+): Record<string, string[]> {
+  const merged = Object.create(null) as Record<string, string[]>;
+  for (const source of sources) {
+    for (const [providerId, keys] of Object.entries(source.candidates).toSorted(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      if (source.position === "prepend") {
+        const next = Object.create(null) as Record<string, string[]>;
+        appendUniqueEnvVarCandidates(next, providerId, keys);
+        appendUniqueEnvVarCandidates(next, providerId, merged[providerId] ?? []);
+        merged[providerId] = next[providerId] ?? [];
+        continue;
+      }
+      appendUniqueEnvVarCandidates(merged, providerId, keys);
+    }
+  }
+  return merged;
+}
+
 function resolveManifestProviderEnvVarCandidates(params?: ProviderEnvVarLookupParams): {
   auth: Record<string, string[]>;
   all: Record<string, string[]>;
@@ -93,20 +117,22 @@ function resolveManifestProviderEnvVarCandidates(params?: ProviderEnvVarLookupPa
 export function resolveProviderAuthEnvVarCandidates(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, readonly string[]> {
-  return {
-    ...resolveManifestProviderEnvVarCandidates(params).auth,
-    ...CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES,
-  };
+  const manifestCandidates = resolveManifestProviderEnvVarCandidates(params);
+  return mergeProviderEnvVarCandidates(
+    { candidates: CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES },
+    { candidates: manifestCandidates.auth },
+  );
 }
 
 export function resolveProviderEnvVars(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, readonly string[]> {
-  return {
-    ...resolveManifestProviderEnvVarCandidates(params).all,
-    ...CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES,
-    ...CORE_PROVIDER_SETUP_ENV_VAR_OVERRIDES,
-  };
+  const manifestCandidates = resolveManifestProviderEnvVarCandidates(params);
+  return mergeProviderEnvVarCandidates(
+    { candidates: CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES },
+    { candidates: manifestCandidates.all },
+    { candidates: CORE_PROVIDER_SETUP_ENV_VAR_OVERRIDES, position: "prepend" },
+  );
 }
 
 /**

--- a/src/secrets/provider-env-vars.ts
+++ b/src/secrets/provider-env-vars.ts
@@ -43,42 +43,58 @@ function appendUniqueEnvVarCandidates(
   }
 }
 
-function resolveManifestProviderAuthEnvVarCandidates(
-  params?: ProviderEnvVarLookupParams,
-): Record<string, string[]> {
+function resolveManifestProviderEnvVarCandidates(params?: ProviderEnvVarLookupParams): {
+  auth: Record<string, string[]>;
+  all: Record<string, string[]>;
+} {
   const registry = loadPluginManifestRegistry({
     config: params?.config,
     workspaceDir: params?.workspaceDir,
     env: params?.env,
   });
-  const candidates: Record<string, string[]> = {};
+  const authCandidates: Record<string, string[]> = Object.create(null) as Record<string, string[]>;
+  const allCandidates: Record<string, string[]> = Object.create(null) as Record<string, string[]>;
   for (const plugin of registry.plugins) {
-    if (!plugin.providerAuthEnvVars) {
-      continue;
+    if (plugin.providerAuthEnvVars) {
+      for (const [providerId, keys] of Object.entries(plugin.providerAuthEnvVars).toSorted(
+        ([left], [right]) => left.localeCompare(right),
+      )) {
+        appendUniqueEnvVarCandidates(authCandidates, providerId, keys);
+        appendUniqueEnvVarCandidates(allCandidates, providerId, keys);
+      }
     }
-    for (const [providerId, keys] of Object.entries(plugin.providerAuthEnvVars).toSorted(
-      ([left], [right]) => left.localeCompare(right),
-    )) {
-      appendUniqueEnvVarCandidates(candidates, providerId, keys);
+    if (plugin.providerSecretEnvVars) {
+      for (const [providerId, keys] of Object.entries(plugin.providerSecretEnvVars).toSorted(
+        ([left], [right]) => left.localeCompare(right),
+      )) {
+        appendUniqueEnvVarCandidates(allCandidates, providerId, keys);
+      }
     }
   }
   const aliases = resolveProviderAuthAliasMap(params);
   for (const [alias, target] of Object.entries(aliases).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
-    const keys = candidates[target];
-    if (keys) {
-      appendUniqueEnvVarCandidates(candidates, alias, keys);
+    const authKeys = authCandidates[target];
+    if (authKeys) {
+      appendUniqueEnvVarCandidates(authCandidates, alias, authKeys);
+    }
+    const allKeys = allCandidates[target];
+    if (allKeys) {
+      appendUniqueEnvVarCandidates(allCandidates, alias, allKeys);
     }
   }
-  return candidates;
+  return {
+    auth: authCandidates,
+    all: allCandidates,
+  };
 }
 
 export function resolveProviderAuthEnvVarCandidates(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, readonly string[]> {
   return {
-    ...resolveManifestProviderAuthEnvVarCandidates(params),
+    ...resolveManifestProviderEnvVarCandidates(params).auth,
     ...CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES,
   };
 }
@@ -87,7 +103,8 @@ export function resolveProviderEnvVars(
   params?: ProviderEnvVarLookupParams,
 ): Record<string, readonly string[]> {
   return {
-    ...resolveProviderAuthEnvVarCandidates(params),
+    ...resolveManifestProviderEnvVarCandidates(params).all,
+    ...CORE_PROVIDER_AUTH_ENV_VAR_CANDIDATES,
     ...CORE_PROVIDER_SETUP_ENV_VAR_OVERRIDES,
   };
 }


### PR DESCRIPTION
## Summary

- Problem: Z.AI env-based multi-key setups were not exposed as rotating runtime auth profiles for gateway runs, so rate-limit failover could stop at the first env key.
- Why it matters: users configuring `ZAI_API_KEYS` or numbered `ZAI_API_KEY_*` entries expect the same auth-profile rotation behavior described in the provider docs, especially under rate limits.
- What changed: the ZAI plugin now synthesizes runtime-only API-key auth profiles from supported env vars, core external-auth overlays now support non-OAuth credentials, and auth-profile persistence skips runtime-only API-key overlays so they are not written back to disk.
- What did NOT change (scope boundary): this does not change provider failover policy, auth-profile ordering semantics outside Z.AI, or introduce new provider-specific core special cases.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the generic runtime auth-profile overlay path only persisted an OAuth-shaped external profile contract, while the ZAI plugin did not surface env-backed API keys as multiple runtime auth candidates for gateway rotation.
- Missing detection / guardrail: we did not have coverage for runtime-only API-key overlays being merged, skipped during persistence, and rebuilt on the next run.
- Contributing context (if known): existing docs already described multi-key env rotation, so the runtime behavior gap was easy to miss until rate-limit fallback was exercised in a real gateway flow.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/zai/index.test.ts`, `src/agents/auth-profiles/external-oauth.test.ts`
- Scenario the test should lock in: multiple Z.AI env keys become runtime-only auth profiles, single live override keys do not create rotation, and runtime-only API-key overlays are omitted from persisted auth-profile writes.
- Why this is the smallest reliable guardrail: the bug lives at the seam between plugin-provided auth overlays and shared auth-profile store persistence, so these tests cover the lowest-level boundary that decides runtime rotation behavior.
- Existing test that already covers this (if any): provider/plugin contract coverage already exercises external auth profile hooks broadly, but not the API-key runtime-only persistence path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Users can now rotate across multiple Z.AI env-backed API keys during gateway auth-profile failover by setting `ZAI_API_KEYS`, numbered `ZAI_API_KEY_*` vars, or legacy `Z_AI_API_KEY`.
- `OPENCLAW_LIVE_ZAI_KEY` remains a single-key override and intentionally does not create a rotation set.
- Docs now explicitly describe the supported env vars and rate-limit rotation behavior.

## Diagram (if applicable)

```text
Before:
[rate-limited zai env key] -> [single resolved auth profile] -> [run error]

After:
[rate-limited zai env key] -> [runtime-only env auth profiles] -> [next Z.AI key] -> [result or later model fallback]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (Yes)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: runtime-only env API keys now flow through the external auth overlay seam, but they are explicitly filtered from persisted auth-profile writes and covered by tests so they do not leak into `auth-profiles.json`.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: `zai/glm-5.1`
- Integration/channel (if any): gateway / model failover auth rotation
- Relevant config (redacted): Z.AI env-backed API keys via `ZAI_API_KEYS`, `ZAI_API_KEY_*`, or `Z_AI_API_KEY`

### Steps

1. Configure multiple Z.AI API keys through the supported env vars.
2. Run a gateway-backed Z.AI request that rate-limits the first key.
3. Observe auth-profile rotation and ensure runtime-only env profiles are not written back to persisted auth-profile state.

### Expected

- The run rotates to the next Z.AI env-backed key before giving up or falling through to model fallback.
- Runtime-only env-backed keys remain runtime-only and are not persisted.

### Actual

- With this patch, the ZAI plugin surfaces runtime-only env auth profiles, shared auth overlay code accepts them, and persistence filters keep them out of the saved auth store.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run locally:

- `pnpm test src/agents/auth-profiles/external-oauth.test.ts extensions/zai/index.test.ts`
- `pnpm test src/agents/auth-profiles.store.save.test.ts`
- `pnpm test:extension zai`
- `pnpm test:contracts:plugins`
- `node scripts/check-src-extension-import-boundary.mjs --json`
- `pnpm plugin-sdk:api:gen`
- `pnpm build`
- `pnpm check`
- `codex review --base origin/main` (run locally during PR prep)

## Human Verification (required)

- Verified scenarios: multi-key env rotation profile synthesis, single live-key override behavior, runtime-only API-key overlay persistence filtering, ZAI extension tests, plugin contract tests, repo check, and full build.
- Edge cases checked: numbered env vars are ordered deterministically, duplicate keys are deduped against persisted non-runtime profiles, and existing runtime env profile ids are rebuilt consistently on subsequent runs.
- What you did **not** verify: a live end-to-end rate-limit event against the real Z.AI API in this environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (Yes)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: runtime-only env profile ids could accidentally collide with persisted profiles and suppress rotation.
  - Mitigation: the ZAI collector ignores reserved runtime env ids when deduping against the saved store, and tests cover rebuilding the same runtime env ids.
- Risk: widening the external auth overlay contract beyond OAuth could accidentally persist runtime-only secrets.
  - Mitigation: persistence filtering now uses the generic external auth contract and is covered by targeted tests.

AI-assisted: Codex. Fully tested locally with the commands above. I understand and reviewed the code paths changed here.
