### PR TITLE
fix(line): allow rich messages to use reply token instead of forcing push

### DIFF
--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -153,9 +153,16 @@ export async function deliverLineAutoReply(params: {
     });
     replyTokenUsed = nextReplyTokenUsed;
     if (!hasQuickReplies || !hasRichOrMedia) {
-      await sendLineMessages(richMessages, false);
+      // Allow rich messages (flex tables, carousels) to use the reply
+      // token if it hasn't been consumed by the text chunks above. On
+      // LINE free plans, push messages are quota-limited — if the quota
+      // is exhausted, these messages are silently dropped with 429.
+      // Using the reply token (free, up to 5 messages) avoids this.
+      // If replyTokenUsed is already true, sendLineMessages falls
+      // through to push automatically (#65656).
+      await sendLineMessages(richMessages, true);
       if (mediaMessages.length > 0) {
-        await sendLineMessages(mediaMessages, false);
+        await sendLineMessages(mediaMessages, true);
       }
     }
   } else {


### PR DESCRIPTION
## Summary

Rich messages (flex tables, carousels) were always sent via Push API (\`allowReplyToken = false\`), even when the Reply token was still available. On LINE free plans where push quota is limited, this caused flex messages to be **silently dropped with 429** while the text portion delivered successfully via the (free) Reply API.

Fixes #65656

## Root cause

\`\`\`ts
// auto-reply-delivery.ts:155-159 (before fix)
if (!hasQuickReplies || !hasRichOrMedia) {
  await sendLineMessages(richMessages, false);   // ← forces Push API
  if (mediaMessages.length > 0) {
    await sendLineMessages(mediaMessages, false); // ← forces Push API
  }
}
\`\`\`

The \`false\` argument means "don't try the reply token, always use push." The Reply API is free and allows up to 5 messages per call, but rich messages were unconditionally excluded from it.

## Fix

Change \`false\` → \`true\` for both rich message and media message sends that follow text chunk delivery:

\`\`\`ts
await sendLineMessages(richMessages, true);
await sendLineMessages(mediaMessages, true);
\`\`\`

\`sendLineMessages\` (line 66-92) already handles the fallback correctly:
- If \`replyTokenUsed\` is false → sends via Reply API (free)
- If \`replyTokenUsed\` is true (text chunks already used it) → falls through to Push API

So the behavioral change only affects cases where the reply token is **still available** after text delivery — flex messages can now ride the same free reply instead of being pushed separately.

### Why line 137 is left as \`false\`

The pre-text-chunk send at line 137 (when quick replies AND rich/media exist) stays \`false\` to preserve **text-first delivery order**. If we sent rich messages via reply token before text chunks, the user would see the table before the explanatory text.

## Scope

- **Files**: \`extensions/line/src/auto-reply-delivery.ts\` — 2 arguments changed (\`false\` → \`true\`)
- **oxlint clean**
- **Zero competing PRs**

Credit to the reporter of #65656 for identifying the free-plan quota interaction with the Push API.