### PR TITLE
fix(feishu): download images in Feishu thread history and inline attachment hints [AI-assisted]

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2672,6 +2672,80 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("downloads images from thread history messages and inlines attachment hints", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValue({
+      messageId: "om_topic_root",
+      chatId: "oc-group",
+      content: "thread root",
+      contentType: "text",
+      threadId: "omt_topic_img",
+    });
+    const imgRawContent = JSON.stringify({ image_key: "img_history_key_1" });
+    mockListFeishuThreadMessages.mockResolvedValue([
+      {
+        messageId: "om_img_msg",
+        senderId: "ou-sender",
+        senderType: "user",
+        content: "[image message]",
+        contentType: "image",
+        rawContent: imgRawContent,
+        createTime: 1710000000000,
+      },
+    ]);
+    mockDownloadMessageResourceFeishu.mockResolvedValueOnce({
+      buffer: Buffer.from("fake-image-data"),
+      contentType: "image/png",
+    });
+    mockSaveMediaBuffer.mockResolvedValueOnce({
+      path: "/fake/.openclaw/media/inbound/thread-img.png",
+      contentType: "image/png",
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group_topic",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: "om_text_followup",
+        root_id: "om_topic_root",
+        thread_id: "omt_topic_img",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "what was in that image?" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    // The image should have been downloaded via the resource API.
+    expect(mockDownloadMessageResourceFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "om_img_msg",
+        fileKey: "img_history_key_1",
+        type: "image",
+      }),
+    );
+    // ThreadHistoryBody should include the attachment hint with the saved path.
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ThreadHistoryBody: expect.stringContaining("/fake/.openclaw/media/inbound/thread-img.png"),
+      }),
+    );
+  });
+
   it("does not dispatch twice for the same image message_id (concurrent dedupe)", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -956,16 +956,53 @@ export async function handleFeishuMessage(params: {
         const historyMessages = includeStarterInHistory
           ? relevantMessages
           : relevantMessages.slice(1);
-        const historyParts = historyMessages.map((msg) => {
+        const historyParts: string[] = [];
+        for (const msg of historyMessages) {
           const role = msg.senderType === "app" ? "assistant" : "user";
-          return core.channel.reply.formatAgentEnvelope({
-            channel: "Feishu",
-            from: `${msg.senderId ?? "Unknown"} (${role})`,
-            timestamp: msg.createTime,
-            body: msg.content,
-            envelope: envelopeOptions,
-          });
-        });
+          let msgBody = msg.content;
+
+          // Download and inline media for image/file/audio/video/sticker/post messages.
+          const mediaTypes = ["image", "file", "audio", "video", "media", "sticker", "post"];
+          if (mediaTypes.includes(msg.contentType)) {
+            try {
+              const mediaItems = await resolveFeishuMediaList({
+                cfg,
+                messageId: msg.messageId,
+                messageType: msg.contentType,
+                content: msg.rawContent ?? "",
+                maxBytes: mediaMaxBytes,
+                log,
+                accountId: account.accountId,
+              });
+              if (mediaItems.length > 0) {
+                const attachmentHints = mediaItems
+                  .map(
+                    (m) =>
+                      `[media attached: ${m.path} (${m.contentType ?? "application/octet-stream"}) | ${m.path}]`,
+                  )
+                  .join("\n");
+                msgBody = [msgBody, attachmentHints].filter(Boolean).join("\n");
+                log(
+                  `feishu[${account.accountId}]: downloaded ${mediaItems.length} media item(s) from thread history message ${msg.messageId}`,
+                );
+              }
+            } catch (err) {
+              log(
+                `feishu[${account.accountId}]: failed to download media for thread history message ${msg.messageId}: ${String(err)}`,
+              );
+            }
+          }
+
+          historyParts.push(
+            core.channel.reply.formatAgentEnvelope({
+              channel: "Feishu",
+              from: `${msg.senderId ?? "Unknown"} (${role})`,
+              timestamp: msg.createTime,
+              body: msgBody,
+              envelope: envelopeOptions,
+            }),
+          );
+        }
 
         threadContext.threadStarterBody = threadStarterBody;
         threadContext.threadHistoryBody =

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -330,6 +330,8 @@ export type FeishuThreadMessageInfo = {
   senderType?: string;
   content: string;
   contentType: string;
+  /** Raw JSON body content from the Feishu API (needed for media key extraction). */
+  rawContent?: string;
   createTime?: number;
 };
 
@@ -403,6 +405,7 @@ export async function listFeishuThreadMessages(params: {
       senderType: parsed.senderType,
       content: parsed.content,
       contentType: parsed.contentType,
+      rawContent: item.body?.content ?? "",
       createTime: parsed.createTime,
     });
 


### PR DESCRIPTION
## Problem

When an image (or other media) message exists in a Feishu thread's history, the agent only receives the placeholder text `[image message]` — it never sees the actual image data.

**Root cause:** `resolveFeishuMediaList` was only called for the *current* inbound message. Historical thread messages fetched via `listFeishuThreadMessages` went through `parseFeishuMessageContent`, which returns `[image message]` for `msgType === "image"` and similar placeholders for other media types.

## Solution

For each message in thread history that has a media content type (`image`, `file`, `audio`, `video`, `media`, `sticker`, `post`), call `resolveFeishuMediaList` to download and save the media locally, then embed the saved path as a `[media attached: /path (mime) | /path]` hint in the message body.

This matches the format the embedded agent runner already uses for current-message attachments, so no changes to the runner are needed.

## Changes

- **`extensions/feishu/src/send.ts`** — Added optional `rawContent` field to `FeishuThreadMessageInfo` and populate it from `item.body?.content` so the raw Feishu API JSON is available for media key extraction.
- **`extensions/feishu/src/bot.ts`** — Changed the synchronous `historyParts.map()` to an async `for...of` loop that calls `resolveFeishuMediaList` for media messages. Download errors are caught per-message and logged; history still renders without the attachment if download fails.
- **`extensions/feishu/src/bot.test.ts`** — Added a test that sends a thread history message with `contentType: "image"` and `rawContent`, and asserts that `downloadMessageResourceFeishu` is called and the resulting path appears in `ThreadHistoryBody`.

## Testing

```
pnpm test:extension feishu
Test Files  61 passed (61)
      Tests  615 passed (615)  ← 614 existing + 1 new
```

`pnpm build` passes cleanly.

`pnpm check` / `pnpm tsgo` has 3 pre-existing failures in `extensions/qa-lab/src/scenario-catalog.test.ts` that are already red on `main` CI (verified by checking out `main` and running the same check — same errors, no change).

## AI Disclosure

- **AI-assisted:** Authored by ClawGuard (an OpenClaw agent running in a Feishu thread) using `claude-sonnet-4-6`.
- **Degree of testing:** Lightly tested — `pnpm test:extension feishu` passes. Not tested against a live Feishu account (no test credentials available in this environment).
- **Human understanding confirmed:** The human operator (gee-bjak) reviewed the approach before execution.