### PR TITLE
fix(tui): tool events dropped when arriving before chat delta

### DIFF
--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -326,9 +326,16 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as AgentEvent;
     syncSessionKey();
-    // Agent events (tool streaming, lifecycle) are emitted per-run. Filter against the
-    // active chat run id, not the session id. Tool results can arrive after the chat
-    // final event, so accept finalized runs for tool updates.
+    // Agent events (lifecycle, tool) can arrive before the first chat delta
+    // when the agent starts with tool calls instead of text output.
+    // Accept runs from the current session so tool cards render promptly.
+    const isSameSession = isSameSessionKey(evt.sessionKey, state.currentSessionKey);
+    if (!sessionRuns.has(evt.runId) && !finalizedRuns.has(evt.runId) && isSameSession) {
+      noteSessionRun(evt.runId);
+      if (!state.activeChatRunId) {
+        state.activeChatRunId = evt.runId;
+      }
+    }
     const isActiveRun = evt.runId === state.activeChatRunId;
     const isKnownRun = isActiveRun || sessionRuns.has(evt.runId) || finalizedRuns.has(evt.runId);
     if (!isKnownRun) {

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -332,8 +332,12 @@ export function createEventHandlers(context: EventHandlerContext) {
     const isSameSession = isSameSessionKey(evt.sessionKey, state.currentSessionKey);
     if (!sessionRuns.has(evt.runId) && !finalizedRuns.has(evt.runId) && isSameSession) {
       noteSessionRun(evt.runId);
-      if (!state.activeChatRunId) {
+      if (!state.activeChatRunId && !isLocalBtwRunId?.(evt.runId)) {
         state.activeChatRunId = evt.runId;
+        if (state.pendingOptimisticUserMessage) {
+          noteLocalRunId?.(evt.runId);
+          state.pendingOptimisticUserMessage = false;
+        }
       }
     }
     const isActiveRun = evt.runId === state.activeChatRunId;

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -32,6 +32,7 @@ export type BtwEvent = {
 export type AgentEvent = {
   runId: string;
   stream: string;
+  sessionKey?: string;
   data?: Record<string, unknown>;
 };
 


### PR DESCRIPTION
## Problem

When `/verbose full` is set in the TUI, tool execution cards are not rendered for live runs. They only appear after reloading history (e.g. via `/verbose full` which triggers `loadHistory()`). This means the user sees no tool activity during an active agent run.

## Root Cause

In `handleAgentEvent` (`src/tui/tui-event-handlers.ts`), agent events are filtered by an `isKnownRun` check that requires the `runId` to already be registered in `sessionRuns` or `finalizedRuns`. However, `sessionRuns` is only populated in `handleChatEvent` — specifically when a `chat` delta arrives.

When an agent starts execution with tool calls (instead of text output), the event arrival order is:

1. `agent` lifecycle start → `isKnownRun=false` → **dropped**
2. `agent` tool start → `isKnownRun=false` → **dropped** (tool card never created)
3. `chat` delta → `noteSessionRun(runId)` → runId now registered
4. Subsequent `agent` tool events → `isKnownRun=true` → rendered

The first tool events are silently discarded, so the tool card is never created and never appears.

History loads work because `loadHistory()` fetches the full message list (including `toolResult` role messages) directly from the Gateway API, bypassing the real-time event stream entirely.

## Fix

Pre-register runIds from the current session in `handleAgentEvent` before the `isKnownRun` check. The Gateway already includes `sessionKey` in agent event payloads, so we can match against the current session to accept legitimate early-arriving events without opening the door to cross-session noise.

Also adds `sessionKey` to the `AgentEvent` type definition since the Gateway payload already includes this field.

## Testing

- All 235 existing TUI tests pass
- All 40 gateway agent-events tests pass
- Pre-commit checks (`pnpm check`) pass
- Manually verified: tool cards now render in real-time with `/verbose full` in the TUI

## AI-Assisted

Yes — this PR was identified and fixed with AI assistance. The bug was diagnosed by tracing the event flow through the TUI and Gateway source code.