### PR TITLE
fix(msteams): forward messageBack card actions (Action.Submit) to agent (#60952)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- MS Teams: forward messageBack card action payloads to the agent instead of dropping empty-text card submit activities. (#64503) Thanks @ndholakia.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Gateway/Tailscale: add opt-in `gateway.tailscale.preserveFunnel` so when `tailscale.mode = "serve"` and an externally configured Tailscale Funnel route already covers the gateway port, OpenClaw skips re-applying `tailscale serve` on startup and skips the `resetOnExit` teardown for that run, keeping operator-managed Funnel exposure alive across gateway restarts. Fixes #57241. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.

--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -101,7 +101,7 @@ describe("msteams adaptive card action invoke", () => {
   it("forwards adaptive card invoke values to the agent as message text", async () => {
     const deps = createDeps();
     const { handler, run } = createActivityHandler();
-    const _registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
+    const registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
       run: NonNullable<MSTeamsActivityHandler["run"]>;
     };
     const payload = {

--- a/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
+++ b/extensions/msteams/src/monitor-handler.adaptive-card.test.ts
@@ -101,7 +101,7 @@ describe("msteams adaptive card action invoke", () => {
   it("forwards adaptive card invoke values to the agent as message text", async () => {
     const deps = createDeps();
     const { handler, run } = createActivityHandler();
-    const registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
+    const _registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
       run: NonNullable<MSTeamsActivityHandler["run"]>;
     };
     const payload = {
@@ -158,5 +158,145 @@ describe("msteams adaptive card action invoke", () => {
         SenderId: "user-aad",
       },
     });
+  });
+});
+
+describe("msteams messageBack card action (#60952)", () => {
+  beforeEach(() => {
+    runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mockClear();
+  });
+
+  it("forwards messageBack value payload to the agent as [CARD_ACTION]", async () => {
+    const deps = createDeps();
+    const { handler, run } = createActivityHandler();
+    const _registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+    const value = { intent: "approve", env: "prod" };
+
+    await run({
+      activity: {
+        id: "msg-1",
+        type: "message",
+        channelId: "msteams",
+        serviceUrl: "https://service.example.test",
+        text: "",
+        from: {
+          id: "user-bf",
+          aadObjectId: "user-aad",
+          name: "User",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:personal-chat;messageid=abc123",
+          conversationType: "personal",
+        },
+        channelData: {},
+        attachments: [],
+        value,
+      },
+      sendActivity: vi.fn(async () => ({ id: "activity-id" })),
+      sendActivities: async () => [],
+    } as unknown as MSTeamsTurnContext);
+
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+    const call =
+      runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      ctxPayload: {
+        RawBody: `[CARD_ACTION] ${JSON.stringify(value)}`,
+        SessionKey: "msteams:direct:user-aad",
+        SenderId: "user-aad",
+      },
+    });
+  });
+
+  it("forwards string messageBack value payload", async () => {
+    const deps = createDeps();
+    const { handler, run } = createActivityHandler();
+    const _registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+
+    await run({
+      activity: {
+        id: "msg-2",
+        type: "message",
+        channelId: "msteams",
+        serviceUrl: "https://service.example.test",
+        text: "",
+        from: {
+          id: "user-bf",
+          aadObjectId: "user-aad",
+          name: "User",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:personal-chat;messageid=abc456",
+          conversationType: "personal",
+        },
+        channelData: {},
+        attachments: [],
+        value: "quick-approve",
+      },
+      sendActivity: vi.fn(async () => ({ id: "activity-id" })),
+      sendActivities: async () => [],
+    } as unknown as MSTeamsTurnContext);
+
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+    const call =
+      runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher.mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      ctxPayload: {
+        RawBody: "[CARD_ACTION] quick-approve",
+      },
+    });
+  });
+
+  it("still drops genuinely empty messages (no text, no value, no attachments)", async () => {
+    const deps = createDeps();
+    const { handler, run } = createActivityHandler();
+    const _registered = registerMSTeamsHandlers(handler, deps) as MSTeamsActivityHandler & {
+      run: NonNullable<MSTeamsActivityHandler["run"]>;
+    };
+
+    await run({
+      activity: {
+        id: "msg-3",
+        type: "message",
+        channelId: "msteams",
+        serviceUrl: "https://service.example.test",
+        text: "",
+        from: {
+          id: "user-bf",
+          aadObjectId: "user-aad",
+          name: "User",
+        },
+        recipient: {
+          id: "bot-id",
+          name: "Bot",
+        },
+        conversation: {
+          id: "19:personal-chat;messageid=abc789",
+          conversationType: "personal",
+        },
+        channelData: {},
+        attachments: [],
+      },
+      sendActivity: vi.fn(async () => ({ id: "activity-id" })),
+      sendActivities: async () => [],
+    } as unknown as MSTeamsTurnContext);
+
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
   });
 });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -204,7 +204,26 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       maxInlineBytes: mediaMaxBytes,
       maxInlineTotalBytes: mediaMaxBytes,
     });
