### PR TITLE
fix(channel-summary): suppress phantom default account when no accounts configured

### DIFF
--- a/src/infra/channel-summary.test.ts
+++ b/src/infra/channel-summary.test.ts
@@ -364,4 +364,30 @@ describe("buildChannelSummary", () => {
 
     expect(lines).toEqual(["Fallback: not configured"]);
   });
+
+  it("does not show phantom default account when no accounts are configured", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "feishu",
+          plugin: makeFallbackSummaryPlugin({
+            enabled: true,
+            configured: false,
+            accountIds: [], // no real accounts configured
+            defaultAccountId: "default",
+          }),
+          source: "test",
+        },
+      ]),
+    );
+
+    const lines = await buildChannelSummary({ channels: {} } as never, {
+      colorize: false,
+      includeAllowFrom: false,
+    });
+
+    // Should not render "not configured" for a default account that has no real config
+    expect(lines).not.toContain("not configured");
+    expect(lines).toEqual([]);
+  });
 });

--- a/src/infra/channel-summary.ts
+++ b/src/infra/channel-summary.ts
@@ -190,8 +190,9 @@ export async function buildChannelSummary(
     // Only build channel summary when there are actually configured accounts.
     // Passing a default/fallback accountId with no real config produces phantom
     // "not configured" entries that confuse the status display.
+    const hasRealAccounts = accountIds.length > 0 || configuredEntries.length > 0;
     const summary =
-      configuredEntries.length > 0 && plugin.status?.buildChannelSummary
+      hasRealAccounts && plugin.status?.buildChannelSummary
         ? await plugin.status.buildChannelSummary({
             account: fallbackEntry?.account ?? {},
             cfg: effective,
@@ -238,7 +239,11 @@ export async function buildChannelSummary(
       line += ` auth ${formatTimeAgo(authAgeMs)}`;
     }
 
-    lines.push(tint(line, statusColor));
+    // Suppress status line entirely when there are no real accounts and no configured entries.
+    // This prevents phantom "not configured" lines for channels that have no accounts.
+    if (hasRealAccounts) {
+      lines.push(tint(line, statusColor));
+    }
 
     if (configuredEntries.length > 0) {
       for (const entry of configuredEntries) {

--- a/src/infra/channel-summary.ts
+++ b/src/infra/channel-summary.ts
@@ -187,15 +187,19 @@ export async function buildChannelSummary(
     const anyEnabled = entries.some((entry) => entry.enabled);
     const fallbackEntry =
       entries.find((entry) => entry.accountId === defaultAccountId) ?? entries[0];
-    const summary = plugin.status?.buildChannelSummary
-      ? await plugin.status.buildChannelSummary({
-          account: fallbackEntry?.account ?? {},
-          cfg: effective,
-          defaultAccountId,
-          snapshot:
-            fallbackEntry?.snapshot ?? ({ accountId: defaultAccountId } as ChannelAccountSnapshot),
-        })
-      : undefined;
+    // Only build channel summary when there are actually configured accounts.
+    // Passing a default/fallback accountId with no real config produces phantom
+    // "not configured" entries that confuse the status display.
+    const summary =
+      configuredEntries.length > 0 && plugin.status?.buildChannelSummary
+        ? await plugin.status.buildChannelSummary({
+            account: fallbackEntry?.account ?? {},
+            cfg: effective,
+            defaultAccountId,
+            snapshot:
+              fallbackEntry?.snapshot ?? ({ accountId: defaultAccountId } as ChannelAccountSnapshot),
+          })
+        : undefined;
 
     const summaryRecord = summary;
     const linked =


### PR DESCRIPTION
## Problem

When `listAccountIds()` returns an empty array (no Feishu accounts configured), `channel-summary.ts` falls back to `[DEFAULT_ACCOUNT_ID]` as the resolved account ids. It then calls `buildChannelSummary` with that fallback default account snapshot, producing a spurious "Feishu account default not configured" status line — a phantom entry for an account that was never actually configured.

This was reported in https://github.com/openclaw/openclaw/issues/64707.

## Fix

Two-layer guard in `buildChannelSummary`:

1. **`buildChannelSummary` call**: only invoke when `accountIds.length > 0 || configuredEntries.length > 0` (was: only `configuredEntries.length > 0`)
2. **`lines.push` call**: also guard with `accountIds.length > 0 || configuredEntries.length > 0` to prevent unconditional emission of the status line

The second guard was missing in the initial submission — confirmed by [Greptile review](https://github.com/openclaw/openclaw/pull/64712#issuecomment-4229091834).

## Changes

- `src/infra/channel-summary.ts`: add `hasRealAccounts = accountIds.length > 0 || configuredEntries.length > 0` variable; gate both `buildChannelSummary` and `lines.push` with it
- `src/infra/channel-summary.test.ts`: regression test for the phantom default account case
