### PR TITLE
[codex] Fix memory-search config resolution and webhooks registration

### DIFF
--- a/extensions/webhooks/index.test.ts
+++ b/extensions/webhooks/index.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
+import type { OpenClawPluginApi } from "./api.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveWebhooksPluginConfigSync: vi.fn<
+    typeof import("./src/config.js").resolveWebhooksPluginConfigSync
+  >(() => []),
+  resolveWebhooksPluginConfig: vi.fn<typeof import("./src/config.js").resolveWebhooksPluginConfig>(
+    async () => [],
+  ),
+}));
+
+vi.mock("./src/config.js", () => ({
+  resolveWebhooksPluginConfigSync: mocks.resolveWebhooksPluginConfigSync,
+  resolveWebhooksPluginConfig: mocks.resolveWebhooksPluginConfig,
+}));
+
+import plugin from "./index.js";
+
+function createApi(params?: {
+  registerHttpRoute?: OpenClawPluginApi["registerHttpRoute"];
+  logger?: OpenClawPluginApi["logger"];
+}): OpenClawPluginApi {
+  const logger =
+    params?.logger ??
+    ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as OpenClawPluginApi["logger"]);
+
+  return createTestPluginApi({
+    id: "webhooks",
+    name: "Webhooks",
+    version: "0",
+    source: "test",
+    pluginConfig: {},
+    runtime: {
+      taskFlow: {
+        bindSession: vi.fn(({ sessionKey }: { sessionKey: string }) => ({ sessionKey })),
+      },
+    } as unknown as OpenClawPluginApi["runtime"],
+    registerHttpRoute: params?.registerHttpRoute,
+    logger,
+  });
+}
+
+describe("webhooks plugin registration", () => {
+  beforeEach(() => {
+    mocks.resolveWebhooksPluginConfigSync.mockReset();
+    mocks.resolveWebhooksPluginConfig.mockReset();
+    mocks.resolveWebhooksPluginConfigSync.mockReturnValue([]);
+    mocks.resolveWebhooksPluginConfig.mockResolvedValue([]);
+  });
+
+  it("registers inline-secret routes synchronously", () => {
+    const registerHttpRoute = vi.fn();
+    mocks.resolveWebhooksPluginConfigSync.mockReturnValue([
+      {
+        routeId: "visionclaw",
+        path: "/plugins/webhooks/visionclaw",
+        sessionKey: "agent:main:main",
+        secret: "shared-secret",
+        controllerId: "webhooks/visionclaw",
+      },
+    ]);
+
+    const result = plugin.register(createApi({ registerHttpRoute }));
+
+    expect(result).toBeUndefined();
+    expect(registerHttpRoute).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveWebhooksPluginConfig).not.toHaveBeenCalled();
+  });
+
+  it("falls back to async route resolution when sync resolution is unavailable", async () => {
+    const registerHttpRoute = vi.fn();
+    mocks.resolveWebhooksPluginConfigSync.mockReturnValue(null);
+    mocks.resolveWebhooksPluginConfig.mockResolvedValue([
+      {
+        routeId: "visionclaw",
+        path: "/plugins/webhooks/visionclaw",
+        sessionKey: "agent:main:main",
+        secret: "shared-secret",
+        controllerId: "webhooks/visionclaw",
+      },
+    ]);
+
+    const result = plugin.register(createApi({ registerHttpRoute }));
+
+    expect(result).toBeUndefined();
+    expect(registerHttpRoute).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(registerHttpRoute).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns when async route resolution fails", async () => {
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+    mocks.resolveWebhooksPluginConfigSync.mockReturnValue(null);
+    mocks.resolveWebhooksPluginConfig.mockRejectedValue(new Error("boom"));
+
+    const result = plugin.register(createApi({ logger }));
+
+    expect(result).toBeUndefined();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logger.warn).toHaveBeenCalledWith("[webhooks] failed to resolve webhook routes: boom");
+  });
+});

--- a/extensions/webhooks/index.ts
+++ b/extensions/webhooks/index.ts
@@ -1,51 +1,76 @@
 import { definePluginEntry, type OpenClawPluginApi } from "./api.js";
