### PR TITLE
Test/run state machine clamp guard

### DIFF
--- a/src/channels/run-state-machine.test.ts
+++ b/src/channels/run-state-machine.test.ts
@@ -18,10 +18,18 @@ describe("createRunStateMachine", () => {
     machine.onRunEnd();
     expect(setStatus).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ activeRuns: 1, busy: true, lastRunActivityAt: 123 }),
+      expect.objectContaining({
+        activeRuns: 1,
+        busy: true,
+        lastRunActivityAt: 123,
+      }),
     );
     expect(setStatus).toHaveBeenLastCalledWith(
-      expect.objectContaining({ activeRuns: 0, busy: false, lastRunActivityAt: 123 }),
+      expect.objectContaining({
+        activeRuns: 0,
+        busy: false,
+        lastRunActivityAt: 123,
+      }),
     );
   });
 
@@ -38,5 +46,29 @@ describe("createRunStateMachine", () => {
     abortController.abort();
     machine.onRunEnd();
     expect(setStatus.mock.calls.length).toBe(callsBeforeAbort);
+  });
+
+  it("clamps activeRuns to zero when onRunEnd is called without a matching onRunStart", () => {
+    const setStatus = vi.fn();
+    const machine = createRunStateMachine({ setStatus, now: () => 1 });
+
+    machine.onRunEnd();
+
+    expect(setStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ activeRuns: 0, busy: false }),
+    );
+  });
+
+  it("clamps activeRuns to zero when onRunEnd is called more times than onRunStart", () => {
+    const setStatus = vi.fn();
+    const machine = createRunStateMachine({ setStatus, now: () => 1 });
+
+    machine.onRunStart();
+    machine.onRunEnd();
+    machine.onRunEnd(); // extra call — should not go negative
+
+    expect(setStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ activeRuns: 0, busy: false }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Problem: The `activeRuns` clamp guard in `onRunEnd()` (`Math.max(0, activeRuns - 1)`) was completely untested. Calling `onRunEnd()` more times than `onRunStart()` (e.g. error handling paths, race conditions) would cause `activeRuns` to go negative without this guard.
- Why it matters: A negative `activeRuns` would cause the machine to report incorrect state permanently, potentially breaking busy indicators across all channels.
- What changed: Added two unit tests covering the clamp guard — one for calling `onRunEnd()` with no prior `onRunStart()`, and one for calling it more times than `onRunStart()`.
- What did NOT change: No production code was changed. This is a test-only PR covering an existing defensive guard.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Gateway / orchestration

## Linked Issue/PR
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)
- Root cause: The `Math.max(0, activeRuns - 1)` guard in `onRunEnd()` was added defensively but never had test coverage to verify it works correctly.
- Missing detection / guardrail: No unit test for mismatched `onRunStart`/`onRunEnd` calls.
- Contributing context (if known): Error handling paths or race conditions can trigger `onRunEnd()` more times than `onRunStart()`.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/channels/run-state-machine.test.ts`
- Scenario the test should lock in: `activeRuns` never goes below zero regardless of call order.
- Why this is the smallest reliable guardrail: Pure function, no dependencies, directly tests the guard condition.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A — two tests added.

## User-visible / Behavior Changes
None.

## Diagram (if applicable)
```text
Before:
[onRunEnd x2] -> activeRuns = -1 (without guard, would break busy state)

After:
[onRunEnd x2] -> activeRuns = 0 (guard clamps correctly, now verified by test)
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: macOS
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): N/A

### Steps
1. Call `machine.onRunEnd()` without calling `onRunStart()`
2. Check `activeRuns` value

### Expected
- `activeRuns` stays at 0

### Actual (before test)
- Guard existed but was unverified by any test

## Evidence
- [x] New unit tests added covering both scenarios

## Human Verification (required)
- Verified scenarios: `onRunEnd` with no prior `onRunStart`, `onRunEnd` called twice after one `onRunStart`
- Edge cases checked: `activeRuns` stays at 0 in both cases
- What you did NOT verify: Race conditions in a live runtime

## Review Conversations
- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
None.