### PR TITLE
fix(android): preserve websocket transport and reduce pairing churn

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -126,9 +126,9 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
     )
   }
 
-  val setupResolvedEndpoint = remember(setupCode) { decodeGatewaySetupCode(setupCode)?.url?.let { parseGatewayEndpoint(it)?.displayUrl } }
+  val setupResolvedEndpoint = remember(setupCode) { decodeGatewaySetupCode(setupCode)?.url?.let { parseGatewayEndpoint(it)?.transportUrl } }
   val manualResolvedEndpoint = remember(manualHostInput, manualPortInput, manualTlsInput) {
-    composeGatewayManualUrl(manualHostInput, manualPortInput, manualTlsInput)?.let { parseGatewayEndpoint(it)?.displayUrl }
+    composeGatewayManualUrl(manualHostInput, manualPortInput, manualTlsInput)?.let { parseGatewayEndpoint(it)?.transportUrl }
   }
 
   val activeEndpoint =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -15,6 +15,7 @@ internal data class GatewayEndpointConfig(
   val port: Int,
   val tls: Boolean,
   val displayUrl: String,
+  val transportUrl: String,
 )
 
 internal data class GatewaySetupCode(
@@ -166,9 +167,21 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
     } else {
       "${if (tls) "https" else "http"}://$displayHost:$port"
     }
+  val transportUrl =
+    if (port == defaultPort) {
+      "${if (tls) "wss" else "ws"}://$displayHost"
+    } else {
+      "${if (tls) "wss" else "ws"}://$displayHost:$port"
+    }
 
   return GatewayEndpointParseResult(
-    config = GatewayEndpointConfig(host = host, port = port, tls = tls, displayUrl = displayUrl),
+    config = GatewayEndpointConfig(
+      host = host,
+      port = port,
+      tls = tls,
+      displayUrl = displayUrl,
+      transportUrl = transportUrl,
+    ),
   )
 }
 
@@ -250,7 +263,7 @@ internal fun composeGatewayManualUrl(hostInput: String, portInput: String, tls: 
     portTrimmed.toIntOrNull() ?: return null
   }
   if (port !in 1..65535) return null
-  val scheme = if (tls) "https" else "http"
+  val scheme = if (tls) "wss" else "ws"
   return "$scheme://$host:$port"
 }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -153,7 +153,6 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
       "ws", "http" -> 18789
       else -> 443
     }
-  val standardTransportPort = if (tls) 443 else 80
   val displayPort =
     when (scheme) {
       "wss", "https" -> 443
@@ -169,8 +168,8 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
       "${if (tls) "https" else "http"}://$displayHost:$port"
     }
   val transportUrl =
