### PR TITLE
fix(model-catalog): cache empty catalog loads briefly

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -82,6 +82,7 @@ describe("loadModelCatalog", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     __setModelCatalogImportForTest();
     resetModelCatalogCacheForTest();
     vi.restoreAllMocks();
@@ -109,6 +110,136 @@ describe("loadModelCatalog", () => {
       setLoggerOverride(null);
       resetLogger();
     }
+  });
+
+  it("briefly caches empty catalog results to avoid repeated slow discovery", async () => {
+    let registryReads = 0;
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage: () => ({}),
+          AuthStorage: function AuthStorage() {},
+          ModelRegistry: class {
+            getAll() {
+              registryReads += 1;
+              return [];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const cfg = {} as OpenClawConfig;
+    await expect(loadModelCatalog({ config: cfg })).resolves.toEqual([]);
+    await expect(loadModelCatalog({ config: cfg })).resolves.toEqual([]);
+
+    expect(registryReads).toBe(1);
+  });
+
+  it("bypasses cached empty catalog results when useCache is false", async () => {
+    let registryReads = 0;
+    let models: unknown[] = [];
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage: () => ({}),
+          AuthStorage: function AuthStorage() {},
+          ModelRegistry: class {
+            getAll() {
+              registryReads += 1;
+              return models;
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const cfg = {} as OpenClawConfig;
+    await expect(loadModelCatalog({ config: cfg })).resolves.toEqual([]);
+
+    models = [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }];
+    await expect(loadModelCatalog({ config: cfg, useCache: false })).resolves.toEqual([
+      { id: "gpt-4.1", name: "GPT-4.1", provider: "openai" },
+    ]);
+    expect(registryReads).toBe(2);
+  });
+
+  it("ignores empty retry state from stale concurrent catalog loads", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-14T00:00:00.000Z"));
+    let registryReads = 0;
+    let importCalls = 0;
+    let releaseFirstImport!: () => void;
+    const firstImportReady = new Promise<void>((resolve) => {
+      releaseFirstImport = resolve;
+    });
+
+    __setModelCatalogImportForTest(async () => {
+      importCalls += 1;
+      const currentCall = importCalls;
+      if (currentCall === 1) {
+        await firstImportReady;
+      }
+      const models =
+        currentCall === 1 ? [] : [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }];
+      return {
+        discoverAuthStorage: () => ({}),
+        AuthStorage: function AuthStorage() {},
+        ModelRegistry: class {
+          getAll() {
+            registryReads += 1;
+            return models;
+          }
+        },
+      } as unknown as PiSdkModule;
+    });
+
+    const cfg = {} as OpenClawConfig;
+    const staleEmptyLoad = loadModelCatalog({ config: cfg });
+    await expect(loadModelCatalog({ config: cfg, useCache: false })).resolves.toEqual([
+      { id: "gpt-4.1", name: "GPT-4.1", provider: "openai" },
+    ]);
+
+    releaseFirstImport();
+    await expect(staleEmptyLoad).resolves.toEqual([]);
+
+    vi.setSystemTime(new Date("2026-04-14T00:01:01.000Z"));
+
+    await expect(loadModelCatalog({ config: cfg })).resolves.toEqual([
+      { id: "gpt-4.1", name: "GPT-4.1", provider: "openai" },
+    ]);
+    expect(registryReads).toBe(2);
+  });
+
+  it("retries an empty catalog after the negative cache window", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-14T00:00:00.000Z"));
+    let registryReads = 0;
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage: () => ({}),
+          AuthStorage: function AuthStorage() {},
+          ModelRegistry: class {
+            getAll() {
+              registryReads += 1;
+              return registryReads === 1
+                ? []
+                : [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+
+    const cfg = {} as OpenClawConfig;
+    await expect(loadModelCatalog({ config: cfg })).resolves.toEqual([]);
+    await expect(loadModelCatalog({ config: cfg })).resolves.toEqual([]);
+    expect(registryReads).toBe(1);
+
+    vi.setSystemTime(new Date("2026-04-14T00:01:01.000Z"));
+
+    await expect(loadModelCatalog({ config: cfg })).resolves.toEqual([
+      { id: "gpt-4.1", name: "GPT-4.1", provider: "openai" },
+    ]);
+    expect(registryReads).toBe(2);
   });
 
   it("returns partial results on discovery errors", async () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -12,6 +12,7 @@ import { ensureOpenClawModelsJson } from "./models-config.js";
 import { normalizeProviderId } from "./provider-id.js";
 
 const log = createSubsystemLogger("model-catalog");
+const EMPTY_MODEL_CATALOG_RETRY_MS = 60_000;
 
 export type { ModelCatalogEntry, ModelInputType } from "./model-catalog.types.js";
 
@@ -36,6 +37,8 @@ type PiRegistryClassLike = {
 };
 
 let modelCatalogPromise: Promise<ModelCatalogEntry[]> | null = null;
+let modelCatalogLoadToken: symbol | null = null;
+let emptyModelCatalogRetryAtMs = 0;
 let hasLoggedModelCatalogError = false;
 const defaultImportPiSdk = () => import("./pi-model-discovery-runtime.js");
 let importPiSdk = defaultImportPiSdk;
@@ -52,6 +55,8 @@ function loadModelSuppression() {
 
 export function resetModelCatalogCacheForTest() {
   modelCatalogPromise = null;
+  modelCatalogLoadToken = null;
+  emptyModelCatalogRetryAtMs = 0;
   hasLoggedModelCatalogError = false;
   importPiSdk = defaultImportPiSdk;
 }
@@ -79,11 +84,21 @@ export async function loadModelCatalog(params?: {
 }): Promise<ModelCatalogEntry[]> {
   if (params?.useCache === false) {
     modelCatalogPromise = null;
+    modelCatalogLoadToken = null;
+    emptyModelCatalogRetryAtMs = 0;
   }
   if (modelCatalogPromise) {
-    return modelCatalogPromise;
+    if (emptyModelCatalogRetryAtMs > 0 && Date.now() >= emptyModelCatalogRetryAtMs) {
+      modelCatalogPromise = null;
+      modelCatalogLoadToken = null;
+      emptyModelCatalogRetryAtMs = 0;
+    } else {
+      return modelCatalogPromise;
+    }
   }
 
+  const loadToken = Symbol("model-catalog-load");
+  modelCatalogLoadToken = loadToken;
   modelCatalogPromise = (async () => {
     const models: ModelCatalogEntry[] = [];
     const timingEnabled = shouldLogModelCatalogTiming();
@@ -176,9 +191,15 @@ export async function loadModelCatalog(params?: {
       }
       logStage("plugin-models-merged", `entries=${models.length}`);
 
-      if (models.length === 0) {
-        // If we found nothing, don't cache this result so we can try again.
-        modelCatalogPromise = null;
+      if (modelCatalogLoadToken !== loadToken) {
+        logStage("stale-load-complete", `entries=${models.length}`);
+      } else if (models.length === 0) {
+        // Empty catalogs can come from slow transient discovery failures. Cache the
+        // empty result briefly so every inbound message does not repeat the slow path.
+        emptyModelCatalogRetryAtMs = Date.now() + EMPTY_MODEL_CATALOG_RETRY_MS;
+        logStage("empty-catalog-cached", `retryAfterMs=${EMPTY_MODEL_CATALOG_RETRY_MS}`);
+      } else {
+        emptyModelCatalogRetryAtMs = 0;
       }
 
       const sorted = sortModels(models);
@@ -190,7 +211,11 @@ export async function loadModelCatalog(params?: {
         log.warn(`Failed to load model catalog: ${String(error)}`);
       }
       // Don't poison the cache on transient dependency/filesystem issues.
-      modelCatalogPromise = null;
+      if (modelCatalogLoadToken === loadToken) {
+        modelCatalogPromise = null;
+        modelCatalogLoadToken = null;
+        emptyModelCatalogRetryAtMs = 0;
+      }
       if (models.length > 0) {
         return sortModels(models);
       }


### PR DESCRIPTION
Closes #66094
## Summary

- Problem: when model discovery returned an empty catalog, `loadModelCatalog()` cleared the in-flight cache immediately.
- Why it matters: slow transient discovery failures could make every subsequent agent turn repeat the slow model catalog path before responding.
- What changed: empty catalog results are now cached briefly with a retry window, while successful non-empty loads and explicit `useCache: false` behavior remain unchanged.
- What did NOT change (scope boundary): this does not change model discovery sources, provider plugin catalog merging, or model validation behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66094
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `loadModelCatalog()` intentionally avoided caching empty catalog results by clearing `modelCatalogPromise` whenever `models.length === 0`. That made sense for retryability, but it also meant a slow transient empty discovery result could be retried on every inbound agent turn.
- Missing detection / guardrail: there was no regression test proving that an empty catalog result is cached long enough to avoid repeated slow discovery, or that it retries after a bounded window.
- Contributing context (if known): earlier fixes preserved retry behavior for import/filesystem failures, but empty successful results used the same immediate retry pattern and could therefore keep the slow path hot.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/model-catalog.test.ts`
- Scenario the test should lock in: repeated calls after an empty catalog result should reuse the cached empty result briefly, then retry discovery after the negative cache window.
- Why this is the smallest reliable guardrail: the bug is local to `loadModelCatalog()` cache invalidation semantics and can be verified by counting `ModelRegistry.getAll()` reads.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Agent turns should no longer repeatedly block on the slow model catalog discovery path after a transient empty catalog result. The catalog still retries after the short retry window.

## Diagram (if applicable)

```text
Before:
[empty catalog load] -> [clear cache] -> [next agent turn repeats slow discovery]

After:
[empty catalog load] -> [briefly cache empty result] -> [next agent turn skips slow discovery]
                   -> [retry window expires] -> [discovery retries]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Agent model catalog loading
- Relevant config (redacted): none

### Steps

1. Mock `ModelRegistry.getAll()` to return an empty catalog.
2. Call `loadModelCatalog()` twice with cache enabled.
3. Advance the clock past the negative cache retry window.
4. Call `loadModelCatalog()` again with a non-empty mocked catalog.

### Expected

- The second call reuses the cached empty result and does not rerun discovery.
- The call after the retry window reruns discovery and returns the non-empty catalog.

### Actual

- Before this change, empty catalog loads cleared `modelCatalogPromise`, so the next call reran discovery immediately.
- After this change, empty catalog loads are cached briefly and retried only after the retry window.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added regression coverage in `src/agents/model-catalog.test.ts`.

Local verification:

```text
pnpm test src/agents/model-catalog.test.ts
# Test Files  1 passed (1)
# Tests       12 passed (12)

pnpm check
# passed
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Empty catalog results are cached across immediate repeated `loadModelCatalog()` calls.
  - Empty catalog results are retried after the retry window.
  - Transient import/filesystem failures still clear the cache and remain retryable.
- Edge cases checked:
  - `useCache: false` clears the negative cache retry state.
  - Non-empty catalog loads clear the empty-catalog retry state.
- What you did **not** verify:
  - Full end-to-end chat latency against a live slow model discovery backend.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a truly fixed model catalog may remain empty until the short retry window expires.
  - Mitigation: the retry window is bounded, explicit `useCache: false` still bypasses it, and import/filesystem failures are not cached.
