### PR TITLE
fix: dedupe session summaries by session id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/externalization: repair missing configured plugin installs from npm by default, reserve ClawHub downloads for explicit `clawhubSpec` metadata, and cover agent-runtime/env-selected plugin repair. Thanks @vincentkoc.
 - Upgrade/config: validate configured web-search providers and statically suppressed model/provider pairs against the active plugin set at config load, so stale plugin state fails loud before runtime fallback.
 - Status/update: resolve beta update-channel checks from the installed version when config still says `stable`, and let `status --deep` reuse live gateway channel credential state instead of warning on command-path-only token misses.
+- Status/sessions: dedupe status and health session summaries by session ID so repeated entries from different store paths don't inflate counts. Thanks @shad0wca7.
 - Doctor/plugins: preserve unmanaged third-party plugin `node_modules` during `doctor --fix`, while still pruning OpenClaw-managed runtime dependency caches.
 - Gateway/restart: add `openclaw gateway restart --force` and `--wait <duration>`, log active task run IDs before restart deferral timers, and report timeout restarts as explicit forced restarts.
 - Discord: persist slash-command deploy hashes across process restarts so unchanged command sets skip redeploy and avoid restart-loop 429s.

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -8,8 +8,12 @@ import { createPluginRecord } from "../plugins/status.test-helpers.js";
 import type { HealthSummary } from "./health.js";
 
 let testConfig: Record<string, unknown> = {};
+<<<<<<< HEAD
 let testStore: Record<string, { updatedAt?: number }> = {};
 let healthPluginsForTest: HealthTestPlugin[] = [];
+=======
+let testStore: Record<string, { sessionId?: string; updatedAt?: number }> = {};
+>>>>>>> 3b9fd77238 (fix: improve overflow guidance and dedupe session summaries)
 
 let setActivePluginRegistry: typeof import("../plugins/runtime.js").setActivePluginRegistry;
 let createChannelTestPluginBase: typeof import("../test-utils/channel-plugins.js").createChannelTestPluginBase;
