### PR TITLE
fix(telegram): improve group message routing reliability

### DIFF
--- a/src/channels/chat-type.ts
+++ b/src/channels/chat-type.ts
@@ -8,7 +8,7 @@ export function normalizeChatType(raw?: string): ChatType | undefined {
   if (value === "direct" || value === "dm") {
     return "direct";
   }
-  if (value === "group") {
+  if (value === "group" || value === "supergroup") {
     return "group";
   }
   if (value === "channel") {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -119,6 +119,11 @@ export function createGatewayReloadHandlers(params: {
         const restartChannel = async (name: ChannelKind) => {
           params.logChannels.info(`restarting ${name} channel`);
           await params.stopChannel(name);
+          // Brief pause after stopping to allow remote services (e.g. Telegram long-poll)
+          // to release the connection before we open a new one. Without this, Telegram
+          // can return a 409 Conflict when the new session starts before the old one
+          // is fully deregistered on their end.
+          await new Promise<void>((resolve) => setTimeout(resolve, 1500));
           await params.startChannel(name);
         };
         for (const channel of plan.restartChannels) {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -123,7 +123,9 @@ export function createGatewayReloadHandlers(params: {
           // to release the connection before we open a new one. Without this, Telegram
           // can return a 409 Conflict when the new session starts before the old one
           // is fully deregistered on their end.
-          await new Promise<void>((resolve) => setTimeout(resolve, 1500));
+          if (name === "telegram") {
+            await new Promise<void>((resolve) => setTimeout(resolve, 1500));
+          }
           await params.startChannel(name);
         };
         for (const channel of plan.restartChannels) {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -398,11 +398,37 @@ export const registerTelegramHandlers = ({
         }
         const groupAllowlist = resolveGroupPolicy(chatId);
         if (groupAllowlist.allowlistEnabled && !groupAllowlist.allowed) {
-          logger.info(
-            { chatId, title: callbackMessage.chat.title, reason: "not-allowed" },
-            "skipping group message",
-          );
-          return;
+          // If the group is not in the allowlist but has an explicit peer binding,
+          // allow it through — the binding implicitly authorizes the group.
+          const peerRoute = resolveAgentRoute({
+            cfg: loadConfig(),
+            channel: "telegram",
+            accountId,
+            peer: {
+              kind: "group",
+              id: buildTelegramGroupPeerId(chatId, resolvedThreadId),
+            },
+            parentPeer: buildTelegramParentPeer({
+              isGroup: true,
+              resolvedThreadId,
+              chatId,
+            }),
+          });
+          const hasPeerBinding =
+            peerRoute.matchedBy === "binding.peer" ||
+            peerRoute.matchedBy === "binding.peer.parent";
+          if (!hasPeerBinding) {
+            logger.info(
+              {
+                chatId,
+                title: callbackMessage.chat.title,
+                reason: "not-allowed",
+                hint: 'Add this group id to channels.telegram.groups or use "*" to allow all groups',
+              },
+              "skipping group message (not in group allowlist and no peer binding)",
+            );
+            return;
+          }
         }
       }
 
@@ -765,11 +791,37 @@ export const registerTelegramHandlers = ({
         // Group allowlist based on configured group IDs.
         const groupAllowlist = resolveGroupPolicy(chatId);
         if (groupAllowlist.allowlistEnabled && !groupAllowlist.allowed) {
-          logger.info(
-            { chatId, title: msg.chat.title, reason: "not-allowed" },
-            "skipping group message",
-          );
-          return;
+          // If the group is not in the allowlist but has an explicit peer binding,
+          // allow it through — the binding implicitly authorizes the group.
+          const peerRoute = resolveAgentRoute({
+            cfg: loadConfig(),
+            channel: "telegram",
+            accountId,
+            peer: {
+              kind: "group",
+              id: buildTelegramGroupPeerId(chatId, resolvedThreadId),
+            },
+            parentPeer: buildTelegramParentPeer({
+              isGroup: true,
+              resolvedThreadId,
+              chatId,
+            }),
+          });
+          const hasPeerBinding =
+            peerRoute.matchedBy === "binding.peer" ||
+            peerRoute.matchedBy === "binding.peer.parent";
+          if (!hasPeerBinding) {
+            logger.info(
+              {
+                chatId,
+                title: msg.chat.title,
+                reason: "not-allowed",
+                hint: 'Add this group id to channels.telegram.groups or use "*" to allow all groups',
+              },
+              "skipping group message (not in group allowlist and no peer binding)",
+            );
+            return;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Three related fixes for Telegram group message handling that were identified while debugging group bindings not working for a bot configured with `groupPolicy: "allowlist"` and explicit `bindings[]` entries.

- **`src/channels/chat-type.ts`**: Add `"supergroup"` as a recognized synonym for `"group"` in `normalizeChatType()`. Telegram reports most groups as `type: "supergroup"`, so without this, peer binding kind matching silently fails for the majority of real-world Telegram groups.

- **`src/telegram/bot-handlers.ts`**: When a group is not in the `channels.telegram.groups` allowlist, check for an explicit peer binding before silently dropping the message. Groups with a binding configured should be processed regardless of the global allowlist state — the binding itself implies intent to handle that peer. This removes the need to configure a group in *both* `channels.telegram.groups` and `bindings[]`.

- **`src/gateway/server-reload-handlers.ts`**: Add a 1.5s pause between stopping and restarting a channel during hot reload. Without the delay, Telegram's long-poll connection from the stopped instance may not be fully released before the new session opens, resulting in a `409 Conflict` that triggers a restart loop on every config change.

## Test plan

- [ ] Confirm `normalizeChatType("supergroup")` returns `"group"`
- [ ] Confirm a group with a binding but NOT in `channels.telegram.groups` allowlist receives and routes messages correctly
- [ ] Confirm hot-reloading `channels.telegram.*` config no longer produces 409 Conflict errors
- [ ] Existing test suite passes (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)