### PR TITLE
fix(cli,sessions): make local model run stateless by default and keep transcript fallback profile-scoped

### DIFF
--- a/docs/refactor/local-model-run-correctness-baseline.md
+++ b/docs/refactor/local-model-run-correctness-baseline.md
@@ -1,0 +1,119 @@
+# Local Model Run Correctness Baseline
+
+Date: 2026-04-12
+
+## Scope
+
+This baseline captures the correctness semantics that were independently
+reproduced on two remote canary nodes using the same local multimodal model
+family.
+
+Validated nodes:
+
+- `Orin-25`
+- `Orin-26`
+
+This document is about semantics and persistence scope. It is not a performance
+fast-path document.
+
+## Closed Statement
+
+The following statement is now closed on both canaries:
+
+- `infer model run --local` default one-shot is stateless
+- explicit reuse is opt-in
+- persistence root is profile-local
+
+## Promotion Scope
+
+The promotion-candidate scope is only:
+
+1. Patch 1: local one-shot session semantics
+2. Patch 2: profile-local session/transcript persistence root
+
+Environment preconditions used during canary validation:
+
+- `llama-server -c 16384`
+- reserve downshift must actually reach local precheck
+- canary profile/config points to the local `llama.cpp` server
+
+These are prerequisites for reproducing the canary validation, not promotion
+patches by themselves.
+
+## Verification Matrix
+
+The same correctness matrix was used on both nodes:
+
+- text only
+- vision only
+- mixed `vision -> text`
+- explicit same-session reuse
+
+Observed on both nodes:
+
+- text-only: pass
+- vision-only: pass
+- mixed `vision -> text`: pass
+- explicit same-session reuse: pass
+
+## What Patch 1 Closed
+
+Before correction, local one-shot model runs could behave like a hidden
+long-lived session and silently reuse `agent:main:main`.
+
+That was enough to permit cross-turn contamination, including text/vision
+carry-over between otherwise independent capability checks.
+
+After correction:
+
+- local one-shot creates an explicit ephemeral session by default
+- default one-shot calls do not silently attach to `agent:main:main`
+- repeated text and mixed probes no longer inherit unrelated assistant output
+
+## What Patch 2 Closed
+
+Before correction, persistence scope could split:
+
+- the session store could be profile-local
+- transcript fallback could still land under the global `~/.openclaw/...` root
+
+After correction:
+
+- session store follows the active profile/agent scope
+- transcript fallback follows the same profile-local sessions directory
+
+This means one-shot local runs persist under the active profile boundary rather
+than the global default root.
+
+## Explicit Reuse Contract
+
+Explicit reuse remains valid and is still supported.
+
+When a caller intentionally supplies `sessionId/sessionKey`:
+
+- the same transcript file is reused
+- `hadSessionFile=true`
+- `prePromptMessageCount > 0`
+- persistence remains profile-local
+
+The important semantics boundary is:
+
+- default one-shot: stateless
+- continuity: explicit opt-in
+
+## Out Of Scope
+
+The following canary work is intentionally excluded from the promotion baseline:
+
+- provider/discovery short-circuit
+- provider-runtime broad scan skips
+- plugin-augment short-circuits
+- env/synthetic auth discovery skips
+- runtime plugin reductions
+- tools-disabled construction skips
+- TTS hint skip
+- silent-reply workaround
+- timing/debug probes
+
+These were useful for canary diagnosis and performance reduction, but they are
+not part of the promotion semantics.

