### PR TITLE
fix(status): include cache tokens in cost estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Status: include cache-read and cache-write tokens when estimating `/status` session cost, including transcript-derived usage. Fixes #65109; carries forward #65381 and refs #52329. Thanks @aounakram, @OwenYWT, and @LouisGameDev.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Cron/Telegram: preserve explicit `:topic:` delivery targets over stale session-derived thread IDs when isolated cron announces to Telegram forum topics. Carries forward #59069; refs #49704 and #43808. Thanks @roytong9.
 - Build/runtime: write the runtime-postbuild stamp after `pnpm build` writes the build stamp, so the next CLI invocation does not re-sync runtime artifacts after a successful build. Fixes #73151. Thanks @bittoby.

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -1335,6 +1335,43 @@ describe("buildStatusMessage", () => {
     expect(text).not.toContain("💵 Cost:");
   });
 
+  it("includes cache read and write tokens in the cost estimate", () => {
+    const text = buildStatusMessage({
+      config: {
+        models: {
+          providers: {
+            anthropic: {
+              models: [
+                {
+                  id: "claude-opus-4-6",
+                  cost: {
+                    input: 0,
+                    output: 0,
+                    cacheRead: 1,
+                    cacheWrite: 2,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: { model: "anthropic/claude-opus-4-6" },
+      sessionEntry: {
+        sessionId: "cache-cost",
+        updatedAt: 0,
+        cacheRead: 1000,
+        cacheWrite: 2000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    expect(normalizeTestText(text)).toContain("Cost: $0.0050");
+  });
+
   function writeTranscriptUsageLog(params: {
     dir: string;
     agentId: string;

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -1554,6 +1554,66 @@ describe("buildStatusMessage", () => {
     );
   });
 
+  it("includes transcript cache read and write tokens in the cost estimate", async () => {
+    await withTempHome(
+      async (dir) => {
+        const sessionId = "sess-cache-cost-transcript";
+        writeTranscriptUsageLog({
+          dir,
+          agentId: "main",
+          sessionId,
+          usage: {
+            input: 0,
+            output: 0,
+            cacheRead: 1000,
+            cacheWrite: 2000,
+            totalTokens: 3000,
+          },
+        });
+
+        const text = buildStatusMessage({
+          config: {
+            models: {
+              providers: {
+                anthropic: {
+                  models: [
+                    {
+                      id: "claude-opus-4-6",
+                      cost: {
+                        input: 0,
+                        output: 0,
+                        cacheRead: 1,
+                        cacheWrite: 2,
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          } as unknown as OpenClawConfig,
+          agent: {
+            model: "anthropic/claude-opus-4-6",
+            contextTokens: 32_000,
+          },
+          sessionEntry: {
+            sessionId,
+            updatedAt: 0,
+            totalTokens: 0,
+            contextTokens: 32_000,
+          },
+          sessionKey: "agent:main:main",
+          sessionScope: "per-sender",
+          queue: { mode: "collect", depth: 0 },
+          includeTranscriptUsage: true,
+          modelAuth: "api-key",
+        });
+
+        expect(normalizeTestText(text)).toContain("Cost: $0.0050");
+      },
+      { prefix: "openclaw-status-" },
+    );
+  });
+
   it("uses the same transcript usage fallback as sessions.list when a delivery mirror is last", async () => {
     await withTempHome(
       async (dir) => {

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -826,13 +826,19 @@ export function buildStatusMessage(args: StatusArgs): string {
         allowPluginNormalization: false,
       })
     : undefined;
-  const hasUsage = typeof inputTokens === "number" || typeof outputTokens === "number";
+  const hasUsage =
+    typeof inputTokens === "number" ||
+    typeof outputTokens === "number" ||
+    typeof cacheRead === "number" ||
+    typeof cacheWrite === "number";
   const cost =
     showCost && hasUsage
       ? estimateUsageCost({
           usage: {
             input: inputTokens ?? undefined,
             output: outputTokens ?? undefined,
+            cacheRead: cacheRead ?? undefined,
+            cacheWrite: cacheWrite ?? undefined,
           },
           cost: costConfig,
         })

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -402,6 +402,12 @@ const formatCacheLine = (
   return `🗄️ Cache: ${hitRate}% hit · ${cachedLabel} cached, ${newLabel} new`;
 };
 
+const hasCostUsage = (input?: number, output?: number, cacheRead?: number, cacheWrite?: number) =>
+  typeof input === "number" ||
+  typeof output === "number" ||
+  typeof cacheRead === "number" ||
+  typeof cacheWrite === "number";
+
 const formatMediaUnderstandingLine = (decisions?: ReadonlyArray<MediaUnderstandingDecision>) => {
   if (!decisions || decisions.length === 0) {
     return null;
@@ -826,11 +832,7 @@ export function buildStatusMessage(args: StatusArgs): string {
         allowPluginNormalization: false,
       })
     : undefined;
-  const hasUsage =
-    typeof inputTokens === "number" ||
-    typeof outputTokens === "number" ||
-    typeof cacheRead === "number" ||
-    typeof cacheWrite === "number";
+  const hasUsage = hasCostUsage(inputTokens, outputTokens, cacheRead, cacheWrite);
   const cost =
     showCost && hasUsage
       ? estimateUsageCost({


### PR DESCRIPTION
## Summary
- include cache read/write counters in the `/status` cost estimate so cache usage appears in the CLI breakdown
- propagate the cache counters into the unit GST cost estimate when they are present

## Testing
- node scripts/run-vitest.mjs run src/auto-reply/status.test.ts