### PR TITLE
fix(amazon-bedrock): track literal contextWindow fallbacks with provenance flag

### DIFF
--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -111,7 +111,23 @@ describe("bedrock discovery", () => {
       config: { defaultContextWindow: 64000, defaultMaxTokens: 8192 },
       clientFactory,
     });
-    expect(models[0]).toMatchObject({ contextWindow: 64000, maxTokens: 8192 });
+    expect(models[0]).toMatchObject({
+      contextWindow: 64000,
+      maxTokens: 8192,
+      contextWindowIsLiteralDefault: false,
+    });
+  });
+
+  it("flags contextWindowIsLiteralDefault=true when no defaultContextWindow config is set", async () => {
+    mockSingleActiveSummary();
+
+    const models = await discoverBedrockModels({
+      region: "us-east-1",
+      config: { defaultContextWindow: undefined, defaultMaxTokens: undefined },
+      clientFactory,
+    });
+    // Uses the hardcoded fallback (32000) with the provenance flag set
+    expect(models[0]).toMatchObject({ contextWindow: 32000, contextWindowIsLiteralDefault: true });
   });
 
   it("caches results when refreshInterval is enabled", async () => {
@@ -253,6 +269,7 @@ describe("bedrock discovery", () => {
       name: "US Anthropic Claude Sonnet 4.6",
       input: ["text", "image"],
       contextWindow: 32000,
+      contextWindowIsLiteralDefault: true,
       maxTokens: 4096,
     });
     expect(euProfile).toMatchObject({ input: ["text", "image"] });

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -155,6 +155,7 @@ function shouldIncludeSummary(summary: BedrockModelSummary, filter: string[]): b
 function toModelDefinition(
   summary: BedrockModelSummary,
   defaults: { contextWindow: number; maxTokens: number },
+  discoveryConfig: BedrockDiscoveryConfig | undefined,
 ): ModelDefinitionConfig {
   const id = summary.modelId?.trim() ?? "";
   return {
@@ -164,6 +165,9 @@ function toModelDefinition(
     input: mapInputModalities(summary),
     cost: DEFAULT_COST,
     contextWindow: defaults.contextWindow,
+    contextWindowIsLiteralDefault:
+      defaults.contextWindow === DEFAULT_CONTEXT_WINDOW &&
+      discoveryConfig?.defaultContextWindow === undefined,
     maxTokens: defaults.maxTokens,
   };
 }
@@ -283,6 +287,10 @@ function resolveInferenceProfiles(
       input: baseModel?.input ?? ["text"],
       cost: baseModel?.cost ?? DEFAULT_COST,
       contextWindow: baseModel?.contextWindow ?? defaults.contextWindow,
+      contextWindowIsLiteralDefault: baseModel?.contextWindow
+        ? baseModel.contextWindowIsLiteralDefault
+        : defaults.contextWindow === DEFAULT_CONTEXT_WINDOW &&
+          config?.defaultContextWindow === undefined,
       maxTokens: baseModel?.maxTokens ?? defaults.maxTokens,
     });
   }
@@ -360,10 +368,14 @@ export async function discoverBedrockModels(params: {
       if (!shouldIncludeSummary(summary, providerFilter)) {
         continue;
       }
-      const def = toModelDefinition(summary, {
-        contextWindow: defaultContextWindow,
-        maxTokens: defaultMaxTokens,
-      });
+      const def = toModelDefinition(
+        summary,
+        {
+          contextWindow: defaultContextWindow,
+          maxTokens: defaultMaxTokens,
+        },
+        params.config,
+      );
       discovered.push(def);
       const normalizedId = normalizeLowercaseStringOrEmpty(def.id);
       seenIds.add(normalizedId);

--- a/src/agents/context-window-guard.test.ts
+++ b/src/agents/context-window-guard.test.ts
@@ -207,6 +207,34 @@ describe("context-window-guard", () => {
     expect(guard.shouldBlock).toBe(false);
   });
 
+  it("returns source=default when modelContextWindowIsLiteralDefault is true", () => {
+    const info = resolveContextWindowInfo({
+      cfg: undefined,
+      provider: "bedrock",
+      modelId: "mistral.mistral-large-3-675b-instruct",
+      modelContextWindow: 32_000,
+      modelContextWindowIsLiteralDefault: true,
+      defaultTokens: 200_000,
+    });
+    // Value is preserved but provenance is "default" (hardcoded fallback)
+    expect(info.source).toBe("default");
+    expect(info.tokens).toBe(32_000);
+  });
+
+  it("returns source=model when modelContextWindowIsLiteralDefault is false", () => {
+    const info = resolveContextWindowInfo({
+      cfg: undefined,
+      provider: "bedrock",
+      modelId: "mistral.mistral-large-3-675b-instruct",
+      modelContextWindow: 32_000,
+      modelContextWindowIsLiteralDefault: false,
+      defaultTokens: 200_000,
+    });
+    // Explicitly user-configured value — provenance is "model"
+    expect(info.source).toBe("model");
+    expect(info.tokens).toBe(32_000);
+  });
+
   it("allows overriding thresholds", () => {
     const info = { tokens: 10_000, source: "model" as const };
     const guard = evaluateContextWindowGuard({

--- a/src/agents/context-window-guard.ts
+++ b/src/agents/context-window-guard.ts
@@ -25,6 +25,7 @@ export function resolveContextWindowInfo(params: {
   modelId: string;
   modelContextTokens?: number;
   modelContextWindow?: number;
+  modelContextWindowIsLiteralDefault?: boolean;
   defaultTokens: number;
 }): ContextWindowInfo {
   const fromModelsConfig = (() => {
@@ -45,7 +46,12 @@ export function resolveContextWindowInfo(params: {
   const baseInfo = fromModelsConfig
     ? { tokens: fromModelsConfig, source: "modelsConfig" as const }
     : fromModel
-      ? { tokens: fromModel, source: "model" as const }
+      ? {
+          tokens: fromModel,
+          source: params.modelContextWindowIsLiteralDefault
+            ? ("default" as const)
+            : ("model" as const),
+        }
       : { tokens: Math.floor(params.defaultTokens), source: "default" as const };
 
   const capTokens = normalizePositiveInt(params.cfg?.agents?.defaults?.contextTokens);

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -477,6 +477,7 @@ export async function compactEmbeddedPiSessionDirect(
       modelId,
       modelContextTokens: readPiModelContextTokens(runtimeModel),
       modelContextWindow: runtimeModelWithContext.contextWindow,
+      modelContextWindowIsLiteralDefault: runtimeModelWithContext.contextWindowIsLiteralDefault,
       defaultTokens: DEFAULT_CONTEXT_TOKENS,
     });
     const effectiveModel = applyAuthHeaderOverride(

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -94,6 +94,7 @@ export function buildEmbeddedExtensionFactories(params: {
       modelId: params.modelId,
       modelContextTokens: params.model?.contextTokens,
       modelContextWindow: params.model?.contextWindow,
+      modelContextWindowIsLiteralDefault: params.model?.contextWindowIsLiteralDefault,
       defaultTokens: DEFAULT_CONTEXT_TOKENS,
     });
     setCompactionSafeguardRuntime(params.sessionManager, {

--- a/src/agents/pi-embedded-runner/model.inline-provider.test.ts
+++ b/src/agents/pi-embedded-runner/model.inline-provider.test.ts
@@ -17,12 +17,15 @@ describe("buildInlineProviderModels", () => {
         provider: "alpha",
         baseUrl: "http://alpha.local",
         api: undefined,
+        // buildInlineProviderModels sets contextWindowIsLiteralDefault=false when contextWindow is defined
+        contextWindowIsLiteralDefault: false,
       },
       {
         ...makeModel("beta-model"),
         provider: "beta",
         baseUrl: "http://beta.local",
         api: undefined,
+        contextWindowIsLiteralDefault: false,
       },
     ]);
   });

--- a/src/agents/pi-embedded-runner/model.inline-provider.ts
+++ b/src/agents/pi-embedded-runner/model.inline-provider.ts
@@ -162,6 +162,12 @@ export function buildInlineProviderModels(
           provider: trimmed,
           baseUrl: requestConfig.baseUrl ?? transport.baseUrl,
           api: requestConfig.api ?? model.api,
+          // Only set when explicitly provided in the model config. User-provided
+          // contextWindow means it is not the discovery-layer literal default.
+          contextWindowIsLiteralDefault:
+            "contextWindow" in model && model.contextWindow !== undefined
+              ? false
+              : undefined,
           headers: requestConfig.headers,
         },
         providerRequest,

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1314,4 +1314,145 @@ describe("resolveModel", () => {
       baseUrl: "https://api.x.ai/v1",
     });
   });
+
+  // -------------------------------------------------------------------------
+  // contextWindowIsLiteralDefault provenance
+  // -------------------------------------------------------------------------
+
+  it("clears contextWindowIsLiteralDefault when user explicitly sets contextWindow on a discovered model", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "bedrock",
+      modelId: "mistral.mistral-large-3-675b-instruct",
+      templateModel: {
+        id: "mistral.mistral-large-3-675b-instruct",
+        name: "Mistral Large 3.0",
+        provider: "bedrock",
+        api: "bedrock-converse-stream" as const,
+        baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+        reasoning: false,
+        input: ["text"] as const,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 32_000,
+        contextWindowIsLiteralDefault: true,
+        maxTokens: 32_000,
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          bedrock: {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            api: "bedrock-converse-stream",
+            models: [{ id: "mistral.mistral-large-3-675b-instruct", contextWindow: 128_000 }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest(
+      "bedrock",
+      "mistral.mistral-large-3-675b-instruct",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      contextWindow: 128_000,
+      contextWindowIsLiteralDefault: false,
+    });
+  });
+
+  it("preserves contextWindowIsLiteralDefault when user does not override contextWindow", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "bedrock",
+      modelId: "mistral.mistral-large-3-675b-instruct",
+      templateModel: {
+        id: "mistral.mistral-large-3-675b-instruct",
+        name: "Mistral Large 3.0",
+        provider: "bedrock",
+        api: "bedrock-converse-stream" as const,
+        baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+        reasoning: false,
+        input: ["text"] as const,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 32_000,
+        contextWindowIsLiteralDefault: true,
+        maxTokens: 32_000,
+      },
+    });
+
+    const cfg = {
+      models: {
+        providers: {
+          bedrock: {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            api: "bedrock-converse-stream",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest(
+      "bedrock",
+      "mistral.mistral-large-3-675b-instruct",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      contextWindow: 32_000,
+      contextWindowIsLiteralDefault: true,
+    });
+  });
+
+  it("layers inline model fields over discovered model, preserving provenance for unset fields", () => {
+    mockDiscoveredModel(discoverModels, {
+      provider: "bedrock",
+      modelId: "mistral.mistral-large-3-675b-instruct",
+      templateModel: {
+        id: "mistral.mistral-large-3-675b-instruct",
+        name: "Mistral Large 3.0",
+        provider: "bedrock",
+        api: "bedrock-converse-stream" as const,
+        baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+        reasoning: false,
+        input: ["text"] as const,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 32_000,
+        contextWindowIsLiteralDefault: true,
+        maxTokens: 4096,
+      },
+    });
+
+    // User provides inline model with only maxTokens override (no contextWindow)
+    const cfg = {
+      models: {
+        providers: {
+          bedrock: {
+            baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+            api: "bedrock-converse-stream",
+            models: [{ id: "mistral.mistral-large-3-675b-instruct", maxTokens: 8192 }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest(
+      "bedrock",
+      "mistral.mistral-large-3-675b-instruct",
+      "/tmp/agent",
+      cfg,
+    );
+
+    expect(result.error).toBeUndefined();
+    // Inline model's maxTokens overrides, but contextWindow and provenance are preserved from discovered model
+    expect(result.model).toMatchObject({
+      contextWindow: 32_000,
+      contextWindowIsLiteralDefault: true,
+      maxTokens: 8192,
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -332,6 +332,10 @@ function applyConfiguredProviderOverrides(params: {
       input: normalizedInput,
       cost: configuredModel?.cost ?? discoveredModel.cost,
       contextWindow: configuredModel?.contextWindow ?? discoveredModel.contextWindow,
+      contextWindowIsLiteralDefault:
+        configuredModel?.contextWindow !== undefined
+          ? false
+          : discoveredModel.contextWindowIsLiteralDefault,
       contextTokens: configuredModel?.contextTokens ?? discoveredModel.contextTokens,
       maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
       headers: requestConfig.headers,

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -365,6 +365,35 @@ function resolveExplicitModelWithRegistry(params: {
     provider,
     modelId,
   });
+  const discoveredModel = modelRegistry.find(provider, modelId) as Model<Api> | null;
+
+  // When both an inline model and a discovered model exist, layer the inline
+  // model's explicit fields on top of the discovered model. This preserves
+  // discovery-layer provenance (e.g. contextWindowIsLiteralDefault) for fields
+  // the inline model does not explicitly override.
+  if (inlineMatch?.api && discoveredModel) {
+    const layered: Model<Api> = {
+      ...discoveredModel,
+      ...inlineMatch,
+      // Preserve discovery provenance for contextWindow unless the inline model
+      // explicitly overrides it.
+      contextWindowIsLiteralDefault:
+        inlineMatch.contextWindow !== undefined
+          ? false
+          : discoveredModel.contextWindowIsLiteralDefault,
+    };
+    return {
+      kind: "resolved",
+      model: normalizeResolvedModel({
+        provider,
+        cfg,
+        agentDir,
+        model: layered,
+        runtimeHooks,
+      }),
+    };
+  }
+
   if (inlineMatch?.api) {
     return {
       kind: "resolved",
@@ -377,9 +406,8 @@ function resolveExplicitModelWithRegistry(params: {
       }),
     };
   }
-  const model = modelRegistry.find(provider, modelId) as Model<Api> | null;
 
-  if (model) {
+  if (discoveredModel) {
     return {
       kind: "resolved",
       model: normalizeResolvedModel({
@@ -388,7 +416,7 @@ function resolveExplicitModelWithRegistry(params: {
         agentDir,
         model: applyConfiguredProviderOverrides({
           provider,
-          discoveredModel: model,
+          discoveredModel,
           providerConfig,
           modelId,
           cfg,

--- a/src/agents/pi-embedded-runner/run/setup.ts
+++ b/src/agents/pi-embedded-runner/run/setup.ts
@@ -112,6 +112,7 @@ export function resolveEffectiveRuntimeModel(params: {
     modelId: params.modelId,
     modelContextTokens: readPiModelContextTokens(params.runtimeModel),
     modelContextWindow: params.runtimeModel.contextWindow,
+    modelContextWindowIsLiteralDefault: params.runtimeModel.contextWindowIsLiteralDefault,
     defaultTokens: DEFAULT_CONTEXT_TOKENS,
   });
 

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -62,6 +62,12 @@ export type ModelDefinitionConfig = {
   };
   contextWindow: number;
   /**
+   * True if contextWindow is set to the discovery layer's literal
+   * fallback value (e.g. 32000), and neither the API nor user config
+   * specified this value.
+   */
+  contextWindowIsLiteralDefault?: boolean;
+  /**
    * Optional effective runtime cap used for compaction/session budgeting.
    * Keeps provider/native contextWindow metadata intact while letting configs
    * prefer a smaller practical window.


### PR DESCRIPTION
## What

Adds `contextWindowIsLiteralDefault?: boolean` to `ModelDefinitionConfig`. Set to `true` only when Bedrock discovery falls back to the hardcoded `DEFAULT_CONTEXT_WINDOW` (`32000`) with no user-configured `defaultContextWindow`.

`resolveContextWindowInfo` uses this flag to mark `source` as `"default"` instead of `"model"`, enabling the guard warning to fire for Bedrock models that used the discovery-layer fallback.

## Why

Bedrock's AWS API does not expose token limits. Discovery pre-sets `contextWindow: 32000` → `source: "model"` → `shouldWarnDefault: false`. The provenance flag lets the runtime distinguish between:
- A real API-provided or user-configured value (`source: "model"`)
- A hardcoded fallback with no provenance (`source: "default"`)

## How

- **Type**: Added optional `contextWindowIsLiteralDefault` to `ModelDefinitionConfig`
- **Discovery**: Bedrock sets `true` only when using literal `DEFAULT_CONTEXT_WINDOW = 32000` and `config.defaultContextWindow` is not set
- **Runtime**: `resolveContextWindowInfo` checks the flag and uses `source: "default"` when `true`
- **Call sites**: Updated all 3 call sites to pass the new flag

## Tests

- context-window-guard: `source=default` when flag is true
- context-window-guard: `source=model` when flag is false
- bedrock discovery: `flag=false` when `defaultContextWindow` is configured
- bedrock discovery: `flag=true` when no `defaultContextWindow` is set
- bedrock inference profiles: inherit flag from foundation model

## Safety

- **Zero breaking changes**: flag is optional on shared type; other providers omit it
- **Provider-local**: only Bedrock sets this; other providers are unaffected
- **Backward-compatible**: existing behavior unchanged when flag is absent

Closes #64919
