### PR TITLE
feat(agents): shuffle auth profile candidates for subagent runs

### DIFF
--- a/src/agents/pi-embedded-runner/run.subagent-profile-shuffle.test.ts
+++ b/src/agents/pi-embedded-runner/run.subagent-profile-shuffle.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+// Test that shuffleArray produces a permutation
+function shuffleArray<T>(arr: readonly T[]): T[] {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j]!, result[i]!];
+  }
+  return result;
+}
+
+describe("subagent profile shuffle", () => {
+  it("returns the same elements in potentially different order", () => {
+    const input = ["a", "b", "c", "d", "e", "f", "g", "h"];
+    const result = shuffleArray(input);
+    expect(result).toHaveLength(input.length);
+    expect(result.sort()).toEqual([...input].sort());
+  });
+
+  it("does not modify the original array", () => {
+    const input = ["a", "b", "c"];
+    const copy = [...input];
+    shuffleArray(input);
+    expect(input).toEqual(copy);
+  });
+
+  it("produces different orderings across multiple calls (probabilistic)", () => {
+    const input = Array.from({ length: 20 }, (_, i) => `p${i}`);
+    const results = new Set<string>();
+    for (let i = 0; i < 10; i++) {
+      results.add(shuffleArray(input).join(","));
+    }
+    // With 20 elements, getting the same order twice in 10 tries is astronomically unlikely
+    expect(results.size).toBeGreaterThan(1);
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -119,6 +119,16 @@ type ApiKeyInfo = ResolvedProviderAuth;
 
 const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
 
+/** Fisher-Yates shuffle - returns a new shuffled copy. */
+function shuffleArray<T>(arr: readonly T[]): T[] {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j]!, result[i]!];
+  }
+  return result;
+}
+
 /**
  * Best-effort backfill of sessionKey from sessionId when not explicitly provided.
  * The return value is normalized: whitespace-only inputs collapse to undefined, and
@@ -326,10 +336,13 @@ export async function runEmbeddedPiAgent(
             provider,
             preferredProfile: preferredProfileId,
           });
+      const isSubagentRun = normalizeOptionalString(params.spawnedBy) !== undefined;
       const profileCandidates = lockedProfileId
         ? [lockedProfileId]
         : profileOrder.length > 0
-          ? profileOrder
+          ? isSubagentRun
+            ? shuffleArray(profileOrder)
+            : profileOrder
           : [undefined];
       let profileIndex = 0;
 


### PR DESCRIPTION
## Problem

When multiple subagents spawn concurrently with the same provider, they all iterate `profileOrder` from index 0, causing a thundering herd on the first auth profile and cascading 429 errors.

## Fix

- Add Fisher-Yates shuffle helper
- Detect subagent runs via `params.spawnedBy` (parent session key)
- Shuffle a copy of `profileOrder` for subagent runs only
- Keep top-level runs and locked-profile runs unchanged

## Testing

```bash
npm test -- src/agents/pi-embedded-runner/run.subagent-profile-shuffle.test.ts
```
