### PR TITLE
fix(custom-provider): add empty required arrays for non-strict OpenAI tool schemas

### DIFF
--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { normalizeOpenAIStrictToolParameters } from "./openai-tool-schema.js";
+
+describe("normalizeOpenAIStrictToolParameters", () => {
+  it("adds an explicit empty required array for non-strict top-level object schemas", () => {
+    expect(
+      normalizeOpenAIStrictToolParameters(
+        {
+          type: "object",
+          properties: {
+            text: { type: "string" },
+          },
+        },
+        false,
+      ),
+    ).toEqual({
+      type: "object",
+      properties: {
+        text: { type: "string" },
+      },
+      required: [],
+    });
+  });
+
+  it("preserves explicit required fields for non-strict object schemas", () => {
+    expect(
+      normalizeOpenAIStrictToolParameters(
+        {
+          type: "object",
+          properties: {
+            text: { type: "string" },
+          },
+          required: ["text"],
+        },
+        false,
+      ),
+    ).toEqual({
+      type: "object",
+      properties: {
+        text: { type: "string" },
+      },
+      required: ["text"],
+    });
+  });
+
+  it("adds explicit empty required arrays recursively for nested non-strict object schemas", () => {
+    expect(
+      normalizeOpenAIStrictToolParameters(
+        {
+          type: "object",
+          properties: {
+            filters: {
+              type: "object",
+              properties: {
+                status: { type: "string" },
+              },
+            },
+          },
+        },
+        false,
+      ),
+    ).toEqual({
+      type: "object",
+      properties: {
+        filters: {
+          type: "object",
+          properties: {
+            status: { type: "string" },
+          },
+          required: [],
+        },
+      },
+      required: [],
+    });
+  });
+});

--- a/src/agents/openai-tool-schema.test.ts
+++ b/src/agents/openai-tool-schema.test.ts
@@ -73,4 +73,48 @@ describe("normalizeOpenAIStrictToolParameters", () => {
       required: [],
     });
   });
