### PR TITLE
feat(agents): split LLM timeout into first-token and idle phases

### DIFF
--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -156,6 +156,7 @@ export class CodexAppServerEventProjector {
       externalAbort: false,
       timedOut: false,
       idleTimedOut: false,
+      llmTimeoutPhase: null,
       timedOutDuringCompaction: false,
       promptError,
       promptErrorSource: promptError ? this.promptErrorSource || "prompt" : null,

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -62,6 +62,7 @@ function createAttemptResult(sessionIdUsed: string): EmbeddedRunAttemptResult {
     externalAbort: false,
     timedOut: false,
     idleTimedOut: false,
+    llmTimeoutPhase: null,
     timedOutDuringCompaction: false,
     promptError: null,
     promptErrorSource: null,

--- a/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.run-embedded-pi-agent.auth-profile-rotation.e2e.test.ts
@@ -188,6 +188,7 @@ const makeAttempt = (overrides: Partial<EmbeddedRunAttemptResult>): EmbeddedRunA
     externalAbort: false,
     timedOut: false,
     idleTimedOut: false,
+    llmTimeoutPhase: null,
     timedOutDuringCompaction: false,
     promptError: null,
     promptErrorSource: null,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -37,6 +37,7 @@ export function makeAttemptResult(
     externalAbort: false,
     timedOut: false,
     idleTimedOut: false,
+    llmTimeoutPhase: null,
     timedOutDuringCompaction: false,
     promptError: null,
     promptErrorSource: null,

--- a/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.timeout-triggered-compaction.test.ts
@@ -227,6 +227,7 @@ describe("timeout-triggered compaction", () => {
       makeAttemptResult({
         timedOut: true,
         idleTimedOut: true,
+        llmTimeoutPhase: "idle",
         lastAssistant: {
           usage: { input: 20000 },
         } as never,
@@ -239,6 +240,29 @@ describe("timeout-triggered compaction", () => {
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(result.payloads?.[0]?.text).toContain("agents.defaults.llm.idleTimeoutSeconds");
     expect(result.payloads?.[0]?.text).not.toContain("agents.defaults.timeoutSeconds");
+    expect(result.payloads?.[0]?.text).not.toContain("firstTokenTimeoutSeconds");
+  });
+
+  it("points first-token-timeout errors at the LLM first-token timeout config key", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        timedOut: true,
+        idleTimedOut: true,
+        llmTimeoutPhase: "first-token",
+        lastAssistant: {
+          usage: { input: 20000 },
+        } as never,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain(
+      "agents.defaults.llm.firstTokenTimeoutSeconds",
+    );
+    expect(result.payloads?.[0]?.text).not.toContain("idleTimeoutSeconds");
   });
 
   it("retries one silent idle timeout before surfacing an error", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -727,6 +727,7 @@ export async function runEmbeddedPiAgent(
             preflightRecovery,
             timedOut,
             idleTimedOut,
+            llmTimeoutPhase,
             timedOutDuringCompaction,
             sessionIdUsed,
             lastAssistant: sessionLastAssistant,
@@ -1527,11 +1528,20 @@ export async function runEmbeddedPiAgent(
           // Emit an explicit timeout error instead of silently completing, so
           // callers do not lose the turn as an orphaned user message.
           if (timedOut && !timedOutDuringCompaction && !payloadsWithToolMedia?.length) {
-            const timeoutText = idleTimedOut
-              ? "The model did not produce a response before the LLM idle timeout. " +
-                "Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config (set to 0 to disable)."
-              : "Request timed out before a response was generated. " +
+            let timeoutText: string;
+            if (llmTimeoutPhase === "first-token") {
+              timeoutText =
+                "The model did not produce its first token before the LLM first-token timeout. " +
+                "Please try again, or increase `agents.defaults.llm.firstTokenTimeoutSeconds` in your config (set to 0 to wait indefinitely for the first token).";
+            } else if (idleTimedOut) {
+              timeoutText =
+                "The model did not produce a response before the LLM idle timeout. " +
+                "Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config (set to 0 to disable).";
+            } else {
+              timeoutText =
+                "Request timed out before a response was generated. " +
                 "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.";
+            }
             const replayInvalid = resolveReplayInvalidForAttempt(null);
             const livenessState = resolveRunLivenessState({
               payloadCount: payloads.length,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -227,7 +227,11 @@ import {
 import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import { buildAttemptReplayMetadata } from "./incomplete-turn.js";
-import { resolveLlmIdleTimeoutMs, streamWithIdleTimeout } from "./llm-idle-timeout.js";
+import {
+  resolveLlmFirstTokenTimeoutMs,
+  resolveLlmIdleTimeoutMs,
+  streamWithIdleTimeout,
+} from "./llm-idle-timeout.js";
 import {
   PREEMPTIVE_OVERFLOW_ERROR_TEXT,
   shouldPreemptivelyCompactBeforePrompt,
@@ -1267,21 +1271,27 @@ export async function runEmbeddedAttempt(
 
       let idleTimeoutTrigger: ((error: Error) => void) | undefined;
 
-      // Wrap stream with idle timeout detection
+      // Wrap stream with two-phase timeout detection.
+      // The first-token window covers cold model loads / proxy warm-ups;
+      // the idle window catches mid-stream hangs. When
+      // firstTokenTimeoutSeconds is unset, the first-token phase inherits
+      // idle (backwards-compatible single-phase behavior).
       const configuredRunTimeoutMs = resolveAgentTimeoutMs({
         cfg: params.config,
       });
-      const idleTimeoutMs = resolveLlmIdleTimeoutMs({
+      const resolveTimeoutParams = {
         cfg: params.config,
         trigger: params.trigger,
         runTimeoutMs: params.timeoutMs !== configuredRunTimeoutMs ? params.timeoutMs : undefined,
-      });
+      };
+      const idleTimeoutMs = resolveLlmIdleTimeoutMs(resolveTimeoutParams);
       if (idleTimeoutMs > 0) {
-        activeSession.agent.streamFn = streamWithIdleTimeout(
-          activeSession.agent.streamFn,
+        const firstTokenTimeoutMs = resolveLlmFirstTokenTimeoutMs(resolveTimeoutParams);
+        activeSession.agent.streamFn = streamWithIdleTimeout(activeSession.agent.streamFn, {
           idleTimeoutMs,
-          (error) => idleTimeoutTrigger?.(error),
-        );
+          firstTokenTimeoutMs,
+          onIdleTimeout: (error) => idleTimeoutTrigger?.(error),
+        });
       }
 
       try {
@@ -1388,6 +1398,7 @@ export async function runEmbeddedAttempt(
       let yieldAborted = false;
       let timedOut = false;
       let idleTimedOut = false;
+      let llmTimeoutPhase: "first-token" | "idle" | null = null;
       let timedOutDuringCompaction = false;
       const getAbortReason = (signal: AbortSignal): unknown =>
         "reason" in signal ? (signal as { reason?: unknown }).reason : undefined;
@@ -1438,6 +1449,10 @@ export async function runEmbeddedAttempt(
       };
       idleTimeoutTrigger = (error) => {
         idleTimedOut = true;
+        // Error message comes from streamWithIdleTimeout and starts with
+        // "LLM first-token timeout (...)" or "LLM idle timeout (...)" — use
+        // it to track which knob the user should tune.
+        llmTimeoutPhase = error.message.includes("first-token") ? "first-token" : "idle";
         abortRun(true, error);
       };
       const abortable = <T>(promise: Promise<T>): Promise<T> => {
@@ -2366,6 +2381,7 @@ export async function runEmbeddedAttempt(
         externalAbort,
         timedOut,
         idleTimedOut,
+        llmTimeoutPhase,
         timedOutDuringCompaction,
         promptError,
         promptErrorSource,

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
   DEFAULT_LLM_IDLE_TIMEOUT_MS,
+  resolveLlmFirstTokenTimeoutMs,
   resolveLlmIdleTimeoutMs,
   streamWithIdleTimeout,
 } from "./llm-idle-timeout.js";
@@ -102,6 +103,47 @@ describe("resolveLlmIdleTimeoutMs", () => {
   });
 });
 
+describe("resolveLlmFirstTokenTimeoutMs", () => {
+  it("returns undefined (inherit-idle) when nothing is set", () => {
+    expect(resolveLlmFirstTokenTimeoutMs()).toBeUndefined();
+  });
+
+  it("returns undefined (inherit-idle) when firstTokenTimeoutSeconds is unset", () => {
+    const cfg = { agents: { defaults: { llm: { idleTimeoutSeconds: 30 } } } } as OpenClawConfig;
+    expect(resolveLlmFirstTokenTimeoutMs({ cfg })).toBeUndefined();
+  });
+
+  it("returns 0 when explicitly disabled", () => {
+    const cfg = {
+      agents: { defaults: { llm: { idleTimeoutSeconds: 30, firstTokenTimeoutSeconds: 0 } } },
+    } as OpenClawConfig;
+    expect(resolveLlmFirstTokenTimeoutMs({ cfg })).toBe(0);
+  });
+
+  it("returns configured value in milliseconds when set", () => {
+    const cfg = {
+      agents: { defaults: { llm: { idleTimeoutSeconds: 30, firstTokenTimeoutSeconds: 300 } } },
+    } as OpenClawConfig;
+    expect(resolveLlmFirstTokenTimeoutMs({ cfg })).toBe(300_000);
+  });
+
+  it("returns undefined when firstTokenTimeoutSeconds is negative (ignored)", () => {
+    const cfg = {
+      agents: { defaults: { llm: { idleTimeoutSeconds: 30, firstTokenTimeoutSeconds: -5 } } },
+    } as OpenClawConfig;
+    expect(resolveLlmFirstTokenTimeoutMs({ cfg })).toBeUndefined();
+  });
+
+  it("caps at max safe timeout", () => {
+    const cfg = {
+      agents: {
+        defaults: { llm: { idleTimeoutSeconds: 30, firstTokenTimeoutSeconds: 10_000_000 } },
+      },
+    } as OpenClawConfig;
+    expect(resolveLlmFirstTokenTimeoutMs({ cfg })).toBe(2_147_000_000);
+  });
+});
+
 describe("streamWithIdleTimeout", () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -130,14 +172,14 @@ describe("streamWithIdleTimeout", () => {
   it("wraps stream function", () => {
     const mockStream = createMockAsyncIterable([]);
     const baseFn = vi.fn().mockReturnValue(mockStream);
-    const wrapped = streamWithIdleTimeout(baseFn, 1000);
+    const wrapped = streamWithIdleTimeout(baseFn, { idleTimeoutMs: 1000 });
     expect(typeof wrapped).toBe("function");
   });
 
   it("passes through model, context, and options", async () => {
     const mockStream = createMockAsyncIterable([]);
     const baseFn = vi.fn().mockReturnValue(mockStream);
-    const wrapped = streamWithIdleTimeout(baseFn, 1000);
+    const wrapped = streamWithIdleTimeout(baseFn, { idleTimeoutMs: 1000 });
 
     const model = { api: "openai" } as Parameters<typeof baseFn>[0];
     const context = {} as Parameters<typeof baseFn>[1];
@@ -148,7 +190,7 @@ describe("streamWithIdleTimeout", () => {
     expect(baseFn).toHaveBeenCalledWith(model, context, options);
   });
 
-  it("throws on idle timeout", async () => {
+  it("throws on first-token timeout (inherits idle when firstTokenTimeoutMs unset)", async () => {
     vi.useFakeTimers();
     // Create a stream that never yields
     const slowStream: AsyncIterable<unknown> = {
@@ -163,7 +205,7 @@ describe("streamWithIdleTimeout", () => {
     };
 
     const baseFn = vi.fn().mockReturnValue(slowStream);
-    const wrapped = streamWithIdleTimeout(baseFn, 50); // 50ms timeout
+    const wrapped = streamWithIdleTimeout(baseFn, { idleTimeoutMs: 50 });
 
     const model = {} as Parameters<typeof baseFn>[0];
     const context = {} as Parameters<typeof baseFn>[1];
@@ -172,7 +214,9 @@ describe("streamWithIdleTimeout", () => {
     const stream = wrapped(model, context, options) as AsyncIterable<unknown>;
     const iterator = stream[Symbol.asyncIterator]();
 
-    const next = expect(iterator.next()).rejects.toThrow(/LLM idle timeout/);
+    // Before any chunk arrives, the first-token phase is active.
+    // With firstTokenTimeoutMs unset, it inherits idleTimeoutMs (50ms).
+    const next = expect(iterator.next()).rejects.toThrow(/LLM first-token timeout/);
     await vi.advanceTimersByTimeAsync(50);
     await next;
   });
@@ -181,7 +225,7 @@ describe("streamWithIdleTimeout", () => {
     const chunks = [{ text: "a" }, { text: "b" }, { text: "c" }];
     const mockStream = createMockAsyncIterable(chunks);
     const baseFn = vi.fn().mockReturnValue(mockStream);
-    const wrapped = streamWithIdleTimeout(baseFn, 1000);
+    const wrapped = streamWithIdleTimeout(baseFn, { idleTimeoutMs: 1000 });
 
     const model = {} as Parameters<typeof baseFn>[0];
     const context = {} as Parameters<typeof baseFn>[1];
@@ -217,7 +261,7 @@ describe("streamWithIdleTimeout", () => {
     };
 
     const baseFn = vi.fn().mockReturnValue(delayedStream);
-    const wrapped = streamWithIdleTimeout(baseFn, 100); // 100ms timeout - should be enough
+    const wrapped = streamWithIdleTimeout(baseFn, { idleTimeoutMs: 100 });
 
     const model = {} as Parameters<typeof baseFn>[0];
     const context = {} as Parameters<typeof baseFn>[1];
@@ -240,7 +284,7 @@ describe("streamWithIdleTimeout", () => {
     expect(results).toHaveLength(3);
   });
 
-  it("calls timeout hook on idle timeout", async () => {
+  it("calls timeout hook on first-token timeout", async () => {
     vi.useFakeTimers();
     // Create a stream that never yields
     const slowStream: AsyncIterable<unknown> = {
@@ -256,7 +300,7 @@ describe("streamWithIdleTimeout", () => {
 
     const baseFn = vi.fn().mockReturnValue(slowStream);
     const onIdleTimeout = vi.fn();
-    const wrapped = streamWithIdleTimeout(baseFn, 50, onIdleTimeout); // 50ms timeout
+    const wrapped = streamWithIdleTimeout(baseFn, { idleTimeoutMs: 50, onIdleTimeout });
 
     const model = {} as Parameters<typeof baseFn>[0];
     const context = {} as Parameters<typeof baseFn>[1];
@@ -269,12 +313,143 @@ describe("streamWithIdleTimeout", () => {
     await vi.advanceTimersByTimeAsync(50);
     const error = await next;
 
-    // Verify the error message is preserved
+    // Before any chunk arrives, the first-token phase is active —
+    // the hook reports the first-token timeout.
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toMatch(/LLM idle timeout/);
+    expect((error as Error).message).toMatch(/LLM first-token timeout/);
     expect(onIdleTimeout).toHaveBeenCalledTimes(1);
     const [timeoutError] = onIdleTimeout.mock.calls[0] ?? [];
     expect(timeoutError).toBeInstanceOf(Error);
-    expect((timeoutError as Error).message).toMatch(/LLM idle timeout/);
+    expect((timeoutError as Error).message).toMatch(/LLM first-token timeout/);
+  });
+
+  it("uses firstTokenTimeoutMs before the first chunk", async () => {
+    vi.useFakeTimers();
+    // Stream that never yields — first-token window should fire.
+    const hangStream: AsyncIterable<unknown> = {
+      [Symbol.asyncIterator]() {
+        return {
+          async next() {
+            return new Promise<IteratorResult<unknown>>(() => {});
+          },
+        };
+      },
+    };
+    const baseFn = vi.fn().mockReturnValue(hangStream);
+    const wrapped = streamWithIdleTimeout(baseFn, {
+      idleTimeoutMs: 10_000, // would never fire in this test
+      firstTokenTimeoutMs: 50, // should fire first
+    });
+
+    const stream = wrapped(
+      {} as Parameters<typeof baseFn>[0],
+      {} as Parameters<typeof baseFn>[1],
+      {} as Parameters<typeof baseFn>[2],
+    ) as AsyncIterable<unknown>;
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const next = expect(iterator.next()).rejects.toThrow(/LLM first-token timeout/);
+    await vi.advanceTimersByTimeAsync(50);
+    await next;
+  });
+
+  it("uses idleTimeoutMs after the first chunk arrives", async () => {
+    vi.useFakeTimers();
+    // First chunk arrives immediately, then stream hangs — idle window should fire,
+    // not the longer first-token window.
+    const hangAfterOne: AsyncIterable<{ text: string }> = {
+      [Symbol.asyncIterator]() {
+        let emitted = false;
+        return {
+          async next() {
+            if (!emitted) {
+              emitted = true;
+              return { done: false, value: { text: "first" } };
+            }
+            return new Promise<IteratorResult<{ text: string }>>(() => {});
+          },
+        };
+      },
+    };
+    const baseFn = vi.fn().mockReturnValue(hangAfterOne);
+    const wrapped = streamWithIdleTimeout(baseFn, {
+      idleTimeoutMs: 50,
+      firstTokenTimeoutMs: 10_000, // first-token generous, idle tight
+    });
+
+    const stream = wrapped(
+      {} as Parameters<typeof baseFn>[0],
+      {} as Parameters<typeof baseFn>[1],
+      {} as Parameters<typeof baseFn>[2],
+    ) as AsyncIterable<{ text: string }>;
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const first = await iterator.next();
+    expect(first).toEqual({ done: false, value: { text: "first" } });
+
+    const next = expect(iterator.next()).rejects.toThrow(/LLM idle timeout/);
+    await vi.advanceTimersByTimeAsync(50);
+    await next;
+  });
+
+  it("waits indefinitely for first chunk when firstTokenTimeoutMs is 0", async () => {
+    vi.useFakeTimers();
+    // Stream hangs forever before first chunk; first-token timer is disabled (0).
+    // Idle timer (50ms) must not fire during the first-token phase.
+    const hangStream: AsyncIterable<unknown> = {
+      [Symbol.asyncIterator]() {
+        return {
+          async next() {
+            return new Promise<IteratorResult<unknown>>(() => {});
+          },
+        };
+      },
+    };
+    const baseFn = vi.fn().mockReturnValue(hangStream);
+    const wrapped = streamWithIdleTimeout(baseFn, {
+      idleTimeoutMs: 50,
+      firstTokenTimeoutMs: 0, // disable first-token timer entirely
+    });
+
+    const stream = wrapped(
+      {} as Parameters<typeof baseFn>[0],
+      {} as Parameters<typeof baseFn>[1],
+      {} as Parameters<typeof baseFn>[2],
+    ) as AsyncIterable<unknown>;
+    const iterator = stream[Symbol.asyncIterator]();
+
+    let settled = false;
+    const next = iterator.next().finally(() => {
+      settled = true;
+    });
+    // Advance well past the idle window — neither timer should fire.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(settled).toBe(false);
+    // Don't await `next` — it would hang forever; the test ends with the
+    // pending promise, which vitest discards on teardown.
+    void next;
+  });
+
+  it("disables all timeouts when idleTimeoutMs is 0 even if firstTokenTimeoutMs is set", async () => {
+    // When idle is 0, the wrapper short-circuits: returns baseFn untouched.
+    // Stream should pass through without a timer firing.
+    const chunks = [{ text: "a" }];
+    const mockStream = createMockAsyncIterable(chunks);
+    const baseFn = vi.fn().mockReturnValue(mockStream);
+    const wrapped = streamWithIdleTimeout(baseFn, {
+      idleTimeoutMs: 0,
+      firstTokenTimeoutMs: 50,
+    });
+
+    const stream = wrapped(
+      {} as Parameters<typeof baseFn>[0],
+      {} as Parameters<typeof baseFn>[1],
+      {} as Parameters<typeof baseFn>[2],
+    ) as AsyncIterable<{ text: string }>;
+    const results: { text: string }[] = [];
+    for await (const chunk of stream) {
+      results.push(chunk);
+    }
+    expect(results).toEqual(chunks);
   });
 });

--- a/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
+++ b/src/agents/pi-embedded-runner/run/llm-idle-timeout.ts
@@ -14,16 +14,27 @@ export const DEFAULT_LLM_IDLE_TIMEOUT_MS = DEFAULT_LLM_IDLE_TIMEOUT_SECONDS * 10
  */
 const MAX_SAFE_TIMEOUT_MS = 2_147_000_000;
 
-/**
- * Resolves the LLM idle timeout from configuration.
- * @returns Idle timeout in milliseconds, or 0 to disable
- */
-export function resolveLlmIdleTimeoutMs(params?: {
+const clampTimeoutMs = (valueMs: number) => Math.min(Math.floor(valueMs), MAX_SAFE_TIMEOUT_MS);
+
+export type ResolveLlmTimeoutParams = {
   cfg?: OpenClawConfig;
   trigger?: EmbeddedRunTrigger;
   runTimeoutMs?: number;
-}): number {
-  const clampTimeoutMs = (valueMs: number) => Math.min(Math.floor(valueMs), MAX_SAFE_TIMEOUT_MS);
+};
+
+/**
+ * Resolves the LLM idle timeout from configuration.
+ *
+ * Applies between tokens once streaming has started. Resolution precedence:
+ *   1. `agents.defaults.llm.idleTimeoutSeconds` (0 = explicitly disabled)
+ *   2. Caller-provided `runTimeoutMs`
+ *   3. `agents.defaults.timeoutSeconds`
+ *   4. Cron triggers default to 0 (disabled)
+ *   5. {@link DEFAULT_LLM_IDLE_TIMEOUT_MS}
+ *
+ * @returns Idle timeout in milliseconds, or 0 to disable
+ */
+export function resolveLlmIdleTimeoutMs(params?: ResolveLlmTimeoutParams): number {
   const raw = params?.cfg?.agents?.defaults?.llm?.idleTimeoutSeconds;
   // 0 means explicitly disabled (no timeout).
   if (raw === 0) {
@@ -58,21 +69,108 @@ export function resolveLlmIdleTimeoutMs(params?: {
 }
 
 /**
- * Wraps a stream function with idle timeout detection.
- * If no token is received within the specified timeout, the request is aborted.
+ * Resolves the first-token timeout from configuration.
+ *
+ * Applies only while waiting for the very first token from the model. Useful
+ * when cold model loads or upstream keepalives make the first-token wait
+ * legitimately longer than mid-stream gaps.
+ *
+ * Resolution precedence:
+ *   1. `agents.defaults.llm.firstTokenTimeoutSeconds === 0` → disabled
+ *      (no first-token timer; waits indefinitely for the first chunk).
+ *      The idle timer still applies after the first chunk arrives.
+ *   2. positive `firstTokenTimeoutSeconds` → clamped ms.
+ *   3. Unset → `undefined`, telling {@link streamWithIdleTimeout} to inherit
+ *      {@link resolveLlmIdleTimeoutMs} for the first-token phase
+ *      (backwards-compatible behavior).
+ *
+ * @returns First-token timeout in ms, `0` for disabled, or `undefined` for inherit-idle
+ */
+export function resolveLlmFirstTokenTimeoutMs(
+  params?: ResolveLlmTimeoutParams,
+): number | undefined {
+  const raw = params?.cfg?.agents?.defaults?.llm?.firstTokenTimeoutSeconds;
+  // Explicit disable — no first-token timer at all.
+  if (raw === 0) {
+    return 0;
+  }
+  // Explicit positive value.
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return clampTimeoutMs(raw * 1000);
+  }
+  // Unset or invalid → inherit idle (handled by streamWithIdleTimeout).
+  return undefined;
+}
+
+/**
+ * Options for {@link streamWithIdleTimeout}.
+ */
+export type StreamIdleTimeoutOptions = {
+  /**
+   * Maximum milliseconds between tokens once streaming has started.
+   * Set to 0 to disable the wrapper entirely (both phases off).
+   */
+  idleTimeoutMs: number;
+  /**
+   * Maximum milliseconds to wait for the first token.
+   * - `undefined`: inherit {@link idleTimeoutMs} (backwards-compatible).
+   * - `0`: disable the first-token timer (wait indefinitely for the first chunk).
+   *   The idle timer still takes over once the first chunk arrives.
+   * - positive: dedicated first-token window. Lets callers set a tight idle
+   *   timeout without killing cold model loads or warm-up gaps.
+   */
+  firstTokenTimeoutMs?: number;
+  /**
+   * Optional callback invoked when a timeout fires. Receives the error
+   * that will be thrown to the stream consumer.
+   */
+  onIdleTimeout?: (error: Error) => void;
+};
+
+/**
+ * Wraps a stream function with two-phase timeout detection.
+ *
+ * Phase 1 — before the first token: uses `firstTokenTimeoutMs` when set
+ * (including `0` to disable), otherwise inherits `idleTimeoutMs`. This is
+ * where cold-load delays live.
+ *
+ * Phase 2 — after the first token: always uses `idleTimeoutMs`. This catches
+ * mid-stream hangs (network stalls, model crashes) quickly, since once
+ * generation starts a long silence is almost certainly a real fault.
+ *
+ * Splitting the two means callers can set a tight idle timeout for
+ * responsive fault detection without accidentally killing cold requests
+ * that are still legitimately loading a model.
+ *
+ * If `idleTimeoutMs` is 0, the wrapper is a no-op and returns `baseFn`
+ * untouched.
  *
  * @param baseFn - The base stream function to wrap
- * @param timeoutMs - Idle timeout in milliseconds
- * @param onIdleTimeout - Optional callback invoked when idle timeout triggers
- * @returns A wrapped stream function with idle timeout detection
+ * @param options - Timeout configuration
+ * @returns A wrapped stream function with two-phase timeout detection
  */
 export function streamWithIdleTimeout(
   baseFn: StreamFn,
-  timeoutMs: number,
-  onIdleTimeout?: (error: Error) => void,
+  options: StreamIdleTimeoutOptions,
 ): StreamFn {
-  return (model, context, options) => {
-    const maybeStream = baseFn(model, context, options);
+  const { idleTimeoutMs, firstTokenTimeoutMs, onIdleTimeout } = options;
+
+  // idleTimeoutMs === 0 is the master off-switch: return the base function
+  // untouched so there is zero wrapping overhead.
+  if (idleTimeoutMs === 0) {
+    return baseFn;
+  }
+
+  // First-token window.
+  //   undefined → inherit idle (legacy behavior).
+  //   0         → disabled (no timer during first-token phase).
+  //   positive  → use as-is.
+  const firstTokenPhaseMs: number = firstTokenTimeoutMs === undefined
+    ? idleTimeoutMs
+    : firstTokenTimeoutMs;
+
+  return (model, context, streamCallOptions) => {
+    const maybeStream = baseFn(model, context, streamCallOptions);
 
     const wrapStream = (stream: ReturnType<typeof streamSimple>) => {
       const originalAsyncIterator = stream[Symbol.asyncIterator].bind(stream);
@@ -80,12 +178,21 @@ export function streamWithIdleTimeout(
         function () {
           const iterator = originalAsyncIterator();
           let idleTimer: NodeJS.Timeout | null = null;
+          // Cleared to false until we receive our first non-done chunk.
+          // Until then the first-token window applies; after, idle does.
+          let firstTokenSeen = false;
 
-          const createTimeoutPromise = (): Promise<never> => {
+          const currentPhase = (): { timeoutMs: number; phase: "first-token" | "idle" } => {
+            return firstTokenSeen
+              ? { timeoutMs: idleTimeoutMs, phase: "idle" }
+              : { timeoutMs: firstTokenPhaseMs, phase: "first-token" };
+          };
+
+          const createTimeoutPromise = (timeoutMs: number, phase: string): Promise<never> => {
             return new Promise((_, reject) => {
               idleTimer = setTimeout(() => {
                 const error = new Error(
-                  `LLM idle timeout (${Math.floor(timeoutMs / 1000)}s): no response from model`,
+                  `LLM ${phase} timeout (${Math.floor(timeoutMs / 1000)}s): no response from model`,
                 );
                 onIdleTimeout?.(error);
                 reject(error);
@@ -105,8 +212,13 @@ export function streamWithIdleTimeout(
               clearTimer();
 
               try {
-                // Race between the actual next() and the timeout
-                const result = await Promise.race([iterator.next(), createTimeoutPromise()]);
+                const { timeoutMs, phase } = currentPhase();
+                // Race only when the current phase actually has a timer.
+                // timeoutMs === 0 means this phase is disabled (wait forever).
+                const result =
+                  timeoutMs === 0
+                    ? await iterator.next()
+                    : await Promise.race([iterator.next(), createTimeoutPromise(timeoutMs, phase)]);
 
                 if (result.done) {
                   clearTimer();
@@ -114,6 +226,8 @@ export function streamWithIdleTimeout(
                 }
 
                 clearTimer();
+                // Received a real chunk — future gaps are "idle", not first-token.
+                firstTokenSeen = true;
                 return result;
               } catch (error) {
                 clearTimer();

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -46,6 +46,13 @@ export type EmbeddedRunAttemptResult = {
   timedOut: boolean;
   /** True when the no-response LLM idle watchdog caused the timeout. */
   idleTimedOut: boolean;
+  /**
+   * Which LLM watchdog phase fired, if any. `"first-token"` means the model
+   * never produced its first chunk; `"idle"` means it stopped streaming
+   * mid-response. `null` when no LLM-phase timeout occurred. Used to point
+   * users at the correct config knob in error messages.
+   */
+  llmTimeoutPhase: "first-token" | "idle" | null;
   /** True if the timeout occurred while compaction was in progress or pending. */
   timedOutDuringCompaction: boolean;
   promptError: unknown;

--- a/src/agents/pi-embedded-runner/usage-reporting.test.ts
+++ b/src/agents/pi-embedded-runner/usage-reporting.test.ts
@@ -21,6 +21,7 @@ function makeAttemptResult(
     externalAbort: false,
     timedOut: false,
     idleTimedOut: false,
+    llmTimeoutPhase: null,
     timedOutDuringCompaction: false,
     promptError: null,
     promptErrorSource: null,

--- a/src/agents/test-helpers/pi-embedded-runner-e2e-fixtures.ts
+++ b/src/agents/test-helpers/pi-embedded-runner-e2e-fixtures.ts
@@ -105,6 +105,7 @@ export function makeEmbeddedRunnerAttempt(
     externalAbort: false,
     timedOut: false,
     idleTimedOut: false,
+    llmTimeoutPhase: null,
     timedOutDuringCompaction: false,
     promptError: null,
     promptErrorSource: null,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4317,7 +4317,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                 properties: {
                   idleTimeoutSeconds: {
                     description:
-                      "Idle timeout for LLM streaming responses in seconds. If no token is received within this time, the request is aborted. Set to 0 to disable. Default: 120 seconds.",
+                      "Idle timeout for LLM streaming responses in seconds. Applies between tokens once streaming has started. If no token is received within this time after the first token, the request is aborted. Set to 0 to disable. Default: 120 seconds.",
+                    type: "integer",
+                    minimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  firstTokenTimeoutSeconds: {
+                    description:
+                      "First-token timeout for LLM streaming responses in seconds. Applies only while waiting for the very first token from the model, allowing cold model loads (or upstream heartbeat-backed routers) a longer warm-up window than mid-stream idle gaps. When unset, the first-token phase inherits idleTimeoutSeconds. Set to 0 to disable only the first-token timer (wait indefinitely for the first chunk; the idle timer still applies after the first chunk arrives).",
                     type: "integer",
                     minimum: 0,
                     maximum: 9007199254740991,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -457,9 +457,23 @@ export type AgentCompactionMemoryFlushConfig = {
 export type AgentLlmConfig = {
   /**
    * Idle timeout for LLM streaming responses in seconds.
-   * If no token is received within this time, the request is aborted.
+   * Applies between tokens once the stream has started producing output.
+   * If no token is received within this time after the first token, the
+   * request is aborted.
    * Set to 0 to disable (never timeout).
    * If unset, OpenClaw uses the default LLM idle timeout.
    */
   idleTimeoutSeconds?: number;
+  /**
+   * First-token timeout for LLM streaming responses in seconds.
+   * Applies only while waiting for the very first token from the model.
+   * Useful when model loading (cold start, model warm-up, proxy keepalives)
+   * may legitimately take much longer than mid-stream token gaps.
+   * When unset, the first-token wait inherits `idleTimeoutSeconds`
+   * (backwards-compatible behavior).
+   * Set to 0 to disable only the first-token timer (wait indefinitely for
+   * the first chunk; the idle timer still applies once the first chunk
+   * arrives).
+   */
+  firstTokenTimeoutSeconds?: number;
 };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -120,7 +120,15 @@ export const AgentDefaultsSchema = z
           .nonnegative()
           .optional()
           .describe(
-            `Idle timeout for LLM streaming responses in seconds. If no token is received within this time, the request is aborted. Set to 0 to disable. Default: ${DEFAULT_LLM_IDLE_TIMEOUT_SECONDS} seconds.`,
+            `Idle timeout for LLM streaming responses in seconds. Applies between tokens once streaming has started. If no token is received within this time after the first token, the request is aborted. Set to 0 to disable. Default: ${DEFAULT_LLM_IDLE_TIMEOUT_SECONDS} seconds.`,
+          ),
+        firstTokenTimeoutSeconds: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe(
+            "First-token timeout for LLM streaming responses in seconds. Applies only while waiting for the very first token from the model, allowing cold model loads (or upstream heartbeat-backed routers) a longer warm-up window than mid-stream idle gaps. When unset, the first-token phase inherits idleTimeoutSeconds. Set to 0 to disable only the first-token timer (wait indefinitely for the first chunk; the idle timer still applies after the first chunk arrives).",
           ),
       })
       .strict()


### PR DESCRIPTION
## Summary

Adds a second, longer timeout window that covers the wait for the **first token** separately from mid-stream **idle** gaps. This lets operators set a tight idle timeout for responsive fault detection without killing cold-loading models or upstream routers whose first byte legitimately takes minutes.

- **New config knob:** `agents.defaults.llm.firstTokenTimeoutSeconds`
  - When unset, the first-token wait inherits `idleTimeoutSeconds` — **fully backwards-compatible** (existing configs behave identically).
  - Set to `0` to disable the first-token timeout without disabling idle.
- **`streamWithIdleTimeout` signature change:** now takes an options object `{ idleTimeoutMs, firstTokenTimeoutMs?, onIdleTimeout? }`. The per-iterator state tracks a `firstTokenSeen` flag and selects the appropriate window before each `next()` race.
- **`idleTimeoutMs === 0` master off-switch:** short-circuits to return `baseFn` unwrapped (zero overhead when timeouts are disabled).
- **Error messages distinguish the phase:**
  - `"LLM first-token timeout (Xs): no response from model"`
  - `"LLM idle timeout (Xs): no response from model"`

## Motivation

Deployments with local Ollama backends can have cold model loads that legitimately take 2–4 minutes, while mid-stream silence almost always indicates a real fault (network stall, model crash). Previously a single `idleTimeoutSeconds` had to be generous enough to cover the worst cold-load, which made mid-stream hangs slow to detect. Splitting the two lets both windows be correctly sized.

Example config for a deployment with cold-loading backends + a heartbeat-emitting proxy:

```yaml
agents:
  defaults:
    llm:
      idleTimeoutSeconds: 30         # catch mid-stream hangs quickly
      firstTokenTimeoutSeconds: 300  # allow cold model loads / warm-up
```

## Test plan

- [x] `pnpm vitest run src/agents/pi-embedded-runner/run/llm-idle-timeout.test.ts` — 23 tests pass (8 existing + 15 new/updated)
  - First-token timeout fires when upstream produces no tokens with short `firstTokenTimeoutMs`
  - Idle timeout fires between chunks with short `idleTimeoutMs` and long `firstTokenTimeoutMs`
  - `idleTimeoutMs: 0` with a positive `firstTokenTimeoutMs` disables both phases (master off-switch)
  - `resolveLlmFirstTokenTimeoutMs` falls back to idle when unset, respects explicit `0`, caps at max safe
- [x] `tsc --noEmit` clean
- [x] JSON schema regenerated (`config:schema:gen`) — new field appears under `agents.defaults.llm`
- [x] Existing callers (`attempt.ts`) updated to the new options-object API

## Breaking changes

`streamWithIdleTimeout`'s signature changed from `(baseFn, timeoutMs, onIdleTimeout?)` to `(baseFn, options)`. The only in-tree caller is `attempt.ts` (updated). External plugins that wrap the stream function would need to migrate — but this isn't a documented extension point, so in practice this is internal.

The config surface is additive and backwards-compatible.