### PR TITLE
fix(feishu): disable ambient proxy inheritance for websocket by default

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -358,7 +358,20 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.agent).toBeUndefined();
   });
 
-  it("creates a ws proxy agent when lowercase https_proxy is set", async () => {
+  it("does not inherit ambient proxy env by default", async () => {
+    process.env.https_proxy = "http://lower-https:8001";
+    process.env.HTTPS_PROXY = "http://upper-https:8002";
+    process.env.HTTP_PROXY = "http://upper-http:8999";
+
+    await createFeishuWSClient(baseAccount);
+
+    expect(proxyAgentCtorMock).not.toHaveBeenCalled();
+    const options = firstWsClientOptions();
+    expect(options.agent).toBeUndefined();
+  });
+
+  it("creates a ws proxy agent when explicitly enabled and lowercase https_proxy is set", async () => {
+    process.env.OPENCLAW_FEISHU_WS_USE_PROXY = "1";
     process.env.https_proxy = "http://lower-https:8001";
 
     await createFeishuWSClient(baseAccount);
@@ -368,7 +381,8 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.agent).toEqual({ proxied: true });
   });
 
-  it("creates a ws proxy agent when uppercase HTTPS_PROXY is set", async () => {
+  it("creates a ws proxy agent when explicitly enabled and uppercase HTTPS_PROXY is set", async () => {
+    process.env.OPENCLAW_FEISHU_WS_USE_PROXY = "1";
     process.env.HTTPS_PROXY = "http://upper-https:8002";
 
     await createFeishuWSClient(baseAccount);
@@ -378,7 +392,8 @@ describe("createFeishuWSClient proxy handling", () => {
     expect(options.agent).toEqual({ proxied: true });
   });
 
-  it("falls back to HTTP_PROXY for ws proxy agent creation", async () => {
+  it("falls back to HTTP_PROXY when explicitly enabled", async () => {
+    process.env.OPENCLAW_FEISHU_WS_USE_PROXY = "1";
     process.env.HTTP_PROXY = "http://upper-http:8999";
 
     await createFeishuWSClient(baseAccount);

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -73,6 +73,7 @@ let feishuClientSdk: FeishuClientSdk = defaultFeishuClientSdk;
 export const FEISHU_HTTP_TIMEOUT_MS = 30_000;
 export const FEISHU_HTTP_TIMEOUT_MAX_MS = 300_000;
 export const FEISHU_HTTP_TIMEOUT_ENV_VAR = "OPENCLAW_FEISHU_HTTP_TIMEOUT_MS";
+export const FEISHU_WS_USE_PROXY_ENV_VAR = "OPENCLAW_FEISHU_WS_USE_PROXY";
 
 type FeishuHttpInstanceLike = Pick<
   typeof feishuClientSdk.defaultHttpInstance,
@@ -80,7 +81,10 @@ type FeishuHttpInstanceLike = Pick<
 >;
 
 async function getWsProxyAgent() {
-  return resolveAmbientNodeProxyAgent<Agent>();
+  if (process.env[FEISHU_WS_USE_PROXY_ENV_VAR] === "1") {
+    return resolveAmbientNodeProxyAgent<Agent>();
+  }
+  return undefined;
 }
 
 // Multi-account client cache


### PR DESCRIPTION
## Summary
- stop Feishu WebSocket from inheriting ambient proxy env by default
- add an explicit `OPENCLAW_FEISHU_WS_USE_PROXY=1` opt-in for proxy usage
- update Feishu WS proxy tests to cover the new default and opt-in behavior

## Why
Feishu inbound can silently break when the gateway process inherits unrelated proxy env, especially `ALL_PROXY` pointing at an unavailable local SOCKS endpoint. In that case Feishu WS only logs a generic `ws connect failed`, while direct connection with the same app credentials succeeds.

This makes Feishu inbound fragile and hard to debug. A safer default is to bypass ambient proxy env for Feishu WS unless explicitly requested.

## Testing
- attempted local test run for `extensions/feishu/src/client.test.ts`
- current temporary clone needed dependency installation first
- live gateway verification on a real install confirmed:
  - Feishu WS failed when ambient proxy inheritance was enabled
  - Feishu WS recovered immediately after bypassing proxy inheritance
  - real Feishu -> OpenClaw -> worker reply path resumed successfully

Closes #65799
