### PR TITLE
fix: resolveModelsConfigInput uses runtimeSource snapshot instead of active config when config is undefined

### DIFF
--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -372,3 +372,27 @@ describe("models-config runtime source snapshot", () => {
     });
   });
 });
+
+it("writes lean config when called with undefined (regression: does not use bloated runtimeSource)", async () => {
+  // Arrange: set up runtime source snapshot (simulates accumulated runtime state)
+  await withTempHome(async () => {
+    await withTempEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS, async () => {
+      unsetEnv(MODELS_CONFIG_IMPLICIT_ENV_VARS);
+      const sourceConfig = createOpenAiApiKeySourceConfig();
+      const runtimeConfig = createOpenAiApiKeyRuntimeConfig();
+
+      try {
+        setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+        // Act: call ensureOpenClawModelsJson with undefined — triggers !config branch
+        await ensureOpenClawModelsJson(undefined);
+
+        // Assert: written config reflects the lean source config (markers), not bloated runtime values
+        await expectGeneratedProviderApiKey("openai", "OPENAI_API_KEY"); // pragma: allowlist secret
+      } finally {
+        clearRuntimeConfigSnapshot();
+        clearConfigCache();
+      }
+    });
+  });
+});

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -97,7 +97,7 @@ function resolveModelsConfigInput(config?: OpenClawConfig): {
   if (!config) {
     const loaded = loadConfig();
     return {
-      config: runtimeSource ?? loaded,
+      config: loaded, // FIX: use lean reference config, not accumulated snapshot
       sourceConfigForSecrets: runtimeSource ?? loaded,
     };
   }


### PR DESCRIPTION
## Summary

Fixes the `models.json` bloat cycle where `ensureOpenClawModelsJson()` was using an accumulated runtime snapshot instead of the lean active config when called with `config=undefined`.

### Root Cause

In `src/agents/models-config.ts`, the `resolveModelsConfigInput()` function was preferring `runtimeSource` (the accumulated runtime snapshot containing ALL providers ever referenced) over the `loaded` config (the lean disk reference from `openclaw.json`) when `config` was `undefined`.

### Fix



The `runtimeSource` is still used correctly for `sourceConfigForSecrets` (secret resolution markers). Only the config written to `models.json` is affected.

### Testing

All existing tests pass (8/8):
- `models-config.runtime-source-snapshot.test.ts` — 7 tests
- `io.runtime-snapshot-write.test.ts` — 1 test

### Issue

Fixes #65020