### PR TITLE
Fix session transcript path canonicalization on save

### DIFF
--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -125,6 +125,35 @@ describe("Integration: saveSessionStore with pruning", () => {
     expect(loaded.fresh).toBeDefined();
   });
 
+  it("canonicalizes persisted session transcript paths into the sessions dir on save", async () => {
+    const sessionsDir = path.join(testDir, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    storePath = path.join(sessionsDir, "sessions.json");
+
+    const sessionId = "canon-session";
+    const outsideDir = path.join(testDir, "workspace-like-paths");
+    await fs.mkdir(outsideDir, { recursive: true });
+    const outsidePath = path.join(outsideDir, `${sessionId}.jsonl`);
+    const store: Record<string, SessionEntry> = {
+      "agent:main:archive:restored:canon": {
+        sessionId,
+        updatedAt: Date.now(),
+        sessionFile: outsidePath,
+        transcriptPath: outsidePath,
+      },
+    };
+
+    await saveSessionStore(storePath, store, { skipMaintenance: true });
+
+    const raw = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<string, SessionEntry>;
+    const canonicalSessionsDir = await fs
+      .realpath(sessionsDir)
+      .catch(() => path.resolve(sessionsDir));
+    const expectedPath = path.join(canonicalSessionsDir, `${sessionId}.jsonl`);
+    expect(raw["agent:main:archive:restored:canon"]?.sessionFile).toBe(expectedPath);
+    expect(raw["agent:main:archive:restored:canon"]?.transcriptPath).toBe(expectedPath);
+  });
+
   it("archives transcript files for stale sessions pruned on write", async () => {
     applyEnforcedMaintenanceConfig(mockLoadConfig);
 

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -7,7 +7,10 @@ import {
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { writeTextAtomic } from "../../infra/json-files.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../../shared/string-coerce.js";
 import {
   deliveryContextFromSession,
   mergeDeliveryContext,
@@ -18,6 +21,7 @@ import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import { enforceSessionDiskBudget, type SessionDiskBudgetSweepResult } from "./disk-budget.js";
 import { deriveSessionMetaPatch } from "./metadata.js";
+import { resolveSessionFilePath } from "./paths.js";
 import {
   dropSessionStoreObjectCache,
   getSerializedSessionStore,
@@ -78,6 +82,55 @@ function removeThreadFromDeliveryContext(context?: DeliveryContext): DeliveryCon
 
 export function normalizeStoreSessionKey(sessionKey: string): string {
   return normalizeLowercaseStringOrEmpty(sessionKey);
+}
+
+function normalizePersistedSessionTranscriptPaths(
+  store: Record<string, SessionEntry>,
+  storePath: string,
+): void {
+  const sessionsDir = path.dirname(path.resolve(storePath));
+  for (const [key, entry] of Object.entries(store)) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const sessionId = normalizeOptionalString(entry.sessionId);
+    if (!sessionId) {
+      continue;
+    }
+    const nextWithTranscript = entry as SessionEntry & { transcriptPath?: string };
+    const hasSessionFile =
+      typeof entry.sessionFile === "string" && entry.sessionFile.trim().length > 0;
+    const hasTranscriptPath =
+      typeof nextWithTranscript.transcriptPath === "string" &&
+      nextWithTranscript.transcriptPath.trim().length > 0;
+    if (!hasSessionFile && !hasTranscriptPath) {
+      continue;
+    }
+
+    let canonicalPath: string;
+    try {
+      canonicalPath = resolveSessionFilePath(sessionId, entry, { sessionsDir });
+    } catch {
+      continue;
+    }
+
+    let next = entry;
+    if (hasSessionFile && entry.sessionFile !== canonicalPath) {
+      if (next === entry) {
+        next = { ...entry };
+      }
+      next.sessionFile = canonicalPath;
+    }
+    if (hasTranscriptPath && nextWithTranscript.transcriptPath !== canonicalPath) {
+      if (next === entry) {
+        next = { ...entry } as SessionEntry;
+      }
+      (next as SessionEntry & { transcriptPath?: string }).transcriptPath = canonicalPath;
+    }
+    if (next !== entry) {
+      store[key] = next;
+    }
+  }
 }
 
 export function resolveSessionStoreEntry(params: {
@@ -279,6 +332,7 @@ async function saveSessionStoreUnlocked(
   opts?: SaveSessionStoreOptions,
 ): Promise<void> {
   normalizeSessionStore(store);
+  normalizePersistedSessionTranscriptPaths(store, storePath);
 
   if (!opts?.skipMaintenance) {
     // Resolve maintenance config once (avoids repeated loadConfig() calls).

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -127,6 +127,8 @@ export type SessionEntry = {
   sessionId: string;
   updatedAt: number;
   sessionFile?: string;
+  /** Legacy alias preserved for compatibility with older callers and tool surfaces. */
+  transcriptPath?: string;
   /** Parent session key that spawned this session (used for sandbox session-tool scoping). */
   spawnedBy?: string;
   /** Workspace inherited by spawned sessions and reused on later turns for the same child session. */


### PR DESCRIPTION
# OpenClaw session-store path fix, 2026-04-12

## Status
Applied live to installed runtime. Also ported carefully into a fresh source clone of the matching `v2026.4.11` upstream tag, but not yet merged upstream or installed from that source tree.

## Source clone
- Repo: `/Users/rocklobster/.openclaw/workspace/external/openclaw-upstream`
- Branch: `fix/session-store-transcript-path-canonicalization`

## Protected file
`/opt/homebrew/lib/node_modules/openclaw/dist/store-Cw5RrVCw.js`

## Backup
`/Users/rocklobster/.openclaw/agents/main/sessions/backups/runtime-patches/store-Cw5RrVCw.js.pre-20260412-1233`

## What changed
Added a save-time canonicalization step so persisted `sessionFile` and `transcriptPath` values are rewritten into the real sessions directory before session-store writes hit disk.

## Why
Without this, restored/recovered session entries could keep workspace-style transcript paths, then later be treated as missing/orphaned and get swept or misread.

## Verification performed
- syntax check passed
- synthetic save test passed
- gateway restarted cleanly
- post-restart audit:
  - `entries 913`
  - `legacy_non_agent_keys 0`
  - `non_cron_duplicate_sessionids 0`
  - `missing_jsonl_paths 0`

## Release blocker rule
Treat this as a release blocker until the fix is confirmed upstream and in the installed version. Before any OpenClaw update or manual overwrite touching runtime/config/session storage, stop and verify this protection first.

## Source patch details
Changed files in the source clone:
- `src/config/sessions/store.ts`
- `src/config/sessions/types.ts`
- `src/config/sessions/store.pruning.integration.test.ts`

Validation in source clone:
- `node --no-maglev node_modules/vitest/vitest.mjs run src/config/sessions/sessions.test.ts src/config/sessions/store.pruning.integration.test.ts`
- Result: `2 passed`, `29 passed`

## Patch export
- Mailbox-style patch export written for handoff/cherry-pick use:
  - `/Users/rocklobster/.openclaw/workspace/patches/openclaw-session-store-path-fix-2026-04-12.patch`

## Current git state
- Branch is clean and still anchored on tag base `v2026.4.11`
- Head commit:
  - `e1c0d1a` `Fix session transcript path canonicalization on save`

## Next upstream action
Open or stage an upstream PR from the source clone using commit `e1c0d1a` or the exported patch above. Keep the live runtime bandage in place until an official release is installed and re-verified on this machine.
