### PR TITLE
fix(ui): format common cron intervals

### DIFF
--- a/ui/src/ui/presenter.test.ts
+++ b/ui/src/ui/presenter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { formatCronSchedule } from "./presenter.ts";
+import type { CronJob } from "./types.ts";
+
+function cronSchedule(expr: string, tz?: string): CronJob {
+  return {
+    id: "job-1",
+    name: "Job",
+    enabled: true,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    schedule: { kind: "cron", expr, tz },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "ping" },
+  };
+}
+
+describe("formatCronSchedule", () => {
+  it("formats common hourly cron intervals as human-readable intervals", () => {
+    expect(formatCronSchedule(cronSchedule("0 */6 * * *"))).toBe("Every 6 hours");
+    expect(formatCronSchedule(cronSchedule("0 */1 * * *", "UTC"))).toBe("Every 1 hour (UTC)");
+  });
+
+  it("keeps unsupported cron expressions on the raw cron fallback", () => {
+    expect(formatCronSchedule(cronSchedule("15 3 * * 1"))).toBe("Cron 15 3 * * 1");
+  });
+});

--- a/ui/src/ui/presenter.test.ts
+++ b/ui/src/ui/presenter.test.ts
@@ -18,8 +18,13 @@ function cronSchedule(expr: string, tz?: string): CronJob {
 
 describe("formatCronSchedule", () => {
   it("formats common hourly cron intervals as human-readable intervals", () => {
+    expect(formatCronSchedule(cronSchedule("0 * * * *"))).toBe("Every 1 hour");
     expect(formatCronSchedule(cronSchedule("0 */6 * * *"))).toBe("Every 6 hours");
     expect(formatCronSchedule(cronSchedule("0 */1 * * *", "UTC"))).toBe("Every 1 hour (UTC)");
+  });
+
+  it("formats common minute cron intervals as human-readable intervals", () => {
+    expect(formatCronSchedule(cronSchedule("*/5 * * * *"))).toBe("Every 5 minutes");
   });
 
   it("keeps unsupported cron expressions on the raw cron fallback", () => {

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -56,6 +56,42 @@ export function formatCronState(job: CronJob) {
   return `${status} · next ${next} · last ${last}`;
 }
 
+function parsePositiveCronStep(field: string): number | null {
+  const match = field.match(/^\*\/([1-9]\d*)$/);
+  if (!match) {
+    return null;
+  }
+  const step = Number(match[1]);
+  return Number.isSafeInteger(step) ? step : null;
+}
+
+function formatCronIntervalUnit(value: number, unit: "minute" | "hour"): string {
+  return `${value} ${unit}${value === 1 ? "" : "s"}`;
+}
+
+function formatCommonCronExpression(expr: string): string | null {
+  const [minute, hour, dayOfMonth, month, dayOfWeek, extra] = expr.trim().split(/\s+/);
+  if (extra !== undefined || !minute || !hour || !dayOfMonth || !month || !dayOfWeek) {
+    return null;
+  }
+  if (dayOfMonth !== "*" || month !== "*" || dayOfWeek !== "*") {
+    return null;
+  }
+  if (minute === "0") {
+    const hourStep = parsePositiveCronStep(hour);
+    if (hourStep !== null) {
+      return `Every ${formatCronIntervalUnit(hourStep, "hour")}`;
+    }
+  }
+  if (hour === "*") {
+    const minuteStep = parsePositiveCronStep(minute);
+    if (minuteStep !== null) {
+      return `Every ${formatCronIntervalUnit(minuteStep, "minute")}`;
+    }
+  }
+  return null;
+}
+
 export function formatCronSchedule(job: CronJob) {
   const s = job.schedule;
   if (s.kind === "at") {
@@ -64,6 +100,10 @@ export function formatCronSchedule(job: CronJob) {
   }
   if (s.kind === "every") {
     return `Every ${formatDurationHuman(s.everyMs)}`;
+  }
+  const commonCron = formatCommonCronExpression(s.expr);
+  if (commonCron) {
+    return `${commonCron}${s.tz ? ` (${s.tz})` : ""}`;
   }
   return `Cron ${s.expr}${s.tz ? ` (${s.tz})` : ""}`;
 }

--- a/ui/src/ui/presenter.ts
+++ b/ui/src/ui/presenter.ts
@@ -78,6 +78,9 @@ function formatCommonCronExpression(expr: string): string | null {
     return null;
   }
   if (minute === "0") {
+    if (hour === "*") {
+      return `Every ${formatCronIntervalUnit(1, "hour")}`;
+    }
     const hourStep = parsePositiveCronStep(hour);
     if (hourStep !== null) {
       return `Every ${formatCronIntervalUnit(hourStep, "hour")}`;


### PR DESCRIPTION
## Summary
- format common cron patterns (every N minutes/hours) so the control tooltip reads "Every ..." instead of raw cron syntax
- keep the existing fallback for unusual schedules and preserve timezone annotations

## Testing
- pnpm --dir ui test src/ui/presenter.test.ts