### PR TITLE
fix(tasks): silence acp child-session completion banners

### DIFF
--- a/src/tasks/task-executor-policy.test.ts
+++ b/src/tasks/task-executor-policy.test.ts
@@ -6,6 +6,7 @@ import {
   isTerminalTaskStatus,
   shouldAutoDeliverTaskStateChange,
   shouldAutoDeliverTaskTerminalUpdate,
+  shouldSilentWakeAcpChildSession,
   shouldSuppressDuplicateTerminalDelivery,
 } from "./task-executor-policy.js";
 import type { TaskEventRecord, TaskRecord } from "./task-registry.types.js";
@@ -182,6 +183,76 @@ describe("task-executor-policy", () => {
         }),
         preferredTaskId: undefined,
       }),
+    ).toBe(false);
+  });
+
+  it("identifies ACP child-session tasks for silent parent wake", () => {
+    // Successful, non-blocked ACP child session -> silent wake
+    expect(
+      shouldSilentWakeAcpChildSession(
+        createTask({
+          runtime: "acp",
+          childSessionKey: "agent:codex:acp:child-1",
+          status: "succeeded",
+        }),
+      ),
+    ).toBe(true);
+
+    // Blocked tasks must still surface visibly
+    expect(
+      shouldSilentWakeAcpChildSession(
+        createTask({
+          runtime: "acp",
+          childSessionKey: "agent:codex:acp:child-1",
+          status: "succeeded",
+          terminalOutcome: "blocked",
+        }),
+      ),
+    ).toBe(false);
+
+    // Failed tasks must still surface visibly
+    expect(
+      shouldSilentWakeAcpChildSession(
+        createTask({
+          runtime: "acp",
+          childSessionKey: "agent:codex:acp:child-1",
+          status: "failed",
+        }),
+      ),
+    ).toBe(false);
+
+    // Timed-out tasks must still surface visibly
+    expect(
+      shouldSilentWakeAcpChildSession(
+        createTask({
+          runtime: "acp",
+          childSessionKey: "agent:codex:acp:child-1",
+          status: "timed_out",
+        }),
+      ),
+    ).toBe(false);
+
+    // No childSessionKey -> not a child-session task
+    expect(
+      shouldSilentWakeAcpChildSession(createTask({ runtime: "acp", status: "succeeded" })),
+    ).toBe(false);
+
+    // Non-ACP runtime -> not applicable
+    expect(
+      shouldSilentWakeAcpChildSession(
+        createTask({
+          runtime: "subagent",
+          childSessionKey: "agent:main:subagent:child",
+          status: "succeeded",
+        }),
+      ),
+    ).toBe(false);
+
+    // Empty/whitespace childSessionKey -> not applicable
+    expect(
+      shouldSilentWakeAcpChildSession(
+        createTask({ runtime: "acp", childSessionKey: "  ", status: "succeeded" }),
+      ),
     ).toBe(false);
   });
 });

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -119,3 +119,30 @@ export function shouldSuppressDuplicateTerminalDelivery(params: {
   }
   return Boolean(params.preferredTaskId && params.preferredTaskId !== params.task.taskId);
 }
