### PR TITLE
feat(plugins): add registerProviderRuntimeAuthOverride API

### DIFF
--- a/src/agents/model-auth-runtime-shared.ts
+++ b/src/agents/model-auth-runtime-shared.ts
@@ -10,6 +10,10 @@ export type ResolvedProviderAuth = {
   profileId?: string;
   source: string;
   mode: "api-key" | "oauth" | "token" | "aws-sdk";
+  /** Optional base URL override for the provider (applies to this call only). */
+  baseUrl?: string;
+  /** Optional extra headers to merge into the outbound provider request. */
+  providerRequestHeaders?: Record<string, string>;
 };
 
 export function resolveAwsSdkEnvVarName(env: NodeJS.ProcessEnv = process.env): string | undefined {

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1160,7 +1160,7 @@ describe("resolveApiKeyForProvider — plugin runtime auth overrides", () => {
           // Simulates a plugin calling back into the resolver from inside its run().
           // Without the reentrancy guard this would recurse indefinitely.
           const inner = await resolveApiKeyForProvider({ provider, store: emptyStore });
-          return { apiKey: inner.apiKey, source: "reentry-via-inner" };
+          return { apiKey: requireApiKey(inner, provider), source: "reentry-via-inner" };
         }),
       ]);
 

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1271,14 +1271,15 @@ describe("resetGlobalProviderRuntimeAuthOverridesForTest", () => {
   });
 });
 
-// 10. hasAvailableAuthForProvider — registration presence treated as "may be available"
+// 10. hasAvailableAuthForProvider — default is conservative; opt-in may treat
+//     override registration as "may be available" for coarse UI signals.
 describe("hasAvailableAuthForProvider — plugin runtime auth overrides", () => {
   afterEach(() => {
     resetGlobalProviderRuntimeAuthOverridesForTest();
   });
 
-  it("returns true when a matching override is registered, false otherwise", async () => {
-    // Before registering: no override, empty store, no env vars → false
+  it("stays false by default for registration-only overrides, and opt-in callers can treat registration as available", async () => {
+    // Before registering: no override, empty store, no env vars -> false
     const before = await hasAvailableAuthForProvider({
       provider: FAKE_PROVIDER,
       store: emptyStore,
@@ -1293,14 +1294,27 @@ describe("hasAvailableAuthForProvider — plugin runtime auth overrides", () => 
       })),
     ]);
 
-    // After registering: provider is in override list → true (without invoking run())
-    const after = await hasAvailableAuthForProvider({ provider: FAKE_PROVIDER, store: emptyStore });
-    expect(after).toBe(true);
+    // Default remains conservative because overrides may return null at runtime.
+    const afterDefault = await hasAvailableAuthForProvider({
+      provider: FAKE_PROVIDER,
+      store: emptyStore,
+    });
+    expect(afterDefault).toBe(false);
+
+    // Opt-in callers that only need a coarse "may be available" signal can
+    // treat registration presence as available without invoking plugin code.
+    const afterOptIn = await hasAvailableAuthForProvider({
+      provider: FAKE_PROVIDER,
+      store: emptyStore,
+      runtimeOverrideRegistrationIsAvailable: true,
+    });
+    expect(afterOptIn).toBe(true);
 
     // A provider not covered by any override stays false
     const other = await hasAvailableAuthForProvider({
       provider: "nonexistent-provider-zzztestonly",
       store: emptyStore,
+      runtimeOverrideRegistrationIsAvailable: true,
     });
     expect(other).toBe(false);
   });

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1,6 +1,12 @@
 import { streamSimpleOpenAICompletions, type Model } from "@mariozechner/pi-ai";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig } from "../config/config.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type {
+  PluginProviderRuntimeAuthOverrideRegistration,
+  PluginRegistry,
+} from "../plugins/registry-types.js";
+import type { ProviderRuntimeAuthOverride } from "../plugins/types.js";
 import { withFetchPreconnect } from "../test-utils/fetch-mock.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import {
