### PR TITLE
fix(qmd): normalize direct file collection paths

### DIFF
--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -175,6 +175,32 @@ describe("resolveMemoryBackendConfig", () => {
     expect(custom?.path).toBe(path.resolve("/workspace/root", "notes"));
   });
 
+  it("normalizes direct file qmd paths to escaped exact-file patterns", async () => {
+    const workspaceDir = await createFixtureDir("direct-file-path");
+    const notesPath = path.join(workspaceDir, "notes[1].md");
+    await fs.writeFile(notesPath, "# Notes\n", "utf8");
+
+    const cfg = {
+      agents: {
+        defaults: { workspace: workspaceDir },
+        list: [{ id: "main", workspace: workspaceDir }],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          paths: [{ path: "notes[1].md", name: "direct-note", pattern: "**/*.md" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    const custom = resolved.qmd?.collections.find((c) => c.name.startsWith("direct-note"));
+    expect(custom).toMatchObject({
+      path: workspaceDir,
+      pattern: String.raw`notes\[1\].md`,
+    });
+  });
+
   it("scopes qmd collection names per agent", () => {
     const cfg = {
       agents: {

--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -194,6 +194,32 @@ describe("resolveMemoryBackendConfig", () => {
     expect(custom.path).toBe(path.resolve("/workspace/root", "notes"));
   });
 
+  it("normalizes direct file qmd paths to escaped exact-file patterns", async () => {
+    const workspaceDir = await createFixtureDir("direct-file-path");
+    const notesPath = path.join(workspaceDir, "notes[1].md");
+    await fs.writeFile(notesPath, "# Notes\n", "utf8");
+
+    const cfg = {
+      agents: {
+        defaults: { workspace: workspaceDir },
+        list: [{ id: "main", workspace: workspaceDir }],
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          paths: [{ path: "notes[1].md", name: "direct-note", pattern: "**/*.md" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const resolved = resolveMemoryBackendConfig({ cfg, agentId: "main" });
+    const custom = resolved.qmd?.collections.find((c) => c.name.startsWith("direct-note"));
+    expect(custom).toMatchObject({
+      path: workspaceDir,
+      pattern: String.raw`notes\[1\].md`,
+    });
+  });
+
   it("scopes qmd collection names per agent", () => {
     const cfg = {
       agents: {

--- a/packages/memory-host-sdk/src/host/backend-config.test.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.test.ts
@@ -196,7 +196,7 @@ describe("resolveMemoryBackendConfig", () => {
 
   it("normalizes direct file qmd paths to escaped exact-file patterns", async () => {
     const workspaceDir = await createFixtureDir("direct-file-path");
-    const notesPath = path.join(workspaceDir, "notes[1].md");
+    const notesPath = path.join(workspaceDir, "notes{a,b}[1].md");
     await fs.writeFile(notesPath, "# Notes\n", "utf8");
 
     const cfg = {
@@ -207,7 +207,7 @@ describe("resolveMemoryBackendConfig", () => {
       memory: {
         backend: "qmd",
         qmd: {
-          paths: [{ path: "notes[1].md", name: "direct-note", pattern: "**/*.md" }],
+          paths: [{ path: "notes{a,b}[1].md", name: "direct-note", pattern: "**/*.md" }],
         },
       },
     } as OpenClawConfig;
@@ -216,7 +216,7 @@ describe("resolveMemoryBackendConfig", () => {
     const custom = resolved.qmd?.collections.find((c) => c.name.startsWith("direct-note"));
     expect(custom).toMatchObject({
       path: workspaceDir,
-      pattern: String.raw`notes\[1\].md`,
+      pattern: String.raw`notes\{a,b\}\[1\].md`,
     });
   });
 

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { escape as escapeGlobPattern } from "minimatch";
 import {
   CANONICAL_ROOT_MEMORY_FILENAME,
   type MemoryBackend,
@@ -306,7 +307,7 @@ function resolveCustomPaths(
         // parent-directory collection with an exact-filename pattern, regardless
         // of any user-supplied glob (a glob does not apply to a single file).
         collectionPath = path.dirname(resolved);
-        pattern = path.basename(resolved);
+        pattern = escapeGlobPattern(path.basename(resolved));
       }
     } catch {
       // not a file or can't stat, use as-is

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -291,26 +291,40 @@ function resolveCustomPaths(
       return;
     }
     let resolved: string;
+    let collectionPath: string;
     try {
       resolved = resolvePath(trimmedPath, workspaceDir);
     } catch {
       return;
     }
-    const pattern = entry.pattern?.trim() || "**/*.md";
-    const dedupeKey = `${resolved}\u0000${pattern}`;
+    collectionPath = resolved;
+    let pattern = entry.pattern?.trim() || "**/*.md";
+    try {
+      const stat = fs.statSync(resolved);
+      if (stat.isFile()) {
+        // When the configured path points directly to a file, normalize into a
+        // parent-directory collection with an exact-filename pattern, regardless
+        // of any user-supplied glob (a glob does not apply to a single file).
+        collectionPath = path.dirname(resolved);
+        pattern = path.basename(resolved);
+      }
+    } catch {
+      // not a file or can't stat, use as-is
+    }
+    const dedupeKey = `${collectionPath}\u0000${pattern}`;
     if (seenRoots.has(dedupeKey)) {
       return;
     }
     seenRoots.add(dedupeKey);
     const explicitName = entry.name?.trim();
     const baseName =
-      explicitName && !isPathInsideRoot(resolved, workspaceDir)
+      explicitName && !isPathInsideRoot(collectionPath, workspaceDir)
         ? explicitName
         : scopeCollectionBase(explicitName || `custom-${index + 1}`, agentId);
     const name = ensureUniqueName(baseName, existing);
     collections.push({
       name,
-      path: resolved,
+      path: collectionPath,
       pattern,
       kind: "custom",
     });

--- a/packages/memory-host-sdk/src/host/backend-config.ts
+++ b/packages/memory-host-sdk/src/host/backend-config.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs";
 import path from "node:path";
-import { escape as escapeGlobPattern } from "minimatch";
 import {
   CANONICAL_ROOT_MEMORY_FILENAME,
   type MemoryBackend,
@@ -20,6 +19,10 @@ import {
 } from "./config-utils.js";
 import { isPathInside } from "./fs-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "./string-utils.js";
+
+function escapeQmdExactFilePattern(fileName: string): string {
+  return fileName.replace(/[\\*?[\]{}()!+@]/g, "\\$&");
+}
 
 export type ResolvedMemoryBackendConfig = {
   backend: MemoryBackend;
@@ -307,7 +310,7 @@ function resolveCustomPaths(
         // parent-directory collection with an exact-filename pattern, regardless
         // of any user-supplied glob (a glob does not apply to a single file).
         collectionPath = path.dirname(resolved);
-        pattern = escapeGlobPattern(path.basename(resolved));
+        pattern = escapeQmdExactFilePattern(path.basename(resolved));
       }
     } catch {
       // not a file or can't stat, use as-is


### PR DESCRIPTION
## Summary

Fix QMD custom collection path handling when a config entry points directly to a file instead of a directory.

Before this change, a direct file path like `shared-memory.md` was treated as the collection root itself, with the usual markdown pattern logic layered on top. This normalizes file targets into:

- `path = parent directory`
- `pattern = exact filename`, escaped as a literal QMD/fast-glob mask

So a config entry pointing at `/some/path/shared-memory.md` becomes a collection rooted at `/some/path` with pattern `shared-memory.md`. File names containing glob metacharacters such as `{}`, `[]`, `*`, or `?` are escaped so they index the one intended file.

## Verification

- `node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/backend-config.test.ts`

## Real behavior proof

**Behavior addressed:** QMD custom collections must handle direct file paths by indexing only that file, even when the file name contains glob metacharacters.

**Real environment tested:** Local OpenClaw checkout on Linux, Node `v24.15.0`, `qmd 2.1.0 (bab86d5)`, temp workspace and temp QMD config/cache directories.

**Exact steps or command run after this patch:**

```bash
tmp=$(mktemp -d)
mkdir -p "$tmp/workspace" "$tmp/xdg" "$tmp/cache"
printf '# Direct QMD proof\nneedle-direct-file-braces\n' > "$tmp/workspace/notes{a,b}[1].md"
XDG_CONFIG_HOME="$tmp/xdg" XDG_CACHE_HOME="$tmp/cache" QMD_CONFIG_DIR="$tmp/xdg/qmd" \
  qmd collection add "$tmp/workspace" --name proof-direct --mask 'notes\{a,b\}\[1\].md' --json
XDG_CONFIG_HOME="$tmp/xdg" XDG_CACHE_HOME="$tmp/cache" QMD_CONFIG_DIR="$tmp/xdg/qmd" \
  qmd update --json
XDG_CONFIG_HOME="$tmp/xdg" XDG_CACHE_HOME="$tmp/cache" QMD_CONFIG_DIR="$tmp/xdg/qmd" \
  qmd search needle-direct-file-braces --json -n 1 -c proof-direct
rm -rf "$tmp"
```

**Evidence after fix:** Redacted terminal output:

```text
qmd --version -> qmd 2.1.0 (bab86d5)
Collection: <tmp>/workspace (notes\{a,b\}\[1\].md)
Indexed: 1 new, 0 updated, 0 unchanged, 0 removed
qmd update: Indexed: 0 new, 0 updated, 1 unchanged, 0 removed
qmd search returned one result:
  collection=file URI qmd://proof-direct/notes-a-b-1.md
  title=Direct QMD proof
  snippet contains needle-direct-file-braces
```

**Observed result after fix:** A direct file named `notes{a,b}[1].md` was indexed through an escaped exact-file mask and returned by collection-filtered QMD search.

**What was not tested:** Vector embedding was not run; this proof exercises collection setup, update, and BM25 search for the direct-file path behavior.


## Additional OpenClaw resolver-to-QMD proof

**Behavior addressed:** OpenClaw must route a direct-file `memory.qmd.paths` entry through its resolver and QMD manager so QMD receives a parent-directory collection plus an escaped exact-file pattern.

**Real environment tested:** Local OpenClaw checkout on Linux, Node `v24.15.0`, `qmd 2.1.0 (bab86d5)`, isolated `OPENCLAW_HOME`, isolated `OPENCLAW_CONFIG_PATH`, temp workspace, and temp QMD config/cache directories.

**Exact steps or command run after this patch:**

```bash
tmp=$(mktemp -d)
mkdir -p "$tmp/home/.openclaw" "$tmp/workspace"
printf '# Direct QMD proof\nneedle-direct-file-braces\n' > "$tmp/workspace/notes{a,b}[1].md"
cat > "$tmp/home/.openclaw/openclaw.json" <<JSON
{
  "agents": {
    "defaults": { "workspace": "$tmp/workspace" },
    "list": [{ "id": "main", "default": true, "workspace": "$tmp/workspace" }]
  },
  "memory": {
    "backend": "qmd",
    "qmd": {
      "includeDefaultMemory": false,
      "searchMode": "search",
      "update": { "interval": "0s", "onBoot": false },
      "paths": [{ "name": "proof-direct", "path": "notes{a,b}[1].md", "pattern": "**/*.md" }]
    }
  }
}
JSON

OPENCLAW_HOME="$tmp/home" \
OPENCLAW_CONFIG_PATH="$tmp/home/.openclaw/openclaw.json" \
OPENCLAW_DISABLE_BONJOUR=1 \
  node scripts/run-node.mjs memory search --agent main --query needle-direct-file-braces --max-results 1 --json

XDG_CONFIG_HOME="$tmp/home/.openclaw/agents/main/qmd/xdg-config" \
XDG_CACHE_HOME="$tmp/home/.openclaw/agents/main/qmd/xdg-cache" \
QMD_CONFIG_DIR="$tmp/home/.openclaw/agents/main/qmd/xdg-config/qmd" \
  qmd collection list

rm -rf "$tmp"
```

**Evidence after fix:** Redacted terminal output:

```text
[memory] qmd manager initialized for agent "main" mode=cli collections=1 durationMs=383
[memory] qmd sync completed for agent "main" reason=session-start durationMs=182

openclaw memory search returned one result:
{
  "results": [
    {
      "path": "notes-a-b-1.md",
      "source": "memory",
      "startLine": 1,
      "endLine": 3,
      "score": 0,
      "snippetContainsNeedle": true,
      "snippet": "@@ -1,3 @@ (0 before, 0 after)\n# Direct QMD proof\nneedle-direct-file-braces\n"
    }
  ]
}

qmd collection list showed the OpenClaw-created collection:
Collections (1):

proof-direct-main (qmd://proof-direct-main/)
  Pattern:  notes\{a,b\}\[1\].md
  Files:    1
  Updated:  2s ago
```

**Observed result after fix:** The patched OpenClaw resolver/manager path converted the configured direct file into an OpenClaw-created QMD collection rooted at the parent workspace directory with escaped exact-file pattern `notes\{a,b\}\[1\].md`, and `openclaw memory search` returned the indexed file containing `needle-direct-file-braces`.
