### PR TITLE
feat(tasks): add observable worker state snapshot

### DIFF
--- a/src/cli/program/register.maintenance.test.ts
+++ b/src/cli/program/register.maintenance.test.ts
@@ -85,6 +85,20 @@ describe("registerMaintenanceCommands doctor action", () => {
     );
   });
 
+  it("passes --json through to doctor command", async () => {
+    doctorCommand.mockResolvedValue(undefined);
+
+    await runMaintenanceCli(["doctor", "--json", "--non-interactive"]);
+
+    expect(doctorCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        json: true,
+        nonInteractive: true,
+      }),
+    );
+  });
+
   it("passes noOpen to dashboard command", async () => {
     dashboardCommand.mockResolvedValue(undefined);
 

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -25,6 +25,7 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--non-interactive", "Run without prompts (safe migrations only)", false)
     .option("--generate-gateway-token", "Generate and configure a gateway token", false)
     .option("--deep", "Scan system services for extra gateway installs", false)
+    .option("--json", "Print a structured JSON summary", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         await doctorCommand(defaultRuntime, {
@@ -35,6 +36,7 @@ export function registerMaintenanceCommands(program: Command) {
           nonInteractive: Boolean(opts.nonInteractive),
           generateGatewayToken: Boolean(opts.generateGatewayToken),
           deep: Boolean(opts.deep),
+          json: Boolean(opts.json),
         });
         defaultRuntime.exit(0);
       });

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -6,7 +6,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { formatHealthCheckFailure } from "./health-format.js";
-import { healthCommand } from "./health.js";
+import { getHealthSnapshot } from "./health.js";
 
 export type GatewayMemoryProbe = {
   checked: boolean;
@@ -24,7 +24,7 @@ export async function checkGatewayHealth(params: {
     typeof params.timeoutMs === "number" && params.timeoutMs > 0 ? params.timeoutMs : 10_000;
   let healthOk = false;
   try {
-    await healthCommand({ json: false, timeoutMs, config: params.cfg }, params.runtime);
+    await getHealthSnapshot({ timeoutMs, probe: true });
     healthOk = true;
   } catch (err) {
     const message = String(err);

--- a/src/commands/doctor-prompter.ts
+++ b/src/commands/doctor-prompter.ts
@@ -16,6 +16,7 @@ export type DoctorOptions = {
   repair?: boolean;
   force?: boolean;
   generateGatewayToken?: boolean;
+  json?: boolean;
 };
 
 export type DoctorPrompter = {

--- a/src/commands/doctor.json-output.test.ts
+++ b/src/commands/doctor.json-output.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDoctorRuntime, mockDoctorConfigSnapshot } from "./doctor.e2e-harness.js";
+import { loadDoctorCommandForTest, terminalNoteMock } from "./doctor.note-test-helpers.js";
+import "./doctor.fast-path-mocks.js";
+
+let doctorCommand: typeof import("./doctor.js").doctorCommand;
+
+describe("doctor command --json", () => {
+  beforeEach(async () => {
+    mockDoctorConfigSnapshot({
+      config: {
+        channels: {
+          telegram: { enabled: true },
+          whatsapp: { enabled: true },
+        },
+      },
+    });
+
+    doctorCommand = await loadDoctorCommandForTest({
+      unmockModules: ["../flows/doctor-health-contributions.js", "./doctor-state-integrity.js"],
+    });
+  });
+
+  it("writes a single JSON payload and suppresses notes/fix hints", async () => {
+    const runtime = createDoctorRuntime();
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    let output = "";
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      output += String(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      await doctorCommand(runtime, {
+        json: true,
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    expect(terminalNoteMock).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      expect.stringContaining('Run "openclaw doctor --fix" to apply changes.'),
+    );
+
+    const parsed = JSON.parse(output);
+    expect(parsed).toMatchObject({
+      ok: true,
+      command: "doctor",
+      channels: expect.any(Array),
+    });
+  });
+});

--- a/src/commands/doctor.note-test-helpers.ts
+++ b/src/commands/doctor.note-test-helpers.ts
@@ -3,14 +3,35 @@ import { vi } from "vitest";
 
 export const terminalNoteMock: Mock<(...args: unknown[]) => unknown> = vi.fn();
 
+function isNoteSuppressedByEnv(value: string | undefined): boolean {
+  if (!value) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+  return normalized !== "0" && normalized !== "false" && normalized !== "off";
+}
+
 vi.mock("../terminal/note.js", () => ({
-  note: (...args: unknown[]) => terminalNoteMock(...args),
+  note: (...args: unknown[]) => {
+    if (isNoteSuppressedByEnv(process.env.OPENCLAW_SUPPRESS_NOTES)) {
+      return;
+    }
+    return terminalNoteMock(...args);
+  },
 }));
 
 export async function loadDoctorCommandForTest(params?: { unmockModules?: string[] }) {
   vi.resetModules();
   vi.doMock("../terminal/note.js", () => ({
-    note: (...args: unknown[]) => terminalNoteMock(...args),
+    note: (...args: unknown[]) => {
+      if (isNoteSuppressedByEnv(process.env.OPENCLAW_SUPPRESS_NOTES)) {
+        return;
+      }
+      return terminalNoteMock(...args);
+    },
   }));
   for (const modulePath of params?.unmockModules ?? []) {
     vi.doUnmock(modulePath);

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -463,7 +463,7 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
     }
     return;
   }
-  if (!ctx.prompter.shouldRepair) {
+  if (!ctx.prompter.shouldRepair && ctx.options.json !== true) {
     ctx.runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
 }

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -11,55 +11,111 @@ import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
-import { runDoctorHealthContributions } from "./doctor-health-contributions.js";
+import {
+  runDoctorHealthContributions,
+  type DoctorHealthFlowContext,
+} from "./doctor-health-contributions.js";
 
 const intro = (message: string) => clackIntro(stylePromptTitle(message) ?? message);
 const outro = (message: string) => clackOutro(stylePromptTitle(message) ?? message);
+
+function buildDoctorJsonSummary(params: {
+  root: string;
+  ctx: {
+    cfg: DoctorHealthFlowContext["cfg"];
+    configPath: string;
+    sourceConfigValid: boolean;
+    healthOk?: boolean;
+    gatewayMemoryProbe?: DoctorHealthFlowContext["gatewayMemoryProbe"];
+  };
+}) {
+  const channels = Object.entries(params.ctx.cfg.channels ?? {}).map(([name, value]) => ({
+    name,
+    enabled:
+      typeof value === "object" && value !== null && "enabled" in value
+        ? (value as { enabled?: unknown }).enabled === true
+        : false,
+  }));
+  return {
+    ok: true,
+    command: "doctor",
+    mode: params.ctx.cfg.gateway?.mode === "remote" ? "remote" : "local",
+    configPath: params.ctx.configPath,
+    packageRoot: params.root,
+    sourceConfigValid: params.ctx.sourceConfigValid,
+    healthOk: params.ctx.healthOk ?? null,
+    gatewayMemoryProbe: params.ctx.gatewayMemoryProbe ?? null,
+    channels,
+    generatedAt: new Date().toISOString(),
+  };
+}
 
 export async function doctorCommand(
   runtime: RuntimeEnv = defaultRuntime,
   options: DoctorOptions = {},
 ) {
   const prompter = createDoctorPrompter({ runtime, options });
-  printWizardHeader(runtime);
-  intro("OpenClaw doctor");
+  const previousSuppressNotes = process.env.OPENCLAW_SUPPRESS_NOTES;
 
-  const root = await resolveOpenClawPackageRoot({
-    moduleUrl: import.meta.url,
-    argv1: process.argv[1],
-    cwd: process.cwd(),
-  });
-
-  const updateResult = await maybeOfferUpdateBeforeDoctor({
-    runtime,
-    options,
-    root,
-    confirm: (p) => prompter.confirm(p),
-    outro,
-  });
-  if (updateResult.handled) {
-    return;
+  if (options.json) {
+    process.env.OPENCLAW_SUPPRESS_NOTES = "1";
+  } else {
+    printWizardHeader(runtime);
+    intro("OpenClaw doctor");
   }
 
-  await maybeRepairUiProtocolFreshness(runtime, prompter);
-  noteSourceInstallIssues(root);
-  noteStartupOptimizationHints();
+  try {
+    const root = await resolveOpenClawPackageRoot({
+      moduleUrl: import.meta.url,
+      argv1: process.argv[1],
+      cwd: process.cwd(),
+    });
 
-  const configResult = await loadAndMaybeMigrateDoctorConfig({
-    options,
-    confirm: (p) => prompter.confirm(p),
-  });
-  const ctx = {
-    runtime,
-    options,
-    prompter,
-    configResult,
-    cfg: configResult.cfg,
-    cfgForPersistence: structuredClone(configResult.cfg),
-    sourceConfigValid: configResult.sourceConfigValid ?? true,
-    configPath: configResult.path ?? CONFIG_PATH,
-  };
-  await runDoctorHealthContributions(ctx);
+    const updateResult = await maybeOfferUpdateBeforeDoctor({
+      runtime,
+      options,
+      root,
+      confirm: (p) => prompter.confirm(p),
+      outro,
+    });
+    if (updateResult.handled) {
+      return;
+    }
 
-  outro("Doctor complete.");
+    await maybeRepairUiProtocolFreshness(runtime, prompter);
+    noteSourceInstallIssues(root);
+    noteStartupOptimizationHints();
+
+    const configResult = await loadAndMaybeMigrateDoctorConfig({
+      options,
+      confirm: (p) => prompter.confirm(p),
+    });
+    const ctx = {
+      runtime,
+      options,
+      prompter,
+      configResult,
+      cfg: configResult.cfg,
+      cfgForPersistence: structuredClone(configResult.cfg),
+      sourceConfigValid: configResult.sourceConfigValid ?? true,
+      configPath: configResult.path ?? CONFIG_PATH,
+    };
+
+    await runDoctorHealthContributions(ctx);
+
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(buildDoctorJsonSummary({ root, ctx }), null, 2)}\n`);
+      return;
+    }
+
+    outro("Doctor complete.");
+  } finally {
+    if (options.json) {
+      if (previousSuppressNotes === undefined) {
+        delete process.env.OPENCLAW_SUPPRESS_NOTES;
+      } else {
+        process.env.OPENCLAW_SUPPRESS_NOTES = previousSuppressNotes;
+      }
+    }
+  }
 }

--- a/src/tasks/task-registry.observable-state.test.ts
+++ b/src/tasks/task-registry.observable-state.test.ts
@@ -1,0 +1,93 @@
+import { existsSync, readFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { startTaskRunByRunId } from "./task-executor.js";
+import { createTaskRecord, deleteTaskRecordById, resetTaskRegistryForTests } from "./task-registry.js";
+import { resolveObservableWorkerStatePath } from "./task-registry.observable-state.js";
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+
+describe("task-registry observable worker state", () => {
+  afterEach(() => {
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+    resetTaskRegistryForTests({ persist: false });
+  });
+
+  it("writes worker-state.json on task create and update", async () => {
+    await withStateDirEnv("openclaw-observable-worker-state-", async ({ stateDir }) => {
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      resetTaskRegistryForTests({ persist: false });
+
+      createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:subagent:child",
+        runId: "run-observable-1",
+        task: "Inspect task lifecycle",
+        status: "queued",
+        deliveryStatus: "pending",
+      });
+
+      const workerStatePath = resolveObservableWorkerStatePath();
+      expect(existsSync(workerStatePath)).toBe(true);
+
+      let snapshot = JSON.parse(readFileSync(workerStatePath, "utf8")) as {
+        summary: { total: number; byStatus: { queued: number } };
+        workers: Array<{ runId?: string; status: string; childSessionKey?: string }>;
+      };
+      expect(snapshot.summary.total).toBe(1);
+      expect(snapshot.summary.byStatus.queued).toBe(1);
+      expect(snapshot.workers[0]).toMatchObject({
+        runId: "run-observable-1",
+        status: "queued",
+        childSessionKey: "agent:main:subagent:child",
+      });
+
+      startTaskRunByRunId({
+        runId: "run-observable-1",
+        startedAt: 100,
+        lastEventAt: 100,
+        eventSummary: "Started.",
+      });
+
+      snapshot = JSON.parse(readFileSync(workerStatePath, "utf8"));
+      expect(snapshot.summary.byStatus.queued).toBe(0);
+      expect(snapshot.workers[0]).toMatchObject({
+        runId: "run-observable-1",
+        status: "running",
+      });
+    });
+  });
+
+  it("updates worker-state.json when a task is deleted", async () => {
+    await withStateDirEnv("openclaw-observable-worker-state-delete-", async ({ stateDir }) => {
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      resetTaskRegistryForTests({ persist: false });
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:main:acp:child",
+        runId: "run-observable-delete",
+        task: "Delete me",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      expect(deleteTaskRecordById(created.taskId)).toBe(true);
+
+      const snapshot = JSON.parse(readFileSync(resolveObservableWorkerStatePath(), "utf8")) as {
+        summary: { total: number };
+        workers: unknown[];
+      };
+      expect(snapshot.summary.total).toBe(0);
+      expect(snapshot.workers).toEqual([]);
+    });
+  });
+});

--- a/src/tasks/task-registry.observable-state.ts
+++ b/src/tasks/task-registry.observable-state.ts
@@ -1,0 +1,118 @@
+import path from "node:path";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { saveJsonFile } from "../infra/json-file.js";
+import { resolveTaskStateDir } from "./task-registry.paths.js";
+import { summarizeTaskRecords } from "./task-registry.summary.js";
+import type { TaskRegistryObserverEvent, TaskRegistryObservers } from "./task-registry.store.js";
+import type { TaskRecord, TaskRegistrySummary } from "./task-registry.types.js";
+
+export type ObservableWorkerStateRecord = {
+  id: string;
+  runtime: TaskRecord["runtime"];
+  status: TaskRecord["status"];
+  task: string;
+  ownerKey: string;
+  scopeKind: TaskRecord["scopeKind"];
+  childSessionKey?: string;
+  agentId?: string;
+  runId?: string;
+  label?: string;
+  createdAt: number;
+  startedAt?: number;
+  endedAt?: number;
+  lastEventAt?: number;
+  error?: string;
+  progressSummary?: string;
+  terminalSummary?: string;
+};
+
+export type ObservableWorkerStateSnapshot = {
+  version: 1;
+  generatedAt: string;
+  summary: TaskRegistrySummary;
+  workers: ObservableWorkerStateRecord[];
+};
+
+const log = createSubsystemLogger("tasks/observable-state");
+
+export function resolveObservableWorkerStatePath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveTaskStateDir(env), "worker-state.json");
+}
+
+function toObservableWorkerStateRecord(task: TaskRecord): ObservableWorkerStateRecord {
+  return {
+    id: task.taskId,
+    runtime: task.runtime,
+    status: task.status,
+    task: task.task,
+    ownerKey: task.ownerKey,
+    scopeKind: task.scopeKind,
+    ...(task.childSessionKey ? { childSessionKey: task.childSessionKey } : {}),
+    ...(task.agentId ? { agentId: task.agentId } : {}),
+    ...(task.runId ? { runId: task.runId } : {}),
+    ...(task.label ? { label: task.label } : {}),
+    createdAt: task.createdAt,
+    ...(task.startedAt != null ? { startedAt: task.startedAt } : {}),
+    ...(task.endedAt != null ? { endedAt: task.endedAt } : {}),
+    ...(task.lastEventAt != null ? { lastEventAt: task.lastEventAt } : {}),
+    ...(task.error ? { error: task.error } : {}),
+    ...(task.progressSummary ? { progressSummary: task.progressSummary } : {}),
+    ...(task.terminalSummary ? { terminalSummary: task.terminalSummary } : {}),
+  };
+}
+
+export function saveObservableWorkerState(params: {
+  tasks: TaskRecord[];
+  summary: TaskRegistrySummary;
+  env?: NodeJS.ProcessEnv;
+}) {
+  const snapshot: ObservableWorkerStateSnapshot = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    summary: params.summary,
+    workers: params.tasks.map((task) => toObservableWorkerStateRecord(task)),
+  };
+  saveJsonFile(resolveObservableWorkerStatePath(params.env), snapshot);
+}
+
+function writeObservableWorkerStateFromMap(tasks: ReadonlyMap<string, TaskRecord>) {
+  const records = [...tasks.values()].toSorted((left, right) => {
+    const leftAt = left.lastEventAt ?? left.startedAt ?? left.createdAt;
+    const rightAt = right.lastEventAt ?? right.startedAt ?? right.createdAt;
+    return rightAt - leftAt;
+  });
+  saveObservableWorkerState({
+    tasks: records,
+    summary: summarizeTaskRecords(records),
+  });
+}
+
+export function createObservableWorkerStateObserver(): TaskRegistryObservers {
+  const currentTasks = new Map<string, TaskRecord>();
+
+  const updateFromEvent = (event: TaskRegistryObserverEvent) => {
+    if (event.kind === "restored") {
+      currentTasks.clear();
+      for (const task of event.tasks) {
+        currentTasks.set(task.taskId, { ...task });
+      }
+      return;
+    }
+    if (event.kind === "upserted") {
+      currentTasks.set(event.task.taskId, { ...event.task });
+      return;
+    }
+    currentTasks.delete(event.taskId);
+  };
+
+  return {
+    onEvent(event) {
+      updateFromEvent(event);
+      try {
+        writeObservableWorkerStateFromMap(currentTasks);
+      } catch (error) {
+        log.warn("Failed to persist observable worker state", { error });
+      }
+    },
+  };
+}

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { createManagedTaskFlow, resetTaskFlowRegistryForTests } from "./task-flow-registry.js";
 import {
@@ -39,6 +39,12 @@ function createStoredTask(): TaskRecord {
 }
 
 describe("task-registry store runtime", () => {
+  beforeEach(() => {
+    delete process.env.OPENCLAW_STATE_DIR;
+    resetTaskRegistryForTests();
+    resetTaskFlowRegistryForTests({ persist: false });
+  });
+
   afterEach(() => {
     delete process.env.OPENCLAW_STATE_DIR;
     resetTaskRegistryForTests();

--- a/src/tasks/task-registry.store.ts
+++ b/src/tasks/task-registry.store.ts
@@ -1,3 +1,4 @@
+import { createObservableWorkerStateObserver } from "./task-registry.observable-state.js";
 import {
   closeTaskRegistrySqliteStore,
   deleteTaskAndDeliveryStateFromSqlite,
@@ -65,7 +66,8 @@ const defaultTaskRegistryStore: TaskRegistryStore = {
 };
 
 let configuredTaskRegistryStore: TaskRegistryStore = defaultTaskRegistryStore;
-let configuredTaskRegistryObservers: TaskRegistryObservers | null = null;
+let configuredTaskRegistryObservers: TaskRegistryObservers | null =
+  createObservableWorkerStateObserver();
 
 export function getTaskRegistryStore(): TaskRegistryStore {
   return configuredTaskRegistryStore;
@@ -90,5 +92,5 @@ export function configureTaskRegistryRuntime(params: {
 export function resetTaskRegistryRuntimeForTests() {
   configuredTaskRegistryStore.close?.();
   configuredTaskRegistryStore = defaultTaskRegistryStore;
-  configuredTaskRegistryObservers = null;
+  configuredTaskRegistryObservers = createObservableWorkerStateObserver();
 }


### PR DESCRIPTION
Adds a lightweight observable `worker-state.json` snapshot derived from the task registry so runtime worker/task state can be inspected without scraping sqlite internals.

### What changed
- adds `src/tasks/task-registry.observable-state.ts`
- persists `worker-state.json` from task registry observer events
- keeps the snapshot outside the task-registry core logic by wiring it through the existing observer layer
- records a compact worker/task view with summary counts and per-worker state
- adds coverage for snapshot creation, updates, and deletion handling

### Snapshot shape
The new file is written to the OpenClaw state dir as:

- `worker-state.json`

It currently includes:
- `version`
- `generatedAt`
- `summary`
- `workers[]`

Each worker record currently includes compact runtime fields such as:
- `id`
- `runtime`
- `status`
- `task`
- `ownerKey`
- `scopeKind`
- `childSessionKey`
- `agentId`
- `runId`
- `label`
- timestamps and optional progress/error summaries

### Tests
- `src/tasks/task-registry.observable-state.test.ts`
- `src/tasks/task-registry.store.test.ts`

### Notes
This is intentionally a small first step toward observable runtime state. It does not yet introduce a full worker lifecycle/state-machine redesign or `session-state.json`; it provides a mergeable foundation for those next steps.
