### PR TITLE
fix(heartbeat): remove markdown fences from HEARTBEAT.md template

### DIFF
--- a/docs/reference/templates/HEARTBEAT.md
+++ b/docs/reference/templates/HEARTBEAT.md
@@ -5,10 +5,6 @@ read_when:
   - Bootstrapping a workspace manually
 ---
 
-# HEARTBEAT.md Template
-
-```markdown
 # Keep this file empty (or with only comments) to skip heartbeat API calls.
 
 # Add tasks below when you want the agent to check something periodically.
-```


### PR DESCRIPTION
## Summary

The shipped \`HEARTBEAT.md\` template wrapped its content in \`\`\`markdown fences. \`isHeartbeatContentEffectivelyEmpty()\` (\`src/auto-reply/heartbeat.ts:30\`) skips \`#\`-headers and empty lines but treats backtick fence lines as content — so **every new workspace's default heartbeat file was classified as \"has tasks\"** and triggered an LLM API call every heartbeat cycle (typically every 30min).

This affects **every new install since v2026.3.22** (~4 weeks) and burns tokens silently with no user-visible benefit.

Fixes #66284

## Root cause

\`\`\`markdown
<!-- docs/reference/templates/HEARTBEAT.md (before fix) -->
---
title: \"HEARTBEAT.md Template\"
...
---

# HEARTBEAT.md Template        ← skipped by emptiness check (# header)

\\\`\\\`\\\`markdown                    ← NOT skipped → treated as content
# Keep this file empty...      ← skipped (# header)
# Add tasks below...           ← skipped (# header)  
\\\`\\\`\\\`                            ← NOT skipped → treated as content
\`\`\`

\`isHeartbeatContentEffectivelyEmpty\` (line 48) only skips lines matching \`/^#+(\s|$)/\`. The backtick fence lines don't match → function returns \`false\` → heartbeat fires.

## Fix

Remove the \`# HEARTBEAT.md Template\` heading and the backtick fences. The remaining \`#\` comment lines are properly recognized as empty by the existing emptiness check.

## Impact

- **Before**: every new workspace burns an LLM API call every 30min on an empty heartbeat
- **After**: empty heartbeat is correctly detected, no API calls until user adds tasks

## Scope

- **1 file**: \`docs/reference/templates/HEARTBEAT.md\` (-4 lines)
- **Zero competing PRs**

Credit to the reporter of #66284 for identifying the backtick fence interaction.