### PR TITLE
Fix/heartbeat task due clock skew

### DIFF
--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   isHeartbeatContentEffectivelyEmpty,
+  isTaskDue,
   parseHeartbeatTasks,
   stripHeartbeatToken,
 } from "./heartbeat.js";
@@ -280,5 +281,26 @@ interval: should-not-bleed
         prompt: "Check for urgent emails",
       },
     ]);
+  });
+});
+
+describe("isTaskDue", () => {
+  it("returns true when task has never run", () => {
+    expect(isTaskDue(undefined, "30m", Date.now())).toBe(true);
+  });
+
+  it("returns true when interval has elapsed", () => {
+    const now = 1_000_000;
+    expect(isTaskDue(now - 31 * 60 * 1000, "30m", now)).toBe(true);
+  });
+
+  it("returns false when interval has not elapsed", () => {
+    const now = 1_000_000;
+    expect(isTaskDue(now - 10 * 60 * 1000, "30m", now)).toBe(false);
+  });
+
+  it("returns true when lastRunMs is in the future (clock skew)", () => {
+    const now = 1_000_000;
+    expect(isTaskDue(now + 5 * 60 * 1000, "30m", now)).toBe(true);
   });
 });

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -26,6 +26,22 @@ describe("stripHeartbeatToken", () => {
     });
   });
 
+  it("does not bleed top-level interval/prompt fields into task parsing", () => {
+    const content = `
+    tasks:- name: email-check
+    interval: 30m
+    prompt: Check for urgent emails
+interval: should-not-bleed
+`;
+    expect(parseHeartbeatTasks(content)).toEqual([
+      {
+        name: "email-check",
+        interval: "30m",
+        prompt: "Check for urgent emails",
+      },
+    ]);
+  });
+
   it("drops heartbeats with small junk in heartbeat mode", () => {
     expect(stripHeartbeatToken("HEARTBEAT_OK 🦞", { mode: "heartbeat" })).toEqual({
       shouldSkip: true,

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -26,22 +26,6 @@ describe("stripHeartbeatToken", () => {
     });
   });
 
-  it("does not bleed top-level interval/prompt fields into task parsing", () => {
-    const content = `
-    tasks:- name: email-check
-    interval: 30m
-    prompt: Check for urgent emails
-interval: should-not-bleed
-`;
-    expect(parseHeartbeatTasks(content)).toEqual([
-      {
-        name: "email-check",
-        interval: "30m",
-        prompt: "Check for urgent emails",
-      },
-    ]);
-  });
-
   it("drops heartbeats with small junk in heartbeat mode", () => {
     expect(stripHeartbeatToken("HEARTBEAT_OK 🦞", { mode: "heartbeat" })).toEqual({
       shouldSkip: true,

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -285,8 +285,8 @@ export function parseHeartbeatTasks(content: string): HeartbeatTask[] {
  * Check if a task is due based on its interval and last run time.
  */
 export function isTaskDue(lastRunMs: number | undefined, interval: string, nowMs: number): boolean {
-  if (lastRunMs === undefined) {
-    return true; // Never run, always due
+  if (lastRunMs === undefined || lastRunMs > nowMs) {
+    return true; // Never run, or clock moved backward — treat as due
   }
 
   try {


### PR DESCRIPTION
## Summary

- Problem: `isTaskDue` silently fails when system clock moves backward (NTP correction, VM resume, timezone change). `nowMs - lastRunMs` becomes negative so the task never runs.
- Why it matters: Heartbeat tasks get permanently stuck until the clock catches up past `lastRunMs + interval`, which could be 30+ minutes with no error or warning.
- What changed: Added a `lastRunMs > nowMs` guard that treats a future `lastRunMs` the same as `undefined` (never run).
- What did NOT change: All existing behavior for normal clock progression is unchanged.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Gateway / orchestration

## Linked Issue/PR
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: `isTaskDue` computes `nowMs - lastRunMs` without checking if `lastRunMs` is in the future. A backward clock jump makes this negative, so the condition `>= intervalMs` is never true.
- Missing detection / guardrail: No guard for `lastRunMs > nowMs` (clock skew scenario).
- Contributing context (if known): Can happen on any system after NTP sync, VM resume, or manual clock correction.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/auto-reply/heartbeat.test.ts`
- Scenario the test should lock in: `isTaskDue` returns `true` when `lastRunMs > nowMs`
- Why this is the smallest reliable guardrail: Pure function, no dependencies, single condition check.
- Existing test that already covers this (if any): None — `isTaskDue` had zero tests before this PR.
- If no new test is added, why not: N/A — test added.

## User-visible / Behavior Changes
Heartbeat tasks now resume immediately after a clock correction instead of being stuck for up to `interval` minutes.

## Diagram (if applicable)
```text
Before:
[clock skew] -> lastRunMs=future -> nowMs - lastRunMs < 0 -> task stuck forever

After:
[clock skew] -> lastRunMs > nowMs -> treat as never-run -> task runs immediately
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): N/A

### Steps
1. Set `lastRunMs` to a future timestamp (simulating clock skew)
2. Call `isTaskDue(futureMs, "30m", nowMs)`
3. Observe result

### Expected
- `true` (task should run)

### Actual (before fix)
- `false` (task permanently stuck)

## Evidence
- [x] Failing test before + passing after (new unit tests added)

## Human Verification (required)
- Verified scenarios: clock skew (lastRunMs in future), normal elapsed interval, interval not yet elapsed, undefined lastRunMs
- Edge cases checked: lastRunMs exactly equal to nowMs (returns false, correct — not due yet)
- What you did NOT verify: actual NTP correction on live system

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Tasks that were intentionally deferred by setting a future lastRunMs would now run immediately.
  - Mitigation: This is not a supported use case — lastRunMs is only ever set to the current time when a task runs.