### PR TITLE
Plugin SDK: add text-only tool_result_before_model hook

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c2c6319c35f152d2a2b36584981b92c22f7e9759a27d47ad66bfdbcef916eace  plugin-sdk-api-baseline.json
-3ba23b54667c75caba3560cc66a399b7bdd9b316009bf5ad6a43aefd469f1552  plugin-sdk-api-baseline.jsonl
+ee702d9f7b7b3f4a0de55d2d4dc1a38806f70c0c1f2e7a465a2335bd5e687f48  plugin-sdk-api-baseline.json
+892ff617a76bbd3dc371be5f6681f659da22befb925140ec327ed25c19efeee9  plugin-sdk-api-baseline.jsonl

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -90,6 +90,7 @@ These run inside the agent loop or gateway pipeline:
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
 - **`before_install`**: inspect built-in scan findings and optionally block skill or plugin installs.
 - **`tool_result_persist`**: synchronously transform tool results before they are written to the session transcript.
+- **`tool_result_before_model`**: synchronously canonicalize a single eligible tool-result text payload before same-turn continuation and default transcript persistence; `details` stay raw unless another hook rewrites them.
 - **`message_received` / `message_sending` / `message_sent`**: inbound + outbound message hooks.
 - **`session_start` / `session_end`**: session lifecycle boundaries.
 - **`gateway_start` / `gateway_stop`**: gateway lifecycle events.

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -180,6 +180,7 @@ Hook guard semantics to keep in mind:
 - `before_tool_call`: `{ block: true }` is terminal and stops lower-priority handlers.
 - `before_tool_call`: `{ block: false }` is treated as no decision.
 - `before_tool_call`: `{ requireApproval: true }` pauses agent execution and prompts the user for approval via the exec approval overlay, Telegram buttons, Discord interactions, or the `/approve` command on any channel.
+- `tool_result_before_model`: sync success-only canonicalization before same-turn continuation and default transcript persistence. Returning `{ text }` replaces a single eligible text payload (`content` must be exactly one text block; legacy plain-string content is skipped). It is fail-open, does not touch `details`, and later ordinary `tool_result` handlers run on that canonicalized event. Use explicit returned patches for downstream rewrites; mutation-only side effects continue to follow the existing `tool_result` runner semantics.
 - `before_install`: `{ block: true }` is terminal and stops lower-priority handlers.
 - `before_install`: `{ block: false }` is treated as no decision.
 - `message_sending`: `{ cancel: true }` is terminal and stops lower-priority handlers.

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -431,6 +431,7 @@ AI CLI backend such as `codex-cli`.
 
 - `before_tool_call`: returning `{ block: true }` is terminal. Once any handler sets it, lower-priority handlers are skipped.
 - `before_tool_call`: returning `{ block: false }` is treated as no decision (same as omitting `block`), not as an override.
+- `tool_result_before_model`: synchronous and success-path-only. Returning `{ text }` replaces a single eligible tool-result text payload before same-turn continuation and before default transcript persistence. v0 only runs for `content` that is exactly one text block, skips legacy plain-string content, never rewrites `details`, and fails open. Later ordinary `tool_result` handlers run on that canonicalized event; use explicit returned patches for downstream rewrites, because mutation-only side effects continue to follow the existing `tool_result` runner semantics.
 - `before_install`: returning `{ block: true }` is terminal. Once any handler sets it, lower-priority handlers are skipped.
 - `before_install`: returning `{ block: false }` is treated as no decision (same as omitting `block`), not as an override.
 - `reply_dispatch`: returning `{ handled: true, ... }` is terminal. Once any handler claims dispatch, lower-priority handlers and the default model dispatch path are skipped.

--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -29,6 +29,7 @@ export const hookRunner = {
   hasHooks: vi.fn<(hookName?: string) => boolean>(),
   runBeforeCompaction: vi.fn(async () => undefined),
   runAfterCompaction: vi.fn(async () => undefined),
+  runToolResultBeforeModel: vi.fn(() => undefined),
 };
 
 export const ensureRuntimePluginsLoaded: Mock<(params?: unknown) => void> = vi.fn();
@@ -151,6 +152,8 @@ export function resetCompactHooksHarnessMocks(): void {
   hookRunner.runBeforeCompaction.mockResolvedValue(undefined);
   hookRunner.runAfterCompaction.mockReset();
   hookRunner.runAfterCompaction.mockResolvedValue(undefined);
+  hookRunner.runToolResultBeforeModel.mockReset();
+  hookRunner.runToolResultBeforeModel.mockReturnValue(undefined);
 
   ensureRuntimePluginsLoaded.mockReset();
 
@@ -453,10 +456,6 @@ export async function loadCompactHooksHarness(): Promise<{
       validateGeminiTurns: false,
       validateAnthropicTurns: false,
     })),
-  }));
-
-  vi.doMock("./extensions.js", () => ({
-    buildEmbeddedExtensionFactories: vi.fn(() => []),
   }));
 
   vi.doMock("./history.js", () => ({

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -106,7 +106,7 @@ import {
   compactWithSafetyTimeout,
   resolveCompactionTimeoutMs,
 } from "./compaction-safety-timeout.js";
-import { buildEmbeddedExtensionFactories } from "./extensions.js";
+import { buildEmbeddedExtensionFactories, buildEmbeddedExtensionsOverride } from "./extensions.js";
 import { applyExtraParamsToAgent } from "./extra-params.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 import { log } from "./logger.js";
@@ -790,6 +790,7 @@ export async function compactEmbeddedPiSessionDirect(
         cfg: params.config,
         contextTokenBudget: ctxInfo.tokens,
       });
+      const globalHookRunner = getGlobalHookRunner() ?? undefined;
       // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.
       const extensionFactories = buildEmbeddedExtensionFactories({
@@ -798,6 +799,14 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
+        hookRunner: globalHookRunner,
+        agentId: sessionAgentId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        runId,
+      });
+      const extensionsOverride = buildEmbeddedExtensionsOverride({
+        hasToolResultBeforeModelBridge: !!globalHookRunner?.hasHooks("tool_result_before_model"),
       });
       // Only create an explicit resource loader when there are extension factories
       // to register; otherwise let createAgentSession use its built-in default.
@@ -808,6 +817,7 @@ export async function compactEmbeddedPiSessionDirect(
           agentDir,
           settingsManager,
           extensionFactories,
+          extensionsOverride,
         });
         await resourceLoader.reload();
       }
@@ -928,7 +938,7 @@ export async function compactEmbeddedPiSessionDirect(
           if (limited.length > 0) {
             session.agent.state.messages = limited;
           }
-          const hookRunner = asCompactionHookRunner(getGlobalHookRunner());
+          const hookRunner = asCompactionHookRunner(globalHookRunner);
           const observedTokenCount = normalizeObservedTokenCount(params.currentTokenCount);
           const beforeHookMetrics = buildBeforeCompactionHookMetrics({
             originalMessages,

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -1,16 +1,22 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
-import type { SessionManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, SessionManager, ToolResultEvent } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
+import { ExtensionRunner } from "../../../node_modules/@mariozechner/pi-coding-agent/dist/core/extensions/runner.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { getCompactionSafeguardRuntime } from "../pi-hooks/compaction-safeguard-runtime.js";
 import compactionSafeguardExtension from "../pi-hooks/compaction-safeguard.js";
 import contextPruningExtension from "../pi-hooks/context-pruning.js";
-import { buildEmbeddedExtensionFactories } from "./extensions.js";
+import { buildEmbeddedExtensionFactories, buildEmbeddedExtensionsOverride } from "./extensions.js";
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
   resolveProviderCacheTtlEligibility: () => undefined,
   resolveProviderRuntimePlugin: () => undefined,
 }));
+
+type ToolResultHandler = (event: ToolResultEvent) => unknown;
+type ToolResultBridgeHookRunner = NonNullable<
+  Parameters<typeof buildEmbeddedExtensionFactories>[0]["hookRunner"]
+>;
 
 function buildSafeguardFactories(cfg: OpenClawConfig) {
   const sessionManager = {} as SessionManager;
@@ -28,6 +34,100 @@ function buildSafeguardFactories(cfg: OpenClawConfig) {
   });
 
   return { factories, sessionManager };
