### PR TITLE
Fix/send poll intent detection clean

### DIFF
--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -123,4 +123,95 @@ describe("runMessageAction core send routing", () => {
       }),
     );
   });
+
+  it("does not reject send when only non-question poll metadata is present", async () => {
+    const sendText = vi.fn().mockResolvedValue({
+      channel: "testchat",
+      messageId: "t3",
+      chatId: "c1",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "testchat",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "testchat",
+            outbound: {
+              deliveryMode: "direct",
+              sendText,
+            },
+          }),
+        },
+      ]),
+    );
+    const cfg = {
+      channels: {
+        testchat: {
+          enabled: true,
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = await runMessageAction({
+      cfg,
+      action: "send",
+      params: {
+        channel: "testchat",
+        target: "channel:abc",
+        message: "hello",
+        pollDurationHours: 2,
+        pollMulti: true,
+        pollAnonymous: true,
+      },
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "hello",
+      }),
+    );
+  });
+
+  it("still rejects send when question or options indicate real poll intent", async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "testchat",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "testchat",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: vi.fn(),
+            },
+          }),
+        },
+      ]),
+    );
+    const cfg = {
+      channels: {
+        testchat: {
+          enabled: true,
+        },
+      },
+    } as OpenClawConfig;
+
+    await expect(
+      runMessageAction({
+        cfg,
+        action: "send",
+        params: {
+          channel: "testchat",
+          target: "channel:abc",
+          message: "hello",
+          pollQuestion: "Lunch?",
+          pollDurationHours: 2,
+        },
+        dryRun: false,
+      }),
+    ).rejects.toThrow(/Poll fields require action "poll"/i);
+  });
 });

--- a/src/infra/outbound/message-action-runner.send-validation.test.ts
+++ b/src/infra/outbound/message-action-runner.send-validation.test.ts
@@ -96,16 +96,6 @@ describe("runMessageAction send validation", () => {
       },
     },
     {
-      name: "string-encoded poll params",
-      actionParams: {
-        channel: "slack",
-        target: "#C12345678",
-        message: "hi",
-        pollDurationSeconds: "60",
-        pollPublic: "true",
-      },
-    },
-    {
       name: "snake_case poll params",
       actionParams: {
         channel: "slack",
@@ -114,6 +104,27 @@ describe("runMessageAction send validation", () => {
         poll_question: "Ready?",
         poll_option: ["Yes", "No"],
         poll_public: "true",
+      },
+    },
+  ])("rejects send actions that include $name", async ({ actionParams }) => {
+    await expect(
+      runDrySend({
+        cfg: slackConfig,
+        actionParams,
+        toolContext: { currentChannelId: "C12345678" },
+      }),
+    ).rejects.toThrow(/use action "poll" instead of "send"/i);
+  });
+
+  it.each([
+    {
+      name: "string-encoded poll metadata",
+      actionParams: {
+        channel: "slack",
+        target: "#C12345678",
+        message: "hi",
+        pollDurationSeconds: "60",
+        pollPublic: "true",
       },
     },
     {
@@ -125,13 +136,13 @@ describe("runMessageAction send validation", () => {
         pollDurationSeconds: -5,
       },
     },
-  ])("rejects send actions that include $name", async ({ actionParams }) => {
-    await expect(
-      runDrySend({
-        cfg: slackConfig,
-        actionParams,
-        toolContext: { currentChannelId: "C12345678" },
-      }),
-    ).rejects.toThrow(/use action "poll" instead of "send"/i);
+  ])("allows send actions that include only $name", async ({ actionParams }) => {
+    const result = await runDrySend({
+      cfg: slackConfig,
+      actionParams,
+      toolContext: { currentChannelId: "C12345678" },
+    });
+
+    expect(result.kind).toBe("send");
   });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -18,7 +18,7 @@ import { hasInteractiveReplyBlocks, hasReplyPayloadContent } from "../../interac
 import type { OutboundMediaAccess } from "../../media/load-options.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
-import { hasPollCreationParams } from "../../poll-params.js";
+import { hasRealPollIntent } from "../../poll-params.js";
 import { resolvePollMaxSelections } from "../../polls.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -910,7 +910,7 @@ export async function runMessageAction(
     cfg,
   });
 
