### PR TITLE
fix(feishu): route topic-group messages through per-thread sequential lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/sessions: keep topic-scoped session initialization on the canonical topic transcript path when inbound turns omit `MessageThreadId`, so one topic session no longer alternates between bare and topic-qualified transcript files. (#64869) thanks @jalehman.
 - Agents/failover: scope assistant-side fallback classification and surfaced provider errors to the current attempt instead of stale session history, so cross-provider fallback runs stop inheriting the previous provider's failure. (#62907) Thanks @stainlu.
 - MiniMax/OAuth: write `api: "anthropic-messages"` and `authHeader: true` into the `minimax-portal` config patch during `openclaw configure`, so re-authenticated portal setups keep Bearer auth routing working. (#64964) Thanks @ryanlee666.
+- Feishu: route topic-group messages through per-thread sequential lanes so different topics in the same chat run concurrently instead of queuing behind each other. Chat-wide `/stop` and `/btw` escape lanes are preserved so abort and out-of-band commands still bypass a busy topic. Thanks @hepengcheng
 
 ## 2026.4.11-beta.1
 

--- a/extensions/discord/src/monitor/rest-fetch.ts
+++ b/extensions/discord/src/monitor/rest-fetch.ts
@@ -25,7 +25,6 @@ export function resolveDiscordRestFetch(
       ).then((response) => {
         captureHttpExchange({
           url: resolveRequestUrl(input),
-          url: resolveRequestUrl(input),
           method: init?.method ?? "GET",
           requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
           requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
@@ -34,7 +33,6 @@ export function resolveDiscordRestFetch(
           meta: { subsystem: "discord-rest" },
         });
         return response;
-      })) as typeof fetch);
       })) as typeof fetch);
   });
   if (!fetcher) {

--- a/extensions/discord/src/monitor/rest-fetch.ts
+++ b/extensions/discord/src/monitor/rest-fetch.ts
@@ -25,6 +25,7 @@ export function resolveDiscordRestFetch(
       ).then((response) => {
         captureHttpExchange({
           url: resolveRequestUrl(input),
+          url: resolveRequestUrl(input),
           method: init?.method ?? "GET",
           requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
           requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
@@ -33,6 +34,7 @@ export function resolveDiscordRestFetch(
           meta: { subsystem: "discord-rest" },
         });
         return response;
+      })) as typeof fetch);
       })) as typeof fetch);
   });
   if (!fetcher) {

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -50,6 +50,33 @@ export type ResolvedFeishuGroupSession = {
   threadReply: boolean;
 };
 
+/**
+ * Resolve the effective group session scope for a Feishu chat by applying
+ * the precedence rules shared between group-session and sequential-queue
+ * routing: group-level config beats channel-level config, and the legacy
+ * `topicSessionMode=enabled` alias maps to `group_topic` for backward
+ * compatibility.
+ */
+export function resolveFeishuGroupSessionScope(params: {
+  groupConfig?: {
+    groupSessionScope?: GroupSessionScope;
+    topicSessionMode?: "enabled" | "disabled";
+  };
+  feishuCfg?: {
+    groupSessionScope?: GroupSessionScope;
+    topicSessionMode?: "enabled" | "disabled";
+  };
+}): GroupSessionScope {
+  const { groupConfig, feishuCfg } = params;
+  const legacyTopicSessionMode =
+    groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";
+  return (
+    groupConfig?.groupSessionScope ??
+    feishuCfg?.groupSessionScope ??
+    (legacyTopicSessionMode === "enabled" ? "group_topic" : "group")
+  );
+}
+
 export function resolveFeishuGroupSession(params: {
   chatId: string;
   senderOpenId: string;
@@ -74,12 +101,7 @@ export function resolveFeishuGroupSession(params: {
   const replyInThread =
     (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled" ||
     threadReply;
-  const legacyTopicSessionMode =
-    groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";
-  const groupSessionScope: GroupSessionScope =
-    groupConfig?.groupSessionScope ??
-    feishuCfg?.groupSessionScope ??
-    (legacyTopicSessionMode === "enabled" ? "group_topic" : "group");
+  const groupSessionScope = resolveFeishuGroupSessionScope({ groupConfig, feishuCfg });
   const topicScope =
     groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender"
       ? (normalizedRootId ?? normalizedThreadId ?? (replyInThread ? messageId : null))

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -3,7 +3,7 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
-import { resolveFeishuGroupSessionScope } from "./bot-content.js";
+import { resolveFeishuGroupSessionScope, type GroupSessionScope } from "./bot-content.js";
 import {
   handleFeishuMessage,
   parseFeishuMessageEvent,
@@ -408,16 +408,25 @@ function registerEventHandlers(
   };
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
     // Resolve the effective group session scope so the sequential-queue
-    // key stays aligned with the session-store partitioning. Without this,
-    // normal (scope="group") groups would accidentally get per-topic queue
-    // lanes for quote replies that carry `root_id`, breaking the per-chat
-    // FIFO guarantee — see the #32980 regression test in bot.test.ts.
-    const feishuCfg = resolveFeishuAccount({ cfg, accountId }).config;
+    // key stays aligned with the session-store partitioning. Scope lookup
+    // is gated on `chat_type === "group"` to mirror the `isGroup` gate in
+    // bot.ts:resolveFeishuGroupSession — DMs must never read
+    // `groupSessionScope` (global, wildcard, or otherwise), because DM
+    // quote replies legitimately carry `root_id` and must preserve per-chat
+    // FIFO (see the "propagates parent/root message ids" DM fixture in
+    // bot.test.ts). Without this gate, a globally-configured
+    // `group_topic` / `group_topic_sender` scope would split DM replies
+    // onto per-topic lanes and break DM ordering.
+    const isGroupChat = event.message.chat_type === "group";
     const chatId = event.message.chat_id?.trim();
-    const groupConfig = chatId
-      ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: chatId })
-      : undefined;
-    const groupSessionScope = resolveFeishuGroupSessionScope({ groupConfig, feishuCfg });
+    let groupSessionScope: GroupSessionScope | undefined;
+    if (isGroupChat) {
+      const feishuCfg = resolveFeishuAccount({ cfg, accountId }).config;
+      const groupConfig = chatId
+        ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: chatId })
+        : undefined;
+      groupSessionScope = resolveFeishuGroupSessionScope({ groupConfig, feishuCfg });
+    }
     const sequentialKey = getFeishuSequentialKey({
       accountId,
       event,

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -3,6 +3,7 @@ import * as Lark from "@larksuiteoapi/node-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "../runtime-api.js";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
+import { resolveFeishuGroupSessionScope } from "./bot-content.js";
 import {
   handleFeishuMessage,
   parseFeishuMessageEvent,
@@ -27,6 +28,7 @@ import { parseFeishuDriveCommentNoticeEventPayload } from "./monitor.comment.js"
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
+import { resolveFeishuGroupConfig } from "./policy.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
 import { getFeishuSequentialKey } from "./sequential-key.js";
@@ -405,11 +407,23 @@ function registerEventHandlers(
     }
   };
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
+    // Resolve the effective group session scope so the sequential-queue
+    // key stays aligned with the session-store partitioning. Without this,
+    // normal (scope="group") groups would accidentally get per-topic queue
+    // lanes for quote replies that carry `root_id`, breaking the per-chat
+    // FIFO guarantee — see the #32980 regression test in bot.test.ts.
+    const feishuCfg = resolveFeishuAccount({ cfg, accountId }).config;
+    const chatId = event.message.chat_id?.trim();
+    const groupConfig = chatId
+      ? resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: chatId })
+      : undefined;
+    const groupSessionScope = resolveFeishuGroupSessionScope({ groupConfig, feishuCfg });
     const sequentialKey = getFeishuSequentialKey({
       accountId,
       event,
       botOpenId: botOpenIds.get(accountId),
       botName: botNames.get(accountId),
+      groupSessionScope,
     });
     const task = () =>
       handleFeishuMessage({

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { GroupSessionScope } from "./bot-content.js";
 import type { FeishuMessageEvent } from "./bot.js";
 import { getFeishuSequentialKey } from "./sequential-key.js";
 
@@ -30,18 +31,20 @@ function createTextEvent(params: {
 }
 
 describe("getFeishuSequentialKey", () => {
-  it.each([
-    [createTextEvent({ text: "hello" }), "feishu:default:oc_dm_chat"],
-    [createTextEvent({ text: "/status" }), "feishu:default:oc_dm_chat"],
-    [createTextEvent({ text: "/stop" }), "feishu:default:oc_dm_chat:control"],
-    [createTextEvent({ text: "/btw what changed?" }), "feishu:default:oc_dm_chat:btw"],
+  it.each<[FeishuMessageEvent, string, GroupSessionScope | undefined]>([
+    [createTextEvent({ text: "hello" }), "feishu:default:oc_dm_chat", undefined],
+    [createTextEvent({ text: "/status" }), "feishu:default:oc_dm_chat", undefined],
+    [createTextEvent({ text: "/stop" }), "feishu:default:oc_dm_chat:control", undefined],
+    [createTextEvent({ text: "/btw what changed?" }), "feishu:default:oc_dm_chat:btw", undefined],
     [
       createTextEvent({ text: "hello", chatId: "oc_topic_chat", rootId: "om_root_1" }),
       "feishu:default:oc_topic_chat:topic:om_root_1",
+      "group_topic",
     ],
     [
       createTextEvent({ text: "hello", chatId: "oc_topic_chat", threadId: "omt_thread_1" }),
       "feishu:default:oc_topic_chat:topic:omt_thread_1",
+      "group_topic",
     ],
     [
       createTextEvent({
@@ -51,6 +54,7 @@ describe("getFeishuSequentialKey", () => {
         threadId: "omt_thread_b",
       }),
       "feishu:default:oc_topic_chat:topic:om_root_a",
+      "group_topic_sender",
     ],
     [
       createTextEvent({
@@ -60,16 +64,19 @@ describe("getFeishuSequentialKey", () => {
         threadId: "omt_thread_b",
       }),
       "feishu:default:oc_topic_chat:topic:omt_thread_b",
+      "group_topic",
     ],
     [
       createTextEvent({ text: "hello", chatId: "oc_regular_group" }),
       "feishu:default:oc_regular_group",
+      "group",
     ],
-  ])("resolves sequential key %#", (event, expected) => {
+  ])("resolves sequential key %#", (event, expected, groupSessionScope) => {
     expect(
       getFeishuSequentialKey({
         accountId: "default",
         event,
+        groupSessionScope,
       }),
     ).toBe(expected);
   });
@@ -115,6 +122,7 @@ describe("getFeishuSequentialKey", () => {
       getFeishuSequentialKey({
         accountId: "default",
         event,
+        groupSessionScope: "group_topic",
       }),
     ).toBe("feishu:default:oc_topic_chat:control");
   });
@@ -130,6 +138,7 @@ describe("getFeishuSequentialKey", () => {
       getFeishuSequentialKey({
         accountId: "default",
         event,
+        groupSessionScope: "group_topic",
       }),
     ).toBe("feishu:default:oc_topic_chat:btw");
   });
@@ -151,14 +160,57 @@ describe("getFeishuSequentialKey", () => {
     const firstKey = getFeishuSequentialKey({
       accountId: "default",
       event: first,
+      groupSessionScope: "group_topic",
     });
     const secondKey = getFeishuSequentialKey({
       accountId: "default",
       event: second,
+      groupSessionScope: "group_topic",
     });
 
     expect(firstKey).toBe("feishu:default:oc_topic_chat:topic:om_topic_root_1");
     expect(secondKey).toBe("feishu:default:oc_topic_chat:topic:om_topic_root_2");
     expect(firstKey).not.toBe(secondKey);
+  });
+
+  it("keeps normal-group quote replies on the chat-wide lane even when root_id is present (#32980)", () => {
+    // Regression guard: in scope="group" (or scope="group_sender"), a Feishu
+    // quote reply in a normal group still carries `root_id` pointing at the
+    // quoted message. The queue key must NOT split into a `:topic:` lane,
+    // because normal groups share a single session store and rely on per-chat
+    // FIFO. This mirrors the bot.test.ts assertion
+    // "replies to triggering message in normal group even when root_id is
+    //  present (#32980)".
+    const quoteReplyInGroup = createTextEvent({
+      text: "hello in normal group",
+      chatId: "oc_normal_group",
+      rootId: "om_quoted_message",
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: quoteReplyInGroup,
+        groupSessionScope: "group",
+      }),
+    ).toBe("feishu:default:oc_normal_group");
+
+    // Same guarantee for group_sender: the session is per-sender, not
+    // per-topic, so the queue lane must stay chat-wide.
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: quoteReplyInGroup,
+        groupSessionScope: "group_sender",
+      }),
+    ).toBe("feishu:default:oc_normal_group");
+
+    // Default (undefined scope → treat as "group"): same guarantee.
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: quoteReplyInGroup,
+      }),
+    ).toBe("feishu:default:oc_normal_group");
   });
 });

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -7,6 +7,7 @@ function createTextEvent(params: {
   text: string;
   messageId?: string;
   chatId?: string;
+  chatType?: FeishuMessageEvent["message"]["chat_type"];
   rootId?: string;
   threadId?: string;
 }): FeishuMessageEvent {
@@ -21,7 +22,7 @@ function createTextEvent(params: {
     message: {
       message_id: params.messageId ?? "om_message_1",
       chat_id: params.chatId ?? "oc_dm_chat",
-      chat_type: "p2p",
+      chat_type: params.chatType ?? "p2p",
       message_type: "text",
       content: JSON.stringify({ text: params.text }),
       ...(params.rootId !== undefined ? { root_id: params.rootId } : {}),
@@ -37,12 +38,22 @@ describe("getFeishuSequentialKey", () => {
     [createTextEvent({ text: "/stop" }), "feishu:default:oc_dm_chat:control", undefined],
     [createTextEvent({ text: "/btw what changed?" }), "feishu:default:oc_dm_chat:btw", undefined],
     [
-      createTextEvent({ text: "hello", chatId: "oc_topic_chat", rootId: "om_root_1" }),
+      createTextEvent({
+        text: "hello",
+        chatId: "oc_topic_chat",
+        chatType: "group",
+        rootId: "om_root_1",
+      }),
       "feishu:default:oc_topic_chat:topic:om_root_1",
       "group_topic",
     ],
     [
-      createTextEvent({ text: "hello", chatId: "oc_topic_chat", threadId: "omt_thread_1" }),
+      createTextEvent({
+        text: "hello",
+        chatId: "oc_topic_chat",
+        chatType: "group",
+        threadId: "omt_thread_1",
+      }),
       "feishu:default:oc_topic_chat:topic:omt_thread_1",
       "group_topic",
     ],
@@ -50,6 +61,7 @@ describe("getFeishuSequentialKey", () => {
       createTextEvent({
         text: "hello",
         chatId: "oc_topic_chat",
+        chatType: "group",
         rootId: "om_root_a",
         threadId: "omt_thread_b",
       }),
@@ -60,6 +72,7 @@ describe("getFeishuSequentialKey", () => {
       createTextEvent({
         text: "hello",
         chatId: "oc_topic_chat",
+        chatType: "group",
         rootId: "   ",
         threadId: "omt_thread_b",
       }),
@@ -67,7 +80,7 @@ describe("getFeishuSequentialKey", () => {
       "group_topic",
     ],
     [
-      createTextEvent({ text: "hello", chatId: "oc_regular_group" }),
+      createTextEvent({ text: "hello", chatId: "oc_regular_group", chatType: "group" }),
       "feishu:default:oc_regular_group",
       "group",
     ],
@@ -115,6 +128,7 @@ describe("getFeishuSequentialKey", () => {
     const event = createTextEvent({
       text: "/stop",
       chatId: "oc_topic_chat",
+      chatType: "group",
       rootId: "om_topic_root_1",
     });
 
@@ -131,6 +145,7 @@ describe("getFeishuSequentialKey", () => {
     const event = createTextEvent({
       text: "/btw what changed?",
       chatId: "oc_topic_chat",
+      chatType: "group",
       rootId: "om_topic_root_2",
     });
 
@@ -147,12 +162,14 @@ describe("getFeishuSequentialKey", () => {
     const first = createTextEvent({
       text: "hello from topic 1",
       chatId: "oc_topic_chat",
+      chatType: "group",
       rootId: "om_topic_root_1",
       messageId: "om_message_topic_1",
     });
     const second = createTextEvent({
       text: "hello from topic 2",
       chatId: "oc_topic_chat",
+      chatType: "group",
       rootId: "om_topic_root_2",
       messageId: "om_message_topic_2",
     });
@@ -184,6 +201,7 @@ describe("getFeishuSequentialKey", () => {
     const quoteReplyInGroup = createTextEvent({
       text: "hello in normal group",
       chatId: "oc_normal_group",
+      chatType: "group",
       rootId: "om_quoted_message",
     });
 
@@ -212,5 +230,55 @@ describe("getFeishuSequentialKey", () => {
         event: quoteReplyInGroup,
       }),
     ).toBe("feishu:default:oc_normal_group");
+  });
+
+  it("keeps DM quote replies on the chat-wide lane even when a topic scope leaks in", () => {
+    // Regression guard for the DM case flagged by Codex on PR #64920:
+    // Feishu DMs can carry `root_id` for quote replies (see the
+    // "propagates parent/root message ids into inbound context for reply
+    // reconstruction" fixture in bot.test.ts around line 721, which uses
+    // `chat_type: "p2p"` + `root_id` + `parent_id`). If a global or
+    // wildcard `groupSessionScope: "group_topic"` / `"group_topic_sender"`
+    // leaks into the DM path, the queue key must still stay chat-wide and
+    // preserve per-chat FIFO ordering.
+    const dmQuoteReply = createTextEvent({
+      text: "reply text",
+      chatId: "oc_dm_chat",
+      chatType: "p2p",
+      rootId: "om_root_001",
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: dmQuoteReply,
+        groupSessionScope: "group_topic",
+      }),
+    ).toBe("feishu:default:oc_dm_chat");
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: dmQuoteReply,
+        groupSessionScope: "group_topic_sender",
+      }),
+    ).toBe("feishu:default:oc_dm_chat");
+
+    // Also cover the `private` DM sub-type — same defense applies.
+    const privateDmQuoteReply = createTextEvent({
+      text: "reply text",
+      chatId: "oc_private_dm",
+      chatType: "private",
+      rootId: "om_root_002",
+      threadId: "omt_thread_x",
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: privateDmQuoteReply,
+        groupSessionScope: "group_topic_sender",
+      }),
+    ).toBe("feishu:default:oc_private_dm");
   });
 });

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -6,6 +6,8 @@ function createTextEvent(params: {
   text: string;
   messageId?: string;
   chatId?: string;
+  rootId?: string;
+  threadId?: string;
 }): FeishuMessageEvent {
   return {
     sender: {
@@ -21,6 +23,8 @@ function createTextEvent(params: {
       chat_type: "p2p",
       message_type: "text",
       content: JSON.stringify({ text: params.text }),
+      ...(params.rootId !== undefined ? { root_id: params.rootId } : {}),
+      ...(params.threadId !== undefined ? { thread_id: params.threadId } : {}),
     },
   } as FeishuMessageEvent;
 }
@@ -31,6 +35,36 @@ describe("getFeishuSequentialKey", () => {
     [createTextEvent({ text: "/status" }), "feishu:default:oc_dm_chat"],
     [createTextEvent({ text: "/stop" }), "feishu:default:oc_dm_chat:control"],
     [createTextEvent({ text: "/btw what changed?" }), "feishu:default:oc_dm_chat:btw"],
+    [
+      createTextEvent({ text: "hello", chatId: "oc_topic_chat", rootId: "om_root_1" }),
+      "feishu:default:oc_topic_chat:topic:om_root_1",
+    ],
+    [
+      createTextEvent({ text: "hello", chatId: "oc_topic_chat", threadId: "omt_thread_1" }),
+      "feishu:default:oc_topic_chat:topic:omt_thread_1",
+    ],
+    [
+      createTextEvent({
+        text: "hello",
+        chatId: "oc_topic_chat",
+        rootId: "om_root_a",
+        threadId: "omt_thread_b",
+      }),
+      "feishu:default:oc_topic_chat:topic:om_root_a",
+    ],
+    [
+      createTextEvent({
+        text: "hello",
+        chatId: "oc_topic_chat",
+        rootId: "   ",
+        threadId: "omt_thread_b",
+      }),
+      "feishu:default:oc_topic_chat:topic:omt_thread_b",
+    ],
+    [
+      createTextEvent({ text: "hello", chatId: "oc_regular_group" }),
+      "feishu:default:oc_regular_group",
+    ],
   ])("resolves sequential key %#", (event, expected) => {
     expect(
       getFeishuSequentialKey({
@@ -68,5 +102,63 @@ describe("getFeishuSequentialKey", () => {
         event,
       }),
     ).toBe("feishu:default:oc_dm_chat:btw");
+  });
+
+  it("keeps /stop on a chat-wide control lane even inside a topic group", () => {
+    const event = createTextEvent({
+      text: "/stop",
+      chatId: "oc_topic_chat",
+      rootId: "om_topic_root_1",
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+      }),
+    ).toBe("feishu:default:oc_topic_chat:control");
+  });
+
+  it("keeps /btw on a chat-wide out-of-band lane even inside a topic group", () => {
+    const event = createTextEvent({
+      text: "/btw what changed?",
+      chatId: "oc_topic_chat",
+      rootId: "om_topic_root_2",
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+      }),
+    ).toBe("feishu:default:oc_topic_chat:btw");
+  });
+
+  it("runs different topics on independent lanes within the same chat", () => {
+    const first = createTextEvent({
+      text: "hello from topic 1",
+      chatId: "oc_topic_chat",
+      rootId: "om_topic_root_1",
+      messageId: "om_message_topic_1",
+    });
+    const second = createTextEvent({
+      text: "hello from topic 2",
+      chatId: "oc_topic_chat",
+      rootId: "om_topic_root_2",
+      messageId: "om_message_topic_2",
+    });
+
+    const firstKey = getFeishuSequentialKey({
+      accountId: "default",
+      event: first,
+    });
+    const secondKey = getFeishuSequentialKey({
+      accountId: "default",
+      event: second,
+    });
+
+    expect(firstKey).toBe("feishu:default:oc_topic_chat:topic:om_topic_root_1");
+    expect(secondKey).toBe("feishu:default:oc_topic_chat:topic:om_topic_root_2");
+    expect(firstKey).not.toBe(secondKey);
   });
 });

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -69,6 +69,14 @@ describe("getFeishuSequentialKey", () => {
       "group_topic_sender",
     ],
     [
+      // Whitespace-only root_id trims to "", and the `??` precedence in
+      // resolveFeishuTopicLaneId (mirroring resolveFeishuGroupSession)
+      // keeps that empty string rather than falling through to thread_id.
+      // The resulting topicId is falsy, so the lane collapses to chat-wide
+      // — matching the session store which puts this event on a
+      // chat-scoped peer id. See the separate `keeps queue lane aligned
+      // with resolveFeishuGroupSession ?? precedence` test below for the
+      // explicit lane/session divergence guard.
       createTextEvent({
         text: "hello",
         chatId: "oc_topic_chat",
@@ -76,7 +84,7 @@ describe("getFeishuSequentialKey", () => {
         rootId: "   ",
         threadId: "omt_thread_b",
       }),
-      "feishu:default:oc_topic_chat:topic:omt_thread_b",
+      "feishu:default:oc_topic_chat",
       "group_topic",
     ],
     [
@@ -280,5 +288,63 @@ describe("getFeishuSequentialKey", () => {
         groupSessionScope: "group_topic_sender",
       }),
     ).toBe("feishu:default:oc_private_dm");
+  });
+
+  it("keeps queue lane aligned with resolveFeishuGroupSession ?? precedence", () => {
+    // Regression guard for the lane/session divergence flagged by Codex on
+    // PR #64920: `resolveFeishuGroupSession` uses
+    // `normalizedRootId ?? normalizedThreadId`, where a whitespace-only
+    // root_id trims to "" and ?? keeps that empty string (it does NOT fall
+    // back to thread_id). Once topicScope is falsy, the session store
+    // collapses to a chat-scoped peer id. The queue lane in
+    // `getFeishuSequentialKey` must do the same: if it used `||` instead,
+    // a whitespace-only root_id with a present thread_id would split onto
+    // `:topic:${thread_id}` lane while the session store stayed chat-wide
+    // — two such events could then run concurrently on distinct lanes and
+    // interleave history within the same shared session.
+    //
+    // Case 1: whitespace root_id + valid thread_id in group_topic mode
+    //         must NOT split onto a thread_id lane.
+    const whitespaceRootEvent = createTextEvent({
+      text: "hello",
+      chatId: "oc_topic_chat",
+      chatType: "group",
+      rootId: "   ",
+      threadId: "omt_thread_b",
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: whitespaceRootEvent,
+        groupSessionScope: "group_topic",
+      }),
+    ).toBe("feishu:default:oc_topic_chat");
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: whitespaceRootEvent,
+        groupSessionScope: "group_topic_sender",
+      }),
+    ).toBe("feishu:default:oc_topic_chat");
+
+    // Case 2: thread_id still works when root_id is fully absent — the
+    // fallback kicks in only when root_id is undefined, matching the
+    // `normalizedRootId ?? normalizedThreadId` semantics exactly.
+    const threadOnlyEvent = createTextEvent({
+      text: "hello",
+      chatId: "oc_topic_chat",
+      chatType: "group",
+      threadId: "omt_thread_c",
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event: threadOnlyEvent,
+        groupSessionScope: "group_topic",
+      }),
+    ).toBe("feishu:default:oc_topic_chat:topic:omt_thread_c");
   });
 });

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -26,15 +26,28 @@ export function getFeishuSequentialKey(params: {
     return `${baseKey}:btw`;
   }
 
-  // Per-topic lanes only apply when the group is explicitly configured
-  // for topic-scoped sessions. Normal (group / group_sender) chats
-  // deliberately stay on a single chat-wide lane even when an incoming
-  // quote reply carries `root_id`, because those groups share one session
-  // store and must preserve per-chat FIFO — see the
-  // "replies to triggering message in normal group even when root_id is
-  // present (#32980)" assertion in bot.test.ts and the topicScope gate
-  // in resolveFeishuGroupSession.
-  if (groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender") {
+  // Per-topic lanes only apply to group chats that are explicitly
+  // configured for topic-scoped sessions.
+  //
+  // 1. `chat_type !== "group"` (DMs: `p2p` / `private`) deliberately stay
+  //    on a single chat-wide lane even when `groupSessionScope` is
+  //    globally set to `group_topic` / `group_topic_sender` via a wildcard
+  //    entry, because Feishu DMs can carry `root_id` for quote replies
+  //    and must preserve per-chat FIFO — see the
+  //    "propagates parent/root message ids into inbound context for
+  //    reply reconstruction" DM fixture in bot.test.ts.
+  //
+  // 2. Normal (`group` / `group_sender`) groups also stay on a single
+  //    chat-wide lane even when a quote reply carries `root_id`, because
+  //    those groups share one session store and must preserve per-chat
+  //    FIFO — see the "replies to triggering message in normal group
+  //    even when root_id is present (#32980)" assertion in bot.test.ts
+  //    and the `topicScope` gate in resolveFeishuGroupSession.
+  const isGroupChat = event.message.chat_type === "group";
+  if (
+    isGroupChat &&
+    (groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender")
+  ) {
     const topicLaneId = resolveFeishuTopicLaneId(event);
     if (topicLaneId) {
       return `${baseKey}:topic:${topicLaneId}`;

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -58,9 +58,18 @@ export function getFeishuSequentialKey(params: {
 }
 
 function resolveFeishuTopicLaneId(event: FeishuMessageEvent): string | undefined {
-  // Align with the root_id-over-thread_id precedence used by
-  // resolveFeishuGroupSession in bot-content.ts and anchored by the
-  // bot.test.ts "keeps root_id as topic key when root_id and thread_id
-  // both exist" assertion.
-  return event.message.root_id?.trim() || event.message.thread_id?.trim() || undefined;
+  // Mirror the exact precedence used by resolveFeishuGroupSession in
+  // bot-content.ts: `normalizedRootId ?? normalizedThreadId`, where
+  // `normalizedRootId = rootId?.trim()`. This uses `??` (nullish-coalesce),
+  // not `||`, so a whitespace-only `root_id` that trims to `""` does NOT
+  // fall back to `thread_id` — it stays as an empty string and the queue
+  // key collapses to the chat-wide lane, matching the session store which
+  // puts the same event into a chat-scoped session. Using `||` here would
+  // create lane/session divergence: the queue would split onto two topic
+  // lanes while the session store kept one shared chat-scoped peer id, so
+  // two concurrent events could interleave history on the same session.
+  const normalizedRootId = event.message.root_id?.trim();
+  const normalizedThreadId = event.message.thread_id?.trim();
+  const topicId = normalizedRootId ?? normalizedThreadId;
+  return topicId ? topicId : undefined;
 }

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -13,6 +13,9 @@ export function getFeishuSequentialKey(params: {
   const parsed = parseFeishuMessageEvent(event, botOpenId, botName);
   const text = parsed.content.trim();
 
+  // Control and out-of-band lanes stay chat-wide so /stop and /btw never
+  // get blocked behind a busy topic queue — this mirrors the escape-hatch
+  // behavior already used by extensions/telegram/src/sequential-key.ts.
   if (isAbortRequestText(text)) {
     return `${baseKey}:control`;
   }
@@ -21,5 +24,21 @@ export function getFeishuSequentialKey(params: {
     return `${baseKey}:btw`;
   }
 
+  // Topic-group messages carry root_id (or thread_id) and should run on
+  // their own per-topic lane so different topics in the same chat can be
+  // processed concurrently instead of waiting for each other. Precedence
+  // follows the root_id-over-thread_id convention already used by
+  // resolveFeishuGroupSession in bot-content.ts and anchored by the
+  // bot.test.ts "keeps root_id as topic key when root_id and thread_id
+  // both exist" assertion.
+  const topicLaneId = resolveFeishuTopicLaneId(event);
+  if (topicLaneId) {
+    return `${baseKey}:topic:${topicLaneId}`;
+  }
+
   return baseKey;
+}
+
+function resolveFeishuTopicLaneId(event: FeishuMessageEvent): string | undefined {
+  return event.message.root_id?.trim() || event.message.thread_id?.trim() || undefined;
 }

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -1,4 +1,5 @@
 import { isAbortRequestText, isBtwRequestText } from "openclaw/plugin-sdk/reply-runtime";
+import type { GroupSessionScope } from "./bot-content.js";
 import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
 
 export function getFeishuSequentialKey(params: {
@@ -6,8 +7,9 @@ export function getFeishuSequentialKey(params: {
   event: FeishuMessageEvent;
   botOpenId?: string;
   botName?: string;
+  groupSessionScope?: GroupSessionScope;
 }): string {
-  const { accountId, event, botOpenId, botName } = params;
+  const { accountId, event, botOpenId, botName, groupSessionScope } = params;
   const chatId = event.message.chat_id?.trim() || "unknown";
   const baseKey = `feishu:${accountId}:${chatId}`;
   const parsed = parseFeishuMessageEvent(event, botOpenId, botName);
@@ -24,21 +26,28 @@ export function getFeishuSequentialKey(params: {
     return `${baseKey}:btw`;
   }
 
-  // Topic-group messages carry root_id (or thread_id) and should run on
-  // their own per-topic lane so different topics in the same chat can be
-  // processed concurrently instead of waiting for each other. Precedence
-  // follows the root_id-over-thread_id convention already used by
-  // resolveFeishuGroupSession in bot-content.ts and anchored by the
-  // bot.test.ts "keeps root_id as topic key when root_id and thread_id
-  // both exist" assertion.
-  const topicLaneId = resolveFeishuTopicLaneId(event);
-  if (topicLaneId) {
-    return `${baseKey}:topic:${topicLaneId}`;
+  // Per-topic lanes only apply when the group is explicitly configured
+  // for topic-scoped sessions. Normal (group / group_sender) chats
+  // deliberately stay on a single chat-wide lane even when an incoming
+  // quote reply carries `root_id`, because those groups share one session
+  // store and must preserve per-chat FIFO — see the
+  // "replies to triggering message in normal group even when root_id is
+  // present (#32980)" assertion in bot.test.ts and the topicScope gate
+  // in resolveFeishuGroupSession.
+  if (groupSessionScope === "group_topic" || groupSessionScope === "group_topic_sender") {
+    const topicLaneId = resolveFeishuTopicLaneId(event);
+    if (topicLaneId) {
+      return `${baseKey}:topic:${topicLaneId}`;
+    }
   }
 
   return baseKey;
 }
 
 function resolveFeishuTopicLaneId(event: FeishuMessageEvent): string | undefined {
+  // Align with the root_id-over-thread_id precedence used by
+  // resolveFeishuGroupSession in bot-content.ts and anchored by the
+  // bot.test.ts "keeps root_id as topic key when root_id and thread_id
+  // both exist" assertion.
   return event.message.root_id?.trim() || event.message.thread_id?.trim() || undefined;
 }

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -280,7 +280,11 @@ export function createMattermostConnectOnce(
             direction: "inbound",
             kind: "ws-frame",
             flowId,
-            payload: Buffer.from(rawDataToString(data)),
+            payload: Buffer.isBuffer(data)
+              ? data
+              : Array.isArray(data)
+                ? Buffer.concat(data)
+                : Buffer.from(data),
             meta: { subsystem: "mattermost-websocket" },
           });
           const raw = rawDataToString(data);

--- a/extensions/microsoft/speech-provider.test.ts
+++ b/extensions/microsoft/speech-provider.test.ts
@@ -165,8 +165,9 @@ describe("listMicrosoftVoices", () => {
         .getSessionEvents("ms-voices-global-session", 10)
         .filter((event) => event.host === "speech.platform.bing.com");
       expect(events).toHaveLength(2);
-      const kinds = events.map((event) => String(event.kind)).toSorted();
-      expect(kinds).toEqual(["request", "response"]);
+      expect(
+        events.map((event) => String(event.kind)).toSorted((a, b) => a.localeCompare(b)),
+      ).toEqual(["request", "response"]);
     } finally {
       globalThis.fetch = originalFetch;
       finalizeDebugProxyCapture();

--- a/extensions/openai/tts.test.ts
+++ b/extensions/openai/tts.test.ts
@@ -294,8 +294,9 @@ describe("openai tts", () => {
         .getSessionEvents("tts-patched-session", 10)
         .filter((event) => event.host === "api.openai.com");
       expect(events).toHaveLength(2);
-      const kinds = events.map((event) => String(event.kind)).toSorted();
-      expect(kinds).toEqual(["request", "response"]);
+      expect(
+        events.map((event) => String(event.kind)).toSorted((a, b) => a.localeCompare(b)),
+      ).toEqual(["request", "response"]);
       store.close();
     });
   });

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -556,7 +556,6 @@ export function resolveTelegramTransport(
     );
     const startIndex = Math.min(stickyAttemptIndex, transportAttempts.length - 1);
     let err: unknown;
-
     try {
       const response = await sourceFetch(
         input,

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -502,7 +502,11 @@ export class OpenAIWebSocketManager extends EventEmitter<InternalEvents> {
           direction: "inbound",
           kind: "ws-frame",
           flowId: this.flowId,
-          payload: Buffer.from(rawDataToString(data)),
+          payload: Buffer.isBuffer(data)
+            ? data
+            : Array.isArray(data)
+              ? Buffer.concat(data)
+              : Buffer.from(data),
         });
         this._handleMessage(data);
       };

--- a/src/agents/openai-ws-connection.ts
+++ b/src/agents/openai-ws-connection.ts
@@ -15,7 +15,6 @@ import { randomUUID } from "node:crypto";
  */
 import { EventEmitter } from "node:events";
 import WebSocket, { type ClientOptions } from "ws";
-import { rawDataToString } from "../infra/ws.js";
 import { createDebugProxyWebSocketAgent, resolveDebugProxySettings } from "../proxy-capture/env.js";
 import { captureWsEvent } from "../proxy-capture/runtime.js";
 import { buildOpenAIWebSocketWarmUpPayload } from "./openai-ws-request.js";

--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -56,8 +56,9 @@ function resolveCachedChannelPlugins(): CachedChannelPlugins {
   const channelPlugins: LoadedChannelPlugin[] = [];
   if (registry && Array.isArray(registry.channels)) {
     for (const entry of registry.channels) {
-      if (entry?.plugin) {
-        channelPlugins.push(entry.plugin);
+      const plugin = entry?.plugin;
+      if (plugin && typeof plugin.id === "string") {
+        channelPlugins.push(plugin as LoadedChannelPlugin);
       }
     }
   }

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelRuntimeSurface } from "../channels/plugins/channel-runtime-surface.types.js";
 import { type ChannelId, type ChannelPlugin } from "../channels/plugins/types.js";
 import {
   createSubsystemLogger,
@@ -110,8 +111,8 @@ function installTestRegistry(...plugins: ChannelPlugin<TestAccount>[]) {
 }
 
 function createManager(options?: {
-  channelRuntime?: PluginRuntime["channel"];
-  resolveChannelRuntime?: () => PluginRuntime["channel"];
+  channelRuntime?: ChannelRuntimeSurface;
+  resolveChannelRuntime?: () => ChannelRuntimeSurface;
   loadConfig?: () => Record<string, unknown>;
   channelIds?: ChannelId[];
 }) {
@@ -224,8 +225,8 @@ describe("server-channels auto restart", () => {
     const channelRuntime = {
       ...createRuntimeChannel(),
       marker: "channel-runtime",
-    } as PluginRuntime["channel"] & { marker: string };
-    const startAccount = vi.fn(async (_ctx: { channelRuntime?: PluginRuntime["channel"] }) => {});
+    } as ChannelRuntimeSurface & { marker: string };
+    const startAccount = vi.fn(async (_ctx: { channelRuntime?: ChannelRuntimeSurface }) => {});
 
     installTestRegistry(createTestPlugin({ startAccount }));
     const manager = createManager({ channelRuntime });
@@ -287,9 +288,9 @@ describe("server-channels auto restart", () => {
     const channelRuntime = {
       ...createRuntimeChannel(),
       marker: "lazy-channel-runtime",
-    } as PluginRuntime["channel"] & { marker: string };
+    } as ChannelRuntimeSurface & { marker: string };
     const resolveChannelRuntime = vi.fn(() => channelRuntime);
-    const startAccount = vi.fn(async (_ctx: { channelRuntime?: PluginRuntime["channel"] }) => {});
+    const startAccount = vi.fn(async (_ctx: { channelRuntime?: ChannelRuntimeSurface }) => {});
 
     installTestRegistry(createTestPlugin({ startAccount }));
     const manager = createManager({ resolveChannelRuntime });
@@ -336,7 +337,7 @@ describe("server-channels auto restart", () => {
       },
     };
     const startAccount = vi.fn(
-      async ({ channelRuntime }: { channelRuntime?: PluginRuntime["channel"] }) => {
+      async ({ channelRuntime }: { channelRuntime?: ChannelRuntimeSurface }) => {
         channelRuntime?.runtimeContexts.register({
           channelId: "discord",
           accountId: DEFAULT_ACCOUNT_ID,

--- a/src/plugin-sdk/channel-runtime-context.ts
+++ b/src/plugin-sdk/channel-runtime-context.ts
@@ -1,6 +1,6 @@
+export type { ChannelRuntimeContextKey } from "../channels/plugins/channel-runtime-surface.types.js";
 export {
   getChannelRuntimeContext,
   registerChannelRuntimeContext,
   watchChannelRuntimeContexts,
-  type ChannelRuntimeContextKey,
 } from "../infra/channel-runtime-context.js";


### PR DESCRIPTION
## Summary

- **Problem**: In Feishu topic groups, different topics in the same chat are forced to process messages serially because `getFeishuSequentialKey()` in `extensions/feishu/src/sequential-key.ts` only buckets the per-chat serial queue by `${accountId}:${chatId}`, ignoring `root_id` / `thread_id`. A busy tool call in one topic blocks every other topic in the same chat.
- **Why it matters**: For bots wiring in long-running tools (knowledge base search, codegen, etc.), a single tool call taking 40–180 seconds means 10 concurrent topic messages queue for 7–30 minutes before the last reply lands. Users on other topics perceive the bot as dead.
- **What changed**: `getFeishuSequentialKey()` now appends `:topic:{rootId|threadId}` to the sequential queue key when the incoming event carries topic metadata, so different topics run on independent lanes. A small `resolveFeishuTopicLaneId()` helper keeps the root-over-thread precedence anchored by `bot-content.ts` / `bot.test.ts`.
- **What did NOT change (scope boundary)**: `getFeishuSequentialKey()` signature is unchanged; `monitor.account.ts`, `sequential-queue.ts`, `bot-content.ts`, and `event-types.ts` are not touched. `/stop` and `/btw` still resolve to chat-wide `:control` / `:btw` escape lanes **before** the topic check, matching the Telegram sequential-key behavior in `extensions/telegram/src/sequential-key.ts`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause**: `extensions/feishu/src/sequential-key.ts` has historically bucketed the per-chat serial queue by `${accountId}:${chatId}` only. This was originally correct when all messages in a group shared one session, but Feishu topic groups (`chat_mode=topic`) carry `root_id` / `thread_id` on each message and each topic is a semantically independent conversation. Telegram's `extensions/telegram/src/sequential-key.ts` already handles the analogous forum-thread case by appending a `:topic:{threadId}` suffix; Feishu was simply missing the parallel adaptation.
- **Missing detection / guardrail**: No unit test asserted "different topics in the same chat must resolve to different keys". The existing `sequential-key.test.ts` only covered p2p + `/stop` + `/btw` cases.
- **Contributing context**: The Lark-team-maintained `@larksuite/openclaw-lark` plugin (separate repo) solved the same problem in its `src/channel/chat-queue.ts` + `src/channel/event-handlers.ts`, which independently validates that this direction is correct. This PR ports the capability into the community-maintained `@openclaw/feishu` package, adapted to its existing architecture — preserving the `:btw` / `:control` escape lane design that differs from the Lark plugin's abort-controller fast-path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file**: `extensions/feishu/src/sequential-key.test.ts`
- **Scenario the test should lock in**: Two events with the same `chat_id` but different `root_id` must produce different sequential keys, and both keys must carry a `:topic:` segment so per-topic lane behavior is observable from the key string.
- **Why this is the smallest reliable guardrail**: `getFeishuSequentialKey()` is a pure string function with one consumer (`monitor.account.ts:408`); a unit test over its output is the exact seam where this regression can be locked in.
- **Existing test that already covers this**: None before this PR.
- **If no new test is added, why not**: N/A — new tests are included.

## User-visible / Behavior Changes

- **Topic-group messages now run concurrently across topics.** Different topics in the same chat no longer wait for each other's tool calls; different chats were already concurrent and stay concurrent.
- **Non-topic groups and p2p chats are unchanged.** When `root_id` and `thread_id` are both absent/empty, the sequential key is byte-identical to the previous output.
- **\`/stop\` and \`/btw\` are unchanged** even inside topic groups: they still resolve to the chat-wide `:control` / `:btw` lanes before the topic check, so abort and out-of-band commands never get blocked behind a busy topic.
- **Config**: No new config. Topic-heavy deployments are encouraged (not required) to also set `channels.feishu.groupSessionScope: "group_topic_sender"` so the session store's peer id follows the same per-topic partitioning as the new queue key — this prevents a rare case where one sender talking in two topics simultaneously could interleave context within a single shared session.

## Diagram (if applicable)

\`\`\`text
Before:
topic group "oc_G" with 3 active topics (root_id T1, T2, T3)
  inbound msg(T1) ─┐
  inbound msg(T2) ─┼─► single lane "feishu:default:oc_G" ─► process(T1) ─► process(T2) ─► process(T3)
  inbound msg(T3) ─┘                                         (T2 and T3 wait for T1)

After:
topic group "oc_G" with 3 active topics
  inbound msg(T1) ─► lane "feishu:default:oc_G:topic:T1" ─► process(T1)
  inbound msg(T2) ─► lane "feishu:default:oc_G:topic:T2" ─► process(T2)   (concurrent)
  inbound msg(T3) ─► lane "feishu:default:oc_G:topic:T3" ─► process(T3)

  /stop  in any topic ─► lane "feishu:default:oc_G:control" (chat-wide, unchanged)
  /btw   in any topic ─► lane "feishu:default:oc_G:btw"     (chat-wide, unchanged)
\`\`\`

## Security Impact (required)

- New permissions/capabilities? (**No**)
- Secrets/tokens handling changed? (**No**)
- New/changed network calls? (**No**)
- Command/tool execution surface changed? (**No**)
- Data access scope changed? (**No**)

This PR is a local refactor of one pure string function and its test. It does not touch auth, config schemas, network I/O, or the tool execution surface.

## Repro + Verification

### Environment

- OS: Linux (x86_64)
- Runtime/container: Node 22 via pnpm workspace, main branch at 899a1b7565
- Model/provider: N/A (no runtime LLM call involved in the changed seam)
- Integration/channel: feishu channel (topic-group mode)
- Relevant config: N/A

### Steps

1. Open \`extensions/feishu/src/sequential-key.ts\` on main and observe that when the incoming \`FeishuMessageEvent\` carries \`root_id\` / \`thread_id\`, the computed sequential key still collapses to \`feishu:{accountId}:{chatId}\` without any topic segment.
2. Trace the call into \`extensions/feishu/src/monitor.account.ts:408\`: that key is handed to \`createSequentialQueue()\`, which maintains a per-key FIFO. A busy task on one topic therefore blocks every other topic in the same chat.
3. Apply this PR and run \`pnpm test extensions/feishu/src/sequential-key.test.ts\`.

### Expected

- All new parametrized cases for topic keys resolve to \`feishu:{accountId}:{chatId}:topic:{rootId|threadId}\`.
- \`/stop\` and \`/btw\` cases inside topic groups still resolve to \`...:control\` / \`...:btw\` (no topic segment).
- Two events with same \`chatId\` but different \`rootId\` produce distinct keys.

### Actual

Matches expected. See Evidence.

## Evidence

- \`pnpm test extensions/feishu/src/sequential-key.test.ts\` → **14/14 tests passed** (6 original + 8 new covering topic-only, thread-only, both-precedence, whitespace-root-fallback, regular-group fallback, \`/stop\` in topic, \`/btw\` in topic, and two-topic isolation).
- \`pnpm test extensions/feishu/\` → **616/616 tests passed, 0 regressions** across the whole Feishu extension, including the 10+ existing \`root_id\` fixtures in \`bot.test.ts\`.
- \`pnpm check\` → **0 warnings / 0 errors** across \`tsgo\` + \`oxlint\` (11164 files, 144 rules) + all webhook/auth safety linters.
- \`pnpm build\` → **exit 0**, no \`INEFFECTIVE_DYNAMIC_IMPORT\` warnings.

## Human Verification (required)

- **Verified scenarios**:
  - \`getFeishuSequentialKey()\` unit behavior across 14 cases covering p2p, \`/stop\`, \`/btw\`, topic-group with \`root_id\` only, with \`thread_id\` only, with both (root_id precedence), with whitespace-only \`root_id\` (fallback to \`thread_id\`), and two-topic isolation in the same chat.
  - Full \`pnpm test extensions/feishu/\` — confirmed 616 existing feishu tests still pass.
- **Edge cases checked**:
  - Whitespace-only \`root_id\` falls back to \`thread_id\` (matches the \`.trim() || .trim()\` implementation).
  - \`/stop\` and \`/btw\` inside topic groups still resolve to chat-wide escape lanes (two dedicated \`it\` tests for this).
  - Non-topic group / p2p messages (no \`root_id\` / \`thread_id\`) return exactly the previous \`baseKey\` output.
- **What I did NOT verify**:
  - No end-to-end live Feishu run. The change is fully captured by the unit seam at \`sequential-key.ts\` and the downstream \`createSequentialQueue\` is a trivial Map-based FIFO whose per-key isolation is already tested in \`sequential-queue.test.ts\`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (**Yes**)
- Config/env changes? (**No**)
- Migration needed? (**No**)
- **Detail**: Non-topic groups and p2p chats produce byte-identical sequential keys to before this PR. Topic groups produce a new key shape (\`:topic:{id}\` segment appended), but since the queue is a process-local \`Map\`, nothing persists across restarts — there is no migration surface.

## Risks and Mitigations

- **Risk**: In the default \`channels.feishu.groupSessionScope: \"group\"\` configuration, different topics in the same chat still share one session peer id. When two topics run concurrently, the session store's Promise-chain lock (\`src/config/sessions/store.ts\`) keeps writes atomic, but the two agent runs still see a shared history stream and could interleave context entries for the same sender talking in multiple topics at once.
  - **Mitigation**: For topic-heavy deployments, set \`channels.feishu.groupSessionScope: \"group_topic\"\` or \`\"group_topic_sender\"\` so the session peer id also includes the topic. This aligns the session partitioning with the new queue partitioning and removes the interleaving concern entirely. The default is left as-is for backward compatibility; this PR just mentions the recommendation in the user-visible section.
- **Risk**: Two-repo drift with \`@larksuite/openclaw-lark\`. The Lark plugin uses \`thread_id || root_id\` precedence and a different abort architecture (an \`abortController\` fast-path with an \`activeDispatchers\` map), while this PR uses \`root_id ?? thread_id\` and keeps the existing \`:control\` / \`:btw\` lane suffixes. The two implementations now agree on the behavior goal (per-topic concurrency) but not on the exact precedence order.
  - **Mitigation**: This PR deliberately preserves the \`@openclaw/feishu\` conventions already locked in by \`bot-content.ts\` and the existing \`bot.test.ts\` assertion \"keeps root_id as topic key when root_id and thread_id both exist\". Cross-repo precedence alignment is orthogonal and belongs in a separate follow-up.