### PR TITLE
fix(ci): add post-publish asset verification for macOS stable releases

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,4 +54,4 @@
 /scripts/release-check.ts @openclaw/openclaw-release-managers
 
 # Sparkle auto-update feed — security-sensitive, requires maintainer review
-appcast.xml @steipete @vincentkoc @mbelinky
+/appcast.xml @steipete @vincentkoc @mbelinky

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,3 +52,6 @@
 /scripts/openclaw-npm-publish.sh @openclaw/openclaw-release-managers
 /scripts/openclaw-npm-release-check.ts @openclaw/openclaw-release-managers
 /scripts/release-check.ts @openclaw/openclaw-release-managers
+
+# Sparkle auto-update feed — security-sensitive, requires maintainer review
+appcast.xml @steipete @vincentkoc @mbelinky

--- a/.github/workflows/verify-release-assets.yml
+++ b/.github/workflows/verify-release-assets.yml
@@ -1,10 +1,5 @@
 name: Verify macOS Release Assets
 
-# Runs after a GitHub release is published to verify that macOS assets
-# were uploaded and appcast.xml was updated. Catches the gap between
-# the public validation workflow (macos-release.yml) and the private
-# signing/upload pipeline (releases-private).
-
 on:
   release:
     types: [published]
@@ -17,18 +12,17 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  EXPECTED_ASSET_COUNT: 3 # .dmg, .zip, .dSYM.zip
+  EXPECTED_ASSET_COUNT: 3
 
 jobs:
   verify_assets:
-    # Only verify stable releases (skip betas, RCs)
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (!github.event.release.prerelease && !github.event.release.draft)
     runs-on: ubuntu-latest
+    timeout-minutes: 50
     permissions:
       contents: read
-      issues: write
     steps:
       - name: Determine release tag
         id: tag
@@ -39,84 +33,36 @@ jobs:
             echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Wait for private pipeline
-        # The private signing/notarization pipeline needs time to complete.
-        # This avoids false positives from checking too early.
-        run: sleep 1800 # 30 minutes
-
-      - name: Check release assets
-        id: check
+      - name: Poll for release assets
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
+          # Private signing pipeline typically completes in 10–20 min.
+          # Poll every 60s for up to 45 min before declaring failure.
+          for i in $(seq 1 45); do
+            ASSET_COUNT=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+              --jq '.assets | length' 2>/dev/null || echo "0")
+            echo "[$i/45] $RELEASE_TAG: $ASSET_COUNT/$EXPECTED_ASSET_COUNT assets"
+            if [ "$ASSET_COUNT" -ge "$EXPECTED_ASSET_COUNT" ]; then
+              echo "Assets present."
+              exit 0
+            fi
+            sleep 60
+          done
+          echo "::error::$RELEASE_TAG has $ASSET_COUNT assets after 45 minutes (expected >= $EXPECTED_ASSET_COUNT)."
+          exit 1
 
-          ASSET_COUNT=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
-            --jq '.assets | length')
-
-          echo "asset_count=$ASSET_COUNT" >> "$GITHUB_OUTPUT"
-          echo "Release $RELEASE_TAG has $ASSET_COUNT assets (expected >= $EXPECTED_ASSET_COUNT)"
-
-          if [ "$ASSET_COUNT" -lt "$EXPECTED_ASSET_COUNT" ]; then
-            echo "missing=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "missing=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check appcast.xml
-        id: appcast
-        if: steps.check.outputs.missing == 'false'
+      - name: Verify appcast.xml
         env:
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          # Strip leading 'v' for version comparison
           VERSION="${RELEASE_TAG#v}"
           if curl -sf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/main/appcast.xml" \
             | grep -q "$VERSION"; then
-            echo "appcast_updated=true" >> "$GITHUB_OUTPUT"
             echo "appcast.xml contains $VERSION"
           else
-            echo "appcast_updated=false" >> "$GITHUB_OUTPUT"
-            echo "appcast.xml does NOT contain $VERSION"
+            echo "::warning::appcast.xml does not contain $VERSION yet. Manual commit may still be pending."
           fi
