### PR TITLE
fix(line): respond to webhook before processing events

### DIFF
--- a/extensions/line/src/webhook-node.ts
+++ b/extensions/line/src/webhook-node.ts
@@ -99,14 +99,19 @@ export function createLineNodeWebhookHandler(params: {
 
       params.onRequestAuthenticated?.();
 
-      if (body.events && body.events.length > 0) {
-        logVerbose(`line: received ${body.events.length} webhook events`);
-        await params.bot.handleWebhook(body);
-      }
-
+      // Respond to LINE immediately — LINE requires a 200 within 1 second
+      // or it marks the webhook as request_timeout and the reply token
+      // expires before the LLM can finish processing (#65375).
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ status: "ok" }));
+
+      if (body.events && body.events.length > 0) {
+        logVerbose(`line: received ${body.events.length} webhook events`);
+        params.bot.handleWebhook(body).catch((err) => {
+          logVerbose(`line: webhook event processing failed: ${String(err)}`);
+        });
+      }
     } catch (err) {
       if (isRequestBodyLimitError(err, "PAYLOAD_TOO_LARGE")) {
         res.statusCode = 413;

--- a/extensions/line/src/webhook.ts
+++ b/extensions/line/src/webhook.ts
@@ -66,12 +66,16 @@ export function createLineWebhookMiddleware(
         return;
       }
 
+      // Respond to LINE immediately — LINE requires a 200 within 1 second
+      // or it marks the webhook as request_timeout (#65375).
+      res.status(200).json({ status: "ok" });
+
       if (body.events && body.events.length > 0) {
         logVerbose(`line: received ${body.events.length} webhook events`);
-        await onEvents(body);
+        onEvents(body).catch((err) => {
+          runtime?.error?.(danger(`line webhook event processing failed: ${String(err)}`));
+        });
       }
-
-      res.status(200).json({ status: "ok" });
     } catch (err) {
       runtime?.error?.(danger(`line webhook error: ${String(err)}`));
       if (!res.headersSent) {


### PR DESCRIPTION
## Summary

Both LINE webhook handlers await the full event processing chain before sending HTTP 200. LINE requires a 200 within 1 second — when LLM processing exceeds that, the reply token expires and LINE records the delivery as \`request_timeout\`. The gateway then sees a false 429 from the expired token, and the reply never reaches LINE.

Fixes #65375

## Root cause

```ts
// webhook-node.ts:102-109 (before fix)
if (body.events && body.events.length > 0) {
  await params.bot.handleWebhook(body);  // ← blocks 200 response
}
res.statusCode = 200;
res.end(JSON.stringify({ status: "ok" }));
```

Same pattern in `webhook.ts:69-74`.

## Fix

Move the 200 response **before** the event processing. Fire-and-forget with `.catch()` error logging:

```ts
res.statusCode = 200;
res.end(JSON.stringify({ status: "ok" }));

if (body.events && body.events.length > 0) {
  params.bot.handleWebhook(body).catch((err) => {
    logVerbose(\`line: webhook event processing failed: \${String(err)}\`);
  });
}
```

This matches how **every other channel plugin** already handles inbound webhooks (Telegram, Discord, Slack, Mattermost — all respond first, process async).

## Files

- \`extensions/line/src/webhook-node.ts\` — Node.js HTTP handler path
- \`extensions/line/src/webhook.ts\` — Express/Koa handler path

Both paths had the same blocking pattern, both are fixed.

## Scope

- **2 files**, ~10 LOC changed per file
- **oxlint clean**
- **Zero competing PRs**

Credit to @myericho for the clear RCA with LINE Developers Console evidence in #65375.