+}
+
+function createToolResultBridgeHandlers(params: {
+  hookRunner: ToolResultBridgeHookRunner;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+}): ToolResultHandler[] {
+  const factories = buildEmbeddedExtensionFactories({
+    cfg: undefined,
+    sessionManager: {} as SessionManager,
+    provider: "openai",
+    modelId: "gpt-5.4",
+    model: undefined,
+    hookRunner: params.hookRunner,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    runId: params.runId,
+  });
+  expect(factories).toHaveLength(1);
+
+  const handlers: ToolResultHandler[] = [];
+  for (const factory of factories) {
+    expect(factory).toBeTypeOf("function");
+    const on = vi.fn();
+    const api = {
+      on,
+    } as unknown as ExtensionAPI;
+    void factory?.(api);
+
+    const toolResultHandler = on.mock.calls.find(
+      ([eventName]) => eventName === "tool_result",
+    )?.[1] as ToolResultHandler | undefined;
+    expect(toolResultHandler).toBeTypeOf("function");
+    handlers.push(toolResultHandler as ToolResultHandler);
+  }
+
+  expect(handlers).toHaveLength(1);
+  return handlers;
+}
+
+async function emitToolResultThroughRunner(
+  event: ToolResultEvent,
+  handlers: ToolResultHandler[],
+): Promise<ToolResultEvent> {
+  const extensions = handlers.map((handler, index) => ({
+    path: `<test:${index + 1}>`,
+    handlers: new Map([["tool_result", [handler]]]),
+    tools: new Map(),
+    commands: new Map(),
+  }));
+  const runner = new ExtensionRunner(
+    extensions as never,
+    {} as never,
+    process.cwd(),
+    {} as SessionManager,
+    {} as never,
+  );
+  const emitted = await runner.emitToolResult(event);
+  return {
+    ...event,
+    ...emitted,
+  } as ToolResultEvent;
+}
+
+function createToolResultEvent(overrides: Partial<ToolResultEvent> = {}): ToolResultEvent {
+  return {
+    type: "tool_result",
+    toolName: "read",
+    toolCallId: "call_1",
+    input: { path: "README.md" },
+    content: [{ type: "text", text: "raw text" }],
+    details: { big: "x".repeat(100) },
+    isError: false,
+    ...overrides,
+  } as ToolResultEvent;
+}
+
+function getToolResultText(content: ToolResultEvent["content"]): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const [first] = content;
+  return first &&
+    typeof first === "object" &&
+    (first as { type?: unknown }).type === "text" &&
+    typeof (first as { text?: unknown }).text === "string"
+    ? ((first as { text: string }).text ?? "")
+    : "";
 }
 
 function expectSafeguardRuntime(
@@ -94,5 +194,342 @@ describe("buildEmbeddedExtensionFactories", () => {
     });
 
     expect(factories).toContain(contextPruningExtension);
+  });
+
+  it("omits the canonical tool-result bridge when no hook is registered", () => {
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: undefined,
+      sessionManager: {} as SessionManager,
+      provider: "openai",
+      modelId: "gpt-5.4",
+      model: undefined,
+      hookRunner: {
+        hasHooks: () => false,
+        runToolResultBeforeModel: () => undefined,
+      },
+    });
+
+    expect(factories).toEqual([]);
+  });
+
+  it("does not add an extensions override when the canonical bridge is absent", () => {
+    const override = buildEmbeddedExtensionsOverride({
+      hasToolResultBeforeModelBridge: false,
+    });
+
+    expect(override).toBeUndefined();
+  });
+
+  it("prioritizes the canonical tool-result bridge ahead of loaded extensions", () => {
+    const override = buildEmbeddedExtensionsOverride({
+      hasToolResultBeforeModelBridge: true,
+    });
+
+    const base = {
+      extensions: [
+        { path: "/tmp/ext-a", handlers: new Map(), tools: new Map(), commands: new Map() },
+        { path: "<inline:1>", handlers: new Map(), tools: new Map(), commands: new Map() },
+        { path: "<inline:2>", handlers: new Map(), tools: new Map(), commands: new Map() },
+        { path: "<inline:3>", handlers: new Map(), tools: new Map(), commands: new Map() },
+      ],
+      runtime: {} as never,
+      errors: [],
+    } as never;
+
+    const reordered = override?.(base);
+
+    expect(reordered?.extensions.map((extension: { path: string }) => extension.path)).toEqual([
+      "<inline:1>",
+      "/tmp/ext-a",
+      "<inline:2>",
+      "<inline:3>",
+    ]);
+  });
+
+  it("registers a tool_result bridge that canonicalizes same-turn results", () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(() => ({
+        text: "canonical text",
+      })),
+    };
+    const [captureToolResultHandler] = createToolResultBridgeHandlers({
+      hookRunner,
+      agentId: "main",
+      sessionKey: "session-1",
+      sessionId: "session-1-id",
+      runId: "run-1",
+    });
+    const event = createToolResultEvent();
+    const patch = captureToolResultHandler(event);
+
+    expect(hookRunner.runToolResultBeforeModel).toHaveBeenCalledWith(
+      {
+        toolName: "read",
+        toolCallId: "call_1",
+        text: "raw text",
+      },
+      {
+        agentId: "main",
+        sessionKey: "session-1",
+        sessionId: "session-1-id",
+        runId: "run-1",
+        toolName: "read",
+        toolCallId: "call_1",
+      },
+    );
+    expect(patch).toEqual({
+      content: [{ type: "text", text: "canonical text" }],
+    });
+  });
+
+  it("does not emit a tool_result patch for no-op canonical hooks", () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(() => undefined),
+    };
+    const [captureToolResultHandler] = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+    const event = createToolResultEvent({
+      details: undefined,
+    });
+    const patch = captureToolResultHandler(event);
+
+    expect(patch).toBeUndefined();
+  });
+
+  it("skips multi-block tool results", () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(),
+    };
+    const [captureToolResultHandler] = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+
+    const event = createToolResultEvent({
+      content: [
+        { type: "text", text: "first" },
+        { type: "text", text: "second" },
+      ],
+    });
+    expect(captureToolResultHandler(event)).toBeUndefined();
+    expect(hookRunner.runToolResultBeforeModel).not.toHaveBeenCalled();
+  });
+
+  it("skips mixed text and non-text tool results", () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(),
+    };
+    const [captureToolResultHandler] = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+
+    const event = createToolResultEvent({
+      content: [
+        { type: "text", text: "raw text" },
+        { type: "image", data: "abc", mimeType: "image/png" },
+      ] as ToolResultEvent["content"],
+    });
+    expect(captureToolResultHandler(event)).toBeUndefined();
+    expect(hookRunner.runToolResultBeforeModel).not.toHaveBeenCalled();
+  });
+
+  it("skips non-text tool results", () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(),
+    };
+    const [captureToolResultHandler] = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+
+    const event = createToolResultEvent({
+      content: [
+        { type: "image", data: "abc", mimeType: "image/png" },
+      ] as ToolResultEvent["content"],
+    });
+    expect(captureToolResultHandler(event)).toBeUndefined();
+    expect(hookRunner.runToolResultBeforeModel).not.toHaveBeenCalled();
+  });
+
+  it("normalizes string content returned by canonical hooks", () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(() => ({
+        text: "canonical string",
+      })),
+    };
+    const [captureToolResultHandler] = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+
+    const event = createToolResultEvent({
+      details: undefined,
+    });
+    const patch = captureToolResultHandler(event);
+
+    expect(patch).toEqual({
+      content: [{ type: "text", text: "canonical string" }],
+    });
+  });
+
+  it("ignores errored tool results at the canonicalization seam", () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(),
+    };
+    const [captureToolResultHandler] = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+    const event = createToolResultEvent({
+      details: { error: "boom" },
+      isError: true,
+    });
+    const patch = captureToolResultHandler(event);
+
+    expect(patch).toBeUndefined();
+    expect(hookRunner.runToolResultBeforeModel).not.toHaveBeenCalled();
+  });
+
+  it("later ordinary tool_result handlers observe canonical content before rewriting", async () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(() => ({
+        text: "canonical text",
+      })),
+    };
+    const bridgeHandlers = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+    let observedContent = "";
+    const ordinaryHandler: ToolResultHandler = (event) => {
+      observedContent = getToolResultText(event.content);
+      return {
+        content: [{ type: "text", text: "late overwrite" }],
+      };
+    };
+
+    const finalEvent = await emitToolResultThroughRunner(createToolResultEvent(), [
+      ...bridgeHandlers,
+      ordinaryHandler,
+    ]);
+
+    expect(observedContent).toBe("canonical text");
+    expect(finalEvent.content).toEqual([{ type: "text", text: "late overwrite" }]);
+    expect(finalEvent.details).toEqual({ big: "x".repeat(100) });
+  });
+
+  it("preserves later ordinary tool_result content rewrites over canonical content", async () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(() => ({
+        text: "canonical text",
+      })),
+    };
+    const bridgeHandlers = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+    const ordinaryHandler: ToolResultHandler = () => ({
+      content: [{ type: "text", text: "late overwrite" }],
+      details: { summary: "late overwrite" },
+    });
+
+    const finalEvent = await emitToolResultThroughRunner(createToolResultEvent(), [
+      ...bridgeHandlers,
+      ordinaryHandler,
+    ]);
+
+    expect(finalEvent.content).toEqual([{ type: "text", text: "late overwrite" }]);
+    expect(finalEvent.details).toEqual({ summary: "late overwrite" });
+  });
+
+  it("later ordinary tool_result handlers may still rewrite details", async () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(() => ({
+        text: "canonical text",
+      })),
+    };
+    const bridgeHandlers = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+    const ordinaryHandler: ToolResultHandler = () => ({
+      details: { summary: "late overwrite" },
+    });
+
+    const finalEvent = await emitToolResultThroughRunner(createToolResultEvent(), [
+      ...bridgeHandlers,
+      ordinaryHandler,
+    ]);
+
+    expect(finalEvent.content).toEqual([{ type: "text", text: "canonical text" }]);
+    expect(finalEvent.details).toEqual({ summary: "late overwrite" });
+  });
+
+  it("documents that later content reassignment without a returned patch is unsupported", async () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(() => undefined),
+    };
+    const bridgeHandlers = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+    const ordinaryHandler: ToolResultHandler = (event) => {
+      event.content = [{ type: "text", text: "late reassignment" }];
+      return undefined;
+    };
+
+    const finalEvent = await emitToolResultThroughRunner(createToolResultEvent(), [
+      ...bridgeHandlers,
+      ordinaryHandler,
+    ]);
+
+    // Without an explicit returned patch, ordinary tool_result content
+    // reassignment is not a supported override path and the raw result wins.
+    expect(finalEvent.content).toEqual([{ type: "text", text: "raw text" }]);
+  });
+
+  it("fails open when the canonical hook throws", async () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(() => {
+        throw new Error("boom");
+      }),
+    };
+    const bridgeHandlers = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+
+    const finalEvent = await emitToolResultThroughRunner(createToolResultEvent(), bridgeHandlers);
+
+    expect(finalEvent.content).toEqual([{ type: "text", text: "raw text" }]);
+    expect(finalEvent.details).toEqual({ big: "x".repeat(100) });
+  });
+
+  it("skips legacy string-backed tool results", async () => {
+    const hookRunner = {
+      hasHooks: (hookName: string) => hookName === "tool_result_before_model",
+      runToolResultBeforeModel: vi.fn(({ text }) => ({
+        text: `${text} [canonical]`,
+      })),
+    };
+    const bridgeHandlers = createToolResultBridgeHandlers({
+      hookRunner,
+    });
+
+    const finalEvent = await emitToolResultThroughRunner(
+      createToolResultEvent({
+        content: "raw string" as unknown as ToolResultEvent["content"],
+        details: { big: "x".repeat(100) },
+      }),
+      bridgeHandlers,
+    );
+
+    expect(hookRunner.runToolResultBeforeModel).not.toHaveBeenCalled();
+    expect(finalEvent.content).toBe("raw string");
+    expect(finalEvent.details).toEqual({ big: "x".repeat(100) });
   });
 });

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -1,5 +1,13 @@
-import type { ExtensionFactory, SessionManager } from "@mariozechner/pi-coding-agent";
+import type {
+  ExtensionAPI,
+  ExtensionFactory,
+  LoadExtensionsResult,
+  SessionManager,
+  ToolResultEvent,
+} from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { PluginHookToolResultBeforeModelContext } from "../../plugins/hook-types.js";
+import type { HookRunner } from "../../plugins/hooks.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
@@ -12,6 +20,140 @@ import { makeToolPrunablePredicate } from "../pi-hooks/context-pruning/tools.js"
 import { ensurePiCompactionReserveTokens } from "../pi-settings.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-ttl.js";
