### PR TITLE
feat(codex-cli): prefer output-last-message artifacts

### DIFF
--- a/src/agents/cli-output.test.ts
+++ b/src/agents/cli-output.test.ts
@@ -279,6 +279,28 @@ describe("parseCliJsonl", () => {
     });
   });
 
+  it("extracts Codex message text from jsonl content records", () => {
+    const result = parseCliJsonl(
+      JSON.stringify({
+        thread_id: "thread-123",
+        type: "message",
+        content: [{ type: "output_text", text: "Codex says hello" }],
+      }),
+      {
+        command: "codex",
+        output: "jsonl",
+        sessionIdFields: ["thread_id", "session_id"],
+      },
+      "codex-cli",
+    );
+
+    expect(result).toEqual({
+      text: "Codex says hello",
+      sessionId: "thread-123",
+      usage: undefined,
+    });
+  });
+
   it("extracts nested Claude API errors from failed stream-json output", () => {
     const message =
       "Third-party apps now draw from your extra usage, not your plan limits. We've added a $200 credit to get you started. Claim it at claude.ai/settings/usage and keep going.";

--- a/src/agents/cli-output.ts
+++ b/src/agents/cli-output.ts
@@ -480,6 +480,16 @@ export function parseCliJsonl(
         if (!type || type.includes("message")) {
           texts.push(item.text);
         }
+        continue;
+      }
+
+      const messageText =
+        collectCliText(parsed.message) ||
+        collectCliText(parsed.content) ||
+        collectCliText(parsed.result) ||
+        collectCliText(parsed.response);
+      if (messageText.trim()) {
+        texts.push(messageText.trim());
       }
     }
   }

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -475,6 +475,87 @@ describe("runCliAgent spawn path", () => {
     expect(promptFileText).toBe("You are a helpful assistant.");
   });
 
