### PR TITLE
fix(gateway): point fallback override guidance to valid docs page

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -662,7 +662,7 @@ describe("loadGatewayPlugins", () => {
         }),
       ),
     ).rejects.toThrow(
-      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime and search for: plugins.entries.<id>.subagent.allowModelOverride',
+      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: plugins.entries.<id>.subagent.allowModelOverride',
     );
   });
 

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -662,7 +662,7 @@ describe("loadGatewayPlugins", () => {
         }),
       ),
     ).rejects.toThrow(
-      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: plugins.entries.<id>.subagent.allowModelOverride',
+      'plugin "voice-call" is not trusted for fallback provider/model override requests. See https://docs.openclaw.ai/plugins/sdk-runtime and search for: plugins.entries.<id>.subagent.allowModelOverride',
     );
   });
 

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -162,7 +162,7 @@ function authorizeFallbackModelOverride(params: {
       allowed: false,
       reason:
         `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
-        "See https://docs.openclaw.ai/plugins/sdk-runtime and search for: " +
+        "See https://docs.openclaw.ai/plugins/sdk-runtime#api-runtime-subagent and search for: " +
         "plugins.entries.<id>.subagent.allowModelOverride",
     };
   }

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -162,7 +162,7 @@ function authorizeFallbackModelOverride(params: {
       allowed: false,
       reason:
         `plugin "${pluginId}" is not trusted for fallback provider/model override requests. ` +
-        "See https://docs.openclaw.ai/tools/plugin#runtime-helpers and search for: " +
+        "See https://docs.openclaw.ai/plugins/sdk-runtime and search for: " +
         "plugins.entries.<id>.subagent.allowModelOverride",
     };
   }


### PR DESCRIPTION
## Summary
- fixes #65860
- update fallback override authorization guidance in gateway error text to point to a valid docs section
- keep assertion text aligned in the corresponding unit test

## Why
The previous docs guidance pointed to a non-resolving location for this runtime configuration path, which made troubleshooting harder when model override trust checks failed.

## Changes
- `src/gateway/server-plugins.ts`
  - docs guidance now points to `plugins/sdk-runtime#api-runtime-subagent`
- `src/gateway/server-plugins.test.ts`
  - update expected message string to match runtime output

## Validation
- `pnpm vitest run src/gateway/server-plugins.test.ts`

## Notes
- no logic behavior change beyond error guidance text
- local test passed

Made with [Cursor](https://cursor.com)