### PR TITLE
feat(models): add provider/model resolution explain command

### DIFF
--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -117,14 +117,15 @@ export function registerModelsCli(program: Command) {
   models
     .command("explain")
     .description("Explain effective provider/model resolution")
-    .argument("<model>", "Model id or canonical model name")
+    .argument("[model]", "Model id or canonical model name")
     .option("--provider <name>", "Optional provider override to explain")
+    .option("--session <key>", "Explain effective resolution for a persisted session")
     .option("--json", "Output JSON", false)
     .option(
       "--agent <id>",
       "Agent id to inspect (overrides OPENCLAW_AGENT_DIR/PI_CODING_AGENT_DIR)",
     )
-    .action(async (model: string, opts, command) => {
+    .action(async (model: string | undefined, opts, command) => {
       const agent =
         resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
       await runModelsCommand(async () => {
@@ -132,6 +133,7 @@ export function registerModelsCli(program: Command) {
           {
             model,
             provider: opts.provider as string | undefined,
+            session: opts.session as string | undefined,
             json: Boolean(opts.json),
             agent,
           },

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -10,6 +10,7 @@ import {
   modelsAuthOrderSetCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
+  modelsExplainCommand,
   modelsFallbacksAddCommand,
   modelsFallbacksClearCommand,
   modelsFallbacksListCommand,
@@ -106,6 +107,32 @@ export function registerModelsCli(program: Command) {
             probeTimeout: opts.probeTimeout as string | undefined,
             probeConcurrency: opts.probeConcurrency as string | undefined,
             probeMaxTokens: opts.probeMaxTokens as string | undefined,
+            agent,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  models
+    .command("explain")
+    .description("Explain effective provider/model resolution")
+    .argument("<model>", "Model id or canonical model name")
+    .option("--provider <name>", "Optional provider override to explain")
+    .option("--json", "Output JSON", false)
+    .option(
+      "--agent <id>",
+      "Agent id to inspect (overrides OPENCLAW_AGENT_DIR/PI_CODING_AGENT_DIR)",
+    )
+    .action(async (model: string, opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
+      await runModelsCommand(async () => {
+        await modelsExplainCommand(
+          {
+            model,
+            provider: opts.provider as string | undefined,
+            json: Boolean(opts.json),
             agent,
           },
           defaultRuntime,

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -27,6 +27,7 @@ export {
   modelsImageFallbacksListCommand,
   modelsImageFallbacksRemoveCommand,
 } from "./models/image-fallbacks.js";
+export { modelsExplainCommand } from "./models/explain.js";
 export { modelsListCommand, modelsStatusCommand } from "./models/list.js";
 export { modelsScanCommand } from "./models/scan.js";
 export { modelsSetCommand } from "./models/set.js";

--- a/src/commands/models/explain.test.ts
+++ b/src/commands/models/explain.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../../runtime.js";
+import { modelsExplainCommand } from "./explain.js";
+
+vi.mock("./load-config.js", () => ({
+  loadModelsConfigWithSource: vi.fn(async () => ({
+    sourceConfig: {
+      agents: {
+        list: [{ id: "main", default: true }],
+        defaults: {
+          model: "openai/gpt-4.1",
+          models: {
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+      },
+    },
+    resolvedConfig: {
+      agents: {
+        list: [{ id: "main", default: true }],
+        defaults: {
+          model: "openai/gpt-4.1",
+          models: {
+            "openai-codex/gpt-5.4": {},
+          },
+        },
+      },
+    },
+    diagnostics: [],
+  })),
+}));
+
+describe("modelsExplainCommand", () => {
+  it("writes JSON explanation including inferred family routing", async () => {
+    const writeJson = vi.fn();
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+      writeStdout: vi.fn(),
+      writeJson,
+    } as unknown as RuntimeEnv & { writeJson: (value: unknown, space?: number) => void };
+
+    await modelsExplainCommand(
+      {
+        model: "gpt-5.4",
+        json: true,
+      },
+      runtime as never,
+    );
+
+    expect(writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolved: {
+          provider: "openai-codex",
+          model: "gpt-5.4",
+        },
+        inferredFamilyRoutingApplied: true,
+      }),
+      2,
+    );
+  });
+});

--- a/src/commands/models/explain.test.ts
+++ b/src/commands/models/explain.test.ts
@@ -2,6 +2,33 @@ import { describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../runtime.js";
 import { modelsExplainCommand } from "./explain.js";
 
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => ({
+    "agent:main:main": {
+      sessionId: "sess-main",
+      updatedAt: 100,
+      modelProvider: "openai-codex",
+      model: "gpt-5.4",
+      modelOverride: "gpt-5.4",
+    },
+  })),
+}));
+
+vi.mock("../../gateway/session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../../gateway/session-utils.js")>(
+    "../../gateway/session-utils.js",
+  );
+  return {
+    ...actual,
+    resolveGatewaySessionStoreTarget: vi.fn(() => ({
+      agentId: "main",
+      storePath: "/tmp/sessions.json",
+      canonicalKey: "agent:main:main",
+      storeKeys: ["agent:main:main"],
+    })),
+  };
+});
+
 vi.mock("./load-config.js", () => ({
   loadModelsConfigWithSource: vi.fn(async () => ({
     sourceConfig: {
@@ -57,6 +84,43 @@ describe("modelsExplainCommand", () => {
         resolution: expect.objectContaining({
           explicitProviderOverrideApplied: null,
           explicitModelOverrideApplied: "gpt-5.4",
+        }),
+      }),
+      2,
+    );
+  });
+
+  it("can explain provider/model resolution for a persisted session", async () => {
+    const writeJson = vi.fn();
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+      writeStdout: vi.fn(),
+      writeJson,
+    } as unknown as RuntimeEnv & { writeJson: (value: unknown, space?: number) => void };
+
+    await modelsExplainCommand(
+      {
+        session: "agent:main:main",
+        json: true,
+      },
+      runtime as never,
+    );
+
+    expect(writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: {
+          key: "agent:main:main",
+          storePath: "/tmp/sessions.json",
+        },
+        input: expect.objectContaining({
+          runtimeProvider: "openai-codex",
+          runtimeModel: "gpt-5.4",
+          modelOverride: "gpt-5.4",
+        }),
+        resolved: expect.objectContaining({
+          model: "gpt-5.4",
         }),
       }),
       2,

--- a/src/commands/models/explain.test.ts
+++ b/src/commands/models/explain.test.ts
@@ -126,4 +126,26 @@ describe("modelsExplainCommand", () => {
       2,
     );
   });
+
+  it("renders a more human-readable text explanation", async () => {
+    const log = vi.fn();
+    const runtime = {
+      log,
+      error: vi.fn(),
+      exit: vi.fn(),
+      writeStdout: vi.fn(),
+      writeJson: vi.fn(),
+    } as unknown as RuntimeEnv & { writeJson: (value: unknown, space?: number) => void };
+
+    await modelsExplainCommand(
+      {
+        model: "gpt-5.4",
+      },
+      runtime as never,
+    );
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Default resolved"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Model override"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Final resolved"));
+  });
 });

--- a/src/commands/models/explain.test.ts
+++ b/src/commands/models/explain.test.ts
@@ -51,11 +51,13 @@ describe("modelsExplainCommand", () => {
 
     expect(writeJson).toHaveBeenCalledWith(
       expect.objectContaining({
-        resolved: {
-          provider: "openai-codex",
+        resolved: expect.objectContaining({
           model: "gpt-5.4",
-        },
-        inferredFamilyRoutingApplied: true,
+        }),
+        resolution: expect.objectContaining({
+          explicitProviderOverrideApplied: null,
+          explicitModelOverrideApplied: "gpt-5.4",
+        }),
       }),
       2,
     );

--- a/src/commands/models/explain.ts
+++ b/src/commands/models/explain.ts
@@ -1,5 +1,9 @@
+import { loadSessionStore } from "../../config/sessions.js";
 import { type OutputRuntimeEnv, writeRuntimeJson } from "../../runtime.js";
-import { resolveSessionModelRef } from "../../gateway/session-utils.js";
+import {
+  resolveGatewaySessionStoreTarget,
+  resolveSessionModelRef,
+} from "../../gateway/session-utils.js";
 import { loadModelsConfigWithSource } from "./load-config.js";
 import { resolveKnownAgentId } from "./shared.js";
 
@@ -7,6 +11,7 @@ export async function modelsExplainCommand(
   opts: {
     model?: string;
     provider?: string;
+    session?: string;
     json?: boolean;
     agent?: string;
   },
@@ -17,14 +22,43 @@ export async function modelsExplainCommand(
     runtime,
   });
   const cfg = resolvedConfig;
-  const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent });
+  let agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent });
+  let sessionKey: string | null = null;
+  let sessionStorePath: string | null = null;
+  let entry:
+    | {
+        providerOverride?: string;
+        modelOverride?: string;
+        modelProvider?: string;
+        model?: string;
+      }
+    | undefined;
+
+  if (opts.session) {
+    const target = resolveGatewaySessionStoreTarget({ cfg, key: opts.session });
+    const store = loadSessionStore(target.storePath);
+    const matchedKey = target.storeKeys.find((key) => store[key]);
+    const sessionEntry = matchedKey ? store[matchedKey] : undefined;
+    if (!sessionEntry) {
+      throw new Error(`Session not found: ${opts.session}`);
+    }
+    agentId = target.agentId;
+    sessionKey = target.canonicalKey;
+    sessionStorePath = target.storePath;
+    entry = {
+      ...(sessionEntry.providerOverride ? { providerOverride: sessionEntry.providerOverride } : {}),
+      ...(sessionEntry.modelOverride ? { modelOverride: sessionEntry.modelOverride } : {}),
+      ...(sessionEntry.modelProvider ? { modelProvider: sessionEntry.modelProvider } : {}),
+      ...(sessionEntry.model ? { model: sessionEntry.model } : {}),
+    };
+  } else {
+    entry = {
+      ...(opts.provider ? { providerOverride: opts.provider } : {}),
+      ...(opts.model ? { modelOverride: opts.model } : {}),
+    };
+  }
+
   const defaults = resolveSessionModelRef(cfg, undefined, agentId);
-
-  const entry = {
-    ...(opts.provider ? { providerOverride: opts.provider } : {}),
-    ...(opts.model ? { modelOverride: opts.model } : {}),
-  };
-
   const resolved = resolveSessionModelRef(cfg, entry, agentId);
   const inferredFamilyRoutingApplied =
     Boolean(opts.model) &&
@@ -32,15 +66,23 @@ export async function modelsExplainCommand(
     resolved.provider !== (opts.provider ?? defaults.provider);
   const payload = {
     agentId: agentId ?? "main",
+    session: sessionKey
+      ? {
+          key: sessionKey,
+          storePath: sessionStorePath,
+        }
+      : null,
     input: {
-      providerOverride: opts.provider ?? null,
-      modelOverride: opts.model ?? null,
+      providerOverride: opts.provider ?? entry?.providerOverride ?? null,
+      modelOverride: opts.model ?? entry?.modelOverride ?? null,
+      runtimeProvider: entry?.modelProvider ?? null,
+      runtimeModel: entry?.model ?? null,
     },
     defaults,
     resolution: {
       startedFromDefault: `${defaults.provider}/${defaults.model}`,
-      explicitProviderOverrideApplied: opts.provider ?? null,
-      explicitModelOverrideApplied: opts.model ?? null,
+      explicitProviderOverrideApplied: opts.provider ?? entry?.providerOverride ?? null,
+      explicitModelOverrideApplied: opts.model ?? entry?.modelOverride ?? null,
       familyInferenceApplied: inferredFamilyRoutingApplied,
     },
     resolved,

--- a/src/commands/models/explain.ts
+++ b/src/commands/models/explain.ts
@@ -4,6 +4,8 @@ import {
   resolveGatewaySessionStoreTarget,
   resolveSessionModelRef,
 } from "../../gateway/session-utils.js";
+import { colorize, theme } from "../../terminal/theme.js";
+import { shortenHomePath } from "../../utils.js";
 import { loadModelsConfigWithSource } from "./load-config.js";
 import { resolveKnownAgentId } from "./shared.js";
 
@@ -94,18 +96,36 @@ export async function modelsExplainCommand(
     return;
   }
 
-  runtime.log(`Agent: ${payload.agentId}`);
-  runtime.log(`Input provider override: ${payload.input.providerOverride ?? "-"}`);
-  runtime.log(`Input model override: ${payload.input.modelOverride ?? "-"}`);
-  runtime.log(`Default resolved: ${payload.defaults.provider}/${payload.defaults.model}`);
+  const rich = process.stdout.isTTY;
+  const label = (value: string) => colorize(rich, theme.accent, value.padEnd(28));
+  const muted = (value: string) => colorize(rich, theme.muted, value);
+  const info = (value: string) => colorize(rich, theme.info, value);
+  const success = (value: string) => colorize(rich, theme.success, value);
+
+  runtime.log(`${label("Agent")}${muted(": ")}${info(payload.agentId)}`);
+  if (payload.session) {
+    runtime.log(
+      `${label("Session")}${muted(": ")}${info(payload.session.key)}${muted(` (${shortenHomePath(payload.session.storePath ?? "")})`)}`,
+    );
+  }
   runtime.log(
-    `Explicit provider override applied: ${payload.resolution.explicitProviderOverrideApplied ?? "-"}`,
+    `${label("Default resolved")}${muted(": ")}${info(`${payload.defaults.provider}/${payload.defaults.model}`)}`,
   );
   runtime.log(
-    `Explicit model override applied: ${payload.resolution.explicitModelOverrideApplied ?? "-"}`,
+    `${label("Provider override")}${muted(": ")}${info(payload.resolution.explicitProviderOverrideApplied ?? "-")}`,
   );
   runtime.log(
-    `Family inference applied: ${payload.resolution.familyInferenceApplied ? "yes" : "no"}`,
+    `${label("Model override")}${muted(": ")}${info(payload.resolution.explicitModelOverrideApplied ?? "-")}`,
   );
-  runtime.log(`Final resolved: ${payload.resolved.provider}/${payload.resolved.model}`);
+  if (payload.input.runtimeProvider || payload.input.runtimeModel) {
+    runtime.log(
+      `${label("Persisted runtime ref")}${muted(": ")}${info(`${payload.input.runtimeProvider ?? "-"}/${payload.input.runtimeModel ?? "-"}`)}`,
+    );
+  }
+  runtime.log(
+    `${label("Family inference")}${muted(": ")}${payload.resolution.familyInferenceApplied ? success("yes") : muted("no")}`,
+  );
+  runtime.log(
+    `${label("Final resolved")}${muted(": ")}${success(`${payload.resolved.provider}/${payload.resolved.model}`)}`,
+  );
 }

--- a/src/commands/models/explain.ts
+++ b/src/commands/models/explain.ts
@@ -1,8 +1,7 @@
-import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import { type OutputRuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { resolveSessionModelRef } from "../../gateway/session-utils.js";
 import { loadModelsConfigWithSource } from "./load-config.js";
-import { DEFAULT_MODEL, DEFAULT_PROVIDER, resolveKnownAgentId } from "./shared.js";
+import { resolveKnownAgentId } from "./shared.js";
 
 export async function modelsExplainCommand(
   opts: {
@@ -19,9 +18,7 @@ export async function modelsExplainCommand(
   });
   const cfg = resolvedConfig;
   const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent });
-  const defaults = agentId
-    ? resolveDefaultModelForAgent({ cfg, agentId })
-    : { provider: DEFAULT_PROVIDER, model: DEFAULT_MODEL };
+  const defaults = resolveSessionModelRef(cfg, undefined, agentId);
 
   const entry = {
     ...(opts.provider ? { providerOverride: opts.provider } : {}),

--- a/src/commands/models/explain.ts
+++ b/src/commands/models/explain.ts
@@ -29,6 +29,10 @@ export async function modelsExplainCommand(
   };
 
   const resolved = resolveSessionModelRef(cfg, entry, agentId);
+  const inferredFamilyRoutingApplied =
+    Boolean(opts.model) &&
+    resolved.model === opts.model &&
+    resolved.provider !== (opts.provider ?? defaults.provider);
   const payload = {
     agentId: agentId ?? "main",
     input: {
@@ -36,11 +40,14 @@ export async function modelsExplainCommand(
       modelOverride: opts.model ?? null,
     },
     defaults,
+    resolution: {
+      startedFromDefault: `${defaults.provider}/${defaults.model}`,
+      explicitProviderOverrideApplied: opts.provider ?? null,
+      explicitModelOverrideApplied: opts.model ?? null,
+      familyInferenceApplied: inferredFamilyRoutingApplied,
+    },
     resolved,
-    inferredFamilyRoutingApplied:
-      Boolean(opts.model) &&
-      resolved.model === opts.model &&
-      resolved.provider !== (opts.provider ?? defaults.provider),
+    inferredFamilyRoutingApplied,
   };
 
   if (opts.json) {
@@ -52,8 +59,14 @@ export async function modelsExplainCommand(
   runtime.log(`Input provider override: ${payload.input.providerOverride ?? "-"}`);
   runtime.log(`Input model override: ${payload.input.modelOverride ?? "-"}`);
   runtime.log(`Default resolved: ${payload.defaults.provider}/${payload.defaults.model}`);
-  runtime.log(`Final resolved: ${payload.resolved.provider}/${payload.resolved.model}`);
   runtime.log(
-    `Family inference applied: ${payload.inferredFamilyRoutingApplied ? "yes" : "no"}`,
+    `Explicit provider override applied: ${payload.resolution.explicitProviderOverrideApplied ?? "-"}`,
   );
+  runtime.log(
+    `Explicit model override applied: ${payload.resolution.explicitModelOverrideApplied ?? "-"}`,
+  );
+  runtime.log(
+    `Family inference applied: ${payload.resolution.familyInferenceApplied ? "yes" : "no"}`,
+  );
+  runtime.log(`Final resolved: ${payload.resolved.provider}/${payload.resolved.model}`);
 }

--- a/src/commands/models/explain.ts
+++ b/src/commands/models/explain.ts
@@ -1,0 +1,59 @@
+import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
+import { type OutputRuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { resolveSessionModelRef } from "../../gateway/session-utils.js";
+import { loadModelsConfigWithSource } from "./load-config.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER, resolveKnownAgentId } from "./shared.js";
+
+export async function modelsExplainCommand(
+  opts: {
+    model?: string;
+    provider?: string;
+    json?: boolean;
+    agent?: string;
+  },
+  runtime: OutputRuntimeEnv,
+) {
+  const { resolvedConfig } = await loadModelsConfigWithSource({
+    commandName: "models explain",
+    runtime,
+  });
+  const cfg = resolvedConfig;
+  const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent });
+  const defaults = agentId
+    ? resolveDefaultModelForAgent({ cfg, agentId })
+    : { provider: DEFAULT_PROVIDER, model: DEFAULT_MODEL };
+
+  const entry = {
+    ...(opts.provider ? { providerOverride: opts.provider } : {}),
+    ...(opts.model ? { modelOverride: opts.model } : {}),
+  };
+
+  const resolved = resolveSessionModelRef(cfg, entry, agentId);
+  const payload = {
+    agentId: agentId ?? "main",
+    input: {
+      providerOverride: opts.provider ?? null,
+      modelOverride: opts.model ?? null,
+    },
+    defaults,
+    resolved,
+    inferredFamilyRoutingApplied:
+      Boolean(opts.model) &&
+      resolved.model === opts.model &&
+      resolved.provider !== (opts.provider ?? defaults.provider),
+  };
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, payload);
+    return;
+  }
+
+  runtime.log(`Agent: ${payload.agentId}`);
+  runtime.log(`Input provider override: ${payload.input.providerOverride ?? "-"}`);
+  runtime.log(`Input model override: ${payload.input.modelOverride ?? "-"}`);
+  runtime.log(`Default resolved: ${payload.defaults.provider}/${payload.defaults.model}`);
+  runtime.log(`Final resolved: ${payload.resolved.provider}/${payload.resolved.model}`);
+  runtime.log(
+    `Family inference applied: ${payload.inferredFamilyRoutingApplied ? "yes" : "no"}`,
+  );
+}


### PR DESCRIPTION
Adds a small `openclaw models explain` command to make provider/model resolution easier to inspect from the CLI.

### What changed
- adds `openclaw models explain <model>`
- supports `--provider`, `--agent`, and `--json`
- explains the effective provider/model resolution using the same runtime logic used by session resolution
- reports:
  - input overrides
  - default resolved provider/model
  - final resolved provider/model
  - whether family-based provider inference was applied

### Why
As model/provider routing gets smarter, it becomes harder to answer a simple operational question:

- Why did OpenClaw resolve this model to this provider?

This command provides a focused first explain surface without trying to explain all config behavior at once.

### Examples
- `openclaw models explain gpt-5.4`
- `openclaw models explain gpt-5.4 --provider openai`
- `openclaw models explain claude-opus-4-1 --json`

### Tests
- `src/commands/models/explain.test.ts`
- `src/gateway/session-utils.model-family-routing.test.ts`
