### PR TITLE
fix(prompt): keep inbound chat ids out of system prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Docs: https://docs.openclaw.ai
 - Codex/app-server: parse Desktop-originated app-server user agents such as `Codex Desktop/0.118.0`, keeping the version gate working when the Codex CLI inherits a multi-word originator. (#64666) Thanks @cyrusaf.
 - Cron/announce delivery: keep isolated announce `NO_REPLY` stripping case-insensitive across direct and text delivery, preserve structured media-only sends when a caption strips silent, and derive main-session awareness from the cleaned payloads so silent captions no longer leak stale `NO_REPLY` text. (#65016) Thanks @BKF-Gitty.
 - Sessions/Codex: skip redundant `delivery-mirror` transcript appends only when the latest assistant message has the same visible text, preventing duplicate visible replies on Codex-backed turns without suppressing repeated answers across turns. (#67185) Thanks @andyylin.
+- Auto-reply/prompt-cache: keep volatile inbound chat IDs out of the stable system prompt so task-scoped adapters can reuse prompt caches across runs, while preserving conversation metadata for the user turn and media-only messages. (#65071) Thanks @MonkeyLeeT.
 
 ## 2026.4.15-beta.1
 

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -112,6 +112,7 @@ let runReplyAgent: typeof import("./agent-runner.runtime.js").runReplyAgent;
 let routeReply: typeof import("./route-reply.runtime.js").routeReply;
 let drainFormattedSystemEvents: typeof import("./session-system-events.js").drainFormattedSystemEvents;
 let resolveTypingMode: typeof import("./typing-mode.js").resolveTypingMode;
+let buildInboundUserContextPrefix: typeof import("./inbound-meta.js").buildInboundUserContextPrefix;
 let getActiveReplyRunCount: typeof import("./reply-run-registry.js").getActiveReplyRunCount;
 let replyRunTesting: typeof import("./reply-run-registry.js").__testing;
 let loadScopeCounter = 0;
@@ -212,6 +213,7 @@ describe("runPreparedReply media-only handling", () => {
     ({ routeReply } = await import("./route-reply.runtime.js"));
     ({ drainFormattedSystemEvents } = await import("./session-system-events.js"));
     ({ resolveTypingMode } = await import("./typing-mode.js"));
+    ({ buildInboundUserContextPrefix } = await import("./inbound-meta.js"));
     ({ __testing: replyRunTesting, getActiveReplyRunCount } =
       await import("./reply-run-registry.js"));
   });
@@ -291,6 +293,40 @@ describe("runPreparedReply media-only handling", () => {
           Body: "",
           BodyStripped: "",
           Provider: "slack",
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "I didn't receive any text in your message. Please resend or add a caption.",
+    });
+    expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
+  });
+
+  it("still skips metadata-only turns when inbound context adds chat_id", async () => {
+    vi.mocked(buildInboundUserContextPrefix).mockReturnValueOnce(
+      [
+        "Conversation info (untrusted metadata):",
+        "```json",
+        JSON.stringify({ chat_id: "paperclip:issue:abc" }, null, 2),
+        "```",
+      ].join("\n"),
+    );
+
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "paperclip",
+          OriginatingChannel: "paperclip",
+          OriginatingTo: "paperclip:issue:abc",
+          ChatType: "direct",
         },
       }),
     );

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -345,11 +345,11 @@ export async function runPreparedReply(
   const baseBodyForPrompt = isBareSessionReset
     ? [startupContextPrelude, baseBodyFinal].filter(Boolean).join("\n\n")
     : [inboundUserContext, baseBodyFinal].filter(Boolean).join("\n\n");
-  const baseBodyTrimmed = baseBodyForPrompt.trim();
+  const hasUserBody = baseBodyFinal.trim().length > 0;
   const hasMediaAttachment = Boolean(
     sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
   );
-  if (!baseBodyTrimmed && !hasMediaAttachment) {
+  if (!hasUserBody && !hasMediaAttachment) {
     // Skip onReplyStart when typing is suppressed (e.g. sendPolicy deny) —
     // otherwise channels that wire onReplyStart to typing indicators leak
     // visible signals even though outbound delivery is suppressed.
@@ -362,11 +362,12 @@ export async function runPreparedReply(
       text: "I didn't receive any text in your message. Please resend or add a caption.",
     };
   }
-  // When the user sends media without text, provide a minimal body so the agent
-  // run proceeds and the image/document is injected by the embedded runner.
-  const effectiveBaseBody = baseBodyTrimmed
+  // Prefix-only inbound metadata should not force a run on empty turns. When media
+  // arrives without text, keep the contextual prefix but append a minimal placeholder
+  // so the embedded runner can inject the attachment.
+  const effectiveBaseBody = hasUserBody
     ? baseBodyForPrompt
-    : "[User sent media without caption]";
+    : [inboundUserContext, "[User sent media without caption]"].filter(Boolean).join("\n\n");
   let prefixedBodyBase = await applySessionHints({
     baseBody: effectiveBaseBody,
     abortedLastRun,

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -65,7 +65,7 @@ function parseHistoryPayload(text: string): Array<Record<string, unknown>> {
 }
 
 describe("buildInboundMetaSystemPrompt", () => {
-  it("includes session-stable routing fields", () => {
+  it("includes stable routing fields and omits chat ids", () => {
     const prompt = buildInboundMetaSystemPrompt({
       MessageSid: "123",
       MessageSidFull: "123",
@@ -80,9 +80,31 @@ describe("buildInboundMetaSystemPrompt", () => {
 
     const payload = parseInboundMetaPayload(prompt);
     expect(payload["schema"]).toBe("openclaw.inbound_meta.v2");
-    expect(payload["chat_id"]).toBe("telegram:5494292670");
+    expect(payload["chat_id"]).toBeUndefined();
     expect(payload["account_id"]).toBe("work");
     expect(payload["channel"]).toBe("telegram");
+  });
+
+  it("keeps task-scoped chat ids out of the system prompt for cache stability", () => {
+    const first = buildInboundMetaSystemPrompt({
+      OriginatingTo: "paperclip:issue:c585d0cc",
+      OriginatingChannel: "paperclip",
+      Provider: "paperclip",
+      Surface: "paperclip",
+      ChatType: "direct",
+      AccountId: "default",
+    } as TemplateContext);
+    const second = buildInboundMetaSystemPrompt({
+      OriginatingTo: "paperclip:issue:ca527062",
+      OriginatingChannel: "paperclip",
+      Provider: "paperclip",
+      Surface: "paperclip",
+      ChatType: "direct",
+      AccountId: "default",
+    } as TemplateContext);
+
+    expect(parseInboundMetaPayload(first)["chat_id"]).toBeUndefined();
+    expect(first).toBe(second);
   });
 
   it("does not include per-turn message identifiers (cache stability)", () => {
@@ -233,12 +255,14 @@ describe("buildInboundUserContextPrefix", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",
       OriginatingChannel: "whatsapp",
+      OriginatingTo: "whatsapp:+15551230000",
       MessageSid: "short-id",
       MessageSidFull: "provider-full-id",
       SenderE164: " +15551234567 ",
     } as TemplateContext);
 
     const conversationInfo = parseConversationInfoPayload(text);
+    expect(conversationInfo["chat_id"]).toBe("whatsapp:+15551230000");
     expect(conversationInfo["message_id"]).toBe("short-id");
     expect(conversationInfo["message_id_full"]).toBeUndefined();
     expect(conversationInfo["sender"]).toBe("+15551234567");

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -117,9 +117,9 @@ export function buildInboundMetaSystemPrompt(
 
   // Keep system metadata strictly free of attacker-controlled strings (sender names, group subjects, etc.).
   // Those belong in the user-role "untrusted context" blocks.
-  // Per-message identifiers and dynamic flags are also excluded here: they change on turns/replies
-  // and would bust prefix-based prompt caches on providers that use stable system prefixes.
-  // They are included in the user-role conversation info block instead.
+  // Conversation ids, per-message identifiers, and dynamic flags are also excluded here:
+  // they change on turns/replies and would bust prefix-based prompt caches on providers that
+  // use stable system prefixes. They are included in the user-role conversation info block instead.
 
   // Resolve channel identity: prefer explicit channel, then surface, then provider.
   // For webchat/Hub Chat sessions (when Surface is 'webchat' or undefined with no real channel),
@@ -128,7 +128,6 @@ export function buildInboundMetaSystemPrompt(
 
   const payload = {
     schema: "openclaw.inbound_meta.v2",
-    chat_id: normalizePromptMetadataString(ctx.OriginatingTo),
     account_id: normalizePromptMetadataString(ctx.AccountId),
     channel: channelValue,
     provider: normalizePromptMetadataString(ctx.Provider),
@@ -172,7 +171,10 @@ export function buildInboundUserContextPrefix(
   const inboundHistory = Array.isArray(ctx.InboundHistory) ? ctx.InboundHistory : [];
   const boundedHistory = inboundHistory.slice(-MAX_UNTRUSTED_HISTORY_ENTRIES);
 
+  // Keep volatile conversation/message identifiers in the user-role block so the system
+  // prompt stays byte-stable across task-scoped sessions and reply turns.
   const conversationInfo = {
+    chat_id: shouldIncludeConversationInfo ? normalizeOptionalString(ctx.OriginatingTo) : undefined,
     message_id: shouldIncludeConversationInfo ? resolvedMessageId : undefined,
     reply_to_id: shouldIncludeConversationInfo
       ? normalizePromptMetadataString(ctx.ReplyToId)

--- a/test/helpers/plugins/tts-contract-suites.ts
+++ b/test/helpers/plugins/tts-contract-suites.ts
@@ -643,27 +643,6 @@ export function describeTtsConfigContract() {
       });
 
       it("passes cfg into auto-selection so model-provider Google keys can configure TTS", () => {
-        const cfg = asLegacyOpenClawConfig({
-          agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
-          models: {
-            providers: {
-              google: {
-                apiKey: "model-provider-google-key",
-              },
-            },
-          },
-          messages: {
-            tts: {
-              providers: {
-                microsoft: {
-                  enabled: false,
-                },
-              },
-            },
-          },
-        });
-        const config = resolveTtsConfig(cfg);
-        const prefsPath = `/tmp/tts-prefs-google-model-provider-${Date.now()}.json`;
         withEnv(
           {
             OPENAI_API_KEY: undefined,
@@ -674,6 +653,28 @@ export function describeTtsConfigContract() {
             GOOGLE_API_KEY: undefined,
           },
           () => {
+            const cfg = asLegacyOpenClawConfig({
+              agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } },
+              models: {
+                providers: {
+                  google: {
+                    apiKey: "model-provider-google-key",
+                  },
+                },
+              },
+              messages: {
+                tts: {
+                  providers: {
+                    microsoft: {
+                      enabled: false,
+                    },
+                  },
+                },
+              },
+            });
+            const config = resolveTtsConfig(cfg);
+            const prefsPath = `/tmp/tts-prefs-google-model-provider-${Date.now()}.json`;
+
             expect(getTtsProvider(config, prefsPath)).toBe("google");
           },
         );


### PR DESCRIPTION
## What changed

- removed volatile `chat_id` from the trusted inbound system metadata so task-scoped adapters do not poison the cache-sensitive system prefix
- moved `chat_id` into the user-role conversation info block so the model still sees the routing context per turn
- fixed the empty-body fast-path so prefix-only metadata does not trigger agent runs, while media-only turns still preserve inbound context plus the existing placeholder

## Why

Task-scoped adapters such as Paperclip were placing a per-run session key in `chat_id` inside `## Inbound Context (trusted metadata)`. Because that block lives above the prompt-cache breakpoint, every task changed the system prompt bytes and prevented cross-run cache reuse.

## Impact

- restores cache stability for task-scoped adapter runs addressed by #65056
- keeps direct external-channel `chat_id` available to the model in per-turn context
- avoids a regression where metadata-only turns could bypass the empty-message reply path

## Validation

- `pnpm test src/auto-reply/reply/inbound-meta.test.ts`
- `pnpm test src/agents/prompt-composition.test.ts`
- `pnpm test src/auto-reply/reply/get-reply-run.media-only.test.ts`

## Notes

- repo-wide `pnpm check` is currently failing on unrelated pre-existing type issues in `extensions/msteams`, `src/agents/tools-effective-inventory.ts`, `src/channels/plugins/registry-loaded.ts`, `src/gateway/server-channels.test.ts`, and `src/plugin-sdk/channel-runtime-context.ts`


## Linked Issue/PR

Closes #65056
