### PR TITLE
fix(gateway): restore codex-cli chat history imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1309,6 +1309,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/chat history: import bound `codex-cli` session transcripts into `chat.history`, so refreshing a Codex-backed chat restores prior turns from the Codex session store instead of showing an empty history when only the external CLI transcript exists.
 - Agents: honor `OPENCLAW_WORKSPACE_DIR` when resolving the default agent workspace, preserving explicit config precedence while keeping env-backed deployments out of the system prompt fallback path. Fixes #66786.
 - Doctor/Codex: stop warning that the message tool is unavailable for source-reply paths where OpenClaw grants `message` at runtime, keeping update and doctor output aligned with the OpenAI happy path. Thanks @pashpashpash.
 - Channels/Weixin: bump the external Weixin catalog entry to `@tencent-weixin/openclaw-weixin@2.4.3` with the matching package integrity. (#81730) Thanks @scotthuang.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/chat history: import bound `codex-cli` session transcripts into `chat.history`, so refreshing a Codex-backed chat restores prior turns from the Codex session store instead of showing an empty history when only the external CLI transcript exists.
 - CLI backends: keep versioned OAuth identity matches reusable when auth profile ids rotate, so Claude CLI sessions do not reset and lose continuity during same-account OAuth refresh/profile alias changes. Fixes #78541.
 - Anthropic: reject uppercase provider-prefixed forward-compat model ids locally instead of sending malformed dynamic ids upstream. Fixes #73715.
 - OpenAI/embeddings: pass configured output dimensionality through single and batched embedding requests so memory embedding indexes can request smaller vectors. Fixes #55126.

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -14,6 +14,7 @@ describe("cli-session helpers", () => {
     const entry: SessionEntry = {
       sessionId: "openclaw-session",
       updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
     };
 
     setCliSessionBinding(entry, "claude-cli", {
@@ -41,6 +42,7 @@ describe("cli-session helpers", () => {
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
     });
+    expect(entry.suppressCliHistoryImport).toBeUndefined();
   });
 
   it("force-reuses explicitly attached CLI sessions despite metadata drift", () => {
@@ -366,6 +368,7 @@ describe("cli-session helpers", () => {
     const entry: SessionEntry = {
       sessionId: "openclaw-session",
       updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
     };
     setCliSessionBinding(entry, "claude-cli", { sessionId: "claude-session" });
     setCliSessionBinding(entry, "codex-cli", { sessionId: "codex-session" });
@@ -373,8 +376,11 @@ describe("cli-session helpers", () => {
     clearCliSession(entry, "codex-cli");
     expect(getCliSessionBinding(entry, "codex-cli")).toBeUndefined();
     expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe("claude-session");
+    expect(entry.suppressCliHistoryImport).toBeUndefined();
 
+    entry.suppressCliHistoryImport = true;
     clearAllCliSessions(entry);
+    expect(entry.suppressCliHistoryImport).toBeUndefined();
     expect(entry.cliSessionBindings).toBeUndefined();
     expect(entry.cliSessionIds).toBeUndefined();
     expect(entry.claudeCliSessionId).toBeUndefined();

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -386,6 +386,31 @@ describe("cli-session helpers", () => {
     expect(entry.claudeCliSessionId).toBeUndefined();
   });
 
+  it("keeps reset CLI import suppression until a new binding is stored", () => {
+    const entry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "claude-session" },
+        "codex-cli": { sessionId: "codex-session" },
+      },
+      cliSessionIds: {
+        "claude-cli": "claude-session",
+        "codex-cli": "codex-session",
+      },
+      claudeCliSessionId: "claude-session",
+    };
+
+    clearCliSession(entry, "codex-cli");
+    expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(getCliSessionBinding(entry, "codex-cli")).toBeUndefined();
+    expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe("claude-session");
+
+    setCliSessionBinding(entry, "codex-cli", { sessionId: "replacement-codex-session" });
+    expect(entry.suppressCliHistoryImport).toBeUndefined();
+  });
+
   it("hashes trimmed extra system prompts consistently", () => {
     expect(hashCliSessionText("  keep this  ")).toBe(hashCliSessionText("keep this"));
     expect(hashCliSessionText("")).toBeUndefined();

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -5,6 +5,7 @@ import {
   clearCliSession,
   getCliSessionBinding,
   hashCliSessionText,
+  resolveSuppressedCliHistoryImportProviders,
   resolveCliSessionReuse,
   setCliSessionBinding,
 } from "./cli-session.js";
@@ -404,11 +405,13 @@ describe("cli-session helpers", () => {
 
     clearCliSession(entry, "codex-cli");
     expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(entry.suppressCliHistoryImportProviders).toEqual(["claude-cli"]);
     expect(getCliSessionBinding(entry, "codex-cli")).toBeUndefined();
     expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe("claude-session");
 
     setCliSessionBinding(entry, "codex-cli", { sessionId: "replacement-codex-session" });
-    expect(entry.suppressCliHistoryImport).toBeUndefined();
+    expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(entry.suppressCliHistoryImportProviders).toEqual(["claude-cli"]);
   });
 
   it("keeps reset CLI import suppression when the preserved session is rebound unchanged", () => {
@@ -428,6 +431,30 @@ describe("cli-session helpers", () => {
 
     expect(entry.suppressCliHistoryImport).toBe(true);
     expect(getCliSessionBinding(entry, "codex-cli")?.sessionId).toBe("preserved-codex-session");
+  });
+
+  it("keeps reset suppression scoped to other preserved providers after a fresh rebind", () => {
+    const entry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "preserved-claude-session" },
+        "codex-cli": { sessionId: "preserved-codex-session" },
+      },
+      cliSessionIds: {
+        "claude-cli": "preserved-claude-session",
+        "codex-cli": "preserved-codex-session",
+      },
+      claudeCliSessionId: "preserved-claude-session",
+    };
+
+    setCliSessionBinding(entry, "codex-cli", { sessionId: "fresh-codex-session" });
+
+    expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(resolveSuppressedCliHistoryImportProviders(entry)).toEqual(["claude-cli"]);
+    expect(getCliSessionBinding(entry, "codex-cli")?.sessionId).toBe("fresh-codex-session");
+    expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe("preserved-claude-session");
   });
 
   it("hashes trimmed extra system prompts consistently", () => {

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -411,6 +411,25 @@ describe("cli-session helpers", () => {
     expect(entry.suppressCliHistoryImport).toBeUndefined();
   });
 
+  it("keeps reset CLI import suppression when the preserved session is rebound unchanged", () => {
+    const entry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
+      cliSessionBindings: {
+        "codex-cli": { sessionId: "preserved-codex-session" },
+      },
+      cliSessionIds: {
+        "codex-cli": "preserved-codex-session",
+      },
+    };
+
+    setCliSessionBinding(entry, "codex-cli", { sessionId: "preserved-codex-session" });
+
+    expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(getCliSessionBinding(entry, "codex-cli")?.sessionId).toBe("preserved-codex-session");
+  });
+
   it("hashes trimmed extra system prompts consistently", () => {
     expect(hashCliSessionText("  keep this  ")).toBe(hashCliSessionText("keep this"));
     expect(hashCliSessionText("")).toBeUndefined();

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -5,6 +5,7 @@ import {
   clearCliSession,
   getCliSessionBinding,
   hashCliSessionText,
+  resolveSuppressedCliHistoryImportProviders,
   resolveCliSessionReuse,
   setCliSessionBinding,
 } from "./cli-session.js";
@@ -391,11 +392,13 @@ describe("cli-session helpers", () => {
 
     clearCliSession(entry, "codex-cli");
     expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(entry.suppressCliHistoryImportProviders).toEqual(["claude-cli"]);
     expect(getCliSessionBinding(entry, "codex-cli")).toBeUndefined();
     expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe("claude-session");
 
     setCliSessionBinding(entry, "codex-cli", { sessionId: "replacement-codex-session" });
-    expect(entry.suppressCliHistoryImport).toBeUndefined();
+    expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(entry.suppressCliHistoryImportProviders).toEqual(["claude-cli"]);
   });
 
   it("keeps reset CLI import suppression when the preserved session is rebound unchanged", () => {
@@ -415,6 +418,30 @@ describe("cli-session helpers", () => {
 
     expect(entry.suppressCliHistoryImport).toBe(true);
     expect(getCliSessionBinding(entry, "codex-cli")?.sessionId).toBe("preserved-codex-session");
+  });
+
+  it("keeps reset suppression scoped to other preserved providers after a fresh rebind", () => {
+    const entry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "preserved-claude-session" },
+        "codex-cli": { sessionId: "preserved-codex-session" },
+      },
+      cliSessionIds: {
+        "claude-cli": "preserved-claude-session",
+        "codex-cli": "preserved-codex-session",
+      },
+      claudeCliSessionId: "preserved-claude-session",
+    };
+
+    setCliSessionBinding(entry, "codex-cli", { sessionId: "fresh-codex-session" });
+
+    expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(resolveSuppressedCliHistoryImportProviders(entry)).toEqual(["claude-cli"]);
+    expect(getCliSessionBinding(entry, "codex-cli")?.sessionId).toBe("fresh-codex-session");
+    expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe("preserved-claude-session");
   });
 
   it("hashes trimmed extra system prompts consistently", () => {

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -14,6 +14,7 @@ describe("cli-session helpers", () => {
     const entry: SessionEntry = {
       sessionId: "openclaw-session",
       updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
     };
 
     setCliSessionBinding(entry, "claude-cli", {
@@ -39,6 +40,7 @@ describe("cli-session helpers", () => {
       mcpConfigHash: "mcp-hash",
       mcpResumeHash: "mcp-resume-hash",
     });
+    expect(entry.suppressCliHistoryImport).toBeUndefined();
   });
 
   it("force-reuses explicitly attached CLI sessions despite metadata drift", () => {
@@ -353,6 +355,7 @@ describe("cli-session helpers", () => {
     const entry: SessionEntry = {
       sessionId: "openclaw-session",
       updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
     };
     setCliSessionBinding(entry, "claude-cli", { sessionId: "claude-session" });
     setCliSessionBinding(entry, "codex-cli", { sessionId: "codex-session" });
@@ -360,8 +363,11 @@ describe("cli-session helpers", () => {
     clearCliSession(entry, "codex-cli");
     expect(getCliSessionBinding(entry, "codex-cli")).toBeUndefined();
     expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe("claude-session");
+    expect(entry.suppressCliHistoryImport).toBeUndefined();
 
+    entry.suppressCliHistoryImport = true;
     clearAllCliSessions(entry);
+    expect(entry.suppressCliHistoryImport).toBeUndefined();
     expect(entry.cliSessionBindings).toBeUndefined();
     expect(entry.cliSessionIds).toBeUndefined();
     expect(entry.claudeCliSessionId).toBeUndefined();

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -373,6 +373,31 @@ describe("cli-session helpers", () => {
     expect(entry.claudeCliSessionId).toBeUndefined();
   });
 
+  it("keeps reset CLI import suppression until a new binding is stored", () => {
+    const entry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
+      cliSessionBindings: {
+        "claude-cli": { sessionId: "claude-session" },
+        "codex-cli": { sessionId: "codex-session" },
+      },
+      cliSessionIds: {
+        "claude-cli": "claude-session",
+        "codex-cli": "codex-session",
+      },
+      claudeCliSessionId: "claude-session",
+    };
+
+    clearCliSession(entry, "codex-cli");
+    expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(getCliSessionBinding(entry, "codex-cli")).toBeUndefined();
+    expect(getCliSessionBinding(entry, "claude-cli")?.sessionId).toBe("claude-session");
+
+    setCliSessionBinding(entry, "codex-cli", { sessionId: "replacement-codex-session" });
+    expect(entry.suppressCliHistoryImport).toBeUndefined();
+  });
+
   it("hashes trimmed extra system prompts consistently", () => {
     expect(hashCliSessionText("  keep this  ")).toBe(hashCliSessionText("keep this"));
     expect(hashCliSessionText("")).toBeUndefined();

--- a/src/agents/cli-session.test.ts
+++ b/src/agents/cli-session.test.ts
@@ -398,6 +398,25 @@ describe("cli-session helpers", () => {
     expect(entry.suppressCliHistoryImport).toBeUndefined();
   });
 
+  it("keeps reset CLI import suppression when the preserved session is rebound unchanged", () => {
+    const entry: SessionEntry = {
+      sessionId: "openclaw-session",
+      updatedAt: Date.now(),
+      suppressCliHistoryImport: true,
+      cliSessionBindings: {
+        "codex-cli": { sessionId: "preserved-codex-session" },
+      },
+      cliSessionIds: {
+        "codex-cli": "preserved-codex-session",
+      },
+    };
+
+    setCliSessionBinding(entry, "codex-cli", { sessionId: "preserved-codex-session" });
+
+    expect(entry.suppressCliHistoryImport).toBe(true);
+    expect(getCliSessionBinding(entry, "codex-cli")?.sessionId).toBe("preserved-codex-session");
+  });
+
   it("hashes trimmed extra system prompts consistently", () => {
     expect(hashCliSessionText("  keep this  ")).toBe(hashCliSessionText("keep this"));
     expect(hashCliSessionText("")).toBeUndefined();

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -103,6 +103,7 @@ export function setCliSessionBinding(
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = trimmed;
   }
+  delete entry.suppressCliHistoryImport;
 }
 
 export function clearCliSession(entry: SessionEntry, provider: string): void {
@@ -120,12 +121,14 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = undefined;
   }
+  delete entry.suppressCliHistoryImport;
 }
 
 export function clearAllCliSessions(entry: SessionEntry): void {
-  entry.cliSessionBindings = undefined;
-  entry.cliSessionIds = undefined;
-  entry.claudeCliSessionId = undefined;
+  delete entry.suppressCliHistoryImport;
+  delete entry.cliSessionBindings;
+  delete entry.cliSessionIds;
+  delete entry.claudeCliSessionId;
 }
 
 export function resolveCliSessionReuse(params: {

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -103,7 +103,7 @@ export function setCliSessionBinding(
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = trimmed;
   }
-  delete entry.suppressCliHistoryImport;
+  entry.suppressCliHistoryImport = undefined;
 }
 
 export function clearCliSession(entry: SessionEntry, provider: string): void {
@@ -121,11 +121,12 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = undefined;
   }
-  delete entry.suppressCliHistoryImport;
+  // Reset-created sessions should keep CLI import suppression until a fresh
+  // CLI binding is written back to the session entry.
 }
 
 export function clearAllCliSessions(entry: SessionEntry): void {
-  delete entry.suppressCliHistoryImport;
+  entry.suppressCliHistoryImport = undefined;
   delete entry.cliSessionBindings;
   delete entry.cliSessionIds;
   delete entry.claudeCliSessionId;

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -71,6 +71,7 @@ export function setCliSessionBinding(
   if (!trimmed) {
     return;
   }
+  const previousSessionId = getCliSessionBinding(entry, normalized)?.sessionId;
   entry.cliSessionBindings = {
     ...entry.cliSessionBindings,
     [normalized]: {
@@ -103,7 +104,9 @@ export function setCliSessionBinding(
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = trimmed;
   }
-  entry.suppressCliHistoryImport = undefined;
+  if (previousSessionId !== trimmed) {
+    entry.suppressCliHistoryImport = undefined;
+  }
 }
 
 export function clearCliSession(entry: SessionEntry, provider: string): void {

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -57,6 +57,71 @@ export function getCliSessionId(
   return getCliSessionBinding(entry, provider)?.sessionId;
 }
 
+export function resolveBoundCliSessionProviders(
+  entry:
+    | Pick<SessionEntry, "cliSessionBindings" | "cliSessionIds" | "claudeCliSessionId">
+    | undefined,
+): string[] {
+  const providers = new Set<string>();
+  if (entry?.cliSessionBindings) {
+    for (const [provider, binding] of Object.entries(entry.cliSessionBindings)) {
+      if (normalizeOptionalString(binding?.sessionId)) {
+        providers.add(normalizeProviderId(provider));
+      }
+    }
+  }
+  if (entry?.cliSessionIds) {
+    for (const [provider, sessionId] of Object.entries(entry.cliSessionIds)) {
+      if (normalizeOptionalString(sessionId)) {
+        providers.add(normalizeProviderId(provider));
+      }
+    }
+  }
+  if (normalizeOptionalString(entry?.claudeCliSessionId)) {
+    providers.add(CLAUDE_CLI_BACKEND_ID);
+  }
+  return [...providers];
+}
+
+export function resolveSuppressedCliHistoryImportProviders(
+  entry:
+    | Pick<
+        SessionEntry,
+        | "suppressCliHistoryImport"
+        | "suppressCliHistoryImportProviders"
+        | "cliSessionBindings"
+        | "cliSessionIds"
+        | "claudeCliSessionId"
+      >
+    | undefined,
+): string[] {
+  const explicitProviders = Array.isArray(entry?.suppressCliHistoryImportProviders)
+    ? entry.suppressCliHistoryImportProviders
+        .map((provider) => normalizeOptionalString(provider))
+        .filter((provider): provider is string => Boolean(provider))
+        .map((provider) => normalizeProviderId(provider))
+    : [];
+  if (explicitProviders.length > 0) {
+    return [...new Set(explicitProviders)];
+  }
+  if (entry?.suppressCliHistoryImport) {
+    return resolveBoundCliSessionProviders(entry);
+  }
+  return [];
+}
+
+function setSuppressedCliHistoryImportProviders(
+  entry: SessionEntry,
+  providers: Iterable<string>,
+): void {
+  const normalizedProviders = [
+    ...new Set([...providers].map((provider) => normalizeProviderId(provider))),
+  ];
+  entry.suppressCliHistoryImportProviders =
+    normalizedProviders.length > 0 ? normalizedProviders : undefined;
+  entry.suppressCliHistoryImport = normalizedProviders.length > 0 ? true : undefined;
+}
+
 export function setCliSessionId(entry: SessionEntry, provider: string, sessionId: string): void {
   setCliSessionBinding(entry, provider, { sessionId });
 }
@@ -105,7 +170,9 @@ export function setCliSessionBinding(
     entry.claudeCliSessionId = trimmed;
   }
   if (previousSessionId !== trimmed) {
-    entry.suppressCliHistoryImport = undefined;
+    const remainingSuppressedProviders = new Set(resolveSuppressedCliHistoryImportProviders(entry));
+    remainingSuppressedProviders.delete(normalized);
+    setSuppressedCliHistoryImportProviders(entry, remainingSuppressedProviders);
   }
 }
 
@@ -124,12 +191,13 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = undefined;
   }
+  setSuppressedCliHistoryImportProviders(entry, resolveSuppressedCliHistoryImportProviders(entry));
   // Reset-created sessions should keep CLI import suppression until a fresh
   // CLI binding is written back to the session entry.
 }
 
 export function clearAllCliSessions(entry: SessionEntry): void {
-  entry.suppressCliHistoryImport = undefined;
+  setSuppressedCliHistoryImportProviders(entry, []);
   delete entry.cliSessionBindings;
   delete entry.cliSessionIds;
   delete entry.claudeCliSessionId;

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -99,6 +99,7 @@ export function setCliSessionBinding(
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = trimmed;
   }
+  delete entry.suppressCliHistoryImport;
 }
 
 export function clearCliSession(entry: SessionEntry, provider: string): void {
@@ -116,12 +117,14 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = undefined;
   }
+  delete entry.suppressCliHistoryImport;
 }
 
 export function clearAllCliSessions(entry: SessionEntry): void {
-  entry.cliSessionBindings = undefined;
-  entry.cliSessionIds = undefined;
-  entry.claudeCliSessionId = undefined;
+  delete entry.suppressCliHistoryImport;
+  delete entry.cliSessionBindings;
+  delete entry.cliSessionIds;
+  delete entry.claudeCliSessionId;
 }
 
 export function resolveCliSessionReuse(params: {

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -56,6 +56,71 @@ export function getCliSessionId(
   return getCliSessionBinding(entry, provider)?.sessionId;
 }
 
+export function resolveBoundCliSessionProviders(
+  entry:
+    | Pick<SessionEntry, "cliSessionBindings" | "cliSessionIds" | "claudeCliSessionId">
+    | undefined,
+): string[] {
+  const providers = new Set<string>();
+  if (entry?.cliSessionBindings) {
+    for (const [provider, binding] of Object.entries(entry.cliSessionBindings)) {
+      if (normalizeOptionalString(binding?.sessionId)) {
+        providers.add(normalizeProviderId(provider));
+      }
+    }
+  }
+  if (entry?.cliSessionIds) {
+    for (const [provider, sessionId] of Object.entries(entry.cliSessionIds)) {
+      if (normalizeOptionalString(sessionId)) {
+        providers.add(normalizeProviderId(provider));
+      }
+    }
+  }
+  if (normalizeOptionalString(entry?.claudeCliSessionId)) {
+    providers.add(CLAUDE_CLI_BACKEND_ID);
+  }
+  return [...providers];
+}
+
+export function resolveSuppressedCliHistoryImportProviders(
+  entry:
+    | Pick<
+        SessionEntry,
+        | "suppressCliHistoryImport"
+        | "suppressCliHistoryImportProviders"
+        | "cliSessionBindings"
+        | "cliSessionIds"
+        | "claudeCliSessionId"
+      >
+    | undefined,
+): string[] {
+  const explicitProviders = Array.isArray(entry?.suppressCliHistoryImportProviders)
+    ? entry.suppressCliHistoryImportProviders
+        .map((provider) => normalizeOptionalString(provider))
+        .filter((provider): provider is string => Boolean(provider))
+        .map((provider) => normalizeProviderId(provider))
+    : [];
+  if (explicitProviders.length > 0) {
+    return [...new Set(explicitProviders)];
+  }
+  if (entry?.suppressCliHistoryImport) {
+    return resolveBoundCliSessionProviders(entry);
+  }
+  return [];
+}
+
+function setSuppressedCliHistoryImportProviders(
+  entry: SessionEntry,
+  providers: Iterable<string>,
+): void {
+  const normalizedProviders = [
+    ...new Set([...providers].map((provider) => normalizeProviderId(provider))),
+  ];
+  entry.suppressCliHistoryImportProviders =
+    normalizedProviders.length > 0 ? normalizedProviders : undefined;
+  entry.suppressCliHistoryImport = normalizedProviders.length > 0 ? true : undefined;
+}
+
 export function setCliSessionId(entry: SessionEntry, provider: string, sessionId: string): void {
   setCliSessionBinding(entry, provider, { sessionId });
 }
@@ -101,7 +166,9 @@ export function setCliSessionBinding(
     entry.claudeCliSessionId = trimmed;
   }
   if (previousSessionId !== trimmed) {
-    entry.suppressCliHistoryImport = undefined;
+    const remainingSuppressedProviders = new Set(resolveSuppressedCliHistoryImportProviders(entry));
+    remainingSuppressedProviders.delete(normalized);
+    setSuppressedCliHistoryImportProviders(entry, remainingSuppressedProviders);
   }
 }
 
@@ -120,12 +187,13 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = undefined;
   }
+  setSuppressedCliHistoryImportProviders(entry, resolveSuppressedCliHistoryImportProviders(entry));
   // Reset-created sessions should keep CLI import suppression until a fresh
   // CLI binding is written back to the session entry.
 }
 
 export function clearAllCliSessions(entry: SessionEntry): void {
-  entry.suppressCliHistoryImport = undefined;
+  setSuppressedCliHistoryImportProviders(entry, []);
   delete entry.cliSessionBindings;
   delete entry.cliSessionIds;
   delete entry.claudeCliSessionId;

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -99,7 +99,7 @@ export function setCliSessionBinding(
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = trimmed;
   }
-  delete entry.suppressCliHistoryImport;
+  entry.suppressCliHistoryImport = undefined;
 }
 
 export function clearCliSession(entry: SessionEntry, provider: string): void {
@@ -117,11 +117,12 @@ export function clearCliSession(entry: SessionEntry, provider: string): void {
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = undefined;
   }
-  delete entry.suppressCliHistoryImport;
+  // Reset-created sessions should keep CLI import suppression until a fresh
+  // CLI binding is written back to the session entry.
 }
 
 export function clearAllCliSessions(entry: SessionEntry): void {
-  delete entry.suppressCliHistoryImport;
+  entry.suppressCliHistoryImport = undefined;
   delete entry.cliSessionBindings;
   delete entry.cliSessionIds;
   delete entry.claudeCliSessionId;

--- a/src/agents/cli-session.ts
+++ b/src/agents/cli-session.ts
@@ -70,6 +70,7 @@ export function setCliSessionBinding(
   if (!trimmed) {
     return;
   }
+  const previousSessionId = getCliSessionBinding(entry, normalized)?.sessionId;
   entry.cliSessionBindings = {
     ...entry.cliSessionBindings,
     [normalized]: {
@@ -99,7 +100,9 @@ export function setCliSessionBinding(
   if (normalized === CLAUDE_CLI_BACKEND_ID) {
     entry.claudeCliSessionId = trimmed;
   }
-  entry.suppressCliHistoryImport = undefined;
+  if (previousSessionId !== trimmed) {
+    entry.suppressCliHistoryImport = undefined;
+  }
 }
 
 export function clearCliSession(entry: SessionEntry, provider: string): void {

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1322,135 +1322,145 @@ describe("clearCliSessionInStore", () => {
   });
 
   it("clears reset CLI import suppression when a new CLI binding is persisted", async () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          cliBackends: {
-            "codex-cli": {
-              command: "codex",
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "codex-cli": {
+                command: "codex",
+              },
             },
           },
         },
-      },
-    } as OpenClawConfig;
-    const sessionKey = "agent:main:explicit:test-codex-cli";
-    const sessionId = "test-openclaw-session";
-    const sessionStore: Record<string, SessionEntry> = {
-      [sessionKey]: {
-        sessionId,
-        updatedAt: 1,
-        suppressCliHistoryImport: true,
-        cliSessionBindings: {
-          "codex-cli": {
-            sessionId: "stale-session",
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-codex-cli";
+      const sessionId = "test-openclaw-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          suppressCliHistoryImport: true,
+          suppressCliHistoryImportProviders: ["codex-cli"],
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId: "stale-session",
+            },
+          },
+          cliSessionIds: {
+            "codex-cli": "stale-session",
           },
         },
-        cliSessionIds: {
-          "codex-cli": "stale-session",
-        },
-      },
-    };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
 
-    const result: EmbeddedPiRunResult = {
-      meta: {
-        durationMs: 1,
-        agentMeta: {
-          sessionId: "cli-session-456",
-          provider: "codex-cli",
-          model: "gpt-5.4",
-          cliSessionBinding: {
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
             sessionId: "cli-session-456",
+            provider: "codex-cli",
+            model: "gpt-5.4",
+            cliSessionBinding: {
+              sessionId: "cli-session-456",
+            },
           },
         },
-      },
-    };
+      };
 
-    await updateSessionStoreAfterAgentRun({
-      cfg,
-      sessionId,
-      sessionKey,
-      storePath,
-      sessionStore,
-      defaultProvider: "codex-cli",
-      defaultModel: "gpt-5.4",
-      result,
-    });
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "codex-cli",
+        defaultModel: "gpt-5.4",
+        result,
+      });
 
-    expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
-    expect(sessionStore[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
-      sessionId: "cli-session-456",
-    });
+      expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
+      expect(sessionStore[sessionKey]?.suppressCliHistoryImportProviders).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+        sessionId: "cli-session-456",
+      });
 
-    const persisted = loadSessionStore(storePath);
-    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
-    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
-      sessionId: "cli-session-456",
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
+      expect(persisted[sessionKey]?.suppressCliHistoryImportProviders).toBeUndefined();
+      expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+        sessionId: "cli-session-456",
+      });
     });
   });
 
   it("keeps reset CLI import suppression when the preserved CLI session is reused", async () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          cliBackends: {
-            "codex-cli": {
-              command: "codex",
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "codex-cli": {
+                command: "codex",
+              },
             },
           },
         },
-      },
-    } as OpenClawConfig;
-    const sessionKey = "agent:main:explicit:test-codex-cli-reuse";
-    const sessionId = "test-openclaw-session";
-    const sessionStore: Record<string, SessionEntry> = {
-      [sessionKey]: {
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-codex-cli-reuse";
+      const sessionId = "test-openclaw-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          suppressCliHistoryImport: true,
+          suppressCliHistoryImportProviders: ["codex-cli"],
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId: "preserved-session",
+            },
+          },
+          cliSessionIds: {
+            "codex-cli": "preserved-session",
+          },
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            sessionId: "preserved-session",
+            provider: "codex-cli",
+            model: "gpt-5.4",
+            cliSessionBinding: {
+              sessionId: "preserved-session",
+            },
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
         sessionId,
-        updatedAt: 1,
-        suppressCliHistoryImport: true,
-        cliSessionBindings: {
-          "codex-cli": {
-            sessionId: "preserved-session",
-          },
-        },
-        cliSessionIds: {
-          "codex-cli": "preserved-session",
-        },
-      },
-    };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "codex-cli",
+        defaultModel: "gpt-5.4",
+        result,
+      });
 
-    const result: EmbeddedPiRunResult = {
-      meta: {
-        durationMs: 1,
-        agentMeta: {
-          sessionId: "preserved-session",
-          provider: "codex-cli",
-          model: "gpt-5.4",
-          cliSessionBinding: {
-            sessionId: "preserved-session",
-          },
-        },
-      },
-    };
+      expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBe(true);
+      expect(sessionStore[sessionKey]?.suppressCliHistoryImportProviders).toEqual(["codex-cli"]);
 
-    await updateSessionStoreAfterAgentRun({
-      cfg,
-      sessionId,
-      sessionKey,
-      storePath,
-      sessionStore,
-      defaultProvider: "codex-cli",
-      defaultModel: "gpt-5.4",
-      result,
-    });
-
-    expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBe(true);
-
-    const persisted = loadSessionStore(storePath);
-    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBe(true);
-    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
-      sessionId: "preserved-session",
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.suppressCliHistoryImport).toBe(true);
+      expect(persisted[sessionKey]?.suppressCliHistoryImportProviders).toEqual(["codex-cli"]);
+      expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+        sessionId: "preserved-session",
+      });
     });
   });
 });

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1320,4 +1320,72 @@ describe("clearCliSessionInStore", () => {
       ).toBe("claude-session-1");
     });
   });