@@ -497,6 +501,26 @@ describe("getHealthSnapshot", () => {
     expect(telegram.probe).toBeUndefined();
     expect(snap.sessions.count).toBe(2);
     expect(snap.sessions.recent[0]?.key).toBe("foo");
+  });
+
+  it("dedupes session summaries by the freshest entry for each session id", async () => {
+    testConfig = { session: { store: "/tmp/x" } };
+    testStore = {
+      "agent:main:stale": { sessionId: "shared-session", updatedAt: 1_000 },
+      "agent:main:fresh": { sessionId: "shared-session", updatedAt: 3_000 },
+      "agent:main:other": { sessionId: "other-session", updatedAt: 2_000 },
+    };
+
+    const snap = (await getHealthSnapshot({
+      timeoutMs: 10,
+      probe: false,
+    })) satisfies HealthSummary;
+
+    expect(snap.sessions.count).toBe(2);
+    expect(snap.sessions.recent.map((session) => session.key)).toEqual([
+      "agent:main:fresh",
+      "agent:main:other",
+    ]);
   });
 
   it("probes telegram getMe + webhook info when configured", async () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -130,10 +130,22 @@ const resolveAgentOrder = (cfg: OpenClawConfig) => {
 const buildSessionSummary = async (storePath: string) => {
   const { loadSessionStore } = await import("../config/sessions/store.js");
   const store = loadSessionStore(storePath);
+  const seenSessionIds = new Set<string>();
   const sessions = Object.entries(store)
     .filter(([key]) => key !== "global" && key !== "unknown")
-    .map(([key, entry]) => ({ key, updatedAt: entry?.updatedAt ?? 0 }))
-    .toSorted((a, b) => b.updatedAt - a.updatedAt);
+    .toSorted(([, a], [, b]) => (b?.updatedAt ?? 0) - (a?.updatedAt ?? 0))
+    .filter(([, entry]) => {
+      const sessionId = entry?.sessionId;
+      if (!sessionId) {
+        return true;
+      }
+      if (seenSessionIds.has(sessionId)) {
+        return false;
+      }
+      seenSessionIds.add(sessionId);
+      return true;
+    })
+    .map(([key, entry]) => ({ key, updatedAt: entry?.updatedAt ?? 0 }));
   const recent = sessions.slice(0, 5).map((s) => ({
     key: s.key,
     updatedAt: s.updatedAt || null,

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const statusSummaryMocks = vi.hoisted(() => ({
   hasConfiguredChannelsForReadOnlyScope: vi.fn(() => true),
   buildChannelSummary: vi.fn(async () => ["ok"]),
+  readSessionStoreReadOnly: vi.fn(() => ({})),
 }));
 
 vi.mock("../plugins/channel-plugin-ids.js", () => ({
@@ -34,8 +35,21 @@ vi.mock("../config/io.js", () => ({
   loadConfig: vi.fn(() => ({})),
 }));
 
+<<<<<<< HEAD
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: vi.fn(() => ({})),
+=======
+vi.mock("../config/sessions/main-session.js", () => ({
+  resolveMainSessionKey: vi.fn(() => "agent:main:main"),
+}));
+
+vi.mock("../config/sessions/paths.js", () => ({
+  resolveStorePath: vi.fn(() => "/tmp/openclaw-test-main-sessions.json"),
+}));
+
+vi.mock("../config/sessions/store-read.js", () => ({
+  readSessionStoreReadOnly: statusSummaryMocks.readSessionStoreReadOnly,
+>>>>>>> 3b9fd77238 (fix: improve overflow guidance and dedupe session summaries)
 }));
 
 vi.mock("../gateway/agent-list.js", () => ({
@@ -100,6 +114,7 @@ vi.mock("../tasks/task-registry.maintenance.js", () => ({
 }));
 
 vi.mock("../routing/session-key.js", () => ({
+  DEFAULT_AGENT_ID: "main",
   normalizeAgentId: vi.fn((value: string) => value),
   normalizeMainKey: vi.fn((value?: string) => value ?? "main"),
   parseAgentSessionKey: vi.fn(() => null),
@@ -132,6 +147,7 @@ describe("getStatusSummary", () => {
     vi.clearAllMocks();
     statusSummaryMocks.hasConfiguredChannelsForReadOnlyScope.mockReturnValue(true);
     statusSummaryMocks.buildChannelSummary.mockResolvedValue(["ok"]);
+    statusSummaryMocks.readSessionStoreReadOnly.mockReturnValue({});
   });
 
   it("includes runtimeVersion in the status payload", async () => {
@@ -166,6 +182,26 @@ describe("getStatusSummary", () => {
     expect(statusSummaryMocks.hasConfiguredChannelsForReadOnlyScope).not.toHaveBeenCalled();
     expect(buildChannelSummary).not.toHaveBeenCalled();
     expect(resolveLinkChannelContext).not.toHaveBeenCalled();
+  });
+
+  it("dedupes session rows by the freshest entry for each session id", async () => {
+    statusSummaryMocks.readSessionStoreReadOnly.mockReturnValue({
+      "agent:main:stale": { sessionId: "shared-session", updatedAt: 1_000 },
+      "agent:main:fresh": { sessionId: "shared-session", updatedAt: 3_000 },
+      "agent:main:other": { sessionId: "other-session", updatedAt: 2_000 },
+    });
+
+    const summary = await getStatusSummary();
+
+    expect(summary.sessions.count).toBe(2);
+    expect(summary.sessions.recent.map((session) => session.key)).toEqual([
+      "agent:main:fresh",
+      "agent:main:other",
+    ]);
+    expect(summary.sessions.byAgent[0]?.recent.map((session) => session.key)).toEqual([
+      "agent:main:fresh",
+      "agent:main:other",
+    ]);
   });
 
   it("does not trigger async context warmup while building status summaries", async () => {

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -185,9 +185,22 @@ export async function getStatusSummary(
   const buildSessionRows = (
     store: Record<string, SessionEntry | undefined>,
     opts: { agentIdOverride?: string } = {},
-  ) =>
-    Object.entries(store)
+  ) => {
+    const seenSessionIds = new Set<string>();
+    return Object.entries(store)
       .filter(([key]) => key !== "global" && key !== "unknown")
+      .toSorted(([, a], [, b]) => (b?.updatedAt ?? 0) - (a?.updatedAt ?? 0))
+      .filter(([, entry]) => {
+        const sessionId = entry?.sessionId;
+        if (!sessionId) {
+          return true;
+        }
+        if (seenSessionIds.has(sessionId)) {
+          return false;
+        }
+        seenSessionIds.add(sessionId);
+        return true;
+      })
       .map(([key, entry]) => {
         const updatedAt = entry?.updatedAt ?? null;
         const age = updatedAt ? now - updatedAt : null;

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -242,7 +242,8 @@ export async function getStatusSummary(
           flags: buildFlags(entry),
         } satisfies SessionStatus;
       })
-      .sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+      .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+  };
 
   const paths = new Set<string>();
   const byAgent = agentList.agents.map((agent) => {


### PR DESCRIPTION
## Summary
- dedupe session listings by `sessionId` in health output
- dedupe session listings by `sessionId` in status summary output
- keep the overflow-guidance update separate in the overflow PR

## Notes
- split out from the mixed local commit so each logical change has a clean PR home
- no behavior changes intended beyond removing duplicate session rows in health/status displays
