### PR TITLE
feat(msteams): implement sendPayload for interactive approval cards

### DIFF
--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -1124,5 +1124,9 @@ export const msteamsPlugin: ChannelPlugin<ResolvedMSTeamsAccount, ProbeMSTeamsRe
         sendMedia: { resolve: (runtime) => runtime.msteamsOutbound.sendMedia },
         sendPoll: { resolve: (runtime) => runtime.msteamsOutbound.sendPoll },
       }),
+      sendPayload: async (ctx) => {
+        const runtime = await loadMSTeamsChannelRuntime();
+        return await runtime.msteamsOutbound.sendPayload!(ctx);
+      },
     },
   });

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -215,9 +215,15 @@ describe("msteamsOutbound cfg threading", () => {
       payload: {
         text: "",
         channelData: { msteams: { card: prebuiltCard } },
+        mediaUrls: ["https://example.com/image.png"],
       },
     });
 
+    // Media sent first, then card finalized
+    expect(mocks.sendMessageMSTeams).toHaveBeenCalledOnce();
+    expect(mocks.sendMessageMSTeams.mock.calls[0][0].mediaUrl).toBe(
+      "https://example.com/image.png",
+    );
     expect(mocks.sendAdaptiveCardMSTeams).toHaveBeenCalledWith({
       cfg,
       to: "conversation:abc",

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -175,6 +175,7 @@ describe("msteamsOutbound cfg threading", () => {
     expect(card.actions[0].data.msteams.type).toBe("messageBack");
     expect(card.actions[0].data.msteams.text).toBe("/approve abc123 yes");
     expect(card.actions[0].data.msteams.displayText).toBe("Approve");
+    expect(card.actions[0].style).toBe("positive");
     expect(card.actions[1].style).toBe("destructive");
   });
 

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -4,12 +4,14 @@ import type { OpenClawConfig } from "../runtime-api.js";
 const mocks = vi.hoisted(() => ({
   sendMessageMSTeams: vi.fn(),
   sendPollMSTeams: vi.fn(),
+  sendAdaptiveCardMSTeams: vi.fn(),
   createPoll: vi.fn(),
 }));
 
 vi.mock("./send.js", () => ({
   sendMessageMSTeams: mocks.sendMessageMSTeams,
   sendPollMSTeams: mocks.sendPollMSTeams,
+  sendAdaptiveCardMSTeams: mocks.sendAdaptiveCardMSTeams,
 }));
 
 vi.mock("./polls.js", () => ({
@@ -24,6 +26,7 @@ describe("msteamsOutbound cfg threading", () => {
   beforeEach(() => {
     mocks.sendMessageMSTeams.mockReset();
     mocks.sendPollMSTeams.mockReset();
+    mocks.sendAdaptiveCardMSTeams.mockReset();
     mocks.createPoll.mockReset();
     mocks.sendMessageMSTeams.mockResolvedValue({
       messageId: "msg-1",
@@ -32,6 +35,10 @@ describe("msteamsOutbound cfg threading", () => {
     mocks.sendPollMSTeams.mockResolvedValue({
       pollId: "poll-1",
       messageId: "msg-poll-1",
+      conversationId: "conv-1",
+    });
+    mocks.sendAdaptiveCardMSTeams.mockResolvedValue({
+      messageId: "msg-card-1",
       conversationId: "conv-1",
     });
     mocks.createPoll.mockResolvedValue(undefined);
@@ -126,5 +133,94 @@ describe("msteamsOutbound cfg threading", () => {
     }
 
     expect(chunker("alpha beta", 5)).toEqual(["alpha", "beta"]);
+  });
+
+  it("sendPayload renders interactive buttons as Adaptive Card with messageBack", async () => {
+    const cfg = {
+      channels: { msteams: { appId: "app-id" } },
+    } as OpenClawConfig;
+
+    await msteamsOutbound.sendPayload!({
+      cfg,
+      to: "conversation:abc",
+      text: "",
+      payload: {
+        text: "Approve this plugin?",
+        interactive: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                { label: "Approve", value: "/approve abc123 yes", style: "primary" },
+                { label: "Deny", value: "/approve abc123 no", style: "danger" },
+              ],
+            },
+          ],
+        },
+      },
+    });
+
+    expect(mocks.sendAdaptiveCardMSTeams).toHaveBeenCalledOnce();
+    const call = mocks.sendAdaptiveCardMSTeams.mock.calls[0][0];
+    expect(call.cfg).toBe(cfg);
+    expect(call.to).toBe("conversation:abc");
+
+    const card = call.card;
+    expect(card.type).toBe("AdaptiveCard");
+    expect(card.body).toEqual([
+      { type: "TextBlock", text: "Approve this plugin?", wrap: true },
+    ]);
+    expect(card.actions).toHaveLength(2);
+    expect(card.actions[0].title).toBe("Approve");
+    expect(card.actions[0].data.msteams.type).toBe("messageBack");
+    expect(card.actions[0].data.msteams.text).toBe("/approve abc123 yes");
+    expect(card.actions[0].data.msteams.displayText).toBe("Approve");
+    expect(card.actions[1].style).toBe("destructive");
+  });
+
+  it("sendPayload falls back to sendText when no interactive buttons present", async () => {
+    const cfg = {
+      channels: { msteams: { appId: "app-id" } },
+    } as OpenClawConfig;
+
+    await msteamsOutbound.sendPayload!({
+      cfg,
+      to: "conversation:abc",
+      text: "plain message",
+      payload: {
+        text: "plain message",
+      },
+    });
+
+    expect(mocks.sendAdaptiveCardMSTeams).not.toHaveBeenCalled();
+    expect(mocks.sendMessageMSTeams).toHaveBeenCalledOnce();
+  });
+
+  it("sendPayload sends pre-built channelData card directly", async () => {
+    const cfg = {
+      channels: { msteams: { appId: "app-id" } },
+    } as OpenClawConfig;
+
+    const prebuiltCard = {
+      type: "AdaptiveCard",
+      version: "1.5",
+      body: [{ type: "TextBlock", text: "Custom card" }],
+    };
+
+    await msteamsOutbound.sendPayload!({
+      cfg,
+      to: "conversation:abc",
+      text: "",
+      payload: {
+        text: "",
+        channelData: { msteams: { card: prebuiltCard } },
+      },
+    });
+
+    expect(mocks.sendAdaptiveCardMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "conversation:abc",
+      card: prebuiltCard,
+    });
   });
 });

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -1,8 +1,52 @@
-import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-send-result";
+import {
+  attachChannelToResult,
+  createAttachedChannelResultAdapter,
+} from "openclaw/plugin-sdk/channel-send-result";
+import { resolveInteractiveTextFallback } from "openclaw/plugin-sdk/interactive-runtime";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/outbound-runtime";
+import {
+  resolvePayloadMediaUrls,
+  sendPayloadMediaSequenceAndFinalize,
+  sendTextMediaPayload,
+} from "openclaw/plugin-sdk/reply-payload";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "../runtime-api.js";
 import { createMSTeamsPollStoreFs } from "./polls.js";
-import { sendMessageMSTeams, sendPollMSTeams } from "./send.js";
+import { sendAdaptiveCardMSTeams, sendMessageMSTeams, sendPollMSTeams } from "./send.js";
+
+/**
+ * Build an Adaptive Card from interactive approval buttons.
+ * Returns undefined if no buttons are found (caller should fall back to text).
+ */
+function buildApprovalAdaptiveCard(
+  interactive: { blocks?: Array<{ type: string; buttons?: Array<{ label: string; value: string; style?: string }> }> } | undefined,
+  text: string,
+): Record<string, unknown> | undefined {
+  const buttons = (interactive?.blocks ?? [])
+    .filter((b) => b.type === "buttons")
+    .flatMap((b) => b.buttons ?? []);
+  if (buttons.length === 0) {
+    return undefined;
+  }
+
+  return {
+    type: "AdaptiveCard",
+    version: "1.5",
+    body: text ? [{ type: "TextBlock", text, wrap: true }] : [],
+    actions: buttons.map((b) => ({
+      type: "Action.Submit",
+      title: b.label,
+      style: b.style === "danger" ? "destructive" : "default",
+      data: {
+        msteams: {
+          type: "messageBack",
+          text: b.value,
+          displayText: b.label,
+          value: { openclawApproval: b.value },
+        },
+      },
+    })),
+  };
+}
 
 export const msteamsOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
@@ -68,4 +112,57 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
       return result;
     },
   }),
+  sendPayload: async (ctx) => {
+    const payload = {
+      ...ctx.payload,
+      text:
+        resolveInteractiveTextFallback({
+          text: ctx.payload.text,
+          interactive: ctx.payload.interactive,
+        }) ?? "",
+    };
+
+    // If a pre-built Teams card was supplied via channelData, send it directly.
+    const teamsChannelData = payload.channelData?.msteams as
+      | { card?: Record<string, unknown> }
+      | undefined;
+    if (teamsChannelData?.card) {
+      const result = await sendAdaptiveCardMSTeams({
+        cfg: ctx.cfg,
+        to: ctx.to,
+        card: teamsChannelData.card,
+      });
+      return attachChannelToResult("msteams", result);
+    }
+
+    // Map interactive buttons to an Adaptive Card.
+    const card = buildApprovalAdaptiveCard(payload.interactive, payload.text);
+    if (!card) {
+      // No interactive buttons — fall back to text+media delivery.
+      return await sendTextMediaPayload({
+        channel: "msteams",
+        ctx: { ...ctx, payload },
+        adapter: msteamsOutbound,
+      });
+    }
+
+    // Send any media first, then finalize with the Adaptive Card.
+    const mediaUrls = resolvePayloadMediaUrls(payload);
+    return attachChannelToResult(
+      "msteams",
+      await sendPayloadMediaSequenceAndFinalize({
+        text: "",
+        mediaUrls,
+        send: async ({ text, mediaUrl }) =>
+          await sendMessageMSTeams({
+            cfg: ctx.cfg,
+            to: ctx.to,
+            text,
+            mediaUrl,
+          }),
+        finalize: async () =>
+          await sendAdaptiveCardMSTeams({ cfg: ctx.cfg, to: ctx.to, card }),
+      }),
+    );
+  },
 };

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -139,6 +139,8 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
               to: ctx.to,
               text,
               mediaUrl,
+              mediaLocalRoots: ctx.mediaLocalRoots,
+              mediaReadFile: ctx.mediaReadFile,
             }),
           finalize: async () =>
             await sendAdaptiveCardMSTeams({
@@ -174,6 +176,8 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
             to: ctx.to,
             text,
             mediaUrl,
+            mediaLocalRoots: ctx.mediaLocalRoots,
+            mediaReadFile: ctx.mediaReadFile,
           }),
         finalize: async () =>
           await sendAdaptiveCardMSTeams({ cfg: ctx.cfg, to: ctx.to, card }),

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -35,7 +35,7 @@ function buildApprovalAdaptiveCard(
     actions: buttons.map((b) => ({
       type: "Action.Submit",
       title: b.label,
-      style: b.style === "danger" ? "destructive" : "default",
+      style: b.style === "danger" ? "destructive" : b.style === "primary" || b.style === "success" ? "positive" : "default",
       data: {
         msteams: {
           type: "messageBack",

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -127,12 +127,27 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
       | { card?: Record<string, unknown> }
       | undefined;
     if (teamsChannelData?.card) {
-      const result = await sendAdaptiveCardMSTeams({
-        cfg: ctx.cfg,
-        to: ctx.to,
-        card: teamsChannelData.card,
-      });
-      return attachChannelToResult("msteams", result);
+      const mediaUrls = resolvePayloadMediaUrls(payload);
+      return attachChannelToResult(
+        "msteams",
+        await sendPayloadMediaSequenceAndFinalize({
+          text: "",
+          mediaUrls,
+          send: async ({ text, mediaUrl }) =>
+            await sendMessageMSTeams({
+              cfg: ctx.cfg,
+              to: ctx.to,
+              text,
+              mediaUrl,
+            }),
+          finalize: async () =>
+            await sendAdaptiveCardMSTeams({
+              cfg: ctx.cfg,
+              to: ctx.to,
+              card: teamsChannelData.card!,
+            }),
+        }),
+      );
     }
 
     // Map interactive buttons to an Adaptive Card.


### PR DESCRIPTION
## Summary

Implements `sendPayload` for the MS Teams channel extension so approval prompts render as Adaptive Cards with clickable buttons instead of plain text with raw `/approve` commands.

Closes #64690

## Problem

The Teams outbound adapter only implemented `sendText`, `sendMedia`, and `sendPoll`. The delivery pipeline checks `handler.sendPayload && hasReplyPayloadContent(...)` before dispatching interactive payloads — since Teams had no `sendPayload`, all approval prompts fell through to `sendText`, rendering as:

> Reply /approve abc123 yes to approve

## Solution

Added `sendPayload` to the Teams outbound adapter following the patterns established by Slack, Discord, and Telegram:

1. **`extensions/msteams/src/outbound.ts`**:
   - Added `buildApprovalAdaptiveCard()` helper that maps interactive button blocks to Adaptive Card `Action.Submit` buttons
   - Uses `messageBack` (not `imBack`) to avoid echoing raw approval tokens — matches the existing poll card pattern in `polls.ts`
   - Honors pre-built `channelData.msteams.card` if supplied
   - Uses `resolveInteractiveTextFallback()` to derive card body text from text blocks
   - Sends media first via `sendPayloadMediaSequenceAndFinalize`, then finalizes with the card
   - Falls back to `sendTextMediaPayload` when no interactive buttons are present

2. **`extensions/msteams/src/channel.ts`**:
   - Wired `sendPayload` directly on the outbound config (since `createRuntimeOutboundDelegates` only supports sendText/sendMedia/sendPoll), following the Slack channel pattern

Result: Approval prompts render as Adaptive Cards with "Approve" / "Deny" buttons. Clicking a button sends the `/approve` command via messageBack.

## Testing

- 3 new test cases in `outbound.test.ts`:
  - Interactive buttons → Adaptive Card with messageBack actions
  - No buttons → falls back to sendText
  - Pre-built channelData card → sent directly
- All 66 Teams extension test files pass (860 tests)
- Run: `pnpm test:extension msteams`

## AI Disclosure

- [x] AI-assisted (GitHub Copilot CLI)
- [x] Fully tested — `pnpm test:extension msteams` passes (860/860 tests)
- [x] I understand what the code does
- [x] I work at Microsoft and can verify this against a real Teams tenant
