### PR TITLE
Render provider errors in chat history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -607,6 +607,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: omit generated command highlights for non-POSIX Windows and shell-wrapper approval commands until those command languages have native highlighting support. (#80566) Thanks @jesse-merhi.
 - Telegram: keep verbose tool progress and result drafts separate from the final assistant answer so tool output no longer blends into the final Telegram message. (#80294) Thanks @jalehman.
 - Plugin SDK/Windows: enable the native require fast path for root `openclaw/plugin-sdk` dist aliases instead of forcing Jiti transforms. (#80878) Thanks @medns.
+- macOS/Chat: render persisted assistant provider failures from `errorMessage` in refreshed chat history while keeping stale non-error provider details hidden. (#65689) Thanks @javierdici.
 
 ## 2026.5.9
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift
@@ -253,7 +253,11 @@ private struct ChatMessageBody: View {
             guard kind == "text" || kind.isEmpty else { return nil }
             return content.text
         }
-        return parts.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        return OpenClawChatMessage.displayText(
+            contentText: parts.joined(separator: "\n"),
+            role: self.message.role,
+            stopReason: self.message.stopReason,
+            errorMessage: self.message.errorMessage)
     }
 
     private var inlineAttachments: [OpenClawChatMessageContent] {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -144,6 +144,7 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
     public let toolName: String?
     public let usage: OpenClawChatUsage?
     public let stopReason: String?
+    public let errorMessage: String?
 
     enum CodingKeys: String, CodingKey {
         case role
@@ -155,6 +156,7 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
         case tool_name
         case usage
         case stopReason
+        case errorMessage
     }
 
     public init(
@@ -165,7 +167,8 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
         toolCallId: String? = nil,
         toolName: String? = nil,
         usage: OpenClawChatUsage? = nil,
-        stopReason: String? = nil)
+        stopReason: String? = nil,
+        errorMessage: String? = nil)
     {
         self.id = id
         self.role = role
@@ -175,6 +178,7 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
         self.toolName = toolName
         self.usage = usage
         self.stopReason = stopReason
+        self.errorMessage = errorMessage
     }
 
     public init(from decoder: Decoder) throws {
@@ -189,9 +193,31 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
             container.decodeIfPresent(String.self, forKey: .tool_name)
         self.usage = try container.decodeIfPresent(OpenClawChatUsage.self, forKey: .usage)
         self.stopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
+        self.errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
+
+        let fallbackErrorContent: [OpenClawChatMessageContent] = {
+            guard let text = self.errorMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !text.isEmpty
+            else {
+                return []
+            }
+            return [
+                OpenClawChatMessageContent(
+                    type: "text",
+                    text: text,
+                    thinking: nil,
+                    thinkingSignature: nil,
+                    mimeType: nil,
+                    fileName: nil,
+                    content: nil,
+                    id: nil,
+                    name: nil,
+                    arguments: nil),
+            ]
+        }()
 
         if let decoded = try? container.decode([OpenClawChatMessageContent].self, forKey: .content) {
-            self.content = decoded
+            self.content = decoded.isEmpty ? fallbackErrorContent : decoded
             return
         }
 
@@ -213,7 +239,7 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
             return
         }
 
-        self.content = []
+        self.content = fallbackErrorContent
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -224,6 +250,7 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
         try container.encodeIfPresent(self.toolName, forKey: .toolName)
         try container.encodeIfPresent(self.usage, forKey: .usage)
         try container.encodeIfPresent(self.stopReason, forKey: .stopReason)
+        try container.encodeIfPresent(self.errorMessage, forKey: .errorMessage)
         try container.encode(self.content, forKey: .content)
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift
@@ -183,41 +183,28 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.role = try container.decode(String.self, forKey: .role)
-        self.timestamp = try container.decodeIfPresent(Double.self, forKey: .timestamp)
-        self.toolCallId =
+        let decodedRole = try container.decode(String.self, forKey: .role)
+        let decodedTimestamp = try container.decodeIfPresent(Double.self, forKey: .timestamp)
+        let decodedToolCallId =
             try container.decodeIfPresent(String.self, forKey: .toolCallId) ??
             container.decodeIfPresent(String.self, forKey: .tool_call_id)
-        self.toolName =
+        let decodedToolName =
             try container.decodeIfPresent(String.self, forKey: .toolName) ??
             container.decodeIfPresent(String.self, forKey: .tool_name)
-        self.usage = try container.decodeIfPresent(OpenClawChatUsage.self, forKey: .usage)
-        self.stopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
-        self.errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
+        let decodedUsage = try container.decodeIfPresent(OpenClawChatUsage.self, forKey: .usage)
+        let decodedStopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
+        let decodedErrorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
 
-        let fallbackErrorContent: [OpenClawChatMessageContent] = {
-            guard let text = self.errorMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !text.isEmpty
-            else {
-                return []
-            }
-            return [
-                OpenClawChatMessageContent(
-                    type: "text",
-                    text: text,
-                    thinking: nil,
-                    thinkingSignature: nil,
-                    mimeType: nil,
-                    fileName: nil,
-                    content: nil,
-                    id: nil,
-                    name: nil,
-                    arguments: nil),
-            ]
-        }()
+        self.role = decodedRole
+        self.timestamp = decodedTimestamp
+        self.toolCallId = decodedToolCallId
+        self.toolName = decodedToolName
+        self.usage = decodedUsage
+        self.stopReason = decodedStopReason
+        self.errorMessage = decodedErrorMessage
 
         if let decoded = try? container.decode([OpenClawChatMessageContent].self, forKey: .content) {
-            self.content = decoded.isEmpty ? fallbackErrorContent : decoded
+            self.content = decoded
             return
         }
 
@@ -239,8 +226,43 @@ public struct OpenClawChatMessage: Codable, Identifiable, Sendable {
             return
         }
 
-        self.content = fallbackErrorContent
+        self.content = []
     }
+
+    static func displayText(
+        contentText: String,
+        role: String,
+        stopReason: String?,
+        errorMessage: String?) -> String
+    {
+        let text = contentText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let errorText = Self.errorDisplayText(
+            role: role,
+            stopReason: stopReason,
+            errorMessage: errorMessage)
+        else {
+            return text
+        }
+        if text.isEmpty || text == Self.streamErrorFallbackText {
+            return errorText
+        }
+        return text
+    }
+
+    static func errorDisplayText(role: String, stopReason: String?, errorMessage: String?) -> String? {
+        let normalizedRole = role.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedStopReason = stopReason?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard normalizedRole == "assistant",
+              normalizedStopReason == "error",
+              let text = errorMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty
+        else {
+            return nil
+        }
+        return text
+    }
+
+    private static let streamErrorFallbackText = "[assistant turn failed before producing content]"
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -390,7 +390,8 @@ public struct OpenClawChatView: View {
                 toolCallId: last.toolCallId,
                 toolName: last.toolName,
                 usage: last.usage,
-                stopReason: last.stopReason)
+                stopReason: last.stopReason,
+                errorMessage: last.errorMessage)
             result[result.count - 1] = merged
         }
 
