### PR TITLE
Improve local gateway RPC diagnostics

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -30,6 +30,7 @@ let lastClientOptions: {
   clientDisplayName?: string;
   scopes?: string[];
   deviceIdentity?: unknown;
+  onConnectError?: (err: Error) => void;
   onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
   onClose?: (code: number, reason: string) => void;
 } | null = null;
@@ -42,6 +43,7 @@ type StartMode = "hello" | "close" | "silent";
 let startMode: StartMode = "hello";
 let closeCode = 1006;
 let closeReason = "";
+let connectErrorBeforeClose: Error | null = null;
 let helloMethods: string[] | undefined = ["health", "secrets.resolve"];
 
 vi.mock("./client.js", () => ({
@@ -61,6 +63,7 @@ vi.mock("./client.js", () => ({
       password?: string;
       clientDisplayName?: string;
       scopes?: string[];
+      onConnectError?: (err: Error) => void;
       onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
       onClose?: (code: number, reason: string) => void;
     }) {
@@ -82,6 +85,9 @@ vi.mock("./client.js", () => ({
           },
         });
       } else if (startMode === "close") {
+        if (connectErrorBeforeClose) {
+          lastClientOptions?.onConnectError?.(connectErrorBeforeClose);
+        }
         lastClientOptions?.onClose?.(closeCode, closeReason);
       }
     }
@@ -99,6 +105,7 @@ class StubGatewayClient {
     password?: string;
     clientDisplayName?: string;
     scopes?: string[];
+    onConnectError?: (err: Error) => void;
     onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
     onClose?: (code: number, reason: string) => void;
   }) {
@@ -120,6 +127,9 @@ class StubGatewayClient {
         },
       });
     } else if (startMode === "close") {
+      if (connectErrorBeforeClose) {
+        lastClientOptions?.onConnectError?.(connectErrorBeforeClose);
+      }
       lastClientOptions?.onClose?.(closeCode, closeReason);
     }
   }
