### PR TITLE
fix(process): reconcile orphaned bash exec runs

### DIFF
--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -96,6 +96,10 @@ export function getSession(id: string) {
   return runningSessions.get(id);
 }
 
+export function hasSession(id: string) {
+  return runningSessions.has(id);
+}
+
 export function getFinishedSession(id: string) {
   return finishedSessions.get(id);
 }

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -31,6 +31,7 @@ import {
   addSession,
   appendOutput,
   createSessionSlug,
+  hasSession,
   markExited,
   tail,
 } from "./bash-process-registry.js";
@@ -553,6 +554,9 @@ export async function runExecProcess(opts: {
     cursorKeyMode: opts.usePty ? "unknown" : "normal",
   };
   addSession(session);
+  await supervisor.reconcileOrphans({
+    isSessionTracked: hasSession,
+  });
 
   // Tracks whether the exec run's promise has settled (process exited or
   // spawn failed).  Once settled the agent-loop no longer expects

--- a/src/agents/bash-tools.process.supervisor.test.ts
+++ b/src/agents/bash-tools.process.supervisor.test.ts
@@ -140,4 +140,28 @@ describe("process tool supervisor cancellation", () => {
       text: "Unable to remove session sess-no-pid: no active supervisor run or process id.",
     });
   });
+
+  it("reconciles orphaned supervisor runs before serving process requests", async () => {
+    addSession(createBackgroundSession("sess-owned"));
+    supervisorMock.reconcileOrphans.mockImplementation(async (params?: unknown) => {
+      const typed = params as { isSessionTracked?: (sessionId: string) => boolean };
+      return {
+        cancelledRunIds: typed.isSessionTracked?.("missing-session") ? [] : ["missing-session"],
+      };
+    });
+    const processTool = createProcessTool();
+
+    await processTool.execute("toolcall", {
+      action: "list",
+    });
+
+    expect(supervisorMock.reconcileOrphans).toHaveBeenCalledTimes(1);
+    const firstCall = supervisorMock.reconcileOrphans.mock.calls[0]?.[0] as
+      | { isSessionTracked: (sessionId: string) => boolean }
+      | undefined;
+    expect(typeof firstCall?.isSessionTracked).toBe("function");
+    const { isSessionTracked } = firstCall as { isSessionTracked: (sessionId: string) => boolean };
+    expect(isSessionTracked("sess-owned")).toBe(true);
+    expect(isSessionTracked("missing-session")).toBe(false);
+  });
 });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -8,6 +8,7 @@ import {
   deleteSession,
   drainSession,
   getFinishedSession,
+  hasSession,
   getSession,
   listFinishedSessions,
   listRunningSessions,
@@ -130,6 +131,9 @@ export function createProcessTool(
     description: describeProcessTool({ hasCronTool: defaults?.hasCronTool === true }),
     parameters: processSchema,
     execute: async (_toolCallId, args, _signal, _onUpdate): Promise<AgentToolResult<unknown>> => {
+      await supervisor.reconcileOrphans({
+        isSessionTracked: hasSession,
+      });
       const params = args as {
         action:
           | "list"

--- a/src/process/supervisor/index.ts
+++ b/src/process/supervisor/index.ts
@@ -15,6 +15,8 @@ export { createProcessSupervisor } from "./supervisor.js";
 export type {
   ManagedRun,
   ProcessSupervisor,
+  ReconcileOrphansParams,
+  ReconcileOrphansResult,
   RunExit,
   RunRecord,
   RunState,

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -255,4 +255,54 @@ describe("process supervisor", () => {
     expect(streamed).toBe("streamed");
     expect(exit.stdout).toBe("");
   });
+
+  it("cancels active runs whose owning session is no longer tracked", async () => {
+    const adapter = createStubChildAdapter({
+      onKill: (signal, current) => {
+        current.settle(null, signal ?? "SIGKILL");
+      },
+    });
+    createChildAdapterMock.mockResolvedValue(adapter);
+
+    const supervisor = createProcessSupervisor();
+    const run = await spawnChild(supervisor, {
+      sessionId: "sess-missing",
+      argv: createSilentIdleArgv(),
+      timeoutMs: 1_000,
+      stdinMode: "pipe-open",
+    });
+
+    const reconcile = await supervisor.reconcileOrphans({
+      isSessionTracked: () => false,
+    });
+    const exit = await run.wait();
+
+    expect(reconcile.cancelledRunIds).toEqual([run.runId]);
+    expect(adapter.killMock).toHaveBeenCalledWith("SIGKILL");
+    expect(exit.reason === "manual-cancel" || exit.reason === "signal").toBe(true);
+  });
+
+  it("preserves active runs when the owning session is still tracked", async () => {
+    const adapter = createStubChildAdapter();
+    createChildAdapterMock.mockResolvedValue(adapter);
+
+    const supervisor = createProcessSupervisor();
+    const run = await spawnChild(supervisor, {
+      sessionId: "sess-owned",
+      argv: createSilentIdleArgv(),
+      timeoutMs: 1_000,
+      stdinMode: "pipe-open",
+    });
+
+    const reconcile = await supervisor.reconcileOrphans({
+      isSessionTracked: (sessionId) => sessionId === "sess-owned",
+    });
+
+    adapter.settle(0);
+    const exit = await run.wait();
+
+    expect(reconcile.cancelledRunIds).toEqual([]);
+    expect(adapter.killMock).not.toHaveBeenCalled();
+    expect(exit.reason).toBe("exit");
+  });
 });

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -7,6 +7,8 @@ import { createRunRegistry } from "./registry.js";
 import type {
   ManagedRun,
   ProcessSupervisor,
+  ReconcileOrphansParams,
+  ReconcileOrphansResult,
   RunExit,
   RunRecord,
   SpawnInput,
@@ -269,14 +271,29 @@ export function createProcessSupervisor(): ProcessSupervisor {
     }
   };
 
+  const reconcileOrphans = async (
+    params: ReconcileOrphansParams,
+  ): Promise<ReconcileOrphansResult> => {
+    const cancelledRunIds: string[] = [];
+    const reason = params.reason ?? "manual-cancel";
+    for (const record of registry.list()) {
+      if (record.state !== "starting" && record.state !== "running") {
+        continue;
+      }
+      if (params.isSessionTracked(record.sessionId)) {
+        continue;
+      }
+      cancel(record.runId, reason);
+      cancelledRunIds.push(record.runId);
+    }
+    return { cancelledRunIds };
+  };
+
   return {
     spawn,
     cancel,
     cancelScope,
-    reconcileOrphans: async () => {
-      // Deliberate no-op: this supervisor uses in-memory ownership only.
-      // Active runs are not recovered after process restart in the current model.
-    },
+    reconcileOrphans,
     getRecord: (runId: string) => registry.get(runId),
   };
 }

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -8,6 +8,15 @@ export type TerminationReason =
   | "signal"
   | "exit";
 
+export type ReconcileOrphansParams = {
+  isSessionTracked: (sessionId: string) => boolean;
+  reason?: TerminationReason;
+};
+
+export type ReconcileOrphansResult = {
+  cancelledRunIds: string[];
+};
+
 export type RunRecord = {
   runId: string;
   sessionId: string;
@@ -101,6 +110,6 @@ export interface ProcessSupervisor {
   spawn(input: SpawnInput): Promise<ManagedRun>;
   cancel(runId: string, reason?: TerminationReason): void;
   cancelScope(scopeKey: string, reason?: TerminationReason): void;
-  reconcileOrphans(): Promise<void>;
+  reconcileOrphans(params: ReconcileOrphansParams): Promise<ReconcileOrphansResult>;
   getRecord(runId: string): RunRecord | undefined;
 }


### PR DESCRIPTION
## Summary
- add a real `reconcileOrphans(...)` contract to the process supervisor
- reconcile active managed runs against bash session ownership
- invoke reconciliation before serving process-tool requests and after registering new exec sessions
- add focused tests for orphan cancellation and owned-run preservation

## Problem
OpenClaw already tracks bash exec/process sessions separately from the supervisor's managed runs. When that session ownership drifts or disappears inside the live process, the supervisor could keep a run alive while the process tool no longer considers the session tracked. Before this patch, `reconcileOrphans()` was a deliberate no-op, so those runs were never cleaned up.

This does **not** implement durable persistence or true cold-start orphan reaping. It is the smaller, defensible fix for the in-process/session-loss half of the problem.

Closes #65983

## Tests
- `pnpm test src/process/supervisor/supervisor.test.ts src/agents/bash-tools.process.supervisor.test.ts`
