### PR TITLE
fix(qqbot): resume after 4009 session timeout

### DIFF
--- a/extensions/qqbot/src/gateway-close-session-recovery.test.ts
+++ b/extensions/qqbot/src/gateway-close-session-recovery.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { resolveQQBotGatewaySessionRecovery } from "./gateway-close-session-recovery.js";
+
+describe("resolveQQBotGatewaySessionRecovery", () => {
+  it("forces re-identify when the gateway reports the session is no longer valid", () => {
+    expect(resolveQQBotGatewaySessionRecovery(4006)).toEqual({
+      clearSession: true,
+      description: "session no longer valid",
+      reconnectMode: "identify",
+      shouldRefreshToken: true,
+    });
+  });
+
+  it("forces re-identify when the resume sequence is invalid", () => {
+    expect(resolveQQBotGatewaySessionRecovery(4007)).toEqual({
+      clearSession: true,
+      description: "invalid seq on resume",
+      reconnectMode: "identify",
+      shouldRefreshToken: true,
+    });
+  });
+
+  it("keeps the saved session for 4009 so the reconnect path can resume", () => {
+    expect(resolveQQBotGatewaySessionRecovery(4009)).toEqual({
+      clearSession: false,
+      description: "session timed out",
+      reconnectMode: "resume",
+      shouldRefreshToken: true,
+    });
+  });
+
+  it("ignores unrelated close codes", () => {
+    expect(resolveQQBotGatewaySessionRecovery(4004)).toBeNull();
+    expect(resolveQQBotGatewaySessionRecovery(4900)).toBeNull();
+  });
+});

--- a/extensions/qqbot/src/gateway-close-session-recovery.ts
+++ b/extensions/qqbot/src/gateway-close-session-recovery.ts
@@ -1,0 +1,36 @@
+export type QQBotGatewaySessionRecovery = {
+  clearSession: boolean;
+  description: string;
+  reconnectMode: "identify" | "resume";
+  shouldRefreshToken: boolean;
+};
+
+export function resolveQQBotGatewaySessionRecovery(
+  code: number,
+): QQBotGatewaySessionRecovery | null {
+  switch (code) {
+    case 4006:
+      return {
+        clearSession: true,
+        description: "session no longer valid",
+        reconnectMode: "identify",
+        shouldRefreshToken: true,
+      };
+    case 4007:
+      return {
+        clearSession: true,
+        description: "invalid seq on resume",
+        reconnectMode: "identify",
+        shouldRefreshToken: true,
+      };
+    case 4009:
+      return {
+        clearSession: false,
+        description: "session timed out",
+        reconnectMode: "resume",
+        shouldRefreshToken: true,
+      };
+    default:
+      return null;
+  }
+}

--- a/extensions/qqbot/src/gateway.ts
+++ b/extensions/qqbot/src/gateway.ts
@@ -18,6 +18,7 @@ import {
   stopBackgroundTokenRefresh,
 } from "./api.js";
 import { formatQQBotAllowFrom } from "./channel-config-shared.js";
+import { resolveQQBotGatewaySessionRecovery } from "./gateway-close-session-recovery.js";
 import { formatVoiceText, processAttachments } from "./inbound-attachments.js";
 import { flushKnownUsers, recordKnownUser } from "./known-users.js";
 import { createMessageQueue, type QueuedMessage } from "./message-queue.js";
@@ -1449,19 +1450,17 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
           return;
         }
 