+
+  it("clears reset CLI import suppression when a new CLI binding is persisted", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "codex-cli": {
+              command: "codex",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:explicit:test-codex-cli";
+    const sessionId = "test-openclaw-session";
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 1,
+        suppressCliHistoryImport: true,
+        cliSessionBindings: {
+          "codex-cli": {
+            sessionId: "stale-session",
+          },
+        },
+        cliSessionIds: {
+          "codex-cli": "stale-session",
+        },
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+    const result: EmbeddedPiRunResult = {
+      meta: {
+        durationMs: 1,
+        agentMeta: {
+          sessionId: "cli-session-456",
+          provider: "codex-cli",
+          model: "gpt-5.4",
+          cliSessionBinding: {
+            sessionId: "cli-session-456",
+          },
+        },
+      },
+    };
+
+    await updateSessionStoreAfterAgentRun({
+      cfg,
+      sessionId,
+      sessionKey,
+      storePath,
+      sessionStore,
+      defaultProvider: "codex-cli",
+      defaultModel: "gpt-5.4",
+      result,
+    });
+
+    expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "cli-session-456",
+    });
+
+    const persisted = loadSessionStore(storePath);
+    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
+    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "cli-session-456",
+    });
+  });
 });

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1388,4 +1388,69 @@ describe("clearCliSessionInStore", () => {
       sessionId: "cli-session-456",
     });
   });
+
+  it("keeps reset CLI import suppression when the preserved CLI session is reused", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "codex-cli": {
+              command: "codex",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:explicit:test-codex-cli-reuse";
+    const sessionId = "test-openclaw-session";
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 1,
+        suppressCliHistoryImport: true,
+        cliSessionBindings: {
+          "codex-cli": {
+            sessionId: "preserved-session",
+          },
+        },
+        cliSessionIds: {
+          "codex-cli": "preserved-session",
+        },
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+    const result: EmbeddedPiRunResult = {
+      meta: {
+        durationMs: 1,
+        agentMeta: {
+          sessionId: "preserved-session",
+          provider: "codex-cli",
+          model: "gpt-5.4",
+          cliSessionBinding: {
+            sessionId: "preserved-session",
+          },
+        },
+      },
+    };
+
+    await updateSessionStoreAfterAgentRun({
+      cfg,
+      sessionId,
+      sessionKey,
+      storePath,
+      sessionStore,
+      defaultProvider: "codex-cli",
+      defaultModel: "gpt-5.4",
+      result,
+    });
+
+    expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBe(true);
+
+    const persisted = loadSessionStore(storePath);
+    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBe(true);
+    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "preserved-session",
+    });
+  });
 });

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1256,4 +1256,72 @@ describe("clearCliSessionInStore", () => {
       ).toBe("claude-session-1");
     });
   });
+
+  it("clears reset CLI import suppression when a new CLI binding is persisted", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "codex-cli": {
+              command: "codex",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:explicit:test-codex-cli";
+    const sessionId = "test-openclaw-session";
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 1,
+        suppressCliHistoryImport: true,
+        cliSessionBindings: {
+          "codex-cli": {
+            sessionId: "stale-session",
+          },
+        },
+        cliSessionIds: {
+          "codex-cli": "stale-session",
+        },
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+    const result: EmbeddedPiRunResult = {
+      meta: {
+        durationMs: 1,
+        agentMeta: {
+          sessionId: "cli-session-456",
+          provider: "codex-cli",
+          model: "gpt-5.4",
+          cliSessionBinding: {
+            sessionId: "cli-session-456",
+          },
+        },
+      },
+    };
+
+    await updateSessionStoreAfterAgentRun({
+      cfg,
+      sessionId,
+      sessionKey,
+      storePath,
+      sessionStore,
+      defaultProvider: "codex-cli",
+      defaultModel: "gpt-5.4",
+      result,
+    });
+
+    expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
+    expect(sessionStore[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "cli-session-456",
+    });
+
+    const persisted = loadSessionStore(storePath);
+    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
+    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "cli-session-456",
+    });
+  });
 });

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1258,135 +1258,145 @@ describe("clearCliSessionInStore", () => {
   });
 
   it("clears reset CLI import suppression when a new CLI binding is persisted", async () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          cliBackends: {
-            "codex-cli": {
-              command: "codex",
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "codex-cli": {
+                command: "codex",
+              },
             },
           },
         },
-      },
-    } as OpenClawConfig;
-    const sessionKey = "agent:main:explicit:test-codex-cli";
-    const sessionId = "test-openclaw-session";
-    const sessionStore: Record<string, SessionEntry> = {
-      [sessionKey]: {
-        sessionId,
-        updatedAt: 1,
-        suppressCliHistoryImport: true,
-        cliSessionBindings: {
-          "codex-cli": {
-            sessionId: "stale-session",
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-codex-cli";
+      const sessionId = "test-openclaw-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          suppressCliHistoryImport: true,
+          suppressCliHistoryImportProviders: ["codex-cli"],
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId: "stale-session",
+            },
+          },
+          cliSessionIds: {
+            "codex-cli": "stale-session",
           },
         },
-        cliSessionIds: {
-          "codex-cli": "stale-session",
-        },
-      },
-    };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
 
-    const result: EmbeddedPiRunResult = {
-      meta: {
-        durationMs: 1,
-        agentMeta: {
-          sessionId: "cli-session-456",
-          provider: "codex-cli",
-          model: "gpt-5.4",
-          cliSessionBinding: {
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
             sessionId: "cli-session-456",
+            provider: "codex-cli",
+            model: "gpt-5.4",
+            cliSessionBinding: {
+              sessionId: "cli-session-456",
+            },
           },
         },
-      },
-    };
+      };
 
-    await updateSessionStoreAfterAgentRun({
-      cfg,
-      sessionId,
-      sessionKey,
-      storePath,
-      sessionStore,
-      defaultProvider: "codex-cli",
-      defaultModel: "gpt-5.4",
-      result,
-    });
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "codex-cli",
+        defaultModel: "gpt-5.4",
+        result,
+      });
 
-    expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
-    expect(sessionStore[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
-      sessionId: "cli-session-456",
-    });
+      expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
+      expect(sessionStore[sessionKey]?.suppressCliHistoryImportProviders).toBeUndefined();
+      expect(sessionStore[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+        sessionId: "cli-session-456",
+      });
 
-    const persisted = loadSessionStore(storePath);
-    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
-    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
-      sessionId: "cli-session-456",
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
+      expect(persisted[sessionKey]?.suppressCliHistoryImportProviders).toBeUndefined();
+      expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+        sessionId: "cli-session-456",
+      });
     });
   });
 
   it("keeps reset CLI import suppression when the preserved CLI session is reused", async () => {
-    const cfg = {
-      agents: {
-        defaults: {
-          cliBackends: {
-            "codex-cli": {
-              command: "codex",
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {
+        agents: {
+          defaults: {
+            cliBackends: {
+              "codex-cli": {
+                command: "codex",
+              },
             },
           },
         },
-      },
-    } as OpenClawConfig;
-    const sessionKey = "agent:main:explicit:test-codex-cli-reuse";
-    const sessionId = "test-openclaw-session";
-    const sessionStore: Record<string, SessionEntry> = {
-      [sessionKey]: {
+      } as OpenClawConfig;
+      const sessionKey = "agent:main:explicit:test-codex-cli-reuse";
+      const sessionId = "test-openclaw-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          suppressCliHistoryImport: true,
+          suppressCliHistoryImportProviders: ["codex-cli"],
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId: "preserved-session",
+            },
+          },
+          cliSessionIds: {
+            "codex-cli": "preserved-session",
+          },
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          agentMeta: {
+            sessionId: "preserved-session",
+            provider: "codex-cli",
+            model: "gpt-5.4",
+            cliSessionBinding: {
+              sessionId: "preserved-session",
+            },
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
         sessionId,
-        updatedAt: 1,
-        suppressCliHistoryImport: true,
-        cliSessionBindings: {
-          "codex-cli": {
-            sessionId: "preserved-session",
-          },
-        },
-        cliSessionIds: {
-          "codex-cli": "preserved-session",
-        },
-      },
-    };
-    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "codex-cli",
+        defaultModel: "gpt-5.4",
+        result,
+      });
 
-    const result: EmbeddedPiRunResult = {
-      meta: {
-        durationMs: 1,
-        agentMeta: {
-          sessionId: "preserved-session",
-          provider: "codex-cli",
-          model: "gpt-5.4",
-          cliSessionBinding: {
-            sessionId: "preserved-session",
-          },
-        },
-      },
-    };
+      expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBe(true);
+      expect(sessionStore[sessionKey]?.suppressCliHistoryImportProviders).toEqual(["codex-cli"]);
 
-    await updateSessionStoreAfterAgentRun({
-      cfg,
-      sessionId,
-      sessionKey,
-      storePath,
-      sessionStore,
-      defaultProvider: "codex-cli",
-      defaultModel: "gpt-5.4",
-      result,
-    });
-
-    expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBe(true);
-
-    const persisted = loadSessionStore(storePath);
-    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBe(true);
-    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
-      sessionId: "preserved-session",
+      const persisted = loadSessionStore(storePath);
+      expect(persisted[sessionKey]?.suppressCliHistoryImport).toBe(true);
+      expect(persisted[sessionKey]?.suppressCliHistoryImportProviders).toEqual(["codex-cli"]);
+      expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+        sessionId: "preserved-session",
+      });
     });
   });
 });

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1324,4 +1324,69 @@ describe("clearCliSessionInStore", () => {
       sessionId: "cli-session-456",
     });
   });
+
+  it("keeps reset CLI import suppression when the preserved CLI session is reused", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "codex-cli": {
+              command: "codex",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const sessionKey = "agent:main:explicit:test-codex-cli-reuse";
+    const sessionId = "test-openclaw-session";
+    const sessionStore: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 1,
+        suppressCliHistoryImport: true,
+        cliSessionBindings: {
+          "codex-cli": {
+            sessionId: "preserved-session",
+          },
+        },
+        cliSessionIds: {
+          "codex-cli": "preserved-session",
+        },
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+    const result: EmbeddedPiRunResult = {
+      meta: {
+        durationMs: 1,
+        agentMeta: {
+          sessionId: "preserved-session",
+          provider: "codex-cli",
+          model: "gpt-5.4",
+          cliSessionBinding: {
+            sessionId: "preserved-session",
+          },
+        },
+      },
+    };
+
+    await updateSessionStoreAfterAgentRun({
+      cfg,
+      sessionId,
+      sessionKey,
+      storePath,
+      sessionStore,
+      defaultProvider: "codex-cli",
+      defaultModel: "gpt-5.4",
+      result,
+    });
+
+    expect(sessionStore[sessionKey]?.suppressCliHistoryImport).toBe(true);
+
+    const persisted = loadSessionStore(storePath);
+    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBe(true);
+    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "preserved-session",
+    });
+  });
 });

--- a/src/agents/pi-project-settings.bundle.test.ts
+++ b/src/agents/pi-project-settings.bundle.test.ts
@@ -370,7 +370,7 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
   it("loads sanitized settings and MCP defaults from enabled bundle plugins", async () => {
     const workspaceDir = await tempDirs.make("openclaw-workspace-");
     const pluginRoot = await createWorkspaceBundle({ workspaceDir });
-    const resolvedPluginRoot = await fs.realpath(pluginRoot);
+    const _resolvedPluginRoot = await fs.realpath(pluginRoot);
     await fs.mkdir(path.join(pluginRoot, "servers"), { recursive: true });
     const resolvedServerPath = await fs.realpath(path.join(pluginRoot, "servers"));
     await fs.writeFile(
@@ -417,12 +417,12 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
       bundleProbe: {
         command: "node",
         args: [path.join(resolvedServerPath, "probe.mjs")],
-        cwd: resolvedPluginRoot,
+        cwd: _resolvedPluginRoot,
       },
       sharedServer: {
         command: "node",
         args: [path.join(resolvedServerPath, "bundle.mjs")],
-        cwd: resolvedPluginRoot,
+        cwd: _resolvedPluginRoot,
       },
     });
 
@@ -448,7 +448,7 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
       bundleProbe: {
         command: "node",
         args: [path.join(resolvedServerPath, "probe.mjs")],
-        cwd: resolvedPluginRoot,
+        cwd: _resolvedPluginRoot,
       },
       sharedServer: {
         url: "https://example.com/mcp",

--- a/src/agents/pi-project-settings.bundle.test.ts
+++ b/src/agents/pi-project-settings.bundle.test.ts
@@ -370,7 +370,7 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
   it("loads sanitized settings and MCP defaults from enabled bundle plugins", async () => {
     const workspaceDir = await tempDirs.make("openclaw-workspace-");
     const pluginRoot = await createWorkspaceBundle({ workspaceDir });
-    const _resolvedPluginRoot = await fs.realpath(pluginRoot);
+    const resolvedPluginRoot = await fs.realpath(pluginRoot);
     await fs.mkdir(path.join(pluginRoot, "servers"), { recursive: true });
     const resolvedServerPath = await fs.realpath(path.join(pluginRoot, "servers"));
     await fs.writeFile(
@@ -417,12 +417,12 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
       bundleProbe: {
         command: "node",
         args: [path.join(resolvedServerPath, "probe.mjs")],
-        cwd: _resolvedPluginRoot,
+        cwd: resolvedPluginRoot,
       },
       sharedServer: {
         command: "node",
         args: [path.join(resolvedServerPath, "bundle.mjs")],
-        cwd: _resolvedPluginRoot,
+        cwd: resolvedPluginRoot,
       },
     });
 
@@ -448,7 +448,7 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
       bundleProbe: {
         command: "node",
         args: [path.join(resolvedServerPath, "probe.mjs")],
-        cwd: _resolvedPluginRoot,
+        cwd: resolvedPluginRoot,
       },
       sharedServer: {
         url: "https://example.com/mcp",

--- a/src/agents/pi-project-settings.bundle.test.ts
+++ b/src/agents/pi-project-settings.bundle.test.ts
@@ -328,7 +328,7 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
   it("loads sanitized settings and MCP defaults from enabled bundle plugins", async () => {
     const workspaceDir = await tempDirs.make("openclaw-workspace-");
     const pluginRoot = await createWorkspaceBundle({ workspaceDir });
-    const resolvedPluginRoot = await fs.realpath(pluginRoot);
+    const _resolvedPluginRoot = await fs.realpath(pluginRoot);
     await fs.mkdir(path.join(pluginRoot, "servers"), { recursive: true });
     const resolvedServerPath = await fs.realpath(path.join(pluginRoot, "servers"));
     await fs.writeFile(
@@ -375,12 +375,12 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
       bundleProbe: {
         command: "node",
         args: [path.join(resolvedServerPath, "probe.mjs")],
-        cwd: resolvedPluginRoot,
+        cwd: _resolvedPluginRoot,
       },
       sharedServer: {
         command: "node",
         args: [path.join(resolvedServerPath, "bundle.mjs")],
-        cwd: resolvedPluginRoot,
+        cwd: _resolvedPluginRoot,
       },
     });
 
@@ -406,7 +406,7 @@ describe("loadEnabledBundlePiSettingsSnapshot", () => {
       bundleProbe: {
         command: "node",
         args: [path.join(resolvedServerPath, "probe.mjs")],
-        cwd: resolvedPluginRoot,
+        cwd: _resolvedPluginRoot,
       },
       sharedServer: {
         url: "https://example.com/mcp",

--- a/src/auto-reply/reply/session-usage.test.ts
+++ b/src/auto-reply/reply/session-usage.test.ts
@@ -62,4 +62,48 @@ describe("persistSessionUsageUpdate", () => {
     });
     expect(persisted[sessionKey]?.cliSessionIds?.["codex-cli"]).toBe("fresh-session");
   });
+
+  it("keeps reset CLI import suppression when persisting the preserved CLI binding", async () => {
+    const sessionKey = "agent:main:usage:test-codex-cli-reuse";
+    const sessionId = "test-openclaw-session";
+    const store: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 1,
+        suppressCliHistoryImport: true,
+        cliSessionBindings: {
+          "codex-cli": {
+            sessionId: "preserved-session",
+          },
+        },
+        cliSessionIds: {
+          "codex-cli": "preserved-session",
+        },
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(store, null, 2));
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      cfg: {} as OpenClawConfig,
+      usage: {
+        input: 10,
+        output: 5,
+      },
+      providerUsed: "codex-cli",
+      modelUsed: "gpt-5.4",
+      contextTokensUsed: 128_000,
+      cliSessionBinding: {
+        sessionId: "preserved-session",
+      },
+    });
+
+    const persisted = loadSessionStore(storePath);
+    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBe(true);
+    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "preserved-session",
+    });
+    expect(persisted[sessionKey]?.cliSessionIds?.["codex-cli"]).toBe("preserved-session");
+  });
 });

