### PR TITLE
fix(feishu): preserve top-level groupPolicy and avoid duplicate registration

### DIFF
--- a/extensions/feishu/index.test.ts
+++ b/extensions/feishu/index.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { assertBundledChannelEntries } from "../../test/helpers/bundled-channel-entry.ts";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.ts";
+import entry from "./index.js";
+import type { OpenClawPluginApi } from "./runtime-api.js";
+import setupEntry from "./setup-entry.js";
+
+function createToolEnabledConfig(): OpenClawPluginApi["config"] {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        accounts: {
+          main: {
+            appId: "app-main",
+            appSecret: "secret-main", // pragma: allowlist secret
+            tools: {
+              doc: true,
+              chat: true,
+              wiki: true,
+              drive: true,
+              perm: true,
+              bitable: true,
+            },
+          },
+        },
+      },
+    },
+  } as OpenClawPluginApi["config"];
+}
+
+describe("feishu bundled entries", () => {
+  assertBundledChannelEntries({
+    entry,
+    expectedId: "feishu",
+    expectedName: "Feishu",
+    setupEntry,
+  });
+
+  it("does not register tools or hooks twice when full registration reruns", () => {
+    const registerTool = vi.fn();
+    const on = vi.fn();
+
+    const api = createTestPluginApi({
+      config: createToolEnabledConfig(),
+      registerTool,
+      on,
+    });
+
+    entry.register(api);
+
+    const firstToolRegistrations = registerTool.mock.calls.length;
+    const firstHookRegistrations = on.mock.calls.length;
+
+    entry.register(api);
+
+    expect(firstToolRegistrations).toBeGreaterThan(0);
+    expect(firstHookRegistrations).toBe(3);
+    expect(registerTool).toHaveBeenCalledTimes(firstToolRegistrations);
+    expect(on).toHaveBeenCalledTimes(firstHookRegistrations);
+  });
+});

--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contra
 type FeishuSubagentHooksModule = typeof import("./api.js");
 
 let feishuSubagentHooksPromise: Promise<FeishuSubagentHooksModule> | null = null;