@@ -434,7 +435,11 @@ public struct OpenClawChatView: View {
             guard kind == "text" || kind.isEmpty else { return nil }
             return content.text
         }
-        return parts.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = parts.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !text.isEmpty {
+            return text
+        }
+        return (message.errorMessage ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func hasInlineAttachments(in message: OpenClawChatMessage) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -389,7 +389,8 @@ public struct OpenClawChatView: View {
                 toolCallId: last.toolCallId,
                 toolName: last.toolName,
                 usage: last.usage,
-                stopReason: last.stopReason)
+                stopReason: last.stopReason,
+                errorMessage: last.errorMessage)
             result[result.count - 1] = merged
         }
 
@@ -433,7 +434,11 @@ public struct OpenClawChatView: View {
             guard kind == "text" || kind.isEmpty else { return nil }
             return content.text
         }
-        return parts.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = parts.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
+        if !text.isEmpty {
+            return text
+        }
+        return (message.errorMessage ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func hasInlineAttachments(in message: OpenClawChatMessage) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift
@@ -434,11 +434,11 @@ public struct OpenClawChatView: View {
             guard kind == "text" || kind.isEmpty else { return nil }
             return content.text
         }
-        let text = parts.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
-        if !text.isEmpty {
-            return text
-        }
-        return (message.errorMessage ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return OpenClawChatMessage.displayText(
+            contentText: parts.joined(separator: "\n"),
+            role: message.role,
+            stopReason: message.stopReason,
+            errorMessage: message.errorMessage)
     }
 
     private func hasInlineAttachments(in message: OpenClawChatMessage) -> Bool {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -305,7 +305,8 @@ public final class OpenClawChatViewModel {
             toolCallId: message.toolCallId,
             toolName: message.toolName,
             usage: message.usage,
-            stopReason: message.stopReason)
+            stopReason: message.stopReason,
+            errorMessage: message.errorMessage)
     }
 
     private static func messageContentFingerprint(for message: OpenClawChatMessage) -> String {
@@ -384,7 +385,8 @@ public final class OpenClawChatViewModel {
                 toolCallId: message.toolCallId,
                 toolName: message.toolName,
                 usage: message.usage,
-                stopReason: message.stopReason)
+                stopReason: message.stopReason,
+                errorMessage: message.errorMessage)
         }
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift
@@ -289,7 +289,8 @@ public final class OpenClawChatViewModel {
             toolCallId: message.toolCallId,
             toolName: message.toolName,
             usage: message.usage,
-            stopReason: message.stopReason)
+            stopReason: message.stopReason,
+            errorMessage: message.errorMessage)
     }
 
     private static func messageContentFingerprint(for message: OpenClawChatMessage) -> String {
@@ -368,7 +369,8 @@ public final class OpenClawChatViewModel {
                 toolCallId: message.toolCallId,
                 toolName: message.toolName,
                 usage: message.usage,
-                stopReason: message.stopReason)
+                stopReason: message.stopReason,
+                errorMessage: message.errorMessage)
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -11,6 +11,16 @@ private func chatTextMessage(role: String, text: String, timestamp: Double) -> A
     ])
 }
 
