### PR TITLE
Discord: persist component registry to disk across gateway restarts

### DIFF
--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -1,3 +1,6 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 
@@ -5,17 +8,29 @@ const DEFAULT_COMPONENT_TTL_MS = 30 * 60 * 1000;
 const DISCORD_COMPONENT_ENTRIES_KEY = Symbol.for("openclaw.discord.componentEntries");
 const DISCORD_MODAL_ENTRIES_KEY = Symbol.for("openclaw.discord.modalEntries");
 
+const DISCORD_COMPONENT_REGISTRY_FILE =
+  process.env.OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE ??
+  join(homedir(), ".openclaw", "cache", "discord-component-registry.json");
+const REGISTRY_FILE_VERSION = 1;
+
+type PersistedRegistryFile = {
+  version: number;
+  components: DiscordComponentEntry[];
+  modals: DiscordModalEntry[];
+};
+
 let componentEntries: Map<string, DiscordComponentEntry> | undefined;
 let modalEntries: Map<string, DiscordModalEntry> | undefined;
+let componentRegistryLoaded = false;
 
-function getComponentEntries(): Map<string, DiscordComponentEntry> {
+function getComponentEntriesStore(): Map<string, DiscordComponentEntry> {
   componentEntries ??= resolveGlobalMap<string, DiscordComponentEntry>(
     DISCORD_COMPONENT_ENTRIES_KEY,
   );
   return componentEntries;
 }
 
-function getModalEntries(): Map<string, DiscordModalEntry> {
+function getModalEntriesStore(): Map<string, DiscordModalEntry> {
   modalEntries ??= resolveGlobalMap<string, DiscordModalEntry>(DISCORD_MODAL_ENTRIES_KEY);
   return modalEntries;
 }
@@ -32,6 +47,97 @@ function normalizeEntryTimestamps<T extends { createdAt?: number; expiresAt?: nu
   const createdAt = entry.createdAt ?? now;
   const expiresAt = entry.expiresAt ?? createdAt + ttlMs;
   return { ...entry, createdAt, expiresAt };
+}
+
+function isRegistryEntryRecord(entry: unknown): entry is { id: string } {
+  return (
+    typeof entry === "object" &&
+    entry !== null &&
+    "id" in entry &&
+    typeof (entry as { id: unknown }).id === "string" &&
+    (entry as { id: string }).id.trim().length > 0
+  );
+}
+
+function loadPersistedEntries<T extends { id: string; createdAt?: number; expiresAt?: number }>(
+  rawEntries: unknown,
+  store: Map<string, T>,
+  now: number,
+): boolean {
+  if (!Array.isArray(rawEntries)) {
+    return false;
+  }
+  let changed = false;
+  for (const rawEntry of rawEntries) {
+    if (!isRegistryEntryRecord(rawEntry)) {
+      changed = true;
+      continue;
+    }
+    const normalized = normalizeEntryTimestamps(rawEntry as T, now, DEFAULT_COMPONENT_TTL_MS);
+    if (isExpired(normalized, now)) {
+      changed = true;
+      continue;
+    }
+    store.set(normalized.id, normalized);
+  }
+  return changed;
+}
+
+function persistComponentRegistry(): void {
+  try {
+    mkdirSync(dirname(DISCORD_COMPONENT_REGISTRY_FILE), { recursive: true });
+    const payload: PersistedRegistryFile = {
+      version: REGISTRY_FILE_VERSION,
+      components: [...getComponentEntriesStore().values()],
+      modals: [...getModalEntriesStore().values()],
+    };
+    writeFileSync(DISCORD_COMPONENT_REGISTRY_FILE, `${JSON.stringify(payload)}\n`);
+  } catch (err) {
+    console.warn(
+      `discord component registry persist failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function loadPersistedComponentRegistry(): void {
+  if (componentRegistryLoaded) {
+    return;
+  }
+  componentRegistryLoaded = true;
+  if (!existsSync(DISCORD_COMPONENT_REGISTRY_FILE)) {
+    return;
+  }
+  try {
+    const raw = JSON.parse(readFileSync(DISCORD_COMPONENT_REGISTRY_FILE, "utf8")) as unknown;
+    const parsed =
+      typeof raw === "object" && raw !== null
+        ? (raw as { components?: unknown; modals?: unknown })
+        : undefined;
+    const now = Date.now();
+    const componentsChanged = loadPersistedEntries(
+      parsed?.components,
+      getComponentEntriesStore(),
+      now,
+    );
+    const modalsChanged = loadPersistedEntries(parsed?.modals, getModalEntriesStore(), now);
+    if (componentsChanged || modalsChanged) {
+      persistComponentRegistry();
+    }
+  } catch (err) {
+    console.warn(
+      `discord component registry load failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function getComponentEntries(): Map<string, DiscordComponentEntry> {
+  loadPersistedComponentRegistry();
+  return getComponentEntriesStore();
+}
+
+function getModalEntries(): Map<string, DiscordModalEntry> {
+  loadPersistedComponentRegistry();
+  return getModalEntriesStore();
 }
 
 function registerEntries<
@@ -62,10 +168,12 @@ function resolveEntry<T extends { expiresAt?: number }>(
   const now = Date.now();
   if (isExpired(entry, now)) {
     store.delete(params.id);
+    persistComponentRegistry();
     return null;
   }
   if (params.consume !== false) {
     store.delete(params.id);
+    persistComponentRegistry();
   }
   return entry;
 }
@@ -84,6 +192,7 @@ export function registerDiscordComponentEntries(params: {
     messageId: params.messageId,
   });
   registerEntries(params.modals, getModalEntries(), { now, ttlMs, messageId: params.messageId });
+  persistComponentRegistry();
 }
 
 export function resolveDiscordComponentEntry(params: {
@@ -103,4 +212,5 @@ export function resolveDiscordModalEntry(params: {
 export function clearDiscordComponentEntries(): void {
   getComponentEntries().clear();
   getModalEntries().clear();
+  persistComponentRegistry();
 }

--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -185,6 +185,21 @@ function loadPersistedEntries<T extends { id: string; createdAt?: number; expire
   return changed;
 }
 
+// Debounce flag: coalesce rapid register/resolve events into a single write
+// so that interactive hot paths (button clicks, modal submissions) don't block
+// the event loop with synchronous disk I/O on every interaction.
+let _persistScheduled = false;
+function schedulePersistComponentRegistry(): void {
+  if (_persistScheduled) {
+    return;
+  }
+  _persistScheduled = true;
+  setImmediate(() => {
+    _persistScheduled = false;
+    persistComponentRegistry();
+  });
+}
+
 function persistComponentRegistry(): void {
   const filePath = getRegistryPath();
   try {
@@ -310,12 +325,12 @@ function resolveEntry<T extends { expiresAt?: number }>(
   const now = Date.now();
   if (isExpired(entry, now)) {
     store.delete(params.id);
-    persistComponentRegistry();
+    schedulePersistComponentRegistry();
     return null;
   }
   if (params.consume !== false) {
     store.delete(params.id);
-    persistComponentRegistry();
+    schedulePersistComponentRegistry();
   }
   return entry;
 }
@@ -334,7 +349,7 @@ export function registerDiscordComponentEntries(params: {
     messageId: params.messageId,
   });
   registerEntries(params.modals, getModalEntries(), { now, ttlMs, messageId: params.messageId });
-  persistComponentRegistry();
+  schedulePersistComponentRegistry();
 }
 
 export function resolveDiscordComponentEntry(params: {

--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -1,6 +1,14 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve, sep as pathSep } from "node:path";
 import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
 import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 
@@ -8,10 +16,31 @@ const DEFAULT_COMPONENT_TTL_MS = 30 * 60 * 1000;
 const DISCORD_COMPONENT_ENTRIES_KEY = Symbol.for("openclaw.discord.componentEntries");
 const DISCORD_MODAL_ENTRIES_KEY = Symbol.for("openclaw.discord.modalEntries");
 
-const DISCORD_COMPONENT_REGISTRY_FILE =
-  process.env.OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE ??
-  join(homedir(), ".openclaw", "cache", "discord-component-registry.json");
 const REGISTRY_FILE_VERSION = 1;
+const MAX_REGISTRY_BYTES = 1_000_000; // 1 MB — prevents unbounded read/parse DoS
+const MAX_ENTRIES_PER_TYPE = 10_000; // cap total entries per registry type
+
+// --- Path hardening: validate env-var path stays under the safe base directory ---
+function resolveRegistryPath(): string {
+  const baseDir = join(homedir(), ".openclaw", "cache");
+  const configured = process.env.OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE;
+  const candidate = configured
+    ? resolve(configured)
+    : join(baseDir, "discord-component-registry.json");
+  const resolvedBase = resolve(baseDir) + pathSep;
+  if (!candidate.startsWith(resolvedBase)) {
+    throw new Error(
+      "OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE must resolve to a path under ~/.openclaw/cache",
+    );
+  }
+  return candidate;
+}
+
+let _registryPath: string | undefined;
+function getRegistryPath(): string {
+  _registryPath ??= resolveRegistryPath();
+  return _registryPath;
+}
 
 type PersistedRegistryFile = {
   version: number;
@@ -49,31 +78,104 @@ function normalizeEntryTimestamps<T extends { createdAt?: number; expiresAt?: nu
   return { ...entry, createdAt, expiresAt };
 }
 
-function isRegistryEntryRecord(entry: unknown): entry is { id: string } {
-  return (
-    typeof entry === "object" &&
-    entry !== null &&
-    "id" in entry &&
-    typeof (entry as { id: unknown }).id === "string" &&
-    (entry as { id: string }).id.trim().length > 0
-  );
+function isComponentEntryRecord(entry: unknown): entry is DiscordComponentEntry {
+  if (typeof entry !== "object" || entry === null) {
+    return false;
+  }
+  const e = entry as Record<string, unknown>;
+  if (typeof e.id !== "string" || !e.id.trim()) {
+    return false;
+  }
+  if (!["button", "select", "modal-trigger"].includes(e.kind as string)) {
+    return false;
+  }
+  if (e.selectType !== undefined && typeof e.selectType !== "string") {
+    return false;
+  }
+  if (e.options !== undefined && !Array.isArray(e.options)) {
+    return false;
+  }
+  if (e.sessionKey !== undefined && typeof e.sessionKey !== "string") {
+    return false;
+  }
+  if (e.agentId !== undefined && typeof e.agentId !== "string") {
+    return false;
+  }
+  if (e.accountId !== undefined && typeof e.accountId !== "string") {
+    return false;
+  }
+  if (e.allowedUsers !== undefined && !Array.isArray(e.allowedUsers)) {
+    return false;
+  }
+  return true;
+}
+
+function isModalEntryRecord(entry: unknown): entry is DiscordModalEntry {
+  if (typeof entry !== "object" || entry === null) {
+    return false;
+  }
+  const e = entry as Record<string, unknown>;
+  if (typeof e.id !== "string" || !e.id.trim()) {
+    return false;
+  }
+  if (typeof e.title !== "string") {
+    return false;
+  }
+  if (!Array.isArray(e.fields)) {
+    return false;
+  }
+  if (e.sessionKey !== undefined && typeof e.sessionKey !== "string") {
+    return false;
+  }
+  if (e.agentId !== undefined && typeof e.agentId !== "string") {
+    return false;
+  }
+  if (e.accountId !== undefined && typeof e.accountId !== "string") {
+    return false;
+  }
+  if (e.allowedUsers !== undefined && !Array.isArray(e.allowedUsers)) {
+    return false;
+  }
+  return true;
+}
+
+function clampExpiresAt(createdAt: number, expiresAt: number, maxAgeMs: number): number {
+  const maxAllowed = createdAt + maxAgeMs;
+  return expiresAt > maxAllowed ? maxAllowed : expiresAt;
 }
 
 function loadPersistedEntries<T extends { id: string; createdAt?: number; expiresAt?: number }>(
   rawEntries: unknown,
   store: Map<string, T>,
   now: number,
+  isValid: (entry: unknown) => entry is T,
 ): boolean {
   if (!Array.isArray(rawEntries)) {
     return false;
   }
   let changed = false;
+  let count = 0;
   for (const rawEntry of rawEntries) {
-    if (!isRegistryEntryRecord(rawEntry)) {
+    if (count++ >= MAX_ENTRIES_PER_TYPE) {
+      changed = true;
+      break;
+    }
+    if (!isValid(rawEntry)) {
       changed = true;
       continue;
     }
-    const normalized = normalizeEntryTimestamps(rawEntry as T, now, DEFAULT_COMPONENT_TTL_MS);
+    // Clamp expiresAt to prevent far-future tampering (issue #3)
+    let normalized = normalizeEntryTimestamps(rawEntry, now, DEFAULT_COMPONENT_TTL_MS);
+    if (normalized.expiresAt) {
+      normalized = {
+        ...normalized,
+        expiresAt: clampExpiresAt(
+          normalized.createdAt ?? now,
+          normalized.expiresAt,
+          DEFAULT_COMPONENT_TTL_MS,
+        ),
+      };
+    }
     if (isExpired(normalized, now)) {
       changed = true;
       continue;
@@ -84,18 +186,42 @@ function loadPersistedEntries<T extends { id: string; createdAt?: number; expire
 }
 
 function persistComponentRegistry(): void {
+  const filePath = getRegistryPath();
   try {
-    mkdirSync(dirname(DISCORD_COMPONENT_REGISTRY_FILE), { recursive: true });
+    const dir = dirname(filePath);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
     const payload: PersistedRegistryFile = {
       version: REGISTRY_FILE_VERSION,
       components: [...getComponentEntriesStore().values()],
       modals: [...getModalEntriesStore().values()],
     };
-    writeFileSync(DISCORD_COMPONENT_REGISTRY_FILE, `${JSON.stringify(payload)}\n`);
+    // Atomic write: temp file + rename, both with restrictive perms (issues #1, #4)
+    const tmp = filePath + ".tmp";
+    writeFileSync(tmp, `${JSON.stringify(payload)}\n`, { mode: 0o600, flag: "w" });
+    chmodSync(tmp, 0o600);
+    atomicRename(tmp, filePath);
   } catch (err) {
     console.warn(
       `discord component registry persist failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+  }
+}
+
+function atomicRename(tmp: string, dest: string): void {
+  try {
+    // On POSIX, rename is atomic per the directory entry level.
+    // Node 22+ provides a native `fs.renameSync` which is atomic on same filesystem.
+    renameSync(tmp, dest);
+  } catch {
+    // If rename fails (e.g. cross-device on some POSIX), fall back to direct write.
+    // The file already has 0o600 so the permissions are correct either way.
+    try {
+      const { copyFileSync, unlinkSync } = require("node:fs");
+      copyFileSync(tmp, dest);
+      unlinkSync(tmp);
+    } catch {
+      // Best-effort; leave the temp file for manual cleanup.
+    }
   }
 }
 
@@ -104,22 +230,38 @@ function loadPersistedComponentRegistry(): void {
     return;
   }
   componentRegistryLoaded = true;
-  if (!existsSync(DISCORD_COMPONENT_REGISTRY_FILE)) {
+  const filePath = getRegistryPath();
+  if (!existsSync(filePath)) {
     return;
   }
   try {
-    const raw = JSON.parse(readFileSync(DISCORD_COMPONENT_REGISTRY_FILE, "utf8")) as unknown;
+    // DoS guard: reject files larger than MAX_REGISTRY_BYTES (issue #2)
+    const st = statSync(filePath);
+    if (st.size > MAX_REGISTRY_BYTES) {
+      console.warn("discord component registry file too large; ignoring");
+      return;
+    }
+    const raw = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
     const parsed =
       typeof raw === "object" && raw !== null
-        ? (raw as { components?: unknown; modals?: unknown })
+        ? (raw as { version?: unknown; components?: unknown; modals?: unknown })
         : undefined;
+    if (parsed?.version !== REGISTRY_FILE_VERSION) {
+      return; // unknown version — silently ignore
+    }
     const now = Date.now();
     const componentsChanged = loadPersistedEntries(
       parsed?.components,
       getComponentEntriesStore(),
       now,
+      isComponentEntryRecord,
     );
-    const modalsChanged = loadPersistedEntries(parsed?.modals, getModalEntriesStore(), now);
+    const modalsChanged = loadPersistedEntries(
+      parsed?.modals,
+      getModalEntriesStore(),
+      now,
+      isModalEntryRecord,
+    );
     if (componentsChanged || modalsChanged) {
       persistComponentRegistry();
     }

--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -97,6 +97,30 @@ function isOptionArray(x: unknown): x is Array<{ value: string; label: string }>
   );
 }
 
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === "boolean";
+}
+
+function isOptionalFiniteNumber(value: unknown): boolean {
+  return value === undefined || (typeof value === "number" && Number.isFinite(value));
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length <= MAX_STRING_ARRAY_LEN &&
+    value.every((entry) => typeof entry === "string")
+  );
+}
+
+function isOptionalStringArray(value: unknown): boolean {
+  return value === undefined || isStringArray(value);
+}
+
 function isModalFieldRecord(entry: unknown): boolean {
   if (typeof entry !== "object" || entry === null) {
     return false;
@@ -115,6 +139,27 @@ function isModalFieldRecord(entry: unknown): boolean {
     return false;
   }
   if (e.options !== undefined && !isOptionArray(e.options)) {
+    return false;
+  }
+  if (!isOptionalString(e.description) || !isOptionalString(e.placeholder)) {
+    return false;
+  }
+  if (!isOptionalBoolean(e.required)) {
+    return false;
+  }
+  if (
+    !isOptionalFiniteNumber(e.minValues) ||
+    !isOptionalFiniteNumber(e.maxValues) ||
+    !isOptionalFiniteNumber(e.minLength) ||
+    !isOptionalFiniteNumber(e.maxLength)
+  ) {
+    return false;
+  }
+  if (
+    e.style !== undefined &&
+    e.style !== "short" &&
+    e.style !== "paragraph"
+  ) {
     return false;
   }
   return true;
@@ -137,6 +182,24 @@ function isComponentEntryRecord(entry: unknown): entry is DiscordComponentEntry 
   if (e.options !== undefined && !isOptionArray(e.options)) {
     return false;
   }
+  if (
+    !isOptionalString(e.callbackData) ||
+    !isOptionalString(e.modalId) ||
+    !isOptionalString(e.sessionKey) ||
+    !isOptionalString(e.agentId) ||
+    !isOptionalString(e.accountId) ||
+    !isOptionalString(e.messageId)
+  ) {
+    return false;
+  }
+  if (
+    !isOptionalBoolean(e.reusable) ||
+    !isOptionalStringArray(e.allowedUsers) ||
+    !isOptionalFiniteNumber(e.createdAt) ||
+    !isOptionalFiniteNumber(e.expiresAt)
+  ) {
+    return false;
+  }
   return true;
 }
 
@@ -155,6 +218,23 @@ function isModalEntryRecord(entry: unknown): entry is DiscordModalEntry {
     return false;
   }
   if (!e.fields.every(isModalFieldRecord)) {
+    return false;
+  }
+  if (
+    !isOptionalString(e.callbackData) ||
+    !isOptionalString(e.sessionKey) ||
+    !isOptionalString(e.agentId) ||
+    !isOptionalString(e.accountId) ||
+    !isOptionalString(e.messageId)
+  ) {
+    return false;
+  }
+  if (
+    !isOptionalBoolean(e.reusable) ||
+    !isOptionalStringArray(e.allowedUsers) ||
+    !isOptionalFiniteNumber(e.createdAt) ||
+    !isOptionalFiniteNumber(e.expiresAt)
+  ) {
     return false;
   }
   return true;

--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -1,11 +1,14 @@
 import {
-  chmodSync,
+  closeSync,
   existsSync,
+  lstatSync,
   mkdirSync,
+  openSync,
   readFileSync,
+  realpathSync,
   renameSync,
   statSync,
-  writeFileSync,
+  writeSync,
 } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve, sep as pathSep } from "node:path";
@@ -19,6 +22,21 @@ const DISCORD_MODAL_ENTRIES_KEY = Symbol.for("openclaw.discord.modalEntries");
 const REGISTRY_FILE_VERSION = 1;
 const MAX_REGISTRY_BYTES = 1_000_000; // 1 MB — prevents unbounded read/parse DoS
 const MAX_ENTRIES_PER_TYPE = 10_000; // cap total entries per registry type
+const MAX_STRING_ARRAY_LEN = 1_000; // cap for options / allowedUsers arrays
+
+// Fields stripped from persisted entries. Routing fields (sessionKey/agentId/
+// accountId) and authorization fields (allowedUsers) are ephemeral by design
+// and must not be written to disk — an attacker reading the cache must not be
+// able to impersonate sessions or bypass allowlists after a gateway restart.
+const SENSITIVE_ENTRY_FIELDS = ["sessionKey", "agentId", "accountId", "allowedUsers"] as const;
+
+function stripSensitiveFields<T extends object>(entry: T): T {
+  const clone: Record<string, unknown> = { ...entry };
+  for (const key of SENSITIVE_ENTRY_FIELDS) {
+    delete clone[key];
+  }
+  return clone as T;
+}
 
 // --- Path hardening: validate env-var path stays under the safe base directory ---
 function resolveRegistryPath(): string {
@@ -78,6 +96,43 @@ function normalizeEntryTimestamps<T extends { createdAt?: number; expiresAt?: nu
   return { ...entry, createdAt, expiresAt };
 }
 
+function isOptionArray(x: unknown): x is Array<{ value: string; label: string }> {
+  return (
+    Array.isArray(x) &&
+    x.length <= MAX_STRING_ARRAY_LEN &&
+    x.every(
+      (o) =>
+        typeof o === "object" &&
+        o !== null &&
+        typeof (o as { value?: unknown }).value === "string" &&
+        typeof (o as { label?: unknown }).label === "string",
+    )
+  );
+}
+
+function isModalFieldRecord(entry: unknown): boolean {
+  if (typeof entry !== "object" || entry === null) {
+    return false;
+  }
+  const e = entry as Record<string, unknown>;
+  if (typeof e.id !== "string" || !e.id.trim()) {
+    return false;
+  }
+  if (typeof e.name !== "string") {
+    return false;
+  }
+  if (typeof e.label !== "string") {
+    return false;
+  }
+  if (typeof e.type !== "string") {
+    return false;
+  }
+  if (e.options !== undefined && !isOptionArray(e.options)) {
+    return false;
+  }
+  return true;
+}
+
 function isComponentEntryRecord(entry: unknown): entry is DiscordComponentEntry {
   if (typeof entry !== "object" || entry === null) {
     return false;
@@ -92,19 +147,7 @@ function isComponentEntryRecord(entry: unknown): entry is DiscordComponentEntry 
   if (e.selectType !== undefined && typeof e.selectType !== "string") {
     return false;
   }
-  if (e.options !== undefined && !Array.isArray(e.options)) {
-    return false;
-  }
-  if (e.sessionKey !== undefined && typeof e.sessionKey !== "string") {
-    return false;
-  }
-  if (e.agentId !== undefined && typeof e.agentId !== "string") {
-    return false;
-  }
-  if (e.accountId !== undefined && typeof e.accountId !== "string") {
-    return false;
-  }
-  if (e.allowedUsers !== undefined && !Array.isArray(e.allowedUsers)) {
+  if (e.options !== undefined && !isOptionArray(e.options)) {
     return false;
   }
   return true;
@@ -121,19 +164,10 @@ function isModalEntryRecord(entry: unknown): entry is DiscordModalEntry {
   if (typeof e.title !== "string") {
     return false;
   }
-  if (!Array.isArray(e.fields)) {
+  if (!Array.isArray(e.fields) || e.fields.length > MAX_STRING_ARRAY_LEN) {
     return false;
   }
-  if (e.sessionKey !== undefined && typeof e.sessionKey !== "string") {
-    return false;
-  }
-  if (e.agentId !== undefined && typeof e.agentId !== "string") {
-    return false;
-  }
-  if (e.accountId !== undefined && typeof e.accountId !== "string") {
-    return false;
-  }
-  if (e.allowedUsers !== undefined && !Array.isArray(e.allowedUsers)) {
+  if (!e.fields.every(isModalFieldRecord)) {
     return false;
   }
   return true;
@@ -200,42 +234,63 @@ function schedulePersistComponentRegistry(): void {
   });
 }
 
+// Reject symlinks at the destination (CWE-59). Resolving the directory via
+// realpathSync and comparing to the expected base protects against attackers
+// staging `discord-component-registry.json` as a symlink into `~/.ssh/` etc.
+function assertSafeRegistryDestination(filePath: string): void {
+  const dir = dirname(filePath);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const expectedBase = resolve(join(homedir(), ".openclaw", "cache")) + pathSep;
+  const realDir = realpathSync(dir) + pathSep;
+  if (!realDir.startsWith(expectedBase)) {
+    throw new Error("registry directory escapes ~/.openclaw/cache after realpath");
+  }
+  if (existsSync(filePath)) {
+    const st = lstatSync(filePath);
+    if (st.isSymbolicLink()) {
+      throw new Error("registry file is a symlink; refusing to write");
+    }
+  }
+}
+
 function persistComponentRegistry(): void {
   const filePath = getRegistryPath();
+  let tmp: string | undefined;
+  let fd: number | undefined;
   try {
-    const dir = dirname(filePath);
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    assertSafeRegistryDestination(filePath);
     const payload: PersistedRegistryFile = {
       version: REGISTRY_FILE_VERSION,
-      components: [...getComponentEntriesStore().values()],
-      modals: [...getModalEntriesStore().values()],
+      components: [...getComponentEntriesStore().values()].map(stripSensitiveFields),
+      modals: [...getModalEntriesStore().values()].map(stripSensitiveFields),
     };
-    // Atomic write: temp file + rename, both with restrictive perms (issues #1, #4)
-    const tmp = filePath + ".tmp";
-    writeFileSync(tmp, `${JSON.stringify(payload)}\n`, { mode: 0o600, flag: "w" });
-    chmodSync(tmp, 0o600);
-    atomicRename(tmp, filePath);
+    // Random tmp name + `wx` open prevents clobbering an attacker-prepared
+    // file (CWE-59/CWE-362). `wx` fails if the path already exists.
+    tmp = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 10)}.tmp`;
+    fd = openSync(tmp, "wx", 0o600);
+    writeSync(fd, `${JSON.stringify(payload)}\n`);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(tmp, filePath);
+    tmp = undefined;
   } catch (err) {
     console.warn(
       `discord component registry persist failed: ${err instanceof Error ? err.message : String(err)}`,
     );
-  }
-}
-
-function atomicRename(tmp: string, dest: string): void {
-  try {
-    // On POSIX, rename is atomic per the directory entry level.
-    // Node 22+ provides a native `fs.renameSync` which is atomic on same filesystem.
-    renameSync(tmp, dest);
-  } catch {
-    // If rename fails (e.g. cross-device on some POSIX), fall back to direct write.
-    // The file already has 0o600 so the permissions are correct either way.
-    try {
-      const { copyFileSync, unlinkSync } = require("node:fs");
-      copyFileSync(tmp, dest);
-      unlinkSync(tmp);
-    } catch {
-      // Best-effort; leave the temp file for manual cleanup.
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // best-effort
+      }
+    }
+    if (tmp !== undefined) {
+      try {
+        const { unlinkSync } = require("node:fs") as typeof import("node:fs");
+        unlinkSync(tmp);
+      } catch {
+        // best-effort
+      }
     }
   }
 }
@@ -250,7 +305,14 @@ function loadPersistedComponentRegistry(): void {
     return;
   }
   try {
-    // DoS guard: reject files larger than MAX_REGISTRY_BYTES (issue #2)
+    // Refuse to read through a symlink — an attacker who can stage a symlink
+    // inside the cache dir could redirect this read to an arbitrary file.
+    const lst = lstatSync(filePath);
+    if (lst.isSymbolicLink()) {
+      console.warn("discord component registry file is a symlink; ignoring");
+      return;
+    }
+    // DoS guard: reject files larger than MAX_REGISTRY_BYTES
     const st = statSync(filePath);
     if (st.size > MAX_REGISTRY_BYTES) {
       console.warn("discord component registry file too large; ignoring");
@@ -297,6 +359,14 @@ function getModalEntries(): Map<string, DiscordModalEntry> {
   return getModalEntriesStore();
 }
 
+function purgeExpired<T extends { expiresAt?: number }>(store: Map<string, T>, now: number): void {
+  for (const [id, entry] of store) {
+    if (isExpired(entry, now)) {
+      store.delete(id);
+    }
+  }
+}
+
 function registerEntries<
   T extends { id: string; messageId?: string; createdAt?: number; expiresAt?: number },
 >(
@@ -304,6 +374,16 @@ function registerEntries<
   store: Map<string, T>,
   params: { now: number; ttlMs: number; messageId?: string },
 ): void {
+  // Purge expired before inserting so stale entries do not hog the cap and
+  // the persisted snapshot only contains live items. Enforces the
+  // MAX_ENTRIES_PER_TYPE hard cap on registration paths, not just at load.
+  purgeExpired(store, params.now);
+  if (store.size + entries.length > MAX_ENTRIES_PER_TYPE) {
+    console.warn(
+      `discord component registry cap reached (${store.size}/${MAX_ENTRIES_PER_TYPE}); rejecting ${entries.length} new entries`,
+    );
+    return;
+  }
   for (const entry of entries) {
     const normalized = normalizeEntryTimestamps(
       { ...entry, messageId: params.messageId ?? entry.messageId },

--- a/extensions/discord/src/components-registry.ts
+++ b/extensions/discord/src/components-registry.ts
@@ -8,6 +8,7 @@ import {
   realpathSync,
   renameSync,
   statSync,
+  unlinkSync,
   writeSync,
 } from "node:fs";
 import { homedir } from "node:os";
@@ -23,20 +24,6 @@ const REGISTRY_FILE_VERSION = 1;
 const MAX_REGISTRY_BYTES = 1_000_000; // 1 MB — prevents unbounded read/parse DoS
 const MAX_ENTRIES_PER_TYPE = 10_000; // cap total entries per registry type
 const MAX_STRING_ARRAY_LEN = 1_000; // cap for options / allowedUsers arrays
-
-// Fields stripped from persisted entries. Routing fields (sessionKey/agentId/
-// accountId) and authorization fields (allowedUsers) are ephemeral by design
-// and must not be written to disk — an attacker reading the cache must not be
-// able to impersonate sessions or bypass allowlists after a gateway restart.
-const SENSITIVE_ENTRY_FIELDS = ["sessionKey", "agentId", "accountId", "allowedUsers"] as const;
-
-function stripSensitiveFields<T extends object>(entry: T): T {
-  const clone: Record<string, unknown> = { ...entry };
-  for (const key of SENSITIVE_ENTRY_FIELDS) {
-    delete clone[key];
-  }
-  return clone as T;
-}
 
 // --- Path hardening: validate env-var path stays under the safe base directory ---
 function resolveRegistryPath(): string {
@@ -173,11 +160,6 @@ function isModalEntryRecord(entry: unknown): entry is DiscordModalEntry {
   return true;
 }
 
-function clampExpiresAt(createdAt: number, expiresAt: number, maxAgeMs: number): number {
-  const maxAllowed = createdAt + maxAgeMs;
-  return expiresAt > maxAllowed ? maxAllowed : expiresAt;
-}
-
 function loadPersistedEntries<T extends { id: string; createdAt?: number; expiresAt?: number }>(
   rawEntries: unknown,
   store: Map<string, T>,
@@ -198,18 +180,7 @@ function loadPersistedEntries<T extends { id: string; createdAt?: number; expire
       changed = true;
       continue;
     }
-    // Clamp expiresAt to prevent far-future tampering (issue #3)
-    let normalized = normalizeEntryTimestamps(rawEntry, now, DEFAULT_COMPONENT_TTL_MS);
-    if (normalized.expiresAt) {
-      normalized = {
-        ...normalized,
-        expiresAt: clampExpiresAt(
-          normalized.createdAt ?? now,
-          normalized.expiresAt,
-          DEFAULT_COMPONENT_TTL_MS,
-        ),
-      };
-    }
+    const normalized = normalizeEntryTimestamps(rawEntry, now, DEFAULT_COMPONENT_TTL_MS);
     if (isExpired(normalized, now)) {
       changed = true;
       continue;
@@ -254,21 +225,26 @@ function assertSafeRegistryDestination(filePath: string): void {
 }
 
 function persistComponentRegistry(): void {
-  const filePath = getRegistryPath();
   let tmp: string | undefined;
   let fd: number | undefined;
   try {
+    const filePath = getRegistryPath();
     assertSafeRegistryDestination(filePath);
     const payload: PersistedRegistryFile = {
       version: REGISTRY_FILE_VERSION,
-      components: [...getComponentEntriesStore().values()].map(stripSensitiveFields),
-      modals: [...getModalEntriesStore().values()].map(stripSensitiveFields),
+      components: [...getComponentEntriesStore().values()],
+      modals: [...getModalEntriesStore().values()],
     };
+    const serialized = `${JSON.stringify(payload)}\n`;
+    if (Buffer.byteLength(serialized, "utf8") > MAX_REGISTRY_BYTES) {
+      console.warn("discord component registry snapshot exceeds size limit; skipping persist");
+      return;
+    }
     // Random tmp name + `wx` open prevents clobbering an attacker-prepared
     // file (CWE-59/CWE-362). `wx` fails if the path already exists.
     tmp = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2, 10)}.tmp`;
     fd = openSync(tmp, "wx", 0o600);
-    writeSync(fd, `${JSON.stringify(payload)}\n`);
+    writeSync(fd, serialized);
     closeSync(fd);
     fd = undefined;
     renameSync(tmp, filePath);
@@ -286,7 +262,6 @@ function persistComponentRegistry(): void {
     }
     if (tmp !== undefined) {
       try {
-        const { unlinkSync } = require("node:fs") as typeof import("node:fs");
         unlinkSync(tmp);
       } catch {
         // best-effort
@@ -300,11 +275,11 @@ function loadPersistedComponentRegistry(): void {
     return;
   }
   componentRegistryLoaded = true;
-  const filePath = getRegistryPath();
-  if (!existsSync(filePath)) {
-    return;
-  }
   try {
+    const filePath = getRegistryPath();
+    if (!existsSync(filePath)) {
+      return;
+    }
     // Refuse to read through a symlink — an attacker who can stage a symlink
     // inside the cache dir could redirect this read to an arbitrary file.
     const lst = lstatSync(filePath);

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { MessageFlags } from "discord-api-types/v10";
@@ -240,6 +240,75 @@ describe("discord component registry", () => {
     });
     expect(reloadedModal?.expiresAt).toBeDefined();
     expect(existsSync(registryFile)).toBe(true);
+  });
+
+  it("drops persisted entries with invalid runtime field types while keeping valid ones", async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), "openclaw-registry-home-"));
+    registryDirCleanup.add(tempHome);
+    process.env.HOME = tempHome;
+    const registryDir = join(tempHome, ".openclaw", "cache");
+    const registryFile = join(registryDir, "discord-component-registry.json");
+    process.env.OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE = registryFile;
+    mkdirSync(registryDir, { recursive: true });
+    writeFileSync(
+      registryFile,
+      `${JSON.stringify({
+        version: 1,
+        components: [
+          {
+            id: "btn_valid",
+            kind: "button",
+            label: "Valid",
+            callbackData: "codex:ok",
+            allowedUsers: ["discord:user-1"],
+            messageId: "msg_valid",
+          },
+          {
+            id: "btn_invalid",
+            kind: "button",
+            label: "Invalid",
+            callbackData: 123,
+            allowedUsers: {},
+          },
+        ],
+        modals: [
+          {
+            id: "mdl_valid",
+            title: "Valid modal",
+            callbackData: "codex:modal",
+            allowedUsers: ["discord:user-1"],
+            fields: [{ id: "fld_1", name: "name", label: "Name", type: "text" }],
+          },
+          {
+            id: "mdl_invalid",
+            title: "Invalid modal",
+            callbackData: 123,
+            allowedUsers: {},
+            fields: [{ id: "fld_1", name: "name", label: "Name", type: "text" }],
+          },
+        ],
+      })}\n`,
+    );
+
+    const registry = (await import(
+      `${componentsRegistryModuleUrl}?t=invalid-runtime-fields-${Date.now()}`
+    )) as typeof import("./components-registry.js");
+
+    expect(registry.resolveDiscordComponentEntry({ id: "btn_valid", consume: false })).toMatchObject(
+      {
+        id: "btn_valid",
+        callbackData: "codex:ok",
+        allowedUsers: ["discord:user-1"],
+        messageId: "msg_valid",
+      },
+    );
+    expect(registry.resolveDiscordComponentEntry({ id: "btn_invalid", consume: false })).toBeNull();
+    expect(registry.resolveDiscordModalEntry({ id: "mdl_valid", consume: false })).toMatchObject({
+      id: "mdl_valid",
+      callbackData: "codex:modal",
+      allowedUsers: ["discord:user-1"],
+    });
+    expect(registry.resolveDiscordModalEntry({ id: "mdl_invalid", consume: false })).toBeNull();
   });
 
   it("treats invalid registry paths as best-effort instead of throwing", async () => {

--- a/extensions/discord/src/components.test.ts
+++ b/extensions/discord/src/components.test.ts
@@ -1,5 +1,9 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { MessageFlags } from "discord-api-types/v10";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { resolveGlobalMap } from "openclaw/plugin-sdk/global-singleton";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 let clearDiscordComponentEntries: typeof import("./components-registry.js").clearDiscordComponentEntries;
 let registerDiscordComponentEntries: typeof import("./components-registry.js").registerDiscordComponentEntries;
@@ -8,6 +12,7 @@ let resolveDiscordModalEntry: typeof import("./components-registry.js").resolveD
 let buildDiscordComponentMessage: typeof import("./components.js").buildDiscordComponentMessage;
 let buildDiscordComponentMessageFlags: typeof import("./components.js").buildDiscordComponentMessageFlags;
 let readDiscordComponentSpec: typeof import("./components.js").readDiscordComponentSpec;
+const ORIGINAL_HOME = process.env.HOME;
 
 beforeAll(async () => {
   ({
@@ -82,8 +87,34 @@ describe("discord components", () => {
 });
 
 describe("discord component registry", () => {
+  const registryDirCleanup = new Set<string>();
+
+  function clearRegistryStores() {
+    resolveGlobalMap<string, unknown>(Symbol.for("openclaw.discord.componentEntries")).clear();
+    resolveGlobalMap<string, unknown>(Symbol.for("openclaw.discord.modalEntries")).clear();
+  }
+
+  async function waitForPersist() {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+
   beforeEach(() => {
     clearDiscordComponentEntries();
+    clearRegistryStores();
+  });
+
+  afterEach(() => {
+    delete process.env.OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE;
+    if (ORIGINAL_HOME === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = ORIGINAL_HOME;
+    }
+    clearRegistryStores();
+    for (const dir of registryDirCleanup) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    registryDirCleanup.clear();
   });
 
   const componentsRegistryModuleUrl = new URL("./components-registry.ts", import.meta.url).href;
@@ -135,5 +166,105 @@ describe("discord component registry", () => {
     );
 
     second.clearDiscordComponentEntries();
+  });
+
+  it("reloads persisted route overrides, allowlists, and custom TTL values", async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), "openclaw-registry-home-"));
+    registryDirCleanup.add(tempHome);
+    process.env.HOME = tempHome;
+    const registryFile = join(
+      tempHome,
+      ".openclaw",
+      "cache",
+      "discord-component-registry.json",
+    );
+    process.env.OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE = registryFile;
+    const first = (await import(
+      `${componentsRegistryModuleUrl}?t=persist-first-${Date.now()}`
+    )) as typeof import("./components-registry.js");
+    const second = (await import(
+      `${componentsRegistryModuleUrl}?t=persist-second-${Date.now()}`
+    )) as typeof import("./components-registry.js");
+
+    first.registerDiscordComponentEntries({
+      entries: [
+        {
+          id: "btn_persist",
+          kind: "button",
+          label: "Persisted",
+          sessionKey: "agent:main:discord:channel:c1",
+          agentId: "main",
+          accountId: "discord-default",
+          allowedUsers: ["discord:user-1"],
+        },
+      ],
+      modals: [
+        {
+          id: "mdl_persist",
+          title: "Persisted modal",
+          sessionKey: "agent:main:discord:channel:c1",
+          agentId: "main",
+          accountId: "discord-default",
+          allowedUsers: ["discord:user-1"],
+          fields: [{ id: "fld_1", name: "name", label: "Name", type: "text" }],
+        },
+      ],
+      ttlMs: 3 * 60 * 60 * 1000,
+      messageId: "msg_persist",
+    });
+    const beforeReload = first.resolveDiscordComponentEntry({ id: "btn_persist", consume: false });
+    expect(beforeReload?.expiresAt).toBeDefined();
+
+    await waitForPersist();
+    clearRegistryStores();
+
+    const reloaded = second.resolveDiscordComponentEntry({ id: "btn_persist", consume: false });
+    const reloadedModal = second.resolveDiscordModalEntry({ id: "mdl_persist", consume: false });
+
+    expect(reloaded).toMatchObject({
+      id: "btn_persist",
+      sessionKey: "agent:main:discord:channel:c1",
+      agentId: "main",
+      accountId: "discord-default",
+      allowedUsers: ["discord:user-1"],
+      messageId: "msg_persist",
+    });
+    expect(reloaded?.expiresAt).toBe(beforeReload?.expiresAt);
+    expect(reloadedModal).toMatchObject({
+      id: "mdl_persist",
+      sessionKey: "agent:main:discord:channel:c1",
+      agentId: "main",
+      accountId: "discord-default",
+      allowedUsers: ["discord:user-1"],
+      messageId: "msg_persist",
+    });
+    expect(reloadedModal?.expiresAt).toBeDefined();
+    expect(existsSync(registryFile)).toBe(true);
+  });
+
+  it("treats invalid registry paths as best-effort instead of throwing", async () => {
+    const tempHome = mkdtempSync(join(tmpdir(), "openclaw-registry-home-"));
+    registryDirCleanup.add(tempHome);
+    process.env.HOME = tempHome;
+    process.env.OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE = join(tempHome, "..", "outside-registry.json");
+    const registry = (await import(
+      `${componentsRegistryModuleUrl}?t=invalid-path-${Date.now()}`
+    )) as typeof import("./components-registry.js");
+
+    expect(() =>
+      registry.registerDiscordComponentEntries({
+        entries: [{ id: "btn_invalid", kind: "button", label: "Still works" }],
+        modals: [],
+      }),
+    ).not.toThrow();
+    await waitForPersist();
+
+    expect(registry.resolveDiscordComponentEntry({ id: "btn_invalid", consume: false })).toMatchObject(
+      {
+        id: "btn_invalid",
+        label: "Still works",
+      },
+    );
+    expect(() => registry.clearDiscordComponentEntries()).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Persist the in-memory Discord component/modal registry to
`~/.openclaw/cache/discord-component-registry.json` (override with
`OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE`) so interactive components stay
resolvable after a gateway restart.

Today the registry lives only in a process-global `Map` keyed on
`Symbol.for("openclaw.discord.componentEntries")`. When the gateway
restarts (upgrade, crash, LaunchAgent cycle, Mac sleep), every pending
button/modal becomes unroutable and the user sees \"component expired\"
even though the Discord message still shows a live button.

This is especially painful in multi-agent setups where cron-owned
components (daily check-ins, hourly prompts) are sent outside the
current Discord session and need to survive beyond the lifetime of one
gateway process.

## Implementation

`extensions/discord/src/components-registry.ts`:

- Add a lazy `loadPersistedComponentRegistry()` that the `getComponentEntries`
  / `getModalEntries` accessors call the first time they are touched. Loader
  validates each record via a small `isRegistryEntryRecord` type guard, drops
  expired entries, and rewrites the file if anything was skipped.
- Add `persistComponentRegistry()` which writes both maps out under a
  versioned envelope (`{ version: 1, components, modals }`). It is called
  after register, successful resolve/consume, and delete-on-expiry.
- File path defaults to `join(homedir(), \".openclaw\", \"cache\", \"discord-component-registry.json\")`
  and honors `OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE` so tests and
  alternate deployments can redirect it.
- Errors from read/write/parse are logged via `console.warn` and the
  in-memory map is still trusted — persistence is best-effort.

No API surface changes; `registerDiscordComponentEntries`,
`resolveDiscord*Entry`, `clearDiscordComponentEntries` keep their existing
signatures.

## Why not core

The registry is discord-specific (keyed on the two `Symbol.for` maps
already defined here), so the persistence lives next to the existing
registry code rather than in a generic helper. If other channels grow a
similar need, the helpers here can move behind a shared
`plugin-sdk/channel-registry-persistence` seam later.

## Test plan

- [ ] Unit: round-trip `registerDiscordComponentEntries` →
      `persistComponentRegistry` → new process →
      `loadPersistedComponentRegistry` → `resolveDiscordComponentEntry`
      returns the same entry.
- [ ] Unit: expired entries on disk are skipped and the file is
      rewritten.
- [ ] Unit: malformed JSON / missing `id` field is dropped without
      throwing.
- [ ] Manual: send a Discord button via OpenClaw, restart gateway,
      click the button — handler fires instead of \"expired\".

## Rollout

No config required. Behavior is backwards compatible: absent or
unreadable file leaves the in-memory map empty (same as today). Set
`OPENCLAW_DISCORD_COMPONENT_REGISTRY_FILE` to a tmp path in tests that
must not touch the real cache.