### PR TITLE
fix(minimax): include OAuth env vars in web_search provider lookup

### DIFF
--- a/extensions/minimax/web-search-contract-api.ts
+++ b/extensions/minimax/web-search-contract-api.ts
@@ -4,7 +4,16 @@ import {
   type WebSearchProviderPlugin,
 } from "openclaw/plugin-sdk/provider-web-search-contract";
 
-const MINIMAX_CODING_PLAN_ENV_VARS = ["MINIMAX_CODE_PLAN_KEY", "MINIMAX_CODING_API_KEY"] as const;
+// Include MINIMAX_OAUTH_TOKEN and MINIMAX_API_KEY so the web_search
+// provider can discover OAuth-managed credentials, not just Coding Plan
+// keys. The chat provider (provider-registration.ts:255) already lists
+// both — the web search provider was missing them (#65768).
+const MINIMAX_CODING_PLAN_ENV_VARS = [
+  "MINIMAX_OAUTH_TOKEN",
+  "MINIMAX_API_KEY",
+  "MINIMAX_CODE_PLAN_KEY",
+  "MINIMAX_CODING_API_KEY",
+] as const;
 
 function getTopLevelCredentialValue(searchConfig?: Record<string, unknown>): unknown {
   return searchConfig?.apiKey;


### PR DESCRIPTION
## Summary

The MiniMax web_search provider's \`envVars\` only listed \`MINIMAX_CODE_PLAN_KEY\` and \`MINIMAX_CODING_API_KEY\`, missing \`MINIMAX_OAUTH_TOKEN\` and \`MINIMAX_API_KEY\`. Users who authenticated via MiniMax OAuth (the recommended \`minimax-portal\` flow) had working chat completions but broken web_search.

Fixes #65768

## Root cause

\`\`\`ts
// web-search-contract-api.ts:7 (before fix)
const MINIMAX_CODING_PLAN_ENV_VARS = ["MINIMAX_CODE_PLAN_KEY", "MINIMAX_CODING_API_KEY"];

// provider-registration.ts:255 (chat provider — has both)
envVars: ["MINIMAX_OAUTH_TOKEN", "MINIMAX_API_KEY"],
\`\`\`

The web search provider was only configured for Coding Plan keys, not OAuth tokens. The chat provider already handles both.

## Fix

Add \`MINIMAX_OAUTH_TOKEN\` and \`MINIMAX_API_KEY\` to the web search provider's \`envVars\` array.

## Scope

- **Files**: \`extensions/minimax/web-search-contract-api.ts\` (+6/-1)
- **oxlint clean**
- **Zero competing PRs**

Credit to @kikibrian for identifying the env var gap in #65768.