### PR TITLE
chore(labeler): remove dead minimax-portal-auth rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -281,10 +281,6 @@
   - changed-files:
       - any-glob-to-any-file:
           - "extensions/cloudflare-ai-gateway/**"
-"extensions: minimax-portal-auth":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "extensions/minimax-portal-auth/**"
 "extensions: huggingface":
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## Summary
- fixes #65861
- remove stale `extensions: minimax-portal-auth` entry from labeler config

## Why
The rule points to a non-existent directory and can never match changed files.

## Changes
- `.github/labeler.yml`
  - delete the `extensions: minimax-portal-auth` block

## Validation
- `pnpm check:no-conflict-markers`

## Notes
- config-only cleanup
- local validation passed

Made with [Cursor](https://cursor.com)