### PR TITLE
warn: emit warning when context window resolved from hardcoded default

### DIFF
--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -205,6 +205,7 @@ describe("context-window-guard", () => {
     expect(info.source).toBe("default");
     expect(guard.shouldWarn).toBe(false);
     expect(guard.shouldBlock).toBe(false);
+    expect(guard.shouldWarnDefault).toBe(true);
   });
 
   it("allows overriding thresholds", () => {
@@ -216,6 +217,7 @@ describe("context-window-guard", () => {
     });
     expect(guard.shouldWarn).toBe(true);
     expect(guard.shouldBlock).toBe(false);
+    expect(guard.shouldWarnDefault).toBe(false);
   });
 
   it("exports thresholds as expected", () => {

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -59,6 +59,9 @@ export function resolveContextWindowInfo(params: {
 export type ContextWindowGuardResult = ContextWindowInfo & {
   shouldWarn: boolean;
   shouldBlock: boolean;
+  /** Set when context window resolved to a hardcoded default (e.g. 32000 for Bedrock),
+   *  meaning the user's per-model config was not applied for this (provider, modelId). */
+  shouldWarnDefault: boolean;
 };
 
 export function evaluateContextWindowGuard(params: {
@@ -77,5 +80,6 @@ export function evaluateContextWindowGuard(params: {
     tokens,
     shouldWarn: tokens > 0 && tokens < warnBelow,
     shouldBlock: tokens > 0 && tokens < hardMin,
+    shouldWarnDefault: params.info.source === "default",
   };
 }

--- a/src/agents/pi-embedded-runner/run/setup.ts
+++ b/src/agents/pi-embedded-runner/run/setup.ts
@@ -142,6 +142,11 @@ export function resolveEffectiveRuntimeModel(params: {
       { reason: "unknown", provider: params.provider, model: params.modelId },
     );
   }
+  if (ctxGuard.shouldWarnDefault) {
+    log.warn(
+      `context window resolved from hardcoded default (${ctxGuard.tokens}) for ${params.provider}/${params.modelId} — set contextWindow explicitly in models config to override`,
+    );
+  }
 
   return {
     ctxInfo,


### PR DESCRIPTION
When OpenClaw resolves a model's context window to a hardcoded default (e.g. 32000 for Amazon Bedrock), it now emits a `log.warn` so users understand why their per-model `contextWindow` config may not be applied.

## What changed

- **`context-window-guard.ts`**: Added `shouldWarnDefault` to `ContextWindowGuardResult` — set when `source === "default"`
- **`pi-embedded-runner/run/setup.ts`**: Added a warning in `resolveEffectiveRuntimeModel` that fires when `shouldWarnDefault` is true, including the resolved token count and model identifier
- **`context-window-guard.test.ts`**: Assertions for `shouldWarnDefault` in the existing "uses default" and "allows overriding thresholds" test cases

## Root cause

Issue #64250 — the AWS Bedrock API does not expose token limits, so discovery uses `contextWindow: 32000` for all models. When a user's provider/model config wasn't matched, the default was silently used, causing premature compaction failures.

## Tests

`context-window-guard.test.ts` already covers the two relevant paths:
- `shouldWarnDefault === true` when `source === "default"