-    if (port == standardTransportPort) {
-      "${if (tls) "wss" else "ws"}://$displayHost"
+    if (tls && port == 443) {
+      "wss://$displayHost"
     } else {
       "${if (tls) "wss" else "ws"}://$displayHost:$port"
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayConfigResolver.kt
@@ -153,6 +153,7 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
       "ws", "http" -> 18789
       else -> 443
     }
+  val standardTransportPort = if (tls) 443 else 80
   val displayPort =
     when (scheme) {
       "wss", "https" -> 443
@@ -168,7 +169,7 @@ internal fun parseGatewayEndpoint(rawInput: String): GatewayEndpointConfig? {
       "${if (tls) "https" else "http"}://$displayHost:$port"
     }
   val transportUrl =
-    if (port == defaultPort) {
+    if (port == standardTransportPort) {
       "${if (tls) "wss" else "ws"}://$displayHost"
     } else {
       "${if (tls) "wss" else "ws"}://$displayHost:$port"

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayPairingRetry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayPairingRetry.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -14,6 +15,10 @@ import kotlinx.coroutines.delay
 
 internal const val PAIRING_AUTO_RETRY_MS = 6_000L
 
+internal fun shouldTriggerPairingRetry(previousPairingRequired: Boolean, pairingRequired: Boolean): Boolean {
+  return pairingRequired && !previousPairingRequired
+}
+
 @Composable
 internal fun PairingAutoRetryEffect(enabled: Boolean, onRetry: () -> Unit) {
   val lifecycleOwner = LocalLifecycleOwner.current
@@ -21,11 +26,16 @@ internal fun PairingAutoRetryEffect(enabled: Boolean, onRetry: () -> Unit) {
     remember(lifecycleOwner) {
       mutableStateOf(lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED))
     }
+  var previousEnabled by remember { mutableStateOf(false) }
+  var retryGeneration by remember { mutableIntStateOf(0) }
 
   DisposableEffect(lifecycleOwner) {
     val observer =
-      LifecycleEventObserver { _, _ ->
+      LifecycleEventObserver { _, event ->
         lifecycleStarted = lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+        if (event == Lifecycle.Event.ON_START) {
+          retryGeneration += 1
+        }
       }
     lifecycleOwner.lifecycle.addObserver(observer)
     onDispose {
@@ -33,13 +43,13 @@ internal fun PairingAutoRetryEffect(enabled: Boolean, onRetry: () -> Unit) {
     }
   }
 
-  LaunchedEffect(enabled, lifecycleStarted) {
-    if (!enabled || !lifecycleStarted) {
+  LaunchedEffect(enabled, lifecycleStarted, retryGeneration) {
+    val shouldRetry = shouldTriggerPairingRetry(previousEnabled, enabled)
+    previousEnabled = enabled
+    if (!shouldRetry || !lifecycleStarted) {
       return@LaunchedEffect
     }
-    while (true) {
-      delay(PAIRING_AUTO_RETRY_MS)
-      onRetry()
-    }
+    delay(PAIRING_AUTO_RETRY_MS)
+    onRetry()
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayPairingRetry.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/GatewayPairingRetry.kt
@@ -45,8 +45,15 @@ internal fun PairingAutoRetryEffect(enabled: Boolean, onRetry: () -> Unit) {
 
   LaunchedEffect(enabled, lifecycleStarted, retryGeneration) {
     val shouldRetry = shouldTriggerPairingRetry(previousEnabled, enabled)
+    if (!enabled) {
+      previousEnabled = false
+      return@LaunchedEffect
+    }
+    if (!lifecycleStarted) {
+      return@LaunchedEffect
+    }
     previousEnabled = enabled
-    if (!shouldRetry || !lifecycleStarted) {
+    if (!shouldRetry) {
       return@LaunchedEffect
     }
     delay(PAIRING_AUTO_RETRY_MS)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -839,7 +839,7 @@ fun OnboardingFlow(viewModel: MainViewModel, modifier: Modifier = Modifier) {
                       )
                     return@Button
                   }
-                  gatewayUrl = parsedGateway.config.displayUrl
+                  gatewayUrl = parsedGateway.config.transportUrl
                   viewModel.setGatewayBootstrapToken("")
                 }
                 step = OnboardingStep.Permissions
@@ -1058,8 +1058,8 @@ private fun GatewayStep(
   onTokenChange: (String) -> Unit,
   onPasswordChange: (String) -> Unit,
 ) {
-  val resolvedEndpoint = remember(setupCode) { decodeGatewaySetupCode(setupCode)?.url?.let { parseGatewayEndpoint(it)?.displayUrl } }
-  val manualResolvedEndpoint = remember(manualHost, manualPort, manualTls) { composeGatewayManualUrl(manualHost, manualPort, manualTls)?.let { parseGatewayEndpoint(it)?.displayUrl } }
+  val resolvedEndpoint = remember(setupCode) { decodeGatewaySetupCode(setupCode)?.url?.let { parseGatewayEndpoint(it)?.transportUrl } }
+  val manualResolvedEndpoint = remember(manualHost, manualPort, manualTls) { composeGatewayManualUrl(manualHost, manualPort, manualTls)?.let { parseGatewayEndpoint(it)?.transportUrl } }
 
   StepShell(title = "Gateway Connection") {
     Text(
@@ -1584,7 +1584,7 @@ private fun FinalStep(
   methodLabel: String,
 ) {
   val context = androidx.compose.ui.platform.LocalContext.current
-  val gatewayAddress = parsedGateway?.displayUrl ?: "Invalid gateway URL"
+  val gatewayAddress = parsedGateway?.transportUrl ?: "Invalid gateway URL"
   val statusLabel = gatewayStatusForDisplay(statusText)
   val showDiagnostics = gatewayStatusHasDiagnostics(statusText)
   val pairingRequired = gatewayStatusLooksLikePairing(statusText)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -217,7 +217,23 @@ class GatewayConfigResolverTest {
         port = 80,
         tls = false,
         displayUrl = "http://localhost:80",
-        transportUrl = "ws://localhost",
+        transportUrl = "ws://localhost:80",
+      ),
+      parsed,
+    )
+  }
+
+  @Test
+  fun parseGatewayEndpointPreservesExplicitCleartextPort80InTransportUrl() {
+    val parsed = parseGatewayEndpoint("ws://localhost:80")
+
+    assertEquals(
+      GatewayEndpointConfig(
+        host = "localhost",
+        port = 80,
+        tls = false,
+        displayUrl = "http://localhost:80",
+        transportUrl = "ws://localhost:80",
       ),
       parsed,
     )

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -19,6 +19,7 @@ class GatewayConfigResolverTest {
         port = 443,
         tls = true,
         displayUrl = "https://gateway.example",
+        transportUrl = "wss://gateway.example",
       ),
       parsed,
     )
@@ -48,6 +49,7 @@ class GatewayConfigResolverTest {
         port = 443,
         tls = true,
         displayUrl = "https://gateway.example",
+        transportUrl = "wss://gateway.example",
       ),
       parsed,
     )
@@ -63,6 +65,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://127.0.0.1:18789",
+        transportUrl = "ws://127.0.0.1",
       ),
       parsed,
     )
@@ -78,6 +81,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://localhost:18789",
+        transportUrl = "ws://localhost",
       ),
       parsed,
     )
@@ -93,6 +97,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://10.0.2.2:18789",
+        transportUrl = "ws://10.0.2.2",
       ),
       parsed,
     )
@@ -108,6 +113,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://192.168.1.20:18789",
+        transportUrl = "ws://192.168.1.20",
       ),
       parsed,
     )
@@ -123,6 +129,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://gateway.local:18789",
+        transportUrl = "ws://gateway.local",
       ),
       parsed,
     )
@@ -136,6 +143,7 @@ class GatewayConfigResolverTest {
     assertEquals(18789, parsed?.port)
     assertEquals(false, parsed?.tls)
     assertEquals("http://[::1]:18789", parsed?.displayUrl)
+    assertEquals("ws://[::1]", parsed?.transportUrl)
   }
 
   @Test
@@ -146,6 +154,7 @@ class GatewayConfigResolverTest {
     assertEquals(18789, parsed?.port)
     assertEquals(false, parsed?.tls)
     assertEquals("http://[::ffff:127.0.0.1]:18789", parsed?.displayUrl)
+    assertEquals("ws://[::ffff:127.0.0.1]", parsed?.transportUrl)
   }
 
   @Test
@@ -170,6 +179,7 @@ class GatewayConfigResolverTest {
     assertEquals(18789, parsed?.port)
     assertEquals(false, parsed?.tls)
     assertEquals("http://[fe80::1%25eth0]:18789", parsed?.displayUrl)
+    assertEquals("ws://[fe80::1%25eth0]", parsed?.transportUrl)
   }
 
   @Test
@@ -180,6 +190,7 @@ class GatewayConfigResolverTest {
     assertEquals(443, parsed?.port)
     assertEquals(true, parsed?.tls)
     assertEquals("https://[fe80::1%25wlan0]", parsed?.displayUrl)
+    assertEquals("wss://[fe80::1%25wlan0]", parsed?.transportUrl)
   }
 
   @Test
@@ -206,6 +217,7 @@ class GatewayConfigResolverTest {
         port = 80,
         tls = false,
         displayUrl = "http://localhost:80",
+        transportUrl = "ws://localhost:80",
       ),
       parsed,
     )
@@ -299,6 +311,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://192.168.1.20:18789",
+        transportUrl = "ws://192.168.1.20",
       ),
       parsed.config,
     )
