### PR TITLE
fix(secrets): distinguish ${ENV_VAR} from plaintext in audit

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -70,6 +70,7 @@ Options:
 Scan OpenClaw state for:
 
 - plaintext secret storage
+- migration guidance for `${ENV_VAR}` values on [SecretRef-capable config fields](/reference/secretref-credential-surface)
 - unresolved refs
 - precedence drift (`auth-profiles.json` credentials shadowing `openclaw.json` refs)
 - generated `agents/*/agent/models.json` residues (provider `apiKey` values and sensitive provider headers)
@@ -95,9 +96,10 @@ Report shape highlights:
 
 - `status`: `clean | findings | unresolved`
 - `resolution`: `refsChecked`, `skippedExecRefs`, `resolvabilityComplete`
-- `summary`: `plaintextCount`, `unresolvedRefCount`, `shadowedRefCount`, `legacyResidueCount`
+- `summary`: `plaintextCount`, `migrationRecommendedCount`, `unresolvedRefCount`, `shadowedRefCount`, `legacyResidueCount`
 - finding codes:
   - `PLAINTEXT_FOUND`
+  - `MIGRATION_RECOMMENDED`
   - `REF_UNRESOLVED`
   - `REF_SHADOWED`
   - `LEGACY_RESIDUE`

--- a/src/cli/secrets-cli.test.ts
+++ b/src/cli/secrets-cli.test.ts
@@ -202,6 +202,7 @@ describe("secrets CLI", () => {
       filesScanned: [],
       summary: {
         plaintextCount: 1,
+        migrationRecommendedCount: 0,
         unresolvedRefCount: 0,
         shadowedRefCount: 0,
         legacyResidueCount: 0,
@@ -233,6 +234,7 @@ describe("secrets CLI", () => {
       filesScanned: [],
       summary: {
         plaintextCount: 0,
+        migrationRecommendedCount: 0,
         unresolvedRefCount: 0,
         shadowedRefCount: 0,
         legacyResidueCount: 0,

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -100,7 +100,7 @@ export function registerSecretsCli(program: Command) {
           defaultRuntime.writeJson(report);
         } else {
           defaultRuntime.log(
-            `Secrets audit: ${report.status}. plaintext=${report.summary.plaintextCount}, unresolved=${report.summary.unresolvedRefCount}, shadowed=${report.summary.shadowedRefCount}, legacy=${report.summary.legacyResidueCount}.`,
+            `Secrets audit: ${report.status}. plaintext=${report.summary.plaintextCount}, migration=${report.summary.migrationRecommendedCount}, unresolved=${report.summary.unresolvedRefCount}, shadowed=${report.summary.shadowedRefCount}, legacy=${report.summary.legacyResidueCount}.`,
           );
           if (report.findings.length > 0) {
             for (const finding of report.findings.slice(0, 20)) {

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -16,6 +16,7 @@ type AuditFixture = {
 };
 
 const OPENAI_API_KEY_MARKER = "OPENAI_API_KEY"; // pragma: allowlist secret
+const OPENAI_API_KEY_TEMPLATE = `\${${OPENAI_API_KEY_MARKER}}`;
 const MAX_AUDIT_MODELS_JSON_BYTES = 5 * 1024 * 1024;
 
 async function writeJsonFile(filePath: string, value: unknown): Promise<void> {
@@ -584,6 +585,92 @@ describe("secrets audit", () => {
           entry.code === "PLAINTEXT_FOUND" &&
           entry.file === fixture.configPath &&
           entry.jsonPath === "models.providers.openai.headers.X-Proxy-Region",
+      ),
+    ).toBe(false);
+  });
+
+  it("reports exact env interpolation on SecretRef-capable config fields as migration guidance", async () => {
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: OPENAI_API_KEY_TEMPLATE,
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "MIGRATION_RECOMMENDED" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(false);
+    expect(report.summary.migrationRecommendedCount).toBe(1);
+  });
+
+  it("keeps mixed env interpolation strings flagged as plaintext on SecretRef-capable config fields", async () => {
+    await writeJsonFile(fixture.configPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: { source: "env", provider: "default", id: OPENAI_API_KEY_MARKER },
+            headers: {
+              Authorization: `Bearer ${OPENAI_API_KEY_TEMPLATE}`,
+            },
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.openai.headers.Authorization",
+      ),
+    ).toBe(true);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "MIGRATION_RECOMMENDED" &&
+          entry.file === fixture.configPath &&
+          entry.jsonPath === "models.providers.openai.headers.Authorization",
       ),
     ).toBe(false);
   });

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -7,6 +7,7 @@ import {
 } from "../agents/model-auth-markers.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
 import { resolveStateDir, type OpenClawConfig } from "../config/config.js";
+import { resolveConfigIncludes } from "../config/includes.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -40,6 +41,7 @@ import { discoverConfigSecretTargets } from "./target-registry.js";
 
 export type SecretsAuditCode =
   | "PLAINTEXT_FOUND"
+  | "MIGRATION_RECOMMENDED"
   | "REF_UNRESOLVED"
   | "REF_SHADOWED"
   | "LEGACY_RESIDUE";
@@ -69,6 +71,7 @@ export type SecretsAuditReport = {
   filesScanned: string[];
   summary: {
     plaintextCount: number;
+    migrationRecommendedCount: number;
     unresolvedRefCount: number;
     shadowedRefCount: number;
     legacyResidueCount: number;
@@ -207,12 +210,26 @@ function collectEnvPlaintext(params: { envPath: string; collector: AuditCollecto
   }
 }
 
+function tryResolveAuthoredConfig(parsed: unknown, configPath: string): OpenClawConfig | undefined {
+  try {
+    return resolveConfigIncludes(parsed, configPath) as OpenClawConfig;
+  } catch {
+    return undefined;
+  }
+}
+
 function collectConfigSecrets(params: {
   config: OpenClawConfig;
+  authoredConfig?: OpenClawConfig;
   configPath: string;
   collector: AuditCollector;
 }): void {
   const defaults = params.config.secrets?.defaults;
+  const authoredTargetsByPath = new Map(
+    (params.authoredConfig ? discoverConfigSecretTargets(params.authoredConfig) : []).map(
+      (target) => [target.path, target],
+    ),
+  );
   for (const target of discoverConfigSecretTargets(params.config)) {
     if (!target.entry.includeInAudit) {
       continue;
@@ -247,6 +264,25 @@ function collectConfigSecrets(params: {
       continue;
     }
     if (!hasPlaintext) {
+      continue;
+    }
+    const authoredTarget = authoredTargetsByPath.get(target.path);
+    const authoredRef = authoredTarget
+      ? resolveSecretInputRef({
+          value: authoredTarget.value,
+          refValue: authoredTarget.refValue,
+          defaults,
+        })
+      : null;
+    if (authoredRef?.inlineRef) {
+      addFinding(params.collector, {
+        code: "MIGRATION_RECOMMENDED",
+        severity: "warn",
+        file: params.configPath,
+        jsonPath: target.path,
+        message: `${target.path} uses exact \${${authoredRef.inlineRef.id}} interpolation. Prefer a SecretRef such as { source: "env", provider: "${authoredRef.inlineRef.provider}", id: "${authoredRef.inlineRef.id}" }.`,
+        provider: target.providerId,
+      });
       continue;
     }
     addFinding(params.collector, {
@@ -631,6 +667,8 @@ function collectShadowingFindings(collector: AuditCollector): void {
 function summarizeFindings(findings: SecretsAuditFinding[]): SecretsAuditReport["summary"] {
   return {
     plaintextCount: findings.filter((entry) => entry.code === "PLAINTEXT_FOUND").length,
+    migrationRecommendedCount: findings.filter((entry) => entry.code === "MIGRATION_RECOMMENDED")
+      .length,
     unresolvedRefCount: findings.filter((entry) => entry.code === "REF_UNRESOLVED").length,
     shadowedRefCount: findings.filter((entry) => entry.code === "REF_SHADOWED").length,
     legacyResidueCount: findings.filter((entry) => entry.code === "LEGACY_RESIDUE").length,
@@ -670,6 +708,7 @@ export async function runSecretsAudit(
   if (snapshot.valid) {
     collectConfigSecrets({
       config,
+      authoredConfig: tryResolveAuthoredConfig(snapshot.parsed, snapshot.path),
       configPath,
       collector,
     });


### PR DESCRIPTION
## Summary

- Problem: `openclaw secrets audit` reported exact `${ENV_VAR}` templates on SecretRef-capable config fields as `PLAINTEXT_FOUND`.
- Why it matters: that blurred migration guidance and real plaintext secrets.
- What changed: audit now emits `MIGRATION_RECOMMENDED` for exact `${ENV_VAR}` templates on SecretRef-capable config fields.
- What did NOT change (scope boundary): literal plaintext detection, mixed strings like `Bearer ${TOKEN}`, SecretRef objects, and `.env` findings.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: audit classified only the resolved post-substitution value, so exact `${ENV_VAR}` templates were indistinguishable from literal plaintext.
- Missing detection / guardrail: it did not compare against the authored pre-substitution config.
- Contributing context (if known): once `${ENV_VAR}` has already been resolved, the authored intent is lost.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/secrets/audit.test.ts`
- Scenario the test should lock in: exact `${ENV_VAR}` reports `MIGRATION_RECOMMENDED`; mixed strings like `Bearer ${TOKEN}` remain `PLAINTEXT_FOUND`.
- Why this is the smallest reliable guardrail: the behavior is local to audit classification for SecretRef-capable config fields.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Exact `${ENV_VAR}` on SecretRef-capable fields now reports `MIGRATION_RECOMMENDED`.
- CLI and JSON summaries now include `migrationRecommendedCount`.

## Diagram (if applicable)

```text
Before:
apiKey: "${OPENAI_API_KEY}" -> PLAINTEXT_FOUND

After:
apiKey: "${OPENAI_API_KEY}" -> MIGRATION_RECOMMENDED
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.providers.openai.apiKey: "${OPENAI_API_KEY}"`

### Steps

1. Set a SecretRef-capable config field to an exact `${ENV_VAR}` template.
2. Run `openclaw secrets audit`.
3. Repeat with a mixed string like `Bearer ${TOKEN}`.

### Expected

- Exact template reports `MIGRATION_RECOMMENDED`
- Mixed string remains `PLAINTEXT_FOUND`
- SecretRef objects remain unchanged

### Actual

- Before this fix, exact `${ENV_VAR}` templates were reported as `PLAINTEXT_FOUND` on the target field.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

- `pnpm vitest run src/secrets/audit.test.ts src/cli/secrets-cli.test.ts`

## Human Verification (required)

- Verified scenarios: exact-template, mixed-string, CLI summary output.
- Edge cases checked: SecretRef objects remain unchanged.
- What you did **not** verify: Windows-specific env behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: exact `${ENV_VAR}` templates could still be mistaken for literal plaintext without authored-config comparison.
  - Mitigation: unit coverage in `src/secrets/audit.test.ts` and explicit `MIGRATION_RECOMMENDED` reporting for exact templates.
