### PR TITLE
fix(plugins): restore memoryCapability in plugin loader cache

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -39,7 +39,9 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   buildMemoryPromptSection,
+  clearMemoryPluginState,
   getMemoryRuntime,
+  listActiveMemoryPublicArtifacts,
   listMemoryCorpusSupplements,
   registerMemoryCorpusSupplement,
   registerMemoryFlushPlanResolver,
@@ -1788,6 +1790,68 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(() => loadOpenClawPlugins({ activate: false, cache: true })).toThrow(
       "activate:false requires cache:false",
     );
+  });
+
+  it("restores unified memory capability from plugin loader cache", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "cache-memory-capability",
+      filename: "cache-memory-capability.cjs",
+      body: `module.exports = {
+        id: "cache-memory-capability",
+        kind: "memory",
+        register(api) {
+          api.registerMemoryCapability({
+            publicArtifacts: {
+              async listArtifacts() {
+                return [{
+                  kind: "memory-root",
+                  workspaceDir: ${JSON.stringify("/tmp/cache-memory-capability")},
+                  relativePath: "MEMORY.md",
+                  absolutePath: ${JSON.stringify("/tmp/cache-memory-capability/MEMORY.md")},
+                  agentIds: ["main"],
+                  contentType: "markdown",
+                }];
+              },
+            },
+          });
+        },
+      };`,
+    });
+
+    const options = {
+      workspaceDir: plugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["cache-memory-capability"],
+          slots: { memory: "cache-memory-capability" },
+        },
+      },
+      onlyPluginIds: ["cache-memory-capability"],
+    };
+
+    loadOpenClawPlugins(options);
+    await expect(
+      listActiveMemoryPublicArtifacts({ cfg: options.config as never }),
+    ).resolves.toHaveLength(1);
+
+    clearMemoryPluginState();
+    setActivePluginRegistry(createEmptyPluginRegistry(), "stale-registry");
+
+    loadOpenClawPlugins(options);
+    await expect(
+      listActiveMemoryPublicArtifacts({ cfg: options.config as never }),
+    ).resolves.toEqual([
+      {
+        kind: "memory-root",
+        workspaceDir: "/tmp/cache-memory-capability",
+        relativePath: "MEMORY.md",
+        absolutePath: "/tmp/cache-memory-capability/MEMORY.md",
+        agentIds: ["main"],
+        contentType: "markdown",
+      },
+    ]);
   });
 
   it("re-initializes global hook runner when serving registry from cache", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -48,6 +48,7 @@ import {
 } from "./memory-embedding-providers.js";
 import {
   clearMemoryPluginState,
+  getMemoryCapabilityRegistration,
   getMemoryFlushPlanResolver,
   getMemoryPromptSectionBuilder,
   getMemoryRuntime,
@@ -147,6 +148,7 @@ export class PluginLoadReentryError extends Error {
 
 type CachedPluginState = {
   registry: PluginRegistry;
+  memoryCapability: ReturnType<typeof getMemoryCapabilityRegistration>;
   memoryCorpusSupplements: ReturnType<typeof listMemoryCorpusSupplements>;
   agentHarnesses: ReturnType<typeof listRegisteredAgentHarnesses>;
   compactionProviders: ReturnType<typeof listRegisteredCompactionProviders>;
@@ -1112,6 +1114,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       restoreRegisteredCompactionProviders(cached.compactionProviders);
       restoreRegisteredMemoryEmbeddingProviders(cached.memoryEmbeddingProviders);
       restoreMemoryPluginState({
+        capability: cached.memoryCapability,
         corpusSupplements: cached.memoryCorpusSupplements,
         promptBuilder: cached.memoryPromptBuilder,
         promptSupplements: cached.memoryPromptSupplements,
@@ -1717,6 +1720,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       const previousAgentHarnesses = listRegisteredAgentHarnesses();
       const previousCompactionProviders = listRegisteredCompactionProviders();
       const previousMemoryEmbeddingProviders = listRegisteredMemoryEmbeddingProviders();
+      const previousMemoryCapability = getMemoryCapabilityRegistration();
       const previousMemoryFlushPlanResolver = getMemoryFlushPlanResolver();
       const previousMemoryPromptBuilder = getMemoryPromptSectionBuilder();
       const previousMemoryCorpusSupplements = listMemoryCorpusSupplements();
@@ -1739,6 +1743,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           restoreRegisteredCompactionProviders(previousCompactionProviders);
           restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
           restoreMemoryPluginState({
+            capability: previousMemoryCapability,
             corpusSupplements: previousMemoryCorpusSupplements,
             promptBuilder: previousMemoryPromptBuilder,
             promptSupplements: previousMemoryPromptSupplements,
@@ -1753,6 +1758,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         restoreRegisteredCompactionProviders(previousCompactionProviders);
         restoreRegisteredMemoryEmbeddingProviders(previousMemoryEmbeddingProviders);
         restoreMemoryPluginState({
+          capability: previousMemoryCapability,
           corpusSupplements: previousMemoryCorpusSupplements,
           promptBuilder: previousMemoryPromptBuilder,
           promptSupplements: previousMemoryPromptSupplements,
@@ -1807,6 +1813,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
     if (cacheEnabled) {
       setCachedPluginRegistry(cacheKey, {
+        memoryCapability: getMemoryCapabilityRegistration(),
         memoryCorpusSupplements: listMemoryCorpusSupplements(),
         registry,
         agentHarnesses: listRegisteredAgentHarnesses(),


### PR DESCRIPTION
## Summary

The plugin loader caches memory-related plugin state (compaction providers,
embedding providers, corpus supplements, prompt builder/supplements, flush
plan resolver) and restores it on reload / failed registration. The
`memoryCapability` registration was missing from that cached state, so
after a hot reload or a failed plugin registration the active memory
capability registration was silently lost — this breaks `memory-wiki`
bridge mode, which depends on the memory capability being present to
answer wiki-backed lookups.

This PR adds `memoryCapability` to `CachedPluginState` and to the two
save/restore points in `loadOpenClawPlugins` (the cache-hit path and the
failed-registration rollback path), so the capability registration
survives hot reload the same way the other memory-related registrations
do.

## Changes

- `src/plugins/loader.ts` (+7): import `getMemoryCapabilityRegistration`,
  add `memoryCapability` to `CachedPluginState`, and save/restore it at
  the two existing save/restore points
- `src/plugins/loader.test.ts` (+64): regression test that loads a plugin
  registering a memory capability, triggers a cache hit, and asserts the
  capability is still registered afterward

## Test plan

- [x] `pnpm test src/plugins/loader.test.ts` (77 passed)
- [x] `pnpm check` (tsgo + oxlint + boundary checks, all green)
- [x] Verified manually on my fork: `memory-wiki` bridge survives
  gateway hot reload instead of going dark after the first reload
- [ ] CI: pnpm build / pnpm test / pnpm check