### PR TITLE
fix(feishu): break circular module init causing ReferenceError on group mention

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -22,11 +22,8 @@ import {
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import {
-  checkBotMentioned,
   normalizeFeishuCommandProbeBody,
-  normalizeMentions,
   parseMergeForwardContent,
-  parseMessageContent,
   resolveFeishuGroupSession,
   resolveFeishuMediaList,
   toMessageResourceType,
@@ -43,7 +40,7 @@ import { type FeishuPermissionError, resolveFeishuSenderName } from "./bot-sende
 import { createFeishuClient } from "./client.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
-import { extractMentionTargets, isMentionForwardRequest } from "./mention.js";
+import { parseFeishuMessageEvent } from "./message-parser.js";
 import {
   resolveFeishuGroupConfig,
   resolveFeishuReplyPolicy,
@@ -60,6 +57,7 @@ import type { FeishuMessageContext, FeishuMessageInfo } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
 export { toMessageResourceType } from "./bot-content.js";
+export { parseFeishuMessageEvent } from "./message-parser.js";
 
 // Cache permission errors to avoid spamming the user with repeated notifications.
 // Key: appId or "default", Value: timestamp of last notification
@@ -93,56 +91,6 @@ export function buildBroadcastSessionKey(
     return `agent:${targetAgentId}:${baseSessionKey.slice(prefix.length)}`;
   }
   return baseSessionKey;
-}
-
-/**
- * Build media payload for inbound context.
- * Similar to Discord's buildDiscordMediaPayload().
- */
-export function parseFeishuMessageEvent(
-  event: FeishuMessageEvent,
-  botOpenId?: string,
-  _botName?: string,
-): FeishuMessageContext {
-  const rawContent = parseMessageContent(event.message.content, event.message.message_type);
-  const mentionedBot = checkBotMentioned(event, botOpenId);
-  const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
-  // Strip the bot's own mention so slash commands like @Bot /help retain
-  // the leading /. This applies in both p2p *and* group contexts — the
-  // mentionedBot flag already captures whether the bot was addressed, so
-  // keeping the mention tag in content only breaks command detection (#35994).
-  // Non-bot mentions (e.g. mention-forward targets) are still normalized to <at> tags.
-  const content = normalizeMentions(rawContent, event.message.mentions, botOpenId);
-  const senderOpenId = event.sender.sender_id.open_id?.trim();
-  const senderUserId = event.sender.sender_id.user_id?.trim();
-  const senderFallbackId = senderOpenId || senderUserId || "";
-
-  const ctx: FeishuMessageContext = {
-    chatId: event.message.chat_id,
-    messageId: event.message.message_id,
-    senderId: senderUserId || senderOpenId || "",
-    // Keep the historical field name, but fall back to user_id when open_id is unavailable
-    // (common in some mobile app deliveries).
-    senderOpenId: senderFallbackId,
-    chatType: event.message.chat_type,
-    mentionedBot,
-    hasAnyMention,
-    rootId: event.message.root_id || undefined,
-    parentId: event.message.parent_id || undefined,
-    threadId: event.message.thread_id || undefined,
-    content,
-    contentType: event.message.message_type,
-  };
-
-  // Detect mention forward request: message mentions bot + at least one other user
-  if (isMentionForwardRequest(event, botOpenId)) {
-    const mentionTargets = extractMentionTargets(event, botOpenId);
-    if (mentionTargets.length > 0) {
-      ctx.mentionTargets = mentionTargets;
-    }
-  }
-
-  return ctx;
 }
 
 export function buildFeishuAgentBody(params: {

--- a/extensions/feishu/src/message-parser.test.ts
+++ b/extensions/feishu/src/message-parser.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for the extracted message-parser module.
+ *
+ * These tests verify that parseFeishuMessageEvent works identically when
+ * imported from the new message-parser.ts module (used by monitor.account.ts
+ * and sequential-key.ts) versus the original bot.ts re-export.
+ *
+ * This extraction was made to fix a circular module initialization issue
+ * that caused ReferenceError in Feishu group chat mention handling.
+ * See: https://github.com/openclaw/openclaw/issues/64783
+ */
+import { describe, it, expect } from "vitest";
+import type { FeishuMessageEvent } from "./event-types.js";
+import { parseFeishuMessageEvent } from "./message-parser.js";
+import { parseFeishuMessageEvent as parseFromBot } from "./bot.js";
+
+// ---- helpers ----
+
+const BOT_OPEN_ID = "ou_bot_123";
+
+function makeEvent(
+  chatType: "p2p" | "group" | "private",
+  mentions?: Array<{ key: string; name: string; id: { open_id?: string } }>,
+  text = "hello",
+): FeishuMessageEvent {
+  return {
+    sender: {
+      sender_id: { user_id: "u1", open_id: "ou_sender" },
+      sender_type: "user",
+    },
+    message: {
+      message_id: "msg_1",
+      chat_id: "oc_chat1",
+      chat_type: chatType,
+      message_type: "text",
+      content: JSON.stringify({ text }),
+      mentions,
+    },
+  } as FeishuMessageEvent;
+}
+
+// ---- parseFeishuMessageEvent from message-parser.ts ----
+
+describe("message-parser: parseFeishuMessageEvent", () => {
+  it("parses a basic text message in p2p chat", () => {
+    const event = makeEvent("p2p", undefined, "hello world");
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.chatId).toBe("oc_chat1");
+    expect(ctx.messageId).toBe("msg_1");
+    expect(ctx.content).toBe("hello world");
+    expect(ctx.chatType).toBe("p2p");
+    expect(ctx.mentionedBot).toBe(false);
+    expect(ctx.hasAnyMention).toBe(false);
+    expect(ctx.mentionTargets).toBeUndefined();
+  });
+
+  it("detects bot mention in group chat", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+    expect(ctx.hasAnyMention).toBe(true);
+  });
+
+  it("does not set mentionedBot when a different user is mentioned", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Other User", id: { open_id: "ou_other_user" } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+    expect(ctx.hasAnyMention).toBe(true);
+  });
+
+  it("detects mention forward request (bot + other user mentioned in group)", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },
+      { key: "@_user_2", name: "Target User", id: { open_id: "ou_target" } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+    expect(ctx.mentionTargets).toBeDefined();
+    expect(ctx.mentionTargets).toHaveLength(1);
+    expect(ctx.mentionTargets![0].openId).toBe("ou_target");
+    expect(ctx.mentionTargets![0].name).toBe("Target User");
+  });
+
+  it("does not detect mention forward when only bot is mentioned in group", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },
+    ]);
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.mentionTargets).toBeUndefined();
+  });
+
+  it("populates sender fields from event", () => {
+    const event = makeEvent("p2p");
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.senderId).toBe("u1");
+    expect(ctx.senderOpenId).toBe("ou_sender");
+  });
+
+  it("falls back to open_id when user_id is empty", () => {
+    const event = makeEvent("p2p");
+    event.sender.sender_id.user_id = "";
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.senderId).toBe("ou_sender");
+    expect(ctx.senderOpenId).toBe("ou_sender");
+  });
+
+  it("handles message with root_id and parent_id", () => {
+    const event = makeEvent("group");
+    (event.message as Record<string, unknown>).root_id = "om_root_1";
+    (event.message as Record<string, unknown>).parent_id = "om_parent_1";
+    const ctx = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    expect(ctx.rootId).toBe("om_root_1");
+    expect(ctx.parentId).toBe("om_parent_1");
+  });
+});
+
+// ---- backward compatibility: re-export from bot.ts ----
+
+describe("message-parser: backward compatibility via bot.ts re-export", () => {
+  it("bot.ts re-exports the same parseFeishuMessageEvent function", () => {
+    // This confirms that code importing from bot.ts still gets the same
+    // implementation, ensuring no regressions for existing consumers.
+    expect(parseFromBot).toBe(parseFeishuMessageEvent);
+  });
+
+  it("produces identical output for a group mention event", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },
+      { key: "@_user_2", name: "Target", id: { open_id: "ou_target" } },
+    ]);
+    const ctxDirect = parseFeishuMessageEvent(event, BOT_OPEN_ID);
+    const ctxReExport = parseFromBot(event, BOT_OPEN_ID);
+    expect(ctxDirect).toEqual(ctxReExport);
+  });
+});
+
+// ---- module graph isolation ----
+
+describe("message-parser: module isolation", () => {
+  it("message-parser.ts does not import from bot.ts (circular break)", async () => {
+    // This test verifies that the module-level fix is structurally sound:
+    // message-parser.ts should only import from lightweight modules
+    // (bot-content, mention, event-types, types) and NOT from bot.ts.
+    //
+    // We do a simple source-level check here rather than relying on the
+    // bundler to catch the cycle, since the TDZ error only manifests in
+    // the bundled output under specific initialization orderings.
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const moduleDir = path.dirname(new URL(import.meta.url).pathname);
+    const source = fs.readFileSync(path.join(moduleDir, "message-parser.ts"), "utf-8");
+
+    // Must NOT contain imports from bot.ts (which would reintroduce the cycle)
+    expect(source).not.toMatch(/from\s+["']\.\/bot\.js["']/);
+    expect(source).not.toMatch(/from\s+["']\.\/bot["']/);
+
+    // Must NOT contain imports from monitor.account.ts
+    expect(source).not.toMatch(/from\s+["']\.\/monitor\.account/);
+
+    // Must NOT contain imports from card-action.ts
+    expect(source).not.toMatch(/from\s+["']\.\/card-action/);
+
+    // Should import from lightweight modules only
+    expect(source).toMatch(/from\s+["']\.\/bot-content\.js["']/);
+    expect(source).toMatch(/from\s+["']\.\/mention\.js["']/);
+    expect(source).toMatch(/from\s+["']\.\/event-types\.js["']/);
+    expect(source).toMatch(/from\s+["']\.\/types\.js["']/);
+  });
+
+  it("monitor.account.ts does not statically import handleFeishuMessage from bot.ts", async () => {
+    // Verify the lazy import pattern is in place — monitor.account.ts
+    // should use dynamic import() for bot.ts, not a static import statement.
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const moduleDir = path.dirname(new URL(import.meta.url).pathname);
+    const source = fs.readFileSync(path.join(moduleDir, "monitor.account.ts"), "utf-8");
+
+    // Static import of handleFeishuMessage from bot.ts should be gone
+    expect(source).not.toMatch(/import\s*\{[^}]*handleFeishuMessage[^}]*\}\s*from\s*["']\.\/bot/);
+
+    // Should use dynamic import pattern instead
+    expect(source).toMatch(/import\(["']\.\/bot\.js["']\)/);
+
+    // parseFeishuMessageEvent should come from message-parser, not bot
+    expect(source).toMatch(/from\s+["']\.\/message-parser\.js["']/);
+  });
+
+  it("sequential-key.ts imports parseFeishuMessageEvent from message-parser, not bot", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+    const moduleDir = path.dirname(new URL(import.meta.url).pathname);
+    const source = fs.readFileSync(path.join(moduleDir, "sequential-key.ts"), "utf-8");
+
+    expect(source).toMatch(/from\s+["']\.\/message-parser\.js["']/);
+    expect(source).not.toMatch(
+      /import\s*\{[^}]*parseFeishuMessageEvent[^}]*\}\s*from\s*["']\.\/bot/,
+    );
+  });
+});

--- a/extensions/feishu/src/message-parser.ts
+++ b/extensions/feishu/src/message-parser.ts
@@ -1,0 +1,87 @@
+/**
+ * Lightweight message parsing module extracted from bot.ts to break a circular
+ * module initialization dependency.
+ *
+ * Problem:  monitor.account.ts imported parseFeishuMessageEvent from bot.ts.
+ *           bot.ts pulls in a heavy dependency tree (bot-content -> post ->
+ *           comment-shared -> openclaw/plugin-sdk/text-runtime, plus policy,
+ *           reply-dispatcher, dedup, etc.).  When the bundler (tsdown/esbuild)
+ *           inlines these into a single output chunk the initialization order
+ *           of the shared utility bindings can violate the Temporal Dead Zone,
+ *           producing:
+ *
+ *               ReferenceError: Cannot access 'utils_1' before initialization
+ *
+ *           The error manifests only when a bot is @-mentioned in a Feishu
+ *           group chat with multi-agent configuration because that code path
+ *           is the first to exercise the full import graph at runtime.
+ *
+ * Solution: Keep parseFeishuMessageEvent in this small, shallow module so
+ *           monitor.account.ts and sequential-key.ts can import it without
+ *           dragging in the entire bot.ts dependency tree.  bot.ts re-exports
+ *           it for backward compatibility.
+ *
+ * Fixes: https://github.com/openclaw/openclaw/issues/64783
+ */
+
+import {
+  checkBotMentioned,
+  normalizeMentions,
+  parseMessageContent,
+} from "./bot-content.js";
+import type { FeishuMessageEvent } from "./event-types.js";
+import { extractMentionTargets, isMentionForwardRequest } from "./mention.js";
+import type { FeishuMessageContext } from "./types.js";
+
+/**
+ * Parse a raw Feishu message event into a normalized context object.
+ *
+ * This is intentionally placed in its own module so that callers that only
+ * need parsing (e.g. monitor.account.ts, sequential-key.ts) do not have to
+ * statically import the heavyweight bot.ts module and its transitive deps.
+ */
+export function parseFeishuMessageEvent(
+  event: FeishuMessageEvent,
+  botOpenId?: string,
+  _botName?: string,
+): FeishuMessageContext {
+  const rawContent = parseMessageContent(event.message.content, event.message.message_type);
+  const mentionedBot = checkBotMentioned(event, botOpenId);
+  const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
+  // Strip the bot's own mention so slash commands like @Bot /help retain
+  // the leading /. This applies in both p2p *and* group contexts — the
+  // mentionedBot flag already captures whether the bot was addressed, so
+  // keeping the mention tag in content only breaks command detection (#35994).
+  // Non-bot mentions (e.g. mention-forward targets) are still normalized to <at> tags.
+  const content = normalizeMentions(rawContent, event.message.mentions, botOpenId);
+  const senderOpenId = event.sender.sender_id.open_id?.trim();
+  const senderUserId = event.sender.sender_id.user_id?.trim();
+  const senderFallbackId = senderOpenId || senderUserId || "";
+
+  const ctx: FeishuMessageContext = {
+    chatId: event.message.chat_id,
+    messageId: event.message.message_id,
+    senderId: senderUserId || senderOpenId || "",
+    // Keep the historical field name, but fall back to user_id when open_id is unavailable
+    // (common in some mobile app deliveries).
+    senderOpenId: senderFallbackId,
+    chatType: event.message.chat_type,
+    mentionedBot,
+    hasAnyMention,
+    rootId: event.message.root_id || undefined,
+    parentId: event.message.parent_id || undefined,
+    threadId: event.message.thread_id || undefined,
+    content,
+    contentType: event.message.message_type,
+  };
+
+  // Detect mention forward request: message mentions bot + at least one other user
+  if (isMentionForwardRequest(event, botOpenId)) {
+    const mentionTargets = extractMentionTargets(event, botOpenId);
+    if (mentionTargets.length > 0) {
+      ctx.mentionTargets = mentionTargets;
+    }
+  }
+
+  return ctx;
+}

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -3,13 +3,9 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
-import {
-  handleFeishuMessage,
-  parseFeishuMessageEvent,
-  type FeishuMessageEvent,
-  type FeishuBotAddedEvent,
-} from "./bot.js";
-import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
+import type { FeishuBotAddedEvent, FeishuMessageEvent } from "./event-types.js";
+import { parseFeishuMessageEvent } from "./message-parser.js";
+import type { FeishuCardActionEvent } from "./card-action.js";
 import { maybeHandleFeishuQuickActionMenu } from "./card-ux-launcher.js";
 import { createEventDispatcher } from "./client.js";
 import { handleFeishuCommentEvent } from "./comment-handler.js";
@@ -391,6 +387,43 @@ function registerEventHandlers(
   // Keep normal Feishu traffic FIFO per chat while allowing explicit out-of-band
   // commands like /btw and /stop to bypass the busy main-chat lane.
   const enqueue = createSequentialQueue();
+  // Lazy-load heavy handler modules to break circular initialization chains.
+  // handleFeishuMessage lives in bot.ts which pulls in a large transitive
+  // dependency tree (bot-content, reply-dispatcher, policy, …).  Importing it
+  // statically from monitor.account.ts causes the bundler to inline both
+  // modules into one chunk, and the shared utility bindings (text-runtime,
+  // comment-shared, etc.) may violate the Temporal Dead Zone when the chunk
+  // initializes — producing:
+  //
+  //   ReferenceError: Cannot access 'utils_1' before initialization
+  //
+  // Dynamic import() defers evaluation of bot.ts (and card-action.ts) until
+  // the first message/card event is actually dispatched, by which time all
+  // utility modules are guaranteed to have been initialized.
+  //
+  // Ref: https://github.com/openclaw/openclaw/issues/64783
+  let _handleFeishuMessage: typeof import("./bot.js").handleFeishuMessage | undefined;
+  const lazyHandleFeishuMessage = async (
+    ...args: Parameters<typeof import("./bot.js").handleFeishuMessage>
+  ) => {
+    if (!_handleFeishuMessage) {
+      const mod = await import("./bot.js");
+      _handleFeishuMessage = mod.handleFeishuMessage;
+    }
+    return _handleFeishuMessage(...args);
+  };
+
+  let _handleFeishuCardAction: typeof import("./card-action.js").handleFeishuCardAction | undefined;
+  const lazyHandleFeishuCardAction = async (
+    ...args: Parameters<typeof import("./card-action.js").handleFeishuCardAction>
+  ) => {
+    if (!_handleFeishuCardAction) {
+      const mod = await import("./card-action.js");
+      _handleFeishuCardAction = mod.handleFeishuCardAction;
+    }
+    return _handleFeishuCardAction(...args);
+  };
+
   const runFeishuHandler = async (params: { task: () => Promise<void>; errorMessage: string }) => {
     if (fireAndForget) {
       void params.task().catch((err) => {
@@ -412,7 +445,7 @@ function registerEventHandlers(
       botName: botNames.get(accountId),
     });
     const task = () =>
-      handleFeishuMessage({
+      lazyHandleFeishuMessage({
         cfg,
         event,
         botOpenId: botOpenIds.get(accountId),
@@ -665,7 +698,7 @@ function registerEventHandlers(
           if (!syntheticEvent) {
             return;
           }
-          const promise = handleFeishuMessage({
+          const promise = lazyHandleFeishuMessage({
             cfg,
             event: syntheticEvent,
             botOpenId: myBotId,
@@ -695,7 +728,7 @@ function registerEventHandlers(
           if (!syntheticEvent) {
             return;
           }
-          const promise = handleFeishuMessage({
+          const promise = lazyHandleFeishuMessage({
             cfg,
             event: syntheticEvent,
             botOpenId: myBotId,
@@ -748,7 +781,7 @@ function registerEventHandlers(
           return;
         }
         const handleLegacyMenu = () =>
-          handleFeishuMessage({
+          lazyHandleFeishuMessage({
             cfg,
             event: syntheticEvent,
             botOpenId: botOpenIds.get(accountId),
@@ -796,7 +829,7 @@ function registerEventHandlers(
           error(`feishu[${accountId}]: ignoring malformed card action payload`);
           return;
         }
-        const promise = handleFeishuCardAction({
+        const promise = lazyHandleFeishuCardAction({
           cfg,
           event,
           botOpenId: botOpenIds.get(accountId),

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -1,5 +1,6 @@
 import { isAbortRequestText, isBtwRequestText } from "openclaw/plugin-sdk/reply-runtime";
-import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
+import type { FeishuMessageEvent } from "./event-types.js";
+import { parseFeishuMessageEvent } from "./message-parser.js";
 
 export function getFeishuSequentialKey(params: {
   accountId: string;


### PR DESCRIPTION
## Summary

Fixes #64783

When mentioning (`@`) a bot in a Feishu group chat with multi-agent configuration, the gateway throws:

```
ReferenceError: Cannot access 'utils_1' before initialization
```

**Root cause:** `monitor.account.ts` statically imports `handleFeishuMessage` and `parseFeishuMessageEvent` from `bot.ts`, which pulls in a deep transitive dependency tree (`bot-content` -> `post` -> `comment-shared` -> `plugin-sdk/text-runtime`, plus `policy`, `reply-dispatcher`, `dedup`, etc.). When `tsdown`/`esbuild` bundles these into a single output chunk, the shared utility bindings can violate the **Temporal Dead Zone** — the bundler evaluates one module scope before the utility variable it references has been initialized.

**Fix (3 changes):**

- **Extract `parseFeishuMessageEvent`** into a new lightweight `message-parser.ts` module that only depends on shallow modules (`bot-content`, `mention`, `event-types`, `types`) — no heavy transitive deps
- **Lazy-load `handleFeishuMessage` and `handleFeishuCardAction`** in `monitor.account.ts` via dynamic `import()` instead of static imports, deferring evaluation of `bot.ts` and `card-action.ts` until the first event is dispatched
- **Update `sequential-key.ts`** to import from `message-parser.ts` instead of `bot.ts`
- `bot.ts` re-exports `parseFeishuMessageEvent` for full backward compatibility

## Test plan

- [x] Added `message-parser.test.ts` with:
  - Unit tests for `parseFeishuMessageEvent` (basic parsing, bot mention detection, mention forward detection, sender fields, thread IDs)
  - Backward compatibility test verifying `bot.ts` re-export is the same function reference
  - Module isolation tests verifying `message-parser.ts` does not import from `bot.ts`, and `monitor.account.ts` uses dynamic import for `bot.ts`
- [ ] Existing tests (`bot.checkBotMentioned.test.ts`, `bot.stripBotMention.test.ts`, `sequential-key.test.ts`, etc.) continue to pass since `bot.ts` re-exports the function
- [ ] Manual test: configure multi-agent Feishu setup, mention a bot in a group chat — no more `ReferenceError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)