### PR TITLE
Add missing message channel admin subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Discord: expose `message channel create|edit|delete|move` so advertised Discord channel admin actions are invokable from the message CLI. (#65065) Thanks @mikepatraw.
 - Providers/xAI: stop sending OpenAI-style reasoning effort controls to native Grok Responses models, so `xai/grok-4.3` no longer fails live Docker/Gateway runs with `Invalid reasoning effort`.
 - Providers/xAI: clamp the bundled xAI thinking profile to `off` so live Gateway runs cannot send unsupported reasoning levels to native Grok Responses models.
 - Discord/gateway: measure heartbeat ACK timeouts from the actual heartbeat send, preventing late initial heartbeats from triggering false reconnect loops while the channel is still awaiting readiness. Fixes #77668. (#78087) Thanks @bryce-d-greybeard and @NikolaFC.
@@ -3635,6 +3636,7 @@ Docs: https://docs.openclaw.ai
 - Channels/replay dedupe: standardize replay claims, retryable-failure release, and post-success commit behavior across Telegram, Discord, Slack, Mattermost, WhatsApp, Matrix, LINE, Feishu, Zalo, Nextcloud Talk, TLON, Nostr, Voice Call, and shared plugin interactive callbacks so duplicate deliveries stay reply-once after success but retry cleanly after pre-delivery failures. Thanks @vincentkoc.
 - Agents/OpenAI mini reasoning: remap unsupported `low` and `minimal` reasoning effort to `medium` for affected OpenAI mini models, and add a live regression lane to keep the compatibility fix covered. (#65478) Thanks @vincentkoc.
 - Configure/wizard: replay wizard edits onto the latest config snapshot after a hash conflict so plugin-auth writes no longer get dropped during `openclaw configure`, including nested config under shared sections such as `plugins`. (#64188) Thanks @feiskyer and @vincentkoc.
+
 
 ## 2026.4.11
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -155,7 +155,7 @@ openclaw [--dev] [--profile <name>] <command>
     emoji list|upload
     sticker send|upload
     role info|add|remove
-    channel info|list
+    channel info|list|create|edit|delete|move
     member info
     voice status
     event list|create

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -176,6 +176,13 @@ Name lookup:
 - `role add` / `role remove` (Discord): `--guild-id`, `--user-id`, `--role-id`
 - `channel info` (Discord): `--target`
 - `channel list` (Discord): `--guild-id`
+- `channel create` (Discord): `--guild-id`, `--name`
+  - Optional: `--type`, `--parent-id`, `--topic`, `--position`, `--nsfw`
+- `channel edit` (Discord): `--channel-id`
+  - Optional: `--name`, `--parent-id`, `--topic`, `--position`, `--nsfw`, `--rate-limit-per-user`
+- `channel delete` (Discord): `--channel-id`
+- `channel move` (Discord): `--guild-id`, `--channel-id`, `--position`
+  - Optional: `--parent-id`
 - `member info` (Discord/Slack): `--user-id` (+ `--guild-id` for Discord)
 - `voice status` (Discord): `--guild-id`, `--user-id`
 

--- a/src/cli/program/message/register.discord-admin.test.ts
+++ b/src/cli/program/message/register.discord-admin.test.ts
@@ -1,0 +1,97 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MessageCliHelpers } from "./helpers.js";
+import { registerMessageDiscordAdminCommands } from "./register.discord-admin.js";
+
+function createHelpers(runMessageAction: MessageCliHelpers["runMessageAction"]): MessageCliHelpers {
+  return {
+    withMessageBase: (command) => command.option("--channel <channel>", "Channel"),
+    withMessageTarget: (command) => command.option("-t, --target <dest>", "Target"),
+    withRequiredMessageTarget: (command) => command.requiredOption("-t, --target <dest>", "Target"),
+    runMessageAction,
+  };
+}
+
+describe("registerMessageDiscordAdminCommands", () => {
+  const runMessageAction = vi.fn(
+    async (_action: string, _opts: Record<string, unknown>) => undefined,
+  );
+
+  beforeEach(() => {
+    runMessageAction.mockClear();
+  });
+
+  it("registers channel create and routes args to channel-create", async () => {
+    const message = new Command().exitOverride();
+    registerMessageDiscordAdminCommands(message, createHelpers(runMessageAction));
+
+    await message.parseAsync(
+      [
+        "channel",
+        "create",
+        "--channel",
+        "discord",
+        "--guild-id",
+        "guild-1",
+        "--name",
+        "test-channel",
+        "--type",
+        "0",
+      ],
+      { from: "user" },
+    );
+
+    expect(runMessageAction).toHaveBeenCalledWith(
+      "channel-create",
+      expect.objectContaining({
+        channel: "discord",
+        guildId: "guild-1",
+        name: "test-channel",
+        type: "0",
+      }),
+    );
+  });
+
+  it("registers channel edit and routes args to channel-edit", async () => {
+    const message = new Command().exitOverride();
+    registerMessageDiscordAdminCommands(message, createHelpers(runMessageAction));
+
+    await message.parseAsync(["channel", "edit", "--channel-id", "123", "--name", "renamed"], {
+      from: "user",
+    });
+
+    expect(runMessageAction).toHaveBeenCalledWith(
+      "channel-edit",
+      expect.objectContaining({ channelId: "123", name: "renamed" }),
+    );
+  });
+
+  it("registers channel delete and routes args to channel-delete", async () => {
+    const message = new Command().exitOverride();
+    registerMessageDiscordAdminCommands(message, createHelpers(runMessageAction));
+
+    await message.parseAsync(["channel", "delete", "--channel-id", "123"], { from: "user" });
+
+    expect(runMessageAction).toHaveBeenCalledWith(
+      "channel-delete",
+      expect.objectContaining({ channelId: "123" }),
+    );
+  });
+
+  it("registers channel move and routes args to channel-move", async () => {
+    const message = new Command().exitOverride();
+    registerMessageDiscordAdminCommands(message, createHelpers(runMessageAction));
+
+    await message.parseAsync(
+      ["channel", "move", "--guild-id", "guild-1", "--channel-id", "123", "--position", "4"],
+      {
+        from: "user",
+      },
+    );
+
+    expect(runMessageAction).toHaveBeenCalledWith(
+      "channel-move",
+      expect.objectContaining({ guildId: "guild-1", channelId: "123", position: "4" }),
+    );
+  });
+});

--- a/src/cli/program/message/register.discord-admin.ts
+++ b/src/cli/program/message/register.discord-admin.ts
@@ -57,6 +57,65 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
       await helpers.runMessageAction("channel-list", opts);
     });
 