@@ -136,6 +146,7 @@ function resetGatewayCallMocks() {
   startMode = "hello";
   closeCode = 1006;
   closeReason = "";
+  connectErrorBeforeClose = null;
   helloMethods = ["health", "secrets.resolve"];
   const loadConfigForTests = loadConfig as unknown as () => OpenClawConfig;
   const resolveGatewayPortForTests = resolveGatewayPort as unknown as (
@@ -741,6 +752,24 @@ describe("callGateway error details", () => {
     expect(err?.message).toContain("Bind: loopback");
   });
 
+  it("includes the underlying connect error when the gateway closes before handshake completes", async () => {
+    startMode = "close";
+    closeCode = 1006;
+    closeReason = "";
+    connectErrorBeforeClose = new Error("connect EPERM 127.0.0.1:18789 - Local");
+    setLocalLoopbackGatewayConfig();
+
+    let err: Error | null = null;
+    try {
+      await callGateway({ method: "health" });
+    } catch (caught) {
+      err = caught as Error;
+    }
+
+    expect(err?.message).toContain("gateway connect failed: connect EPERM 127.0.0.1:18789 - Local");
+    expect(err?.message).toContain("gateway closed (1006");
+  });
+
   it("includes connection details on timeout", async () => {
     startMode = "silent";
     setLocalLoopbackGatewayConfig();
@@ -786,6 +815,26 @@ describe("callGateway error details", () => {
 
     expect(lastRequestOptions?.method).toBe("health");
     expect(lastRequestOptions?.opts?.timeoutMs).toBe(45_000);
+  });
+
+  it("omits device identity for unauthenticated local loopback calls", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.deviceIdentity).toBeNull();
+  });
+
+  it("keeps device identity for authenticated local loopback calls", async () => {
+    loadConfig.mockReturnValue({
+      gateway: { mode: "local", bind: "loopback", auth: { mode: "token", token: "local-token" } },
+    });
+    setGatewayNetworkDefaults(18789);
+
+    await callGateway({ method: "health" });
+
+    expect(lastClientOptions?.token).toBe("local-token");
+    expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
   });
 
   it("does not inject wrapper timeout defaults into expectFinal requests", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -36,6 +36,7 @@ import {
   resolveLeastPrivilegeOperatorScopesForMethod,
   type OperatorScope,
 } from "./method-scopes.js";
+import { isLoopbackHost } from "./net.js";
 import { PROTOCOL_VERSION } from "./protocol/index.js";
 export type { GatewayConnectionDetails };
 
@@ -184,12 +185,27 @@ export const __testing = {
   },
 };
 
-function resolveDeviceIdentityForGatewayCall(): ReturnType<
-  typeof loadOrCreateDeviceIdentity
-> | null {
-  // Shared-auth local calls should still stay device-bound so operator scopes
-  // remain available for detail RPCs such as status / system-presence /
-  // last-heartbeat.
+function shouldOmitDeviceIdentityForGatewayCall(params: {
+  url: string;
+  token?: string;
+  password?: string;
+}): boolean {
+  try {
+    const hostname = new URL(params.url).hostname;
+    return isLoopbackHost(hostname) && !(params.token || params.password);
+  } catch {
+    return false;
+  }
+}
+
+function resolveDeviceIdentityForGatewayCall(params: {
+  url: string;
+  token?: string;
+  password?: string;
+}): ReturnType<typeof loadOrCreateDeviceIdentity> | null {
+  if (shouldOmitDeviceIdentityForGatewayCall(params)) {
+    return null;
+  }
   try {
     return gatewayCallDeps.loadOrCreateDeviceIdentity();
   } catch {
@@ -400,12 +416,18 @@ function formatGatewayCloseError(
   code: number,
   reason: string,
   connectionDetails: GatewayConnectionDetails,
+  connectError?: Error | null,
 ): string {
   const reasonText = normalizeOptionalString(reason) || "no close reason";
   const hint =
     code === 1006 ? "abnormal closure (no close frame)" : code === 1000 ? "normal closure" : "";
   const suffix = hint ? ` ${hint}` : "";
-  return `gateway closed (${code}${suffix}): ${reasonText}\n${connectionDetails.message}`;
+  const parts = [
+    connectError ? `gateway connect failed: ${connectError.message}` : undefined,
+    `gateway closed (${code}${suffix}): ${reasonText}`,
+    connectionDetails.message,
+  ].filter(Boolean);
+  return parts.join("\n");
 }
 
 function formatGatewayTimeoutError(
@@ -465,6 +487,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
   return await new Promise<T>((resolve, reject) => {
     let settled = false;
     let ignoreClose = false;
+    let connectError: Error | null = null;
     const stop = (err?: Error, value?: T) => {
       if (settled) {
         return;
@@ -491,9 +514,16 @@ async function executeGatewayRequestWithScopes<T>(params: {
       mode: opts.mode ?? GATEWAY_CLIENT_MODES.CLI,
       role: "operator",
       scopes,
-      deviceIdentity: resolveDeviceIdentityForGatewayCall(),
+      deviceIdentity: resolveDeviceIdentityForGatewayCall({
+        url,
+        token,
+        password,
+      }),
       minProtocol: opts.minProtocol ?? PROTOCOL_VERSION,
       maxProtocol: opts.maxProtocol ?? PROTOCOL_VERSION,
+      onConnectError: (err) => {
+        connectError = err;
+      },
       onHelloOk: async (hello) => {
         try {
           ensureGatewaySupportsRequiredMethods({
@@ -520,7 +550,9 @@ async function executeGatewayRequestWithScopes<T>(params: {
         }
         ignoreClose = true;
         client.stop();
-        stop(new Error(formatGatewayCloseError(code, reason, params.connectionDetails)));
+        stop(
+          new Error(formatGatewayCloseError(code, reason, params.connectionDetails, connectError)),
+        );
       },
     });
 

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import { generateKeyPairSync } from "node:crypto";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv } from "../test-utils/env.js";
@@ -6,6 +7,7 @@ import { captureEnv } from "../test-utils/env.js";
 const wsInstances = vi.hoisted((): MockWebSocket[] => []);
 const clearDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const loadDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
+const loadOrCreateDeviceIdentityMock = vi.hoisted(() => vi.fn());
 const storeDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const logDebugMock = vi.hoisted(() => vi.fn());
 const logErrorMock = vi.hoisted(() => vi.fn());
@@ -113,6 +115,16 @@ vi.mock("../infra/device-auth-store.js", async () => {
   };
 });
 
+vi.mock("../infra/device-identity.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/device-identity.js")>(
+    "../infra/device-identity.js",
+  );
+  return {
+    ...actual,
+    loadOrCreateDeviceIdentity: (...args: unknown[]) => loadOrCreateDeviceIdentityMock(...args),
+  };
+});
+
 vi.mock("../logger.js", async () => {
   const actual = await vi.importActual<typeof import("../logger.js")>("../logger.js");
   return {
@@ -174,6 +186,16 @@ function expectSecurityConnectError(
 
 beforeAll(async () => {
   await loadGatewayClientModule();
+});
+
+beforeEach(() => {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  loadOrCreateDeviceIdentityMock.mockReset();
+  loadOrCreateDeviceIdentityMock.mockReturnValue({
+    deviceId: "mock-device",
+    privateKeyPem: privateKey.export({ type: "pkcs8", format: "pem" }),
+    publicKeyPem: publicKey.export({ type: "spki", format: "pem" }),
+  } satisfies DeviceIdentity);
 });
 
 describe("GatewayClient security checks", () => {
@@ -275,6 +297,37 @@ describe("GatewayClient security checks", () => {
     expect(onConnectError).not.toHaveBeenCalled();
     expect(wsInstances.length).toBe(1);
     client.stop();
+  });
+});
+
+describe("GatewayClient device identity handling", () => {
+  it("preserves explicit null device identity", () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      deviceIdentity: null,
+    });
+
+    expect(loadOrCreateDeviceIdentityMock).not.toHaveBeenCalled();
+    expect(
+      (client as unknown as { opts: { deviceIdentity: DeviceIdentity | null } }).opts
+        .deviceIdentity,
+    ).toBeNull();
+  });
+
+  it("loads device identity when omitted", () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+    });
+
+    expect(loadOrCreateDeviceIdentityMock).toHaveBeenCalledTimes(1);
+    expect(
+      (client as unknown as { opts: { deviceIdentity: DeviceIdentity | null } }).opts
+        .deviceIdentity,
+    ).toEqual(
+      expect.objectContaining({
+        deviceId: "mock-device",
+      }),
+    );
   });
 });
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -197,9 +197,7 @@ export class GatewayClient {
     this.opts = {
       ...opts,
       deviceIdentity:
-        opts.deviceIdentity === null
-          ? undefined
-          : (opts.deviceIdentity ?? loadOrCreateDeviceIdentity()),
+        opts.deviceIdentity === null ? null : (opts.deviceIdentity ?? loadOrCreateDeviceIdentity()),
     };
     this.requestTimeoutMs =
       typeof opts.requestTimeoutMs === "number" && Number.isFinite(opts.requestTimeoutMs)

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -441,6 +441,6 @@ describe("GatewayChatClient", () => {
     expect(
       (client as unknown as { client: { opts: { deviceIdentity?: unknown } } }).client.opts
         .deviceIdentity,
-    ).toBeUndefined();
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
# Respect explicit null deviceIdentity and improve local gateway RPC error reporting

## Summary

This PR improves gateway RPC behavior in two ways:

1. It makes `GatewayClient` honor an explicit `deviceIdentity: null` instead of replacing it with an auto-loaded device identity.
2. It improves RPC failure reporting so early connection failures are not surfaced only as a generic `1006` close.

Fixes #65621.

## Motivation

Local RPC commands could fail with:

```text
gateway closed (1006 abnormal closure (no close frame)): no close reason
```

even when the real cause happened earlier in the connection flow.

This made it unnecessarily hard to distinguish:
- low-level socket/connect failures
- auth failures
- handshake timeouts
- device-auth / pairing-related behavior

Additionally, callers currently cannot reliably suppress device identity because explicit `null` is treated like an absent value.

## Changes

- preserve explicit `deviceIdentity: null` in `GatewayClient`
- avoid auto-loading device identity when the caller explicitly requested omission
- propagate early connect errors more clearly through the RPC failure path
- improve test coverage for local loopback RPC behavior

## Files of interest

- `dist/client-mAkhLNco.js`
- `dist/call-BzHcsP5K.js`

## Test coverage to add

- explicit `deviceIdentity: null` is preserved
- loopback RPC path with configured auth succeeds
- pre-handshake connect failures surface a meaningful error
- probe and normal RPC paths remain consistent and diagnosable