+
+  it("does not mutate literal object values under non-schema keywords", () => {
+    const literalObject = { type: "object", label: "literal" };
+
+    expect(
+      normalizeOpenAIStrictToolParameters(
+        {
+          type: "object",
+          properties: {
+            enumValue: {
+              enum: [literalObject],
+            },
+            constValue: {
+              const: literalObject,
+            },
+            defaultValue: {
+              default: literalObject,
+            },
+            examplesValue: {
+              examples: [literalObject],
+            },
+          },
+        },
+        false,
+      ),
+    ).toEqual({
+      type: "object",
+      properties: {
+        enumValue: {
+          enum: [literalObject],
+        },
+        constValue: {
+          const: literalObject,
+        },
+        defaultValue: {
+          default: literalObject,
+        },
+        examplesValue: {
+          examples: [literalObject],
+        },
+      },
+      required: [],
+    });
+  });
 });

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -18,6 +18,47 @@ type ToolWithParameters = {
 
 const optionalString = readStringValue;
 
+const OPENAI_OBJECT_REQUIRED_ARRAY_SCHEMA_MAP_KEYS = new Set([
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+  "patternProperties",
+  "properties",
+]);
+
+const OPENAI_OBJECT_REQUIRED_ARRAY_NESTED_KEYS = new Set([
+  "additionalProperties",
+  "allOf",
+  "anyOf",
+  "contains",
+  "else",
+  "if",
+  "items",
+  "not",
+  "oneOf",
+  "prefixItems",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+]);
+
+function normalizeOpenAIObjectRequiredArraysSchemaMap(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
+    return schema;
+  }
+
+  let changed = false;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    const next = normalizeOpenAIObjectRequiredArraysRecursive(value);
+    normalized[key] = next;
+    changed ||= next !== value;
+  }
+
+  return changed ? normalized : schema;
+}
+
 function normalizeOpenAIObjectRequiredArraysRecursive(schema: unknown): unknown {
   if (Array.isArray(schema)) {
     let changed = false;
@@ -36,7 +77,12 @@ function normalizeOpenAIObjectRequiredArraysRecursive(schema: unknown): unknown 
   let changed = false;
   const normalized: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
-    const next = normalizeOpenAIObjectRequiredArraysRecursive(value);
+    let next = value;
+    if (OPENAI_OBJECT_REQUIRED_ARRAY_SCHEMA_MAP_KEYS.has(key)) {
+      next = normalizeOpenAIObjectRequiredArraysSchemaMap(value);
+    } else if (OPENAI_OBJECT_REQUIRED_ARRAY_NESTED_KEYS.has(key)) {
+      next = normalizeOpenAIObjectRequiredArraysRecursive(value);
+    }
     normalized[key] = next;
     changed ||= next !== value;
   }

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -18,6 +18,37 @@ type ToolWithParameters = {
 
 const optionalString = readStringValue;
 
+function normalizeOpenAIObjectRequiredArraysRecursive(schema: unknown): unknown {
+  if (Array.isArray(schema)) {
+    let changed = false;
+    const normalized = schema.map((entry) => {
+      const next = normalizeOpenAIObjectRequiredArraysRecursive(entry);
+      changed ||= next !== entry;
+      return next;
+    });
+    return changed ? normalized : schema;
+  }
+  if (!schema || typeof schema !== "object") {
+    return schema;
+  }
+
+  const record = schema as Record<string, unknown>;
+  let changed = false;
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const next = normalizeOpenAIObjectRequiredArraysRecursive(value);
+    normalized[key] = next;
+    changed ||= next !== value;
+  }
+
+  if (normalized.type === "object" && !Array.isArray(normalized.required)) {
+    normalized.required = [];
+    changed = true;
+  }
+
+  return changed ? normalized : schema;
+}
+
 export function normalizeStrictOpenAIJsonSchema(schema: unknown): unknown {
   return normalizeStrictOpenAIJsonSchemaRecursive(normalizeToolParameterSchema(schema ?? {}));
 }
@@ -63,7 +94,9 @@ function normalizeStrictOpenAIJsonSchemaRecursive(schema: unknown): unknown {
 
 export function normalizeOpenAIStrictToolParameters<T>(schema: T, strict: boolean): T {
   if (!strict) {
-    return normalizeToolParameterSchema(schema ?? {}) as T;
+    return normalizeOpenAIObjectRequiredArraysRecursive(
+      normalizeToolParameterSchema(schema ?? {}),
+    ) as T;
   }
   return normalizeStrictOpenAIJsonSchema(schema) as T;
 }

--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -403,6 +403,7 @@ describe("convertTools", () => {
     expect(result[0]?.parameters).toEqual({
       type: "object",
       properties: {},
+      required: [],
     });
   });
 
@@ -484,7 +485,7 @@ describe("convertTools", () => {
     ];
     const result = convertTools(tools as unknown as Parameters<typeof convertTools>[0]);
     expect(result[0]?.parameters).toEqual({
-      allOf: [{ type: "object", properties: { id: { type: "string" } } }],
+      allOf: [{ type: "object", properties: { id: { type: "string" } }, required: [] }],
     });
   });
 
@@ -500,6 +501,7 @@ describe("convertTools", () => {
     expect(result[0]?.parameters).toEqual({
       type: "object",
       properties: { cmd: { type: "string" } },
+      required: [],
     });
   });
 
@@ -553,6 +555,7 @@ describe("convertTools", () => {
         type: "object",
         properties: { path: { type: "string" } },
         additionalProperties: false,
+        required: [],
       },
       strict: false,
     });


### PR DESCRIPTION
## Summary

- add `required: []` for object schemas on the non-strict OpenAI tool path
- limit the recursive rewrite to schema-bearing keywords so literal objects under `enum`, `const`, `default`, and `examples` are left unchanged
- update regression coverage and websocket tool-schema expectations

## Scope

- non-strict OpenAI tool parameter normalization only
- strict mode behavior is unchanged
- generic non-OpenAI schema normalization is unchanged

## Testing

- `corepack pnpm vitest run src/agents/openai-tool-schema.test.ts src/agents/pi-tools.schema.test.ts src/agents/openai-ws-stream.test.ts`
