### PR TITLE
fix(gateway): harden agent-to-agent routing, timeout handling, and main-session metadata sanitization

### DIFF
--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -157,6 +157,19 @@ You are free to edit `HEARTBEAT.md` with a short checklist or reminders. Keep it
 
 **Tip:** Batch similar periodic checks into `HEARTBEAT.md` instead of creating multiple cron jobs. Use cron for precise schedules and standalone tasks.
 
+### Pending-Review Anti-Loop Policy (Template)
+
+Use this policy to avoid false idle detection on long-running delegated tasks.
+
+- If user intent is ambiguous or a restart happened mid-flow, set workflow state to `pending-review`.
+- Record this minimum state: `lastConfirmedIntent`, `lastSuccessfulStage`, `blockedStage`, `expectedDuration`, and `nextReversibleAction`.
+- Before any recovery re-dispatch, compute an `intentHash` (same stage + same objective + same expected output).
+- If the same `intentHash` is already in-flight, mark `active-longrun` and do not re-dispatch.
+- Long tasks are active while any progress signal exists in the stall window: token growth, session `updatedAt`, artifact timestamp change, or task `lastEventAt`.
+- Recommended stall windows by task class: quick >= 10m, analytical >= 30m, heavy >= 90m.
+- Allow at most one recovery re-dispatch per `intentHash` per cooldown window (default 6h).
+- If recovery still returns timeout/no actionable output, stop auto-retries and ask user with fixed options: continue waiting, revise scope, or terminate branch.
+
 **Things to check (rotate through these, 2-4 times per day):**
 
 - **Emails** - Any urgent unread messages?

--- a/docs/reference/templates/HEARTBEAT.md
+++ b/docs/reference/templates/HEARTBEAT.md
@@ -11,4 +11,35 @@ read_when:
 # Keep this file empty (or with only comments) to skip heartbeat API calls.
 
 # Add tasks below when you want the agent to check something periodically.