+
+/**
+ * Determines whether an ACP child-session task should bypass user-visible
+ * delivery and instead silently wake the parent session via heartbeat.
+ *
+ * This fires for all non-blocked ACP runs that belong to a child session,
+ * regardless of notifyPolicy — ensuring orchestration continuation even if
+ * notifyPolicy propagation is fixed in the future to set "silent" on these
+ * task records.
+ */
+export function shouldSilentWakeAcpChildSession(task: TaskRecord): boolean {
+  if (task.runtime !== "acp") {
+    return false;
+  }
+  if (!task.childSessionKey?.trim()) {
+    return false;
+  }
+  // Only silence successful, non-blocked completions. Failures, timeouts, and
+  // blocked outcomes may need human attention and must surface visibly.
+  if (task.status !== "succeeded") {
+    return false;
+  }
+  if (task.terminalOutcome === "blocked") {
+    return false;
+  }
+  return true;
+}

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -531,7 +531,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("delivers ACP completion to the requester channel when a delivery origin exists", async () => {
+  it("silently wakes the parent for ACP child-session completions instead of sending a banner", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
@@ -570,23 +570,15 @@ describe("task-registry", () => {
       await waitForAssertion(() =>
         expect(findTaskByRunId("run-delivery")).toMatchObject({
           status: "succeeded",
-          deliveryStatus: "delivered",
+          deliveryStatus: "session_queued",
         }),
       );
-      await waitForAssertion(() =>
-        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
-          expect.objectContaining({
-            channel: "telegram",
-            to: "telegram:123",
-            threadId: "321",
-            content: expect.stringContaining("Background task done: ACP background task"),
-            mirror: expect.objectContaining({
-              sessionKey: "agent:main:main",
-            }),
-          }),
-        ),
-      );
+      // No user-visible banner sent
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+      // No raw system event queued into parent session
       expect(peekSystemEvents("agent:main:main")).toEqual([]);
+      // Parent session was woken via heartbeat
+      expect(hasPendingHeartbeatWake()).toBe(true);
     });
   });
 