-    const rawBody = text || attachmentPlaceholder;
+    // If text and attachments are both empty but activity.value is present,
+    // this is a messageBack card action (Action.Submit). Serialize the value
+    // payload so it reaches the agent instead of being dropped. (#60952)
+    // Accept any truthy value — object, string, or primitive — since
+    // messageBack payloads are not guaranteed to be objects.
+    let rawBody = text || attachmentPlaceholder;
+    if (!rawBody && activity.value != null) {
+      try {
+        const serialized =
+          typeof activity.value === "string" ? activity.value : JSON.stringify(activity.value);
+        if (serialized) {
+          rawBody = `[CARD_ACTION] ${serialized}`;
+          log.info("messageBack card action detected; forwarding value payload", {
+            valueType: typeof activity.value,
+          });
+        }
+      } catch {
+        log.warn("failed to serialize messageBack value payload");
+      }
+    }
     const quoteInfo = extractMSTeamsQuoteInfo(attachments);
     let quoteSenderId: string | undefined;
     let quoteSenderName: string | undefined;

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -204,11 +204,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       maxInlineBytes: mediaMaxBytes,
       maxInlineTotalBytes: mediaMaxBytes,
     });
-    // If text and attachments are both empty but activity.value is present,
-    // this is a messageBack card action (Action.Submit). Serialize the value
-    // payload so it reaches the agent instead of being dropped. (#60952)
-    // Accept any truthy value — object, string, or primitive — since
-    // messageBack payloads are not guaranteed to be objects.
+    // Forward messageBack card action payloads instead of dropping empty text.
     let rawBody = text || attachmentPlaceholder;
     if (!rawBody && activity.value != null) {
       try {
@@ -221,7 +217,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
           });
         }
       } catch {
-        log.warn("failed to serialize messageBack value payload");
+        log.warn?.("failed to serialize messageBack value payload");
       }
     }
     const quoteInfo = extractMSTeamsQuoteInfo(attachments);


### PR DESCRIPTION
## Summary

Forward `Action.Submit` messageBack activities to the agent instead of dropping them as empty messages. Closes #60952.

When a user clicks an `Action.Submit` button on an Adaptive Card in Teams, the click is sent as a messageBack activity (`type="message"` with empty text and a `value` object). The message handler strips mentions, finds empty text, and drops the message with "skipping empty message after stripping mentions." The value payload is never forwarded to the agent.

This change adds a check for `activity.value` before the empty-text drop at line 452 of `message-handler.ts`. If the value payload is a non-empty object, it serializes it as `[CARD_ACTION] {json}` so the agent receives the button payload. This is consistent with:

- The `adaptiveCard/action` invoke handling added in #60431 (which handles `Action.Execute`)
- The `fileConsent/invoke` handling added in #64087

The detection pattern: `activity.type === "message" && !text && activity.value && typeof activity.value === "object"`

## Test plan

- [ ] Send an Adaptive Card with `Action.Submit` buttons to a Teams DM
- [ ] Click a button — verify the agent receives `[CARD_ACTION] {"key":"value"}` as the message body
- [ ] Verify normal text messages still work (no regression)
- [ ] Verify empty messages are still dropped (no spurious forwarding)
- [ ] Verify `Action.Execute` invoke path (#60431) is unaffected

## Context

This is the companion fix to #55384/#60431 (Action.Execute). Together they cover both invoke formats Teams uses for Adaptive Card interactions. We've been running a sidecar HTTP proxy workaround for this since March 2026 — this fix eliminates the need for that sidecar for card actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)