### PR TITLE
fix: treat empty heartbeat config as disabled (closes #64293)

### DIFF
--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -24,9 +24,16 @@ export type HeartbeatSummary = {
 
 const DEFAULT_HEARTBEAT_TARGET = "none";
 
+// #64293: treat empty heartbeat config ({}) as explicitly disabled
+function isEmptyObject(obj: unknown): boolean {
+  return (
+    typeof obj === "object" && obj !== null && !Array.isArray(obj) && Object.keys(obj).length === 0
+  );
+}
+
 function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   const list = cfg.agents?.list ?? [];
-  return list.some((entry) => Boolean(entry?.heartbeat));
+  return list.some((entry) => Boolean(entry?.heartbeat) && !isEmptyObject(entry?.heartbeat));
 }
 
 export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string): boolean {
@@ -35,8 +42,16 @@ export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string
   const hasExplicit = hasExplicitHeartbeatAgents(cfg);
   if (hasExplicit) {
     return list.some(
-      (entry) => Boolean(entry?.heartbeat) && normalizeAgentId(entry?.id) === resolvedAgentId,
+      (entry) =>
+        Boolean(entry?.heartbeat) &&
+        !isEmptyObject(entry?.heartbeat) &&
+        normalizeAgentId(entry?.id) === resolvedAgentId,
     );
+  }
+  // #64293: treat empty defaults heartbeat as disabled
+  const defaults = cfg.agents?.defaults?.heartbeat;
+  if (isEmptyObject(defaults)) {
+    return false;
   }
   return resolvedAgentId === resolveDefaultAgentId(cfg);
 }
@@ -46,6 +61,10 @@ export function resolveHeartbeatIntervalMs(
   overrideEvery?: string,
   heartbeat?: HeartbeatConfig,
 ) {
+  // #64293: treat empty heartbeat config as disabled
+  if (isEmptyObject(heartbeat)) {
+    return null;
+  }
   const raw =
     overrideEvery ??
     heartbeat?.every ??


### PR DESCRIPTION
## Summary

- **Problem:** Setting `agents.defaults.heartbeat: {}` in config does not disable heartbeats — they still fire every 30 minutes, burning ~2M+ input tokens/day with zero user activity.
- **Why it matters:** Users expect `heartbeat: {}` to mean "disabled". Silent token burn at ~$6/day (Claude Sonnet 4.5 rates) with no visible indication.
- **What changed:** Added empty-object detection in `isHeartbeatEnabledForAgent` and `resolveHeartbeatIntervalMs` so that `heartbeat: {}` is treated as disabled instead of falling through to the default 30m interval.
- **What did NOT change:** Non-empty heartbeat configs (e.g. `{ every: "1h" }`, `{ prompt: "..." }`) are completely unaffected. Default behavior when no heartbeat key is present is also unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64293
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `resolveHeartbeatIntervalMs()` falls through to `DEFAULT_HEARTBEAT_EVERY` ("30m") when `heartbeat?.every` is `undefined` — which is the case for an empty `{}` config. Similarly, `isHeartbeatEnabledForAgent()` returns `true` for the default agent even when the defaults heartbeat is `{}`, because it only checks for explicit agent-level heartbeat entries and never inspects the defaults object itself.
- **Missing detection / guardrail:** No check for empty-object heartbeat config anywhere in the resolution chain.
- **Contributing context:** Users naturally assume `heartbeat: {}` means "I acknowledged this config key but want it off" (similar to how `cron: {}` or `memory: {}` would imply disabled).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/infra/heartbeat-summary.test.ts`
- Scenario the test should lock in: `resolveHeartbeatIntervalMs(cfg, undefined, {})` returns `null`; `isHeartbeatEnabledForAgent(cfg)` returns `false` when defaults heartbeat is `{}`
- Why this is the smallest reliable guardrail: Pure function, easily testable in isolation
- If no new test is added, why not: Keeping PR minimal — happy to add tests if requested by reviewer

## User-visible / Behavior Changes

- `agents.defaults.heartbeat: {}` now correctly disables heartbeat polling (previously silently ran every 30m)
- Per-agent `heartbeat: {}` in agents list now correctly disables that agent's heartbeat

## Diagram (if applicable)

```text
Before:
heartbeat: {} -> resolveHeartbeatIntervalMs -> falls through to DEFAULT "30m" -> schedules heartbeat

After:
heartbeat: {} -> resolveHeartbeatIntervalMs -> detects empty object -> returns null -> no heartbeat scheduled
```

## Security Impact (required)

- New permissions/capabilities? No
- Auth boundary changes? No
- Secrets/token exposure risk? No
- New external calls? No
- Sandbox/isolation changes? No

## Evidence

- Code inspection: traced the full heartbeat resolution chain from config load → `resolveHeartbeatConfig` → `resolveHeartbeatIntervalMs` → scheduling
- `pnpm check` passes (lint + typecheck)
- AI-assisted (Claude): fix authored with AI assistance, manually reviewed and verified

## Human Verification (required)

- Verified scenarios: Traced config resolution for `heartbeat: {}`, `heartbeat: { every: "1h" }`, and no heartbeat key — confirmed only empty-object case is affected
- Edge cases checked: `heartbeat: undefined`, `heartbeat: null`, `heartbeat: { every: "0" }` — all unaffected by this change
- What you did **not** verify: Full integration test with running gateway (no Docker setup locally for this)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — only changes behavior for the specific `{}` empty-object case
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Someone intentionally uses `heartbeat: {}` expecting default 30m behavior
  - Mitigation: This is extremely unlikely — `{}` universally signals "empty/disabled" in config conventions. Users wanting defaults would simply omit the key.