### PR TITLE
fix(tui): preserve spaces between thinking fragments

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -219,7 +219,28 @@ describe("extractThinkingFromMessage", () => {
       ],
     });
 
-    expect(text).toBe("alpha\nbeta");
+    expect(text).toBe("alpha beta");
+  });
+
+  it("converts single-line thinking boundaries into spaces", () => {
+    const text = extractThinkingFromMessage({
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "First sentence." },
+        { type: "thinking", thinking: "Second sentence." },
+      ],
+    });
+
+    expect(text).toBe("First sentence. Second sentence.");
+  });
+
+  it("preserves paragraph breaks inside thinking text", () => {
+    const text = extractThinkingFromMessage({
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "Paragraph one.\n\nParagraph two." }],
+    });
+
+    expect(text).toBe("Paragraph one.\n\nParagraph two.");
   });
 });
 

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -240,6 +240,16 @@ function collectSanitizedBlockStrings(params: {
   return parts;
 }
 
+function normalizeThinkingWhitespace(text: string): string {
+  if (!text) {
+    return "";
+  }
+  // Streaming thinking often arrives as sentence-sized fragments. Preserve
+  // explicit paragraph breaks, but turn single-line boundaries into spaces so
+  // the markdown renderer does not smush sentences together.
+  return text.replace(/(?<!\n)\n(?!\n)/g, " ");
+}
+
 /**
  * Extract ONLY thinking blocks from message content.
  * Model-agnostic: returns empty string if no thinking blocks exist.
@@ -258,7 +268,7 @@ export function extractThinkingFromMessage(message: unknown): string {
     blockType: "thinking",
     valueKey: "thinking",
   });
-  return parts.join("\n").trim();
+  return normalizeThinkingWhitespace(parts.join("\n")).trim();
 }
 
 /**
@@ -327,7 +337,7 @@ function extractTextBlocks(content: unknown, opts?: { includeThinking?: boolean 
       : [];
 
   return composeThinkingAndContent({
-    thinkingText: thinkingParts.join("\n").trim(),
+    thinkingText: normalizeThinkingWhitespace(thinkingParts.join("\n")).trim(),
     contentText: textParts.join("\n").trim(),
     showThinking: opts?.includeThinking ?? false,
   });

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -79,6 +79,20 @@ describe("TuiStreamAssembler", () => {
     expect(output).toBe("Visible");
   });
 
+  it("keeps spaces between streamed thinking fragments", () => {
+    const assembler = new TuiStreamAssembler();
+    const output = assembler.ingestDelta(
+      "run-2-thinking-spaces",
+      messageWithContent([
+        thinking("First sentence."),
+        thinking("Second sentence."),
+        text("Visible"),
+      ]),
+      true,
+    );
+    expect(output).toBe("[thinking]\nFirst sentence. Second sentence.\n\nVisible");
+  });
+
   it("falls back to streamed text on empty final payload", () => {
     const assembler = new TuiStreamAssembler();
     assembler.ingestDelta("run-3", messageWithContent([text("Streamed")]), false);


### PR DESCRIPTION
## Summary

- Problem: streamed thinking fragments were joined with single newlines, and the TUI markdown renderer collapsed those boundaries so adjacent sentences appeared smushed together
- Why it matters: reasoning output in the terminal became hard to read even though the underlying content arrived correctly
- What changed: normalize single-line thinking boundaries into spaces while preserving paragraph breaks, and add formatter/stream-assembler regressions
- What did NOT change (scope boundary): assistant answer text rendering and non-thinking text block joining remain unchanged

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66008
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the TUI formatter preserved single newlines between thinking fragments, but the markdown renderer did not render those boundaries as readable spaces
- Missing detection / guardrail: there was no regression test covering multiple thinking blocks rendered in a single streamed assistant update
- Contributing context (if known): reasoning/thinking often arrives in sentence-sized chunks instead of one complete paragraph

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: src/tui/tui-formatters.test.ts and src/tui/tui-stream-assembler.test.ts
- Scenario the test should lock in: consecutive thinking fragments stay readable with spaces while explicit paragraph breaks survive
- Why this is the smallest reliable guardrail: it exercises the exact formatter and streamed-assembly surfaces that build terminal assistant output
- Existing test that already covers this (if any): prior tests covered thinking visibility but not fragment boundary spacing
- If no new test is added, why not:

## User-visible / Behavior Changes

- Streamed thinking text in the TUI now keeps sentence spacing instead of smushing adjacent fragments together.

## Diagram (if applicable)

```text
Before:
[thinking chunk A]\n[thinking chunk B] -> markdown render -> "chunk Achunk B"

After:
[thinking chunk A]\n[thinking chunk B] -> whitespace normalization -> "chunk A chunk B"
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm/vitest
- Model/provider: N/A
- Integration/channel (if any): TUI
- Relevant config (redacted): showThinking=true

### Steps

1. Render an assistant message containing multiple thinking fragments.
2. Show thinking in the TUI.
3. Inspect the rendered output.

### Expected

- Adjacent thinking fragments remain readable with spaces between sentences.

### Actual

- Before this fix, sentence boundaries could collapse and appear as one long smushed block.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted vitest run for src/tui/tui-formatters.test.ts and src/tui/tui-stream-assembler.test.ts
- Edge cases checked: consecutive thinking fragments and explicit paragraph breaks
- What you did **not** verify: full interactive terminal reproduction against a live model stream

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: some intentionally line-broken thinking text could become single-paragraph prose
  - Mitigation: explicit blank-line paragraph breaks are preserved, and the fix only touches thinking text in the TUI path

AI-assisted: Yes (Codex). Testing: targeted vitest coverage listed above. I attempted codex review --base origin/main, but the local Codex CLI is currently rate-limited.
