### PR TITLE
feat(gateway): infer provider from configured model families

### DIFF
--- a/src/gateway/session-utils.model-family-routing.test.ts
+++ b/src/gateway/session-utils.model-family-routing.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveSessionModelRef } from "./session-utils.js";
+
+describe("resolveSessionModelRef model-family routing", () => {
+  test("infers provider from configured models when override model is canonical and provider is default/fallback", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "main", default: true }],
+        defaults: {
+          model: "openai/gpt-4.1",
+          models: {
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const resolved = resolveSessionModelRef(
+      cfg,
+      {
+        modelOverride: "gpt-5.4",
+      },
+      "main",
+    );
+
+    expect(resolved).toEqual({
+      provider: "openai-codex",
+      model: "gpt-5.4",
+    });
+  });
+
+  test("does not override an explicit providerOverride when model family routing is ambiguous or user-selected", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "main", default: true }],
+        defaults: {
+          model: "openai/gpt-4.1",
+          models: {
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const resolved = resolveSessionModelRef(
+      cfg,
+      {
+        providerOverride: "openai",
+        modelOverride: "gpt-5.4",
+      },
+      "main",
+    );
+
+    expect(resolved).toEqual({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+  });
+
+  test("keeps provider/model encoded refs untouched", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "main", default: true }],
+        defaults: {
+          model: "openai/gpt-4.1",
+          models: {
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const resolved = resolveSessionModelRef(
+      cfg,
+      {
+        modelOverride: "anthropic/claude-opus-4-1",
+      },
+      "main",
+    );
+
+    expect(resolved).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-4-1",
+    });
+  });
+});

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1037,6 +1037,58 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
   };
 }
 
+function normalizeResolvedSessionModelRef(params: {
+  cfg: OpenClawConfig;
+  ref: { provider: string; model: string };
+  entry?: Pick<SessionEntry, "model" | "modelProvider" | "modelOverride" | "providerOverride">;
+}): { provider: string; model: string } {
+  const normalizedModel = params.ref.model.trim();
+  if (!normalizedModel) {
+    return params.ref;
+  }
+  if (normalizedModel.includes("/")) {
+    const parsed = parseModelRef(normalizedModel, params.ref.provider || DEFAULT_PROVIDER);
+    if (parsed) {
+      return parsed;
+    }
+    return params.ref;
+  }
+
+  const inferredProvider = inferUniqueProviderFromConfiguredModels({
+    cfg: params.cfg,
+    model: normalizedModel,
+  });
+  if (!inferredProvider) {
+    return params.ref;
+  }
+
+  const explicitOverrideProvider = params.entry?.providerOverride?.trim();
+  const runtimeProvider = params.entry?.modelProvider?.trim();
+  if (explicitOverrideProvider) {
+    return {
+      provider: explicitOverrideProvider,
+      model: normalizedModel,
+    };
+  }
+  if (runtimeProvider) {
+    return {
+      provider: runtimeProvider,
+      model: normalizedModel,
+    };
+  }
+  if (!params.ref.provider || params.ref.provider === DEFAULT_PROVIDER) {
+    return {
+      provider: inferredProvider,
+      model: normalizedModel,
+    };
+  }
+
+  return {
+    provider: params.ref.provider,
+    model: normalizedModel,
+  };
+}
+
 export function resolveSessionModelRef(
   cfg: OpenClawConfig,
   entry?:
@@ -1060,7 +1112,11 @@ export function resolveSessionModelRef(
     overrideModel: entry?.modelOverride,
   });
   if (persisted) {
-    return persisted;
+    return normalizeResolvedSessionModelRef({
+      cfg,
+      ref: persisted,
+      entry,
+    });
   }
   return resolved;
 }


### PR DESCRIPTION
Adds a small model-family routing normalization step to `resolveSessionModelRef()` so canonical model names can resolve to the correct configured provider when that mapping is unique.

### What changed
- adds a normalization step on top of `resolveSessionModelRef()`
- infers provider from configured model families when a canonical model name maps uniquely in config
- preserves explicit `providerOverride` selections from the user
- preserves fully-qualified `provider/model` refs without rewriting them
- adds focused tests for canonical-model inference and explicit-provider preservation

### Why
OpenClaw already resolves default/session model refs, but canonical model names like `gpt-5.4` can still rely too heavily on the default provider when the config already makes the intended provider unambiguous.

This PR improves that specific case without redesigning the broader model fallback system.

### Examples
- `modelOverride: "gpt-5.4"` + configured `openai-codex/gpt-5.4`
  → resolves to `openai-codex/gpt-5.4`
- `providerOverride: "openai"` + `modelOverride: "gpt-5.4"`
  → stays on `openai/gpt-5.4`
- `modelOverride: "anthropic/claude-opus-4-1"`
  → preserved as-is

### Tests
- `src/gateway/session-utils.model-family-routing.test.ts`
- `src/gateway/session-utils.search.test.ts`