@@ -105,6 +111,7 @@ vi.mock("../plugins/provider-runtime.js", async () => {
 
 let applyAuthHeaderOverride: typeof import("./model-auth.js").applyAuthHeaderOverride;
 let applyLocalNoAuthHeaderOverride: typeof import("./model-auth.js").applyLocalNoAuthHeaderOverride;
+let hasAvailableAuthForProvider: typeof import("./model-auth.js").hasAvailableAuthForProvider;
 let hasUsableCustomProviderApiKey: typeof import("./model-auth.js").hasUsableCustomProviderApiKey;
 let requireApiKey: typeof import("./model-auth.js").requireApiKey;
 let resolveApiKeyForProvider: typeof import("./model-auth.js").resolveApiKeyForProvider;
@@ -113,6 +120,10 @@ let resolveModelAuthMode: typeof import("./model-auth.js").resolveModelAuthMode;
 let resolveUsableCustomProviderApiKey: typeof import("./model-auth.js").resolveUsableCustomProviderApiKey;
 let clearRuntimeConfigSnapshot: typeof import("../config/config.js").clearRuntimeConfigSnapshot;
 let setRuntimeConfigSnapshot: typeof import("../config/config.js").setRuntimeConfigSnapshot;
+let getGlobalProviderRuntimeAuthOverrides: typeof import("../plugins/provider-runtime-auth-override-global.js").getGlobalProviderRuntimeAuthOverrides;
+let setGlobalProviderRuntimeAuthOverrides: typeof import("../plugins/provider-runtime-auth-override-global.js").setGlobalProviderRuntimeAuthOverrides;
+let resetGlobalProviderRuntimeAuthOverridesForTest: typeof import("../plugins/provider-runtime-auth-override-global.js").resetGlobalProviderRuntimeAuthOverridesForTest;
+let setActivePluginRegistry: typeof import("../plugins/runtime.js").setActivePluginRegistry;
 
 beforeAll(async () => {
   vi.resetModules();
@@ -120,6 +131,7 @@ beforeAll(async () => {
   ({
     applyAuthHeaderOverride,
     applyLocalNoAuthHeaderOverride,
+    hasAvailableAuthForProvider,
     hasUsableCustomProviderApiKey,
     requireApiKey,
     resolveApiKeyForProvider,
@@ -127,6 +139,12 @@ beforeAll(async () => {
     resolveModelAuthMode,
     resolveUsableCustomProviderApiKey,
   } = await import("./model-auth.js"));
+  ({
+    getGlobalProviderRuntimeAuthOverrides,
+    setGlobalProviderRuntimeAuthOverrides,
+    resetGlobalProviderRuntimeAuthOverridesForTest,
+  } = await import("../plugins/provider-runtime-auth-override-global.js"));
+  ({ setActivePluginRegistry } = await import("../plugins/runtime.js"));
 });
 
 beforeEach(() => {
@@ -978,5 +996,312 @@ describe("applyAuthHeaderOverride", () => {
       "X-Custom": "keep",
       Authorization: "Bearer test-api-key",
     });
+  });
+});
+
+// ── plugin runtime auth override tests ──────────────────────────────────────
+//
+// A clearly made-up provider name with no env vars or profiles in any env.
+const FAKE_PROVIDER = "test-runtime-auth-override-zzzprovider";
+
+// In-memory auth store to prevent filesystem access in fallthrough paths.
+const emptyStore: AuthProfileStore = { version: 1, profiles: {} };
+
+function makeOverrideReg(
+  pluginId: string,
+  providers: string[],
+  run: ProviderRuntimeAuthOverride["run"],
+): PluginProviderRuntimeAuthOverrideRegistration {
+  return { pluginId, source: "test", override: { providers, run } };
+}
+
+function registryWithOverrides(
+  overrides: PluginProviderRuntimeAuthOverrideRegistration[],
+): PluginRegistry {
+  const registry = createEmptyPluginRegistry();
+  registry.providerRuntimeAuthOverrides = overrides;
+  return registry;
+}
+
+describe("resolveApiKeyForProvider — plugin runtime auth overrides", () => {
+  afterEach(() => {
+    resetGlobalProviderRuntimeAuthOverridesForTest();
+  });
+
+  // 1. Override applied
+  it("returns the override result when an override is registered for the provider", async () => {
+    setGlobalProviderRuntimeAuthOverrides([
+      makeOverrideReg(FAKE_PROVIDER + "-plugin", [FAKE_PROVIDER], async () => ({
+        apiKey: "override-key-123",
+        source: "override-source",
+        mode: "api-key",
+      })),
+    ]);
+
+    const result = await resolveApiKeyForProvider({ provider: FAKE_PROVIDER, store: emptyStore });
+
+    expect(result.apiKey).toBe("override-key-123");
+    expect(result.source).toBe("override-source");
+    expect(result.mode).toBe("api-key");
+  });
+
+  // 2. Provider mismatch — override is not applied
+  it("ignores an override registered for a different provider", async () => {
+    setGlobalProviderRuntimeAuthOverrides([
+      makeOverrideReg("other-plugin", ["not-" + FAKE_PROVIDER], async () => ({
+        apiKey: "should-not-see-this",
+        source: "other-plugin",
+        mode: "api-key",
+      })),
+    ]);
+
+    await expect(
+      resolveApiKeyForProvider({ provider: FAKE_PROVIDER, store: emptyStore }),
+    ).rejects.toThrow(/No API key found for provider/);
+  });
+
+  // 3. Null result — falls through to default resolution
+  it("skips an override that returns null and falls through to default resolution", async () => {
+    setGlobalProviderRuntimeAuthOverrides([
+      makeOverrideReg(FAKE_PROVIDER + "-null-plugin", [FAKE_PROVIDER], async () => null),
+    ]);
+
+    await expect(
+      resolveApiKeyForProvider({ provider: FAKE_PROVIDER, store: emptyStore }),
+    ).rejects.toThrow(/No API key found for provider/);
+  });
+
+  // 4. Override throws — error propagates, no implicit fallback
+  it("propagates an error thrown by the override", async () => {
+    setGlobalProviderRuntimeAuthOverrides([
+      makeOverrideReg(FAKE_PROVIDER + "-broken", [FAKE_PROVIDER], async () => {
+        throw new Error("plugin-override-exploded");
+      }),
+    ]);
+
+    await expect(
+      resolveApiKeyForProvider({ provider: FAKE_PROVIDER, store: emptyStore }),
+    ).rejects.toThrow("plugin-override-exploded");
+  });
+
+  // 5. Multiple registrations — first non-null wins
+  it("returns the first non-null override result when multiple overrides are registered", async () => {
+    setGlobalProviderRuntimeAuthOverrides([
+      makeOverrideReg(FAKE_PROVIDER + "-first", [FAKE_PROVIDER], async () => null),
+      makeOverrideReg(FAKE_PROVIDER + "-second", [FAKE_PROVIDER], async () => ({
+        apiKey: "second-key",
+        source: "second-plugin",
+        mode: "api-key",
+      })),
+      makeOverrideReg(FAKE_PROVIDER + "-third", [FAKE_PROVIDER], async () => ({
+        apiKey: "third-key-should-not-win",
+        source: "third-plugin",
+        mode: "api-key",
+      })),
+    ]);
+
+    const result = await resolveApiKeyForProvider({ provider: FAKE_PROVIDER, store: emptyStore });
+
+    expect(result.apiKey).toBe("second-key");
+    expect(result.source).toBe("second-plugin");
+  });
+
+  // 6. Unknown mode is normalised to "api-key" with a warning
+  it("normalises an unknown mode value to api-key", async () => {
+    setGlobalProviderRuntimeAuthOverrides([
+      makeOverrideReg(FAKE_PROVIDER + "-mode-plugin", [FAKE_PROVIDER], async () => ({
+        apiKey: "some-key",
+        source: "mode-plugin",
+        mode: "magic-mode" as never,
+      })),
+    ]);
+
+    const result = await resolveApiKeyForProvider({ provider: FAKE_PROVIDER, store: emptyStore });
+
+    expect(result.apiKey).toBe("some-key");
+    expect(result.mode).toBe("api-key");
+  });
+
+  // 7. baseUrl and providerRequestHeaders pass-through
+  it("passes through baseUrl and providerRequestHeaders from the override result", async () => {
+    setGlobalProviderRuntimeAuthOverrides([
+      makeOverrideReg(FAKE_PROVIDER + "-proxy", [FAKE_PROVIDER], async () => ({
+        apiKey: "proxy-key",
+        source: "proxy-plugin",
+        mode: "api-key",
+        baseUrl: "https://proxy.example.com/v1",
+        providerRequestHeaders: { "x-my-header": "custom-value", "x-other": "val" },
+      })),
+    ]);
+
+    const result = await resolveApiKeyForProvider({ provider: FAKE_PROVIDER, store: emptyStore });
+
+    expect(result.apiKey).toBe("proxy-key");
+    expect(result.baseUrl).toBe("https://proxy.example.com/v1");
+    expect(result.providerRequestHeaders).toEqual({
+      "x-my-header": "custom-value",
+      "x-other": "val",
+    });
+  });
+
+  // 8. Reentrancy guard — exactly one invocation, no infinite recursion
+  it("reentrancy guard allows exactly one override invocation when the override calls resolveApiKeyForProvider internally", async () => {
+    // Seed a default env-based credential so the inner call (which skips
+    // overrides due to the guard) can resolve successfully via env.
+    const prevKey = process.env["OPENAI_API_KEY"];
+    process.env["OPENAI_API_KEY"] = "inner-default-key"; // pragma: allowlist secret
+
+    try {
+      const callCount = { override: 0 };
+
+      setGlobalProviderRuntimeAuthOverrides([
+        makeOverrideReg("reentry-plugin", ["openai"], async ({ provider }) => {
+          callCount.override++;
+          // Simulates a plugin calling back into the resolver from inside its run().
+          // Without the reentrancy guard this would recurse indefinitely.
+          const inner = await resolveApiKeyForProvider({ provider, store: emptyStore });
+          return { apiKey: inner.apiKey, source: "reentry-via-inner" };
+        }),
+      ]);
+
+      const result = await resolveApiKeyForProvider({ provider: "openai", store: emptyStore });
+
+      // Override was invoked exactly once — guard prevented infinite recursion.
+      expect(callCount.override).toBe(1);
+      // Outer result is the inner-resolved default credential, proving the inner
+      // call succeeded via env (skipping the override), not that it was suppressed.
+      expect(result.apiKey).toBe("inner-default-key");
+    } finally {
+      if (prevKey === undefined) {
+        delete process.env["OPENAI_API_KEY"];
+      } else {
+        process.env["OPENAI_API_KEY"] = prevKey;
+      }
+    }
+  });
+});
+
+// 9. setActivePluginRegistry keeps the global override accessor in lockstep
+//    with every registry swap — the real production coupling, not just the
+//    loader path. This catches the stale-state bug where a non-loader call
+//    site (e.g. gateway server installing an empty registry) leaves the old
+//    override list live.
+describe("setActivePluginRegistry — provider runtime auth override sync", () => {
+  afterEach(() => {
+    // Put runtime back into a clean empty state and clear global accessors.
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    resetGlobalProviderRuntimeAuthOverridesForTest();
+  });
+
+  it("installs overrides from the new registry and clears them when a registry without overrides replaces it", async () => {
+    const override = makeOverrideReg(FAKE_PROVIDER + "-swap", [FAKE_PROVIDER], async () => ({
+      apiKey: "from-registry-activation",
+      source: "swap-plugin",
+      mode: "api-key",
+    }));
+
+    // Activate a registry with an override — accessor AND resolution both see it.
+    setActivePluginRegistry(registryWithOverrides([override]));
+    expect(getGlobalProviderRuntimeAuthOverrides()).toHaveLength(1);
+    const active = await resolveApiKeyForProvider({ provider: FAKE_PROVIDER, store: emptyStore });
+    expect(active.apiKey).toBe("from-registry-activation");
+
+    // Now simulate the production path where a non-loader caller (e.g.
+    // gateway server-plugins.ts installing an empty registry, or a config
+    // reload) swaps the registry. Before the fix this would leave the old
+    // override list live; after the fix the accessor must be empty and
+    // resolution must no longer find the removed override.
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    expect(getGlobalProviderRuntimeAuthOverrides()).toHaveLength(0);
+    await expect(
+      resolveApiKeyForProvider({ provider: FAKE_PROVIDER, store: emptyStore }),
+    ).rejects.toThrow(/No API key found for provider/);
+  });
+
+  it("replaces one registry's overrides with the next registry's overrides on swap", async () => {
+    const oldOverride = makeOverrideReg("old-plugin", [FAKE_PROVIDER], async () => ({
+      apiKey: "old-key",
+      source: "old-plugin",
+      mode: "api-key",
+    }));
+    const newOverride = makeOverrideReg("new-plugin", [FAKE_PROVIDER], async () => ({
+      apiKey: "new-key",
+      source: "new-plugin",
+      mode: "api-key",
+    }));
+
+    setActivePluginRegistry(registryWithOverrides([oldOverride]));
+    const firstResolve = await resolveApiKeyForProvider({
+      provider: FAKE_PROVIDER,
+      store: emptyStore,
+    });
+    expect(firstResolve.apiKey).toBe("old-key");
+
+    // Swap to a registry whose override list is different — resolution must
+    // use the new registry's override, not the old one.
+    setActivePluginRegistry(registryWithOverrides([newOverride]));
+    const secondResolve = await resolveApiKeyForProvider({
+      provider: FAKE_PROVIDER,
+      store: emptyStore,
+    });
+    expect(secondResolve.apiKey).toBe("new-key");
+  });
+});
+
+// Dedicated override global accessor teardown for test isolation.
+describe("resetGlobalProviderRuntimeAuthOverridesForTest", () => {
+  afterEach(() => {
+    resetGlobalProviderRuntimeAuthOverridesForTest();
+  });
+
+  it("clears the global override accessor", () => {
+    setGlobalProviderRuntimeAuthOverrides([
+      makeOverrideReg(FAKE_PROVIDER + "-teardown", [FAKE_PROVIDER], async () => ({
+        apiKey: "should-be-gone-after-reset",
+        source: "teardown-plugin",
+        mode: "api-key",
+      })),
+    ]);
+
+    expect(getGlobalProviderRuntimeAuthOverrides()).toHaveLength(1);
+
+    resetGlobalProviderRuntimeAuthOverridesForTest();
+
+    expect(getGlobalProviderRuntimeAuthOverrides()).toHaveLength(0);
+  });
+});
+
+// 10. hasAvailableAuthForProvider — registration presence treated as "may be available"
+describe("hasAvailableAuthForProvider — plugin runtime auth overrides", () => {
+  afterEach(() => {
+    resetGlobalProviderRuntimeAuthOverridesForTest();
+  });
+
+  it("returns true when a matching override is registered, false otherwise", async () => {
+    // Before registering: no override, empty store, no env vars → false
+    const before = await hasAvailableAuthForProvider({
+      provider: FAKE_PROVIDER,
+      store: emptyStore,
+    });
+    expect(before).toBe(false);
+
+    setGlobalProviderRuntimeAuthOverrides([
+      makeOverrideReg(FAKE_PROVIDER + "-avail", [FAKE_PROVIDER], async () => ({
+        apiKey: "avail-key",
+        source: "avail-plugin",
+        mode: "api-key",
+      })),
+    ]);
+
+    // After registering: provider is in override list → true (without invoking run())
+    const after = await hasAvailableAuthForProvider({ provider: FAKE_PROVIDER, store: emptyStore });
+    expect(after).toBe(true);
+
+    // A provider not covered by any override stays false
+    const other = await hasAvailableAuthForProvider({
+      provider: "nonexistent-provider-zzztestonly",
+      store: emptyStore,
+    });
+    expect(other).toBe(false);
   });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -58,7 +58,7 @@ const log = createSubsystemLogger("model-auth");
  */
 const providerRuntimeAuthOverrideReentry = new AsyncLocalStorage<true>();
 
-const VALID_RESOLVED_PROVIDER_AUTH_MODES: ReadonlyArray<ResolvedProviderAuth["mode"]> = new Set([
+const VALID_RESOLVED_PROVIDER_AUTH_MODES = new Set<ResolvedProviderAuth["mode"]>([
   "api-key",
   "oauth",
   "token",
@@ -676,15 +676,15 @@ export async function hasAvailableAuthForProvider(params: {
   preferredProfile?: string;
   store?: AuthProfileStore;
   agentDir?: string;
+  runtimeOverrideRegistrationIsAvailable?: boolean;
 }): Promise<boolean> {
   const { provider, cfg, preferredProfile } = params;
 
   // Plugin runtime auth override registered for this provider.
-  // Note: we can't invoke run() here (it may be async and side-effecting),
-  // so registration presence is treated as "auth may be available."
-  // A registered override that returns null at runtime will fall through
-  // to default resolution at actual resolve time.
-  {
+  // Callers that need a conservative "auth definitely available now" answer
+  // should keep the default false here. Opt-in callers may treat registration
+  // presence as "auth may be available" when they only need a coarse UI signal.
+  if (params.runtimeOverrideRegistrationIsAvailable) {
     const { getGlobalProviderRuntimeAuthOverrides } =
       await import("../plugins/provider-runtime-auth-override-global.js");
     const overrides = getGlobalProviderRuntimeAuthOverrides();

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -345,6 +345,7 @@ function shouldDeferSyntheticProfileAuth(params: {
 
 export async function resolveApiKeyForProvider(params: {
   provider: string;
+  modelId?: string;
   cfg?: OpenClawConfig;
   profileId?: string;
   preferredProfile?: string;
@@ -356,6 +357,38 @@ export async function resolveApiKeyForProvider(params: {
   credentialPrecedence?: ProviderCredentialPrecedence;
 }): Promise<ResolvedProviderAuth> {
   const { provider, cfg, profileId, preferredProfile } = params;
+
+  // ── Plugin runtime auth overrides ──
+  // Registered via api.registerProviderRuntimeAuthOverride() in plugins.
+  // First non-null result wins. Throwing fails the request (no implicit fallback).
+  {
+    const { getGlobalPluginRegistry } = await import("../plugins/hook-runner-global.js");
+    const pluginRegistry = getGlobalPluginRegistry();
+    if (pluginRegistry) {
+      for (const reg of pluginRegistry.providerRuntimeAuthOverrides) {
+        if (!reg.override.providers.includes(provider)) {
+          continue;
+        }
+        const result = await reg.override.run({
+          provider,
+          modelId: params.modelId ?? "",
+          profileId: params.profileId,
+        });
+        if (result != null) {
+          log.info(
+            `[runtime-auth-override] provider "${provider}" overridden by plugin "${reg.pluginId}"`,
+          );
+          return {
+            apiKey: result.apiKey,
+            source: result.source ?? `plugin-override:${reg.pluginId}`,
+            mode: (result.mode as ResolvedProviderAuth["mode"]) ?? "api-key",
+            baseUrl: result.baseUrl,
+            providerRequestHeaders: result.providerRequestHeaders,
+          };
+        }
+      }
+    }
+  }
 
   if (profileId) {
     const store = params.store ?? ensureAuthProfileStore(params.agentDir);
@@ -659,6 +692,7 @@ export async function getApiKeyForModel(params: {
 }): Promise<ResolvedProviderAuth> {
   return resolveApiKeyForProvider({
     provider: params.model.provider,
+    modelId: params.model.id,
     cfg: params.cfg,
     profileId: params.profileId,
     preferredProfile: params.preferredProfile,
@@ -673,20 +707,32 @@ export function applyLocalNoAuthHeaderOverride<T extends Model<Api>>(
   model: T,
   auth: ResolvedProviderAuth | null | undefined,
 ): T {
-  if (auth?.apiKey !== CUSTOM_LOCAL_AUTH_MARKER || model.api !== "openai-completions") {
-    return model;
+  // Apply plugin runtime auth override fields (baseUrl, providerRequestHeaders)
+  let effective = model;
+  if (auth?.providerRequestHeaders || auth?.baseUrl) {
+    effective = {
+      ...effective,
+      ...(auth.baseUrl ? { baseUrl: auth.baseUrl } : {}),
+      ...(auth.providerRequestHeaders
+        ? { headers: { ...effective.headers, ...auth.providerRequestHeaders } }
+        : {}),
+    };
+  }
+
+  if (auth?.apiKey !== CUSTOM_LOCAL_AUTH_MARKER || effective.api !== "openai-completions") {
+    return effective;
   }
 
   // OpenAI's SDK always generates Authorization from apiKey. Keep the non-secret
   // placeholder so construction succeeds, then clear the header at request build
   // time for local servers that intentionally do not require auth.
   const headers = {
-    ...model.headers,
+    ...effective.headers,
     Authorization: null,
   } as unknown as Record<string, string>;
 
   return {
-    ...model,
+    ...effective,
     headers,
   };
 }

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import path from "node:path";
 import { type Api, type Model } from "@mariozechner/pi-ai";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -46,6 +47,24 @@ export type { ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
 export type ProviderCredentialPrecedence = "profile-first" | "env-first";
 
 const log = createSubsystemLogger("model-auth");
+
+/**
+ * Reentrancy guard for provider runtime auth overrides.
+ *
+ * Plugins can call `resolveApiKeyForProvider` via the public SDK helper from
+ * inside their own override `run()` handler. Without a guard, that would
+ * recurse back into the override loop indefinitely. The guard causes the
+ * inner call to skip overrides and fall through to default resolution.
+ */
+const providerRuntimeAuthOverrideReentry = new AsyncLocalStorage<true>();
+
+const VALID_RESOLVED_PROVIDER_AUTH_MODES: ReadonlyArray<ResolvedProviderAuth["mode"]> = new Set([
+  "api-key",
+  "oauth",
+  "token",
+  "aws-sdk",
+]);
+
 function resolveProviderConfig(
   cfg: OpenClawConfig | undefined,
   provider: string,
@@ -361,31 +380,53 @@ export async function resolveApiKeyForProvider(params: {
   // ── Plugin runtime auth overrides ──
   // Registered via api.registerProviderRuntimeAuthOverride() in plugins.
   // First non-null result wins. Throwing fails the request (no implicit fallback).
-  {
-    const { getGlobalPluginRegistry } = await import("../plugins/hook-runner-global.js");
-    const pluginRegistry = getGlobalPluginRegistry();
-    if (pluginRegistry) {
-      for (const reg of pluginRegistry.providerRuntimeAuthOverrides) {
-        if (!reg.override.providers.includes(provider)) {
-          continue;
-        }
-        const result = await reg.override.run({
-          provider,
-          modelId: params.modelId ?? "",
-          profileId: params.profileId,
-        });
-        if (result != null) {
-          log.info(
-            `[runtime-auth-override] provider "${provider}" overridden by plugin "${reg.pluginId}"`,
+  //
+  // Reentrancy: if a plugin's override calls resolveApiKeyForProvider via the
+  // public SDK helper, the guard causes the inner call to skip overrides and
+  // fall through to default resolution (preventing infinite recursion).
+  if (!providerRuntimeAuthOverrideReentry.getStore()) {
+    const { getGlobalProviderRuntimeAuthOverrides } =
+      await import("../plugins/provider-runtime-auth-override-global.js");
+    const overrides = getGlobalProviderRuntimeAuthOverrides();
+    for (const reg of overrides) {
+      if (!reg.override.providers.includes(provider)) {
+        continue;
+      }
+      const result = await providerRuntimeAuthOverrideReentry.run(true, async () => {
+        try {
+          return await reg.override.run({
+            provider,
+            modelId: params.modelId ?? "",
+            profileId: params.profileId,
+          });
+        } catch (err) {
+          log.error(
+            `[runtime-auth-override] plugin "${reg.pluginId}" override for provider "${provider}" threw: ${String(err)}`,
           );
-          return {
-            apiKey: result.apiKey,
-            source: result.source ?? `plugin-override:${reg.pluginId}`,
-            mode: (result.mode as ResolvedProviderAuth["mode"]) ?? "api-key",
-            baseUrl: result.baseUrl,
-            providerRequestHeaders: result.providerRequestHeaders,
-          };
+          throw err;
         }
+      });
+      if (result != null) {
+        log.info(
+          `[runtime-auth-override] provider "${provider}" overridden by plugin "${reg.pluginId}"`,
+        );
+        const declaredMode = result.mode;
+        const validatedMode =
+          declaredMode && VALID_RESOLVED_PROVIDER_AUTH_MODES.has(declaredMode)
+            ? declaredMode
+            : "api-key";
+        if (declaredMode && !VALID_RESOLVED_PROVIDER_AUTH_MODES.has(declaredMode)) {
+          log.warn(
+            `[runtime-auth-override] plugin "${reg.pluginId}" returned unknown mode "${String(result.mode)}"; defaulting to "api-key"`,
+          );
+        }
+        return {
+          apiKey: result.apiKey,
+          source: result.source ?? `plugin-override:${reg.pluginId}`,
+          mode: validatedMode,
+          baseUrl: result.baseUrl,
+          providerRequestHeaders: result.providerRequestHeaders,
+        };
       }
     }
   }
@@ -637,6 +678,20 @@ export async function hasAvailableAuthForProvider(params: {
   agentDir?: string;
 }): Promise<boolean> {
   const { provider, cfg, preferredProfile } = params;
+
+  // Plugin runtime auth override registered for this provider.
+  // Note: we can't invoke run() here (it may be async and side-effecting),
+  // so registration presence is treated as "auth may be available."
+  // A registered override that returns null at runtime will fall through
+  // to default resolution at actual resolve time.
+  {
+    const { getGlobalProviderRuntimeAuthOverrides } =
+      await import("../plugins/provider-runtime-auth-override-global.js");
+    const overrides = getGlobalProviderRuntimeAuthOverrides();
+    if (overrides.some((reg) => reg.override.providers.includes(provider))) {
+      return true;
+    }
+  }
 
   const authOverride = resolveProviderAuthOverride(cfg, provider);
   if (authOverride === "aws-sdk") {

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -95,6 +95,7 @@ const createRegistry = (diagnostics: PluginDiagnostic[]): PluginRegistry => ({
   cliRegistrars: [],
   services: [],
   conversationBindingResolvedHandlers: [],
+  providerRuntimeAuthOverrides: [],
   diagnostics,
 });
 

--- a/src/gateway/test-helpers.plugin-registry.ts
+++ b/src/gateway/test-helpers.plugin-registry.ts
@@ -31,6 +31,7 @@ function createStubPluginRegistry(): PluginRegistry {
     services: [],
     commands: [],
     conversationBindingResolvedHandlers: [],
+    providerRuntimeAuthOverrides: [],
     diagnostics: [],
   };
 }

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -8,14 +8,19 @@ import { runCapability } from "./runner.js";
 import { withAudioFixture } from "./runner.test-utils.js";
 import type { AudioTranscriptionRequest, MediaUnderstandingProvider } from "./types.js";
 
+type HasAvailableAuthForProviderFn =
+  typeof import("../agents/model-auth.js").hasAvailableAuthForProvider;
+type ResolveApiKeyForProviderFn = typeof import("../agents/model-auth.js").resolveApiKeyForProvider;
+type RequireApiKeyFn = typeof import("../agents/model-auth.js").requireApiKey;
+
 const modelAuthMocks = vi.hoisted(() => ({
-  hasAvailableAuthForProvider: vi.fn(() => true),
-  resolveApiKeyForProvider: vi.fn(async () => ({
+  hasAvailableAuthForProvider: vi.fn<HasAvailableAuthForProviderFn>(async () => true),
+  resolveApiKeyForProvider: vi.fn<ResolveApiKeyForProviderFn>(async () => ({
     apiKey: "test-key",
     source: "test",
-    mode: "api-key",
+    mode: "api-key" as const,
   })),
-  requireApiKey: vi.fn((auth: { apiKey?: string }) => auth.apiKey ?? "test-key"),
+  requireApiKey: vi.fn<RequireApiKeyFn>((auth) => auth.apiKey ?? "test-key"),
 }));
 
 vi.mock("../agents/model-auth.js", () => ({
@@ -180,13 +185,13 @@ describe("runCapability auto audio entries", () => {
 
   it("tries later key-backed providers when an override-only provider is considered available but fails at execution time", async () => {
     modelAuthMocks.hasAvailableAuthForProvider.mockImplementation(
-      async (params: { provider: string; runtimeOverrideRegistrationIsAvailable?: boolean }) =>
+      async (params: Parameters<HasAvailableAuthForProviderFn>[0]) =>
         params.provider === "openai"
           ? params.runtimeOverrideRegistrationIsAvailable === true
           : params.provider === "mistral",
     );
     modelAuthMocks.resolveApiKeyForProvider.mockImplementation(
-      async (params: { provider: string }) => {
+      async (params: Parameters<ResolveApiKeyForProviderFn>[0]) => {
         if (params.provider === "openai") {
           throw new Error("broker unavailable");
         }
@@ -200,59 +205,58 @@ describe("runCapability auto audio entries", () => {
 
     try {
       let runResult: Awaited<ReturnType<typeof runCapability>> | undefined;
-      await withAudioFixture("openclaw-auto-audio-runtime-override-fallback", async ({
-        ctx,
-        media,
-        cache,
-      }) => {
-        const providerRegistry = createProviderRegistry({
-          openai: {
-            id: "openai",
-            capabilities: ["audio"],
-            transcribeAudio: async () => ({
-              text: "openai",
-              model: "gpt-4o-transcribe",
-            }),
-          },
-          mistral: {
-            id: "mistral",
-            capabilities: ["audio"],
-            transcribeAudio: async (req) => ({
-              text: "mistral",
-              model: req.model ?? "unknown",
-            }),
-          },
-        });
-        const cfg = {
-          models: {
-            providers: {
-              openai: {
-                models: [],
-              },
-              mistral: {
-                apiKey: "mistral-test-key", // pragma: allowlist secret
-                models: [],
+      await withAudioFixture(
+        "openclaw-auto-audio-runtime-override-fallback",
+        async ({ ctx, media, cache }) => {
+          const providerRegistry = createProviderRegistry({
+            openai: {
+              id: "openai",
+              capabilities: ["audio"],
+              transcribeAudio: async () => ({
+                text: "openai",
+                model: "gpt-4o-transcribe",
+              }),
+            },
+            mistral: {
+              id: "mistral",
+              capabilities: ["audio"],
+              transcribeAudio: async (req) => ({
+                text: "mistral",
+                model: req.model ?? "unknown",
+              }),
+            },
+          });
+          const cfg = {
+            models: {
+              providers: {
+                openai: {
+                  models: [],
+                },
+                mistral: {
+                  apiKey: "mistral-test-key", // pragma: allowlist secret
+                  models: [],
+                },
               },
             },
-          },
-          tools: {
-            media: {
-              audio: {
-                enabled: true,
+            tools: {
+              media: {
+                audio: {
+                  enabled: true,
+                },
               },
             },
-          },
-        } as unknown as OpenClawConfig;
+          } as unknown as OpenClawConfig;
 
-        runResult = await runCapability({
-          capability: "audio",
-          cfg,
-          ctx,
-          attachments: cache,
-          media,
-          providerRegistry,
-        });
-      });
+          runResult = await runCapability({
+            capability: "audio",
+            cfg,
+            ctx,
+            attachments: cache,
+            media,
+            providerRegistry,
+          });
+        },
+      );
 
       if (!runResult) {
         throw new Error("Expected auto audio fallback result");
@@ -260,20 +264,19 @@ describe("runCapability auto audio entries", () => {
       expect(runResult.decision.outcome).toBe("success");
       expect(runResult.outputs[0]?.provider).toBe("mistral");
       expect(runResult.outputs[0]?.text).toBe("mistral");
-      expect(runResult.decision.attachments[0]?.attempts.map((attempt) => attempt.provider)).toEqual([
-        "openai",
-        "mistral",
-      ]);
+      expect(
+        runResult.decision.attachments[0]?.attempts.map((attempt) => attempt.provider),
+      ).toEqual(["openai", "mistral"]);
       expect(runResult.decision.attachments[0]?.attempts[0]?.outcome).toBe("failed");
       expect(runResult.decision.attachments[0]?.attempts[1]?.outcome).toBe("success");
     } finally {
       modelAuthMocks.hasAvailableAuthForProvider.mockReset();
-      modelAuthMocks.hasAvailableAuthForProvider.mockImplementation(() => true);
+      modelAuthMocks.hasAvailableAuthForProvider.mockImplementation(async () => true);
       modelAuthMocks.resolveApiKeyForProvider.mockReset();
       modelAuthMocks.resolveApiKeyForProvider.mockImplementation(async () => ({
         apiKey: "test-key",
         source: "test",
-        mode: "api-key",
+        mode: "api-key" as const,
       }));
     }
   });

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -178,6 +178,106 @@ describe("runCapability auto audio entries", () => {
     expect(seenPrompt).toBe("Focus on names");
   });
 
+  it("tries later key-backed providers when an override-only provider is considered available but fails at execution time", async () => {
+    modelAuthMocks.hasAvailableAuthForProvider.mockImplementation(
+      async (params: { provider: string; runtimeOverrideRegistrationIsAvailable?: boolean }) =>
+        params.provider === "openai"
+          ? params.runtimeOverrideRegistrationIsAvailable === true
+          : params.provider === "mistral",
+    );
+    modelAuthMocks.resolveApiKeyForProvider.mockImplementation(
+      async (params: { provider: string }) => {
+        if (params.provider === "openai") {
+          throw new Error("broker unavailable");
+        }
+        return {
+          apiKey: "mistral-test-key",
+          source: "test",
+          mode: "api-key" as const,
+        };
+      },
+    );
+
+    try {
+      let runResult: Awaited<ReturnType<typeof runCapability>> | undefined;
+      await withAudioFixture("openclaw-auto-audio-runtime-override-fallback", async ({
+        ctx,
+        media,
+        cache,
+      }) => {
+        const providerRegistry = createProviderRegistry({
+          openai: {
+            id: "openai",
+            capabilities: ["audio"],
+            transcribeAudio: async () => ({
+              text: "openai",
+              model: "gpt-4o-transcribe",
+            }),
+          },
+          mistral: {
+            id: "mistral",
+            capabilities: ["audio"],
+            transcribeAudio: async (req) => ({
+              text: "mistral",
+              model: req.model ?? "unknown",
+            }),
+          },
+        });
+        const cfg = {
+          models: {
+            providers: {
+              openai: {
+                models: [],
+              },
+              mistral: {
+                apiKey: "mistral-test-key", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+          tools: {
+            media: {
+              audio: {
+                enabled: true,
+              },
+            },
+          },
+        } as unknown as OpenClawConfig;
+
+        runResult = await runCapability({
+          capability: "audio",
+          cfg,
+          ctx,
+          attachments: cache,
+          media,
+          providerRegistry,
+        });
+      });
+
+      if (!runResult) {
+        throw new Error("Expected auto audio fallback result");
+      }
+      expect(runResult.decision.outcome).toBe("success");
+      expect(runResult.outputs[0]?.provider).toBe("mistral");
+      expect(runResult.outputs[0]?.text).toBe("mistral");
+      expect(runResult.decision.attachments[0]?.attempts.map((attempt) => attempt.provider)).toEqual([
+        "openai",
+        "mistral",
+      ]);
+      expect(runResult.decision.attachments[0]?.attempts[0]?.outcome).toBe("failed");
+      expect(runResult.decision.attachments[0]?.attempts[1]?.outcome).toBe("success");
+    } finally {
+      modelAuthMocks.hasAvailableAuthForProvider.mockReset();
+      modelAuthMocks.hasAvailableAuthForProvider.mockImplementation(() => true);
+      modelAuthMocks.resolveApiKeyForProvider.mockReset();
+      modelAuthMocks.resolveApiKeyForProvider.mockImplementation(async () => ({
+        apiKey: "test-key",
+        source: "test",
+        mode: "api-key",
+      }));
+    }
+  });
+
   it("uses mistral when only mistral key is configured", async () => {
     const isolatedAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audio-agent-"));
     let runResult: Awaited<ReturnType<typeof runCapability>> | undefined;

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -415,13 +415,13 @@ async function resolveGeminiCliEntry(
   };
 }
 
-async function resolveKeyEntry(params: {
+async function resolveKeyEntries(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
-}): Promise<MediaUnderstandingModelConfig | null> {
+}): Promise<MediaUnderstandingModelConfig[]> {
   const { cfg, agentDir, providerRegistry, capability } = params;
   const checkProvider = async (
     providerId: string,
@@ -445,6 +445,7 @@ async function resolveKeyEntry(params: {
         provider: providerId,
         cfg,
         agentDir,
+        runtimeOverrideRegistrationIsAvailable: true,
       }))
     ) {
       return null;
@@ -459,12 +460,23 @@ async function resolveKeyEntry(params: {
     return { type: "provider" as const, provider: providerId, model: resolvedModel };
   };
 
+  const entries: MediaUnderstandingModelConfig[] = [];
+  const seen = new Set<string>();
+  const pushEntry = (entry: MediaUnderstandingModelConfig | null) => {
+    if (!entry || entry.type === "cli") {
+      return;
+    }
+    const key = `${entry.provider}::${entry.model ?? ""}`;
+    if (seen.has(key)) {
+      return;
+    }
+    seen.add(key);
+    entries.push(entry);
+  };
+
   const activeProvider = params.activeModel?.provider?.trim();
   if (activeProvider) {
-    const activeEntry = await checkProvider(activeProvider, params.activeModel?.model);
-    if (activeEntry) {
-      return activeEntry;
-    }
+    pushEntry(await checkProvider(activeProvider, params.activeModel?.model));
   }
   for (const providerId of resolveConfiguredKeyProviderOrder({
     cfg,
@@ -476,12 +488,9 @@ async function resolveKeyEntry(params: {
       providerRegistry,
     }),
   })) {
-    const entry = await checkProvider(providerId, undefined);
-    if (entry) {
-      return entry;
-    }
+    pushEntry(await checkProvider(providerId, undefined));
   }
-  return null;
+  return entries;
 }
 
 function resolveImageModelFromAgentDefaults(cfg: OpenClawConfig): MediaUnderstandingModelConfig[] {
@@ -540,9 +549,9 @@ async function resolveAutoEntries(params: {
   if (gemini) {
     return [gemini];
   }
-  const keys = await resolveKeyEntry(params);
-  if (keys) {
-    return [keys];
+  const keyEntries = await resolveKeyEntries(params);
+  if (keyEntries.length > 0) {
+    return keyEntries;
   }
   return [];
 }
@@ -575,14 +584,14 @@ export async function resolveAutoImageModel(params: {
   if (resolvedActive) {
     return resolvedActive;
   }
-  const keyEntry = await resolveKeyEntry({
+  const keyEntries = await resolveKeyEntries({
     cfg: params.cfg,
     agentDir: params.agentDir,
     providerRegistry,
     capability: "image",
     activeModel: params.activeModel,
   });
-  return toActive(keyEntry);
+  return toActive(keyEntries[0] ?? null);
 }
 
 async function resolveActiveModelEntry(params: {

--- a/src/plugins/api-builder.ts
+++ b/src/plugins/api-builder.ts
@@ -55,6 +55,7 @@ export type BuildPluginApiParams = {
       | "registerMemoryFlushPlan"
       | "registerMemoryRuntime"
       | "registerMemoryEmbeddingProvider"
+      | "registerProviderRuntimeAuthOverride"
       | "on"
     >
   >;
@@ -109,6 +110,8 @@ const noopRegisterMemoryRuntime: OpenClawPluginApi["registerMemoryRuntime"] = ()
 const noopRegisterMemoryEmbeddingProvider: OpenClawPluginApi["registerMemoryEmbeddingProvider"] =
   () => {};
 const noopOn: OpenClawPluginApi["on"] = () => {};
+const noopRegisterProviderRuntimeAuthOverride: OpenClawPluginApi["registerProviderRuntimeAuthOverride"] =
+  () => {};
 
 export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi {
   const handlers = params.handlers ?? {};
@@ -177,5 +180,7 @@ export function buildPluginApi(params: BuildPluginApiParams): OpenClawPluginApi 
       handlers.registerMemoryEmbeddingProvider ?? noopRegisterMemoryEmbeddingProvider,
     resolvePath: params.resolvePath,
     on: handlers.on ?? noopOn,
+    registerProviderRuntimeAuthOverride:
+      handlers.registerProviderRuntimeAuthOverride ?? noopRegisterProviderRuntimeAuthOverride,
   };
 }

--- a/src/plugins/provider-runtime-auth-override-global.test.ts
+++ b/src/plugins/provider-runtime-auth-override-global.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { PluginProviderRuntimeAuthOverrideRegistration } from "./registry-types.js";
+
+async function importOverrideGlobalModule() {
+  return import("./provider-runtime-auth-override-global.js");
+}
+
+function createOverride(pluginId: string): PluginProviderRuntimeAuthOverrideRegistration {
+  return {
+    pluginId,
+    source: "test",
+    override: {
+      providers: ["openai"],
+      run: async () => ({
+        apiKey: `${pluginId}-key`,
+        mode: "api-key",
+      }),
+    },
+  };
+}
+
+afterEach(async () => {
+  const mod = await importOverrideGlobalModule();
+  mod.resetGlobalProviderRuntimeAuthOverridesForTest();
+});
+
+describe("provider-runtime-auth-override-global", () => {
+  it("preserves override state across module reloads", async () => {
+    const modA = await importOverrideGlobalModule();
+    const overrides = [createOverride("persisted-plugin")];
+    modA.setGlobalProviderRuntimeAuthOverrides(overrides);
+
+    const modB = await importOverrideGlobalModule();
+
+    expect(modB.getGlobalProviderRuntimeAuthOverrides()).toEqual(overrides);
+  });
+
+  it("resets override state for test isolation", async () => {
+    const mod = await importOverrideGlobalModule();
+    mod.setGlobalProviderRuntimeAuthOverrides([createOverride("teardown-plugin")]);
+
+    mod.resetGlobalProviderRuntimeAuthOverridesForTest();
+
+    expect(mod.getGlobalProviderRuntimeAuthOverrides()).toEqual([]);
+  });
+
+  it("hydrates malformed shared state to an empty override list", async () => {
+    const stateKey = Symbol.for("openclaw.plugins.provider-runtime-auth-override-global-state");
+    const globalStore = globalThis as Record<PropertyKey, unknown>;
+    globalStore[stateKey] = undefined;
+
+    const mod = await importOverrideGlobalModule();
+
+    expect(mod.getGlobalProviderRuntimeAuthOverrides()).toEqual([]);
+  });
+});

--- a/src/plugins/provider-runtime-auth-override-global.ts
+++ b/src/plugins/provider-runtime-auth-override-global.ts
@@ -1,0 +1,39 @@
+import type { PluginProviderRuntimeAuthOverrideRegistration } from "./registry-types.js";
+
+type ProviderRuntimeAuthOverrideGlobalState = {
+  overrides: PluginProviderRuntimeAuthOverrideRegistration[];
+};
+
+const providerRuntimeAuthOverrideGlobalStateKey = Symbol.for(
+  "openclaw.plugins.provider-runtime-auth-override-global-state",
+);
+
+function getState(): ProviderRuntimeAuthOverrideGlobalState {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const existing = globalStore[providerRuntimeAuthOverrideGlobalStateKey] as
+    | { overrides?: PluginProviderRuntimeAuthOverrideRegistration[] }
+    | undefined;
+  if (!existing || typeof existing !== "object") {
+    const created: ProviderRuntimeAuthOverrideGlobalState = { overrides: [] };
+    globalStore[providerRuntimeAuthOverrideGlobalStateKey] = created;
+    return created;
+  }
+  if (!Array.isArray(existing.overrides)) {
+    existing.overrides = [];
+  }
+  return existing as ProviderRuntimeAuthOverrideGlobalState;
+}
+
+export function setGlobalProviderRuntimeAuthOverrides(
+  overrides: PluginProviderRuntimeAuthOverrideRegistration[],
+): void {
+  getState().overrides = overrides;
+}
+
+export function getGlobalProviderRuntimeAuthOverrides(): PluginProviderRuntimeAuthOverrideRegistration[] {
+  return getState().overrides;
+}
+
+export function resetGlobalProviderRuntimeAuthOverridesForTest(): void {
+  getState().overrides = [];
+}

--- a/src/plugins/registry-empty.ts
+++ b/src/plugins/registry-empty.ts
@@ -32,6 +32,7 @@ export function createEmptyPluginRegistry(): PluginRegistry {
     services: [],
     commands: [],
     conversationBindingResolvedHandlers: [],
+    providerRuntimeAuthOverrides: [],
     diagnostics: [],
   };
 }

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -43,6 +43,7 @@ import type {
   VideoGenerationProviderPlugin,
   WebFetchProviderPlugin,
   WebSearchProviderPlugin,
+  ProviderRuntimeAuthOverride,
 } from "./types.js";
 
 export type PluginToolRegistration = {
@@ -261,6 +262,12 @@ export type PluginRecord = {
   memorySlotSelected?: boolean;
 };
 
+export type PluginProviderRuntimeAuthOverrideRegistration = {
+  pluginId: string;
+  override: ProviderRuntimeAuthOverride;
+  source: string;
+};
+
 export type PluginRegistry = {
   plugins: PluginRecord[];
   tools: PluginToolRegistration[];
@@ -292,6 +299,7 @@ export type PluginRegistry = {
   services: PluginServiceRegistration[];
   commands: PluginCommandRegistration[];
   conversationBindingResolvedHandlers: PluginConversationBindingResolvedHandlerRegistration[];
+  providerRuntimeAuthOverrides: PluginProviderRuntimeAuthOverrideRegistration[];
   diagnostics: PluginDiagnostic[];
 };
 

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -106,6 +106,7 @@ import type {
   VideoGenerationProviderPlugin,
   WebFetchProviderPlugin,
   WebSearchProviderPlugin,
+  ProviderRuntimeAuthOverride,
 } from "./types.js";
 
 export type PluginHttpRouteRegistration = RegistryTypesPluginHttpRouteRegistration & {
@@ -1027,6 +1028,35 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
     });
   };
 
+  const registerProviderRuntimeAuthOverride = (
+    record: PluginRecord,
+    override: ProviderRuntimeAuthOverride,
+  ): void => {
+    if (!override.providers?.length) {
+      pushDiagnostic({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message: `registerProviderRuntimeAuthOverride: empty providers list, registration ignored`,
+      });
+      return;
+    }
+    if (typeof override.run !== "function") {
+      pushDiagnostic({
+        level: "error",
+        pluginId: record.id,
+        source: record.source,
+        message: `registerProviderRuntimeAuthOverride: run must be a function`,
+      });
+      return;
+    }
+    registry.providerRuntimeAuthOverrides.push({
+      pluginId: record.id,
+      override,
+      source: record.source,
+    });
+  };
+
   const registerTypedHook = <K extends PluginHookName>(
     record: PluginRecord,
     hookName: K,
@@ -1403,6 +1433,8 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
               },
               on: (hookName, handler, opts) =>
                 registerTypedHook(record, hookName, handler, opts, params.hookPolicy),
+              registerProviderRuntimeAuthOverride: (override: ProviderRuntimeAuthOverride) =>
+                registerProviderRuntimeAuthOverride(record, override),
             }
           : {}),
         // Allow setup-only/setup-runtime paths to surface parse-time CLI metadata

--- a/src/plugins/runtime.test.ts
+++ b/src/plugins/runtime.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getGlobalProviderRuntimeAuthOverrides } from "./provider-runtime-auth-override-global.js";
+import type { PluginProviderRuntimeAuthOverrideRegistration } from "./registry-types.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 import type { PluginHttpRouteRegistration } from "./registry.js";
 import {
@@ -9,6 +11,7 @@ import {
   pinActivePluginHttpRouteRegistry,
   recordImportedPluginId,
   releasePinnedPluginHttpRouteRegistry,
+  requireActivePluginRegistry,
   resetPluginRuntimeStateForTest,
   resolveActivePluginHttpRouteRegistry,
   setActivePluginRegistry,
@@ -32,6 +35,20 @@ function createRuntimeRegistryPair() {
   return {
     startupRegistry: createEmptyPluginRegistry(),
     laterRegistry: createEmptyPluginRegistry(),
+  };
+}
+
+function createAuthOverride(pluginId: string): PluginProviderRuntimeAuthOverrideRegistration {
+  return {
+    pluginId,
+    source: "test",
+    override: {
+      providers: ["openai"],
+      run: async () => ({
+        apiKey: `${pluginId}-key`,
+        mode: "api-key",
+      }),
+    },
   };
 }
 
@@ -213,5 +230,31 @@ describe("setActivePluginRegistry", () => {
     recordImportedPluginId("broken-plugin");
 
     expect(listImportedRuntimePluginIds()).toEqual(["broken-plugin"]);
+  });
+
+  it("syncs provider runtime auth overrides when lazily creating an empty registry", () => {
+    resetPluginRuntimeStateForTest();
+
+    expect(getGlobalProviderRuntimeAuthOverrides()).toHaveLength(0);
+
+    const registry = getActivePluginRegistry();
+    expect(registry).toBeNull();
+
+    const required = requireActivePluginRegistry();
+    expect(required.providerRuntimeAuthOverrides).toEqual([]);
+    expect(getGlobalProviderRuntimeAuthOverrides()).toEqual([]);
+  });
+
+  it("clears provider runtime auth overrides when resetting runtime state for tests", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.providerRuntimeAuthOverrides = [createAuthOverride("override-plugin")];
+
+    setActivePluginRegistry(registry);
+    expect(getGlobalProviderRuntimeAuthOverrides()).toHaveLength(1);
+
+    resetPluginRuntimeStateForTest();
+
+    expect(getGlobalProviderRuntimeAuthOverrides()).toHaveLength(0);
+    expect(getActivePluginRegistry()).toBeNull();
   });
 });

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -1,3 +1,4 @@
+import { setGlobalProviderRuntimeAuthOverrides } from "./provider-runtime-auth-override-global.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRegistry } from "./registry-types.js";
 import {
@@ -86,6 +87,10 @@ export function setActivePluginRegistry(
   state.key = cacheKey ?? null;
   state.workspaceDir = workspaceDir ?? null;
   state.runtimeSubagentMode = runtimeSubagentMode;
+  // Keep global override accessor in lockstep with the active registry so any
+  // code path that swaps registries (reload, unload, gateway startup, tests)
+  // can't leave a stale override list behind.
+  setGlobalProviderRuntimeAuthOverrides(registry.providerRuntimeAuthOverrides);
 }
 
 export function getActivePluginRegistry(): PluginRegistry | null {
@@ -102,6 +107,7 @@ export function requireActivePluginRegistry(): PluginRegistry {
     state.activeVersion += 1;
     syncTrackedSurface(state.httpRoute, state.activeRegistry);
     syncTrackedSurface(state.channel, state.activeRegistry);
+    setGlobalProviderRuntimeAuthOverrides(state.activeRegistry.providerRuntimeAuthOverrides);
   }
   return asPluginRegistry(state.activeRegistry)!;
 }
@@ -238,4 +244,5 @@ export function resetPluginRuntimeStateForTest(): void {
   state.workspaceDir = null;
   state.runtimeSubagentMode = "default";
   state.importedPluginIds.clear();
+  setGlobalProviderRuntimeAuthOverrides([]);
 }

--- a/src/plugins/status.test-helpers.ts
+++ b/src/plugins/status.test-helpers.ts
@@ -139,6 +139,7 @@ export function createPluginLoadResult(
     services: [],
     commands: [],
     conversationBindingResolvedHandlers: [],
+    providerRuntimeAuthOverrides: [],
     ...rest,
     realtimeTranscriptionProviders: realtimeTranscriptionProviders ?? [],
     realtimeVoiceProviders: realtimeVoiceProviders ?? [],

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2035,9 +2035,19 @@ export type ProviderRuntimeAuthOverrideContext = {
 
 export type ProviderRuntimeAuthOverrideResult = {
   apiKey: string;
-  mode?: string;
+  mode?: "api-key" | "oauth" | "token" | "aws-sdk";
   source?: string;
+  /**
+   * Optional per-call base URL override. Applied only to the main LLM
+   * inference runner path. Side paths (media understanding, TTS, image
+   * generation) currently consume only `apiKey` in v1.
+   */
   baseUrl?: string;
+  /**
+   * Optional extra headers merged into the outbound provider request in
+   * the main LLM inference runner path. Side paths currently consume only
+   * `apiKey` in v1.
+   */
   providerRequestHeaders?: Record<string, string>;
 };
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2014,6 +2014,38 @@ export type OpenClawPluginApi = {
     handler: PluginHookHandlerMap[K],
     opts?: { priority?: number },
   ) => void;
+  /**
+   * Register a runtime auth override for specific built-in model providers.
+   *
+   * When OpenClaw resolves auth for a listed provider, the override callback
+   * is invoked. The first registration that returns a non-null result wins.
+   * Returning `null` or `undefined` means "no override — continue default behavior."
+   * Throwing fails the request after logging (no implicit fallback).
+   */
+  registerProviderRuntimeAuthOverride: (override: ProviderRuntimeAuthOverride) => void;
+};
+
+// ── Provider Runtime Auth Override types ──
+
+export type ProviderRuntimeAuthOverrideContext = {
+  provider: string;
+  modelId: string;
+  profileId?: string;
+};
+
+export type ProviderRuntimeAuthOverrideResult = {
+  apiKey: string;
+  mode?: string;
+  source?: string;
+  baseUrl?: string;
+  providerRequestHeaders?: Record<string, string>;
+};
+
+export type ProviderRuntimeAuthOverride = {
+  providers: string[];
+  run: (
+    ctx: ProviderRuntimeAuthOverrideContext,
+  ) => Promise<ProviderRuntimeAuthOverrideResult | null | undefined>;
 };
 
 // Plugin hook contracts now live in hook-types.ts so hook runners can import a

--- a/src/test-utils/channel-plugins.ts
+++ b/src/test-utils/channel-plugins.ts
@@ -48,6 +48,7 @@ export const createTestRegistry = (channels: TestChannelRegistration[] = []): Pl
   services: [],
   commands: [],
   conversationBindingResolvedHandlers: [],
+  providerRuntimeAuthOverrides: [],
   diagnostics: [],
 });
 

--- a/test/helpers/plugins/plugin-api.ts
+++ b/test/helpers/plugins/plugin-api.ts
@@ -52,6 +52,7 @@ export function createTestPluginApi(api: TestPluginApiInput = {}): OpenClawPlugi
       return input;
     },
     on() {},
+    registerProviderRuntimeAuthOverride() {},
     ...api,
   };
 }


### PR DESCRIPTION
## Summary

Add a public plugin registration API, `registerProviderRuntimeAuthOverride`, that lets external plugins provide runtime auth for specific built-in model providers without replacing the provider implementation.

This is intended for integrations that need brokered, short-lived, vault-backed, or proxy-routed credentials for built-in providers like `anthropic`, `openai`, or `openrouter`, and currently end up carrying downstream patches in `src/agents/model-auth.ts`.

## What Changed

- Added `api.registerProviderRuntimeAuthOverride({ providers, run })` to the plugin SDK.
- Added runtime resolution support in `src/agents/model-auth.ts`.
- Added a dedicated global module for active override registrations: `src/plugins/provider-runtime-auth-override-global.ts`.
  This keeps override state in sync with the active registry without widening the hook-runner global state.
- Added a reentrancy guard so a plugin override can safely call back into `resolveApiKeyForProvider()` via the public SDK helper without infinite recursion.
- Added plugin-id error logging when an override throws.
- Tightened `ProviderRuntimeAuthOverrideResult.mode` to the auth-mode union and kept runtime validation as defense-in-depth.
- Added an opt-in registration-based availability signal for callers that only need a coarse "may be available" answer, while keeping default availability checks conservative.

## API Shape

```ts
export type ProviderRuntimeAuthOverrideContext = {
  provider: string;
  modelId: string;
  profileId?: string;
};

export type ProviderRuntimeAuthOverrideResult = {
  apiKey: string;
  mode?: "api-key" | "oauth" | "token" | "aws-sdk";
  source?: string;
  baseUrl?: string;
  providerRequestHeaders?: Record<string, string>;
};

export type ProviderRuntimeAuthOverride = {
  providers: string[];
  run: (
    ctx: ProviderRuntimeAuthOverrideContext,
  ) => Promise<ProviderRuntimeAuthOverrideResult | null | undefined>;
};
```

Example:

```ts
api.registerProviderRuntimeAuthOverride({
  providers: ["anthropic", "openai", "openrouter"],
  run: async (ctx) => {
    const token = await resolveBrokeredToken(ctx.provider);
    return token
      ? {
          apiKey: token,
          source: "broker:runtime",
          providerRequestHeaders: { "x-session": sessionId() },
        }
      : null;
  },
});
```

## Semantics

1. OpenClaw resolves provider and model normally.
2. Registered overrides for that provider are evaluated in registration order.
3. The first non-null result wins.
4. `null` / `undefined` means "no override, continue default behavior."
5. Throw means fail the request after logging the plugin id; there is no implicit fallback.
6. Unknown provider ids in the registration list are ignored.
7. If an override calls `resolveApiKeyForProvider()` internally, the inner call skips overrides and falls through to normal resolution.

## Scope Notes

- `baseUrl` and `providerRequestHeaders` are applied in the main LLM inference runner path.
- Side paths such as media understanding, image generation, and TTS currently consume only the override `apiKey` in v1.
- `hasAvailableAuthForProvider()` stays conservative by default because overrides may legally return `null` at runtime; callers that only need a coarse UI signal can opt into treating registration as "may be available."
- `resolveModelAuthMode()` is intentionally unchanged in this PR. A meaningful override-aware mode result would need static mode metadata on the registration API rather than a heuristic.

## Why A Dedicated Global Module

This PR originally stored active override registrations alongside the hook-runner global state. During review and implementation, that proved too easy to conflate with unrelated hook-runner lifecycle concerns.

The final shape keeps the feature but moves override registration state into a dedicated singleton module:

- clearer ownership
- smaller surface area
- easier reasoning for tests and registry swaps
- no widening of `GlobalHookRunnerRegistry`

## Security Impact

- New capability: a trusted plugin can opt in to runtime auth overrides for listed providers.
- The override callback receives only `{ provider, modelId, profileId? }`.
- The API does not expose already-resolved secrets from other providers.
- Throwing is explicit failure, not silent fallback.
- Override activity and thrown plugin ids are logged.

## Verification

Focused regression coverage was added for:

- override applied
- provider mismatch
- null result fallthrough
- thrown override
- first non-null wins
- unknown mode normalization
- `baseUrl` and `providerRequestHeaders` passthrough
- reentrancy guard
- active-registry swap synchronization
- runtime reset synchronization
- `hasAvailableAuthForProvider()` with registered overrides
- dedicated global override singleton behavior

Local command run:

```bash
npx vitest run   src/agents/model-auth.test.ts   src/plugins/runtime.test.ts   src/plugins/runtime.channel-pin.test.ts   src/plugins/hook-runner-global.test.ts   src/plugins/provider-runtime-auth-override-global.test.ts
```

Result:

- 5 test files passed
- 76 tests passed

## Compatibility

- Fully additive. If no plugin registers an override, behavior is unchanged.
- No config migration required.

## Optional Follow-ups

1. Extend `baseUrl` / header override application consistently across side paths such as media understanding, image generation, and TTS.
2. Add plugin SDK docs with a concrete override example.
3. Consider explicit static metadata if `resolveModelAuthMode()` ever needs to reflect runtime overrides accurately.