+
+type ToolResultBeforeModelHookRunner = Pick<HookRunner, "hasHooks" | "runToolResultBeforeModel">;
+// ResourceLoader assigns inline extension paths in factory order (`<inline:1>`,
+// `<inline:2>`, ...). We always register the early canonicalization bridge first.
+const TOOL_RESULT_BEFORE_MODEL_CAPTURE_INLINE_PATH = "<inline:1>";
+type ToolResultTextProjection = {
+  text: string;
+  toContent: (text: string) => ToolResultEvent["content"];
+};
+
+function getToolResultTextProjection(
+  content: ToolResultEvent["content"],
+): ToolResultTextProjection | undefined {
+  // Keep the hook aligned with the canonical tool_result shape that downstream
+  // truncation and context guards already understand. Legacy string-backed
+  // tool results are skipped rather than implicitly normalized here.
+  if (!Array.isArray(content) || content.length !== 1) {
+    return undefined;
+  }
+
+  const [block] = content;
+  if (
+    !block ||
+    typeof block !== "object" ||
+    (block as { type?: unknown }).type !== "text" ||
+    typeof (block as { text?: unknown }).text !== "string"
+  ) {
+    return undefined;
+  }
+
+  const baseBlock = { ...(block as unknown as Record<string, unknown>) };
+  return {
+    text: baseBlock.text as string,
+    toContent: (nextText) =>
+      [
+        {
+          ...baseBlock,
+          text: nextText,
+        },
+      ] as ToolResultEvent["content"],
+  };
+}
+
+function buildToolResultBeforeModelFactories(params: {
+  sessionManager: SessionManager;
+  hookRunner?: ToolResultBeforeModelHookRunner;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
+}): ExtensionFactory[] {
+  if (!params.hookRunner?.hasHooks("tool_result_before_model")) {
+    return [];
+  }
+
+  const hookContext: PluginHookToolResultBeforeModelContext = {
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    runId: params.runId,
+  };
+
+  const captureFactory: ExtensionFactory = (api: ExtensionAPI) => {
+    api.on("tool_result", (event) => {
+      if (event.isError) {
+        return undefined;
+      }
+
+      const projection = getToolResultTextProjection(event.content);
+      if (!projection) {
+        return undefined;
+      }
+
+      let nextText: string | undefined;
+      try {
+        nextText = params.hookRunner?.runToolResultBeforeModel(
+          {
+            toolName: event.toolName,
+            toolCallId: event.toolCallId,
+            text: projection.text,
+          },
+          {
+            ...hookContext,
+            toolName: event.toolName,
+            toolCallId: event.toolCallId,
+          },
+        )?.text;
+      } catch {
+        // The embedded bridge intentionally stays fail-open even if a custom
+        // hook runner was constructed with stricter failure handling.
+        return undefined;
+      }
+
+      if (typeof nextText !== "string" || nextText === projection.text) {
+        return undefined;
+      }
+
+      return {
+        content: projection.toContent(nextText),
+      };
+    });
+  };
+
+  return [captureFactory];
+}
+
+export function buildEmbeddedExtensionsOverride(params: {
+  hasToolResultBeforeModelBridge: boolean;
+}): ((base: LoadExtensionsResult) => LoadExtensionsResult) | undefined {
+  if (!params.hasToolResultBeforeModelBridge) {
+    return undefined;
+  }
+
+  return (base: LoadExtensionsResult) => {
+    const bridgeIndex = base.extensions.findIndex(
+      (extension) => extension.path === TOOL_RESULT_BEFORE_MODEL_CAPTURE_INLINE_PATH,
+    );
+    if (bridgeIndex <= 0) {
+      return base;
+    }
+
+    const reorderedExtensions = [...base.extensions];
+    const [bridgeExtension] = reorderedExtensions.splice(bridgeIndex, 1);
+    if (!bridgeExtension) {
+      return base;
+    }
+
+    reorderedExtensions.unshift(bridgeExtension);
+    return {
+      ...base,
+      extensions: reorderedExtensions,
+    };
+  };
+}
 
 function resolveContextWindowTokens(params: {
   cfg: OpenClawConfig | undefined;
@@ -83,8 +225,14 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  hookRunner?: ToolResultBeforeModelHookRunner;
+  agentId?: string;
+  sessionKey?: string;
+  sessionId?: string;
+  runId?: string;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
+  factories.push(...buildToolResultBeforeModelFactories(params));
   if (resolveCompactionMode(params.cfg) === "safeguard") {
     const compactionCfg = params.cfg?.agents?.defaults?.compaction;
     const qualityGuardCfg = compactionCfg?.qualityGuard;

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -270,6 +270,7 @@ vi.mock("../../pi-settings.js", () => ({
 
 vi.mock("../extensions.js", () => ({
   buildEmbeddedExtensionFactories: () => [],
+  buildEmbeddedExtensionsOverride: () => undefined,
 }));
 
 vi.mock("../replay-history.js", () => ({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -127,7 +127,7 @@ import { isRunnerAbortError } from "../abort.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { resolveCompactionTimeoutMs } from "../compaction-safety-timeout.js";
 import { runContextEngineMaintenance } from "../context-engine-maintenance.js";
-import { buildEmbeddedExtensionFactories } from "../extensions.js";
+import { buildEmbeddedExtensionFactories, buildEmbeddedExtensionsOverride } from "../extensions.js";
 import { applyExtraParamsToAgent, resolveAgentTransportOverride } from "../extra-params.js";
 import { prepareGooglePromptCacheStreamFn } from "../google-prompt-cache.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
@@ -930,15 +930,25 @@ export async function runEmbeddedAttempt(
         settingsManager,
         contextEngineInfo: params.contextEngine?.info,
       });
+      const hookRunner = getGlobalHookRunner();
 
       // Sets compaction/pruning runtime state and returns extension factories
-      // that must be passed to the resource loader for the safeguard to be active.
+      // that must be passed to the resource loader for embedded hooks and the
+      // safeguard to be active.
       const extensionFactories = buildEmbeddedExtensionFactories({
         cfg: params.config,
         sessionManager,
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        hookRunner: hookRunner ?? undefined,
+        agentId: sessionAgentId,
+        sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
+        runId: params.runId,
+      });
+      const extensionsOverride = buildEmbeddedExtensionsOverride({
+        hasToolResultBeforeModelBridge: !!hookRunner?.hasHooks("tool_result_before_model"),
       });
       // Only create an explicit resource loader when there are extension factories
       // to register; otherwise let createAgentSession use its built-in default.
@@ -949,12 +959,10 @@ export async function runEmbeddedAttempt(
           agentDir,
           settingsManager,
           extensionFactories,
+          extensionsOverride,
         });
         await resourceLoader.reload();
       }
-
-      // Get hook runner early so it's available when creating tools
-      const hookRunner = getGlobalHookRunner();
 
       const { builtInTools, customTools } = splitSdkTools({
         tools: effectiveTools,

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -240,6 +240,23 @@ describe("installToolResultContextGuard", () => {
 
     expectPiStyleTruncation(getToolResultText(transformed[0]));
   });
+
+  it("keeps under-budget tool results byte-stable across repeated guarded passes", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [makeToolResult("call_ok", "stable output")];
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 1_000,
+    });
+
+    const signal = new AbortController().signal;
+    const first = (await agent.transformContext?.(contextForNextCall, signal)) as AgentMessage[];
+    const second = (await agent.transformContext?.(contextForNextCall, signal)) as AgentMessage[];
+
+    expect(first).toBe(contextForNextCall);
+    expect(second).toBe(contextForNextCall);
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
 });
 
 type MockedEngine = ContextEngine & {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -754,6 +754,61 @@ describe("handleToolExecutionEnd derived tool events", () => {
     );
   });
 
+  it("keeps exec live output sourced from aggregated details when content is present", async () => {
+    const { ctx, onAgentEvent } = createTestContext();
+
+    await handleToolExecutionStart(
+      ctx as never,
+      {
+        type: "tool_execution_start",
+        toolName: "exec",
+        toolCallId: "tool-exec-canonical-live-output",
+        args: { command: "ls" },
+      } as never,
+    );
+
+    await handleToolExecutionEnd(
+      ctx as never,
+      {
+        type: "tool_execution_end",
+        toolName: "exec",
+        toolCallId: "tool-exec-canonical-live-output",
+        isError: false,
+        result: {
+          content: [{ type: "text", text: "canonical summary" }],
+          details: {
+            status: "completed",
+            aggregated: "raw stdout that should not drive live output",
+            exitCode: 0,
+            durationMs: 10,
+            cwd: "/tmp/work",
+          },
+        },
+      } as never,
+    );
+
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "command_output",
+        data: expect.objectContaining({
+          itemId: "command:tool-exec-canonical-live-output",
+          phase: "end",
+          output: "raw stdout that should not drive live output",
+          exitCode: 0,
+          cwd: "/tmp/work",
+        }),
+      }),
+    );
+    expect(onAgentEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "command_output",
+        data: expect.objectContaining({
+          output: "canonical summary",
+        }),
+      }),
+    );
+  });
+
   it("emits patch summary events for apply_patch results", async () => {
     const { ctx, onAgentEvent } = createTestContext();
 

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
@@ -11,8 +11,8 @@ import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "../plugins/hook-runner-global.js";
-import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
+import { loadOpenClawPlugins } from "../plugins/loader.js";
 import { buildEmbeddedExtensionFactories } from "./pi-embedded-runner/extensions.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 
@@ -304,8 +304,8 @@ describe("tool_result persistence with tool_result_before_model", () => {
 
     appendToolCallAndResult(sm);
     const toolResult = getPersistedToolResult(sm);
-    const text = toolResult.content.find((block: { type: string }) => block.type === "text")?.text;
-    expect(typeof text).toBe("string");
+    expect(toolResult).toBeTruthy();
+    const text = getToolResultText(toolResult);
     expect(text.length).toBeLessThanOrEqual(120);
     expect(text).toContain("truncated");
   });
@@ -486,8 +486,8 @@ describe("tool_result persistence with tool_result_before_model", () => {
 
     appendToolCallAndResult(sm);
     const toolResult = getPersistedToolResult(sm);
-    const text = toolResult.content.find((block: { type: string }) => block.type === "text")?.text;
-    expect(typeof text).toBe("string");
+    expect(toolResult).toBeTruthy();
+    const text = getToolResultText(toolResult);
     expect(text.length).toBeLessThanOrEqual(120);
     expect(text).toContain("truncated");
   });

--- a/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
+++ b/src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts
@@ -2,17 +2,40 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
-import { describe, expect, it, afterEach } from "vitest";
+import type { ToolResultEvent, SessionManager } from "@mariozechner/pi-coding-agent";
+import { SessionManager as PiSessionManager } from "@mariozechner/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExtensionRunner } from "../../node_modules/@mariozechner/pi-coding-agent/dist/core/extensions/runner.js";
 import {
+  getGlobalHookRunner,
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "../plugins/hook-runner-global.js";
 import { loadOpenClawPlugins } from "../plugins/loader.js";
+import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
+import { buildEmbeddedExtensionFactories } from "./pi-embedded-runner/extensions.js";
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 
 const EMPTY_PLUGIN_SCHEMA = { type: "object", additionalProperties: false, properties: {} };
 const originalBundledPluginsDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+
+type ToolResultPatch = {
+  content?: ToolResultEvent["content"];
+  details?: unknown;
+  isError?: boolean;
+};
+
+type ToolResultHandler = (
+  event: ToolResultEvent,
+) => ToolResultPatch | undefined | Promise<ToolResultPatch | undefined>;
+
+function appendToolCall(sm: ReturnType<typeof PiSessionManager.inMemory>) {
+  const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
+  appendMessage({
+    role: "assistant",
+    content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+  } as AgentMessage);
+}
 
 function writeTempPlugin(params: { dir: string; id: string; body: string }): string {
   const pluginDir = path.join(params.dir, params.id);
@@ -34,29 +57,163 @@ function writeTempPlugin(params: { dir: string; id: string; body: string }): str
   return file;
 }
 
-function appendToolCallAndResult(sm: ReturnType<typeof SessionManager.inMemory>) {
-  const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
-  appendMessage({
-    role: "assistant",
-    content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
-  } as AgentMessage);
-
-  appendMessage({
+function createToolResult(
+  text = "ok",
+  details: unknown = { big: "x".repeat(10_000) },
+): AgentMessage {
+  return {
     role: "toolResult",
     toolCallId: "call_1",
+    toolName: "read",
     isError: false,
-    content: [{ type: "text", text: "ok" }],
-    details: { big: "x".repeat(10_000) },
-  } as any);
+    content: [{ type: "text", text }],
+    ...(details !== undefined ? { details } : {}),
+  } as AgentMessage;
 }
 
-function getPersistedToolResult(sm: ReturnType<typeof SessionManager.inMemory>) {
-  const messages = sm
-    .getEntries()
-    .filter((e) => e.type === "message")
-    .map((e) => (e as { message: AgentMessage }).message);
+function appendToolResult(
+  sm: ReturnType<typeof PiSessionManager.inMemory>,
+  message: AgentMessage = createToolResult(),
+) {
+  const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
+  appendMessage({
+    ...(message as unknown as Record<string, unknown>),
+  } as unknown as AgentMessage);
+}
 
-  return messages.find((m) => (m as any).role === "toolResult") as any;
+function appendToolCallAndResult(sm: ReturnType<typeof PiSessionManager.inMemory>) {
+  appendToolCall(sm);
+  appendToolResult(sm);
+}
+
+function getPersistedMessages(sm: ReturnType<typeof PiSessionManager.inMemory>) {
+  return sm
+    .getEntries()
+    .filter((entry) => entry.type === "message")
+    .map((entry) => (entry as { message: AgentMessage }).message);
+}
+
+function getPersistedToolResult(sm: ReturnType<typeof PiSessionManager.inMemory>) {
+  return getPersistedMessages(sm).find(
+    (message) => (message as { role?: unknown }).role === "toolResult",
+  ) as (AgentMessage & { details?: unknown }) | undefined;
+}
+
+function getToolResultText(message: AgentMessage | undefined): string {
+  const content = (message as { content?: unknown } | undefined)?.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  const [first] = content;
+  return first &&
+    typeof first === "object" &&
+    (first as { type?: unknown }).type === "text" &&
+    typeof (first as { text?: unknown }).text === "string"
+    ? (first as { text: string }).text
+    : "";
+}
+
+function normalizeToolResultEventContent(content: unknown): ToolResultEvent["content"] {
+  if (Array.isArray(content)) {
+    return content as ToolResultEvent["content"];
+  }
+  if (typeof content === "string") {
+    return content as unknown as ToolResultEvent["content"];
+  }
+  return [];
+}
+
+function toToolResultEvent(message: AgentMessage): ToolResultEvent {
+  const record = message as unknown as Record<string, unknown>;
+  return {
+    type: "tool_result",
+    toolName: typeof record.toolName === "string" ? record.toolName : "read",
+    toolCallId: typeof record.toolCallId === "string" ? record.toolCallId : "call_1",
+    input: { path: "README.md" },
+    content: normalizeToolResultEventContent(record.content),
+    details: record.details,
+    isError: record.isError === true,
+  } as ToolResultEvent;
+}
+
+function applyToolResultPatch(message: AgentMessage, event: ToolResultEvent): AgentMessage {
+  return {
+    ...(message as unknown as Record<string, unknown>),
+    content: event.content,
+    ...(event.details !== undefined ? { details: event.details } : {}),
+  } as AgentMessage;
+}
+
+async function emitToolResultThroughRunner(
+  event: ToolResultEvent,
+  handlers: ToolResultHandler[],
+): Promise<ToolResultEvent> {
+  const extensions = handlers.map((handler, index) => ({
+    path: `<persist-test:${index + 1}>`,
+    handlers: new Map([["tool_result", [handler]]]),
+    tools: new Map(),
+    commands: new Map(),
+  }));
+  const runner = new ExtensionRunner(
+    extensions as never,
+    {} as never,
+    process.cwd(),
+    {} as SessionManager,
+    {} as never,
+  );
+  const emitted = await runner.emitToolResult(event);
+  return {
+    ...event,
+    ...emitted,
+  } as ToolResultEvent;
+}
+
+async function canonicalizeToolResultThroughBridge(
+  sessionManager: SessionManager,
+  message: AgentMessage,
+  extraHandlers: ToolResultHandler[] = [],
+  hookRunnerOverride:
+    | Parameters<typeof buildEmbeddedExtensionFactories>[0]["hookRunner"]
+    | null = null,
+): Promise<AgentMessage> {
+  const hookRunner = hookRunnerOverride ?? getGlobalHookRunner();
+  const factories = buildEmbeddedExtensionFactories({
+    cfg: undefined,
+    sessionManager,
+    provider: "openai",
+    modelId: "gpt-5.4",
+    model: undefined,
+    hookRunner: hookRunner ?? undefined,
+    agentId: "main",
+    sessionKey: "main",
+    sessionId: "session-1",
+    runId: "run-1",
+  });
+
+  const handlers: ToolResultHandler[] = [];
+  for (const factory of factories) {
+    const on = vi.fn();
+    void factory({ on } as never);
+    const toolResultHandler = on.mock.calls.find(
+      ([eventName]) => eventName === "tool_result",
+    )?.[1] as ToolResultHandler | undefined;
+    if (toolResultHandler) {
+      handlers.push(toolResultHandler);
+    }
+  }
+
+  if (handlers.length === 0 && extraHandlers.length === 0) {
+    return message;
+  }
+
+  const finalEvent = await emitToolResultThroughRunner(toToolResultEvent(message), [
+    ...handlers,
+    ...extraHandlers,
+  ]);
+  return applyToolResultPatch(message, finalEvent);
 }
 
 afterEach(() => {
@@ -68,73 +225,46 @@ afterEach(() => {
   }
 });
 
-describe("tool_result_persist hook", () => {
+describe("tool_result persistence with tool_result_before_model", () => {
   it("does not modify persisted toolResult messages when no hook is registered", () => {
-    const sm = guardSessionManager(SessionManager.inMemory(), {
+    const sm = guardSessionManager(PiSessionManager.inMemory(), {
       agentId: "main",
       sessionKey: "main",
     });
-    appendToolCallAndResult(sm);
+
+    appendToolCall(sm);
+    appendToolResult(sm);
+
     const toolResult = getPersistedToolResult(sm);
     expect(toolResult).toBeTruthy();
-    expect(toolResult.details).toBeTruthy();
+    expect(getToolResultText(toolResult)).toBe("ok");
+    expect(toolResult?.details).toEqual({ big: "x".repeat(10_000) });
   });
 
-  it("loads tool_result_persist hooks without breaking persistence", () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-toolpersist-"));
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
-
-    const pluginA = writeTempPlugin({
-      dir: tmp,
-      id: "persist-a",
-      body: `export default { id: "persist-a", register(api) {
-  api.on("tool_result_persist", (event, ctx) => {
-    const msg = event.message;
-    // Example: remove large diagnostic payloads before persistence.
-    const { details: _details, ...rest } = msg;
-    return { message: { ...rest, persistOrder: ["a"], agentSeen: ctx.agentId ?? null } };
-  }, { priority: 10 });
-} };`,
-    });
-
-    const pluginB = writeTempPlugin({
-      dir: tmp,
-      id: "persist-b",
-      body: `export default { id: "persist-b", register(api) {
-  api.on("tool_result_persist", (event) => {
-    const prior = (event.message && event.message.persistOrder) ? event.message.persistOrder : [];
-    return { message: { ...event.message, persistOrder: [...prior, "b"] } };
-  }, { priority: 5 });
-} };`,
-    });
-
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: tmp,
-      config: {
-        plugins: {
-          load: { paths: [pluginA, pluginB] },
-          allow: ["persist-a", "persist-b"],
+  it("persists canonical content by default while keeping raw details unchanged", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "tool_result_before_model",
+          pluginId: "canonical",
+          handler: () => ({ text: "canonical text" }),
         },
-      },
-    });
-    initializeGlobalHookRunner(registry);
+      ]),
+    );
 
-    const sm = guardSessionManager(SessionManager.inMemory(), {
+    const sm = guardSessionManager(PiSessionManager.inMemory(), {
       agentId: "main",
       sessionKey: "main",
     });
 
-    appendToolCallAndResult(sm);
+    appendToolCall(sm);
+    const canonical = await canonicalizeToolResultThroughBridge(sm, createToolResult("raw text"));
+    appendToolResult(sm, canonical);
+
     const toolResult = getPersistedToolResult(sm);
-    expect(toolResult).toBeTruthy();
-
-    // Hook registration should preserve a valid toolResult message shape.
-    expect(toolResult.role).toBe("toolResult");
-    expect(toolResult.toolCallId).toBe("call_1");
-    expect(Array.isArray(toolResult.content)).toBe(true);
+    expect(getToolResultText(toolResult)).toBe("canonical text");
+    expect(toolResult?.details).toEqual({ big: "x".repeat(10_000) });
   });
-
   it("reapplies the cap after tool_result_persist expands a tool result", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-toolpersist-expand-"));
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
@@ -166,7 +296,7 @@ describe("tool_result_persist hook", () => {
     });
     initializeGlobalHookRunner(registry);
 
-    const sm = guardSessionManager(SessionManager.inMemory(), {
+    const sm = guardSessionManager(PiSessionManager.inMemory(), {
       agentId: "main",
       sessionKey: "main",
       contextWindowTokens: 100,
@@ -179,53 +309,141 @@ describe("tool_result_persist hook", () => {
     expect(text.length).toBeLessThanOrEqual(120);
     expect(text).toContain("truncated");
   });
-});
 
-describe("before_message_write hook", () => {
-  it("continues persistence when a before_message_write hook throws", () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-before-write-"));
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
-
-    const plugin = writeTempPlugin({
-      dir: tmp,
-      id: "before-write-throws",
-      body: `export default { id: "before-write-throws", register(api) {
-  api.on("before_message_write", () => {
-    throw new Error("boom");
-  }, { priority: 10 });
-} };`,
-    });
-
-    const registry = loadOpenClawPlugins({
-      cache: false,
-      workspaceDir: tmp,
-      config: {
-        plugins: {
-          load: { paths: [plugin] },
-          allow: ["before-write-throws"],
+  it("persists later ordinary tool_result content rewrites after early canonicalization", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "tool_result_before_model",
+          pluginId: "canonical",
+          handler: () => ({ text: "canonical text" }),
         },
-      },
-    });
-    initializeGlobalHookRunner(registry);
+      ]),
+    );
 
-    const sm = guardSessionManager(SessionManager.inMemory(), {
+    const sm = guardSessionManager(PiSessionManager.inMemory(), {
       agentId: "main",
       sessionKey: "main",
     });
-    const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
-    appendMessage({
-      role: "user",
-      content: "hello",
-      timestamp: Date.now(),
+
+    appendToolCall(sm);
+    const canonical = await canonicalizeToolResultThroughBridge(sm, createToolResult("raw text"), [
+      () => ({
+        content: [{ type: "text", text: "late overwrite" }],
+      }),
+    ]);
+    appendToolResult(sm, canonical);
+
+    expect(getToolResultText(getPersistedToolResult(sm))).toBe("late overwrite");
+  });
+
+  it("lets tool_result_persist observe canonical content plus raw details and rewrite the transcript", async () => {
+    const seen = {
+      content: "",
+      details: undefined as unknown,
+    };
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "tool_result_before_model",
+          pluginId: "canonical",
+          handler: (event) => {
+            const hookEvent = event as { text: string };
+            return { text: `${hookEvent.text} [canonical]` };
+          },
+        },
+        {
+          hookName: "tool_result_persist",
+          pluginId: "persist",
+          handler: (event) => {
+            const persistEvent = event as { message: AgentMessage & { details?: unknown } };
+            seen.content = getToolResultText(persistEvent.message);
+            seen.details = persistEvent.message.details;
+            return {
+              message: {
+                ...(persistEvent.message as unknown as Record<string, unknown>),
+                content: [{ type: "text", text: "persisted text" }],
+                details: { summary: "persisted" },
+              } as AgentMessage,
+            };
+          },
+        },
+      ]),
+    );
+
+    const sm = guardSessionManager(PiSessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    appendToolCall(sm);
+    const canonical = await canonicalizeToolResultThroughBridge(sm, createToolResult("raw text"));
+    appendToolResult(sm, canonical);
+
+    expect(seen.content).toBe("raw text [canonical]");
+    expect(seen.details).toEqual({ big: "x".repeat(10_000) });
+    const persisted = getPersistedToolResult(sm);
+    expect(getToolResultText(persisted)).toBe("persisted text");
+    expect(persisted?.details).toEqual({ summary: "persisted" });
+  });
+
+  it("does not invent empty details objects for no-details tools", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "tool_result_before_model",
+          pluginId: "canonical",
+          handler: () => ({ text: "canonical text" }),
+        },
+      ]),
+    );
+
+    const sm = guardSessionManager(PiSessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    appendToolCall(sm);
+    const canonical = await canonicalizeToolResultThroughBridge(sm, {
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      isError: false,
+      content: [{ type: "text", text: "raw text" }],
     } as AgentMessage);
+    appendToolResult(sm, canonical);
 
-    const messages = sm
-      .getEntries()
-      .filter((e) => e.type === "message")
-      .map((e) => (e as { message: AgentMessage }).message);
+    const persisted = getPersistedToolResult(sm) as Record<string, unknown> | undefined;
+    expect(getToolResultText(persisted as AgentMessage | undefined)).toBe("canonical text");
+    expect(persisted).toBeTruthy();
+    expect((persisted as { details?: unknown } | undefined)?.details).toBeUndefined();
+  });
 
-    expect(messages).toHaveLength(1);
-    expect(messages[0]?.role).toBe("user");
+  it("preserves raw persisted content when tool_result_before_model throws", async () => {
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "tool_result_before_model",
+          pluginId: "boom",
+          handler: () => {
+            throw new Error("boom");
+          },
+        },
+      ]),
+    );
+
+    const sm = guardSessionManager(PiSessionManager.inMemory(), {
+      agentId: "main",
+      sessionKey: "main",
+    });
+
+    appendToolCall(sm);
+    const canonical = await canonicalizeToolResultThroughBridge(sm, createToolResult("raw text"));
+    appendToolResult(sm, canonical);
+
+    const persisted = getPersistedToolResult(sm);
+    expect(getToolResultText(persisted)).toBe("raw text");
+    expect(persisted?.details).toEqual({ big: "x".repeat(10_000) });
   });
 
   it("reapplies the cap after before_message_write expands a tool result", () => {
@@ -260,7 +478,7 @@ describe("before_message_write hook", () => {
     });
     initializeGlobalHookRunner(registry);
 
-    const sm = guardSessionManager(SessionManager.inMemory(), {
+    const sm = guardSessionManager(PiSessionManager.inMemory(), {
       agentId: "main",
       sessionKey: "main",
       contextWindowTokens: 100,

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -197,6 +197,10 @@ export function installSessionToolResultGuard(
       if (id) {
         pendingState.delete(id);
       }
+      // `nextMessage` already reflects any earlier content canonicalization
+      // performed by tool_result_before_model before the final tool-result
+      // message was emitted. Runtime details stay raw here unless some later
+      // persistence hook rewrites them.
       const normalizedToolResult = normalizePersistedToolResultName(nextMessage, toolName);
       // Apply hard size cap before persistence to prevent oversized tool results
       // from consuming the entire context window on subsequent LLM calls.

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -70,6 +70,7 @@ export type PluginHookName =
   | "before_tool_call"
   | "after_tool_call"
   | "tool_result_persist"
+  | "tool_result_before_model"
   | "before_message_write"
   | "session_start"
   | "session_end"
@@ -101,6 +102,7 @@ export const PLUGIN_HOOK_NAMES = [
   "before_tool_call",
   "after_tool_call",
   "tool_result_persist",
+  "tool_result_before_model",
   "before_message_write",
   "session_start",
   "session_end",
@@ -128,6 +130,7 @@ export const isPluginHookName = (hookName: unknown): hookName is PluginHookName 
 export const PROMPT_INJECTION_HOOK_NAMES = [
   "before_prompt_build",
   "before_agent_start",
+  "tool_result_before_model",
 ] as const satisfies readonly PluginHookName[];
 
 export type PromptInjectionHookName = (typeof PROMPT_INJECTION_HOOK_NAMES)[number];
@@ -341,12 +344,49 @@ export type PluginHookToolResultPersistContext = {
 export type PluginHookToolResultPersistEvent = {
   toolName?: string;
   toolCallId?: string;
+  /**
+   * The toolResult message about to be written to the session transcript.
+   * By default this already reflects any earlier content canonicalization from
+   * tool_result_before_model. Raw details stay untouched unless some other
+   * hook rewrites them.
+   * Handlers may return a modified message (e.g. drop non-essential fields).
+   */
   message: AgentMessage;
   isSynthetic?: boolean;
 };
 
 export type PluginHookToolResultPersistResult = {
   message?: AgentMessage;
+};
+
+export type PluginHookToolResultBeforeModelContext = PluginHookToolResultPersistContext & {
+  sessionId?: string;
+  runId?: string;
+};
+
+export type PluginHookToolResultBeforeModelEvent = {
+  toolName?: string;
+  toolCallId?: string;
+  /**
+   * The single model-facing text payload extracted from a successful tool
+   * result before same-turn continuation and before the default transcript
+   * persistence path.
+   *
+   * v0 only runs when the tool result content is exactly one text block.
+   * Legacy plain-string content is skipped. The hook is content-only: it never
+   * reads or writes runtime details metadata. If a handler returns `{ text }`,
+   * later same-turn tool_result handlers run on that canonicalized event, and
+   * default transcript persistence follows the final emitted tool result
+   * content. Plugin errors fail open and leave the original tool result
+   * unchanged. Plugins should use explicit returned patches for downstream
+   * rewrites; mutation-only side effects continue to follow the underlying
+   * tool_result runner semantics.
+   */
+  text: string;
+};
+
+export type PluginHookToolResultBeforeModelResult = {
+  text?: string;
 };
 
 export type PluginHookBeforeMessageWriteEvent = {
@@ -639,6 +679,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookToolResultPersistEvent,
     ctx: PluginHookToolResultPersistContext,
   ) => PluginHookToolResultPersistResult | void;
+  tool_result_before_model: (
+    event: PluginHookToolResultBeforeModelEvent,
+    ctx: PluginHookToolResultBeforeModelContext,
+  ) => PluginHookToolResultBeforeModelResult | void;
   before_message_write: (
     event: PluginHookBeforeMessageWriteEvent,
     ctx: { agentId?: string; sessionKey?: string },

--- a/src/plugins/hooks.sync-only.test.ts
+++ b/src/plugins/hooks.sync-only.test.ts
@@ -1,6 +1,10 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
-import { createHookRunner, type HookRunnerLogger } from "./hooks.js";
+import {
+  createHookRunner,
+  type HookRunnerLogger,
+  type PluginHookToolResultBeforeModelContext,
+} from "./hooks.js";
 import { createMockPluginRegistry } from "./hooks.test-helpers.js";
 
 function createToolResultMessage(text: string): AgentMessage {
@@ -22,6 +26,11 @@ function createLogger(): HookRunnerLogger & {
     warn,
     error,
   };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 describe("sync-only plugin hooks", () => {
@@ -77,6 +86,135 @@ describe("sync-only plugin hooks", () => {
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining(
         "before_message_write handler from async-before-write returned a Promise",
+      ),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("warns and ignores accidental async tool_result_before_model handlers", () => {
+    const logger = createLogger();
+    const originalText = "original";
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "tool_result_before_model",
+          pluginId: "async-before-model",
+          handler: async () => ({ text: "replacement" }),
+        },
+      ]),
+      { logger },
+    );
+
+    const result = runner.runToolResultBeforeModel(
+      { toolName: "read", toolCallId: "call_1", text: originalText },
+      {
+        agentId: "agent-1",
+        sessionKey: "session-1",
+        sessionId: "session-1-id",
+        runId: "run-1",
+        toolName: "read",
+        toolCallId: "call_1",
+      },
+    );
+
+    expect(result).toEqual({ text: originalText });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "tool_result_before_model handler from async-before-model returned a Promise",
+      ),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("does not leak pre-await context mutations from async tool_result_before_model handlers", () => {
+    const logger = createLogger();
+    const originalText = "original";
+    let seenRunId: string | undefined;
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "tool_result_before_model",
+          pluginId: "async-before-model-mutate",
+          handler: async (_event, ctx) => {
+            const hookCtx = ctx as PluginHookToolResultBeforeModelContext;
+            hookCtx.runId = "mutated-run-id";
+            await Promise.resolve();
+            return undefined;
+          },
+        },
+        {
+          hookName: "tool_result_before_model",
+          pluginId: "ctx-observer",
+          handler: (_event, ctx) => {
+            seenRunId = (ctx as PluginHookToolResultBeforeModelContext).runId;
+            return undefined;
+          },
+        },
+      ]),
+      { logger },
+    );
+
+    const result = runner.runToolResultBeforeModel(
+      { toolName: "read", toolCallId: "call_1", text: originalText },
+      {
+        agentId: "agent-1",
+        sessionKey: "session-1",
+        sessionId: "session-1-id",
+        runId: "run-1",
+        toolName: "read",
+        toolCallId: "call_1",
+      },
+    );
+
+    expect(result).toEqual({ text: originalText });
+    expect(seenRunId).toBe("run-1");
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "tool_result_before_model handler from async-before-model-mutate returned a Promise",
+      ),
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("observes later rejections from ignored async tool_result_before_model handlers", async () => {
+    const logger = createLogger();
+    const originalText = "original";
+    const runner = createHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "tool_result_before_model",
+          pluginId: "async-before-model-reject",
+          handler: async () => {
+            await Promise.resolve();
+            throw new Error("later boom");
+          },
+        },
+      ]),
+      { logger },
+    );
+
+    const result = runner.runToolResultBeforeModel(
+      { toolName: "read", toolCallId: "call_1", text: originalText },
+      {
+        agentId: "agent-1",
+        sessionKey: "session-1",
+        sessionId: "session-1-id",
+        runId: "run-1",
+        toolName: "read",
+        toolCallId: "call_1",
+      },
+    );
+
+    expect(result).toEqual({ text: originalText });
+    await flushMicrotasks();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "tool_result_before_model handler from async-before-model-reject returned a Promise",
+      ),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "tool_result_before_model handler from async-before-model-reject returned a Promise and later rejected: Error: later boom",
       ),
     );
     expect(logger.error).not.toHaveBeenCalled();

--- a/src/plugins/hooks.tool-result-before-model.test.ts
+++ b/src/plugins/hooks.tool-result-before-model.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createHookRunner } from "./hooks.js";
+import { addTestHook } from "./hooks.test-helpers.js";
+import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
+import type {
+  PluginHookRegistration,
+  PluginHookToolResultBeforeModelContext,
+  PluginHookToolResultBeforeModelEvent,
+  PluginHookToolResultBeforeModelResult,
+} from "./types.js";
+
+const stubEvent: PluginHookToolResultBeforeModelEvent = {
+  toolName: "read",
+  toolCallId: "call_1",
+  text: "original",
+};
+
+const stubCtx: PluginHookToolResultBeforeModelContext = {
+  agentId: "agent-1",
+  sessionKey: "session-1",
+  sessionId: "session-1-id",
+  runId: "run-1",
+  toolName: "read",
+  toolCallId: "call_1",
+};
+
+describe("tool_result_before_model hook", () => {
+  let registry: PluginRegistry;
+
+  beforeEach(() => {
+    registry = createEmptyPluginRegistry();
+  });
+
+  function addHook(params: {
+    pluginId: string;
+    priority?: number;
+    handler: (
+      event: PluginHookToolResultBeforeModelEvent,
+      ctx: PluginHookToolResultBeforeModelContext,
+    ) => PluginHookToolResultBeforeModelResult | void;
+  }) {
+    addTestHook({
+      registry,
+      pluginId: params.pluginId,
+      hookName: "tool_result_before_model",
+      handler: params.handler as PluginHookRegistration["handler"],
+      priority: params.priority,
+    });
+  }
+
+  it("replaces the canonical text for a single hook", () => {
+    addHook({
+      pluginId: "single",
+      handler: () => ({ text: "replacement" }),
+    });
+
+    const runner = createHookRunner(registry);
+    const result = runner.runToolResultBeforeModel(stubEvent, stubCtx);
+
+    expect(result).toEqual({ text: "replacement" });
+  });
+
+  it("chains replacements across multiple hooks in priority order", () => {
+    addHook({
+      pluginId: "high",
+      priority: 10,
+      handler: (event) => ({ text: `${event.text} -> high` }),
+    });
+    addHook({
+      pluginId: "low",
+      priority: 5,
+      handler: (event) => ({ text: `${event.text} -> low` }),
+    });
+
+    const runner = createHookRunner(registry);
+    const result = runner.runToolResultBeforeModel(stubEvent, stubCtx);
+
+    expect(result).toEqual({ text: "original -> high -> low" });
+  });
+
+  it("treats empty handler returns as no-op", () => {
+    addHook({
+      pluginId: "noop",
+      handler: () => ({}),
+    });
+
+    const runner = createHookRunner(registry);
+    const result = runner.runToolResultBeforeModel(stubEvent, stubCtx);
+
+    expect(result).toEqual({ text: "original" });
+  });
+
+  it("ignores invalid non-string replacement values", () => {
+    addHook({
+      pluginId: "invalid",
+      handler: () => ({ text: 123 as unknown as string }),
+    });
+
+    const runner = createHookRunner(registry);
+    const result = runner.runToolResultBeforeModel(stubEvent, stubCtx);
+
+    expect(result).toEqual({ text: "original" });
+  });
+
+  it("passes tool identity through unchanged", () => {
+    const seen = vi.fn();
+    addHook({
+      pluginId: "inspect",
+      handler: (event, ctx) => {
+        seen(event, ctx);
+        return undefined;
+      },
+    });
+
+    const runner = createHookRunner(registry);
+    const result = runner.runToolResultBeforeModel(stubEvent, stubCtx);
+
+    expect(result).toEqual({ text: "original" });
+    expect(seen).toHaveBeenCalledWith(stubEvent, stubCtx);
+  });
+
+  it("fails open when a handler throws", () => {
+    const logger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    addHook({
+      pluginId: "boom",
+      handler: () => {
+        throw new Error("boom");
+      },
+    });
+
+    const runner = createHookRunner(registry, { logger });
+    const result = runner.runToolResultBeforeModel(stubEvent, stubCtx);
+
+    expect(result).toEqual({ text: "original" });
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("tool_result_before_model handler from boom failed"),
+    );
+  });
+});

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -4,7 +4,6 @@
  * Provides utilities for executing plugin lifecycle hooks with proper
  * error handling, priority ordering, and async support.
  */
-
 import { formatErrorMessage } from "../infra/errors.js";
 import { concatOptionalTextSegments } from "../shared/text/join-segments.js";
 import type { GlobalHookRunnerRegistry, HookRunnerRegistry } from "./hook-registry.types.js";
@@ -57,6 +56,9 @@ import type {
   PluginHookSubagentEndedEvent,
   PluginHookSubagentSpawnedEvent,
   PluginHookToolContext,
+  PluginHookToolResultBeforeModelContext,
+  PluginHookToolResultBeforeModelEvent,
+  PluginHookToolResultBeforeModelResult,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
@@ -102,6 +104,9 @@ export type {
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginHookAfterToolCallEvent,
+  PluginHookToolResultBeforeModelContext,
+  PluginHookToolResultBeforeModelEvent,
+  PluginHookToolResultBeforeModelResult,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
   PluginHookToolResultPersistResult,
@@ -174,7 +179,7 @@ export type PluginTargetedInboundClaimOutcome =
       error: string;
     };
 
-type SyncHookName = "tool_result_persist" | "before_message_write";
+type SyncHookName = "tool_result_persist" | "tool_result_before_model" | "before_message_write";
 type SyncHookHandler<K extends SyncHookName> = NonNullable<PluginHookRegistration<K>["handler"]>;
 type SyncHookEvent<K extends SyncHookName> = Parameters<SyncHookHandler<K>>[0];
 type SyncHookContext<K extends SyncHookName> = Parameters<SyncHookHandler<K>>[1];
@@ -307,8 +312,26 @@ export function createHookRunner(
     event: SyncHookEvent<K>,
     ctx: SyncHookContext<K>,
   ): SyncHookResult<K> | PromiseLike<unknown> => {
-    const handler = hook.handler as SyncHookHandler<K>;
-    return handler(event, ctx) as SyncHookResult<K> | PromiseLike<unknown>;
+    const handler = hook.handler as (
+      event: SyncHookEvent<K>,
+      ctx: SyncHookContext<K>,
+    ) => SyncHookResult<K> | PromiseLike<unknown>;
+    return handler(event, ctx);
+  };
+
+  const observeIgnoredSyncHookPromise = (
+    hookName: SyncHookName,
+    pluginId: string,
+    promise: PromiseLike<unknown>,
+  ): void => {
+    void promise.then(
+      () => undefined,
+      (err) => {
+        logger?.warn?.(
+          `[hooks] ${hookName} handler from ${pluginId} returned a Promise and later rejected: ${String(err)}`,
+        );
+      },
+    );
   };
 
   /**
@@ -875,6 +898,63 @@ export function createHookRunner(
     return { message: current };
   }
 
+  /**
+   * Run tool_result_before_model hook.
+   *
+   * This hook is intentionally synchronous: it runs immediately after a
+   * successful raw tool result exists and before same-turn continuation plus
+   * default transcript persistence.
+   *
+   * Handlers are executed sequentially in priority order (higher first). Each
+   * handler may return `{ text }` to replace the text passed to the next
+   * handler. This seam is intentionally text-only: it never clones or composes
+   * the full toolResult message and leaves runtime details untouched.
+   */
+  function runToolResultBeforeModel(
+    event: PluginHookToolResultBeforeModelEvent,
+    ctx: PluginHookToolResultBeforeModelContext,
+  ): PluginHookToolResultBeforeModelResult | undefined {
+    const hooks = getHooksForName(registry, "tool_result_before_model");
+    if (hooks.length === 0) {
+      return undefined;
+    }
+
+    let current = event.text;
+
+    for (const hook of hooks) {
+      try {
+        const out = runSyncHookHandler(hook, { ...event, text: current }, { ...ctx });
+
+        // Guard against accidental async handlers (this hook is sync-only).
+        if (isPromiseLike(out)) {
+          observeIgnoredSyncHookPromise("tool_result_before_model", hook.pluginId, out);
+          const msg =
+            `[hooks] tool_result_before_model handler from ${hook.pluginId} returned a Promise; ` +
+            `this hook is synchronous and the result was ignored.`;
+          if (shouldCatchHookErrors("tool_result_before_model")) {
+            logger?.warn?.(msg);
+            continue;
+          }
+          throw new Error(msg);
+        }
+
+        const next = (out as PluginHookToolResultBeforeModelResult | undefined)?.text;
+        if (typeof next === "string") {
+          current = next;
+        }
+      } catch (err) {
+        const msg = `[hooks] tool_result_before_model handler from ${hook.pluginId} failed: ${String(err)}`;
+        if (shouldCatchHookErrors("tool_result_before_model")) {
+          logger?.error(msg);
+        } else {
+          throw new Error(msg, { cause: err });
+        }
+      }
+    }
+
+    return { text: current };
+  }
+
   // =========================================================================
   // Message Write Hooks
   // =========================================================================
@@ -1131,6 +1211,7 @@ export function createHookRunner(
     runBeforeToolCall,
     runAfterToolCall,
     runToolResultPersist,
+    runToolResultBeforeModel,
     // Message write hooks
     runBeforeMessageWrite,
     // Session hooks

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3905,6 +3905,43 @@ module.exports = {
     expect(constrainedDiagnostics).toHaveLength(1);
   });
 
+  it("blocks tool_result_before_model when prompt injection is disabled", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "hook-policy-before-model",
+      filename: "hook-policy-before-model.cjs",
+      body: `module.exports = { id: "hook-policy-before-model", register(api) {
+  api.on("tool_result_before_model", () => ({ text: "rewritten" }));
+} };`,
+    });
+
+    const registry = loadRegistryFromSinglePlugin({
+      plugin,
+      pluginConfig: {
+        allow: ["hook-policy-before-model"],
+        entries: {
+          "hook-policy-before-model": {
+            hooks: {
+              allowPromptInjection: false,
+            },
+          },
+        },
+      },
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "hook-policy-before-model")?.status).toBe(
+      "loaded",
+    );
+    expect(registry.typedHooks.map((entry) => entry.hookName)).toEqual([]);
+    expect(
+      registry.diagnostics.some((diag) =>
+        diag.message.includes(
+          'typed hook "tool_result_before_model" blocked by plugins.entries.hook-policy-before-model.hooks.allowPromptInjection=false',
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("keeps prompt-injection typed hooks enabled by default", () => {
     useNoBundledPlugins();
     const plugin = writePlugin({

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1041,7 +1041,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     }
     let effectiveHandler = handler;
     if (policy?.allowPromptInjection === false && isPromptInjectionHookName(hookName)) {
-      if (hookName === "before_prompt_build") {
+      if (hookName === "before_prompt_build" || hookName === "tool_result_before_model") {
         pushDiagnostic({
           level: "warn",
           pluginId: record.id,


### PR DESCRIPTION
## Summary

- Problem: plugins had no typed seam to canonicalize successful tool-result text before it became model-visible by default, so noisy tool output could leak into same-turn and future-turn context.
- What changed: added synchronous `tool_result_before_model` as an early hook in the embedded `tool_result` chain, and classified it as a prompt-injecting hook so existing `allowPromptInjection=false` policy continues to apply.
- Final scope: the hook is text-only and content-only. It only runs for successful tool results whose `content` is exactly one text block, leaves `details` untouched, and skips legacy plain-string content.
- Behavior: if a handler returns `{ text }`, later same-turn `tool_result` handlers see that text as the new base, default transcript persistence follows the final emitted tool result, and hook failures fail open.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34144
- Related #14544
- Related #62123
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/plugins/hooks.tool-result-before-model.test.ts`
  - `src/plugins/hooks.sync-only.test.ts`
  - `src/agents/pi-embedded-runner/extensions.test.ts`
  - `src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts`
  - `src/agents/pi-embedded-runner/tool-result-context-guard.test.ts`
  - `src/agents/pi-embedded-runner/tool-result-truncation.test.ts`
- Scenario the test should lock in: successful tool results with exactly one text block can be canonicalized early, later ordinary `tool_result` handlers run on canonical text as the new base, downstream rewrites should use explicit returned content patches, mutation-only side effects continue to follow the existing runner semantics, raw `details` stay untouched, default transcript persistence follows the final emitted tool result, and legacy plain-string content is skipped.
- Why this is the smallest reliable guardrail: the behavior crosses the public hook contract, the embedded runner `tool_result` chain, and transcript truncation/persistence boundaries, so seam-level coverage is the narrowest reliable level.
- Existing test that already covers this (if any): the targeted seam/integration suites above cover the touched contract and runtime boundaries.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Plugin authors can now use `tool_result_before_model` to rewrite a single model-facing tool-result text payload before same-turn continuation.

In v0, the hook only runs for successful tool results whose `content` is exactly one text block. It leaves `details` untouched, skips legacy plain-string content, and default transcript persistence follows the final emitted tool result.

There are no new config knobs or UI changes.

## Diagram (if applicable)

```text
Before:
[tool returns raw text block]
  -> [later tool_result handlers see raw text]
  -> [default transcript stores raw text]

After:
[tool returns raw text block]
  -> [tool_result_before_model canonicalizes text]
  -> [later tool_result handlers see canonical text as the new base]
  -> [default transcript stores final emitted text]
  -> [optional tool_result_persist may still rewrite transcript-specific output]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

This adds a new trusted-plugin capability to rewrite only model-facing text for successful tool results before same-turn continuation and default transcript persistence. The scope is intentionally narrow: it only runs when tool-result `content` is exactly one text block, it never rewrites runtime `details`, it skips legacy plain-string content, and handler failures fail open. It does not grant new tool permissions, network access, secret access, or host-level raw artifact access. Risk remains bounded by the existing plugin trust model, the synchronous, content-only contract, and the existing `allowPromptInjection=false` host policy, which now blocks this hook for policy-restricted plugins.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Integration/channel (if any): embedded runner + local test/build gates
- Relevant config (redacted): local plugin SDK development branch

### Steps

1. Register a `tool_result_before_model` handler that returns `{ text: ... }`.
2. Run a successful tool result whose `content` is exactly one text block through the embedded `tool_result` chain.
3. Verify that later ordinary `tool_result` handlers see canonical text as the new base, raw `details` stay untouched, and legacy plain-string content is skipped.

### Expected

- The hook only runs for successful tool results with exactly one text block.
- Later ordinary `tool_result` handlers run on canonical text as the new base; downstream rewrites should use explicit returned content patches, while mutation-only side effects continue to follow the existing runner semantics.
- Raw `details` remain unchanged by default.
- Default transcript persistence follows the final emitted tool result.
- Legacy plain-string content is skipped.

### Actual

- Verified locally through targeted seam/integration tests and build validation on this branch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Notes:
- Branch-local verification commands passed:
  - `OPENCLAW_LOCAL_CHECK=0 pnpm test src/plugins/hooks.tool-result-before-model.test.ts src/plugins/hooks.sync-only.test.ts src/agents/pi-embedded-runner/extensions.test.ts src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts src/agents/pi-embedded-runner/tool-result-context-guard.test.ts src/agents/pi-embedded-runner/tool-result-truncation.test.ts`
  - `OPENCLAW_LOCAL_CHECK=0 pnpm build`
- The screenshots below are preserved from the earlier local demo of same-turn canonicalization and are retained as illustrative evidence only; the authoritative final contract for this PR is the narrowed text-only behavior described above and covered by the targeted tests.

Screenshots:

Before:
<img width="1526" height="660" alt="before-1" src="https://github.com/user-attachments/assets/938a401d-40a5-49ac-9f6c-401e08c14355" />
<img width="592" height="611" alt="before-2" src="https://github.com/user-attachments/assets/22a9f898-2a76-4fb4-8fdf-6603d7ca5071" />

After:
<img width="1554" height="752" alt="after" src="https://github.com/user-attachments/assets/49c3e4bc-7fbf-45cd-8eb3-33eab15373a9" />

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - early same-turn text canonicalization for successful tool results with exactly one text block
  - later ordinary `tool_result` handlers see canonical text as the new base
  - later ordinary `tool_result` handlers run on canonical text as the new base; explicit returned content patches remain covered in the targeted tests, while mutation-only side effects continue to follow the existing runner semantics
  - raw `details` remain untouched by this hook
  - default transcript persistence follows the final emitted tool result
  - legacy plain-string tool results are skipped
- Edge cases checked:
  - multi-block tool results are skipped
  - mixed text and non-text tool results are skipped
  - non-text tool results are skipped
  - hook failures fail open
- What you did **not** verify:
  - async hook semantics
  - any `details` canonicalization path
  - multi-block or non-text canonicalization beyond skip behavior
  - a fresh UI demo for the final narrowed contract

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk:
  - trusted plugins can now rewrite successful model-facing tool-result text before same-turn continuation and default transcript persistence
  - Mitigation:
    - limited to trusted plugins
    - synchronous typed hook only
    - content-only scope
    - raw `details` untouched
    - fail-open behavior
    - focused seam and integration coverage

- Risk:
  - plugin authors may assume this hook also supports metadata rewriting or legacy plain-string tool results
  - Mitigation:
    - v0 is explicitly limited to exactly one text block
    - legacy plain-string content is skipped
    - metadata and transcript-specific shaping remain in `tool_result_persist`




