### PR TITLE
docs: fix link audit to ignore fenced code blocks correctly

### DIFF
--- a/scripts/docs-link-audit.mjs
+++ b/scripts/docs-link-audit.mjs
@@ -174,6 +174,24 @@ function collectNavPageEntries(node) {
 
 const markdownLinkRegex = /!?\[[^\]]*\]\(([^)]+)\)/g;
 
+/**
+ * @param {string} line
+ * @returns {{marker: "`" | "~"; length: number} | null}
+ */
+export function parseFenceDelimiter(line) {
+  const trimmed = line.trimStart();
+  const match = trimmed.match(/^(`{3,}|~{3,})/);
+  if (!match?.[1]) {
+    return null;
+  }
+  const token = match[1];
+  const marker = token[0];
+  if (marker !== "`" && marker !== "~") {
+    return null;
+  }
+  return { marker, length: token.length };
+}
+
 export function sanitizeDocsConfigForEnglishOnly(value) {
   if (Array.isArray(value)) {
     return value
@@ -324,16 +342,22 @@ export function auditDocsLinks() {
     const rawText = fs.readFileSync(abs, "utf8");
     const lines = rawText.split("\n");
 
-    let inCodeFence = false;
+    /** @type {{marker: "`" | "~"; length: number} | null} */
+    let codeFence = null;
 
     for (let lineNum = 0; lineNum < lines.length; lineNum++) {
       let line = lines[lineNum];
 
-      if (line.trim().startsWith("```")) {
-        inCodeFence = !inCodeFence;
+      const fence = parseFenceDelimiter(line);
+      if (fence) {
+        if (!codeFence) {
+          codeFence = fence;
+        } else if (fence.marker === codeFence.marker && fence.length >= codeFence.length) {
+          codeFence = null;
+        }
         continue;
       }
-      if (inCodeFence) {
+      if (codeFence) {
         continue;
       }
 

--- a/src/scripts/docs-link-audit.test.ts
+++ b/src/scripts/docs-link-audit.test.ts
@@ -6,12 +6,14 @@ import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 
 const {
   normalizeRoute,
+  parseFenceDelimiter,
   prepareAnchorAuditDocsDir,
   resolveRoute,
   runDocsLinkAuditCli,
   sanitizeDocsConfigForEnglishOnly,
 } = (await import("../../scripts/docs-link-audit.mjs")) as unknown as {
   normalizeRoute: (route: string) => string;
+  parseFenceDelimiter: (line: string) => { marker: "`" | "~"; length: number } | null;
   prepareAnchorAuditDocsDir: (sourceDir?: string) => string;
   resolveRoute: (
     route: string,
@@ -49,6 +51,17 @@ describe("docs-link-audit", () => {
       ok: true,
       terminal: "/plugins/building-plugins",
     });
+  });
+
+  it("parses backtick and tilde fences with length", () => {
+    expect(parseFenceDelimiter("```ts")).toEqual({ marker: "`", length: 3 });
+    expect(parseFenceDelimiter("~~~~md")).toEqual({ marker: "~", length: 4 });
+  });
+
+  it("ignores non-fence lines when parsing delimiters", () => {
+    expect(parseFenceDelimiter("``short")).toBeNull();
+    expect(parseFenceDelimiter("  [text](/route)")).toBeNull();
+    expect(parseFenceDelimiter("code ``` inline")).toBeNull();
   });
 
   it("sanitizes docs.json to English-only route targets", () => {


### PR DESCRIPTION
## Summary
- Fix docs link audit fenced-code detection to support both backtick and tilde fences.
- Track fence marker type and opening length so closing only occurs on matching markers with sufficient length.
- Add unit tests for fence delimiter parsing to prevent regressions.

## Test plan
- [x] node scripts/docs-link-audit.mjs (with temporary fenced repro containing an invalid route, now ignored)
- [x] pnpm test src/scripts/docs-link-audit.test.ts