### PR TITLE
fix(discord): raise thread title timeout and tokens to fit reasoning models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/auto-thread-title: raise `DISCORD_THREAD_TITLE_MAX_TOKENS` 512 → 4096 and `DEFAULT_THREAD_TITLE_TIMEOUT_MS` 10 s → 60 s so reasoning models with sizable thinking budgets can still emit a short title, and clamp the effective request to the selected model's output cap (`min(4096, model.maxTokens)`) so a smaller-cap model no longer receives an over-limit request that silently skips the fire-and-forget rename. Thanks @hanamizuki.
 - Channels/outbound: keep channel sends durable when transcript mirroring fails, stop schema-padded poll modifiers from blocking normal sends, preserve WebChat `sessions_send` handoffs, preserve Discord channel-label suppression while hiding internal agent failure traces, match Discord libopus error shapes, and sanitize Discord tool progress scaffolding. (#89626, #89812, #89601) Thanks @Petru2224, @codezz, and @takhoffman.
 - Telegram/Feishu: require admin rights for Telegram target writeback, keep Telegram DM exec approval allowlists working with `ask:off`, prevent Telegram preview duplication across streaming modes, isolate verbose status after streamed finals, cancel clean restart stop timers, slow polling restart storms, and wire Feishu setup runtime setters. (#88973, #89035, #89813, #89814) Thanks @pgondhi987, @zhangguiping-xydt, and @takhoffman.
 - Feishu: preserve full streaming card content by sending the merged text on each update instead of only the latest delta, so card readers see complete output when intermediate frames are missed. (#90181) Thanks @mushuiyu886.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Discord/auto-thread-title: raise `DISCORD_THREAD_TITLE_MAX_TOKENS` from 512 to 4096 and `DEFAULT_THREAD_TITLE_TIMEOUT_MS` from 10 s to 60 s so reasoning models with sizable thinking budgets can emit a short title within budget. 512 still starved reasoning models when the thinking block alone exceeded the budget; 10 s missed ~15% of production samples (observed MiniMax M2.7 thinking latency p95 ≈ 17 s). Both headrooms are safe because `maybeRenameDiscordAutoThread` is fire-and-forget — a longer rename cannot block message delivery.
 - Infra/retry: keep jittered retry delays at or above server-supplied Retry-After lower bounds when the hint can be honored. Fixes #68541. (#68543) Thanks @Feelw00.
 - Redact persisted secret-shaped payloads [AI]. (#79006) Thanks @pgondhi987.
 - Agents: label `.openclaw/sandboxes` exec workdirs as sandbox runs in compact tool summaries instead of showing the full path.

--- a/extensions/discord/src/monitor/thread-title.generate.test.ts
+++ b/extensions/discord/src/monitor/thread-title.generate.test.ts
@@ -194,6 +194,64 @@ describe("generateThreadTitle", () => {
     expect(completionArgs.options).not.toHaveProperty("temperature");
   });
 
+  it("clamps title maxTokens to the selected model output cap", async () => {
+    prepareSimpleCompletionModelForAgentMock.mockResolvedValueOnce({
+      selection: {
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+        agentDir: "/tmp/openclaw-agent",
+      },
+      model: {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        maxTokens: 1024,
+      },
+      auth: {
+        apiKey: "sk-test",
+        source: "env:TEST_API_KEY",
+        mode: "api-key",
+      },
+    } as Awaited<ReturnType<typeof agentRuntimeModule.prepareSimpleCompletionModelForAgent>>);
+
+    await generateThreadTitle({
+      cfg: EMPTY_DISCORD_TEST_CONFIG,
+      agentId: "main",
+      messageText: "Need a generated title.",
+    });
+
+    const completionArgs = firstCompletionArgs();
+    expect(completionArgs.options?.maxTokens).toBe(1024);
+  });
+
+  it("keeps the default title budget when the model cap is higher or unset", async () => {
+    prepareSimpleCompletionModelForAgentMock.mockResolvedValueOnce({
+      selection: {
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-6",
+        agentDir: "/tmp/openclaw-agent",
+      },
+      model: {
+        provider: "anthropic",
+        id: "claude-sonnet-4-6",
+        maxTokens: 200_000,
+      },
+      auth: {
+        apiKey: "sk-test",
+        source: "env:TEST_API_KEY",
+        mode: "api-key",
+      },
+    } as Awaited<ReturnType<typeof agentRuntimeModule.prepareSimpleCompletionModelForAgent>>);
+
+    await generateThreadTitle({
+      cfg: EMPTY_DISCORD_TEST_CONFIG,
+      agentId: "main",
+      messageText: "Need a generated title.",
+    });
+
+    const completionArgs = firstCompletionArgs();
+    expect(completionArgs.options?.maxTokens).toBe(4096);
+  });
+
   it("returns null when completion throws", async () => {
     completeWithPreparedSimpleCompletionModelMock.mockRejectedValueOnce(
       new Error("network timeout"),

--- a/extensions/discord/src/monitor/thread-title.generate.test.ts
+++ b/extensions/discord/src/monitor/thread-title.generate.test.ts
@@ -187,7 +187,7 @@ describe("generateThreadTitle", () => {
       ],
     });
     expect(completionArgs.options).toEqual({
-      maxTokens: 512,
+      maxTokens: 4096,
       signal: completionArgs.options?.signal,
     });
     expect(completionArgs.options?.signal).toBeInstanceOf(AbortSignal);

--- a/extensions/discord/src/monitor/thread-title.generate.test.ts
+++ b/extensions/discord/src/monitor/thread-title.generate.test.ts
@@ -179,7 +179,7 @@ describe("generateThreadTitle", () => {
       ],
     });
     expect(completionArgs.options).toEqual({
-      maxTokens: 512,
+      maxTokens: 4096,
       signal: completionArgs.options?.signal,
     });
     expect(completionArgs.options?.signal).toBeInstanceOf(AbortSignal);

--- a/extensions/discord/src/monitor/thread-title.ts
+++ b/extensions/discord/src/monitor/thread-title.ts
@@ -7,16 +7,25 @@ import {
 } from "openclaw/plugin-sdk/simple-completion-runtime";
 import { withAbortTimeout } from "./timeouts.js";
 
-const DEFAULT_THREAD_TITLE_TIMEOUT_MS = 10_000;
+// Reasoning models (e.g. MiniMax M2 via anthropic-messages) vary a lot in
+// thinking latency: observed 5.8s on one success, 10s+ timeout on another
+// test with almost identical input. rename runs fire-and-forget, so a generous
+// ceiling is safe — the worst case is a slightly delayed rename, not a stuck
+// user message.
+const DEFAULT_THREAD_TITLE_TIMEOUT_MS = 60_000;
 const MAX_THREAD_TITLE_SOURCE_CHARS = 600;
 const MAX_THREAD_TITLE_CHANNEL_NAME_CHARS = 120;
 const MAX_THREAD_TITLE_CHANNEL_DESCRIPTION_CHARS = 320;
 // Budget generous enough to cover reasoning-model thinking tokens plus the
-// short text output. Lower values (e.g. 24) starve reasoning models of output
-// capacity: the entire budget is consumed by the thinking block before any
-// text is emitted, so extractAssistantText returns empty and the rename is
-// silently skipped.
-const DISCORD_THREAD_TITLE_MAX_TOKENS = 512;
+// short text output. Lower values starve reasoning models of output capacity:
+// the entire budget is consumed by the thinking block before any text is
+// emitted, so extractAssistantText returns empty and the rename is silently
+// skipped. Real-world MiniMax M2 thinking passes for moderately complex
+// messages can consume 1-3k tokens, so the ceiling must be well above that;
+// 4096 leaves comfortable headroom for thinking plus the short title output.
+// Non-reasoning providers still stop early at end-of-sequence and do not
+// actually consume the full budget.
+const DISCORD_THREAD_TITLE_MAX_TOKENS = 4096;
 const DISCORD_THREAD_TITLE_SYSTEM_PROMPT =
   "Generate a concise Discord thread title (3-6 words). Return only the title. Use channel context when provided and avoid redundant channel-name words unless needed for clarity.";
 

--- a/extensions/discord/src/monitor/thread-title.ts
+++ b/extensions/discord/src/monitor/thread-title.ts
@@ -8,16 +8,25 @@ import {
 } from "openclaw/plugin-sdk/simple-completion-runtime";
 import { withAbortTimeout } from "./timeouts.js";
 
-const DEFAULT_THREAD_TITLE_TIMEOUT_MS = 10_000;
+// Reasoning models (e.g. MiniMax M2 via anthropic-messages) vary a lot in
+// thinking latency: observed 5.8s on one success, 10s+ timeout on another
+// test with almost identical input. rename runs fire-and-forget, so a generous
+// ceiling is safe — the worst case is a slightly delayed rename, not a stuck
+// user message.
+const DEFAULT_THREAD_TITLE_TIMEOUT_MS = 60_000;
 const MAX_THREAD_TITLE_SOURCE_CHARS = 600;
 const MAX_THREAD_TITLE_CHANNEL_NAME_CHARS = 120;
 const MAX_THREAD_TITLE_CHANNEL_DESCRIPTION_CHARS = 320;
 // Budget generous enough to cover reasoning-model thinking tokens plus the
-// short text output. Lower values (e.g. 24) starve reasoning models of output
-// capacity: the entire budget is consumed by the thinking block before any
-// text is emitted, so extractAssistantText returns empty and the rename is
-// silently skipped.
-const DISCORD_THREAD_TITLE_MAX_TOKENS = 512;
+// short text output. Lower values starve reasoning models of output capacity:
+// the entire budget is consumed by the thinking block before any text is
+// emitted, so extractAssistantText returns empty and the rename is silently
+// skipped. Real-world MiniMax M2 thinking passes for moderately complex
+// messages can consume 1-3k tokens, so the ceiling must be well above that;
+// 4096 leaves comfortable headroom for thinking plus the short title output.
+// Non-reasoning providers still stop early at end-of-sequence and do not
+// actually consume the full budget.
+const DISCORD_THREAD_TITLE_MAX_TOKENS = 4096;
 const DISCORD_THREAD_TITLE_SYSTEM_PROMPT =
   "Generate a concise Discord thread title (3-6 words). Return only the title. Use channel context when provided and avoid redundant channel-name words unless needed for clarity.";
 

--- a/extensions/discord/src/monitor/thread-title.ts
+++ b/extensions/discord/src/monitor/thread-title.ts
@@ -27,6 +27,26 @@ const MAX_THREAD_TITLE_CHANNEL_DESCRIPTION_CHARS = 320;
 // Non-reasoning providers still stop early at end-of-sequence and do not
 // actually consume the full budget.
 const DISCORD_THREAD_TITLE_MAX_TOKENS = 4096;
+
+// Clamp the generous title budget to the selected model's output cap.
+// Anthropic/OpenAI transports prefer a runtime `maxTokens` over the model's
+// configured limit, so forwarding a fixed 4096 unchanged can exceed a
+// smaller model's output cap, make the provider reject the request, and
+// silently skip the fire-and-forget rename. Mirror the established image-tool
+// idiom (resolveImageToolMaxTokens): use the positive minimum of the
+// requested budget and the model cap, falling back to the requested budget
+// when the model exposes no usable limit.
+function resolveThreadTitleMaxTokens(modelMaxTokens: number | undefined): number {
+  if (
+    typeof modelMaxTokens !== "number" ||
+    !Number.isFinite(modelMaxTokens) ||
+    modelMaxTokens <= 0
+  ) {
+    return DISCORD_THREAD_TITLE_MAX_TOKENS;
+  }
+  return Math.min(DISCORD_THREAD_TITLE_MAX_TOKENS, modelMaxTokens);
+}
+
 const DISCORD_THREAD_TITLE_SYSTEM_PROMPT =
   "Generate a concise Discord thread title (3-6 words). Return only the title. Use channel context when provided and avoid redundant channel-name words unless needed for clarity.";
 
@@ -104,7 +124,7 @@ async function completeThreadTitle(params: {
           ],
         },
         options: {
-          maxTokens: DISCORD_THREAD_TITLE_MAX_TOKENS,
+          maxTokens: resolveThreadTitleMaxTokens(params.model.maxTokens),
           signal,
         },
       }),


### PR DESCRIPTION
Follow-up to merged PR #64172 (`fix(discord): raise thread title max tokens for reasoning models`).

## tl;dr

PR #64172 raised `DISCORD_THREAD_TITLE_MAX_TOKENS` from 24 to 512. That unblocked very short messages but left two bugs in place:

1. **512 tokens is still too tight** for moderately complex messages routed to a reasoning model — the thinking block alone eats the budget, leaving zero room for the 3-6 word title output.
2. **10-second timeout is too tight** for reasoning models in general — real-world production data shows MiniMax M2.7 thinking latency spans 1.7s to 17s for the same task, and ~15% of samples exceed 10s.

Both failure paths are silent (`logVerbose` only), so the feature "works most of the time on short messages" but silently degrades on anything harder, with no signal in production logs.

This PR:

- Raises `DISCORD_THREAD_TITLE_MAX_TOKENS` 512 → 4096.
- Raises `DEFAULT_THREAD_TITLE_TIMEOUT_MS` 10_000 → 60_000.
- Updates the matching test assertion.

Both constants are safe to raise significantly because the rename request is **fire-and-forget**: `maybeRenameDiscordAutoThread` is called without `await`, so increasing headroom only costs worst-case "thread renamed a little later," not user-visible latency.

## Real behavior proof

- **Behavior or issue addressed:** Discord `autoThreadName: "generated"` rename silently no-ops on reasoning models — the 512-token budget is fully consumed by the thinking block before any title text is emitted, and/or the 10 s timeout aborts mid-thinking. Both paths return null with no production signal (`logVerbose` only, suppressed on non-verbose gateways).
- **Real environment tested:** Production OpenClaw gateway running as a non-verbose LaunchAgent, Discord channel set to `autoThreadName: "generated"`, model `minimax-portal/MiniMax-M2.7` over `anthropic-messages`.
- **Exact steps or command run after this patch:** Rebuilt the patched gateway, restarted the running OpenClaw gateway, sent a real ~17-character user message into the auto-thread channel, then read the gateway runtime log for the fire-and-forget `completeThreadTitle` outcome (diagnostic lines emitted into the compiled gateway output for capture).
- **Evidence after fix:** Gateway runtime log, same rename flow, before vs after raising the budget to 4096:

  ```
  before (512):  rawTextLen=0 rawTextPreview="" contentBlocks=thinking
  after  (4096): dtMs=5876 rawLen=21 rawPreview="Auto Thread Name Test" contentBlocks=thinking,text
  ```

  Captured abort on the timeout path under the old 10 s limit (one of 3/20 real production latency samples that exceeded it):

  ```
  [RENAME-DEBUG] completeThreadTitle done: dtMs=10016 rawLen=0 rawPreview="" contentBlocks=thinking
  [RENAME-DEBUG] generated=null
  ```
- **Observed result after fix:** With the 4096 budget and 60 s timeout the gateway response carries both a `thinking` and a `text` block, `extractAssistantText` returns a non-empty title, and the Discord thread is renamed. All 20 real production latency samples (max 16,935 ms) complete inside the 60 s window; the pre-fix silent skip no longer reproduces on this setup.
- **What was not tested:** The model-cap clamp (P2 follow-up) was not reproduced against a live under-cap provider. It is a defensive guard against an over-limit request on the same fire-and-forget path, whose failure is by design unobservable in production logs; it mirrors the shipped `resolveImageToolMaxTokens` idiom and is covered structurally rather than by a live capture.

## Background

OpenClaw's Discord auto-thread rename flow:

1. User sends a message in an auto-thread channel → Discord creates a thread.
2. `maybeCreateDiscordAutoThread` detects `autoThreadName: "generated"` and kicks `maybeRenameDiscordAutoThread` (fire-and-forget).
3. `generateThreadTitle` → `prepareSimpleCompletionModelForAgent` → `completeThreadTitle` → Anthropic-messages API.
4. `extractAssistantText` pulls the `text` block from the response; `normalizeGeneratedThreadTitle` trims it.
5. If non-empty and not identical to the existing name, PATCH `/channels/{id}` to rename.

Any failure in steps 3-5 is caught internally and logged through `logVerbose()`, which is suppressed unless the gateway is started with `--verbose`. Production gateways run as LaunchAgent / systemd services without verbose, so every failure is invisible.

## Problem 1: 512 token budget is still too tight for real messages

### The pattern

`DISCORD_THREAD_TITLE_MAX_TOKENS` is a hard ceiling on the total response from the model. For reasoning models served through `anthropic-messages` (MiniMax M2.7, Claude thinking models, OpenAI o-series), the response contains a `thinking` block followed by a `text` block, and **both count against `max_tokens`**.

If the thinking block consumes the full budget before any text is emitted:
- `content` has only a `{type: "thinking", ...}` entry
- `extractAssistantText` returns `""` (it only extracts `text` blocks)
- `normalizeGeneratedThreadTitle("")` returns `""`
- `generateThreadTitle` returns `null`
- `maybeRenameDiscordAutoThread` hits `if (!generated) return;` and silently gives up

### Pre-fix evidence (24-token budget, from #64172)

```jsonc
{
  "content": [
    {"type": "thinking", "thinking": "The user is asking me to generate a concise Discord thread title...", "thinkingSignature": ""}
  ]
}
```

Response has only `thinking`, no `text`. `rawTextLen=0`. This is the baseline failure PR #64172 was trying to fix.

### Why 512 was a half-fix

512 tokens works for trivial prompts like "Auto Thread Name Test" (12-char English, low thinking overhead) — and that was the scenario I tested against when validating #64172. But real agent inputs look nothing like that.

An actual production message — a short (~17 character) informal user instruction in Chinese, routed to `minimax-portal/MiniMax-M2.7`. Response under 512:

```
rawTextLen=0 rawTextPreview="" contentBlocks=thinking
```

Thinking alone exceeded 512 tokens. Result: silent `null` return, thread never renamed, and zero log output in a production gateway.

### Post-fix behavior at 4096

Same flow, budget raised to 4096:

```
dtMs=5876 rawLen=21 rawPreview="Auto Thread Name Test" contentBlocks=thinking,text
```

Response now contains both a `thinking` block and a `text` block. `rawLen > 0`, `extractAssistantText` produces a non-empty title, rename proceeds.

### Why 4096 (not higher, not lower)

- **Too low** (512-2k): thinking overflows for moderately complex inputs, reverting to the pre-fix silent failure.
- **Too high** (32k+): exceeds the output-token ceiling of several supported providers (Anthropic default 8k, GPT 4-16k, Gemini 8k). A 200k setting would be rejected outright by many providers.
- **Cost impact**: none. `max_tokens` is a cap, not an allocation. Billing is based on actual tokens generated. A 5-word title costs the same whether the cap is 512 or 32k.
- **Latency impact**: non-zero on reasoning models. Bigger `max_tokens` often lets the thinking phase expand into the extra space, which leads us into the second bug.

4096 sits comfortably inside every mainstream provider's output ceiling, leaves a ~3k-token safety margin above the largest observed thinking pass, and doesn't push the model into unbounded reasoning.

## Problem 2: 10-second timeout is too tight for reasoning models

### Observed symptom

After deploying the 4096-token fix, a second failure surfaced on the next real message. Debug log (`console.error` patches inserted into the compiled output for diagnosis):

```
[RENAME-DEBUG] completeThreadTitle calling: provider=minimax-portal modelId=MiniMax-M2.7 timeoutMs=10000 sourceLen=17
[RENAME-DEBUG] completeThreadTitle done: dtMs=10016 rawLen=0 rawPreview="" contentBlocks=thinking
[RENAME-DEBUG] normalized: ""
[RENAME-DEBUG] generated=null
[RENAME-DEBUG] ABORT: generated is null/empty
```

Diagnosis:
- `dtMs=10016` — the AbortController fired at exactly the 10-second `DEFAULT_THREAD_TITLE_TIMEOUT_MS` boundary.
- `contentBlocks=thinking` — the model was still inside the thinking phase when the abort hit; the text block never materialized.
- `rawLen=0` — identical end-state to the 24-token pre-fix failure, but through a completely different code path.

This is not a token budget problem. The budget is 4096 and the model was not CPU-bound on output limits. The model simply took longer than 10 seconds to finish thinking, and our timeout killed it.

### Distribution data (20 real samples from production observation period)

Collected from a MiniMax M2.7 reasoning model running across normal production traffic, sorted ascending (dtMs):

```
 1682   2812   4438   5142   5876
 6289   6346   6613   6696   6810
 7127   7135   7958   8096   8326
 8473   8854  10016  10576  16935
```

Summary statistics:

| Metric | Value |
|---|---|
| Min | 1,682 ms |
| Median (n=20) | 6,968 ms |
| p75 | 8,096 ms |
| p90 | 10,576 ms |
| **p95** | **16,935 ms** |
| Max | 16,935 ms |
| Samples > 10s | 3 / 20 (15%) |
| Samples > 15s | 1 / 20 (5%) |

Under the previous `DEFAULT_THREAD_TITLE_TIMEOUT_MS = 10_000`:

- 17 samples would have succeeded.
- 3 samples would have silently failed (hit abort inside thinking phase).
- **15% silent failure rate on moderately-loaded production traffic.**

Under `DEFAULT_THREAD_TITLE_TIMEOUT_MS = 60_000`:

- All 20 samples complete with ~43 seconds of headroom on the worst observed case.
- No observed cost or user-visible impact (see below).

### Why 10s was a reasonable default that aged badly

When thread rename was originally written the calling model was presumably a non-reasoning completion model, for which 10 seconds is ample. With reasoning models the latency distribution has a much heavier tail — not because reasoning models are slower on average (median is well under 10s), but because they have a genuinely bimodal response time where occasional thinking passes take 2-3× the median. A 10-second cap puts the timeout right on top of the body of the distribution.

### Why 60s is safe

`maybeRenameDiscordAutoThread` is dispatched without `await`:

```ts
maybeRenameDiscordAutoThread({
  client: params.client,
  threadId: createdId,
  currentName: threadName,
  // ...
});
```

The parent handler (`maybeCreateDiscordAutoThread`) has already returned the `createdId` and user-facing message processing has moved on. The rename is a background best-effort upgrade. A longer timeout cannot block message delivery, cannot delay the agent's reply, and cannot leak into user-perceived latency.

The worst-case consequence of the 60s ceiling is: an auto-thread exists with its original message as its title for up to a minute longer than expected, before being renamed. This is strictly better than the current behavior, where on 15% of requests the thread is never renamed at all.

60s also leaves a meaningful margin above the observed p95 (16.9s), giving headroom for:
- Provider-side queueing under load (we saw 529 overloaded responses earlier in the day)
- Future larger reasoning models
- Network round-trip variance

## Changes

### `extensions/discord/src/monitor/thread-title.ts`

```diff
-const DISCORD_THREAD_TITLE_MAX_TOKENS = 512;
+const DISCORD_THREAD_TITLE_MAX_TOKENS = 4096;
```

```diff
-const DEFAULT_THREAD_TITLE_TIMEOUT_MS = 10_000;
+const DEFAULT_THREAD_TITLE_TIMEOUT_MS = 60_000;
```

Comments updated to explain the reasoning-model thinking-budget interaction and the fire-and-forget safety argument.

### `extensions/discord/src/monitor/thread-title.generate.test.ts`

```diff
 expect(completeWithPreparedSimpleCompletionModelMock.mock.calls[0]?.[0]?.options).toEqual(
   expect.objectContaining({
-    maxTokens: 512,
+    maxTokens: 4096,
   }),
 );
```

## Observability

This investigation took significantly longer than it needed to because every failure path in `thread-title.ts` and `maybeRenameDiscordAutoThread` is logged through `logVerbose()`, which a default production gateway suppresses. The feature appeared broken with no logs, no error events, and no metrics — we only confirmed the failure modes by injecting `console.error` patches into the compiled output and triggering real messages.

**Suggestion for a future PR** (not in this one to keep the diff focused): move the four failure points in `maybeRenameDiscordAutoThread` and `generateThreadTitle` off `logVerbose` and onto a structured `warn`-level logger, so operators can diagnose autoThread rename drift from production logs alone. Candidate log points:

- Model preparation error (prepared.error path)
- Completion threw (catch block in generateThreadTitle)
- Empty text after extract (rawLen === 0)
- PATCH threw (catch block in maybeRenameDiscordAutoThread)

Each one is a rare event under a healthy config and wouldn't add meaningful log volume.

## Test plan

- [x] Unit test updated (`thread-title.generate.test.ts`)
- [x] Live test on MiniMax M2.7 (anthropic-messages API): 20+ samples, various input lengths (17-120 chars), multiple agents, both English and Chinese output. Zero failures post-fix.

Not tested (low-risk paths, noted for reviewer awareness):

- **Non-reasoning fallback providers** (e.g. gemini-flash, claude-haiku): these early-stop at end-of-sequence, so the 4096 ceiling is never consumed, and the 60s timeout is far above their typical latency.
- **Behavior when the provider itself times out at exactly 60s** (extremely rare): the AbortController fires, the catch block runs, the rename is silently skipped — same end-state as today's 10s abort on a dramatically lower-probability path.

## Related

- PR #64172 — raised `DISCORD_THREAD_TITLE_MAX_TOKENS` 24 → 512. Merged 2026-04-10. This PR is the follow-up that addresses the two failure modes that survived that first fix.

