### PR TITLE
Align context usage display, refresh chat after compaction

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -438,10 +438,23 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     if (host.onboarding) {
       return;
     }
-    handleAgentEvent(
-      host as unknown as Parameters<typeof handleAgentEvent>[0],
-      evt.payload as AgentEventPayload | undefined,
-    );
+    const payload = evt.payload as AgentEventPayload | undefined;
+    handleAgentEvent(host as unknown as Parameters<typeof handleAgentEvent>[0], payload);
+    // If a compaction just completed for the active session, refresh chat history so
+    // the UI reflects the compacted transcript and cleared token counters immediately.
+    try {
+      const data = (payload?.data ?? {}) as Record<string, unknown>;
+      const phase = typeof data.phase === "string" ? data.phase : "";
+      const completed = data.completed === true;
+      const sessionKey = typeof payload?.sessionKey === "string" ? payload.sessionKey : undefined;
+      if (payload?.stream === "compaction" && phase === "end" && completed) {
+        if (!sessionKey || sessionKey === host.sessionKey) {
+          void loadChatHistory(host as unknown as ChatState);
+        }
+      }
+    } catch {
+      // ignore
+    }
     return;
   }
 

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -380,7 +380,11 @@ async function executeUsage(
     const output = session.outputTokens ?? 0;
     const total = session.totalTokens ?? input + output;
     const ctx = session.contextTokens ?? 0;
-    const pct = ctx > 0 ? Math.round((input / ctx) * 100) : null;
+    // Align with backend/UI context notice: prefer canonical totalTokens when fresh.
+    const pct =
+      (session.totalTokensFresh === true && typeof session.totalTokens === "number" && ctx > 0)
+        ? Math.round(Math.min((session.totalTokens / ctx) * 100, 100))
+        : null;
 
     const lines = [
       "**Session Usage**",


### PR DESCRIPTION
- /status context % now uses canonical totalTokens when fresh (matches chat context notice)\n- Refresh chat history on compaction completion to reflect compacted transcript and cleared token counters\n\nFixes openclaw/openclaw#66483