### PR TITLE
fix(hooks): respect agentId and sessionKey for wake-mode hook mappings

### DIFF
--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -43,6 +43,8 @@ export type HookAction =
       kind: "wake";
       text: string;
       mode: "now" | "next-heartbeat";
+      agentId?: string;
+      sessionKey?: string;
     }
   | {
       kind: "agent";
@@ -249,6 +251,8 @@ function buildActionFromMapping(
         kind: "wake",
         text,
         mode: mapping.wakeMode ?? "now",
+        agentId: mapping.agentId,
+        sessionKey: renderOptional(mapping.sessionKey, ctx),
       },
     };
   }
@@ -286,7 +290,13 @@ function mergeAction(
     const baseWake = base.kind === "wake" ? base : undefined;
     const text = typeof override.text === "string" ? override.text : (baseWake?.text ?? "");
     const mode = override.mode === "next-heartbeat" ? "next-heartbeat" : (baseWake?.mode ?? "now");
-    return validateAction({ kind: "wake", text, mode });
+    const agentId =
+      typeof override.agentId === "string" ? override.agentId : (baseWake?.agentId ?? undefined);
+    const sessionKey =
+      typeof override.sessionKey === "string"
+        ? override.sessionKey
+        : (baseWake?.sessionKey ?? undefined);
+    return validateAction({ kind: "wake", text, mode, agentId, sessionKey });
   }
   const baseAgent = base.kind === "agent" ? base : undefined;
   const message =

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -89,7 +89,12 @@ const HOOK_AUTH_FAILURE_LIMIT = 20;
 const HOOK_AUTH_FAILURE_WINDOW_MS = 60_000;
 
 type HookDispatchers = {
-  dispatchWakeHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => void;
+  dispatchWakeHook: (value: {
+    text: string;
+    mode: "now" | "next-heartbeat";
+    agentId?: string;
+    sessionKey?: string;
+  }) => void;
   dispatchAgentHook: (value: HookAgentDispatchPayload) => string;
 };
 
