### PR TITLE
fix(build): add missing config/sessions/store.runtime entry

### DIFF
--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -113,6 +113,15 @@ describe("tsdown config", () => {
     }
   });
 
+  // Regression test for session store runtime entry
+  // See: https://github.com/openclaw/openclaw/pull/XXXXX
+  it("includes config/sessions/store.runtime entry", () => {
+    const unifiedGraph = unifiedDistGraph();
+    const entries = entryKeys(unifiedGraph!);
+
+    expect(entries).toContain("config/sessions/store.runtime");
+  });
+
   it("suppresses unresolved imports from extension source", () => {
     const configured = unifiedDistGraph()?.inputOptions?.({})?.onLog;
     const handled: TsdownLog[] = [];

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -114,7 +114,7 @@ describe("tsdown config", () => {
   });
 
   // Regression test for session store runtime entry
-  // See: https://github.com/openclaw/openclaw/pull/XXXXX
+  // See: https://github.com/openclaw/openclaw/pull/65962
   it("includes config/sessions/store.runtime entry", () => {
     const unifiedGraph = unifiedDistGraph();
     const entries = entryKeys(unifiedGraph!);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -148,6 +148,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",
+    "config/sessions/store.runtime": "src/config/sessions/store.runtime.ts",
     "infra/boundary-file-read": "src/infra/boundary-file-read.ts",
     "plugins/provider-discovery.runtime": "src/plugins/provider-discovery.runtime.ts",
     "plugins/provider-runtime.runtime": "src/plugins/provider-runtime.runtime.ts",


### PR DESCRIPTION
## Problem

Runtime error when session-override loads the session store:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/path/to/dist/store.runtime-eZQ7KuiZ.js'
```

## When This Bug Is Triggered

This bug is triggered when users configure **multiple auth profiles** (e.g., rotating between OpenAI and Anthropic providers). Specifically, it occurs in two code paths:

1. **Manual auth profile override** — When a user explicitly selects a specific provider auth profile via session override
2. **Automatic auth profile rotation** — When the system auto-rotates providers based on cooldown policy

In both cases, the system persists the session auth profile override state to disk via `updateSessionStore()`, which triggers the dynamic import of `store.runtime.js`.

Users with a single provider (the default setup) will not hit this bug.

## Root Cause

`src/agents/auth-profiles/session-override.ts` dynamically imports `../../config/sessions/store.runtime.js` via `import()`, which tsdown cannot statically analyze. The entry was missing from `buildCoreDistEntries()`, so the file was not emitted as a standalone chunk.

Introduced in `c0933e2fc8` (2026-03-22, `perf(reply): lazy-load session store writes`).

## Fix

Added a namespaced entry to `buildCoreDistEntries()` in `tsdown.config.ts`:

```ts
"config/sessions/store.runtime": "src/config/sessions/store.runtime.ts"
```

This emits `dist/config/sessions/store.runtime.js` at the path where `session-override.js` expects to find it via relative import (`"./config/sessions/store.runtime.js"`).

## Testing

- `npm run build` emits `dist/config/sessions/store.runtime.js` ✅
- Regression test added in `src/infra/tsdown-config.test.ts` ✅
- Gateway restart confirms error is resolved ✅

Same pattern as #65735 (missing tsdown entries for dynamically-imported runtime modules).