### PR TITLE
fix(logging): route model timing through subsystem logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: keep native web search observations out of mirrored chat transcripts while preserving tool progress telemetry. Fixes #85109. Thanks @ugitmebaby.
 - OpenCode Go: strip unsupported Kimi reasoning replay fields before provider requests so repeated `kimi-k2.6` turns do not fail schema validation. Fixes #83812. Thanks @Sleeck.
 - Browser/CDP: add a WSL2 portproxy self-loop hint when Chrome DevTools endpoints accept connections but return an empty HTTP reply. Fixes #59209. Thanks @Owlock.
+- Agents/model selection: route `OPENCLAW_DEBUG_INGRESS_TIMING` model-selection timing entries through subsystem logging so they remain visible in console logs and structured log files. (#64630) Thanks @slepybear.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -5,6 +5,44 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 
+const subsystemLoggerMock = vi.hoisted(() => {
+  const logger = {
+    subsystem: "model-selection",
+    isEnabled: vi.fn(() => true),
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  const createSubsystemLogger = vi.fn(() => logger);
+  return {
+    createSubsystemLogger,
+    logger,
+    reset() {
+      createSubsystemLogger.mockClear();
+      logger.isEnabled.mockClear();
+      logger.trace.mockClear();
+      logger.debug.mockClear();
+      logger.info.mockClear();
+      logger.warn.mockClear();
+      logger.error.mockClear();
+      logger.fatal.mockClear();
+      logger.raw.mockClear();
+      logger.child.mockClear();
+      logger.child.mockReturnValue(logger);
+    },
+  };
+});
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: subsystemLoggerMock.createSubsystemLogger,
+}));
+
 vi.mock("../../agents/model-catalog.runtime.js", () => ({
   loadModelCatalog: vi.fn(async () => [
     { provider: "anthropic", id: "claude-opus-4-6", name: "Claude Opus 4.5" },
@@ -54,6 +92,7 @@ vi.mock("../../agents/auth-profiles.runtime.js", () => ({
 afterEach(() => {
   MODEL_CONTEXT_TOKEN_CACHE.clear();
   authProfileStoreMock.reset();
+  subsystemLoggerMock.reset();
 });
 
 const makeConfiguredModel = (overrides: Record<string, unknown> = {}) => ({
@@ -68,6 +107,59 @@ const makeConfiguredModel = (overrides: Record<string, unknown> = {}) => ({
 });
 
 describe("createModelSelectionState catalog loading", () => {
+  it("routes ingress timing through the model-selection subsystem logger", async () => {
+    const previousTiming = process.env.OPENCLAW_DEBUG_INGRESS_TIMING;
+    process.env.OPENCLAW_DEBUG_INGRESS_TIMING = "1";
+    try {
+      const cfg = {
+        agents: {
+          defaults: {
+            thinkingDefault: "low",
+            models: {
+              "openai-codex/gpt-5.4": {},
+            },
+          },
+        },
+        models: {
+          providers: {
+            "openai-codex": {
+              baseUrl: "https://api.openai.com/v1",
+              models: [makeConfiguredModel()],
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      await createModelSelectionState({
+        cfg,
+        agentCfg: cfg.agents?.defaults,
+        defaultProvider: "openai-codex",
+        defaultModel: "gpt-5.4",
+        provider: "openai-codex",
+        model: "gpt-5.4",
+        hasModelDirective: false,
+        sessionKey: "discord:agent:user",
+      });
+
+      expect(subsystemLoggerMock.logger.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "session=discord:agent:user stage=configured-allowlist-built elapsedMs=",
+        ),
+        expect.objectContaining({
+          sessionKey: "discord:agent:user",
+          stage: "configured-allowlist-built",
+          details: "allowed=1 keys=1",
+        }),
+      );
+    } finally {
+      if (previousTiming === undefined) {
+        delete process.env.OPENCLAW_DEBUG_INGRESS_TIMING;
+      } else {
+        process.env.OPENCLAW_DEBUG_INGRESS_TIMING = previousTiming;
+      }
+    }
+  });
+
   it("skips full catalog loading for ordinary allowlist-backed turns", async () => {
     vi.mocked(loadModelCatalog).mockClear();
     const cfg = {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -21,6 +21,7 @@ import {
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { ThinkLevel } from "./directives.js";
@@ -72,6 +73,7 @@ function shouldLogModelSelectionTiming(): boolean {
   return process.env.OPENCLAW_DEBUG_INGRESS_TIMING === "1";
 }
 
+const modelSelectionTimingLog = createSubsystemLogger("model-selection");
 const modelCatalogRuntimeLoader = createLazyImportLoader(
   () => import("../../agents/model-catalog.runtime.js"),
 );
@@ -116,9 +118,16 @@ export async function createModelSelectionState(params: {
     if (!timingEnabled) {
       return;
     }
+    const elapsedMs = Date.now() - startMs;
     const suffix = extra ? ` ${extra}` : "";
-    console.log(
-      `[model-selection] session=${params.sessionKey ?? "(no-session)"} stage=${stage} elapsedMs=${Date.now() - startMs}${suffix}`,
+    const sessionKey = params.sessionKey ?? "(no-session)";
+    const meta: Record<string, unknown> = { sessionKey, stage, elapsedMs };
+    if (extra) {
+      meta.details = extra;
+    }
+    modelSelectionTimingLog.info(
+      `session=${sessionKey} stage=${stage} elapsedMs=${elapsedMs}${suffix}`,
+      meta,
     );
   };
   const {


### PR DESCRIPTION
## Summary
- replaces the broad console-log cleanup shape with one concrete diagnostics fix: `OPENCLAW_DEBUG_INGRESS_TIMING` model-selection timing now goes through the `model-selection` subsystem logger
- keeps dotenv and user-facing Tailscale command output out of this patch because current `main` already covers the former and the latter is not diagnostic logging
- adds regression coverage and an unreleased changelog entry crediting @slepybear

## Verification
- `git diff --check origin/main...HEAD`
- `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- remote proof attempted but blocked before test execution: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --shell -- "pnpm test:serial src/auto-reply/reply/model-selection.test.ts"` failed because Blacksmith is not authenticated
- direct AWS Crabbox fallback attempted but blocked before test execution: `../crabbox/bin/crabbox run --provider aws --shell -- "pnpm test:serial src/auto-reply/reply/model-selection.test.ts"` failed because AWS credentials/IMDS role are unavailable

Behavior addressed: `OPENCLAW_DEBUG_INGRESS_TIMING` model-selection timing used a bare debug console path, so structured log files could miss a concrete diagnostic signal.
Real environment tested: not completed; both permitted remote runners are blocked before command execution in this environment.
Exact steps or command run after this patch: `git diff --check origin/main...HEAD`; autoreview command listed above; remote Crabbox/Testbox commands listed above.
Evidence after fix: focused regression coverage is included in `src/auto-reply/reply/model-selection.test.ts`; autoreview is clean.
Observed result after fix: static diff check and autoreview pass; remote runtime proof is blocked by runner auth/credentials.
What was not tested: the focused Vitest file and `pnpm check:changed` were not run because local testing is disallowed for this task and remote runners are unavailable.
