### PR TITLE
Improve bootstrap file truncation visibility and edit failure diagnostics

### DIFF
--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -350,6 +350,7 @@ export function appendBootstrapPromptWarning(
     "Some workspace bootstrap files were truncated before injection.",
     "Treat Project Context as partial and read the relevant files directly if details seem missing.",
     ...normalizedLines.map((line) => `- ${line}`),
+    "⚠ Edits to truncated files may fail (non-unique matches, text not found). If edits fail, use the `write` tool to rewrite the full file, or trim the file to fit within the limit.",
   ].join("\n");
   return prompt ? `${prompt}\n\n${warningBlock}` : warningBlock;
 }

--- a/src/agents/pi-tools.host-edit.ts
+++ b/src/agents/pi-tools.host-edit.ts
@@ -135,12 +135,18 @@ function shouldAddMismatchHint(error: unknown) {
   return error instanceof Error && error.message.includes(EDIT_MISMATCH_MESSAGE);
 }
 
-function appendMismatchHint(error: Error, currentContent: string): Error {
+const TRUNCATION_SIZE_THRESHOLD = 20_000;
+
+function appendMismatchHint(error: Error, currentContent: string, pathParam?: string): Error {
   const snippet =
     currentContent.length <= EDIT_MISMATCH_HINT_LIMIT
       ? currentContent
       : `${currentContent.slice(0, EDIT_MISMATCH_HINT_LIMIT)}\n... (truncated)`;
-  const enhanced = new Error(`${error.message}\nCurrent file contents:\n${snippet}`);
+  let hint = `${error.message}\nCurrent file contents:\n${snippet}`;
+  if (currentContent.length > TRUNCATION_SIZE_THRESHOLD) {
+    hint += `\nNote: This file (${currentContent.length} chars) exceeds the typical bootstrap file limit. It may have been truncated in the agent's context, causing this edit to fail. Consider using the \`write\` tool to rewrite the full file, or trim the file to fit within the limit.`;
+  }
+  const enhanced = new Error(hint);
   enhanced.stack = error.stack;
   return enhanced;
 }
@@ -206,7 +212,7 @@ export function wrapEditToolWithRecovery(
           err instanceof Error &&
           shouldAddMismatchHint(err)
         ) {
-          throw appendMismatchHint(err, currentContent);
+          throw appendMismatchHint(err, currentContent, pathParam);
         }
 
         throw err;

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -410,6 +410,43 @@ const formatVoiceModeLine = (
   return `🔊 Voice: ${snapshot.autoMode} · provider=${snapshot.provider} · limit=${snapshot.maxLength} · summary=${snapshot.summarize ? "on" : "off"}`;
 };
 
+type WorkspaceFileEntry = {
+  name: string;
+  rawChars: number;
+  injectedChars: number;
+  truncated: boolean;
+  missing: boolean;
+};
+
+function formatWorkspaceFileLines(
+  files: WorkspaceFileEntry[] | undefined,
+  bootstrapMaxChars: number | undefined,
+): string | null {
+  if (!files || files.length === 0) {
+    return null;
+  }
+  const maxChars = bootstrapMaxChars ?? 20_000;
+  const nearLimitRatio = 0.85;
+  const lines: string[] = ["📂 Workspace files:"];
+  for (const file of files) {
+    if (file.missing) {
+      lines.push(`  ${file.name}: MISSING`);
+      continue;
+    }
+    const pct = Math.round((file.rawChars / maxChars) * 100);
+    if (file.truncated) {
+      lines.push(
+        `  ${file.name}: ${formatInt(file.rawChars)} chars ❌ TRUNCATED (injected as ${formatInt(file.injectedChars)})`,
+      );
+    } else if (file.rawChars >= maxChars * nearLimitRatio) {
+      lines.push(`  ${file.name}: ${formatInt(file.rawChars)} chars ⚠️ NEAR LIMIT (${pct}% of ${formatInt(maxChars)})`);
+    } else {
+      lines.push(`  ${file.name}: ${formatInt(file.rawChars)} chars`);
+    }
+  }
+  return lines.join("\n");
+}
+
 export function buildStatusMessage(args: StatusArgs): string {
   const now = args.now ?? Date.now();
   const entry = args.sessionEntry;
@@ -821,7 +858,7 @@ export function buildStatusMessage(args: StatusArgs): string {
   const mediaLine = formatMediaUnderstandingLine(args.mediaDecisions);
   const voiceLine = formatVoiceModeLine(args.config, args.sessionEntry);
 
-  return [
+  const statusBase = [
     versionLine,
     args.timeLine,
     modelLine,
@@ -839,9 +876,14 @@ export function buildStatusMessage(args: StatusArgs): string {
     pluginStatusLine ? `🧩 ${pluginStatusLine}` : null,
     voiceLine,
     activationLine,
-  ]
-    .filter(Boolean)
-    .join("\n");
+  ].filter(Boolean).join("\n");
+
+  // Append workspace file health if available from the session's system prompt report.
+  const workspaceFileLines = formatWorkspaceFileLines(
+    entry?.systemPromptReport?.injectedWorkspaceFiles,
+    entry?.systemPromptReport?.bootstrapMaxChars,
+  );
+  return workspaceFileLines ? `${statusBase}\n${workspaceFileLines}` : statusBase;
 }
 
 type ToolsMessageItem = {


### PR DESCRIPTION
## Problem

When workspace bootstrap files (MEMORY.md, AGENTS.md, etc.) exceed `bootstrapMaxChars` (default 20K), they are silently truncated. The existing "once" mode warning is easy to miss because:

1. It says "Treat Project Context as partial" — generic advice that doesn't convey the real risk
2. `/status` shows no file health information — users must know to run `/context list`
3. Edit tool failures on truncated files don't mention truncation as a possible cause

This leads to a silent degradation cascade: truncation → edit failures → memory file stops updating → agent quality erodes over weeks without detection.

## Changes

### 1. Strengthen truncation warning text (`src/agents/bootstrap-budget.ts`)

Added edit failure risk to the existing bootstrap truncation warning block:

> ⚠ Edits to truncated files may fail (non-unique matches, text not found). If edits fail on a truncated file, use the `write` tool to rewrite the full file, or trim the file to fit within the limit.

### 2. Add bootstrap file health to `/status` (`src/auto-reply/status.ts`)

Added a "📂 Workspace files" section to `/status` output showing each bootstrap file's size relative to the limit. Files over 85% get ⚠️ NEAR LIMIT, truncated files get ❌ TRUNCATED with the injected size.

### 3. Add truncation hint to edit tool errors (`src/agents/pi-tools.host-edit.ts`)

When the edit tool throws a mismatch error on a file exceeding 20K chars, the error now includes a note about the bootstrap file limit being the likely cause.

## Related Issues

- Closes #45415 — Feature request: MEMORY.md size warning/limit enforcement
- Related #42084 — Agent silently fails to reply when workspace bootstrap file exceeds bootstrapMaxChars
- Related #60218 — Tool write/embedded limit causing timeouts on large file edits
- Related #33406 — Feature: Expose context compression hook to agents for automatic workspace MD file trimming
- Complementary to PR #60288 — feat: warn user when bootstrap file truncation exceeds threshold (that PR adds user-visible chat warnings; this PR strengthens the injected warning, adds `/status` visibility, and improves edit error messages)

## Implementation Notes

- **Backward compatible** — all changes are additive, no config changes needed
- **Minimal scope** — 3 files touched, no new dependencies
- Uses data already stored in `sessionEntry.systemPromptReport` — no new computation required
EOF