### PR TITLE
perf(context-pruning): reduce keepLastAssistants to 1 in skill mode

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -795,7 +795,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
-        skillsSnapshot: params.skillsSnapshot,
+        promptMode,
       });
       // Only create an explicit resource loader when there are extension factories
       // to register; otherwise let createAgentSession use its built-in default.

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -795,6 +795,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
+        skillsSnapshot: params.skillsSnapshot,
       });
       // Only create an explicit resource loader when there are extension factories
       // to register; otherwise let createAgentSession use its built-in default.

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { getCompactionSafeguardRuntime } from "../pi-hooks/compaction-safeguard-runtime.js";
 import compactionSafeguardExtension from "../pi-hooks/compaction-safeguard.js";
 import contextPruningExtension from "../pi-hooks/context-pruning.js";
+import { getContextPruningRuntime } from "../pi-hooks/context-pruning/runtime.js";
 import { buildEmbeddedExtensionFactories } from "./extensions.js";
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
@@ -94,5 +95,52 @@ describe("buildEmbeddedExtensionFactories", () => {
     });
 
     expect(factories).toContain(contextPruningExtension);
+  });
+
+  it("reduces keepLastAssistants to 1 when skillsSnapshot is present", () => {
+    const sessionManager = {} as SessionManager;
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: {
+        agents: {
+          defaults: {
+            contextPruning: {
+              mode: "cache-ttl",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      sessionManager,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      model: { api: "anthropic-messages", contextWindow: 200_000 } as Model<Api>,
+      skillsSnapshot: { prompt: "test skill", skills: [{ name: "test" }] },
+    });
+
+    expect(factories).toContain(contextPruningExtension);
+    const runtime = getContextPruningRuntime(sessionManager);
+    expect(runtime?.settings.keepLastAssistants).toBe(1);
+  });
+
+  it("keeps default keepLastAssistants of 3 without skillsSnapshot", () => {
+    const sessionManager = {} as SessionManager;
+    const factories = buildEmbeddedExtensionFactories({
+      cfg: {
+        agents: {
+          defaults: {
+            contextPruning: {
+              mode: "cache-ttl",
+            },
+          },
+        },
+      } as OpenClawConfig,
+      sessionManager,
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      model: { api: "anthropic-messages", contextWindow: 200_000 } as Model<Api>,
+    });
+
+    expect(factories).toContain(contextPruningExtension);
+    const runtime = getContextPruningRuntime(sessionManager);
+    expect(runtime?.settings.keepLastAssistants).toBe(3);
   });
 });

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -97,7 +97,7 @@ describe("buildEmbeddedExtensionFactories", () => {
     expect(factories).toContain(contextPruningExtension);
   });
 
