### PR TITLE
fix(mcp-stdio): propagate proxy env vars to child processes

### DIFF
--- a/src/agents/mcp-stdio.test.ts
+++ b/src/agents/mcp-stdio.test.ts
@@ -164,6 +164,15 @@ describe("getProxyEnvDefaults", () => {
 
     expect(getProxyEnvDefaults()).toEqual({});
   });
+
+  it("does not mangle --inspect substrings inside other argument values", () => {
+    // The path contains "--inspect" as a directory name — it must survive.
+    process.env.NODE_OPTIONS = "--require /tmp/--inspect-hook.js --inspect-brk";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      NODE_OPTIONS: "--require /tmp/--inspect-hook.js",
+    });
+  });
 });
 
 describe("resolveStdioMcpServerLaunchConfig — proxy env propagation", () => {

--- a/src/agents/mcp-stdio.test.ts
+++ b/src/agents/mcp-stdio.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getProxyEnvDefaults, resolveStdioMcpServerLaunchConfig } from "./mcp-stdio.js";
+
+/**
+ * Proxy env var keys that we expect to be forwarded to MCP stdio child
+ * processes when set in the gateway's process.env.
+ */
+const ALL_PROXY_KEYS = [
+  "HTTPS_PROXY",
+  "https_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "NO_PROXY",
+  "no_proxy",
+  "NODE_OPTIONS",
+] as const;
+
+describe("getProxyEnvDefaults", () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ALL_PROXY_KEYS) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ALL_PROXY_KEYS) {
+      const prev = saved.get(key);
+      if (prev === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prev;
+      }
+    }
+  });
+
+  it("returns empty object when no proxy vars are set", () => {
+    expect(getProxyEnvDefaults()).toEqual({});
+  });
+
+  it("collects HTTPS_PROXY and HTTP_PROXY", () => {
+    process.env.HTTPS_PROXY = "http://proxy:3128";
+    process.env.HTTP_PROXY = "http://proxy:3128";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      HTTPS_PROXY: "http://proxy:3128",
+      HTTP_PROXY: "http://proxy:3128",
+    });
+  });
+
+  it("collects lower-case proxy vars", () => {
+    process.env.https_proxy = "http://lower:3128";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      https_proxy: "http://lower:3128",
+    });
+  });
+
+  it("collects NO_PROXY and NODE_OPTIONS", () => {
+    process.env.NO_PROXY = "localhost,127.0.0.1";
+    process.env.NODE_OPTIONS = "--require /path/to/proxy-patch.js";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      NO_PROXY: "localhost,127.0.0.1",
+      NODE_OPTIONS: "--require /path/to/proxy-patch.js",
+    });
+  });
+
+  it("ignores empty string values", () => {
+    process.env.HTTPS_PROXY = "";
+    process.env.HTTP_PROXY = "http://proxy:3128";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      HTTP_PROXY: "http://proxy:3128",
+    });
+  });
+});
+
+describe("resolveStdioMcpServerLaunchConfig — proxy env propagation", () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ALL_PROXY_KEYS) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ALL_PROXY_KEYS) {
+      const prev = saved.get(key);
+      if (prev === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prev;
+      }
+    }
+  });
+
+  it("propagates gateway proxy vars when user env is not configured", () => {
+    process.env.HTTPS_PROXY = "http://proxy:3128";
+    process.env.NODE_OPTIONS = "--require /patch.js";
+
+    const result = resolveStdioMcpServerLaunchConfig({ command: "node", args: ["server.js"] });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.config.env).toEqual({
+      HTTPS_PROXY: "http://proxy:3128",
+      NODE_OPTIONS: "--require /patch.js",
+    });
+  });
+
+  it("user-configured env overrides gateway proxy vars", () => {
+    process.env.HTTPS_PROXY = "http://gateway-proxy:3128";
+
+    const result = resolveStdioMcpServerLaunchConfig({
+      command: "node",
+      args: ["server.js"],
+      env: { HTTPS_PROXY: "http://user-proxy:9999", CUSTOM_VAR: "value" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.config.env).toEqual({
+      HTTPS_PROXY: "http://user-proxy:9999",
+      CUSTOM_VAR: "value",
+    });
+  });
+
+  it("merges gateway proxy vars with user env (user wins on conflict)", () => {
+    process.env.HTTPS_PROXY = "http://gateway:3128";
+    process.env.NO_PROXY = "localhost";
+
+    const result = resolveStdioMcpServerLaunchConfig({
+      command: "node",
+      args: ["server.js"],
+      env: { MY_TOKEN: "secret" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.config.env).toEqual({
+      HTTPS_PROXY: "http://gateway:3128",
+      NO_PROXY: "localhost",
+      MY_TOKEN: "secret",
+    });
+  });
+
+  it("returns undefined env when no proxy vars and no user env", () => {
+    const result = resolveStdioMcpServerLaunchConfig({ command: "node", args: ["server.js"] });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.config.env).toBeUndefined();
+  });
+});

--- a/src/agents/mcp-stdio.test.ts
+++ b/src/agents/mcp-stdio.test.ts
@@ -84,13 +84,14 @@ describe("getProxyEnvDefaults", () => {
     process.env.http_proxy = "http://lower-http:3128";
 
     const result = getProxyEnvDefaults();
-    // Only uppercase should survive when both are present
+    // Only lowercase should survive when both are present (lowercase
+    // takes precedence per src/infra/net/proxy-env.ts convention)
     expect(result).toEqual({
-      HTTPS_PROXY: "http://upper:3128",
-      HTTP_PROXY: "http://upper-http:3128",
+      https_proxy: "http://lower:3128",
+      http_proxy: "http://lower-http:3128",
     });
-    expect(result).not.toHaveProperty("https_proxy");
-    expect(result).not.toHaveProperty("http_proxy");
+    expect(result).not.toHaveProperty("HTTPS_PROXY");
+    expect(result).not.toHaveProperty("HTTP_PROXY");
   });
 
   it("keeps lowercase when only lowercase is set", () => {
@@ -119,6 +120,23 @@ describe("getProxyEnvDefaults", () => {
 
   it("strips --inspect-port=N from NODE_OPTIONS", () => {
     process.env.NODE_OPTIONS = "--require /patch.js --inspect-port=9230";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      NODE_OPTIONS: "--require /patch.js",
+    });
+  });
+
+  it("strips --inspect-publish-uid=stderr from NODE_OPTIONS", () => {
+    process.env.NODE_OPTIONS = "--require /patch.js --inspect-publish-uid=stderr";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      NODE_OPTIONS: "--require /patch.js",
+    });
+  });
+
+  it("strips all --inspect* variants from NODE_OPTIONS at once", () => {
+    process.env.NODE_OPTIONS =
+      "--inspect --inspect-brk --inspect-port=9230 --inspect-publish-uid=stderr --require /patch.js";
 
     expect(getProxyEnvDefaults()).toEqual({
       NODE_OPTIONS: "--require /patch.js",

--- a/src/agents/mcp-stdio.test.ts
+++ b/src/agents/mcp-stdio.test.ts
@@ -68,13 +68,29 @@ describe("getProxyEnvDefaults", () => {
     });
   });
 
-  it("ignores empty string values", () => {
+  it("preserves empty string values (explicit proxy disable)", () => {
     process.env.HTTPS_PROXY = "";
     process.env.HTTP_PROXY = "http://proxy:3128";
 
     expect(getProxyEnvDefaults()).toEqual({
+      HTTPS_PROXY: "",
       HTTP_PROXY: "http://proxy:3128",
     });
+  });
+
+  it("keeps empty lowercase proxy that overrides uppercase (disable proxy)", () => {
+    // Gateway has uppercase proxy configured, but lowercase empty overrides it
+    // to mean "no proxy". Both must be forwarded so the child's proxy resolver
+    // sees the lowercase empty and skips the uppercase fallback.
+    process.env.HTTPS_PROXY = "http://proxy:8080";
+    process.env.https_proxy = "";
+
+    const result = getProxyEnvDefaults();
+    // Case-dedup keeps only lowercase when both are present
+    expect(result).toEqual({
+      https_proxy: "",
+    });
+    expect(result).not.toHaveProperty("HTTPS_PROXY");
   });
 
   it("deduplicates when both upper and lower case proxy vars are set", () => {

--- a/src/agents/mcp-stdio.test.ts
+++ b/src/agents/mcp-stdio.test.ts
@@ -76,6 +76,60 @@ describe("getProxyEnvDefaults", () => {
       HTTP_PROXY: "http://proxy:3128",
     });
   });
+
+  it("deduplicates when both upper and lower case proxy vars are set", () => {
+    process.env.HTTPS_PROXY = "http://upper:3128";
+    process.env.https_proxy = "http://lower:3128";
+    process.env.HTTP_PROXY = "http://upper-http:3128";
+    process.env.http_proxy = "http://lower-http:3128";
+
+    const result = getProxyEnvDefaults();
+    // Only uppercase should survive when both are present
+    expect(result).toEqual({
+      HTTPS_PROXY: "http://upper:3128",
+      HTTP_PROXY: "http://upper-http:3128",
+    });
+    expect(result).not.toHaveProperty("https_proxy");
+    expect(result).not.toHaveProperty("http_proxy");
+  });
+
+  it("keeps lowercase when only lowercase is set", () => {
+    process.env.https_proxy = "http://lower:3128";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      https_proxy: "http://lower:3128",
+    });
+  });
+
+  it("strips --inspect from NODE_OPTIONS", () => {
+    process.env.NODE_OPTIONS = "--inspect --require /patch.js";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      NODE_OPTIONS: "--require /patch.js",
+    });
+  });
+
+  it("strips --inspect-brk from NODE_OPTIONS", () => {
+    process.env.NODE_OPTIONS = "--inspect-brk --require /patch.js";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      NODE_OPTIONS: "--require /patch.js",
+    });
+  });
+
+  it("strips --inspect-port=N from NODE_OPTIONS", () => {
+    process.env.NODE_OPTIONS = "--require /patch.js --inspect-port=9230";
+
+    expect(getProxyEnvDefaults()).toEqual({
+      NODE_OPTIONS: "--require /patch.js",
+    });
+  });
+
+  it("removes NODE_OPTIONS entirely if only inspect flags remain", () => {
+    process.env.NODE_OPTIONS = "--inspect-brk";
+
+    expect(getProxyEnvDefaults()).toEqual({});
+  });
 });
 
 describe("resolveStdioMcpServerLaunchConfig — proxy env propagation", () => {
@@ -159,5 +213,55 @@ describe("resolveStdioMcpServerLaunchConfig — proxy env propagation", () => {
       return;
     }
     expect(result.config.env).toBeUndefined();
+  });
+
+  it("drops uppercase default when user sets lowercase equivalent", () => {
+    process.env.HTTPS_PROXY = "http://gateway:3128";
+
+    const result = resolveStdioMcpServerLaunchConfig({
+      command: "node",
+      args: ["server.js"],
+      env: { https_proxy: "http://user:9999" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    // User's lowercase wins; gateway's uppercase default must not leak through
+    expect(result.config.env).toEqual({
+      https_proxy: "http://user:9999",
+    });
+    expect(result.config.env).not.toHaveProperty("HTTPS_PROXY");
+  });
+
+  it("drops lowercase default when user sets uppercase equivalent", () => {
+    process.env.https_proxy = "http://gateway:3128";
+
+    const result = resolveStdioMcpServerLaunchConfig({
+      command: "node",
+      args: ["server.js"],
+      env: { HTTPS_PROXY: "http://user:9999" },
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.config.env).toEqual({
+      HTTPS_PROXY: "http://user:9999",
+    });
+    expect(result.config.env).not.toHaveProperty("https_proxy");
+  });
+
+  it("strips --inspect-brk from propagated NODE_OPTIONS", () => {
+    process.env.NODE_OPTIONS = "--inspect-brk --require /patch.js";
+
+    const result = resolveStdioMcpServerLaunchConfig({ command: "node", args: ["server.js"] });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.config.env).toEqual({
+      NODE_OPTIONS: "--require /patch.js",
+    });
   });
 });

--- a/src/agents/mcp-stdio.ts
+++ b/src/agents/mcp-stdio.ts
@@ -44,13 +44,17 @@ const PROXY_CASE_PAIRS: ReadonlyArray<[uppercase: string, lowercase: string]> = 
 ];
 
 /**
- * Regex that matches ALL `--inspect*` flags inside a NODE_OPTIONS string.
- * This covers `--inspect`, `--inspect-brk`, `--inspect-port=…`,
- * `--inspect-publish-uid=…`, and any future `--inspect-*` variants.
- * If the gateway process is running under a debugger these flags would cause
- * every MCP child to hang waiting for its own debugger connection.
+ * Remove all `--inspect*` tokens from a NODE_OPTIONS string.
+ *
+ * Instead of a global regex replace (which could mangle `--inspect` substrings
+ * inside unrelated argument values like `--require /tmp/--inspect-hook.js`),
+ * we split on whitespace, filter out tokens that _start_ with `--inspect`, and
+ * rejoin.  This correctly respects argument boundaries.
  */
-const INSPECT_FLAG_RE = /--inspect[-\w]*(=\S+)?/g;
+function stripInspectFlags(nodeOptions: string): string {
+  const tokens = nodeOptions.split(/\s+/).filter((t) => !t.startsWith("--inspect"));
+  return tokens.join(" ").trim();
+}
 
 /**
  * Collect proxy-related env vars from the current process so they can be
@@ -86,9 +90,7 @@ export function getProxyEnvDefaults(): Record<string, string> {
 
   // Strip --inspect* flags from NODE_OPTIONS so child processes don't hang.
   if (defaults.NODE_OPTIONS !== undefined) {
-    const sanitized = defaults.NODE_OPTIONS.replace(INSPECT_FLAG_RE, "")
-      .trim()
-      .replace(/\s{2,}/g, " ");
+    const sanitized = stripInspectFlags(defaults.NODE_OPTIONS);
     if (sanitized.length === 0) {
       delete defaults.NODE_OPTIONS;
     } else {

--- a/src/agents/mcp-stdio.ts
+++ b/src/agents/mcp-stdio.ts
@@ -44,21 +44,22 @@ const PROXY_CASE_PAIRS: ReadonlyArray<[uppercase: string, lowercase: string]> = 
 ];
 
 /**
- * Regex that matches `--inspect`, `--inspect-brk`, and `--inspect-port=…`
- * tokens inside a NODE_OPTIONS string.  If the gateway process is running
- * under a debugger these flags would cause every MCP child to hang waiting
- * for its own debugger connection.
+ * Regex that matches ALL `--inspect*` flags inside a NODE_OPTIONS string.
+ * This covers `--inspect`, `--inspect-brk`, `--inspect-port=…`,
+ * `--inspect-publish-uid=…`, and any future `--inspect-*` variants.
+ * If the gateway process is running under a debugger these flags would cause
+ * every MCP child to hang waiting for its own debugger connection.
  */
-const INSPECT_FLAG_RE = /--inspect(?:-brk|-port(?:=\S*)?)?(?:\s+\d+)?/g;
+const INSPECT_FLAG_RE = /--inspect[-\w]*(=\S+)?/g;
 
 /**
  * Collect proxy-related env vars from the current process so they can be
  * forwarded to MCP stdio child processes as lowest-priority defaults.
  *
  * Case-dedup: when the gateway has both `HTTPS_PROXY` and `https_proxy` set,
- * only the uppercase variant is forwarded.  This avoids a subtle bug where
- * both keys reach the child and the lowercase one silently wins (per
- * convention), overriding any explicit user config for the uppercase key.
+ * only the lowercase variant is forwarded.  Lowercase takes precedence per
+ * convention (see `src/infra/net/proxy-env.ts`), so forwarding the lowercase
+ * variant preserves the documented precedence order for MCP children.
  *
  * NODE_OPTIONS: `--inspect*` flags are stripped so that MCP child processes
  * don't hang waiting for a debugger connection when the gateway itself is
@@ -75,10 +76,11 @@ export function getProxyEnvDefaults(): Record<string, string> {
     }
   }
 
-  // Case-insensitive dedup: when both cases are present, keep only uppercase.
+  // Case-insensitive dedup: when both cases are present, keep only lowercase.
+  // Lowercase takes precedence per convention (src/infra/net/proxy-env.ts).
   for (const [upper, lower] of PROXY_CASE_PAIRS) {
     if (defaults[upper] !== undefined && defaults[lower] !== undefined) {
-      delete defaults[lower];
+      delete defaults[upper];
     }
   }
 

--- a/src/agents/mcp-stdio.ts
+++ b/src/agents/mcp-stdio.ts
@@ -32,8 +32,37 @@ const PROXY_ENV_KEYS = [
 ] as const;
 
 /**
+ * Case-insensitive pairs for proxy env vars.  Used to deduplicate defaults so
+ * that we never forward both `HTTPS_PROXY` and `https_proxy` simultaneously
+ * (lowercase takes precedence per convention, so forwarding both would cause
+ * the user's explicit uppercase override to be silently ignored).
+ */
+const PROXY_CASE_PAIRS: ReadonlyArray<[uppercase: string, lowercase: string]> = [
+  ["HTTPS_PROXY", "https_proxy"],
+  ["HTTP_PROXY", "http_proxy"],
+  ["NO_PROXY", "no_proxy"],
+];
+
+/**
+ * Regex that matches `--inspect`, `--inspect-brk`, and `--inspect-port=…`
+ * tokens inside a NODE_OPTIONS string.  If the gateway process is running
+ * under a debugger these flags would cause every MCP child to hang waiting
+ * for its own debugger connection.
+ */
+const INSPECT_FLAG_RE = /--inspect(?:-brk|-port(?:=\S*)?)?(?:\s+\d+)?/g;
+
+/**
  * Collect proxy-related env vars from the current process so they can be
  * forwarded to MCP stdio child processes as lowest-priority defaults.
+ *
+ * Case-dedup: when the gateway has both `HTTPS_PROXY` and `https_proxy` set,
+ * only the uppercase variant is forwarded.  This avoids a subtle bug where
+ * both keys reach the child and the lowercase one silently wins (per
+ * convention), overriding any explicit user config for the uppercase key.
+ *
+ * NODE_OPTIONS: `--inspect*` flags are stripped so that MCP child processes
+ * don't hang waiting for a debugger connection when the gateway itself is
+ * being debugged.
  *
  * @internal — exported for testing only.
  */
@@ -45,6 +74,26 @@ export function getProxyEnvDefaults(): Record<string, string> {
       defaults[key] = value;
     }
   }
