### PR TITLE
tool result microcompress

### DIFF
--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -92,6 +92,10 @@ To disable: set `mode: "off"`.
 They complement each other -- pruning keeps tool output lean between
 compaction cycles.
 
+With `contextPruning.microCompress.enabled`, prunable tool output always gets
+line-ending normalization plus outer empty-line trimming before any optional
+ANSI stripping, trailing-whitespace trimming, or blank-line collapse.
+
 ## Further reading
 
 - [Compaction](/concepts/compaction) -- summarization-based context reduction

--- a/docs/concepts/session-pruning.md
+++ b/docs/concepts/session-pruning.md
@@ -23,6 +23,12 @@ Long sessions accumulate tool output that inflates the context window. This
 increases cost and can force [compaction](/concepts/compaction) sooner than
 necessary.
 
+OpenClaw can also micro-compress prunable tool-result text by removing
+formatting noise such as ANSI color codes, outer blank lines, trailing
+whitespace, and repeated blank lines. This normalization is intentionally
+limited to in-memory tool output and does not rewrite conversation text, code,
+or on-disk transcripts.
+
 Pruning is especially valuable for **Anthropic prompt caching**. After the cache
 TTL expires, the next request re-caches the full prompt. Pruning reduces the
 cache-write size, directly lowering cost.
@@ -31,9 +37,10 @@ cache-write size, directly lowering cost.
 
 1. Wait for the cache TTL to expire (default 5 minutes).
 2. Find old tool results for normal pruning (conversation text is left alone).
-3. **Soft-trim** oversized results -- keep the head and tail, insert `...`.
-4. **Hard-clear** the rest -- replace with a placeholder.
-5. Reset the TTL so follow-up requests reuse the fresh cache.
+3. Optionally micro-compress prunable tool-result text to remove formatting noise.
+4. **Soft-trim** oversized results -- keep the head and tail, insert `...`.
+5. **Hard-clear** the rest -- replace with a placeholder.
+6. Reset the TTL so follow-up requests reuse the fresh cache.
 
 ## Legacy image cleanup
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1323,7 +1323,7 @@ Prunes **old tool results** from in-memory context before sending to the LLM. Do
 Notes:
 
 - Image blocks are never trimmed/cleared.
-- `microCompress` only affects prunable `toolResult` text in memory. It normalizes line endings, removes outer blank lines, and can strip ANSI escapes, trim trailing whitespace, and collapse repeated blank lines when that reduces size.
+- `microCompress` only affects prunable `toolResult` text in memory. When enabled, it always normalizes line endings and removes outer blank lines; the sub-flags additionally control ANSI stripping, trailing-whitespace trimming, and repeated blank-line collapse.
 - Ratios are character-based (approximate), not exact token counts.
 - If fewer than `keepLastAssistants` assistant messages exist, pruning is skipped.
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1296,6 +1296,12 @@ Prunes **old tool results** from in-memory context before sending to the LLM. Do
         minPrunableToolChars: 50000,
         softTrim: { maxChars: 4000, headChars: 1500, tailChars: 1500 },
         hardClear: { enabled: true, placeholder: "[Old tool result content cleared]" },
+        microCompress: {
+          enabled: true,
+          stripAnsi: true,
+          trimTrailingWhitespace: true,
+          collapseBlankLines: true,
+        },
         tools: { deny: ["browser", "canvas"] },
       },
     },
@@ -1307,6 +1313,7 @@ Prunes **old tool results** from in-memory context before sending to the LLM. Do
 
 - `mode: "cache-ttl"` enables pruning passes.
 - `ttl` controls how often pruning can run again (after the last cache touch).
+- `microCompress` runs a safe normalization pass on prunable tool-result text before trim/clear decisions.
 - Pruning soft-trims oversized tool results first, then hard-clears older tool results if needed.
 
 **Soft-trim** keeps beginning + end and inserts `...` in the middle.
@@ -1316,6 +1323,7 @@ Prunes **old tool results** from in-memory context before sending to the LLM. Do
 Notes:
 
 - Image blocks are never trimmed/cleared.
+- `microCompress` only affects prunable `toolResult` text in memory. It normalizes line endings, removes outer blank lines, and can strip ANSI escapes, trim trailing whitespace, and collapse repeated blank lines when that reduces size.
 - Ratios are character-based (approximate), not exact token counts.
 - If fewer than `keepLastAssistants` assistant messages exist, pruning is skipped.
 