+
+# Optional: Pending-review anti-loop state for long-running delegated tasks
+
+## WorkflowState
+
+- status: active|active-longrun|pending-review|blocked
+- stage: <current stage>
+- lastConfirmedIntent: <summary>
+- lastSuccessfulStage: <stage>
+- blockedStage: <stage or none>
+- expectedDuration: quick|analytical|heavy
+- intentHash: <stable hash for stage+objective+expected output>
+
+## ProgressSignals
+
+- lastSessionUpdatedAt: <iso8601>
+- lastTaskEventAt: <iso8601>
+- lastTokenGrowthAt: <iso8601>
+- lastArtifactChangeAt: <iso8601>
+
+## RecoveryPolicy
+
+- stallWindowMinutes: quick=10, analytical=30, heavy=90
+- cooldownHoursPerIntentHash: 6
+- maxRecoveryDispatchPerCooldown: 1
+
+## RecoveryDecision
+
+- if no progress across full stall window: enter pending-review
+- if same intentHash already in-flight: keep active-longrun, do not redispatch
+- if recovery exhausted: ask user with fixed options (continue waiting|revise scope|terminate branch)
 ```

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -121,8 +121,6 @@ export async function runSessionsSendA2AFlow(params: {
       extraSystemPrompt: announcePrompt,
       timeoutMs: params.announceTimeoutMs,
       lane: AGENT_LANE_NESTED,
-      sourceSessionKey: params.requesterSessionKey,
-      sourceChannel: params.requesterChannel,
       sourceTool: "sessions_send",
     });
     if (announceTarget && announceReply && announceReply.trim() && !isAnnounceSkip(announceReply)) {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -42,6 +42,37 @@ const SessionsSendToolSchema = Type.Object({
 
 type GatewayCaller = typeof callGateway;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
+const MIN_AGENT_TO_AGENT_TIMEOUT_SECONDS = 45;
+
+function resolveSessionsSendTimeoutSeconds(
+  params: Record<string, unknown>,
+  options?: {
+    requesterSessionKey?: string;
+    targetSessionKey?: string;
+  },
+): number {
+  const requestedTimeoutSeconds =
+    typeof params.timeoutSeconds === "number" && Number.isFinite(params.timeoutSeconds)
+      ? Math.max(0, Math.floor(params.timeoutSeconds))
+      : 30;
+
+  if (requestedTimeoutSeconds === 0) {
+    return 0;
+  }
+
+  const requesterAgentId = options?.requesterSessionKey
+    ? resolveAgentIdFromSessionKey(options.requesterSessionKey)
+    : undefined;
+  const targetAgentId = options?.targetSessionKey
+    ? resolveAgentIdFromSessionKey(options.targetSessionKey)
+    : undefined;
+
+  if (requesterAgentId && targetAgentId) {
+    return Math.max(MIN_AGENT_TO_AGENT_TIMEOUT_SECONDS, requestedTimeoutSeconds);
+  }
+
+  return requestedTimeoutSeconds;
+}
 
 async function startAgentRun(params: {
   callGateway: GatewayCaller;
@@ -228,10 +259,10 @@ export function createSessionsSendTool(opts?: {
       // Normalize sessionKey/sessionId input into a canonical session key.
       const resolvedKey = visibleSession.key;
       const displayKey = visibleSession.displayKey;
-      const timeoutSeconds =
-        typeof params.timeoutSeconds === "number" && Number.isFinite(params.timeoutSeconds)
-          ? Math.max(0, Math.floor(params.timeoutSeconds))
-          : 30;
+      const timeoutSeconds = resolveSessionsSendTimeoutSeconds(params, {
+        requesterSessionKey: effectiveRequesterKey,
+        targetSessionKey: resolvedKey,
+      });
       const timeoutMs = timeoutSeconds * 1000;
       const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
       const idempotencyKey = crypto.randomUUID();
@@ -280,8 +311,6 @@ export function createSessionsSendTool(opts?: {
         extraSystemPrompt: agentMessageContext,
         inputProvenance: {
           kind: "inter_session",
-          sourceSessionKey: opts?.agentSessionKey,
-          sourceChannel: opts?.agentChannel,
           sourceTool: "sessions_send",
         },
       };

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -951,6 +951,43 @@ describe("gateway agent handler", () => {
     expect(callArgs.runContext?.messageChannel).toBe("webchat");
   });
 
+  it("clears stale qq routing metadata from webchat-backed main sessions", async () => {
+    mockMainSessionEntry({
+      sessionId: "existing-session-id",
+      channel: "qqbot",
+      lastChannel: "webchat",
+      chatType: "group",
+      displayName: "qqbot:legacy-group",
+      origin: {
+        provider: "qqbot",
+        chatType: "group",
+      },
+      groupId: "legacy-group-id",
+      subject: "Legacy Group",
+      groupChannel: "qqbot",
+      space: "legacy-space",
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    const capturedEntry = await runMainAgentAndCaptureEntry("test-webchat-route-sanitization");
+
+    expect(capturedEntry).toMatchObject({
+      sessionId: "existing-session-id",
+      channel: "webchat",
+      lastChannel: "webchat",
+    });
+    expect(capturedEntry?.chatType).toBeUndefined();
+    expect(capturedEntry?.displayName).toBeUndefined();
+    expect(capturedEntry?.origin).toBeUndefined();
+    expect(capturedEntry?.groupId).toBeUndefined();
+    expect(capturedEntry?.subject).toBeUndefined();
+    expect(capturedEntry?.groupChannel).toBeUndefined();
+    expect(capturedEntry?.space).toBeUndefined();
+  });
+
   it("tracks async gateway agent runs in the shared task registry", async () => {
     await withTempDir({ prefix: "openclaw-gateway-agent-task-" }, async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -563,6 +563,20 @@ export const agentHandlers: GatewayRequestHandlers = {
       resolvedGroupChannel = resolvedGroupChannel || inheritedGroup?.groupChannel;
       resolvedGroupSpace = resolvedGroupSpace || inheritedGroup?.groupSpace;
       const deliveryFields = normalizeSessionDeliveryFields(entry);
+      const routeMainSessionKey = resolveAgentMainSessionKey({ cfg, agentId: sessionAgent });
+      const routeChannel =
+        deliveryFields.lastChannel ??
+        entry?.lastChannel ??
+        entry?.channel ??
+        request.channel?.trim();
+      const shouldClearInheritedRouteMeta =
+        canonicalKey === routeMainSessionKey &&
+        routeChannel === "webchat" &&
+        (entry?.chatType === "group" ||
+          entry?.origin?.chatType === "group" ||
+          entry?.channel === "qqbot" ||
+          entry?.origin?.provider === "qqbot" ||
+          Boolean(entry?.displayName?.startsWith("qqbot:")));
       const nextEntryPatch: SessionEntry = {
         sessionId,
         updatedAt: now,
@@ -584,10 +598,16 @@ export const agentHandlers: GatewayRequestHandlers = {
         spawnedBy: spawnedByValue,
         spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
         spawnDepth: entry?.spawnDepth,
-        channel: entry?.channel ?? request.channel?.trim(),
-        groupId: resolvedGroupId ?? entry?.groupId,
-        groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
-        space: resolvedGroupSpace ?? entry?.space,
+        channel: routeChannel,
+        chatType: shouldClearInheritedRouteMeta ? undefined : entry?.chatType,
+        displayName: shouldClearInheritedRouteMeta ? undefined : entry?.displayName,
+        origin: shouldClearInheritedRouteMeta ? undefined : entry?.origin,
+        groupId: shouldClearInheritedRouteMeta ? undefined : (resolvedGroupId ?? entry?.groupId),
+        subject: shouldClearInheritedRouteMeta ? undefined : entry?.subject,
+        groupChannel: shouldClearInheritedRouteMeta
+          ? undefined
+          : (resolvedGroupChannel ?? entry?.groupChannel),
+        space: shouldClearInheritedRouteMeta ? undefined : (resolvedGroupSpace ?? entry?.space),
         cliSessionIds: entry?.cliSessionIds,
         claudeCliSessionId: entry?.claudeCliSessionId,
       };
@@ -596,8 +616,8 @@ export const agentHandlers: GatewayRequestHandlers = {
         cfg,
         entry,
         sessionKey: canonicalKey,
-        channel: entry?.channel,
-        chatType: entry?.chatType,
+        channel: routeChannel,
+        chatType: shouldClearInheritedRouteMeta ? undefined : entry?.chatType,
       });
       if (sendPolicy === "deny") {
         respond(

--- a/src/infra/outbound/message-action-runner.threading.test.ts
+++ b/src/infra/outbound/message-action-runner.threading.test.ts
@@ -86,6 +86,45 @@ describe("message action threading helpers", () => {
     expect(ensureOutboundSessionEntry).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves currentSessionKey for outbound mirroring when present", async () => {
+    const actionParams: Record<string, unknown> = {
+      channel: "qqbot",
+      target: "qqbot:c2c:3939A3986EAE03D9FC2E266CAF10F997",
+      message: "hi",
+    };
+    resolveOutboundSessionRoute.mockResolvedValue({
+      sessionKey: "agent:technical_architect:qqbot:group:c2c:3939a3986eae03d9fc2e266caf10f997",
+      baseSessionKey: "agent:technical_architect:qqbot:group:c2c:3939a3986eae03d9fc2e266caf10f997",
+      peer: { id: "c2c:3939a3986eae03d9fc2e266caf10f997", kind: "group" },
+      chatType: "group",
+      from: "qqbot:group:c2c:3939A3986EAE03D9FC2E266CAF10F997",
+      to: "channel:c2c:3939A3986EAE03D9FC2E266CAF10F997",
+    });
+
+    const result = await prepareOutboundMirrorRoute({
+      cfg: {} as OpenClawConfig,
+      channel: "qqbot",
+      to: "qqbot:c2c:3939A3986EAE03D9FC2E266CAF10F997",
+      actionParams,
+      agentId: "technical_architect",
+      currentSessionKey: "agent:technical_architect:main",
+      resolveOutboundSessionRoute,
+      ensureOutboundSessionEntry,
+    });
+
+    expect(result.outboundRoute?.sessionKey).toBe("agent:technical_architect:main");
+    expect(result.outboundRoute?.baseSessionKey).toBe("agent:technical_architect:main");
+    expect(actionParams.__sessionKey).toBe("agent:technical_architect:main");
+    expect(ensureOutboundSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        route: expect.objectContaining({
+          sessionKey: "agent:technical_architect:main",
+          baseSessionKey: "agent:technical_architect:main",
+        }),
+      }),
+    );
+  });
+
   it.each([
     {
       name: "injects threadId for matching target",

--- a/src/infra/outbound/message-action-threading.ts
+++ b/src/infra/outbound/message-action-threading.ts
@@ -72,7 +72,7 @@ export async function prepareOutboundMirrorRoute(params: {
     toolContext: params.toolContext,
     resolveAutoThreadId: params.resolveAutoThreadId,
   });
-  const outboundRoute =
+  const resolvedRoute =
     params.agentId && !params.dryRun
       ? await params.resolveOutboundSessionRoute({
           cfg: params.cfg,
@@ -86,6 +86,14 @@ export async function prepareOutboundMirrorRoute(params: {
           threadId: resolvedThreadId,
         })
       : null;
+  const outboundRoute =
+    resolvedRoute && params.currentSessionKey
+      ? {
+          ...resolvedRoute,
+          sessionKey: params.currentSessionKey,
+          baseSessionKey: params.currentSessionKey,
+        }
+      : resolvedRoute;
   if (outboundRoute && params.agentId && !params.dryRun) {
     await params.ensureOutboundSessionEntry({
       cfg: params.cfg,


### PR DESCRIPTION
# PR Title

fix(gateway): harden agent-to-agent routing, timeout handling, and main-session metadata sanitization

## 中文问题说明

### 背景

在一个长期运行的多 agent 软件工厂场景中，我们发现 OpenClaw 的跨代理协同存在三个相互叠加的问题：

1. `sessions_send` 在代理之间通信时会受到过短默认超时影响，复杂任务或串行协作场景下容易提前超时。
2. agent 主会话在已经切换到 `webchat` 语义后，仍可能保留旧的 `qqbot/group` 路由元数据，导致会话展示、回包路径和 announce 行为被脏历史状态污染。
3. outbound mirror 在已知当前主会话的情况下，仍可能重新解析出新的镜像 session key，造成跨代理回复继续绑定到错误的历史路由。

这些问题在多 agent 串行协作时会表现为：

1. 某些 agent 间消息无故超时
2. 某些 agent 返回 `NO_REPLY` 或错误地尝试走外部渠道回复
3. session 列表显示为错误的 channel/chatType/displayName
4. 修复运行态后，后续消息又因为旧 session 元数据被重新污染

### 根因

1. `sessions_send` 没有对 agent-to-agent 场景施加更保守的最小时限，导致复杂链路在默认值下容易失败。
2. gateway 在持久化 canonical main session 时，会继承旧的 session 路由字段，但没有在 `webchat` 主会话场景下主动清理不再成立的 `qqbot/group` 元数据。
3. outbound mirror 路由在已有 `currentSessionKey` 的情况下，没有优先保留当前会话连续性。

## 中文修复说明

本 PR 做了以下修复：

1. 为 agent-to-agent `sessions_send` 增加最小超时下限 `45s`，避免复杂代理协作链路被过短超时截断。
2. 在 `sessions_send` 的 inter-session / announce 流程中移除不必要的 `sourceSessionKey` / `sourceChannel` 注入，减少错误 provenance 对后续 routing 的干扰。
3. 在 gateway 的 agent session 持久化逻辑中，当 canonical main session 已经明确属于 `webchat` 路由时，清理继承下来的陈旧 `qqbot/group` 元数据，包括：
   - `chatType`
   - `displayName`
   - `origin`
   - `groupId`
   - `subject`
   - `groupChannel`
   - `space`
4. 在 outbound mirroring 逻辑中，如果当前运行上下文已经携带 `currentSessionKey`，则优先保留该 session key，避免镜像路由漂移到历史错误 session。
5. 补充回归测试，覆盖：
   - outbound mirroring 保留 `currentSessionKey`
   - `webchat` 主会话清除陈旧 `qqbot/group` 元数据

### 影响

这组修复主要改善以下场景：

1. 多 agent 串行或嵌套协作
2. 从外部渠道历史会话迁移到 `webchat` 主会话后的 session 正常化
3. agent-to-agent announce / reply-back 场景中的 routing 连续性

## English Problem Statement

### Background

In a long-running multi-agent automation setup, we observed three compounding issues in OpenClaw's cross-agent coordination flow:

1. `sessions_send` used timeouts that were too aggressive for agent-to-agent collaboration, causing complex or chained requests to fail prematurely.
2. Canonical main agent sessions could retain stale inherited `qqbot/group` routing metadata even after the effective delivery context had become `webchat`.
3. Outbound mirror routing could rebind to a newly resolved historical route even when the current run already knew the correct `currentSessionKey`.

In practice, these issues showed up as:

1. unexpected agent-to-agent timeouts
2. `NO_REPLY` or incorrect external-channel reply behavior in A2A scenarios
3. wrong `channel`, `chatType`, or `displayName` in session listings
4. repaired runtime state becoming polluted again by persisted stale metadata

### Root Cause

1. Agent-to-agent `sessions_send` calls did not enforce a safer minimum timeout for multi-step coordination.
2. Gateway session persistence reused inherited routing metadata without sanitizing stale `qqbot/group` fields when the canonical main session was now clearly a `webchat` session.
3. Outbound mirroring did not consistently preserve the active session continuity when `currentSessionKey` was already known.

## English Fix Summary

This PR makes the following changes:

1. Introduces a `45s` minimum timeout floor for agent-to-agent `sessions_send` flows.
2. Removes unnecessary `sourceSessionKey` / `sourceChannel` propagation in inter-session and announce paths to reduce misleading provenance in A2A flows.
3. Sanitizes stale inherited `qqbot/group` metadata when persisting canonical main sessions that now route through `webchat`, clearing fields such as:
   - `chatType`
   - `displayName`
   - `origin`
   - `groupId`
   - `subject`
   - `groupChannel`
   - `space`
4. Preserves `currentSessionKey` for outbound mirroring when it is already available, preventing route drift to historical mirror sessions.
5. Adds regression coverage for:
   - preserving `currentSessionKey` in outbound mirroring
   - clearing stale `qqbot/group` metadata for `webchat`-backed main sessions

## Validation

Focused tests executed against the fix branch:

1. `src/gateway/server-methods/agent.test.ts`
2. `src/agents/tools/sessions-send-tool.a2a.test.ts`
3. `src/infra/outbound/message-action-runner.threading.test.ts`

All targeted tests passed locally.

## Branch / Commit

Local branch prepared for push:

- `fix/a2a-routing-and-session-sanitization`

Validated local commit:

- `eb2eba62521deea5db12bf472603845ea247e8c3`