### PR TITLE
fix: inbound NUL safety, Gemini 3.1 CLI templates, Sonnet 4.6 default 1M context

### DIFF
--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -119,10 +119,15 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
         provider: "google-gemini-cli",
         modelId: "gemini-3.1-pro-preview",
         models: [
-          createTemplateModel("google-gemini-cli", "gemini-3-pro-preview", {
+          createTemplateModel("google-gemini-cli", "gemini-3.1-pro-preview", {
             api: "google-gemini-cli",
             baseUrl: "https://cloudcode-pa.googleapis.com",
             contextWindow: 1_048_576,
+          }),
+          createTemplateModel("google-gemini-cli", "gemini-3-pro-preview", {
+            api: "google-gemini-cli",
+            baseUrl: "https://cloudcode-pa.googleapis.com",
+            contextWindow: 200_000,
           }),
           createTemplateModel("google", "gemini-3-pro-preview", {
             api: "google-generative-ai",

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -16,9 +16,10 @@ const GEMMA_PREFIX = "gemma-";
 const GEMINI_2_5_PRO_TEMPLATE_IDS = ["gemini-2.5-pro"] as const;
 const GEMINI_2_5_FLASH_LITE_TEMPLATE_IDS = ["gemini-2.5-flash-lite"] as const;
 const GEMINI_2_5_FLASH_TEMPLATE_IDS = ["gemini-2.5-flash"] as const;
-const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3-pro-preview"] as const;
+// Prefer 3.1 preview ids for forward-compat clones; keep 3.0 fallbacks for older catalogs.
+const GEMINI_3_1_PRO_TEMPLATE_IDS = ["gemini-3.1-pro-preview", "gemini-3-pro-preview"] as const;
 const GEMINI_3_1_FLASH_LITE_TEMPLATE_IDS = ["gemini-3.1-flash-lite-preview"] as const;
-const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3-flash-preview"] as const;
+const GEMINI_3_1_FLASH_TEMPLATE_IDS = ["gemini-3.1-flash-preview", "gemini-3-flash-preview"] as const;
 // Gemma uses the Gemini flash template as a forward-compat approximation
 // until a dedicated Gemma template is registered in the catalog.
 const GEMMA_TEMPLATE_IDS = GEMINI_3_1_FLASH_TEMPLATE_IDS;

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -228,6 +228,42 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(200_000);
   });
 
+  it("defaults claude-sonnet-4-6 to 1M without context1m when models.providers omits it", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        agents: {
+          defaults: {},
+        },
+      },
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+  });
+
+  it("respects explicit models.providers contextWindow for claude-sonnet-4-6", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [testModelContextWindow("claude-sonnet-4-6", 200_000)],
+            },
+          },
+        },
+      },
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(200_000);
+  });
+
   it("does not force 1M context for non-opus/sonnet Anthropic models", () => {
     const result = resolveContextTokensForModel({
       cfg: {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -381,6 +381,18 @@ function isAnthropic1MModel(provider: string, model: string): boolean {
   return ANTHROPIC_1M_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
 }
 
+/** Sonnet 4.6 ships with a 1M context window; discovery catalogs may still list 200k. */
+function isAnthropicSonnet46Native1mModel(provider: string, model: string): boolean {
+  if (normalizeLowercaseStringOrEmpty(provider) !== "anthropic") {
+    return false;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(model);
+  const modelId = normalized.includes("/")
+    ? (normalized.split("/").at(-1) ?? normalized)
+    : normalized;
+  return modelId === "claude-sonnet-4-6";
+}
+
 export function resolveContextTokensForModel(params: {
   cfg?: OpenClawConfig;
   provider?: string;
@@ -419,6 +431,9 @@ export function resolveContextTokensForModel(params: {
       if (configuredWindow !== undefined) {
         return configuredWindow;
       }
+    }
+    if (isAnthropicSonnet46Native1mModel(ref.provider, ref.model)) {
+      return ANTHROPIC_CONTEXT_1M_TOKENS;
     }
   }
 

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -46,7 +46,7 @@ function truncateUntrustedJsonString(value: string): string {
 
 function sanitizeUntrustedJsonValue(value: unknown): unknown {
   if (typeof value === "string") {
-    return neutralizeMarkdownFences(truncateUntrustedJsonString(value));
+    return neutralizeMarkdownFences(truncateUntrustedJsonString(stripNullBytes(value)));
   }
   if (Array.isArray(value)) {
     return value.map((entry) => sanitizeUntrustedJsonValue(entry));
@@ -136,7 +136,7 @@ export function buildInboundMetaSystemPrompt(
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
     response_format:
       options?.includeFormattingHints === false ? undefined : resolveInboundFormattingHints(ctx),
-  };
+  });
 
   // Keep the instructions local to the payload so the meaning survives prompt overrides.
   return [

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -136,7 +136,7 @@ export function buildInboundMetaSystemPrompt(
     chat_type: chatType ?? (isDirect ? "direct" : undefined),
     response_format:
       options?.includeFormattingHints === false ? undefined : resolveInboundFormattingHints(ctx),
-  });
+  };
 
   // Keep the instructions local to the payload so the meaning survives prompt overrides.
   return [

--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -408,6 +408,31 @@ describe("buildStatusMessage", () => {
     expect(normalizeTestText(text)).toContain("Context: 200k/1.0m");
   });
 
+  it("shows 1M context for anthropic claude-sonnet-4-6 without context1m params", () => {
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "anthropic/claude-sonnet-4-6",
+      },
+      sessionEntry: {
+        sessionId: "sonnet-46-default-1m",
+        updatedAt: 0,
+        totalTokens: 300_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+
+    expect(normalizeTestText(text)).toContain("Context: 300k/1.0m");
+  });
+
   it("recomputes context window from the active model after switching away from a smaller session override", () => {
     const sessionEntry = {
       sessionId: "switch-back",


### PR DESCRIPTION
## Summary

- **Inbound metadata / spawn safety**: Strip NUL bytes from strings before JSON-serializing inbound context blocks so downstream surfaces (e.g. spawn args) do not hit `ERR_INVALID_ARG_VALUE` (related: #65389).
- **Google Gemini CLI forward-compat**: Prefer `gemini-3.1-pro-preview` / `gemini-3.1-flash-preview` template IDs first, with 3.0 preview fallbacks for older catalogs (#65363).
- **Context limits**: Treat `anthropic/claude-sonnet-4-6` as 1M context by default when not overridden in `models.providers`; add `/status` regression coverage (#65360).

## Test plan

- `pnpm exec vitest run src/auto-reply/reply/inbound-meta.test.ts extensions/google/provider-models.test.ts src/agents/context.test.ts`
- `pnpm exec vitest run src/auto-reply/status.test.ts -t "claude-sonnet-4-6 without context1m"`
