### PR TITLE
feat: keep vite-plus companion bin on daemon PATH

### DIFF
--- a/src/commands/daemon-install-plan.shared.test.ts
+++ b/src/commands/daemon-install-plan.shared.test.ts
@@ -32,6 +32,12 @@ describe("resolveDaemonInstallRuntimeInputs", () => {
 });
 
 describe("resolveDaemonNodeBinDir", () => {
+  it("includes the vite-plus companion bin for vite-plus managed runtimes", () => {
+    expect(
+      resolveDaemonNodeBinDir("/Users/test/.vite-plus/js_runtime/node/24.14.1/bin/node"),
+    ).toEqual(["/Users/test/.vite-plus/js_runtime/node/24.14.1/bin", "/Users/test/.vite-plus/bin"]);
+  });
+
   it("returns the absolute node bin directory", () => {
     expect(resolveDaemonNodeBinDir("/custom/node/bin/node")).toEqual(["/custom/node/bin"]);
   });

--- a/src/commands/daemon-install-plan.shared.ts
+++ b/src/commands/daemon-install-plan.shared.ts
@@ -44,10 +44,26 @@ export async function emitDaemonInstallRuntimeWarning(params: {
   });
 }
 
+function resolveVitePlusCompanionBinDir(nodePath: string): string | undefined {
+  const normalized = nodePath.replaceAll("\\", "/");
+  const marker = "/.vite-plus/js_runtime/node/";
+  const markerIndex = normalized.indexOf(marker);
+  if (markerIndex < 0) {
+    return undefined;
+  }
+  const vitePlusRoot = `${normalized.slice(0, markerIndex)}/.vite-plus`;
+  return path.normalize(path.join(vitePlusRoot, "bin"));
+}
+
 export function resolveDaemonNodeBinDir(nodePath?: string): string[] | undefined {
   const trimmed = nodePath?.trim();
   if (!trimmed || !path.isAbsolute(trimmed)) {
     return undefined;
   }
-  return [path.dirname(trimmed)];
+  const dirs = [path.dirname(trimmed)];
+  const vitePlusBinDir = resolveVitePlusCompanionBinDir(trimmed);
+  if (vitePlusBinDir && !dirs.includes(vitePlusBinDir)) {
+    dirs.push(vitePlusBinDir);
+  }
+  return dirs;
 }


### PR DESCRIPTION
## Summary

AI-assisted: yes (Codex). Testing degree: lightly tested.

- Problem: daemon installs that use a `.vite-plus/js_runtime/node/.../bin/node` runtime only keep that Node bin dir on the supervised service PATH.
- Why it matters: companion tools from the same managed toolchain, including `~/.vite-plus/bin/qmd`, are then missing at runtime and QMD-backed memory falls back with `spawn qmd ENOENT`.
- What changed: `resolveDaemonNodeBinDir()` now also appends the matching `.vite-plus/bin` companion dir when the selected runtime comes from a vite-plus managed Node install, and a focused regression test locks that in.
- What did NOT change (scope boundary): no generic PATH broadening, no service-env security policy changes, and no changes to non-vite-plus runtime path handling.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [ ] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: daemon install path planning only preserved the selected runtime's Node bin dir, but vite-plus installs place sibling tools like `qmd` under `~/.vite-plus/bin` instead of the Node runtime bin directory.
- Missing detection / guardrail: there was no targeted regression test covering vite-plus managed runtime paths and their companion bin directory.
- Prior context (`git blame`, prior PR, issue, or refactor if known): the current behavior comes from the existing `resolveDaemonNodeBinDir()` helper, which returned only `path.dirname(nodePath)`.
- Why this regressed now: QMD memory relies on resolving `qmd` from the supervised service PATH, and vite-plus-managed installs expose that mismatch immediately.
- If unknown, what was ruled out: ruled out launchd not honoring service PATH at all; the actual issue was the generated PATH contents, not launchd inheritance.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/daemon-install-plan.shared.test.ts`
- Scenario the test should lock in: a vite-plus runtime path such as `/Users/test/.vite-plus/js_runtime/node/24.14.1/bin/node` must yield both the runtime bin dir and `/Users/test/.vite-plus/bin`.
- Why this is the smallest reliable guardrail: the bug is introduced at install-time PATH planning, so the helper-level regression test catches the break exactly where the wrong PATH is produced.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Gateway/node daemon installs that use a vite-plus-managed Node runtime now keep the matching `.vite-plus/bin` companion tools on the supervised service PATH, so QMD-backed memory can resolve `qmd` without manual service plist edits.

## Diagram (if applicable)

```text
Before:
vite-plus node runtime selected
  -> service PATH keeps only .../.vite-plus/js_runtime/node/.../bin
  -> qmd lives in .../.vite-plus/bin
  -> memory init falls back with ENOENT

After:
vite-plus node runtime selected
  -> service PATH keeps runtime bin + matching .../.vite-plus/bin
  -> qmd resolves from the same managed toolchain
  -> memory init can use qmd normally
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this only widens the supervised PATH for runtimes that already come from `.vite-plus/js_runtime/node/...`, and only adds the sibling `.vite-plus/bin` under the same managed root instead of importing arbitrary shell PATH segments.

## Repro + Verification

### Environment

- OS: macOS 15.3 / Darwin 25.3.0 arm64
- Runtime/container: local launchd-installed gateway using a vite-plus managed Node runtime
- Model/provider: N/A
- Integration/channel (if any): local gateway / QMD memory
- Relevant config (redacted): `memory.backend=qmd`

### Steps

1. Install the gateway using a vite-plus managed Node runtime such as `~/.vite-plus/js_runtime/node/24.14.1/bin/node`.
2. Configure QMD memory with `memory.backend=qmd`, with `qmd` available in `~/.vite-plus/bin`.
3. Start the supervised gateway service and let memory initialization run.

### Expected

- The supervised service PATH includes both the selected vite-plus runtime bin and the matching `~/.vite-plus/bin`, so `qmd` resolves normally.

### Actual

- The supervised service PATH only includes the Node runtime bin, and memory initialization logs `spawn qmd ENOENT` / falls back to builtin memory.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before, the installed gateway logged:

```text
[memory] qmd binary unavailable (qmd); falling back to builtin: spawn qmd ENOENT
```

After the fix, targeted regression coverage passes:

```text
pnpm vitest run src/commands/daemon-install-plan.shared.test.ts src/commands/daemon-install-helpers.test.ts src/commands/node-daemon-install-helpers.test.ts
Test Files  3 passed (3)
Tests       25 passed (25)
```

## Human Verification (required)

- Verified scenarios: reproduced the missing PATH segment on a local `ai.openclaw.gateway` launchd install, confirmed `qmd` existed only in `~/.vite-plus/bin`, and verified the helper now emits both required vite-plus directories.
- Edge cases checked: generic absolute Node paths still return only their own bin directory; bare executable names still return `undefined`.
- What you did **not** verify: I did not run the full `pnpm build && pnpm test` suite, and I did not perform a second live daemon reinstall from this patched branch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the vite-plus companion-bin detection could over-match unrelated paths that merely contain the same substring.
  - Mitigation: the helper only activates for absolute runtime paths containing the exact `/.vite-plus/js_runtime/node/` marker and derives the companion dir from that same managed root.

## Additional Notes

- I attempted `codex review --base origin/main` twice before opening this PR, but the local Codex CLI crashed during OTEL/system-configuration initialization on this machine before producing review findings.
