### PR TITLE
fix(acp): fall through to thread-binding when token doesn't resolve

### DIFF
--- a/src/auto-reply/reply/commands-acp/targets.ts
+++ b/src/auto-reply/reply/commands-acp/targets.ts
@@ -61,13 +61,13 @@ export async function resolveAcpTargetSessionKey(params: {
   const token = normalizeOptionalString(params.token) ?? "";
   if (token) {
     const resolved = await resolveSessionKeyByToken(token);
-    if (!resolved) {
-      return {
-        ok: false,
-        error: `Unable to resolve session target: ${token}`,
-      };
+    if (resolved) {
+      return { ok: true, sessionKey: resolved };
     }
-    return { ok: true, sessionKey: resolved };
+    // Token didn't resolve as a session key/id/label — fall through to
+    // thread-binding lookup instead of returning an error. This handles
+    // the case where Discord slash command auto-fills the current thread
+    // ID as a positional arg, which is not a session identifier (#66299).
   }
 
   const threadBound = resolveBoundAcpThreadSessionKey(params.commandParams);


### PR DESCRIPTION
## Summary

\`resolveAcpTargetSessionKey\` returned an error immediately when the token was non-empty but didn't resolve as a session key — blocking the thread-binding fallback from ever being reached. This means \`/acp close\` inside a bound Discord thread fails when the slash command layer auto-fills the thread ID as a positional arg.

Fixes #66299

## Root cause

\`\`\`ts
// targets.ts:62-69 (before fix)
if (token) {
  const resolved = await resolveSessionKeyByToken(token);
  if (!resolved) {
    return { ok: false, error: \`Unable to resolve session target: \${token}\` };  // ← blocks fallback
  }
  return { ok: true, sessionKey: resolved };
}
// Line 73: resolveBoundAcpThreadSessionKey — UNREACHABLE when token is non-empty
\`\`\`

## Fix

When \`resolveSessionKeyByToken\` returns null, fall through to the thread-binding lookup:

\`\`\`ts
if (token) {
  const resolved = await resolveSessionKeyByToken(token);
  if (resolved) {
    return { ok: true, sessionKey: resolved };
  }
  // Fall through to thread-binding lookup
}
const threadBound = resolveBoundAcpThreadSessionKey(params.commandParams);
\`\`\`

## Scope

- **1 file**: \`src/auto-reply/reply/commands-acp/targets.ts\` (+5/-5)
- **oxlint clean**
- **Zero competing PRs**

Credit to @kindomLee for the exact RCA in #66299.