### PR TITLE
fix(qqbot): add missing QQ media domains to SSRF hostname allowlist

### DIFF
--- a/extensions/qqbot/src/utils/file-utils.test.ts
+++ b/extensions/qqbot/src/utils/file-utils.test.ts
@@ -47,7 +47,14 @@ describe("qqbot file-utils downloadFile", () => {
       ssrfPolicy: QQBOT_MEDIA_SSRF_POLICY,
     });
     expect(QQBOT_MEDIA_SSRF_POLICY).toEqual({
-      hostnameAllowlist: ["*.myqcloud.com", "*.qpic.cn", "*.qq.com", "*.tencentcos.com"],
+      hostnameAllowlist: [
+        "*.myqcloud.com",
+        "*.qpic.cn",
+        "*.qq.com",
+        "*.qq.com.cn",
+        "*.tencentcos.com",
+        "*.ugcimg.cn",
+      ],
       allowRfc2544BenchmarkRange: true,
     });
   });

--- a/extensions/qqbot/src/utils/file-utils.ts
+++ b/extensions/qqbot/src/utils/file-utils.ts
@@ -16,7 +16,9 @@ const QQBOT_MEDIA_HOSTNAME_ALLOWLIST = [
   "*.myqcloud.com",
   "*.qpic.cn",
   "*.qq.com",
+  "*.qq.com.cn",
   "*.tencentcos.com",
+  "*.ugcimg.cn",
 ];
 
 export const QQBOT_MEDIA_SSRF_POLICY: SsrFPolicy = {


### PR DESCRIPTION
## Summary

QQ Bot voice messages (`.wav`) and media files fail to download — blocked by the SSRF security policy because the hostname allowlist is missing domains that QQ Open Platform actually uses for media delivery.

Fixes #65268

## Root cause

`QQBOT_MEDIA_HOSTNAME_ALLOWLIST` in `extensions/qqbot/src/utils/file-utils.ts:15-20`:

```ts
const QQBOT_MEDIA_HOSTNAME_ALLOWLIST = [
  "*.myqcloud.com",
  "*.qpic.cn",
  "*.qq.com",        // does NOT match *.qq.com.cn
  "*.tencentcos.com",
];
```

Missing domains:

| Domain | Purpose |
|--------|---------|
| `*.qq.com.cn` | `multimedia.nt.qq.com.cn` — media download endpoint. `*.qq.com` does not match because the TLD is `.qq.com.cn`, not `.qq.com`. |
| `*.ugcimg.cn` | `qqbot.ugcimg.cn` — voice message `.wav` files. |

## Fix

Add the two missing domains to the allowlist. Alphabetical order preserved.

## Scope

- **Files**: `extensions/qqbot/src/utils/file-utils.ts` (+2 lines)
- **oxlint clean**
- **Zero competing PRs**

Credit to @thehappyboy for the exact domain analysis in #65268.