### PR TITLE
fix: allow symlinks within ~/.openclaw directory in boundary path checks

### DIFF
--- a/src/infra/boundary-path.ts
+++ b/src/infra/boundary-path.ts
@@ -309,11 +309,18 @@ function applyResolvedSymlinkHop(params: {
   boundaryLabel: string;
 }): void {
   if (!isPathInside(params.rootCanonicalPath, params.linkCanonical)) {
-    throw symlinkEscapeError({
-      boundaryLabel: params.boundaryLabel,
-      rootCanonicalPath: params.rootCanonicalPath,
-      symlinkPath: params.state.lexicalCursor,
-    });
+    // Allow symlinks that resolve within the user's ~/.openclaw directory tree.
+    // This supports common setups where workspace files are symlinked to a
+    // knowledge-base sync directory (e.g. ~/.openclaw/kb/) while still blocking
+    // symlinks that escape to arbitrary locations outside the OpenClaw root.
+    const openclawRoot = path.join(os.homedir(), ".openclaw");
+    if (!isPathInside(openclawRoot, params.linkCanonical)) {
+      throw symlinkEscapeError({
+        boundaryLabel: params.boundaryLabel,
+        rootCanonicalPath: params.rootCanonicalPath,
+        symlinkPath: params.state.lexicalCursor,
+      });
+    }
   }
   params.state.canonicalCursor = params.linkCanonical;
   params.state.lexicalCursor = params.linkCanonical;
@@ -635,6 +642,11 @@ function assertLexicalBoundaryOrCanonicalAlias(params: {
   if (isPathInside(params.rootCanonicalPath, params.canonicalOutsideLexicalPath)) {
     return;
   }
+  // Allow canonical paths within ~/.openclaw (supports symlinked workspace files).
+  const openclawRoot = path.join(os.homedir(), ".openclaw");
+  if (isPathInside(openclawRoot, params.canonicalOutsideLexicalPath)) {
+    return;
+  }
   throw pathEscapeError({
     boundaryLabel: params.boundaryLabel,
     rootPath: params.rootPath,
@@ -783,6 +795,12 @@ function assertInsideBoundary(params: {
   absolutePath: string;
 }): void {
   if (isPathInside(params.rootCanonicalPath, params.candidatePath)) {
+    return;
+  }
+  // Allow paths that resolve within ~/.openclaw (e.g. symlinked workspace files
+  // pointing to a knowledge-base sync directory under ~/.openclaw/kb/).
+  const openclawRoot = path.join(os.homedir(), ".openclaw");
+  if (isPathInside(openclawRoot, params.candidatePath)) {
     return;
   }
   throw new Error(


### PR DESCRIPTION
Fixes #64472

## Problem

Workspace bootstrap files that are symlinks pointing to targets within `~/.openclaw/` (but outside `~/.openclaw/workspace/`) are rejected by the boundary path security check. This causes them to show as `[MISSING]` in the system prompt, silently breaking all workspace-level instructions.

This commonly happens when users set up knowledge-base sync (e.g., Syncthing) with a dedicated directory like `~/.openclaw/kb/` and symlink workspace files to it.

## Solution

Add a fallback check in three boundary enforcement points (`applyResolvedSymlinkHop`, `assertInsideBoundary`, `assertLexicalBoundaryOrCanonicalAlias`): if a symlink target is not inside the workspace root but IS inside `~/.openclaw/`, allow it.

### Security Considerations

- Symlinks to arbitrary locations outside `~/.openclaw/` are **still blocked**
- The `~/.openclaw/` directory is already a trusted boundary — it contains the gateway config, agent data, plugins, and workspace
- This change only relaxes the check for sibling directories within the same trust boundary
- All other safety checks (TOCTOU protection, hardlink rejection, file type validation, max size) remain unchanged

## Changes

- `src/infra/boundary-path.ts`: 3 functions modified, 23 lines added, 5 removed
  - `applyResolvedSymlinkHop()`: fallback `~/.openclaw/` check before throwing symlink escape error
  - `assertInsideBoundary()`: fallback `~/.openclaw/` check before throwing boundary error
  - `assertLexicalBoundaryOrCanonicalAlias()`: fallback `~/.openclaw/` check before throwing path escape error

## Testing

Existing boundary path tests should continue to pass — they use temp directories outside `~/.openclaw/`, so the new fallback check does not apply to them.

Manual verification: symlinked workspace bootstrap files to `~/.openclaw/kb/` directory, confirmed they are now loaded correctly in the system prompt.