### PR TITLE
fix(reply): gate preflight compaction fast-path on token threshold (#63892)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Gemini: strip orphaned `required` entries from Gemini tool schemas so provider validation no longer rejects tools after schema cleanup or union flattening. (#64284) Thanks @xxxxxmax.
 - Assistant text: strip Qwen-style XML tool call payloads from visible replies so web and channel messages no longer show raw `<tool_call><function=...>` output. (#64214) Thanks @MoerAI.
 - Daemon/gateway: prevent systemd restart storms on configuration errors by exiting with `EX_CONFIG` and adding generated unit restart-prevention guards. (#63913) Thanks @neo1027144-creator.
+- Auto-reply/memory: gate the preflight compaction fast-path on the fresh-token threshold so proactive compaction re-fires on subsequent cycles instead of short-circuiting at `totalTokensFresh === true`; overflow-retry recovery was unaffected. (#63892) Thanks @martingarramon.
 
 ## 2026.4.9
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -8,13 +8,18 @@ import {
   registerMemoryFlushPlanResolver,
 } from "../../plugins/memory-state.js";
 import type { TemplateContext } from "../templating.js";
-import { runMemoryFlushIfNeeded, setAgentRunnerMemoryTestDeps } from "./agent-runner-memory.js";
+import {
+  runMemoryFlushIfNeeded,
+  runPreflightCompactionIfNeeded,
+  setAgentRunnerMemoryTestDeps,
+} from "./agent-runner-memory.js";
 import type { FollowupRun } from "./queue.js";
 
 const runWithModelFallbackMock = vi.fn();
 const runEmbeddedPiAgentMock = vi.fn();
 const refreshQueuedFollowupSessionMock = vi.fn();
 const incrementCompactionCountMock = vi.fn();
+const compactEmbeddedPiSessionMock = vi.fn();
 
 function createReplyOperation() {
   return {
@@ -104,11 +109,13 @@ describe("runMemoryFlushIfNeeded", () => {
       }
       return nextEntry.compactionCount;
     });
+    compactEmbeddedPiSessionMock.mockReset().mockResolvedValue({ ok: false, reason: "test_skip" });
     setAgentRunnerMemoryTestDeps({
       runWithModelFallback: runWithModelFallbackMock as never,
       runEmbeddedPiAgent: runEmbeddedPiAgentMock as never,
       refreshQueuedFollowupSession: refreshQueuedFollowupSessionMock as never,
       incrementCompactionCount: incrementCompactionCountMock as never,
+      compactEmbeddedPiSession: compactEmbeddedPiSessionMock as never,
       registerAgentRunContext: vi.fn() as never,
       randomUUID: () => "00000000-0000-0000-0000-000000000001",
       now: () => 1_700_000_000_000,
@@ -286,5 +293,87 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(flushCall.silentExpected).toBe(true);
     expect(flushCall.bootstrapPromptWarningSignaturesSeen).toEqual(["sig-a", "sig-b"]);
     expect(flushCall.bootstrapPromptWarningSignature).toBe("sig-b");
+  });
+});
+
+describe("runPreflightCompactionIfNeeded", () => {
+  beforeEach(() => {
+    registerMemoryFlushPlanResolver(() => ({
+      softThresholdTokens: 4_000,
+      forceFlushTranscriptBytes: 1_000_000_000,
+      reserveTokensFloor: 20_000,
+      prompt: "flush",
+      systemPrompt: "flush",
+      relativePath: "memory/2023-11-14.md",
+    }));
+    compactEmbeddedPiSessionMock.mockReset().mockResolvedValue({ ok: false, reason: "test_skip" });
+    setAgentRunnerMemoryTestDeps({
+      compactEmbeddedPiSession: compactEmbeddedPiSessionMock as never,
+      registerAgentRunContext: vi.fn() as never,
+    });
+  });
+
+  afterEach(() => {
+    setAgentRunnerMemoryTestDeps();
+    clearMemoryPluginState();
+  });
+
+  // Regression for #63892: after the first compaction, `totalTokensFresh` is
+  // set to `true`. The early-return gate used to short-circuit unconditionally
+  // in that state, so proactive compaction never re-fired once fresh tokens
+  // grew back past the threshold. The gate must now also check that fresh
+  // persisted tokens are still below the compaction threshold before skipping.
+  it("re-runs preflight when totalTokensFresh is true but tokens exceed threshold (#63892)", async () => {
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 90_000,
+      totalTokensFresh: true,
+      compactionCount: 1,
+    };
+
+    await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: {} } } },
+      followupRun: createFollowupRun(),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    // threshold = 100_000 - 20_000 - 4_000 = 76_000; 90_000 > 76_000, so the
+    // early-return must fall through and compaction must be attempted.
+    expect(compactEmbeddedPiSessionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips preflight when totalTokensFresh is true and tokens are below threshold", async () => {
+    const sessionKey = "main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+      totalTokens: 10_000,
+      totalTokensFresh: true,
+      compactionCount: 1,
+    };
+
+    const result = await runPreflightCompactionIfNeeded({
+      cfg: { agents: { defaults: { compaction: {} } } },
+      followupRun: createFollowupRun(),
+      defaultModel: "anthropic/claude-opus-4-6",
+      agentCfgContextTokens: 100_000,
+      sessionEntry,
+      sessionStore: { [sessionKey]: sessionEntry },
+      sessionKey,
+      isHeartbeat: false,
+      replyOperation: createReplyOperation(),
+    });
+
+    // Fresh tokens are below threshold — the fast-path early return must fire.
+    expect(compactEmbeddedPiSessionMock).not.toHaveBeenCalled();
+    expect(result).toBe(sessionEntry);
   });
 });

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -376,7 +376,16 @@ export async function runPreflightCompactionIfNeeded(params: {
     Number.isFinite(persistedTotalTokens) &&
     persistedTotalTokens > 0;
   const shouldUseTranscriptFallback = entry.totalTokensFresh === false || !hasPersistedTotalTokens;
-  if (!shouldUseTranscriptFallback) {
+  const preflightThreshold = contextWindowTokens - reserveTokensFloor - softThresholdTokens;
+  const freshPersistedTokensBelowThreshold =
+    typeof freshPersistedTokens === "number" && freshPersistedTokens < preflightThreshold;
+  // Skip preflight only when fresh persisted tokens are still below the
+  // compaction threshold. Without this guard, the first compaction sets
+  // entry.totalTokensFresh = true, and every subsequent run short-circuits
+  // here without re-checking the (now-growing) token count, so proactive
+  // compaction never re-fires. Overflow-retry remains unaffected because it
+  // runs through a separate path in pi-embedded-runner/run.ts. (#63892)
+  if (!shouldUseTranscriptFallback && freshPersistedTokensBelowThreshold) {
     return entry ?? params.sessionEntry;
   }
   const promptTokenEstimate = estimatePromptTokensForMemoryFlush(
@@ -401,11 +410,10 @@ export async function runPreflightCompactionIfNeeded(params: {
       ? projectedTokenCount
       : undefined;
 
-  const threshold = contextWindowTokens - reserveTokensFloor - softThresholdTokens;
   logVerbose(
     `preflightCompaction check: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +
-      `contextWindow=${contextWindowTokens} threshold=${threshold} ` +
+      `contextWindow=${contextWindowTokens} threshold=${preflightThreshold} ` +
       `isHeartbeat=${params.isHeartbeat} isCli=${isCli} ` +
       `persistedFresh=${entry?.totalTokensFresh === true} ` +
       `transcriptPromptTokens=${transcriptPromptTokens ?? "undefined"} ` +
@@ -426,7 +434,7 @@ export async function runPreflightCompactionIfNeeded(params: {
   logVerbose(
     `preflightCompaction triggered: sessionKey=${params.sessionKey} ` +
       `tokenCount=${tokenCountForCompaction ?? freshPersistedTokens ?? "undefined"} ` +
-      `threshold=${threshold}`,
+      `threshold=${preflightThreshold}`,
   );
 
   params.replyOperation.setPhase("preflight_compacting");


### PR DESCRIPTION
## Summary

Fixes #63892. After the first compaction, \`entry.totalTokensFresh\` is set to \`true\` by \`incrementRunCompactionCount\`. On subsequent runs, \`runPreflightCompactionIfNeeded\` unconditionally short-circuits at \`src/auto-reply/reply/agent-runner-memory.ts:379\` because \`shouldUseTranscriptFallback\` is \`false\`. The stale-tokens path below (which is what runs the actual threshold check) is never reached, so proactive compaction never re-fires. Overflow-retry recovery still worked because it runs through a separate path in \`src/auto-reply/reply/pi-embedded-runner/run.ts\` that catches \`isLikelyContextOverflowError\` directly, bypassing the preflight gate entirely.

- **Problem:** Proactive compaction never re-fires after the first checkpoint on long-lived sessions. Users only see compaction when a request actually overflows the context window.
- **Why it matters:** On 100k+ sessions (reported against GLM-5.1:cloud, observed against Anthropic + Gemini providers in the issue thread) this turns every long conversation into an eventual overflow-and-retry instead of a smooth proactive checkpoint.
- **What changed:** The preflight fast-path early return now also requires \`freshPersistedTokens < preflightThreshold\`. When fresh tokens have grown back above the threshold, the guard falls through and the existing \`shouldRunPreflightCompaction\` path runs normally. The duplicate \`threshold\` local was consolidated onto the new \`preflightThreshold\` that the guard uses, so the \`logVerbose\` output is unchanged.
- **What did NOT change (scope boundary):** No changes to \`shouldRunPreflightCompaction\`, \`incrementRunCompactionCount\`, the overflow-retry path, or the stale-tokens transcript-fallback branch. No config/schema/public SDK surface touched.

## Change Type

- [x] Bug fix

## Scope

- [x] Memory / storage
- [x] Agents / orchestration (preflight compaction)

## Verification

- \`pnpm test src/auto-reply/reply/agent-runner-memory.test.ts\` — 5/5 passing
- \`pnpm check\` — clean (tsgo, lint, all policy gates)
- \`pnpm build\` — clean
- Regression test covers both directions:
  - \`totalTokensFresh: true\` + tokens **above** threshold → \`compactEmbeddedPiSession\` is called (proactive compaction fires — this is the bug fix).
  - \`totalTokensFresh: true\` + tokens **below** threshold → fast-path early return still fires unchanged.

I also verified the equivalent gate on the compiled dist of v2026.4.9 on a long-running gateway against GLM-5.1:cloud (\`contextWindowTokens\` ≈ 200k, \`reserveTokensFloor\` 40k, \`softThresholdTokens\` 25k). Before the patch: zero proactive checkpoints after the first, overflow-retry checkpoints only. After the patch: proactive checkpoints fire on every subsequent cycle as expected.

## Credit

The root cause analysis, exact file/line pointers, and the fix direction are all @martingarramon's from the issue thread. My earlier hypothesis about \`compactionCount\` latching was wrong — thanks for the correction. @mjamiv independently confirmed the repro on v2026.4.9, which is what motivated digging past the first hypothesis.

## AI-assisted disclosure

This PR was written with AI assistance (Claude). I (the submitter) read and understand the change, verified the fix against the live compiled runtime before writing the source patch, and wrote the regression tests to directly exercise the \`totalTokensFresh === true\` re-fire case.

Fixes #63892