@@ -468,7 +481,7 @@ class GatewayConfigResolverTest {
   fun composeGatewayManualUrlDefaultsPortTo443WhenTlsAndPortBlank() {
     val url = composeGatewayManualUrl("mydevice.tail1234.ts.net", "", tls = true)
 
-    assertEquals("https://mydevice.tail1234.ts.net:443", url)
+    assertEquals("wss://mydevice.tail1234.ts.net:443", url)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayConfigResolverTest.kt
@@ -65,7 +65,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://127.0.0.1:18789",
-        transportUrl = "ws://127.0.0.1",
+        transportUrl = "ws://127.0.0.1:18789",
       ),
       parsed,
     )
@@ -81,7 +81,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://localhost:18789",
-        transportUrl = "ws://localhost",
+        transportUrl = "ws://localhost:18789",
       ),
       parsed,
     )
@@ -97,7 +97,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://10.0.2.2:18789",
-        transportUrl = "ws://10.0.2.2",
+        transportUrl = "ws://10.0.2.2:18789",
       ),
       parsed,
     )
@@ -113,7 +113,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://192.168.1.20:18789",
-        transportUrl = "ws://192.168.1.20",
+        transportUrl = "ws://192.168.1.20:18789",
       ),
       parsed,
     )
@@ -129,7 +129,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://gateway.local:18789",
-        transportUrl = "ws://gateway.local",
+        transportUrl = "ws://gateway.local:18789",
       ),
       parsed,
     )
