### PR TITLE
CLI: escape zsh completion descriptions

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -11,6 +11,10 @@ function createCompletionProgram(): Command {
   program.name("openclaw");
   program.description("CLI root");
   program.option("-v, --verbose", "Verbose output");
+  program.option(
+    "--status-json",
+    "Output JSON (alias for `models status --json`) in $OPENCLAW_STATE_DIR",
+  );
 
   const gateway = program.command("gateway").description("Gateway commands");
   gateway.option("--force", "Force the action");
@@ -29,6 +33,8 @@ describe("completion-cli", () => {
     expect(script).toContain("(status) _openclaw_gateway_status ;;");
     expect(script).toContain("(restart) _openclaw_gateway_restart ;;");
     expect(script).toContain("--force[Force the action]");
+    expect(script).toContain("\\`models status --json\\`");
+    expect(script).toContain("\\$OPENCLAW_STATE_DIR");
   });
 
   it("defers zsh registration until compinit is available", async () => {

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -12,6 +12,10 @@ function createCompletionProgram(): Command {
   program.name("openclaw");
   program.description("CLI root");
   program.option("-v, --verbose", "Verbose output");
+  program.option(
+    "--status-json",
+    "Output JSON (alias for `models status --json`) in $OPENCLAW_STATE_DIR",
+  );
 
   const gateway = program.command("gateway").description("Gateway commands");
   gateway.option("--force", "Force the action");
@@ -38,6 +42,8 @@ describe("completion-cli", () => {
     expect(script).toContain("(status) _openclaw_gateway_status ;;");
     expect(script).toContain("(restart) _openclaw_gateway_restart ;;");
     expect(script).toContain("--force[Force the action]");
+    expect(script).toContain("\\`models status --json\\`");
+    expect(script).toContain("\\$OPENCLAW_STATE_DIR");
   });
 
   it("defers zsh registration until compinit is available", async () => {

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -46,6 +46,19 @@ describe("completion-cli", () => {
     expect(script).toContain("\\$OPENCLAW_STATE_DIR");
   });
 
+  it("escapes zsh option descriptions for double-quoted arguments specs", () => {
+    const program = new Command()
+      .name("openclaw")
+      .option("--literal", "Use $OPENCLAW_STATE_DIR with `model/list` and John's profile");
+
+    const script = getCompletionScript("zsh", program);
+
+    expect(script).toContain(
+      "--literal[Use \\$OPENCLAW_STATE_DIR with \\`model/list\\` and John's profile]",
+    );
+    expect(script).not.toContain("John'\\''s");
+  });
+
   it("defers zsh registration until compinit is available", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -206,7 +206,10 @@ function escapeZshDoubleQuotedDescription(description: string): string {
     .replace(/"/g, '\\"')
     .replace(/\$/g, "\\$")
     .replace(/`/g, "\\`")
-    .replace(/'/g, "'\\''")
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
     .replace(/\[/g, "\\[")
     .replace(/\]/g, "\\]");
 }

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -176,12 +176,7 @@ function generateZshArgs(cmd: Command): string {
       const flags = opt.flags.split(/[ ,|]+/);
       const name = flags.find((f) => f.startsWith("--")) || flags[0];
       const short = flags.find((f) => f.startsWith("-") && !f.startsWith("--"));
-      const desc = opt.description
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
-        .replace(/'/g, "'\\''")
-        .replace(/\[/g, "\\[")
-        .replace(/\]/g, "\\]");
+      const desc = escapeZshDoubleQuotedDescription(opt.description);
       if (short) {
         return `"(${name} ${short})"{${name},${short}}"[${desc}]"`;
       }
@@ -203,6 +198,17 @@ function generateZshSubcmdList(cmd: Command): string {
     })
     .join(" ");
   return `"1: :_values 'command' ${list}"`;
+}
+
+function escapeZshDoubleQuotedDescription(description: string): string {
+  return description
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`")
+    .replace(/'/g, "'\\''")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
 }
 
 function generateZshSubcommands(program: Command, prefix: string): string {

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -205,11 +205,7 @@ function escapeZshDoubleQuotedDescription(description: string): string {
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')
     .replace(/\$/g, "\\$")
-    .replace(/`/g, "\\`")
-    .replace(/\$/g, "\\$")
-    .replace(/`/g, "\\`")
-    .replace(/\[/g, "\\[")
-    .replace(/\]/g, "\\]");
+    .replaceAll("`", "\\`")
     .replace(/\[/g, "\\[")
     .replace(/\]/g, "\\]");
 }

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -323,7 +323,10 @@ function escapeZshDoubleQuotedDescription(description: string): string {
     .replace(/"/g, '\\"')
     .replace(/\$/g, "\\$")
     .replace(/`/g, "\\`")
-    .replace(/'/g, "'\\''")
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
     .replace(/\[/g, "\\[")
     .replace(/\]/g, "\\]");
 }

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -293,12 +293,7 @@ function generateZshArgs(cmd: Command): string {
       const flags = opt.flags.split(/[ ,|]+/);
       const name = flags.find((f) => f.startsWith("--")) || flags[0];
       const short = flags.find((f) => f.startsWith("-") && !f.startsWith("--"));
-      const desc = opt.description
-        .replace(/\\/g, "\\\\")
-        .replace(/"/g, '\\"')
-        .replace(/'/g, "'\\''")
-        .replace(/\[/g, "\\[")
-        .replace(/\]/g, "\\]");
+      const desc = escapeZshDoubleQuotedDescription(opt.description);
       if (short) {
         return `"(${name} ${short})"{${name},${short}}"[${desc}]"`;
       }
@@ -320,6 +315,17 @@ function generateZshSubcmdList(cmd: Command): string {
     })
     .join(" ");
   return `"1: :_values 'command' ${list}"`;
+}
+
+function escapeZshDoubleQuotedDescription(description: string): string {
+  return description
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\$/g, "\\$")
+    .replace(/`/g, "\\`")
+    .replace(/'/g, "'\\''")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
 }
 
 function generateZshSubcommands(program: Command, prefix: string): string {

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -322,11 +322,7 @@ function escapeZshDoubleQuotedDescription(description: string): string {
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')
     .replace(/\$/g, "\\$")
-    .replace(/`/g, "\\`")
-    .replace(/\$/g, "\\$")
-    .replace(/`/g, "\\`")
-    .replace(/\[/g, "\\[")
-    .replace(/\]/g, "\\]");
+    .replaceAll("`", "\\`")
     .replace(/\[/g, "\\[")
     .replace(/\]/g, "\\]");
 }


### PR DESCRIPTION
<img width="620" height="177" alt="image" src="https://github.com/user-attachments/assets/df9f44fb-368a-4de3-abb5-89d714c5cca6" />

## What Problem This Solves

Zsh completion descriptions are emitted inside double-quoted `_arguments` specs, but `$` and backticks were not escaped. Descriptions such as `$OPENCLAW_STATE_DIR/completions` or examples wrapped in backticks can be interpreted by zsh instead of being displayed literally.

This can break or corrupt CLI tab-completion output and degrades the developer experience.

## Why This Change Was Made

This PR keeps the scope limited to zsh option-description escaping. The branch was repaired in place by ProjectClownfish while preserving @EdenKangdw’s original contributor PR and branch history.

The repair keeps the useful `$` and backtick escaping, avoids single-quote escaping that does not apply to this double-quoted zsh context, and adds focused regression coverage.

## User Impact

Generated zsh completions display CLI option descriptions with `$`, backticks, and single quotes literally instead of evaluating or corrupting the description text.

## Evidence

- Source PR: https://github.com/openclaw/openclaw/pull/64490, credited to @EdenKangdw.
- Focused repair validated by ProjectClownfish with `pnpm test src/cli/completion-cli.test.ts` and `pnpm check:changed`.
- Current PR head: `5543a13e1b4ce4a8e4259d8a1668473bd1cdac12`.

## Change Type

* [x] Bug fix
* [x] Refactor required for the fix

## Scope

* [x] UI / DX

## Compatibility

* Backward compatible: Yes