### PR TITLE
feat: split model routing for tool-call turns

### DIFF
--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveAgentModelFallbackValues } from "../config/model-input.js";
+import { resolveAgentModelFallbackValues, resolveAgentModelToolValue } from "../config/model-input.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.js";
 import {
@@ -109,6 +109,44 @@ export function resolveAgentEffectiveModelPrimary(
 // Backward-compatible alias. Prefer explicit/effective helpers at new call sites.
 export function resolveAgentModelPrimary(cfg: OpenClawConfig, agentId: string): string | undefined {
   return resolveAgentExplicitModelPrimary(cfg, agentId);
+}
+
+export function resolveAgentExplicitModelTool(
+  cfg: OpenClawConfig,
+  agentId: string,
+): string | undefined {
+  const raw = resolveAgentConfig(cfg, agentId)?.model;
+  return resolveAgentModelToolValue(raw);
+}
+
+export function resolveAgentEffectiveModelTool(
+  cfg: OpenClawConfig,
+  agentId: string,
+): string | undefined {
+  return (
+    resolveAgentExplicitModelTool(cfg, agentId) ??
+    resolveAgentModelToolValue(cfg.agents?.defaults?.model)
+  );
+}
+
+/**
+ * Check whether split model routing is configured for the given agent.
+ * Returns the tool model reference string (e.g. "anthropic/claude-sonnet-4-20250514")
+ * or undefined when not configured.
+ */
+export function resolveConfiguredToolModel(params: {
+  cfg: OpenClawConfig | undefined;
+  agentId?: string | null;
+  sessionKey?: string | null;
+}): string | undefined {
+  if (!params.cfg) {
+    return undefined;
+  }
+  const agentId = resolveFallbackAgentId({
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+  return resolveAgentEffectiveModelTool(params.cfg, agentId);
 }
 
 export function resolveAgentModelFallbacksOverride(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -15,6 +15,7 @@ import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import {
   hasConfiguredModelFallbacks,
   resolveAgentExecutionContract,
+  resolveConfiguredToolModel,
   resolveSessionAgentIds,
 } from "../agent-scope.js";
 import {
@@ -47,6 +48,7 @@ import {
   shouldPreferExplicitConfigApiKeyAuth,
 } from "../model-auth.js";
 import { normalizeProviderId } from "../model-selection.js";
+import { parseModelRef } from "../model-selection-normalize.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { disposeSessionMcpRuntime } from "../pi-bundle-mcp-tools.js";
 import {
@@ -288,6 +290,45 @@ export async function runEmbeddedPiAgent(
         });
       }
       let runtimeModel = model;
+
+      // ── Split model routing: resolve tool model ──────────────────────
+      const toolModelRef = resolveConfiguredToolModel({
+        cfg: params.config,
+        agentId: params.agentId,
+        sessionKey: params.sessionKey,
+      });
+      let resolvedToolModel: typeof model | undefined;
+      let toolModelProvider: string | undefined;
+      let toolModelIdResolved: string | undefined;
+      if (toolModelRef) {
+        const parsed = parseModelRef(toolModelRef, provider);
+        if (parsed) {
+          toolModelProvider = parsed.provider;
+          toolModelIdResolved = parsed.model;
+          const toolModelResult = await resolveModelAsync(
+            parsed.provider,
+            parsed.model,
+            agentDir,
+            params.config,
+            { authStorage, modelRegistry },
+          );
+          if (toolModelResult.model) {
+            resolvedToolModel = toolModelResult.model;
+            log.info(
+              `split-model routing enabled: primary=${provider}/${modelId} tool=${parsed.provider}/${parsed.model}`,
+            );
+          } else {
+            log.warn(
+              `split-model routing: tool model ${toolModelRef} could not be resolved: ${toolModelResult.error ?? "unknown error"}; using primary model for all turns`,
+            );
+          }
+        } else {
+          log.warn(
+            `split-model routing: could not parse tool model ref "${toolModelRef}"; using primary model for all turns`,
+          );
+        }
+      }
+      // ────────────────────────────────────────────────────────────────
 
       const resolvedRuntimeModel = resolveEffectiveRuntimeModel({
         cfg: params.config,
@@ -682,6 +723,9 @@ export async function runEmbeddedPiAgent(
             initialReplayState: accumulatedReplayState,
             authStorage,
             modelRegistry,
+            toolModel: resolvedToolModel,
+            toolModelProvider,
+            toolModelId: toolModelIdResolved,
             agentId: workspaceResolution.agentId,
             legacyBeforeAgentStartResult,
             thinkLevel,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -154,6 +154,7 @@ import {
   resolveEmbeddedAgentBaseStreamFn,
   resolveEmbeddedAgentStreamFn,
 } from "../stream-resolution.js";
+import { wrapStreamFnWithSplitModelRouting } from "../split-model-stream.js";
 import {
   applySystemPromptOverrideToSession,
   buildEmbeddedSystemPrompt,
@@ -1278,6 +1279,20 @@ export async function runEmbeddedAttempt(
       activeSession.agent.streamFn = wrapStreamFnHandleSensitiveStopReason(
         activeSession.agent.streamFn,
       );
+
+      // ── Split model routing ────────────────────────────────────────
+      // When a tool model is configured, wrap the streamFn so that
+      // tool-continuation turns (where the last message is a tool result)
+      // are routed to the tool model instead of the primary model.
+      if (params.toolModel && params.toolModelProvider) {
+        activeSession.agent.streamFn = wrapStreamFnWithSplitModelRouting({
+          innerStreamFn: activeSession.agent.streamFn,
+          toolModel: params.toolModel,
+          primaryProvider: params.provider,
+          toolProvider: params.toolModelProvider,
+        });
+      }
+      // ──────────────────────────────────────────────────────────────
 
       let idleTimeoutTrigger: ((error: Error) => void) | undefined;
 

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -33,6 +33,13 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   provider: string;
   modelId: string;
   model: Model<Api>;
+  /** Resolved tool model for split model routing. When set, tool-continuation
+   *  turns are routed to this model instead of the primary. */
+  toolModel?: Model<Api>;
+  /** Provider id for the tool model (e.g. "anthropic"). */
+  toolModelProvider?: string;
+  /** Model id for the tool model (e.g. "claude-sonnet-4-20250514"). */
+  toolModelId?: string;
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
   thinkLevel: ThinkLevel;

--- a/src/agents/pi-embedded-runner/split-model-stream.test.ts
+++ b/src/agents/pi-embedded-runner/split-model-stream.test.ts
@@ -1,0 +1,194 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Api, Context, Model } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { wrapStreamFnWithSplitModelRouting } from "./split-model-stream.js";
+
+function createMockModel(overrides: Partial<Model<Api>>): Model<Api> {
+  return {
+    api: "anthropic-messages",
+    provider: "anthropic",
+    id: "claude-sonnet-4-20250514",
+    name: "anthropic/claude-sonnet-4-20250514",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 8192,
+    ...overrides,
+  } as Model<Api>;
+}
+
+describe("split model routing stream wrapper", () => {
+  it("routes chat turns to the primary model", () => {
+    const calls: Array<{ modelId: string }> = [];
+    const baseStreamFn: StreamFn = (model, _context, _options) => {
+      calls.push({ modelId: (model as Model<Api>).id });
+      return createAssistantMessageEventStream();
+    };
+
+    const primaryModel = createMockModel({ id: "qwen2.5-7b", provider: "ollama" });
+    const toolModel = createMockModel({ id: "claude-sonnet-4-20250514", provider: "anthropic" });
+
+    const wrapped = wrapStreamFnWithSplitModelRouting({
+      innerStreamFn: baseStreamFn,
+      toolModel,
+      primaryProvider: "ollama",
+      toolProvider: "anthropic",
+    });
+
+    // Chat turn: last message is from user
+    const chatContext: Context = {
+      messages: [{ role: "user", content: "Hello" }],
+    };
+    void wrapped(primaryModel, chatContext, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].modelId).toBe("qwen2.5-7b");
+  });
+
+  it("routes tool-continuation turns to the tool model", () => {
+    const calls: Array<{ modelId: string }> = [];
+    const baseStreamFn: StreamFn = (model, _context, _options) => {
+      calls.push({ modelId: (model as Model<Api>).id });
+      return createAssistantMessageEventStream();
+    };
+
+    const primaryModel = createMockModel({ id: "qwen2.5-7b", provider: "ollama" });
+    const toolModel = createMockModel({ id: "claude-sonnet-4-20250514", provider: "anthropic" });
+
+    const wrapped = wrapStreamFnWithSplitModelRouting({
+      innerStreamFn: baseStreamFn,
+      toolModel,
+      primaryProvider: "ollama",
+      toolProvider: "anthropic",
+    });
+
+    // Tool continuation: last message is a tool result
+    const toolContext: Context = {
+      messages: [
+        { role: "user", content: "Read the file" },
+        {
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tc_1", name: "read", input: {} }],
+        },
+        { role: "tool", content: "file contents here" },
+      ],
+    };
+    void wrapped(primaryModel, toolContext, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].modelId).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("routes toolResult role messages to the tool model", () => {
+    const calls: Array<{ modelId: string }> = [];
+    const baseStreamFn: StreamFn = (model, _context, _options) => {
+      calls.push({ modelId: (model as Model<Api>).id });
+      return createAssistantMessageEventStream();
+    };
+
+    const primaryModel = createMockModel({ id: "qwen2.5-7b", provider: "ollama" });
+    const toolModel = createMockModel({ id: "claude-sonnet-4-20250514", provider: "anthropic" });
+
+    const wrapped = wrapStreamFnWithSplitModelRouting({
+      innerStreamFn: baseStreamFn,
+      toolModel,
+      primaryProvider: "ollama",
+      toolProvider: "anthropic",
+    });
+
+    // Some providers use "toolResult" role instead of "tool"
+    const toolResultContext: Context = {
+      messages: [
+        { role: "user", content: "Read the file" },
+        { role: "toolResult", content: "file contents here" },
+      ],
+    };
+    void wrapped(primaryModel, toolResultContext, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].modelId).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("returns to primary model after tool continuation completes", () => {
+    const calls: Array<{ modelId: string }> = [];
+    const baseStreamFn: StreamFn = (model, _context, _options) => {
+      calls.push({ modelId: (model as Model<Api>).id });
+      return createAssistantMessageEventStream();
+    };
+
+    const primaryModel = createMockModel({ id: "qwen2.5-7b", provider: "ollama" });
+    const toolModel = createMockModel({ id: "claude-sonnet-4-20250514", provider: "anthropic" });
+
+    const wrapped = wrapStreamFnWithSplitModelRouting({
+      innerStreamFn: baseStreamFn,
+      toolModel,
+      primaryProvider: "ollama",
+      toolProvider: "anthropic",
+    });
+
+    // First: tool continuation turn
+    void wrapped(primaryModel, {
+      messages: [{ role: "tool", content: "result" }],
+    } as Context, {});
+
+    // Second: back to chat turn
+    void wrapped(primaryModel, {
+      messages: [{ role: "user", content: "Thanks" }],
+    } as Context, {});
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].modelId).toBe("claude-sonnet-4-20250514");
+    expect(calls[1].modelId).toBe("qwen2.5-7b");
+  });
+
+  it("uses primary model when messages are empty", () => {
+    const calls: Array<{ modelId: string }> = [];
+    const baseStreamFn: StreamFn = (model, _context, _options) => {
+      calls.push({ modelId: (model as Model<Api>).id });
+      return createAssistantMessageEventStream();
+    };
+
+    const primaryModel = createMockModel({ id: "qwen2.5-7b", provider: "ollama" });
+    const toolModel = createMockModel({ id: "claude-sonnet-4-20250514", provider: "anthropic" });
+
+    const wrapped = wrapStreamFnWithSplitModelRouting({
+      innerStreamFn: baseStreamFn,
+      toolModel,
+      primaryProvider: "ollama",
+      toolProvider: "anthropic",
+    });
+
+    void wrapped(primaryModel, { messages: [] } as Context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].modelId).toBe("qwen2.5-7b");
+  });
+
+  it("passes through options unchanged", () => {
+    const capturedOptions: unknown[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      capturedOptions.push(options);
+      return createAssistantMessageEventStream();
+    };
+
+    const primaryModel = createMockModel({ id: "qwen2.5-7b", provider: "ollama" });
+    const toolModel = createMockModel({ id: "claude-sonnet-4-20250514", provider: "anthropic" });
+
+    const wrapped = wrapStreamFnWithSplitModelRouting({
+      innerStreamFn: baseStreamFn,
+      toolModel,
+      primaryProvider: "ollama",
+      toolProvider: "anthropic",
+    });
+
+    const opts = { temperature: 0.7 };
+    void wrapped(primaryModel, {
+      messages: [{ role: "tool", content: "result" }],
+    } as Context, opts);
+
+    expect(capturedOptions).toHaveLength(1);
+    expect(capturedOptions[0]).toBe(opts);
+  });
+});

--- a/src/agents/pi-embedded-runner/split-model-stream.ts
+++ b/src/agents/pi-embedded-runner/split-model-stream.ts
@@ -1,0 +1,66 @@
+import type { Api, Model } from "@mariozechner/pi-ai";
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+
+const log = createSubsystemLogger("split-model-routing");
+
+/**
+ * Detects whether the current LLM call is a tool-continuation turn by
+ * inspecting the last message in the conversation context. When the most
+ * recent message has role "tool" or "toolResult", the session is re-prompting
+ * the LLM after executing one or more tool calls.
+ */
+function isToolContinuationTurn(context: unknown): boolean {
+  const ctx = context as { messages?: unknown } | undefined;
+  const messages = ctx?.messages;
+  if (!Array.isArray(messages) || messages.length === 0) {
+    return false;
+  }
+  const lastMessage = messages[messages.length - 1] as AgentMessage | undefined;
+  if (!lastMessage) {
+    return false;
+  }
+  const role = (lastMessage as { role?: string }).role;
+  return role === "tool" || role === "toolResult";
+}
+
+/**
+ * Wraps a StreamFn to route tool-continuation turns to a different model.
+ *
+ * On chat turns (user prompt → assistant response), the primary model is used.
+ * On tool-continuation turns (tool result → assistant re-prompt), the tool model
+ * is substituted so that a capable API model handles tool calls while the primary
+ * (potentially local/cheap) model handles conversational turns.
+ */
+export function wrapStreamFnWithSplitModelRouting(params: {
+  innerStreamFn: StreamFn;
+  toolModel: Model<Api>;
+  primaryProvider: string;
+  toolProvider: string;
+}): StreamFn {
+  const { innerStreamFn, toolModel, primaryProvider, toolProvider } = params;
+  let lastRouteWasTool = false;
+
+  const wrappedStreamFn: StreamFn = (callModel, context, options) => {
+    if (isToolContinuationTurn(context)) {
+      if (!lastRouteWasTool) {
+        log.info(
+          `split-model routing: switching to tool model ${toolProvider}/${toolModel.id} for tool-continuation turn`,
+        );
+      }
+      lastRouteWasTool = true;
+      return innerStreamFn(toolModel, context, options);
+    }
+
+    if (lastRouteWasTool) {
+      log.info(
+        `split-model routing: returning to primary model ${primaryProvider}/${callModel.id} for chat turn`,
+      );
+    }
+    lastRouteWasTool = false;
+    return innerStreamFn(callModel, context, options);
+  };
+
+  return wrappedStreamFn;
+}

--- a/src/config/model-input.split-model.test.ts
+++ b/src/config/model-input.split-model.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveAgentModelToolValue,
+  resolveAgentModelPrimaryValue,
+  resolveAgentModelFallbackValues,
+} from "./model-input.js";
+
+describe("resolveAgentModelToolValue", () => {
+  it("returns undefined for string config", () => {
+    expect(resolveAgentModelToolValue("anthropic/claude-sonnet-4-20250514")).toBeUndefined();
+  });
+
+  it("returns undefined for undefined config", () => {
+    expect(resolveAgentModelToolValue(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when tool is not set", () => {
+    expect(resolveAgentModelToolValue({ primary: "ollama/qwen2.5-7b" })).toBeUndefined();
+  });
+
+  it("returns tool model when configured", () => {
+    expect(
+      resolveAgentModelToolValue({
+        primary: "ollama/qwen2.5-7b",
+        tool: "anthropic/claude-sonnet-4-20250514",
+      }),
+    ).toBe("anthropic/claude-sonnet-4-20250514");
+  });
+
+  it("returns undefined for empty string tool", () => {
+    expect(
+      resolveAgentModelToolValue({
+        primary: "ollama/qwen2.5-7b",
+        tool: "",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only tool", () => {
+    expect(
+      resolveAgentModelToolValue({
+        primary: "ollama/qwen2.5-7b",
+        tool: "   ",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("trims whitespace from tool value", () => {
+    expect(
+      resolveAgentModelToolValue({
+        primary: "ollama/qwen2.5-7b",
+        tool: "  anthropic/claude-sonnet-4-20250514  ",
+      }),
+    ).toBe("anthropic/claude-sonnet-4-20250514");
+  });
+
+  it("coexists with primary and fallbacks", () => {
+    const config = {
+      primary: "ollama/qwen2.5-7b",
+      tool: "anthropic/claude-sonnet-4-20250514",
+      fallbacks: ["openai/gpt-4o"],
+    };
+    expect(resolveAgentModelToolValue(config)).toBe("anthropic/claude-sonnet-4-20250514");
+    expect(resolveAgentModelPrimaryValue(config)).toBe("ollama/qwen2.5-7b");
+    expect(resolveAgentModelFallbackValues(config)).toEqual(["openai/gpt-4o"]);
+  });
+});

--- a/src/config/model-input.ts
+++ b/src/config/model-input.ts
@@ -10,6 +10,13 @@ export function resolveAgentModelPrimaryValue(model?: AgentModelConfig): string 
   return resolvePrimaryStringValue(model);
 }
 
+export function resolveAgentModelToolValue(model?: AgentModelConfig): string | undefined {
+  if (!model || typeof model !== "object") {
+    return undefined;
+  }
+  return typeof model.tool === "string" && model.tool.trim() ? model.tool.trim() : undefined;
+}
+
 export function resolveAgentModelFallbackValues(model?: AgentModelConfig): string[] {
   if (!model || typeof model !== "object") {
     return [];

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -10,6 +10,10 @@ export type AgentModelConfig =
   | {
       /** Primary model (provider/model). */
       primary?: string;
+      /** Model used for tool-call turns (provider/model). When set, the agent loop
+       *  swaps to this model whenever the assistant response triggers tool use,
+       *  then returns to the primary model for subsequent chat turns. */
+      tool?: string;
       /** Per-agent model fallbacks (provider/model). */
       fallbacks?: string[];
     };

--- a/src/config/zod-schema.agent-model.split-model.test.ts
+++ b/src/config/zod-schema.agent-model.split-model.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { AgentModelSchema } from "./zod-schema.agent-model.js";
+
+describe("AgentModelSchema with tool field", () => {
+  it("accepts config with tool model", () => {
+    const result = AgentModelSchema.safeParse({
+      primary: "ollama/qwen2.5-7b",
+      tool: "anthropic/claude-sonnet-4-20250514",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts config with primary, tool, and fallbacks", () => {
+    const result = AgentModelSchema.safeParse({
+      primary: "ollama/qwen2.5-7b",
+      tool: "anthropic/claude-sonnet-4-20250514",
+      fallbacks: ["openai/gpt-4o"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts config with only tool", () => {
+    const result = AgentModelSchema.safeParse({
+      tool: "anthropic/claude-sonnet-4-20250514",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("still accepts string-only config", () => {
+    const result = AgentModelSchema.safeParse("anthropic/claude-sonnet-4-20250514");
+    expect(result.success).toBe(true);
+  });
+
+  it("still accepts config without tool", () => {
+    const result = AgentModelSchema.safeParse({
+      primary: "ollama/qwen2.5-7b",
+      fallbacks: ["openai/gpt-4o"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects unknown fields in strict mode", () => {
+    const result = AgentModelSchema.safeParse({
+      primary: "ollama/qwen2.5-7b",
+      tool: "anthropic/claude-sonnet-4-20250514",
+      unknownField: "bad",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/config/zod-schema.agent-model.ts
+++ b/src/config/zod-schema.agent-model.ts
@@ -5,6 +5,7 @@ export const AgentModelSchema = z.union([
   z
     .object({
       primary: z.string().optional(),
+      tool: z.string().optional(),
       fallbacks: z.array(z.string()).optional(),
     })
     .strict(),


### PR DESCRIPTION
## Summary

- Adds `model.tool` config alongside `model.primary` so tool-call turns route to a different model than chat turns
- Enables cost-efficient setups like local Ollama for chat + Claude API for tool execution
- Wraps the session `StreamFn` to detect tool-continuation turns and swap models transparently

## Motivation

Small local models (7b-14b) are fast and free but can't reliably use tools. API models handle tools perfectly but cost money. This feature lets users get the best of both worlds within a single conversation:

```json
{
  "agents": {
    "defaults": {
      "model": {
        "primary": "ollama/qwen2.5-7b-fast",
        "tool": "anthropic/claude-sonnet-4-20250514"
      }
    }
  }
}
```

Chat turns use the primary model. When the assistant triggers tool use, the tool model handles tool-call turns. Multi-step tool chains stay on the tool model until the chain completes.

## Changes

**Config layer:**
- `src/config/types.agents-shared.ts` — Added `tool?: string` to `AgentModelConfig`
- `src/config/zod-schema.agent-model.ts` — Added `tool` to zod schema (`.strict()` preserved)
- `src/config/model-input.ts` — Added `resolveAgentModelToolValue()` resolver

**Resolution layer:**
- `src/agents/agent-scope.ts` — Added `resolveConfiguredToolModel()` with per-agent override + global defaults

**Routing layer:**
- `src/agents/pi-embedded-runner/split-model-stream.ts` — New `StreamFn` wrapper that detects tool-continuation turns (last message role is `"tool"` or `"toolResult"`) and routes to the tool model
- `src/agents/pi-embedded-runner/run.ts` — Resolves tool model alongside primary, passes through to attempt
- `src/agents/pi-embedded-runner/run/types.ts` — Added optional `toolModel`, `toolModelProvider`, `toolModelId` to attempt params
- `src/agents/pi-embedded-runner/run/attempt.ts` — Wires split model wrapper into the `streamFn` chain

## How it works

```
User prompt → Primary Model (local/cheap)
                    │
                    ├─ No tool calls → respond directly
                    │
                    └─ Tool calls detected → Tool Model (API/capable)
                                                  │
                                                  ├─ More tool calls → stay on tool model
                                                  └─ Done → next user turn uses primary
```

The routing is implemented as a `StreamFn` wrapper positioned after message sanitization but before timeout detection in the wrapper chain. This means tool-continuation turns get all the same message cleanup (thinking block removal, tool call ID sanitization, etc.) before the routing decision.

## Test plan

- [x] 8 tests for `resolveAgentModelToolValue()` config resolver
- [x] 6 tests for `AgentModelSchema` zod validation with `tool` field
- [x] 6 tests for `wrapStreamFnWithSplitModelRouting()` stream wrapper (chat routing, tool routing, model swap-back, empty messages, options passthrough)
- [ ] Manual integration test with Ollama primary + Anthropic tool model
- [ ] Full `pnpm build && pnpm check && pnpm test` (in progress)

## Known limitations

1. **Context window mismatch**: Session uses primary model's context budget for compaction regardless of which model is active
2. **Auth profile routing**: Tool model uses primary model's auth resolution; separate auth profiles not yet supported
3. **Fallback interaction**: Tool model failures fall back to primary's fallback chain, not a tool-specific chain

## AI-assisted PR 🤖

- [x] **AI-assisted**: Built with Claude Code (Claude Opus 4.6)
- [x] **Degree of testing**: Unit tests fully passing (20/20). Manual integration test pending.
- [x] **I understand what the code does**: The `StreamFn` wrapper intercepts every LLM call within the session's tool-execution loop. It checks if the last message in the conversation context has role `"tool"` or `"toolResult"` — if so, the tool model `Model` object is substituted for the primary. The wrapper is stateless per-call (inspects messages each time) and positioned in the streamFn chain after message sanitization but before timeout/logging wrappers.
- [x] Session logs available on request

🤖 Generated with [Claude Code](https://claude.com/claude-code)