### PR TITLE
[codex] fix(imessage): normalize attributed echo prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels/iMessage: normalize leading attributed-text, replacement, and control corruption bytes before sent-message echo-cache text matching, while ignoring all-prefix/all-control keys so echoed agent replies are deduped without suppressing intentional message body text. Carries forward #66169; covers #62191. Thanks @coder999999999 and @maguilar631697.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Cron/Telegram: preserve explicit `:topic:` delivery targets over stale session-derived thread IDs when isolated cron announces to Telegram forum topics. Carries forward #59069; refs #49704 and #43808. Thanks @roytong9.
 - Build/runtime: write the runtime-postbuild stamp after `pnpm build` writes the build stamp, so the next CLI invocation does not re-sync runtime artifacts after a successful build. Fixes #73151. Thanks @bittoby.

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -23,11 +23,72 @@ export type SentMessageCache = {
 const SENT_MESSAGE_TEXT_TTL_MS = 4_000;
 const SENT_MESSAGE_ID_TTL_MS = 60_000;
 
+function isLowControlOrReplacementChar(char: string): boolean {
+  if (char === "\uFFFD") {
+    return true;
+  }
+  const code = char.charCodeAt(0);
+  return code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+}
+
+function isHighAttributedLeadChar(char: string): boolean {
+  if (char === "\uFFFD") {
+    return true;
+  }
+  const code = char.charCodeAt(0);
+  return code >= 0x80 && code <= 0x9f;
+}
+
+function isAsciiPrintableChar(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code >= 0x20 && code <= 0x7e;
+}
+
+function stripLeadingIMessageAttributedTextPrefix(text: string): string {
+  let offset = 0;
+
+  while (offset < text.length) {
+    const first = text[offset];
+    if (!first) {
+      break;
+    }
+    const second = text[offset + 1];
+    const third = text[offset + 2];
+    if (
+      isHighAttributedLeadChar(first) &&
+      third &&
+      isLowControlOrReplacementChar(third) &&
+      (!second || isAsciiPrintableChar(second))
+    ) {
+      offset += second ? 3 : 2;
+      continue;
+    }
+
+    let runEnd = offset;
+    while (runEnd < text.length && runEnd - offset < 4) {
+      const char = text[runEnd];
+      if (!char || !isLowControlOrReplacementChar(char)) {
+        break;
+      }
+      runEnd += 1;
+    }
+    if (runEnd > offset) {
+      offset = runEnd;
+      continue;
+    }
+
+    break;
+  }
+
+  const stripped = offset > 0 ? text.slice(offset) : text;
+  return stripped || text;
+}
+
 function normalizeEchoTextKey(text: string | undefined): string | null {
   if (!text) {
     return null;
   }
-  const normalized = text.replace(/\r\n?/g, "\n").trim();
+  const normalized = stripLeadingIMessageAttributedTextPrefix(text).replace(/\r\n?/g, "\n").trim();
   return normalized ? normalized : null;
 }
 

--- a/extensions/imessage/src/monitor/echo-cache.ts
+++ b/extensions/imessage/src/monitor/echo-cache.ts
@@ -52,16 +52,17 @@ function stripLeadingIMessageAttributedTextPrefix(text: string): string {
     if (!first) {
       break;
     }
-    const second = text[offset + 1];
-    const third = text[offset + 2];
-    if (
-      isHighAttributedLeadChar(first) &&
-      third &&
-      isLowControlOrReplacementChar(third) &&
-      (!second || isAsciiPrintableChar(second))
-    ) {
-      offset += second ? 3 : 2;
-      continue;
+    if (isHighAttributedLeadChar(first)) {
+      const second = text[offset + 1];
+      const third = text[offset + 2];
+      if (second && third && isAsciiPrintableChar(second) && isLowControlOrReplacementChar(third)) {
+        offset += 3;
+        continue;
+      }
+      if (second && isLowControlOrReplacementChar(second)) {
+        offset += 2;
+        continue;
+      }
     }
 
     let runEnd = offset;
@@ -80,8 +81,7 @@ function stripLeadingIMessageAttributedTextPrefix(text: string): string {
     break;
   }
 
-  const stripped = offset > 0 ? text.slice(offset) : text;
-  return stripped || text;
+  return offset > 0 ? text.slice(offset) : text;
 }
 
 function normalizeEchoTextKey(text: string | undefined): string | null {

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
@@ -41,4 +41,23 @@ describe("iMessage sent-message echo cache", () => {
     expect(cache.has("acct:imessage:+1555", { text: "hello" })).toBe(false);
     expect(cache.has("acct:imessage:+1555", { messageId: "m-1" })).toBe(true);
   });
+
+  it("strips attributed-text prefix bytes before text fallback matching", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", {
+      text: "Confirmed full access",
+      messageId: "p:0/GUID-outbound",
+    });
+
+    expect(
+      cache.has(
+        "acct:imessage:+1555",
+        { text: "\u0093b\u0002Confirmed full access", messageId: "123799" },
+        true,
+      ),
+    ).toBe(true);
+  });
 });

