### PR TITLE
fix(memory): preserve surrogate pairs in chunker; sanitize embed inputs

### DIFF
--- a/extensions/memory-core/src/memory/manager-embedding-ops.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { stripUnpairedSurrogates } from "./manager-embedding-ops.js";
+
+describe("stripUnpairedSurrogates", () => {
+  it("preserves text without surrogates", () => {
+    expect(stripUnpairedSurrogates("hello world")).toBe("hello world");
+  });
+
+  it("preserves valid surrogate pairs (emoji, CJK Extension B)", () => {
+    expect(stripUnpairedSurrogates("hi 🌸")).toBe("hi 🌸");
+    expect(stripUnpairedSurrogates("\u{20000}")).toBe("\u{20000}");
+  });
+
+  it("replaces a lone high surrogate with U+FFFD", () => {
+    // High surrogate of 🌸 (U+1F338) without its low partner.
+    expect(stripUnpairedSurrogates("hi \uD83C")).toBe("hi \uFFFD");
+  });
+
+  it("replaces a lone low surrogate with U+FFFD", () => {
+    // Low surrogate of 🌸 without its high partner.
+    expect(stripUnpairedSurrogates("\uDF38 hi")).toBe("\uFFFD hi");
+  });
+
+  it("replaces both halves when a pair is reversed (low then high)", () => {
+    expect(stripUnpairedSurrogates("\uDF38\uD83C")).toBe("\uFFFD\uFFFD");
+  });
+
+  it("handles empty / non-string inputs gracefully", () => {
+    expect(stripUnpairedSurrogates("")).toBe("");
+    // Non-string inputs return as-is — the embed call paths only pass strings,
+    // but the helper guards against accidental misuse.
+    expect(stripUnpairedSurrogates(undefined as unknown as string)).toBe(
+      undefined as unknown as string,
+    );
+  });
+});

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -286,13 +286,14 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
     const provider = this.provider;
     const embedBatchInputs = provider?.embedBatchInputs;
+    if (!embedBatchInputs) {
+      // Fall through — embedBatchWithRetry sanitizes its own input, so we pass raw texts.
+      return await this.embedBatchWithRetry(inputs.map((input) => input.text));
+    }
     const sanitizedInputs = inputs.map((input) => ({
       ...input,
       text: stripUnpairedSurrogates(input.text),
     }));
