### PR TITLE
fix(agents): default provider catalog discovery timeout in non-live mode

### DIFF
--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -36,6 +36,7 @@ const PROVIDER_IMPLICIT_MERGERS: Partial<
 };
 
 const PLUGIN_DISCOVERY_ORDERS = ["simple", "profile", "paired", "late"] as const;
+const DEFAULT_PROVIDER_DISCOVERY_TIMEOUT_MS = 15_000;
 
 type ImplicitProviderParams = {
   agentDir: string;
@@ -52,18 +53,38 @@ type ImplicitProviderContext = ImplicitProviderParams & {
   resolveProviderAuth: ProviderAuthResolver;
 };
 
-function resolveLiveProviderCatalogTimeoutMs(env: NodeJS.ProcessEnv): number | null {
+function resolveProviderCatalogTimeoutMs(env: NodeJS.ProcessEnv): number {
+  // Explicit env var override takes priority
+  const explicit = env.OPENCLAW_PROVIDER_DISCOVERY_TIMEOUT_MS?.trim();
+  if (explicit) {
+    const parsed = Number.parseInt(explicit, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+    log.warn(
+      `OPENCLAW_PROVIDER_DISCOVERY_TIMEOUT_MS="${explicit}" is not a valid positive integer; using default`,
+    );
+  }
+
   const live =
     env.OPENCLAW_LIVE_TEST === "1" || env.OPENCLAW_LIVE_GATEWAY === "1" || env.LIVE === "1";
-  if (!live) {
-    return null;
-  }
-  const raw = env.OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS?.trim();
-  if (!raw) {
+  if (live) {
+    const raw = env.OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS?.trim();
+    if (raw) {
+      const parsed = Number.parseInt(raw, 10);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+      }
+      log.warn(
+        `OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS="${raw}" is not a valid positive integer; using default`,
+      );
+    }
     return 15_000;
   }
-  const parsed = Number.parseInt(raw, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 15_000;
+
+  // Default: 15s timeout so a stuck provider doesn't hang the gateway.
+  // Matches the live-mode default for consistency.
+  return DEFAULT_PROVIDER_DISCOVERY_TIMEOUT_MS;
 }
 
 function resolveProviderDiscoveryFilter(params: {
@@ -252,7 +273,7 @@ async function resolvePluginImplicitProviders(
       resolveProviderApiKey: resolveCatalogProviderApiKey,
       resolveProviderAuth: (providerId, options) =>
         ctx.resolveProviderAuth(providerId?.trim() || provider.id, options),
-      timeoutMs: resolveLiveProviderCatalogTimeoutMs(ctx.env),
+      timeoutMs: resolveProviderCatalogTimeoutMs(ctx.env),
     });
     if (!result) {
       continue;


### PR DESCRIPTION
## Summary

`resolveLiveProviderCatalogTimeoutMs` only returns a timeout when the
process is running in live-test mode (`OPENCLAW_LIVE_TEST=1` or equivalent).
In normal runtime it returns `null`, so the provider catalog discovery call
in `resolveImplicitProviders` has no client-side deadline: if a provider's
catalog endpoint stalls (slow DNS, hung TLS handshake, upstream 503 without
body), plugin discovery can wait indefinitely and block gateway startup /
config reload.

The inconsistency is also a little odd on its face: live-test mode is where
the discovery call is expected to be fast and well-behaved (CI, local
scripts), and production is where the endpoint is most likely to go slow
under real network conditions. If we're willing to cap it at 15 s in tests,
the same cap is a reasonable safety net in production.

This PR:

- Renames the helper from `resolveLiveProviderCatalogTimeoutMs` to
  `resolveProviderCatalogTimeoutMs` now that it applies to both modes.
- Adds a `DEFAULT_PROVIDER_DISCOVERY_TIMEOUT_MS = 15_000` constant, used
  as the non-live default to match the existing live-mode default.
- Adds an explicit `OPENCLAW_PROVIDER_DISCOVERY_TIMEOUT_MS` env var override
  that takes priority in both modes, so operators with slow networks can
  raise the budget without code changes.
- Keeps the existing `OPENCLAW_LIVE_PROVIDER_DISCOVERY_TIMEOUT_MS` behavior
  unchanged in live mode, so current live-lane callers continue to work.

15 s matches the live-mode default and is generous enough for VPN/proxy
environments (Surge, Tailscale, corporate proxies) with slow first-contact
to complete a catalog fetch, while still ensuring gateway startup cannot
hang indefinitely on a single stuck provider.

## Changes

- `src/agents/models-config.providers.implicit.ts` (+22/-9):
  - Add `DEFAULT_PROVIDER_DISCOVERY_TIMEOUT_MS = 15_000`
  - Rename helper and switch to returning the default in non-live mode
  - Add `OPENCLAW_PROVIDER_DISCOVERY_TIMEOUT_MS` env override branch

## Test plan

- [x] `pnpm check` (tsgo + oxlint + boundary checks, all green)
- [x] Ran the gateway against a deliberately stalled catalog endpoint on
  my fork; startup now fails fast at 15 s instead of hanging
- [ ] CI: pnpm build / pnpm test / pnpm check

This helper does not currently have a dedicated test file in
`src/agents/`; the change is small and contained to a single pure
function, and the env-var plus live-mode paths are covered by manual
reproduction. Happy to add one if reviewers prefer.