--- a/docs/refactor/local-model-run-promotion-patchset.md
+++ b/docs/refactor/local-model-run-promotion-patchset.md
@@ -1,0 +1,124 @@
+# Local Model Run Promotion Patchset
+
+Date: 2026-04-12
+
+## Goal
+
+Define the minimum patchset that should be promoted from the canary recovery
+work into canonical OpenClaw source.
+
+Promotion candidates:
+
+1. Patch 1: `infer model run --local` uses ephemeral session by default
+2. Patch 2: session store and transcript fallback use a profile-local root
+
+These two patches are semantic corrections. They are not performance shortcuts.
+
+## Why These Two Patches Qualify
+
+Both issues were:
+
+- reproduced on `Orin-25`
+- reproduced on `Orin-26`
+- fixed independently
+- revalidated with the same correctness matrix
+
+That makes them node-independent promotion candidates rather than canary-only
+workarounds.
+
+## Patch 1
+
+### Name
+
+`infer model run --local` ephemeral session by default
+
+### Before
+
+Default local one-shot behavior could implicitly reuse the main session:
+
+- reused `agent:main:main`
+- reused prior transcript state
+- allowed cross-turn contamination between otherwise unrelated capability probes
+
+### After
+
+Default local one-shot behavior becomes:
+
+- stateless by default
+- continuity only when `sessionId/sessionKey` are intentionally supplied
+
+### Correct Contract
+
+- one-shot smoke test / benchmark / capability probe:
+  - stateless
+- explicit conversation continuity:
+  - opt-in
+
+## Patch 2
+
+### Name
+
+Profile-local session/transcript persistence root
+
+### Before
+
+Persistence scope could split:
+
+- store path under the active profile
+- transcript fallback under global `~/.openclaw/...`
+
+That violated the meaning of the active profile boundary.
+
+### After
+
+Both persistence artifacts follow the same profile/agent scope:
+
+- session store
+- transcript fallback
+
+### Correct Contract
+
+If the active local run uses profile `X`, then:
+
+- the store path belongs to profile `X`
+- the transcript path belongs to profile `X`
+
+## Environment Preconditions
+
+These are required to reproduce the canary validation, but they are not part of
+the promotion patchset:
+
+- `llama-server -c 16384`
+- reserve downshift must actually reach precheck
+- canary service overlay / profile-to-model alignment
+
+## Explicitly Excluded From Promotion
+
+The following must stay out of Patch 1/2:
+
+- discovery short-circuit
+- provider-runtime broad scan skip
+- plugin-augment caller short-circuit
+- env or synthetic auth discovery skips
+- runtime plugin candidate reductions
+- tools-disabled construction skip
+- TTS hint skip
+- silent-reply section skip
+- timing/debug probes
+- canary-only env-gated explicit reuse injection hooks
+
+Reason:
+
+- they were useful for canary debugging and performance reduction
+- but they are bounded fast-path or recovery gates, not semantics corrections
+
+## Expected Promotion Order
+
+The clean promotion order is:
+
+1. Patch 1: local one-shot session semantics
+2. Patch 2: profile-local persistence root
+3. documentation for baseline and promotion boundary
+
+Performance fast-path work, if promoted later, should be handled as a separate
+design/optimization stream.

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -337,6 +337,12 @@ describe("capability cli", () => {
 
     expect(mocks.agentCommand).toHaveBeenCalledTimes(1);
     expect(mocks.callGateway).not.toHaveBeenCalled();
+    const localOpts = mocks.agentCommand.mock.calls[0]?.[0] as {
+      sessionId?: string;
+      sessionKey?: string;
+    };
+    expect(localOpts.sessionId).toMatch(/^cap-model-run-/);
+    expect(localOpts.sessionKey).toBe(`agent:main:explicit:${localOpts.sessionId}`);
     expect(mocks.runtime.writeJson).toHaveBeenCalledWith(
       expect.objectContaining({
         capability: "model.run",

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { Command } from "commander";
@@ -518,11 +519,14 @@ async function runModelRun(params: {
   const cfg = loadConfig();
   const agentId = resolveDefaultAgentId(cfg);
   if (params.transport === "local") {
+    const sessionId = `cap-model-run-${randomUUID()}`;
     const result = await agentCommand(
       {
         message: params.prompt,
         agentId,
         model: params.model,
+        sessionId,
+        sessionKey: `agent:${agentId}:explicit:${sessionId}`,
         json: false,
       },
       {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -2,10 +2,12 @@ import fs from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import * as transcriptEvents from "../../sessions/transcript-events.js";
 import { resolveSessionTranscriptPathInDir } from "./paths.js";
+import { loadSessionStore } from "./store.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
 import {
   appendAssistantMessageToSessionTranscript,
   appendExactAssistantMessageToSessionTranscript,
+  resolveSessionTranscriptFile,
 } from "./transcript.js";
 
 describe("appendAssistantMessageToSessionTranscript", () => {
@@ -284,5 +286,31 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       expect(emitSpy).toHaveBeenCalledWith(result.sessionFile);
     }
     emitSpy.mockRestore();
+  });
+
+  it("uses the profile-local sessions dir when resolving fresh transcript fallback paths", async () => {
+    const profileLocalStorePath = fixture.storePath();
+    const store = {
+      [sessionKey]: {
+        sessionId,
+        chatType: "direct",
+        channel: "discord",
+      },
+    };
+    fs.writeFileSync(profileLocalStorePath, JSON.stringify(store), "utf-8");
+    const sessionStore = loadSessionStore(profileLocalStorePath, { skipCache: true });
+
+    const result = await resolveSessionTranscriptFile({
+      sessionId,
+      sessionKey,
+      sessionEntry: sessionStore[sessionKey],
+      sessionStore,
+      storePath: profileLocalStorePath,
+      agentId: "main",
+    });
+
+    expect(result.sessionFile).toBe(
+      resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir()),
+    );
   });
 });

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -8,6 +8,7 @@ import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   resolveSessionTranscriptPath,
+  resolveSessionTranscriptPathInDir,
 } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { loadSessionStore, normalizeStoreSessionKey } from "./store.js";
@@ -64,12 +65,19 @@ export async function resolveSessionTranscriptFile(params: {
 
   if (params.sessionStore && params.storePath) {
     const threadIdFromSessionKey = parseSessionThreadInfo(params.sessionKey).threadId;
+    const fallbackSessionsDir = sessionPathOpts?.sessionsDir;
     const fallbackSessionFile = !sessionEntry?.sessionFile
-      ? resolveSessionTranscriptPath(
-          params.sessionId,
-          params.agentId,
-          params.threadId ?? threadIdFromSessionKey,
-        )
+      ? fallbackSessionsDir
+        ? resolveSessionTranscriptPathInDir(
+            params.sessionId,
+            fallbackSessionsDir,
+            params.threadId ?? threadIdFromSessionKey,
+          )
+        : resolveSessionTranscriptPath(
+            params.sessionId,
+            params.agentId,
+            params.threadId ?? threadIdFromSessionKey,
+          )
       : undefined;
     const resolvedSessionFile = await resolveAndPersistSessionFile({
       sessionId: params.sessionId,


### PR DESCRIPTION
## 요약

이 PR은 local one-shot model run correctness를 복구하기 위한 승격 패치셋이다.

포함된 변경은 두 가지다.

1. `infer model run --local`의 기본 동작을 stateless로 변경
   - 기본 one-shot은 ephemeral session을 사용
   - explicit `sessionId/sessionKey`가 있을 때만 reuse가 살아 있음

2. session store / transcript fallback root를 profile-scoped로 정렬
   - local one-shot 실행이 global `~/.openclaw/...`가 아니라
     profile/agent-dir 기준 persistence root를 사용

추가로, 위 두 패치가 `Orin-25`, `Orin-26` canary에서 노드 독립적으로 재현되었다는 기준선 문서를 함께 기록했다.

## 배경

기존 local one-shot model run은 암묵적으로 main session을 재사용할 수 있었고,
transcript fallback도 global root에 붙을 수 있었다.

그 결과:
- text / vision cross-turn contamination
- local canary와 unrelated global session의 결합
- one-shot probe semantics와 실제 persistence scope의 불일치

가 발생할 수 있었다.

이번 변경으로 기본 semantics를 다음처럼 고정한다.

- one-shot 기본: stateless
- 연속성: explicit opt-in
- persistence root: profile-scoped

## 포함 커밋

- `4a41951056` `fix(cli): make local model run stateless by default`
- `05b1862690` `fix(sessions): keep local transcript fallback profile-scoped`
- `b3392f307a` `docs(refactor): record local model run promotion baseline`

## 범위

포함:
- local model run one-shot session semantics
- transcript fallback persistence scope
- promotion baseline / patchset docs

제외:
- discovery/provider/plugin fast-path
- TTS/tool/silent-reply canary workarounds
- performance-only canary gates

## 검증

Focused tests:
- `src/cli/capability-cli.test.ts` 관련 신규 assertion 통과
- `src/config/sessions/transcript.test.ts` 관련 신규 assertion 통과

추가 참고:
- `transcript.test.ts` 전체 파일 런에서 기존 file mode (`0o600`) 가정 1건 실패가 남아 있으나,
  이번 패치와는 무관함

Canary validation:
- `Orin-25`, `Orin-26` 둘 다에서 재현 확인
- text only: 정상
- vision only: 정상
- mixed `vision -> text`: 정상
- explicit same-session reuse: 정상
- profile-local transcript/store 생성 확인

## 위험도

낮음.

이 PR은 local one-shot correctness와 persistence scope만 다룬다.
성능용 canary 우회나 provider/plugin shortcut은 포함하지 않는다.