-    if (!embedBatchInputs) {
-      return await this.embedBatchWithRetry(sanitizedInputs.map((input) => input.text));
-    }
     return await runMemoryEmbeddingRetryLoop({
       run: async () => {
         const timeoutMs = this.resolveEmbeddingTimeout("batch");

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -53,6 +53,24 @@ const EMBEDDING_BATCH_TIMEOUT_LOCAL_MS = 10 * 60_000;
 
 const log = createSubsystemLogger("memory");
 
+const UNPAIRED_SURROGATE_RE =
+  /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+/**
+ * Replace any unpaired UTF-16 surrogate code unit with U+FFFD before sending
+ * text to the embeddings provider. Lone surrogates can appear when upstream
+ * chunking splits an emoji or supplementary-plane character across a chunk
+ * boundary; most embedding HTTP clients reject them with a 500 from
+ * `'utf-8' codec can't encode character ...: surrogates not allowed`,
+ * which kills the whole indexing batch (see openclaw#27753).
+ */
+export function stripUnpairedSurrogates(text: string): string {
+  if (typeof text !== "string" || text.length === 0) {
+    return text;
+  }
+  return text.replace(UNPAIRED_SURROGATE_RE, "\uFFFD");
+}
+
 export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected abstract batchFailureCount: number;
   protected abstract batchFailureLastError?: string;
@@ -238,16 +256,17 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     if (!provider) {
       throw new Error("Cannot embed batch in FTS-only mode (no embedding provider)");
     }
+    const sanitizedTexts = texts.map(stripUnpairedSurrogates);
     return await runMemoryEmbeddingRetryLoop({
       run: async () => {
         const timeoutMs = this.resolveEmbeddingTimeout("batch");
         log.debug("memory embeddings: batch start", {
           provider: provider.id,
-          items: texts.length,
+          items: sanitizedTexts.length,
           timeoutMs,
         });
         return await this.withTimeout(
-          provider.embedBatch(texts),
+          provider.embedBatch(sanitizedTexts),
           timeoutMs,
           `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
         );
@@ -267,19 +286,23 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     }
     const provider = this.provider;
     const embedBatchInputs = provider?.embedBatchInputs;
+    const sanitizedInputs = inputs.map((input) => ({
+      ...input,
+      text: stripUnpairedSurrogates(input.text),
+    }));
     if (!embedBatchInputs) {
-      return await this.embedBatchWithRetry(inputs.map((input) => input.text));
+      return await this.embedBatchWithRetry(sanitizedInputs.map((input) => input.text));
     }
     return await runMemoryEmbeddingRetryLoop({
       run: async () => {
         const timeoutMs = this.resolveEmbeddingTimeout("batch");
         log.debug("memory embeddings: structured batch start", {
           provider: provider.id,
-          items: inputs.length,
+          items: sanitizedInputs.length,
           timeoutMs,
         });
         return await this.withTimeout(
-          embedBatchInputs(inputs),
+          embedBatchInputs(sanitizedInputs),
           timeoutMs,
           `memory embeddings batch timed out after ${Math.round(timeoutMs / 1000)}s`,
         );

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -359,6 +359,33 @@ describe("chunkMarkdown", () => {
       }
     }
   });
+  it("does not break surrogate pairs at the coarse split boundary (issue #27753)", () => {
+    // tokens=10 -> maxChars = max(32, 10*4) = 40.
+    // A line of 39 ASCII chars followed by an emoji (a surrogate pair) places
+    // the high surrogate at index 39 and the low surrogate at index 40, so the
+    // outer coarse cut at `start + maxChars = 40` lands BETWEEN the pair.
+    // estimateStringChars(coarse) stays <= maxChars (Latin-only weight), so the
+    // inner fine-split path that already handles surrogates is bypassed.
+    const line = "a".repeat(39) + "\uD83C\uDF38" + "b".repeat(39); // 🌸
+    const chunks = chunkMarkdown(line, { tokens: 10, overlap: 0 });
+    for (const chunk of chunks) {
+      for (let i = 0; i < chunk.text.length; i += 1) {
+        const code = chunk.text.charCodeAt(i);
+        if (code >= 0xd800 && code <= 0xdbff) {
+          const next = chunk.text.charCodeAt(i + 1);
+          expect(next).toBeGreaterThanOrEqual(0xdc00);
+          expect(next).toBeLessThanOrEqual(0xdfff);
+        } else if (code >= 0xdc00 && code <= 0xdfff) {
+          const prev = chunk.text.charCodeAt(i - 1);
+          expect(prev).toBeGreaterThanOrEqual(0xd800);
+          expect(prev).toBeLessThanOrEqual(0xdbff);
+        }
+      }
+    }
+    // The emoji must survive intact in the reconstructed text.
+    expect(chunks.map((c) => c.text).join("")).toContain("\uD83C\uDF38");
+  });
+
   it("does not over-split long Latin lines (backward compat)", () => {
     // 2000 ASCII chars / 800 maxChars -> about 3 segments, not 10 tiny ones.
     const longLatinLine = "a".repeat(2000);

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -402,8 +402,17 @@ export function chunkMarkdown(
       // Second pass: if a segment's *weighted* size still exceeds the budget
       // (happens for CJK-heavy text where 1 char ≈ 1 token), re-split it at
       // chunking.tokens so the chunk stays within the token budget.
-      for (let start = 0; start < line.length; start += maxChars) {
-        const coarse = line.slice(start, start + maxChars);
+      for (let start = 0; start < line.length; ) {
+        let coarseEnd = Math.min(line.length, start + maxChars);
+        // Avoid splitting inside a UTF-16 surrogate pair (emoji, CJK Extension B+).
+        if (coarseEnd < line.length) {
+          const lastCode = line.charCodeAt(coarseEnd - 1);
+          if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+            coarseEnd += 1; // include the trailing low surrogate
+          }
+        }
+        const coarse = line.slice(start, coarseEnd);
+        start = coarseEnd;
         if (estimateStringChars(coarse) > maxChars) {
           const fineStep = Math.max(1, chunking.tokens);
           for (let j = 0; j < coarse.length; ) {


### PR DESCRIPTION
## Summary

- Fix the outer coarse-split loop in `chunkMarkdown` so it does not bisect a UTF-16 surrogate pair (root cause of indexing stalls).
- Add a defensive `stripUnpairedSurrogates` sanitizer at the embed boundary (the safety net #27753 originally requested).
- Tests for both, including a new regression test that triggers the exact code path the existing surrogate-pair test missed.

Closes #27753.
Fixes #65782.

## Why

Memory indexing stalls permanently for any agent whose content contains an emoji or supplementary-plane character that the chunker happens to split across a surrogate-pair boundary. `openclaw memory status` reports the index as `clean / no issues` while ~98% of sessions are unindexed.

End-to-end symptom (verbose):

```
[memory] embeddings: batch start  (×N)
Memory index failed (<agent>): openai embeddings failed: 500
{"error":{"message":"... 'utf-8' codec can't encode character '\\ud83c'
in position 3229: surrogates not allowed ..."}}
```

Two failure modes compound:

1. **Chunker** (`packages/memory-host-sdk/src/host/internal.ts`) — the inner fine-split loop already guards against splitting inside a surrogate pair, but the outer coarse loop advances by `start += maxChars` without checking the boundary. When the cut lands inside e.g. an emoji like 🌸 (`U+1F338` = `\uD83C\uDF38`), the chunk ends with a lone high surrogate and the next begins with a lone low surrogate. The existing surrogate-pair test (`"does not break surrogate pairs when splitting long CJK lines"`) does not catch this because it uses an all-surrogate-pair line — the high `estimateStringChars` weight forces the inner pass, which is correct.
2. **Embedding HTTP path** — Python JSON encoders (e.g. via LiteLLM proxies) reject lone surrogates with a 500 wrapping a `UnicodeEncodeError`. The retry policy only matches `rate_limit | 429 | 5\d\d | cloudflare | tokens per day`, but the body shape is a connect-error, not a transient one — and the indexer is transactional, so a single bad batch rolls back the entire run. Every subsequent `openclaw memory index` invocation reproduces the same failure.

## What changed

### `packages/memory-host-sdk/src/host/internal.ts`

```diff
- for (let start = 0; start < line.length; start += maxChars) {
-   const coarse = line.slice(start, start + maxChars);
+ for (let start = 0; start < line.length; ) {
+   let coarseEnd = Math.min(line.length, start + maxChars);
+   // Avoid splitting inside a UTF-16 surrogate pair (emoji, CJK Extension B+).
+   if (coarseEnd < line.length) {
+     const lastCode = line.charCodeAt(coarseEnd - 1);
+     if (lastCode >= 0xd800 && lastCode <= 0xdbff) {
+       coarseEnd += 1; // include the trailing low surrogate
+     }
+   }
+   const coarse = line.slice(start, coarseEnd);
+   start = coarseEnd;
```

Mirrors the existing inner-loop guard at the same file/line. New regression test (`"does not break surrogate pairs at the coarse split boundary (issue #27753)"`) constructs a line of `39 ASCII + 🌸 + 39 ASCII` so the outer cut at `start + maxChars = 40` lands between the high and low surrogate. Without the fix, the test fails by producing chunks containing lone surrogates.

### `extensions/memory-core/src/memory/manager-embedding-ops.ts`

Adds a tiny exported helper:

```ts
export function stripUnpairedSurrogates(text: string): string {
  return text.replace(
    /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g,
    "\uFFFD",
  );
}
```

…and applies it at the entry of `embedBatchWithRetry` and `embedBatchInputsWithRetry`. This is the change #27753 originally requested. It protects against any other code path that might produce a lone surrogate (LLM tool output, file ingestion, future chunkers) — chunker-only fix is necessary but not sufficient.

Adds `manager-embedding-ops.test.ts` with focused unit tests for the helper (preserves valid pairs, replaces lone high/low surrogates, handles reversed pairs, no-op on empty/non-string).

## Test plan

- [x] Verified live on installed runtime (`openclaw 2026.4.5`) by patching the equivalent bundled artifact under `dist/manager-CKYnEo0k.js` and running `openclaw memory index --agent <id>`:

  | | before | after |
  |---|---:|---:|
  | clawdea files | 6 | **166** |
  | clawdea chunks | 93 | **4584** |
  | dev files | 2 | **17** |
  | dev chunks | 251 | **588** |

  `openclaw memory search` works end-to-end after the fix.
- [ ] CI runs `pnpm test` against the new unit tests in `extensions/memory-core` and `packages/memory-host-sdk`.
- [ ] Existing surrogate-pair test (`"does not break surrogate pairs when splitting long CJK lines"`) still passes.

## Notes for reviewers

- I did not run `pnpm install` locally to execute vitest — the runtime fix is verified live, and the new tests follow the same vitest patterns as adjacent files (`manager-embedding-cache.test.ts`, `internal.test.ts`).
- The retry-policy gap (`fetch failed` / `UnicodeEncodeError` 500 not retried) is a separate concern tracked in #56815 / #58255 — out of scope for this PR. With the chunker + sanitizer in place, the original failure no longer reaches the retry path.
- If the team prefers the helper to live in a shared utility module (e.g. under `packages/memory-host-sdk`) rather than `manager-embedding-ops.ts`, happy to relocate.