### PR TITLE
Doctor: add regression coverage for archived transcript artifacts in orphan checks

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -440,6 +440,23 @@ describe("doctor state integrity oauth dir checks", () => {
     },
   );
 
+  it("ignores archived deleted transcript files when checking for orphan transcripts", async () => {
+    const cfg: OpenClawConfig = {};
+    setupSessionState(cfg, process.env, process.env.HOME ?? "");
+    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
+    fs.writeFileSync(
+      path.join(sessionsDir, "orphan-session.jsonl.deleted.2026-04-10T00-00-00.000Z"),
+      '{"type":"session"}\n',
+    );
+
+    const confirmRuntimeRepair = vi.fn(async () => false);
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+
+    expect(stateIntegrityText()).not.toContain(
+      "These .jsonl files are no longer referenced by sessions.json",
+    );
+    expect(confirmRuntimeRepair).not.toHaveBeenCalled();
+  });
   it("suppresses orphan transcript warnings when QMD sessions are enabled", async () => {
     const confirmRuntimeRepair = await runOrphanTranscriptCheckWithQmdSessions(true, tempHome);
 


### PR DESCRIPTION
## Summary
- add regression coverage ensuring archived `*.jsonl.deleted.<timestamp>` transcript artifacts do not trigger doctor orphan-transcript warnings
- keep orphan detection focused on active primary transcript files only

## Testing
- `npx vitest run src/commands/doctor-state-integrity.test.ts`
