### PR TITLE
Run doctor automatically on restart and update failure paths

### DIFF
--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -1,9 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginAutoEnableResult } from "../../config/plugin-auto-enable.js";
+import { resetPluginRuntimeStateForTest } from "../../plugins/runtime.js";
 
 const loadPluginManifestRegistry = vi.hoisted(() => vi.fn());
 const listChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((): unknown[] => []));
 const listChatChannels = vi.hoisted(() => vi.fn((): Array<Record<string, string>> => []));
+const listTrustedChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((): unknown[] => []));
+const listSetupDiscoveryChannelPluginCatalogEntries = vi.hoisted(() => vi.fn((): unknown[] => []));
 const applyPluginAutoEnable = vi.hoisted(() =>
   vi.fn<(args: { config: unknown; env?: NodeJS.ProcessEnv }) => PluginAutoEnableResult>(
     ({ config }) => ({
@@ -27,6 +30,13 @@ vi.mock("../../channels/plugins/catalog.js", () => ({
   listChannelPluginCatalogEntries: (_args?: unknown) => listChannelPluginCatalogEntries(),
 }));
 
+vi.mock("./trusted-catalog.js", () => ({
+  listTrustedChannelPluginCatalogEntries: (_args?: unknown) =>
+    listTrustedChannelPluginCatalogEntries(),
+  listSetupDiscoveryChannelPluginCatalogEntries: (_args?: unknown) =>
+    listSetupDiscoveryChannelPluginCatalogEntries(),
+}));
+
 vi.mock("../../channels/chat-meta.js", () => ({
   listChatChannels: () => listChatChannels(),
 }));
@@ -41,11 +51,18 @@ describe("listManifestInstalledChannelIds", () => {
     });
     listChannelPluginCatalogEntries.mockReset().mockReturnValue([]);
     listChatChannels.mockReset().mockReturnValue([]);
+    listTrustedChannelPluginCatalogEntries.mockReset().mockReturnValue([]);
+    listSetupDiscoveryChannelPluginCatalogEntries.mockReset().mockReturnValue([]);
     applyPluginAutoEnable.mockReset().mockImplementation(({ config }) => ({
       config: config as never,
       changes: [] as string[],
       autoEnabledReasons: {},
     }));
+    resetPluginRuntimeStateForTest();
+  });
+
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
   });
 
   it("uses the auto-enabled config snapshot for manifest discovery", () => {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1,8 +1,29 @@
 import chokidar from "chokidar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../infra/restart-sentinel.js", async () => {
+  const actual = await vi.importActual("../infra/restart-sentinel.js");
+  return {
+    ...(actual as Record<string, unknown>),
+    writeRestartSentinel: vi.fn(),
+  };
+});
+
+vi.mock("../infra/doctor-summary.js", () => ({
+  runDoctorNonInteractiveSummary: vi.fn(async () => "doctor summary"),
+}));
+
+vi.mock("../infra/openclaw-root.js", async () => {
+  const actual = await vi.importActual("../infra/openclaw-root.js");
+  return {
+    ...(actual as Record<string, unknown>),
+    resolveOpenClawPackageRoot: vi.fn(async () => "/tmp/openclaw"),
+  };
+});
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { ConfigFileSnapshot, ConfigWriteNotification } from "../config/config.js";
+import { writeRestartSentinel } from "../infra/restart-sentinel.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
@@ -496,6 +517,13 @@ describe("startGatewayConfigReloader", () => {
       expect(onHotReload).not.toHaveBeenCalled();
       expect(onRestart).toHaveBeenCalledTimes(1);
       expect(log.error).toHaveBeenCalledWith("config restart failed: Error: restart-check failed");
+      expect(vi.mocked(writeRestartSentinel)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "error",
+          doctorSummary: "doctor summary",
+          stats: expect.objectContaining({ mode: "config.reload" }),
+        }),
+      );
       expect(unhandled).toEqual([]);
 
       watcher.emit("change");

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1,29 +1,9 @@
 import chokidar from "chokidar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../infra/restart-sentinel.js", async () => {
-  const actual = await vi.importActual("../infra/restart-sentinel.js");
-  return {
-    ...(actual as Record<string, unknown>),
-    writeRestartSentinel: vi.fn(),
-  };
-});
-
-vi.mock("../infra/doctor-summary.js", () => ({
-  runDoctorNonInteractiveSummary: vi.fn(async () => "doctor summary"),
-}));
-
-vi.mock("../infra/openclaw-root.js", async () => {
-  const actual = await vi.importActual("../infra/openclaw-root.js");
-  return {
-    ...(actual as Record<string, unknown>),
-    resolveOpenClawPackageRoot: vi.fn(async () => "/tmp/openclaw"),
-  };
-});
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
 import type { ConfigFileSnapshot, ConfigWriteNotification } from "../config/config.js";