-        if (code === 4006 || code === 4007 || code === 4009) {
-          const codeDesc: Record<number, string> = {
-            4006: "session no longer valid",
-            4007: "invalid seq on resume",
-            4009: "session timed out",
-          };
+        const sessionRecovery = resolveQQBotGatewaySessionRecovery(code);
+        if (sessionRecovery) {
           log?.info(
-            `[qqbot:${account.accountId}] Error ${code} (${codeDesc[code]}), will re-identify`,
+            `[qqbot:${account.accountId}] Error ${code} (${sessionRecovery.description}), will ${sessionRecovery.reconnectMode === "identify" ? "re-identify" : "resume"}`,
           );
-          sessionId = null;
-          lastSeq = null;
-          clearSession(account.accountId);
-          shouldRefreshToken = true;
+          if (sessionRecovery.clearSession) {
+            sessionId = null;
+            lastSeq = null;
+            clearSession(account.accountId);
+          }
+          shouldRefreshToken = sessionRecovery.shouldRefreshToken;
         } else if (code >= 4900 && code <= 4913) {
           log?.info(`[qqbot:${account.accountId}] Internal error (${code}), will re-identify`);
           sessionId = null;


### PR DESCRIPTION
## Summary

- Problem: QQBot close code `4009` was treated like `4006/4007`, which cleared the saved session and forced a full re-identify.
- Why it matters: `4009` is a session-timeout reconnect case, so clearing `sessionId` and `lastSeq` makes reconnects heavier and can widen the message-loss window.
- What changed: extracted QQBot close-code recovery into a tiny policy helper and changed `4009` to preserve the saved session so the next reconnect attempts resume.
- What did NOT change (scope boundary): no changes to token refresh strategy, heartbeat timing, or invalid-session handling outside the close-code policy.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65579
- Related #55631
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: QQBot close handling grouped `4009` with `4006` and `4007`, so a resumable timeout path cleared `sessionId` and `lastSeq` before reconnect.
- Missing detection / guardrail: there was no focused regression test for QQBot gateway close-code recovery behavior.
- Contributing context (if known): the reconnect path already supported resume on hello when `sessionId` and `lastSeq` are present, so the bug was isolated to the close-code branch.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/qqbot/src/gateway-close-session-recovery.test.ts`
  - `extensions/qqbot/`
- Scenario the test should lock in: `4006/4007` still force re-identify, while `4009` preserves the saved session and reconnects on the resume path.
- Why this is the smallest reliable guardrail: the behavior change is a small close-code policy decision, and the full QQBot extension suite catches accidental regressions around the surrounding gateway/runtime flow.
- Existing test that already covers this (if any): none specific to the close-code policy before this change.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

QQBot sessions that close with `4009 (session timed out)` now reconnect using the saved session instead of always falling back to a full re-identify.

## Diagram

```text
Before:
[close 4009] -> [clear sessionId + lastSeq] -> [re-identify]

After:
[close 4009] -> [keep sessionId + lastSeq] -> [resume]
```

## Security Impact

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): QQBot
- Relevant config (redacted): QQBot gateway reconnect path

### Steps

1. Trigger QQBot gateway close-code recovery evaluation for `4006`, `4007`, and `4009`.
2. Confirm the helper preserves session state only for `4009`.
3. Run the QQBot extension suite plus repo gates.

### Expected

- `4009` resolves to a resume path without clearing saved session state.
- `4006/4007` still force a clean re-identify.
- QQBot tests and repo gates remain green.

### Actual

- Matches expected.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run locally on the clean branch:

- `pnpm test extensions/qqbot/src/gateway-close-session-recovery.test.ts`
- `pnpm test extensions/qqbot/`
- `pnpm check`
- `pnpm build`

## Human Verification

- Verified scenarios:
  - `4006` and `4007` still force re-identify.
  - `4009` preserves the saved session and reconnect mode resolves to resume.
  - Full QQBot extension suite remains green.
- Edge cases checked:
  - unrelated close codes still fall through untouched
  - repo-wide type/lint/build gates remain green after the QQBot change
- What you did **not** verify:
  - live QQBot WebSocket behavior against the real QQ platform

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No

## Risks and Mitigations

- Risk: if the QQ platform changes `4009` semantics, resume could fail and require a later re-identify.
  - Mitigation: the existing invalid-session paths for `4006/4007` still clear the session and recover with re-identify.
