### PR TITLE
feat: expose model pricing to plugins via runtime.usage API

### DIFF
--- a/docs/plugins/sdk-runtime.md
+++ b/docs/plugins/sdk-runtime.md
@@ -202,6 +202,38 @@ two-party event loops that do not go through the shared inbound reply runner.
     </Warning>
 
   </Accordion>
+
+  <Accordion title="api.runtime.usage">
+    Resolve configured model pricing and estimate token usage cost without
+    duplicating OpenClaw pricing tables inside a plugin.
+
+    ```typescript
+    const costConfig = api.runtime.usage.resolveModelCostConfig({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+
+    if (costConfig) {
+      const estimatedCostUsd = api.runtime.usage.estimateUsageCost({
+        usage: {
+          input: 12_000,
+          output: 2_000,
+        },
+        cost: costConfig,
+      });
+    }
+    ```
+
+    `resolveModelCostConfig(...)` returns OpenClaw's active pricing config for
+    the requested provider/model pair when one is available. `estimateUsageCost(...)`
+    applies that config to token usage and returns the estimated USD cost.
+
+    This namespace is intended for local plugin accounting, preflight warnings,
+    and status/reporting surfaces. It should not be used as a billing authority;
+    providers remain the source of truth for final charged usage.
+
+  </Accordion>
+
   <Accordion title="api.runtime.subagent">
     Launch and manage background subagent runs.
 

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -761,11 +761,11 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
     },
     usage: {
       resolveModelCostConfig: vi.fn(
-        () => undefined,
-      ) as unknown as PluginRuntime["usage"]["resolveModelCostConfig"],
+        (_params: Parameters<PluginRuntime["usage"]["resolveModelCostConfig"]>[0]) => undefined,
+      ) as PluginRuntime["usage"]["resolveModelCostConfig"],
       estimateUsageCost: vi.fn(
-        () => undefined,
-      ) as unknown as PluginRuntime["usage"]["estimateUsageCost"],
+        (_params: Parameters<PluginRuntime["usage"]["estimateUsageCost"]>[0]) => undefined,
+      ) as PluginRuntime["usage"]["estimateUsageCost"],
     },
     state: {
       resolveStateDir: vi.fn(() => "/tmp/openclaw"),

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -759,6 +759,14 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
         debug: vi.fn(),
       })),
     },
