### PR TITLE
fix(telegram): guard hashText against undefined text in dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 - Performance: prebuild QA runtime probes with generated plugin assets but without CLI startup metadata.
 - Performance: skip declaration bundling for runtime-only CLI startup and gateway watch build profiles.
 - Performance: reuse prepared provider handles, strict tool schemas, gateway runtime metadata, session maintenance config, plugin metadata, bundled skill allowlists, package-local plugin artifacts, single-entry store writes, and validated/serialized session prompt blobs.
+- Telegram/dispatch: guard `hashText` and `emitSystemStatus` against undefined `event.text` on textless visible `usage_update` status events, preventing a `TypeError: Cannot read properties of undefined (reading 'trim')` that crashed Telegram dispatch on group-chat follow-up messages. (#65567)
 
 ## 2026.5.28
 

--- a/src/auto-reply/reply/acp-projector.test.ts
+++ b/src/auto-reply/reply/acp-projector.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { AcpRuntimeEvent } from "../../acp/runtime/types.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
 import { createAcpReplyProjector } from "./acp-projector.js";
 import { createAcpTestConfig as createCfg } from "./test-fixtures/acp-runtime.js";
@@ -583,6 +584,50 @@ describe("createAcpReplyProjector", () => {
       { kind: "tool", text: prefixSystemMessage("usage updated: 10/100") },
       { kind: "tool", text: prefixSystemMessage("usage updated: 11/100") },
     ]);
+  });
+
+  it("does not crash on textless visible usage_update events (#65567)", async () => {
+    // Regression for the Telegram dispatch crash: a visible usage_update
+    // status event with `text` undefined previously hit
+    // `hashText(event.text).trim()` and `emitSystemStatus(event.text).trim()`
+    // and threw TypeError on the .trim() call. Both call sites now guard
+    // against undefined; this test pins both shapes that can reach those
+    // paths so they cannot regress silently.
+    const { deliveries, projector } = createProjectorHarness(
+      createLiveCfgOverrides({
+        coalesceIdleMs: 0,
+        maxChunkChars: 64,
+        tagVisibility: {
+          usage_update: true,
+        },
+      }),
+    );
+
+    // Shape 1: no numeric usage fields, no text. The `usage_update` branch
+    // falls back to `hashText(event.text)` for the dedup tuple; previously
+    // `(undefined).trim()` threw. Now hashText returns "" without crashing.
+    // Cast is required because AcpRuntimeEvent's status variant types `text`
+    // as required; this test deliberately constructs the type-violating
+    // shape the runtime can emit in practice.
+    await projector.onEvent({
+      type: "status",
+      tag: "usage_update",
+    } as unknown as AcpRuntimeEvent);
+
+    // Shape 2: numeric textless usage update. The dedup tuple is built from
+    // `used`/`size`, but `emitSystemStatus(event.text ?? "")` is still
+    // called with the missing text. Previously this crashed on .trim();
+    // the explicit `?? ""` guard makes it a no-op visible delivery.
+    await projector.onEvent({
+      type: "status",
+      tag: "usage_update",
+      used: 10,
+      size: 100,
+    } as unknown as AcpRuntimeEvent);
+
+    // Neither shape carried renderable text, so no system-status delivery
+    // is expected. The assertion is "no crash" plus "no spurious output".
+    expect(deliveries).toEqual([]);
   });
 
   it("hides available_commands_update by default", async () => {

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -467,7 +467,7 @@ export function createAcpReplyProjector(params: {
         }
         lastUsageTuple = usageTuple;
       }
-      await emitSystemStatus(event.text, event.tag ? { tag: event.tag } : undefined, {
+      await emitSystemStatus(event.text ?? "", event.tag ? { tag: event.tag } : undefined, {
         dedupe: true,
       });
       return;

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -54,8 +54,8 @@ function truncateText(input: string, maxChars: number): string {
   return `${input.slice(0, maxChars - 1)}…`;
 }
 
-function hashText(text: string): string {
-  return text.trim();
+function hashText(text: string | undefined): string {
+  return (text ?? "").trim();
 }
 
 function normalizeToolStatus(status: string | undefined): string | undefined {

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -54,8 +54,8 @@ function truncateText(input: string, maxChars: number): string {
   return `${input.slice(0, maxChars - 1)}…`;
 }
 
-function hashText(text: string): string {
-  return text.trim();
+function hashText(text: string | undefined): string {
+  return (text ?? "").trim();
 }
 
 function normalizeToolStatus(status: string | undefined): string | undefined {
@@ -497,7 +497,7 @@ export function createAcpReplyProjector(params: {
         }
         lastUsageTuple = usageTuple;
       }
-      await emitSystemStatus(event.text, event.tag ? { tag: event.tag } : undefined, {
+      await emitSystemStatus(event.text ?? "", event.tag ? { tag: event.tag } : undefined, {
         dedupe: true,
       });
       return;


### PR DESCRIPTION
## Summary

- Telegram dispatch crashed with `TypeError: Cannot read properties of undefined (reading 'trim')` on group-chat follow-up messages because the ACP projector forwarded an undefined `event.text` from textless `usage_update` status events into two `.trim()` call sites.
- This guards both call sites against undefined so a textless visible `usage_update` becomes a delivery no-op instead of tearing down the dispatch loop.
- A regression test pins both production-shape `usage_update` event objects through the projector.
- Out of scope: broadening the `AcpRuntimeEvent` status-variant `text` typing to `text?: string`; that is a wider contract change tracked as a possible follow-up.
- AI-assisted: drafted and validated with an AI coding agent; the real behavior proof below was produced by running the affected function bodies, not by AI alone.

## Linked context

No separate issue was filed; this PR fixes a production Telegram dispatch crash surfaced in the OpenClaw ACP projector.

The fix addresses a production Telegram dispatch crash. The narrower of the two options ClawSweeper raised on this PR (call-site guard plus a `?? ""` default in `hashText`) was taken over the broader typing change.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: production Telegram dispatch crash on textless visible `usage_update` status events. The ACP projector at [`src/auto-reply/reply/acp-projector.ts:464`](https://github.com/openclaw/openclaw/blob/fix/hash-text-undefined-guard/src/auto-reply/reply/acp-projector.ts#L464) called `hashText(event.text)` and at line 470 called `emitSystemStatus(event.text, ...)` with `event.text` undefined; both downstream `.trim()` calls threw and tore down the dispatch loop.
- Real environment tested: a local Node.js 22.16.0 runtime executing the pre-fix and post-fix function bodies copied verbatim from `src/auto-reply/reply/acp-projector.ts`. Two production-shape `usage_update` event objects are used: the textless tag-only shape and the textless numeric `used`/`size` shape that the in-repo regression test pins.
- Exact steps or command run after this patch: `node repro.mjs`, where `repro.mjs` defines two functions with the pre-fix bodies (`hashText(text) { return text.trim(); }` and `emitSystemStatus(text) { return text.trim(); }`) and two with the post-fix bodies (`hashText(text) { return (text ?? "").trim(); }` and the call-site guard `emitSystemStatus(event.text ?? "")`), then runs both production-shape `usage_update` event objects through each.
- Evidence after fix (terminal capture from the `node` invocation above):

```text
=== PRE-FIX (current main without #65567) ===

shape: {"type":"status","tag":"usage_update"}
  hashText_old:         CRASH: Cannot read properties of undefined (reading 'trim')
  emitSystemStatus_old: CRASH: Cannot read properties of undefined (reading 'trim')

shape: {"type":"status","tag":"usage_update","used":10,"size":100}
  hashText_old:         CRASH: Cannot read properties of undefined (reading 'trim')
  emitSystemStatus_old: CRASH: Cannot read properties of undefined (reading 'trim')

=== POST-FIX (this PR) ===

shape: {"type":"status","tag":"usage_update"}
  hashText_new:         returned ""
  emitSystemStatus_new: returned ""

shape: {"type":"status","tag":"usage_update","used":10,"size":100}
  hashText_new:         returned ""
  emitSystemStatus_new: returned ""
```

- Observed result after fix: for both production event shapes, `hashText` returns `""` and the call site that used to forward undefined into `emitSystemStatus` now passes `""`, which `emitSystemStatus` short-circuits via `if (!bounded) return;`. Net behavior: the visible delivery becomes a no-op instead of a crash, matching what the in-repo regression test asserts. The pre-fix functions reproduce the exact `TypeError: Cannot read properties of undefined (reading 'trim')` from the original Telegram crash.
- What was not tested: a live Telegram group session was not exercised; no Telegram bot was bound to a group with the `usage_update` tag visibility configured.
- Proof limitations or environment constraints: the repro runs the same function bodies copied from production source against the same event shapes the regression test uses, so the path that crashed in production is the path the repro exercises, but it is not an end-to-end Telegram delivery.
- Before evidence: captured above as the `PRE-FIX` block, where both functions crash on each shape.

## Tests and validation

Which commands did you run?

- `node repro.mjs` (the pre-fix vs post-fix behavior capture shown above).

What regression coverage was added or updated?

- New regression test in `src/auto-reply/reply/acp-projector.test.ts:452-491`, `does not crash on textless visible usage_update events (#65567)`, pins both shapes through the projector. The fixtures are cast `as unknown as AcpRuntimeEvent` because the runtime contract declares `text: string` on the status variant but production emits status events with `text` undefined; the cast captures the runtime reality the regression covers.

What failed before this fix, if known?

- Before the fix, dispatch threw `TypeError: Cannot read properties of undefined (reading 'trim')` from `hashText(event.text)` and `emitSystemStatus(event.text, ...)` on textless `usage_update` status events, tearing down the dispatch loop.

## Risk checklist

Did user-visible behavior change? (`Yes/No`)

Yes. A textless visible `usage_update` now becomes a delivery no-op instead of crashing the dispatch loop.

Did config, environment, or migration behavior change? (`Yes/No`)

No.

Did security, auth, secrets, network, or tool execution behavior change? (`Yes/No`)

No.

What is the highest-risk area?

The `?? ""` default in `hashText` and the call-site guard could mask a genuinely missing `text` elsewhere rather than surfacing it.

How is that risk mitigated?

The guards only convert an absent `text` to `""`, and `emitSystemStatus` already short-circuits empty input via `if (!bounded) return;`, so a textless event becomes an explicit no-op rather than silently changing visible output.

## Current review state

What is the next action?

Maintainer review.

What is still waiting on author, maintainer, CI, or external proof?

A live Telegram group session was not exercised (no bot bound to a group with `usage_update` tag visibility); the function-body repro stands in for that path.

Which bot or reviewer comments were addressed?

Took ClawSweeper's narrower option (call-site guard plus `?? ""` in `hashText`) over the broader `AcpRuntimeEvent` typing change; happy to do the typing change as a follow-up if maintainers prefer. The branch was rebased onto current `main` (`b47c7431bc` -> `8844ffe995`) to pick up the Real behavior proof CI script that landed after this branch was first opened.