### PR TITLE
fix(memory): respect qmd status timeout and skip checkpoint exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,7 @@ Docs: https://docs.openclaw.ai
 - Configure/models: keep the model picker scoped to the selected manifest provider and enable its bundled plugin before catalog lookup, so choosing GitHub Copilot no longer falls back to Ollama or skips the catalog. (#74322) Thanks @obviyus.
 - Auto-reply/subagents: reject `/focus` from leaf subagents and scope fallback target resolution to the requesting subagent's children, so subagents cannot bind conversations outside their control boundary. (#73613) Thanks @drobison00.
 - Gateway/startup: skip inherited workspace startup memory for sandboxed spawned sessions without real-workspace write access, so `/new` no longer preloads host workspace memory into isolated child runs. (#73611) Thanks @drobison00.
+- Memory/QMD: respect `memory.qmd.limits.timeoutMs` during vector status probes and keep valid session transcripts whose IDs contain `.checkpoint.` in QMD session exports. Carries forward #65914. Thanks @shawnduggan.
 
 ## 2026.4.27
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4776,7 +4776,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("excludes checkpoint transcripts from exported qmd session documents", async () => {
+  it("exports valid session transcripts whose IDs contain checkpoint words", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -4802,15 +4802,15 @@ describe("QmdMemoryManager", () => {
       `${JSON.stringify({ type: "message", message: { role: "user", content: "live" } })}\n`,
     );
     await fs.writeFile(
-      path.join(sessionsDir, "live-session.checkpoint.123.jsonl"),
-      `${JSON.stringify({ type: "message", message: { role: "user", content: "checkpoint" } })}\n`,
+      path.join(sessionsDir, "team.checkpoint.notes.jsonl"),
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "notes" } })}\n`,
     );
 
     const { manager } = await createManager({ mode: "full" });
     const sessionExportDir = path.join(stateDir, "agents", agentId, "qmd", "sessions");
     const exported = (await fs.readdir(sessionExportDir)).toSorted();
 
-    expect(exported).toEqual(["live-session.md"]);
+    expect(exported).toEqual(["live-session.md", "team.checkpoint.notes.md"]);
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4744,6 +4744,76 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("uses the configured qmd timeout for status probes", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          limits: { timeoutMs: 25 },
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "status") {
+        return createMockChild({ autoClose: false });
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+
+    await expect(manager.probeVectorAvailability()).resolves.toBe(false);
+    expect(manager.status().vector).toEqual({
+      enabled: true,
+      available: false,
+      loadError: expect.stringContaining("timed out after 25ms"),
+    });
+    await manager.close();
+  });
+
+  it("excludes checkpoint transcripts from exported qmd session documents", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          sessions: { enabled: true },
+          update: {
+            interval: "0s",
+            debounceMs: 0,
+            onBoot: true,
+            waitForBootSync: true,
+          },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionsDir, "live-session.jsonl"),
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "live" } })}\n`,
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "live-session.checkpoint.123.jsonl"),
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "checkpoint" } })}\n`,
+    );
+
+    const { manager } = await createManager({ mode: "full" });
+    const sessionExportDir = path.join(stateDir, "agents", agentId, "qmd", "sessions");
+    const exported = (await fs.readdir(sessionExportDir)).toSorted();
+
+    expect(exported).toEqual(["live-session.md"]);
+    await manager.close();
+  });
+
   it("reports vector availability as unavailable when qmd status shows zero vectors", async () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "status") {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4751,6 +4751,7 @@ describe("QmdMemoryManager", () => {
         backend: "qmd",
         qmd: {
           includeDefaultMemory: false,
+          searchMode: "query",
           limits: { timeoutMs: 25 },
           update: { interval: "0s", debounceMs: 60_000, onBoot: false },
           paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4806,12 +4806,19 @@ describe("QmdMemoryManager", () => {
       path.join(sessionsDir, "team.checkpoint.notes.jsonl"),
       `${JSON.stringify({ type: "message", message: { role: "user", content: "notes" } })}\n`,
     );
+    await fs.writeFile(
+      path.join(sessionsDir, "live-session.checkpoint.11111111-1111-4111-8111-111111111111.jsonl"),
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "checkpoint" } })}\n`,
+    );
 
     const { manager } = await createManager({ mode: "full" });
     const sessionExportDir = path.join(stateDir, "agents", agentId, "qmd", "sessions");
     const exported = (await fs.readdir(sessionExportDir)).toSorted();
 
     expect(exported).toEqual(["live-session.md", "team.checkpoint.notes.md"]);
