### PR TITLE
fix(sandbox): use resolveGlobalSingleton for backend registry

### DIFF
--- a/src/agents/sandbox/backend.ts
+++ b/src/agents/sandbox/backend.ts
@@ -1,3 +1,4 @@
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import type {
   RegisteredSandboxBackend,
@@ -23,7 +24,10 @@ export type {
   SandboxFsBridgeContext,
 } from "./backend-handle.types.js";
 
-const SANDBOX_BACKEND_FACTORIES = new Map<SandboxBackendId, RegisteredSandboxBackend>();
+const SANDBOX_BACKEND_FACTORIES = resolveGlobalSingleton(
+  Symbol.for("openclaw.sandboxBackendFactories"),
+  () => new Map<SandboxBackendId, RegisteredSandboxBackend>(),
+);
 
 function normalizeSandboxBackendId(id: string): SandboxBackendId {
   const normalized = normalizeOptionalLowercaseString(id);


### PR DESCRIPTION
## Summary

- `SANDBOX_BACKEND_FACTORIES` in `src/agents/sandbox/backend.ts` used a plain module-level `Map`, causing third-party plugins loaded via jiti to operate on a separate Map instance — registration succeeds but runtime lookup fails with `Sandbox backend "xxx" is not registered`
- Replace with `resolveGlobalSingleton(Symbol.for("openclaw.sandboxBackendFactories"), ...)` so all module graph copies (native ESM + jiti) share the same registry via `globalThis`
- This is the same pattern already used 30+ times across the codebase for other process-global registries

## Test plan

- [x] `pnpm tsgo` — type check passes
- [x] `pnpm test src/agents/sandbox/` — 18 test files, 121 tests all pass
- [x] `pnpm check` — lint, format, import cycles, all green
- [ ] Manual: configure a third-party sandbox backend plugin, verify it is discoverable by runtime after registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)