### PR TITLE
feat(cron): support custom job ids on add

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -72,6 +72,7 @@ type CronUpdatePatch = {
 };
 
 type CronAddParams = {
+  id?: string;
   schedule?: { kind?: string; staggerMs?: number };
   payload?: { model?: string; thinking?: string; lightContext?: boolean };
   delivery?: { mode?: string; accountId?: string };
@@ -399,6 +400,23 @@ describe("cron cli", () => {
     const addCall = callGatewayFromCli.mock.calls.find((call) => call[0] === "cron.add");
     const params = addCall?.[2] as { agentId?: string };
     expect(params?.agentId).toBe("ops");
+  });
+
+  it("passes custom job ids through cron add", async () => {
+    const params = await runCronAddAndGetParams([
+      "--id",
+      "daily-brief",
+      "--name",
+      "Daily brief",
+      "--cron",
+      "* * * * *",
+      "--session",
+      "isolated",
+      "--message",
+      "hello",
+    ]);
+
+    expect(params?.id).toBe("daily-brief");
   });
 
   it("sets lightContext on cron add when --light-context is passed", async () => {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { normalizeOptionalCronJobId } from "../../cron/job-id.js";
 import type { CronJob } from "../../cron/types.js";
 import { sanitizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -66,6 +67,10 @@ export function registerCronAddCommand(cron: Command) {
       .command("add")
       .alias("create")
       .description("Add a cron job")
+      .option(
+        "--id <id>",
+        "Optional custom job id (letters, numbers, dots, underscores, hyphens)",
+      )
       .requiredOption("--name <name>", "Job name")
       .option("--description <text>", "Optional description")
       .option("--disabled", "Create job disabled", false)
@@ -220,6 +225,7 @@ export function registerCronAddCommand(cron: Command) {
           const sessionKey = normalizeOptionalString(opts.sessionKey);
 
           const params = {
+            id: normalizeOptionalCronJobId(opts.id),
             name,
             description,
             enabled: !opts.disabled,

--- a/src/cron/job-id.ts
+++ b/src/cron/job-id.ts
@@ -1,0 +1,19 @@
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+export const CRON_CUSTOM_JOB_ID_PATTERN = "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$";
+
+const cronCustomJobIdRegex = new RegExp(CRON_CUSTOM_JOB_ID_PATTERN);
+
+export function normalizeOptionalCronJobId(value: unknown): string | undefined {
+  return normalizeOptionalString(value) ?? undefined;
+}
+
+export function assertSafeCronCustomJobId(value: string): string {
+  const normalized = normalizeOptionalCronJobId(value) ?? "";
+  if (!normalized || !cronCustomJobIdRegex.test(normalized)) {
+    throw new Error(
+      "invalid cron job id: use 1-128 letters, numbers, dots, underscores, or hyphens, starting with an alphanumeric character",
+    );
+  }
+  return normalized;
+}

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -150,6 +150,30 @@ describe("normalizeCronJobCreate", () => {
     expect("sessionKey" in cleared).toBe(false);
   });
 
+  it("trims custom ids and drops blanks", () => {
+    const normalized = normalizeCronJobCreate({
+      id: "  daily-brief  ",
+      name: "daily brief",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "hi" },
+    }) as unknown as Record<string, unknown>;
+    expect(normalized.id).toBe("daily-brief");
+
+    const cleared = normalizeCronJobCreate({
+      id: "   ",
+      name: "blank id",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "hi" },
+    }) as unknown as Record<string, unknown>;
+    expect("id" in cleared).toBe(false);
+  });
+
   it("strips top-level legacy delivery hints from live input", () => {
     const normalized = normalizeIsolatedAgentTurnCreateJob({
       name: "legacy top-level delivery",

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -11,6 +11,7 @@ import {
   parseDeliveryInput,
   parseOptionalField,
 } from "./delivery-field-schemas.js";
+import { normalizeOptionalCronJobId } from "./job-id.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
 import { inferLegacyName } from "./service/normalize.js";
 import { assertSafeCronSessionTargetId } from "./session-target.js";
@@ -522,6 +523,14 @@ export function normalizeCronJobInput(
       const trimmed = next.name.trim();
       if (trimmed) {
         next.name = trimmed;
+      }
+    }
+    if ("id" in next) {
+      const id = normalizeOptionalCronJobId(next.id);
+      if (id) {
+        next.id = id;
+      } else {
+        delete next.id;
       }
     }
     if (!next.sessionTarget && isRecord(next.payload)) {

--- a/src/cron/service.get-job.test.ts
+++ b/src/cron/service.get-job.test.ts
@@ -67,4 +67,39 @@ describe("CronService.getJob", () => {
       cron.stop();
     }
   });
+
+  it("preserves custom ids and rejects duplicate ids on create", async () => {
+    const { storePath } = await makeStorePath();
+    const cron = createCronService(storePath);
+    await cron.start();
+
+    try {
+      const added = await cron.add({
+        id: "daily-brief",
+        name: "lookup-test",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "ping" },
+      });
+
+      expect(added.id).toBe("daily-brief");
+      expect(cron.getJob("daily-brief")?.id).toBe("daily-brief");
+
+      await expect(
+        cron.add({
+          id: "daily-brief",
+          name: "duplicate",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+          payload: { kind: "systemEvent", text: "ping" },
+        }),
+      ).rejects.toThrow(/cron job id already exists: daily-brief/i);
+    } finally {
+      cron.stop();
+    }
+  });
 });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -5,6 +5,7 @@ import {
   normalizeOptionalThreadValue,
 } from "../../shared/string-coerce.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
+import { assertSafeCronCustomJobId } from "../job-id.js";
 import {
   coerceFiniteScheduleNumber,
   computeNextRunAtMs,
@@ -515,7 +516,10 @@ export function nextWakeAtMs(state: CronServiceState) {
 
 export function createJob(state: CronServiceState, input: CronJobCreate): CronJob {
   const now = state.deps.nowMs();
-  const id = crypto.randomUUID();
+  const id = input.id ? assertSafeCronCustomJobId(input.id) : crypto.randomUUID();
+  if (state.store?.jobs.some((job) => job.id === id)) {
+    throw new Error(`cron job id already exists: ${id}`);
+  }
   const schedule =
     input.schedule.kind === "every"
       ? {

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -154,6 +154,7 @@ export type CronStoreFile = {
 };
 
 export type CronJobCreate = Omit<CronJob, "id" | "createdAtMs" | "updatedAtMs" | "state"> & {
+  id?: string;
   state?: Partial<CronJobState>;
 };
 

--- a/src/gateway/protocol/cron-validators.test.ts
+++ b/src/gateway/protocol/cron-validators.test.ts
@@ -21,6 +21,27 @@ describe("cron protocol validators", () => {
     expect(validateCronAddParams(minimalAddParams)).toBe(true);
   });
 
+  it("accepts safe custom add ids and rejects unsafe ones", () => {
+    expect(
+      validateCronAddParams({
+        ...minimalAddParams,
+        id: "daily-brief",
+      }),
+    ).toBe(true);
+    expect(
+      validateCronAddParams({
+        ...minimalAddParams,
+        id: "daily brief",
+      }),
+    ).toBe(false);
+    expect(
+      validateCronAddParams({
+        ...minimalAddParams,
+        id: "../daily-brief",
+      }),
+    ).toBe(false);
+  });
+
   it("accepts current and custom session targets", () => {
     expect(
       validateCronAddParams({

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -1,4 +1,5 @@
 import { Type, type TSchema } from "@sinclair/typebox";
+import { CRON_CUSTOM_JOB_ID_PATTERN } from "../../../cron/job-id.js";
 import { NonEmptyString } from "./primitives.js";
 
 function cronAgentTurnPayloadSchema(params: { message: TSchema; toolsAllow: TSchema }) {
@@ -98,6 +99,12 @@ const CronRunLogJobIdSchema = Type.String({
   minLength: 1,
   // Prevent path traversal via separators in cron.runs id/jobId.
   pattern: "^[^/\\\\]+$",
+});
+
+const CronCustomJobIdSchema = Type.String({
+  minLength: 1,
+  maxLength: 128,
+  pattern: CRON_CUSTOM_JOB_ID_PATTERN,
 });
 
 export const CronScheduleSchema = Type.Union([
@@ -286,6 +293,7 @@ export const CronStatusParamsSchema = Type.Object({}, { additionalProperties: fa
 
 export const CronAddParamsSchema = Type.Object(
   {
+    id: Type.Optional(CronCustomJobIdSchema),
     name: NonEmptyString,
     ...CronCommonOptionalFields,
     schedule: CronScheduleSchema,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw cron add` always generated a UUID and had no supported way to create a stable human-readable job id.
- Why it matters: operators then had to look up opaque ids before using `cron edit`, `cron run`, `cron runs --id`, or automation/scripts that refer back to an existing job.
- What changed: added `--id` to `cron add`, validated safe custom ids at the protocol/service layer, preserved them on create, and reject collisions with an explicit error.
- What did NOT change (scope boundary): default UUID behavior, cron scheduling semantics, and edit/run/remove behavior for existing jobs remain unchanged.
- AI-assisted: Yes, built with Codex. Testing: lightly tested locally with focused CLI/normalize/service/protocol coverage.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65636
- Related #65636
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: the create path omitted `id` end-to-end. `CronJobCreate` excluded it, the CLI exposed no flag, the add schema rejected it, and the service always called `randomUUID()`.
- Missing detection / guardrail: create-path tests covered names/schedules/delivery, but not user-supplied ids or duplicate-id rejection.
- Contributing context (if known): store/load paths already tolerated string ids, so feature support drifted from what the underlying storage format already allowed.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/cli/cron-cli.test.ts`
  - `src/gateway/protocol/cron-validators.test.ts`
  - `src/cron/normalize.test.ts`
  - `src/cron/service.get-job.test.ts`
- Scenario the test should lock in: `cron add --id daily-brief` forwards the id, safe ids validate, whitespace-only ids are dropped during normalization, created jobs keep the requested id, and duplicate ids fail clearly.
- Why this is the smallest reliable guardrail: these tests cover the exact add path layers touched by the feature without pulling in the full cron scheduler matrix.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- `openclaw cron add` now accepts `--id <id>`.
- Safe custom ids are preserved on create instead of always being replaced with a UUID.
- Reusing an existing job id now fails with `cron job id already exists: <id>`.

## Diagram (if applicable)

```text
Before:
user -> cron add -> UUID assigned -> later commands require lookup

After:
user -> cron add --id daily-brief -> stable id stored -> later commands can reuse daily-brief directly
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this adds a new user-controlled identifier surface for cron jobs, so the implementation restricts ids to a file-safe slug-like character set and rejects duplicates before persistence.

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: Node `v25.7.0`, pnpm `10.32.1`
- Model/provider: N/A
- Integration/channel (if any): Cron CLI / gateway / service
- Relevant config (redacted): N/A

### Steps

1. Run the focused cron test suite.
2. Create a cron job with a custom id through the add path.
3. Attempt to create a second job with the same id.

### Expected

- Safe ids validate and flow through the add path.
- Created jobs preserve the requested id.
- Duplicate ids fail explicitly.

### Actual

- Verified by the focused suite listed below.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reviewed the end-to-end add path diff; ran `npx --yes pnpm exec vitest run src/cli/cron-cli.test.ts src/gateway/protocol/cron-validators.test.ts src/cron/normalize.test.ts src/cron/service.get-job.test.ts` and confirmed all targeted tests pass.
- Edge cases checked: whitespace-only ids are dropped, ids with spaces/path traversal fail schema validation, and duplicate ids are rejected before persistence.
- What you did **not** verify: full `pnpm build && pnpm check && pnpm test` across the entire monorepo.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: overly permissive ids could leak into filenames or make run-log paths unsafe.
  - Mitigation: custom ids are constrained to a conservative slug-like pattern and collisions are rejected before save.
- Risk: callers relying on silent UUID generation for every create could be surprised if they now pass an id accidentally.
  - Mitigation: `--id` is explicit/optional, and omitting it keeps the old UUID behavior unchanged.