+
+  // Case-insensitive dedup: when both cases are present, keep only uppercase.
+  for (const [upper, lower] of PROXY_CASE_PAIRS) {
+    if (defaults[upper] !== undefined && defaults[lower] !== undefined) {
+      delete defaults[lower];
+    }
+  }
+
+  // Strip --inspect* flags from NODE_OPTIONS so child processes don't hang.
+  if (defaults.NODE_OPTIONS !== undefined) {
+    const sanitized = defaults.NODE_OPTIONS.replace(INSPECT_FLAG_RE, "")
+      .trim()
+      .replace(/\s{2,}/g, " ");
+    if (sanitized.length === 0) {
+      delete defaults.NODE_OPTIONS;
+    } else {
+      defaults.NODE_OPTIONS = sanitized;
+    }
+  }
+
   return defaults;
 }
 
@@ -70,8 +119,22 @@ export function resolveStdioMcpServerLaunchConfig(raw: unknown): StdioMcpServerL
 
   // Merge proxy/NODE_OPTIONS env vars from the gateway process as
   // lowest-priority defaults. User-configured env values always win.
+  //
+  // Cross-case dedup: if userEnv explicitly sets `https_proxy`, drop the
+  // uppercase `HTTPS_PROXY` default (and vice-versa) so both aren't
+  // forwarded to the child.
   const proxyDefaults = getProxyEnvDefaults();
   const userEnv = toMcpStringRecord(raw.env);
