### PR TITLE
fix: use completeSimple for LLM slug generation instead of runEmbeddedPiAgent

### DIFF
--- a/src/agents/model-fallback-observation.ts
+++ b/src/agents/model-fallback-observation.ts
@@ -58,9 +58,7 @@ export function logModelFallbackDecision(params: {
   const observedError = buildErrorObservationFields(params.error);
   const detailText = observedError.providerErrorMessagePreview ?? observedError.errorPreview;
   const detailSuffix = detailText ? ` detail=${sanitizeForLog(detailText)}` : "";
-  decisionLog.warn("model fallback decision", {
-    event: "model_fallback_decision",
-    tags: ["error_handling", "model_fallback", params.decision],
+  const sharedPayload = {
     runId: params.runId,
     decision: params.decision,
     requestedProvider: params.requestedProvider,
@@ -88,8 +86,25 @@ export function logModelFallbackDecision(params: {
       code: attempt.code,
       ...buildErrorObservationFields(attempt.error),
     })),
+  };
+  decisionLog.warn("model fallback decision", {
+    event: "model_fallback_decision",
+    tags: ["error_handling", "model_fallback", params.decision],
+    ...sharedPayload,
     consoleMessage:
       `model fallback decision: decision=${params.decision} requested=${sanitizeForLog(params.requestedProvider)}/${sanitizeForLog(params.requestedModel)} ` +
       `candidate=${sanitizeForLog(params.candidate.provider)}/${sanitizeForLog(params.candidate.model)} reason=${reasonText} next=${nextText}${detailSuffix}`,
+  });
+  if (params.reason !== "timeout") {
+    return;
+  }
+  decisionLog.error("model fallback timeout loud", {
+    event: "model_fallback_timeout_loud",
+    tags: ["error_handling", "timeout", "model_fallback", params.decision],
+    ...sharedPayload,
+    consoleMessage:
+      `[TIMEOUT LOUD] model fallback: decision=${params.decision} requested=${sanitizeForLog(params.requestedProvider)}/${sanitizeForLog(params.requestedModel)} ` +
+      `candidate=${sanitizeForLog(params.candidate.provider)}/${sanitizeForLog(params.candidate.model)} next=${nextText} ` +
+      `status=${params.status ?? "-"}${detailSuffix}`,
   });
 }

--- a/src/agents/pi-embedded-runner/run/failover-observation.ts
+++ b/src/agents/pi-embedded-runner/run/failover-observation.ts
@@ -1,5 +1,6 @@
 import { redactIdentifier } from "../../../logging/redact-identifier.js";
 import type { AuthProfileFailureReason } from "../../auth-profiles.js";
+import { resolveFailoverStatus } from "../../failover-error.js";
 import {
   buildApiErrorObservationFields,
   sanitizeForConsole,
@@ -35,6 +36,27 @@ export function normalizeFailoverDecisionObservationBase(
   };
 }
 
+function isTimeoutObservation(base: FailoverDecisionLoggerBase): boolean {
+  return (
+    base.timedOut === true ||
+    base.failoverReason === "timeout" ||
+    base.profileFailureReason === "timeout"
+  );
+}
+
+function describeTimeoutOutcome(decision: FailoverDecisionLoggerInput["decision"]): string {
+  switch (decision) {
+    case "fallback_model":
+      return "escalating_to_model_fallback";
+    case "rotate_profile":
+      return "rotating_auth_profile";
+    case "surface_error":
+      return "surfacing_timeout";
+    default:
+      return "timeout_observed";
+  }
+}
+
 export function createFailoverDecisionLogger(
   base: FailoverDecisionLoggerBase,
 ): (
@@ -50,8 +72,12 @@ export function createFailoverDecisionLogger(
   const safeModel = sanitizeForConsole(normalizedBase.model) ?? "-";
   const profileText = safeProfileId ?? "-";
   const reasonText = normalizedBase.failoverReason ?? "none";
+  const timeoutObserved = isTimeoutObservation(normalizedBase);
   return (decision, extra) => {
     const observedError = buildApiErrorObservationFields(normalizedBase.rawError);
+    const status = extra?.status ?? (timeoutObserved ? resolveFailoverStatus("timeout") : undefined);
+    const detailText = observedError.providerErrorMessagePreview ?? observedError.rawErrorPreview;
+    const detailSuffix = detailText ? ` detail=${sanitizeForConsole(detailText)}` : "";
     log.warn("embedded run failover decision", {
       event: "embedded_run_failover_decision",
       tags: ["error_handling", "failover", normalizedBase.stage, decision],
@@ -66,11 +92,38 @@ export function createFailoverDecisionLogger(
       fallbackConfigured: normalizedBase.fallbackConfigured,
       timedOut: normalizedBase.timedOut,
       aborted: normalizedBase.aborted,
-      status: extra?.status,
+      status,
       ...observedError,
       consoleMessage:
         `embedded run failover decision: runId=${safeRunId} stage=${normalizedBase.stage} decision=${decision} ` +
         `reason=${reasonText} provider=${safeProvider}/${safeModel} profile=${profileText}`,
+    });
+    if (!timeoutObserved) {
+      return;
+    }
+    const timeoutOutcome = describeTimeoutOutcome(decision);
+    log.error("embedded run timeout loud", {
+      event: "embedded_run_timeout_loud",
+      tags: ["error_handling", "timeout", "failover", normalizedBase.stage, decision],
+      runId: normalizedBase.runId,
+      stage: normalizedBase.stage,
+      decision,
+      timeoutOutcome,
+      failoverReason: normalizedBase.failoverReason,
+      profileFailureReason: normalizedBase.profileFailureReason,
+      provider: normalizedBase.provider,
+      model: normalizedBase.model,
+      profileId: safeProfileId,
+      fallbackConfigured: normalizedBase.fallbackConfigured,
+      timedOut: normalizedBase.timedOut,
+      aborted: normalizedBase.aborted,
+      status,
+      ...observedError,
+      consoleMessage:
+        `[TIMEOUT LOUD] embedded run timeout: runId=${safeRunId} stage=${normalizedBase.stage} ` +
+        `decision=${decision} outcome=${timeoutOutcome} provider=${safeProvider}/${safeModel} ` +
+        `profile=${profileText} fallbackConfigured=${normalizedBase.fallbackConfigured ? "yes" : "no"} ` +
+        `status=${status ?? "-"}${detailSuffix}`,
     });
   };
 }

--- a/src/hooks/llm-slug-generator.ts
+++ b/src/hooks/llm-slug-generator.ts
@@ -1,99 +1,142 @@
 /**
- * LLM-based slug generator for session memory filenames
+ * LLM-based slug generator for session memory filenames.
+ *
+ * Uses the lightweight `completeSimple` path (no agent scaffold, no system
+ * prompt, no tools) to generate a short 1-2 word filename slug from session
+ * content.  This avoids the 16-48k token overhead of `runEmbeddedPiAgent`
+ * which loads the full workspace context for what is essentially a
+ * ~200-token prompt producing a ~5-token response.
+ *
+ * Model resolution order:
+ *   1. agents.defaults.heartbeat.model (typically a cheap model)
+ *   2. Agent primary model (fallback)
  */
 
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+import { completeSimple, type TextContent } from "@mariozechner/pi-ai";
 import {
   resolveDefaultAgentId,
-  resolveAgentWorkspaceDir,
   resolveAgentDir,
-  resolveAgentEffectiveModelPrimary,
 } from "../agents/agent-scope.js";
-import { DEFAULT_PROVIDER, DEFAULT_MODEL } from "../agents/defaults.js";
-import { parseModelRef } from "../agents/model-selection.js";
-import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { getApiKeyForModel, requireApiKey } from "../agents/model-auth.js";
+import { parseModelRef, resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import { resolveModelAsync } from "../agents/pi-embedded-runner/model.js";
+import { prepareModelForSimpleCompletion } from "../agents/simple-completion-transport.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 const log = createSubsystemLogger("llm-slug-generator");
 
+const TIMEOUT_MS = 15_000;
+const MAX_CONTENT_SLICE = 2_000;
+const MAX_SLUG_LENGTH = 30;
+
+function isTextContentBlock(block: { type: string }): block is TextContent {
+  return block.type === "text";
+}
+
 /**
- * Generate a short 1-2 word filename slug from session content using LLM
+ * Resolve the model to use for slug generation.
+ *
+ * Prefers the heartbeat model (cheap, fast) when configured.
+ * Falls back to the agent's primary model otherwise.
+ */
+function resolveSlugModel(cfg: OpenClawConfig): { provider: string; modelId: string } {
+  // Prefer heartbeat model — it's configured to be cheap
+  const heartbeatModelRef = cfg?.agents?.defaults?.heartbeat?.model;
+  if (heartbeatModelRef) {
+    const parsed = parseModelRef(heartbeatModelRef, DEFAULT_PROVIDER);
+    return { provider: parsed.provider, modelId: parsed.model };
+  }
+
+  // Fall back to agent primary
+  const agentId = resolveDefaultAgentId(cfg);
+  const fallback = resolveDefaultModelForAgent({ cfg, agentId });
+  return { provider: fallback.provider, modelId: fallback.model };
+}
+
+/**
+ * Generate a short 1-2 word filename slug from session content using LLM.
  */
 export async function generateSlugViaLLM(params: {
   sessionContent: string;
   cfg: OpenClawConfig;
 }): Promise<string | null> {
-  let tempSessionFile: string | null = null;
-
   try {
     const agentId = resolveDefaultAgentId(params.cfg);
-    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
     const agentDir = resolveAgentDir(params.cfg, agentId);
+    const { provider, modelId } = resolveSlugModel(params.cfg);
 
-    // Create a temporary session file for this one-off LLM call
-    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-slug-"));
-    tempSessionFile = path.join(tempDir, "session.jsonl");
+    const resolved = await resolveModelAsync(provider, modelId, agentDir, params.cfg);
+    if (!resolved.model) {
+      log.warn(`Failed to resolve model ${provider}/${modelId} for slug generation`);
+      return null;
+    }
+
+    const completionModel = prepareModelForSimpleCompletion({
+      model: resolved.model,
+      cfg: params.cfg,
+    });
+
+    const apiKey = requireApiKey(
+      await getApiKeyForModel({ model: completionModel, cfg: params.cfg, agentDir }),
+      provider,
+    );
 
     const prompt = `Based on this conversation, generate a short 1-2 word filename slug (lowercase, hyphen-separated, no file extension).
 
 Conversation summary:
-${params.sessionContent.slice(0, 2000)}
+${params.sessionContent.slice(0, MAX_CONTENT_SLICE)}
 
 Reply with ONLY the slug, nothing else. Examples: "vendor-pitch", "api-design", "bug-fix"`;
 
-    // Resolve model from agent config instead of using hardcoded defaults
-    const modelRef = resolveAgentEffectiveModelPrimary(params.cfg, agentId);
-    const parsed = modelRef ? parseModelRef(modelRef, DEFAULT_PROVIDER) : null;
-    const provider = parsed?.provider ?? DEFAULT_PROVIDER;
-    const model = parsed?.model ?? DEFAULT_MODEL;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
-    const result = await runEmbeddedPiAgent({
-      sessionId: `slug-generator-${Date.now()}`,
-      sessionKey: "temp:slug-generator",
-      agentId,
-      sessionFile: tempSessionFile,
-      workspaceDir,
-      agentDir,
-      config: params.cfg,
-      prompt,
-      provider,
-      model,
-      timeoutMs: 15_000, // 15 second timeout
-      runId: `slug-gen-${Date.now()}`,
-    });
+    try {
+      const result = await completeSimple(
+        completionModel,
+        {
+          messages: [
+            {
+              role: "user",
+              content: prompt,
+              timestamp: Date.now(),
+            },
+          ],
+        },
+        {
+          apiKey,
+          maxTokens: 20,
+          temperature: 0.3,
+          signal: controller.signal,
+        },
+      );
 
-    // Extract text from payloads
-    if (result.payloads && result.payloads.length > 0) {
-      const text = result.payloads[0]?.text;
-      if (text) {
-        // Clean up the response - extract just the slug
-        const slug = normalizeLowercaseStringOrEmpty(text)
-          .replace(/[^a-z0-9-]/g, "-")
-          .replace(/-+/g, "-")
-          .replace(/^-|-$/g, "")
-          .slice(0, 30); // Max 30 chars
+      const text = result.content
+        .filter(isTextContentBlock)
+        .map((block) => block.text)
+        .join("")
+        .trim();
 
-        return slug || null;
+      if (!text) {
+        return null;
       }
-    }
 
-    return null;
+      const slug = normalizeLowercaseStringOrEmpty(text)
+        .replace(/[^a-z0-9-]/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "")
+        .slice(0, MAX_SLUG_LENGTH);
+
+      return slug || null;
+    } finally {
+      clearTimeout(timeout);
+    }
   } catch (err) {
     const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
     log.error(`Failed to generate slug: ${message}`);
     return null;
-  } finally {
-    // Clean up temporary session file
-    if (tempSessionFile) {
-      try {
-        await fs.rm(path.dirname(tempSessionFile), { recursive: true, force: true });
-      } catch {
-        // Ignore cleanup errors
-      }
-    }
   }
 }


### PR DESCRIPTION
## Problem

`runEmbeddedPiAgent` spins up a full agent session with system prompt, workspace context, tools, and session file — consuming **16-48k input tokens** for a ~200-token prompt that produces a ~5-token slug response. Every session save triggers this, making slug generation absurdly expensive.

## Solution

Switch to `completeSimple` (already used by `conversation-label-generator` and the TTS system) which makes a direct completion call with no agent scaffold, system prompt, or workspace context.

Also prefer `agents.defaults.heartbeat.model` (typically a cheap model like Qwen) when configured, falling back to agent primary model otherwise.

## Cost Impact

| Before | After |
|--------|-------|
| ~16-48k input tokens | ~200 input tokens |
| Full agent lifecycle | Direct completion call |
| Temp session files | No temp files |
| Opus/Sonnet (typically) | Heartbeat model (Qwen) |
| ~$0.10-0.30/slug | ~$0.001/slug |

## Related

This fix makes our local [patch](https://github.com/Kyzcreig/openclaw-blackbox/blob/main/patches/apply-blackbox-patches.py#L236-L256) to use the heartbeat model for slug generation obsolete — the upstream fix properly eliminates the `runEmbeddedPiAgent` call entirely instead of just changing which model it uses.