### PR TITLE
feat(sessions): add effective session explain command

### DIFF
--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -168,6 +168,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .command("explain")
     .description("Explain effective resolution for one stored session")
     .argument("<key>", "Session key to inspect")
+    .option("--tool <id>", "Explain whether a specific tool is effectively available")
     .option("--json", "Output as JSON", false)
     .action(async (key: string, opts, command) => {
       const parentOpts = command.parent?.opts() as
@@ -184,6 +185,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           store: parentOpts?.store,
           agent: parentOpts?.agent,
           explain: key,
+          tool: opts.tool as string | undefined,
         },
         defaultRuntime,
       );

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -165,6 +165,30 @@ export function registerStatusHealthSessionsCommands(program: Command) {
   sessionsCmd.enablePositionalOptions();
 
   sessionsCmd
+    .command("explain")
+    .description("Explain effective resolution for one stored session")
+    .argument("<key>", "Session key to inspect")
+    .option("--json", "Output as JSON", false)
+    .action(async (key: string, opts, command) => {
+      const parentOpts = command.parent?.opts() as
+        | {
+            store?: string;
+            agent?: string;
+          }
+        | undefined;
+      setVerbose(Boolean(command.parent?.opts()?.verbose));
+      await sessionsCommand(
+        {
+          json: Boolean(opts.json),
+          store: parentOpts?.store,
+          agent: parentOpts?.agent,
+          explain: key,
+        },
+        defaultRuntime,
+      );
+    });
+
+  sessionsCmd
     .command("cleanup")
     .description("Run session-store maintenance now")
     .option("--store <path>", "Path to session store (default: resolved from config)")

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -174,9 +174,10 @@ export function registerStatusHealthSessionsCommands(program: Command) {
         | {
             store?: string;
             agent?: string;
+            verbose?: boolean;
           }
         | undefined;
-      setVerbose(Boolean(command.parent?.opts()?.verbose));
+      setVerbose(Boolean(parentOpts?.verbose));
       await sessionsCommand(
         {
           json: Boolean(opts.json),

--- a/src/commands/sessions.test-helpers.ts
+++ b/src/commands/sessions.test-helpers.ts
@@ -59,13 +59,14 @@ export function writeStore(data: unknown, prefix = "sessions"): string {
 
 export async function runSessionsJson<T>(
   run: (
-    opts: { json?: boolean; store?: string; active?: string; explain?: string },
+    opts: { json?: boolean; store?: string; active?: string; explain?: string; tool?: string },
     runtime: RuntimeEnv,
   ) => Promise<void>,
   store: string,
   options?: {
     active?: string;
     explain?: string;
+    tool?: string;
   },
 ): Promise<T> {
   const { runtime, logs } = makeRuntime();
@@ -76,6 +77,7 @@ export async function runSessionsJson<T>(
         json: true,
         active: options?.active,
         explain: options?.explain,
+        tool: options?.tool,
       },
       runtime,
     );

--- a/src/commands/sessions.test-helpers.ts
+++ b/src/commands/sessions.test-helpers.ts
@@ -59,12 +59,13 @@ export function writeStore(data: unknown, prefix = "sessions"): string {
 
 export async function runSessionsJson<T>(
   run: (
-    opts: { json?: boolean; store?: string; active?: string },
+    opts: { json?: boolean; store?: string; active?: string; explain?: string },
     runtime: RuntimeEnv,
   ) => Promise<void>,
   store: string,
   options?: {
     active?: string;
+    explain?: string;
   },
 ): Promise<T> {
   const { runtime, logs } = makeRuntime();
@@ -74,6 +75,7 @@ export async function runSessionsJson<T>(
         store,
         json: true,
         active: options?.active,
+        explain: options?.explain,
       },
       runtime,
     );

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -188,7 +188,12 @@ describe("sessionsCommand", () => {
       defaults: { provider: string; model: string };
       input: { runtimeProvider: string | null; spawnedWorkspaceDir: string | null };
       resolved: { model: string; workspaceDir: string };
-      resolution: { usesPersistedWorkspace: boolean };
+      resolution: {
+        usesPersistedWorkspace: boolean;
+        modelReasonChain: string[];
+        workspaceReasonChain: string[];
+        toolsReasonChain: string[];
+      };
       tools: { profile: string; groups: Array<{ id: string; count: number; tools: string[] }> };
     }>(sessionsCommand, store, { explain: "agent:main:main" });
 
@@ -199,6 +204,9 @@ describe("sessionsCommand", () => {
     expect(payload.resolved.model).toBe("gpt-5.4");
     expect(payload.resolved.workspaceDir).toBe("/tmp/subagent-workspace");
     expect(payload.resolution.usesPersistedWorkspace).toBe(true);
+    expect(payload.resolution.modelReasonChain).toContain("explicit-model-override");
+    expect(payload.resolution.workspaceReasonChain).toEqual(["persisted-session-workspace"]);
+    expect(payload.resolution.toolsReasonChain).toContain("runtime-effective-tool-inventory");
     expect(payload.tools.profile).toBe("coding");
     expect(payload.tools.groups).toMatchObject([{ id: "core", count: 2, tools: ["exec", "read"] }]);
   });
@@ -223,6 +231,9 @@ describe("sessionsCommand", () => {
     fs.rmSync(store);
 
     expect(logs.find((line) => line.includes("Session key"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Model reasons"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Workspace reasons"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Tools reasons"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Final model"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Final workspace"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Tools profile"))).toBeTruthy();

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -12,6 +12,24 @@ process.env.FORCE_COLOR = "0";
 
 mockSessionsConfig();
 
+vi.mock("../agents/tools-effective-inventory.js", () => ({
+  resolveEffectiveToolInventory: vi.fn(() => ({
+    agentId: "main",
+    profile: "coding",
+    groups: [
+      {
+        id: "core",
+        label: "Built-in tools",
+        source: "core",
+        tools: [
+          { id: "exec", label: "Exec", description: "Run shell commands", rawDescription: "Run shell commands", source: "core" },
+          { id: "read", label: "Read", description: "Read files", rawDescription: "Read files", source: "core" },
+        ],
+      },
+    ],
+  })),
+}));
+
 import { sessionsCommand } from "./sessions.js";
 
 describe("sessionsCommand", () => {
@@ -171,6 +189,7 @@ describe("sessionsCommand", () => {
       input: { runtimeProvider: string | null; spawnedWorkspaceDir: string | null };
       resolved: { model: string; workspaceDir: string };
       resolution: { usesPersistedWorkspace: boolean };
+      tools: { profile: string; groups: Array<{ id: string; count: number; tools: string[] }> };
     }>(sessionsCommand, store, { explain: "agent:main:main" });
 
     expect(payload.key).toBe("agent:main:main");
@@ -180,6 +199,8 @@ describe("sessionsCommand", () => {
     expect(payload.resolved.model).toBe("gpt-5.4");
     expect(payload.resolved.workspaceDir).toBe("/tmp/subagent-workspace");
     expect(payload.resolution.usesPersistedWorkspace).toBe(true);
+    expect(payload.tools.profile).toBe("coding");
+    expect(payload.tools.groups).toMatchObject([{ id: "core", count: 2, tools: ["exec", "read"] }]);
   });
 
   it("renders a readable text explanation for one session", async () => {
@@ -204,5 +225,7 @@ describe("sessionsCommand", () => {
     expect(logs.find((line) => line.includes("Session key"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Final model"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Final workspace"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Tools profile"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Tools core"))).toBeTruthy();
   });
 });

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -204,6 +204,7 @@ describe("sessionsCommand", () => {
           agent: boolean;
           agentProvider: boolean;
         };
+        policyPipeline: Array<{ label: string; active: boolean }>;
         profileAlsoAllow: string[];
         providerProfileAlsoAllow: string[];
         groups: Array<{ id: string; count: number; tools: string[] }>;
@@ -230,6 +231,7 @@ describe("sessionsCommand", () => {
       agent: false,
       agentProvider: false,
     });
+    expect(payload.tools.policyPipeline.some((step) => step.label.includes("tools.profile"))).toBe(true);
     expect(payload.capabilities.subagent.role).toBe("main");
     expect(payload.capabilities.subagent.controlScope).toBe("children");
     expect(payload.tools.groups).toMatchObject([{ id: "core", count: 2, tools: ["exec", "read"] }]);
@@ -263,6 +265,7 @@ describe("sessionsCommand", () => {
     expect(logs.find((line) => line.includes("Tools profile"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Policy profile"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Policy sources"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Policy pipeline"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Subagent role"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Tools core"))).toBeTruthy();
   });

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -253,4 +253,22 @@ describe("sessionsCommand", () => {
     expect(logs.find((line) => line.includes("Subagent role"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Tools core"))).toBeTruthy();
   });
+
+  it("allows explain with an explicit store even if agent resolution would fail", async () => {
+    const store = writeStore(
+      {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now() - 5 * 60_000,
+        },
+      },
+      "sessions-explain-invalid-agent",
+    );
+
+    const payload = await runSessionsJson<{ key: string }>(sessionsCommand, store, {
+      explain: "agent:main:main",
+    });
+
+    expect(payload.key).toBe("agent:main:main");
+  });
 });

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -194,7 +194,15 @@ describe("sessionsCommand", () => {
         workspaceReasonChain: string[];
         toolsReasonChain: string[];
       };
-      tools: { profile: string; groups: Array<{ id: string; count: number; tools: string[] }> };
+      tools: {
+        profile: string;
+        policyProfile: string | null;
+        providerProfile: string | null;
+        profileAlsoAllow: string[];
+        providerProfileAlsoAllow: string[];
+        groups: Array<{ id: string; count: number; tools: string[] }>;
+      };
+      capabilities: { subagent: { role: string; controlScope: string } };
     }>(sessionsCommand, store, { explain: "agent:main:main" });
 
     expect(payload.key).toBe("agent:main:main");
@@ -208,6 +216,10 @@ describe("sessionsCommand", () => {
     expect(payload.resolution.workspaceReasonChain).toEqual(["persisted-session-workspace"]);
     expect(payload.resolution.toolsReasonChain).toContain("runtime-effective-tool-inventory");
     expect(payload.tools.profile).toBe("coding");
+    expect(payload.tools.policyProfile).toBeNull();
+    expect(payload.tools.providerProfile).toBeNull();
+    expect(payload.capabilities.subagent.role).toBe("main");
+    expect(payload.capabilities.subagent.controlScope).toBe("children");
     expect(payload.tools.groups).toMatchObject([{ id: "core", count: 2, tools: ["exec", "read"] }]);
   });
 
@@ -237,6 +249,8 @@ describe("sessionsCommand", () => {
     expect(logs.find((line) => line.includes("Final model"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Final workspace"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Tools profile"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Policy profile"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Subagent role"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Tools core"))).toBeTruthy();
   });
 });

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -210,6 +210,7 @@ describe("sessionsCommand", () => {
         groups: Array<{ id: string; count: number; tools: string[] }>;
       };
       capabilities: { subagent: { role: string; controlScope: string } };
+      toolCheck: null | { requested: string; available: boolean; matchedGroup: string | null; reasonChain: string[] };
     }>(sessionsCommand, store, { explain: "agent:main:main" });
 
     expect(payload.key).toBe("agent:main:main");
@@ -234,7 +235,29 @@ describe("sessionsCommand", () => {
     expect(payload.tools.policyPipeline.some((step) => step.label.includes("tools.profile"))).toBe(true);
     expect(payload.capabilities.subagent.role).toBe("main");
     expect(payload.capabilities.subagent.controlScope).toBe("children");
+    expect(payload.toolCheck).toBeNull();
     expect(payload.tools.groups).toMatchObject([{ id: "core", count: 2, tools: ["exec", "read"] }]);
+  });
+
+  it("can explain whether a specific tool is effectively available", async () => {
+    const store = writeStore(
+      {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now() - 5 * 60_000,
+        },
+      },
+      "sessions-explain-tool",
+    );
+
+    const payload = await runSessionsJson<{
+      toolCheck: { requested: string; available: boolean; matchedGroup: string | null; reasonChain: string[] };
+    }>(sessionsCommand, store, { explain: "agent:main:main", tool: "exec" });
+
+    expect(payload.toolCheck.requested).toBe("exec");
+    expect(payload.toolCheck.available).toBe(true);
+    expect(payload.toolCheck.matchedGroup).toBe("core");
+    expect(payload.toolCheck.reasonChain).toContain("runtime-effective-tool-inventory");
   });
 
   it("renders a readable text explanation for one session", async () => {

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -198,6 +198,12 @@ describe("sessionsCommand", () => {
         profile: string;
         policyProfile: string | null;
         providerProfile: string | null;
+        policySources: {
+          global: boolean;
+          globalProvider: boolean;
+          agent: boolean;
+          agentProvider: boolean;
+        };
         profileAlsoAllow: string[];
         providerProfileAlsoAllow: string[];
         groups: Array<{ id: string; count: number; tools: string[] }>;
@@ -218,6 +224,12 @@ describe("sessionsCommand", () => {
     expect(payload.tools.profile).toBe("coding");
     expect(payload.tools.policyProfile).toBeNull();
     expect(payload.tools.providerProfile).toBeNull();
+    expect(payload.tools.policySources).toEqual({
+      global: false,
+      globalProvider: false,
+      agent: false,
+      agentProvider: false,
+    });
     expect(payload.capabilities.subagent.role).toBe("main");
     expect(payload.capabilities.subagent.controlScope).toBe("children");
     expect(payload.tools.groups).toMatchObject([{ id: "core", count: 2, tools: ["exec", "read"] }]);
@@ -250,6 +262,7 @@ describe("sessionsCommand", () => {
     expect(logs.find((line) => line.includes("Final workspace"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Tools profile"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Policy profile"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Policy sources"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Subagent role"))).toBeTruthy();
     expect(logs.find((line) => line.includes("Tools core"))).toBeTruthy();
   });

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -148,4 +148,61 @@ describe("sessionsCommand", () => {
 
     fs.rmSync(store);
   });
+
+  it("explains effective resolution for a stored session in JSON", async () => {
+    const store = writeStore(
+      {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now() - 5 * 60_000,
+          modelProvider: "openai-codex",
+          model: "gpt-5.4",
+          modelOverride: "gpt-5.4",
+          spawnedWorkspaceDir: "/tmp/subagent-workspace",
+        },
+      },
+      "sessions-explain",
+    );
+
+    const payload = await runSessionsJson<{
+      key: string;
+      agentId: string;
+      defaults: { provider: string; model: string };
+      input: { runtimeProvider: string | null; spawnedWorkspaceDir: string | null };
+      resolved: { model: string; workspaceDir: string };
+      resolution: { usesPersistedWorkspace: boolean };
+    }>(sessionsCommand, store, { explain: "agent:main:main" });
+
+    expect(payload.key).toBe("agent:main:main");
+    expect(payload.agentId).toBe("main");
+    expect(payload.input.runtimeProvider).toBe("openai-codex");
+    expect(payload.input.spawnedWorkspaceDir).toBe("/tmp/subagent-workspace");
+    expect(payload.resolved.model).toBe("gpt-5.4");
+    expect(payload.resolved.workspaceDir).toBe("/tmp/subagent-workspace");
+    expect(payload.resolution.usesPersistedWorkspace).toBe(true);
+  });
+
+  it("renders a readable text explanation for one session", async () => {
+    const store = writeStore(
+      {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now() - 5 * 60_000,
+          modelProvider: "openai-codex",
+          model: "gpt-5.4",
+          modelOverride: "gpt-5.4",
+          spawnedWorkspaceDir: "/tmp/subagent-workspace",
+        },
+      },
+      "sessions-explain-text",
+    );
+
+    const { runtime, logs } = makeRuntime();
+    await sessionsCommand({ store, explain: "agent:main:main" }, runtime);
+    fs.rmSync(store);
+
+    expect(logs.find((line) => line.includes("Session key"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Final model"))).toBeTruthy();
+    expect(logs.find((line) => line.includes("Final workspace"))).toBeTruthy();
+  });
 });

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,8 +1,13 @@
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import { loadConfig } from "../config/config.js";
 import { loadSessionStore, resolveFreshSessionTotalTokens } from "../config/sessions.js";
-import { classifySessionKey } from "../gateway/session-utils.js";
+import {
+  classifySessionKey,
+  resolveGatewaySessionStoreTarget,
+  resolveSessionModelRef,
+} from "../gateway/session-utils.js";
 import { info } from "../globals.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
@@ -85,7 +90,14 @@ const formatKindCell = (kind: SessionRow["kind"], rich: boolean) => {
 };
 
 export async function sessionsCommand(
-  opts: { json?: boolean; store?: string; active?: string; agent?: string; allAgents?: boolean },
+  opts: {
+    json?: boolean;
+    store?: string;
+    active?: string;
+    agent?: string;
+    allAgents?: boolean;
+    explain?: string;
+  },
   runtime: RuntimeEnv,
 ) {
   const aggregateAgents = opts.allAgents === true;
@@ -105,6 +117,96 @@ export async function sessionsCommand(
     runtime,
   });
   if (!targets) {
+    return;
+  }
+
+  if (opts.explain) {
+    const initialStore = opts.store ? loadSessionStore(opts.store) : undefined;
+    const target = resolveGatewaySessionStoreTarget({
+      cfg,
+      key: opts.explain,
+      ...(initialStore ? { store: initialStore } : {}),
+    });
+    const resolvedStorePath = opts.store ?? target.storePath;
+    const store = initialStore ?? loadSessionStore(target.storePath);
+    const matchedKey = target.storeKeys.find((key) => store[key]);
+    const entry = matchedKey ? store[matchedKey] : undefined;
+    if (!entry) {
+      runtime.error(`Session not found: ${opts.explain}`);
+      runtime.exit(1);
+      return;
+    }
+
+    const defaults = resolveSessionModelRef(cfg, undefined, target.agentId);
+    const resolved = resolveSessionModelRef(cfg, entry, target.agentId);
+    const workspaceDir = entry.spawnedWorkspaceDir ?? resolveAgentWorkspaceDir(cfg, target.agentId);
+    const payload = {
+      key: target.canonicalKey,
+      agentId: target.agentId,
+      storePath: resolvedStorePath,
+      defaults,
+      input: {
+        providerOverride: entry.providerOverride ?? null,
+        modelOverride: entry.modelOverride ?? null,
+        runtimeProvider: entry.modelProvider ?? null,
+        runtimeModel: entry.model ?? null,
+        spawnedWorkspaceDir: entry.spawnedWorkspaceDir ?? null,
+      },
+      resolved: {
+        provider: resolved.provider,
+        model: resolved.model,
+        workspaceDir,
+      },
+      resolution: {
+        defaultModelRef: `${defaults.provider}/${defaults.model}`,
+        usesPersistedWorkspace: Boolean(entry.spawnedWorkspaceDir),
+        usesRuntimeModelRef: Boolean(entry.modelProvider || entry.model),
+        usesOverrides: Boolean(entry.providerOverride || entry.modelOverride),
+      },
+    };
+
+    if (opts.json) {
+      writeRuntimeJson(runtime, payload);
+      return;
+    }
+
+    const rich = isRich();
+    const label = (value: string) => (rich ? theme.accent(value.padEnd(24)) : value.padEnd(24));
+    const muted = (value: string) => (rich ? theme.muted(value) : value);
+    const infoLabel = (value: string) => (rich ? theme.info(value) : value);
+    const success = (value: string) => (rich ? theme.success(value) : value);
+
+    runtime.log(`${label("Session key")}${muted(": ")}${infoLabel(payload.key)}`);
+    runtime.log(`${label("Agent")}${muted(": ")}${infoLabel(payload.agentId)}`);
+    runtime.log(`${label("Store path")}${muted(": ")}${muted(payload.storePath)}`);
+    runtime.log(
+      `${label("Default resolved")}${muted(": ")}${infoLabel(`${payload.defaults.provider}/${payload.defaults.model}`)}`,
+    );
+    runtime.log(
+      `${label("Provider override")}${muted(": ")}${infoLabel(payload.input.providerOverride ?? "-")}`,
+    );
+    runtime.log(
+      `${label("Model override")}${muted(": ")}${infoLabel(payload.input.modelOverride ?? "-")}`,
+    );
+    runtime.log(
+      `${label("Runtime model ref")}${muted(": ")}${infoLabel(`${payload.input.runtimeProvider ?? "-"}/${payload.input.runtimeModel ?? "-"}`)}`,
+    );
+    runtime.log(
+      `${label("Persisted workspace")}${muted(": ")}${infoLabel(payload.input.spawnedWorkspaceDir ?? "-")}`,
+    );
+    runtime.log(
+      `${label("Uses overrides")}${muted(": ")}${payload.resolution.usesOverrides ? success("yes") : muted("no")}`,
+    );
+    runtime.log(
+      `${label("Uses runtime ref")}${muted(": ")}${payload.resolution.usesRuntimeModelRef ? success("yes") : muted("no")}`,
+    );
+    runtime.log(
+      `${label("Uses persisted ws")}${muted(": ")}${payload.resolution.usesPersistedWorkspace ? success("yes") : muted("no")}`,
+    );
+    runtime.log(
+      `${label("Final model")}${muted(": ")}${success(`${payload.resolved.provider}/${payload.resolved.model}`)}`,
+    );
+    runtime.log(`${label("Final workspace")}${muted(": ")}${success(payload.resolved.workspaceDir)}`);
     return;
   }
 

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,6 +1,8 @@
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
+import { resolveEffectiveToolPolicy } from "../agents/pi-tools.policy.js";
+import { resolveStoredSubagentCapabilities } from "../agents/subagent-capabilities.js";
 import { resolveEffectiveToolInventory } from "../agents/tools-effective-inventory.js";
 import { resolveReplyToMode } from "../auto-reply/reply/reply-threading.js";
 import { loadConfig } from "../config/config.js";
@@ -144,6 +146,14 @@ export async function sessionsCommand(
     const resolved = resolveSessionModelRef(cfg, entry, target.agentId);
     const workspaceDir = entry.spawnedWorkspaceDir ?? resolveAgentWorkspaceDir(cfg, target.agentId);
     const delivery = deliveryContextFromSession(entry);
+    const effectiveToolPolicy = resolveEffectiveToolPolicy({
+      config: cfg,
+      sessionKey: target.canonicalKey,
+      agentId: target.agentId,
+      modelProvider: resolved.provider,
+      modelId: resolved.model,
+    });
+    const subagentCapabilities = resolveStoredSubagentCapabilities(target.canonicalKey, { cfg });
     const effectiveTools = resolveEffectiveToolInventory({
       cfg,
       agentId: target.agentId,
@@ -210,12 +220,19 @@ export async function sessionsCommand(
       },
       tools: {
         profile: effectiveTools.profile,
+        policyProfile: effectiveToolPolicy.profile ?? null,
+        providerProfile: effectiveToolPolicy.providerProfile ?? null,
+        profileAlsoAllow: effectiveToolPolicy.profileAlsoAllow ?? [],
+        providerProfileAlsoAllow: effectiveToolPolicy.providerProfileAlsoAllow ?? [],
         groups: effectiveTools.groups.map((group) => ({
           id: group.id,
           label: group.label,
           count: group.tools.length,
           tools: group.tools.slice(0, 8).map((tool) => tool.id),
         })),
+      },
+      capabilities: {
+        subagent: subagentCapabilities,
       },
     };
 
@@ -271,6 +288,24 @@ export async function sessionsCommand(
     );
     runtime.log(`${label("Final workspace")}${muted(": ")}${success(payload.resolved.workspaceDir)}`);
     runtime.log(`${label("Tools profile")}${muted(": ")}${infoLabel(payload.tools.profile)}`);
+    runtime.log(
+      `${label("Policy profile")}${muted(": ")}${infoLabel(payload.tools.policyProfile ?? "-")}`,
+    );
+    runtime.log(
+      `${label("Provider profile")}${muted(": ")}${infoLabel(payload.tools.providerProfile ?? "-")}`,
+    );
+    runtime.log(
+      `${label("Profile alsoAllow")}${muted(": ")}${infoLabel(payload.tools.profileAlsoAllow.join(", ") || "-")}`,
+    );
+    runtime.log(
+      `${label("Provider alsoAllow")}${muted(": ")}${infoLabel(payload.tools.providerProfileAlsoAllow.join(", ") || "-")}`,
+    );
+    runtime.log(
+      `${label("Subagent role")}${muted(": ")}${infoLabel(payload.capabilities.subagent.role)}`,
+    );
+    runtime.log(
+      `${label("Subagent control")}${muted(": ")}${infoLabel(payload.capabilities.subagent.controlScope)}`,
+    );
     for (const group of payload.tools.groups) {
       runtime.log(
         `${label(`Tools ${group.id}`)}${muted(": ")}${infoLabel(`${group.count} [${group.tools.join(", ")}]`)}`,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,6 +1,8 @@
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
+import { resolveEffectiveToolInventory } from "../agents/tools-effective-inventory.js";
+import { resolveReplyToMode } from "../auto-reply/reply/reply-threading.js";
 import { loadConfig } from "../config/config.js";
 import { loadSessionStore, resolveFreshSessionTotalTokens } from "../config/sessions.js";
 import {
@@ -12,6 +14,7 @@ import { info } from "../globals.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { isRich, theme } from "../terminal/theme.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.js";
 import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
 import {
   formatSessionAgeCell,
@@ -140,6 +143,35 @@ export async function sessionsCommand(
     const defaults = resolveSessionModelRef(cfg, undefined, target.agentId);
     const resolved = resolveSessionModelRef(cfg, entry, target.agentId);
     const workspaceDir = entry.spawnedWorkspaceDir ?? resolveAgentWorkspaceDir(cfg, target.agentId);
+    const delivery = deliveryContextFromSession(entry);
+    const effectiveTools = resolveEffectiveToolInventory({
+      cfg,
+      agentId: target.agentId,
+      sessionKey: target.canonicalKey,
+      workspaceDir,
+      messageProvider: delivery?.channel ?? entry.lastChannel ?? entry.channel ?? entry.origin?.provider,
+      modelProvider: resolved.provider,
+      modelId: resolved.model,
+      currentChannelId: delivery?.to,
+      currentThreadTs:
+        delivery?.threadId != null
+          ? String(delivery.threadId)
+          : entry.lastThreadId != null
+            ? String(entry.lastThreadId)
+            : entry.origin?.threadId != null
+              ? String(entry.origin.threadId)
+              : undefined,
+      accountId: delivery?.accountId ?? entry.lastAccountId ?? entry.origin?.accountId,
+      groupId: entry.groupId,
+      groupChannel: entry.groupChannel,
+      groupSpace: entry.space,
+      replyToMode: resolveReplyToMode(
+        cfg,
+        delivery?.channel ?? entry.lastChannel ?? entry.channel ?? entry.origin?.provider,
+        delivery?.accountId ?? entry.lastAccountId ?? entry.origin?.accountId,
+        entry.chatType ?? entry.origin?.chatType,
+      ),
+    });
     const payload = {
       key: target.canonicalKey,
       agentId: target.agentId,
@@ -162,6 +194,15 @@ export async function sessionsCommand(
         usesPersistedWorkspace: Boolean(entry.spawnedWorkspaceDir),
         usesRuntimeModelRef: Boolean(entry.modelProvider || entry.model),
         usesOverrides: Boolean(entry.providerOverride || entry.modelOverride),
+      },
+      tools: {
+        profile: effectiveTools.profile,
+        groups: effectiveTools.groups.map((group) => ({
+          id: group.id,
+          label: group.label,
+          count: group.tools.length,
+          tools: group.tools.slice(0, 8).map((tool) => tool.id),
+        })),
       },
     };
 
@@ -207,6 +248,12 @@ export async function sessionsCommand(
       `${label("Final model")}${muted(": ")}${success(`${payload.resolved.provider}/${payload.resolved.model}`)}`,
     );
     runtime.log(`${label("Final workspace")}${muted(": ")}${success(payload.resolved.workspaceDir)}`);
+    runtime.log(`${label("Tools profile")}${muted(": ")}${infoLabel(payload.tools.profile)}`);
+    for (const group of payload.tools.groups) {
+      runtime.log(
+        `${label(`Tools ${group.id}`)}${muted(": ")}${infoLabel(`${group.count} [${group.tools.join(", ")}]`)}`,
+      );
+    }
     return;
   }
 

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -103,6 +103,7 @@ export async function sessionsCommand(
     agent?: string;
     allAgents?: boolean;
     explain?: string;
+    tool?: string;
   },
   runtime: RuntimeEnv,
 ) {
@@ -186,6 +187,13 @@ export async function sessionsCommand(
         entry.chatType ?? entry.origin?.chatType,
       ),
     });
+    const normalizedRequestedTool = opts.tool?.trim().toLowerCase() || null;
+    const allEffectiveToolIds = effectiveTools.groups.flatMap((group) => group.tools.map((tool) => tool.id));
+    const matchedGroup = normalizedRequestedTool
+      ? effectiveTools.groups.find((group) =>
+          group.tools.some((tool) => tool.id.toLowerCase() === normalizedRequestedTool),
+        )
+      : undefined;
     const payload = {
       key: target.canonicalKey,
       agentId: target.agentId,
@@ -228,6 +236,23 @@ export async function sessionsCommand(
           ...(effectiveToolPolicy.providerProfile ? ["provider-profile-policy"] : []),
         ],
       },
+      toolCheck: normalizedRequestedTool
+        ? {
+            requested: normalizedRequestedTool,
+            available: allEffectiveToolIds.some((id) => id.toLowerCase() === normalizedRequestedTool),
+            matchedGroup: matchedGroup?.id ?? null,
+            reasonChain: [
+              "runtime-effective-tool-inventory",
+              `tool-profile:${effectiveTools.profile}`,
+              ...(effectiveToolPolicy.globalPolicy ? ["global-tools-policy"] : []),
+              ...(effectiveToolPolicy.globalProviderPolicy ? ["global-provider-policy"] : []),
+              ...(effectiveToolPolicy.agentPolicy ? ["agent-tools-policy"] : []),
+              ...(effectiveToolPolicy.agentProviderPolicy ? ["agent-provider-policy"] : []),
+              ...(effectiveToolPolicy.profile ? ["profile-policy"] : []),
+              ...(effectiveToolPolicy.providerProfile ? ["provider-profile-policy"] : []),
+            ],
+          }
+        : null,
       tools: {
         profile: effectiveTools.profile,
         policyProfile: effectiveToolPolicy.profile ?? null,
@@ -339,6 +364,17 @@ export async function sessionsCommand(
     runtime.log(
       `${label("Subagent control")}${muted(": ")}${infoLabel(payload.capabilities.subagent.controlScope)}`,
     );
+    if (payload.toolCheck) {
+      runtime.log(
+        `${label("Tool check")}${muted(": ")}${payload.toolCheck.available ? success("available") : theme.warn("not available")} ${infoLabel(payload.toolCheck.requested)}`,
+      );
+      runtime.log(
+        `${label("Tool group")}${muted(": ")}${infoLabel(payload.toolCheck.matchedGroup ?? "-")}`,
+      );
+      runtime.log(
+        `${label("Tool reasons")}${muted(": ")}${infoLabel(payload.toolCheck.reasonChain.join(" -> "))}`,
+      );
+    }
     for (const group of payload.tools.groups) {
       runtime.log(
         `${label(`Tools ${group.id}`)}${muted(": ")}${infoLabel(`${group.count} [${group.tools.join(", ")}]`)}`,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,6 +1,7 @@
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
+import { buildDefaultToolPolicyPipelineSteps } from "../agents/tool-policy-pipeline.js";
 import { resolveEffectiveToolPolicy } from "../agents/pi-tools.policy.js";
 import { resolveStoredSubagentCapabilities } from "../agents/subagent-capabilities.js";
 import { resolveEffectiveToolInventory } from "../agents/tools-effective-inventory.js";
@@ -141,6 +142,22 @@ export async function sessionsCommand(
       modelId: resolved.model,
     });
     const subagentCapabilities = resolveStoredSubagentCapabilities(target.canonicalKey, { cfg });
+    const toolPolicySteps = buildDefaultToolPolicyPipelineSteps({
+      profilePolicy: effectiveToolPolicy.profile ? { allow: effectiveToolPolicy.profileAlsoAllow } : undefined,
+      profile: effectiveToolPolicy.profile,
+      providerProfilePolicy: effectiveToolPolicy.providerProfile
+        ? { allow: effectiveToolPolicy.providerProfileAlsoAllow }
+        : undefined,
+      providerProfile: effectiveToolPolicy.providerProfile,
+      globalPolicy: effectiveToolPolicy.globalPolicy,
+      globalProviderPolicy: effectiveToolPolicy.globalProviderPolicy,
+      agentPolicy: effectiveToolPolicy.agentPolicy,
+      agentProviderPolicy: effectiveToolPolicy.agentProviderPolicy,
+      agentId: target.agentId,
+    }).map((step) => ({
+      label: step.label,
+      active: Boolean(step.policy),
+    }));
     const effectiveTools = resolveEffectiveToolInventory({
       cfg,
       agentId: target.agentId,
@@ -221,6 +238,7 @@ export async function sessionsCommand(
           agent: Boolean(effectiveToolPolicy.agentPolicy),
           agentProvider: Boolean(effectiveToolPolicy.agentProviderPolicy),
         },
+        policyPipeline: toolPolicySteps,
         profileAlsoAllow: effectiveToolPolicy.profileAlsoAllow ?? [],
         providerProfileAlsoAllow: effectiveToolPolicy.providerProfileAlsoAllow ?? [],
         groups: effectiveTools.groups.map((group) => ({
@@ -305,6 +323,14 @@ export async function sessionsCommand(
           .filter(([, enabled]) => enabled)
           .map(([name]) => name)
           .join(", ") || "-",
+      )}`,
+    );
+    runtime.log(
+      `${label("Policy pipeline")}${muted(": ")}${infoLabel(
+        payload.tools.policyPipeline
+          .filter((step) => step.active)
+          .map((step) => step.label)
+          .join(" -> ") || "-",
       )}`,
     );
     runtime.log(

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -112,19 +112,6 @@ export async function sessionsCommand(
     cfg.agents?.defaults?.contextTokens ??
     lookupContextTokens(displayDefaults.model) ??
     DEFAULT_CONTEXT_TOKENS;
-  const targets = resolveSessionStoreTargetsOrExit({
-    cfg,
-    opts: {
-      store: opts.store,
-      agent: opts.agent,
-      allAgents: opts.allAgents,
-    },
-    runtime,
-  });
-  if (!targets) {
-    return;
-  }
-
   if (opts.explain) {
     const initialStore = opts.store ? loadSessionStore(opts.store) : undefined;
     const target = resolveGatewaySessionStoreTarget({
@@ -311,6 +298,19 @@ export async function sessionsCommand(
         `${label(`Tools ${group.id}`)}${muted(": ")}${infoLabel(`${group.count} [${group.tools.join(", ")}]`)}`,
       );
     }
+    return;
+  }
+
+  const targets = resolveSessionStoreTargetsOrExit({
+    cfg,
+    opts: {
+      store: opts.store,
+      agent: opts.agent,
+      allAgents: opts.allAgents,
+    },
+    runtime,
+  });
+  if (!targets) {
     return;
   }
 

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -194,6 +194,19 @@ export async function sessionsCommand(
         usesPersistedWorkspace: Boolean(entry.spawnedWorkspaceDir),
         usesRuntimeModelRef: Boolean(entry.modelProvider || entry.model),
         usesOverrides: Boolean(entry.providerOverride || entry.modelOverride),
+        modelReasonChain: [
+          "default-model-ref",
+          ...(entry.providerOverride ? ["explicit-provider-override"] : []),
+          ...(entry.modelOverride ? ["explicit-model-override"] : []),
+          ...(entry.modelProvider || entry.model ? ["persisted-runtime-model-ref"] : []),
+        ],
+        workspaceReasonChain: [
+          entry.spawnedWorkspaceDir ? "persisted-session-workspace" : "agent-default-workspace",
+        ],
+        toolsReasonChain: [
+          "runtime-effective-tool-inventory",
+          `tool-profile:${effectiveTools.profile}`,
+        ],
       },
       tools: {
         profile: effectiveTools.profile,
@@ -243,6 +256,15 @@ export async function sessionsCommand(
     );
     runtime.log(
       `${label("Uses persisted ws")}${muted(": ")}${payload.resolution.usesPersistedWorkspace ? success("yes") : muted("no")}`,
+    );
+    runtime.log(
+      `${label("Model reasons")}${muted(": ")}${infoLabel(payload.resolution.modelReasonChain.join(" -> "))}`,
+    );
+    runtime.log(
+      `${label("Workspace reasons")}${muted(": ")}${infoLabel(payload.resolution.workspaceReasonChain.join(" -> "))}`,
+    );
+    runtime.log(
+      `${label("Tools reasons")}${muted(": ")}${infoLabel(payload.resolution.toolsReasonChain.join(" -> "))}`,
     );
     runtime.log(
       `${label("Final model")}${muted(": ")}${success(`${payload.resolved.provider}/${payload.resolved.model}`)}`,

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -203,12 +203,24 @@ export async function sessionsCommand(
         toolsReasonChain: [
           "runtime-effective-tool-inventory",
           `tool-profile:${effectiveTools.profile}`,
+          ...(effectiveToolPolicy.globalPolicy ? ["global-tools-policy"] : []),
+          ...(effectiveToolPolicy.globalProviderPolicy ? ["global-provider-policy"] : []),
+          ...(effectiveToolPolicy.agentPolicy ? ["agent-tools-policy"] : []),
+          ...(effectiveToolPolicy.agentProviderPolicy ? ["agent-provider-policy"] : []),
+          ...(effectiveToolPolicy.profile ? ["profile-policy"] : []),
+          ...(effectiveToolPolicy.providerProfile ? ["provider-profile-policy"] : []),
         ],
       },
       tools: {
         profile: effectiveTools.profile,
         policyProfile: effectiveToolPolicy.profile ?? null,
         providerProfile: effectiveToolPolicy.providerProfile ?? null,
+        policySources: {
+          global: Boolean(effectiveToolPolicy.globalPolicy),
+          globalProvider: Boolean(effectiveToolPolicy.globalProviderPolicy),
+          agent: Boolean(effectiveToolPolicy.agentPolicy),
+          agentProvider: Boolean(effectiveToolPolicy.agentProviderPolicy),
+        },
         profileAlsoAllow: effectiveToolPolicy.profileAlsoAllow ?? [],
         providerProfileAlsoAllow: effectiveToolPolicy.providerProfileAlsoAllow ?? [],
         groups: effectiveTools.groups.map((group) => ({
@@ -286,6 +298,14 @@ export async function sessionsCommand(
     );
     runtime.log(
       `${label("Provider alsoAllow")}${muted(": ")}${infoLabel(payload.tools.providerProfileAlsoAllow.join(", ") || "-")}`,
+    );
+    runtime.log(
+      `${label("Policy sources")}${muted(": ")}${infoLabel(
+        Object.entries(payload.tools.policySources)
+          .filter(([, enabled]) => enabled)
+          .map(([name]) => name)
+          .join(", ") || "-",
+      )}`,
     );
     runtime.log(
       `${label("Subagent role")}${muted(": ")}${infoLabel(payload.capabilities.subagent.role)}`,


### PR DESCRIPTION
Adds a focused `openclaw sessions explain <key>` command to inspect how a stored session resolves today.

### What changed
- adds `openclaw sessions explain <key>`
- supports both human-readable text output and `--json`
- resolves the session through the canonical session-store lookup path
- explains:
  - session key
  - agent id
  - backing store path
  - default provider/model baseline
  - persisted overrides
  - persisted runtime provider/model
  - persisted workspace binding (`spawnedWorkspaceDir`)
  - final effective provider/model
  - final effective workspace
  - simple resolution flags (`usesOverrides`, `usesRuntimeModelRef`, `usesPersistedWorkspace`)

### Why
OpenClaw already had the pieces to resolve a session's effective model/provider/workspace, but there was no focused CLI explain surface for a real stored session. This makes it easier to debug why a given session is behaving the way it is.

### Output modes
- text: readable troubleshooting summary
- json: machine-friendly payload for tooling

### Tests
- `src/commands/sessions.test.ts`
