### PR TITLE
feat: pass `user` field through to API request body

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -20,6 +20,7 @@ import {
   createOpenAIResponsesContextManagementWrapper,
   createOpenAIStringContentWrapper,
 } from "./openai-stream-wrappers.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { resolveCacheRetention } from "./prompt-cache-retention.js";
 import { createOpenRouterSystemCacheWrapper } from "./proxy-stream-wrappers.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
@@ -325,6 +326,27 @@ function resolveAliasedParamValue(
   return seen ? resolved : undefined;
 }
 
+function createUserFieldWrapper(
+  baseStreamFn: StreamFn | undefined,
+  user: string,
+): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    log.debug(
+      `applying user field for ${model.provider ?? "unknown"}/${model.id ?? "unknown"}`,
+    );
+    return streamWithPayloadPatch(
+      underlying,
+      model,
+      context,
+      options,
+      (payloadObj) => {
+        payloadObj.user = user;
+      },
+    );
+  };
+}
+
 function createParallelToolCallsWrapper(
   baseStreamFn: StreamFn | undefined,
   enabled: boolean,
@@ -412,6 +434,13 @@ function applyPostPluginStreamWrappers(
   // visible reply path because it does not emit native Anthropic thinking
   // blocks. Disable thinking unless an earlier wrapper already set it.
   ctx.agent.streamFn = createMinimaxThinkingDisabledWrapper(ctx.agent.streamFn);
+
+  // Inject user field into API payloads for per-request attribution
+  // (e.g., OpenRouter cost tracking, abuse detection).
+  const user = normalizeOptionalString(ctx.effectiveExtraParams.user);
+  if (user) {
+    ctx.agent.streamFn = createUserFieldWrapper(ctx.agent.streamFn, user);
+  }
 
   const rawParallelToolCalls = resolveAliasedParamValue(
     [ctx.resolvedExtraParams, ctx.override],


### PR DESCRIPTION
## Summary

- Problem: OpenClaw's `createStreamFnWithExtraParams` silently drops the `user` field from agent/model config params, preventing per-request attribution on OpenRouter/OpenAI.
- Why it matters: Users cannot use provider features like OpenRouter broadcast, cost-per-project tracking, or abuse detection.
- What changed: Added `createUserFieldWrapper` that uses `streamWithPayloadPatch` to inject `user` into the API request body (same pattern as `parallelToolCalls`).
- What did NOT change: No changes to config schema, no new config options, no changes to providers. Single file, single concern.

## Change Type

- [x] Feature

## Details

When `user` is set in agent/model params:

```json
{
  "agents": {
    "defaults": {
      "params": {
        "user": "mission-control"
      }
    }
  }
}
```

The gateway now injects it into every API request body via `streamWithPayloadPatch`. Zero overhead when `user` is not set.

**Implementation:** Follows the exact same pattern as `createParallelToolCallsWrapper` — wraps the stream function with `streamWithPayloadPatch` to modify the JSON payload before it's sent to the provider.

Fixes #64812