### PR TITLE
fix(feishu): add doctor migration for legacy botName → name rename

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrations.channels.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.channels.ts
@@ -892,4 +892,77 @@ export const LEGACY_CONFIG_MIGRATIONS_CHANNELS: LegacyConfigMigrationSpec[] = [
       raw.channels = channels;
     },
   }),
+  defineLegacyConfigMigration({
+    id: "channels.feishu.botName->name",
+    describe:
+      "Rename legacy channels.feishu.accounts.*.botName to name (Feishu account display name)",
+    legacyRules: [
+      {
+        path: ["channels", "feishu"],
+        message:
+          'channels.feishu.botName was renamed to channels.feishu.name. Run "openclaw doctor --fix".',
+        match: (value) => {
+          const feishu = getRecord(value);
+          if (!feishu) {
+            return false;
+          }
+          if (hasOwnKey(feishu, "botName")) {
+            return true;
+          }
+          const accounts = getRecord(feishu.accounts);
+          if (!accounts) {
+            return false;
+          }
+          return Object.values(accounts).some((account) => {
+            const acc = getRecord(account);
+            return acc != null && hasOwnKey(acc, "botName");
+          });
+        },
+      },
+    ],
+    apply: (raw, changes) => {
+      const channels = getRecord(raw.channels);
+      if (!channels) {
+        return;
+      }
+      const feishu = getRecord(channels.feishu);
+      if (!feishu) {
+        return;
+      }
+
+      const renameBotName = (
+        owner: Record<string, unknown>,
+        pathPrefix: string,
+      ) => {
+        if (!hasOwnKey(owner, "botName")) {
+          return;
+        }
+        if (!hasOwnKey(owner, "name")) {
+          owner.name = owner.botName;
+        }
+        delete owner.botName;
+        changes.push(
+          `${pathPrefix}.botName renamed to ${pathPrefix}.name.`,
+        );
+      };
+
+      renameBotName(feishu, "channels.feishu");
+
+      const accounts = getRecord(feishu.accounts);
+      if (accounts) {
+        for (const [accountId, accountValue] of Object.entries(accounts)) {
+          const account = getRecord(accountValue);
+          if (!account) {
+            continue;
+          }
+          renameBotName(account, `channels.feishu.accounts.${accountId}`);
+          accounts[accountId] = account;
+        }
+        feishu.accounts = accounts;
+      }
+
+      channels.feishu = feishu;
+      raw.channels = channels;
+    },
+  }),
 ];


### PR DESCRIPTION
## Summary

The Feishu account config schema was updated to use `name` instead of `botName`, but no doctor migration was added. Users upgrading to 2026.4.11 with an existing `botName` hit a fatal config validation error that blocks gateway startup:

```
Config validation failed: channels.feishu.accounts.main:
invalid config: must NOT have additional properties
```

`openclaw doctor --fix` does not repair it because no migration rule exists for the rename.

Fixes #65177

## Fix

Add a `defineLegacyConfigMigration` in `src/commands/doctor/shared/legacy-config-migrations.channels.ts` that renames `botName` → `name` at both:

- Channel level: `channels.feishu.botName` → `channels.feishu.name`
- Per-account level: `channels.feishu.accounts.*.botName` → `channels.feishu.accounts.*.name`

If `name` already exists alongside `botName`, the migration preserves `name` and deletes the stale `botName` to avoid overwriting a deliberate user update.

## Pattern

Follows the existing migration pattern used by:
- `thread-bindings.ttlHours → idleHours` (same file, line 607)
- `channels.streaming-keys → channels.streaming` (same file, line 660)
- PR #63474 (`fix(doctor): strip stale install/plugin keys from channel account configs`) — same doctor migration family

## Scope

- **Files**: `legacy-config-migrations.channels.ts` (+73)
- **oxlint clean**
- **Zero competing PRs** — PR #63474 handles `installs`/`plugins` keys, not `botName`

cc @Takhoffman — Feishu channel ownership. Credit to @fireshort for the clear reproduction in #65177.