+    usage: {
+      resolveModelCostConfig: vi.fn(
+        () => undefined,
+      ) as unknown as PluginRuntime["usage"]["resolveModelCostConfig"],
+      estimateUsageCost: vi.fn(
+        () => undefined,
+      ) as unknown as PluginRuntime["usage"]["estimateUsageCost"],
+    },
     state: {
       resolveStateDir: vi.fn(() => "/tmp/openclaw"),
       openKeyedStore: vi.fn(() => {

--- a/src/plugins/runtime/index.test.ts
+++ b/src/plugins/runtime/index.test.ts
@@ -274,6 +274,15 @@ describe("plugin runtime command execution", () => {
       },
     },
     {
+      name: "exposes runtime.usage pricing helpers",
+      assert: (runtime: ReturnType<typeof createPluginRuntime>) => {
+        expectFunctionKeys(runtime.usage as Record<string, unknown>, [
+          "resolveModelCostConfig",
+          "estimateUsageCost",
+        ]);
+      },
+    },
+    {
       name: "exposes canonical runtime.tasks task runtimes while keeping legacy TaskFlow aliases",
       assert: (runtime: ReturnType<typeof createPluginRuntime>) => {
         expectFunctionKeys(runtime.tasks.runs as Record<string, unknown>, [

--- a/src/plugins/runtime/index.ts
+++ b/src/plugins/runtime/index.ts
@@ -32,6 +32,7 @@ import { createRuntimeMedia } from "./runtime-media.js";
 import { createRuntimeSystem } from "./runtime-system.js";
 import { createRuntimeTaskFlow } from "./runtime-taskflow.js";
 import { createRuntimeTasks } from "./runtime-tasks.js";
+import { createRuntimeUsage } from "./runtime-usage.js";
 import type { CreatePluginRuntimeOptions, PluginRuntime } from "./types.js";
 
 export type { CreatePluginRuntimeOptions } from "./types.js";
@@ -248,6 +249,7 @@ export function createPluginRuntime(_options: CreatePluginRuntimeOptions = {}): 
     channel: createRuntimeChannel(),
     events: createRuntimeEvents(),
     logging: createRuntimeLogging(),
+    usage: createRuntimeUsage(),
     state: {
       resolveStateDir,
       openKeyedStore: () => {

--- a/src/plugins/runtime/runtime-usage.ts
+++ b/src/plugins/runtime/runtime-usage.ts
@@ -1,0 +1,9 @@
+import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";
+import type { PluginRuntime } from "./types.js";
+
+export function createRuntimeUsage(): PluginRuntime["usage"] {
+  return {
+    resolveModelCostConfig,
+    estimateUsageCost,
+  };
+}

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -306,6 +306,12 @@ export type PluginRuntimeCore = {
       opts?: { level?: LogLevel },
     ) => RuntimeLogger;
   };
+  usage: {
+    /** Resolve per-token pricing for a provider/model pair. Returns undefined when pricing is unknown. */
+    resolveModelCostConfig: typeof import("../../utils/usage-format.js").resolveModelCostConfig;
+    /** Estimate total cost in USD from token usage and a cost config. */
+    estimateUsageCost: typeof import("../../utils/usage-format.js").estimateUsageCost;
+  };
   state: {
     resolveStateDir: typeof import("../../config/paths.js").resolveStateDir;
     openKeyedStore: <T>(


### PR DESCRIPTION
## Summary
Adds a `runtime.usage` namespace to the plugin runtime, exposing `resolveModelCostConfig()` and `estimateUsageCost()` so context engine plugins can calculate model-cost estimates from OpenClaw's configured pricing instead of hardcoded heuristics.

## Motivation
Context engine plugins, such as [ContextClaw](https://github.com/dodge1218/contextclaw), truncate stale or large context to save tokens. Today they can only estimate savings with a fixed heuristic. OpenClaw already has per-model pricing through `resolveModelCostConfig`; this PR threads those helpers through the plugin runtime so plugins can use the same pricing source as the host.

## Changes
- `src/plugins/runtime/runtime-usage.ts` — adds the runtime usage facade.
- `src/plugins/runtime/types-core.ts` — adds the `usage` namespace to `PluginRuntimeCore`.
- `src/plugins/runtime/index.ts` — wires `createRuntimeUsage()` into runtime assembly.
- `src/plugin-sdk/test-helpers/plugin-runtime-mock.ts` — updates the plugin runtime mock.
- `src/plugins/runtime/index.test.ts` — asserts the runtime exposes both usage helpers.
- `docs/plugins/sdk-runtime.md` — documents the plugin SDK usage helpers.
- `docs/.generated/plugin-sdk-api-baseline.sha256` — regenerates the public SDK API baseline.

## Real Behavior Proof
- **Behavior or issue addressed:** A plugin can access the new `api.runtime.usage` namespace and call both pricing helpers without importing OpenClaw internals.

- **Real environment tested:** Local OpenClaw checkout on branch `feat/plugin-cost-api` at `39b243468f`, after rebasing onto upstream `main` and narrowing the PR to the plugin runtime/docs/test surface.

- **Exact steps or command run after this patch:**

```bash
pnpm exec tsx .artifacts/pr64436-runtime-usage-proof/run-direct-plugin-api-proof.ts
```

- **Evidence after fix:** Terminal output from a minimal external plugin fixture with `openclaw.plugin.json` plus `index.mjs`; its `register(api)` calls `api.runtime.usage.resolveModelCostConfig(...)` and `api.runtime.usage.estimateUsageCost(...)`.

```text
[proof] repoHead=39b243468f
[proof] pluginDir=/tmp/openclaw-runtime-usage-direct-ile3Im
[proof] manifest=/tmp/openclaw-runtime-usage-direct-ile3Im/openclaw.plugin.json
[plugin] id=runtime-usage-proof
[plugin] hasRuntimeUsage=true
[plugin] resolveModelCostConfig cost={"input":3,"output":15,"cacheRead":0.3,"cacheWrite":3.75}
[plugin] estimateUsageCost total=0.010950
[proof] PASS plugin register(api) called both api.runtime.usage helpers
```

- **Observed result after fix:** The plugin saw `api.runtime.usage`, resolved the configured proof model cost, estimated usage cost as `0.010950`, and exited with the PASS line above.

- **What was not tested:** Full OpenClaw app startup and provider billing reconciliation; this proof is scoped to the plugin runtime API surface added by this PR.

## Local Verification
- `git diff --check upstream/main...HEAD`
- `NODE_OPTIONS=--max-old-space-size=8192 node --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check`
- `pnpm format:check docs/.generated/plugin-sdk-api-baseline.sha256 docs/plugins/sdk-runtime.md src/plugins/runtime/index.test.ts src/plugins/runtime/index.ts src/plugins/runtime/types-core.ts src/plugins/runtime/runtime-usage.ts src/plugin-sdk/test-helpers/plugin-runtime-mock.ts`
- `pnpm exec vitest run src/plugins/runtime/index.test.ts -t 'exposes runtime.usage pricing helpers' --reporter=dot`

## Related
- Issue #64085 — Provider circuit breaker cost/status reporting.
- PR #64127 — companion status-provider work.

