### PR TITLE
fix: drop stale operational alerts from transcript mirror

### DIFF
--- a/src/config/sessions/transcript-mirror.ts
+++ b/src/config/sessions/transcript-mirror.ts
@@ -31,6 +31,18 @@ function extractFileNameFromMediaUrl(value: string): string | null {
   }
 }
 
+const OPERATIONAL_ALERT_PATTERNS = [
+  /^(?:⚠️\s*)?error en\b/i,
+  /^alerta de backup:/i,
+  /^git backup failed\b/i,
+  /^se han producido conflictos durante el pull --rebase\b/i,
+];
+
+export function isOperationalAlertMirrorText(text: string): boolean {
+  const trimmed = text.trim();
+  return OPERATIONAL_ALERT_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
 export function resolveMirroredTranscriptText(params: {
   text?: string;
   mediaUrls?: string[];
@@ -48,5 +60,11 @@ export function resolveMirroredTranscriptText(params: {
 
   const text = params.text ?? "";
   const trimmed = text.trim();
-  return trimmed ? trimmed : null;
+  if (!trimmed) {
+    return null;
+  }
+  if (isOperationalAlertMirrorText(trimmed)) {
+    return null;
+  }
+  return trimmed;
 }

--- a/src/config/sessions/transcript-mirror.ts
+++ b/src/config/sessions/transcript-mirror.ts
@@ -32,7 +32,7 @@ function extractFileNameFromMediaUrl(value: string): string | null {
 }
 
 const OPERATIONAL_ALERT_PATTERNS = [
-  /^(?:⚠️\s*)?error en\b/i,
+  /^⚠️\s*error en\b/i,
   /^alerta de backup:/i,
   /^git backup failed\b/i,
   /^se han producido conflictos durante el pull --rebase\b/i,

--- a/src/config/sessions/transcript-mirror.ts
+++ b/src/config/sessions/transcript-mirror.ts
@@ -31,6 +31,18 @@ function extractFileNameFromMediaUrl(value: string): string | null {
   }
 }
 
+const OPERATIONAL_ALERT_PATTERNS = [
+  /^⚠️\s*error en backup-git:/i,
+  /^alerta de backup:/i,
+  /^git backup failed\b/i,
+  /^se han producido conflictos durante el pull --rebase\b/i,
+];
+
+export function isOperationalAlertMirrorText(text: string): boolean {
+  const trimmed = text.trim();
+  return OPERATIONAL_ALERT_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
 export function resolveMirroredTranscriptText(params: {
   text?: string;
   mediaUrls?: string[];
@@ -48,5 +60,11 @@ export function resolveMirroredTranscriptText(params: {
 
   const text = params.text ?? "";
   const trimmed = text.trim();
-  return trimmed ? trimmed : null;
+  if (!trimmed) {
+    return null;
+  }
+  if (isOperationalAlertMirrorText(trimmed)) {
+    return null;
+  }
+  return trimmed;
 }

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -122,6 +122,7 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(
       isOperationalAlertMirrorText("Git backup failed due to conflicts during pull --rebase"),
     ).toBe(true);
+    expect(isOperationalAlertMirrorText("Error en el procesamiento de tu solicitud")).toBe(false);
     expect(isOperationalAlertMirrorText("Hello from delivery mirror!")).toBe(false);
   });
 

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import * as transcriptEvents from "../../sessions/transcript-events.js";
 import { resolveSessionTranscriptPathInDir } from "./paths.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
+import { isOperationalAlertMirrorText } from "./transcript-mirror.js";
 import {
   appendAssistantMessageToSessionTranscript,
   appendExactAssistantMessageToSessionTranscript,
@@ -91,6 +92,37 @@ describe("appendAssistantMessageToSessionTranscript", () => {
       }),
     );
     emitSpy.mockRestore();
+  });
+
+  it("skips operational alert delivery mirrors so stale alerts do not pollute transcripts", async () => {
+    writeTranscriptStore();
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "⚠️ Error en backup-git: Se han producido conflictos durante el pull --rebase en el workspace",
+      storePath: fixture.storePath(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("empty text");
+    }
+
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    expect(fs.existsSync(sessionFile)).toBe(false);
+  });
+
+  it("detects operational alert mirror text patterns", () => {
+    expect(
+      isOperationalAlertMirrorText(
+        "⚠️ Error en backup-git: Se han producido conflictos durante el pull --rebase en el workspace",
+      ),
+    ).toBe(true);
+    expect(isOperationalAlertMirrorText("Alerta de Backup: conflicto detectado")).toBe(true);
+    expect(
+      isOperationalAlertMirrorText("Git backup failed due to conflicts during pull --rebase"),
+    ).toBe(true);
+    expect(isOperationalAlertMirrorText("Hello from delivery mirror!")).toBe(false);
   });
 
   it("does not append a duplicate delivery mirror for the same idempotency key", async () => {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -6,6 +6,7 @@ import type { SessionTranscriptUpdate } from "../../sessions/transcript-events.j
 import { resolveSessionTranscriptPathInDir } from "./paths.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
 import { appendSessionTranscriptMessage } from "./transcript-append.js";
+import { isOperationalAlertMirrorText } from "./transcript-mirror.js";
 import { withOwnedSessionTranscriptWrites } from "./transcript-write-context.js";
 import {
   appendAssistantMessageToSessionTranscript,
@@ -232,6 +233,39 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(message?.model).toBe("delivery-mirror");
     expect(message?.content).toEqual([{ type: "text", text: "Hello from delivery mirror!" }]);
     emitSpy.mockRestore();
+  });
+
+  it("skips operational alert delivery mirrors so stale alerts do not pollute transcripts", async () => {
+    writeTranscriptStore();
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "⚠️ Error en backup-git: Se han producido conflictos durante el pull --rebase en el workspace",
+      storePath: fixture.storePath(),
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("empty text");
+    }
+
+    const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());
+    expect(fs.existsSync(sessionFile)).toBe(false);
+  });
+
+  it("detects operational alert mirror text patterns", () => {
+    expect(
+      isOperationalAlertMirrorText(
+        "⚠️ Error en backup-git: Se han producido conflictos durante el pull --rebase en el workspace",
+      ),
+    ).toBe(true);
+    expect(isOperationalAlertMirrorText("Alerta de Backup: conflicto detectado")).toBe(true);
+    expect(
+      isOperationalAlertMirrorText("Git backup failed due to conflicts during pull --rebase"),
+    ).toBe(true);
+    expect(isOperationalAlertMirrorText("Hello from delivery mirror!")).toBe(false);
+    expect(isOperationalAlertMirrorText("Error en el procesamiento de tu solicitud")).toBe(false);
+    expect(isOperationalAlertMirrorText("⚠️ Error en la API: reintenta luego")).toBe(false);
   });
 
   it("does not append a duplicate delivery mirror for the same idempotency key", async () => {


### PR DESCRIPTION
## Summary
- filter backup/git operational alert text out of `resolveMirroredTranscriptText`
- add regression coverage so stale backup/conflict alerts do not pollute session transcripts
- keep normal delivery-mirror text unchanged, including Spanish error text that is not the backup alert

## Problem
There is already upstream discussion around delivery-mirror duplicates and stale replay behavior, especially:
- #65493
- #44467
- #51628

This patch addresses a narrower but user-visible manifestation: old operational alerts like backup conflict warnings can be mirrored into the transcript as normal assistant text, then later resurfaced as if they were current state.

## Repro shape
A mirrored assistant message such as:
- `⚠️ Error en backup-git: Se han producido conflictos durante el pull --rebase en el workspace`

gets appended to the transcript, survives in session history, and can later contaminate responses during heartbeat/completion flows.

## Fix
Treat known backup/git operational alert patterns as non-user-facing transcript mirror content and return `null` from `resolveMirroredTranscriptText`.

The Spanish warning pattern is intentionally backup-specific (`⚠️ Error en backup-git:`), not a generic `⚠️ Error en...` matcher, so normal assistant messages like `⚠️ Error en la API: reintenta luego` stay in the transcript.

## Real behavior proof

**Behavior or issue addressed:** The changed mirror resolver suppresses the backup/git operational alert before transcript persistence by returning `null`, while preserving ordinary mirrored assistant text.

**Real environment tested:** Real local OpenClaw checkout on Linux arm64, rebased onto current `openclaw/openclaw main` at the time of validation. Command was run from the checked-out PR branch with project dependencies installed via pnpm.

**Exact steps or command run after this patch:**
1. Rebased the PR branch onto current `main`.
2. Ran the changed resolver directly from the OpenClaw source checkout with three input strings: one backup/git operational alert, one warning-prefixed normal Spanish error, and one plain Spanish error sentence.
3. Confirmed the backup/git alert resolves to `null` and the normal messages resolve to their original text.

**Evidence after fix:** Terminal output from the rebased PR branch:

```console
$ corepack pnpm exec tsx -e 'import { resolveMirroredTranscriptText } from "./src/config/sessions/transcript-mirror.ts"; const samples = [{name:"backup alert", text:"⚠️ Error en backup-git: Se han producido conflictos durante el pull --rebase en el workspace"}, {name:"normal warning", text:"⚠️ Error en la API: reintenta luego"}, {name:"normal spanish", text:"Error en el procesamiento de tu solicitud"}]; for (const sample of samples) console.log(`${sample.name}: ${JSON.stringify(resolveMirroredTranscriptText({text: sample.text}))}`);'
backup alert: null
normal warning: "⚠️ Error en la API: reintenta luego"
normal spanish: "Error en el procesamiento de tu solicitud"
```

**Observed result after fix:** The backup/git operational alert is suppressed (`null`), so it will not be appended as delivery-mirror transcript text. The normal warning-prefixed and plain Spanish error messages are preserved, so the fix does not silently drop generic `Error en...` assistant content.

**What was not tested:** I did not force a live backup/git conflict in a production gateway because that would require deliberately creating a failing backup/rebase condition. The proof above validates the exact resolver boundary used before transcript append; the focused transcript and outbound tests below cover the append path.

## Validation
- `git diff --check upstream/main...HEAD`
- `node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts` — 24 passed
- `node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts` — 83 passed

## Notes
This is intentionally scoped. It does not try to solve every delivery replay/duplication path, but it stops a concrete stale-state leak that can surface in real sessions when backup/git operational alerts are emitted as mirrored assistant text.
