### PR TITLE
fix(web-ui): respect effective chat defaults

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import { CURRENT_SESSION_VERSION, SessionManager } from "@mariozechner/pi-coding-agent";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { resolveThinkingDefault } from "../../agents/model-selection.js";
+import { resolveAgentConfig, resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveReasoningDefault, resolveThinkingDefault } from "../../agents/model-selection.js";
 import { rewriteTranscriptEntriesInSessionFile } from "../../agents/pi-embedded-runner/transcript-rewrite.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { dispatchInboundMessage } from "../../auto-reply/dispatch.js";
@@ -1614,6 +1614,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
     const sessionId = entry?.sessionId;
     const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
+    const agentConfig = resolveAgentConfig(cfg, sessionAgentId);
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
     const localMessages =
       sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
@@ -1647,14 +1648,29 @@ export const chatHandlers: GatewayRequestHandlers = {
         `chat.history omitted oversized payloads placeholders=${placeholderCount} total=${chatHistoryPlaceholderEmitCount}`,
       );
     }
+    let catalog: Awaited<ReturnType<typeof context.loadGatewayModelCatalog>> | undefined;
+    const loadCatalog = async () => {
+      catalog ??= await context.loadGatewayModelCatalog();
+      return catalog;
+    };
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
-      const catalog = await context.loadGatewayModelCatalog();
-      thinkingLevel = resolveThinkingDefault({
-        cfg,
+      thinkingLevel =
+        agentConfig?.thinkingDefault ??
+        resolveThinkingDefault({
+          cfg,
+          provider: resolvedSessionModel.provider,
+          model: resolvedSessionModel.model,
+          catalog: await loadCatalog(),
+        });
+    }
+    const explicitReasoningLevel = entry?.reasoningLevel ?? agentConfig?.reasoningDefault;
+    let reasoningLevel = explicitReasoningLevel ?? "off";
+    if (!explicitReasoningLevel && thinkingLevel === "off") {
+      reasoningLevel = resolveReasoningDefault({
         provider: resolvedSessionModel.provider,
         model: resolvedSessionModel.model,
-        catalog,
+        catalog: await loadCatalog(),
       });
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
@@ -1663,6 +1679,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionId,
       messages: bounded.messages,
       thinkingLevel,
+      reasoningLevel,
       fastMode: entry?.fastMode,
       verboseLevel,
     });

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -542,6 +542,49 @@ describe("gateway server chat", () => {
     expect(textValues).toEqual(["hello", "real reply", "real text field reply", "NO_REPLY"]);
   });
 
