### PR TITLE
[codex] fix devices approve local fallback

### DIFF
--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -152,7 +152,9 @@ When you set `--url`, the CLI does not fall back to config or environment creden
   rotate or revoke a token that currently carries `operator.admin` or
   `operator.write`.
 - `devices clear` is intentionally gated by `--yes`.
-- If pairing scope is unavailable on local loopback (and no explicit `--url` is passed), list/approve can use a local pairing fallback.
+- If pairing scope is unavailable on local loopback, list/approve can use a local
+  pairing fallback only when you did not pass explicit `--url`, `--token`, or
+  `--password` flags.
 - `devices approve` requires an explicit request ID before minting tokens; omitting `requestId` or passing `--latest` only previews the newest pending request.
 
 ## Token drift recovery checklist

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -636,6 +636,25 @@ describe("devices cli local fallback", () => {
     ).rejects.toThrow("pairing required");
     expect(listDevicePairing).not.toHaveBeenCalled();
   });
+
+  it("does not use local list fallback when an explicit --token is provided", async () => {
+    rejectGatewayForLocalFallback();
+
+    await expect(runDevicesCommand(["list", "--json", "--token", "token-1"])).rejects.toThrow(
+      "pairing required",
+    );
+    expect(listDevicePairing).not.toHaveBeenCalled();
+  });
+
+  it("does not use local approve fallback when an explicit --password is provided", async () => {
+    callGateway.mockRejectedValue(new Error("gateway closed (1008): pairing required"));
+
+    await expect(runDevicesApprove(["req-password", "--password", "secret"])).rejects.toThrow(
+      "pairing required",
+    );
+    expect(listDevicePairing).not.toHaveBeenCalled();
+    expect(approveDevicePairing).not.toHaveBeenCalled();
+  });
 });
 
 describe("devices cli list", () => {

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -163,6 +163,9 @@ function resolveLocalPairingFallback(
     // switch to local pairing files in that case.
     return null;
   }
+  if (normalizeOptionalString(opts.token) || normalizeOptionalString(opts.password)) {
+    return null;
+  }
   const connection = buildGatewayConnectionDetails();
   if (connection.urlSource !== "local loopback") {
     return null;


### PR DESCRIPTION
## Summary
- rebase the device approval fix onto current `main` after the recent gateway-side pairing changes
- keep `devices approve` on the Gateway-first path so Gateway authorization, approval logging, and `device.pair.resolved` broadcasts are preserved
- disable local pairing fallback when explicit `--url`, `--token`, or `--password` flags are provided, with CLI tests and docs coverage

## Root cause / resolution
The original local-first approval change is no longer the right shape on current `main`: it could bypass Gateway approval side effects and device-token authorization checks. This update keeps approval routed through `device.pair.approve` first and only allows the existing local loopback fallback for implicit local credentials. When a caller provides explicit Gateway/auth flags, the CLI now stays on the Gateway-authenticated path instead of silently reading local pairing files.

## Real behavior proof
- **Behavior or issue addressed:** Explicit `--token` auth on a local loopback `devices list` command must stay on the Gateway-authenticated path and must not silently fall back to local pairing files.
- **Real environment tested:** Local macOS source checkout on this rebased branch, with a temporary `OPENCLAW_STATE_DIR`, temporary `OPENCLAW_CONFIG_PATH`, and a current-branch loopback gateway started on `127.0.0.1:18891` using `pnpm openclaw gateway run --bind loopback --port 18891 --force --allow-unconfigured`.
- **Exact steps or command run after the patch:** Started the temporary gateway, waited for the port to bind, then ran `pnpm openclaw devices list --json --token [REDACTED_TOKEN]` with `OPENCLAW_GATEWAY_PORT=18891` and the same temporary config/state environment.
- **Evidence after fix:** Redacted terminal output and gateway log excerpt from the live local run:

```text
$ pnpm openclaw devices list --json --token [REDACTED_TOKEN]
gateway connect failed: GatewayClientRequestError: unauthorized: gateway token mismatch (set gateway.remote.token to match gateway.auth.token)
[openclaw] Could not start the CLI.
[openclaw] Reason: gateway closed (1008): unauthorized: gateway token mismatch (set gateway.remote.token to match gateway.auth.token)
Gateway target: ws://127.0.0.1:18891
Source: local loopback
Config: [TMPDIR]/openclaw.json
Bind: loopback

$ tail -n 30 gateway.log
[gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 3.3s)
[gateway] ready
[ws] unauthorized ... client=cli cli v2026.5.8 role=operator scopes=1 auth=token device=yes ... reason=token_mismatch
[ws] closed before connect ... code=1008 reason=connect failed
```

- **Observed result after fix:** The explicit-token CLI call failed through Gateway auth with `token_mismatch` on the local loopback gateway. The output did not include `Direct scope access failed; using local fallback.`, and the gateway log recorded `auth=token`, which shows the command remained on the explicit Gateway auth path.
- **What was not tested:** No additional gaps.

## Tests
- `pnpm test src/cli/devices-cli.test.ts`
- `pnpm test src/gateway/server-methods/devices.test.ts`
- `pnpm check:changed`