+private func chatErrorMessage(role: String, errorMessage: String, timestamp: Double) -> AnyCodable {
+    AnyCodable([
+        "role": role,
+        "content": [],
+        "timestamp": timestamp,
+        "stopReason": "error",
+        "errorMessage": errorMessage,
+    ])
+}
+
 private func historyPayload(
     sessionKey: String = "main",
     sessionId: String? = "sess-main",
@@ -658,6 +668,47 @@ extension TestChatTransportState {
         try await waitUntil("pending run clears") { await MainActor.run { vm.pendingRunCount == 0 } }
         try await waitUntil("history refresh") {
             await MainActor.run { vm.messages.contains(where: { $0.role == "assistant" }) }
+        }
+    }
+
+    @Test func surfacesAssistantErrorMessageAfterOwnRunRefresh() async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let history1 = historyPayload()
+        let history2 = historyPayload(
+            messages: [
+                chatErrorMessage(
+                    role: "assistant",
+                    errorMessage: "You have hit your ChatGPT usage limit (plus plan). Try again in ~28 min.",
+                    timestamp: now),
+            ])
+
+        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2])
+        try await loadAndWaitBootstrap(vm: vm)
+
+        await sendUserMessage(vm)
+        try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+
+        let runId = try #require(await transport.lastSentRunId())
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: runId,
+                    sessionKey: "main",
+                    state: "error",
+                    message: nil,
+                    errorMessage: "You have hit your ChatGPT usage limit (plus plan). Try again in ~28 min.")))
+
+        try await waitUntil("pending run clears after error") {
+            await MainActor.run { vm.pendingRunCount == 0 }
+        }
+        try await waitUntil("history refresh shows assistant error message") {
+            await MainActor.run {
+                vm.messages.contains(where: { message in
+                    message.role == "assistant" &&
+                        message.content.compactMap(\.text).joined(separator: "\n")
+                            .contains("You have hit your ChatGPT usage limit")
+                })
+            }
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -11,6 +11,16 @@ private func chatTextMessage(role: String, text: String, timestamp: Double) -> A
     ])
 }
 