+  if (userEnv) {
+    for (const [upper, lower] of PROXY_CASE_PAIRS) {
+      if (userEnv[lower] !== undefined) {
+        delete proxyDefaults[upper];
+      }
+      if (userEnv[upper] !== undefined) {
+        delete proxyDefaults[lower];
+      }
+    }
+  }
   const hasProxyDefaults = Object.keys(proxyDefaults).length > 0;
   const mergedEnv = hasProxyDefaults || userEnv ? { ...proxyDefaults, ...userEnv } : undefined;
 

--- a/src/agents/mcp-stdio.ts
+++ b/src/agents/mcp-stdio.ts
@@ -11,6 +11,43 @@ type StdioMcpServerLaunchResult =
   | { ok: true; config: StdioMcpServerLaunchConfig }
   | { ok: false; reason: string };
 
+/**
+ * Env var keys that should be propagated from the gateway process to MCP stdio
+ * child processes.  The MCP SDK intentionally restricts env inheritance (on
+ * Linux it only forwards HOME, LOGNAME, PATH, SHELL, TERM, USER).  Without
+ * explicit propagation, proxy configuration and NODE_OPTIONS preloads that the
+ * gateway relies on are silently lost in child processes.
+ *
+ * Both upper- and lower-case variants are included because Node/undici honour
+ * both (lower-case takes precedence per convention).
+ */
+const PROXY_ENV_KEYS = [
+  "HTTPS_PROXY",
+  "https_proxy",
+  "HTTP_PROXY",
+  "http_proxy",
+  "NO_PROXY",
+  "no_proxy",
+  "NODE_OPTIONS",
+] as const;
+
+/**
+ * Collect proxy-related env vars from the current process so they can be
+ * forwarded to MCP stdio child processes as lowest-priority defaults.
+ *
+ * @internal — exported for testing only.
+ */
+export function getProxyEnvDefaults(): Record<string, string> {
+  const defaults: Record<string, string> = {};
+  for (const key of PROXY_ENV_KEYS) {
+    const value = process.env[key];
+    if (value !== undefined && value !== "") {
+      defaults[key] = value;
+    }
+  }
+  return defaults;
+}
+
 export function resolveStdioMcpServerLaunchConfig(raw: unknown): StdioMcpServerLaunchResult {
   if (!isMcpConfigRecord(raw)) {
     return { ok: false, reason: "server config must be an object" };
@@ -30,12 +67,20 @@ export function resolveStdioMcpServerLaunchConfig(raw: unknown): StdioMcpServerL
       : typeof raw.workingDirectory === "string" && raw.workingDirectory.trim().length > 0
         ? raw.workingDirectory
         : undefined;
+
+  // Merge proxy/NODE_OPTIONS env vars from the gateway process as
+  // lowest-priority defaults. User-configured env values always win.
+  const proxyDefaults = getProxyEnvDefaults();
+  const userEnv = toMcpStringRecord(raw.env);
+  const hasProxyDefaults = Object.keys(proxyDefaults).length > 0;
+  const mergedEnv = hasProxyDefaults || userEnv ? { ...proxyDefaults, ...userEnv } : undefined;
+
   return {
     ok: true,
     config: {
       command: raw.command,
       args: toMcpStringArray(raw.args),
-      env: toMcpStringRecord(raw.env),
+      env: mergedEnv,
       cwd,
     },
   };

--- a/src/agents/mcp-stdio.ts
+++ b/src/agents/mcp-stdio.ts
@@ -71,7 +71,7 @@ export function getProxyEnvDefaults(): Record<string, string> {
   const defaults: Record<string, string> = {};
   for (const key of PROXY_ENV_KEYS) {
     const value = process.env[key];
-    if (value !== undefined && value !== "") {
+    if (value !== undefined) {
       defaults[key] = value;
     }
   }


### PR DESCRIPTION
## Summary

MCP stdio child processes silently lose proxy configuration (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`) and `NODE_OPTIONS` from the gateway process. This breaks MCP servers in proxy-only environments (sandboxed containers, corporate networks, OpenShell).

**Root cause:** The MCP SDK's `StdioClientTransport` intentionally restricts env inheritance to 6 vars on Linux. `resolveStdioMcpServerLaunchConfig` passes user-configured env straight through without compensating for this restriction.

**Fix:** Merge proxy-related env vars from `process.env` as lowest-priority defaults before passing to `StdioClientTransport`. User-configured env values always take precedence. When no proxy vars are set, behavior is unchanged (`env` remains `undefined`).

### Changes

- **`src/agents/mcp-stdio.ts`**: Added `getProxyEnvDefaults()` to collect proxy env vars from the gateway process. Modified `resolveStdioMcpServerLaunchConfig` to merge these as lowest-priority defaults with user-configured env.
- **`src/agents/mcp-stdio.test.ts`**: 9 tests covering proxy propagation, user override precedence, merge behavior, empty-string filtering, and no-op when no proxy vars are set.

### How it works

```js
// Proxy vars from gateway (lowest priority)
const proxyDefaults = getProxyEnvDefaults();
// User config from openclaw.json (highest priority)
const userEnv = toMcpStringRecord(raw.env);
// Merge: user wins on conflict
const mergedEnv = { ...proxyDefaults, ...userEnv };
```

### Prior art

Same class of fix as #62878 (Slack Socket Mode proxy support), which was merged for the same reason — child processes not honoring ambient proxy configuration.

Fixes #65525
Fixes #65526

## Test plan

- [x] `getProxyEnvDefaults` returns empty object when no proxy vars set
- [x] `getProxyEnvDefaults` collects upper and lower case proxy vars
- [x] `getProxyEnvDefaults` collects `NO_PROXY` and `NODE_OPTIONS`
- [x] `getProxyEnvDefaults` ignores empty string values
- [x] Gateway proxy vars propagated when user env not configured
- [x] User-configured env overrides gateway proxy vars
- [x] Gateway proxy vars merge with user env (user wins on conflict)
- [x] `env` is `undefined` when no proxy vars and no user env (no behavior change)
- [x] All 9 tests pass: `npx vitest run src/agents/mcp-stdio.test.ts --config test/vitest/vitest.agents.config.ts`
- [x] Existing `mcp-transport-config.test.ts` tests still pass
- [x] TypeScript compiles cleanly (`tsc --noEmit` — no errors in `mcp-stdio`)
- [x] `oxlint` reports 0 warnings, 0 errors