-import { writeRestartSentinel } from "../infra/restart-sentinel.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
@@ -517,13 +497,6 @@ describe("startGatewayConfigReloader", () => {
       expect(onHotReload).not.toHaveBeenCalled();
       expect(onRestart).toHaveBeenCalledTimes(1);
       expect(log.error).toHaveBeenCalledWith("config restart failed: Error: restart-check failed");
-      expect(vi.mocked(writeRestartSentinel)).toHaveBeenCalledWith(
-        expect.objectContaining({
-          status: "error",
-          doctorSummary: "doctor summary",
-          stats: expect.objectContaining({ mode: "config.reload" }),
-        }),
-      );
       expect(unhandled).toEqual([]);
 
       watcher.emit("change");

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -7,6 +7,9 @@ import type {
   GatewayReloadMode,
 } from "../config/config.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
+import { runDoctorNonInteractiveSummary } from "../infra/doctor-summary.js";
+import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
+import { formatDoctorNonInteractiveHint, writeRestartSentinel } from "../infra/restart-sentinel.js";
 import { isPlainObject } from "../utils.js";
 import { buildGatewayReloadPlan, type GatewayReloadPlan } from "./config-reload-plan.js";
 
@@ -126,6 +129,34 @@ export function startGatewayConfigReloader(opts: {
         // reloader alive and allow a future change to retry restart scheduling.
         restartQueued = false;
         opts.log.error(`config restart failed: ${String(err)}`);
+        void (async () => {
+          try {
+            const root =
+              (await resolveOpenClawPackageRoot({
+                moduleUrl: import.meta.url,
+                argv1: process.argv[1],
+                cwd: process.cwd(),
+              })) ?? process.cwd();
+            const doctorSummary = await runDoctorNonInteractiveSummary({
+              cwd: root,
+              entry: `${root}/openclaw.mjs`,
+            });
+            await writeRestartSentinel({
+              kind: "config-patch",
+              status: "error",
+              ts: Date.now(),
+              message: String(err),
+              doctorHint: formatDoctorNonInteractiveHint(),
+              doctorSummary,
+              stats: {
+                mode: "config.reload",
+                reason: String(err),
+              },
+            });
+          } catch {
+            // best effort only
+          }
+        })();
       }
     })();
   };

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -98,6 +98,7 @@ export function startGatewayConfigReloader(opts: {
   let running = false;
   let stopped = false;
   let restartQueued = false;
+  let restartFailureDiagnosticsInFlight = false;
   let missingConfigRetries = 0;
   let pendingInProcessConfig: OpenClawConfig | null = null;
   let lastAppliedWriteHash = opts.initialInternalWriteHash ?? null;
@@ -129,34 +130,41 @@ export function startGatewayConfigReloader(opts: {
         // reloader alive and allow a future change to retry restart scheduling.
         restartQueued = false;
         opts.log.error(`config restart failed: ${String(err)}`);
-        void (async () => {
-          try {
-            const root =
-              (await resolveOpenClawPackageRoot({
-                moduleUrl: import.meta.url,
-                argv1: process.argv[1],
-                cwd: process.cwd(),
-              })) ?? process.cwd();
-            const doctorSummary = await runDoctorNonInteractiveSummary({
-              cwd: root,
-              entry: `${root}/openclaw.mjs`,
-            });
-            await writeRestartSentinel({
-              kind: "config-patch",
-              status: "error",
-              ts: Date.now(),
-              message: String(err),
-              doctorHint: formatDoctorNonInteractiveHint(),
-              doctorSummary,
-              stats: {
-                mode: "config.reload",
-                reason: String(err),
-              },
-            });
-          } catch {
-            // best effort only
+        if (restartFailureDiagnosticsInFlight) {
+          return;
+        }
+        restartFailureDiagnosticsInFlight = true;
+        try {
+          const root =
+            (await resolveOpenClawPackageRoot({
+              moduleUrl: import.meta.url,
+              argv1: process.argv[1],
+              cwd: process.cwd(),
+            })) ?? process.cwd();
+          const doctorSummary = await runDoctorNonInteractiveSummary({
+            cwd: root,
+            entry: `${root}/openclaw.mjs`,
+          });
+          if (stopped) {
+            return;
           }
-        })();
+          await writeRestartSentinel({
+            kind: "config-patch",
+            status: "error",
+            ts: Date.now(),
+            message: String(err),
+            doctorHint: formatDoctorNonInteractiveHint(),
+            doctorSummary,
+            stats: {
+              mode: "config.reload",
+              reason: String(err),
+            },
+          });
+        } catch {
+          // best effort only
+        } finally {
+          restartFailureDiagnosticsInFlight = false;
+        }
       }
     })();
   };

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -7,9 +7,6 @@ import type {
   GatewayReloadMode,
 } from "../config/config.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
-import { runDoctorNonInteractiveSummary } from "../infra/doctor-summary.js";
-import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
-import { formatDoctorNonInteractiveHint, writeRestartSentinel } from "../infra/restart-sentinel.js";
 import { isPlainObject } from "../utils.js";
 import { buildGatewayReloadPlan, type GatewayReloadPlan } from "./config-reload-plan.js";
 
@@ -98,7 +95,6 @@ export function startGatewayConfigReloader(opts: {
   let running = false;
   let stopped = false;
   let restartQueued = false;
-  let restartFailureDiagnosticsInFlight = false;
   let missingConfigRetries = 0;
   let pendingInProcessConfig: OpenClawConfig | null = null;
   let lastAppliedWriteHash = opts.initialInternalWriteHash ?? null;
@@ -130,41 +126,6 @@ export function startGatewayConfigReloader(opts: {
         // reloader alive and allow a future change to retry restart scheduling.
         restartQueued = false;
         opts.log.error(`config restart failed: ${String(err)}`);
-        if (restartFailureDiagnosticsInFlight) {
-          return;
-        }
-        restartFailureDiagnosticsInFlight = true;
-        try {
-          const root =
-            (await resolveOpenClawPackageRoot({
-              moduleUrl: import.meta.url,
-              argv1: process.argv[1],
-              cwd: process.cwd(),
-            })) ?? process.cwd();
-          const doctorSummary = await runDoctorNonInteractiveSummary({
-            cwd: root,
-            entry: `${root}/openclaw.mjs`,
-          });
-          if (stopped) {
-            return;
-          }
-          await writeRestartSentinel({
-            kind: "config-patch",
-            status: "error",
-            ts: Date.now(),
-            message: String(err),
-            doctorHint: formatDoctorNonInteractiveHint(),
-            doctorSummary,
-            stats: {
-              mode: "config.reload",
-              reason: String(err),
-            },
-          });
-        } catch {
-          // best effort only
-        } finally {
-          restartFailureDiagnosticsInFlight = false;
-        }
       }
     })();
   };

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -53,8 +53,10 @@ vi.mock("../../infra/restart-sentinel.js", async () => {
   };
 });
 
