### PR TITLE
fix(agents): align final tag regexes to handle self-closing <final/> variant

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -20,6 +20,12 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips self-closing final tags (regression #65867)", () => {
+    expect(sanitizeUserFacingText("<final>Hello<final/>")).toBe("Hello");
+    expect(sanitizeUserFacingText("<final>Hello</final >")).toBe("Hello");
+    expect(sanitizeUserFacingText("<final >Hello< /final>")).toBe("Hello");
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -39,7 +39,7 @@ const MODEL_CAPACITY_ERROR_USER_MESSAGE =
   "⚠️ Selected model is at capacity. Try a different model, or wait and retry.";
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
-const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
+const FINAL_TAG_RE = /<\s*\/?\s*final\b[^<>]*>/gi;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -94,6 +94,25 @@ describe("subscribeEmbeddedPiSession", () => {
     const payload = onPartialReply.mock.calls[0][0];
     expect(payload.text).toBe("Hello world");
   });
+  it("treats self-closing <final/> as close tag in enforcement mode (review feedback)", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      enforceFinalTag: true,
+      onPartialReply,
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "<final>Hello world<final/>" });
+
+    expect(onPartialReply).toHaveBeenCalled();
+    const payload = onPartialReply.mock.calls[0][0];
+    expect(payload.text).toBe("Hello world");
+  });
   it("does not require <final> when enforcement is off", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.filters-final-suppresses-output-without-start-tag.test.ts
@@ -78,6 +78,22 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(onPartialReply).toHaveBeenCalled();
     expect(onPartialReply.mock.calls[0][0].text).toBe("Hello world");
   });
+  it("strips self-closing <final/> tags when enforcement is off (regression #65867)", () => {
+    const { session, emit } = createStubSessionHarness();
+
+    const onPartialReply = vi.fn();
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run",
+      onPartialReply,
+    });
+
+    emitAssistantTextDelta({ emit, delta: "<final>Hello world<final/>" });
+
+    const payload = onPartialReply.mock.calls[0][0];
+    expect(payload.text).toBe("Hello world");
+  });
   it("does not require <final> when enforcement is off", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -586,7 +586,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
         continue;
       }
       const isClose = match[1] === "/";
-      const isSelfClosing = !isClose && match[0].includes("/");
+      const isSelfClosing = !isClose && /\/\s*>$/.test(match[0]);
 
       if (isSelfClosing) {
         // Self-closing <final/> — treat as close if already inside a block.

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -41,7 +41,7 @@ import {
 } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
-const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\s*>/gi;
+const FINAL_TAG_SCAN_RE = /<\s*(\/?)\s*final\b[^<>]*>/gi;
 const log = createSubsystemLogger("agent/embedded");
 
 function collectPendingMediaFromInternalEvents(

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -586,8 +586,16 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
         continue;
       }
       const isClose = match[1] === "/";
+      const isSelfClosing = !isClose && match[0].includes("/");
 
-      if (!inFinal && !isClose) {
+      if (isSelfClosing) {
+        // Self-closing <final/> — treat as close if already inside a block.
+        if (inFinal) {
+          result += processed.slice(lastFinalIndex, idx);
+          inFinal = false;
+        }
+        lastFinalIndex = idx + match[0].length;
+      } else if (!inFinal && !isClose) {
         // Found <final> start tag.
         inFinal = true;
         everInFinal = true;


### PR DESCRIPTION
## Summary

- Aligns `FINAL_TAG_SCAN_RE` (streaming subscriber) and `FINAL_TAG_RE` (user-facing text sanitizer) with the broader pattern already used by `reasoning-tags.ts`
- The narrower regex `/<\s*\/?\s*final\s*>/gi` matched `<final>` and `</final>` but **not** `<final/>` (self-closing), which some Gemini models emit
- The shared `reasoning-tags.ts` already used `/<\s*\/?\s*final\b[^<>]*>/gi` which handles all variants — this change aligns the other two callsites

## Root Cause

Three separate `FINAL_TAG_RE` regexes existed in the codebase with different patterns:
1. `reasoning-tags.ts`: `\b[^<>]*` after `final` — handles `<final/>` ✓
2. `sanitize-user-facing-text.ts`: `\s*` after `final` — misses `<final/>` ✗
3. `pi-embedded-subscribe.ts`: `\s*` after `final` — misses `<final/>` ✗

The webui streaming path uses #3, so `<final/>` tags leaked into the display.

## Test Plan

- [x] Added regression test for `sanitizeUserFacingText` stripping `<final/>` self-closing tags
- [x] Added regression test for streaming subscriber stripping `<final/>` tags when enforcement is off
- [x] All 82 sanitizer tests pass, all 6 subscriber tests pass, all 45 reasoning-tags tests pass

Closes #65867