### PR TITLE
Add final reply payloads plugin hook

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -815,6 +815,31 @@ export async function runReplyAgent(params: {
     if (prefixPayloads.length > 0) {
       finalPayloads = [...prefixPayloads, ...finalPayloads];
     }
+
+    if (getGlobalHookRunner()?.hasHooks("final_reply_payloads")) {
+      const finalReplyHookResult = await getGlobalHookRunner()?.runFinalReplyPayloads(
+        {
+          payloads: finalPayloads,
+          sessionKey,
+          channelId: replyToChannel,
+          providerUsed,
+          modelUsed,
+          responseUsageMode,
+          responseUsageLine,
+        },
+        {
+          cfg,
+          runId,
+        },
+      );
+      if (finalReplyHookResult?.payloads) {
+        finalPayloads = finalReplyHookResult.payloads;
+      }
+      if (finalReplyHookResult?.responseUsageLine !== undefined) {
+        responseUsageLine = finalReplyHookResult.responseUsageLine;
+      }
+    }
+
     if (responseUsageLine) {
       finalPayloads = appendUsageLine(finalPayloads, responseUsageLine);
     }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -14,6 +14,7 @@ import type { TypingMode } from "../../config/types.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../../utils/usage-format.js";

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -81,6 +81,7 @@ export type PluginHookName =
   | "gateway_stop"
   | "before_dispatch"
   | "reply_dispatch"
+  | "final_reply_payloads"
   | "before_install";
 
 export const PLUGIN_HOOK_NAMES = [
@@ -112,6 +113,7 @@ export const PLUGIN_HOOK_NAMES = [
   "gateway_stop",
   "before_dispatch",
   "reply_dispatch",
+  "final_reply_payloads",
   "before_install",
 ] as const satisfies readonly PluginHookName[];
 
@@ -277,6 +279,26 @@ export type PluginHookReplyDispatchResult = {
   handled: boolean;
   queuedFinal: boolean;
   counts: Record<ReplyDispatchKind, number>;
+};
+
+export type PluginHookFinalReplyPayloadsEvent = {
+  payloads: ReplyPayload[];
+  sessionKey?: string;
+  channelId?: string;
+  providerUsed?: string;
+  modelUsed?: string;
+  responseUsageMode?: "off" | "tokens" | "full";
+  responseUsageLine?: string;
+};
+
+export type PluginHookFinalReplyPayloadsContext = {
+  cfg: OpenClawConfig;
+  runId?: string;
+};
+
+export type PluginHookFinalReplyPayloadsResult = {
+  payloads?: ReplyPayload[];
+  responseUsageLine?: string;
 };
 
 export type PluginHookToolContext = {
@@ -615,6 +637,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookReplyDispatchEvent,
     ctx: PluginHookReplyDispatchContext,
   ) => Promise<PluginHookReplyDispatchResult | void> | PluginHookReplyDispatchResult | void;
+  final_reply_payloads: (
+    event: PluginHookFinalReplyPayloadsEvent,
+    ctx: PluginHookFinalReplyPayloadsContext,
+  ) => Promise<PluginHookFinalReplyPayloadsResult | void> | PluginHookFinalReplyPayloadsResult | void;
   message_received: (
     event: PluginHookMessageReceivedEvent,
     ctx: PluginHookMessageContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -23,6 +23,9 @@ import type {
   PluginHookReplyDispatchContext,
   PluginHookReplyDispatchEvent,
   PluginHookReplyDispatchResult,
+  PluginHookFinalReplyPayloadsContext,
+  PluginHookFinalReplyPayloadsEvent,
+  PluginHookFinalReplyPayloadsResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -80,6 +83,9 @@ export type {
   PluginHookReplyDispatchContext,
   PluginHookReplyDispatchEvent,
   PluginHookReplyDispatchResult,
+  PluginHookFinalReplyPayloadsContext,
+  PluginHookFinalReplyPayloadsEvent,
+  PluginHookFinalReplyPayloadsResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -727,6 +733,28 @@ export function createHookRunner(
   }
 
   /**
+   * Run final_reply_payloads hook.
+   * Allows plugins to modify finalized reply payloads with resolved model/usage context.
+   * Runs sequentially.
+   */
+  async function runFinalReplyPayloads(
+    event: PluginHookFinalReplyPayloadsEvent,
+    ctx: PluginHookFinalReplyPayloadsContext,
+  ): Promise<PluginHookFinalReplyPayloadsResult | undefined> {
+    return runModifyingHook<"final_reply_payloads", PluginHookFinalReplyPayloadsResult>(
+      "final_reply_payloads",
+      event,
+      ctx,
+      {
+        mergeResults: (acc, next) => ({
+          payloads: lastDefined(acc?.payloads, next.payloads),
+          responseUsageLine: lastDefined(acc?.responseUsageLine, next.responseUsageLine),
+        }),
+      },
+    );
+  }
+
+  /**
    * Run message_sending hook.
    * Allows plugins to modify or cancel outgoing messages.
    * Runs sequentially.
@@ -1125,6 +1153,7 @@ export function createHookRunner(
     runMessageReceived,
     runBeforeDispatch,
     runReplyDispatch,
+    runFinalReplyPayloads,
     runMessageSending,
     runMessageSent,
     // Tool hooks


### PR DESCRIPTION
## Summary
- add a new `final_reply_payloads` plugin hook at the final reply assembly stage
- expose resolved `providerUsed`, `modelUsed`, `responseUsageMode`, and `responseUsageLine`
- let plugins modify finalized reply payloads before the usage footer is appended

## Why
Existing hooks can either see outbound text without stable resolved model context (`message_sending`) or intercept earlier dispatch paths that do not cover every final reply route (`reply_dispatch`).

This hook gives plugins a single reliable place to add things like a truthful `Model:` line next to `Usage:`.