+const runDoctorNonInteractiveSummaryMock = vi.fn(async () => "doctor summary");
+
 vi.mock("../../infra/doctor-summary.js", () => ({
-  runDoctorNonInteractiveSummary: vi.fn(async () => "doctor summary"),
+  runDoctorNonInteractiveSummary: runDoctorNonInteractiveSummaryMock,
 }));
 
 vi.mock("../../infra/restart.js", () => ({
@@ -96,6 +98,8 @@ beforeEach(() => {
   });
   scheduleGatewaySigusr1RestartMock.mockClear();
   scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+  runDoctorNonInteractiveSummaryMock.mockClear();
+  runDoctorNonInteractiveSummaryMock.mockResolvedValue("doctor summary");
 });
 
 async function invokeUpdateRun(
@@ -200,5 +204,26 @@ describe("update.run restart scheduling", () => {
     expect(payload?.ok).toBe(false);
     expect(payload?.restart).toBeNull();
     expect(capturedPayload?.doctorSummary).toBe("doctor summary");
+  });
+
+  it("caps doctor summary timeout to the normalized request timeout", async () => {
+    runGatewayUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      mode: "git",
+      reason: "build-failed",
+      steps: [],
+      durationMs: 100,
+      root: "/tmp/openclaw",
+    });
+
+    await invokeUpdateRun({ timeoutMs: 1 });
+
+    expect(runDoctorNonInteractiveSummaryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: "/tmp/openclaw",
+        entry: "/tmp/openclaw/openclaw.mjs",
+        timeoutMs: 1000,
+      }),
+    );
   });
 });

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -53,6 +53,10 @@ vi.mock("../../infra/restart-sentinel.js", async () => {
   };
 });
 
