### PR TITLE
fix(skills): support Discord multi-account config in skills check

### DIFF
--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: discord
 description: "Discord ops via the message tool (channel=discord)."
-metadata: { "openclaw": { "emoji": "🎮", "requires": { "config": ["channels.discord.token"] } } }
+metadata: { "openclaw": { "emoji": "🎮", "requires": { "anyConfig": ["channels.discord.token", "channels.discord.accounts"] } } }
 allowed-tools: ["message"]
 ---
 

--- a/src/agents/skills-status.test.ts
+++ b/src/agents/skills-status.test.ts
@@ -74,6 +74,41 @@ describe("buildWorkspaceSkillStatus", () => {
     expect(check).toEqual({ path: "channels.discord.token", satisfied: true });
     expect(check && "value" in check).toBe(false);
   });
+
+  it("treats multi-account Discord config as satisfying anyConfig requirements", () => {
+    const entry: SkillEntry = {
+      skill: createFixtureSkill({
+        name: "discord",
+        description: "test",
+        filePath: "/tmp/discord/SKILL.md",
+        baseDir: "/tmp/discord",
+        source: "test",
+      }),
+      frontmatter: {},
+      metadata: {
+        requires: {
+          anyConfig: ["channels.discord.token", "channels.discord.accounts"],
+        },
+      },
+    };
+
+    const report = buildWorkspaceSkillStatus("/tmp/ws", {
+      entries: [entry],
+      config: {
+        channels: {
+          discord: {
+            enabled: true,
+            accounts: {
+              default: { token: "secret-token" }, // pragma: allowlist secret
+            },
+          },
+        },
+      },
+    });
+
+    expect(report.skills[0]?.eligible).toBe(true);
+    expect(report.skills[0]?.missing.anyConfig ?? []).toEqual([]);
+  });
 });
 
 function createFixtureSkill(params: {

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -28,6 +28,7 @@ export type OpenClawSkillMetadata = {
     anyBins?: string[];
     env?: string[];
     config?: string[];
+    anyConfig?: string[];
   };
   install?: SkillInstallSpec[];
 };

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -88,6 +88,9 @@ function formatSkillMissingSummary(skill: SkillStatusEntry): string {
   if (skill.missing.config.length > 0) {
     missing.push(`config: ${skill.missing.config.join(", ")}`);
   }
+  if ((skill.missing.anyConfig ?? []).length > 0) {
+    missing.push(`anyConfig: ${(skill.missing.anyConfig ?? []).join(", ")}`);
+  }
   if (skill.missing.os.length > 0) {
     missing.push(`os: ${skill.missing.os.join(", ")}`);
   }
@@ -218,6 +221,7 @@ export function formatSkillInfo(
     skill.requirements.anyBins.length > 0 ||
     skill.requirements.env.length > 0 ||
     skill.requirements.config.length > 0 ||
+    (skill.requirements.anyConfig ?? []).length > 0 ||
     skill.requirements.os.length > 0;
 
   if (hasRequirements) {
@@ -251,6 +255,14 @@ export function formatSkillInfo(
         return missing ? theme.error(`✗ ${cfg}`) : theme.success(`✓ ${cfg}`);
       });
       lines.push(`${theme.muted("  Config:")} ${configStatus.join(", ")}`);
+    }
+    if ((skill.requirements.anyConfig ?? []).length > 0) {
+      const anyConfigRequired = skill.requirements.anyConfig ?? [];
+      const anyConfigMissing = (skill.missing.anyConfig ?? []).length > 0;
+      const anyConfigStatus = anyConfigRequired.map((cfg) =>
+        anyConfigMissing ? theme.error(`✗ ${cfg}`) : theme.success(`✓ ${cfg}`),
+      );
+      lines.push(`${theme.muted("  Any config:")} ${anyConfigStatus.join(", ")}`);
     }
     if (skill.requirements.os.length > 0) {
       const osStatus = skill.requirements.os.map((osName) => {

--- a/src/shared/config-eval.test.ts
+++ b/src/shared/config-eval.test.ts
@@ -171,6 +171,24 @@ describe("evaluateRuntimeRequires", () => {
         isConfigPathTruthy: () => true,
       }),
     ).toBe(false);
+
+    expect(
+      evaluateRuntimeRequires({
+        requires: { anyConfig: ["channels.discord.token", "channels.discord.accounts"] },
+        hasBin: () => true,
+        hasEnv: () => true,
+        isConfigPathTruthy: () => false,
+      }),
+    ).toBe(false);
+
+    expect(
+      evaluateRuntimeRequires({
+        requires: { anyConfig: ["channels.discord.token", "channels.discord.accounts"] },
+        hasBin: () => true,
+        hasEnv: () => true,
+        isConfigPathTruthy: (path) => path === "channels.discord.accounts",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/src/shared/config-eval.ts
+++ b/src/shared/config-eval.ts
@@ -46,6 +46,7 @@ export type RuntimeRequires = {
   anyBins?: string[];
   env?: string[];
   config?: string[];
+  anyConfig?: string[];
 };
 
 type RuntimeRequirementEvalParams = {
@@ -99,6 +100,16 @@ export function evaluateRuntimeRequires(params: RuntimeRequirementEvalParams): b
       if (!params.isConfigPathTruthy(configPath)) {
         return false;
       }
+    }
+  }
+
+  const requiredAnyConfig = requires.anyConfig ?? [];
+  if (requiredAnyConfig.length > 0) {
+    const anySatisfied = requiredAnyConfig.some((configPath) =>
+      params.isConfigPathTruthy(configPath),
+    );
+    if (!anySatisfied) {
+      return false;
     }
   }
 

--- a/src/shared/frontmatter.test.ts
+++ b/src/shared/frontmatter.test.ts
@@ -76,6 +76,7 @@ describe("shared/frontmatter", () => {
       anyBins: ["ffmpeg"],
       env: ["OPENCLAW_TOKEN", "OPENCLAW_URL"],
       config: [],
+      anyConfig: [],
     });
     expect(resolveOpenClawManifestRequires({})).toBeUndefined();
     expect(resolveOpenClawManifestOs({ os: [" darwin ", "linux", ""] })).toEqual([

--- a/src/shared/frontmatter.ts
+++ b/src/shared/frontmatter.ts
@@ -53,6 +53,7 @@ export type OpenClawManifestRequires = {
   anyBins: string[];
   env: string[];
   config: string[];
+  anyConfig: string[];
 };
 
 export function resolveOpenClawManifestRequires(
@@ -70,6 +71,7 @@ export function resolveOpenClawManifestRequires(
     anyBins: normalizeStringList(requiresRaw.anyBins),
     env: normalizeStringList(requiresRaw.env),
     config: normalizeStringList(requiresRaw.config),
+    anyConfig: normalizeStringList(requiresRaw.anyConfig),
   };
 }
 

--- a/src/shared/requirements.test.ts
+++ b/src/shared/requirements.test.ts
@@ -75,7 +75,13 @@ describe("requirements helpers", () => {
     const res = evaluateRequirementsFromMetadata({
       always: false,
       metadata: {
-        requires: { bins: ["a"], anyBins: ["b"], env: ["E"], config: ["cfg.value"] },
+        requires: {
+          bins: ["a"],
+          anyBins: ["b"],
+          env: ["E"],
+          config: ["cfg.value"],
+          anyConfig: ["cfg.alt"],
+        },
         os: ["darwin"],
       },
       hasLocalBin: (bin) => bin === "a",
@@ -86,6 +92,7 @@ describe("requirements helpers", () => {
 
     expect(res.required.bins).toEqual(["a"]);
     expect(res.missing.config).toEqual(["cfg.value"]);
+    expect(res.missing.anyConfig).toEqual(["cfg.alt"]);
     expect(res.missing.os).toEqual(["darwin"]);
     expect(res.eligible).toBe(false);
   });
@@ -98,6 +105,7 @@ describe("requirements helpers", () => {
         anyBins: ["bun", "deno"],
         env: ["OPENAI_API_KEY"],
         config: ["browser.enabled", "gateway.enabled"],
+        anyConfig: ["channels.discord.token", "channels.discord.accounts"],
         os: ["darwin"],
       },
       hasLocalBin: () => false,
@@ -114,6 +122,7 @@ describe("requirements helpers", () => {
       anyBins: ["bun", "deno"],
       env: ["OPENAI_API_KEY"],
       config: ["browser.enabled"],
+      anyConfig: ["channels.discord.token", "channels.discord.accounts"],
       os: ["darwin"],
     });
     expect(res.configChecks).toEqual([
@@ -131,6 +140,7 @@ describe("requirements helpers", () => {
         anyBins: ["bun"],
         env: ["OPENAI_API_KEY"],
         config: ["browser.enabled"],
+        anyConfig: ["channels.discord.token"],
         os: ["darwin"],
       },
       hasLocalBin: () => false,
@@ -139,7 +149,14 @@ describe("requirements helpers", () => {
       isConfigSatisfied: () => false,
     });
 
-    expect(res.missing).toEqual({ bins: [], anyBins: [], env: [], config: [], os: [] });
+    expect(res.missing).toEqual({
+      bins: [],
+      anyBins: [],
+      env: [],
+      config: [],
+      anyConfig: [],
+      os: [],
+    });
     expect(res.configChecks).toEqual([{ path: "browser.enabled", satisfied: false }]);
     expect(res.eligible).toBe(true);
   });
@@ -148,7 +165,12 @@ describe("requirements helpers", () => {
     const res = evaluateRequirementsFromMetadataWithRemote({
       always: false,
       metadata: {
-        requires: { bins: ["node"], anyBins: ["bun"], env: ["OPENAI_API_KEY"] },
+        requires: {
+          bins: ["node"],
+          anyBins: ["bun"],
+          env: ["OPENAI_API_KEY"],
+          anyConfig: ["channels.discord.token", "channels.discord.accounts"],
+        },
         os: ["darwin"],
       },
       remote: {
@@ -159,7 +181,7 @@ describe("requirements helpers", () => {
       hasLocalBin: () => false,
       localPlatform: "linux",
       isEnvSatisfied: (name) => name === "OPENAI_API_KEY",
-      isConfigSatisfied: () => true,
+      isConfigSatisfied: (path) => path === "channels.discord.accounts",
     });
 
     expect(res.required).toEqual({
@@ -167,9 +189,17 @@ describe("requirements helpers", () => {
       anyBins: ["bun"],
       env: ["OPENAI_API_KEY"],
       config: [],
+      anyConfig: ["channels.discord.token", "channels.discord.accounts"],
       os: ["darwin"],
     });
-    expect(res.missing).toEqual({ bins: [], anyBins: [], env: [], config: [], os: [] });
+    expect(res.missing).toEqual({
+      bins: [],
+      anyBins: [],
+      env: [],
+      config: [],
+      anyConfig: [],
+      os: [],
+    });
     expect(res.eligible).toBe(true);
   });
 
@@ -187,6 +217,7 @@ describe("requirements helpers", () => {
       anyBins: [],
       env: [],
       config: [],
+      anyConfig: [],
       os: [],
     });
     expect(res.missing).toEqual({
@@ -194,6 +225,7 @@ describe("requirements helpers", () => {
       anyBins: [],
       env: [],
       config: [],
+      anyConfig: [],
       os: [],
     });
     expect(res.configChecks).toEqual([]);

--- a/src/shared/requirements.ts
+++ b/src/shared/requirements.ts
@@ -3,6 +3,7 @@ export type Requirements = {
   anyBins: string[];
   env: string[];
   config: string[];
+  anyConfig?: string[];
   os: string[];
 };
 
@@ -12,7 +13,7 @@ export type RequirementConfigCheck = {
 };
 
 export type RequirementsMetadata = {
-  requires?: Partial<Pick<Requirements, "bins" | "anyBins" | "env" | "config">>;
+  requires?: Partial<Pick<Requirements, "bins" | "anyBins" | "env" | "config" | "anyConfig">>;
   os?: string[];
 };
 
@@ -141,14 +142,18 @@ export function evaluateRequirements(
     isSatisfied: params.isConfigSatisfied,
   });
   const missingConfig = configChecks.filter((check) => !check.satisfied).map((check) => check.path);
+  const requiredAnyConfig = params.required.anyConfig ?? [];
+  const hasAnyConfig = requiredAnyConfig.some((pathStr) => params.isConfigSatisfied(pathStr));
+  const missingAnyConfig = requiredAnyConfig.length > 0 && !hasAnyConfig ? requiredAnyConfig : [];
 
   const missing = params.always
-    ? { bins: [], anyBins: [], env: [], config: [], os: [] }
+    ? { bins: [], anyBins: [], env: [], config: [], anyConfig: [], os: [] }
     : {
         bins: missingBins,
         anyBins: missingAnyBins,
         env: missingEnv,
         config: missingConfig,
+        anyConfig: missingAnyConfig,
         os: missingOs,
       };
 
@@ -158,6 +163,7 @@ export function evaluateRequirements(
       missing.anyBins.length === 0 &&
       missing.env.length === 0 &&
       missing.config.length === 0 &&
+      missing.anyConfig.length === 0 &&
       missing.os.length === 0);
 
   return { missing, eligible, configChecks };
@@ -179,6 +185,7 @@ export function evaluateRequirementsFromMetadata(
     anyBins: params.metadata?.requires?.anyBins ?? [],
     env: params.metadata?.requires?.env ?? [],
     config: params.metadata?.requires?.config ?? [],
+    anyConfig: params.metadata?.requires?.anyConfig ?? [],
     os: params.metadata?.os ?? [],
   };
 


### PR DESCRIPTION
## Summary
- Fixes #66088.
- Add generic anyConfig requirement support so a skill can be eligible when any one config path is satisfied.
- Update bundled Discord skill gating to accept either channels.discord.token or multi-account channels.discord.accounts.
- Extend requirements/frontmatter parsing and skills check formatting/tests to cover anyConfig.

## Test plan
- [x] pnpm test src/shared/requirements.test.ts src/shared/config-eval.test.ts src/shared/frontmatter.test.ts src/agents/skills-status.test.ts