### PR TITLE
fix(config): allow historyLimit: 0 in GroupChatSchema

### DIFF
--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -354,7 +354,10 @@ export const ModelsConfigSchema = z
 export const GroupChatSchema = z
   .object({
     mentionPatterns: z.array(z.string()).optional(),
-    historyLimit: z.number().int().positive().optional(),
+    // Use .min(0) not .positive() — 0 is a valid value meaning "no history".
+    // Consistent with DmConfigSchema.historyLimit and all other historyLimit
+    // fields in this file (#65305).
+    historyLimit: z.number().int().min(0).optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

`GroupChatSchema.historyLimit` uses `.positive()` which rejects `0`, while every other `historyLimit` in the codebase uses `.min(0)`. Setting `messages.groupChat.historyLimit: 0` (meaning "disable group chat history") causes a **silent config reload failure** — Zod rejects the value and the runtime falls back to the previously cached config with no prominent error.

Fixes #65305

## Root cause

```ts
// zod-schema.core.ts:357 (before fix)
historyLimit: z.number().int().positive().optional(),  // rejects 0

// zod-schema.core.ts:364 (sibling — correct)
historyLimit: z.number().int().min(0).optional(),      // accepts 0
```

## Fix

`.positive()` → `.min(0)` on line 357. One token changed.

## Scope

- **Files**: `src/config/zod-schema.core.ts` (+3/-1)
- **oxlint clean**
- **Zero competing PRs**

Credit to @maxreith for identifying the inconsistency in #65305.