-
-      - name: Open issue if assets or appcast missing
-        if: steps.check.outputs.missing == 'true' || steps.appcast.outputs.appcast_updated == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
-          ASSET_COUNT: ${{ steps.check.outputs.asset_count }}
-          APPCAST_UPDATED: ${{ steps.appcast.outputs.appcast_updated }}
-        run: |
-          BODY="## Release integrity check failed for $RELEASE_TAG
-
-          | Check | Status |
-          |-------|--------|
-          | Assets uploaded | ${ASSET_COUNT}/${EXPECTED_ASSET_COUNT} |
-          | appcast.xml updated | ${APPCAST_UPDATED:-not checked} |
-
-          ### Required actions
-          1. Run \`openclaw/releases-private\` macOS publish workflow for \`$RELEASE_TAG\`
-          2. Download \`macos-appcast-$RELEASE_TAG\` artifact and commit \`appcast.xml\` to main
-          3. Verify: \`gh api repos/\$REPO/releases/tags/$RELEASE_TAG --jq '.assets | length'\`
-
-          ### Context
-          The public \`macos-release.yml\` validation passed, but the private signing/upload
-          pipeline either was not triggered or did not complete for this stable release.
-          Mac app users on the stable Sparkle channel will not receive this update.
-
-          *Opened automatically by verify-release-assets.yml*"
-
-          gh issue create \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "[Release] $RELEASE_TAG: macOS assets missing or appcast not updated" \
-            --label "bug,release,macOS" \
-            --body "$BODY"
-
-      - name: Fail if incomplete
-        if: steps.check.outputs.missing == 'true' || steps.appcast.outputs.appcast_updated == 'false'
-        run: |
-          echo "::error::Release ${{ steps.tag.outputs.tag }} is incomplete. See opened issue."
-          exit 1

--- a/.github/workflows/verify-release-assets.yml
+++ b/.github/workflows/verify-release-assets.yml
@@ -26,12 +26,22 @@ jobs:
     steps:
       - name: Determine release tag
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
-            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+            TAG="$RELEASE_TAG_NAME"
           fi
+          if [[ ! "$TAG" =~ ^v[0-9]{4}\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Invalid tag format: $TAG"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Poll for release assets
         env:
@@ -39,8 +49,6 @@ jobs:
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -euo pipefail
-          # Private signing pipeline typically completes in 10–20 min.
-          # Poll every 60s for up to 45 min before declaring failure.
           for i in $(seq 1 45); do
             ASSET_COUNT=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
               --jq '.assets | length' 2>/dev/null || echo "0")

--- a/.github/workflows/verify-release-assets.yml
+++ b/.github/workflows/verify-release-assets.yml
@@ -1,0 +1,122 @@
+name: Verify macOS Release Assets
+
+# Runs after a GitHub release is published to verify that macOS assets
+# were uploaded and appcast.xml was updated. Catches the gap between
+# the public validation workflow (macos-release.yml) and the private
+# signing/upload pipeline (releases-private).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to verify (e.g. v2026.4.12)"
+        required: true
+        type: string
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  EXPECTED_ASSET_COUNT: 3 # .dmg, .zip, .dSYM.zip
+
+jobs:
+  verify_assets:
+    # Only verify stable releases (skip betas, RCs)
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (!github.event.release.prerelease && !github.event.release.draft)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Determine release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for private pipeline
+        # The private signing/notarization pipeline needs time to complete.
+        # This avoids false positives from checking too early.
+        run: sleep 1800 # 30 minutes
+
+      - name: Check release assets
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          ASSET_COUNT=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" \
+            --jq '.assets | length')
+
+          echo "asset_count=$ASSET_COUNT" >> "$GITHUB_OUTPUT"
+          echo "Release $RELEASE_TAG has $ASSET_COUNT assets (expected >= $EXPECTED_ASSET_COUNT)"
+
+          if [ "$ASSET_COUNT" -lt "$EXPECTED_ASSET_COUNT" ]; then
+            echo "missing=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "missing=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check appcast.xml
+        id: appcast
+        if: steps.check.outputs.missing == 'false'
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Strip leading 'v' for version comparison
+          VERSION="${RELEASE_TAG#v}"
+          if curl -sf "https://raw.githubusercontent.com/$GITHUB_REPOSITORY/main/appcast.xml" \
+            | grep -q "$VERSION"; then
+            echo "appcast_updated=true" >> "$GITHUB_OUTPUT"
+            echo "appcast.xml contains $VERSION"
+          else
+            echo "appcast_updated=false" >> "$GITHUB_OUTPUT"
+            echo "appcast.xml does NOT contain $VERSION"
+          fi
+
+      - name: Open issue if assets or appcast missing
+        if: steps.check.outputs.missing == 'true' || steps.appcast.outputs.appcast_updated == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+          ASSET_COUNT: ${{ steps.check.outputs.asset_count }}
+          APPCAST_UPDATED: ${{ steps.appcast.outputs.appcast_updated }}
+        run: |
+          BODY="## Release integrity check failed for $RELEASE_TAG
+
+          | Check | Status |
+          |-------|--------|
+          | Assets uploaded | ${ASSET_COUNT}/${EXPECTED_ASSET_COUNT} |
+          | appcast.xml updated | ${APPCAST_UPDATED:-not checked} |
+
+          ### Required actions
+          1. Run \`openclaw/releases-private\` macOS publish workflow for \`$RELEASE_TAG\`
+          2. Download \`macos-appcast-$RELEASE_TAG\` artifact and commit \`appcast.xml\` to main
+          3. Verify: \`gh api repos/\$REPO/releases/tags/$RELEASE_TAG --jq '.assets | length'\`
+
+          ### Context
+          The public \`macos-release.yml\` validation passed, but the private signing/upload
+          pipeline either was not triggered or did not complete for this stable release.
+          Mac app users on the stable Sparkle channel will not receive this update.
+
+          *Opened automatically by verify-release-assets.yml*"
+
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "[Release] $RELEASE_TAG: macOS assets missing or appcast not updated" \
+            --label "bug,release,macOS" \
+            --body "$BODY"
+
+      - name: Fail if incomplete
+        if: steps.check.outputs.missing == 'true' || steps.appcast.outputs.appcast_updated == 'false'
+        run: |
+          echo "::error::Release ${{ steps.tag.outputs.tag }} is incomplete. See opened issue."
+          exit 1


### PR DESCRIPTION
## Summary

- add `verify-release-assets.yml` — polls for macOS binaries after a stable GitHub release is published
- add CODEOWNERS entry for `appcast.xml` requiring maintainer review

## Why

v2026.4.12 stable was published at 2026-04-13T12:35:53Z with 0 assets. The beta (v2026.4.12-beta.1) has all 3. The public `macos-release.yml` reported success because it is validation-only — the private signing/upload pipeline either was not triggered or did not complete. `appcast.xml` was not updated, so Sparkle reports v2026.4.11 as latest.

No automated check exists to catch this gap between public validation and private asset upload.

```bash
# stable: 0 assets
gh api repos/openclaw/openclaw/releases/tags/v2026.4.12 --jq '.assets | length'
# beta: 3 assets
gh api repos/openclaw/openclaw/releases/tags/v2026.4.12-beta.1 --jq '[.assets[].name]'
# appcast: no entry
curl -s https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml | grep "2026.4.12"
```

## What changed

**`verify-release-assets.yml`** — triggers on `release: published` (stable only) or `workflow_dispatch`. Polls every 60s for up to 45 min for asset count >= 3. Fails the workflow if assets never appear. Warns (does not fail) if `appcast.xml` is not yet updated, since the manual commit may still be pending.

**`.github/CODEOWNERS`** — adds `appcast.xml @steipete @vincentkoc @mbelinky`. The Sparkle feed controls what binaries are served to all macOS users.

## What did NOT change

- No changes to `macos-release.yml` or the private pipeline
- No auto-opened issues — workflow just fails red, visible in Actions tab
- Does not block or gate the release itself

## Verification

```bash
# validate workflow syntax
actionlint .github/workflows/verify-release-assets.yml

# dispatch against known-bad release (should fail after polling)
gh workflow run verify-release-assets.yml -f tag=v2026.4.12

# dispatch against known-good release (should pass)
gh workflow run verify-release-assets.yml -f tag=v2026.4.11
```