@@ -684,7 +676,6 @@ describe("task-registry", () => {
         runtime: "acp",
         ownerKey: "agent:main:main",
         scopeKind: "session",
-        childSessionKey: "agent:main:acp:child",
         runId: "run-session-queued",
         task: "Investigate issue",
         status: "running",
@@ -766,7 +757,6 @@ describe("task-registry", () => {
           to: "telegram:123",
           threadId: "321",
         },
-        childSessionKey: "agent:main:acp:child",
         runId: "run-detail-leak",
         task: "Create the file and verify it",
         status: "running",
@@ -859,7 +849,6 @@ describe("task-registry", () => {
           channel: "telegram",
           to: "telegram:123",
         },
-        childSessionKey: "agent:main:acp:child",
         runId: "run-succeeded-outcome",
         task: "Create the file and verify it",
         status: "succeeded",
@@ -985,7 +974,6 @@ describe("task-registry", () => {
           channel: "telegram",
           to: "telegram:123",
         },
-        childSessionKey: "agent:main:acp:child",
         runId: "run-shared-delivery",
         task: "Direct ACP child",
         status: "succeeded",
@@ -999,7 +987,6 @@ describe("task-registry", () => {
           channel: "telegram",
           to: "telegram:123",
         },
-        childSessionKey: "agent:main:acp:child",
         runId: "run-shared-delivery",
         task: "Spawn ACP child",
         preferMetadata: true,
@@ -1656,7 +1643,6 @@ describe("task-registry", () => {
           channel: "discord",
           to: "discord:123",
         },
-        childSessionKey: "agent:codex:acp:child",
         runId: "run-quiet-terminal",
         task: "Create the file",
         status: "running",
@@ -2010,6 +1996,201 @@ describe("task-registry", () => {
           taskId: task.taskId,
           status: "cancelled",
         }),
+      });
+    });
+  });
+
+  describe("ACP child-session silent wake regression", () => {
+    it("two runs in the same child session produce zero user-visible banners and wake the parent", async () => {
+      await withTaskRegistryTempDir(async (root) => {
+        process.env.OPENCLAW_STATE_DIR = root;
+        resetTaskRegistryForTests();
+        resetHeartbeatWakeStateForTests();
+        hoisted.sendMessageMock.mockResolvedValue({
+          channel: "telegram",
+          to: "telegram:822430204",
+          via: "direct",
+        });
+
+        // Initial spawn run
+        createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:telegram:main:direct:822430204",
+          scopeKind: "session",
+          requesterOrigin: {
+            channel: "telegram",
+            to: "telegram:822430204",
+          },
+          childSessionKey: "agent:claude:acp:5435d550",
+          runId: "d8dcebd3",
+          label: "pr68-fix-followup",
+          task: "Implement the fix",
+          status: "running",
+          deliveryStatus: "pending",
+          startedAt: 100,
+        });
+
+        // Follow-up run via sessions_send (different runId, same child session)
+        createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:telegram:main:direct:822430204",
+          scopeKind: "session",
+          requesterOrigin: {
+            channel: "telegram",
+            to: "telegram:822430204",
+          },
+          childSessionKey: "agent:claude:acp:5435d550",
+          runId: "f7d2c6b2",
+          label: "pr68-fix-followup",
+          task: "Continue with verification",
+          status: "running",
+          deliveryStatus: "pending",
+          startedAt: 200,
+        });
+
+        // First run completes
+        emitAgentEvent({
+          runId: "d8dcebd3",
+          stream: "lifecycle",
+          data: { phase: "end", endedAt: 300 },
+        });
+
+        await waitForAssertion(() =>
+          expect(findTaskByRunId("d8dcebd3")).toMatchObject({
+            status: "succeeded",
+            deliveryStatus: "session_queued",
+          }),
+        );
+
+        // Second run completes
+        emitAgentEvent({
+          runId: "f7d2c6b2",
+          stream: "lifecycle",
+          data: { phase: "end", endedAt: 400 },
+        });
+
+        await waitForAssertion(() =>
+          expect(findTaskByRunId("f7d2c6b2")).toMatchObject({
+            status: "succeeded",
+            deliveryStatus: "session_queued",
+          }),
+        );
+
+        // No banner sent to Telegram for either run
+        expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+        // No raw system events in parent session
+        expect(peekSystemEvents("agent:main:telegram:main:direct:822430204")).toEqual([]);
+        // Parent was woken via heartbeat
+        expect(hasPendingHeartbeatWake()).toBe(true);
+      });
+    });
+
+    it("blocked ACP child-session task still surfaces visibly", async () => {
+      await withTaskRegistryTempDir(async (root) => {
+        process.env.OPENCLAW_STATE_DIR = root;
+        resetTaskRegistryForTests();
+        resetHeartbeatWakeStateForTests();
+        hoisted.sendMessageMock.mockResolvedValue({
+          channel: "telegram",
+          to: "telegram:822430204",
+          via: "direct",
+        });
+
+        const task = createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:telegram:main:direct:822430204",
+          scopeKind: "session",
+          requesterOrigin: {
+            channel: "telegram",
+            to: "telegram:822430204",
+          },
+          childSessionKey: "agent:claude:acp:blocked-child",
+          runId: "blocked-run-1",
+          label: "blocked-task",
+          task: "Run blocked command",
+          status: "succeeded",
+          deliveryStatus: "pending",
+          terminalOutcome: "blocked",
+          terminalSummary: "Needs approval",
+        });
+
+        await maybeDeliverTaskTerminalUpdate(task.taskId);
+
+        // Blocked task MUST deliver visibly
+        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channel: "telegram",
+            to: "telegram:822430204",
+            content: expect.stringContaining("Background task blocked"),
+          }),
+        );
+      });
+    });
+
+    it("non-ACP tasks with childSessionKey are unaffected", async () => {
+      await withTaskRegistryTempDir(async (root) => {
+        process.env.OPENCLAW_STATE_DIR = root;
+        resetTaskRegistryForTests();
+        hoisted.sendMessageMock.mockResolvedValue({
+          channel: "telegram",
+          to: "telegram:123",
+          via: "direct",
+        });
+
+        const task = createTaskRecord({
+          runtime: "cli",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          requesterOrigin: {
+            channel: "telegram",
+            to: "telegram:123",
+          },
+          childSessionKey: "agent:cli:session:1",
+          runId: "cli-run-1",
+          task: "Run CLI command",
+          status: "succeeded",
+          deliveryStatus: "pending",
+        });
+
+        await maybeDeliverTaskTerminalUpdate(task.taskId);
+
+        // CLI task delivers normally — not affected by ACP silent wake
+        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channel: "telegram",
+            to: "telegram:123",
+            content: expect.stringContaining("Background task done"),
+          }),
+        );
+      });
+    });
+
+    it("ACP child-session silent wake fires even when notifyPolicy is silent", async () => {
+      await withTaskRegistryTempDir(async (root) => {
+        process.env.OPENCLAW_STATE_DIR = root;
+        resetTaskRegistryForTests();
+        resetHeartbeatWakeStateForTests();
+
+        const task = createTaskRecord({
+          runtime: "acp",
+          ownerKey: "agent:main:main",
+          scopeKind: "session",
+          childSessionKey: "agent:claude:acp:silent-child",
+          runId: "silent-run-1",
+          task: "Silent task",
+          status: "succeeded",
+          deliveryStatus: "pending",
+          notifyPolicy: "silent",
+        });
+
+        await maybeDeliverTaskTerminalUpdate(task.taskId);
+
+        // Even with notifyPolicy=silent, parent gets woken
+        expect(hasPendingHeartbeatWake()).toBe(true);
+        expect(findTaskByRunId("silent-run-1")).toMatchObject({
+          deliveryStatus: "session_queued",
+        });
+        expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -17,6 +17,7 @@ import {
   isTerminalTaskStatus,
   shouldAutoDeliverTaskStateChange,
   shouldAutoDeliverTaskTerminalUpdate,
+  shouldSilentWakeAcpChildSession,
   shouldSuppressDuplicateTerminalDelivery,
 } from "./task-executor-policy.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
@@ -1018,8 +1019,28 @@ function queueBlockedTaskFollowup(task: TaskRecord) {
 export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<TaskRecord | null> {
   ensureTaskRegistryReady();
   const current = tasks.get(taskId);
-  if (!current || !shouldAutoDeliverTaskTerminalUpdate(current)) {
-    return current ? cloneTaskRecord(current) : null;
+  if (!current) {
+    return null;
+  }
+  // ACP child-session runs get a silent parent wake instead of a user-visible
+  // banner. This check runs BEFORE the notifyPolicy gate so that orchestration
+  // continuation works even if notifyPolicy is set to "silent" on these tasks.
+  // Uses "session_queued" because delivery was handled via session-layer
+  // infrastructure (heartbeat wake), not via a user-facing channel.
+  if (
+    shouldSilentWakeAcpChildSession(current) &&
+    isTerminalTaskStatus(current.status) &&
+    current.deliveryStatus === "pending"
+  ) {
+    const owner = resolveTaskDeliveryOwner(current);
+    const ownerKey = owner.sessionKey?.trim();
+    if (ownerKey) {
+      requestHeartbeatNow({ reason: "background-task", sessionKey: ownerKey });
+    }
+    return updateTask(taskId, { deliveryStatus: "session_queued", lastEventAt: Date.now() });
+  }
+  if (!shouldAutoDeliverTaskTerminalUpdate(current)) {
+    return cloneTaskRecord(current);
   }
   if (tasksWithPendingDelivery.has(taskId)) {
     return cloneTaskRecord(current);


### PR DESCRIPTION
## What
- detect ACP child-session terminal tasks via `childSessionKey` instead of the nonexistent `spawnedBy` task field
- silently wake the parent session for successful non-blocked ACP child-session completions before notify-policy gating
- add regressions for same-child-session multi-run behavior, blocked visibility, non-ACP isolation, and silent-notify wake behavior

## Why
- repeated `Background task done` banners were being delivered per runId even when those runs belonged to the same ACP child session
- successful ACP child-session follow-up runs should resume the parent silently, while blocked and failure paths must remain visible

## Testing
- `pnpm test src/tasks/task-executor-policy.test.ts src/tasks/task-registry.test.ts`
- `pnpm tsgo`
- `pnpm lint -- src/tasks/task-executor-policy.ts src/tasks/task-registry.ts src/tasks/task-executor-policy.test.ts src/tasks/task-registry.test.ts`
- pre-commit hook `pnpm check` passed during commit