@@ -143,7 +143,7 @@ class GatewayConfigResolverTest {
     assertEquals(18789, parsed?.port)
     assertEquals(false, parsed?.tls)
     assertEquals("http://[::1]:18789", parsed?.displayUrl)
-    assertEquals("ws://[::1]", parsed?.transportUrl)
+    assertEquals("ws://[::1]:18789", parsed?.transportUrl)
   }
 
   @Test
@@ -154,7 +154,7 @@ class GatewayConfigResolverTest {
     assertEquals(18789, parsed?.port)
     assertEquals(false, parsed?.tls)
     assertEquals("http://[::ffff:127.0.0.1]:18789", parsed?.displayUrl)
-    assertEquals("ws://[::ffff:127.0.0.1]", parsed?.transportUrl)
+    assertEquals("ws://[::ffff:127.0.0.1]:18789", parsed?.transportUrl)
   }
 
   @Test
@@ -179,7 +179,7 @@ class GatewayConfigResolverTest {
     assertEquals(18789, parsed?.port)
     assertEquals(false, parsed?.tls)
     assertEquals("http://[fe80::1%25eth0]:18789", parsed?.displayUrl)
-    assertEquals("ws://[fe80::1%25eth0]", parsed?.transportUrl)
+    assertEquals("ws://[fe80::1%25eth0]:18789", parsed?.transportUrl)
   }
 
   @Test
@@ -217,7 +217,7 @@ class GatewayConfigResolverTest {
         port = 80,
         tls = false,
         displayUrl = "http://localhost:80",
-        transportUrl = "ws://localhost:80",
+        transportUrl = "ws://localhost",
       ),
       parsed,
     )