--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts
@@ -60,4 +60,54 @@ describe("iMessage sent-message echo cache", () => {
       ),
     ).toBe(true);
   });
+
+  it("strips two-byte attributed-text prefixes before text fallback matching", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", {
+      text: "Confirmed full access",
+      messageId: "p:0/GUID-outbound",
+    });
+
+    expect(
+      cache.has(
+        "acct:imessage:+1555",
+        { text: "\u0093\u0002Confirmed full access", messageId: "123800" },
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("strips replacement/control prefixes before text fallback matching", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", {
+      text: "Confirmed full access",
+      messageId: "p:0/GUID-outbound",
+    });
+
+    expect(
+      cache.has(
+        "acct:imessage:+1555",
+        { text: "\uFFFD\u0000\u0001Confirmed full access", messageId: "123801" },
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not cache all-prefix or all-control text keys", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-25T00:00:00Z"));
+    const cache = createSentMessageCache();
+
+    cache.remember("acct:imessage:+1555", { text: "\u0093\u0002" });
+    cache.remember("acct:imessage:+1555", { text: "\uFFFD\u0000\u0001" });
+
+    expect(cache.has("acct:imessage:+1555", { text: "\u0093\u0002" })).toBe(false);
+    expect(cache.has("acct:imessage:+1555", { text: "\uFFFD\u0000\u0001" })).toBe(false);
+  });
 });

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -748,6 +748,41 @@ describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {
     // With skipIdShortCircuit=false (default), ID mismatch causes early return false.
     expect(echoCache.has(scope, { text: "Cached reply", messageId: "123799" }, false)).toBe(false);
   });