--- a/src/auto-reply/reply/session-usage.test.ts
+++ b/src/auto-reply/reply/session-usage.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { loadSessionStore, type SessionEntry } from "../../config/sessions.js";
+import { persistSessionUsageUpdate } from "./session-usage.js";
+
+describe("persistSessionUsageUpdate", () => {
+  let tmpDir = "";
+  let storePath = "";
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-usage-"));
+    storePath = path.join(tmpDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("clears reset CLI import suppression when persisting a fresh CLI binding", async () => {
+    const sessionKey = "agent:main:usage:test-codex-cli";
+    const sessionId = "test-openclaw-session";
+    const store: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: 1,
+        suppressCliHistoryImport: true,
+        cliSessionBindings: {
+          "codex-cli": {
+            sessionId: "stale-session",
+          },
+        },
+        cliSessionIds: {
+          "codex-cli": "stale-session",
+        },
+      },
+    };
+    await fs.writeFile(storePath, JSON.stringify(store, null, 2));
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      cfg: {} as OpenClawConfig,
+      usage: {
+        input: 10,
+        output: 5,
+      },
+      providerUsed: "codex-cli",
+      modelUsed: "gpt-5.4",
+      contextTokensUsed: 128_000,
+      cliSessionBinding: {
+        sessionId: "fresh-session",
+      },
+    });
+
+    const persisted = loadSessionStore(storePath);
+    expect(persisted[sessionKey]?.suppressCliHistoryImport).toBeUndefined();
+    expect(persisted[sessionKey]?.cliSessionBindings?.["codex-cli"]).toEqual({
+      sessionId: "fresh-session",
+    });
+    expect(persisted[sessionKey]?.cliSessionIds?.["codex-cli"]).toBe("fresh-session");
+  });
+});

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -30,6 +30,7 @@ function applyCliSessionIdToSessionPatch(
     return {
       ...patch,
       suppressCliHistoryImport: nextEntry.suppressCliHistoryImport,
+      suppressCliHistoryImportProviders: nextEntry.suppressCliHistoryImportProviders,
       cliSessionIds: nextEntry.cliSessionIds,
       cliSessionBindings: nextEntry.cliSessionBindings,
       claudeCliSessionId: nextEntry.claudeCliSessionId,
@@ -41,6 +42,7 @@ function applyCliSessionIdToSessionPatch(
     return {
       ...patch,
       suppressCliHistoryImport: nextEntry.suppressCliHistoryImport,
+      suppressCliHistoryImportProviders: nextEntry.suppressCliHistoryImportProviders,
       cliSessionIds: nextEntry.cliSessionIds,
       cliSessionBindings: nextEntry.cliSessionBindings,
       claudeCliSessionId: nextEntry.claudeCliSessionId,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -29,6 +29,7 @@ function applyCliSessionIdToSessionPatch(
     setCliSessionBinding(nextEntry, cliProvider, params.cliSessionBinding);
     return {
       ...patch,
+      suppressCliHistoryImport: nextEntry.suppressCliHistoryImport,
       cliSessionIds: nextEntry.cliSessionIds,
       cliSessionBindings: nextEntry.cliSessionBindings,
       claudeCliSessionId: nextEntry.claudeCliSessionId,
@@ -39,6 +40,7 @@ function applyCliSessionIdToSessionPatch(
     setCliSessionId(nextEntry, cliProvider, params.cliSessionId);
     return {
       ...patch,
+      suppressCliHistoryImport: nextEntry.suppressCliHistoryImport,
       cliSessionIds: nextEntry.cliSessionIds,
       cliSessionBindings: nextEntry.cliSessionBindings,
       claudeCliSessionId: nextEntry.claudeCliSessionId,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -341,6 +341,11 @@ export type SessionEntry = {
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
   memoryFlushContextHash?: string;
+  /**
+   * Blocks CLI transcript backfill for fresh sessions created by reset while
+   * their previous external CLI bindings are still preserved.
+   */
+  suppressCliHistoryImport?: boolean;
   cliSessionIds?: Record<string, string>;
   cliSessionBindings?: Record<string, CliSessionBinding>;
   claudeCliSessionId?: string;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -346,6 +346,11 @@ export type SessionEntry = {
    * their previous external CLI bindings are still preserved.
    */
   suppressCliHistoryImport?: boolean;
+  /**
+   * Provider-scoped CLI transcript backfill suppression for reset-preserved
+   * external bindings. Absent means legacy/global semantics keyed by the bool.
+   */
+  suppressCliHistoryImportProviders?: string[];
   cliSessionIds?: Record<string, string>;
   cliSessionBindings?: Record<string, CliSessionBinding>;
   claudeCliSessionId?: string;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -309,6 +309,11 @@ export type SessionEntry = {
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;
   memoryFlushContextHash?: string;
+  /**
+   * Blocks CLI transcript backfill for fresh sessions created by reset while
+   * their previous external CLI bindings are still preserved.
+   */
+  suppressCliHistoryImport?: boolean;
   cliSessionIds?: Record<string, string>;
   cliSessionBindings?: Record<string, CliSessionBinding>;
   claudeCliSessionId?: string;

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -314,6 +314,11 @@ export type SessionEntry = {
    * their previous external CLI bindings are still preserved.
    */
   suppressCliHistoryImport?: boolean;
+  /**
+   * Provider-scoped CLI transcript backfill suppression for reset-preserved
+   * external bindings. Absent means legacy/global semantics keyed by the bool.
+   */
+  suppressCliHistoryImportProviders?: string[];
   cliSessionIds?: Record<string, string>;
   cliSessionBindings?: Record<string, CliSessionBinding>;
   claudeCliSessionId?: string;

--- a/src/gateway/cli-session-history.codex.ts
+++ b/src/gateway/cli-session-history.codex.ts
@@ -8,6 +8,8 @@ import { normalizeOptionalString } from "../shared/string-coerce.js";
 export const CODEX_CLI_PROVIDER = "codex-cli";
 const CODEX_SESSIONS_RELATIVE_DIR = path.join(".codex", "sessions");
 const codexCliSessionPathCache = new Map<string, string>();
+const DEFAULT_MAX_CODEX_CLI_SESSION_PATH_CACHE_ENTRIES = 256;
+let maxCodexCliSessionPathCacheEntries = DEFAULT_MAX_CODEX_CLI_SESSION_PATH_CACHE_ENTRIES;
 
 type CodexCliTranscriptEntry = {
   timestamp?: unknown;
@@ -71,6 +73,22 @@ function buildCodexCliSessionPathCacheKey(params: {
   return `${params.sessionsDir}\t${params.cliSessionId}`;
 }
 
+function pruneCodexCliSessionPathCache(): void {
+  while (codexCliSessionPathCache.size > maxCodexCliSessionPathCacheEntries) {
+    const oldestKey = codexCliSessionPathCache.keys().next().value;
+    if (typeof oldestKey !== "string") {
+      break;
+    }
+    codexCliSessionPathCache.delete(oldestKey);
+  }
+}
+
+function setCachedCodexCliSessionPath(cacheKey: string, filePath: string): void {
+  codexCliSessionPathCache.delete(cacheKey);
+  codexCliSessionPathCache.set(cacheKey, filePath);
+  pruneCodexCliSessionPathCache();
+}
+
 function findCodexCliSessionFile(params: {
   sessionsDir: string;
   cliSessionId: string;
@@ -78,7 +96,11 @@ function findCodexCliSessionFile(params: {
   const cacheKey = buildCodexCliSessionPathCacheKey(params);
   const cached = codexCliSessionPathCache.get(cacheKey);
   if (cached && fs.existsSync(cached)) {
+    setCachedCodexCliSessionPath(cacheKey, cached);
     return cached;
+  }
+  if (cached) {
+    codexCliSessionPathCache.delete(cacheKey);
   }
   if (!fs.existsSync(params.sessionsDir)) {
     return undefined;
@@ -105,7 +127,7 @@ function findCodexCliSessionFile(params: {
       if (!entry.isFile() || !isCodexCliHistoryFile(filePath, params.cliSessionId)) {
         continue;
       }
-      codexCliSessionPathCache.set(cacheKey, filePath);
+      setCachedCodexCliSessionPath(cacheKey, filePath);
       return filePath;
     }
   }
@@ -403,3 +425,23 @@ export function readCodexCliSessionMessages(params: {
   }
   return messages;
 }
+
+export const __testing = {
+  get codexCliSessionPathCacheSize(): number {
+    return codexCliSessionPathCache.size;
+  },
+  get maxCodexCliSessionPathCacheEntries(): number {
+    return maxCodexCliSessionPathCacheEntries;
+  },
+  resetCodexCliSessionPathCacheForTests(): void {
+    codexCliSessionPathCache.clear();
+    maxCodexCliSessionPathCacheEntries = DEFAULT_MAX_CODEX_CLI_SESSION_PATH_CACHE_ENTRIES;
+  },
+  setMaxCodexCliSessionPathCacheEntriesForTests(limit: number): void {
+    if (!Number.isFinite(limit)) {
+      return;
+    }
+    maxCodexCliSessionPathCacheEntries = Math.max(1, Math.trunc(limit));
+    pruneCodexCliSessionPathCache();
+  },
+};

--- a/src/gateway/cli-session-history.codex.ts
+++ b/src/gateway/cli-session-history.codex.ts
@@ -89,6 +89,33 @@ function setCachedCodexCliSessionPath(cacheKey: string, filePath: string): void 
   pruneCodexCliSessionPathCache();
 }
 
+function resolveCodexCliSessionFileCandidateMtime(filePath: string): number {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return Number.NEGATIVE_INFINITY;
+  }
+}
+
+function shouldReplaceCodexCliSessionFileCandidate(
+  currentBest: { filePath: string; mtimeMs: number } | undefined,
+  nextCandidate: { filePath: string; mtimeMs: number },
+): boolean {
+  if (!currentBest) {
+    return true;
+  }
+  if (nextCandidate.mtimeMs !== currentBest.mtimeMs) {
+    return nextCandidate.mtimeMs > currentBest.mtimeMs;
+  }
+  const nextName = path.basename(nextCandidate.filePath);
+  const currentName = path.basename(currentBest.filePath);
+  const fileNameCompare = nextName.localeCompare(currentName);
+  if (fileNameCompare !== 0) {
+    return fileNameCompare > 0;
+  }
+  return nextCandidate.filePath.localeCompare(currentBest.filePath) > 0;
+}
+
 function findCodexCliSessionFile(params: {
   sessionsDir: string;
   cliSessionId: string;
@@ -107,6 +134,7 @@ function findCodexCliSessionFile(params: {
   }
 
   const stack = [params.sessionsDir];
+  let bestMatch: { filePath: string; mtimeMs: number } | undefined;
   while (stack.length > 0) {
     const currentDir = stack.pop();
     if (!currentDir) {
@@ -127,11 +155,20 @@ function findCodexCliSessionFile(params: {
       if (!entry.isFile() || !isCodexCliHistoryFile(filePath, params.cliSessionId)) {
         continue;
       }
-      setCachedCodexCliSessionPath(cacheKey, filePath);
-      return filePath;
+      const candidate = {
+        filePath,
+        mtimeMs: resolveCodexCliSessionFileCandidateMtime(filePath),
+      };
+      if (shouldReplaceCodexCliSessionFileCandidate(bestMatch, candidate)) {
+        bestMatch = candidate;
+      }
     }
   }
-  return undefined;
+  if (!bestMatch) {
+    return undefined;
+  }
+  setCachedCodexCliSessionPath(cacheKey, bestMatch.filePath);
+  return bestMatch.filePath;
 }
 
 export function resolveCodexCliSessionFilePath(params: {

--- a/src/gateway/cli-session-history.codex.ts
+++ b/src/gateway/cli-session-history.codex.ts
@@ -63,7 +63,7 @@ function resolveTimestampMs(value: unknown): number | undefined {
 }
 
 function isCodexCliHistoryFile(filePath: string, cliSessionId: string): boolean {
-  return path.basename(filePath).endsWith(`${cliSessionId}.jsonl`);
+  return path.basename(filePath).endsWith(`-${cliSessionId}.jsonl`);
 }
 
 function buildCodexCliSessionPathCacheKey(params: {

--- a/src/gateway/cli-session-history.codex.ts
+++ b/src/gateway/cli-session-history.codex.ts
@@ -1,0 +1,405 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { SessionEntry } from "../config/sessions.js";
+import { normalizeAssistantPhase } from "../shared/chat-message-content.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+export const CODEX_CLI_PROVIDER = "codex-cli";
+const CODEX_SESSIONS_RELATIVE_DIR = path.join(".codex", "sessions");
+const codexCliSessionPathCache = new Map<string, string>();
+
+type CodexCliTranscriptEntry = {
+  timestamp?: unknown;
+  type?: unknown;
+  payload?: {
+    type?: unknown;
+    message?: unknown;
+    phase?: unknown;
+    images?: unknown;
+    local_images?: unknown;
+    text_elements?: unknown;
+  };
+};
+
+type TranscriptContentBlock = {
+  type: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+};
+
+type TranscriptLikeMessage = Record<string, unknown>;
+
+function resolveHistoryHomeDir(homeDir?: string): string {
+  return normalizeOptionalString(homeDir) || process.env.HOME || os.homedir();
+}
+
+function resolveCodexSessionsDir(homeDir?: string): string {
+  return path.join(resolveHistoryHomeDir(homeDir), CODEX_SESSIONS_RELATIVE_DIR);
+}
+
+export function resolveCodexCliBindingSessionId(
+  entry: SessionEntry | undefined,
+): string | undefined {
+  const bindingSessionId = normalizeOptionalString(
+    entry?.cliSessionBindings?.[CODEX_CLI_PROVIDER]?.sessionId,
+  );
+  if (bindingSessionId) {
+    return bindingSessionId;
+  }
+  const legacyMapSessionId = normalizeOptionalString(entry?.cliSessionIds?.[CODEX_CLI_PROVIDER]);
+  return legacyMapSessionId || undefined;
+}
+
+function resolveTimestampMs(value: unknown): number | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function isCodexCliHistoryFile(filePath: string, cliSessionId: string): boolean {
+  return path.basename(filePath).endsWith(`${cliSessionId}.jsonl`);
+}
+
+function buildCodexCliSessionPathCacheKey(params: {
+  sessionsDir: string;
+  cliSessionId: string;
+}): string {
+  return `${params.sessionsDir}\t${params.cliSessionId}`;
+}
+
+function findCodexCliSessionFile(params: {
+  sessionsDir: string;
+  cliSessionId: string;
+}): string | undefined {
+  const cacheKey = buildCodexCliSessionPathCacheKey(params);
+  const cached = codexCliSessionPathCache.get(cacheKey);
+  if (cached && fs.existsSync(cached)) {
+    return cached;
+  }
+  if (!fs.existsSync(params.sessionsDir)) {
+    return undefined;
+  }
+
+  const stack = [params.sessionsDir];
+  while (stack.length > 0) {
+    const currentDir = stack.pop();
+    if (!currentDir) {
+      continue;
+    }
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries.toSorted((a, b) => a.name.localeCompare(b.name))) {
+      const filePath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(filePath);
+        continue;
+      }
+      if (!entry.isFile() || !isCodexCliHistoryFile(filePath, params.cliSessionId)) {
+        continue;
+      }
+      codexCliSessionPathCache.set(cacheKey, filePath);
+      return filePath;
+    }
+  }
+  return undefined;
+}
+
+export function resolveCodexCliSessionFilePath(params: {
+  cliSessionId: string;
+  homeDir?: string;
+}): string | undefined {
+  return findCodexCliSessionFile({
+    sessionsDir: resolveCodexSessionsDir(params.homeDir),
+    cliSessionId: params.cliSessionId,
+  });
+}
+
+function buildImportedMessageMeta(params: {
+  cliSessionId: string;
+  externalId: string;
+  phase?: string;
+}) {
+  return {
+    importedFrom: CODEX_CLI_PROVIDER,
+    cliSessionId: params.cliSessionId,
+    externalId: params.externalId,
+    ...(params.phase ? { phase: params.phase } : {}),
+  };
+}
+
+function buildTextBlock(text: string): TranscriptContentBlock {
+  return {
+    type: "text",
+    text,
+  };
+}
+
+function appendUniqueTextBlock(blocks: TranscriptContentBlock[], value: unknown): void {
+  const text = normalizeOptionalString(value);
+  if (!text) {
+    return;
+  }
+  if (blocks.some((block) => block.type === "text" && block.text === text)) {
+    return;
+  }
+  blocks.push(buildTextBlock(text));
+}
+
+function resolveCodexCliTextElementText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return normalizeOptionalString(value);
+  }
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as {
+    text?: unknown;
+    content?: unknown;
+    message?: unknown;
+    value?: unknown;
+  };
+  return (
+    normalizeOptionalString(record.text) ??
+    normalizeOptionalString(record.content) ??
+    normalizeOptionalString(record.message) ??
+    normalizeOptionalString(record.value)
+  );
+}
+
+function parseDataUriImage(value: string): TranscriptContentBlock | null {
+  const trimmed = value.trim();
+  const match = /^data:([^;,]+);base64,(.+)$/iu.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+  const [, mimeType, data] = match;
+  return {
+    type: "image",
+    mimeType,
+    data,
+  };
+}
+
+function resolveCodexCliInlineImage(value: unknown): TranscriptContentBlock | null {
+  if (typeof value === "string") {
+    return parseDataUriImage(value);
+  }
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const record = value as {
+    data?: unknown;
+    base64?: unknown;
+    image?: unknown;
+    mimeType?: unknown;
+    mediaType?: unknown;
+    media_type?: unknown;
+    contentType?: unknown;
+    content_type?: unknown;
+  };
+  const mimeType =
+    normalizeOptionalString(record.mimeType) ??
+    normalizeOptionalString(record.mediaType) ??
+    normalizeOptionalString(record.media_type) ??
+    normalizeOptionalString(record.contentType) ??
+    normalizeOptionalString(record.content_type);
+  const directData = normalizeOptionalString(record.data) ?? normalizeOptionalString(record.base64);
+  if (mimeType && directData) {
+    return {
+      type: "image",
+      mimeType,
+      data: directData,
+    };
+  }
+  if (typeof record.image === "string") {
+    const parsedDataUri = parseDataUriImage(record.image);
+    if (parsedDataUri) {
+      return parsedDataUri;
+    }
+    if (mimeType) {
+      return {
+        type: "image",
+        mimeType,
+        data: record.image,
+      };
+    }
+  }
+  return null;
+}
+
+function resolveCodexCliAttachmentLabel(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const normalized = normalizeOptionalString(value);
+    if (!normalized) {
+      return undefined;
+    }
+    return path.basename(normalized) || normalized;
+  }
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const record = value as {
+    label?: unknown;
+    name?: unknown;
+    fileName?: unknown;
+    filename?: unknown;
+    path?: unknown;
+    uri?: unknown;
+    url?: unknown;
+  };
+  const normalized =
+    normalizeOptionalString(record.label) ??
+    normalizeOptionalString(record.name) ??
+    normalizeOptionalString(record.fileName) ??
+    normalizeOptionalString(record.filename) ??
+    normalizeOptionalString(record.path) ??
+    normalizeOptionalString(record.uri) ??
+    normalizeOptionalString(record.url);
+  if (!normalized) {
+    return undefined;
+  }
+  return path.basename(normalized) || normalized;
+}
+
+function appendCodexCliAttachmentBlocks(params: {
+  blocks: TranscriptContentBlock[];
+  attachments: unknown;
+  placeholderPrefix: string;
+}): void {
+  if (!Array.isArray(params.attachments)) {
+    return;
+  }
+  for (const attachment of params.attachments) {
+    const inlineImage = resolveCodexCliInlineImage(attachment);
+    if (inlineImage) {
+      params.blocks.push(inlineImage);
+      continue;
+    }
+    const label = resolveCodexCliAttachmentLabel(attachment);
+    if (label) {
+      params.blocks.push(buildTextBlock(`[${params.placeholderPrefix}: ${label}]`));
+    }
+  }
+}
+
+function buildCodexCliUserContent(
+  payload: CodexCliTranscriptEntry["payload"],
+): string | TranscriptContentBlock[] | undefined {
+  const blocks: TranscriptContentBlock[] = [];
+  appendUniqueTextBlock(blocks, payload?.message);
+  if (Array.isArray(payload?.text_elements)) {
+    for (const textElement of payload.text_elements) {
+      appendUniqueTextBlock(blocks, resolveCodexCliTextElementText(textElement));
+    }
+  }
+  appendCodexCliAttachmentBlocks({
+    blocks,
+    attachments: payload?.images,
+    placeholderPrefix: "Image attachment",
+  });
+  appendCodexCliAttachmentBlocks({
+    blocks,
+    attachments: payload?.local_images,
+    placeholderPrefix: "Local image attachment",
+  });
+  if (blocks.length === 0) {
+    return undefined;
+  }
+  if (blocks.length === 1 && blocks[0]?.type === "text" && typeof blocks[0].text === "string") {
+    return blocks[0].text;
+  }
+  return blocks;
+}
+
+function parseCodexCliHistoryEntry(
+  entry: CodexCliTranscriptEntry,
+  cliSessionId: string,
+  sequence: number,
+): TranscriptLikeMessage | null {
+  if (entry.type !== "event_msg" || !entry.payload || typeof entry.payload !== "object") {
+    return null;
+  }
+  const payloadType = normalizeOptionalString(entry.payload.type);
+  if (!payloadType) {
+    return null;
+  }
+  const timestamp = resolveTimestampMs(entry.timestamp);
+  const phase = normalizeOptionalString(entry.payload.phase);
+  const externalId = `${payloadType}:${normalizeOptionalString(entry.timestamp) ?? "no-ts"}:${sequence}`;
+
+  if (payloadType === "user_message") {
+    const content = buildCodexCliUserContent(entry.payload);
+    if (content === undefined) {
+      return null;
+    }
+    return {
+      role: "user",
+      content,
+      ...(timestamp !== undefined ? { timestamp } : {}),
+      __openclaw: buildImportedMessageMeta({ cliSessionId, externalId }),
+    };
+  }
+
+  if (payloadType === "agent_message") {
+    const message = normalizeOptionalString(entry.payload.message);
+    if (!message) {
+      return null;
+    }
+    const normalizedPhase = normalizeAssistantPhase(phase);
+    return {
+      role: "assistant",
+      provider: CODEX_CLI_PROVIDER,
+      content: [{ type: "text", text: message }],
+      ...(normalizedPhase ? { phase: normalizedPhase } : {}),
+      ...(timestamp !== undefined ? { timestamp } : {}),
+      __openclaw: buildImportedMessageMeta({ cliSessionId, externalId, phase }),
+    };
+  }
+
+  return null;
+}
+
+export function readCodexCliSessionMessages(params: {
+  cliSessionId: string;
+  homeDir?: string;
+}): unknown[] {
+  const filePath = resolveCodexCliSessionFilePath(params);
+  if (!filePath) {
+    return [];
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const lines = content.split(/\r?\n/);
+  const messages: TranscriptLikeMessage[] = [];
+  let sequence = 0;
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const entry = JSON.parse(line) as CodexCliTranscriptEntry;
+      const parsed = parseCodexCliHistoryEntry(entry, params.cliSessionId, sequence);
+      if (parsed) {
+        messages.push(parsed);
+        sequence += 1;
+      }
+    } catch {
+      // Ignore malformed Codex history lines and keep the usable transcript.
+    }
+  }
+  return messages;
+}

--- a/src/gateway/cli-session-history.codex.ts
+++ b/src/gateway/cli-session-history.codex.ts
@@ -122,11 +122,14 @@ function findCodexCliSessionFile(params: {
 }): string | undefined {
   const cacheKey = buildCodexCliSessionPathCacheKey(params);
   const cached = codexCliSessionPathCache.get(cacheKey);
-  if (cached && fs.existsSync(cached)) {
-    setCachedCodexCliSessionPath(cacheKey, cached);
-    return cached;
-  }
-  if (cached) {
+  const cachedCandidate =
+    cached && fs.existsSync(cached)
+      ? {
+          filePath: cached,
+          mtimeMs: resolveCodexCliSessionFileCandidateMtime(cached),
+        }
+      : undefined;
+  if (cached && !cachedCandidate) {
     codexCliSessionPathCache.delete(cacheKey);
   }
   if (!fs.existsSync(params.sessionsDir)) {
@@ -134,7 +137,7 @@ function findCodexCliSessionFile(params: {
   }
 
   const stack = [params.sessionsDir];
-  let bestMatch: { filePath: string; mtimeMs: number } | undefined;
+  let bestMatch: { filePath: string; mtimeMs: number } | undefined = cachedCandidate;
   while (stack.length > 0) {
     const currentDir = stack.pop();
     if (!currentDir) {

--- a/src/gateway/cli-session-history.codex.ts
+++ b/src/gateway/cli-session-history.codex.ts
@@ -16,7 +16,10 @@ type CodexCliTranscriptEntry = {
   timestamp?: unknown;
   type?: unknown;
   payload?: {
+    id?: unknown;
     type?: unknown;
+    role?: unknown;
+    content?: unknown;
     message?: unknown;
     phase?: unknown;
     images?: unknown;
@@ -33,6 +36,10 @@ type TranscriptContentBlock = {
 };
 
 type TranscriptLikeMessage = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
 
 function resolveHistoryHomeDir(homeDir?: string): string {
   return normalizeOptionalString(homeDir) || process.env.HOME || os.homedir();
@@ -335,6 +342,8 @@ function resolveCodexCliAttachmentLabel(value: unknown): string | undefined {
     path?: unknown;
     uri?: unknown;
     url?: unknown;
+    imageUrl?: unknown;
+    image_url?: unknown;
   };
   const normalized =
     normalizeOptionalString(record.label) ??
@@ -343,7 +352,9 @@ function resolveCodexCliAttachmentLabel(value: unknown): string | undefined {
     normalizeOptionalString(record.filename) ??
     normalizeOptionalString(record.path) ??
     normalizeOptionalString(record.uri) ??
-    normalizeOptionalString(record.url);
+    normalizeOptionalString(record.url) ??
+    normalizeOptionalString(record.imageUrl) ??
+    normalizeOptionalString(record.image_url);
   if (!normalized) {
     return undefined;
   }
@@ -400,20 +411,79 @@ function buildCodexCliUserContent(
   return blocks;
 }
 
-function parseCodexCliHistoryEntry(
+function appendCodexCliResponseItemContentBlock(
+  blocks: TranscriptContentBlock[],
+  value: unknown,
+): void {
+  if (typeof value === "string") {
+    appendUniqueTextBlock(blocks, value);
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  const text =
+    normalizeOptionalString(value.text) ??
+    normalizeOptionalString(value.input_text) ??
+    normalizeOptionalString(value.output_text);
+  if (text) {
+    appendUniqueTextBlock(blocks, text);
+    return;
+  }
+
+  const type = normalizeOptionalString(value.type);
+  if (type !== "input_image" && type !== "image_url") {
+    return;
+  }
+  const inlineImage = resolveCodexCliInlineImage(value.image_url ?? value.imageUrl ?? value.url);
+  if (inlineImage) {
+    blocks.push(inlineImage);
+    return;
+  }
+  const label = resolveCodexCliAttachmentLabel(value);
+  if (label) {
+    blocks.push(buildTextBlock(`[Image attachment: ${label}]`));
+  }
+}
+
+function buildCodexCliResponseItemContentBlocks(
+  payload: CodexCliTranscriptEntry["payload"],
+): TranscriptContentBlock[] {
+  const blocks: TranscriptContentBlock[] = [];
+  if (Array.isArray(payload?.content)) {
+    for (const item of payload.content) {
+      appendCodexCliResponseItemContentBlock(blocks, item);
+    }
+  } else {
+    appendUniqueTextBlock(blocks, payload?.content);
+  }
+  return blocks;
+}
+
+function resolveCodexCliResponseItemContent(
+  payload: CodexCliTranscriptEntry["payload"],
+): string | TranscriptContentBlock[] | undefined {
+  const blocks = buildCodexCliResponseItemContentBlocks(payload);
+  if (blocks.length === 0) {
+    return undefined;
+  }
+  if (blocks.length === 1 && blocks[0]?.type === "text" && typeof blocks[0].text === "string") {
+    return blocks[0].text;
+  }
+  return blocks;
+}
+
+function parseCodexCliEventMessageHistoryEntry(
   entry: CodexCliTranscriptEntry,
   cliSessionId: string,
   sequence: number,
 ): TranscriptLikeMessage | null {
-  if (entry.type !== "event_msg" || !entry.payload || typeof entry.payload !== "object") {
-    return null;
-  }
-  const payloadType = normalizeOptionalString(entry.payload.type);
+  const payloadType = normalizeOptionalString(entry.payload?.type);
   if (!payloadType) {
     return null;
   }
   const timestamp = resolveTimestampMs(entry.timestamp);
-  const phase = normalizeOptionalString(entry.payload.phase);
+  const phase = normalizeOptionalString(entry.payload?.phase);
   const externalId = `${payloadType}:${normalizeOptionalString(entry.timestamp) ?? "no-ts"}:${sequence}`;
 
   if (payloadType === "user_message") {
@@ -430,7 +500,7 @@ function parseCodexCliHistoryEntry(
   }
 
   if (payloadType === "agent_message") {
-    const message = normalizeOptionalString(entry.payload.message);
+    const message = normalizeOptionalString(entry.payload?.message);
     if (!message) {
       return null;
     }
@@ -445,6 +515,70 @@ function parseCodexCliHistoryEntry(
     };
   }
 
+  return null;
+}
+
+function parseCodexCliResponseItemHistoryEntry(
+  entry: CodexCliTranscriptEntry,
+  cliSessionId: string,
+  sequence: number,
+): TranscriptLikeMessage | null {
+  const payloadType = normalizeOptionalString(entry.payload?.type);
+  if (payloadType !== "message") {
+    return null;
+  }
+  const role = normalizeOptionalString(entry.payload?.role);
+  if (role !== "user" && role !== "assistant") {
+    return null;
+  }
+  const timestamp = resolveTimestampMs(entry.timestamp);
+  const phase = normalizeOptionalString(entry.payload?.phase);
+  const payloadId = normalizeOptionalString(entry.payload?.id);
+  const externalId =
+    payloadId ?? `response_item:${normalizeOptionalString(entry.timestamp) ?? "no-ts"}:${sequence}`;
+
+  if (role === "user") {
+    const content = resolveCodexCliResponseItemContent(entry.payload);
+    if (content === undefined) {
+      return null;
+    }
+    return {
+      role,
+      content,
+      ...(timestamp !== undefined ? { timestamp } : {}),
+      __openclaw: buildImportedMessageMeta({ cliSessionId, externalId }),
+    };
+  }
+
+  const content = buildCodexCliResponseItemContentBlocks(entry.payload);
+  if (content.length === 0) {
+    return null;
+  }
+  const normalizedPhase = normalizeAssistantPhase(phase);
+  return {
+    role,
+    provider: CODEX_CLI_PROVIDER,
+    content,
+    ...(normalizedPhase ? { phase: normalizedPhase } : {}),
+    ...(timestamp !== undefined ? { timestamp } : {}),
+    __openclaw: buildImportedMessageMeta({ cliSessionId, externalId, phase }),
+  };
+}
+
+function parseCodexCliHistoryEntry(
+  entry: CodexCliTranscriptEntry,
+  cliSessionId: string,
+  sequence: number,
+): TranscriptLikeMessage | null {
+  if (!isRecord(entry.payload)) {
+    return null;
+  }
+  if (entry.type === "event_msg") {
+    return parseCodexCliEventMessageHistoryEntry(entry, cliSessionId, sequence);
+  }
+  if (entry.type === "response_item") {
+    return parseCodexCliResponseItemHistoryEntry(entry, cliSessionId, sequence);
+  }
   return null;
 }
 

--- a/src/gateway/cli-session-history.codex.ts
+++ b/src/gateway/cli-session-history.codex.ts
@@ -485,7 +485,7 @@ export function readCodexCliSessionMessages(params: {
   return messages;
 }
 
-export const __testing = {
+export const codexCliHistoryTesting = {
   get codexCliSessionPathCacheSize(): number {
     return codexCliSessionPathCache.size;
   },

--- a/src/gateway/cli-session-history.codex.ts
+++ b/src/gateway/cli-session-history.codex.ts
@@ -6,7 +6,8 @@ import { normalizeAssistantPhase } from "../shared/chat-message-content.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 export const CODEX_CLI_PROVIDER = "codex-cli";
-const CODEX_SESSIONS_RELATIVE_DIR = path.join(".codex", "sessions");
+const DEFAULT_CODEX_HOME_RELATIVE_DIR = ".codex";
+const CODEX_SESSIONS_DIR = "sessions";
 const codexCliSessionPathCache = new Map<string, string>();
 const DEFAULT_MAX_CODEX_CLI_SESSION_PATH_CACHE_ENTRIES = 256;
 let maxCodexCliSessionPathCacheEntries = DEFAULT_MAX_CODEX_CLI_SESSION_PATH_CACHE_ENTRIES;
@@ -37,8 +38,26 @@ function resolveHistoryHomeDir(homeDir?: string): string {
   return normalizeOptionalString(homeDir) || process.env.HOME || os.homedir();
 }
 
+function resolveMaybeHomeRelativePath(value: string, homeDir?: string): string {
+  if (value === "~") {
+    return resolveHistoryHomeDir(homeDir);
+  }
+  if (value.startsWith("~/")) {
+    return path.join(resolveHistoryHomeDir(homeDir), value.slice(2));
+  }
+  return path.resolve(value);
+}
+
+function resolveCodexHomeDir(homeDir?: string): string {
+  const configuredCodexHome = normalizeOptionalString(process.env.CODEX_HOME);
+  if (configuredCodexHome) {
+    return resolveMaybeHomeRelativePath(configuredCodexHome, homeDir);
+  }
+  return path.join(resolveHistoryHomeDir(homeDir), DEFAULT_CODEX_HOME_RELATIVE_DIR);
+}
+
 function resolveCodexSessionsDir(homeDir?: string): string {
-  return path.join(resolveHistoryHomeDir(homeDir), CODEX_SESSIONS_RELATIVE_DIR);
+  return path.join(resolveCodexHomeDir(homeDir), CODEX_SESSIONS_DIR);
 }
 
 export function resolveCodexCliBindingSessionId(

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -564,6 +564,66 @@ describe("cli session history", () => {
     });
   });
 
+  it("keeps reset suppression scoped to preserved providers after another provider rebounds", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-suppress-scope-"));
+    const homeDir = path.join(root, "home");
+    const originalHome = process.env.HOME;
+    const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+    const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    await fs.mkdir(claudeProjectsDir, { recursive: true });
+    await fs.mkdir(codexSessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(claudeProjectsDir, `${claudeSessionId}.jsonl`),
+      createClaudeHistoryLines(claudeSessionId),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${codexSessionId}.jsonl`),
+      createCodexHistoryLines(codexSessionId),
+      "utf-8",
+    );
+    process.env.HOME = homeDir;
+    try {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "fresh-session",
+          updatedAt: Date.now(),
+          suppressCliHistoryImport: true,
+          suppressCliHistoryImportProviders: ["claude-cli"],
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId: claudeSessionId,
+            },
+            "codex-cli": {
+              sessionId: codexSessionId,
+            },
+          },
+        },
+        provider: undefined,
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+      expect(messages[1]).toMatchObject({
+        role: "assistant",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("imports codex user content from text elements and attachments", async () => {
     await withCodexSessionsDir(
       async ({ homeDir, sessionId }) => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { __testing as codexCliHistoryTesting } from "./cli-session-history.codex.js";
+import { codexCliHistoryTesting } from "./cli-session-history.codex.js";
 import {
   augmentChatHistoryWithCliSessionImports,
   mergeImportedChatHistoryMessages,

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -733,6 +733,40 @@ describe("cli session history", () => {
     }
   });
 
+  it("does not match a codex transcript whose session token only shares a suffix", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-suffix-"));
+    const homeDir = path.join(root, "home");
+    const requestedSessionId = "abc";
+    const otherSessionId = "xabc";
+    const sessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    const otherFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${otherSessionId}.jsonl`);
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      otherFile,
+      createCodexHistoryLines(otherSessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from the wrong transcript",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+
+    try {
+      expect(
+        resolveCodexCliSessionFilePath({ cliSessionId: requestedSessionId, homeDir }),
+      ).toBeUndefined();
+      expect(readCodexCliSessionMessages({ cliSessionId: requestedSessionId, homeDir })).toEqual(
+        [],
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("ignores non-event Codex transcript records while importing event messages", async () => {
     const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     await withCodexSessionsDir(

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -887,7 +887,7 @@ describe("cli session history", () => {
     }
   });
 
-  it("ignores non-event Codex transcript records while importing event messages", async () => {
+  it("imports Codex response_item message records while ignoring unsupported records", async () => {
     const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     await withCodexSessionsDir(
       async ({ homeDir }) => {
@@ -895,29 +895,75 @@ describe("cli session history", () => {
         expect(messages).toHaveLength(2);
         expect(messages[0]).toMatchObject({
           role: "user",
-          content: "Why is the history missing after refresh?",
+          content: "Response item question",
+          __openclaw: {
+            importedFrom: "codex-cli",
+            cliSessionId: sessionId,
+            externalId: "response_item:2026-04-11T07:38:34.000Z:0",
+          },
         });
         expect(messages[1]).toMatchObject({
           role: "assistant",
+          provider: "codex-cli",
+          phase: "final_answer",
           content: [
             {
               type: "text",
-              text: "The current history view only reads the persisted transcript.",
+              text: "Response item answer",
             },
           ],
+          __openclaw: {
+            importedFrom: "codex-cli",
+            cliSessionId: sessionId,
+            externalId: "response_item:2026-04-11T07:38:36.000Z:1",
+            phase: "final_answer",
+          },
         });
       },
       {
         lines: [
-          createCodexHistoryLines(sessionId),
           JSON.stringify({
-            timestamp: "2026-04-11T07:38:38.000Z",
+            timestamp: "2026-04-11T07:38:33.999Z",
+            type: "session_meta",
+            payload: {
+              id: sessionId,
+              cwd: "/tmp/demo",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:34.000Z",
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "Response item question" }],
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:35.000Z",
+            type: "response_item",
+            payload: {
+              type: "reasoning",
+              content: [{ type: "summary_text", text: "internal reasoning" }],
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:36.000Z",
             type: "response_item",
             payload: {
               type: "message",
               role: "assistant",
-              content: [{ type: "output_text", text: "Ignored response item." }],
+              content: [{ type: "output_text", text: "Response item answer" }],
               phase: "final_answer",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:37.000Z",
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "developer",
+              content: [{ type: "input_text", text: "hidden instructions" }],
             },
           }),
         ].join("\n"),

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -672,6 +672,67 @@ describe("cli session history", () => {
     }
   });
 
+  it("re-scans matching codex transcript files before reusing a cached path", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-cache-refresh-"));
+    const homeDir = path.join(root, "home");
+    const sessionId = "same-session-id";
+    const sessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    const olderFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`);
+    const newerFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-34-${sessionId}.jsonl`);
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      olderFile,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from the older transcript",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    await fs.utimes(
+      olderFile,
+      new Date("2026-04-11T07:38:33.000Z"),
+      new Date("2026-04-11T07:38:33.000Z"),
+    );
+
+    try {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(olderFile);
+
+      await fs.writeFile(
+        newerFile,
+        createCodexHistoryLines(sessionId, [
+          {
+            timestamp: "2026-04-11T07:38:34.000Z",
+            payload: {
+              type: "user_message",
+              message: "Loaded from the newer transcript",
+            },
+          },
+        ]),
+        "utf-8",
+      );
+      await fs.utimes(
+        newerFile,
+        new Date("2026-04-11T07:38:34.000Z"),
+        new Date("2026-04-11T07:38:34.000Z"),
+      );
+
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(newerFile);
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "Loaded from the newer transcript",
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("ignores non-event Codex transcript records while importing event messages", async () => {
     const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     await withCodexSessionsDir(

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -6,9 +6,12 @@ import {
   augmentChatHistoryWithCliSessionImports,
   mergeImportedChatHistoryMessages,
   readClaudeCliFallbackSeed,
+  readCodexCliSessionMessages,
   readClaudeCliSessionMessages,
+  resolveCodexCliSessionFilePath,
   resolveClaudeCliSessionFilePath,
 } from "./cli-session-history.js";
+import { sanitizeChatHistoryMessages } from "./server-methods/chat.js";
 
 const ORIGINAL_HOME = process.env.HOME;
 
@@ -142,6 +145,84 @@ async function withClaudeProjectsDir<T>(
   }
 }
 
+type CodexHistoryEvent = {
+  timestamp: string;
+  payload: Record<string, unknown>;
+};
+
+function createCodexHistoryLines(sessionId: string, events?: CodexHistoryEvent[]) {
+  const eventLines = events ?? [
+    {
+      timestamp: "2026-04-11T07:38:34.000Z",
+      payload: {
+        type: "user_message",
+        message: "Why is the history missing after refresh?",
+      },
+    },
+    {
+      timestamp: "2026-04-11T07:38:35.000Z",
+      payload: {
+        type: "token_count",
+      },
+    },
+    {
+      timestamp: "2026-04-11T07:38:36.000Z",
+      payload: {
+        type: "agent_message",
+        message: "The current history view only reads the persisted transcript.",
+        phase: "final_answer",
+      },
+    },
+    {
+      timestamp: "2026-04-11T07:38:37.000Z",
+      payload: {
+        type: "task_complete",
+      },
+    },
+  ];
+  return [
+    JSON.stringify({
+      timestamp: "2026-04-11T07:38:33.999Z",
+      type: "session_meta",
+      payload: {
+        id: sessionId,
+        cwd: "/tmp/demo",
+      },
+    }),
+    ...eventLines.map((event) =>
+      JSON.stringify({
+        timestamp: event.timestamp,
+        type: "event_msg",
+        payload: event.payload,
+      }),
+    ),
+  ].join("\n");
+}
+
+async function withCodexSessionsDir<T>(
+  run: (params: { homeDir: string; sessionId: string; filePath: string }) => Promise<T>,
+  options?: { lines?: string },
+): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-"));
+  const homeDir = path.join(root, "home");
+  const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+  const sessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+  const filePath = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`);
+  await fs.mkdir(sessionsDir, { recursive: true });
+  await fs.writeFile(filePath, options?.lines ?? createCodexHistoryLines(sessionId), "utf-8");
+  process.env.HOME = homeDir;
+  try {
+    return await run({ homeDir, sessionId, filePath });
+  } finally {
+    if (ORIGINAL_HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = ORIGINAL_HOME;
+    }
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
 describe("cli session history", () => {
   afterEach(() => {
     if (ORIGINAL_HOME === undefined) {
@@ -215,6 +296,335 @@ describe("cli session history", () => {
         resolveClaudeCliSessionFilePath({ cliSessionId: "nested\\session", homeDir }),
       ).toBeUndefined();
     });
+  });
+
+  it("reads codex-cli session messages from the Codex sessions store", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId, filePath }) => {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(filePath);
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "Why is the history missing after refresh?",
+        __openclaw: {
+          importedFrom: "codex-cli",
+          cliSessionId: sessionId,
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        role: "assistant",
+        provider: "codex-cli",
+        phase: "final_answer",
+        content: [
+          { type: "text", text: "The current history view only reads the persisted transcript." },
+        ],
+        __openclaw: {
+          importedFrom: "codex-cli",
+          cliSessionId: sessionId,
+          phase: "final_answer",
+        },
+      });
+    });
+  });
+
+  it("keeps the final codex reply when commentary shares a timestamp", async () => {
+    await withCodexSessionsDir(
+      async ({ homeDir, sessionId }) => {
+        const rawMessages = augmentChatHistoryWithCliSessionImports({
+          entry: {
+            sessionId: "openclaw-session",
+            updatedAt: Date.now(),
+            cliSessionBindings: {
+              "codex-cli": {
+                sessionId,
+              },
+            },
+          },
+          provider: "codex-cli",
+          localMessages: [],
+          homeDir,
+        });
+        expect(rawMessages).toHaveLength(2);
+        const visibleMessages = sanitizeChatHistoryMessages(rawMessages, 4_000);
+        expect(visibleMessages).toHaveLength(2);
+        expect(visibleMessages[1]).toMatchObject({
+          role: "assistant",
+          phase: "final_answer",
+          content: [
+            {
+              type: "text",
+              text: "The current history view only reads the persisted transcript.",
+            },
+          ],
+        });
+      },
+      {
+        lines: createCodexHistoryLines("019d7b7a-6bf8-7fb3-8abb-412fb4107f9f", [
+          {
+            timestamp: "2026-04-11T07:38:34.000Z",
+            payload: {
+              type: "user_message",
+              message: "Why is the history missing after refresh?",
+            },
+          },
+          {
+            timestamp: "2026-04-11T07:38:35.000Z",
+            payload: {
+              type: "agent_message",
+              message: "I am checking the persisted transcript now.",
+              phase: "commentary",
+            },
+          },
+          {
+            timestamp: "2026-04-11T07:38:35.000Z",
+            payload: {
+              type: "agent_message",
+              message: "The current history view only reads the persisted transcript.",
+              phase: "final_answer",
+            },
+          },
+        ]),
+      },
+    );
+  });
+
+  it("merges all bound CLI histories when local transcript is empty", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-merge-"));
+    const homeDir = path.join(root, "home");
+    const originalHome = process.env.HOME;
+    const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+    const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    await fs.mkdir(claudeProjectsDir, { recursive: true });
+    await fs.mkdir(codexSessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(claudeProjectsDir, `${claudeSessionId}.jsonl`),
+      createClaudeHistoryLines(claudeSessionId),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${codexSessionId}.jsonl`),
+      createCodexHistoryLines(codexSessionId),
+      "utf-8",
+    );
+    process.env.HOME = homeDir;
+    try {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId: claudeSessionId,
+            },
+            "codex-cli": {
+              sessionId: codexSessionId,
+            },
+          },
+        },
+        provider: "codex-cli",
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toHaveLength(5);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "claude-cli", cliSessionId: claudeSessionId },
+      });
+      expect(messages[3]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+      expect(messages[4]).toMatchObject({
+        role: "assistant",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not re-import CLI history when reset suppresses old CLI backfill", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "fresh-session",
+          updatedAt: Date.now(),
+          suppressCliHistoryImport: true,
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId,
+            },
+          },
+        },
+        provider: "codex-cli",
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toEqual([]);
+    });
+  });
+
+  it("imports codex user content from text elements and attachments", async () => {
+    await withCodexSessionsDir(
+      async ({ homeDir, sessionId }) => {
+        const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+        expect(messages).toHaveLength(2);
+        expect(messages[0]).toMatchObject({
+          role: "user",
+          content: [
+            { type: "text", text: "Compare these inputs." },
+            { type: "image", mimeType: "image/png", data: "QUJD" },
+            { type: "text", text: "[Local image attachment: before.png]" },
+          ],
+          __openclaw: {
+            importedFrom: "codex-cli",
+            cliSessionId: sessionId,
+          },
+        });
+      },
+      {
+        lines: createCodexHistoryLines("019d7b7a-6bf8-7fb3-8abb-412fb4107f9f", [
+          {
+            timestamp: "2026-04-11T07:38:34.000Z",
+            payload: {
+              type: "user_message",
+              text_elements: [{ text: "Compare these inputs." }],
+              images: [{ mimeType: "image/png", data: "QUJD" }],
+              local_images: [{ path: "/tmp/screenshots/before.png" }],
+            },
+          },
+          {
+            timestamp: "2026-04-11T07:38:36.000Z",
+            payload: {
+              type: "agent_message",
+              message: "I can compare the inline image and the local attachment.",
+              phase: "final_answer",
+            },
+          },
+        ]),
+      },
+    );
+  });
+
+  it("returns an empty import when a cached codex file disappears before read", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId, filePath }) => {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(filePath);
+      await fs.rm(filePath, { force: true });
+      expect(readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir })).toEqual([]);
+    });
+  });
+
+  it("ignores non-event Codex transcript records while importing event messages", async () => {
+    const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    await withCodexSessionsDir(
+      async ({ homeDir }) => {
+        const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+        expect(messages).toHaveLength(2);
+        expect(messages[0]).toMatchObject({
+          role: "user",
+          content: "Why is the history missing after refresh?",
+        });
+        expect(messages[1]).toMatchObject({
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "The current history view only reads the persisted transcript.",
+            },
+          ],
+        });
+      },
+      {
+        lines: [
+          createCodexHistoryLines(sessionId),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:38.000Z",
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: "Ignored response item." }],
+              phase: "final_answer",
+            },
+          }),
+        ].join("\n"),
+      },
+    );
+  });
+
+  it("isolates the codex session path cache by home directory", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-cache-"));
+    const sessionId = "same-session-id";
+    const homeA = path.join(root, "home-a");
+    const homeB = path.join(root, "home-b");
+    const fileA = path.join(
+      homeA,
+      ".codex",
+      "sessions",
+      "2026",
+      "04",
+      "11",
+      `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`,
+    );
+    const fileB = path.join(
+      homeB,
+      ".codex",
+      "sessions",
+      "2026",
+      "04",
+      "11",
+      `rollout-2026-04-11T15-38-34-${sessionId}.jsonl`,
+    );
+    await fs.mkdir(path.dirname(fileA), { recursive: true });
+    await fs.mkdir(path.dirname(fileB), { recursive: true });
+    await fs.writeFile(
+      fileA,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from home A",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    await fs.writeFile(
+      fileB,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from home B",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    try {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir: homeA })).toBe(
+        fileA,
+      );
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir: homeB })).toBe(
+        fileB,
+      );
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir: homeB });
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "Loaded from home B",
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("deduplicates imported messages against similar local transcript entries", () => {
@@ -410,6 +820,34 @@ describe("cli session history", () => {
         role: "user",
       });
       expectFields(readRecord(messages[0])["__openclaw"], { cliSessionId: sessionId });
+    });
+  });
+
+  it("augments chat history when a session has a codex-cli binding", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId,
+            },
+          },
+        },
+        provider: "codex-cli",
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: { cliSessionId: sessionId, importedFrom: "codex-cli" },
+      });
+      expect(messages[1]).toMatchObject({
+        role: "assistant",
+        __openclaw: { cliSessionId: sessionId, importedFrom: "codex-cli" },
+      });
     });
   });
 });

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -390,8 +390,70 @@ describe("cli session history", () => {
     );
   });
 
-  it("merges all bound CLI histories when local transcript is empty", async () => {
+  it("merges all bound CLI histories when provider is unknown and local transcript is empty", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-merge-"));
+    const homeDir = path.join(root, "home");
+    const originalHome = process.env.HOME;
+    const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+    const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    await fs.mkdir(claudeProjectsDir, { recursive: true });
+    await fs.mkdir(codexSessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(claudeProjectsDir, `${claudeSessionId}.jsonl`),
+      createClaudeHistoryLines(claudeSessionId),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${codexSessionId}.jsonl`),
+      createCodexHistoryLines(codexSessionId),
+      "utf-8",
+    );
+    process.env.HOME = homeDir;
+    try {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId: claudeSessionId,
+            },
+            "codex-cli": {
+              sessionId: codexSessionId,
+            },
+          },
+        },
+        provider: undefined,
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toHaveLength(5);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "claude-cli", cliSessionId: claudeSessionId },
+      });
+      expect(messages[3]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+      expect(messages[4]).toMatchObject({
+        role: "assistant",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scopes empty-transcript imports to the active provider when one is resolved", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-scope-"));
     const homeDir = path.join(root, "home");
     const originalHome = process.env.HOME;
     const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
@@ -429,16 +491,12 @@ describe("cli session history", () => {
         localMessages: [],
         homeDir,
       });
-      expect(messages).toHaveLength(5);
+      expect(messages).toHaveLength(2);
       expect(messages[0]).toMatchObject({
-        role: "user",
-        __openclaw: { importedFrom: "claude-cli", cliSessionId: claudeSessionId },
-      });
-      expect(messages[3]).toMatchObject({
         role: "user",
         __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
       });
-      expect(messages[4]).toMatchObject({
+      expect(messages[1]).toMatchObject({
         role: "assistant",
         __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
       });
@@ -554,6 +612,64 @@ describe("cli session history", () => {
       await fs.rm(filePath, { force: true });
       expect(readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir })).toEqual([]);
     });
+  });
+
+  it("prefers the newest matching codex transcript file for the same session id", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-newest-"));
+    const homeDir = path.join(root, "home");
+    const sessionId = "same-session-id";
+    const sessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    const olderFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`);
+    const newerFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-34-${sessionId}.jsonl`);
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      olderFile,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from the older transcript",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    await fs.writeFile(
+      newerFile,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from the newer transcript",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    await fs.utimes(
+      olderFile,
+      new Date("2026-04-11T07:38:33.000Z"),
+      new Date("2026-04-11T07:38:33.000Z"),
+    );
+    await fs.utimes(
+      newerFile,
+      new Date("2026-04-11T07:38:34.000Z"),
+      new Date("2026-04-11T07:38:34.000Z"),
+    );
+
+    try {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(newerFile);
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "Loaded from the newer transcript",
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("ignores non-event Codex transcript records while importing event messages", async () => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __testing as codexCliHistoryTesting } from "./cli-session-history.codex.js";
 import {
   augmentChatHistoryWithCliSessionImports,
   mergeImportedChatHistoryMessages,
@@ -225,6 +226,7 @@ async function withCodexSessionsDir<T>(
 
 describe("cli session history", () => {
   afterEach(() => {
+    codexCliHistoryTesting.resetCodexCliSessionPathCacheForTests();
     if (ORIGINAL_HOME === undefined) {
       delete process.env.HOME;
     } else {
@@ -624,6 +626,27 @@ describe("cli session history", () => {
       });
     } finally {
       await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("bounds the codex session path cache", async () => {
+    const previousCacheCap = codexCliHistoryTesting.maxCodexCliSessionPathCacheEntries;
+    codexCliHistoryTesting.setMaxCodexCliSessionPathCacheEntriesForTests(2);
+
+    try {
+      await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+        expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBeTruthy();
+      });
+      await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+        expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBeTruthy();
+      });
+      await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+        expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBeTruthy();
+      });
+
+      expect(codexCliHistoryTesting.codexCliSessionPathCacheSize).toBeLessThanOrEqual(2);
+    } finally {
+      codexCliHistoryTesting.setMaxCodexCliSessionPathCacheEntriesForTests(previousCacheCap);
     }
   });
 

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -15,6 +15,7 @@ import {
 import { sanitizeChatHistoryMessages } from "./server-methods/chat.js";
 
 const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CODEX_HOME = process.env.CODEX_HOME;
 
 type ClaudeCliFallbackSeed = NonNullable<ReturnType<typeof readClaudeCliFallbackSeed>>;
 
@@ -212,6 +213,7 @@ async function withCodexSessionsDir<T>(
   await fs.mkdir(sessionsDir, { recursive: true });
   await fs.writeFile(filePath, options?.lines ?? createCodexHistoryLines(sessionId), "utf-8");
   process.env.HOME = homeDir;
+  delete process.env.CODEX_HOME;
   try {
     return await run({ homeDir, sessionId, filePath });
   } finally {
@@ -219,6 +221,11 @@ async function withCodexSessionsDir<T>(
       delete process.env.HOME;
     } else {
       process.env.HOME = ORIGINAL_HOME;
+    }
+    if (ORIGINAL_CODEX_HOME === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = ORIGINAL_CODEX_HOME;
     }
     await fs.rm(root, { recursive: true, force: true });
   }
@@ -231,6 +238,11 @@ describe("cli session history", () => {
       delete process.env.HOME;
     } else {
       process.env.HOME = ORIGINAL_HOME;
+    }
+    if (ORIGINAL_CODEX_HOME === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = ORIGINAL_CODEX_HOME;
     }
   });
 
@@ -329,6 +341,33 @@ describe("cli session history", () => {
     });
   });
 
+  it("resolves codex-cli session messages from CODEX_HOME before HOME", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-home-history-"));
+    const homeDir = path.join(root, "home");
+    const codexHome = path.join(root, "custom-codex-home");
+    const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    const sessionsDir = path.join(codexHome, "sessions", "2026", "04", "11");
+    const filePath = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`);
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(filePath, createCodexHistoryLines(sessionId), "utf-8");
+    process.env.HOME = homeDir;
+    process.env.CODEX_HOME = codexHome;
+    try {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId })).toBe(filePath);
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId });
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: {
+          importedFrom: "codex-cli",
+          cliSessionId: sessionId,
+        },
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps the final codex reply when commentary shares a timestamp", async () => {
     await withCodexSessionsDir(
       async ({ homeDir, sessionId }) => {
@@ -394,6 +433,7 @@ describe("cli session history", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-merge-"));
     const homeDir = path.join(root, "home");
     const originalHome = process.env.HOME;
+    const originalCodexHome = process.env.CODEX_HOME;
     const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
     const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
@@ -411,6 +451,7 @@ describe("cli session history", () => {
       "utf-8",
     );
     process.env.HOME = homeDir;
+    delete process.env.CODEX_HOME;
     try {
       const messages = augmentChatHistoryWithCliSessionImports({
         entry: {
@@ -448,6 +489,11 @@ describe("cli session history", () => {
       } else {
         process.env.HOME = originalHome;
       }
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
+      }
       await fs.rm(root, { recursive: true, force: true });
     }
   });
@@ -456,6 +502,7 @@ describe("cli session history", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-scope-"));
     const homeDir = path.join(root, "home");
     const originalHome = process.env.HOME;
+    const originalCodexHome = process.env.CODEX_HOME;
     const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
     const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
@@ -473,6 +520,7 @@ describe("cli session history", () => {
       "utf-8",
     );
     process.env.HOME = homeDir;
+    delete process.env.CODEX_HOME;
     try {
       const messages = augmentChatHistoryWithCliSessionImports({
         entry: {
@@ -505,6 +553,11 @@ describe("cli session history", () => {
         delete process.env.HOME;
       } else {
         process.env.HOME = originalHome;
+      }
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
       }
       await fs.rm(root, { recursive: true, force: true });
     }
@@ -568,6 +621,7 @@ describe("cli session history", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-suppress-scope-"));
     const homeDir = path.join(root, "home");
     const originalHome = process.env.HOME;
+    const originalCodexHome = process.env.CODEX_HOME;
     const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
     const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
@@ -585,6 +639,7 @@ describe("cli session history", () => {
       "utf-8",
     );
     process.env.HOME = homeDir;
+    delete process.env.CODEX_HOME;
     try {
       const messages = augmentChatHistoryWithCliSessionImports({
         entry: {
@@ -619,6 +674,11 @@ describe("cli session history", () => {
         delete process.env.HOME;
       } else {
         process.env.HOME = originalHome;
+      }
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
       }
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -473,6 +473,39 @@ describe("cli session history", () => {
     });
   });
 
+  it("does not merge stale CLI history into reset sessions with local transcript entries", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+      const localMessages = [
+        {
+          role: "user",
+          content: "fresh local question",
+          timestamp: Date.parse("2026-04-11T08:00:00.000Z"),
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "fresh local answer" }],
+          timestamp: Date.parse("2026-04-11T08:00:01.000Z"),
+        },
+      ];
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "fresh-session",
+          updatedAt: Date.now(),
+          suppressCliHistoryImport: true,
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId,
+            },
+          },
+        },
+        provider: "codex-cli",
+        localMessages,
+        homeDir,
+      });
+      expect(messages).toEqual(localMessages);
+    });
+  });
+
   it("imports codex user content from text elements and attachments", async () => {
     await withCodexSessionsDir(
       async ({ homeDir, sessionId }) => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -521,6 +521,66 @@ describe("cli session history", () => {
     });
   });
 
+  it("keeps reset suppression scoped to preserved providers after another provider rebounds", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-suppress-scope-"));
+    const homeDir = path.join(root, "home");
+    const originalHome = process.env.HOME;
+    const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+    const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    await fs.mkdir(claudeProjectsDir, { recursive: true });
+    await fs.mkdir(codexSessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(claudeProjectsDir, `${claudeSessionId}.jsonl`),
+      createClaudeHistoryLines(claudeSessionId),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${codexSessionId}.jsonl`),
+      createCodexHistoryLines(codexSessionId),
+      "utf-8",
+    );
+    process.env.HOME = homeDir;
+    try {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "fresh-session",
+          updatedAt: Date.now(),
+          suppressCliHistoryImport: true,
+          suppressCliHistoryImportProviders: ["claude-cli"],
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId: claudeSessionId,
+            },
+            "codex-cli": {
+              sessionId: codexSessionId,
+            },
+          },
+        },
+        provider: undefined,
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+      expect(messages[1]).toMatchObject({
+        role: "assistant",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("imports codex user content from text elements and attachments", async () => {
     await withCodexSessionsDir(
       async ({ homeDir, sessionId }) => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -15,6 +15,7 @@ import {
 import { sanitizeChatHistoryMessages } from "./server-methods/chat.js";
 
 const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_CODEX_HOME = process.env.CODEX_HOME;
 
 function createClaudeHistoryLines(sessionId: string) {
   return [
@@ -183,6 +184,7 @@ async function withCodexSessionsDir<T>(
   await fs.mkdir(sessionsDir, { recursive: true });
   await fs.writeFile(filePath, options?.lines ?? createCodexHistoryLines(sessionId), "utf-8");
   process.env.HOME = homeDir;
+  delete process.env.CODEX_HOME;
   try {
     return await run({ homeDir, sessionId, filePath });
   } finally {
@@ -190,6 +192,11 @@ async function withCodexSessionsDir<T>(
       delete process.env.HOME;
     } else {
       process.env.HOME = ORIGINAL_HOME;
+    }
+    if (ORIGINAL_CODEX_HOME === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = ORIGINAL_CODEX_HOME;
     }
     await fs.rm(root, { recursive: true, force: true });
   }
@@ -202,6 +209,11 @@ describe("cli session history", () => {
       delete process.env.HOME;
     } else {
       process.env.HOME = ORIGINAL_HOME;
+    }
+    if (ORIGINAL_CODEX_HOME === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = ORIGINAL_CODEX_HOME;
     }
   });
 
@@ -286,6 +298,33 @@ describe("cli session history", () => {
     });
   });
 
+  it("resolves codex-cli session messages from CODEX_HOME before HOME", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-home-history-"));
+    const homeDir = path.join(root, "home");
+    const codexHome = path.join(root, "custom-codex-home");
+    const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    const sessionsDir = path.join(codexHome, "sessions", "2026", "04", "11");
+    const filePath = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`);
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(filePath, createCodexHistoryLines(sessionId), "utf-8");
+    process.env.HOME = homeDir;
+    process.env.CODEX_HOME = codexHome;
+    try {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId })).toBe(filePath);
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId });
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: {
+          importedFrom: "codex-cli",
+          cliSessionId: sessionId,
+        },
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("keeps the final codex reply when commentary shares a timestamp", async () => {
     await withCodexSessionsDir(
       async ({ homeDir, sessionId }) => {
@@ -351,6 +390,7 @@ describe("cli session history", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-merge-"));
     const homeDir = path.join(root, "home");
     const originalHome = process.env.HOME;
+    const originalCodexHome = process.env.CODEX_HOME;
     const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
     const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
@@ -368,6 +408,7 @@ describe("cli session history", () => {
       "utf-8",
     );
     process.env.HOME = homeDir;
+    delete process.env.CODEX_HOME;
     try {
       const messages = augmentChatHistoryWithCliSessionImports({
         entry: {
@@ -405,6 +446,11 @@ describe("cli session history", () => {
       } else {
         process.env.HOME = originalHome;
       }
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
+      }
       await fs.rm(root, { recursive: true, force: true });
     }
   });
@@ -413,6 +459,7 @@ describe("cli session history", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-scope-"));
     const homeDir = path.join(root, "home");
     const originalHome = process.env.HOME;
+    const originalCodexHome = process.env.CODEX_HOME;
     const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
     const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
@@ -430,6 +477,7 @@ describe("cli session history", () => {
       "utf-8",
     );
     process.env.HOME = homeDir;
+    delete process.env.CODEX_HOME;
     try {
       const messages = augmentChatHistoryWithCliSessionImports({
         entry: {
@@ -462,6 +510,11 @@ describe("cli session history", () => {
         delete process.env.HOME;
       } else {
         process.env.HOME = originalHome;
+      }
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
       }
       await fs.rm(root, { recursive: true, force: true });
     }
@@ -525,6 +578,7 @@ describe("cli session history", () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-suppress-scope-"));
     const homeDir = path.join(root, "home");
     const originalHome = process.env.HOME;
+    const originalCodexHome = process.env.CODEX_HOME;
     const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
     const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
@@ -542,6 +596,7 @@ describe("cli session history", () => {
       "utf-8",
     );
     process.env.HOME = homeDir;
+    delete process.env.CODEX_HOME;
     try {
       const messages = augmentChatHistoryWithCliSessionImports({
         entry: {
@@ -576,6 +631,11 @@ describe("cli session history", () => {
         delete process.env.HOME;
       } else {
         process.env.HOME = originalHome;
+      }
+      if (originalCodexHome === undefined) {
+        delete process.env.CODEX_HOME;
+      } else {
+        process.env.CODEX_HOME = originalCodexHome;
       }
       await fs.rm(root, { recursive: true, force: true });
     }

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -430,6 +430,39 @@ describe("cli session history", () => {
     });
   });
 
+  it("does not merge stale CLI history into reset sessions with local transcript entries", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+      const localMessages = [
+        {
+          role: "user",
+          content: "fresh local question",
+          timestamp: Date.parse("2026-04-11T08:00:00.000Z"),
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "fresh local answer" }],
+          timestamp: Date.parse("2026-04-11T08:00:01.000Z"),
+        },
+      ];
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "fresh-session",
+          updatedAt: Date.now(),
+          suppressCliHistoryImport: true,
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId,
+            },
+          },
+        },
+        provider: "codex-cli",
+        localMessages,
+        homeDir,
+      });
+      expect(messages).toEqual(localMessages);
+    });
+  });
+
   it("imports codex user content from text elements and attachments", async () => {
     await withCodexSessionsDir(
       async ({ homeDir, sessionId }) => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -629,6 +629,67 @@ describe("cli session history", () => {
     }
   });
 
+  it("re-scans matching codex transcript files before reusing a cached path", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-cache-refresh-"));
+    const homeDir = path.join(root, "home");
+    const sessionId = "same-session-id";
+    const sessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    const olderFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`);
+    const newerFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-34-${sessionId}.jsonl`);
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      olderFile,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from the older transcript",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    await fs.utimes(
+      olderFile,
+      new Date("2026-04-11T07:38:33.000Z"),
+      new Date("2026-04-11T07:38:33.000Z"),
+    );
+
+    try {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(olderFile);
+
+      await fs.writeFile(
+        newerFile,
+        createCodexHistoryLines(sessionId, [
+          {
+            timestamp: "2026-04-11T07:38:34.000Z",
+            payload: {
+              type: "user_message",
+              message: "Loaded from the newer transcript",
+            },
+          },
+        ]),
+        "utf-8",
+      );
+      await fs.utimes(
+        newerFile,
+        new Date("2026-04-11T07:38:34.000Z"),
+        new Date("2026-04-11T07:38:34.000Z"),
+      );
+
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(newerFile);
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "Loaded from the newer transcript",
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("ignores non-event Codex transcript records while importing event messages", async () => {
     const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     await withCodexSessionsDir(

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __testing as codexCliHistoryTesting } from "./cli-session-history.codex.js";
 import {
   augmentChatHistoryWithCliSessionImports,
   mergeImportedChatHistoryMessages,
@@ -196,6 +197,7 @@ async function withCodexSessionsDir<T>(
 
 describe("cli session history", () => {
   afterEach(() => {
+    codexCliHistoryTesting.resetCodexCliSessionPathCacheForTests();
     if (ORIGINAL_HOME === undefined) {
       delete process.env.HOME;
     } else {
@@ -581,6 +583,27 @@ describe("cli session history", () => {
       });
     } finally {
       await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("bounds the codex session path cache", async () => {
+    const previousCacheCap = codexCliHistoryTesting.maxCodexCliSessionPathCacheEntries;
+    codexCliHistoryTesting.setMaxCodexCliSessionPathCacheEntriesForTests(2);
+
+    try {
+      await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+        expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBeTruthy();
+      });
+      await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+        expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBeTruthy();
+      });
+      await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+        expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBeTruthy();
+      });
+
+      expect(codexCliHistoryTesting.codexCliSessionPathCacheSize).toBeLessThanOrEqual(2);
+    } finally {
+      codexCliHistoryTesting.setMaxCodexCliSessionPathCacheEntriesForTests(previousCacheCap);
     }
   });
 

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -690,6 +690,40 @@ describe("cli session history", () => {
     }
   });
 
+  it("does not match a codex transcript whose session token only shares a suffix", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-suffix-"));
+    const homeDir = path.join(root, "home");
+    const requestedSessionId = "abc";
+    const otherSessionId = "xabc";
+    const sessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    const otherFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${otherSessionId}.jsonl`);
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      otherFile,
+      createCodexHistoryLines(otherSessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from the wrong transcript",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+
+    try {
+      expect(
+        resolveCodexCliSessionFilePath({ cliSessionId: requestedSessionId, homeDir }),
+      ).toBeUndefined();
+      expect(readCodexCliSessionMessages({ cliSessionId: requestedSessionId, homeDir })).toEqual(
+        [],
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("ignores non-event Codex transcript records while importing event messages", async () => {
     const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
     await withCodexSessionsDir(

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -347,8 +347,70 @@ describe("cli session history", () => {
     );
   });
 
-  it("merges all bound CLI histories when local transcript is empty", async () => {
+  it("merges all bound CLI histories when provider is unknown and local transcript is empty", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-merge-"));
+    const homeDir = path.join(root, "home");
+    const originalHome = process.env.HOME;
+    const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+    const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    await fs.mkdir(claudeProjectsDir, { recursive: true });
+    await fs.mkdir(codexSessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(claudeProjectsDir, `${claudeSessionId}.jsonl`),
+      createClaudeHistoryLines(claudeSessionId),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${codexSessionId}.jsonl`),
+      createCodexHistoryLines(codexSessionId),
+      "utf-8",
+    );
+    process.env.HOME = homeDir;
+    try {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId: claudeSessionId,
+            },
+            "codex-cli": {
+              sessionId: codexSessionId,
+            },
+          },
+        },
+        provider: undefined,
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toHaveLength(5);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "claude-cli", cliSessionId: claudeSessionId },
+      });
+      expect(messages[3]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+      expect(messages[4]).toMatchObject({
+        role: "assistant",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scopes empty-transcript imports to the active provider when one is resolved", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-scope-"));
     const homeDir = path.join(root, "home");
     const originalHome = process.env.HOME;
     const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
@@ -386,16 +448,12 @@ describe("cli session history", () => {
         localMessages: [],
         homeDir,
       });
-      expect(messages).toHaveLength(5);
+      expect(messages).toHaveLength(2);
       expect(messages[0]).toMatchObject({
-        role: "user",
-        __openclaw: { importedFrom: "claude-cli", cliSessionId: claudeSessionId },
-      });
-      expect(messages[3]).toMatchObject({
         role: "user",
         __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
       });
-      expect(messages[4]).toMatchObject({
+      expect(messages[1]).toMatchObject({
         role: "assistant",
         __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
       });
@@ -511,6 +569,64 @@ describe("cli session history", () => {
       await fs.rm(filePath, { force: true });
       expect(readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir })).toEqual([]);
     });
+  });
+
+  it("prefers the newest matching codex transcript file for the same session id", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-newest-"));
+    const homeDir = path.join(root, "home");
+    const sessionId = "same-session-id";
+    const sessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    const olderFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`);
+    const newerFile = path.join(sessionsDir, `rollout-2026-04-11T15-38-34-${sessionId}.jsonl`);
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      olderFile,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from the older transcript",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    await fs.writeFile(
+      newerFile,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from the newer transcript",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    await fs.utimes(
+      olderFile,
+      new Date("2026-04-11T07:38:33.000Z"),
+      new Date("2026-04-11T07:38:33.000Z"),
+    );
+    await fs.utimes(
+      newerFile,
+      new Date("2026-04-11T07:38:34.000Z"),
+      new Date("2026-04-11T07:38:34.000Z"),
+    );
+
+    try {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(newerFile);
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "Loaded from the newer transcript",
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("ignores non-event Codex transcript records while importing event messages", async () => {

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -6,9 +6,12 @@ import {
   augmentChatHistoryWithCliSessionImports,
   mergeImportedChatHistoryMessages,
   readClaudeCliFallbackSeed,
+  readCodexCliSessionMessages,
   readClaudeCliSessionMessages,
+  resolveCodexCliSessionFilePath,
   resolveClaudeCliSessionFilePath,
 } from "./cli-session-history.js";
+import { sanitizeChatHistoryMessages } from "./server-methods/chat.js";
 
 const ORIGINAL_HOME = process.env.HOME;
 
@@ -113,6 +116,84 @@ async function withClaudeProjectsDir<T>(
   }
 }
 
+type CodexHistoryEvent = {
+  timestamp: string;
+  payload: Record<string, unknown>;
+};
+
+function createCodexHistoryLines(sessionId: string, events?: CodexHistoryEvent[]) {
+  const eventLines = events ?? [
+    {
+      timestamp: "2026-04-11T07:38:34.000Z",
+      payload: {
+        type: "user_message",
+        message: "Why is the history missing after refresh?",
+      },
+    },
+    {
+      timestamp: "2026-04-11T07:38:35.000Z",
+      payload: {
+        type: "token_count",
+      },
+    },
+    {
+      timestamp: "2026-04-11T07:38:36.000Z",
+      payload: {
+        type: "agent_message",
+        message: "The current history view only reads the persisted transcript.",
+        phase: "final_answer",
+      },
+    },
+    {
+      timestamp: "2026-04-11T07:38:37.000Z",
+      payload: {
+        type: "task_complete",
+      },
+    },
+  ];
+  return [
+    JSON.stringify({
+      timestamp: "2026-04-11T07:38:33.999Z",
+      type: "session_meta",
+      payload: {
+        id: sessionId,
+        cwd: "/tmp/demo",
+      },
+    }),
+    ...eventLines.map((event) =>
+      JSON.stringify({
+        timestamp: event.timestamp,
+        type: "event_msg",
+        payload: event.payload,
+      }),
+    ),
+  ].join("\n");
+}
+
+async function withCodexSessionsDir<T>(
+  run: (params: { homeDir: string; sessionId: string; filePath: string }) => Promise<T>,
+  options?: { lines?: string },
+): Promise<T> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-"));
+  const homeDir = path.join(root, "home");
+  const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+  const sessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+  const filePath = path.join(sessionsDir, `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`);
+  await fs.mkdir(sessionsDir, { recursive: true });
+  await fs.writeFile(filePath, options?.lines ?? createCodexHistoryLines(sessionId), "utf-8");
+  process.env.HOME = homeDir;
+  try {
+    return await run({ homeDir, sessionId, filePath });
+  } finally {
+    if (ORIGINAL_HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = ORIGINAL_HOME;
+    }
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
 describe("cli session history", () => {
   afterEach(() => {
     if (ORIGINAL_HOME === undefined) {
@@ -172,6 +253,335 @@ describe("cli session history", () => {
         ],
       });
     });
+  });
+
+  it("reads codex-cli session messages from the Codex sessions store", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId, filePath }) => {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(filePath);
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "Why is the history missing after refresh?",
+        __openclaw: {
+          importedFrom: "codex-cli",
+          cliSessionId: sessionId,
+        },
+      });
+      expect(messages[1]).toMatchObject({
+        role: "assistant",
+        provider: "codex-cli",
+        phase: "final_answer",
+        content: [
+          { type: "text", text: "The current history view only reads the persisted transcript." },
+        ],
+        __openclaw: {
+          importedFrom: "codex-cli",
+          cliSessionId: sessionId,
+          phase: "final_answer",
+        },
+      });
+    });
+  });
+
+  it("keeps the final codex reply when commentary shares a timestamp", async () => {
+    await withCodexSessionsDir(
+      async ({ homeDir, sessionId }) => {
+        const rawMessages = augmentChatHistoryWithCliSessionImports({
+          entry: {
+            sessionId: "openclaw-session",
+            updatedAt: Date.now(),
+            cliSessionBindings: {
+              "codex-cli": {
+                sessionId,
+              },
+            },
+          },
+          provider: "codex-cli",
+          localMessages: [],
+          homeDir,
+        });
+        expect(rawMessages).toHaveLength(2);
+        const visibleMessages = sanitizeChatHistoryMessages(rawMessages, 4_000);
+        expect(visibleMessages).toHaveLength(2);
+        expect(visibleMessages[1]).toMatchObject({
+          role: "assistant",
+          phase: "final_answer",
+          content: [
+            {
+              type: "text",
+              text: "The current history view only reads the persisted transcript.",
+            },
+          ],
+        });
+      },
+      {
+        lines: createCodexHistoryLines("019d7b7a-6bf8-7fb3-8abb-412fb4107f9f", [
+          {
+            timestamp: "2026-04-11T07:38:34.000Z",
+            payload: {
+              type: "user_message",
+              message: "Why is the history missing after refresh?",
+            },
+          },
+          {
+            timestamp: "2026-04-11T07:38:35.000Z",
+            payload: {
+              type: "agent_message",
+              message: "I am checking the persisted transcript now.",
+              phase: "commentary",
+            },
+          },
+          {
+            timestamp: "2026-04-11T07:38:35.000Z",
+            payload: {
+              type: "agent_message",
+              message: "The current history view only reads the persisted transcript.",
+              phase: "final_answer",
+            },
+          },
+        ]),
+      },
+    );
+  });
+
+  it("merges all bound CLI histories when local transcript is empty", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-history-merge-"));
+    const homeDir = path.join(root, "home");
+    const originalHome = process.env.HOME;
+    const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+    const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "demo-workspace");
+    const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+    await fs.mkdir(claudeProjectsDir, { recursive: true });
+    await fs.mkdir(codexSessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(claudeProjectsDir, `${claudeSessionId}.jsonl`),
+      createClaudeHistoryLines(claudeSessionId),
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${codexSessionId}.jsonl`),
+      createCodexHistoryLines(codexSessionId),
+      "utf-8",
+    );
+    process.env.HOME = homeDir;
+    try {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: {
+            "claude-cli": {
+              sessionId: claudeSessionId,
+            },
+            "codex-cli": {
+              sessionId: codexSessionId,
+            },
+          },
+        },
+        provider: "codex-cli",
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toHaveLength(5);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "claude-cli", cliSessionId: claudeSessionId },
+      });
+      expect(messages[3]).toMatchObject({
+        role: "user",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+      expect(messages[4]).toMatchObject({
+        role: "assistant",
+        __openclaw: { importedFrom: "codex-cli", cliSessionId: codexSessionId },
+      });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not re-import CLI history when reset suppresses old CLI backfill", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "fresh-session",
+          updatedAt: Date.now(),
+          suppressCliHistoryImport: true,
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId,
+            },
+          },
+        },
+        provider: "codex-cli",
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toEqual([]);
+    });
+  });
+
+  it("imports codex user content from text elements and attachments", async () => {
+    await withCodexSessionsDir(
+      async ({ homeDir, sessionId }) => {
+        const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+        expect(messages).toHaveLength(2);
+        expect(messages[0]).toMatchObject({
+          role: "user",
+          content: [
+            { type: "text", text: "Compare these inputs." },
+            { type: "image", mimeType: "image/png", data: "QUJD" },
+            { type: "text", text: "[Local image attachment: before.png]" },
+          ],
+          __openclaw: {
+            importedFrom: "codex-cli",
+            cliSessionId: sessionId,
+          },
+        });
+      },
+      {
+        lines: createCodexHistoryLines("019d7b7a-6bf8-7fb3-8abb-412fb4107f9f", [
+          {
+            timestamp: "2026-04-11T07:38:34.000Z",
+            payload: {
+              type: "user_message",
+              text_elements: [{ text: "Compare these inputs." }],
+              images: [{ mimeType: "image/png", data: "QUJD" }],
+              local_images: [{ path: "/tmp/screenshots/before.png" }],
+            },
+          },
+          {
+            timestamp: "2026-04-11T07:38:36.000Z",
+            payload: {
+              type: "agent_message",
+              message: "I can compare the inline image and the local attachment.",
+              phase: "final_answer",
+            },
+          },
+        ]),
+      },
+    );
+  });
+
+  it("returns an empty import when a cached codex file disappears before read", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId, filePath }) => {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir })).toBe(filePath);
+      await fs.rm(filePath, { force: true });
+      expect(readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir })).toEqual([]);
+    });
+  });
+
+  it("ignores non-event Codex transcript records while importing event messages", async () => {
+    const sessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+    await withCodexSessionsDir(
+      async ({ homeDir }) => {
+        const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir });
+        expect(messages).toHaveLength(2);
+        expect(messages[0]).toMatchObject({
+          role: "user",
+          content: "Why is the history missing after refresh?",
+        });
+        expect(messages[1]).toMatchObject({
+          role: "assistant",
+          content: [
+            {
+              type: "text",
+              text: "The current history view only reads the persisted transcript.",
+            },
+          ],
+        });
+      },
+      {
+        lines: [
+          createCodexHistoryLines(sessionId),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:38.000Z",
+            type: "response_item",
+            payload: {
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: "Ignored response item." }],
+              phase: "final_answer",
+            },
+          }),
+        ].join("\n"),
+      },
+    );
+  });
+
+  it("isolates the codex session path cache by home directory", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-history-cache-"));
+    const sessionId = "same-session-id";
+    const homeA = path.join(root, "home-a");
+    const homeB = path.join(root, "home-b");
+    const fileA = path.join(
+      homeA,
+      ".codex",
+      "sessions",
+      "2026",
+      "04",
+      "11",
+      `rollout-2026-04-11T15-38-33-${sessionId}.jsonl`,
+    );
+    const fileB = path.join(
+      homeB,
+      ".codex",
+      "sessions",
+      "2026",
+      "04",
+      "11",
+      `rollout-2026-04-11T15-38-34-${sessionId}.jsonl`,
+    );
+    await fs.mkdir(path.dirname(fileA), { recursive: true });
+    await fs.mkdir(path.dirname(fileB), { recursive: true });
+    await fs.writeFile(
+      fileA,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from home A",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    await fs.writeFile(
+      fileB,
+      createCodexHistoryLines(sessionId, [
+        {
+          timestamp: "2026-04-11T07:38:34.000Z",
+          payload: {
+            type: "user_message",
+            message: "Loaded from home B",
+          },
+        },
+      ]),
+      "utf-8",
+    );
+    try {
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir: homeA })).toBe(
+        fileA,
+      );
+      expect(resolveCodexCliSessionFilePath({ cliSessionId: sessionId, homeDir: homeB })).toBe(
+        fileB,
+      );
+      const messages = readCodexCliSessionMessages({ cliSessionId: sessionId, homeDir: homeB });
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        content: "Loaded from home B",
+      });
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("deduplicates imported messages against similar local transcript entries", () => {
@@ -361,6 +771,34 @@ describe("cli session history", () => {
       expect(messages[0]).toMatchObject({
         role: "user",
         __openclaw: { cliSessionId: sessionId },
+      });
+    });
+  });
+
+  it("augments chat history when a session has a codex-cli binding", async () => {
+    await withCodexSessionsDir(async ({ homeDir, sessionId }) => {
+      const messages = augmentChatHistoryWithCliSessionImports({
+        entry: {
+          sessionId: "openclaw-session",
+          updatedAt: Date.now(),
+          cliSessionBindings: {
+            "codex-cli": {
+              sessionId,
+            },
+          },
+        },
+        provider: "codex-cli",
+        localMessages: [],
+        homeDir,
+      });
+      expect(messages).toHaveLength(2);
+      expect(messages[0]).toMatchObject({
+        role: "user",
+        __openclaw: { cliSessionId: sessionId, importedFrom: "codex-cli" },
+      });
+      expect(messages[1]).toMatchObject({
+        role: "assistant",
+        __openclaw: { cliSessionId: sessionId, importedFrom: "codex-cli" },
       });
     });
   });

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -1,5 +1,6 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { resolveAssistantMessagePhase } from "../shared/chat-message-content.js";
 import {
   type ClaudeCliFallbackSeed,
   CLAUDE_CLI_PROVIDER,
@@ -8,11 +9,19 @@ import {
   resolveClaudeCliBindingSessionId,
   resolveClaudeCliSessionFilePath,
 } from "./cli-session-history.claude.js";
+import {
+  CODEX_CLI_PROVIDER,
+  readCodexCliSessionMessages,
+  resolveCodexCliBindingSessionId,
+  resolveCodexCliSessionFilePath,
+} from "./cli-session-history.codex.js";
 import { mergeImportedChatHistoryMessages } from "./cli-session-history.merge.js";
 
 const ANTHROPIC_PROVIDER = "anthropic";
 
 export {
+  readCodexCliSessionMessages,
+  resolveCodexCliSessionFilePath,
   mergeImportedChatHistoryMessages,
   readClaudeCliFallbackSeed,
   readClaudeCliSessionMessages,
@@ -21,31 +30,80 @@ export {
 };
 export type { ClaudeCliFallbackSeed };
 
+function shouldKeepImportedHistoryMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return true;
+  }
+  if ((message as { role?: unknown }).role !== "assistant") {
+    return true;
+  }
+  return resolveAssistantMessagePhase(message) !== "commentary";
+}
+
+function cliHistoryImportMatchesProvider(importProvider: string, normalizedProvider: string): boolean {
+  if (importProvider === normalizedProvider) {
+    return true;
+  }
+  return importProvider === CLAUDE_CLI_PROVIDER && normalizedProvider === ANTHROPIC_PROVIDER;
+}
+
 export function augmentChatHistoryWithCliSessionImports(params: {
   entry: SessionEntry | undefined;
   provider?: string;
   localMessages: unknown[];
   homeDir?: string;
 }): unknown[] {
-  const cliSessionId = resolveClaudeCliBindingSessionId(params.entry);
-  if (!cliSessionId) {
-    return params.localMessages;
-  }
-
   const normalizedProvider = normalizeProviderId(params.provider ?? "");
-  if (
-    normalizedProvider &&
-    normalizedProvider !== CLAUDE_CLI_PROVIDER &&
-    normalizedProvider !== ANTHROPIC_PROVIDER &&
-    params.localMessages.length > 0
-  ) {
+  const availableImports = [
+    {
+      provider: CODEX_CLI_PROVIDER,
+      sessionId: resolveCodexCliBindingSessionId(params.entry),
+      readMessages: (sessionId: string) =>
+        readCodexCliSessionMessages({
+          cliSessionId: sessionId,
+          homeDir: params.homeDir,
+        }),
+    },
+    {
+      provider: CLAUDE_CLI_PROVIDER,
+      sessionId: resolveClaudeCliBindingSessionId(params.entry),
+      readMessages: (sessionId: string) =>
+        readClaudeCliSessionMessages({
+          cliSessionId: sessionId,
+          homeDir: params.homeDir,
+        }),
+    },
+  ].filter(
+    (
+      entry,
+    ): entry is {
+      provider: string;
+      sessionId: string;
+      readMessages: (sessionId: string) => unknown[];
+    } => typeof entry.sessionId === "string" && entry.sessionId.length > 0,
+  );
+  if (availableImports.length === 0) {
     return params.localMessages;
   }
 
-  const importedMessages = readClaudeCliSessionMessages({
-    cliSessionId,
-    homeDir: params.homeDir,
-  });
+  const matchingImports = normalizedProvider
+    ? availableImports.filter((entry) =>
+        cliHistoryImportMatchesProvider(entry.provider, normalizedProvider),
+      )
+    : [];
+  const importsToMerge =
+    params.localMessages.length === 0
+      ? params.entry?.suppressCliHistoryImport
+        ? []
+        : availableImports
+      : matchingImports;
+  if (importsToMerge.length === 0) {
+    return params.localMessages;
+  }
+
+  const importedMessages = importsToMerge
+    .flatMap((entry) => entry.readMessages(entry.sessionId))
+    .filter(shouldKeepImportedHistoryMessage);
   return mergeImportedChatHistoryMessages({
     localMessages: params.localMessages,
     importedMessages,

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -94,7 +94,11 @@ export function augmentChatHistoryWithCliSessionImports(params: {
         cliHistoryImportMatchesProvider(entry.provider, normalizedProvider),
       )
     : [];
-  const importsToMerge = params.localMessages.length === 0 ? availableImports : matchingImports;
+  const importsToMerge = normalizedProvider
+    ? matchingImports
+    : params.localMessages.length === 0
+      ? availableImports
+      : [];
   if (importsToMerge.length === 0) {
     return params.localMessages;
   }

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -1,3 +1,4 @@
+import { resolveSuppressedCliHistoryImportProviders } from "../agents/cli-session.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { resolveAssistantMessagePhase } from "../shared/chat-message-content.js";
@@ -85,19 +86,20 @@ export function augmentChatHistoryWithCliSessionImports(params: {
   if (availableImports.length === 0) {
     return params.localMessages;
   }
-  if (params.entry?.suppressCliHistoryImport) {
-    return params.localMessages;
-  }
+  const suppressedProviders = new Set(resolveSuppressedCliHistoryImportProviders(params.entry));
+  const eligibleImports = availableImports.filter(
+    (entry) => !suppressedProviders.has(entry.provider),
+  );
 
   const matchingImports = normalizedProvider
-    ? availableImports.filter((entry) =>
+    ? eligibleImports.filter((entry) =>
         cliHistoryImportMatchesProvider(entry.provider, normalizedProvider),
       )
     : [];
   const importsToMerge = normalizedProvider
     ? matchingImports
     : params.localMessages.length === 0
-      ? availableImports
+      ? eligibleImports
       : [];
   if (importsToMerge.length === 0) {
     return params.localMessages;

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -41,7 +41,10 @@ function shouldKeepImportedHistoryMessage(message: unknown): boolean {
   return resolveAssistantMessagePhase(message) !== "commentary";
 }
 
-function cliHistoryImportMatchesProvider(importProvider: string, normalizedProvider: string): boolean {
+function cliHistoryImportMatchesProvider(
+  importProvider: string,
+  normalizedProvider: string,
+): boolean {
   if (importProvider === normalizedProvider) {
     return true;
   }

--- a/src/gateway/cli-session-history.ts
+++ b/src/gateway/cli-session-history.ts
@@ -85,18 +85,16 @@ export function augmentChatHistoryWithCliSessionImports(params: {
   if (availableImports.length === 0) {
     return params.localMessages;
   }
+  if (params.entry?.suppressCliHistoryImport) {
+    return params.localMessages;
+  }
 
   const matchingImports = normalizedProvider
     ? availableImports.filter((entry) =>
         cliHistoryImportMatchesProvider(entry.provider, normalizedProvider),
       )
     : [];
-  const importsToMerge =
-    params.localMessages.length === 0
-      ? params.entry?.suppressCliHistoryImport
-        ? []
-        : availableImports
-      : matchingImports;
+  const importsToMerge = params.localMessages.length === 0 ? availableImports : matchingImports;
   if (importsToMerge.length === 0) {
     return params.localMessages;
   }

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -818,6 +818,95 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history does not merge stale codex-cli history into reset sessions with local transcript entries", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      const originalHome = process.env.HOME;
+      const homeDir = path.join(sessionDir, "home");
+      const cliSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+      const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+      await fs.mkdir(codexSessionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${cliSessionId}.jsonl`),
+        [
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:34.000Z",
+            type: "event_msg",
+            payload: {
+              type: "user_message",
+              message: "stale external question",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:35.000Z",
+            type: "event_msg",
+            payload: {
+              type: "agent_message",
+              message: "stale external answer",
+              phase: "final_answer",
+            },
+          }),
+        ].join("\n"),
+        "utf-8",
+      );
+      process.env.HOME = homeDir;
+      try {
+        await writeSessionStore({
+          entries: {
+            main: {
+              sessionId: "sess-main",
+              updatedAt: Date.now(),
+              modelProvider: "codex-cli",
+              model: "gpt-5.4",
+              suppressCliHistoryImport: true,
+              cliSessionBindings: {
+                "codex-cli": {
+                  sessionId: cliSessionId,
+                },
+              },
+            },
+          },
+        });
+
+        await writeMainSessionTranscript(sessionDir, [
+          JSON.stringify({
+            message: {
+              role: "user",
+              timestamp: Date.now(),
+              content: "fresh local question",
+            },
+          }),
+          JSON.stringify({
+            message: {
+              role: "assistant",
+              timestamp: Date.now() + 1,
+              content: [{ type: "text", text: "fresh local answer" }],
+            },
+          }),
+        ]);
+
+        const messages = await fetchHistoryMessages(ws);
+        expect(messages).toHaveLength(2);
+        expect(messages[0]).toMatchObject({
+          role: "user",
+          content: "fresh local question",
+        });
+        expect(messages[1]).toMatchObject({
+          role: "assistant",
+          content: [{ type: "text", text: "fresh local answer" }],
+        });
+        expect(JSON.stringify(messages)).not.toContain("stale external");
+      } finally {
+        if (originalHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = originalHome;
+        }
+      }
+    });
+  });
+
   test("smoke: caps history payload and preserves routing metadata", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const historyMaxBytes = 64 * 1024;

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -818,6 +818,109 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history scopes empty CLI imports to the active provider", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      const originalHome = process.env.HOME;
+      const homeDir = path.join(sessionDir, "home");
+      const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+      const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+      const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "workspace");
+      const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+      await fs.mkdir(claudeProjectsDir, { recursive: true });
+      await fs.mkdir(codexSessionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(claudeProjectsDir, `${claudeSessionId}.jsonl`),
+        [
+          JSON.stringify({
+            type: "user",
+            uuid: "claude-user-1",
+            timestamp: "2026-03-26T16:29:54.800Z",
+            message: {
+              role: "user",
+              content: "[Thu 2026-03-26 16:29 GMT] claude question",
+            },
+          }),
+          JSON.stringify({
+            type: "assistant",
+            uuid: "claude-assistant-1",
+            timestamp: "2026-03-26T16:29:55.500Z",
+            message: {
+              role: "assistant",
+              model: "claude-sonnet-4-6",
+              content: [{ type: "text", text: "hello from Claude" }],
+            },
+          }),
+        ].join("\n"),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${codexSessionId}.jsonl`),
+        [
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:34.000Z",
+            type: "event_msg",
+            payload: {
+              type: "user_message",
+              message: "codex question",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:35.000Z",
+            type: "event_msg",
+            payload: {
+              type: "agent_message",
+              message: "codex answer",
+              phase: "final_answer",
+            },
+          }),
+        ].join("\n"),
+        "utf-8",
+      );
+      process.env.HOME = homeDir;
+      try {
+        await writeSessionStore({
+          entries: {
+            main: {
+              sessionId: "sess-main",
+              updatedAt: Date.now(),
+              modelProvider: "codex-cli",
+              model: "gpt-5.4",
+              cliSessionBindings: {
+                "claude-cli": {
+                  sessionId: claudeSessionId,
+                },
+                "codex-cli": {
+                  sessionId: codexSessionId,
+                },
+              },
+            },
+          },
+        });
+
+        const messages = await fetchHistoryMessages(ws);
+        expect(messages).toHaveLength(2);
+        expect(messages[0]).toMatchObject({
+          role: "user",
+          content: "codex question",
+        });
+        expect(messages[1]).toMatchObject({
+          role: "assistant",
+          provider: "codex-cli",
+          content: [{ type: "text", text: "codex answer" }],
+        });
+        expect(JSON.stringify(messages)).not.toContain("Claude");
+      } finally {
+        if (originalHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = originalHome;
+        }
+      }
+    });
+  });
+
   test("chat.history does not merge stale codex-cli history into reset sessions with local transcript entries", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await connectOk(ws);

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -868,18 +868,20 @@ describe("gateway server chat", () => {
         [
           JSON.stringify({
             timestamp: "2026-04-11T07:38:34.000Z",
-            type: "event_msg",
+            type: "response_item",
             payload: {
-              type: "user_message",
-              message: "codex question",
+              type: "message",
+              role: "user",
+              content: [{ type: "input_text", text: "codex question" }],
             },
           }),
           JSON.stringify({
             timestamp: "2026-04-11T07:38:35.000Z",
-            type: "event_msg",
+            type: "response_item",
             payload: {
-              type: "agent_message",
-              message: "codex answer",
+              type: "message",
+              role: "assistant",
+              content: [{ type: "output_text", text: "codex answer" }],
               phase: "final_answer",
             },
           }),

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -745,6 +745,7 @@ describe("gateway server chat", () => {
       await connectOk(ws);
       const sessionDir = await createSessionDir();
       const originalHome = process.env.HOME;
+      const originalCodexHome = process.env.CODEX_HOME;
       const homeDir = path.join(sessionDir, "home");
       const cliSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
       const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "workspace");
@@ -783,6 +784,7 @@ describe("gateway server chat", () => {
         "utf-8",
       );
       process.env.HOME = homeDir;
+      delete process.env.CODEX_HOME;
       try {
         await writeSessionStore({
           entries: {
@@ -814,6 +816,11 @@ describe("gateway server chat", () => {
         } else {
           process.env.HOME = originalHome;
         }
+        if (originalCodexHome === undefined) {
+          delete process.env.CODEX_HOME;
+        } else {
+          process.env.CODEX_HOME = originalCodexHome;
+        }
       }
     });
   });
@@ -823,6 +830,7 @@ describe("gateway server chat", () => {
       await connectOk(ws);
       const sessionDir = await createSessionDir();
       const originalHome = process.env.HOME;
+      const originalCodexHome = process.env.CODEX_HOME;
       const homeDir = path.join(sessionDir, "home");
       const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
       const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
@@ -879,6 +887,7 @@ describe("gateway server chat", () => {
         "utf-8",
       );
       process.env.HOME = homeDir;
+      delete process.env.CODEX_HOME;
       try {
         await writeSessionStore({
           entries: {
@@ -917,6 +926,11 @@ describe("gateway server chat", () => {
         } else {
           process.env.HOME = originalHome;
         }
+        if (originalCodexHome === undefined) {
+          delete process.env.CODEX_HOME;
+        } else {
+          process.env.CODEX_HOME = originalCodexHome;
+        }
       }
     });
   });
@@ -926,6 +940,7 @@ describe("gateway server chat", () => {
       await connectOk(ws);
       const sessionDir = await createSessionDir();
       const originalHome = process.env.HOME;
+      const originalCodexHome = process.env.CODEX_HOME;
       const homeDir = path.join(sessionDir, "home");
       const cliSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
       const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
@@ -954,6 +969,7 @@ describe("gateway server chat", () => {
         "utf-8",
       );
       process.env.HOME = homeDir;
+      delete process.env.CODEX_HOME;
       try {
         await writeSessionStore({
           entries: {
@@ -1005,6 +1021,11 @@ describe("gateway server chat", () => {
           delete process.env.HOME;
         } else {
           process.env.HOME = originalHome;
+        }
+        if (originalCodexHome === undefined) {
+          delete process.env.CODEX_HOME;
+        } else {
+          process.env.CODEX_HOME = originalCodexHome;
         }
       }
     });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -547,6 +547,7 @@ describe("gateway server chat", () => {
       await connectOk(ws);
       const sessionDir = await createSessionDir();
       const originalHome = process.env.HOME;
+      const originalCodexHome = process.env.CODEX_HOME;
       const homeDir = path.join(sessionDir, "home");
       const cliSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
       const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "workspace");
@@ -585,6 +586,7 @@ describe("gateway server chat", () => {
         "utf-8",
       );
       process.env.HOME = homeDir;
+      delete process.env.CODEX_HOME;
       try {
         await writeSessionStore({
           entries: {
@@ -618,6 +620,11 @@ describe("gateway server chat", () => {
         } else {
           process.env.HOME = originalHome;
         }
+        if (originalCodexHome === undefined) {
+          delete process.env.CODEX_HOME;
+        } else {
+          process.env.CODEX_HOME = originalCodexHome;
+        }
       }
     });
   });
@@ -627,6 +634,7 @@ describe("gateway server chat", () => {
       await connectOk(ws);
       const sessionDir = await createSessionDir();
       const originalHome = process.env.HOME;
+      const originalCodexHome = process.env.CODEX_HOME;
       const homeDir = path.join(sessionDir, "home");
       const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
       const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
@@ -683,6 +691,7 @@ describe("gateway server chat", () => {
         "utf-8",
       );
       process.env.HOME = homeDir;
+      delete process.env.CODEX_HOME;
       try {
         await writeSessionStore({
           entries: {
@@ -721,6 +730,11 @@ describe("gateway server chat", () => {
         } else {
           process.env.HOME = originalHome;
         }
+        if (originalCodexHome === undefined) {
+          delete process.env.CODEX_HOME;
+        } else {
+          process.env.CODEX_HOME = originalCodexHome;
+        }
       }
     });
   });
@@ -730,6 +744,7 @@ describe("gateway server chat", () => {
       await connectOk(ws);
       const sessionDir = await createSessionDir();
       const originalHome = process.env.HOME;
+      const originalCodexHome = process.env.CODEX_HOME;
       const homeDir = path.join(sessionDir, "home");
       const cliSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
       const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
@@ -758,6 +773,7 @@ describe("gateway server chat", () => {
         "utf-8",
       );
       process.env.HOME = homeDir;
+      delete process.env.CODEX_HOME;
       try {
         await writeSessionStore({
           entries: {
@@ -809,6 +825,11 @@ describe("gateway server chat", () => {
           delete process.env.HOME;
         } else {
           process.env.HOME = originalHome;
+        }
+        if (originalCodexHome === undefined) {
+          delete process.env.CODEX_HOME;
+        } else {
+          process.env.CODEX_HOME = originalCodexHome;
         }
       }
     });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -622,6 +622,109 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history scopes empty CLI imports to the active provider", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      const originalHome = process.env.HOME;
+      const homeDir = path.join(sessionDir, "home");
+      const claudeSessionId = "5b8b202c-f6bb-4046-9475-d2f15fd07530";
+      const codexSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+      const claudeProjectsDir = path.join(homeDir, ".claude", "projects", "workspace");
+      const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+      await fs.mkdir(claudeProjectsDir, { recursive: true });
+      await fs.mkdir(codexSessionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(claudeProjectsDir, `${claudeSessionId}.jsonl`),
+        [
+          JSON.stringify({
+            type: "user",
+            uuid: "claude-user-1",
+            timestamp: "2026-03-26T16:29:54.800Z",
+            message: {
+              role: "user",
+              content: "[Thu 2026-03-26 16:29 GMT] claude question",
+            },
+          }),
+          JSON.stringify({
+            type: "assistant",
+            uuid: "claude-assistant-1",
+            timestamp: "2026-03-26T16:29:55.500Z",
+            message: {
+              role: "assistant",
+              model: "claude-sonnet-4-6",
+              content: [{ type: "text", text: "hello from Claude" }],
+            },
+          }),
+        ].join("\n"),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${codexSessionId}.jsonl`),
+        [
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:34.000Z",
+            type: "event_msg",
+            payload: {
+              type: "user_message",
+              message: "codex question",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:35.000Z",
+            type: "event_msg",
+            payload: {
+              type: "agent_message",
+              message: "codex answer",
+              phase: "final_answer",
+            },
+          }),
+        ].join("\n"),
+        "utf-8",
+      );
+      process.env.HOME = homeDir;
+      try {
+        await writeSessionStore({
+          entries: {
+            main: {
+              sessionId: "sess-main",
+              updatedAt: Date.now(),
+              modelProvider: "codex-cli",
+              model: "gpt-5.4",
+              cliSessionBindings: {
+                "claude-cli": {
+                  sessionId: claudeSessionId,
+                },
+                "codex-cli": {
+                  sessionId: codexSessionId,
+                },
+              },
+            },
+          },
+        });
+
+        const messages = await fetchHistoryMessages(ws);
+        expect(messages).toHaveLength(2);
+        expect(messages[0]).toMatchObject({
+          role: "user",
+          content: "codex question",
+        });
+        expect(messages[1]).toMatchObject({
+          role: "assistant",
+          provider: "codex-cli",
+          content: [{ type: "text", text: "codex answer" }],
+        });
+        expect(JSON.stringify(messages)).not.toContain("Claude");
+      } finally {
+        if (originalHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = originalHome;
+        }
+      }
+    });
+  });
+
   test("chat.history does not merge stale codex-cli history into reset sessions with local transcript entries", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       await connectOk(ws);

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -622,6 +622,95 @@ describe("gateway server chat", () => {
     });
   });
 
+  test("chat.history does not merge stale codex-cli history into reset sessions with local transcript entries", async () => {
+    await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
+      await connectOk(ws);
+      const sessionDir = await createSessionDir();
+      const originalHome = process.env.HOME;
+      const homeDir = path.join(sessionDir, "home");
+      const cliSessionId = "019d7b7a-6bf8-7fb3-8abb-412fb4107f9f";
+      const codexSessionsDir = path.join(homeDir, ".codex", "sessions", "2026", "04", "11");
+      await fs.mkdir(codexSessionsDir, { recursive: true });
+      await fs.writeFile(
+        path.join(codexSessionsDir, `rollout-2026-04-11T15-38-33-${cliSessionId}.jsonl`),
+        [
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:34.000Z",
+            type: "event_msg",
+            payload: {
+              type: "user_message",
+              message: "stale external question",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-04-11T07:38:35.000Z",
+            type: "event_msg",
+            payload: {
+              type: "agent_message",
+              message: "stale external answer",
+              phase: "final_answer",
+            },
+          }),
+        ].join("\n"),
+        "utf-8",
+      );
+      process.env.HOME = homeDir;
+      try {
+        await writeSessionStore({
+          entries: {
+            main: {
+              sessionId: "sess-main",
+              updatedAt: Date.now(),
+              modelProvider: "codex-cli",
+              model: "gpt-5.4",
+              suppressCliHistoryImport: true,
+              cliSessionBindings: {
+                "codex-cli": {
+                  sessionId: cliSessionId,
+                },
+              },
+            },
+          },
+        });
+
+        await writeMainSessionTranscript(sessionDir, [
+          JSON.stringify({
+            message: {
+              role: "user",
+              timestamp: Date.now(),
+              content: "fresh local question",
+            },
+          }),
+          JSON.stringify({
+            message: {
+              role: "assistant",
+              timestamp: Date.now() + 1,
+              content: [{ type: "text", text: "fresh local answer" }],
+            },
+          }),
+        ]);
+
+        const messages = await fetchHistoryMessages(ws);
+        expect(messages).toHaveLength(2);
+        expect(messages[0]).toMatchObject({
+          role: "user",
+          content: "fresh local question",
+        });
+        expect(messages[1]).toMatchObject({
+          role: "assistant",
+          content: [{ type: "text", text: "fresh local answer" }],
+        });
+        expect(JSON.stringify(messages)).not.toContain("stale external");
+      } finally {
+        if (originalHome === undefined) {
+          delete process.env.HOME;
+        } else {
+          process.env.HOME = originalHome;
+        }
+      }
+    });
+  });
+
   test("smoke: caps history payload and preserves routing metadata", async () => {
     await withGatewayChatHarness(async ({ ws, createSessionDir }) => {
       const historyMaxBytes = 64 * 1024;

--- a/src/gateway/server.sessions.reset-hooks.test.ts
+++ b/src/gateway/server.sessions.reset-hooks.test.ts
@@ -523,6 +523,8 @@ test("sessions.reset drops cli session bindings so the next turn does not --resu
   expect(nextEntry?.claudeCliSessionId).toBeUndefined();
   expect(nextEntry?.cliSessionBindings).toBeUndefined();
   expect(nextEntry?.cliSessionIds).toBeUndefined();
+  expect(nextEntry?.suppressCliHistoryImport).toBeUndefined();
+  expect(nextEntry?.suppressCliHistoryImportProviders).toBeUndefined();
 });
 
 test("sessions.reset clears cli session bindings for parent-linked non-subagent sessions (e.g. dashboard children)", async () => {
@@ -580,6 +582,8 @@ test("sessions.reset clears cli session bindings for parent-linked non-subagent 
   expect(nextEntry?.claudeCliSessionId).toBeUndefined();
   expect(nextEntry?.cliSessionBindings).toBeUndefined();
   expect(nextEntry?.cliSessionIds).toBeUndefined();
+  expect(nextEntry?.suppressCliHistoryImport).toBeUndefined();
+  expect(nextEntry?.suppressCliHistoryImportProviders).toBeUndefined();
 });
 
 test("sessions.reset preserves cli session bindings for spawned subagents (Tak Hoffman's fa56682b3ced contract)", async () => {
@@ -637,4 +641,6 @@ test("sessions.reset preserves cli session bindings for spawned subagents (Tak H
     "claude-cli": { sessionId: "claude-cli-child-session" },
   });
   expect(nextEntry?.cliSessionIds).toEqual({ "claude-cli": "claude-cli-child-session" });
+  expect(nextEntry?.suppressCliHistoryImport).toBe(true);
+  expect(nextEntry?.suppressCliHistoryImportProviders).toEqual(["claude-cli"]);
 });

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -44,12 +44,14 @@ type ResetSessionEntry = {
   execAsk?: string;
   execNode?: string;
   displayName?: string;
+  suppressCliHistoryImport?: boolean;
   cliSessionBindings?: Record<
     string,
     {
       sessionId?: string;
       authProfileId?: string;
       extraSystemPromptHash?: string;
+      promptToolNamesHash?: string;
       mcpConfigHash?: string;
     }
   >;
@@ -459,6 +461,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
   expect(reset.payload?.entry.execAsk).toBe("on-miss");
   expect(reset.payload?.entry.execNode).toBe("mac-mini");
   expect(reset.payload?.entry.displayName).toBe("Ops Child");
+  expect(reset.payload?.entry.suppressCliHistoryImport).toBe(true);
   expect(reset.payload?.entry.cliSessionBindings).toEqual({
     "claude-cli": {
       sessionId: "cli-session-123",
@@ -515,6 +518,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
   expect(store["agent:main:subagent:child"]?.execAsk).toBe("on-miss");
   expect(store["agent:main:subagent:child"]?.execNode).toBe("mac-mini");
   expect(store["agent:main:subagent:child"]?.displayName).toBe("Ops Child");
+  expect(store["agent:main:subagent:child"]?.suppressCliHistoryImport).toBe(true);
   expect(store["agent:main:subagent:child"]?.cliSessionBindings).toEqual({
     "claude-cli": {
       sessionId: "cli-session-123",

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -45,6 +45,7 @@ type ResetSessionEntry = {
   execNode?: string;
   displayName?: string;
   suppressCliHistoryImport?: boolean;
+  suppressCliHistoryImportProviders?: string[];
   cliSessionBindings?: Record<
     string,
     {
@@ -462,6 +463,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
   expect(reset.payload?.entry.execNode).toBe("mac-mini");
   expect(reset.payload?.entry.displayName).toBe("Ops Child");
   expect(reset.payload?.entry.suppressCliHistoryImport).toBe(true);
+  expect(reset.payload?.entry.suppressCliHistoryImportProviders).toEqual(["claude-cli"]);
   expect(reset.payload?.entry.cliSessionBindings).toEqual({
     "claude-cli": {
       sessionId: "cli-session-123",
@@ -519,6 +521,9 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
   expect(store["agent:main:subagent:child"]?.execNode).toBe("mac-mini");
   expect(store["agent:main:subagent:child"]?.displayName).toBe("Ops Child");
   expect(store["agent:main:subagent:child"]?.suppressCliHistoryImport).toBe(true);
+  expect(store["agent:main:subagent:child"]?.suppressCliHistoryImportProviders).toEqual([
+    "claude-cli",
+  ]);
   expect(store["agent:main:subagent:child"]?.cliSessionBindings).toEqual({
     "claude-cli": {
       sessionId: "cli-session-123",

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -313,6 +313,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
       execAsk?: string;
       execNode?: string;
       displayName?: string;
+      suppressCliHistoryImport?: boolean;
       cliSessionBindings?: Record<
         string,
         {
@@ -368,6 +369,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
   expect(reset.payload?.entry.execAsk).toBe("on-miss");
   expect(reset.payload?.entry.execNode).toBe("mac-mini");
   expect(reset.payload?.entry.displayName).toBe("Ops Child");
+  expect(reset.payload?.entry.suppressCliHistoryImport).toBe(true);
   expect(reset.payload?.entry.cliSessionBindings).toEqual({
     "claude-cli": {
       sessionId: "cli-session-123",
@@ -423,6 +425,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
       execAsk?: string;
       execNode?: string;
       displayName?: string;
+      suppressCliHistoryImport?: boolean;
       cliSessionBindings?: Record<
         string,
         {
@@ -476,6 +479,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
   expect(store["agent:main:subagent:child"]?.execAsk).toBe("on-miss");
   expect(store["agent:main:subagent:child"]?.execNode).toBe("mac-mini");
   expect(store["agent:main:subagent:child"]?.displayName).toBe("Ops Child");
+  expect(store["agent:main:subagent:child"]?.suppressCliHistoryImport).toBe(true);
   expect(store["agent:main:subagent:child"]?.cliSessionBindings).toEqual({
     "claude-cli": {
       sessionId: "cli-session-123",

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -314,6 +314,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
       execNode?: string;
       displayName?: string;
       suppressCliHistoryImport?: boolean;
+      suppressCliHistoryImportProviders?: string[];
       cliSessionBindings?: Record<
         string,
         {
@@ -370,6 +371,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
   expect(reset.payload?.entry.execNode).toBe("mac-mini");
   expect(reset.payload?.entry.displayName).toBe("Ops Child");
   expect(reset.payload?.entry.suppressCliHistoryImport).toBe(true);
+  expect(reset.payload?.entry.suppressCliHistoryImportProviders).toEqual(["claude-cli"]);
   expect(reset.payload?.entry.cliSessionBindings).toEqual({
     "claude-cli": {
       sessionId: "cli-session-123",
@@ -426,6 +428,7 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
       execNode?: string;
       displayName?: string;
       suppressCliHistoryImport?: boolean;
+      suppressCliHistoryImportProviders?: string[];
       cliSessionBindings?: Record<
         string,
         {
@@ -480,6 +483,9 @@ test("sessions.reset preserves spawned session ownership metadata", async () => 
   expect(store["agent:main:subagent:child"]?.execNode).toBe("mac-mini");
   expect(store["agent:main:subagent:child"]?.displayName).toBe("Ops Child");
   expect(store["agent:main:subagent:child"]?.suppressCliHistoryImport).toBe(true);
+  expect(store["agent:main:subagent:child"]?.suppressCliHistoryImportProviders).toEqual([
+    "claude-cli",
+  ]);
   expect(store["agent:main:subagent:child"]?.cliSessionBindings).toEqual({
     "claude-cli": {
       sessionId: "cli-session-123",

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -723,6 +723,7 @@ export async function performGatewaySessionReset(params: {
       storePath,
       agentId: sessionAgentId,
     });
+    const suppressedCliHistoryImportProviders = resolveBoundCliSessionProviders(currentEntry);
     const nextEntry: SessionEntry = {
       sessionId: nextSessionId,
       sessionFile,
@@ -773,13 +774,11 @@ export async function performGatewaySessionReset(params: {
       space: currentEntry?.space,
       origin: snapshotSessionOrigin(currentEntry),
       deliveryContext: currentEntry?.deliveryContext,
-      suppressCliHistoryImport:
-        currentEntry?.cliSessionBindings ||
-        currentEntry?.cliSessionIds ||
-        currentEntry?.claudeCliSessionId
-          ? true
+      suppressCliHistoryImport: suppressedCliHistoryImportProviders.length > 0 ? true : undefined,
+      suppressCliHistoryImportProviders:
+        suppressedCliHistoryImportProviders.length > 0
+          ? suppressedCliHistoryImportProviders
           : undefined,
-      suppressCliHistoryImportProviders: resolveBoundCliSessionProviders(currentEntry),
       cliSessionBindings: currentEntry?.cliSessionBindings,
       cliSessionIds: currentEntry?.cliSessionIds,
       claudeCliSessionId: currentEntry?.claudeCliSessionId,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -773,6 +773,12 @@ export async function performGatewaySessionReset(params: {
       space: currentEntry?.space,
       origin: snapshotSessionOrigin(currentEntry),
       deliveryContext: currentEntry?.deliveryContext,
+      suppressCliHistoryImport:
+        currentEntry?.cliSessionBindings ||
+        currentEntry?.cliSessionIds ||
+        currentEntry?.claudeCliSessionId
+          ? true
+          : undefined,
       cliSessionBindings: currentEntry?.cliSessionBindings,
       cliSessionIds: currentEntry?.cliSessionIds,
       claudeCliSessionId: currentEntry?.claudeCliSessionId,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -7,7 +7,7 @@ import { getAcpRuntimeBackend } from "../acp/runtime/registry.js";
 import { readAcpSessionEntry, upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
-import { clearAllCliSessions } from "../agents/cli-session.js";
+import { clearAllCliSessions, resolveBoundCliSessionProviders } from "../agents/cli-session.js";
 import { retireSessionMcpRuntime } from "../agents/pi-bundle-mcp-tools.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
@@ -779,6 +779,7 @@ export async function performGatewaySessionReset(params: {
         currentEntry?.claudeCliSessionId
           ? true
           : undefined,
+      suppressCliHistoryImportProviders: resolveBoundCliSessionProviders(currentEntry),
       cliSessionBindings: currentEntry?.cliSessionBindings,
       cliSessionIds: currentEntry?.cliSessionIds,
       claudeCliSessionId: currentEntry?.claudeCliSessionId,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -616,6 +616,12 @@ export async function performGatewaySessionReset(params: {
       space: currentEntry?.space,
       origin: snapshotSessionOrigin(currentEntry),
       deliveryContext: currentEntry?.deliveryContext,
+      suppressCliHistoryImport:
+        currentEntry?.cliSessionBindings ||
+        currentEntry?.cliSessionIds ||
+        currentEntry?.claudeCliSessionId
+          ? true
+          : undefined,
       cliSessionBindings: currentEntry?.cliSessionBindings,
       cliSessionIds: currentEntry?.cliSessionIds,
       claudeCliSessionId: currentEntry?.claudeCliSessionId,

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -7,6 +7,7 @@ import { getAcpRuntimeBackend } from "../acp/runtime/registry.js";
 import { readAcpSessionEntry, upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { clearBootstrapSnapshot } from "../agents/bootstrap-cache.js";
+import { resolveBoundCliSessionProviders } from "../agents/cli-session.js";
 import { retireSessionMcpRuntime } from "../agents/pi-bundle-mcp-tools.js";
 import { abortEmbeddedPiRun, waitForEmbeddedPiRunEnd } from "../agents/pi-embedded.js";
 import { stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
@@ -622,6 +623,7 @@ export async function performGatewaySessionReset(params: {
         currentEntry?.claudeCliSessionId
           ? true
           : undefined,
+      suppressCliHistoryImportProviders: resolveBoundCliSessionProviders(currentEntry),
       cliSessionBindings: currentEntry?.cliSessionBindings,
       cliSessionIds: currentEntry?.cliSessionIds,
       claudeCliSessionId: currentEntry?.claudeCliSessionId,

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -96,6 +96,8 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "memoryFlushAt",
   "memoryFlushCompactionCount",
   "memoryFlushContextHash",
+  "suppressCliHistoryImport",
+  "suppressCliHistoryImportProviders",
   "cliSessionIds",
   "cliSessionBindings",
   "claudeCliSessionId",

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -90,6 +90,8 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "memoryFlushAt",
   "memoryFlushCompactionCount",
   "memoryFlushContextHash",
+  "suppressCliHistoryImport",
+  "suppressCliHistoryImportProviders",
   "cliSessionIds",
   "cliSessionBindings",
   "claudeCliSessionId",


### PR DESCRIPTION
## Summary

- Problem: `chat.history` only backfilled external CLI transcript history for `claude-cli`, so Codex-backed sessions could look empty
after refresh when the local transcript was missing.
- Why it matters: users could lose visible history in Gateway/Control UI refresh flows even though the Codex CLI transcript still
existed on disk.
- What changed: added Codex CLI transcript parsing + import support, filtered commentary-only Codex history before merge, merged
multiple bound CLI transcripts when backfilling an empty local history, and blocked old CLI backfill after session reset until a new
CLI binding is established.
- What did NOT change (scope boundary): no changes to live chat send flow, provider execution, or non-CLI session history behavior.

AI-assisted. Testing: targeted tests + `pnpm check` passed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the CLI session history import path only supported `claude-cli`, and the import selection logic only chose one external
transcript source.
- Missing detection / guardrail: there was no Codex-specific history import coverage in `src/gateway/cli-session-history.test.ts`,
and no guard for reset semantics with preserved CLI bindings.
- Contributing context (if known): Codex transcripts include commentary/final-answer phases and can coexist with other CLI bindings
on the same OpenClaw session.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/cli-session-history.test.ts`
  - `src/gateway/server.chat.gateway-server-chat-b.test.ts`
  - `src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
  - `src/agents/cli-session.test.ts`
- Scenario the test should lock in:
  - Codex-backed sessions backfill history from the Codex session store when the local transcript is empty.
  - Commentary-only Codex messages do not consume `chat.history` visibility budget before sanitization.
  - Empty local history can merge multiple bound CLI transcript sources.
  - Session reset preserves CLI bindings without re-importing old external CLI history into the fresh session.
  - Rebinding a CLI session clears the reset-time suppression flag.
- Why this is the smallest reliable guardrail:
  - these tests cover the parser, merge policy, Gateway `chat.history` seam, and reset persistence without needing a full end-to-end
CLI run.
- Existing test that already covers this (if any):
  - `src/gateway/server.chat.gateway-server-chat-b.test.ts` already covered Claude CLI backfill.
- If no new test is added, why not:
  - N/A

## User-visible / Behavior Changes

- Codex-backed Gateway chat history now restores prior turns from the Codex CLI session store on refresh when no local transcript is
available.
- Commentary-only Codex progress messages are not surfaced as visible history entries.
- Reset sessions no longer repopulate old external CLI history just because preserved CLI bindings still exist.

## Diagram (if applicable)

```text
Before:
[refresh chat] -> [local transcript empty] -> [claude-cli only backfill] -> [codex history missing]

After:
[refresh chat] -> [local transcript empty] -> [merge visible bound CLI transcripts] -> [history restored]
[sessions.reset] -> [preserve CLI binding + suppress old import] -> [fresh empty session stays empty]
```


## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:
    - N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: codex-cli
- Integration/channel (if any): Gateway chat.history
- Relevant config (redacted): session entry with cliSessionBindings["codex-cli"].sessionId

### Steps

1. Create or reuse a session entry whose local transcript is empty, but whose cliSessionBindings points at an existing Codex CLI
   session.
2. Call chat.history for that session.
3. Reset the session and call chat.history again.

### Expected

- Before reset: Codex transcript turns are restored from the external Codex session store.
- After reset: the new session remains empty until new local or newly bound CLI history exists.

### Actual

- Before this fix: Codex-backed refreshes could show empty history because only Claude CLI backfill existed.
- Before this fix: if multiple CLI bindings existed, only one external transcript source was imported.
- During review hardening: reset needed an explicit suppression path so preserved old CLI bindings would not refill the new empty
  session.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
    - pnpm check
    - pnpm test src/agents/cli-session.test.ts
    - pnpm test src/gateway/cli-session-history.test.ts
    - pnpm test src/gateway/server.chat.gateway-server-chat-b.test.ts -t "chat.history backfills claude-cli sessions from Claude
      project files"
    - pnpm test src/gateway/server.sessions.gateway-server-sessions-a.test.ts -t "sessions.reset preserves spawned session ownership
      metadata"
- Edge cases checked:
    - commentary and final answer sharing timestamps
    - Codex text elements and attachment import
    - Codex session-path cache isolation by home directory
    - missing cached Codex file
    - multiple CLI bindings on one session
    - reset suppression and suppression clearing on CLI rebind
- What you did not verify:
    - a fully green repo-wide pnpm test run; the full suite had unrelated existing failures outside this change set

## Real behavior proof

- Behavior or issue addressed: Codex-backed Gateway `chat.history` import now restores visible turns from current Codex rollout `response_item` message records when the OpenClaw local transcript is empty, while preserving commentary filtering, multi-CLI merge behavior, and reset-time import suppression.
- Real environment tested: macOS local OpenClaw repo checkout on commit `77de40575d1d76b3bb6ea1d5b860a4c977b7ecca`, Node `v25.8.2`, pnpm `11.1.0`, real source modules from `src/gateway/cli-session-history.ts`, `src/gateway/cli-session-history.codex.ts`, and `src/gateway/cli-session-history.claude.ts`, temporary on-disk `CODEX_HOME` plus Claude project transcript files.
- Exact steps or command run after this patch: From the repo root, ran a `node --import tsx` terminal probe that created a temporary Codex JSONL rollout containing `response_item` records for user, assistant commentary, assistant final answer, reasoning, and developer messages; then called the production Codex resolver/parser and `augmentChatHistoryWithCliSessionImports` for Codex-only import, multi-binding merge, full reset suppression, and provider-scoped suppression.
- Evidence after fix: terminal output from the current-head probe:

```json
{
  "command": "node --import tsx response_item Codex/Claude CLI transcript import probe",
  "head": "77de40575d1d76b3bb6ea1d5b860a4c977b7ecca",
  "nodeVersion": "v25.8.2",
  "pnpmVersion": "11.1.0",
  "codePath": "src/gateway/cli-session-history.ts",
  "codePathCodex": "src/gateway/cli-session-history.codex.ts",
  "codexHomeHonored": true,
  "rawCodexMessageCount": 3,
  "rawCodexMessages": [
    {
      "role": "user",
      "text": "show prior codex response_item history",
      "importedFrom": "codex-cli",
      "externalId": "response_item:2026-05-22T01:52:01.000Z:0"
    },
    {
      "role": "assistant",
      "provider": "codex-cli",
      "phase": "commentary",
      "text": "working on the imported history",
      "importedFrom": "codex-cli",
      "externalId": "response_item:2026-05-22T01:52:03.000Z:1"
    },
    {
      "role": "assistant",
      "provider": "codex-cli",
      "phase": "final_answer",
      "text": "codex response_item history restored",
      "importedFrom": "codex-cli",
      "externalId": "response_item:2026-05-22T01:52:04.000Z:2"
    }
  ],
  "codexOnlyVisibleCount": 2,
  "codexOnlyVisibleMessages": [
    {
      "role": "user",
      "text": "show prior codex response_item history",
      "importedFrom": "codex-cli",
      "externalId": "response_item:2026-05-22T01:52:01.000Z:0"
    },
    {
      "role": "assistant",
      "provider": "codex-cli",
      "phase": "final_answer",
      "text": "codex response_item history restored",
      "importedFrom": "codex-cli",
      "externalId": "response_item:2026-05-22T01:52:04.000Z:2"
    }
  ],
  "mergedVisibleMessageCount": 4,
  "mergedVisibleMessages": [
    {
      "role": "user",
      "text": "show prior codex response_item history",
      "importedFrom": "codex-cli",
      "externalId": "response_item:2026-05-22T01:52:01.000Z:0"
    },
    {
      "role": "assistant",
      "provider": "codex-cli",
      "phase": "final_answer",
      "text": "codex response_item history restored",
      "importedFrom": "codex-cli",
      "externalId": "response_item:2026-05-22T01:52:04.000Z:2"
    },
    {
      "role": "user",
      "text": "also merge claude history",
      "importedFrom": "claude-cli",
      "externalId": "claude-user-1"
    },
    {
      "role": "assistant",
      "provider": "claude-cli",
      "text": "claude history also restored",
      "importedFrom": "claude-cli",
      "externalId": "claude-assistant-1"
    }
  ],
  "resetSuppressedMessageCount": 0,
  "codexOnlySuppressedKeepsClaudeCount": 2,
  "codexOnlySuppressedKeepsClaudeMessages": [
    {
      "role": "user",
      "text": "also merge claude history",
      "importedFrom": "claude-cli",
      "externalId": "claude-user-1"
    },
    {
      "role": "assistant",
      "provider": "claude-cli",
      "text": "claude history also restored",
      "importedFrom": "claude-cli",
      "externalId": "claude-assistant-1"
    }
  ]
}
```

- Observed result after fix: The production resolver found the transcript under `CODEX_HOME`, the parser imported current Codex `response_item` user/assistant messages, ignored reasoning and developer records, filtered assistant commentary out of visible `chat.history`, merged Codex and Claude CLI transcripts for empty-history backfill, returned an empty history under full reset suppression, and allowed Claude history through when only Codex import was provider-suppressed.
- Focused tests run against the same head:
  - `pnpm test src/gateway/cli-session-history.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts -- --reporter=verbose` passed 1 Vitest shard, 2 files, 55 tests.
  - `pnpm test src/agents/cli-session.test.ts src/gateway/cli-session-history.test.ts src/gateway/server.sessions.reset-hooks.test.ts src/gateway/server.sessions.reset-models.test.ts -- --reporter=verbose` passed 2 Vitest shards, 4 files, 70 tests.
  - `pnpm check:changed --base upstream/main` passed lanes `core`, `coreTests`, and `docs`.
- Independent review: a separate review agent checked the `response_item` parser/test changes and reported `No blocking findings`.
- CI status at proof update: GitHub checks are rerunning for current head `77de40575d1d76b3bb6ea1d5b860a4c977b7ecca` after this push.
- What was not tested: Full browser/UI refresh and a live Codex CLI binary run were not exercised in this terminal probe; the proof targets the production filesystem transcript import, parser, merge, commentary filtering, multi-binding merge, provider-scoped suppression, and reset suppression path that backs Gateway `chat.history`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:
    - N/A

## Risks and Mitigations

- Risk:
    - Codex transcript parsing assumptions may miss future transcript record variants.
    - Mitigation:
    - parser only imports recognized event message shapes and ignores malformed/unsupported records; tests cover current known Codex
      transcript structures.
- Risk:
    - reset suppression could accidentally block desired external history import.
    - Mitigation:
    - suppression is explicit reset-owned session state and is cleared when a new CLI binding is written.