-import { resolveWebhooksPluginConfig } from "./src/config.js";
+import {
+  resolveWebhooksPluginConfig,
+  resolveWebhooksPluginConfigSync,
+  type ResolvedWebhookRouteConfig,
+} from "./src/config.js";
 import { createTaskFlowWebhookRequestHandler, type TaskFlowWebhookTarget } from "./src/http.js";
+
+function registerWebhookRoutes(api: OpenClawPluginApi, routes: ResolvedWebhookRouteConfig[]): void {
+  if (routes.length === 0) {
+    return;
+  }
+
+  const targetsByPath = new Map<string, TaskFlowWebhookTarget[]>();
+  const handler = createTaskFlowWebhookRequestHandler({
+    cfg: api.config,
+    targetsByPath,
+  });
+
+  for (const route of routes) {
+    const taskFlow = api.runtime.taskFlow.bindSession({
+      sessionKey: route.sessionKey,
+    });
+    const target: TaskFlowWebhookTarget = {
+      routeId: route.routeId,
+      path: route.path,
+      secret: route.secret,
+      defaultControllerId: route.controllerId,
+      taskFlow,
+    };
+    targetsByPath.set(target.path, [...(targetsByPath.get(target.path) ?? []), target]);
+    api.registerHttpRoute({
+      path: target.path,
+      auth: "plugin",
+      match: "exact",
+      replaceExisting: true,
+      handler,
+    });
+    api.logger.info?.(
+      `[webhooks] registered route ${route.routeId} on ${route.path} for session ${route.sessionKey}`,
+    );
+  }
+}
 
 export default definePluginEntry({
   id: "webhooks",
   name: "Webhooks",
   description:
     "Authenticated inbound webhooks that bind external automation to OpenClaw TaskFlows.",
-  async register(api: OpenClawPluginApi) {
-    const routes = await resolveWebhooksPluginConfig({
+  register(api: OpenClawPluginApi) {
+    const syncRoutes = resolveWebhooksPluginConfigSync({
+      pluginConfig: api.pluginConfig,
+    });
+    if (syncRoutes) {
+      registerWebhookRoutes(api, syncRoutes);
+      return;
+    }
+
+    void resolveWebhooksPluginConfig({
       pluginConfig: api.pluginConfig,
       cfg: api.config,
       env: process.env,
       logger: api.logger,
-    });
-    if (routes.length === 0) {
-      return;
-    }
-
-    const targetsByPath = new Map<string, TaskFlowWebhookTarget[]>();
-    const handler = createTaskFlowWebhookRequestHandler({
-      cfg: api.config,
-      targetsByPath,
-    });
-
-    for (const route of routes) {
-      const taskFlow = api.runtime.taskFlow.bindSession({
-        sessionKey: route.sessionKey,
+    })
+      .then((routes) => {
+        registerWebhookRoutes(api, routes);
+      })
+      .catch((error) => {
+        api.logger.warn?.(
+          `[webhooks] failed to resolve webhook routes: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
       });
-      const target: TaskFlowWebhookTarget = {
-        routeId: route.routeId,
-        path: route.path,
-        secret: route.secret,
-        defaultControllerId: route.controllerId,
-        taskFlow,
-      };
-      targetsByPath.set(target.path, [...(targetsByPath.get(target.path) ?? []), target]);
-      api.registerHttpRoute({
-        path: target.path,
-        auth: "plugin",
-        match: "exact",
-        replaceExisting: true,
-        handler,
-      });
-      api.logger.info?.(
-        `[webhooks] registered route ${route.routeId} on ${route.path} for session ${route.sessionKey}`,
-      );
-    }
   },
 });

--- a/extensions/webhooks/src/config.test.ts
+++ b/extensions/webhooks/src/config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
-import { resolveWebhooksPluginConfig } from "./config.js";
+import { resolveWebhooksPluginConfig, resolveWebhooksPluginConfigSync } from "./config.js";
 
 describe("resolveWebhooksPluginConfig", () => {
   it("resolves default paths and SecretRef-backed secrets", async () => {
@@ -82,5 +82,47 @@ describe("resolveWebhooksPluginConfig", () => {
         env: {},
       }),
     ).rejects.toThrow(/conflicts with routes\.first\.path/i);
+  });
+
+  it("resolves inline string secrets synchronously", () => {
+    const routes = resolveWebhooksPluginConfigSync({
+      pluginConfig: {
+        routes: {
+          visionclaw: {
+            sessionKey: "agent:main:main",
+            secret: "shared-secret",
+          },
+        },
+      },
+    });
+
+    expect(routes).toEqual([
+      {
+        routeId: "visionclaw",
+        path: "/plugins/webhooks/visionclaw",
+        sessionKey: "agent:main:main",
+        secret: "shared-secret",
+        controllerId: "webhooks/visionclaw",
+      },
+    ]);
+  });
+
+  it("returns null from the sync resolver when a route secret needs async resolution", () => {
+    const routes = resolveWebhooksPluginConfigSync({
+      pluginConfig: {
+        routes: {
+          visionclaw: {
+            sessionKey: "agent:main:main",
+            secret: {
+              source: "env",
+              provider: "default",
+              id: "OPENCLAW_WEBHOOK_SECRET",
+            },
+          },
+        },
+      },
+    });
+
+    expect(routes).toBeNull();
   });
 });

--- a/extensions/webhooks/src/config.ts
+++ b/extensions/webhooks/src/config.ts
@@ -42,6 +42,42 @@ export type ResolvedWebhookRouteConfig = {
   description?: string;
 };
 
+export function resolveWebhooksPluginConfigSync(params: {
+  pluginConfig: unknown;
+}): ResolvedWebhookRouteConfig[] | null {
+  const parsed = webhooksPluginConfigSchema.parse(params.pluginConfig ?? {});
+  const resolvedRoutes: ResolvedWebhookRouteConfig[] = [];
+  const seenPaths = new Map<string, string>();
+
+  for (const [routeId, route] of Object.entries(parsed.routes)) {
+    if (!route.enabled) {
+      continue;
+    }
+    if (typeof route.secret !== "string") {
+      return null;
+    }
+    const path = normalizeWebhookPath(route.path ?? `/plugins/webhooks/${routeId}`);
+    const existingRouteId = seenPaths.get(path);
+    if (existingRouteId) {
+      throw new Error(
+        `webhooks.routes.${routeId}.path conflicts with routes.${existingRouteId}.path (${path}).`,
+      );
+    }
+
+    seenPaths.set(path, routeId);
+    resolvedRoutes.push({
+      routeId,
+      path,
+      sessionKey: route.sessionKey,
+      secret: route.secret,
+      controllerId: route.controllerId ?? `webhooks/${routeId}`,
+      ...(route.description ? { description: route.description } : {}),
+    });
+  }
+
+  return resolvedRoutes;
+}
+
 export async function resolveWebhooksPluginConfig(params: {
   pluginConfig: unknown;
   cfg: OpenClawConfig;

--- a/src/agents/memory-search.runtime-config.test.ts
+++ b/src/agents/memory-search.runtime-config.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+
+const mocks = vi.hoisted(() => ({
+  getMemoryEmbeddingProvider: vi.fn(
+    (id: string) =>
+      ({
+        id,
+        defaultModel: `${id}-default`,
+        transport: id === "local" ? "local" : "remote",
+        supportsMultimodalEmbeddings: () => true,
+        create: async () => ({ provider: null }),
+      }) as const,
+  ),
+}));
+
+vi.mock("../plugins/memory-embedding-provider-runtime.js", () => ({
+  getMemoryEmbeddingProvider: mocks.getMemoryEmbeddingProvider,
+}));
+
+import { resolveMemorySearchConfig } from "./memory-search.js";
+
+const asConfig = (cfg: OpenClawConfig): OpenClawConfig => cfg;
+
+describe("resolveMemorySearchConfig runtime config forwarding", () => {
+  beforeEach(() => {
+    mocks.getMemoryEmbeddingProvider.mockClear();
+  });
+
+  it("passes cfg to provider and fallback resolution", () => {
+    const cfg = asConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "local",
+            fallback: "openai",
+          },
+        },
+      },
+    });
+
+    resolveMemorySearchConfig(cfg, "main");
+
+    expect(mocks.getMemoryEmbeddingProvider).toHaveBeenCalledWith("local", cfg);
+    expect(mocks.getMemoryEmbeddingProvider).toHaveBeenCalledWith("openai", cfg);
+  });
+
+  it("passes cfg to multimodal provider validation", () => {
+    const cfg = asConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "gemini",
+            model: "gemini-embedding-2-preview",
+            multimodal: {
+              enabled: true,
+              modalities: ["image"],
+            },
+          },
+        },
+      },
+    });
+
+    resolveMemorySearchConfig(cfg, "main");
+
+    expect(mocks.getMemoryEmbeddingProvider).toHaveBeenCalledWith("gemini", cfg);
+    expect(
+      mocks.getMemoryEmbeddingProvider.mock.calls.every(([, passedCfg]) => passedCfg === cfg),
+    ).toBe(true);
+  });
+});

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -146,17 +146,19 @@ function mergeConfig(
   defaults: MemorySearchConfig | undefined,
   overrides: MemorySearchConfig | undefined,
   agentId: string,
+  cfg: OpenClawConfig,
 ): ResolvedMemorySearchConfig {
   const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
   const sessionMemory =
     overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
   const provider = overrides?.provider ?? defaults?.provider ?? "auto";
-  const primaryAdapter = provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider);
+  const primaryAdapter =
+    provider === "auto" ? undefined : getMemoryEmbeddingProvider(provider, cfg);
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
   const fallback = overrides?.fallback ?? defaults?.fallback ?? "none";
   const fallbackAdapter =
-    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback) : undefined;
+    fallback && fallback !== "none" ? getMemoryEmbeddingProvider(fallback, cfg) : undefined;
   const hasRemoteConfig = Boolean(
     overrideRemote?.baseUrl ||
     overrideRemote?.apiKey ||
@@ -382,13 +384,13 @@ export function resolveMemorySearchConfig(
 ): ResolvedMemorySearchConfig | null {
   const defaults = cfg.agents?.defaults?.memorySearch;
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
-  const resolved = mergeConfig(defaults, overrides, agentId);
+  const resolved = mergeConfig(defaults, overrides, agentId, cfg);
   if (!resolved.enabled) {
     return null;
   }
   const multimodalActive = isMemoryMultimodalEnabled(resolved.multimodal);
   const multimodalProvider =
-    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider);
+    resolved.provider === "auto" ? undefined : getMemoryEmbeddingProvider(resolved.provider, cfg);
   const builtinMultimodalSupport =
     resolved.provider === "auto"
       ? false


### PR DESCRIPTION
## What changed
- fixed memory-search runtime config resolution so provider lookup, fallback lookup, and multimodal validation all receive the active `OpenClawConfig`
- fixed the bundled `webhooks` plugin so routes with inline string secrets register synchronously instead of returning a promise from plugin registration
- added regression tests for both fixes

## Why this changed
- `resolveMemorySearchConfig` resolved embedding providers without the active runtime config, which could trigger incorrect fallback plugin discovery and bogus status warnings
- `webhooks.register()` was async because secret resolution always went through the async path, which caused the runtime warning that async plugin registration is ignored

## Impact
- removes false-positive `plugins.allow` and untracked-plugin warnings from status when memory search uses configured providers
- preserves webhook route registration for inline-secret setups while keeping async fallback for env/file/exec-backed secrets
- adds coverage for the corrected runtime behavior

## Root cause
- provider resolution in memory-search was calling `getMemoryEmbeddingProvider(...)` without forwarding `cfg`
- webhook config resolution treated all routes as async even when the secret was already an inline string

## Validation
- `node scripts/run-vitest.mjs run --config vitest.agents.config.ts src/agents/memory-search.test.ts src/agents/memory-search.runtime-config.test.ts`
- `OPENCLAW_VITEST_INCLUDE_FILE=<tempfile> node scripts/run-vitest.mjs run --config vitest.extension-misc.config.ts`
- `pnpm exec oxfmt --check src/agents/memory-search.ts src/agents/memory-search.runtime-config.test.ts extensions/webhooks/src/config.ts extensions/webhooks/src/config.test.ts extensions/webhooks/index.ts extensions/webhooks/index.test.ts`
- `node scripts/run-oxlint.mjs src/agents/memory-search.ts src/agents/memory-search.runtime-config.test.ts extensions/webhooks/src/config.ts extensions/webhooks/src/config.test.ts extensions/webhooks/index.ts extensions/webhooks/index.test.ts`
- `pnpm build`