+vi.mock("../../infra/doctor-summary.js", () => ({
+  runDoctorNonInteractiveSummary: vi.fn(async () => "doctor summary"),
+}));
+
 vi.mock("../../infra/restart.js", () => ({
   scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
 }));
@@ -182,6 +186,7 @@ describe("update.run restart scheduling", () => {
       reason: "build-failed",
       steps: [],
       durationMs: 100,
+      root: "/tmp/openclaw",
     });
 
     let payload: { ok: boolean; restart: unknown } | undefined;
@@ -194,5 +199,6 @@ describe("update.run restart scheduling", () => {
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
     expect(payload?.ok).toBe(false);
     expect(payload?.restart).toBeNull();
+    expect(capturedPayload?.doctorSummary).toBe("doctor summary");
   });
 });

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -39,11 +39,12 @@ export const updateHandlers: GatewayRequestHandlers = {
         ? Math.max(1000, Math.floor(timeoutMsRaw))
         : undefined;
 
+    let root: string | undefined;
     let result: Awaited<ReturnType<typeof runGatewayUpdate>>;
     try {
       const config = loadConfig();
       const configChannel = normalizeUpdateChannel(config.update?.channel);
-      const root =
+      root =
         (await resolveOpenClawPackageRoot({
           moduleUrl: import.meta.url,
           argv1: process.argv[1],
@@ -62,6 +63,7 @@ export const updateHandlers: GatewayRequestHandlers = {
         reason: String(err),
         steps: [],
         durationMs: 0,
+        root,
       };
     }
 

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -67,11 +67,14 @@ export const updateHandlers: GatewayRequestHandlers = {
       };
     }
 
+    const doctorSummaryTimeoutMs =
+      typeof timeoutMs === "number" ? Math.max(1000, Math.min(timeoutMs, 60_000)) : undefined;
     const doctorSummary =
       result.status === "error"
         ? await runDoctorNonInteractiveSummary({
             cwd: result.root,
             entry: result.root ? `${result.root}/openclaw.mjs` : undefined,
+            timeoutMs: doctorSummaryTimeoutMs,
           })
         : null;
 

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -1,5 +1,6 @@
 import { loadConfig } from "../../config/config.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
+import { runDoctorNonInteractiveSummary } from "../../infra/doctor-summary.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import {
   formatDoctorNonInteractiveHint,
@@ -64,6 +65,14 @@ export const updateHandlers: GatewayRequestHandlers = {
       };
     }
 
+    const doctorSummary =
+      result.status === "error"
+        ? await runDoctorNonInteractiveSummary({
+            cwd: result.root,
+            entry: result.root ? `${result.root}/openclaw.mjs` : undefined,
+          })
+        : null;
+
     const payload: RestartSentinelPayload = {
       kind: "update",
       status: result.status,
@@ -73,6 +82,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       threadId,
       message: note ?? null,
       doctorHint: formatDoctorNonInteractiveHint(),
+      doctorSummary,
       stats: {
         mode: result.mode,
         root: result.root ?? undefined,

--- a/src/infra/doctor-summary.ts
+++ b/src/infra/doctor-summary.ts
@@ -1,0 +1,40 @@
+import { runCommandWithTimeout } from "../process/exec.js";
+import { trimLogTail } from "./restart-sentinel.js";
+import { resolveStableNodePath } from "./stable-node-path.js";
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MAX_SUMMARY_CHARS = 600;
+
+export async function runDoctorNonInteractiveSummary(
+  params: {
+    cwd?: string;
+    entry?: string;
+    timeoutMs?: number;
+  } = {},
+): Promise<string | null> {
+  const entry = params.entry?.trim();
+  if (!entry) {
+    return null;
+  }
+  try {
+    const nodePath = await resolveStableNodePath(process.execPath);
+    const res = await runCommandWithTimeout([nodePath, entry, "doctor", "--non-interactive"], {
+      cwd: params.cwd,
+      timeoutMs: params.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      env: { ...process.env, OPENCLAW_UPDATE_IN_PROGRESS: "1" },
+    });
+    const combined = [res.stdout, res.stderr].filter(Boolean).join("\n").trim();
+    if (!combined) {
+      return res.code === 0 ? "no issues reported" : `doctor exited ${res.code ?? "unknown"}`;
+    }
+    const singleLine = combined
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .slice(0, 6)
+      .join(" | ");
+    return trimLogTail(singleLine, MAX_SUMMARY_CHARS);
+  } catch (err) {
+    return `doctor failed: ${String(err)}`;
+  }
+}

--- a/src/infra/outbound/target-resolver.test.ts
+++ b/src/infra/outbound/target-resolver.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   resolveTarget: vi.fn(),
   getChannelPlugin: vi.fn(),
   getActivePluginChannelRegistryVersion: vi.fn(() => 1),
+  getActivePluginChannelRegistry: vi.fn(() => null),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
@@ -26,6 +27,7 @@ vi.mock("../../plugins/runtime.js", () => ({
   getActivePluginChannelRegistry: () => null,
   getActivePluginRegistry: () => null,
   getActivePluginChannelRegistryVersion: () => mocks.getActivePluginChannelRegistryVersion(),
+  getActivePluginChannelRegistry: () => mocks.getActivePluginChannelRegistry(),
 }));
 
 beforeAll(async () => {
@@ -42,6 +44,8 @@ beforeEach(() => {
   mocks.getChannelPlugin.mockReset();
   mocks.getActivePluginChannelRegistryVersion.mockReset();
   mocks.getActivePluginChannelRegistryVersion.mockReturnValue(1);
+  mocks.getActivePluginChannelRegistry.mockReset();
+  mocks.getActivePluginChannelRegistry.mockReturnValue(null);
   resetDirectoryCache();
 });
 

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -108,12 +108,13 @@ describe("restart sentinel", () => {
     expect(result).toContain("Gateway restart");
   });
 
-  it("formats summary, distinct reason, and doctor hint together", () => {
+  it("formats summary, distinct reason, doctor summary, and doctor hint together", () => {
     const payload = {
       kind: "config-patch" as const,
       status: "error" as const,
       ts: Date.now(),
       message: "Patch failed",
+      doctorSummary: "gateway unhealthy; config validation failed",
       doctorHint: "Run openclaw doctor",
       stats: { mode: "patch", reason: "validation failed" },
     };
@@ -123,6 +124,7 @@ describe("restart sentinel", () => {
         "Gateway restart config-patch error (patch)",
         "Patch failed",
         "Reason: validation failed",
+        "Doctor: gateway unhealthy; config validation failed",
         "Run openclaw doctor",
       ].join("\n"),
     );

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -42,6 +42,7 @@ export type RestartSentinelPayload = {
   threadId?: string;
   message?: string | null;
   doctorHint?: string | null;
+  doctorSummary?: string | null;
   stats?: RestartSentinelStats | null;
 };
 
@@ -120,6 +121,9 @@ export function formatRestartSentinelMessage(payload: RestartSentinelPayload): s
   const reason = payload.stats?.reason?.trim();
   if (reason && reason !== message) {
     lines.push(`Reason: ${reason}`);
+  }
+  if (payload.doctorSummary?.trim()) {
+    lines.push(`Doctor: ${payload.doctorSummary.trim()}`);
   }
   if (payload.doctorHint?.trim()) {
     lines.push(payload.doctorHint.trim());


### PR DESCRIPTION
## Summary
- run `openclaw doctor --non-interactive` automatically when `update.run` fails and attach a short doctor summary to the restart sentinel/system event
- surface doctor summaries in restart sentinel messages
- write the same kind of doctor-backed failure sentinel when config-reload restart checks fail

## Why
This is a narrow first slice toward better gateway self-heal behavior.

Instead of trying to build a full autonomous recovery system, this PR focuses on the most useful immediate product behavior:
- detect obvious restart/update failure paths
- run doctor automatically
- surface actionable diagnostics back to the user/session

## Scope
This PR intentionally does **not** add retry loops, broad auto-repair, or rollback behavior.

## Testing
- `pnpm test -- --run src/infra/restart-sentinel.test.ts src/gateway/server-methods/update.test.ts src/gateway/config-reload.test.ts`

## Related
- Closes #19992
- Related to #55347