-  if (action === "send" && hasPollCreationParams(params)) {
+  if (action === "send" && hasRealPollIntent(params)) {
     throw new Error('Poll fields require action "poll"; use action "poll" instead of "send".');
   }
 

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -66,6 +66,7 @@ describe("poll params", () => {
 
   it("only treats question or options as real poll intent", () => {
     expect(hasRealPollIntent({ pollQuestion: "Lunch?" })).toBe(true);
+    expect(hasRealPollIntent({ poll_question: "Lunch?" })).toBe(true);
     expect(hasRealPollIntent({ pollOption: ["Pizza", "Sushi"] })).toBe(true);
     expect(hasRealPollIntent({ poll_option: "Pizza" })).toBe(true);
 

--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { hasPollCreationParams, resolveTelegramPollVisibility } from "./poll-params.js";
+import {
+  hasPollCreationParams,
+  hasRealPollIntent,
+  resolveTelegramPollVisibility,
+} from "./poll-params.js";
 
 describe("poll params", () => {
   it("does not treat explicit false booleans as poll creation params", () => {
@@ -58,6 +62,19 @@ describe("poll params", () => {
     expect(hasPollCreationParams({ poll_option: ["Pizza", "Sushi"] })).toBe(true);
     expect(hasPollCreationParams({ poll_duration_seconds: "60" })).toBe(true);
     expect(hasPollCreationParams({ poll_public: "true" })).toBe(true);
+  });
+
+  it("only treats question or options as real poll intent", () => {
+    expect(hasRealPollIntent({ pollQuestion: "Lunch?" })).toBe(true);
+    expect(hasRealPollIntent({ pollOption: ["Pizza", "Sushi"] })).toBe(true);
+    expect(hasRealPollIntent({ poll_option: "Pizza" })).toBe(true);
+
+    expect(hasRealPollIntent({ pollDurationSeconds: 60 })).toBe(false);
+    expect(hasRealPollIntent({ poll_duration_hours: 2 })).toBe(false);
+    expect(hasRealPollIntent({ pollMulti: true })).toBe(false);
+    expect(hasRealPollIntent({ pollAnonymous: true })).toBe(false);
+    expect(hasRealPollIntent({ pollPublic: true })).toBe(false);
+    expect(hasRealPollIntent({ pollQuestion: "   ", pollOption: [] })).toBe(false);
   });
 
   it("resolves telegram poll visibility flags", () => {

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -95,3 +95,26 @@ export function hasPollCreationParams(params: Record<string, unknown>): boolean 
   }
   return false;
 }
+
+/**
+ * Stricter poll intent check: only pollQuestion (non-empty) or pollOption (with entries)
+ * indicate real poll intent. Duration, multi, anonymous, public flags alone do NOT
+ * indicate poll intent.
+ */
+export function hasRealPollIntent(params: Record<string, unknown>): boolean {
+  const pollQuestion = readPollParamRaw(params, "pollQuestion");
+  if (typeof pollQuestion === "string" && pollQuestion.trim().length > 0) {
+    return true;
+  }
+  const pollOption = readPollParamRaw(params, "pollOption");
+  if (
+    Array.isArray(pollOption) &&
+    pollOption.some((entry) => typeof entry === "string" && entry.trim())
+  ) {
+    return true;
+  }
+  if (typeof pollOption === "string" && pollOption.trim().length > 0) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: `message-action-runner` treated any poll-related params on `action="send"` as poll intent, including metadata-only fields like duration and boolean flags.
- Why it matters: normal sends could be rejected even when the payload did not actually contain a poll question or options.
- What changed: `send` now only treats non-empty `pollQuestion` or `pollOption` as real poll intent, and regression tests were added for both the relaxed send path and the retained real-poll rejection path.
- What did NOT change (scope boundary): poll creation behavior, poll validation rules, and poll-only parameter parsing for actual `action="poll"` requests were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #55478
- Closes #52118
- Closes #55994
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the send-side guard reused broad poll-parameter detection that was designed to notice any poll-related fields, not to distinguish real poll payloads from metadata-only params.
- Missing detection / guardrail: there was no narrower intent check requiring actual poll content such as a question or options before rejecting `action="send"`.
- Contributing context (if known): tool schemas and channel-specific params can populate poll metadata fields independently of a real poll payload, which made the broad check too aggressive.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/poll-params.test.ts`, `src/infra/outbound/message-action-runner.core-send.test.ts`
- Scenario the test should lock in: `action="send"` must succeed when only poll metadata is present, and must still reject when `pollQuestion` or `pollOption` indicates a real poll payload.
- Why this is the smallest reliable guardrail: the regression lives in local parameter classification and send routing, so focused unit tests cover the failure mode without requiring channel end-to-end setup.
- Existing test that already covers this (if any): there was partial coverage for zero-valued poll params, but not for non-question metadata-only poll params on `send`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`message send` no longer rejects non-poll sends just because poll metadata fields are present. Real poll payloads on `action="send"` are still rejected and must use `action="poll"`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[send action + poll metadata only] -> [broad poll param check] -> [rejected as poll]

After:
[send action + poll metadata only] -> [real poll intent check] -> [sent normally]
[send action + pollQuestion/pollOption] -> [real poll intent check] -> [rejected, use poll action]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): outbound message action routing
- Relevant config (redacted): minimal test config with outbound test plugin

### Steps

1. Run `runMessageAction` with `action: "send"` and metadata-only poll fields such as `pollDurationHours`, `pollMulti`, or `pollAnonymous`.
2. Observe behavior before the fix: the request is rejected with `Poll fields require action "poll"`.
3. Run the same scenario after the fix and confirm the send succeeds.
4. Run `runMessageAction` with `action: "send"` plus `pollQuestion` or `pollOption`.
5. Confirm the request is still rejected and must use `action: "poll"`.

### Expected

- Metadata-only poll params do not force `action="send"` into the poll-only rejection path.
- Real poll payloads still require `action="poll"`.

### Actual

- Before the fix, metadata-only poll params could incorrectly trigger poll rejection.
- After the fix, only real poll content triggers that rejection.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted unit tests for `hasRealPollIntent` and `runMessageAction` send routing were run locally.
- Edge cases checked: empty question, empty option array, metadata-only params, and real poll question payloads.
- What you did **not** verify: live channel delivery against real Telegram/Discord/other integrations was not manually exercised.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: some caller may have implicitly depended on metadata-only poll params being rejected on `action="send"`.
  - Mitigation: the new tests lock the intended behavior to actual poll content only, which matches the error message and action contract more closely.
