### PR TITLE
Populate codex-cli tool entries in system prompt report

### DIFF
--- a/src/agents/bundle-mcp-shared.test-harness.ts
+++ b/src/agents/bundle-mcp-shared.test-harness.ts
@@ -18,6 +18,7 @@ export async function writeBundleProbeMcpServer(
     startupDelayMs?: number;
     pidPath?: string;
     exitMarkerPath?: string;
+    exclusiveLockPath?: string;
   } = {},
 ): Promise<void> {
   await writeExecutable(
@@ -46,6 +47,27 @@ if (exitMarkerPath) {
   process.once("exit", () => {
     try {
       fs.writeFileSync(exitMarkerPath, "exited", "utf8");
+    } catch {}
+  });
+}
+const exclusiveLockPath = ${JSON.stringify(params.exclusiveLockPath ?? "")};
+if (exclusiveLockPath) {
+  try {
+    const existing = await fsp.readFile(exclusiveLockPath, "utf8");
+    if (existing.trim()) {
+      throw new Error(
+        "exclusive bundle-probe lock already held by pid " + existing.trim(),
+      );
+    }
+  } catch (error) {
+    if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) {
+      throw error;
+    }
+  }
+  await fsp.writeFile(exclusiveLockPath, String(process.pid), "utf8");
+  process.once("exit", () => {
+    try {
+      fs.unlinkSync(exclusiveLockPath);
     } catch {}
   });
 }

--- a/src/agents/cli-runner.bundle-mcp.e2e.test.ts
+++ b/src/agents/cli-runner.bundle-mcp.e2e.test.ts
@@ -41,10 +41,11 @@ describe("runCliAgent bundle MCP e2e", () => {
       const sessionFile = path.join(tempHome, "session.jsonl");
       const binDir = path.join(tempHome, "bin");
       const serverScriptPath = path.join(tempHome, "mcp", "bundle-probe.mjs");
+      const exclusiveLockPath = path.join(tempHome, "mcp", "bundle-probe.lock");
       const fakeClaudePath = path.join(binDir, "fake-claude.mjs");
       const pluginRoot = path.join(tempHome, ".openclaw", "extensions", "bundle-probe");
       await fs.mkdir(workspaceDir, { recursive: true });
-      await writeBundleProbeMcpServer(serverScriptPath);
+      await writeBundleProbeMcpServer(serverScriptPath, { exclusiveLockPath });
       await writeFakeClaudeCli(fakeClaudePath);
       await writeClaudeBundle({ pluginRoot, serverScriptPath });
 

--- a/src/agents/cli-runner.bundle-mcp.e2e.test.ts
+++ b/src/agents/cli-runner.bundle-mcp.e2e.test.ts
@@ -83,6 +83,14 @@ describe("runCliAgent bundle MCP e2e", () => {
 
         expect(result.payloads?.[0]?.text).toContain("BUNDLE MCP OK FROM-BUNDLE");
         expect(result.meta.agentMeta?.sessionId.length ?? 0).toBeGreaterThan(0);
+        expect(result.meta.systemPromptReport?.tools.entries).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              name: "bundleProbe__bundle_probe",
+            }),
+          ]),
+        );
+        expect(result.meta.systemPromptReport?.tools.schemaChars ?? 0).toBeGreaterThan(0);
       } finally {
         await fs.rm(tempHome, { recursive: true, force: true });
         envSnapshot.restore();

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -16,7 +16,7 @@ import {
 } from "./cli-runner.test-support.js";
 import { buildCliEnvAuthLog, executePreparedCliRun } from "./cli-runner/execute.js";
 import { buildSystemPrompt } from "./cli-runner/helpers.js";
-import { setCliRunnerPrepareTestDeps } from "./cli-runner/prepare.js";
+import { prepareCliRunContext, setCliRunnerPrepareTestDeps } from "./cli-runner/prepare.js";
 import type { PreparedCliRunContext } from "./cli-runner/types.js";
 
 beforeEach(() => {
@@ -959,6 +959,71 @@ describe("runCliAgent spawn path", () => {
       expect(allArgs).toContain("USER-SECRET");
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
+      restoreCliRunnerPrepareTestDeps();
+    }
+  });
+
+  it("passes effective plugin config to the report MCP runtime", async () => {
+    const createBundleMcpToolRuntimeMock = vi.fn(async () => ({
+      tools: [],
+      dispose: async () => {},
+    }));
+
+    setCliRunnerPrepareTestDeps({
+      makeBootstrapWarn: () => () => {},
+      resolveBootstrapContextForRun: async () => ({
+        bootstrapFiles: [],
+        contextFiles: [],
+      }),
+      createBundleMcpToolRuntime: createBundleMcpToolRuntimeMock,
+      getActiveMcpLoopbackRuntime: () =>
+        ({
+          port: 23119,
+          token: "loopback-token-123",
+        }) as { port: number; token: string },
+      resolveOpenClawDocsPath: async () => null,
+    });
+
+    try {
+      await prepareCliRunContext(
+        buildRunClaudeCliAgentParams({
+          sessionId: "s1",
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/tmp",
+          prompt: "hi",
+          runId: "run-prepare-plugin-config",
+          timeoutMs: 1_000,
+          config: {
+            plugins: {
+              entries: {
+                "bundle-probe": {
+                  enabled: false,
+                },
+              },
+            },
+          },
+        }),
+      );
+
+      expect(createBundleMcpToolRuntimeMock).toHaveBeenCalledTimes(1);
+      expect(createBundleMcpToolRuntimeMock.mock.calls[0]?.[0]).toMatchObject({
+        workspaceDir: "/tmp",
+        cfg: {
+          plugins: {
+            entries: {
+              "bundle-probe": {
+                enabled: false,
+              },
+            },
+          },
+          mcp: {
+            servers: {
+              openclaw: expect.any(Object),
+            },
+          },
+        },
+      });
+    } finally {
       restoreCliRunnerPrepareTestDeps();
     }
   });

--- a/src/agents/cli-runner/bundle-mcp.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.test.ts
@@ -240,6 +240,9 @@ describe("prepareCliBundleMcpConfig", () => {
         backend: {
           command: "node",
           args: ["./fake-claude.mjs", "--mcp-config", existingConfigPath],
+          env: {
+            BACKEND_ONLY_TOKEN: "backend-token-456",
+          },
         },
         workspaceDir,
         config,
@@ -252,6 +255,7 @@ describe("prepareCliBundleMcpConfig", () => {
               headers: {
                 Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
                 "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
+                "x-backend-token": "${BACKEND_ONLY_TOKEN}",
               },
             },
           },
@@ -273,6 +277,7 @@ describe("prepareCliBundleMcpConfig", () => {
       expect(prepared.reportMcpConfig?.mcpServers.openclaw?.headers).toEqual({
         Authorization: "Bearer loopback-token-123",
         "x-session-key": "agent:main:telegram:group:chat123",
+        "x-backend-token": "backend-token-456",
       });
 
       await prepared.cleanup?.();
@@ -371,6 +376,9 @@ describe("prepareCliBundleMcpConfig", () => {
       backend: {
         command: "gemini",
         args: ["--prompt", "{prompt}"],
+        env: {
+          BACKEND_ONLY_TOKEN: "backend-token-456",
+        },
       },
       workspaceDir: "/tmp/openclaw-bundle-mcp-gemini",
       additionalConfig: {
@@ -380,6 +388,7 @@ describe("prepareCliBundleMcpConfig", () => {
             url: "http://127.0.0.1:23119/mcp",
             headers: {
               Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
+              "x-backend-token": "${BACKEND_ONLY_TOKEN}",
             },
           },
         },
@@ -401,6 +410,7 @@ describe("prepareCliBundleMcpConfig", () => {
     expect(raw.mcp?.allowed).toEqual(["openclaw"]);
     expect(raw.mcpServers?.openclaw?.url).toBe("http://127.0.0.1:23119/mcp");
     expect(raw.mcpServers?.openclaw?.headers?.Authorization).toBe("Bearer loopback-token-123");
+    expect(raw.mcpServers?.openclaw?.headers?.["x-backend-token"]).toBe("backend-token-456");
 
     await prepared.cleanup?.();
   });

--- a/src/agents/cli-runner/bundle-mcp.test.ts
+++ b/src/agents/cli-runner/bundle-mcp.test.ts
@@ -198,6 +198,89 @@ describe("prepareCliBundleMcpConfig", () => {
     }
   });
 
+  it("builds report MCP config from the final merged backend config", async () => {
+    const env = captureEnv(["HOME"]);
+    try {
+      const homeDir = await tempHarness.createTempDir("openclaw-cli-bundle-mcp-home-");
+      const workspaceDir = await tempHarness.createTempDir("openclaw-cli-bundle-mcp-workspace-");
+      process.env.HOME = homeDir;
+
+      await createBundleProbePlugin(homeDir);
+
+      const existingConfigPath = path.join(workspaceDir, "existing-mcp.json");
+      await fs.writeFile(
+        existingConfigPath,
+        `${JSON.stringify(
+          {
+            mcpServers: {
+              externalProbe: {
+                type: "http",
+                transport: "streamable-http",
+                url: "http://127.0.0.1:4100/mcp",
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      const config: OpenClawConfig = {
+        plugins: {
+          entries: {
+            "bundle-probe": { enabled: true },
+          },
+        },
+      };
+
+      const prepared = await prepareCliBundleMcpConfig({
+        enabled: true,
+        mode: "claude-config-file",
+        backend: {
+          command: "node",
+          args: ["./fake-claude.mjs", "--mcp-config", existingConfigPath],
+        },
+        workspaceDir,
+        config,
+        additionalConfig: {
+          mcpServers: {
+            openclaw: {
+              type: "http",
+              transport: "streamable-http",
+              url: "http://127.0.0.1:23119/mcp",
+              headers: {
+                Authorization: "Bearer ${OPENCLAW_MCP_TOKEN}",
+                "x-session-key": "${OPENCLAW_MCP_SESSION_KEY}",
+              },
+            },
+          },
+        },
+        env: {
+          OPENCLAW_MCP_TOKEN: "loopback-token-123",
+          OPENCLAW_MCP_SESSION_KEY: "agent:main:telegram:group:chat123",
+        },
+      });
+
+      expect(Object.keys(prepared.reportMcpConfig?.mcpServers ?? {}).toSorted()).toEqual([
+        "bundleProbe",
+        "externalProbe",
+        "openclaw",
+      ]);
+      expect(prepared.reportMcpConfig?.mcpServers.externalProbe?.url).toBe(
+        "http://127.0.0.1:4100/mcp",
+      );
+      expect(prepared.reportMcpConfig?.mcpServers.openclaw?.headers).toEqual({
+        Authorization: "Bearer loopback-token-123",
+        "x-session-key": "agent:main:telegram:group:chat123",
+      });
+
+      await prepared.cleanup?.();
+    } finally {
+      env.restore();
+    }
+  });
+
   it("preserves extra env values alongside generated MCP config", async () => {
     const workspaceDir = await tempHarness.createTempDir("openclaw-cli-bundle-mcp-env-");
 

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -23,6 +23,8 @@ type PreparedCliBundleMcpConfig = {
   cleanup?: () => Promise<void>;
   mcpConfigHash?: string;
   env?: Record<string, string>;
+  mergedConfig?: BundleMcpConfig;
+  reportMcpConfig?: BundleMcpConfig;
 };
 
 function resolveBundleMcpMode(mode: CliBundleMcpMode | undefined): CliBundleMcpMode {
@@ -179,6 +181,46 @@ function resolveEnvPlaceholder(
   }
   const resolved = inheritedEnv?.[decoded.envVar] ?? process.env[decoded.envVar] ?? "";
   return decoded.bearer ? `Bearer ${resolved}` : resolved;
+}
+
+function resolveReportServerConfig(
+  server: BundleMcpServerConfig,
+  inheritedEnv: Record<string, string> | undefined,
+): BundleMcpServerConfig {
+  const next: BundleMcpServerConfig = { ...server };
+  const headers = normalizeStringRecord(next.headers);
+  if (headers) {
+    next.headers = Object.fromEntries(
+      Object.entries(headers).map(([name, value]) => [
+        name,
+        resolveEnvPlaceholder(value, inheritedEnv),
+      ]),
+    );
+  }
+  const env = normalizeStringRecord(next.env);
+  if (env) {
+    next.env = Object.fromEntries(
+      Object.entries(env).map(([name, value]) => [
+        name,
+        resolveEnvPlaceholder(value, inheritedEnv),
+      ]),
+    );
+  }
+  return next;
+}
+
+function resolveReportMcpConfig(
+  mergedConfig: BundleMcpConfig,
+  inheritedEnv: Record<string, string> | undefined,
+): BundleMcpConfig {
+  return {
+    mcpServers: Object.fromEntries(
+      Object.entries(mergedConfig.mcpServers).map(([name, server]) => [
+        name,
+        resolveReportServerConfig(server, inheritedEnv),
+      ]),
+    ),
+  };
 }
 
 function normalizeGeminiServerConfig(
@@ -352,10 +394,16 @@ export async function prepareCliBundleMcpConfig(params: {
     mergedConfig = applyMergePatch(mergedConfig, params.additionalConfig) as BundleMcpConfig;
   }
 
-  return await prepareModeSpecificBundleMcpConfig({
+  const prepared = await prepareModeSpecificBundleMcpConfig({
     mode,
     backend: params.backend,
     mergedConfig,
     env: params.env,
   });
+
+  return {
+    ...prepared,
+    mergedConfig,
+    reportMcpConfig: resolveReportMcpConfig(mergedConfig, params.env),
+  };
 }

--- a/src/agents/cli-runner/bundle-mcp.ts
+++ b/src/agents/cli-runner/bundle-mcp.ts
@@ -223,6 +223,17 @@ function resolveReportMcpConfig(
   };
 }
 
+function mergeBundleMcpEnv(
+  backendEnv: Record<string, string> | undefined,
+  runtimeEnv: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  const merged = {
+    ...backendEnv,
+    ...runtimeEnv,
+  };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
 function normalizeGeminiServerConfig(
   server: BundleMcpServerConfig,
   inheritedEnv: Record<string, string> | undefined,
@@ -262,6 +273,7 @@ function injectCodexMcpConfigArgs(args: string[] | undefined, config: BundleMcpC
 async function writeGeminiSystemSettings(
   mergedConfig: BundleMcpConfig,
   inheritedEnv: Record<string, string> | undefined,
+  runtimeEnv: Record<string, string> | undefined,
 ): Promise<{ env: Record<string, string>; cleanup: () => Promise<void> }> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gemini-mcp-"));
   const settingsPath = path.join(tempDir, "settings.json");
@@ -288,7 +300,7 @@ async function writeGeminiSystemSettings(
   await fs.writeFile(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, "utf-8");
   return {
     env: {
-      ...inheritedEnv,
+      ...runtimeEnv,
       GEMINI_CLI_SYSTEM_SETTINGS_PATH: settingsPath,
     },
     cleanup: async () => {
@@ -302,6 +314,7 @@ async function prepareModeSpecificBundleMcpConfig(params: {
   backend: CliBackendConfig;
   mergedConfig: BundleMcpConfig;
   env?: Record<string, string>;
+  inheritedEnv?: Record<string, string>;
 }): Promise<PreparedCliBundleMcpConfig> {
   const serializedConfig = `${JSON.stringify(params.mergedConfig, null, 2)}\n`;
   const mcpConfigHash = crypto.createHash("sha256").update(serializedConfig).digest("hex");
@@ -322,7 +335,11 @@ async function prepareModeSpecificBundleMcpConfig(params: {
   }
 
   if (params.mode === "gemini-system-settings") {
-    const settings = await writeGeminiSystemSettings(params.mergedConfig, params.env);
+    const settings = await writeGeminiSystemSettings(
+      params.mergedConfig,
+      params.inheritedEnv,
+      params.env,
+    );
     return {
       backend: params.backend,
       mcpConfigHash,
@@ -394,16 +411,19 @@ export async function prepareCliBundleMcpConfig(params: {
     mergedConfig = applyMergePatch(mergedConfig, params.additionalConfig) as BundleMcpConfig;
   }
 
+  const inheritedEnv = mergeBundleMcpEnv(params.backend.env, params.env);
+
   const prepared = await prepareModeSpecificBundleMcpConfig({
     mode,
     backend: params.backend,
     mergedConfig,
     env: params.env,
+    inheritedEnv,
   });
 
   return {
     ...prepared,
     mergedConfig,
-    reportMcpConfig: resolveReportMcpConfig(mergedConfig, params.env),
+    reportMcpConfig: resolveReportMcpConfig(mergedConfig, inheritedEnv),
   };
 }

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -172,13 +172,22 @@ export async function prepareCliRunContext(
     config: params.config,
     agentId: sessionAgentId,
   });
-  const reportToolRuntime = backendResolved.bundleMcp
-    ? await createBundleMcpToolRuntime({
-        workspaceDir,
-        cfg: params.config,
-      })
-    : undefined;
-  const reportTools = reportToolRuntime?.tools ?? [];
+  let reportTools: import("../pi-bundle-mcp-types.js").BundleMcpToolRuntime["tools"] = [];
+  if (backendResolved.bundleMcp && preparedBackend.reportMcpConfig) {
+    const reportToolRuntime = await createBundleMcpToolRuntime({
+      workspaceDir,
+      cfg: {
+        mcp: {
+          servers: preparedBackend.reportMcpConfig.mcpServers,
+        },
+      },
+    });
+    try {
+      reportTools = reportToolRuntime.tools;
+    } finally {
+      await reportToolRuntime.dispose();
+    }
+  }
   const builtSystemPrompt =
     resolveSystemPromptOverride({
       config: params.config,
@@ -234,30 +243,12 @@ export async function prepareCliRunContext(
     skillsPrompt,
     tools: reportTools,
   });
-  const preparedBackendWithReportCleanup = reportToolRuntime
-    ? {
-        ...preparedBackend,
-        cleanup: async () => {
-          const cleanupResults = await Promise.allSettled([
-            preparedBackend.cleanup?.(),
-            reportToolRuntime.dispose(),
-          ]);
-          const firstRejected = cleanupResults.find(
-            (result): result is PromiseRejectedResult => result.status === "rejected",
-          );
-          if (firstRejected) {
-            throw firstRejected.reason;
-          }
-        },
-      }
-    : preparedBackend;
-
   return {
     params,
     started,
     workspaceDir,
     backendResolved,
-    preparedBackend: preparedBackendWithReportCleanup,
+    preparedBackend,
     reusableCliSession,
     modelId,
     normalizedModel,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -17,6 +17,7 @@ import { resolveCliAuthEpoch } from "../cli-auth-epoch.js";
 import { resolveCliBackendConfig } from "../cli-backends.js";
 import { hashCliSessionText, resolveCliSessionReuse } from "../cli-session.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../heartbeat-system-prompt.js";
+import { createBundleMcpToolRuntime } from "../pi-bundle-mcp-materialize.js";
 import {
   resolveBootstrapMaxChars,
   resolveBootstrapPromptTruncationWarningMode,
@@ -171,6 +172,13 @@ export async function prepareCliRunContext(
     config: params.config,
     agentId: sessionAgentId,
   });
+  const reportToolRuntime = backendResolved.bundleMcp
+    ? await createBundleMcpToolRuntime({
+        workspaceDir,
+        cfg: params.config,
+      })
+    : undefined;
+  const reportTools = reportToolRuntime?.tools ?? [];
   const builtSystemPrompt =
     resolveSystemPromptOverride({
       config: params.config,
@@ -224,15 +232,32 @@ export async function prepareCliRunContext(
     bootstrapFiles,
     injectedFiles: contextFiles,
     skillsPrompt,
-    tools: [],
+    tools: reportTools,
   });
+  const preparedBackendWithReportCleanup = reportToolRuntime
+    ? {
+        ...preparedBackend,
+        cleanup: async () => {
+          const cleanupResults = await Promise.allSettled([
+            preparedBackend.cleanup?.(),
+            reportToolRuntime.dispose(),
+          ]);
+          const firstRejected = cleanupResults.find(
+            (result): result is PromiseRejectedResult => result.status === "rejected",
+          );
+          if (firstRejected) {
+            throw firstRejected.reason;
+          }
+        },
+      }
+    : preparedBackend;
 
   return {
     params,
     started,
     workspaceDir,
     backendResolved,
-    preparedBackend,
+    preparedBackend: preparedBackendWithReportCleanup,
     reusableCliSession,
     modelId,
     normalizedModel,

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -1,3 +1,4 @@
+import { applyMergePatch } from "../../config/merge-patch.js";
 import {
   createMcpLoopbackServerConfig,
   getActiveMcpLoopbackRuntime,
@@ -36,6 +37,7 @@ import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
 const prepareDeps = {
   makeBootstrapWarn: makeBootstrapWarnImpl,
   resolveBootstrapContextForRun: resolveBootstrapContextForRunImpl,
+  createBundleMcpToolRuntime,
   getActiveMcpLoopbackRuntime,
   createMcpLoopbackServerConfig,
   resolveOpenClawDocsPath: async (
@@ -174,13 +176,13 @@ export async function prepareCliRunContext(
   });
   let reportTools: import("../pi-bundle-mcp-types.js").BundleMcpToolRuntime["tools"] = [];
   if (backendResolved.bundleMcp && preparedBackend.reportMcpConfig) {
-    const reportToolRuntime = await createBundleMcpToolRuntime({
+    const reportToolRuntime = await prepareDeps.createBundleMcpToolRuntime({
       workspaceDir,
-      cfg: {
+      cfg: applyMergePatch(params.config ?? {}, {
         mcp: {
           servers: preparedBackend.reportMcpConfig.mcpServers,
         },
-      },
+      }),
     });
     try {
       reportTools = reportToolRuntime.tools;


### PR DESCRIPTION
## Summary
- materialize bundle MCP tools for the codex-cli system prompt report path
- feed those effective tools into `buildSystemPromptReport(...)` instead of `[]`
- assert via the existing bundle MCP e2e that CLI runs now report tool entries and schema chars

## Testing
- node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/cli-runner.bundle-mcp.e2e.test.ts

Closes #65404