### PR TITLE
fix: prefer process.env.HOME over os.homedir() in sandbox expandPath

### DIFF
--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -19,13 +19,17 @@ function normalizeAtPrefix(filePath: string): string {
   return filePath.startsWith("@") ? filePath.slice(1) : filePath;
 }
 
+function resolveHome(): string {
+  return process.env.HOME || process.env.USERPROFILE || os.homedir();
+}
+
 function expandPath(filePath: string): string {
   const normalized = normalizeUnicodeSpaces(normalizeAtPrefix(filePath));
   if (normalized === "~") {
-    return os.homedir();
+    return resolveHome();
   }
   if (normalized.startsWith("~/")) {
-    return os.homedir() + normalized.slice(1);
+    return resolveHome() + normalized.slice(1);
   }
   return normalized;
 }

--- a/src/agents/sandbox-paths.ts
+++ b/src/agents/sandbox-paths.ts
@@ -218,8 +218,9 @@ async function assertNoTmpAliasEscape(params: {
 }
 
 function shortPath(value: string) {
-  if (value.startsWith(os.homedir())) {
-    return `~${value.slice(os.homedir().length)}`;
+  const home = resolveHome();
+  if (value.startsWith(home)) {
+    return `~${value.slice(home.length)}`;
   }
   return value;
 }


### PR DESCRIPTION
## Summary

- `expandPath` in `src/agents/sandbox-paths.ts` uses `os.homedir()` directly for tilde (`~`) expansion
- `os.homedir()` reads from `/etc/passwd`, not from `process.env.HOME`
- In systemd user services and sub-agent sessions, `$HOME` is set correctly but `os.homedir()` returns a different value (e.g. `/root/` instead of `/home/user/`)
- This causes the `write` tool to fail with EACCES or silently write to the wrong directory

## Fix

Extract a `resolveHome()` helper that prefers `process.env.HOME`, falls back to `process.env.USERPROFILE`, then `os.homedir()`. This matches the pattern already used in `fs-safe` (line 377).

## How we found it

Sub-agent spawned from a cron session via `sessions_spawn` tried to write to `~/brain/...` using the `write` tool. The tool resolved `~` to `/root/` instead of `/home/oc2/`. The agent self-corrected by using `exec cat >` instead. We traced through the minified dist to `sandbox-paths`, found `expandPath` calling `os.homedir()` directly.

## Test plan

- Verify `write` tool correctly expands `~` in a systemd user service context
- Verify `write` tool still works when `$HOME` is unset (falls back to `os.homedir()`)

Fixes #50227
Related: #54014