### PR TITLE
feat(sessions): add observable session state snapshot

### DIFF
--- a/src/config/sessions/observable-state.test.ts
+++ b/src/config/sessions/observable-state.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import { resolveDefaultSessionStorePath } from "./paths.js";
 import { saveSessionStore, updateSessionStore } from "./store.js";
-import { resolveObservableSessionStatePath } from "./observable-state.js";
+import { resolveObservableSessionStatePathForStore } from "./observable-state.js";
 import type { SessionEntry } from "./types.js";
 
 const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
@@ -28,7 +28,7 @@ describe("sessions observable state", () => {
     }
   });
 
-  it("writes session-state.json when saving the session store", async () => {
+  it("writes per-agent session-state.json when saving the session store", async () => {
     await withStateDirEnv("openclaw-session-state-", async ({ stateDir }) => {
       process.env.OPENCLAW_STATE_DIR = stateDir;
       const storePath = resolveDefaultSessionStorePath();
@@ -41,7 +41,7 @@ describe("sessions observable state", () => {
         }),
       });
 
-      const observablePath = resolveObservableSessionStatePath();
+      const observablePath = resolveObservableSessionStatePathForStore(storePath);
       expect(existsSync(observablePath)).toBe(true);
 
       const snapshot = JSON.parse(readFileSync(observablePath, "utf8")) as {
@@ -61,7 +61,7 @@ describe("sessions observable state", () => {
     });
   });
 
-  it("updates session-state.json when the session store changes", async () => {
+  it("updates the per-agent session-state.json when the session store changes", async () => {
     await withStateDirEnv("openclaw-session-state-update-", async ({ stateDir }) => {
       process.env.OPENCLAW_STATE_DIR = stateDir;
       const storePath = resolveDefaultSessionStorePath();
@@ -84,7 +84,9 @@ describe("sessions observable state", () => {
         });
       });
 
-      const snapshot = JSON.parse(readFileSync(resolveObservableSessionStatePath(), "utf8")) as {
+      const snapshot = JSON.parse(
+        readFileSync(resolveObservableSessionStatePathForStore(storePath), "utf8"),
+      ) as {
         sessions: Array<{ sessionKey: string; status?: string; runtimeMs?: number; updatedAt: number }>;
       };
 
@@ -94,6 +96,42 @@ describe("sessions observable state", () => {
         runtimeMs: 1234,
         updatedAt: 300,
       });
+    });
+  });
+
+  it("keeps separate snapshots for different agents", async () => {
+    await withStateDirEnv("openclaw-session-state-multi-agent-", async ({ stateDir }) => {
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      const mainStorePath = resolveDefaultSessionStorePath("main");
+      const opsStorePath = resolveDefaultSessionStorePath("ops");
+
+      await saveSessionStore(mainStorePath, {
+        "agent:main:main": createSessionEntry({
+          sessionId: "sess-main",
+          updatedAt: 100,
+          displayName: "Main session",
+        }),
+      });
+
+      await saveSessionStore(opsStorePath, {
+        "agent:ops:main": createSessionEntry({
+          sessionId: "sess-ops",
+          updatedAt: 200,
+          displayName: "Ops session",
+        }),
+      });
+
+      const mainSnapshot = JSON.parse(
+        readFileSync(resolveObservableSessionStatePathForStore(mainStorePath), "utf8"),
+      ) as { agentId: string; sessions: Array<{ sessionKey: string }> };
+      const opsSnapshot = JSON.parse(
+        readFileSync(resolveObservableSessionStatePathForStore(opsStorePath), "utf8"),
+      ) as { agentId: string; sessions: Array<{ sessionKey: string }> };
+
+      expect(mainSnapshot.agentId).toBe("main");
+      expect(mainSnapshot.sessions).toMatchObject([{ sessionKey: "agent:main:main" }]);
+      expect(opsSnapshot.agentId).toBe("ops");
+      expect(opsSnapshot.sessions).toMatchObject([{ sessionKey: "agent:ops:main" }]);
     });
   });
 });

--- a/src/config/sessions/observable-state.test.ts
+++ b/src/config/sessions/observable-state.test.ts
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+import { resolveDefaultSessionStorePath } from "./paths.js";
+import { saveSessionStore, updateSessionStore } from "./store.js";
+import { resolveObservableSessionStatePath } from "./observable-state.js";
+import type { SessionEntry } from "./types.js";
+
+const ORIGINAL_STATE_DIR = process.env.OPENCLAW_STATE_DIR;
+
+function createSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {
+  return {
+    sessionId: overrides.sessionId ?? "sess-1",
+    updatedAt: overrides.updatedAt ?? 100,
+    model: overrides.model ?? "openai-codex/gpt-5.4",
+    modelProvider: overrides.modelProvider ?? "openai-codex",
+    channel: overrides.channel ?? "discord",
+    ...overrides,
+  };
+}
+
+describe("sessions observable state", () => {
+  afterEach(() => {
+    if (ORIGINAL_STATE_DIR === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = ORIGINAL_STATE_DIR;
+    }
+  });
+
+  it("writes session-state.json when saving the session store", async () => {
+    await withStateDirEnv("openclaw-session-state-", async ({ stateDir }) => {
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      const storePath = resolveDefaultSessionStorePath();
+
+      await saveSessionStore(storePath, {
+        "agent:main:main": createSessionEntry({
+          sessionId: "sess-main",
+          updatedAt: 200,
+          displayName: "Main session",
+        }),
+      });
+
+      const observablePath = resolveObservableSessionStatePath();
+      expect(existsSync(observablePath)).toBe(true);
+
+      const snapshot = JSON.parse(readFileSync(observablePath, "utf8")) as {
+        agentId: string;
+        total: number;
+        sessions: Array<{ sessionKey: string; sessionId: string; displayName?: string; model?: string }>;
+      };
+
+      expect(snapshot.agentId).toBe("main");
+      expect(snapshot.total).toBe(1);
+      expect(snapshot.sessions[0]).toMatchObject({
+        sessionKey: "agent:main:main",
+        sessionId: "sess-main",
+        displayName: "Main session",
+        model: "openai-codex/gpt-5.4",
+      });
+    });
+  });
+
+  it("updates session-state.json when the session store changes", async () => {
+    await withStateDirEnv("openclaw-session-state-update-", async ({ stateDir }) => {
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      const storePath = resolveDefaultSessionStorePath();
+
+      await saveSessionStore(storePath, {
+        "agent:main:main": createSessionEntry({
+          sessionId: "sess-main",
+          updatedAt: 100,
+          status: "running",
+        }),
+      });
+
+      await updateSessionStore(storePath, (store) => {
+        store["agent:main:main"] = createSessionEntry({
+          ...store["agent:main:main"],
+          sessionId: "sess-main",
+          updatedAt: 300,
+          status: "done",
+          runtimeMs: 1234,
+        });
+      });
+
+      const snapshot = JSON.parse(readFileSync(resolveObservableSessionStatePath(), "utf8")) as {
+        sessions: Array<{ sessionKey: string; status?: string; runtimeMs?: number; updatedAt: number }>;
+      };
+
+      expect(snapshot.sessions[0]).toMatchObject({
+        sessionKey: "agent:main:main",
+        status: "done",
+        runtimeMs: 1234,
+        updatedAt: 300,
+      });
+    });
+  });
+});

--- a/src/config/sessions/observable-state.ts
+++ b/src/config/sessions/observable-state.ts
@@ -1,5 +1,4 @@
 import path from "node:path";
-import { resolveStateDir } from "../paths.js";
 import { saveJsonFile } from "../../infra/json-file.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
 import type { SessionEntry } from "./types.js";
@@ -32,10 +31,6 @@ export type ObservableSessionStateSnapshot = {
   sessions: ObservableSessionStateEntry[];
 };
 
-export function resolveObservableSessionStatePath(env: NodeJS.ProcessEnv = process.env): string {
-  return path.join(resolveStateDir(env), "session-state.json");
-}
-
 function resolveAgentIdFromStorePath(storePath: string): string {
   const normalized = path.normalize(path.resolve(storePath));
   const parts = normalized.split(path.sep).filter(Boolean);
@@ -44,6 +39,10 @@ function resolveAgentIdFromStorePath(storePath: string): string {
     return normalizeAgentId(parts[sessionsIndex - 1] ?? DEFAULT_AGENT_ID);
   }
   return DEFAULT_AGENT_ID;
+}
+
+export function resolveObservableSessionStatePathForStore(storePath: string): string {
+  return path.join(path.dirname(path.resolve(storePath)), "session-state.json");
 }
 
 function toObservableSessionStateEntry(params: {
@@ -76,7 +75,6 @@ function toObservableSessionStateEntry(params: {
 export function saveObservableSessionState(params: {
   storePath: string;
   store: Record<string, SessionEntry>;
-  env?: NodeJS.ProcessEnv;
 }) {
   const agentId = resolveAgentIdFromStorePath(params.storePath);
   const sessions = Object.entries(params.store)
@@ -91,5 +89,5 @@ export function saveObservableSessionState(params: {
     sessions,
   };
 
-  saveJsonFile(resolveObservableSessionStatePath(params.env), snapshot);
+  saveJsonFile(resolveObservableSessionStatePathForStore(params.storePath), snapshot);
 }

--- a/src/config/sessions/observable-state.ts
+++ b/src/config/sessions/observable-state.ts
@@ -1,0 +1,95 @@
+import path from "node:path";
+import { resolveStateDir } from "../paths.js";
+import { saveJsonFile } from "../../infra/json-file.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../../routing/session-key.js";
+import type { SessionEntry } from "./types.js";
+
+export type ObservableSessionStateEntry = {
+  sessionKey: string;
+  sessionId: string;
+  agentId: string;
+  updatedAt: number;
+  model?: string;
+  provider?: string;
+  status?: NonNullable<SessionEntry["status"]>;
+  startedAt?: number;
+  endedAt?: number;
+  runtimeMs?: number;
+  channel?: string;
+  label?: string;
+  displayName?: string;
+  subject?: string;
+  parentSessionKey?: string;
+  spawnedBy?: string;
+  spawnedWorkspaceDir?: string;
+};
+
+export type ObservableSessionStateSnapshot = {
+  version: 1;
+  generatedAt: string;
+  agentId: string;
+  total: number;
+  sessions: ObservableSessionStateEntry[];
+};
+
+export function resolveObservableSessionStatePath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), "session-state.json");
+}
+
+function resolveAgentIdFromStorePath(storePath: string): string {
+  const normalized = path.normalize(path.resolve(storePath));
+  const parts = normalized.split(path.sep).filter(Boolean);
+  const sessionsIndex = parts.lastIndexOf("sessions");
+  if (sessionsIndex >= 2 && parts[sessionsIndex - 2] === "agents") {
+    return normalizeAgentId(parts[sessionsIndex - 1] ?? DEFAULT_AGENT_ID);
+  }
+  return DEFAULT_AGENT_ID;
+}
+
+function toObservableSessionStateEntry(params: {
+  sessionKey: string;
+  entry: SessionEntry;
+  agentId: string;
+}): ObservableSessionStateEntry {
+  const { entry } = params;
+  return {
+    sessionKey: params.sessionKey,
+    sessionId: entry.sessionId,
+    agentId: params.agentId,
+    updatedAt: entry.updatedAt,
+    ...(entry.model ? { model: entry.model } : {}),
+    ...(entry.modelProvider ? { provider: entry.modelProvider } : {}),
+    ...(entry.status ? { status: entry.status } : {}),
+    ...(entry.startedAt != null ? { startedAt: entry.startedAt } : {}),
+    ...(entry.endedAt != null ? { endedAt: entry.endedAt } : {}),
+    ...(entry.runtimeMs != null ? { runtimeMs: entry.runtimeMs } : {}),
+    ...(entry.channel ? { channel: entry.channel } : {}),
+    ...(entry.label ? { label: entry.label } : {}),
+    ...(entry.displayName ? { displayName: entry.displayName } : {}),
+    ...(entry.subject ? { subject: entry.subject } : {}),
+    ...(entry.parentSessionKey ? { parentSessionKey: entry.parentSessionKey } : {}),
+    ...(entry.spawnedBy ? { spawnedBy: entry.spawnedBy } : {}),
+    ...(entry.spawnedWorkspaceDir ? { spawnedWorkspaceDir: entry.spawnedWorkspaceDir } : {}),
+  };
+}
+
+export function saveObservableSessionState(params: {
+  storePath: string;
+  store: Record<string, SessionEntry>;
+  env?: NodeJS.ProcessEnv;
+}) {
+  const agentId = resolveAgentIdFromStorePath(params.storePath);
+  const sessions = Object.entries(params.store)
+    .map(([sessionKey, entry]) => toObservableSessionStateEntry({ sessionKey, entry, agentId }))
+    .toSorted((left, right) => right.updatedAt - left.updatedAt);
+
+  const snapshot: ObservableSessionStateSnapshot = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    agentId,
+    total: sessions.length,
+    sessions,
+  };
+
+  saveJsonFile(resolveObservableSessionStatePath(params.env), snapshot);
+}

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -7,6 +7,7 @@ import {
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { writeTextAtomic } from "../../infra/json-files.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { saveObservableSessionState } from "./observable-state.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import {
   deliveryContextFromSession,
@@ -535,6 +536,10 @@ async function writeSessionStoreAtomic(params: {
     storePath: params.storePath,
     store: params.store,
     serialized: params.serialized,
+  });
+  saveObservableSessionState({
+    storePath: params.storePath,
+    store: params.store,
   });
 }
 


### PR DESCRIPTION
Adds a lightweight observable `session-state.json` snapshot derived from the persisted session store so runtime session state can be inspected without scraping `sessions.json` directly.

### What changed
- adds `src/config/sessions/observable-state.ts`
- persists `session-state.json` whenever the session store is written
- records a compact per-session snapshot derived from `sessions.json`
- keeps the implementation small and focused on useful runtime/session metadata
- adds coverage for initial write and subsequent updates

### Snapshot shape
The new file is written to the OpenClaw state dir as:

- `session-state.json`

It currently includes:
- `version`
- `generatedAt`
- `agentId`
- `total`
- `sessions[]`

Each session record currently includes compact fields such as:
- `sessionKey`
- `sessionId`
- `agentId`
- `updatedAt`
- `model`
- `provider`
- `status`
- `startedAt`
- `endedAt`
- `runtimeMs`
- `channel`
- `label`
- `displayName`
- `subject`
- `parentSessionKey`
- `spawnedBy`
- `spawnedWorkspaceDir`

### Tests
- `src/config/sessions/observable-state.test.ts`
- `src/config/sessions/store.session-key-normalization.test.ts`

### Notes
This is intentionally a compact first observable session snapshot. It complements the task-based `worker-state.json` work without trying to redesign broader session lifecycle/state semantics in the same change.