+    await expect(
+      fs.readFile(path.join(sessionExportDir, "team.checkpoint.notes.md"), "utf-8"),
+    ).resolves.toContain("notes");
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5182,6 +5182,76 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("uses the configured qmd timeout for status probes", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          limits: { timeoutMs: 25 },
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "status") {
+        return createMockChild({ autoClose: false });
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+
+    await expect(manager.probeVectorAvailability()).resolves.toBe(false);
+    expect(manager.status().vector).toEqual({
+      enabled: true,
+      available: false,
+      loadError: expect.stringContaining("timed out after 25ms"),
+    });
+    await manager.close();
+  });
+
+  it("excludes checkpoint transcripts from exported qmd session documents", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          sessions: { enabled: true },
+          update: {
+            interval: "0s",
+            debounceMs: 0,
+            onBoot: true,
+            waitForBootSync: true,
+          },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const sessionsDir = path.join(stateDir, "agents", agentId, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionsDir, "live-session.jsonl"),
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "live" } })}\n`,
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "live-session.checkpoint.123.jsonl"),
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "checkpoint" } })}\n`,
+    );
+
+    const { manager } = await createManager({ mode: "full" });
+    const sessionExportDir = path.join(stateDir, "agents", agentId, "qmd", "sessions");
+    const exported = (await fs.readdir(sessionExportDir)).toSorted();
+
+    expect(exported).toEqual(["live-session.md"]);
+    await manager.close();
+  });
+
   it("reports vector availability as unavailable when qmd status shows zero vectors", async () => {
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "status") {

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5214,7 +5214,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("excludes checkpoint transcripts from exported qmd session documents", async () => {
+  it("exports valid session transcripts whose IDs contain checkpoint words", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -5240,15 +5240,15 @@ describe("QmdMemoryManager", () => {
       `${JSON.stringify({ type: "message", message: { role: "user", content: "live" } })}\n`,
     );
     await fs.writeFile(
-      path.join(sessionsDir, "live-session.checkpoint.123.jsonl"),
-      `${JSON.stringify({ type: "message", message: { role: "user", content: "checkpoint" } })}\n`,
+      path.join(sessionsDir, "team.checkpoint.notes.jsonl"),
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "notes" } })}\n`,
     );
 
     const { manager } = await createManager({ mode: "full" });
     const sessionExportDir = path.join(stateDir, "agents", agentId, "qmd", "sessions");
     const exported = (await fs.readdir(sessionExportDir)).toSorted();
 
-    expect(exported).toEqual(["live-session.md"]);
+    expect(exported).toEqual(["live-session.md", "team.checkpoint.notes.md"]);
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5183,6 +5183,7 @@ describe("QmdMemoryManager", () => {
   });
 
   it("uses the configured qmd timeout for status probes", async () => {
+    vi.useFakeTimers();
     cfg = {
       ...cfg,
       memory: {
@@ -5190,27 +5191,36 @@ describe("QmdMemoryManager", () => {
         qmd: {
           includeDefaultMemory: false,
           searchMode: "query",
-          limits: { timeoutMs: 25 },
+          limits: { timeoutMs: 6000 },
           update: { interval: "0s", debounceMs: 60_000, onBoot: false },
           paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
         },
       },
     } as OpenClawConfig;
 
+    let statusKill: Mock | null = null;
     spawnMock.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "status") {
-        return createMockChild({ autoClose: false });
+        const child = createMockChild({ autoClose: false });
+        statusKill = vi.fn();
+        child.kill = statusKill;
+        return child;
       }
       return createMockChild();
     });
 
     const { manager } = await createManager();
 
-    await expect(manager.probeVectorAvailability()).resolves.toBe(false);
+    const probe = manager.probeVectorAvailability();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(statusKill).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect(probe).resolves.toBe(false);
     expect(manager.status().vector).toEqual({
       enabled: true,
       available: false,
-      loadError: expect.stringContaining("timed out after 25ms"),
+      semanticAvailable: false,
+      loadError: expect.stringContaining("timed out after 6000ms"),
     });
     await manager.close();
   });
@@ -5244,12 +5254,19 @@ describe("QmdMemoryManager", () => {
       path.join(sessionsDir, "team.checkpoint.notes.jsonl"),
       `${JSON.stringify({ type: "message", message: { role: "user", content: "notes" } })}\n`,
     );
+    await fs.writeFile(
+      path.join(sessionsDir, "live-session.checkpoint.11111111-1111-4111-8111-111111111111.jsonl"),
+      `${JSON.stringify({ type: "message", message: { role: "user", content: "checkpoint" } })}\n`,
+    );
 
     const { manager } = await createManager({ mode: "full" });
     const sessionExportDir = path.join(stateDir, "agents", agentId, "qmd", "sessions");
     const exported = (await fs.readdir(sessionExportDir)).toSorted();
 
     expect(exported).toEqual(["live-session.md", "team.checkpoint.notes.md"]);
+    await expect(
+      fs.readFile(path.join(sessionExportDir, "team.checkpoint.notes.md"), "utf-8"),
+    ).resolves.toContain("notes");
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -5189,6 +5189,7 @@ describe("QmdMemoryManager", () => {
         backend: "qmd",
         qmd: {
           includeDefaultMemory: false,
+          searchMode: "query",
           limits: { timeoutMs: 25 },
           update: { interval: "0s", debounceMs: 60_000, onBoot: false },
           paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1392,8 +1392,9 @@ export class QmdMemoryManager implements MemorySearchManager {
       return false;
     }
     try {
+      const timeoutMs = this.qmd.limits.timeoutMs;
       const result = await this.runQmd(["status"], {
-        timeoutMs: this.qmd.limits.timeoutMs,
+        timeoutMs,
       });
       const vectorCount = parseQmdStatusVectorCount(`${result.stdout}\n${result.stderr}`);
       if (vectorCount === null) {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -2202,10 +2202,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const exportDir = this.sessionExporter.dir;
     await fs.mkdir(exportDir, { recursive: true });
-    const files = (await listSessionFilesForAgent(this.agentId)).filter((sessionFile) => {
-      const baseName = path.basename(sessionFile);
-      return !baseName.includes(".checkpoint.");
-    });
+    const files = await listSessionFilesForAgent(this.agentId);
     const keep = new Set<string>();
     const tracked = new Set<string>();
     const cutoff = this.sessionExporter.retentionMs

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1393,7 +1393,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     try {
       const result = await this.runQmd(["status"], {
-        timeoutMs: Math.min(this.qmd.limits.timeoutMs, 5_000),
+        timeoutMs: this.qmd.limits.timeoutMs,
       });
       const vectorCount = parseQmdStatusVectorCount(`${result.stdout}\n${result.stderr}`);
       if (vectorCount === null) {
@@ -2202,7 +2202,10 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const exportDir = this.sessionExporter.dir;
     await fs.mkdir(exportDir, { recursive: true });
-    const files = await listSessionFilesForAgent(this.agentId);
+    const files = (await listSessionFilesForAgent(this.agentId)).filter((sessionFile) => {
+      const baseName = path.basename(sessionFile);
+      return !baseName.includes(".checkpoint.");
+    });
     const keep = new Set<string>();
     const tracked = new Set<string>();
     const cutoff = this.sessionExporter.retentionMs

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1436,8 +1436,9 @@ export class QmdMemoryManager implements MemorySearchManager {
       return false;
     }
     try {
+      const timeoutMs = this.qmd.limits.timeoutMs;
       const result = await this.runQmd(["status"], {
-        timeoutMs: this.qmd.limits.timeoutMs,
+        timeoutMs,
       });
       const vectorCount = parseQmdStatusVectorCount(`${result.stdout}\n${result.stderr}`);
       if (vectorCount === null) {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1437,7 +1437,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     try {
       const result = await this.runQmd(["status"], {
-        timeoutMs: Math.min(this.qmd.limits.timeoutMs, 5_000),
+        timeoutMs: this.qmd.limits.timeoutMs,
       });
       const vectorCount = parseQmdStatusVectorCount(`${result.stdout}\n${result.stderr}`);
       if (vectorCount === null) {

--- a/extensions/sms/src/channel.test.ts
+++ b/extensions/sms/src/channel.test.ts
@@ -27,6 +27,37 @@ afterEach(() => {
   vi.doUnmock("./twilio.js");
 });
 
+describe("smsPlugin status", () => {
+  it("builds a status snapshot for configured SMS accounts", async () => {
+    const snapshot = await smsPlugin.status?.buildAccountSnapshot?.({
+      cfg: {},
+      account: {
+        accountId: "support",
+        enabled: true,
+        accountSid: "AC123",
+        authToken: "secret",
+        fromNumber: "+15557654321",
+        messagingServiceSid: "",
+        defaultTo: "",
+        webhookPath: "/webhooks/sms",
+        publicWebhookUrl: "",
+        dangerouslyDisableSignatureValidation: false,
+        dmPolicy: "pairing",
+        allowFrom: [],
+        textChunkLimit: 1500,
+      },
+    });
+
+    expect(snapshot).toEqual({
+      accountId: "support",
+      name: "+15557654321",
+      enabled: true,
+      configured: true,
+      statusState: "configured",
+    });
+  });
+});
+
 describe("smsPlugin outbound", () => {
   it("declares an active text chunker and account-aware chunk limit", () => {
     expect(smsPlugin.configSchema).toBeDefined();

--- a/extensions/sms/src/channel.ts
+++ b/extensions/sms/src/channel.ts
@@ -254,12 +254,16 @@ export const smsPlugin: ChannelPlugin<ResolvedSmsAccount> = createChatChannelPlu
       },
     },
     status: {
-      buildAccountSnapshot: ({ account }) => ({
-        accountId: account.accountId,
-        name: account.fromNumber || account.messagingServiceSid || "SMS",
-        configured: isSmsAccountConfigured(account),
-        enabled: account.enabled,
-      }),
+      buildAccountSnapshot: ({ account }) => {
+        const configured = isSmsAccountConfigured(account);
+        return {
+          accountId: account.accountId,
+          name: account.fromNumber || account.messagingServiceSid || "SMS",
+          enabled: account.enabled,
+          configured,
+          statusState: !account.enabled ? "disabled" : configured ? "configured" : "unconfigured",
+        };
+      },
       buildCapabilitiesDiagnostics: async ({ account }) => ({
         lines: collectSmsStartupWarnings(account).map((text) => ({ text, tone: "warn" })),
       }),

--- a/extensions/sms/src/inbound.test.ts
+++ b/extensions/sms/src/inbound.test.ts
@@ -34,7 +34,20 @@ function createRuntime() {
   const readAllowFromStore = vi.fn(async () => [] as string[]);
   const upsertPairingRequest = vi.fn(async () => ({ code: "PAIR123", created: true }));
   const resolveAgentRoute = vi.fn();
-  const run = vi.fn();
+  const run = vi.fn<
+    (params: {
+      adapter: {
+        ingest: (msg: {
+          from: string;
+          to: string;
+          body: string;
+          messageSid: string;
+          accountSid: string;
+        }) => unknown;
+        resolveTurn: (ingested: unknown) => Promise<{ routeSessionKey: string }>;
+      };
+    }) => void
+  >();
   const buildContext = vi.fn();
   const resolveStorePath = vi.fn();
   const runtime = {

--- a/extensions/sms/src/twilio.test.ts
+++ b/extensions/sms/src/twilio.test.ts
@@ -246,7 +246,7 @@ describe("Twilio SMS helpers", () => {
   });
 
   it("throws structured Twilio errors from JSON error bodies", async () => {
-    const fetchImpl = vi.fn(
+    const fetchImpl = vi.fn<typeof fetch>(
       async () =>
         new Response(
           JSON.stringify({
@@ -276,7 +276,9 @@ describe("Twilio SMS helpers", () => {
   });
 
   it("includes non-JSON Twilio error text in send failures", async () => {
-    const fetchImpl = vi.fn(async () => new Response("upstream unavailable", { status: 503 }));
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new Response("upstream unavailable", { status: 503 }),
+    );
 
     await expect(
       sendSmsViaTwilio({
@@ -289,7 +291,7 @@ describe("Twilio SMS helpers", () => {
   });
 
   it("rejects malformed JSON from successful Twilio sends", async () => {
-    const fetchImpl = vi.fn(async () => new Response("not json", { status: 201 }));
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response("not json", { status: 201 }));
 
     await expect(
       sendSmsViaTwilio({
@@ -314,7 +316,7 @@ describe("Twilio SMS helpers", () => {
   });
 
   it("requires successful Twilio sends to include a Message SID", async () => {
-    const fetchImpl = vi.fn(
+    const fetchImpl = vi.fn<typeof fetch>(
       async () => new Response(JSON.stringify({ status: "queued" }), { status: 201 }),
     );
 

--- a/src/agents/cli-runner.binding-flush.test.ts
+++ b/src/agents/cli-runner.binding-flush.test.ts
@@ -37,34 +37,29 @@ describe("isCliBindingFlushed", () => {
   });
 
   it("retries up to three times before giving up", async () => {
-    vi.useFakeTimers();
+    const delay = vi.fn(async () => undefined);
     const probe = vi.fn(async () => false);
-    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe, delay });
 
-    const resultPromise = isCliBindingFlushed("sid-cold", "claude-cli", workspaceDir);
-    await vi.advanceTimersByTimeAsync(0);
-    await vi.advanceTimersByTimeAsync(50);
-    await vi.advanceTimersByTimeAsync(150);
-
-    await expect(resultPromise).resolves.toBe(false);
+    expect(await isCliBindingFlushed("sid-cold", "claude-cli", workspaceDir)).toBe(false);
     expect(probe).toHaveBeenCalledTimes(3);
+    expect(delay).toHaveBeenCalledTimes(2);
+    expect(delay).toHaveBeenNthCalledWith(1, 50);
+    expect(delay).toHaveBeenNthCalledWith(2, 150);
   });
 
   it("succeeds when the transcript becomes visible on a later retry", async () => {
-    vi.useFakeTimers();
+    const delay = vi.fn(async () => undefined);
     let calls = 0;
     const probe = vi.fn(async () => {
       calls += 1;
       return calls >= 2;
     });
-    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe });
+    setCliRunnerTestDeps({ claudeCliSessionTranscriptHasContent: probe, delay });
 
-    const resultPromise = isCliBindingFlushed("sid-late", "claude-cli", workspaceDir);
-    await vi.advanceTimersByTimeAsync(0);
-    await vi.advanceTimersByTimeAsync(50);
-
-    await expect(resultPromise).resolves.toBe(true);
+    expect(await isCliBindingFlushed("sid-late", "claude-cli", workspaceDir)).toBe(true);
     expect(probe).toHaveBeenCalledTimes(2);
+    expect(delay).toHaveBeenCalledExactlyOnceWith(50);
   });
 
   it("schedules at most 0 + 50 + 150ms of delay across the bounded retry", async () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -37,6 +37,9 @@ const log = createSubsystemLogger("agents/cli-runner");
 
 const cliRunnerDeps = {
   claudeCliSessionTranscriptHasContent: claudeCliSessionTranscriptHasContentImpl,
+  delay: async (delayMs: number) => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  },
 };
 
 export function setCliRunnerTestDeps(overrides: Partial<typeof cliRunnerDeps>): void {
@@ -45,6 +48,9 @@ export function setCliRunnerTestDeps(overrides: Partial<typeof cliRunnerDeps>): 
 
 export function restoreCliRunnerTestDeps(): void {
   cliRunnerDeps.claudeCliSessionTranscriptHasContent = claudeCliSessionTranscriptHasContentImpl;
+  cliRunnerDeps.delay = async (delayMs: number) => {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  };
 }
 
 function isClaudeCliProvider(provider: string): boolean {
@@ -64,7 +70,7 @@ export async function isCliBindingFlushed(
   }
   for (const delayMs of [0, 50, 150]) {
     if (delayMs > 0) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await cliRunnerDeps.delay(delayMs);
     }
     if (await cliRunnerDeps.claudeCliSessionTranscriptHasContent({ sessionId, workspaceDir })) {
       return true;

--- a/src/agents/model-catalog-browse.test.ts
+++ b/src/agents/model-catalog-browse.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
-import { loadModelCatalogForBrowse } from "./model-catalog-browse.js";
+import {
+  DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS,
+  loadModelCatalogForBrowse,
+  restoreModelCatalogBrowseTestDeps,
+  setModelCatalogBrowseTestDeps,
+} from "./model-catalog-browse.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 
 const readOnlyCatalog: ModelCatalogEntry[] = [
@@ -32,6 +37,7 @@ describe("loadModelCatalogForBrowse", () => {
     vi.clearAllTimers();
     vi.restoreAllMocks();
     vi.useRealTimers();
+    restoreModelCatalogBrowseTestDeps();
   });
 
   it("uses the read-only catalog for default browse views", async () => {
@@ -71,14 +77,17 @@ describe("loadModelCatalogForBrowse", () => {
   });
 
   it("returns an empty catalog when read-only catalog loading times out", async () => {
-    vi.useFakeTimers();
     const onTimeout = vi.fn();
-    const loadCatalog = vi.fn(
-      () =>
-        new Promise<ModelCatalogEntry[]>((_, reject) => {
-          setTimeout(() => reject(new Error("late catalog failure")), 10);
-        }),
-    );
+    const timeoutHandle = { unref: vi.fn() } as unknown as NodeJS.Timeout;
+    const clearTimeout = vi.fn();
+    setModelCatalogBrowseTestDeps({
+      setTimeout: vi.fn((callback: () => void) => {
+        queueMicrotask(callback);
+        return timeoutHandle;
+      }) as unknown as typeof globalThis.setTimeout,
+      clearTimeout: clearTimeout as unknown as typeof globalThis.clearTimeout,
+    });
+    const loadCatalog = vi.fn(() => new Promise<ModelCatalogEntry[]>(() => undefined));
 
     const resultPromise = loadModelCatalogForBrowse({
       cfg: config(),
@@ -87,21 +96,22 @@ describe("loadModelCatalogForBrowse", () => {
       onTimeout,
     });
 
-    await vi.advanceTimersByTimeAsync(5);
     await expect(resultPromise).resolves.toEqual([]);
     expect(onTimeout).toHaveBeenCalledExactlyOnceWith(5);
-    await vi.advanceTimersByTimeAsync(10);
+    expect(timeoutHandle.unref).toHaveBeenCalledOnce();
+    expect(clearTimeout).toHaveBeenCalledExactlyOnceWith(timeoutHandle);
   });
 
   it("uses the default timeout when timeoutMs is non-finite", async () => {
-    vi.useFakeTimers();
     const onTimeout = vi.fn();
-    const loadCatalog = vi.fn(
-      () =>
-        new Promise<ModelCatalogEntry[]>((resolve) => {
-          setTimeout(() => resolve(readOnlyCatalog), 5);
-        }),
-    );
+    const timeoutHandle = { unref: vi.fn() } as unknown as NodeJS.Timeout;
+    const setTimeout = vi.fn(() => timeoutHandle);
+    const clearTimeout = vi.fn();
+    setModelCatalogBrowseTestDeps({
+      setTimeout: setTimeout as unknown as typeof globalThis.setTimeout,
+      clearTimeout: clearTimeout as unknown as typeof globalThis.clearTimeout,
+    });
+    const loadCatalog = vi.fn(async () => readOnlyCatalog);
 
     const resultPromise = loadModelCatalogForBrowse({
       cfg: config(),
@@ -110,37 +120,33 @@ describe("loadModelCatalogForBrowse", () => {
       onTimeout,
     });
 
-    await vi.advanceTimersByTimeAsync(5);
-
     await expect(resultPromise).resolves.toBe(readOnlyCatalog);
+    expect(setTimeout).toHaveBeenCalledExactlyOnceWith(
+      expect.any(Function),
+      DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS,
+    );
+    expect(clearTimeout).toHaveBeenCalledExactlyOnceWith(timeoutHandle);
     expect(onTimeout).not.toHaveBeenCalled();
   });
 
   it("caps oversized browse timeouts before scheduling the fallback timer", async () => {
-    vi.useFakeTimers();
-    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
-    try {
-      const loadCatalog = vi.fn(
-        () =>
-          new Promise<ModelCatalogEntry[]>((resolve) => {
-            setTimeout(() => resolve(readOnlyCatalog), 5);
-          }),
-      );
+    const timeoutHandle = { unref: vi.fn() } as unknown as NodeJS.Timeout;
+    const setTimeout = vi.fn(() => timeoutHandle);
+    const clearTimeout = vi.fn();
+    setModelCatalogBrowseTestDeps({
+      setTimeout: setTimeout as unknown as typeof globalThis.setTimeout,
+      clearTimeout: clearTimeout as unknown as typeof globalThis.clearTimeout,
+    });
+    const loadCatalog = vi.fn(async () => readOnlyCatalog);
 
-      const resultPromise = loadModelCatalogForBrowse({
-        cfg: config(),
-        loadCatalog,
-        timeoutMs: Number.MAX_SAFE_INTEGER,
-      });
+    const resultPromise = loadModelCatalogForBrowse({
+      cfg: config(),
+      loadCatalog,
+      timeoutMs: Number.MAX_SAFE_INTEGER,
+    });
 
-      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
-      await vi.advanceTimersByTimeAsync(5);
-
-      await expect(resultPromise).resolves.toBe(readOnlyCatalog);
-    } finally {
-      timeoutSpy.mockRestore();
-      vi.clearAllTimers();
-      vi.useRealTimers();
-    }
+    await expect(resultPromise).resolves.toBe(readOnlyCatalog);
+    expect(setTimeout).toHaveBeenCalledExactlyOnceWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
+    expect(clearTimeout).toHaveBeenCalledExactlyOnceWith(timeoutHandle);
   });
 });

--- a/src/agents/model-catalog-browse.ts
+++ b/src/agents/model-catalog-browse.ts
@@ -10,6 +10,22 @@ export const DEFAULT_MODEL_CATALOG_BROWSE_TIMEOUT_MS = 750;
 
 export type ModelCatalogBrowseView = "default" | "configured" | "all";
 
+const modelCatalogBrowseDeps = {
+  setTimeout: globalThis.setTimeout,
+  clearTimeout: globalThis.clearTimeout,
+};
+
+export function setModelCatalogBrowseTestDeps(
+  overrides: Partial<typeof modelCatalogBrowseDeps>,
+): void {
+  Object.assign(modelCatalogBrowseDeps, overrides);
+}
+
+export function restoreModelCatalogBrowseTestDeps(): void {
+  modelCatalogBrowseDeps.setTimeout = globalThis.setTimeout;
+  modelCatalogBrowseDeps.clearTimeout = globalThis.clearTimeout;
+}
+
 function resolveModelCatalogBrowseTimeoutMs(value: number | undefined): number {
   return (
     clampTimerTimeoutMs(value, 1) ??
@@ -37,7 +53,7 @@ export async function loadModelCatalogForBrowse(params: {
   const timedOut = Symbol("model-catalog-browse-timeout");
   const catalogPromise = params.loadCatalog({ readOnly: true });
   const timeoutPromise = new Promise<typeof timedOut>((resolve) => {
-    timeout = setTimeout(() => resolve(timedOut), timeoutMs);
+    timeout = modelCatalogBrowseDeps.setTimeout(() => resolve(timedOut), timeoutMs);
     timeout.unref?.();
   });
 
@@ -51,7 +67,7 @@ export async function loadModelCatalogForBrowse(params: {
     return result;
   } finally {
     if (timeout) {
-      clearTimeout(timeout);
+      modelCatalogBrowseDeps.clearTimeout(timeout);
     }
   }
 }

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -3,6 +3,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "../shared/number-coercion.js";
 import { createTypingCallbacks } from "./typing.js";
 
 type TypingCallbackOverrides = Partial<Parameters<typeof createTypingCallbacks>[0]>;
+type TypingHarnessOptions = TypingCallbackOverrides & { useDefaultMaxDuration?: boolean };
 type TypingHarnessStart = ReturnType<typeof vi.fn<() => Promise<void>>>;
 type TypingHarnessError = ReturnType<typeof vi.fn<(err: unknown) => void>>;
 
@@ -11,18 +12,30 @@ const flushMicrotasks = async () => {
   await Promise.resolve();
 };
 
+const activeCallbacks = new Set<ReturnType<typeof createTypingCallbacks>>();
+
+afterEach(async () => {
+  for (const callbacks of activeCallbacks) {
+    callbacks.onCleanup?.();
+  }
+  activeCallbacks.clear();
+  await flushMicrotasks();
+  vi.useRealTimers();
+});
+
 async function withFakeTimers(run: () => Promise<void>) {
   vi.useFakeTimers();
   try {
     await run();
   } finally {
+    await flushMicrotasks();
     vi.clearAllTimers();
     vi.useRealTimers();
     vi.restoreAllMocks();
   }
 }
 
-function createTypingHarness(overrides: TypingCallbackOverrides = {}) {
+function createTypingHarness(overrides: TypingHarnessOptions = {}) {
   const start: TypingHarnessStart = vi.fn<() => Promise<void>>(async () => {});
   const stop: TypingHarnessStart = vi.fn<() => Promise<void>>(async () => {});
   const onStartError: TypingHarnessError = vi.fn<(err: unknown) => void>();
@@ -52,8 +65,13 @@ function createTypingHarness(overrides: TypingCallbackOverrides = {}) {
     ...(overrides.keepaliveIntervalMs !== undefined
       ? { keepaliveIntervalMs: overrides.keepaliveIntervalMs }
       : {}),
-    ...(overrides.maxDurationMs !== undefined ? { maxDurationMs: overrides.maxDurationMs } : {}),
+    ...(overrides.maxDurationMs !== undefined
+      ? { maxDurationMs: overrides.maxDurationMs }
+      : overrides.useDefaultMaxDuration
+        ? {}
+        : { maxDurationMs: 0 }),
   });
+  activeCallbacks.add(callbacks);
   return { start, stop, onStartError, onStopError, callbacks };
 }
 
@@ -353,7 +371,7 @@ describe("createTypingCallbacks", () => {
 
     it("uses default 60s TTL when not specified", async () => {
       await withFakeTimers(async () => {
-        const { stop, callbacks } = createTypingHarness();
+        const { stop, callbacks } = createTypingHarness({ useDefaultMaxDuration: true });
 
         await callbacks.onReplyStart();
 


### PR DESCRIPTION
## Summary

This PR fixes the QMD vector status timeout path and keeps the checkpoint-related coverage narrow:

1. `probeVectorAvailability()` now respects the configured `memory.qmd.limits.timeoutMs` instead of capping `qmd status` at 5 seconds.
2. Regression coverage verifies the configured timeout is used when the QMD status subprocess hangs, with a configured value above the old 5 second cap.
3. Regression coverage verifies valid session transcript IDs containing checkpoint words still export, while actual checkpoint snapshot transcripts remain excluded by the centralized session artifact helpers.
4. Adds an `Unreleased` changelog entry for the QMD status timeout fix and checkpoint transcript coverage.

## Problem: false QMD vector-health failures

Before this change, `probeVectorAvailability()` hard-capped `qmd status` to 5 seconds:

```ts
timeoutMs: Math.min(this.qmd.limits.timeoutMs, 5_000)
```

That meant a config like this:

```json
{
  "memory": {
    "qmd": {
      "limits": { "timeoutMs": 10000 }
    }
  }
}
```

could still time out after 5 seconds during the vector status probe.

`openclaw memory status --deep` and related vector-health checks could then report QMD as unavailable even when the configured timeout should have allowed the probe to keep waiting.

## Fix

Use the configured timeout directly on the vector status probe path:

```ts
const timeoutMs = this.qmd.limits.timeoutMs;
const result = await this.runQmd(["status"], { timeoutMs });
```

The checkpoint-related change is intentionally test coverage only now: valid transcripts whose IDs contain checkpoint words still export, and checkpoint snapshot filtering stays centralized in the session artifact helpers instead of adding a broad QMD export-layer filename filter.

## Real behavior proof

**Behavior or issue addressed:** `openclaw memory status --deep` should let the real `qmd status` vector probe use the configured `memory.qmd.limits.timeoutMs` instead of failing at the previous hard 5000 ms cap.

**Real environment tested:** macOS on Apple M4, local OpenClaw branch `5c9862887164d28eb2513409446e652c0467198c`, QMD 2.1.0 at `/opt/homebrew/bin/qmd`, using a temporary OpenClaw config and state directory.

**Exact steps or command run after this patch:** The proof config sets `memory.qmd.limits.timeoutMs: 8000` and points `memory.qmd.command` at a local wrapper that sleeps 5.5 seconds before delegating `qmd status` to `/opt/homebrew/bin/qmd`. Then I ran:

```bash
/usr/bin/time -p env \
  OPENCLAW_CONFIG_PATH=/Users/shawn/Dev/openclaw/.artifacts/qmd-pr-65914/openclaw.json \
  OPENCLAW_STATE_DIR=/Users/shawn/Dev/openclaw/.artifacts/qmd-pr-65914/state \
  pnpm openclaw memory status --deep --json
```

**Evidence after fix:** Terminal output from the real command above:

```json
{
  "backend": "qmd",
  "provider": "qmd",
  "vector": {
    "enabled": true,
    "available": false,
    "semanticAvailable": false,
    "loadError": "QMD index has 0 vectors; semantic search is unavailable until embeddings finish"
  },
  "embeddingProbe": {
    "ok": false,
    "error": "QMD index has 0 vectors; semantic search is unavailable until embeddings finish"
  }
}
```

```text
real 14.71
user 2.18
sys 0.67
```

**Observed result after fix:** The command completed successfully after the delayed real `qmd status` probe. OpenClaw reported QMD vector status from QMD itself (`QMD index has 0 vectors; semantic search is unavailable until embeddings finish`) instead of timing out after 5000 ms.

**What was not tested:** No vector embeddings were generated in this proof fixture, so the expected observed vector availability is `false`; this proof only verifies the real delayed status probe path and configured timeout behavior.

## Validation

Ran after rebasing onto current `main`:

```bash
pnpm exec vitest run extensions/memory-core/src/memory/qmd-manager.test.ts --testNamePattern "uses the configured qmd timeout for status probes|exports valid session transcripts whose IDs contain checkpoint words"
pnpm check:changed
```

Results:

- Focused Vitest: 1 file passed, 2 tests passed, 106 skipped.
- `pnpm check:changed`: passed.