+private func chatErrorMessage(role: String, errorMessage: String, timestamp: Double) -> AnyCodable {
+    AnyCodable([
+        "role": role,
+        "content": [],
+        "timestamp": timestamp,
+        "stopReason": "error",
+        "errorMessage": errorMessage,
+    ])
+}
+
 private func historyPayload(
     sessionKey: String = "main",
     sessionId: String? = "sess-main",
@@ -662,6 +672,47 @@ extension TestChatTransportState {
         try await waitUntil("pending run clears") { await MainActor.run { vm.pendingRunCount == 0 } }
         try await waitUntil("history refresh") {
             await MainActor.run { vm.messages.contains(where: { $0.role == "assistant" }) }
+        }
+    }
+
+    @Test func surfacesAssistantErrorMessageAfterOwnRunRefresh() async throws {
+        let now = Date().timeIntervalSince1970 * 1000
+        let history1 = historyPayload()
+        let history2 = historyPayload(
+            messages: [
+                chatErrorMessage(
+                    role: "assistant",
+                    errorMessage: "You have hit your ChatGPT usage limit (plus plan). Try again in ~28 min.",
+                    timestamp: now),
+            ])
+
+        let (transport, vm) = await makeViewModel(historyResponses: [history1, history2])
+        try await loadAndWaitBootstrap(vm: vm)
+
+        await sendUserMessage(vm)
+        try await waitUntil("pending run starts") { await MainActor.run { vm.pendingRunCount == 1 } }
+
+        let runId = try #require(await transport.lastSentRunId())
+        transport.emit(
+            .chat(
+                OpenClawChatEventPayload(
+                    runId: runId,
+                    sessionKey: "main",
+                    state: "error",
+                    message: nil,
+                    errorMessage: "You have hit your ChatGPT usage limit (plus plan). Try again in ~28 min.")))
+
+        try await waitUntil("pending run clears after error") {
+            await MainActor.run { vm.pendingRunCount == 0 }
+        }
+        try await waitUntil("history refresh shows assistant error message") {
+            await MainActor.run {
+                vm.messages.contains(where: { message in
+                    message.role == "assistant" &&
+                        message.content.compactMap(\.text).joined(separator: "\n")
+                            .contains("You have hit your ChatGPT usage limit")
+                })
+            }
         }
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -464,6 +464,76 @@ extension TestChatTransportState {
 }
 
 @Suite struct ChatViewModelTests {
+    @Test func displaysErrorMessageFallbackOnlyForAssistantErrorTurns() throws {
+        func decodeMessage(role: String, stopReason: String, contentText: String? = nil) throws -> OpenClawChatMessage {
+            let contentJSON = contentText.map { #"[{"type":"text","text":"\#($0)"}]"# } ?? "[]"
+            let data = """
+            {
+              "role": "\(role)",
+              "content": \(contentJSON),
+              "timestamp": 1,
+              "stopReason": "\(stopReason)",
+              "errorMessage": "stale provider failure"
+            }
+            """.data(using: .utf8)!
+            return try JSONDecoder().decode(OpenClawChatMessage.self, from: data)
+        }
+
+        let assistantError = try decodeMessage(role: "assistant", stopReason: "error")
+        #expect(assistantError.content.isEmpty)
+        #expect(
+            OpenClawChatMessage.errorDisplayText(
+                role: assistantError.role,
+                stopReason: assistantError.stopReason,
+                errorMessage: assistantError.errorMessage) == "stale provider failure")
+        #expect(
+            OpenClawChatMessage.displayText(
+                contentText: "",
+                role: assistantError.role,
+                stopReason: assistantError.stopReason,
+                errorMessage: assistantError.errorMessage) == "stale provider failure")
+
+        let sentinelAssistant = try decodeMessage(
+            role: "assistant",
+            stopReason: "error",
+            contentText: "[assistant turn failed before producing content]")
+        #expect(
+            OpenClawChatMessage.displayText(
+                contentText: sentinelAssistant.content.compactMap(\.text).joined(separator: "\n"),
+                role: sentinelAssistant.role,
+                stopReason: sentinelAssistant.stopReason,
+                errorMessage: sentinelAssistant.errorMessage) == "stale provider failure")
+
+        let partialAssistant = try decodeMessage(
+            role: "assistant",
+            stopReason: "error",
+            contentText: "partial answer")
+        #expect(
+            OpenClawChatMessage.displayText(
+                contentText: partialAssistant.content.compactMap(\.text).joined(separator: "\n"),
+                role: partialAssistant.role,
+                stopReason: partialAssistant.stopReason,
+                errorMessage: partialAssistant.errorMessage) == "partial answer")
+
+        let stoppedAssistant = try decodeMessage(role: "assistant", stopReason: "stop")
+        #expect(stoppedAssistant.errorMessage == "stale provider failure")
+        #expect(stoppedAssistant.content.isEmpty)
+        #expect(
+            OpenClawChatMessage.errorDisplayText(
+                role: stoppedAssistant.role,
+                stopReason: stoppedAssistant.stopReason,
+                errorMessage: stoppedAssistant.errorMessage) == nil)
+
+        let toolUseAssistant = try decodeMessage(role: "assistant", stopReason: "toolUse")
+        #expect(toolUseAssistant.errorMessage == "stale provider failure")
+        #expect(toolUseAssistant.content.isEmpty)
+        #expect(
+            OpenClawChatMessage.errorDisplayText(
+                role: toolUseAssistant.role,
+                stopReason: toolUseAssistant.stopReason,
+                errorMessage: toolUseAssistant.errorMessage) == nil)
+    }
+
     @Test func streamsAssistantAndClearsOnFinal() async throws {
         let sessionId = "sess-main"
         let history1 = historyPayload(sessionId: sessionId)
@@ -709,8 +779,12 @@ extension TestChatTransportState {
             await MainActor.run {
                 vm.messages.contains(where: { message in
                     message.role == "assistant" &&
-                        message.content.compactMap(\.text).joined(separator: "\n")
-                            .contains("You have hit your ChatGPT usage limit")
+                        OpenClawChatMessage.displayText(
+                            contentText: message.content.compactMap(\.text).joined(separator: "\n"),
+                            role: message.role,
+                            stopReason: message.stopReason,
+                            errorMessage: message.errorMessage)
+                        .contains("You have hit your ChatGPT usage limit")
                 })
             }
         }


### PR DESCRIPTION
## Summary
- Preserve assistant `errorMessage` metadata in macOS chat history decoding.
- Render provider error details for assistant `stopReason: "error"` turns when content is empty or the backend sentinel is present.
- Keep stale/background `errorMessage` values hidden for non-error assistant turns, and preserve real partial assistant content when present.

## Testing
- GitHub CI: https://github.com/openclaw/openclaw/actions/runs/25851461787
- `git diff --check -- CHANGELOG.md apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMessageViews.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModels.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatView.swift apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel.swift apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift`

## Real behavior proof

- Behavior or issue addressed: macOS chat history refresh now shows the provider error for failed assistant turns stored with peer `errorMessage`, while hiding stale non-error `errorMessage` values.
- Real environment tested: `glitch@zebroid-devbox`, macOS arm64, Xcode 26.5 (17F42), Apple Swift 6.3.2, PR head `eb29ef15e1f0f36474ac5e8dc0a83592cff9c5d7` synced by Crabbox static SSH.
- Exact steps or command run after this patch: `crabbox run --provider ssh --target macos --static-host zebroid-devbox --static-user glitch --static-work-root /Users/glitch/crabbox --shell -- 'export DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer; xcodebuild -version; xcrun swift --version; swift build --package-path apps/macos --product OpenClaw --configuration release; swift test --package-path apps/macos --parallel --enable-code-coverage --show-codecov-path'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
CRABBOX_PHASE:toolchain
Xcode 26.5
Build version 17F42
swift-driver version: 1.148.6 Apple Swift version 6.3.2 (swiftlang-6.3.2.1.108 clang-2100.1.1.101)
Target: arm64-apple-macosx26.0
CRABBOX_PHASE:macos-build
Build of product 'OpenClaw' complete! (93.31s)
CRABBOX_PHASE:macos-tests
/Users/glitch/crabbox/static_zebroid-devbox/pr-65689/apps/macos/.build/arm64-apple-macosx/debug/codecov/OpenClaw.json
run summary sync=712ms command=1m35.625s total=1m36.418s sync_skipped=true exit=0 command_phases=user-command:258ms,toolchain:389ms,macos-build:1m34.34s,macos-tests:637ms
```

Additional live Swift payload probe on the same synced macOS checkout:

```text
partial answer wins: partial answer
empty assistant error: rate limit: try again later
sentinel assistant error: rate limit: try again later
stale non-error:
```

- Observed result after fix: the macOS build and Swift test command complete successfully on the real mac mini; the live payload probe renders error text only for assistant error turns with empty/sentinel content, keeps stale non-error text hidden, and keeps partial assistant content visible.
- What was not tested: manual visual clicking through the full macOS app UI was not performed.
- Before evidence (optional but encouraged): current `main` decodes `OpenClawChatMessage` without `errorMessage` in the Swift model and `primaryText` only joins `content` text blocks. A zebroid before/after payload probe showed the old display rule versus the patched rule on the same macOS/Xcode setup:

```text
CASE: empty assistant error
  before-main: <empty>
  after-pr:    rate limit: try again later
CASE: sentinel assistant error
  before-main: [assistant turn failed before producing content]
  after-pr:    rate limit: try again later
CASE: stale non-error
  before-main: <empty>
  after-pr:    <empty>
CASE: partial answer wins
  before-main: partial answer
  after-pr:    partial answer
```

## Root Cause

- Root cause: the Swift chat message model and display path did not carry the backend's peer `errorMessage` field through refreshed history rendering.
- Missing detection / guardrail: macOS chat history tests did not cover assistant error turns with empty content/sentinel content plus peer `errorMessage`.
- Contributing context: backend replay safety keeps raw provider errors out of replayed assistant `content`, so UI clients need to read the peer field directly.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift`
- Scenario the test should lock in: assistant error turns render peer `errorMessage` for empty/sentinel content, do not render stale non-error `errorMessage`, and preserve partial assistant content.
- Why this is the smallest reliable guardrail: the failure sits in the Swift decode/display boundary used by refreshed macOS chat history.
- Existing test that already covers this (if any): added `displaysErrorMessageFallbackOnlyForAssistantErrorTurns` and `surfacesAssistantErrorMessageAfterOwnRunRefresh`.