+  helpers
+    .withMessageBase(
+      channel
+        .command("create")
+        .description("Create a channel")
+        .requiredOption("--guild-id <id>", "Guild id")
+        .requiredOption("--name <name>", "Channel name"),
+    )
+    .option("--type <n>", "Channel type")
+    .option("--parent-id <id>", "Parent category id")
+    .option("--topic <text>", "Channel topic")
+    .option("--position <n>", "Channel position")
+    .option("--nsfw", "Mark channel as NSFW", false)
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-create", opts);
+    });
+
+  helpers
+    .withMessageBase(
+      channel
+        .command("edit")
+        .description("Edit a channel")
+        .requiredOption("--channel-id <id>", "Channel id"),
+    )
+    .option("--name <name>", "Channel name")
+    .option("--parent-id <id>", "Parent category id")
+    .option("--topic <text>", "Channel topic")
+    .option("--position <n>", "Channel position")
+    .option("--nsfw", "Mark channel as NSFW")
+    .option("--rate-limit-per-user <n>", "Slowmode seconds")
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-edit", opts);
+    });
+
+  helpers
+    .withMessageBase(
+      channel
+        .command("delete")
+        .description("Delete a channel")
+        .requiredOption("--channel-id <id>", "Channel id"),
+    )
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-delete", opts);
+    });
+
+  helpers
+    .withMessageBase(
+      channel
+        .command("move")
+        .description("Move a channel")
+        .requiredOption("--guild-id <id>", "Guild id")
+        .requiredOption("--channel-id <id>", "Channel id")
+        .requiredOption("--position <n>", "New channel position"),
+    )
+    .option("--parent-id <id>", "Parent category id")
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-move", opts);
+    });
+
   const member = message.command("member").description("Member actions");
   helpers
     .withMessageBase(


### PR DESCRIPTION
## Summary
- add CLI registration for `openclaw message channel create|edit|delete|move`
- add targeted tests covering the new channel admin routes
- update CLI docs to list the newly exposed `message channel` subcommands

## Problem
Discord provider capabilities and backend handlers already support channel admin actions like `channel-create`, but the CLI only exposed `message channel info|list`. That left a wiring gap where capabilities advertised support and backend dispatch worked, but the CLI invocation surface was missing the subcommands.

## Verification
- `npm test -- src/cli/program/message/register.discord-admin.test.ts src/cli/program/register.message.test.ts`
- `pnpm test src/cli/program/message/register.discord-admin.test.ts src/cli/program/register.message.test.ts`
- `git diff --check`
- full `pnpm check` in this clone fails due to unrelated missing optional extension dependencies across the repo, so verification here was scoped to the affected CLI surface

## Real behavior proof

- **Behavior or issue addressed:** The Discord `openclaw message channel` CLI namespace now exposes `create`, `edit`, `delete`, and `move`, and each parsed command dispatches to the Discord admin action name already handled by the backend.
- **Real environment tested:** PR branch checkout running Node 22.18.0 with the real OpenClaw Commander registration from `src/cli/program/message/register.discord-admin.ts`.
- **Exact steps or command run after this patch:** Ran a Node/tsx proof command that imports the real OpenClaw message-channel registrar, builds the Commander `message channel` command tree, prints the registered subcommands, and parses representative `create`, `edit`, `delete`, and `move` invocations.
- **Evidence after fix:** Terminal output from the after-fix command:

```text
registered channel subcommands: info, list, create, edit, delete, move
channel help contains:
  create [options]  Create a channel
  edit [options]    Edit a channel
  delete [options]  Delete a channel
  move [options]    Move a channel
parsed actions: [
  {
    "action": "channel-create",
    "opts": {
      "nsfw": false,
      "channel": "discord",
      "guildId": "guild-1",
      "name": "proof-channel",
      "type": "0"
    }
  },
  {
    "action": "channel-edit",
    "opts": {
      "channelId": "chan-1",
      "name": "renamed"
    }
  },
  {
    "action": "channel-delete",
    "opts": {
      "channelId": "chan-1"
    }
  },
  {
    "action": "channel-move",
    "opts": {
      "guildId": "guild-1",
      "channelId": "chan-1",
      "position": "4"
    }
  }
]
```

- **Observed result after fix:** The command tree contains `create`, `edit`, `delete`, and `move`; parsing representative invocations dispatches `channel-create`, `channel-edit`, `channel-delete`, and `channel-move` with the expected option payloads.
- **What was not tested:** No live Discord channel was created, edited, moved, or deleted; the proof intentionally stops at the CLI parser/dispatcher boundary to avoid mutating a real server.


## Related
Closes #64402
