### PR TITLE
fix(memory-wiki): preserve non-Latin characters in wiki slugs

### DIFF
--- a/extensions/memory-wiki/src/claim-health.ts
+++ b/extensions/memory-wiki/src/claim-health.ts
@@ -65,8 +65,10 @@ function normalizeClaimTextKey(text: string): string {
 }
 
 function normalizeTextKey(text: string): string {
+  // Use Unicode-aware regex so CJK and other non-Latin contradiction
+  // notes produce distinct keys instead of collapsing to empty (#64620).
   return normalizeLowercaseStringOrEmpty(text)
-    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
     .replace(/\s+/g, " ");
 }
 

--- a/extensions/memory-wiki/src/markdown.test.ts
+++ b/extensions/memory-wiki/src/markdown.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { slugifyWikiSegment } from "./markdown.js";
+
+describe("slugifyWikiSegment (#64620)", () => {
+  it("slugifies ASCII text normally", () => {
+    expect(slugifyWikiSegment("Hello World")).toBe("hello-world");
+    expect(slugifyWikiSegment("my-page-title")).toBe("my-page-title");
+    expect(slugifyWikiSegment("  spaced  out  ")).toBe("spaced-out");
+  });
+
+  it("preserves CJK characters in slugs", () => {
+    expect(slugifyWikiSegment("大语言模型概述")).toBe("大语言模型概述");
+    expect(slugifyWikiSegment("断路器自动恢复")).toBe("断路器自动恢复");
+  });
+
+  it("produces distinct slugs for different CJK titles", () => {
+    const slug1 = slugifyWikiSegment("大语言模型概述");
+    const slug2 = slugifyWikiSegment("断路器自动恢复");
+    expect(slug1).not.toBe(slug2);
+    expect(slug1).not.toBe("page");
+    expect(slug2).not.toBe("page");
+  });
+
+  it("handles mixed ASCII and CJK text", () => {
+    expect(slugifyWikiSegment("LLM 大语言模型 overview")).toBe("llm-大语言模型-overview");
+  });
+
+  it("preserves Cyrillic and other non-Latin scripts", () => {
+    expect(slugifyWikiSegment("Привет мир")).toBe("привет-мир");
+  });
+
+  it("falls back to 'page' only when input is empty or all-punctuation", () => {
+    expect(slugifyWikiSegment("")).toBe("page");
+    expect(slugifyWikiSegment("!@#$%")).toBe("page");
+    expect(slugifyWikiSegment("   ")).toBe("page");
+  });
+});

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -67,8 +67,11 @@ const RELATED_BLOCK_PATTERN = new RegExp(
 );
 
 export function slugifyWikiSegment(raw: string): string {
+  // Use Unicode-aware \p{L} (letters) and \p{N} (numbers) so CJK,
+  // Cyrillic, Arabic, and other non-Latin scripts produce meaningful
+  // slugs instead of collapsing to the "page" fallback (#64620).
   const slug = normalizeLowercaseStringOrEmpty(raw)
-    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
     .replace(/-+/g, "-")
     .replace(/^-+|-+$/g, "");
   return slug || "page";


### PR DESCRIPTION
## Summary

`slugifyWikiSegment()` and `normalizeTextKey()` in the Memory Wiki plugin use `/[^a-z0-9]+/g` which strips all non-ASCII characters. CJK, Cyrillic, Arabic, and other non-Latin titles collapse to the `"page"` fallback slug, causing wiki pages to silently overwrite each other and contradiction deduplication to treat distinct notes as identical.

Fixes #64620

## Impact

- **Chinese/Japanese/Korean titles** → `syntheses/page.md` (instead of `syntheses/大语言模型概述.md`)
- **Multiple CJK-only pages** silently overwrite each other (all map to `page.md`)
- **Contradiction deduplication** treats all CJK notes as identical (empty key after stripping)
- Affects every non-Latin-script user of Memory Wiki

## Root cause

```ts
// extensions/memory-wiki/src/markdown.ts:71 (before fix)
.replace(/[^a-z0-9]+/g, "-")  // strips ALL non-ASCII

// extensions/memory-wiki/src/claim-health.ts:69 (before fix)
.replace(/[^a-z0-9]+/g, " ")  // same pattern for text key normalization
```

## Fix

Replace `/[^a-z0-9]+/g` with `/[^\p{L}\p{N}]+/gu` (Unicode property escapes) in both functions:

- `\p{L}` matches letters from all scripts (Latin, CJK, Cyrillic, Arabic, etc.)
- `\p{N}` matches numbers from all scripts
- `/u` flag enables Unicode mode

This produces meaningful slugs like `大语言模型概述` instead of `page`, while preserving the existing ASCII slug behavior (hyphen-separated lowercase).

### Before/after examples

| Input | Before | After |
|-------|--------|-------|
| `"大语言模型概述"` | `page` | `大语言模型概述` |
| `"断路器自动恢复"` | `page` (overwrites!) | `断路器自动恢复` |
| `"LLM 大语言模型 overview"` | `llm-overview` | `llm-大语言模型-overview` |
| `"Привет мир"` | `page` | `привет-мир` |
| `"Hello World"` | `hello-world` | `hello-world` (unchanged) |

## Tests

Added `extensions/memory-wiki/src/markdown.test.ts` with 6 cases:
1. ASCII text slugifies normally (existing behavior preserved)
2. CJK characters are preserved in slugs
3. Different CJK titles produce distinct slugs (no collision)
4. Mixed ASCII + CJK text produces a meaningful combined slug
5. Cyrillic and other non-Latin scripts preserved
6. Empty / all-punctuation input still falls back to `"page"`

## Scope

- **Files**: `markdown.ts` (+3/-1), `claim-health.ts` (+3/-1), `markdown.test.ts` (+37 new)
- **Production LOC**: 2 regex changes (identical pattern in both files)
- **oxlint clean**
- **Zero competition**: 4 open PRs target `normalizeHyphenSlug` in `src/shared/` — different function, different file, different extension

cc @vincentkoc — memory/plugins area. Credit to @fuyizheng3120 for the clear reproduction and RCA in #64620.