+let feishuToolsRegistered = false;
 
 function loadFeishuSubagentHooksModule() {
   feishuSubagentHooksPromise ??= import("./api.js");
@@ -79,6 +80,11 @@ export default defineBundledChannelEntry({
     exportName: "setFeishuRuntime",
   },
   registerFull(api) {
+    // Prevent duplicate tool registration on cache miss
+    if (feishuToolsRegistered) {
+      return;
+    }
+    feishuToolsRegistered = true;
     api.on("subagent_spawning", async (event, ctx) => {
       const { handleFeishuSubagentSpawning } = await loadFeishuSubagentHooksModule();
       return await handleFeishuSubagentSpawning(event, ctx);

--- a/extensions/feishu/src/setup-core.ts
+++ b/extensions/feishu/src/setup-core.ts
@@ -6,6 +6,13 @@ import {
 import { resolveDefaultFeishuAccountId } from "./accounts.js";
 import type { FeishuConfig } from "./types.js";
 
+export const feishuNamedAccountPromotionKeys = [
+  "appId",
+  "appSecret",
+  "encryptKey",
+  "verificationToken",
+] as const;
+
 export function setFeishuNamedAccountEnabled(
   cfg: OpenClawConfig,
   accountId: string,
@@ -32,6 +39,7 @@ export function setFeishuNamedAccountEnabled(
 
 export const feishuSetupAdapter: ChannelSetupAdapter = {
   resolveAccountId: ({ cfg, accountId }) => accountId?.trim() || resolveDefaultFeishuAccountId(cfg),
+  namedAccountPromotionKeys: feishuNamedAccountPromotionKeys,
   applyAccountConfig: ({ cfg, accountId }) => {
     const isDefault = !accountId || accountId === DEFAULT_ACCOUNT_ID;
     if (isDefault) {

--- a/extensions/feishu/src/setup-surface.test.ts
+++ b/extensions/feishu/src/setup-surface.test.ts
@@ -120,6 +120,15 @@ describe("feishu setup wizard", () => {
     ).toBe("work");
   });
 
+  it("setup adapter only promotes Feishu auth fields for named accounts", () => {
+    expect(feishuSetupPlugin.setup?.namedAccountPromotionKeys).toEqual([
+      "appId",
+      "appSecret",
+      "encryptKey",
+      "verificationToken",
+    ]);
+  });
+
   it("does not throw when config appId/appSecret are SecretRef objects", async () => {
     const text = vi
       .fn()

--- a/src/channels/plugins/setup-promotion-helpers.ts
+++ b/src/channels/plugins/setup-promotion-helpers.ts
@@ -49,6 +49,8 @@ const BUNDLED_SINGLE_ACCOUNT_PROMOTION_FALLBACKS: Record<string, readonly string
 const BUNDLED_NAMED_ACCOUNT_PROMOTION_FALLBACKS: Record<string, readonly string[]> = {
   // Keep top-level Telegram policy fallback intact when only auth needs seeding.
   telegram: ["botToken", "tokenFile"],
+  // Keep shared Feishu group and DM policy fallback at the top level.
+  feishu: ["appId", "appSecret", "encryptKey", "verificationToken"],
 };
 
 type ChannelSetupPromotionSurface = {

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -285,6 +285,70 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("preserves top-level Feishu group policy fallback for existing named accounts", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        feishu: {
+          enabled: true,
+          groupPolicy: "open",
+          groups: {
+            "*": {
+              requireMention: false,
+            },
+          },
+          accounts: {
+            main: {
+              appId: "main-app-id",
+              appSecret: "main-app-secret",
+            },
+            candy: {
+              appId: "candy-app-id",
+              appSecret: "candy-app-secret",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.config.channels?.feishu?.groupPolicy).toBe("open");
+    expect(res.config.channels?.feishu?.accounts?.default).toBeUndefined();
+    expect(res.changes).not.toContain(
+      "Moved channels.feishu single-account top-level values into channels.feishu.accounts.default.",
+    );
+  });
+
+  it("keeps Feishu shared auth and policy fallback top-level for named accounts", () => {
+    const res = normalizeCompatibilityConfigValues({
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "legacy-app-id",
+          appSecret: "legacy-app-secret",
+          groupPolicy: "open",
+          groups: {
+            "*": {
+              requireMention: false,
+            },
+          },
+          accounts: {
+            main: {
+              appId: "main-app-id",
+              appSecret: "main-app-secret",
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.config.channels?.feishu?.appId).toBe("legacy-app-id");
+    expect(res.config.channels?.feishu?.appSecret).toBe("legacy-app-secret");
+    expect(res.config.channels?.feishu?.groupPolicy).toBe("open");
+    expect(res.config.channels?.feishu?.accounts?.default).toBeUndefined();
+    expect(res.changes).not.toContain(
+      "Moved channels.feishu single-account top-level values into channels.feishu.accounts.default.",
+    );
+  });
+
   it("migrates browser ssrfPolicy allowPrivateNetwork to dangerouslyAllowPrivateNetwork", () => {
     const res = normalizeCompatibilityConfigValues({
       browser: {


### PR DESCRIPTION
## Summary
- Problem: Feishu had two regressions in the same flow: repeated tool/hook registration on plugin cache misses, and named-account config loads silently rewrote top-level `groupPolicy: "open"` back to `allowlist`.
- Why it matters: repeated registrations add log noise and risk duplicate side effects, while the `groupPolicy` rewrite blocks group replies even when the user explicitly configured Feishu groups to stay open.
- What changed: added an idempotency guard around Feishu `registerFull`, declared Feishu-specific named-account promotion keys, added the early promotion fallback used by legacy config loading, and locked the behavior with regression tests.
- What did NOT change (scope boundary): this does not change generic promotion behavior for other channels, and it does not alter Feishu routing or security defaults outside the named-account migration path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #56520
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Feishu `registerFull` had no idempotency guard when plugin loader cache misses caused re-registration, and Feishu had no named-account promotion contract, so legacy config normalization treated shared top-level policy keys like single-account fields and moved `groupPolicy` into `accounts.default`.
- Missing detection / guardrail: there was no regression coverage for repeated Feishu full registration or for loading a named-account Feishu config with top-level `groupPolicy: "open"`.
- Contributing context (if known): the live config on the affected machine used `channels.feishu.defaultAccount = "main"` with named `main`/`candy` accounts and a top-level `groupPolicy`, which hits the legacy promotion path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/index.test.ts`, `extensions/feishu/src/setup-surface.test.ts`, `src/commands/doctor-legacy-config.migrations.test.ts`
- Scenario the test should lock in: rerunning Feishu full registration must not duplicate tools/hooks, and loading Feishu named-account configs must preserve top-level `groupPolicy` and avoid synthesizing `accounts.default`.
- Why this is the smallest reliable guardrail: the bug lives in the entry registration seam and the legacy config normalization seam; both are reproducible without booting the full gateway.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Feishu group messages respect a top-level `channels.feishu.groupPolicy` again when named accounts are configured.
- Feishu tools and subagent hooks no longer re-register repeatedly when plugin cache misses cause `registerFull` to rerun.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Ubuntu Linux
- Runtime/container: Node v24.14.0, local gateway service
- Model/provider: minimax/MiniMax-M2.7
- Integration/channel (if any): Feishu (websocket mode)
- Relevant config (redacted): `channels.feishu.defaultAccount = "main"`, named `main`/`candy` accounts, top-level `groupPolicy = "open"`, wildcard group route with `requireMention = false`

### Steps

1. Configure Feishu with named accounts and a top-level `groupPolicy: "open"`.
2. Start the gateway and load config through the normal runtime path.
3. Send a Feishu group message and watch the runtime config and gateway logs.

### Expected

- Top-level `channels.feishu.groupPolicy` stays `open`.
- No synthetic `channels.feishu.accounts.default` is created.
- Feishu group messages are accepted under the configured open policy.
- Feishu tools/hooks register once per process.

### Actual

- Before the fix, runtime config rewrote the top-level `groupPolicy` to `allowlist`, created `accounts.default.groupPolicy = "open"`, and dropped group messages with `groupPolicy=allowlist` logs.
- Before the fix, repeated Feishu tool registration logs appeared when full registration reran.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the bad loaded runtime config on the affected machine, patched the code, confirmed both `src` and `dist` `loadConfig()` preserved top-level `groupPolicy: "open"`, restarted the live gateway service, and confirmed Feishu messages started arriving again.
- Edge cases checked: named-account Feishu config without an existing `default` account, shared top-level auth plus shared top-level policy, repeated `registerFull` calls.
- What you did **not** verify: webhook mode and account-specific `groupPolicy` overrides were not retested in a live environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Feishu named-account promotion now keeps shared top-level auth/policy fields in place instead of synthesizing `accounts.default`.
  - Mitigation: the change is limited to Feishu, the early fallback matches the Feishu setup contract, and regression tests cover both the migration seam and the entry registration seam.
