### PR TITLE
fix(telegram): keep ack reactions without mentions

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -718,6 +718,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     - Telegram expects unicode emoji (for example "👀").
     - Use `""` to disable the reaction for a channel or account.
+    - With the default `messages.ackReactionScope: "group-mentions"`, Telegram still sends ack reactions for groups where `requireMention` is disabled, because every visible group message is treated as reply-worthy.
 
   </Accordion>
 

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -382,11 +382,15 @@ export const buildTelegramMessageContext = async ({
   const ackReactionEmoji =
     ackReaction && isTelegramSupportedReactionEmoji(ackReaction) ? ackReaction : undefined;
   const removeAckAfterReply = cfg.messages?.removeAckAfterReply ?? false;
+  const effectiveAckReactionScope =
+    ackReactionScope === "group-mentions" && isGroup && !requireMention
+      ? "group-all"
+      : ackReactionScope;
   const shouldAckReaction = () =>
     Boolean(
       ackReaction &&
       shouldAckReactionGate({
-        scope: ackReactionScope,
+        scope: effectiveAckReactionScope,
         isDirect: !isGroup,
         isGroup,
         isMentionableGroup: isGroup,

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1743,6 +1743,36 @@ describe("createTelegramBot", () => {
       { type: "emoji", emoji: EYES_EMOJI },
     ]);
   });
+  it("keeps ack reactions for group messages when requireMention is disabled", async () => {
+    resetHarnessSpies();
+
+    loadConfig.mockReturnValue({
+      messages: {
+        ackReaction: EYES_EMOJI,
+        ackReactionScope: "group-mentions",
+      },
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: false } },
+        },
+      },
+    });
+
+    await dispatchMessage({
+      message: {
+        chat: { id: 7, type: "group", title: "Test Group" },
+        text: "hello team",
+        date: 1736380800,
+        message_id: 124,
+        from: { id: 9, first_name: "Ada" },
+      },
+    });
+
+    expect(setMessageReactionSpy).toHaveBeenCalledWith(7, 124, [
+      { type: "emoji", emoji: EYES_EMOJI },
+    ]);
+  });
   it("clears native commands when disabled", () => {
     resetHarnessSpies();
     loadConfig.mockReturnValue({


### PR DESCRIPTION
## Summary

- Problem: Telegram ack reactions stop when group `requireMention` is disabled, even though those group messages still trigger runs.
- Why it matters: always-on Telegram groups look ignored while the agent is actually working.
- What changed: when Telegram is using the default `messages.ackReactionScope: "group-mentions"`, groups with `requireMention: false` now keep ack reactions; added a focused regression test and docs note.
- What did NOT change (scope boundary): no change to non-Telegram channels, and no change to explicit ack scopes such as `all`, `direct`, `group-all`, `off`, or `none`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65808
- Related #65808
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the shared ack-reaction gate required `requireMention=true` for `group-mentions`, so Telegram groups configured to process unmentioned messages stopped qualifying for the ack emoji.
- Missing detection / guardrail: there was no regression test covering ack reactions in Telegram groups with `requireMention: false`.
- Contributing context (if known): Telegram already treats those messages as reply-worthy once mention gating is disabled, so the ack surface drifted from actual processing behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/bot.create-telegram-bot.test.ts`
- Scenario the test should lock in: a group message without a mention still receives the ack reaction when Telegram group config sets `requireMention: false`.
- Why this is the smallest reliable guardrail: the behavior depends on the Telegram message pipeline, config resolution, and reaction dispatch, so the existing create-bot harness is the smallest seam that exercises the full path.
- Existing test that already covers this (if any): the adjacent mention-gated ack reaction test in the same file.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Telegram groups configured with `requireMention: false` now keep the ack emoji while the message is being processed, even when the global ack scope remains `group-mentions`.

## Diagram (if applicable)

```text
Before:
[group message, no mention] -> [Telegram run starts] -> [no ack reaction shown]

After:
[group message, no mention] -> [Telegram run starts] -> [ack reaction shown] -> [reply arrives]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `messages.ackReaction="👀"`, `messages.ackReactionScope="group-mentions"`, `channels.telegram.groups["*"].requireMention=false`

### Steps

1. Configure Telegram with `messages.ackReaction` enabled and `channels.telegram.groups["*"].requireMention=false`.
2. Send a normal group message without mentioning the bot.
3. Observe whether the ack reaction appears before the reply is delivered.

### Expected

- The bot acknowledges the inbound group message because that message is eligible to trigger a run.

### Actual

- Before this change, no ack reaction was sent for that message path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused verification after the patch:

```text
$ npx --yes pnpm exec vitest run extensions/telegram/src/bot.create-telegram-bot.test.ts
Test Files  1 passed (1)
Tests       51 passed (51)
```

## Human Verification (required)

- Verified scenarios: mention-gated Telegram group messages still ack; Telegram groups with `requireMention: false` now ack without a mention.
- Edge cases checked: the change is gated to Telegram and only rewrites the effective scope when the current scope is `group-mentions`.
- What you did **not** verify: live Telegram Bot API behavior against a real bot account; multi-account Telegram setups.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Telegram users who intentionally paired `requireMention: false` with `group-mentions` may now see more ack reactions in always-on groups.
  - Mitigation: the change is limited to Telegram groups already configured to process every visible message, and users can still opt into `off`, `none`, `direct`, `group-all`, or `all` explicitly.

AI-assisted: Yes (Codex). I attempted `codex review --base origin/main`, but the local Codex CLI review could not complete because the authenticated Codex session had hit its usage limit.
