### PR TITLE
Feat/google genai sdk as common provider across Google AI Studio and Google Cloud

### DIFF
--- a/docs/google-genai-auth.md
+++ b/docs/google-genai-auth.md
@@ -81,10 +81,19 @@ pnpm exec vitest run src/agents/google-genai.live.test.ts
 
 ### Troubleshooting
 
+#### 1. Node.js / gaxios dynamic import bug
 If you encounter an error like `Cannot convert undefined or null to object` originating from `gaxios` when using Vertex AI on Node.js, it may be due to a known bug in how `gaxios` dynamically imports `node-fetch`.
 
 As a workaround (already applied in our test file), you can polyfill `window` at the very top of your entry script:
 
 ```typescript
 (global as any).window = globalThis;
+```
+
+#### 2. Resource Not Found (404) on Vertex AI
+If you get a 404 error when using aliases like `gemini-flash-latest` on Vertex AI, it is likely because that alias is not supported in your specific region (e.g., `us-central1`). 
+
+**Solution**: Switch to the `global` location, which supports these aliases:
+```bash
+export GOOGLE_CLOUD_LOCATION="global"
 ```

--- a/docs/google-genai-auth.md
+++ b/docs/google-genai-auth.md
@@ -38,7 +38,7 @@ If you are working on your local machine and have the Google Cloud SDK (`gcloud`
 2.  **Set Project and Location**:
     ```bash
     export GOOGLE_CLOUD_PROJECT="your-project-id"
-    export GOOGLE_CLOUD_LOCATION="us-central1" # Optional, defaults to us-central1
+    export GOOGLE_CLOUD_LOCATION="global" # Default to global, use "us-central1" if needed
     ```
     _Ensure you do NOT have `GEMINI_API_KEY` set if you want to force the use of Vertex AI._
 
@@ -52,7 +52,7 @@ If `gcloud` login is not working (e.g., on a managed Cloudtop with certificate i
     ```bash
     export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-key.json"
     export GOOGLE_CLOUD_PROJECT="your-project-id"
-    export GOOGLE_CLOUD_LOCATION="us-central1"
+    export GOOGLE_CLOUD_LOCATION="global" # Or "us-central1"
     ```
 
 ---
@@ -74,7 +74,7 @@ pnpm exec vitest run src/agents/google-genai.live.test.ts
 ```bash
 GEMINI_LIVE_TEST=1 \
 GOOGLE_CLOUD_PROJECT="your-project-id" \
-GOOGLE_CLOUD_LOCATION="us-central1" \
+GOOGLE_CLOUD_LOCATION="global" \
 GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/key.json" \
 pnpm exec vitest run src/agents/google-genai.live.test.ts
 ```

--- a/docs/google-genai-auth.md
+++ b/docs/google-genai-auth.md
@@ -1,0 +1,90 @@
+# Google GenAI Authentication Guide
+
+The `google-genai` provider in OpenClaw supports two main access paths, which can be configured in three different ways depending on your environment.
+
+---
+
+## Path 1: Gemini API (Google AI Studio)
+
+This is the simplest path and requires a direct API key.
+
+### Configuration
+
+1.  **Obtain an API Key**: Get a key from Google AI Studio.
+2.  **Set Environment Variable**:
+    ```bash
+    export GEMINI_API_KEY="AIzaSy..."
+    ```
+    _Note: Gemini API keys typically start with `AIzaSy`._
+
+The SDK will automatically use this key if it is present in the environment.
+
+---
+
+## Path 2: Vertex AI (Google Cloud)
+
+This path uses Google Cloud's Vertex AI and relies on Application Default Credentials (ADC). You must ensure that the Vertex AI API is enabled in your Google Cloud project.
+
+You can authenticate in two ways:
+
+### Option A: User Login (Best for Local Development)
+
+If you are working on your local machine and have the Google Cloud SDK (`gcloud`) installed:
+
+1.  **Login**:
+    ```bash
+    gcloud auth application-default login
+    ```
+2.  **Set Project and Location**:
+    ```bash
+    export GOOGLE_CLOUD_PROJECT="your-project-id"
+    export GOOGLE_CLOUD_LOCATION="us-central1" # Optional, defaults to us-central1
+    ```
+    _Ensure you do NOT have `GEMINI_API_KEY` set if you want to force the use of Vertex AI._
+
+### Option B: Service Account Key (Best for Servers/CI/CD or Workarounds)
+
+If `gcloud` login is not working (e.g., on a managed Cloudtop with certificate issues) or you are running on a server:
+
+1.  **Create a Service Account**: In the Google Cloud Console, create a service account and grant it the **Vertex AI User** role (`roles/aiplatform.user`).
+2.  **Download Key**: Download the private key in JSON format.
+3.  **Set Environment Variables**:
+    ```bash
+    export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-key.json"
+    export GOOGLE_CLOUD_PROJECT="your-project-id"
+    export GOOGLE_CLOUD_LOCATION="us-central1"
+    ```
+
+---
+
+## Running Live Tests
+
+To verify your configuration, you can run the live tests. You must enable them by setting `GEMINI_LIVE_TEST=1`.
+
+### Example: Testing API Key
+
+```bash
+GEMINI_LIVE_TEST=1 \
+GEMINI_API_KEY="AIzaSy..." \
+pnpm exec vitest run src/agents/google-genai.live.test.ts
+```
+
+### Example: Testing Vertex AI (Service Account)
+
+```bash
+GEMINI_LIVE_TEST=1 \
+GOOGLE_CLOUD_PROJECT="your-project-id" \
+GOOGLE_CLOUD_LOCATION="us-central1" \
+GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/key.json" \
+pnpm exec vitest run src/agents/google-genai.live.test.ts
+```
+
+### Troubleshooting
+
+If you encounter an error like `Cannot convert undefined or null to object` originating from `gaxios` when using Vertex AI on Node.js, it may be due to a known bug in how `gaxios` dynamically imports `node-fetch`.
+
+As a workaround (already applied in our test file), you can polyfill `window` at the very top of your entry script:
+
+```typescript
+(global as any).window = globalThis;
+```

--- a/src/agents/google-genai-stream.ts
+++ b/src/agents/google-genai-stream.ts
@@ -30,7 +30,7 @@ export function createGoogleGenAiStreamFnForModel(
       try {
         const apiKey = options?.apiKey ?? env.GEMINI_API_KEY;
         const project = env.GOOGLE_CLOUD_PROJECT;
-        const location = env.GOOGLE_CLOUD_LOCATION;
+        const location = env.GOOGLE_CLOUD_LOCATION || "global"; // Default to global, use "us-central1" if needed
 
         let ai: GoogleGenAI;
 
@@ -41,11 +41,6 @@ export function createGoogleGenAiStreamFnForModel(
           if (!project) {
             throw new Error(
               "Google Vertex ADC Error: Project ID is missing.\nRecovery: Vertex AI requires a project ID. Either define 'GOOGLE_CLOUD_PROJECT' in your environment or set 'models.providers.google-genai.vertexai.project' in openclaw.json.",
-            );
-          }
-          if (!location) {
-            throw new Error(
-              "Google Vertex ADC Error: Location is missing.\nRecovery: Vertex AI requires a location (e.g., 'us-central1'). Either define 'GOOGLE_CLOUD_LOCATION' in your environment or set 'models.providers.google-genai.vertexai.location' in openclaw.json.",
             );
           }
 
@@ -139,6 +134,15 @@ export function createGoogleGenAiStreamFnForModel(
             const project = env.GOOGLE_CLOUD_PROJECT || "[PROJECT_ID]";
             processedError = new Error(
               `${errorMessage}\nRecovery: Received 401 from Vertex AI. Ensure the authenticated Service Account or User has the 'Vertex AI User' (roles/aiplatform.user) IAM role assigned for project ${project}. Run 'gcloud auth application-default login' to refresh credentials.`,
+            );
+          }
+        }
+        // Intercept 404 Not Found from Vertex AI
+        if (errorMessage.includes("404") || errorMessage.includes("NOT_FOUND") || errorMessage.includes("not found")) {
+          const currentLoc = env.GOOGLE_CLOUD_LOCATION || "global";
+          if (currentLoc !== "global") {
+            processedError = new Error(
+              `${errorMessage}\nRecovery: Resource not found. Your current location is '${currentLoc}'. Some models/aliases (like 'gemini-flash-latest') are only available on the 'global' endpoint in Vertex AI. Try setting GOOGLE_CLOUD_LOCATION="global" in your environment or openclaw.json.`,
             );
           }
         }

--- a/src/agents/google-genai-stream.ts
+++ b/src/agents/google-genai-stream.ts
@@ -9,7 +9,7 @@ import {
 } from "./transport-stream-shared.js";
 
 export function createGoogleGenAiStreamFnForModel(
-  model: { id: string; provider: string; baseUrl?: string },
+  model: { id: string; provider: string; baseUrl?: string; vertexai?: { project?: string; location?: string } },
   env: NodeJS.ProcessEnv = process.env,
 ): StreamFn {
   return (rawModel: unknown, context: Context, options?: SimpleStreamOptions) => {
@@ -29,8 +29,8 @@ export function createGoogleGenAiStreamFnForModel(
 
       try {
         const apiKey = options?.apiKey ?? env.GEMINI_API_KEY;
-        const project = env.GOOGLE_CLOUD_PROJECT;
-        const location = env.GOOGLE_CLOUD_LOCATION || "global"; // Default to global, use "us-central1" if needed
+        const project = model.vertexai?.project ?? env.GOOGLE_CLOUD_PROJECT;
+        const location = model.vertexai?.location ?? (env.GOOGLE_CLOUD_LOCATION || "global"); // Default to global
 
         let ai: GoogleGenAI;
 
@@ -79,6 +79,7 @@ export function createGoogleGenAiStreamFnForModel(
         const responseStream = await ai.models.generateContentStream({
           model: model.id,
           contents: contents,
+          config: context.systemPrompt ? { systemInstruction: context.systemPrompt } : undefined,
         });
 
         let currentBlockIndex = -1;

--- a/src/agents/google-genai-stream.ts
+++ b/src/agents/google-genai-stream.ts
@@ -57,24 +57,38 @@ export function createGoogleGenAiStreamFnForModel(
         const contents = context.messages
           .map((msg: unknown) => {
             const m = msg as {
-              content: string | Array<{ type: string; text?: string }>;
+              content: string | Array<{ type: string; text?: string; data?: string; mimeType?: string }>;
               role: string;
             };
-            let text = "";
+
+            let parts: any[] = [];
+
             if (typeof m.content === "string") {
-              text = m.content;
+              parts.push({ text: sanitizeTransportPayloadText(m.content) });
             } else if (Array.isArray(m.content)) {
-              text = m.content
-                .filter((part) => part.type === "text")
-                .map((part) => part.text || "")
-                .join("\n");
+              parts = m.content
+                .map((part) => {
+                  if (part.type === "text" && part.text) {
+                    return { text: sanitizeTransportPayloadText(part.text) };
+                  } else if (part.type === "image" && part.data && part.mimeType) {
+                    return {
+                      inlineData: {
+                        mimeType: part.mimeType,
+                        data: part.data,
+                      },
+                    };
+                  }
+                  return null;
+                })
+                .filter((p): p is nonNullable<typeof p> => p !== null);
             }
+
             return {
               role: m.role === "user" ? "user" : "model",
-              parts: [{ text: sanitizeTransportPayloadText(text) }],
+              parts: parts,
             };
           })
-          .filter((c: { parts: Array<{ text: string }> }) => c.parts[0].text.length > 0);
+          .filter((c: { parts: any[] }) => c.parts.length > 0);
 
         const responseStream = await ai.models.generateContentStream({
           model: model.id,

--- a/src/agents/google-genai-stream.ts
+++ b/src/agents/google-genai-stream.ts
@@ -1,0 +1,151 @@
+import { GoogleGenAI } from "@google/genai";
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import {
+  createWritableTransportEventStream,
+  finalizeTransportStream,
+  failTransportStream,
+  sanitizeTransportPayloadText,
+} from "./transport-stream-shared.js";
+
+export function createGoogleGenAiStreamFnForModel(
+  model: { id: string; provider: string; baseUrl?: string },
+  env: NodeJS.ProcessEnv = process.env,
+): StreamFn {
+  return (rawModel: unknown, context: Context, options?: SimpleStreamOptions) => {
+    const { eventStream, stream } = createWritableTransportEventStream();
+
+    void (async () => {
+      const output = {
+        role: "assistant",
+        content: [] as Array<{ type: "text"; text: string }>,
+        api: "google-genai",
+        provider: model.provider,
+        model: model.id,
+        usage: { input: 0, output: 0, totalTokens: 0 },
+        stopReason: "stop",
+        timestamp: Date.now(),
+      };
+
+      try {
+        const apiKey = options?.apiKey ?? env.GEMINI_API_KEY;
+        const project = env.GOOGLE_CLOUD_PROJECT;
+        const location = env.GOOGLE_CLOUD_LOCATION;
+
+        let ai: GoogleGenAI;
+
+        if (apiKey) {
+          ai = new GoogleGenAI({ apiKey });
+        } else {
+          // Vertex AI / ADC mode
+          if (!project) {
+            throw new Error(
+              "Google Vertex ADC Error: Project ID is missing.\nRecovery: Vertex AI requires a project ID. Either define 'GOOGLE_CLOUD_PROJECT' in your environment or set 'models.providers.google-genai.vertexai.project' in openclaw.json.",
+            );
+          }
+          if (!location) {
+            throw new Error(
+              "Google Vertex ADC Error: Location is missing.\nRecovery: Vertex AI requires a location (e.g., 'us-central1'). Either define 'GOOGLE_CLOUD_LOCATION' in your environment or set 'models.providers.google-genai.vertexai.location' in openclaw.json.",
+            );
+          }
+
+          ai = new GoogleGenAI({
+            vertexai: true,
+            project: project,
+            location: location,
+          });
+        }
+
+        stream.push({ type: "start", partial: output as never });
+
+        // Simplified message conversion for now
+        const contents = context.messages
+          .map((msg: unknown) => {
+            const m = msg as {
+              content: string | Array<{ type: string; text?: string }>;
+              role: string;
+            };
+            let text = "";
+            if (typeof m.content === "string") {
+              text = m.content;
+            } else if (Array.isArray(m.content)) {
+              text = m.content
+                .filter((part) => part.type === "text")
+                .map((part) => part.text || "")
+                .join("\n");
+            }
+            return {
+              role: m.role === "user" ? "user" : "model",
+              parts: [{ text: sanitizeTransportPayloadText(text) }],
+            };
+          })
+          .filter((c: { parts: Array<{ text: string }> }) => c.parts[0].text.length > 0);
+
+        const responseStream = await ai.models.generateContentStream({
+          model: model.id,
+          contents: contents,
+        });
+
+        let currentBlockIndex = -1;
+
+        for await (const chunk of responseStream) {
+          const text = chunk.text;
+          if (text) {
+            if (currentBlockIndex < 0) {
+              output.content.push({ type: "text", text: "" });
+              currentBlockIndex = output.content.length - 1;
+              stream.push({
+                type: "text_start",
+                contentIndex: currentBlockIndex,
+                partial: output as never,
+              });
+            }
+
+            const activeBlock = output.content[currentBlockIndex];
+            if (activeBlock && activeBlock.type === "text") {
+              activeBlock.text += text;
+              stream.push({
+                type: "text_delta",
+                contentIndex: currentBlockIndex,
+                delta: text,
+                partial: output as never,
+              });
+            }
+          }
+        }
+
+        if (currentBlockIndex >= 0) {
+          const activeBlock = output.content[currentBlockIndex];
+          if (activeBlock && activeBlock.type === "text") {
+            stream.push({
+              type: "text_end",
+              contentIndex: currentBlockIndex,
+              content: activeBlock.text,
+              partial: output as never,
+            });
+          }
+        }
+
+        finalizeTransportStream({ stream, output, signal: options?.signal });
+      } catch (error: unknown) {
+        console.error("Stream error:", error);
+        let processedError = error;
+        const errorMessage = error instanceof Error ? error.message : String(error);
+
+        // Intercept 401 Unauthorized from Vertex AI
+        if (errorMessage.includes("401") || errorMessage.includes("UNAUTHENTICATED")) {
+          const apiKey = options?.apiKey ?? env.GEMINI_API_KEY;
+          if (!apiKey) {
+            const project = env.GOOGLE_CLOUD_PROJECT || "[PROJECT_ID]";
+            processedError = new Error(
+              `${errorMessage}\nRecovery: Received 401 from Vertex AI. Ensure the authenticated Service Account or User has the 'Vertex AI User' (roles/aiplatform.user) IAM role assigned for project ${project}. Run 'gcloud auth application-default login' to refresh credentials.`,
+            );
+          }
+        }
+        failTransportStream({ stream, output, signal: options?.signal, error: processedError });
+      }
+    })();
+
+    return eventStream as unknown as ReturnType<StreamFn>;
+  };
+}

--- a/src/agents/google-genai-stream.ts
+++ b/src/agents/google-genai-stream.ts
@@ -1,12 +1,15 @@
 import { GoogleGenAI } from "@google/genai";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   createWritableTransportEventStream,
   finalizeTransportStream,
   failTransportStream,
   sanitizeTransportPayloadText,
 } from "./transport-stream-shared.js";
+
+const log = createSubsystemLogger("google-genai");
 
 export function createGoogleGenAiStreamFnForModel(
   model: { id: string; provider: string; baseUrl?: string; vertexai?: { project?: string; location?: string } },
@@ -138,7 +141,7 @@ export function createGoogleGenAiStreamFnForModel(
 
         finalizeTransportStream({ stream, output, signal: options?.signal });
       } catch (error: unknown) {
-        console.error("Stream error:", error);
+        log.error("Stream error:", error);
         let processedError = error;
         const errorMessage = error instanceof Error ? error.message : String(error);
 

--- a/src/agents/google-genai-stream.ts
+++ b/src/agents/google-genai-stream.ts
@@ -83,7 +83,7 @@ export function createGoogleGenAiStreamFnForModel(
                   }
                   return null;
                 })
-                .filter((p): p is nonNullable<typeof p> => p !== null);
+                .filter((p): p is NonNullable<typeof p> => p !== null);
             }
 
             return {
@@ -141,7 +141,7 @@ export function createGoogleGenAiStreamFnForModel(
 
         finalizeTransportStream({ stream, output, signal: options?.signal });
       } catch (error: unknown) {
-        log.error("Stream error:", error);
+        log.error("Stream error: " + String(error));
         let processedError = error;
         const errorMessage = error instanceof Error ? error.message : String(error);
 

--- a/src/agents/google-genai.live.test.ts
+++ b/src/agents/google-genai.live.test.ts
@@ -1,7 +1,4 @@
-// Polyfill window to avoid gaxios node-fetch dynamic import bug
-(global as any).window = globalThis;
-
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
 import { createGoogleGenAiStreamFnForModel } from "./google-genai-stream.js";
 import { isLiveTestEnabled } from "./live-test-helpers.js";
 
@@ -15,6 +12,21 @@ const LIVE = isLiveTestEnabled(["GEMINI_LIVE_TEST"]);
 const describeLive = LIVE ? describe : describe.skip;
 
 describeLive("google-genai live tests", () => {
+  let originalWindow: any;
+
+  beforeAll(() => {
+    originalWindow = (global as any).window;
+    (global as any).window = globalThis;
+  });
+
+  afterAll(() => {
+    if (originalWindow === undefined) {
+      delete (global as any).window;
+    } else {
+      (global as any).window = originalWindow;
+    }
+  });
+
   const describeApiKey = GEMINI_KEY ? describe : describe.skip;
   describeApiKey("API Key Access", () => {
     it("can stream responses using API Key", async () => {

--- a/src/agents/google-genai.live.test.ts
+++ b/src/agents/google-genai.live.test.ts
@@ -7,7 +7,8 @@ import { isLiveTestEnabled } from "./live-test-helpers.js";
 
 const GEMINI_KEY = process.env.GEMINI_API_KEY ?? "";
 const PROJECT = process.env.GOOGLE_CLOUD_PROJECT ?? "";
-const LOCATION = process.env.GOOGLE_CLOUD_LOCATION ?? "";
+const LOCATION = process.env.GOOGLE_CLOUD_LOCATION ?? "global";
+const TEST_MODEL = "gemini-flash-latest";
 
 const LIVE = isLiveTestEnabled(["GEMINI_LIVE_TEST"]);
 
@@ -18,7 +19,7 @@ describeLive("google-genai live tests", () => {
   describeApiKey("API Key Access", () => {
     it("can stream responses using API Key", async () => {
       const streamFn = createGoogleGenAiStreamFnForModel({
-        id: "gemini-2.5-flash",
+        id: TEST_MODEL,
         provider: "google-genai",
       });
 
@@ -51,7 +52,7 @@ describeLive("google-genai live tests", () => {
   describeVertex("Vertex AI (ADC) Access", () => {
     it("can stream responses using Vertex AI / ADC", async () => {
       const streamFn = createGoogleGenAiStreamFnForModel({
-        id: "gemini-2.5-flash",
+        id: TEST_MODEL,
         provider: "google-genai",
       });
 

--- a/src/agents/google-genai.live.test.ts
+++ b/src/agents/google-genai.live.test.ts
@@ -1,0 +1,91 @@
+// Polyfill window to avoid gaxios node-fetch dynamic import bug
+(global as any).window = globalThis;
+
+import { describe, expect, it } from "vitest";
+import { createGoogleGenAiStreamFnForModel } from "./google-genai-stream.js";
+import { isLiveTestEnabled } from "./live-test-helpers.js";
+
+const GEMINI_KEY = process.env.GEMINI_API_KEY ?? "";
+const PROJECT = process.env.GOOGLE_CLOUD_PROJECT ?? "";
+const LOCATION = process.env.GOOGLE_CLOUD_LOCATION ?? "";
+
+const LIVE = isLiveTestEnabled(["GEMINI_LIVE_TEST"]);
+
+const describeLive = LIVE ? describe : describe.skip;
+
+describeLive("google-genai live tests", () => {
+  const describeApiKey = GEMINI_KEY ? describe : describe.skip;
+  describeApiKey("API Key Access", () => {
+    it("can stream responses using API Key", async () => {
+      const streamFn = createGoogleGenAiStreamFnForModel({
+        id: "gemini-2.5-flash",
+        provider: "google-genai",
+      });
+
+      const eventStream = streamFn(
+        {} as any,
+        {
+          messages: [
+            {
+              role: "user",
+              content: "Reply with 'Hello from API Key'.",
+              timestamp: Date.now(),
+            },
+          ],
+        } as any,
+        {
+          apiKey: GEMINI_KEY,
+        } as any,
+      );
+
+      const result = await (eventStream as any).result();
+      if (result.stopReason === "error") {
+        console.error("API Key Test Failed. Result:", JSON.stringify(result, null, 2));
+      }
+      expect(result.stopReason).toBe("stop");
+      expect(result.content[0].text).toContain("Hello from API Key");
+    }, 20000);
+  });
+
+  const describeVertex = PROJECT && LOCATION ? describe : describe.skip;
+  describeVertex("Vertex AI (ADC) Access", () => {
+    it("can stream responses using Vertex AI / ADC", async () => {
+      const streamFn = createGoogleGenAiStreamFnForModel({
+        id: "gemini-2.5-flash",
+        provider: "google-genai",
+      });
+
+      // Temporarily remove GEMINI_API_KEY to force ADC fallback
+      const oldKey = process.env.GEMINI_API_KEY;
+      delete process.env.GEMINI_API_KEY;
+
+      try {
+        const eventStream = streamFn(
+          {} as any,
+          {
+            messages: [
+              {
+                role: "user",
+                content: "Reply with 'Hello from Vertex AI'.",
+                timestamp: Date.now(),
+              },
+            ],
+          } as any,
+          {} as any, // No API key
+        );
+
+        const result = await (eventStream as any).result();
+        if (result.stopReason === "error") {
+          console.error("Vertex AI Test Failed. Result:", JSON.stringify(result, null, 2));
+        }
+        expect(result.stopReason).toBe("stop");
+        expect(result.content[0].text).toContain("Hello from Vertex AI");
+      } finally {
+        // Restore GEMINI_API_KEY
+        if (oldKey !== undefined) {
+          process.env.GEMINI_API_KEY = oldKey;
+        }
+      }
+    }, 20000);
+  });
+});

--- a/src/agents/model-auth-runtime-shared.ts
+++ b/src/agents/model-auth-runtime-shared.ts
@@ -9,7 +9,7 @@ export type ResolvedProviderAuth = {
   apiKey?: string;
   profileId?: string;
   source: string;
-  mode: "api-key" | "oauth" | "token" | "aws-sdk";
+  mode: "api-key" | "oauth" | "token" | "aws-sdk" | "google-genai-sdk";
 };
 
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -137,7 +137,13 @@ function resolveProviderAuthOverride(
 ): ModelProviderAuthMode | undefined {
   const entry = resolveProviderConfig(cfg, provider);
   const auth = entry?.auth;
-  if (auth === "api-key" || auth === "aws-sdk" || auth === "oauth" || auth === "token") {
+  if (
+    auth === "api-key" ||
+    auth === "aws-sdk" ||
+    auth === "oauth" ||
+    auth === "token" ||
+    auth === "google-genai-sdk"
+  ) {
     return auth;
   }
   return undefined;
@@ -323,6 +329,21 @@ function resolveAwsSdkAuthInfo(): { mode: "aws-sdk"; source: string } {
   return { mode: "aws-sdk", source: "aws-sdk default chain" };
 }
 
+function resolveGoogleGenAiSdkAuthInfo(): { mode: "google-genai-sdk"; source: string } {
+  const applied = new Set(getShellEnvAppliedKeys());
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS?.trim()) {
+    return {
+      mode: "google-genai-sdk",
+      source: resolveEnvSourceLabel({
+        applied,
+        envVars: ["GOOGLE_APPLICATION_CREDENTIALS"],
+        label: "GOOGLE_APPLICATION_CREDENTIALS",
+      }),
+    };
+  }
+  return { mode: "google-genai-sdk", source: "google-genai-sdk default chain" };
+}
+
 function shouldDeferSyntheticProfileAuth(params: {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -397,6 +418,9 @@ export async function resolveApiKeyForProvider(params: {
   const authOverride = resolveProviderAuthOverride(cfg, provider);
   if (authOverride === "aws-sdk") {
     return resolveAwsSdkAuthInfo();
+  }
+  if (authOverride === "google-genai-sdk") {
+    return resolveGoogleGenAiSdkAuthInfo();
   }
   if (shouldPreferExplicitConfigApiKeyAuth(cfg, provider)) {
     const customKey = resolveUsableCustomProviderApiKey({ cfg, provider });
@@ -535,7 +559,14 @@ export async function resolveApiKeyForProvider(params: {
   );
 }
 
-export type ModelAuthMode = "api-key" | "oauth" | "token" | "mixed" | "aws-sdk" | "unknown";
+export type ModelAuthMode =
+  | "api-key"
+  | "oauth"
+  | "token"
+  | "mixed"
+  | "aws-sdk"
+  | "unknown"
+  | "google-genai-sdk";
 
 export { resolveEnvApiKey } from "./model-auth-env.js";
 export type { EnvApiKeyResult } from "./model-auth-env.js";
@@ -553,6 +584,9 @@ export function resolveModelAuthMode(
   const authOverride = resolveProviderAuthOverride(cfg, resolved);
   if (authOverride === "aws-sdk") {
     return "aws-sdk";
+  }
+  if (authOverride === "google-genai-sdk") {
+    return "google-genai-sdk";
   }
 
   const authStore = store ?? ensureAuthProfileStore();
@@ -607,6 +641,9 @@ export async function hasAvailableAuthForProvider(params: {
 
   const authOverride = resolveProviderAuthOverride(cfg, provider);
   if (authOverride === "aws-sdk") {
+    return true;
+  }
+  if (authOverride === "google-genai-sdk") {
     return true;
   }
   if (resolveEnvApiKey(provider)) {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -366,7 +366,7 @@ export async function compactEmbeddedPiSessionDirect(
     });
 
     if (!apiKeyInfo.apiKey) {
-      if (apiKeyInfo.mode !== "aws-sdk") {
+      if (apiKeyInfo.mode !== "aws-sdk" && apiKeyInfo.mode !== "google-genai-sdk") {
         throw new Error(
           `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,
         );

--- a/src/agents/pi-embedded-runner/run/auth-controller.ts
+++ b/src/agents/pi-embedded-runner/run/auth-controller.ts
@@ -349,7 +349,7 @@ export function createEmbeddedRunAuthController(params: {
     params.setApiKeyInfo(apiKeyInfo);
     const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
     if (!apiKeyInfo.apiKey) {
-      if (apiKeyInfo.mode !== "aws-sdk") {
+      if (apiKeyInfo.mode !== "aws-sdk" && apiKeyInfo.mode !== "google-genai-sdk") {
         const runtimeModel = params.getRuntimeModel();
         throw new Error(
           `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,

--- a/src/agents/pi-embedded-runner/stream-resolution.ts
+++ b/src/agents/pi-embedded-runner/stream-resolution.ts
@@ -1,6 +1,7 @@
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import { streamSimple } from "@mariozechner/pi-ai";
 import { createAnthropicVertexStreamFnForModel } from "../anthropic-vertex-stream.js";
+import { createGoogleGenAiStreamFnForModel } from "../google-genai-stream.js";
 import { createOpenAIWebSocketStreamFn } from "../openai-ws-stream.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
 import { createBoundaryAwareStreamFnForModel } from "../provider-transport-stream.js";
@@ -115,6 +116,10 @@ export function resolveEmbeddedAgentStreamFn(params: {
 
   if (params.model.provider === "anthropic-vertex") {
     return createAnthropicVertexStreamFnForModel(params.model);
+  }
+
+  if (params.model.provider === "google-genai") {
+    return createGoogleGenAiStreamFnForModel(params.model);
   }
 
   if (params.currentStreamFn === undefined || params.currentStreamFn === streamSimple) {

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -46,7 +46,7 @@ export type ModelCompatConfig = SupportedOpenAICompatFields & {
   requiresOpenAiAnthropicToolPayload?: boolean;
 };
 
-export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token";
+export type ModelProviderAuthMode = "api-key" | "aws-sdk" | "oauth" | "token" | "google-genai-sdk";
 
 export type ModelDefinitionConfig = {
   id: string;
@@ -73,9 +73,13 @@ export type ModelDefinitionConfig = {
 };
 
 export type ModelProviderConfig = {
-  baseUrl: string;
+  baseUrl?: string;
   apiKey?: SecretInput;
   auth?: ModelProviderAuthMode;
+  vertexai?: {
+    project?: string;
+    location?: string;
+  };
   api?: ModelApi;
   injectNumCtxForOpenAICompat?: boolean;
   headers?: Record<string, SecretInput>;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -327,10 +327,22 @@ export const ModelDefinitionSchema = z
 
 export const ModelProviderSchema = z
   .object({
-    baseUrl: z.string().min(1),
+    baseUrl: z.string().min(1).optional(),
     apiKey: SecretInputSchema.optional().register(sensitive),
     auth: z
-      .union([z.literal("api-key"), z.literal("aws-sdk"), z.literal("oauth"), z.literal("token")])
+      .union([
+        z.literal("api-key"),
+        z.literal("aws-sdk"),
+        z.literal("oauth"),
+        z.literal("token"),
+        z.literal("google-genai-sdk"),
+      ])
+      .optional(),
+    vertexai: z
+      .object({
+        project: z.string().optional(),
+        location: z.string().optional(),
+      })
       .optional(),
     api: ModelApiSchema.optional(),
     injectNumCtxForOpenAICompat: z.boolean().optional(),


### PR DESCRIPTION
## Summary

This PR integrates the new unified `@google/genai` SDK into OpenClaw, enabling support for both Google AI Studio (Gemini API) and Vertex AI (Google Cloud) via a single provider (`google-genai`).

- **Problem**: Google AI Studio `API_KEY` and Google Cloud Vertex AI are confusing to users, and hard to configure - non-API_KEY auth needs to be standardized in several spots in the codebase.
- **Why it matters**: IAM or ADC auth is more secure than API_KEYs and may help users get access.
- **What changed**: Similar to the AWS SDK provider, we added a Google Gen AI SDK which is unified across endpoints and maintained by Google.
- **What did NOT change (scope boundary)**: We did not yet deprecate or migrate other providers, but that's a reasonable next step.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #48033, #49191, #52648, #62212 (Resolves/improves Vertex AI ADC authentication issues by providing a working SDK integration).

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [X] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/google-genai.live.test.ts`
- Scenario the test should lock in: Successful streaming and authentication for both API Key and Vertex AI (ADC) paths.
- Why this is the smallest reliable guardrail: It exercises the actual SDK network calls and authentication resolution against live Google endpoints.
- Existing test that already covers this (if any): None (this is a new provider integration).
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Added a new provider `google-genai` that can be used in `openclaw.json`.
- Added support for `google-genai-sdk` authentication mode.
- Defaulted Vertex AI location to `"global"` to better support modern model aliases (like `gemini-flash-latest`).

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before (Vertex AI):
[User Config] -> [Legacy Auth Resolution] -> [Failures on ADC/IAM paths]

After (google-genai):
[User Config] -> [google-genai-sdk Auth] -> [Checks API Key -> Falls back to ADC (global default)] -> [Success]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: 
  - **Risk**: New network calls to Google GenAI endpoints.
  - **Mitigation**: The calls use standard official Google SDKs and follow secure Application Default Credentials (ADC) patterns, which are preferred over static API keys.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js (ESM)
- Model/provider: `gemini-flash-latest` via `google-genai`
- Integration/channel (if any): N/A
- Relevant config (redacted): Set `GEMINI_LIVE_TEST=1`, `GEMINI_API_KEY` or `GOOGLE_APPLICATION_CREDENTIALS`.

### Steps

1. Configure environment with either an API Key or a Service Account JSON file.
2. Run the live test: `pnpm exec vitest run src/agents/google-genai.live.test.ts`

### Expected

- Both tests (API Key and Vertex AI) pass and stream content successfully.

### Actual

- Both tests passed successfully after applying a workaround for a known `gaxios` bug in Node ESM.

## Evidence

Attach at least one:

- [X] Failing test/log before + passing after (The Vertex AI test originally failed with a `gaxios` dynamic import error before the polyfill fix).
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Live streaming via API Key and live streaming via Vertex AI using a Service Account JSON key.
- Edge cases checked: Verified that omitting the location defaults to `global` and successfully resolves the `gemini-flash-latest` alias on Vertex AI.
- What you did **not** verify: Did not verify `gcloud auth application-default login` directly due to environment constraints on the test machine, but verified the identical ADC resolution path via a service account file.

## Review Conversations

- [X] I replied to or resolved every bot review conversation I addressed in this PR.
- [X] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes` - adds new config options for the new provider).
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The underlying `gaxios` library has a bug in Node ESM environments where it fails to dynamically import `node-fetch` when checking for `window.fetch`.
  - Mitigation: We added documentation in `docs/google-genai-auth.md` explaining the workaround (`global.window = globalThis`) and applied it in the test file.