### PR TITLE
fix(heartbeat): preserve direct webchat relay context when target is none

### DIFF
--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -1,11 +1,11 @@
 import type { SessionEntry } from "../../config/sessions.js";
 import { buildAgentMainSessionKey } from "../../routing/session-key.js";
-import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "../../shared/string-coerce.js";
+  isDirectSessionKey,
+  isMainSessionKey,
+  parseAgentSessionKey,
+} from "../../sessions/session-key-utils.js";
+import { normalizeOptionalLowercaseString } from "../../shared/string-coerce.js";
 import {
   deliveryContextFromSession,
   deliveryContextKey,
@@ -33,58 +33,6 @@ function resolveSessionKeyChannelHint(sessionKey?: string): string | undefined {
     return undefined;
   }
   return normalizeMessageChannel(head);
-}
-
-function isMainSessionKey(sessionKey?: string): boolean {
-  const parsed = parseAgentSessionKey(sessionKey);
-  if (!parsed) {
-    return normalizeLowercaseStringOrEmpty(sessionKey) === "main";
-  }
-  return normalizeLowercaseStringOrEmpty(parsed.rest) === "main";
-}
-
-const DIRECT_SESSION_MARKERS = new Set(["direct", "dm"]);
-const THREAD_SESSION_MARKERS = new Set(["thread", "topic"]);
-
-function hasStrictDirectSessionTail(parts: string[], markerIndex: number): boolean {
-  const peerId = normalizeOptionalString(parts[markerIndex + 1]);
-  if (!peerId) {
-    return false;
-  }
-  const tail = parts.slice(markerIndex + 2);
-  if (tail.length === 0) {
-    return true;
-  }
-  return (
-    tail.length === 2 &&
-    THREAD_SESSION_MARKERS.has(tail[0] ?? "") &&
-    Boolean(normalizeOptionalString(tail[1]))
-  );
-}
-
-function isDirectSessionKey(sessionKey?: string): boolean {
-  const raw = normalizeLowercaseStringOrEmpty(sessionKey);
-  if (!raw) {
-    return false;
-  }
-  const scoped = parseAgentSessionKey(raw)?.rest ?? raw;
-  const parts = scoped.split(":").filter(Boolean);
-  if (parts.length < 2) {
-    return false;
-  }
-  if (DIRECT_SESSION_MARKERS.has(parts[0] ?? "")) {
-    return hasStrictDirectSessionTail(parts, 0);
-  }
-  const channel = normalizeMessageChannel(parts[0]);
-  if (!channel || !isDeliverableMessageChannel(channel)) {
-    return false;
-  }
-  if (DIRECT_SESSION_MARKERS.has(parts[1] ?? "")) {
-    return hasStrictDirectSessionTail(parts, 1);
-  }
-  return Boolean(normalizeOptionalString(parts[1])) && DIRECT_SESSION_MARKERS.has(parts[2] ?? "")
-    ? hasStrictDirectSessionTail(parts, 2)
-    : false;
 }
 
 function isExternalRoutingChannel(channel?: string): channel is string {

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1594,6 +1594,189 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("uses a user-relay exec prompt for direct internal main sessions even when target is none", async () => {
+    const tmpDir = await createCaseDir("hb-exec-target-none-direct-internal");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "none" },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          chatType: "direct",
+          lastChannel: "webchat",
+          lastTo: "webchat:user-123",
+        },
+      }),
+    );
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup",
+    });
+
+    const replySpy = vi.fn();
+    replySpy.mockResolvedValue({ text: "Relay completed" });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "exec-event",
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+      expect(res.status).toBe("ran");
+      expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+      const calledCtx = replySpy.mock.calls[0]?.[0] as {
+        Provider?: string;
+        Body?: string;
+        ForceSenderIsOwnerFalse?: boolean;
+      };
+      expect(calledCtx.Provider).toBe("exec-event");
+      expect(calledCtx.ForceSenderIsOwnerFalse).toBe(true);
+      expect(calledCtx.Body).toContain("Please relay the command output to the user");
+      expect(calledCtx.Body).not.toContain("Handle the result internally");
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
+  it.each([
+    { name: "heartbeat placeholder", routeTarget: "heartbeat" },
+    { name: "legacy web placeholder", routeTarget: "web" },
+    { name: "internal session lane", routeTarget: "session:dashboard" },
+  ])(
+    "keeps exec prompts internal-only when the stored internal route is $name",
+    async ({ routeTarget }) => {
+      const tmpDir = await createCaseDir("hb-exec-target-none-nonrelayable-internal");
+      const storePath = path.join(tmpDir, "sessions.json");
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "none" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            chatType: "direct",
+            lastChannel: "webchat",
+            lastTo: routeTarget,
+          },
+        }),
+      );
+      enqueueSystemEvent("exec finished: backup completed", {
+        sessionKey,
+        contextKey: "exec:backup",
+      });
+
+      const replySpy = vi.fn();
+      replySpy.mockResolvedValue({ text: "Handled internally" });
+      const sendWhatsApp = vi
+        .fn<
+          (
+            to: string,
+            text: string,
+            opts?: unknown,
+          ) => Promise<{ messageId: string; toJid: string }>
+        >()
+        .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+      try {
+        const res = await runHeartbeatOnce({
+          cfg,
+          reason: "exec-event",
+          deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+        });
+        expect(res.status).toBe("ran");
+        expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+        const calledCtx = replySpy.mock.calls[0]?.[0] as { Body?: string };
+        expect(calledCtx.Body).toContain("Handle the result internally");
+        expect(calledCtx.Body).not.toContain("Please relay the command output to the user");
+      } finally {
+        replySpy.mockReset();
+      }
+    },
+  );
+
+  it("uses a user-relay cron prompt for direct internal main sessions even when target is none", async () => {
+    const tmpDir = await createCaseDir("hb-cron-target-none-direct-internal");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "none" },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid",
+          updatedAt: Date.now(),
+          chatType: "direct",
+          lastChannel: "webchat",
+          lastTo: "webchat:user-123",
+        },
+      }),
+    );
+    enqueueSystemEvent("Cron: rotate logs", {
+      sessionKey,
+      contextKey: "cron:rotate-logs",
+    });
+
+    const replySpy = vi.fn();
+    replySpy.mockResolvedValue({ text: "Relay completed" });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    try {
+      const res = await runHeartbeatOnce({
+        cfg,
+        reason: "interval",
+        deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+      });
+      expect(res.status).toBe("ran");
+      expect(sendWhatsApp).toHaveBeenCalledTimes(0);
+      const calledCtx = replySpy.mock.calls[0]?.[0] as { Provider?: string; Body?: string };
+      expect(calledCtx.Provider).toBe("cron-event");
+      expect(calledCtx.Body).toContain("Please relay this reminder to the user");
+      expect(calledCtx.Body).not.toContain("Handle this reminder internally");
+    } finally {
+      replySpy.mockReset();
+    }
+  });
+
   it("uses an internal-only exec prompt when heartbeat delivery target is none", async () => {
     const tmpDir = await createCaseDir("hb-exec-target-none");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -59,11 +59,13 @@ import {
   toAgentStoreSessionKey,
 } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
+import { isDirectSessionKey, isMainSessionKey } from "../sessions/session-key-utils.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { escapeRegExp } from "../utils.js";
+import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS, resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
 import { formatErrorMessage, hasErrnoCode } from "./errors.js";
@@ -646,6 +648,57 @@ type HeartbeatPromptResolution = {
   hasCronEvents: boolean;
 };
 
+function isRelayableInternalRouteTarget(raw?: string): boolean {
+  const target = normalizeOptionalString(raw);
+  if (!target) {
+    return false;
+  }
+  const normalized = normalizeLowercaseStringOrEmpty(target);
+  if (!normalized) {
+    return false;
+  }
+  return normalized !== "heartbeat" && normalized !== "web" && !normalized.startsWith("session:");
+}
+
+function canRelayHeartbeatPromptsToUser(params: {
+  delivery: ReturnType<typeof resolveHeartbeatDeliveryTarget>;
+  visibility: { showAlerts: boolean };
+  sessionKey: string;
+  sessionEntry?: {
+    chatType?: string;
+    lastChannel?: string;
+    lastTo?: string;
+    deliveryContext?: { channel?: string; to?: string };
+  };
+}): boolean {
+  if (params.delivery.channel !== "none" && params.delivery.to && params.visibility.showAlerts) {
+    return true;
+  }
+  if (
+    !params.visibility.showAlerts ||
+    (!isMainSessionKey(params.sessionKey) && !isDirectSessionKey(params.sessionKey))
+  ) {
+    return false;
+  }
+
+  const sessionRouteChannel = normalizeLowercaseStringOrEmpty(
+    params.sessionEntry?.deliveryContext?.channel ?? params.sessionEntry?.lastChannel,
+  );
+  if (sessionRouteChannel !== INTERNAL_MESSAGE_CHANNEL) {
+    return false;
+  }
+
+  const sessionRouteTo = normalizeOptionalString(
+    params.sessionEntry?.deliveryContext?.to ?? params.sessionEntry?.lastTo,
+  );
+  if (!isRelayableInternalRouteTarget(sessionRouteTo)) {
+    return false;
+  }
+
+  const chatType = normalizeLowercaseStringOrEmpty(params.sessionEntry?.chatType);
+  return isMainSessionKey(params.sessionKey) ? chatType === "direct" : true;
+}
+
 function appendHeartbeatWorkspacePathHint(prompt: string, workspaceDir: string): string {
   if (!/heartbeat\.md/i.test(prompt)) {
     return prompt;
@@ -837,9 +890,12 @@ export async function runHeartbeatOnce(opts: {
     accountId: delivery.accountId,
   }).responsePrefix;
 
-  const canRelayToUser = Boolean(
-    delivery.channel !== "none" && delivery.to && visibility.showAlerts,
-  );
+  const canRelayToUser = canRelayHeartbeatPromptsToUser({
+    delivery,
+    visibility,
+    sessionKey,
+    sessionEntry: entry,
+  });
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const { prompt, hasExecCompletion, hasCronEvents } = resolveHeartbeatRunPrompt({
     cfg,

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -3,7 +3,6 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
-import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 
 export type ParsedAgentSessionKey = {
   agentId: string;
@@ -88,11 +87,7 @@ export function isDirectSessionKey(sessionKey: string | undefined | null): boole
   if (DIRECT_SESSION_MARKERS.has(parts[0] ?? "")) {
     return hasStrictDirectSessionTail(parts, 0);
   }
-  const channel = normalizeMessageChannel(parts[0]);
-  if (!channel || !isDeliverableMessageChannel(channel)) {
-    return false;
-  }
-  if (DIRECT_SESSION_MARKERS.has(parts[1] ?? "")) {
+  if (Boolean(normalizeOptionalString(parts[0])) && DIRECT_SESSION_MARKERS.has(parts[1] ?? "")) {
     return hasStrictDirectSessionTail(parts, 1);
   }
   return Boolean(normalizeOptionalString(parts[1])) && DIRECT_SESSION_MARKERS.has(parts[2] ?? "")

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -3,6 +3,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
+import { isDeliverableMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
 
 export type ParsedAgentSessionKey = {
   agentId: string;
@@ -45,6 +46,58 @@ export function parseAgentSessionKey(
     return null;
   }
   return { agentId, rest };
+}
+
+const DIRECT_SESSION_MARKERS = new Set(["direct", "dm"]);
+const THREAD_SESSION_MARKERS = new Set(["thread", "topic"]);
+
+export function isMainSessionKey(sessionKey: string | undefined | null): boolean {
+  const parsed = parseAgentSessionKey(sessionKey);
+  if (!parsed) {
+    return normalizeLowercaseStringOrEmpty(sessionKey) === "main";
+  }
+  return normalizeLowercaseStringOrEmpty(parsed.rest) === "main";
+}
+
+function hasStrictDirectSessionTail(parts: string[], markerIndex: number): boolean {
+  const peerId = normalizeOptionalString(parts[markerIndex + 1]);
+  if (!peerId) {
+    return false;
+  }
+  const tail = parts.slice(markerIndex + 2);
+  if (tail.length === 0) {
+    return true;
+  }
+  return (
+    tail.length === 2 &&
+    THREAD_SESSION_MARKERS.has(parts[markerIndex + 2] ?? "") &&
+    Boolean(normalizeOptionalString(parts[markerIndex + 3]))
+  );
+}
+
+export function isDirectSessionKey(sessionKey: string | undefined | null): boolean {
+  const raw = normalizeLowercaseStringOrEmpty(sessionKey);
+  if (!raw) {
+    return false;
+  }
+  const scoped = parseAgentSessionKey(raw)?.rest ?? raw;
+  const parts = scoped.split(":").filter(Boolean);
+  if (parts.length < 2) {
+    return false;
+  }
+  if (DIRECT_SESSION_MARKERS.has(parts[0] ?? "")) {
+    return hasStrictDirectSessionTail(parts, 0);
+  }
+  const channel = normalizeMessageChannel(parts[0]);
+  if (!channel || !isDeliverableMessageChannel(channel)) {
+    return false;
+  }
+  if (DIRECT_SESSION_MARKERS.has(parts[1] ?? "")) {
+    return hasStrictDirectSessionTail(parts, 1);
+  }
+  return Boolean(normalizeOptionalString(parts[1])) && DIRECT_SESSION_MARKERS.has(parts[2] ?? "")
+    ? hasStrictDirectSessionTail(parts, 2)
+    : false;
 }
 
 export function isCronRunSessionKey(sessionKey: string | undefined | null): boolean {


### PR DESCRIPTION
## Summary

AI-assisted: yes (implemented with Codex assistance, then manually reviewed and validated locally).
Testing level: fully tested for the touched surface (`pnpm build`, `pnpm check`, targeted regression tests, and `codex review --base origin/main`).

- Problem: heartbeat exec/cron resumes in direct webchat sessions could be treated as internal-only when `heartbeat.target` resolved to `none`, even when there was still an active direct user route.
- Why it matters: async command completions and cron reminders could stop relaying back to the active webchat operator, and the session route could degrade from a real `lastTo` to the placeholder `heartbeat`.
- What changed: preserve relay-capable prompt selection for direct internal webchat main/direct sessions, and preserve persisted `lastTo` when the incoming target is the internal heartbeat placeholder.
- What did NOT change (scope boundary): this does not revert `heartbeat.target = "none"`, does not broaden outbound heartbeat delivery, and does not change routing behavior for unrelated channels/sessions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A (no existing issue linked)
- Related #N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the February 25 heartbeat change that defaulted `heartbeat.target` to `none` and internalized non-relayable prompts used `delivery.channel !== "none" && delivery.to` as the relay gate. That is correct for outbound delivery, but too strict for direct internal webchat sessions, where the active operator can still relay the result even when heartbeat delivery intentionally resolves to `none`.
- Missing detection / guardrail: there was no narrow exception for direct internal webchat main/direct sessions with an established internal route, and no regression test for a heartbeat placeholder target overwriting a persisted `lastTo`.
- Contributing context (if known): this appears to be an unintended interaction between the intentional `target = "none"` tightening and later session-route preservation work, not an intentional behavior change for direct webchat resumes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/session-delivery.test.ts`
  - `src/infra/heartbeat-runner.returns-default-unset.test.ts`
- Scenario the test should lock in:
  - a direct internal main session keeps its persisted `lastTo` when the incoming target is the heartbeat placeholder
  - exec/cron heartbeat resumes still use user-relay wording for direct internal main sessions even when `heartbeat.target` resolves to `none`
- Why this is the smallest reliable guardrail: the regression happens at the routing/prompt-selection seam, so a small `resolveLastToRaw` unit test plus `runHeartbeatOnce` seam coverage catches the break without requiring a full end-to-end harness.
- Existing test that already covers this (if any): related heartbeat/session-routing coverage already existed in `heartbeat-runner.returns-default-unset.test.ts` and `session.heartbeat-no-reset.test.ts`, but it did not pin this direct-webchat `target:none` path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Direct webchat heartbeat resumes for async exec completions now keep user-relay wording when the active session route is internal webchat and `heartbeat.target` is `none`.
- Direct webchat heartbeat placeholder routing no longer overwrites an established `lastTo` destination with `heartbeat`.
- No behavior change intended for non-direct or non-webchat sessions.

## Diagram (if applicable)

```text
Before:
[exec/cron event] -> [heartbeat target resolves to none] -> [prompt becomes internal-only]
                                      -> [placeholder "heartbeat" may replace lastTo]
                                      -> [user-facing relay can be lost]

After:
[exec/cron event] -> [heartbeat target resolves to none]
                  -> [direct internal webchat route detected]
                  -> [prompt stays user-relayable]
                  -> [persisted lastTo is preserved]
                  -> [active operator can relay result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux x64
- Runtime/container: Node.js v22.22.2
- Model/provider: N/A for reproduction, heartbeat prompt path only
- Integration/channel (if any): direct webchat main session
- Relevant config (redacted): `agents.defaults.heartbeat.target = "none"`, session entry with `chatType: "direct"`, `lastChannel: "webchat"`, `lastTo: "webchat:user-123"`

### Steps

1. Persist a direct internal webchat main session route.
2. Queue an exec completion or cron system event.
3. Run heartbeat with `heartbeat.target = "none"`.

### Expected

- Exec/cron resumes should still use user-relay wording for that direct internal webchat session.
- The persisted direct route should remain intact.

### Actual

- Before this change, the resume prompt could become internal-only.
- The placeholder target `heartbeat` could overwrite the real persisted `lastTo`.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm build`
  - `pnpm check`
  - `pnpm test -- src/infra/heartbeat-events-filter.test.ts src/infra/heartbeat-runner.sender-prefers-delivery-target.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts src/auto-reply/reply/session-delivery.test.ts src/auto-reply/reply/session.heartbeat-no-reset.test.ts src/auto-reply/reply/followup-delivery.test.ts src/auto-reply/reply/origin-routing.test.ts`
  - `codex review --base origin/main`
- Edge cases checked:
  - `target:none` still stays internal-only for sessions that are not relay-capable
  - the placeholder preservation only applies to internal webchat main/direct sessions
  - existing heartbeat/session-routing regressions remain covered by nearby tests
- What you did **not** verify:
  - a full end-to-end hosted reproduction against a live external channel deployment

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: broadening relay prompts for sessions that should remain internal-only.
  - Mitigation: the new relay gate only relaxes prompt selection for main/direct sessions with an established internal webchat route and existing alert visibility.
- Risk: preserving a stale destination in cases other than the heartbeat placeholder.
  - Mitigation: the `lastTo` preservation only triggers for the internal heartbeat placeholder on main/direct sessions; all other route-preservation logic stays unchanged.
