### PR TITLE
fix(sessions): allow env override for sessions_history text truncation limit

### DIFF
--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -10,7 +10,7 @@ import {
   describeSessionsHistoryTool,
   SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
-import { readEnvInt } from "../bash-tools.shared.js";
+import { clampWithDefault, readEnvInt } from "../bash-tools.shared.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 import {
@@ -34,7 +34,12 @@ const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
 // matching the pattern used by PI_BASH_MAX_OUTPUT_CHARS in exec-runtime.
 // Default 4000 chars keeps session history responses compact while allowing
 // override for users who need longer context windows (#64970).
-const SESSIONS_HISTORY_TEXT_MAX_CHARS = readEnvInt("SESSIONS_HISTORY_TEXT_MAX_CHARS") ?? 4000;
+const SESSIONS_HISTORY_TEXT_MAX_CHARS = clampWithDefault(
+  readEnvInt("SESSIONS_HISTORY_TEXT_MAX_CHARS"),
+  4000,
+  1,
+  Number.MAX_SAFE_INTEGER,
+);
 type GatewayCaller = typeof callGateway;
 
 // sandbox policy handling is shared with sessions-list-tool via sessions-helpers.ts

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -10,6 +10,7 @@ import {
   describeSessionsHistoryTool,
   SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY,
 } from "../tool-description-presets.js";
+import { readEnvInt } from "../bash-tools.shared.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 import {
@@ -29,7 +30,11 @@ const SessionsHistoryToolSchema = Type.Object({
 });
 
 const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
-const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;
+// Allow operators to override the per-entry text truncation limit via env,
+// matching the pattern used by PI_BASH_MAX_OUTPUT_CHARS in exec-runtime.
+// Default 4000 chars keeps session history responses compact while allowing
+// override for users who need longer context windows (#64970).
+const SESSIONS_HISTORY_TEXT_MAX_CHARS = readEnvInt("SESSIONS_HISTORY_TEXT_MAX_CHARS") ?? 4000;
 type GatewayCaller = typeof callGateway;
 
 // sandbox policy handling is shared with sessions-list-tool via sessions-helpers.ts


### PR DESCRIPTION
## Summary

`SESSIONS_HISTORY_TEXT_MAX_CHARS` was hardcoded to `4000` in `src/agents/tools/sessions-history-tool.ts`, unlike `PI_BASH_MAX_OUTPUT_CHARS` which reads from env via `readEnvInt()`. Users with large context windows or long conversation histories had no way to increase the per-entry text truncation limit.

Fixes #64970

## Root cause

```ts
// sessions-history-tool.ts:32 (before fix)
const SESSIONS_HISTORY_TEXT_MAX_CHARS = 4000;  // hardcoded, no env override

// bash-tools.exec-runtime.ts:105 (existing pattern)
readEnvInt("PI_BASH_MAX_OUTPUT_CHARS"),  // reads from env, falls back to default
```

## Fix

```ts
const SESSIONS_HISTORY_TEXT_MAX_CHARS = readEnvInt("SESSIONS_HISTORY_TEXT_MAX_CHARS") ?? 4000;
```

Matches the existing env-override pattern used by `PI_BASH_MAX_OUTPUT_CHARS` and `OPENCLAW_BASH_PENDING_MAX_OUTPUT_CHARS` in `bash-tools.exec-runtime.ts`. Import added from `../bash-tools.shared.js` where `readEnvInt` is already exported.

## Scope

- **Files**: `sessions-history-tool.ts` (+6/-1)
- **Production LOC**: 1 line changed (+ import + comment)
- **oxlint clean**
- **Zero competing PRs**

Credit to @Galaxy-Chen for identifying the inconsistency in #64970.