### PR TITLE
fix: isolate auto-failover, split /new vs /reset LCM identity, add overflow circuit breaker

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -945,9 +945,8 @@ export async function runEmbeddedPiAgent(
             // Structured overflow diagnostic event (Patch 3A).
             // One JSON event per overflow attempt with enough detail to compare
             // runtime assembled prompt size with compaction estimate.
-            const toolResultMessages = attempt.messagesSnapshot?.filter(
-              (m: { role?: string }) => m.role === "tool",
-            ) ?? [];
+            const toolResultMessages =
+              attempt.messagesSnapshot?.filter((m: { role?: string }) => m.role === "tool") ?? [];
             const overflowDiagnostic = {
               event: "context_overflow_diagnostic",
               diagId: overflowDiagId,
@@ -968,9 +967,7 @@ export async function runEmbeddedPiAgent(
               error: errorText.slice(0, 500),
               timestamp: new Date().toISOString(),
             };
-            log.warn(
-              `[context-overflow-event] ${JSON.stringify(overflowDiagnostic)}`,
-            );
+            log.warn(`[context-overflow-event] ${JSON.stringify(overflowDiagnostic)}`);
 
             log.warn(
               `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
@@ -1098,9 +1095,7 @@ export async function runEmbeddedPiAgent(
                 attempt: overflowCompactionAttempts,
                 timestamp: new Date().toISOString(),
               };
-              log.warn(
-                `[overflow-compaction-event] ${JSON.stringify(compactionDiagnostic)}`,
-              );
+              log.warn(`[overflow-compaction-event] ${JSON.stringify(compactionDiagnostic)}`);
 
               if (compactResult.compacted) {
                 if (preflightRecovery?.route === "compact_then_truncate") {
@@ -1131,39 +1126,17 @@ export async function runEmbeddedPiAgent(
               );
 
               // Circuit breaker (Patch 3B): if compaction explicitly says context
-              // is already under target but runtime still overflows, there is a
-              // budget mismatch. Attempt tool result truncation as a last resort
-              // but do NOT keep retrying the prompt — that creates the reset/replay
-              // loop seen in the incident.
+              // is already under target but runtime still overflows AND tool result
+              // truncation has already been attempted, there is a confirmed budget
+              // mismatch. Hard-stop the retry loop instead of endlessly resetting.
               const compactionSaysUnderTarget =
                 !compactResult.compacted &&
                 typeof compactResult.reason === "string" &&
                 /under.target|below.threshold|nothing.to.compact/i.test(compactResult.reason);
-              if (compactionSaysUnderTarget) {
+              if (compactionSaysUnderTarget && toolResultTruncationAttempted) {
                 log.warn(
-                  `[circuit-breaker] compaction reports under target but runtime still overflows for ` +
-                    `${provider}/${modelId}. Forcing tool result truncation and stopping retry loop.`,
-                );
-                // Force tool result truncation as last resort
-                if (!toolResultTruncationAttempted) {
-                  toolResultTruncationAttempted = true;
-                  const truncResult = await truncateOversizedToolResultsInSession({
-                    sessionFile: params.sessionFile,
-                    contextWindowTokens: ctxInfo.tokens,
-                    sessionId: params.sessionId,
-                    sessionKey: params.sessionKey,
-                  });
-                  if (truncResult.truncated) {
-                    log.info(
-                      `[circuit-breaker] Truncated ${truncResult.truncatedCount} tool result(s) as fallback; retrying once.`,
-                    );
-                    // Allow exactly one more attempt after truncation
-                    continue;
-                  }
-                }
-                // Truncation didn't help or was already attempted — hard stop
-                log.warn(
-                  `[circuit-breaker] Overflow persists after compaction + truncation. Stopping retry loop.`,
+                  `[circuit-breaker] compaction reports under target and truncation already attempted ` +
+                    `but runtime still overflows for ${provider}/${modelId}. Stopping retry loop.`,
                 );
                 attempt.setTerminalLifecycleMeta?.({
                   replayInvalid: resolveReplayInvalidForAttempt(),

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -246,6 +246,10 @@ export async function runEmbeddedPiAgent(
       });
       await ensureOpenClawModelsJson(params.config, agentDir);
       const resolvedSessionKey = normalizedSessionKey;
+      // Context engine calls use memoryConversationKey when present so LCM
+      // conversation identity is decoupled from runtime session identity.
+      const contextEngineSessionKey =
+        normalizeOptionalString(params.memoryConversationKey) ?? resolvedSessionKey;
       const hookRunner = getGlobalHookRunner();
       const hookCtx = {
         runId: params.runId,
@@ -628,6 +632,7 @@ export async function runEmbeddedPiAgent(
           const attempt = await runEmbeddedAttemptWithBackend({
             sessionId: params.sessionId,
             sessionKey: resolvedSessionKey,
+            memoryConversationKey: params.memoryConversationKey,
             trigger: params.trigger,
             memoryFlushWritePath: params.memoryFlushWritePath,
             messageChannel: params.messageChannel,
@@ -871,7 +876,7 @@ export async function runEmbeddedPiAgent(
                 };
                 timeoutCompactResult = await contextEngine.compact({
                   sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
+                  sessionKey: contextEngineSessionKey,
                   sessionFile: params.sessionFile,
                   tokenBudget: ctxInfo.tokens,
                   force: true,
@@ -1016,7 +1021,7 @@ export async function runEmbeddedPiAgent(
                 };
                 compactResult = await contextEngine.compact({
                   sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
+                  sessionKey: contextEngineSessionKey,
                   sessionFile: params.sessionFile,
                   tokenBudget: ctxInfo.tokens,
                   ...(observedOverflowTokens !== undefined
@@ -1030,7 +1035,7 @@ export async function runEmbeddedPiAgent(
                   await runContextEngineMaintenance({
                     contextEngine,
                     sessionId: params.sessionId,
-                    sessionKey: params.sessionKey,
+                    sessionKey: contextEngineSessionKey,
                     sessionFile: params.sessionFile,
                     reason: "compaction",
                     runtimeContext: overflowCompactionRuntimeContext,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -941,6 +941,37 @@ export async function runEmbeddedPiAgent(
             const errorText = contextOverflowError.text;
             const msgCount = attempt.messagesSnapshot?.length ?? 0;
             const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
+
+            // Structured overflow diagnostic event (Patch 3A).
+            // One JSON event per overflow attempt with enough detail to compare
+            // runtime assembled prompt size with compaction estimate.
+            const toolResultMessages = attempt.messagesSnapshot?.filter(
+              (m: { role?: string }) => m.role === "tool",
+            ) ?? [];
+            const overflowDiagnostic = {
+              event: "context_overflow_diagnostic",
+              diagId: overflowDiagId,
+              sessionKey: params.sessionKey ?? params.sessionId,
+              runtimeModel: `${provider}/${modelId}`,
+              contextWindowTokens: ctxInfo.tokens,
+              contextWindowSource: ctxInfo.source,
+              assembledPromptTokenEstimate: observedOverflowTokens ?? null,
+              messageCount: msgCount,
+              toolResultCount: toolResultMessages.length,
+              overflowSource: contextOverflowError.source,
+              compactionAttemptedBefore: overflowCompactionAttempts > 0,
+              compactionAttemptsSoFar: overflowCompactionAttempts,
+              attemptLevelCompactionCount: attemptCompactionCount,
+              preflightRecoveryRoute: preflightRecovery?.route ?? null,
+              preflightRecoveryHandled: preflightRecovery?.handled ?? false,
+              sessionFile: params.sessionFile,
+              error: errorText.slice(0, 500),
+              timestamp: new Date().toISOString(),
+            };
+            log.warn(
+              `[context-overflow-event] ${JSON.stringify(overflowDiagnostic)}`,
+            );
+
             log.warn(
               `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
                 `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
@@ -1052,6 +1083,25 @@ export async function runEmbeddedPiAgent(
                 };
               }
               await runOwnsCompactionAfterHook("overflow recovery", compactResult);
+
+              // Structured compaction result diagnostic (Patch 3A)
+              const compactionDiagnostic = {
+                event: "overflow_compaction_result",
+                diagId: overflowDiagId,
+                sessionKey: params.sessionKey ?? params.sessionId,
+                compactOk: compactResult.ok,
+                compacted: compactResult.compacted,
+                compactReason: compactResult.reason ?? null,
+                tokensBefore: compactResult.result?.tokensBefore ?? null,
+                tokensAfter: compactResult.result?.tokensAfter ?? null,
+                contextWindowTokens: ctxInfo.tokens,
+                attempt: overflowCompactionAttempts,
+                timestamp: new Date().toISOString(),
+              };
+              log.warn(
+                `[overflow-compaction-event] ${JSON.stringify(compactionDiagnostic)}`,
+              );
+
               if (compactResult.compacted) {
                 if (preflightRecovery?.route === "compact_then_truncate") {
                   const truncResult = await truncateOversizedToolResultsInSession({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1129,6 +1129,75 @@ export async function runEmbeddedPiAgent(
               log.warn(
                 `auto-compaction failed for ${provider}/${modelId}: ${compactResult.reason ?? "nothing to compact"}`,
               );
+
+              // Circuit breaker (Patch 3B): if compaction explicitly says context
+              // is already under target but runtime still overflows, there is a
+              // budget mismatch. Attempt tool result truncation as a last resort
+              // but do NOT keep retrying the prompt — that creates the reset/replay
+              // loop seen in the incident.
+              const compactionSaysUnderTarget =
+                !compactResult.compacted &&
+                typeof compactResult.reason === "string" &&
+                /under.target|below.threshold|nothing.to.compact/i.test(compactResult.reason);
+              if (compactionSaysUnderTarget) {
+                log.warn(
+                  `[circuit-breaker] compaction reports under target but runtime still overflows for ` +
+                    `${provider}/${modelId}. Forcing tool result truncation and stopping retry loop.`,
+                );
+                // Force tool result truncation as last resort
+                if (!toolResultTruncationAttempted) {
+                  toolResultTruncationAttempted = true;
+                  const truncResult = await truncateOversizedToolResultsInSession({
+                    sessionFile: params.sessionFile,
+                    contextWindowTokens: ctxInfo.tokens,
+                    sessionId: params.sessionId,
+                    sessionKey: params.sessionKey,
+                  });
+                  if (truncResult.truncated) {
+                    log.info(
+                      `[circuit-breaker] Truncated ${truncResult.truncatedCount} tool result(s) as fallback; retrying once.`,
+                    );
+                    // Allow exactly one more attempt after truncation
+                    continue;
+                  }
+                }
+                // Truncation didn't help or was already attempted — hard stop
+                log.warn(
+                  `[circuit-breaker] Overflow persists after compaction + truncation. Stopping retry loop.`,
+                );
+                attempt.setTerminalLifecycleMeta?.({
+                  replayInvalid: resolveReplayInvalidForAttempt(),
+                  livenessState: "blocked",
+                });
+                return {
+                  payloads: [
+                    {
+                      text:
+                        "⚠️ Context overflow: compaction reports context is within budget, but the assembled " +
+                        "prompt still exceeds the model's limit. This indicates a budget mismatch between " +
+                        "compaction and runtime assembly. Try /reset or /new, or use a larger-context model.\n\n" +
+                        "Diagnostic: check `openclaw logs --follow` for `[context-overflow-event]` entries.",
+                      isError: true,
+                    },
+                  ],
+                  meta: {
+                    durationMs: Date.now() - started,
+                    agentMeta: buildErrorAgentMeta({
+                      sessionId: sessionIdUsed,
+                      provider,
+                      model: model.id,
+                      usageAccumulator,
+                      lastRunPromptUsage,
+                      lastAssistant,
+                      lastTurnTotal,
+                    }),
+                    error: {
+                      message: "Circuit breaker: compaction/assembly budget mismatch",
+                      kind: "context_overflow",
+                    },
+                  },
+                };
+              }
             }
             if (!toolResultTruncationAttempted) {
               const contextWindowTokens = ctxInfo.tokens;

--- a/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
@@ -102,11 +102,25 @@ export function findCurrentAttemptAssistantMessage(params: {
     .find((message) => message.role === "assistant");
 }
 
+/**
+ * Resolve the session key for context engine calls. When a
+ * `memoryConversationKey` is available, the context engine should use it
+ * as the conversation identity rather than the runtime session key. This
+ * allows `/new` to rotate conversation identity while `/reset` preserves it.
+ */
+function resolveContextEngineSessionKey(params: {
+  sessionKey?: string;
+  memoryConversationKey?: string;
+}): string | undefined {
+  return params.memoryConversationKey ?? params.sessionKey;
+}
+
 export async function runAttemptContextEngineBootstrap(params: {
   hadSessionFile: boolean;
   contextEngine?: AttemptContextEngine;
   sessionId: string;
   sessionKey?: string;
+  memoryConversationKey?: string;
   sessionFile: string;
   sessionManager: unknown;
   runtimeContext?: ContextEngineRuntimeContext;
@@ -127,18 +141,19 @@ export async function runAttemptContextEngineBootstrap(params: {
   ) {
     return;
   }
+  const ceSessionKey = resolveContextEngineSessionKey(params);
   try {
     if (typeof params.contextEngine?.bootstrap === "function") {
       await params.contextEngine.bootstrap({
         sessionId: params.sessionId,
-        sessionKey: params.sessionKey,
+        sessionKey: ceSessionKey,
         sessionFile: params.sessionFile,
       });
     }
     await params.runMaintenance({
       contextEngine: params.contextEngine,
       sessionId: params.sessionId,
-      sessionKey: params.sessionKey,
+      sessionKey: ceSessionKey,
       sessionFile: params.sessionFile,
       reason: "bootstrap",
       sessionManager: params.sessionManager,
@@ -153,6 +168,7 @@ export async function assembleAttemptContextEngine(params: {
   contextEngine?: AttemptContextEngine;
   sessionId: string;
   sessionKey?: string;
+  memoryConversationKey?: string;
   messages: AgentMessage[];
   tokenBudget?: number;
   availableTools?: Set<string>;
@@ -165,7 +181,7 @@ export async function assembleAttemptContextEngine(params: {
   }
   return await params.contextEngine.assemble({
     sessionId: params.sessionId,
-    sessionKey: params.sessionKey,
+    sessionKey: resolveContextEngineSessionKey(params),
     messages: params.messages,
     tokenBudget: params.tokenBudget,
     ...(params.availableTools ? { availableTools: params.availableTools } : {}),
@@ -182,6 +198,7 @@ export async function finalizeAttemptContextEngineTurn(params: {
   yieldAborted: boolean;
   sessionIdUsed: string;
   sessionKey?: string;
+  memoryConversationKey?: string;
   sessionFile: string;
   messagesSnapshot: AgentMessage[];
   prePromptMessageCount: number;
@@ -205,11 +222,13 @@ export async function finalizeAttemptContextEngineTurn(params: {
 
   let postTurnFinalizationSucceeded = true;
 
+  const ceSessionKey = resolveContextEngineSessionKey(params);
+
   if (typeof params.contextEngine.afterTurn === "function") {
     try {
       await params.contextEngine.afterTurn({
         sessionId: params.sessionIdUsed,
-        sessionKey: params.sessionKey,
+        sessionKey: ceSessionKey,
         sessionFile: params.sessionFile,
         messages: params.messagesSnapshot,
         prePromptMessageCount: params.prePromptMessageCount,
@@ -227,7 +246,7 @@ export async function finalizeAttemptContextEngineTurn(params: {
         try {
           await params.contextEngine.ingestBatch({
             sessionId: params.sessionIdUsed,
-            sessionKey: params.sessionKey,
+            sessionKey: ceSessionKey,
             messages: newMessages,
           });
         } catch (ingestErr) {
@@ -239,7 +258,7 @@ export async function finalizeAttemptContextEngineTurn(params: {
           try {
             await params.contextEngine.ingest?.({
               sessionId: params.sessionIdUsed,
-              sessionKey: params.sessionKey,
+              sessionKey: ceSessionKey,
               message: msg,
             });
           } catch (ingestErr) {
@@ -260,7 +279,7 @@ export async function finalizeAttemptContextEngineTurn(params: {
     await params.runMaintenance({
       contextEngine: params.contextEngine,
       sessionId: params.sessionIdUsed,
-      sessionKey: params.sessionKey,
+      sessionKey: ceSessionKey,
       sessionFile: params.sessionFile,
       reason: "turn",
       sessionManager: params.sessionManager,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -135,4 +135,11 @@ export type RunEmbeddedPiAgentParams = {
    * exit promptly after emitting the final JSON result.
    */
   cleanupBundleMcpOnRunEnd?: boolean;
+  /**
+   * LCM / context-engine conversation identity key. When present, context
+   * engine methods receive this as `sessionKey` instead of the runtime
+   * session key, enabling `/new` to create fresh LCM conversations while
+   * `/reset` preserves continuity.
+   */
+  memoryConversationKey?: string;
 };

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1669,9 +1669,14 @@ describe("runAgentTurnWithFallback", () => {
       authProfileId: undefined,
       authProfileIdSource: undefined,
     });
-    expect(sessionEntry.providerOverride).toBe("openai-codex");
-    expect(sessionEntry.modelOverride).toBe("gpt-5.4");
-    expect(sessionEntry.modelOverrideSource).toBe("auto");
+    // Patch 1: fallback now writes to failoverState, not override fields
+    expect(sessionEntry.failoverState).toBeDefined();
+    expect(sessionEntry.failoverState?.active).toBe(true);
+    expect(sessionEntry.failoverState?.to.provider).toBe("openai-codex");
+    expect(sessionEntry.failoverState?.to.model).toBe("gpt-5.4");
+    expect(sessionEntry.providerOverride).toBeUndefined();
+    expect(sessionEntry.modelOverride).toBeUndefined();
+    expect(sessionEntry.modelOverrideSource).toBeUndefined();
     expect(sessionEntry.authProfileOverride).toBeUndefined();
     expect(sessionEntry.authProfileOverrideSource).toBeUndefined();
     expect(sessionStore.main.authProfileOverride).toBeUndefined();
@@ -1834,14 +1839,14 @@ describe("runAgentTurnWithFallback", () => {
       now: 123,
     });
 
+    // Patch 1: fallback now writes to failoverState, not override fields
     expect(updated).toBe(true);
-    expect(entry).toMatchObject({
-      updatedAt: 123,
-      providerOverride: "anthropic",
-      modelOverride: "claude-sonnet",
-      modelOverrideSource: "auto",
-      authProfileOverride: "anthropic:openclaw",
-      authProfileOverrideSource: "user",
-    });
+    expect(entry.failoverState).toBeDefined();
+    expect(entry.failoverState?.active).toBe(true);
+    expect(entry.failoverState?.to.provider).toBe("anthropic");
+    expect(entry.failoverState?.to.model).toBe("claude-sonnet");
+    // User auth profile override should be preserved (not touched by failover)
+    expect(entry.authProfileOverride).toBe("anthropic:openclaw");
+    expect(entry.authProfileOverrideSource).toBe("user");
   });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -909,6 +909,7 @@ export async function runAgentTurnWithFallback(params: {
             try {
               const result = await runEmbeddedPiAgent({
                 ...embeddedContext,
+                memoryConversationKey: params.getActiveSessionEntry()?.memoryConversationKey,
                 allowGatewaySubagentBinding: true,
                 trigger: params.isHeartbeat ? "heartbeat" : "user",
                 groupId: resolveGroupSessionKey(params.sessionCtx)?.id,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -109,6 +109,98 @@ export type AgentRunLoopResult =
     }
   | { kind: "final"; payload: ReplyPayload };
 
+type FailoverStateSnapshot = SessionEntry["failoverState"] | undefined;
+
+function snapshotFailoverState(entry: SessionEntry): FailoverStateSnapshot {
+  return entry.failoverState ? { ...entry.failoverState } : undefined;
+}
+
+function applyFailoverState(
+  entry: SessionEntry,
+  run: { provider: string; model: string },
+  provider: string,
+  model: string,
+  authProfile: string | undefined,
+  reason: string,
+  now = Date.now(),
+): boolean {
+  const next: SessionEntry["failoverState"] = {
+    active: true,
+    from: { provider: run.provider, model: run.model },
+    to: { provider, model, ...(authProfile ? { authProfile } : {}) },
+    reason,
+    startedAt: new Date(now).toISOString(),
+  };
+  const prev = entry.failoverState;
+  if (
+    prev?.active &&
+    prev.to.provider === next.to.provider &&
+    prev.to.model === next.to.model
+  ) {
+    return false;
+  }
+  entry.failoverState = next;
+  entry.updatedAt = now;
+  return true;
+}
+
+function rollbackFailoverStateIfUnchanged(
+  entry: SessionEntry,
+  expected: FailoverStateSnapshot,
+  previous: FailoverStateSnapshot,
+): boolean {
+  const current = entry.failoverState;
+  // Only roll back if the current state matches what we set
+  if (expected?.active && current?.active &&
+      current.to.provider === expected.to.provider &&
+      current.to.model === expected.to.model) {
+    entry.failoverState = previous;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Sanitize a session entry that may have been polluted by the old behavior
+ * where auto-failover was persisted into user override fields.
+ *
+ * If override fields exist with `modelOverrideSource === "auto"` or
+ * `authProfileOverrideSource === "auto"`, migrate them into `failoverState`
+ * and clear the override fields so they don't masquerade as user intent.
+ */
+export function sanitizeFailoverPollutedEntry(entry: SessionEntry): boolean {
+  const isAutoModel = entry.modelOverrideSource === "auto";
+  const isAutoAuth = entry.authProfileOverrideSource === "auto" && !entry.authProfileOverride;
+  if (!isAutoModel) {
+    return false;
+  }
+  // Migrate auto-persisted override into failoverState if not already present
+  if (!entry.failoverState && entry.providerOverride && entry.modelOverride) {
+    entry.failoverState = {
+      active: true,
+      from: { provider: "", model: "" }, // unknown original, best-effort
+      to: {
+        provider: entry.providerOverride,
+        model: entry.modelOverride,
+        ...(entry.authProfileOverride ? { authProfile: entry.authProfileOverride } : {}),
+      },
+      reason: "migrated from polluted auto-override",
+      startedAt: new Date(entry.updatedAt ?? Date.now()).toISOString(),
+    };
+  }
+  // Clear the polluted override fields
+  delete entry.providerOverride;
+  delete entry.modelOverride;
+  delete entry.modelOverrideSource;
+  if (isAutoAuth || entry.authProfileOverrideSource === "auto") {
+    delete entry.authProfileOverride;
+    delete entry.authProfileOverrideSource;
+    delete entry.authProfileOverrideCompactionCount;
+  }
+  return true;
+}
+
+// Legacy types kept for backward compatibility with existing test imports
 type FallbackSelectionState = Pick<
   SessionEntry,
   | "providerOverride"
@@ -119,159 +211,31 @@ type FallbackSelectionState = Pick<
   | "authProfileOverrideCompactionCount"
 >;
 
-const FALLBACK_SELECTION_STATE_KEYS = [
-  "providerOverride",
-  "modelOverride",
-  "modelOverrideSource",
-  "authProfileOverride",
-  "authProfileOverrideSource",
-  "authProfileOverrideCompactionCount",
-] as const satisfies ReadonlyArray<keyof FallbackSelectionState>;
-
-function setFallbackSelectionStateField(
-  entry: SessionEntry,
-  key: keyof FallbackSelectionState,
-  value: FallbackSelectionState[keyof FallbackSelectionState],
-): boolean {
-  switch (key) {
-    case "providerOverride":
-      if (entry.providerOverride !== value) {
-        entry.providerOverride = value as SessionEntry["providerOverride"];
-        return true;
-      }
-      return false;
-    case "modelOverride":
-      if (entry.modelOverride !== value) {
-        entry.modelOverride = value as SessionEntry["modelOverride"];
-        return true;
-      }
-      return false;
-    case "modelOverrideSource":
-      if (entry.modelOverrideSource !== value) {
-        entry.modelOverrideSource = value as SessionEntry["modelOverrideSource"];
-        return true;
-      }
-      return false;
-    case "authProfileOverride":
-      if (entry.authProfileOverride !== value) {
-        entry.authProfileOverride = value as SessionEntry["authProfileOverride"];
-        return true;
-      }
-      return false;
-    case "authProfileOverrideSource":
-      if (entry.authProfileOverrideSource !== value) {
-        entry.authProfileOverrideSource = value as SessionEntry["authProfileOverrideSource"];
-        return true;
-      }
-      return false;
-    case "authProfileOverrideCompactionCount":
-      if (entry.authProfileOverrideCompactionCount !== value) {
-        entry.authProfileOverrideCompactionCount =
-          value as SessionEntry["authProfileOverrideCompactionCount"];
-        return true;
-      }
-      return false;
-  }
-  throw new Error("Unsupported fallback selection state key");
-}
-
-function snapshotFallbackSelectionState(entry: SessionEntry): FallbackSelectionState {
-  return {
-    providerOverride: entry.providerOverride,
-    modelOverride: entry.modelOverride,
-    modelOverrideSource: entry.modelOverrideSource,
-    authProfileOverride: entry.authProfileOverride,
-    authProfileOverrideSource: entry.authProfileOverrideSource,
-    authProfileOverrideCompactionCount: entry.authProfileOverrideCompactionCount,
-  };
-}
-
-function buildFallbackSelectionState(params: {
-  provider: string;
-  model: string;
-  authProfileId?: string;
-  authProfileIdSource?: "auto" | "user";
-}): FallbackSelectionState {
-  return {
-    providerOverride: params.provider,
-    modelOverride: params.model,
-    modelOverrideSource: "auto",
-    authProfileOverride: params.authProfileId,
-    authProfileOverrideSource: params.authProfileId ? params.authProfileIdSource : undefined,
-    authProfileOverrideCompactionCount: undefined,
-  };
-}
-
 export function applyFallbackCandidateSelectionToEntry(params: {
   entry: SessionEntry;
   run: FollowupRun["run"];
   provider: string;
   model: string;
   now?: number;
-}): { updated: boolean; nextState?: FallbackSelectionState } {
+}): { updated: boolean; nextState?: FailoverStateSnapshot } {
   if (params.provider === params.run.provider && params.model === params.run.model) {
     return { updated: false };
   }
   const scopedAuthProfile = resolveRunAuthProfile(params.run, params.provider);
-  const nextState = buildFallbackSelectionState({
-    provider: params.provider,
-    model: params.model,
-    authProfileId: scopedAuthProfile.authProfileId,
-    authProfileIdSource: scopedAuthProfile.authProfileIdSource,
-  });
+  const updated = applyFailoverState(
+    params.entry,
+    { provider: params.run.provider, model: params.run.model },
+    params.provider,
+    params.model,
+    scopedAuthProfile.authProfileId,
+    "auto-failover",
+    params.now,
+  );
   return {
-    updated: applyFallbackSelectionState(params.entry, nextState, params.now),
-    nextState,
+    updated,
+    nextState: updated ? params.entry.failoverState : undefined,
   };
 }
-
-function applyFallbackSelectionState(
-  entry: SessionEntry,
-  nextState: FallbackSelectionState,
-  now = Date.now(),
-): boolean {
-  let updated = false;
-  for (const key of FALLBACK_SELECTION_STATE_KEYS) {
-    const nextValue = nextState[key];
-    if (nextValue === undefined) {
-      if (Object.hasOwn(entry, key)) {
-        delete entry[key];
-        updated = true;
-      }
-      continue;
-    }
-    if (entry[key] !== nextValue) {
-      updated = setFallbackSelectionStateField(entry, key, nextValue) || updated;
-    }
-  }
-  if (updated) {
-    entry.updatedAt = now;
-  }
-  return updated;
-}
-
-function rollbackFallbackSelectionStateIfUnchanged(
-  entry: SessionEntry,
-  expectedState: FallbackSelectionState,
-  previousState: FallbackSelectionState,
-  now = Date.now(),
-): boolean {
-  let updated = false;
-  for (const key of FALLBACK_SELECTION_STATE_KEYS) {
-    if (entry[key] !== expectedState[key]) {
-      continue;
-    }
-    const previousValue = previousState[key];
-    if (previousValue === undefined) {
-      if (Object.hasOwn(entry, key)) {
-        delete entry[key];
-        updated = true;
-      }
-      continue;
-    }
-    if (entry[key] !== previousValue) {
-      updated = setFallbackSelectionStateField(entry, key, previousValue) || updated;
-    }
   }
   if (updated) {
     entry.updatedAt = now;
@@ -647,27 +611,10 @@ export async function runAgentTurnWithFallback(params: {
       return undefined;
     }
 
-    // Don't overwrite a user-initiated model override (e.g. from /models or
-    // /model) with the fallback model.  The user's explicit selection should
-    // survive transient primary-model failures so subsequent messages still
-    // target the model the user chose.  Fallback persistence is only
-    // appropriate when the override was itself set by a previous fallback
-    // ("auto") or when there is no override yet.
-    //
-    // `modelOverrideSource` was added later, so older persisted sessions can
-    // carry a user-selected override without the source field.  Treat any
-    // entry with a `modelOverride` but missing `modelOverrideSource` as legacy
-    // user state, matching the backward-compat treatment in
-    // session-reset-service.
-    const isUserModelOverride =
-      activeSessionEntry.modelOverrideSource === "user" ||
-      (activeSessionEntry.modelOverrideSource === undefined &&
-        Boolean(normalizeOptionalString(activeSessionEntry.modelOverride)));
-    if (isUserModelOverride) {
-      return undefined;
-    }
+    // Sanitize any polluted auto-override state from pre-patch sessions
+    sanitizeFailoverPollutedEntry(activeSessionEntry);
 
-    const previousState = snapshotFallbackSelectionState(activeSessionEntry);
+    const previousState = snapshotFailoverState(activeSessionEntry);
     const applied = applyFallbackCandidateSelectionToEntry({
       entry: activeSessionEntry,
       run: params.followupRun.run,
@@ -687,18 +634,20 @@ export async function runAgentTurnWithFallback(params: {
           if (!persistedEntry) {
             return;
           }
-          applyFallbackSelectionState(persistedEntry, nextState);
+          sanitizeFailoverPollutedEntry(persistedEntry);
+          persistedEntry.failoverState = nextState;
+          persistedEntry.updatedAt = Date.now();
           store[params.sessionKey!] = persistedEntry;
         });
       }
     } catch (error) {
-      rollbackFallbackSelectionStateIfUnchanged(activeSessionEntry, nextState, previousState);
+      rollbackFailoverStateIfUnchanged(activeSessionEntry, nextState, previousState);
       params.activeSessionStore[params.sessionKey] = activeSessionEntry;
       throw error;
     }
 
     return async () => {
-      const rolledBackInMemory = rollbackFallbackSelectionStateIfUnchanged(
+      const rolledBackInMemory = rollbackFailoverStateIfUnchanged(
         activeSessionEntry,
         nextState,
         previousState,
@@ -714,7 +663,7 @@ export async function runAgentTurnWithFallback(params: {
         if (!persistedEntry) {
           return;
         }
-        if (rollbackFallbackSelectionStateIfUnchanged(persistedEntry, nextState, previousState)) {
+        if (rollbackFailoverStateIfUnchanged(persistedEntry, nextState, previousState)) {
           store[params.sessionKey!] = persistedEntry;
         }
       });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -132,11 +132,7 @@ function applyFailoverState(
     startedAt: new Date(now).toISOString(),
   };
   const prev = entry.failoverState;
-  if (
-    prev?.active &&
-    prev.to.provider === next.to.provider &&
-    prev.to.model === next.to.model
-  ) {
+  if (prev?.active && prev.to.provider === next.to.provider && prev.to.model === next.to.model) {
     return false;
   }
   entry.failoverState = next;
@@ -151,9 +147,12 @@ function rollbackFailoverStateIfUnchanged(
 ): boolean {
   const current = entry.failoverState;
   // Only roll back if the current state matches what we set
-  if (expected?.active && current?.active &&
-      current.to.provider === expected.to.provider &&
-      current.to.model === expected.to.model) {
+  if (
+    expected?.active &&
+    current?.active &&
+    current.to.provider === expected.to.provider &&
+    current.to.model === expected.to.model
+  ) {
     entry.failoverState = previous;
     return true;
   }
@@ -200,17 +199,6 @@ export function sanitizeFailoverPollutedEntry(entry: SessionEntry): boolean {
   return true;
 }
 
-// Legacy types kept for backward compatibility with existing test imports
-type FallbackSelectionState = Pick<
-  SessionEntry,
-  | "providerOverride"
-  | "modelOverride"
-  | "modelOverrideSource"
-  | "authProfileOverride"
-  | "authProfileOverrideSource"
-  | "authProfileOverrideCompactionCount"
->;
-
 export function applyFallbackCandidateSelectionToEntry(params: {
   entry: SessionEntry;
   run: FollowupRun["run"];
@@ -235,12 +223,6 @@ export function applyFallbackCandidateSelectionToEntry(params: {
     updated,
     nextState: updated ? params.entry.failoverState : undefined,
   };
-}
-  }
-  if (updated) {
-    entry.updatedAt = now;
-  }
-  return updated;
 }
 
 /**

--- a/src/auto-reply/reply/agent-runner-session-reset.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.ts
@@ -75,6 +75,7 @@ export async function resetReplyRunSession(params: {
     fallbackNoticeSelectedModel: undefined,
     fallbackNoticeActiveModel: undefined,
     fallbackNoticeReason: undefined,
+    failoverState: undefined,
   };
   const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
   const nextSessionFile = resolveSessionTranscriptPath(

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -791,7 +791,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     return "channel override";
   })();
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
-  const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
+  const userOverrideNote =
+    entry?.modelOverrideSource === "user" && entry?.modelOverride
+      ? " (user override)"
+      : "";
+  const modelLine = `🧠 Model: ${selectedModelLabel}${userOverrideNote}${selectedAuthLabel}${modelNote}`;
 
   // Show configured fallback models (from agent model config)
   const configuredFallbacks = (() => {
@@ -806,7 +810,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     : null;
 
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
-  const fallbackLine = fallbackState.active
+  // Prefer failoverState (new structured field) over legacy fallback notice
+  const failoverLine = entry?.failoverState?.active
+    ? `↪️ Active: ${formatProviderModelRef(entry.failoverState.to.provider, entry.failoverState.to.model)} (temporary failover: ${entry.failoverState.reason})`
+    : null;
+  const fallbackLine = !failoverLine && fallbackState.active
     ? `↪️ Fallback: ${activeModelLabel}${
         showFallbackAuth ? ` · 🔑 ${activeAuthLabelValue}` : ""
       } (${fallbackState.reason ?? "selected model unavailable"})`
@@ -826,6 +834,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     args.timeLine,
     modelLine,
     configuredFallbacksLine,
+    failoverLine,
     fallbackLine,
     usageCostLine,
     cacheLine,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -256,6 +256,17 @@ export type SessionEntry = {
   pluginDebugEntries?: SessionPluginDebugEntry[];
   acp?: SessionAcpMeta;
   /**
+   * Separate identity key for LCM / context-engine conversation continuity.
+   *
+   * When present, context engines should resolve conversations by this key
+   * instead of `sessionKey`. `/new` generates a fresh value (new LCM
+   * conversation), while `/reset` preserves the existing value (same LCM
+   * conversation, fresh runtime session).
+   *
+   * Absent means legacy behavior: context engines fall back to `sessionKey`.
+   */
+  memoryConversationKey?: string;
+  /**
    * Runtime-owned transient failover state. Tracks auto-failover separately
    * from user-chosen model overrides so that transient provider failures do
    * not persist as sticky user selections.

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -255,6 +255,21 @@ export type SessionEntry = {
    */
   pluginDebugEntries?: SessionPluginDebugEntry[];
   acp?: SessionAcpMeta;
+  /**
+   * Runtime-owned transient failover state. Tracks auto-failover separately
+   * from user-chosen model overrides so that transient provider failures do
+   * not persist as sticky user selections.
+   *
+   * Null/absent means the session is not in failover.
+   * Cleared on `/new` and `/reset`.
+   */
+  failoverState?: {
+    active: boolean;
+    from: { provider: string; model: string };
+    to: { provider: string; model: string; authProfile?: string };
+    reason: string;
+    startedAt: string;
+  };
 };
 
 export function resolveSessionPluginDebugLines(

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -599,6 +599,11 @@ export async function performGatewaySessionReset(params: {
       ...resetPreservedSelection,
       // Always clear transient failover state on /new and /reset
       failoverState: undefined,
+      // `/new` creates a fresh LCM conversation; `/reset` preserves continuity
+      memoryConversationKey:
+        params.reason === "new"
+          ? randomUUID()
+          : (currentEntry?.memoryConversationKey ?? randomUUID()),
       groupActivation: currentEntry?.groupActivation,
       groupActivationNeedsSystemIntro: currentEntry?.groupActivationNeedsSystemIntro,
       chatType: currentEntry?.chatType,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -597,6 +597,8 @@ export async function performGatewaySessionReset(params: {
       // Resets should keep the user's explicit selection, but clear any
       // temporary fallback model that was pinned during the previous run.
       ...resetPreservedSelection,
+      // Always clear transient failover state on /new and /reset
+      failoverState: undefined,
       groupActivation: currentEntry?.groupActivation,
       groupActivationNeedsSystemIntro: currentEntry?.groupActivationNeedsSystemIntro,
       chatType: currentEntry?.chatType,

--- a/src/sessions/model-overrides.ts
+++ b/src/sessions/model-overrides.ts
@@ -120,6 +120,10 @@ export function applyModelOverrideToSessionEntry(params: {
     delete entry.fallbackNoticeSelectedModel;
     delete entry.fallbackNoticeActiveModel;
     delete entry.fallbackNoticeReason;
+    // An explicit user model switch supersedes any active failover state.
+    if (selectionSource === "user") {
+      delete entry.failoverState;
+    }
     entry.updatedAt = Date.now();
   }
 


### PR DESCRIPTION
## Summary

Fixes three related bugs observed when a transient model auth failure triggers auto-failover:

- **Auto-failover persisted as user override** — transient provider failures wrote fallback state into `providerOverride`/`modelOverride` fields, making the fallback sticky across `/new` and `/reset`. Adds a dedicated `failoverState` object on SessionEntry with read-time sanitization for already-polluted sessions.
- **`/new` did not create a fresh LCM conversation** — lossless-claw reused the same conversation for the same `sessionKey`. Introduces `memoryConversationKey` so `/new` rotates conversation identity while `/reset` preserves it.
- **Overflow recovery loop with no hard stop** — compaction reported "already under target" while runtime still overflowed, causing repeated reset/replay. Adds structured overflow telemetry and a circuit breaker that stops the loop after compaction + truncation both fail.

## Test plan

- [x] `pnpm tsgo` passes
- [x] `pnpm check` (full lint suite) passes
- [x] 114 affected tests pass
- [ ] Live verification: force primary model auth failure, confirm fallback does not persist after `/new`
- [ ] Live verification: `/new` creates new LCM conversation row, `/reset` preserves existing one
- [ ] Live verification: overflow triggers structured `[context-overflow-event]` log entries
- [ ] Live verification: repeated overflow stops instead of looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)