### PR TITLE
fix(ui): pause chat announcements during streaming

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -251,6 +251,41 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
 }
 
 describe("chat view", () => {
+  it("keeps the chat thread live region polite when idle", () => {
+    const container = document.createElement("div");
+    render(renderChat(createProps()), container);
+
+    expect(container.querySelector(".chat-thread")?.getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("turns the chat thread live region off while streaming", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          stream: "partial reply",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-thread")?.getAttribute("aria-live")).toBe("off");
+  });
+
+  it("turns the chat thread live region off while sending", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          sending: true,
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-thread")?.getAttribute("aria-live")).toBe("off");
+  });
+
   it("renders BTW side results outside transcript history", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1180,7 +1180,7 @@ export function renderChat(props: ChatProps) {
     <div
       class="chat-thread"
       role="log"
-      aria-live="polite"
+      aria-live=${isBusy ? "off" : "polite"}
       @scroll=${props.onChatScroll}
       @click=${handleCodeBlockCopy}
     >


### PR DESCRIPTION
## Summary

- Problem: `ui/src/ui/views/chat.ts` hardcoded `aria-live="polite"` on the chat thread, so screen readers could announce every streaming DOM mutation.
- Why it matters: streamed replies became noisy and difficult to follow for screen-reader users.
- What changed: the chat thread now sets `aria-live="off"` while `sending` or `stream !== null`, then returns to `"polite"` when idle; added focused coverage in `ui/src/ui/views/chat.test.ts`.
- What did NOT change (scope boundary): no visual/layout changes, no message-content changes, and no other live regions were modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65538
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the chat transcript container used a hardcoded `aria-live="polite"` even while streaming incremental assistant updates.
- Missing detection / guardrail: no focused view test asserted the live-region behavior for idle vs. streaming/sending states.
- Contributing context (if known): the transcript is a `role="log"` region and receives frequent DOM updates while replies stream.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/views/chat.test.ts`
- Scenario the test should lock in: `.chat-thread` uses `aria-live="off"` while streaming or sending and `aria-live="polite"` when idle.
- Why this is the smallest reliable guardrail: it exercises the rendered DOM attribute directly without requiring a full gateway/session run.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Screen readers are no longer asked to announce every streamed token in Control UI chat. There are no visual changes.

## Diagram (if applicable)

```text
Before:
[user sends message] -> [chat-thread aria-live="polite" during stream] -> [screen reader announces partial updates]

After:
[user sends message] -> [chat-thread aria-live="off" while busy] -> [final reply rendered] -> [chat-thread aria-live="polite"]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: local `pnpm` / Vitest / build
- Model/provider: N/A
- Integration/channel (if any): Control UI chat
- Relevant config (redacted): default local UI render path

### Steps

1. Open Control UI chat with a screen reader enabled.
2. Send a message that produces a streamed assistant reply.
3. Observe the transcript live region while the reply is in progress, then after the final reply is rendered.

### Expected

- Intermediate streamed updates are not announced token-by-token.
- The completed reply remains in the transcript once the run finishes.

### Actual

- Local verification shows `.chat-thread` is `aria-live="off"` while streaming/sending and returns to `"polite"` once the final reply is present in the DOM.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test ui/src/ui/views/chat.test.ts` (`72/72`), `pnpm test ui/src/ui/views/chat.browser.test.ts` (`2/2`), `pnpm build`, and an extra local DOM rerender check confirming `{"streamingLive":"off","finalLive":"polite","hasFinal":true}`.
- Edge cases checked: idle state, sending without stream, active streaming, and the transition back to idle after a final assistant message render.
- What you did **not** verify: live VoiceOver/NVDA behavior has not been tested yet.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: if the busy state were ever to get stuck, transcript announcements could stay muted longer than intended.
  - Mitigation: the change is tied to the existing `isBusy` logic already used by the chat UI, and focused tests cover idle, sending, and streaming states.
- Risk: assistive-tech/browser combinations may still differ in how they announce the final settled message.
  - Mitigation: the final message is rendered before `chatStream` is cleared, automated DOM verification is green, and live screen-reader verification is still called out as pending.
