### PR TITLE
Tasks: mark stale ACP zombie sessions lost during maintenance

### DIFF
--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AcpSessionStoreEntry } from "../acp/runtime/session-meta.js";
 import type { SessionEntry } from "../config/sessions.js";
@@ -80,6 +81,7 @@ function createTaskRegistryMaintenanceHarness(params: {
             sessionKey: "",
             storeSessionKey: "",
             entry: acpEntry,
+            acp: acpEntry?.acp,
             storeReadFailed: false,
           } satisfies AcpSessionStoreEntry)
         : ({
@@ -88,6 +90,7 @@ function createTaskRegistryMaintenanceHarness(params: {
             sessionKey: "",
             storeSessionKey: "",
             entry: undefined,
+            acp: undefined,
             storeReadFailed: false,
           } satisfies AcpSessionStoreEntry),
     loadSessionStore: params.loadSessionStore ?? (() => sessionStore),
@@ -408,6 +411,109 @@ describe("task-registry maintenance issue #60299", () => {
 
     expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
     expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("marks stale ACP tasks lost when metadata still says running but the transcript file is gone", async () => {
+    const childSessionKey = "agent:codex:acp:zombie-session";
+    const now = Date.now();
+    const task = makeStaleTask({
+      runtime: "acp",
+      childSessionKey,
+      createdAt: now - GRACE_EXPIRED_MS - 8 * 24 * 60 * 60_000,
+      startedAt: now - GRACE_EXPIRED_MS - 8 * 24 * 60 * 60_000,
+      lastEventAt: now - GRACE_EXPIRED_MS - 8 * 24 * 60 * 60_000,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      acpEntry: {
+        sessionId: childSessionKey,
+        updatedAt: now - 8 * 24 * 60 * 60_000,
+        sessionFile: undefined,
+        acp: {
+          backend: "codex",
+          agent: "codex",
+          runtimeSessionName: "zombie-session",
+          mode: "persistent",
+          state: "running",
+          lastActivityAt: now - 8 * 24 * 60 * 60_000,
+        },
+      },
+    });
+
+    expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("marks stale ACP tasks lost when sessionFile points to a nonexistent file", async () => {
+    const childSessionKey = "agent:codex:acp:dangling-session";
+    const now = Date.now();
+    const danglingPath = `/tmp/nonexistent-acp-zombie-${Date.now()}.jsonl`;
+    const task = makeStaleTask({
+      runtime: "acp",
+      childSessionKey,
+      createdAt: now - GRACE_EXPIRED_MS - 8 * 24 * 60 * 60_000,
+      startedAt: now - GRACE_EXPIRED_MS - 8 * 24 * 60 * 60_000,
+      lastEventAt: now - GRACE_EXPIRED_MS - 8 * 24 * 60 * 60_000,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      acpEntry: {
+        sessionId: childSessionKey,
+        updatedAt: now - 8 * 24 * 60 * 60_000,
+        sessionFile: danglingPath,
+        acp: {
+          backend: "codex",
+          agent: "codex",
+          runtimeSessionName: "dangling-session",
+          mode: "persistent",
+          state: "running",
+          lastActivityAt: now - 8 * 24 * 60 * 60_000,
+        },
+      },
+    });
+
+    expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+    expect(currentTasks.get(task.taskId)).toMatchObject({ status: "lost" });
+  });
+
+  it("keeps stale ACP tasks live when the transcript file exists on disk", async () => {
+    const childSessionKey = "agent:codex:acp:live-session";
+    const now = Date.now();
+    const task = makeStaleTask({
+      runtime: "acp",
+      childSessionKey,
+      createdAt: now - GRACE_EXPIRED_MS - 8 * 24 * 60 * 60_000,
+      startedAt: now - GRACE_EXPIRED_MS - 8 * 24 * 60 * 60_000,
+      lastEventAt: now - GRACE_EXPIRED_MS - 8 * 24 * 60 * 60_000,
+    });
+
+    const livePath = `/tmp/acp-live-session-${Date.now()}.jsonl`;
+    fs.writeFileSync(livePath, '{"type":"session"}\n');
+    try {
+      const { currentTasks } = createTaskRegistryMaintenanceHarness({
+        tasks: [task],
+        acpEntry: {
+          sessionId: childSessionKey,
+          updatedAt: now - 8 * 24 * 60 * 60_000,
+          sessionFile: livePath,
+          acp: {
+            backend: "codex",
+            agent: "codex",
+            runtimeSessionName: "live-session",
+            mode: "persistent",
+            state: "running",
+            lastActivityAt: now - 8 * 24 * 60 * 60_000,
+          },
+        },
+      });
+
+      expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 0 });
+      expect(currentTasks.get(task.taskId)).toMatchObject({ status: "running" });
+    } finally {
+      fs.rmSync(livePath, { force: true });
+    }
   });
 
   it("keeps chat-backed cli tasks live while the owning run context is still active", async () => {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import {
   listAcpSessionEntries,
@@ -464,7 +465,13 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
     if (!acpEntry || acpEntry.storeReadFailed) {
       return true;
     }
-    return Boolean(acpEntry.entry);
+    if (!acpEntry.entry) {
+      return false;
+    }
+    if (hasZombieAcpBackingSession(task, Date.now(), acpEntry)) {
+      return false;
+    }
+    return true;
   }
   if (task.runtime === "subagent" || task.runtime === "cli") {
     if (task.runtime === "cli") {
@@ -481,6 +488,52 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
   }
 
   return true;
+}
+
+const ACP_ZOMBIE_STALE_MS = 7 * 24 * 60 * 60 * 1000;
+
+function hasZombieAcpBackingSession(
+  task: TaskRecord,
+  now: number,
+  acpEntry?: AcpSessionStoreEntry | null,
+): boolean {
+  if (task.runtime !== "acp") {
+    return false;
+  }
+  const childSessionKey = task.childSessionKey?.trim();
+  if (!childSessionKey) {
+    return false;
+  }
+  acpEntry ??= taskRegistryMaintenanceRuntime.readAcpSessionEntry({
+    sessionKey: childSessionKey,
+  });
+  if (!acpEntry || acpEntry.storeReadFailed || !acpEntry.entry || !acpEntry.acp) {
+    return false;
+  }
+  if (acpEntry.acp.state !== "running") {
+    return false;
+  }
+  const referenceAt = task.lastEventAt ?? task.startedAt ?? task.createdAt;
+  const entryUpdatedAt = acpEntry.entry.updatedAt ?? 0;
+  const lastActivityAt = acpEntry.acp.lastActivityAt ?? 0;
+  const freshestSeenAt = Math.max(referenceAt, entryUpdatedAt, lastActivityAt);
+  if (now - freshestSeenAt < ACP_ZOMBIE_STALE_MS) {
+    return false;
+  }
+  // Check if stored sessionFile exists on disk; missing metadata or
+  // dangling path (file deleted but path retained) both count as zombie.
+  const sessionFile = acpEntry.entry.sessionFile;
+  if (!sessionFile) {
+    return true;
+  }
+  try {
+    if (!fs.existsSync(sessionFile)) {
+      return true;
+    }
+  } catch {
+    return true;
+  }
+  return false;
 }
 
 function resolveTaskLostError(task: TaskRecord, context?: BackingSessionLookupContext): string {


### PR DESCRIPTION
## Summary
- detect stale ACP task records whose ACP metadata still reports `running` but whose session transcript file is gone
- treat those ACP zombie sessions as missing backing sessions during task-registry maintenance
- add regression coverage for both the zombie and still-live ACP cases

## Testing
- `npx vitest run src/tasks/task-registry.maintenance.issue-60299.test.ts`
- `npx vitest run src/commands/status.test.ts`
