### PR TITLE
fix: redact secrets in /config show replies

### DIFF
--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -11,12 +11,14 @@ import {
   validateConfigObjectWithPlugins,
   writeConfigFile,
 } from "../../config/config.js";
+import { redactConfigObject } from "../../config/redact-snapshot.js";
 import {
   getConfigOverrides,
   resetConfigOverrides,
   setConfigOverride,
   unsetConfigOverride,
 } from "../../config/runtime-overrides.js";
+import { readBestEffortRuntimeConfigSchema } from "../../config/runtime-schema.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { resolveChannelAccountId } from "./channel-context.js";
@@ -116,6 +118,8 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
   const parsedBase = structuredClone(snapshot.parsed as Record<string, unknown>);
 
   if (configCommand.action === "show") {
+    const schema = await readBestEffortRuntimeConfigSchema();
+    const redactedBase = redactConfigObject(parsedBase, schema.uiHints);
     const pathRaw = normalizeOptionalString(configCommand.path);
     if (pathRaw) {
       const parsedPath = parseConfigPath(pathRaw);
@@ -125,7 +129,7 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
           reply: { text: `⚠️ ${parsedPath.error ?? "Invalid path."}` },
         };
       }
-      const value = getConfigValueAtPath(parsedBase, parsedPath.path);
+      const value = getConfigValueAtPath(redactedBase, parsedPath.path);
       const rendered = JSON.stringify(value ?? null, null, 2);
       return {
         shouldContinue: false,
@@ -134,7 +138,7 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
         },
       };
     }
-    const json = JSON.stringify(parsedBase, null, 2);
+    const json = JSON.stringify(redactedBase, null, 2);
     return {
       shouldContinue: false,
       reply: { text: `⚙️ Config (raw):\n\`\`\`json\n${json}\n\`\`\`` },

--- a/src/auto-reply/reply/commands-gating.test.ts
+++ b/src/auto-reply/reply/commands-gating.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { isCommandFlagEnabled } from "../../config/commands.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { REDACTED_SENTINEL } from "../../config/redact-snapshot.js";
 import type { MsgContext } from "../templating.js";
 import { handleBashChatCommand } from "./bash-command.js";
 import { handleConfigCommand, handleDebugCommand } from "./commands-config.js";
@@ -22,6 +23,9 @@ const getConfigOverridesMock = vi.hoisted(() => vi.fn(() => ({})));
 const getConfigValueAtPathMock = vi.hoisted(() => vi.fn());
 const parseConfigPathMock = vi.hoisted(() => vi.fn());
 const setConfigValueAtPathMock = vi.hoisted(() => vi.fn());
+const readBestEffortRuntimeConfigSchemaMock = vi.hoisted(() =>
+  vi.fn(async () => ({ uiHints: {} })),
+);
 const resolveConfigWriteDeniedTextMock = vi.hoisted(() =>
   vi.fn<(...args: never[]) => string | null>(() => null),
 );
@@ -80,6 +84,10 @@ vi.mock("../../config/config.js", () => ({
   readConfigFileSnapshot: readConfigFileSnapshotMock,
   validateConfigObjectWithPlugins: validateConfigObjectWithPluginsMock,
   writeConfigFile: writeConfigFileMock,
+}));
+
+vi.mock("../../config/runtime-schema.js", () => ({
+  readBestEffortRuntimeConfigSchema: readBestEffortRuntimeConfigSchemaMock,
 }));
 
 vi.mock("../../config/runtime-overrides.js", () => ({
@@ -218,6 +226,7 @@ describe("command gating", () => {
         }
       },
     );
+    readBestEffortRuntimeConfigSchemaMock.mockResolvedValue({ uiHints: {} });
   });
 
   it("blocks disabled bash", async () => {
@@ -311,6 +320,59 @@ describe("command gating", () => {
     debugParams.command.senderIsOwner = true;
     const debugResult = await handleDebugCommand(debugParams, true);
     expect(debugResult?.reply?.text).toContain("Debug overrides");
+  });
+
+  it("redacts secrets in full /config show output", async () => {
+    readBestEffortRuntimeConfigSchemaMock.mockResolvedValueOnce({
+      uiHints: {
+        "gateway.auth.token": { input: "SecretInput" },
+        "gateway.auth.password": { input: "SecretInput" },
+        "channels.telegram.botToken": { input: "SecretInput" },
+      },
+    });
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: {
+        gateway: { auth: { token: "secret-token", password: "secret-password" } },
+        channels: { telegram: { botToken: "telegram-secret" } },
+      },
+    });
+    const params = buildParams("/config show", {
+      commands: { config: true, text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.command.senderIsOwner = true;
+
+    const result = await handleConfigCommand(params, true);
+
+    expect(result?.reply?.text).toContain(REDACTED_SENTINEL);
+    expect(result?.reply?.text).not.toContain("secret-token");
+    expect(result?.reply?.text).not.toContain("secret-password");
+    expect(result?.reply?.text).not.toContain("telegram-secret");
+  });
+
+  it("redacts secrets in path-specific /config show output", async () => {
+    readBestEffortRuntimeConfigSchemaMock.mockResolvedValueOnce({
+      uiHints: {
+        "gateway.auth.token": { input: "SecretInput" },
+      },
+    });
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: {
+        gateway: { auth: { token: "secret-token" } },
+      },
+    });
+    const params = buildParams("/config show gateway.auth.token", {
+      commands: { config: true, text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.command.senderIsOwner = true;
+
+    const result = await handleConfigCommand(params, true);
+
+    expect(result?.reply?.text).toContain(REDACTED_SENTINEL);
+    expect(result?.reply?.text).not.toContain("secret-token");
   });
 
   it("returns explicit unauthorized replies for native privileged commands", async () => {


### PR DESCRIPTION
## Fix Summary
`/config show` exposed the raw parsed config object directly in chat replies, so owner-triggered config inspection could leak gateway tokens, provider API keys, and channel secrets into message history. This patch routes both full-config and path-specific `/config show` responses through the existing schema-aware config redaction pipeline before rendering the JSON reply.

## Issue Linkage
Fixes #65623

## Security Snapshot
- CVSS v3.1: 7.7 (High)
- CVSS v4.0: 8.3 (High)

## Implementation Details
### Files Changed
- `src/auto-reply/reply/commands-config.ts` (+6/-2)
- `src/auto-reply/reply/commands-gating.test.ts` (+62/-0)

### Technical Analysis
The vulnerable `/config show` path in `handleConfigCommand` cloned `snapshot.parsed` and serialized it directly into the chat response. The fix now loads runtime schema UI hints and applies `redactConfigObject(...)` before either subtree lookup or full-object rendering, so the chat-command path matches the existing redaction guarantees already used by `config.get`.

## Validation Evidence
- Command: `pnpm test src/auto-reply/reply/commands-gating.test.ts`
- Status: passed

## Risk and Compatibility
- non-breaking; reply format is unchanged apart from replacing sensitive values with the standard redaction sentinel

## AI-Assisted Disclosure
- AI-assisted: yes
- Model: github-copilot/gpt-5.4
