### PR TITLE
fix(cron): guard against undefined sessionTarget in job validation

### DIFF
--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -72,7 +72,7 @@ export function resolveCronDeliveryPlan(job: CronJob): CronDeliveryPlan {
     job.payload.kind === "agentTurn" &&
     (job.sessionTarget === "isolated" ||
       job.sessionTarget === "current" ||
-      job.sessionTarget.startsWith("session:"));
+      (typeof job.sessionTarget === "string" && job.sessionTarget.startsWith("session:")));
   const resolvedMode = isIsolatedAgentTurn ? "announce" : "none";
 
   return {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -135,6 +135,9 @@ function resolveEveryAnchorMs(params: {
 }
 
 export function assertSupportedJobSpec(job: Pick<CronJob, "sessionTarget" | "payload">) {
+  if (!job.sessionTarget) {
+    throw new Error("cron job requires a sessionTarget (e.g. isolated, main, current, or session:<key>)");
+  }
   const isIsolatedLike =
     job.sessionTarget === "isolated" ||
     job.sessionTarget === "current" ||
@@ -186,7 +189,7 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
   const isIsolatedLike =
     job.sessionTarget === "isolated" ||
     job.sessionTarget === "current" ||
-    job.sessionTarget.startsWith("session:");
+    (typeof job.sessionTarget === "string" && job.sessionTarget.startsWith("session:"));
   if (!isIsolatedLike) {
     throw new Error('cron channel delivery config is only supported for sessionTarget="isolated"');
   }


### PR DESCRIPTION
## Summary

\`assertSupportedJobSpec\` and \`resolveDeliveryPlan\` both call \`sessionTarget.startsWith(\"session:\")\` without checking if \`sessionTarget\` is defined. When a cron job is created without \`sessionTarget\`, the gateway crashes:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'startsWith')
\`\`\`

Fixes #66283

## Fix

3 sites guarded across 2 files:

- **\`jobs.ts:137\`** (\`assertSupportedJobSpec\`): add early \`if (!job.sessionTarget) throw\` with clear error message
- **\`delivery-plan.ts:75\`**: add \`typeof job.sessionTarget === \"string\" &&\` before \`.startsWith()\`
- **\`jobs.ts:192\`**: same typeof guard

## Scope

- **Files**: \`src/cron/service/jobs.ts\` (+4), \`src/cron/delivery-plan.ts\` (+1)
- **oxlint clean**
- **Zero competing PRs**
- NOT in the session.ts AVOID zone — these are different cron files

Credit to @soloxue for the crash report in #66283.