@@ -631,6 +636,8 @@ export function createHooksRequestHandler(
             dispatchWakeHook({
               text: mapped.action.text,
               mode: mapped.action.mode,
+              agentId: mapped.action.agentId,
+              sessionKey: mapped.action.sessionKey,
             });
             sendJson(res, 200, { ok: true, mode: mapped.action.mode });
             return true;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -29,8 +29,20 @@ export function createGatewayHooksRequestHandler(params: {
 }) {
   const { deps, getHooksConfig, getClientIpConfig, bindHost, port, logHooks } = params;
 
-  const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
-    const sessionKey = resolveMainSessionKeyFromConfig();
+  const dispatchWakeHook = (value: {
+    text: string;
+    mode: "now" | "next-heartbeat";
+    agentId?: string;
+    sessionKey?: string;
+  }) => {
+    // Honor the configured sessionKey/agentId from hook mappings so
+    // wake-mode hooks can target non-default agents. Falls back to the
+    // main session key when neither is provided (#64556).
+    const sessionKey =
+      value.sessionKey ??
+      (value.agentId
+        ? `agent:${value.agentId}:main`
+        : resolveMainSessionKeyFromConfig());
     enqueueSystemEvent(value.text, { sessionKey, trusted: false });
     if (value.mode === "now") {
       requestHeartbeatNow({ reason: "hook:wake" });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -6,6 +6,7 @@ import { runCronIsolatedAgentTurn } from "../../cron/isolated-agent.js";
 import type { CronJob } from "../../cron/types.js";
 import { requestHeartbeatNow } from "../../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { type HookAgentDispatchPayload, type HooksConfigResolved } from "../hooks.js";
 import { createHooksRequestHandler, type HookClientIpConfig } from "../server-http.js";
@@ -38,10 +39,14 @@ export function createGatewayHooksRequestHandler(params: {
     // Honor the configured sessionKey/agentId from hook mappings so
     // wake-mode hooks can target non-default agents. Falls back to the
     // main session key when neither is provided (#64556).
+    // Normalize the agent ID to match the convention used by
+    // buildMainSessionKey / normalizeHookDispatchSessionKey — without
+    // this, mixed-case agent IDs produce keys that don't match any
+    // real session, silently routing the event nowhere.
     const sessionKey =
       value.sessionKey ??
       (value.agentId
-        ? `agent:${value.agentId}:main`
+        ? `agent:${normalizeAgentId(value.agentId)}:main`
         : resolveMainSessionKeyFromConfig());
     enqueueSystemEvent(value.text, { sessionKey, trusted: false });
     if (value.mode === "now") {


### PR DESCRIPTION
## Summary

`dispatchWakeHook()` hard-codes the session target to `resolveMainSessionKeyFromConfig()`, ignoring any `agentId` or `sessionKey` configured in `hooks.mappings[]`. Every wake-mode hook ends up in the default `main` agent's heartbeat session regardless of the mapping config — silently.

The gateway returns `200 {"ok":true,"mode":"now"}` and the user has no indication that routing was disregarded. Multi-agent setups silently funnel **all** wake hooks into the wrong agent.

Fixes #64556

## Root cause

```ts
// server/hooks.ts (before fix)
const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
  const sessionKey = resolveMainSessionKeyFromConfig();  // ← always main
  enqueueSystemEvent(value.text, { sessionKey, trusted: false });
};
```

For comparison, `dispatchAgentHook` (the `action: "agent"` path) already resolves the hook's `sessionKey` and `agentId` from the mapping config via `resolveHookSessionKey` + `resolveHookTargetAgentId`. The wake path was simply never wired.

The mapping dispatch call at `server-http.ts:631` passed only `text` and `mode`, discarding the `agentId`/`sessionKey` that `buildActionFromMapping` could have propagated from the hook mapping config.

## Fix

Three files, ~30 LOC:

**`hooks-mapping.ts`**:
- Add `agentId?: string` and `sessionKey?: string` to the `wake` variant of `HookAction`
- Thread them through `buildActionFromMapping` (from `mapping.agentId` / `mapping.sessionKey`)
- Thread them through `mergeAction` (for transform override support)

**`server/hooks.ts`**:
- Expand `dispatchWakeHook` signature to accept optional `agentId` / `sessionKey`
- Resolve session key with fallback chain: `value.sessionKey ?? agent:${value.agentId}:main ?? resolveMainSessionKeyFromConfig()`

**`server-http.ts`**:
- Update `HooksHandlerDeps.dispatchWakeHook` type to match
- Pass `mapped.action.agentId` / `mapped.action.sessionKey` at the mapping dispatch site

### Fallback behavior

| Config | Resolved session key |
|--------|---------------------|
| Both `sessionKey` and `agentId` | Uses `sessionKey` (explicit) |
| Only `agentId: "integrations"` | Derives `agent:integrations:main` |
| Neither | Falls back to `resolveMainSessionKeyFromConfig()` (existing behavior) |

### What about the direct `/hooks/wake` path?

The direct `POST /hooks/wake` path at `server-http.ts:533-541` sends `normalizeWakePayload(payload)` which only extracts `text` and `mode` from the request body. This path continues to use the main session key — which is correct because direct wake requests don't have a mapping config to draw routing from. Only **mapped** wake hooks (`hooks.mappings[].action: "wake"`) gain the new routing.

## Related work

- **PR #39046** (open, 33 days, 0 reviews): `fix(hooks): gateway hook event routing respects target agent session` — fixes hook **completion/error** system event routing (different function, different code path). Complementary, not conflicting: #39046 fixes `buildCompletionSystemEvent`, this PR fixes `dispatchWakeHook`. Both touch `server/hooks.ts` but different functions.
- **#3432** (closed): original feature request for this routing. Fields were later added to the schema, but implementation was never wired through for `wake`.

## Scope

- **Files**: `hooks-mapping.ts` (+10/-1), `server/hooks.ts` (+14/-2), `server-http.ts` (+7/-1)
- **Production LOC**: ~30 lines across 3 files
- **oxlint clean**
- **No changes** to the `agent` action path, no changes to `resolveHookSessionKey`, no changes to the direct `/hooks/wake` endpoint

cc @steipete — gateway hooks routing. Credit to @jaserNo1 for the complete RCA and clear reproduction in #64556.