### PR TITLE
 [security fix] Fix SQL injection in memory schema management

### DIFF
--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -1,6 +1,17 @@
 import type { DatabaseSync } from "node:sqlite";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
 
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function quoteTable(table: string): string {
+  return table
+    .split(".")
+    .map((part) => quoteIdentifier(part))
+    .join(".");
+}
+
 export function ensureMemoryIndexSchema(params: {
   db: DatabaseSync;
   embeddingCacheTable: string;
@@ -39,8 +50,9 @@ export function ensureMemoryIndexSchema(params: {
     );
   `);
   if (params.cacheEnabled) {
+    const quotedCacheTable = quoteTable(params.embeddingCacheTable);
     params.db.exec(`
-      CREATE TABLE IF NOT EXISTS ${params.embeddingCacheTable} (
+      CREATE TABLE IF NOT EXISTS ${quotedCacheTable} (
         provider TEXT NOT NULL,
         model TEXT NOT NULL,
         provider_key TEXT NOT NULL,
@@ -52,7 +64,7 @@ export function ensureMemoryIndexSchema(params: {
       );
     `);
     params.db.exec(
-      `CREATE INDEX IF NOT EXISTS idx_embedding_cache_updated_at ON ${params.embeddingCacheTable}(updated_at);`,
+      `CREATE INDEX IF NOT EXISTS idx_embedding_cache_updated_at ON ${quotedCacheTable}(updated_at);`,
     );
   }
 
@@ -62,8 +74,9 @@ export function ensureMemoryIndexSchema(params: {
     try {
       const tokenizer = params.ftsTokenizer ?? "unicode61";
       const tokenizeClause = tokenizer === "trigram" ? `, tokenize='trigram case_sensitive 0'` : "";
+      const quotedFtsTable = quoteTable(params.ftsTable);
       params.db.exec(
-        `CREATE VIRTUAL TABLE IF NOT EXISTS ${params.ftsTable} USING fts5(\n` +
+        `CREATE VIRTUAL TABLE IF NOT EXISTS ${quotedFtsTable} USING fts5(\n` +
           `  text,\n` +
           `  id UNINDEXED,\n` +
           `  path UNINDEXED,\n` +
@@ -95,9 +108,11 @@ function ensureColumn(
   column: string,
   definition: string,
 ): void {
-  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  const quotedTable = quoteTable(table);
+  const rows = db.prepare(`PRAGMA table_info(${quotedTable})`).all() as Array<{ name: string }>;
   if (rows.some((row) => row.name === column)) {
     return;
   }
-  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+  const quotedColumn = quoteIdentifier(column);
+  db.exec(`ALTER TABLE ${quotedTable} ADD COLUMN ${quotedColumn} ${definition}`);
 }

--- a/src/memory-host-sdk/host/memory-schema.ts
+++ b/src/memory-host-sdk/host/memory-schema.ts
@@ -1,6 +1,17 @@
 import type { DatabaseSync } from "node:sqlite";
 import { formatErrorMessage } from "../../infra/errors.js";
 
+function quoteIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+function quoteTable(table: string): string {
+  return table
+    .split(".")
+    .map((part) => quoteIdentifier(part))
+    .join(".");
+}
+
 export function ensureMemoryIndexSchema(params: {
   db: DatabaseSync;
   embeddingCacheTable: string;
@@ -39,8 +50,9 @@ export function ensureMemoryIndexSchema(params: {
     );
   `);
   if (params.cacheEnabled) {
+    const quotedCacheTable = quoteTable(params.embeddingCacheTable);
     params.db.exec(`
-      CREATE TABLE IF NOT EXISTS ${params.embeddingCacheTable} (
+      CREATE TABLE IF NOT EXISTS ${quotedCacheTable} (
         provider TEXT NOT NULL,
         model TEXT NOT NULL,
         provider_key TEXT NOT NULL,
@@ -52,7 +64,7 @@ export function ensureMemoryIndexSchema(params: {
       );
     `);
     params.db.exec(
-      `CREATE INDEX IF NOT EXISTS idx_embedding_cache_updated_at ON ${params.embeddingCacheTable}(updated_at);`,
+      `CREATE INDEX IF NOT EXISTS idx_embedding_cache_updated_at ON ${quotedCacheTable}(updated_at);`,
     );
   }
 
@@ -62,8 +74,9 @@ export function ensureMemoryIndexSchema(params: {
     try {
       const tokenizer = params.ftsTokenizer ?? "unicode61";
       const tokenizeClause = tokenizer === "trigram" ? `, tokenize='trigram case_sensitive 0'` : "";
+      const quotedFtsTable = quoteTable(params.ftsTable);
       params.db.exec(
-        `CREATE VIRTUAL TABLE IF NOT EXISTS ${params.ftsTable} USING fts5(\n` +
+        `CREATE VIRTUAL TABLE IF NOT EXISTS ${quotedFtsTable} USING fts5(\n` +
           `  text,\n` +
           `  id UNINDEXED,\n` +
           `  path UNINDEXED,\n` +
@@ -95,9 +108,11 @@ function ensureColumn(
   column: string,
   definition: string,
 ): void {
-  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  const quotedTable = quoteTable(table);
+  const rows = db.prepare(`PRAGMA table_info(${quotedTable})`).all() as Array<{ name: string }>;
   if (rows.some((row) => row.name === column)) {
     return;
   }
-  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+  const quotedColumn = quoteIdentifier(column);
+  db.exec(`ALTER TABLE ${quotedTable} ADD COLUMN ${quotedColumn} ${definition}`);
 }

--- a/src/memory-host-sdk/host/memory-schema.ts
+++ b/src/memory-host-sdk/host/memory-schema.ts
@@ -114,5 +114,5 @@ function ensureColumn(
     return;
   }
   const quotedColumn = quoteIdentifier(column);
-  db.exec(`ALTER TABLE ${quotedTable} ADD COLUMN ${quotedColumn} ${definition}`);
+  db.exec(`ALTER TABLE ${quotedTable} ADD COLUMN ${quotedColumn} ${definition}`); // definition must be a hardcoded DDL fragment, never user-controlled
 }


### PR DESCRIPTION
This PR addresses a security vulnerability where dynamic identifiers were being interpolated directly into SQL queries in the memory schema management code.

 **What:** The vulnerability fixed
SQL Injection via Template Literals in `src/memory-host-sdk/host/memory-schema.ts`. Dynamic identifiers such as table names (`embeddingCacheTable`, `ftsTable`) and column names were interpolated directly into SQL strings without proper quoting or escaping.

 **Risk:** The potential impact if left unfixed
An attacker could provide malicious identifiers containing SQL command separators and additional statements. For example, a column name like `new_col" TEXT; DROP TABLE files; --` would cause the `ALTER TABLE` statement to terminate prematurely and execute a `DROP TABLE` command, leading to data loss or corruption.

 **Changes :** How the fix addresses the vulnerability
Introduced `quoteIdentifier` and `quoteTable` helper functions.
- `quoteIdentifier` correctly escapes double quotes and wraps the identifier in double quotes.
- `quoteTable` extends this logic to support schema-qualified names (e.g. `aux.files`) by quoting each part individually, which prevents regressions for callers using attached databases.

The fix has been applied to:
- `src/memory-host-sdk/host/memory-schema.ts`
- `packages/memory-host-sdk/src/host/memory-schema.ts` (mirrored SDK file)

Verification:
- Tested with a reproduction script confirming that malicious input is blocked and that schema-qualified names continue to work correctly in DDL statements.
- Verified that existing functionality (normal column addition) remains intact.
- Synchronized mirrored files while maintaining directory-appropriate import paths.