### PR TITLE
fix(heartbeat): remove doc-display fences from HEARTBEAT.md template

### DIFF
--- a/docs/reference/templates/HEARTBEAT.md
+++ b/docs/reference/templates/HEARTBEAT.md
@@ -5,10 +5,6 @@ read_when:
   - Bootstrapping a workspace manually
 ---
 
-# HEARTBEAT.md Template
-
-```markdown
 # Keep this file empty (or with only comments) to skip heartbeat API calls.
 
 # Add tasks below when you want the agent to check something periodically.
-```


### PR DESCRIPTION
## Summary

Removes the markdown code fences and doc-display heading from the \HEARTBEAT.md\ workspace template so that \loadTemplate()\ writes a clean file into user workspaces.

Closes #66284

## Problem

Commit \198de10\ ("docs: add missing H1 headings and fix HEARTBEAT template") wrapped the template body in a \# HEARTBEAT.md Template\ heading and \\\\\\markdown\\\ / \\\\\\\\\ fences for documentation display. Since \loadTemplate()\ in \src/agents/workspace.ts\ only strips YAML front matter (via \stripFrontMatter()\), these doc artifacts were written verbatim into every new user's workspace \HEARTBEAT.md\.

## Prior mitigation

This was **already mitigated at runtime** in commit \790343c\ ("fix(heartbeat): widen empty-detection to skip API calls for comment-only HEARTBEAT.md", Apr 10 by @ravyg) which added a regex to \isHeartbeatContentEffectivelyEmpty()\ to skip fence markers (\/^\\\[A-Za-z0-9_-]*$/\). So the silent token waste described in the issue is no longer happening.

## This fix

This commit fixes the **root cause** — the template itself — so that new workspaces get a clean \HEARTBEAT.md\ without stray fences or a doc heading that serves no runtime purpose.

## Changes

- \docs/reference/templates/HEARTBEAT.md\: Removed \# HEARTBEAT.md Template\ heading and surrounding code fences. YAML front matter is preserved (stripped by \loadTemplate()\ at runtime).

## Testing

- All heartbeat and workspace tests pass (28+ heartbeat tests, 8 workspace tests)
- Template is excluded from markdownlint (\.markdownlint-cli2.jsonc\ ignores \docs/reference/templates/**\)
- Change is a 4-line deletion with no logic changes

## AI Disclosure

- [x] AI-assisted (GitHub Copilot CLI)
- [x] Fully tested — ran \pnpm test:unit\ and all heartbeat/workspace tests pass
- [x] I understand what the code does