+  test("chat.history returns effective thinking and reasoning defaults for new agent sessions", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-agent-defaults-"));
+    try {
+      testState.agentConfig = {
+        thinkingDefault: "low",
+      };
+      testState.agentsConfig = {
+        list: [
+          {
+            id: "ops",
+            reasoningDefault: "stream",
+          },
+        ],
+      };
+      testState.sessionStorePath = path.join(dir, "sessions.json");
+      await writeSessionStore({
+        entries: {
+          "agent:ops:main": {
+            sessionId: "sess-ops-main",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+
+      const res = await rpcReq<{
+        messages?: unknown[];
+        thinkingLevel?: string;
+        reasoningLevel?: string;
+      }>(ws, "chat.history", {
+        sessionKey: "agent:ops:main",
+      });
+      expect(res.ok).toBe(true);
+      expect(res.payload?.messages ?? []).toEqual([]);
+      expect(res.payload?.thinkingLevel).toBe("low");
+      expect(res.payload?.reasoningLevel).toBe("stream");
+    } finally {
+      testState.agentConfig = undefined;
+      testState.agentsConfig = undefined;
+      testState.sessionStorePath = undefined;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test("chat.history hides commentary-only assistant entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -375,6 +375,7 @@ describe("switchChatSession", () => {
       chatToolMessages: [{ id: "tool-1" }],
       chatStreamSegments: [{ text: "segment", ts: 1 }],
       chatThinkingLevel: "high",
+      chatReasoningLevel: "stream",
       chatStream: "stream",
       chatSideResult: {
         kind: "btw",
@@ -412,6 +413,7 @@ describe("switchChatSession", () => {
 
     expect(state.chatSideResult).toBeNull();
     expect(state.chatSideResultTerminalRuns.size).toBe(0);
+    expect(state.chatReasoningLevel).toBeNull();
     expect(refreshChatAvatarMock).toHaveBeenCalledWith(state);
     expect(refreshSlashCommandsMock).toHaveBeenCalledWith({
       client: undefined,
@@ -452,6 +454,7 @@ describe("switchChatSession", () => {
       chatToolMessages: [],
       chatStreamSegments: [],
       chatThinkingLevel: null,
+      chatReasoningLevel: null,
       chatStream: null,
       chatSideResult: null,
       lastError: null,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -77,6 +77,7 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
   state.chatToolMessages = [];
   state.chatStreamSegments = [];
   state.chatThinkingLevel = null;
+  state.chatReasoningLevel = null;
   state.chatStream = null;
   state.chatSideResult = null;
   state.lastError = null;
@@ -678,9 +679,11 @@ function resolveChatThinkingSelectState(state: AppViewState): ChatThinkingSelect
           catalog: state.chatModelCatalog ?? [],
         })
       : "off";
+  const effectiveDefaultLevel =
+    currentOverride === "" && state.chatThinkingLevel ? state.chatThinkingLevel : defaultLevel;
   return {
     currentOverride,
-    defaultLabel: `Default (${defaultLevel})`,
+    defaultLabel: `Default (${effectiveDefaultLevel})`,
     options: buildThinkingOptions(provider, model, currentOverride),
   };
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1855,6 +1855,7 @@ export function renderApp(state: AppViewState) {
                 switchChatSession(state, next);
               },
               thinkingLevel: state.chatThinkingLevel,
+              reasoningLevel: state.chatReasoningLevel,
               showThinking,
               showToolCalls,
               loading: state.chatLoading,

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -85,6 +85,7 @@ export type AppViewState = {
   fallbackStatus: FallbackStatus | null;
   chatAvatarUrl: string | null;
   chatThinkingLevel: string | null;
+  chatReasoningLevel: string | null;
   chatModelOverrides: Record<string, ChatModelOverride | null>;
   chatModelsLoading: boolean;
   chatModelCatalog: ModelCatalogEntry[];

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -181,6 +181,7 @@ export class OpenClawApp extends LitElement {
   @state() fallbackStatus: FallbackStatus | null = null;
   @state() chatAvatarUrl: string | null = null;
   @state() chatThinkingLevel: string | null = null;
+  @state() chatReasoningLevel: string | null = null;
   @state() chatModelOverrides: Record<string, ChatModelOverride | null> = {};
   @state() chatModelsLoading = false;
   @state() chatModelCatalog: ModelCatalogEntry[] = [];

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -15,6 +15,7 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     chatLoading: false,
     chatMessage: "",
     chatMessages: [],
+    chatReasoningLevel: null,
     chatRunId: null,
     chatSending: false,
     chatStream: null,
@@ -530,7 +531,11 @@ describe("loadChatHistory", () => {
       { role: "assistant", text: "  NO_REPLY  " },
     ];
     const mockClient = {
-      request: vi.fn().mockResolvedValue({ messages, thinkingLevel: "low" }),
+      request: vi.fn().mockResolvedValue({
+        messages,
+        thinkingLevel: "low",
+        reasoningLevel: "stream",
+      }),
     };
     const state = createState({
       client: mockClient as unknown as ChatState["client"],
@@ -543,6 +548,7 @@ describe("loadChatHistory", () => {
     expect(state.chatMessages[0]).toEqual(messages[0]);
     expect(state.chatMessages[1]).toEqual(messages[2]);
     expect(state.chatThinkingLevel).toBe("low");
+    expect(state.chatReasoningLevel).toBe("stream");
     expect(state.chatLoading).toBe(false);
   });
 
@@ -698,6 +704,7 @@ describe("loadChatHistory", () => {
         .mockResolvedValueOnce({
           messages: [{ role: "assistant", content: [{ type: "text", text: "awake" }] }],
           thinkingLevel: "low",
+          reasoningLevel: "on",
         });
       const state = createState({
         connected: true,
@@ -717,6 +724,7 @@ describe("loadChatHistory", () => {
         { role: "assistant", content: [{ type: "text", text: "awake" }] },
       ]);
       expect(state.chatThinkingLevel).toBe("low");
+      expect(state.chatReasoningLevel).toBe("on");
       expect(state.chatLoading).toBe(false);
       expect(state.lastError).toBeNull();
     } finally {
@@ -766,19 +774,29 @@ describe("loadChatHistory", () => {
       client: { request } as unknown as ChatState["client"],
       chatMessages: [{ role: "assistant", content: [{ type: "text", text: "old" }] }],
       chatThinkingLevel: "high",
+      chatReasoningLevel: "stream",
     });
 
     await loadChatHistory(state);
 
     expect(state.chatMessages).toEqual([]);
     expect(state.chatThinkingLevel).toBeNull();
+    expect(state.chatReasoningLevel).toBeNull();
     expect(state.lastError).toContain("operator.read");
     expect(state.chatLoading).toBe(false);
   });
 
   it("ignores stale history responses after switching sessions", async () => {
-    const mainRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
-    const otherRequest = createDeferred<{ messages: Array<unknown>; thinkingLevel?: string }>();
+    const mainRequest = createDeferred<{
+      messages: Array<unknown>;
+      thinkingLevel?: string;
+      reasoningLevel?: string;
+    }>();
+    const otherRequest = createDeferred<{
+      messages: Array<unknown>;
+      thinkingLevel?: string;
+      reasoningLevel?: string;
+    }>();
     const request = vi.fn((_method: string, params?: { sessionKey?: string }) => {
       if (params?.sessionKey === "main") {
         return mainRequest.promise;
@@ -801,6 +819,7 @@ describe("loadChatHistory", () => {
     mainRequest.resolve({
       messages: [{ role: "assistant", content: [{ type: "text", text: "main history" }] }],
       thinkingLevel: "high",
+      reasoningLevel: "stream",
     });
     await firstLoad;
 
@@ -809,10 +828,12 @@ describe("loadChatHistory", () => {
       { role: "assistant", content: [{ type: "text", text: "visible old" }] },
     ]);
     expect(state.chatThinkingLevel).toBeNull();
+    expect(state.chatReasoningLevel).toBeNull();
 
     otherRequest.resolve({
       messages: [{ role: "assistant", content: [{ type: "text", text: "other history" }] }],
       thinkingLevel: "low",
+      reasoningLevel: "off",
     });
     await secondLoad;
 
@@ -821,5 +842,6 @@ describe("loadChatHistory", () => {
       { role: "assistant", content: [{ type: "text", text: "other history" }] },
     ]);
     expect(state.chatThinkingLevel).toBe("low");
+    expect(state.chatReasoningLevel).toBe("off");
   });
 });

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -107,6 +107,7 @@ export type ChatState = {
   chatLoading: boolean;
   chatMessages: unknown[];
   chatThinkingLevel: string | null;
+  chatReasoningLevel: string | null;
   chatSending: boolean;
   chatMessage: string;
   chatAttachments: ChatAttachment[];
@@ -146,16 +147,17 @@ export async function loadChatHistory(state: ChatState) {
   state.chatLoading = true;
   state.lastError = null;
   try {
-    let res: { messages?: Array<unknown>; thinkingLevel?: string };
+    let res: { messages?: Array<unknown>; thinkingLevel?: string; reasoningLevel?: string };
     for (;;) {
       try {
-        res = await state.client.request<{ messages?: Array<unknown>; thinkingLevel?: string }>(
-          "chat.history",
-          {
-            sessionKey,
-            limit: 200,
-          },
-        );
+        res = await state.client.request<{
+          messages?: Array<unknown>;
+          thinkingLevel?: string;
+          reasoningLevel?: string;
+        }>("chat.history", {
+          sessionKey,
+          limit: 200,
+        });
         break;
       } catch (err) {
         if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey)) {
@@ -179,6 +181,7 @@ export async function loadChatHistory(state: ChatState) {
     const messages = Array.isArray(res.messages) ? res.messages : [];
     state.chatMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
     state.chatThinkingLevel = res.thinkingLevel ?? null;
+    state.chatReasoningLevel = res.reasoningLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
     maybeResetToolStream(state);
@@ -191,6 +194,7 @@ export async function loadChatHistory(state: ChatState) {
     if (isMissingOperatorReadScopeError(err)) {
       state.chatMessages = [];
       state.chatThinkingLevel = null;
+      state.chatReasoningLevel = null;
       state.lastError = formatMissingOperatorReadScopeMessage("existing chat history");
     } else {
       state.lastError = String(err);

--- a/ui/src/ui/views/chat.browser.test.ts
+++ b/ui/src/ui/views/chat.browser.test.ts
@@ -25,6 +25,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     sessionKey: "main",
     onSessionKeyChange: () => undefined,
     thinkingLevel: null,
+    reasoningLevel: null,
     showThinking: false,
     showToolCalls: true,
     loading: false,

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -158,6 +158,7 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
     sessionKey: "main",
     onSessionKeyChange: () => undefined,
     thinkingLevel: null,
+    reasoningLevel: null,
     showThinking: false,
     showToolCalls: true,
     loading: false,
@@ -251,6 +252,58 @@ function createOverviewProps(overrides: Partial<OverviewProps> = {}): OverviewPr
 }
 
 describe("chat view", () => {
+  it("shows assistant reasoning blocks when the effective reasoning level is on", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: true,
+          reasoningLevel: "on",
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "Internal reasoning", thinkingSignature: "sig-1" },
+                { type: "text", text: "Visible answer" },
+              ],
+              timestamp: 1,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-thinking")).not.toBeNull();
+    expect(container.textContent).toContain("Visible answer");
+  });
+
+  it("keeps assistant reasoning hidden when the effective reasoning level is off", () => {
+    const container = document.createElement("div");
+    render(
+      renderChat(
+        createProps({
+          showThinking: true,
+          reasoningLevel: "off",
+          messages: [
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: "Internal reasoning", thinkingSignature: "sig-1" },
+                { type: "text", text: "Visible answer" },
+              ],
+              timestamp: 1,
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-thinking")).toBeNull();
+    expect(container.textContent).toContain("Visible answer");
+  });
+
   it("renders BTW side results outside transcript history", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -51,6 +51,7 @@ export type ChatProps = {
   sessionKey: string;
   onSessionKeyChange: (next: string) => void;
   thinkingLevel: string | null;
+  reasoningLevel: string | null;
   showThinking: boolean;
   showToolCalls: boolean;
   loading: boolean;
@@ -1122,7 +1123,7 @@ export function renderChat(props: ChatProps) {
   const isBusy = props.sending || props.stream !== null;
   const canAbort = Boolean(props.canAbort && props.onAbort);
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
-  const reasoningLevel = activeSession?.reasoningLevel ?? "off";
+  const reasoningLevel = props.reasoningLevel ?? activeSession?.reasoningLevel ?? "off";
   const showReasoning = props.showThinking && reasoningLevel !== "off";
   const assistantIdentity = {
     name: props.assistantName,


### PR DESCRIPTION
## Summary

- Problem: the Web UI only looked at persisted session overrides, so a new session could already be running with effective thinking/reasoning defaults while the chat header still rendered the fallback model label or hid reasoning incorrectly
- Why it matters: users configuring default chat behavior had to manually re-check or re-toggle the UI even when the backend had already resolved the intended defaults
- What changed: `chat.history` now returns effective thinking and reasoning levels, the Web UI stores those effective values for the active chat session, and the chat view uses them for the default thinking label and reasoning visibility
- What did NOT change (scope boundary): this PR does not add new config keys, does not change `config.patch`, and does not add a separate reasoning selector to the Web UI

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A (partial fix)
- Related #64830
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the gateway computed effective defaults for runtime behavior, but `chat.history` did not expose the effective reasoning level and the Web UI still derived default presentation from persisted session rows instead of the active resolved state
- Missing detection / guardrail: there was no gateway regression test asserting effective chat defaults for a fresh agent session, and no UI test covering reasoning visibility from effective chat state
- Contributing context (if known): the chat header already received `thinkingLevel` from history, but the default-label path ignored it, and reasoning visibility was still coupled to `sessions.list` rows only

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server.chat.gateway-server-chat.test.ts`, `ui/src/ui/controllers/chat.test.ts`, `ui/src/ui/views/chat.test.ts`
- Scenario the test should lock in: a fresh agent session should surface effective thinking/reasoning defaults through `chat.history`, and the Web UI should render thinking/reasoning based on that effective state rather than only persisted overrides
- Why this is the smallest reliable guardrail: it exercises the exact gateway response boundary plus the UI state/view wiring that was previously out of sync
- Existing test that already covers this (if any): existing history tests covered message filtering, but not effective default propagation
- If no new test is added, why not:

## User-visible / Behavior Changes

- New chat sessions now show the effective thinking default in the chat header instead of always showing the model fallback label.
- Reasoning blocks in the Web UI now follow the effective reasoning state returned by the gateway for the active session.
- No new configuration knobs were introduced.

## Diagram (if applicable)

```text
Before:
[new session]
  -> [gateway resolves effective defaults]
  -> [UI reads persisted row only]
  -> [header label / reasoning visibility can disagree with runtime]

After:
[new session]
  -> [gateway returns effective thinking + reasoning in chat.history]
  -> [UI stores effective chat state]
  -> [header label / reasoning visibility match runtime]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local pnpm/vitest
- Model/provider: default gateway test config (`anthropic/claude-opus-4-6`)
- Integration/channel (if any): Web UI chat + gateway RPC
- Relevant config (redacted): agent/session defaults exercised through gateway test config and UI history loading

### Steps

1. Create or open a chat session without persisted `thinkingLevel` / `reasoningLevel` overrides.
2. Load chat history in the Web UI.
3. Compare the header default label and reasoning visibility with the gateway's effective defaults.

### Expected

- The chat header should reflect the effective thinking default, and reasoning visibility should follow the effective resolved reasoning level.

### Actual

- Before this change, the header default label and reasoning visibility could still reflect fallback row/model state instead of the active resolved defaults.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted vitest run for `src/gateway/server.chat.gateway-server-chat.test.ts`, `ui/src/ui/controllers/chat.test.ts`, `ui/src/ui/app-render.helpers.node.test.ts`, `ui/src/ui/views/chat.test.ts`, and `ui/src/ui/views/chat.browser.test.ts`
- Edge cases checked: fresh agent session defaults, reasoning hidden when effective level is off, reasoning shown when effective level is on, session-switch reset of effective reasoning state
- What you did **not** verify: full repo-wide `pnpm check` / `pnpm test`, a browser recording of the live Web UI, or the separate `config.patch` issue mentioned in #64830

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: `chat.history` now carries one more effective field, and consumers could accidentally treat it as a persisted override
  - Mitigation: the UI still keeps persisted overrides separate and only uses the new field for active-session display state
- Risk: reasoning visibility could diverge from runtime if the gateway defaulting logic drifted again
  - Mitigation: the new gateway regression test and UI tests lock the effective-default path together

AI-assisted: Yes (Codex). Testing: targeted vitest coverage listed above. I attempted `codex review --base origin/main`, but the local Codex CLI is currently rate-limited.