+  it("prefers Codex output-last-message artifacts over stdout for the final reply", async () => {
+    let artifactPath = "";
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { argv?: string[] };
+      const artifactArgIndex = input.argv?.indexOf("--output-last-message") ?? -1;
+      expect(artifactArgIndex).toBeGreaterThanOrEqual(0);
+      artifactPath = input.argv?.[artifactArgIndex + 1] ?? "";
+      expect(artifactPath).toBeTruthy();
+      await fs.writeFile(artifactPath, "ARTIFACT_WINS_20260413", "utf-8");
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: JSON.stringify({
+          thread_id: "thread-123",
+          type: "message",
+          content: [{ type: "output_text", text: "STDOUT_ONLY_20260413" }],
+        }),
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "codex-cli",
+        model: "gpt-5.4",
+        runId: "run-codex-output-last-message",
+        backend: {
+          output: "jsonl",
+        },
+      }),
+      "thread-123",
+    );
+
+    expect(result.text).toBe("ARTIFACT_WINS_20260413");
+    expect(result.sessionId).toBe("thread-123");
+    await expect(fs.access(artifactPath)).rejects.toThrow();
+  });
+
+  it("falls back to Codex stdout when the output-last-message artifact is empty", async () => {
+    supervisorSpawnMock.mockImplementationOnce(async (...args: unknown[]) => {
+      const input = (args[0] ?? {}) as { argv?: string[] };
+      const artifactArgIndex = input.argv?.indexOf("--output-last-message") ?? -1;
+      expect(artifactArgIndex).toBeGreaterThanOrEqual(0);
+      const artifactPath = input.argv?.[artifactArgIndex + 1] ?? "";
+      await fs.writeFile(artifactPath, "", "utf-8");
+      return createManagedRun({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 50,
+        stdout: JSON.stringify({
+          thread_id: "thread-123",
+          type: "message",
+          content: [{ type: "output_text", text: "STDOUT_ONLY_20260413" }],
+        }),
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+    });
+
+    const result = await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "codex-cli",
+        model: "gpt-5.4",
+        runId: "run-codex-output-last-message-empty",
+        backend: {
+          output: "jsonl",
+        },
+      }),
+      "thread-123",
+    );
+
+    expect(result.text).toBe("STDOUT_ONLY_20260413");
+    expect(result.sessionId).toBe("thread-123");
+  });
+
   it("cancels the managed CLI run when the abort signal fires", async () => {
     const abortController = new AbortController();
     let resolveWait!: (value: {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1,8 +1,11 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { shouldLogVerbose } from "../../globals.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
 import { requestHeartbeatNow as requestHeartbeatNowImpl } from "../../infra/heartbeat-wake.js";
 import { sanitizeHostExecEnv } from "../../infra/host-env-security.js";
+import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
 import { enqueueSystemEvent as enqueueSystemEventImpl } from "../../infra/system-events.js";
 import { getProcessSupervisor as getProcessSupervisorImpl } from "../../process/supervisor/index.js";
 import { scopedHeartbeatWakeOptions } from "../../routing/session-key.js";
@@ -94,6 +97,34 @@ function buildCliLogArgs(params: {
     }
   }
   return logArgs;
+}
+
+function isCodexCliBackend(context: PreparedCliRunContext): boolean {
+  return context.backendResolved.id === "codex-cli";
+}
+
+async function prepareCodexLastMessageArtifact(params: {
+  runId: string;
+}): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
+  const dir = await fs.mkdtemp(
+    path.join(resolvePreferredOpenClawTmpDir(), "openclaw-codex-last-message-"),
+  );
+  const safeRunId = params.runId.replace(/[^a-zA-Z0-9._-]+/g, "-") || "run";
+  const filePath = path.join(dir, `${safeRunId}.txt`);
+  return {
+    filePath,
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function readCodexLastMessageArtifact(filePath: string): Promise<string> {
+  try {
+    return (await fs.readFile(filePath, "utf-8")).trim();
+  } catch {
+    return "";
+  }
 }
 
 const CLI_ENV_AUTH_LOG_KEYS = [
@@ -238,6 +269,14 @@ export async function executePreparedCliRun(
     promptArg: argsPrompt,
     useResume,
   });
+  const codexLastMessageArtifact = isCodexCliBackend(context)
+    ? await prepareCodexLastMessageArtifact({
+        runId: params.runId,
+      })
+    : undefined;
+  if (codexLastMessageArtifact) {
+    args.push("--output-last-message", codexLastMessageArtifact.filePath);
+  }
 
   const queueKey = resolveCliRunQueueKey({
     backendId: context.backendResolved.id,
@@ -462,10 +501,14 @@ export async function executePreparedCliRun(
           outputMode: useResume ? (backend.resumeOutput ?? backend.output) : backend.output,
           fallbackSessionId: resolvedSessionId,
         });
+        const artifactText = codexLastMessageArtifact
+          ? await readCodexLastMessageArtifact(codexLastMessageArtifact.filePath)
+          : "";
+        const finalText = artifactText || parsed.text;
         return {
           ...parsed,
           text: applyPluginTextReplacements(
-            parsed.text,
+            finalText,
             context.backendResolved.textTransforms?.output,
           ),
         };
@@ -475,6 +518,7 @@ export async function executePreparedCliRun(
     });
   } finally {
     await claudeSkillsPlugin.cleanup();
+    await codexLastMessageArtifact?.cleanup();
     if (systemPromptFile) {
       await systemPromptFile.cleanup();
     }


### PR DESCRIPTION
## Summary

- Problem: direct `codex-cli` runs still finalize the user-visible reply from stdout even though Codex can write a dedicated final-message artifact
- Why it matters: stdout is useful for transport and telemetry, but it is a weaker source of truth for the final assistant answer than Codex's explicit `--output-last-message` output
- What changed: `codex-cli` runs now allocate a temp `--output-last-message` file, prefer that artifact when it contains text, and keep stdout parsing as the fallback path
- What did NOT change (scope boundary): other CLI backends still use their existing stdout/json/jsonl parsing paths, and this PR does not change failure classification or streaming behavior

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65074
- Related #39317
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the direct `codex-cli` runner only treated stdout parsing as the final reply source even though Codex already exposes a more stable final-message artifact contract
- Missing detection / guardrail: there was no runner-level test that forced stdout and the final-message artifact to disagree and verified that OpenClaw finalized from the artifact
- Contributing context (if known): Codex CLI already supports `--output-last-message`, but OpenClaw was not wiring that contract into the `codex-cli` backend path

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/cli-runner.spawn.test.ts`, `src/agents/cli-output.test.ts`
- Scenario the test should lock in: when Codex writes both stdout JSONL and an `--output-last-message` file, OpenClaw should prefer the artifact when it is non-empty and fall back to parsed stdout when the artifact is empty
- Why this is the smallest reliable guardrail: it exercises the exact runner boundary where args are built, the artifact is read, stdout is still parsed, and the final reply is selected
- Existing test that already covers this (if any): none covered the artifact-vs-stdout precedence or Codex message-content JSONL fallback
- If no new test is added, why not:

## User-visible / Behavior Changes

- `codex-cli` replies now finalize from Codex's explicit final-message artifact when available, which makes delegated Codex runs less dependent on stdout formatting details.

## Diagram (if applicable)

```text
Before:
[codex exec --json] -> [stdout parsed] -> [reply text selected from stdout]

After:
[codex exec --json --output-last-message <file>]
  -> [stdout parsed for session/usage/fallback]
  -> [artifact read]
  -> [artifact text wins when present]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - This only adds Codex's own `--output-last-message` flag plus a temp file under OpenClaw's preferred temp dir. The file is per-run, read back locally, and deleted in cleanup even when parsing falls back to stdout.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm/vitest
- Model/provider: `codex-cli/gpt-5.4`
- Integration/channel (if any): direct CLI runner
- Relevant config (redacted): default `codex-cli` backend with `--json`

### Steps

1. Run a direct `codex-cli` execution through the CLI runner.
2. Have Codex emit stdout JSONL and write a final-message artifact.
3. Compare the final reply selection when the artifact is populated vs empty.

### Expected

- OpenClaw should prefer the artifact text when it exists and keep stdout parsing as the fallback.

### Actual

- Before this change, the runner always finalized from stdout because it never requested or read Codex's final-message artifact.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted vitest run for `src/agents/cli-output.test.ts`, `src/agents/cli-runner.spawn.test.ts`, and `src/agents/cli-runner.reliability.test.ts`
- Edge cases checked: non-empty artifact overriding stdout; empty artifact falling back to stdout; Codex JSONL message content still parsing to plain assistant text
- What you did **not** verify: full repo-wide `pnpm check` / `pnpm test` lanes and a live end-to-end Codex CLI run against the actual binary in this branch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: temp artifact cleanup could leak files if the runner exits early
  - Mitigation: cleanup runs in the outer `finally`, and the unit test asserts the artifact path is removed after success
- Risk: Codex stdout fallback could regress if the artifact is empty and stdout uses the normal message-content JSONL shape
  - Mitigation: `parseCliJsonl` now extracts text from Codex message content records, and the fallback path is covered by a dedicated unit test

AI-assisted: Yes (Codex). Testing: targeted vitest coverage listed above. I attempted `codex review --base origin/main`, but the local Codex CLI is currently rate-limited.
