### PR TITLE
OpenResponses: emit internal tool call events in SSE stream

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -882,6 +882,7 @@ export async function handleToolExecutionEnd(
       meta,
       isError: isToolError,
       result: sanitizedResult,
+      rawResult: result,
     },
   });
   const endedAt = Date.now();

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -11,6 +11,7 @@ import {
   emitAgentEvent,
   emitAgentItemEvent,
   emitAgentPatchSummaryEvent,
+  withAgentEventToolRawResult,
 } from "../infra/agent-events.js";
 import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
@@ -872,19 +873,23 @@ export async function handleToolExecutionEnd(
     ctx.state.successfulCronAdds += 1;
   }
 
-  emitAgentEvent({
-    runId: ctx.params.runId,
-    stream: "tool",
-    data: {
-      phase: "result",
-      name: toolName,
-      toolCallId,
-      meta,
-      isError: isToolError,
-      result: sanitizedResult,
-      rawResult: result,
-    },
-  });
+  emitAgentEvent(
+    withAgentEventToolRawResult(
+      {
+        runId: ctx.params.runId,
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: toolName,
+          toolCallId,
+          meta,
+          isError: isToolError,
+          result: sanitizedResult,
+        },
+      },
+      result,
+    ),
+  );
   const endedAt = Date.now();
   const itemId = buildToolItemId(toolCallId);
   const itemData: AgentItemEventData = {

--- a/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -86,6 +86,7 @@ async function loadFreshAfterToolCallModulesForTest() {
     emitAgentCommandOutputEvent: vi.fn(),
     emitAgentEvent: vi.fn(),
     emitAgentItemEvent: vi.fn(),
+    withAgentEventToolRawResult: (event: unknown) => event,
   }));
   vi.doMock("./pi-tools.before-tool-call.js", () => ({
     consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -256,6 +256,15 @@ export const OutputItemSchema = z.discriminatedUnion("type", [
     .strict(),
   z
     .object({
+      type: z.literal("function_call_output"),
+      id: z.string(),
+      call_id: z.string(),
+      output: z.string(),
+      status: z.enum(["completed", "failed"]).optional(),
+    })
+    .strict(),
+  z
+    .object({
       type: z.literal("reasoning"),
       id: z.string(),
       content: z.string().optional(),

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
-import { emitAgentEvent } from "../infra/agent-events.js";
+import { emitAgentEvent, withAgentEventToolRawResult } from "../infra/agent-events.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
   agentCommand,
@@ -645,6 +645,51 @@ describe("OpenResponses HTTP API (e2e)", () => {
         "invalid_request_error",
       );
       await ensureResponseConsumed(resNoUser);
+
+      mockAgentOnce([{ text: "ok" }]);
+      const resTypedExtraFields = await postResponses(port, {
+        model: "openclaw",
+        input: [
+          {
+            type: "message",
+            id: "item_abc",
+            role: "user",
+            phase: "commentary",
+            content: "typed item with AI SDK extras",
+          },
+        ],
+      });
+      expect(resTypedExtraFields.status).toBe(200);
+      await ensureResponseConsumed(resTypedExtraFields);
+
+      mockAgentOnce([{ text: "ok" }]);
+      const resFunctionCallExtraFields = await postResponses(port, {
+        model: "openclaw",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: "continue from tool output",
+          },
+          {
+            type: "function_call",
+            id: "fc_1",
+            call_id: "call_1",
+            name: "email_search",
+            arguments: "{}",
+            status: "completed",
+          },
+          {
+            type: "function_call_output",
+            id: "fco_1",
+            call_id: "call_1",
+            output: "[]",
+            status: "completed",
+          },
+        ],
+      });
+      expect(resFunctionCallExtraFields.status).toBe(200);
+      await ensureResponseConsumed(resFunctionCallExtraFields);
     } finally {
       // shared server
     }
@@ -737,6 +782,109 @@ describe("OpenResponses HTTP API (e2e)", () => {
         const parsed = JSON.parse(event.data) as { type?: string };
         expect(event.event).toBe(parsed.type);
       }
+
+      agentCommand.mockClear();
+      agentCommand.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId ?? "";
+        const rawToolResult: Record<string, unknown> = {
+          hits: [{ subject: "Quarterly planning" }],
+          count: 1n,
+        };
+        rawToolResult.self = rawToolResult;
+        const toolArgs: Record<string, unknown> = {
+          query: "quarterly planning",
+          count: 1n,
+        };
+        toolArgs.self = toolArgs;
+        emitAgentEvent({
+          runId,
+          stream: "tool",
+          data: {
+            phase: "start",
+            name: "email_search",
+            toolCallId: "tool_call_1",
+            args: toolArgs,
+          },
+        });
+        emitAgentEvent(
+          withAgentEventToolRawResult(
+            {
+              runId,
+              stream: "tool",
+              data: {
+                phase: "result",
+                name: "email_search",
+                toolCallId: "tool_call_1",
+                result: "[sanitized]",
+              },
+            },
+            rawToolResult,
+          ),
+        );
+        return { payloads: [{ text: "Found one email." }] };
+      }) as never);
+
+      const resToolEvents = await postResponses(port, {
+        stream: true,
+        model: "openclaw",
+        input: "search email",
+      });
+      expect(resToolEvents.status).toBe(200);
+      const toolEvents = parseSseEvents(await resToolEvents.text());
+      const parsedToolEvents = toolEvents
+        .filter((event) => event.data !== "[DONE]")
+        .map((event) => JSON.parse(event.data) as Record<string, unknown>);
+      const itemEvents = parsedToolEvents.filter(
+        (event) =>
+          event.type === "response.output_item.added" || event.type === "response.output_item.done",
+      );
+      const functionCallAdded = itemEvents.find(
+        (event) =>
+          event.type === "response.output_item.added" &&
+          (event.item as Record<string, unknown> | undefined)?.type === "function_call",
+      );
+      const functionCallDone = itemEvents.find(
+        (event) =>
+          event.type === "response.output_item.done" &&
+          (event.item as Record<string, unknown> | undefined)?.type === "function_call",
+      );
+      const functionCallOutputAdded = itemEvents.find(
+        (event) =>
+          event.type === "response.output_item.added" &&
+          (event.item as Record<string, unknown> | undefined)?.type === "function_call_output",
+      );
+      const functionCallOutputDone = itemEvents.find(
+        (event) =>
+          event.type === "response.output_item.done" &&
+          (event.item as Record<string, unknown> | undefined)?.type === "function_call_output",
+      );
+
+      expect(functionCallAdded?.output_index).toBe(1);
+      expect(functionCallDone?.output_index).toBe(functionCallAdded?.output_index);
+      expect((functionCallDone?.item as Record<string, unknown> | undefined)?.arguments).toBe(
+        JSON.stringify({
+          query: "quarterly planning",
+          count: "1",
+          self: "[Circular]",
+        }),
+      );
+      expect(functionCallOutputAdded?.output_index).toBe(2);
+      expect(functionCallOutputDone?.output_index).toBe(functionCallOutputAdded?.output_index);
+      expect((functionCallOutputDone?.item as Record<string, unknown> | undefined)?.output).toBe(
+        JSON.stringify({
+          hits: [{ subject: "Quarterly planning" }],
+          count: "1",
+          self: "[Circular]",
+        }),
+      );
+      const completed = parsedToolEvents.find((event) => event.type === "response.completed") as
+        | { response?: { output?: Array<Record<string, unknown>> } }
+        | undefined;
+      expect(completed?.response?.output?.map((item) => item.type)).toEqual([
+        "message",
+        "function_call",
+        "function_call_output",
+      ]);
     } finally {
       // shared server
     }
@@ -872,19 +1020,42 @@ describe("OpenResponses HTTP API (e2e)", () => {
   it("falls back to payload text for streamed function_call responses", async () => {
     const port = enabledPort;
     agentCommand.mockClear();
-    agentCommand.mockResolvedValueOnce({
-      payloads: [{ text: "Let me check that." }],
-      meta: {
-        stopReason: "tool_calls",
-        pendingToolCalls: [
-          {
-            id: "call_1",
-            name: "get_weather",
-            arguments: '{"city":"Taipei"}',
-          },
-        ],
-      },
-    } as never);
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string }).runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: {
+          phase: "start",
+          name: "email_search",
+          toolCallId: "tool_call_1",
+          args: { query: "weather" },
+        },
+      });
+      emitAgentEvent({
+        runId,
+        stream: "tool",
+        data: {
+          phase: "result",
+          name: "email_search",
+          toolCallId: "tool_call_1",
+          result: "No matching email.",
+        },
+      });
+      return {
+        payloads: [{ text: "Let me check that." }],
+        meta: {
+          stopReason: "tool_calls",
+          pendingToolCalls: [
+            {
+              id: "call_1",
+              name: "get_weather",
+              arguments: '{"city":"Taipei"}',
+            },
+          ],
+        },
+      };
+    }) as never);
 
     const res = await postResponses(port, {
       stream: true,
@@ -910,13 +1081,30 @@ describe("OpenResponses HTTP API (e2e)", () => {
       }
     ).response;
     expect(response?.status).toBe("incomplete");
-    expect(response?.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
+    expect(response?.output?.map((item) => item.type)).toEqual([
+      "message",
+      "function_call",
+      "function_call_output",
+      "function_call",
+    ]);
     expect(response?.output?.[0]?.phase).toBe("commentary");
     expect(
       (((response?.output?.[0]?.content as Array<Record<string, unknown>> | undefined) ?? [])[0]
         ?.text as string | undefined) ?? "",
     ).toBe("Let me check that.");
-    expect(response?.output?.[1]?.name).toBe("get_weather");
+    expect(response?.output?.[1]?.name).toBe("email_search");
+    expect(response?.output?.[2]?.output).toBe("No matching email.");
+    expect(response?.output?.[3]?.name).toBe("get_weather");
+    const clientToolAdded = events
+      .filter((event) => event.data !== "[DONE]")
+      .map((event) => JSON.parse(event.data) as Record<string, unknown>)
+      .find(
+        (event) =>
+          event.type === "response.output_item.added" &&
+          (event.item as Record<string, unknown> | undefined)?.type === "function_call" &&
+          (event.item as Record<string, unknown> | undefined)?.name === "get_weather",
+      );
+    expect(clientToolAdded?.output_index).toBe(3);
     expect(events.some((event) => event.data === "[DONE]")).toBe(true);
   });
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -14,7 +14,7 @@ import { createDefaultDeps } from "../cli/deps.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import type { GatewayHttpResponsesConfig } from "../config/types.gateway.js";
-import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
+import { emitAgentEvent, getAgentEventToolRawResult, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import { renderFileContextBlock } from "../media/file-context.js";
 import {
@@ -363,6 +363,92 @@ function extractUsageFromResult(result: unknown): Usage {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringifyToolOutput(value: unknown): string {
+  if (value == null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+
+  const seen = new WeakSet<object>();
+  try {
+    const json = JSON.stringify(value, (_key, nested) => {
+      if (typeof nested === "bigint") {
+        return nested.toString();
+      }
+      if (nested && typeof nested === "object") {
+        if (seen.has(nested)) {
+          return "[Circular]";
+        }
+        seen.add(nested);
+      }
+      return nested;
+    });
+    return json ?? "";
+  } catch {
+    return "[Unserializable tool result]";
+  }
+}
+
+function normalizeOpenResponsesCompatBody(body: unknown): unknown {
+  if (!isRecord(body) || !Array.isArray(body.input)) {
+    return body;
+  }
+
+  return {
+    ...body,
+    input: body.input.map((item) => {
+      if (!isRecord(item)) {
+        return item;
+      }
+
+      if (item.type === "function_call") {
+        const normalized: Record<string, unknown> = {
+          type: "function_call",
+          name: item.name,
+          arguments: item.arguments,
+        };
+        if (typeof item.id === "string") {
+          normalized.id = item.id;
+        }
+        if (typeof item.call_id === "string") {
+          normalized.call_id = item.call_id;
+        }
+        return normalized;
+      }
+
+      if (item.type === "function_call_output") {
+        return {
+          type: "function_call_output",
+          call_id: item.call_id,
+          output: item.output,
+        };
+      }
+
+      if (!("role" in item) || !("content" in item)) {
+        return item;
+      }
+
+      const normalized: Record<string, unknown> = {
+        type: typeof item.type === "string" ? item.type : "message",
+        role: item.role,
+        content: item.content,
+      };
+
+      if (item.role === "assistant" && typeof item.phase === "string") {
+        normalized.phase = item.phase;
+      }
+
+      return normalized;
+    }),
+  };
+}
+
 type PendingToolCall = { id: string; name: string; arguments: string };
 
 function resolveStopReasonAndPendingToolCalls(meta: unknown): {
@@ -466,7 +552,9 @@ export async function handleOpenResponsesHttpRequest(
   const senderIsOwner = resolveOpenAiCompatibleHttpSenderIsOwner(req, handled.requestAuth);
 
   // Validate request body with Zod
-  const parseResult = CreateResponseBodySchema.safeParse(handled.body);
+  const parseResult = CreateResponseBodySchema.safeParse(
+    normalizeOpenResponsesCompatBody(handled.body),
+  );
   if (!parseResult.success) {
     const issue = parseResult.error.issues[0];
     const message = issue ? `${issue.path.join(".")}: ${issue.message}` : "Invalid request body";
@@ -814,6 +902,13 @@ export async function handleOpenResponsesHttpRequest(
   let stopWatchingDisconnect = () => {};
   let finalUsage: Usage | undefined;
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
+  let nextOutputIndex = 1;
+  const toolCallMeta = new Map<string, { outputIndex: number; argsStr: string }>();
+  const streamedOutputItems = new Map<number, OutputItem>();
+  const orderedStreamedOutputItems = () =>
+    Array.from(streamedOutputItems)
+      .toSorted(([a], [b]) => a - b)
+      .map(([, item]) => item);
 
   const maybeFinalize = () => {
     if (closed) {
@@ -864,7 +959,7 @@ export async function handleOpenResponsesHttpRequest(
       id: responseId,
       model,
       status: finalizeRequested.status,
-      output: [completedItem],
+      output: [completedItem, ...orderedStreamedOutputItems()],
       usage,
     });
 
@@ -958,9 +1053,10 @@ export async function handleOpenResponsesHttpRequest(
 
       if (phase === "start") {
         const args = evt.data?.args;
-        const argsStr = args ? JSON.stringify(args) : "{}";
+        const argsStr = args === undefined ? "{}" : stringifyToolOutput(args);
         const callItemId = `fc_${toolCallId}`;
         const outputIndex = nextOutputIndex++;
+        toolCallMeta.set(toolCallId, { outputIndex, argsStr });
 
         // Emit function_call output item (what the model asked for)
         const functionCallItem: OutputItem = {
@@ -977,17 +1073,21 @@ export async function handleOpenResponsesHttpRequest(
           output_index: outputIndex,
           item: functionCallItem,
         });
+        streamedOutputItems.set(outputIndex, functionCallItem);
         return;
       }
 
       if (phase === "result") {
         const isError = evt.data?.isError as boolean | undefined;
-        // Prefer rawResult (unsanitized/untruncated) for HTTP consumers
-        const result = evt.data?.rawResult ?? evt.data?.result;
-        const resultStr =
-          result != null ? (typeof result === "string" ? result : JSON.stringify(result)) : "";
+        const rawResult = getAgentEventToolRawResult(evt);
+        const result = rawResult !== undefined ? rawResult : evt.data?.result;
+        const resultStr = stringifyToolOutput(result);
         const callItemId = `fc_${toolCallId}`;
         const resultItemId = `fco_${toolCallId}`;
+        const meta = toolCallMeta.get(toolCallId);
+        const doneIndex = meta?.outputIndex ?? nextOutputIndex++;
+        const argsStr = meta?.argsStr ?? "{}";
+        toolCallMeta.delete(toolCallId);
 
         // Complete the function_call item
         const completedCallItem: OutputItem = {
@@ -995,18 +1095,16 @@ export async function handleOpenResponsesHttpRequest(
           id: callItemId,
           call_id: toolCallId,
           name: toolName,
-          arguments: "{}",
+          arguments: argsStr,
           status: "completed",
         };
-
-        // Find the output_index for this call (use a new index for done event)
-        const doneIndex = nextOutputIndex++;
 
         writeSseEvent(res, {
           type: "response.output_item.done",
           output_index: doneIndex,
           item: completedCallItem,
         });
+        streamedOutputItems.set(doneIndex, completedCallItem);
 
         // Emit function_call_output item (the tool result)
         const resultOutputIndex = nextOutputIndex++;
@@ -1029,6 +1127,7 @@ export async function handleOpenResponsesHttpRequest(
           output_index: resultOutputIndex,
           item: resultItem,
         });
+        streamedOutputItems.set(resultOutputIndex, resultItem);
         return;
       }
     }
@@ -1123,9 +1222,10 @@ export async function handleOpenResponsesHttpRequest(
           name: functionCall.name,
           arguments: functionCall.arguments,
         });
+        const functionCallOutputIndex = nextOutputIndex++;
         writeSseEvent(res, {
           type: "response.output_item.added",
-          output_index: 1,
+          output_index: functionCallOutputIndex,
           item: functionCallItem,
         });
         const completedFunctionCallItem = createFunctionCallOutputItem({
@@ -1137,7 +1237,7 @@ export async function handleOpenResponsesHttpRequest(
         });
         writeSseEvent(res, {
           type: "response.output_item.done",
-          output_index: 1,
+          output_index: functionCallOutputIndex,
           item: completedFunctionCallItem,
         });
 
@@ -1145,7 +1245,7 @@ export async function handleOpenResponsesHttpRequest(
           id: responseId,
           model,
           status: "incomplete",
-          output: [completedItem, functionCallItem],
+          output: [completedItem, ...orderedStreamedOutputItems(), completedFunctionCallItem],
           usage,
         });
         closed = true;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -947,6 +947,91 @@ export async function handleOpenResponsesHttpRequest(
       return;
     }
 
+    if (evt.stream === "tool") {
+      const phase = evt.data?.phase as string | undefined;
+      const toolName = evt.data?.name as string | undefined;
+      const toolCallId = evt.data?.toolCallId as string | undefined;
+
+      if (!toolName || !toolCallId) {
+        return;
+      }
+
+      if (phase === "start") {
+        const args = evt.data?.args;
+        const argsStr = args ? JSON.stringify(args) : "{}";
+        const callItemId = `fc_${toolCallId}`;
+        const outputIndex = nextOutputIndex++;
+
+        // Emit function_call output item (what the model asked for)
+        const functionCallItem: OutputItem = {
+          type: "function_call",
+          id: callItemId,
+          call_id: toolCallId,
+          name: toolName,
+          arguments: argsStr,
+          status: "in_progress",
+        };
+
+        writeSseEvent(res, {
+          type: "response.output_item.added",
+          output_index: outputIndex,
+          item: functionCallItem,
+        });
+        return;
+      }
+
+      if (phase === "result") {
+        const isError = evt.data?.isError as boolean | undefined;
+        // Prefer rawResult (unsanitized/untruncated) for HTTP consumers
+        const result = evt.data?.rawResult ?? evt.data?.result;
+        const resultStr =
+          result != null ? (typeof result === "string" ? result : JSON.stringify(result)) : "";
+        const callItemId = `fc_${toolCallId}`;
+        const resultItemId = `fco_${toolCallId}`;
+
+        // Complete the function_call item
+        const completedCallItem: OutputItem = {
+          type: "function_call",
+          id: callItemId,
+          call_id: toolCallId,
+          name: toolName,
+          arguments: "{}",
+          status: "completed",
+        };
+
+        // Find the output_index for this call (use a new index for done event)
+        const doneIndex = nextOutputIndex++;
+
+        writeSseEvent(res, {
+          type: "response.output_item.done",
+          output_index: doneIndex,
+          item: completedCallItem,
+        });
+
+        // Emit function_call_output item (the tool result)
+        const resultOutputIndex = nextOutputIndex++;
+        const resultItem: OutputItem = {
+          type: "function_call_output",
+          id: resultItemId,
+          call_id: toolCallId,
+          output: resultStr,
+          status: isError ? "failed" : "completed",
+        };
+
+        writeSseEvent(res, {
+          type: "response.output_item.added",
+          output_index: resultOutputIndex,
+          item: resultItem,
+        });
+
+        writeSseEvent(res, {
+          type: "response.output_item.done",
+          output_index: resultOutputIndex,
+          item: resultItem,
+        });
+        return;
+      }
+    }
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -2,12 +2,15 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
   clearAgentRunContext,
   emitAgentEvent,
+  getAgentEventToolRawResult,
   getAgentRunContext,
   onAgentEvent,
   registerAgentRunContext,
   resetAgentEventsForTest,
   resetAgentRunContextForTest,
   sweepStaleRunContexts,
+  type AgentEventPayload,
+  withAgentEventToolRawResult,
 } from "./agent-events.js";
 
 type AgentEventsModule = typeof import("./agent-events.js");
@@ -47,6 +50,32 @@ describe("agent-events sequencing", () => {
 
     expect(seen["run-1"]).toEqual([1, 2, 3]);
     expect(seen["run-2"]).toEqual([1]);
+  });
+
+  test("keeps raw tool results off enumerable event payloads", async () => {
+    let seen: AgentEventPayload | undefined;
+    const stop = onAgentEvent((evt) => {
+      seen = evt;
+    });
+    emitAgentEvent(
+      withAgentEventToolRawResult(
+        {
+          runId: "run-raw",
+          stream: "tool",
+          data: {
+            phase: "result",
+            result: "[sanitized]",
+          },
+        },
+        { secret: "full tool payload" },
+      ),
+    );
+    stop();
+
+    expect(seen).toBeTruthy();
+    expect(seen?.data).toEqual({ phase: "result", result: "[sanitized]" });
+    expect(JSON.stringify(seen)).not.toContain("full tool payload");
+    expect(getAgentEventToolRawResult(seen!)).toEqual({ secret: "full tool payload" });
   });
 
   test("preserves compaction ordering on the event bus", async () => {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -124,6 +124,11 @@ type AgentEventState = {
 };
 
 const AGENT_EVENT_STATE_KEY = Symbol.for("openclaw.agentEvents.state");
+const AGENT_EVENT_TOOL_RAW_RESULT = Symbol.for("openclaw.agentEvents.toolRawResult");
+
+type AgentEventWithToolRawResult = Omit<AgentEventPayload, "seq" | "ts"> & {
+  [AGENT_EVENT_TOOL_RAW_RESULT]?: unknown;
+};
 
 function getAgentEventState(): AgentEventState {
   return resolveGlobalSingleton<AgentEventState>(AGENT_EVENT_STATE_KEY, () => ({
@@ -162,6 +167,24 @@ export function registerAgentRunContext(runId: string, context: AgentRunContext)
 
 export function getAgentRunContext(runId: string) {
   return getAgentEventState().runContextById.get(runId);
+}
+
+export function withAgentEventToolRawResult<T extends Omit<AgentEventPayload, "seq" | "ts">>(
+  event: T,
+  rawResult: unknown,
+): T {
+  Object.defineProperty(event, AGENT_EVENT_TOOL_RAW_RESULT, {
+    value: rawResult,
+    enumerable: false,
+    configurable: true,
+  });
+  return event;
+}
+
+export function getAgentEventToolRawResult(event: AgentEventPayload): unknown {
+  return (event as AgentEventPayload & { [AGENT_EVENT_TOOL_RAW_RESULT]?: unknown })[
+    AGENT_EVENT_TOOL_RAW_RESULT
+  ];
 }
 
 export function clearAgentRunContext(runId: string) {
@@ -215,6 +238,13 @@ export function emitAgentEvent(event: Omit<AgentEventPayload, "seq" | "ts">) {
     seq: nextSeq,
     ts: Date.now(),
   };
+  if (Object.prototype.hasOwnProperty.call(event, AGENT_EVENT_TOOL_RAW_RESULT)) {
+    Object.defineProperty(enriched, AGENT_EVENT_TOOL_RAW_RESULT, {
+      value: (event as AgentEventWithToolRawResult)[AGENT_EVENT_TOOL_RAW_RESULT],
+      enumerable: false,
+      configurable: true,
+    });
+  }
   notifyListeners(state.listeners, enriched);
 }
 


### PR DESCRIPTION
Closes #48489
Supersedes #48491

## Summary

- Surface internal tool execution as `function_call` and `function_call_output` output items in the OpenResponses `/v1/responses` SSE stream
- Preserve raw internal tool results for HTTP `function_call_output` payloads while retaining sanitized results for existing internal consumers
- Normalize AI SDK-style message input items before strict schema validation

## Review feedback addressed

- Reuses the original `output_index` when emitting `response.output_item.done` for an internal `function_call`
- Preserves the original tool arguments in the completed `function_call` item
- Strips unsupported extra fields from typed message inputs, while adding `type: "message"` when AI SDK payloads omit it
- Adds `function_call_output` to the OpenResponses output item schema

## Test plan

- [x] `pnpm test:gateway src/gateway/openresponses-http.test.ts`
- [x] `pnpm check`
- [x] Commit hook reran `pnpm check` successfully