+
+  it("drops self-chat echoes when reflected text carries attributed prefix bytes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-24T12:00:00Z"));
+
+    const echoCache = createSentMessageCache();
+    const selfChatCache = createSelfChatCache();
+    const scope = "default:imessage:+15551234567";
+    echoCache.remember(scope, {
+      text: "Cached reply",
+      messageId: "p:0/GUID-echo",
+    });
+
+    vi.advanceTimersByTime(1000);
+
+    const decision = resolveIMessageInboundDecision(
+      createParams({
+        message: {
+          id: 123799,
+          sender: "+15551234567",
+          chat_identifier: "+15551234567",
+          destination_caller_id: "+15551234567",
+          text: "\u0093b\u0002Cached reply",
+          is_from_me: true,
+          is_group: false,
+        },
+        messageText: "\u0093b\u0002Cached reply",
+        bodyText: "\u0093b\u0002Cached reply",
+        echoCache,
+        selfChatCache,
+      }),
+    );
+
+    expect(decision).toEqual({ kind: "drop", reason: "agent echo in self-chat" });
+  });
 });
 
 describe("echo cache — text fallback for null-id inbound messages", () => {


### PR DESCRIPTION
## Summary

- Problem: iMessage reflected replies can carry short attributed-text prefix bytes like `\x93b\x02`, which makes echo-cache text fallback miss the agent's own outbound text.
- Why it matters: when the reflected text misses echo matching, self-chat and direct-chat reply loops can re-enter the session and trigger duplicate or recursive replies.
- What changed: `extensions/imessage/src/monitor/echo-cache.ts` now strips the leading attributed-text marker pattern before newline/trim normalization, and targeted regression tests were added for cache matching plus the self-chat inbound decision path.
- What did NOT change (scope boundary): no routing changes, no TTL changes, no send-path changes, and no generic text sanitization outside the iMessage echo cache.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64309
- Related #59386
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `normalizeEchoTextKey()` normalized newlines and trimming only, so reflected texts like `"\x93b\x02Cached reply"` did not match the clean outbound text stored in the echo cache.
- Missing detection / guardrail: there was no regression test covering attributed-text prefix bytes in the iMessage echo fallback path.
- Contributing context (if known): iMessage `chat.db` reflections can preserve short attributed-text marker bytes on some messages, especially richer/longer text.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/imessage/src/monitor/monitor-provider.echo-cache.test.ts`
  - `extensions/imessage/src/monitor/self-chat-dedupe.test.ts`
- Scenario the test should lock in: a reflected iMessage body with a leading attributed-text prefix should still match the clean outbound cached text and be dropped as an echo.
- Why this is the smallest reliable guardrail: it exercises the exact normalization seam and the self-chat inbound decision seam without needing a live iMessage environment.
- Existing test that already covers this (if any): existing echo-cache and self-chat tests covered clean text and control-character-ish cases, but not the attributed prefix byte shape from #64309.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- iMessage reflected replies with attributed-text prefix bytes should stop re-entering the session as fresh inbound messages.

## Diagram (if applicable)

```text
Before:
[agent reply] -> [iMessage reflection with prefix bytes] -> [text mismatch in echo cache] -> [loop / duplicate reply]

After:
[agent reply] -> [iMessage reflection with prefix bytes] -> [prefix stripped before echo match] -> [echo dropped]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm checkout
- Model/provider: N/A
- Integration/channel (if any): iMessage
- Relevant config (redacted): iMessage echo-cache/self-chat test paths; local `imsg` access to Messages database

### Steps

1. Cache a clean outbound iMessage reply text.
2. Simulate a reflected inbound message carrying a leading attributed-text prefix like `\x93b\x02`.
3. Verify the reflected text still matches the cached outbound text and is dropped as an echo.
4. Manually send live verification messages through `imsg` to a real iMessage target and confirm delivery on the recipient device.

### Expected

- The prefixed reflected text normalizes to the clean outbound text and is treated as an echo.
- Live iMessage test messages deliver successfully to the target device.

### Actual

- Before this patch, the prefixed reflected text missed echo matching and could re-enter the session.
- After this patch, the prefixed text matches in the targeted regression path, and the live verification sends delivered successfully.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted echo-cache regression test, targeted self-chat inbound regression test, successful branch commit hook (`pnpm check`), and live iMessage test sends via `imsg` during validation.
- Edge cases checked: prefixed reflected text with a GUID-backed outbound cache entry; self-chat `is_from_me=true` reflection path with the same prefix shape; real iMessage delivery path remained functional while validating on macOS.
- What you did **not** verify: a full live OpenClaw+iMessage end-to-end loop reproduction with the branch wired into an enabled iMessage channel.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the prefix stripper could normalize an unusual legitimate leading control-byte sequence that was not an iMessage attributed-text marker.
  - Mitigation: the logic is intentionally narrow, only strips short leading marker-like runs, and is covered by targeted tests instead of broad text rewriting.
