### PR TITLE
feat(agents): configurable gateway timeout floor for subagent calls

### DIFF
--- a/src/agents/subagent-spawn.gateway-timeout.test.ts
+++ b/src/agents/subagent-spawn.gateway-timeout.test.ts
@@ -1,0 +1,108 @@
+import os from "node:os";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSubagentSpawnTestConfig,
+  loadSubagentSpawnModuleForTest,
+} from "./subagent-spawn.test-helpers.js";
+import { installAcceptedSubagentGatewayMock } from "./test-helpers/subagent-gateway.js";
+
+const hoisted = vi.hoisted(() => ({
+  callGatewayMock: vi.fn(),
+  configOverride: {} as Record<string, unknown>,
+}));
+
+let spawnSubagentDirect: typeof import("./subagent-spawn.js").spawnSubagentDirect;
+
+function buildConfig(gatewayTimeoutMs?: number) {
+  return createSubagentSpawnTestConfig(os.tmpdir(), {
+    agents: {
+      defaults: {
+        workspace: os.tmpdir(),
+        ...(typeof gatewayTimeoutMs === "number" ? { subagents: { gatewayTimeoutMs } } : {}),
+      },
+    },
+  });
+}
+
+async function spawnOne() {
+  return await spawnSubagentDirect(
+    {
+      task: "check timeout floor",
+      model: "openai-codex/gpt-5.4",
+    },
+    {
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+      agentAccountId: "acct-1",
+      agentTo: "user-1",
+      workspaceDir: "/tmp/requester-workspace",
+    },
+  );
+}
+
+function gatewayCalls() {
+  return hoisted.callGatewayMock.mock.calls.map((call) =>
+    (call[0] ?? {}) as { method?: string; timeoutMs?: number },
+  );
+}
+
+describe("subagent spawn gateway timeout floor", () => {
+  beforeEach(async () => {
+    ({ spawnSubagentDirect } = await loadSubagentSpawnModuleForTest({
+      callGatewayMock: hoisted.callGatewayMock,
+      loadConfig: () => hoisted.configOverride,
+      resolveSubagentSpawnModelSelection: () => "openai-codex/gpt-5.4",
+      resolveSandboxRuntimeStatus: () => ({ sandboxed: false }),
+    }));
+    hoisted.callGatewayMock.mockReset();
+    installAcceptedSubagentGatewayMock(hoisted.callGatewayMock);
+    hoisted.configOverride = buildConfig();
+  });
+
+  it("uses default floors: 30s for agent and 20s for non-agent methods", async () => {
+    const result = await spawnOne();
+    expect(result.status).toBe("accepted");
+
+    const calls = gatewayCalls();
+    const agentCalls = calls.filter((entry) => entry.method === "agent");
+    const nonAgentCalls = calls.filter((entry) => entry.method && entry.method !== "agent");
+
+    expect(agentCalls.length).toBeGreaterThan(0);
+    for (const entry of agentCalls) {
+      expect(entry.timeoutMs).toBe(30_000);
+    }
+
+    expect(nonAgentCalls.length).toBeGreaterThan(0);
+    for (const entry of nonAgentCalls) {
+      expect(entry.timeoutMs).toBe(20_000);
+    }
+  });
+
+  it("respects config override floor for all methods", async () => {
+    hoisted.configOverride = buildConfig(45_000);
+
+    const result = await spawnOne();
+    expect(result.status).toBe("accepted");
+
+    for (const entry of gatewayCalls()) {
+      if (!entry.method) {
+        continue;
+      }
+      expect(entry.timeoutMs).toBe(45_000);
+    }
+  });
+
+  it("keeps caller timeout when it is higher than configured floor", async () => {
+    hoisted.configOverride = buildConfig(5_000);
+
+    const result = await spawnOne();
+    expect(result.status).toBe("accepted");
+
+    for (const entry of gatewayCalls()) {
+      if (!entry.method) {
+        continue;
+      }
+      expect(entry.timeoutMs).toBe(10_000);
+    }
+  });
+});

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -155,9 +155,20 @@ async function callSubagentGateway(
   // "agent" → write) keep their least-privilege scope so that the gateway does
   // not treat the caller as owner (senderIsOwner) and expose owner-only tools.
   const scopes = params.scopes ?? (isAdminOnlyMethod(params.method) ? [ADMIN_SCOPE] : undefined);
+  const cfg = subagentSpawnDeps.loadConfig();
+  const configuredMs = cfg.agents?.defaults?.subagents?.gatewayTimeoutMs;
+  const floorMs =
+    typeof configuredMs === "number" && configuredMs > 0
+      ? configuredMs
+      : params.method === "agent"
+        ? 30_000
+        : 20_000;
+  const effectiveTimeoutMs = Math.max(params.timeoutMs ?? 0, floorMs);
+
   return await subagentSpawnDeps.callGateway({
     ...params,
     ...(scopes != null ? { scopes } : {}),
+    timeoutMs: effectiveTimeoutMs,
   });
 }
 

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -362,6 +362,8 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 90000). */
     announceTimeoutMs?: number;
+    /** Minimum gateway timeout in ms for sub-agent gateway calls. */
+    gatewayTimeoutMs?: number;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
     requireAgentId?: boolean;
   };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -234,6 +234,7 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        gatewayTimeoutMs: z.number().int().positive().optional(),
         requireAgentId: z.boolean().optional(),
       })
       .strict()


### PR DESCRIPTION
## Problem

All subagent gateway calls (spawn, session patch, session delete, cleanup) use a hardcoded `timeoutMs: 10_000`. Under high concurrency (40+ lanes), the gateway loopback regularly exceeds 10 s, causing spurious `gateway timeout after 10000ms` errors even when the child agent starts and runs successfully.

This is particularly painful for `sessions_spawn` because the parent receives an error response while the child session may actually be running — wasting compute and causing confusing duplicate spawns on retry.

## Fix

- Add `agents.defaults.subagents.gatewayTimeoutMs` config key (positive integer, optional).
- In `callSubagentGateway`, read the config value and apply it as a minimum floor via `Math.max(caller timeout, floor)`.
- Default floors when unconfigured: 30 s for `agent` spawn calls, 20 s for lifecycle calls (patch/delete).
- All 9 existing `timeoutMs: 10_000` call sites automatically benefit through the centralized wrapper.
- Preserves existing scope-pinning logic for admin methods.

## Config

```json
{
  "agents": {
    "defaults": {
      "subagents": {
        "gatewayTimeoutMs": 30000
      }
    }
  }
}
```

## Testing

```bash
npm test -- --grep 'gateway timeout'
```