-  it("reduces keepLastAssistants to 1 when skillsSnapshot is present", () => {
+  it("reduces keepLastAssistants to 1 in minimal prompt mode (subagent/cron)", () => {
     const sessionManager = {} as SessionManager;
     const factories = buildEmbeddedExtensionFactories({
       cfg: {
@@ -113,7 +113,7 @@ describe("buildEmbeddedExtensionFactories", () => {
       provider: "anthropic",
       modelId: "claude-sonnet-4-6",
       model: { api: "anthropic-messages", contextWindow: 200_000 } as Model<Api>,
-      skillsSnapshot: { prompt: "test skill", skills: [{ name: "test" }] },
+      promptMode: "minimal",
     });
 
     expect(factories).toContain(contextPruningExtension);
@@ -121,7 +121,7 @@ describe("buildEmbeddedExtensionFactories", () => {
     expect(runtime?.settings.keepLastAssistants).toBe(1);
   });
 
-  it("keeps default keepLastAssistants of 3 without skillsSnapshot", () => {
+  it("keeps default keepLastAssistants of 3 in full prompt mode", () => {
     const sessionManager = {} as SessionManager;
     const factories = buildEmbeddedExtensionFactories({
       cfg: {
@@ -137,6 +137,7 @@ describe("buildEmbeddedExtensionFactories", () => {
       provider: "anthropic",
       modelId: "claude-sonnet-4-6",
       model: { api: "anthropic-messages", contextWindow: 200_000 } as Model<Api>,
+      promptMode: "full",
     });
 
     expect(factories).toContain(contextPruningExtension);

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -1,4 +1,5 @@
 import type { ExtensionFactory, SessionManager } from "@mariozechner/pi-coding-agent";
+import type { SkillSnapshot } from "../../agents/skills/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
@@ -35,6 +36,7 @@ function buildContextPruningFactory(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  skillsSnapshot?: SkillSnapshot;
 }): ExtensionFactory | undefined {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
   if (raw?.mode !== "cache-ttl") {
@@ -47,6 +49,12 @@ function buildContextPruningFactory(params: {
   const settings = computeEffectiveSettings(raw);
   if (!settings) {
     return undefined;
+  }
+  // In skill mode the agent drives all tool calls and consumes results in the
+  // same turn, so retaining 3 turns of full tool results is wasteful. Reduce
+  // to 1 while still respecting an explicit user override of 0.
+  if (params.skillsSnapshot) {
+    settings.keepLastAssistants = Math.min(settings.keepLastAssistants, 1);
   }
   const transcriptPolicy = resolveTranscriptPolicy({
     modelApi: params.model?.api,
@@ -83,6 +91,7 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  skillsSnapshot?: SkillSnapshot;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {
@@ -110,7 +119,14 @@ export function buildEmbeddedExtensionFactories(params: {
     });
     factories.push(compactionSafeguardExtension);
   }
-  const pruningFactory = buildContextPruningFactory(params);
+  const pruningFactory = buildContextPruningFactory({
+    cfg: params.cfg,
+    sessionManager: params.sessionManager,
+    provider: params.provider,
+    modelId: params.modelId,
+    model: params.model,
+    skillsSnapshot: params.skillsSnapshot,
+  });
   if (pruningFactory) {
     factories.push(pruningFactory);
   }

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -1,5 +1,4 @@
 import type { ExtensionFactory, SessionManager } from "@mariozechner/pi-coding-agent";
-import type { SkillSnapshot } from "../../agents/skills/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
@@ -36,7 +35,7 @@ function buildContextPruningFactory(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
-  skillsSnapshot?: SkillSnapshot;
+  promptMode?: "full" | "minimal";
 }): ExtensionFactory | undefined {
   const raw = params.cfg?.agents?.defaults?.contextPruning;
   if (raw?.mode !== "cache-ttl") {
@@ -50,10 +49,11 @@ function buildContextPruningFactory(params: {
   if (!settings) {
     return undefined;
   }
-  // In skill mode the agent drives all tool calls and consumes results in the
-  // same turn, so retaining 3 turns of full tool results is wasteful. Reduce
-  // to 1 while still respecting an explicit user override of 0.
-  if (params.skillsSnapshot) {
+  // In autonomous execution modes (subagents, cron jobs) the agent drives all
+  // tool calls and consumes results in the same turn, so retaining 3 turns of
+  // full tool results is wasteful. Reduce to 1 while still respecting an
+  // explicit user override of 0.
+  if (params.promptMode === "minimal") {
     settings.keepLastAssistants = Math.min(settings.keepLastAssistants, 1);
   }
   const transcriptPolicy = resolveTranscriptPolicy({
@@ -91,7 +91,7 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
-  skillsSnapshot?: SkillSnapshot;
+  promptMode?: "full" | "minimal";
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {
@@ -125,7 +125,7 @@ export function buildEmbeddedExtensionFactories(params: {
     provider: params.provider,
     modelId: params.modelId,
     model: params.model,
-    skillsSnapshot: params.skillsSnapshot,
+    promptMode: params.promptMode,
   });
   if (pruningFactory) {
     factories.push(pruningFactory);

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -913,7 +913,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
-        skillsSnapshot: params.skillsSnapshot,
+        promptMode,
       });
       // Only create an explicit resource loader when there are extension factories
       // to register; otherwise let createAgentSession use its built-in default.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -913,6 +913,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        skillsSnapshot: params.skillsSnapshot,
       });
       // Only create an explicit resource loader when there are extension factories
       // to register; otherwise let createAgentSession use its built-in default.


### PR DESCRIPTION
## Summary

- In skill mode (agent-autonomous execution), the model drives all tool calls and consumes results in the same turn — retaining 3 turns of full tool results wastes context window space
- Detect skill mode via `skillsSnapshot` presence and automatically reduce `keepLastAssistants` from 3 to 1
- Respects explicit user override of 0 via `Math.min()`
- Normal chat mode retains the existing default of 3

## Changes

- `src/agents/pi-embedded-runner/extensions.ts` — add `skillsSnapshot` param; override `keepLastAssistants` to 1 when snapshot present
- `src/agents/pi-embedded-runner/run/attempt.ts` — pass `skillsSnapshot` through to extension factories
- `src/agents/pi-embedded-runner/compact.ts` — same for the compaction path
- `src/agents/pi-embedded-runner/extensions.test.ts` — 2 new tests verifying skill vs chat behavior

## Test plan

- [x] `pnpm tsgo` — no new type errors
- [x] `pnpm test src/agents/pi-embedded-runner/extensions.test.ts` — 5/5 passed (2 new)
- [x] `pnpm format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)