### PR TITLE
fix: keep gateway service path stable across pnpm upgrades

### DIFF
--- a/src/daemon/program-args.test.ts
+++ b/src/daemon/program-args.test.ts
@@ -87,4 +87,31 @@ describe("resolveGatewayProgramArguments", () => {
       "18789",
     ]);
   });
+
+  it("prefers stable pnpm package path when invoked via a versioned global shim entrypoint", async () => {
+    const versionedEntrypoint = path.resolve(
+      "/Users/test/Library/pnpm/global/5/.pnpm/openclaw@2026.4.12/node_modules/openclaw/openclaw.mjs",
+    );
+    const stableIndexPath = path.resolve(
+      "/Users/test/Library/pnpm/global/5/node_modules/openclaw/dist/index.js",
+    );
+    process.argv = ["node", versionedEntrypoint];
+    fsMocks.realpath.mockResolvedValue(versionedEntrypoint);
+    fsMocks.access.mockImplementation(async (target: string) => {
+      if (target === stableIndexPath) {
+        return;
+      }
+      throw new Error(`missing: ${target}`);
+    });
+
+    const result = await resolveGatewayProgramArguments({ port: 18789 });
+
+    expect(result.programArguments).toEqual([
+      process.execPath,
+      stableIndexPath,
+      "gateway",
+      "--port",
+      "18789",
+    ]);
+  });
 });

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -82,6 +82,7 @@ function buildDistCandidates(...inputs: string[]): string[] {
     appendDistCandidates(candidates, seen, path.resolve(baseDir, ".."));
     appendDistCandidates(candidates, seen, baseDir);
     appendNodeModulesBinCandidates(candidates, seen, inputPath);
+    appendPnpmPackageCandidates(candidates, seen, inputPath);
   }
 
   return candidates;
@@ -121,6 +122,66 @@ function appendNodeModulesBinCandidates(
   const nodeModulesDir = parts.slice(0, binIndex).join(path.sep);
   const packageRoot = path.join(nodeModulesDir, binName);
   appendDistCandidates(candidates, seen, packageRoot);
+}
+
+function parseNodeModulesPackagePath(relativePath: string):
+  | {
+      packageName: string;
+      remainder: string;
+    }
+  | null {
+  const cleaned = relativePath.replace(/^[/\\]+/, "");
+  const parts = cleaned.split(/[\\/]+/).filter(Boolean);
+  if (parts.length < 2) {
+    return null;
+  }
+
+  const packageName = parts[0]?.startsWith("@")
+    ? parts.length >= 3
+      ? `${parts[0]}/${parts[1]}`
+      : null
+    : parts[0];
+  if (!packageName) {
+    return null;
+  }
+
+  const remainderStart = packageName.startsWith("@") ? 2 : 1;
+  const remainder = parts.slice(remainderStart).join(path.sep);
+  return { packageName, remainder };
+}
+
+function appendPnpmPackageCandidates(
+  candidates: string[],
+  seen: Set<string>,
+  inputPath: string,
+): void {
+  const normalized = path.resolve(inputPath);
+  const pnpmMarker = `${path.sep}.pnpm${path.sep}`;
+  const pnpmIndex = normalized.lastIndexOf(pnpmMarker);
+  if (pnpmIndex === -1) {
+    return;
+  }
+
+  const afterPnpm = normalized.slice(pnpmIndex + pnpmMarker.length);
+  const nodeModulesMarker = `${path.sep}node_modules${path.sep}`;
+  const nodeModulesIndex = afterPnpm.indexOf(nodeModulesMarker);
+  if (nodeModulesIndex === -1) {
+    return;
+  }
+
+  const parsed = parseNodeModulesPackagePath(
+    afterPnpm.slice(nodeModulesIndex + nodeModulesMarker.length),
+  );
+  if (!parsed) {
+    return;
+  }
+
+  const stablePackageRoot = path.join(normalized.slice(0, pnpmIndex), "node_modules", parsed.packageName);
+  appendDistCandidates(candidates, seen, stablePackageRoot);
+
+  if (parsed.remainder) {
+    appendDistCandidates(candidates, seen, path.join(stablePackageRoot, path.dirname(parsed.remainder)));
+  }
 }
 
 function resolveRepoRootForDev(): string {


### PR DESCRIPTION
## Summary
- keep gateway service installs off version-pinned pnpm store paths
- resolve stable `node_modules/openclaw/...` candidates when the CLI is launched from a versioned `.pnpm/.../openclaw.mjs` path
- add a regression test for the global pnpm upgrade case

## Why
After pnpm global upgrades, launchd could keep pointing at the old gateway entrypoint while the CLI/TUI had already moved to the new version. That produced TUI ↔ gateway schema mismatches after upgrades.

## Validation
- pnpm exec vitest run src/daemon/program-args.test.ts
- pnpm exec vitest run src/daemon/program-args.test.ts src/daemon/launchd.test.ts src/cli/daemon-cli.coverage.test.ts

(Validated in the original repo checkout; the temporary clean worktree used for the PR did not have a full standalone node_modules install.)