--- a/src/agents/pi-hooks/context-pruning.test.ts
+++ b/src/agents/pi-hooks/context-pruning.test.ts
@@ -139,7 +139,7 @@ function makeSimpleToolPruningMessages(includeTrailingAssistant = false): AgentM
 type ContextHandler = (
   event: { messages: AgentMessage[] },
   ctx: ExtensionContext,
-) => { messages: AgentMessage[] } | undefined;
+) => Promise<{ messages: AgentMessage[] } | undefined> | { messages: AgentMessage[] } | undefined;
 
 function createContextHandler(): ContextHandler {
   let handler: ContextHandler | undefined;
@@ -335,7 +335,7 @@ describe("context-pruning", () => {
     const messages = makeSimpleToolPruningMessages(true);
 
     const handler = createContextHandler();
-    const result = runContextHandler(handler, messages, sessionManager);
+    const result = await runContextHandler(handler, messages, sessionManager);
 
     if (!result) {
       throw new Error("expected handler to return messages");
@@ -343,7 +343,7 @@ describe("context-pruning", () => {
     expect(toolText(findToolResult(result.messages, "t1"))).toBe("[cleared]");
   });
 
-  it("cache-ttl prunes once and resets the ttl window", () => {
+  it("cache-ttl prunes once and resets the ttl window", async () => {
     const sessionManager = {};
     const lastTouch = Date.now() - DEFAULT_CONTEXT_PRUNING_SETTINGS.ttlMs - 1000;
 
@@ -358,7 +358,7 @@ describe("context-pruning", () => {
     const messages = makeSimpleToolPruningMessages();
 
     const handler = createContextHandler();
-    const first = runContextHandler(handler, messages, sessionManager);
+    const first = await runContextHandler(handler, messages, sessionManager);
     if (!first) {
       throw new Error("expected first prune");
     }
@@ -370,7 +370,7 @@ describe("context-pruning", () => {
     }
     expect(runtime.lastCacheTouchAt).toBeGreaterThan(lastTouch);
 
-    const second = runContextHandler(handler, messages, sessionManager);
+    const second = await runContextHandler(handler, messages, sessionManager);
     expect(second).toBeUndefined();
   });
 

--- a/src/agents/pi-hooks/context-pruning.test.ts
+++ b/src/agents/pi-hooks/context-pruning.test.ts
@@ -176,6 +176,17 @@ describe("context-pruning", () => {
     expect(computeEffectiveSettings({})).toBeNull();
   });
 
+  it("defaults micro-compression settings when cache-ttl pruning is enabled", () => {
+    const settings = computeEffectiveSettings({ mode: "cache-ttl" });
+
+    expect(settings?.microCompress).toEqual({
+      enabled: true,
+      stripAnsi: true,
+      trimTrailingWhitespace: true,
+      collapseBlankLines: true,
+    });
+  });
+
   it("does not touch tool results after the last N assistants", () => {
     const messages: AgentMessage[] = [
       makeUser("u1"),

--- a/src/agents/pi-hooks/context-pruning/extension.ts
+++ b/src/agents/pi-hooks/context-pruning/extension.ts
@@ -1,9 +1,19 @@
 import type { ContextEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { pruneContextMessages } from "./pruner.js";
 import { getContextPruningRuntime } from "./runtime.js";
 
+let pruneContextMessagesPromise:
+  | Promise<typeof import("./pruner.js").pruneContextMessages>
+  | undefined;
+
+async function getPruneContextMessages() {
+  if (!pruneContextMessagesPromise) {
+    pruneContextMessagesPromise = import("./pruner.js").then((mod) => mod.pruneContextMessages);
+  }
+  return await pruneContextMessagesPromise;
+}
+
 export default function contextPruningExtension(api: ExtensionAPI): void {
-  api.on("context", (event: ContextEvent, ctx: ExtensionContext) => {
+  api.on("context", async (event: ContextEvent, ctx: ExtensionContext) => {
     const runtime = getContextPruningRuntime(ctx.sessionManager);
     if (!runtime) {
       return undefined;
@@ -20,6 +30,7 @@ export default function contextPruningExtension(api: ExtensionAPI): void {
       }
     }
 
+    const pruneContextMessages = await getPruneContextMessages();
     const next = pruneContextMessages({
       messages: event.messages,
       settings: runtime.settings,

--- a/src/agents/pi-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.test.ts
@@ -599,6 +599,46 @@ describe("pruneContextMessages", () => {
     expect(getToolResultText(result, 2)).toBe("X".repeat(250));
   });
 
+  it("still rewrites image placeholders after micro-compression drops below soft-trim ratio", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "\r\n".repeat(200) + "alpha\r\nbeta\r\n" }]),
+      makeToolResult([
+        { type: "text", text: "\r\n\r\nbefore  " },
+        { type: "image", data: "img", mimeType: "image/png" },
+        { type: "text", text: "\n\nafter\t\t" },
+      ]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 1,
+        softTrimRatio: 0.7,
+        hardClearRatio: 10,
+        hardClear: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear,
+          enabled: false,
+        },
+        softTrim: {
+          maxChars: 5_000,
+          headChars: 2_000,
+          tailChars: 2_000,
+        },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 120,
+    });
+
+    expect(getToolResultText(result)).toBe("alpha\nbeta");
+    expect(getToolResultText(result, 2)).toBe(
+      "before\n[image removed during context pruning]\n\nafter",
+    );
+  });
+
   it("hard-clears image-containing tool results once ratios require clearing", () => {
     const messages: AgentMessage[] = [
       makeUser("summarize this"),

--- a/src/agents/pi-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.test.ts
@@ -639,6 +639,48 @@ describe("pruneContextMessages", () => {
     );
   });
 
+  it("keeps text-only tool results once only image cleanup remains necessary", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "\r\n".repeat(200) + "alpha\r\nbeta\r\n" }]),
+      makeToolResult([{ type: "text", text: "B".repeat(6_000) }]),
+      makeToolResult([
+        { type: "text", text: "\r\n\r\nbefore  " },
+        { type: "image", data: "img", mimeType: "image/png" },
+        { type: "text", text: "\n\nafter\t\t" },
+      ]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 1,
+        softTrimRatio: 0.7,
+        hardClearRatio: 10,
+        hardClear: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear,
+          enabled: false,
+        },
+        softTrim: {
+          maxChars: 5_000,
+          headChars: 2_000,
+          tailChars: 2_000,
+        },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 5_100,
+    });
+
+    expect(getToolResultText(result)).toBe("alpha\nbeta");
+    expect(getToolResultText(result, 2)).toBe("B".repeat(6_000));
+    expect(getToolResultText(result, 3)).toBe(
+      "before\n[image removed during context pruning]\n\nafter",
+    );
+  });
+
   it("hard-clears image-containing tool results once ratios require clearing", () => {
     const messages: AgentMessage[] = [
       makeUser("summarize this"),

--- a/src/agents/pi-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.test.ts
@@ -316,6 +316,37 @@ describe("pruneContextMessages", () => {
     expect(result).toBe(messages);
   });
 
+  it("skips micro-compression rewrites that would grow multi-block tool results", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([
+        { type: "text", text: "alpha" },
+        { type: "text", text: "beta" },
+        { type: "text", text: "gamma " },
+      ]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...buildToolTrimSettings(),
+        softTrimRatio: 0,
+        hardClearRatio: 10,
+        softTrim: {
+          maxChars: 5_000,
+          headChars: 2_000,
+          tailChars: 2_000,
+        },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    expect(result).toBe(messages);
+  });
+
   it("can disable micro-compression entirely", () => {
     const messages: AgentMessage[] = [
       makeUser("summarize this"),
@@ -534,11 +565,11 @@ describe("pruneContextMessages", () => {
     ]);
   });
 
-  it("still replaces image blocks after micro-compression drops below soft-trim ratio", () => {
+  it("stops before soft-trim once micro-compression drops below soft-trim ratio", () => {
     const messages: AgentMessage[] = [
       makeUser("summarize this"),
-      makeToolResult([{ type: "text", text: "\r\n\r\nalpha\r\nbeta\r\n" }]),
-      makeToolResult([{ type: "image", data: "img", mimeType: "image/png" }]),
+      makeToolResult([{ type: "text", text: "\r\n".repeat(200) + "alpha\r\nbeta\r\n" }]),
+      makeToolResult([{ type: "text", text: "X".repeat(250) }]),
       makeAssistant([{ type: "text", text: "done" }]),
     ];
 
@@ -547,7 +578,7 @@ describe("pruneContextMessages", () => {
       settings: {
         ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
         keepLastAssistants: 1,
-        softTrimRatio: 0.5,
+        softTrimRatio: 0.7,
         hardClearRatio: 10,
         hardClear: {
           ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear,
@@ -561,11 +592,11 @@ describe("pruneContextMessages", () => {
       },
       ctx: CONTEXT_WINDOW_1M,
       isToolPrunable: () => true,
-      contextWindowTokensOverride: 6,
+      contextWindowTokensOverride: 120,
     });
 
     expect(getToolResultText(result)).toBe("alpha\nbeta");
-    expect(getToolResultText(result, 2)).toBe("[image removed during context pruning]");
+    expect(getToolResultText(result, 2)).toBe("X".repeat(250));
   });
 
   it("hard-clears image-containing tool results once ratios require clearing", () => {

--- a/src/agents/pi-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.test.ts
@@ -369,6 +369,34 @@ describe("pruneContextMessages", () => {
     expect(getToolResultText(result)).toBe("\u001b[31merror\u001b[0m");
   });
 
+  it("still normalizes CR-only line endings when that is the only change", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "alpha\rbeta\r" }]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...buildToolTrimSettings(),
+        softTrimRatio: 0,
+        hardClearRatio: 10,
+        microCompress: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS.microCompress,
+          stripAnsi: false,
+          trimTrailingWhitespace: false,
+          collapseBlankLines: false,
+        },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    expect(getToolResultText(result)).toBe("alpha\nbeta");
+  });
+
   it("never micro-compresses user or assistant messages", () => {
     const messages: AgentMessage[] = [
       makeUser("alpha  \r\n\r\n"),
@@ -504,6 +532,40 @@ describe("pruneContextMessages", () => {
     expect(toolResult.content).toEqual([
       { type: "text", text: "[image removed during context pruning]" },
     ]);
+  });
+
+  it("still replaces image blocks after micro-compression drops below soft-trim ratio", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "\r\n\r\nalpha\r\nbeta\r\n" }]),
+      makeToolResult([{ type: "image", data: "img", mimeType: "image/png" }]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 1,
+        softTrimRatio: 0.5,
+        hardClearRatio: 10,
+        hardClear: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear,
+          enabled: false,
+        },
+        softTrim: {
+          maxChars: 5_000,
+          headChars: 2_000,
+          tailChars: 2_000,
+        },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 6,
+    });
+
+    expect(getToolResultText(result)).toBe("alpha\nbeta");
+    expect(getToolResultText(result, 2)).toBe("[image removed during context pruning]");
   });
 
   it("hard-clears image-containing tool results once ratios require clearing", () => {

--- a/src/agents/pi-hooks/context-pruning/pruner.test.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.test.ts
@@ -91,6 +91,7 @@ function buildToolTrimSettings() {
     tools: DEFAULT_CONTEXT_PRUNING_SETTINGS.tools,
     softTrim: { maxChars: 200, headChars: 100, tailChars: 50 },
     hardClear: { ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear, enabled: false },
+    microCompress: DEFAULT_CONTEXT_PRUNING_SETTINGS.microCompress,
   };
 }
 
@@ -101,6 +102,12 @@ function expectToolResultWasTrimmed(result: AgentMessage[]) {
   >;
   const textBlock = toolResult.content[0] as { type: "text"; text: string };
   expect(textBlock.text).toContain("[Tool result trimmed:");
+}
+
+function getToolResultText(result: AgentMessage[], index = 1): string {
+  const toolResult = result[index] as Extract<AgentMessage, { role: "toolResult" }>;
+  const textBlock = toolResult.content[0] as { type: "text"; text: string };
+  return textBlock.text;
 }
 
 describe("pruneContextMessages", () => {
@@ -219,6 +226,207 @@ describe("pruneContextMessages", () => {
     });
 
     expect(result).toBe(messages);
+  });
+
+  it("micro-compresses CRLF-heavy tool output before trim thresholds are evaluated", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "\r\n\r\nalpha\r\nbeta\r\n" }]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...buildToolTrimSettings(),
+        softTrimRatio: 0,
+        hardClearRatio: 10,
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    expect(getToolResultText(result)).toBe("alpha\nbeta");
+  });
+
+  it("strips ANSI-colored output before trim thresholds are evaluated", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "\u001b[31merror\u001b[0m\nok" }]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...buildToolTrimSettings(),
+        softTrimRatio: 0,
+        hardClearRatio: 10,
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    expect(getToolResultText(result)).toBe("error\nok");
+  });
+
+  it("collapses repeated blank lines and trims trailing whitespace", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "alpha  \n\n\n\nbeta   \n" }]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...buildToolTrimSettings(),
+        softTrimRatio: 0,
+        hardClearRatio: 10,
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    expect(getToolResultText(result)).toBe("alpha\n\nbeta");
+  });
+
+  it("leaves tool results unchanged when micro-compression cannot reduce size", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "alpha\nbeta" }]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...buildToolTrimSettings(),
+        softTrimRatio: 0,
+        hardClearRatio: 10,
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    expect(result).toBe(messages);
+  });
+
+  it("can disable micro-compression entirely", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "\u001b[31merror\u001b[0m\r\n" }]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...buildToolTrimSettings(),
+        softTrimRatio: 0,
+        hardClearRatio: 10,
+        microCompress: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS.microCompress,
+          enabled: false,
+        },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    expect(result).toBe(messages);
+  });
+
+  it("supports disabling individual micro-compression transforms", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([{ type: "text", text: "\u001b[31merror\u001b[0m\r\n\r\n" }]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...buildToolTrimSettings(),
+        softTrimRatio: 0,
+        hardClearRatio: 10,
+        microCompress: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS.microCompress,
+          stripAnsi: false,
+          collapseBlankLines: false,
+        },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    expect(getToolResultText(result)).toBe("\u001b[31merror\u001b[0m");
+  });
+
+  it("never micro-compresses user or assistant messages", () => {
+    const messages: AgentMessage[] = [
+      makeUser("alpha  \r\n\r\n"),
+      makeAssistant([{ type: "text", text: "\u001b[31mbeta\u001b[0m  " }]),
+      makeToolResult([{ type: "text", text: "X".repeat(2_000) }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...buildToolTrimSettings(),
+        keepLastAssistants: 0,
+        softTrimRatio: 0,
+      },
+      ctx: CONTEXT_WINDOW_5K,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 100,
+    });
+
+    expect(result[0]).toBe(messages[0]);
+    expect(result[1]).toBe(messages[1]);
+    expectToolResultWasTrimmed(result);
+  });
+
+  it("normalizes text around image placeholders before trimming", () => {
+    const messages: AgentMessage[] = [
+      makeUser("summarize this"),
+      makeToolResult([
+        { type: "text", text: "\r\n\r\nalpha  " },
+        { type: "image", data: "img", mimeType: "image/png" },
+        { type: "text", text: "\n\n\nbeta\t\t" },
+      ]),
+      makeAssistant([{ type: "text", text: "done" }]),
+    ];
+
+    const result = pruneContextMessages({
+      messages,
+      settings: {
+        ...DEFAULT_CONTEXT_PRUNING_SETTINGS,
+        keepLastAssistants: 1,
+        softTrimRatio: 0,
+        hardClearRatio: 10,
+        hardClear: {
+          ...DEFAULT_CONTEXT_PRUNING_SETTINGS.hardClear,
+          enabled: false,
+        },
+        softTrim: {
+          maxChars: 5_000,
+          headChars: 2_000,
+          tailChars: 2_000,
+        },
+      },
+      ctx: CONTEXT_WINDOW_1M,
+      isToolPrunable: () => true,
+      contextWindowTokensOverride: 1,
+    });
+
+    expect(getToolResultText(result)).toBe("alpha\n[image removed during context pruning]\n\nbeta");
   });
 
   it("soft-trims image-containing tool results by replacing image blocks with placeholders", () => {

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -115,7 +115,10 @@ function maybeMicroCompressToolResultMessage(params: {
   if (normalized === joined) {
     return null;
   }
-  return { ...msg, content: [asText(normalized)] };
+  const rewritten = { ...msg, content: [asText(normalized)] };
+  const beforeChars = estimateMessageChars(msg as unknown as AgentMessage);
+  const afterChars = estimateMessageChars(rewritten as unknown as AgentMessage);
+  return afterChars < beforeChars ? rewritten : null;
 }
 
 function estimateJoinedTextLength(parts: string[]): number {
@@ -309,11 +312,14 @@ function softTrimToolResultMessage(params: {
   const effectiveJoined = maybeMicroCompressJoinedText({ text: joined, settings });
   const effectiveParts = effectiveJoined === joined ? parts : effectiveJoined.split("\n");
   const rawLen = estimateJoinedTextLength(effectiveParts);
+  const normalizedWithoutTrim = { ...msg, content: [asText(effectiveJoined)] };
+  const beforeChars = estimateMessageChars(msg as unknown as AgentMessage);
+  const normalizedChars = estimateMessageChars(normalizedWithoutTrim as unknown as AgentMessage);
   if (rawLen <= settings.softTrim.maxChars) {
     if (!hasImages && effectiveJoined === joined) {
       return null;
     }
-    return { ...msg, content: [asText(effectiveJoined)] };
+    return hasImages || normalizedChars < beforeChars ? normalizedWithoutTrim : null;
   }
 
   const headChars = Math.max(0, settings.softTrim.headChars);
@@ -322,7 +328,7 @@ function softTrimToolResultMessage(params: {
     if (!hasImages && effectiveJoined === joined) {
       return null;
     }
-    return { ...msg, content: [asText(effectiveJoined)] };
+    return hasImages || normalizedChars < beforeChars ? normalizedWithoutTrim : null;
   }
 
   const head = takeHeadFromJoinedText(effectiveParts, headChars);
@@ -416,6 +422,9 @@ export function pruneContextMessages(params: {
   }
 
   ratio = totalChars / charWindow;
+  if (ratio < settings.softTrimRatio) {
+    return next ?? messages;
+  }
   for (const i of prunableToolIndexes) {
     const msg = (next ?? messages)[i];
     if (!msg || msg.role !== "toolResult") {

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -426,12 +426,16 @@ export function pruneContextMessages(params: {
   }
 
   ratio = totalChars / charWindow;
-  if (ratio < settings.softTrimRatio && !hasPrunableImageToolResult) {
+  const restrictSoftTrimToImagesOnly = ratio < settings.softTrimRatio && hasPrunableImageToolResult;
+  if (ratio < settings.softTrimRatio && !restrictSoftTrimToImagesOnly) {
     return next ?? messages;
   }
   for (const i of prunableToolIndexes) {
     const msg = (next ?? messages)[i];
     if (!msg || msg.role !== "toolResult") {
+      continue;
+    }
+    if (restrictSoftTrimToImagesOnly && !hasImageBlocks(msg.content)) {
       continue;
     }
 

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -72,6 +72,9 @@ function normalizeMicroCompressedText(
   settings: EffectiveContextPruningSettings["microCompress"] | undefined,
 ): string {
   const effectiveSettings = settings ?? DEFAULT_MICRO_COMPRESS_SETTINGS;
+  // CR/CRLF normalization plus outer empty-line trimming are always-on safety
+  // steps for prunable tool text; the per-flag toggles only control the more
+  // opinionated formatting-noise reductions below.
   let next = text.replace(/\r\n?/g, "\n");
   if (effectiveSettings.stripAnsi) {
     next = next.replace(ANSI_ESCAPE_PATTERN, "");
@@ -95,7 +98,7 @@ function maybeMicroCompressJoinedText(params: {
     return params.text;
   }
   const normalized = normalizeMicroCompressedText(params.text, microCompress);
-  return normalized.length < params.text.length ? normalized : params.text;
+  return normalized !== params.text ? normalized : params.text;
 }
 
 function maybeMicroCompressToolResultMessage(params: {
@@ -413,10 +416,6 @@ export function pruneContextMessages(params: {
   }
 
   ratio = totalChars / charWindow;
-  if (ratio < settings.softTrimRatio) {
-    return next ?? messages;
-  }
-
   for (const i of prunableToolIndexes) {
     const msg = (next ?? messages)[i];
     if (!msg || msg.role !== "toolResult") {

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -392,6 +392,7 @@ export function pruneContextMessages(params: {
   }
 
   const prunableToolIndexes: number[] = [];
+  let hasPrunableImageToolResult = false;
   let next: AgentMessage[] | null = null;
 
   for (let i = pruneStartIndex; i < cutoffIndex; i++) {
@@ -403,6 +404,9 @@ export function pruneContextMessages(params: {
       continue;
     }
     prunableToolIndexes.push(i);
+    if (hasImageBlocks((msg as unknown as ToolResultMessage).content)) {
+      hasPrunableImageToolResult = true;
+    }
 
     const microCompressed = maybeMicroCompressToolResultMessage({
       msg: msg as unknown as ToolResultMessage,
@@ -422,7 +426,7 @@ export function pruneContextMessages(params: {
   }
 
   ratio = totalChars / charWindow;
-  if (ratio < settings.softTrimRatio) {
+  if (ratio < settings.softTrimRatio && !hasPrunableImageToolResult) {
     return next ?? messages;
   }
   for (const i of prunableToolIndexes) {

--- a/src/agents/pi-hooks/context-pruning/pruner.ts
+++ b/src/agents/pi-hooks/context-pruning/pruner.ts
@@ -8,6 +8,18 @@ import { makeToolPrunablePredicate } from "./tools.js";
 
 const IMAGE_CHAR_ESTIMATE = 8_000;
 const PRUNED_CONTEXT_IMAGE_MARKER = "[image removed during context pruning]";
+const ESC = String.fromCharCode(27);
+const BEL = String.fromCharCode(7);
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  `${ESC}(?:\\[[0-?]*[ -/]*[@-~]|\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)|[@-Z\\\\-_])`,
+  "g",
+);
+const DEFAULT_MICRO_COMPRESS_SETTINGS: EffectiveContextPruningSettings["microCompress"] = {
+  enabled: true,
+  stripAnsi: true,
+  trimTrailingWhitespace: true,
+  collapseBlankLines: true,
+};
 
 function asText(text: string): TextContent {
   return { type: "text", text };
@@ -37,6 +49,70 @@ function collectPrunableToolResultSegments(
     }
   }
   return parts;
+}
+
+function trimOuterEmptyLines(text: string): string {
+  if (text.length === 0) {
+    return text;
+  }
+  const lines = text.split("\n");
+  let start = 0;
+  let end = lines.length;
+  while (start < end && lines[start]?.trim() === "") {
+    start++;
+  }
+  while (end > start && lines[end - 1]?.trim() === "") {
+    end--;
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+function normalizeMicroCompressedText(
+  text: string,
+  settings: EffectiveContextPruningSettings["microCompress"] | undefined,
+): string {
+  const effectiveSettings = settings ?? DEFAULT_MICRO_COMPRESS_SETTINGS;
+  let next = text.replace(/\r\n?/g, "\n");
+  if (effectiveSettings.stripAnsi) {
+    next = next.replace(ANSI_ESCAPE_PATTERN, "");
+  }
+  if (effectiveSettings.trimTrailingWhitespace) {
+    next = next.replace(/[^\S\n]+$/gm, "");
+  }
+  next = trimOuterEmptyLines(next);
+  if (effectiveSettings.collapseBlankLines) {
+    next = next.replace(/\n{3,}/g, "\n\n");
+  }
+  return next;
+}
+
+function maybeMicroCompressJoinedText(params: {
+  text: string;
+  settings: EffectiveContextPruningSettings;
+}): string {
+  const microCompress = params.settings.microCompress ?? DEFAULT_MICRO_COMPRESS_SETTINGS;
+  if (!microCompress.enabled) {
+    return params.text;
+  }
+  const normalized = normalizeMicroCompressedText(params.text, microCompress);
+  return normalized.length < params.text.length ? normalized : params.text;
+}
+
+function maybeMicroCompressToolResultMessage(params: {
+  msg: ToolResultMessage;
+  settings: EffectiveContextPruningSettings;
+}): ToolResultMessage | null {
+  const { msg, settings } = params;
+  const microCompress = settings.microCompress ?? DEFAULT_MICRO_COMPRESS_SETTINGS;
+  if (!microCompress.enabled || hasImageBlocks(msg.content)) {
+    return null;
+  }
+  const joined = collectTextSegments(msg.content).join("\n");
+  const normalized = maybeMicroCompressJoinedText({ text: joined, settings });
+  if (normalized === joined) {
+    return null;
+  }
+  return { ...msg, content: [asText(normalized)] };
 }
 
 function estimateJoinedTextLength(parts: string[]): number {
@@ -226,25 +302,28 @@ function softTrimToolResultMessage(params: {
   const parts = hasImages
     ? collectPrunableToolResultSegments(msg.content)
     : collectTextSegments(msg.content);
-  const rawLen = estimateJoinedTextLength(parts);
+  const joined = parts.join("\n");
+  const effectiveJoined = maybeMicroCompressJoinedText({ text: joined, settings });
+  const effectiveParts = effectiveJoined === joined ? parts : effectiveJoined.split("\n");
+  const rawLen = estimateJoinedTextLength(effectiveParts);
   if (rawLen <= settings.softTrim.maxChars) {
-    if (!hasImages) {
+    if (!hasImages && effectiveJoined === joined) {
       return null;
     }
-    return { ...msg, content: [asText(parts.join("\n"))] };
+    return { ...msg, content: [asText(effectiveJoined)] };
   }
 
   const headChars = Math.max(0, settings.softTrim.headChars);
   const tailChars = Math.max(0, settings.softTrim.tailChars);
   if (headChars + tailChars >= rawLen) {
-    if (!hasImages) {
+    if (!hasImages && effectiveJoined === joined) {
       return null;
     }
-    return { ...msg, content: [asText(parts.join("\n"))] };
+    return { ...msg, content: [asText(effectiveJoined)] };
   }
 
-  const head = takeHeadFromJoinedText(parts, headChars);
-  const tail = takeTailFromJoinedText(parts, tailChars);
+  const head = takeHeadFromJoinedText(effectiveParts, headChars);
+  const tail = takeTailFromJoinedText(effectiveParts, tailChars);
   const trimmed = `${head}
 ...
 ${tail}`;
@@ -315,6 +394,34 @@ export function pruneContextMessages(params: {
       continue;
     }
     prunableToolIndexes.push(i);
+
+    const microCompressed = maybeMicroCompressToolResultMessage({
+      msg: msg as unknown as ToolResultMessage,
+      settings,
+    });
+    if (!microCompressed) {
+      continue;
+    }
+
+    const beforeChars = estimateMessageChars(msg);
+    const afterChars = estimateMessageChars(microCompressed as unknown as AgentMessage);
+    totalChars += afterChars - beforeChars;
+    if (!next) {
+      next = messages.slice();
+    }
+    next[i] = microCompressed as unknown as AgentMessage;
+  }
+
+  ratio = totalChars / charWindow;
+  if (ratio < settings.softTrimRatio) {
+    return next ?? messages;
+  }
+
+  for (const i of prunableToolIndexes) {
+    const msg = (next ?? messages)[i];
+    if (!msg || msg.role !== "toolResult") {
+      continue;
+    }
 
     const updated = softTrimToolResultMessage({
       msg: msg as unknown as ToolResultMessage,

--- a/src/agents/pi-hooks/context-pruning/settings.ts
+++ b/src/agents/pi-hooks/context-pruning/settings.ts
@@ -24,6 +24,12 @@ export type ContextPruningConfig = {
     enabled?: boolean;
     placeholder?: string;
   };
+  microCompress?: {
+    enabled?: boolean;
+    stripAnsi?: boolean;
+    trimTrailingWhitespace?: boolean;
+    collapseBlankLines?: boolean;
+  };
 };
 
 export type EffectiveContextPruningSettings = {
@@ -43,6 +49,12 @@ export type EffectiveContextPruningSettings = {
     enabled: boolean;
     placeholder: string;
   };
+  microCompress: {
+    enabled: boolean;
+    stripAnsi: boolean;
+    trimTrailingWhitespace: boolean;
+    collapseBlankLines: boolean;
+  };
 };
 
 export const DEFAULT_CONTEXT_PRUNING_SETTINGS: EffectiveContextPruningSettings = {
@@ -61,6 +73,12 @@ export const DEFAULT_CONTEXT_PRUNING_SETTINGS: EffectiveContextPruningSettings =
   hardClear: {
     enabled: true,
     placeholder: "[Old tool result content cleared]",
+  },
+  microCompress: {
+    enabled: true,
+    stripAnsi: true,
+    trimTrailingWhitespace: true,
+    collapseBlankLines: true,
   },
 };
 
@@ -116,6 +134,20 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
     }
     if (typeof cfg.hardClear.placeholder === "string" && cfg.hardClear.placeholder.trim()) {
       s.hardClear.placeholder = cfg.hardClear.placeholder.trim();
+    }
+  }
+  if (cfg.microCompress) {
+    if (typeof cfg.microCompress.enabled === "boolean") {
+      s.microCompress.enabled = cfg.microCompress.enabled;
+    }
+    if (typeof cfg.microCompress.stripAnsi === "boolean") {
+      s.microCompress.stripAnsi = cfg.microCompress.stripAnsi;
+    }
+    if (typeof cfg.microCompress.trimTrailingWhitespace === "boolean") {
+      s.microCompress.trimTrailingWhitespace = cfg.microCompress.trimTrailingWhitespace;
+    }
+    if (typeof cfg.microCompress.collapseBlankLines === "boolean") {
+      s.microCompress.collapseBlankLines = cfg.microCompress.collapseBlankLines;
     }
   }
 

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4316,7 +4316,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         type: "boolean",
                         title: "Enable Tool Result Micro-Compression",
                         description:
-                          "Enables safe in-memory micro-compression for prunable tool results before trim/clear decisions (default: true in cache-ttl mode). Disable to preserve current pruning behavior exactly.",
+                          "Enables safe in-memory micro-compression for prunable tool results before trim/clear decisions (default: true in cache-ttl mode). When enabled, line endings are normalized and outer empty lines are removed before any optional ANSI stripping, trailing-whitespace trimming, or blank-line collapse. Disable to preserve current pruning behavior exactly.",
                       },
                       stripAnsi: {
                         type: "boolean",
@@ -23718,7 +23718,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     },
     "agents.defaults.contextPruning.microCompress.enabled": {
       label: "Enable Tool Result Micro-Compression",
-      help: "Enables safe in-memory micro-compression for prunable tool results before trim/clear decisions (default: true in cache-ttl mode). Disable to preserve current pruning behavior exactly.",
+      help: "Enables safe in-memory micro-compression for prunable tool results before trim/clear decisions (default: true in cache-ttl mode). When enabled, line endings are normalized and outer empty lines are removed before any optional ANSI stripping, trailing-whitespace trimming, or blank-line collapse. Disable to preserve current pruning behavior exactly.",
       tags: ["advanced"],
     },
     "agents.defaults.contextPruning.microCompress.stripAnsi": {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4314,15 +4314,27 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     properties: {
                       enabled: {
                         type: "boolean",
+                        title: "Enable Tool Result Micro-Compression",
+                        description:
+                          "Enables safe in-memory micro-compression for prunable tool results before trim/clear decisions (default: true in cache-ttl mode). Disable to preserve current pruning behavior exactly.",
                       },
                       stripAnsi: {
                         type: "boolean",
+                        title: "Strip ANSI Escape Codes",
+                        description:
+                          "Strips ANSI escape sequences from prunable tool-result text before pruning (default: true). Disable only if terminal color codes themselves are semantically important.",
                       },
                       trimTrailingWhitespace: {
                         type: "boolean",
+                        title: "Trim Trailing Tool Output Whitespace",
+                        description:
+                          "Removes trailing spaces and tabs from each line of prunable tool-result text before pruning (default: true). Keep enabled unless exact whitespace at line ends matters to the tool output.",
                       },
                       collapseBlankLines: {
                         type: "boolean",
+                        title: "Collapse Repeated Blank Lines",
+                        description:
+                          "Collapses runs of three or more blank lines down to two in prunable tool-result text before pruning (default: true). Disable if repeated blank-line spacing carries meaning in your tool output.",
                       },
                     },
                     additionalProperties: false,
@@ -23703,6 +23715,26 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       label: "Agent Tool Allowlist Additions",
       help: "Per-agent additive allowlist for tools on top of global and profile policy. Keep narrow to avoid accidental privilege expansion on specialized agents.",
       tags: ["access"],
+    },
+    "agents.defaults.contextPruning.microCompress.enabled": {
+      label: "Enable Tool Result Micro-Compression",
+      help: "Enables safe in-memory micro-compression for prunable tool results before trim/clear decisions (default: true in cache-ttl mode). Disable to preserve current pruning behavior exactly.",
+      tags: ["advanced"],
+    },
+    "agents.defaults.contextPruning.microCompress.stripAnsi": {
+      label: "Strip ANSI Escape Codes",
+      help: "Strips ANSI escape sequences from prunable tool-result text before pruning (default: true). Disable only if terminal color codes themselves are semantically important.",
+      tags: ["advanced"],
+    },
+    "agents.defaults.contextPruning.microCompress.trimTrailingWhitespace": {
+      label: "Trim Trailing Tool Output Whitespace",
+      help: "Removes trailing spaces and tabs from each line of prunable tool-result text before pruning (default: true). Keep enabled unless exact whitespace at line ends matters to the tool output.",
+      tags: ["advanced"],
+    },
+    "agents.defaults.contextPruning.microCompress.collapseBlankLines": {
+      label: "Collapse Repeated Blank Lines",
+      help: "Collapses runs of three or more blank lines down to two in prunable tool-result text before pruning (default: true). Disable if repeated blank-line spacing carries meaning in your tool output.",
+      tags: ["advanced"],
     },
     "tools.byProvider": {
       label: "Tool Policy by Provider",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4309,6 +4309,24 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     },
                     additionalProperties: false,
                   },
+                  microCompress: {
+                    type: "object",
+                    properties: {
+                      enabled: {
+                        type: "boolean",
+                      },
+                      stripAnsi: {
+                        type: "boolean",
+                      },
+                      trimTrailingWhitespace: {
+                        type: "boolean",
+                      },
+                      collapseBlankLines: {
+                        type: "boolean",
+                      },
+                    },
+                    additionalProperties: false,
+                  },
                 },
                 additionalProperties: false,
               },

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1034,7 +1034,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.sync.sessions.postCompactionForce":
     "Forces a session memory-search reindex after compaction-triggered transcript updates (default: true). Keep enabled when compacted summaries must be immediately searchable, or disable to reduce write-time indexing pressure.",
   "agents.defaults.contextPruning.microCompress.enabled":
-    "Enables safe in-memory micro-compression for prunable tool results before trim/clear decisions (default: true in cache-ttl mode). Disable to preserve current pruning behavior exactly.",
+    "Enables safe in-memory micro-compression for prunable tool results before trim/clear decisions (default: true in cache-ttl mode). When enabled, line endings are normalized and outer empty lines are removed before any optional ANSI stripping, trailing-whitespace trimming, or blank-line collapse. Disable to preserve current pruning behavior exactly.",
   "agents.defaults.contextPruning.microCompress.stripAnsi":
     "Strips ANSI escape sequences from prunable tool-result text before pruning (default: true). Disable only if terminal color codes themselves are semantically important.",
   "agents.defaults.contextPruning.microCompress.trimTrailingWhitespace":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1033,6 +1033,14 @@ export const FIELD_HELP: Record<string, string> = {
     "Requires at least this many appended transcript messages before reindex is triggered (default: 50). Lower this for near-real-time transcript recall, or raise it to reduce indexing churn.",
   "agents.defaults.memorySearch.sync.sessions.postCompactionForce":
     "Forces a session memory-search reindex after compaction-triggered transcript updates (default: true). Keep enabled when compacted summaries must be immediately searchable, or disable to reduce write-time indexing pressure.",
+  "agents.defaults.contextPruning.microCompress.enabled":
+    "Enables safe in-memory micro-compression for prunable tool results before trim/clear decisions (default: true in cache-ttl mode). Disable to preserve current pruning behavior exactly.",
+  "agents.defaults.contextPruning.microCompress.stripAnsi":
+    "Strips ANSI escape sequences from prunable tool-result text before pruning (default: true). Disable only if terminal color codes themselves are semantically important.",
+  "agents.defaults.contextPruning.microCompress.trimTrailingWhitespace":
+    "Removes trailing spaces and tabs from each line of prunable tool-result text before pruning (default: true). Keep enabled unless exact whitespace at line ends matters to the tool output.",
+  "agents.defaults.contextPruning.microCompress.collapseBlankLines":
+    "Collapses runs of three or more blank lines down to two in prunable tool-result text before pruning (default: true). Disable if repeated blank-line spacing carries meaning in your tool output.",
   ui: "UI presentation settings for accenting and assistant identity shown in control surfaces. Use this for branding and readability customization without changing runtime behavior.",
   "ui.seamColor":
     "Primary accent color used by UI surfaces for emphasis, badges, and visual identity cues. Use high-contrast values that remain readable across light/dark themes.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -169,6 +169,12 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.alsoAllow": "Tool Allowlist Additions",
   "agents.list[].tools.profile": "Agent Tool Profile",
   "agents.list[].tools.alsoAllow": "Agent Tool Allowlist Additions",
+  "agents.defaults.contextPruning.microCompress.enabled": "Enable Tool Result Micro-Compression",
+  "agents.defaults.contextPruning.microCompress.stripAnsi": "Strip ANSI Escape Codes",
+  "agents.defaults.contextPruning.microCompress.trimTrailingWhitespace":
+    "Trim Trailing Tool Output Whitespace",
+  "agents.defaults.contextPruning.microCompress.collapseBlankLines":
+    "Collapse Repeated Blank Lines",
   "tools.byProvider": "Tool Policy by Provider",
   "agents.list[].tools.byProvider": "Agent Tool Policy by Provider",
   "tools.exec.applyPatch.enabled": "Enable apply_patch",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -48,6 +48,12 @@ export type AgentContextPruningConfig = {
     enabled?: boolean;
     placeholder?: string;
   };
+  microCompress?: {
+    enabled?: boolean;
+    stripAnsi?: boolean;
+    trimTrailingWhitespace?: boolean;
+    collapseBlankLines?: boolean;
+  };
 };
 
 export type AgentStartupContextConfig = {

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -55,6 +55,23 @@ describe("agent defaults schema", () => {
     expect(result.embeddedPi?.executionContract).toBe("strict-agentic");
   });
 
+  it("accepts contextPruning.microCompress options", () => {
+    const result = AgentDefaultsSchema.parse({
+      contextPruning: {
+        mode: "cache-ttl",
+        microCompress: {
+          enabled: true,
+          stripAnsi: false,
+          trimTrailingWhitespace: true,
+          collapseBlankLines: false,
+        },
+      },
+    })!;
+
+    expect(result.contextPruning?.microCompress?.stripAnsi).toBe(false);
+    expect(result.contextPruning?.microCompress?.collapseBlankLines).toBe(false);
+  });
+
   it("accepts positive heartbeat timeoutSeconds on defaults and agent entries", () => {
     const defaults = AgentDefaultsSchema.parse({
       heartbeat: { timeoutSeconds: 45 },

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -109,6 +109,15 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        microCompress: z
+          .object({
+            enabled: z.boolean().optional(),
+            stripAnsi: z.boolean().optional(),
+            trimTrailingWhitespace: z.boolean().optional(),
+            collapseBlankLines: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -65,8 +65,9 @@ describe("bundled plugin public surface loader", () => {
     }
   });
 
-  it("prefers source require for bundled source public artifacts when a ts require hook exists", async () => {
-    const createJiti = vi.fn(() => vi.fn(() => ({ marker: "jiti-should-not-run" })));
+  it("prefers jiti for bundled source public artifacts even when a ts require hook exists", async () => {
+    const jitiLoader = vi.fn(() => ({ marker: "source-jiti-ok" }));
+    const createJiti = vi.fn(() => jitiLoader);
     vi.doMock("jiti", () => ({
       createJiti,
     }));
@@ -101,8 +102,9 @@ describe("bundled plugin public surface loader", () => {
         dirName: "demo",
         artifactBasename: "secret-contract-api.js",
       }).marker,
-    ).toBe("source-require-ok");
-    expect(requireLoader).toHaveBeenCalledWith(pathModule.resolve(modulePath));
-    expect(createJiti).not.toHaveBeenCalled();
+    ).toBe("source-jiti-ok");
+    expect(jitiLoader).toHaveBeenCalledWith(pathModule.resolve(modulePath));
+    expect(requireLoader).not.toHaveBeenCalled();
+    expect(createJiti).toHaveBeenCalled();
   });
 });

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -45,14 +45,6 @@ function isSourceArtifactPath(modulePath: string): boolean {
   }
 }
 
-function canUseSourceArtifactRequire(params: { modulePath: string; tryNative: boolean }): boolean {
-  return (
-    !params.tryNative &&
-    isSourceArtifactPath(params.modulePath) &&
-    typeof sourceArtifactRequire.extensions?.[".ts"] === "function"
-  );
-}
-
 function createResolutionKey(params: { dirName: string; artifactBasename: string }): string {
   const bundledPluginsDir = resolveBundledPluginsDir();
   return `${params.dirName}::${params.artifactBasename}::${bundledPluginsDir ? path.resolve(bundledPluginsDir) : "<default>"}`;
@@ -124,7 +116,15 @@ function loadPublicSurfaceModule(modulePath: string): unknown {
     moduleUrl: import.meta.url,
     preferBuiltDist: true,
   });
-  if (canUseSourceArtifactRequire({ modulePath, tryNative })) {
+  if (!tryNative && isSourceArtifactPath(modulePath)) {
+    // Bundled source artifacts commonly use repo-wide `.js` import specifiers
+    // that rely on Jiti's extension remapping when loading from `.ts` sources.
+    return getJiti(modulePath)(modulePath);
+  }
+  if (
+    typeof sourceArtifactRequire.extensions?.[".ts"] === "function" &&
+    isSourceArtifactPath(modulePath)
+  ) {
     return sourceArtifactRequire(modulePath);
   }
   return getJiti(modulePath)(modulePath);


### PR DESCRIPTION
Phase 1 of #65250.

## Summary

- Problem: context pruning evaluated trim/clear thresholds against raw prunable tool-result text, so CRLF-heavy output, ANSI color codes, trailing whitespace, and repeated blank lines could inflate size and trigger avoidable pruning. Review follow-ups also exposed a bundled public-surface source-loading path that could miss repo-wide `.js` specifier remapping.
- Why it matters: unnecessary pruning reduces useful tool context and weakens cache-ttl prompt-cache savings; the loader issue could break bundled plugin public artifact loading from source artifacts.
- What changed: added safe in-memory micro-compression for prunable text tool results before trim/clear decisions in `src/agents/pi-hooks/context-pruning/pruner.ts`, added config/schema/docs coverage for `contextPruning.microCompress.*`, and updated `src/plugins/public-surface-loader.ts` to route bundled source artifacts through the correct loader path.
- What did NOT change (scope boundary): no transcript rewrites, no changes to normal conversation text, no image-block micro-compression, and no change to non-prunable messages.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65250
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/agents/pi-hooks/context-pruning/pruner.ts` was making pruning decisions from raw prunable tool-result text instead of first removing formatting-only noise, so harmless output formatting could push messages over trim thresholds. The review follow-up in `src/plugins/public-surface-loader.ts` addressed bundled source-artifact loading that depended on `.js` specifier remapping.
- Missing detection / guardrail: there was no regression coverage locking in CRLF/ANSI/blank-line-heavy tool results before trim evaluation, and no targeted coverage for the bundled source-artifact loader path.
- Contributing context (if known): cache-ttl pruning is specifically trying to reduce prompt-cache write size, so formatting noise had an outsized effect.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-hooks/context-pruning/pruner.test.ts`, `src/config/zod-schema.agent-defaults.test.ts`, `src/plugins/public-surface-loader.test.ts`
- Scenario the test should lock in: prunable text tool results are normalized before trim/clear decisions; image-containing tool results are left alone; config/schema surfaces stay aligned; bundled public-surface source artifacts still load correctly.
- Why this is the smallest reliable guardrail: the behavior is implemented at the pruning/loader seam rather than in a single leaf helper.
- Existing test that already covers this (if any): targeted pruning and loader tests in this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Prunable text tool results can now be micro-compressed in memory before trim/clear thresholds are evaluated.
- `contextPruning.microCompress.*` is now documented/configurable with clearer schema help.
- Persisted transcripts and normal conversation text are unchanged.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Run pruning against CRLF/ANSI/blank-line-heavy prunable tool output.
2. Verify normalization happens before trim/clear decisions.
3. Verify bundled plugin public-surface loading still works from source artifacts.

### Expected

- Formatting-only noise does not trigger avoidable pruning.
- Image-containing tool results are not micro-compressed.
- Bundled public-surface source loading still succeeds.

### Actual

- `pnpm build` passed
- `pnpm check` passed
- targeted tests passed
- gateway-watch regression passed
- full `pnpm test` still reports unrelated baseline failures outside the touched surface

## Human Verification (required)

- Verified scenarios: micro-compression before pruning thresholds, config/schema/docs alignment, bundled public-surface loader follow-up.
- Edge cases checked: CRLF normalization, ANSI stripping, optional blank-line/whitespace controls, image tool-result opt-out.
- What you did **not** verify: unrelated baseline failures in the full suite remain out of scope for this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: tool-result text normalization could remove formatting a user expected to remain byte-identical in prunable output.
  - Mitigation: the behavior is limited to in-memory prunable tool results, excludes image blocks, and remains configurable via `contextPruning.microCompress.*`.
