### PR TITLE
feat(workspace): respect OPENCLAW_STATE_DIR for workspace base path

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -15,11 +15,15 @@ export function resolveDefaultAgentWorkspaceDir(
   homedir: () => string = os.homedir,
 ): string {
   const home = resolveRequiredHomeDir(env, homedir);
+  // Allow OPENCLAW_STATE_DIR to override the base directory so multiple
+  // instances can run on the same machine with isolated state.
+  const stateDir = env.OPENCLAW_STATE_DIR?.trim();
+  const base = stateDir || path.join(home, ".openclaw");
   const profile = env.OPENCLAW_PROFILE?.trim();
   if (profile && normalizeOptionalLowercaseString(profile) !== "default") {
-    return path.join(home, ".openclaw", `workspace-${profile}`);
+    return path.join(base, `workspace-${profile}`);
   }
-  return path.join(home, ".openclaw", "workspace");
+  return path.join(base, "workspace");
 }
 
 export const DEFAULT_AGENT_WORKSPACE_DIR = resolveDefaultAgentWorkspaceDir();


### PR DESCRIPTION
Allow OPENCLAW_STATE_DIR environment variable to override the default ~/.openclaw base directory used for workspace path resolution.

Motivation

Running multiple OpenClaw instances on the same machine currently requires profile names via OPENCLAW_PROFILE. But profile names only differentiate the workspace subdirectory — the base ~/.openclaw is shared, which means logs, sessions, plugins, and config all share the same parent.

OPENCLAW_STATE_DIR allows full isolation with a single env var:

OPENCLAW_STATE_DIR=~/.openclaw-work openclaw gateway start

Change

• resolveDefaultAgentWorkspaceDir() reads OPENCLAW_STATE_DIR and uses it as the base directory
• Falls back to ~/.openclaw when unset — no behavior change for existing deployments
• Works correctly with OPENCLAW_PROFILE (profile suffix appended to the custom base)

Testing

Existing workspace tests pass. Manual verification with custom state dir.