### PR TITLE
fix(plugins): iterate all providers in wrapProviderStreamFn

### DIFF
--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -527,6 +527,56 @@ describe("provider-runtime", () => {
     ).toBe(wrappedStreamFn);
   });
 
+  it("chains wrapStreamFn from primary provider and hookAlias plugin, skipping unrelated providers", () => {
+    const baseStreamFn = vi.fn();
+    const builtinWrappedFn = vi.fn();
+    const pluginWrappedFn = vi.fn();
+    const unrelatedWrapStreamFn = vi.fn();
+
+    resolvePluginProvidersMock.mockReturnValue([
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        auth: [],
+        wrapStreamFn: ({ streamFn }) => {
+          // Built-in provider wraps the base stream
+          expect(streamFn).toBe(baseStreamFn);
+          return builtinWrappedFn;
+        },
+      },
+      {
+        id: "custom-anthropic",
+        label: "Custom Anthropic",
+        hookAliases: ["anthropic"],
+        auth: [],
+        wrapStreamFn: ({ streamFn }) => {
+          // External plugin should receive the built-in's wrapped stream
+          expect(streamFn).toBe(builtinWrappedFn);
+          return pluginWrappedFn;
+        },
+      },
+      {
+        id: "openrouter",
+        label: "OpenRouter",
+        auth: [],
+        wrapStreamFn: unrelatedWrapStreamFn,
+      },
+    ]);
+
+    const result = wrapProviderStreamFn({
+      provider: "anthropic",
+      context: createDemoResolvedModelContext({
+        provider: "anthropic",
+        streamFn: baseStreamFn,
+      }),
+    });
+
+    // The final result should be the external plugin's wrapped function
+    expect(result).toBe(pluginWrappedFn);
+    // Unrelated provider should NOT have been called
+    expect(unrelatedWrapStreamFn).not.toHaveBeenCalled();
+  });
+
   it("normalizes transport hooks without needing provider ownership", () => {
     resolvePluginProvidersMock.mockReturnValue([
       {

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -633,7 +633,33 @@ export function wrapProviderStreamFn(params: {
   env?: NodeJS.ProcessEnv;
   context: ProviderWrapStreamFnContext;
 }) {
-  return resolveProviderHookPlugin(params)?.wrapStreamFn?.(params.context) ?? undefined;
+  // First, let the primary matched plugin wrap the stream (e.g. built-in Anthropic
+  // adding beta headers, service tier, fast mode).
+  const matchedPlugin = resolveProviderHookPlugin(params);
+  let wrappedStreamFn = matchedPlugin?.wrapStreamFn?.(params.context) ?? undefined;
+
+  // Then let any other matching plugins (e.g. external plugins with hookAliases)
+  // wrap the already-wrapped stream. This enables external plugins to compose
+  // additional stream transformations on top of the built-in provider's wrapper.
+  const matchedPluginId = matchedPlugin?.id;
+  for (const candidate of resolveProviderPluginsForHooks(params)) {
+    if (
+      !candidate.wrapStreamFn ||
+      candidate.id === matchedPluginId ||
+      !matchesProviderId(candidate, params.provider)
+    ) {
+      continue;
+    }
+    const candidateResult = candidate.wrapStreamFn({
+      ...params.context,
+      streamFn: wrappedStreamFn ?? params.context.streamFn,
+    });
+    if (candidateResult) {
+      wrappedStreamFn = candidateResult;
+    }
+  }
+
+  return wrappedStreamFn;
 }
 
 export function resolveProviderTransportTurnStateWithPlugin(params: {


### PR DESCRIPTION
## Summary

- **Problem:** `wrapProviderStreamFn()` only checked a single provider via `resolveProviderHookPlugin()`. When a built-in provider (e.g. Anthropic) owned the provider ID, external plugins with matching `hookAliases` could never contribute their own `wrapStreamFn`.
- **Why it matters:** External plugins that want to compose stream transformations (e.g. injecting custom tool types into the API payload) on top of a built-in provider's wrapper are silently ignored.
- **What changed:** Applied the same iteration pattern already used by `normalizeProviderTransportWithPlugin()` and `normalizeProviderConfigWithPlugin()`: check the primary matched plugin first, then iterate all providers from `resolveProviderPluginsForHooks()`.
- **Scope:** Only `wrapProviderStreamFn()` in `src/plugins/provider-runtime.ts`. No other functions changed.

## Change Type

Bug fix — `wrapStreamFn` on external plugins with `hookAliases` is accepted at registration but never called when a built-in provider matches.

## Root Cause

`wrapProviderStreamFn()` called `resolveProviderHookPlugin()` which returns the first matching provider (typically the built-in). The built-in provider's `wrapStreamFn` was used exclusively. External plugins registered via `hookAliases` were discovered by `resolveProviderPluginsForHooks()` but never consulted for `wrapStreamFn`.

The pattern for iterating all providers already existed in `normalizeProviderTransportWithPlugin()` (line 457) and `normalizeProviderConfigWithPlugin()` (line 486) — `wrapProviderStreamFn` was the only provider hook that didn't follow it.

## Regression Test Plan

Added test: "chains wrapStreamFn from primary provider and hookAlias plugin"

- Registers two providers: a primary (`id: "anthropic"`) and an external plugin (`id: "custom-anthropic"`, `hookAliases: ["anthropic"]`)
- Both have `wrapStreamFn`
- Verifies the external plugin receives the primary's wrapped stream as `ctx.streamFn`
- Verifies the final result is the external plugin's wrapped function

Run: `pnpm vitest run src/plugins/provider-runtime.test.ts`

## Security Impact

- **Auth/credentials:** No — does not touch auth flows
- **File system:** No
- **Network:** No — stream wrapping is in-process function composition
- **User data:** No

## Human Verification

- Confirmed test passes locally (18/18 in `provider-runtime.test.ts`)
- Confirmed the pattern matches `normalizeProviderTransportWithPlugin` exactly
- Confirmed chaining semantics: each subsequent plugin gets the previous wrapper's output as `ctx.streamFn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)