### PR TITLE
fix(ui): humanize cron expressions in dreaming phase and cron job displays

### DIFF
--- a/ui/src/ui/format.test.ts
+++ b/ui/src/ui/format.test.ts
@@ -120,6 +120,8 @@ describe("describeCronExpression", () => {
     expect(describeCronExpression("0 */6 * * *")).toBe("Every 6 hours");
     expect(describeCronExpression("0 */2 * * *")).toBe("Every 2 hours");
     expect(describeCronExpression("0 */1 * * *")).toBe("Every hour");
+    expect(describeCronExpression("15 */8 * * *")).toBe("Every 8 hours at :15");
+    expect(describeCronExpression("30 */1 * * *")).toBe("Every hour at :30");
   });
 
   it("describes every-hour-at-minute patterns", () => {

--- a/ui/src/ui/format.test.ts
+++ b/ui/src/ui/format.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { formatRelativeTimestamp, formatUnknownText, stripThinkingTags } from "./format.ts";
+import {
+  describeCronExpression,
+  formatRelativeTimestamp,
+  formatUnknownText,
+  stripThinkingTags,
+} from "./format.ts";
 
 describe("formatAgo", () => {
   it("returns 'in <1m' for timestamps less than 60s in the future", () => {
@@ -97,6 +102,65 @@ describe("stripThinkingTags", () => {
   it("hides unfinished <relevant-memories> block tails", () => {
     const input = ["Hello", "<relevant-memories>", "internal-only"].join("\n");
     expect(stripThinkingTags(input)).toBe("Hello\n");
+  });
+});
+
+describe("describeCronExpression", () => {
+  it("describes every-N-minutes patterns", () => {
+    expect(describeCronExpression("*/5 * * * *")).toBe("Every 5 minutes");
+    expect(describeCronExpression("*/15 * * * *")).toBe("Every 15 minutes");
+  });
+
+  it("describes every-minute pattern", () => {
+    expect(describeCronExpression("* * * * *")).toBe("Every minute");
+    expect(describeCronExpression("*/1 * * * *")).toBe("Every minute");
+  });
+
+  it("describes every-N-hours patterns", () => {
+    expect(describeCronExpression("0 */6 * * *")).toBe("Every 6 hours");
+    expect(describeCronExpression("0 */2 * * *")).toBe("Every 2 hours");
+    expect(describeCronExpression("0 */1 * * *")).toBe("Every hour");
+  });
+
+  it("describes every-hour-at-minute patterns", () => {
+    expect(describeCronExpression("30 * * * *")).toBe("Every hour at :30");
+  });
+
+  it("describes daily-at-time patterns", () => {
+    expect(describeCronExpression("0 3 * * *")).toBe("Daily at 3:00 AM");
+    expect(describeCronExpression("0 15 * * *")).toBe("Daily at 3:00 PM");
+    expect(describeCronExpression("30 0 * * *")).toBe("Daily at 12:30 AM");
+    expect(describeCronExpression("0 12 * * *")).toBe("Daily at 12:00 PM");
+  });
+
+  it("describes weekly patterns", () => {
+    expect(describeCronExpression("0 5 * * 0")).toBe("Weekly Sun at 5:00 AM");
+    expect(describeCronExpression("0 9 * * 1")).toBe("Weekly Mon at 9:00 AM");
+    expect(describeCronExpression("30 14 * * 5")).toBe("Weekly Fri at 2:30 PM");
+  });
+
+  it("treats day-of-week 7 as Sunday", () => {
+    expect(describeCronExpression("0 5 * * 7")).toBe("Weekly Sun at 5:00 AM");
+  });
+
+  it("falls back for step-zero expressions", () => {
+    expect(describeCronExpression("*/0 * * * *")).toBe("*/0 * * * *");
+    expect(describeCronExpression("0 */0 * * *")).toBe("0 */0 * * *");
+  });
+
+  it("falls back to raw expression for complex patterns", () => {
+    expect(describeCronExpression("0 0 1 * *")).toBe("0 0 1 * *");
+    expect(describeCronExpression("0 0 * * 1-5")).toBe("0 0 * * 1-5");
+    expect(describeCronExpression("*/5 */2 * * *")).toBe("*/5 */2 * * *");
+  });
+
+  it("returns raw string for non-standard field counts", () => {
+    expect(describeCronExpression("0 0 * *")).toBe("0 0 * *");
+    expect(describeCronExpression("0 0 * * * *")).toBe("0 0 * * * *");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(describeCronExpression("")).toBe("");
   });
 });
 

--- a/ui/src/ui/format.ts
+++ b/ui/src/ui/format.ts
@@ -114,3 +114,83 @@ export function formatTokens(tokens: number | null | undefined, fallback = "0"):
   const m = tokens / 1_000_000;
   return m < 10 ? `${m.toFixed(1)}M` : `${Math.round(m)}M`;
 }
+
+const WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+
+/**
+ * Convert a 5-field cron expression to a short human-readable description.
+ * Handles common patterns; falls back to the raw expression for anything exotic.
+ */
+export function describeCronExpression(expr: string): string {
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    return expr;
+  }
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
+
+  // Every N minutes: *\/N * * * *
+  if (hour === "*" && dayOfMonth === "*" && month === "*" && dayOfWeek === "*") {
+    const stepMatch = minute.match(/^\*\/(\d+)$/);
+    if (stepMatch) {
+      const n = Number(stepMatch[1]);
+      if (n === 0) {
+        return expr;
+      }
+      return n === 1 ? "Every minute" : `Every ${n} minutes`;
+    }
+    if (minute === "*") {
+      return "Every minute";
+    }
+  }
+
+  // Every N hours: 0 *\/N * * *  (minute must be a plain number, not a step)
+  if (dayOfMonth === "*" && month === "*" && dayOfWeek === "*") {
+    const hourStep = hour.match(/^\*\/(\d+)$/);
+    if (hourStep && /^\d+$/.test(minute)) {
+      const n = Number(hourStep[1]);
+      if (n === 0) {
+        return expr;
+      }
+      return n === 1 ? "Every hour" : `Every ${n} hours`;
+    }
+    if (hour === "*" && /^\d+$/.test(minute)) {
+      // minute is fixed, hour is *, e.g. "30 * * * *"
+      return `Every hour at :${minute.padStart(2, "0")}`;
+    }
+  }
+
+  // Daily at H:MM — M H * * *
+  if (dayOfMonth === "*" && month === "*" && dayOfWeek === "*") {
+    const h = Number(hour);
+    const m = Number(minute);
+    if (Number.isInteger(h) && Number.isInteger(m) && h >= 0 && h <= 23 && m >= 0 && m <= 59) {
+      const period = h >= 12 ? "PM" : "AM";
+      const displayHour = h === 0 ? 12 : h > 12 ? h - 12 : h;
+      return `Daily at ${displayHour}:${String(m).padStart(2, "0")} ${period}`;
+    }
+  }
+
+  // Weekly on DAY at H:MM — M H * * D
+  if (dayOfMonth === "*" && month === "*") {
+    const h = Number(hour);
+    const m = Number(minute);
+    const d = Number(dayOfWeek);
+    if (
+      Number.isInteger(h) &&
+      Number.isInteger(m) &&
+      Number.isInteger(d) &&
+      h >= 0 &&
+      h <= 23 &&
+      m >= 0 &&
+      m <= 59 &&
+      d >= 0 &&
+      d <= 7
+    ) {
+      const period = h >= 12 ? "PM" : "AM";
+      const displayHour = h === 0 ? 12 : h > 12 ? h - 12 : h;
+      return `Weekly ${WEEKDAY_NAMES[d % 7]} at ${displayHour}:${String(m).padStart(2, "0")} ${period}`;
+    }
+  }
+
+  return expr;
+}

--- a/ui/src/ui/format.ts
+++ b/ui/src/ui/format.ts
@@ -148,10 +148,16 @@ export function describeCronExpression(expr: string): string {
     const hourStep = hour.match(/^\*\/(\d+)$/);
     if (hourStep && /^\d+$/.test(minute)) {
       const n = Number(hourStep[1]);
-      if (n === 0) {
+      const m = Number(minute);
+      if (n === 0 || m < 0 || m > 59) {
         return expr;
       }
-      return n === 1 ? "Every hour" : `Every ${n} hours`;
+      if (m === 0) {
+        return n === 1 ? "Every hour" : `Every ${n} hours`;
+      }
+      return n === 1
+        ? `Every hour at :${minute.padStart(2, "0")}`
+        : `Every ${n} hours at :${minute.padStart(2, "0")}`;
     }
     if (hour === "*" && /^\d+$/.test(minute)) {
       // minute is fixed, hour is *, e.g. "30 * * * *"

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -4,6 +4,7 @@ import {
   formatDurationHuman,
   formatMs,
   formatUnknownText,
+  describeCronExpression,
 } from "./format.ts";
 import type { CronJob, GatewaySessionRow, PresenceEntry } from "./types.ts";
 
@@ -65,7 +66,9 @@ export function formatCronSchedule(job: CronJob) {
   if (s.kind === "every") {
     return `Every ${formatDurationHuman(s.everyMs)}`;
   }
-  return `Cron ${s.expr}${s.tz ? ` (${s.tz})` : ""}`;
+  const description = describeCronExpression(s.expr);
+  const tz = s.tz ? ` (${s.tz})` : "";
+  return description !== s.expr ? `${description}${tz}` : `Cron ${s.expr}${tz}`;
 }
 
 export function formatCronPayload(job: CronJob) {

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -365,6 +365,10 @@ function flattenDiaryBody(body: string): string[] {
 
 function formatPhaseSchedule(cron?: string, nextRunAtMs?: number): string {
   if (!cron) {
+    // Preserve next-run fallback for legacy/partial payloads missing the cron string.
+    if (nextRunAtMs) {
+      return new Date(nextRunAtMs).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+    }
     return "—";
   }
   const description = describeCronExpression(cron);

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -5,6 +5,7 @@ import type {
   WikiImportInsights,
   WikiMemoryPalace,
 } from "../controllers/dreaming.ts";
+import { describeCronExpression } from "../format.ts";
 
 // ── Diary entry parser ─────────────────────────────────────────────────
 
@@ -362,12 +363,19 @@ function flattenDiaryBody(body: string): string[] {
   );
 }
 
-function formatPhaseNextRun(nextRunAtMs?: number): string {
-  if (!nextRunAtMs) {
+function formatPhaseSchedule(cron?: string, nextRunAtMs?: number): string {
+  if (!cron) {
     return "—";
   }
-  const d = new Date(nextRunAtMs);
-  return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  const description = describeCronExpression(cron);
+  if (!nextRunAtMs) {
+    return description;
+  }
+  const nextTime = new Date(nextRunAtMs).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${description} · next ${nextTime}`;
 }
 
 function renderScene(props: DreamingProps, idle: boolean, dreamText: string) {
@@ -436,9 +444,9 @@ function renderScene(props: DreamingProps, idle: boolean, dreamText: string) {
             const phase = props.phases?.[phaseId];
             const hasPhaseStatus = phase !== undefined;
             const enabled = phase?.enabled === true;
-            const nextRun = formatPhaseNextRun(phase?.nextRunAtMs);
+            const schedule = formatPhaseSchedule(phase?.cron, phase?.nextRunAtMs);
             const label = t(DREAM_PHASE_LABEL_KEYS[phaseId]);
-            const status = !hasPhaseStatus ? "—" : enabled ? nextRun : t("dreaming.phase.off");
+            const status = !hasPhaseStatus ? "—" : enabled ? schedule : t("dreaming.phase.off");
             return html`
               <div class="dreams__phase ${hasPhaseStatus && !enabled ? "dreams__phase--off" : ""}">
                 <div class="dreams__phase-dot ${enabled ? "dreams__phase-dot--on" : ""}"></div>


### PR DESCRIPTION
## Summary

- Fixes #65135 — the Dreaming panel showed only the next-run timestamp (e.g. "3:00") for all sleep phases, making them indistinguishable when schedules happened to share the same next-run time
- Adds `describeCronExpression()` utility that converts common 5-field cron patterns to human-readable text ("Every 6 hours", "Daily at 3:00 AM", "Weekly Sun at 5:00 AM"), with graceful fallback to the raw expression for exotic patterns
- Updates the Cron Jobs panel to also show humanized descriptions instead of "Cron 0 */6 * * *"

**Before:** All three dreaming phases display "3:00" (the next-run timestamp), regardless of their actual schedule.

**After:** Phases display "Every 6 hours · next 3:00 AM", "Daily at 3:00 AM · next 3:00 AM", "Weekly Sun at 5:00 AM · next 5:00 AM" — clearly distinguishable.

## Test plan

- [x] `pnpm build` passes
- [x] 130 relevant tests pass
- [x] New test cases cover: every-N-minutes, every-N-hours, hourly, daily, weekly, day=7 Sunday alias, `*/0` fallback, complex expression fallback, empty input
- [ ] Visual check: Dreaming tab shows distinct schedule descriptions per phase
- [ ] Visual check: Cron Jobs panel shows humanized schedule for cron-type jobs

> Note: screenshots not included — the change affects rendered text content only (no layout or style changes). Happy to add before/after screenshots if requested.

## AI disclosure

This PR was AI-assisted (Claude). Code has been reviewed for correctness, edge cases, and adherence to project conventions (American English, single-concern PR, tests included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>