### PR TITLE
Fix commentary leaks in OpenResponses HTTP streaming

### DIFF
--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -742,6 +742,105 @@ describe("OpenResponses HTTP API (e2e)", () => {
     }
   });
 
+  it("does not stream commentary deltas before function calls", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { delta: "Let me check that.", phase: "commentary" },
+      });
+      return {
+        payloads: [{ text: "Let me check that." }],
+        meta: {
+          stopReason: "tool_calls",
+          pendingToolCalls: [
+            {
+              id: "call_1",
+              name: "get_weather",
+              arguments: '{"city":"Taipei"}',
+            },
+          ],
+        },
+      };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "check the weather",
+      tools: WEATHER_TOOL,
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const events = parseSseEvents(text);
+    const deltaTexts = events
+      .filter((event) => event.event === "response.output_text.delta")
+      .map((event) => (JSON.parse(event.data) as { delta?: string }).delta ?? "")
+      .filter(Boolean);
+    expect(deltaTexts).toEqual([]);
+
+    const outputTextDone = events.find((event) => event.event === "response.output_text.done");
+    expect((JSON.parse(outputTextDone?.data ?? "{}") as { text?: string }).text).toBe(
+      "Let me check that.",
+    );
+
+    const completed = events.find((event) => event.event === "response.completed");
+    const response = (
+      JSON.parse(completed?.data ?? "{}") as {
+        response?: { status?: string; output?: Array<Record<string, unknown>> };
+      }
+    ).response;
+    expect(response?.status).toBe("incomplete");
+    expect(response?.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
+    expect(response?.output?.[0]?.phase).toBe("commentary");
+    expect(response?.output?.[1]?.name).toBe("get_weather");
+    expect(events.some((event) => event.data === "[DONE]")).toBe(true);
+  });
+
+  it("streams explicit final_answer deltas", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    agentCommand.mockImplementationOnce((async (opts: unknown) => {
+      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+      emitAgentEvent({
+        runId,
+        stream: "assistant",
+        data: { delta: "hello", phase: "final_answer" },
+      });
+      return {
+        payloads: [{ text: "hello" }],
+      };
+    }) as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "hi",
+    });
+    expect(res.status).toBe(200);
+
+    const eventText = await res.text();
+    const events = parseSseEvents(eventText);
+    const deltas = events
+      .filter((event) => event.event === "response.output_text.delta")
+      .map((event) => (JSON.parse(event.data) as { delta?: string }).delta ?? "")
+      .join("");
+    expect(deltas).toBe("hello");
+
+    const completed = events.find((event) => event.event === "response.completed");
+    const output = (
+      JSON.parse(completed?.data ?? "{}") as {
+        response?: { output?: Array<Record<string, unknown>> };
+      }
+    ).response?.output;
+    expect(output?.[0]?.phase).toBe("final_answer");
+    expect(events.some((event) => event.data === "[DONE]")).toBe(true);
+  });
+
   it("treats write-scoped HTTP callers as non-owner and admin-scoped callers as owner", async () => {
     const port = enabledPort;
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -801,12 +801,37 @@ export async function handleOpenResponsesHttpRequest(
   setSseHeaders(res);
 
   let accumulatedText = "";
-  let sawAssistantDelta = false;
+  let bufferedVisibleText = "";
+  let streamedVisibleText = "";
+  let sawVisibleAssistantDelta = false;
   let closed = false;
   let unsubscribe = () => {};
   let stopWatchingDisconnect = () => {};
   let finalUsage: Usage | undefined;
   let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
+
+  const emitBufferedVisibleText = () => {
+    if (!bufferedVisibleText) {
+      return;
+    }
+
+    const delta = bufferedVisibleText.startsWith(streamedVisibleText)
+      ? bufferedVisibleText.slice(streamedVisibleText.length)
+      : bufferedVisibleText;
+    if (!delta) {
+      return;
+    }
+
+    streamedVisibleText = bufferedVisibleText;
+    sawVisibleAssistantDelta = true;
+    writeSseEvent(res, {
+      type: "response.output_text.delta",
+      item_id: outputItemId,
+      output_index: 0,
+      content_index: 0,
+      delta,
+    });
+  };
 
   const maybeFinalize = () => {
     if (closed) {
@@ -919,24 +944,33 @@ export async function handleOpenResponsesHttpRequest(
     if (evt.stream === "assistant") {
       const text = evt.data?.text;
       const replace = evt.data?.replace === true;
+      const phase =
+        evt.data?.phase === "commentary" || evt.data?.phase === "final_answer"
+          ? evt.data.phase
+          : undefined;
       if (replace && typeof text === "string") {
         accumulatedText = text;
+        bufferedVisibleText = phase === "commentary" ? "" : text;
+        if (phase !== "commentary") {
+          emitBufferedVisibleText();
+        }
       }
       const content = resolveAssistantStreamDeltaText(evt);
       if (!content) {
         return;
       }
 
-      sawAssistantDelta = true;
-      accumulatedText += content;
+      if (!replace || typeof text !== "string") {
+        accumulatedText += content;
+      }
 
-      writeSseEvent(res, {
-        type: "response.output_text.delta",
-        item_id: outputItemId,
-        output_index: 0,
-        content_index: 0,
-        delta: content,
-      });
+      if (phase === "commentary") {
+        return;
+      }
+
+      bufferedVisibleText =
+        replace && typeof text === "string" ? text : bufferedVisibleText + content;
+      emitBufferedVisibleText();
       return;
     }
 
@@ -1072,27 +1106,21 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
 
-      // Fallback: if no streaming deltas were received, send the full response as text
-      if (!sawAssistantDelta) {
+      // Fallback: if no user-visible streaming deltas were received, send the final visible text.
+      if (!sawVisibleAssistantDelta) {
         const payloads = resultAny.payloads;
         const content =
-          Array.isArray(payloads) && payloads.length > 0
+          bufferedVisibleText ||
+          (Array.isArray(payloads) && payloads.length > 0
             ? payloads
                 .map((p) => (typeof p.text === "string" ? p.text : ""))
                 .filter(Boolean)
                 .join("\n\n")
-            : "No response from OpenClaw.";
+            : "No response from OpenClaw.");
 
         accumulatedText = content;
-        sawAssistantDelta = true;
-
-        writeSseEvent(res, {
-          type: "response.output_text.delta",
-          item_id: outputItemId,
-          output_index: 0,
-          content_index: 0,
-          delta: content,
-        });
+        bufferedVisibleText = content;
+        emitBufferedVisibleText();
       }
     } catch (err) {
       if (closed || abortController.signal.aborted) {


### PR DESCRIPTION
## Summary
- stop streaming assistant commentary deltas to OpenResponses HTTP clients before the phase is known
- keep completed OpenResponses output items tagged with the right phase so commentary + tool-call turns still preserve structure
- add regression coverage for commentary suppression and explicit final-answer streaming

## What changed
The OpenResponses HTTP SSE path was forwarding every `assistant` delta immediately, even when the turn later finalized as `phase: "commentary"` for a tool call. That leaked internal planning text like tool-call scaffolding to end users.

This patch buffers assistant text until the phase is known:
- `commentary` deltas stay buffered and are not emitted as `response.output_text.delta`
- `final_answer` deltas are emitted normally
- completed output items still carry the expected `phase` metadata so tool-call turns remain structured correctly

## Tests
Passed:
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/openresponses-http.test.ts src/gateway/openresponses-phase.test.ts`
- `pnpm build`

Known unrelated repo baseline failures observed while validating:
- `pnpm check` fails on existing type errors outside this patch (for example in `extensions/discord`, `extensions/feishu`, `extensions/nextcloud-talk`, `extensions/whatsapp`, `src/cron`, `src/mcp`, `src/wizard`)
- `pnpm test` also hits unrelated existing failures / resource issues outside this patch (for example `src/commands/daemon-install-helpers.test.ts`, `src/agents/model-fallback.probe.test.ts`, and an out-of-memory worker termination)