@@ -311,7 +311,7 @@ class GatewayConfigResolverTest {
         port = 18789,
         tls = false,
         displayUrl = "http://192.168.1.20:18789",
-        transportUrl = "ws://192.168.1.20",
+        transportUrl = "ws://192.168.1.20:18789",
       ),
       parsed.config,
     )

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayPairingRetryLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayPairingRetryLogicTest.kt
@@ -19,4 +19,12 @@ class GatewayPairingRetryLogicTest {
   fun blocksRetryWhenPairingIsNotRequired() {
     assertFalse(shouldTriggerPairingRetry(previousPairingRequired = false, pairingRequired = false))
   }
+
+  @Test
+  fun preservesPendingRetryWhenPairingStartsWhileStopped() {
+    val shouldRetryWhileStopped = shouldTriggerPairingRetry(previousPairingRequired = false, pairingRequired = true)
+    assertTrue(shouldRetryWhileStopped)
+    val shouldRetryAfterResume = shouldTriggerPairingRetry(previousPairingRequired = false, pairingRequired = true)
+    assertTrue(shouldRetryAfterResume)
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayPairingRetryLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/GatewayPairingRetryLogicTest.kt
@@ -1,0 +1,22 @@
+package ai.openclaw.app.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GatewayPairingRetryLogicTest {
+  @Test
+  fun allowsSingleRetryWhenPairingStarts() {
+    assertTrue(shouldTriggerPairingRetry(previousPairingRequired = false, pairingRequired = true))
+  }
+
+  @Test
+  fun blocksRepeatedRetryWhilePairingStateIsUnchanged() {
+    assertFalse(shouldTriggerPairingRetry(previousPairingRequired = true, pairingRequired = true))
+  }
+
+  @Test
+  fun blocksRetryWhenPairingIsNotRequired() {
+    assertFalse(shouldTriggerPairingRetry(previousPairingRequired = false, pairingRequired = false))
+  }
+}

--- a/docs/cli/qr.md
+++ b/docs/cli/qr.md
@@ -50,3 +50,4 @@ openclaw qr --url wss://gateway.example/ws
 - After scanning, approve device pairing with:
   - `openclaw devices list`
   - `openclaw devices approve <requestId>`
+- During onboarding, a valid gateway route can still surface `pairing required` until you approve the pending request. If you see repeated fresh requests, that is client retry churn, not a routing failure. Approve the newest pending request and prefer the latest Android build with the pairing retry fix.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2859,8 +2859,11 @@ Related: [/concepts/oauth](/concepts/oauth) (OAuth flows, token storage, multi-a
     Quick fixes:
 
     1. Use the WS URL: `ws://<host>:18789` (or `wss://...` if HTTPS).
-    2. Don't open the WS port in a normal browser tab.
-    3. If auth is on, include the token/password in the `connect` frame.
+    2. For Tailscale/public mobile pairing, do not use raw `ws://` tailnet/public URLs. Use Tailscale Serve/Funnel or another `wss://` route.
+    3. Don't open the WS port in a normal browser tab.
+    4. If auth is on, include the token/password in the `connect` frame.
+
+    If mobile onboarding reaches `pairing required`, the route is usually working and the next step is approving the pending device request. Repeatedly rotating pending requests points to client retry churn rather than a transport failure.
 
     If you're using the CLI or TUI, the URL should look like:
 


### PR DESCRIPTION
## Summary

This PR started as the Android transport fix for gateway setup codes and manual gateway URLs that carried `wss://` / `ws://`, but were still being normalized into HTTP-facing URLs in actual transport flows.

Live testing over Tailscale Serve exposed a second Android UX issue after the transport path was fixed: once the phone could actually reach the gateway, the onboarding/connect UI kept auto-retrying on `pairing required`, which created repeated pending pairing requests and made approval racey.

This branch now fixes both issues.

## What changed

### 1. Preserve WebSocket transport URLs

- keep a distinct `transportUrl` alongside the human-facing `displayUrl`
- use `transportUrl` in Android onboarding/connect flows when dialing the gateway
- keep `displayUrl` as `http(s)://...` for presentation only
- preserve explicit non-default WebSocket ports in `transportUrl`
  - omit only standard defaults (`ws:80`, `wss:443`)
  - keep `:18789` for `ws://...:18789`

### 2. Reduce pairing-request churn

- stop looping auto-retries forever while the UI remains in the same `pairing required` state
- retry once when pairing first becomes required, instead of generating a new pending request every few seconds

## User-visible effect

Before:
- `wss://...` setup codes could be used as `https://...` during transport, causing failures like:
  - `Expected HTTP 101 response but was '200 OK'`
- after the route was corrected, Android could still create rapidly rotating pending pairing requests during onboarding

After:
- Android preserves the correct WebSocket transport URL
- `pairing required` means the route is working and approval is the next step
- the app no longer churns fresh pairing requests continuously while waiting for approval

## Validation

```bash
./gradlew :app:testPlayDebugUnitTest \
  --tests ai.openclaw.app.ui.GatewayConfigResolverTest \
  --tests ai.openclaw.app.ui.GatewayPairingRetryLogicTest \
  --tests ai.openclaw.app.ui.OnboardingFlowLogicTest \
  :app:assemblePlayDebug
```

Live-tested against a gateway behind Tailscale Serve.
