### PR TITLE
fix(telegram): respect configured text chunk limit

### DIFF
--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1655,6 +1655,8 @@ describe("sendMessageTelegram", () => {
     const chatId = "123";
     const htmlText = `<b>${"A".repeat(5000)}</b>`;
 
+    loadConfig.mockReturnValue({ channels: { telegram: {} } });
+
     const sendMessage = vi
       .fn()
       .mockResolvedValueOnce({ message_id: 90, chat: { id: chatId } })
@@ -1680,6 +1682,25 @@ describe("sendMessageTelegram", () => {
       inline_keyboard: [[{ text: "OK", callback_data: "ok" }]],
     });
     expect(res.messageId).toBe("91");
+  });
+
+  it("uses configured telegram textChunkLimit for html chunk planning", async () => {
+    const chatId = "123";
+    const htmlText = `<b>${"A".repeat(4050)}</b>`;
+
+    loadConfig.mockReturnValue({ channels: { telegram: { textChunkLimit: 4096 } } });
+
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 90, chat: { id: chatId } });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    await sendMessageTelegram(chatId, htmlText, {
+      token: "tok",
+      api,
+      textMode: "html",
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(String(sendMessage.mock.calls[0]?.[1] ?? "").length).toBeLessThanOrEqual(4096);
   });
 
   it("preserves caller plain-text fallback across chunked html parse retries", async () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -4,6 +4,7 @@ import { type ApiClientOptions, Bot, HttpError } from "grammy";
 import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { formatUncaughtError } from "openclaw/plugin-sdk/error-runtime";
 import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
+import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-runtime";
 import { createTelegramRetryRunner, type RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -749,25 +750,35 @@ export async function sendMessageTelegram(
 
   const buildChunkedTextPlan = (rawText: string, context: string): TelegramTextChunk[] => {
     const fallbackText = opts.plainText ?? rawText;
+    const textChunkLimit = Math.min(
+      4096,
+      resolveTextChunkLimit(cfg, "telegram", account.accountId, { fallbackLimit: 4000 }),
+    );
     let htmlChunks: string[];
     try {
-      htmlChunks = splitTelegramHtmlChunks(rawText, 4000);
+      htmlChunks = splitTelegramHtmlChunks(rawText, textChunkLimit);
     } catch (error) {
       logVerbose(
         `telegram ${context} failed HTML chunk planning, retrying as plain text: ${formatErrorMessage(
           error,
         )}`,
       );
-      return splitTelegramPlainTextChunks(fallbackText, 4000).map((plainText) => ({ plainText }));
+      return splitTelegramPlainTextChunks(fallbackText, textChunkLimit).map((plainText) => ({
+        plainText,
+      }));
     }
-    const fixedPlainTextChunks = splitTelegramPlainTextChunks(fallbackText, 4000);
+    const fixedPlainTextChunks = splitTelegramPlainTextChunks(fallbackText, textChunkLimit);
     if (fixedPlainTextChunks.length > htmlChunks.length) {
       logVerbose(
         `telegram ${context} plain-text fallback needs more chunks than HTML; sending plain text`,
       );
       return fixedPlainTextChunks.map((plainText) => ({ plainText }));
     }
-    const plainTextChunks = splitTelegramPlainTextFallback(fallbackText, htmlChunks.length, 4000);
+    const plainTextChunks = splitTelegramPlainTextFallback(
+      fallbackText,
+      htmlChunks.length,
+      textChunkLimit,
+    );
     return htmlChunks.map((htmlText, index) => ({
       htmlText,
       plainText: plainTextChunks[index] ?? htmlText,


### PR DESCRIPTION
## Summary
- use the configured Telegram text chunk limit when planning HTML/plain-text chunks
- keep the existing 4096 hard cap while honoring lower configured limits
- add a test covering `channels.telegram.textChunkLimit = 4096`

## Testing
- corepack pnpm exec vitest run extensions/telegram/src/send.test.ts --pool=forks