### PR TITLE
fix(doctor): warn that plugins.allow is an exclusive allowlist [AI-assisted]

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -95,7 +95,8 @@ export function resolveMissingPluginCommandMessage(
       return (
         `"${normalizedPluginId}" is not a plugin; it is a command provided by the ` +
         `"${parentPluginId}" plugin. Add "${parentPluginId}" to \`plugins.allow\` ` +
-        `instead of "${normalizedPluginId}".`
+        `instead of "${normalizedPluginId}". ` +
+        `Note: plugins.allow is an exclusive allowlist — any active plugin not listed will be disabled.`
       );
     }
     if (config?.plugins?.entries?.[parentPluginId]?.enabled === false) {
@@ -121,7 +122,8 @@ export function resolveMissingPluginCommandMessage(
     return (
       `The \`openclaw ${normalizedPluginId}\` command is unavailable because ` +
       `\`plugins.allow\` excludes "${normalizedPluginId}". Add "${normalizedPluginId}" to ` +
-      `\`plugins.allow\` if you want that bundled plugin CLI surface.`
+      `\`plugins.allow\` if you want that bundled plugin CLI surface. ` +
+      `Note: plugins.allow is an exclusive allowlist — ensure all active plugins are listed.`
     );
   }
   if (config?.plugins?.entries?.[normalizedPluginId]?.enabled === false) {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1054,7 +1054,8 @@ function validateConfigObjectWithPluginsBase(
           path: "plugins.allow",
           message:
             `"${pluginId}" is not a plugin — it is a command provided by the "${commandAlias.pluginId}" plugin. ` +
-            `Use "${commandAlias.pluginId}" in plugins.allow instead.`,
+            `Use "${commandAlias.pluginId}" in plugins.allow instead. ` +
+            `Note: plugins.allow is an exclusive allowlist — any plugin not listed will be disabled.`,
         });
       } else {
         pushMissingPluginIssue("plugins.allow", pluginId, { warnOnly: true });

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1016,7 +1016,9 @@ function warnWhenAllowlistIsOpen(params: {
   const extra = autoDiscoverable.length > 6 ? ` (+${autoDiscoverable.length - 6} more)` : "";
   openAllowlistWarningCache.add(params.warningCacheKey);
   params.logger.warn(
-    `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+    `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. ` +
+      `plugins.allow is an exclusive allowlist — only listed plugins will load, all others (including bundled plugins) are disabled. ` +
+      `Include every plugin you rely on when setting this field.`,
   );
 }
 

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -664,7 +664,10 @@ export async function collectPluginsTrustFindings(params: {
           (skillCommandsLikelyExposed
             ? "\nNative skill commands are enabled on at least one configured chat surface; treat unpinned/unallowlisted extensions as high risk."
             : ""),
-        remediation: "Set plugins.allow to an explicit list of plugin ids you trust.",
+        remediation:
+          "Set plugins.allow to an explicit list of all plugin ids you trust — " +
+          "this is an exclusive allowlist, so any plugin not listed (including bundled plugins) will be disabled. " +
+          "Include every active plugin when setting this field.",
       });
     }
 


### PR DESCRIPTION
AI-assisted: yes (Antigravity).
Testing: fully tested — all existing tests passed locally.

Fixes #64982

## Summary

When `openclaw doctor`, security audit, config validation, or the plugin loader suggests setting `plugins.allow`, the advisory now explicitly warns that this field is an **exclusive allowlist** — any plugin not listed (including bundled plugins like discord, memory-core) will be disabled. Previously, following the advisory to add a single plugin caused silent breakage of all other active plugins, resulting in a 4-hour production outage for the reporter.

## Changes

4 advisory sites updated:

- **`src/plugins/loader.ts`** (`warnWhenAllowlistIsOpen`): Warning now states that `plugins.allow` is exclusive and that bundled plugins are also affected, instructing users to include every plugin they rely on.
- **`src/security/audit-extra.async.ts`** (`collectPluginsTrustFindings`): Remediation text warns about exclusivity and that bundled plugins are also disabled if not listed.
- **`src/cli/run-main.ts`** (`resolveMissingPluginCommandMessage`): Two CLI error messages now note that `plugins.allow` is an exclusive allowlist.
- **`src/config/validation.ts`**: Command-alias-in-allowlist warning now notes exclusivity.

## Testing

- `src/cli/run-main.test.ts`: 15/15 passed
- `src/security/audit-plugins-trust.test.ts`: 2/2 passed
- `src/config/config.plugin-validation.test.ts`: relevant test passed
- No test modifications needed — existing assertions use substring matching on text portions that were preserved.
