### PR TITLE
feat(config): add ratio-based sibling fields for compaction token budgets

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -786,6 +786,7 @@ export async function compactEmbeddedPiSessionDirect(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
+        contextWindowTokens: model?.contextWindow,
       });
       // Sets compaction/pruning runtime state and returns extension factories
       // that must be passed to the resource loader for the safeguard to be active.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -913,6 +913,7 @@ export async function runEmbeddedAttempt(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
+        contextWindowTokens: params.model.contextWindow,
       });
       applyPiAutoCompactionGuard({
         settingsManager,

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -187,11 +187,17 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
   cwd: string;
   agentDir: string;
   cfg?: OpenClawConfig;
+  /**
+   * Model context window in tokens; enables resolution of the `*Share`
+   * compaction-budget sibling fields against the actual model window.
+   */
+  contextWindowTokens?: number;
 }): SettingsManager {
   const settingsManager = createEmbeddedPiSettingsManager(params);
   applyPiCompactionSettingsFromConfig({
     settingsManager,
     cfg: params.cfg,
+    contextWindowTokens: params.contextWindowTokens,
   });
   return settingsManager;
 }

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -3,6 +3,7 @@ import {
   applyPiCompactionSettingsFromConfig,
   DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,
   resolveCompactionReserveTokensFloor,
+  resolveShareBasedTokenBudget,
 } from "./pi-settings.js";
 
 describe("applyPiCompactionSettingsFromConfig", () => {
@@ -138,5 +139,282 @@ describe("resolveCompactionReserveTokensFloor", () => {
         agents: { defaults: { compaction: { reserveTokensFloor: 0 } } },
       }),
     ).toBe(0);
+  });
+
+  it("computes floor from share when context window is provided", () => {
+    // 200k window × 0.1 share = 20_000
+    expect(
+      resolveCompactionReserveTokensFloor(
+        { agents: { defaults: { compaction: { reserveTokensFloorShare: 0.1 } } } },
+        200_000,
+      ),
+    ).toBe(20_000);
+    // 1M window × 0.1 share = 100_000 (scales up for larger window)
+    expect(
+      resolveCompactionReserveTokensFloor(
+        { agents: { defaults: { compaction: { reserveTokensFloorShare: 0.1 } } } },
+        1_000_000,
+      ),
+    ).toBe(100_000);
+    // 8k window × 0.1 share = 800 (scales down for small window)
+    expect(
+      resolveCompactionReserveTokensFloor(
+        { agents: { defaults: { compaction: { reserveTokensFloorShare: 0.1 } } } },
+        8_000,
+      ),
+    ).toBe(800);
+  });
+
+  it("prefers share over absolute when both are set", () => {
+    expect(
+      resolveCompactionReserveTokensFloor(
+        {
+          agents: {
+            defaults: {
+              compaction: { reserveTokensFloor: 50_000, reserveTokensFloorShare: 0.2 },
+            },
+          },
+        },
+        200_000,
+      ),
+    ).toBe(40_000); // 200k × 0.2 wins over 50_000 absolute
+  });
+
+  it("falls back to absolute when context window is unknown", () => {
+    expect(
+      resolveCompactionReserveTokensFloor(
+        {
+          agents: {
+            defaults: {
+              compaction: { reserveTokensFloor: 12_345, reserveTokensFloorShare: 0.2 },
+            },
+          },
+        },
+        undefined,
+      ),
+    ).toBe(12_345);
+  });
+});
+
+describe("resolveShareBasedTokenBudget", () => {
+  it("uses absolute value when share is not set (regression)", () => {
+    expect(
+      resolveShareBasedTokenBudget({
+        absolute: 50_000,
+        contextWindowTokens: 200_000,
+        fallback: 9_999,
+      }),
+    ).toBe(50_000);
+  });
+
+  it("computes from context window when only share is set", () => {
+    expect(
+      resolveShareBasedTokenBudget({
+        share: 0.25,
+        contextWindowTokens: 200_000,
+        fallback: 9_999,
+      }),
+    ).toBe(50_000);
+  });
+
+  it("prefers share over absolute when both set (precedence)", () => {
+    expect(
+      resolveShareBasedTokenBudget({
+        share: 0.25,
+        absolute: 12_345,
+        contextWindowTokens: 200_000,
+        fallback: 9_999,
+      }),
+    ).toBe(50_000);
+  });
+
+  it("falls back to absolute when share is set but context window is missing", () => {
+    expect(
+      resolveShareBasedTokenBudget({
+        share: 0.25,
+        absolute: 12_345,
+        fallback: 9_999,
+      }),
+    ).toBe(12_345);
+  });
+
+  it("returns fallback when neither share nor absolute are usable", () => {
+    expect(resolveShareBasedTokenBudget({ fallback: 9_999 })).toBe(9_999);
+  });
+
+  it("scales reasonably across heterogeneous context windows", () => {
+    // Same 0.05 share over GLM 200k, Claude 200k, Kimi K2 1M, Gemma-2B 8k
+    const share = 0.05;
+    expect(
+      resolveShareBasedTokenBudget({
+        share,
+        contextWindowTokens: 200_000,
+        fallback: 0,
+      }),
+    ).toBe(10_000);
+    expect(
+      resolveShareBasedTokenBudget({
+        share,
+        contextWindowTokens: 1_000_000,
+        fallback: 0,
+      }),
+    ).toBe(50_000);
+    // Small window still gets a proportional share instead of over-reserving.
+    expect(
+      resolveShareBasedTokenBudget({
+        share,
+        contextWindowTokens: 8_000,
+        fallback: 0,
+      }),
+    ).toBe(400);
+  });
+});
+
+describe("applyPiCompactionSettingsFromConfig share-based budgets", () => {
+  function mkSettings(current = { reserve: 16_000, keepRecent: 20_000 }) {
+    return {
+      getCompactionReserveTokens: () => current.reserve,
+      getCompactionKeepRecentTokens: () => current.keepRecent,
+      applyOverrides: vi.fn(),
+    };
+  }
+
+  it("only absolute set → uses absolute (backward compat regression)", () => {
+    const settingsManager = mkSettings();
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { reserveTokens: 60_000, reserveTokensFloor: 0 },
+          },
+        },
+      },
+      contextWindowTokens: 200_000,
+    });
+    expect(result.compaction.reserveTokens).toBe(60_000);
+  });
+
+  it("only share set → computes from model context window", () => {
+    const settingsManager = mkSettings();
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { reserveTokensShare: 0.25, reserveTokensFloor: 0 },
+          },
+        },
+      },
+      contextWindowTokens: 200_000,
+    });
+    expect(result.compaction.reserveTokens).toBe(50_000);
+  });
+
+  it("both absolute and share set → share wins", () => {
+    const settingsManager = mkSettings();
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokens: 10_000,
+              reserveTokensShare: 0.25,
+              reserveTokensFloor: 0,
+            },
+          },
+        },
+      },
+      contextWindowTokens: 200_000,
+    });
+    expect(result.compaction.reserveTokens).toBe(50_000); // 200k × 0.25
+  });
+
+  it("share + floor → floor respected when share yields less", () => {
+    const settingsManager = mkSettings();
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { reserveTokensShare: 0.01, reserveTokensFloor: 25_000 },
+          },
+        },
+      },
+      contextWindowTokens: 200_000,
+    });
+    // 200k × 0.01 = 2_000; floor lifts to 25_000
+    expect(result.compaction.reserveTokens).toBe(25_000);
+  });
+
+  it("1M window + share scales up reasonably (heterogeneous-model scenario)", () => {
+    const settingsManager = mkSettings();
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { reserveTokensShare: 0.1, reserveTokensFloor: 0 },
+          },
+        },
+      },
+      contextWindowTokens: 1_000_000,
+    });
+    expect(result.compaction.reserveTokens).toBe(100_000);
+  });
+
+  it("small window (8k) + share avoids over-reserving absolute numbers", () => {
+    const settingsManager = mkSettings({ reserve: 0, keepRecent: 1_000 });
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { reserveTokensShare: 0.2, reserveTokensFloor: 0 },
+          },
+        },
+      },
+      contextWindowTokens: 8_000,
+    });
+    expect(result.compaction.reserveTokens).toBe(1_600); // 8k × 0.2
+  });
+
+  it("keepRecentTokensShare is resolved when share is set", () => {
+    const settingsManager = mkSettings();
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              keepRecentTokensShare: 0.1,
+              reserveTokensFloor: 0,
+            },
+          },
+        },
+      },
+      contextWindowTokens: 200_000,
+    });
+    expect(result.compaction.keepRecentTokens).toBe(20_000);
+  });
+
+  it("falls back to absolute fields when contextWindowTokens is omitted (backward compat)", () => {
+    const settingsManager = mkSettings();
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              reserveTokens: 30_000,
+              reserveTokensShare: 0.5, // ignored without window
+              reserveTokensFloor: 0,
+            },
+          },
+        },
+      },
+    });
+    expect(result.compaction.reserveTokens).toBe(30_000);
   });
 });

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -33,8 +33,73 @@ export function ensurePiCompactionReserveTokens(params: {
   return { didOverride: true, reserveTokens: minReserveTokens };
 }
 
-export function resolveCompactionReserveTokensFloor(cfg?: OpenClawConfig): number {
-  const raw = cfg?.agents?.defaults?.compaction?.reserveTokensFloor;
+/**
+ * Resolve a ratio-based token budget sibling field.
+ *
+ * Precedence (highest to lowest):
+ *   1. `share` + `contextWindowTokens` → `Math.floor(contextWindow * share)`
+ *   2. `absolute` if set
+ *   3. `fallback` (caller-provided default)
+ *
+ * Designed to support heterogeneous models: one config can carry a `*Share` ratio
+ * that scales across 8k, 200k, and 1M context windows instead of locking to a
+ * single absolute token count.
+ *
+ * @param share       fractional share of the context window (0.01–0.9); pass
+ *                    `undefined` when only the absolute path should apply.
+ * @param absolute    existing absolute-token field; used when share is not set
+ *                    or the context window is unknown.
+ * @param contextWindowTokens known context window in tokens; when missing, the
+ *                    share is ignored and the absolute/fallback path is used.
+ * @param fallback    value returned when neither share nor absolute produces a
+ *                    usable number.
+ */
+export function resolveShareBasedTokenBudget(params: {
+  share?: number;
+  absolute?: number;
+  contextWindowTokens?: number;
+  fallback: number;
+}): number {
+  const { share, absolute, contextWindowTokens, fallback } = params;
+  if (
+    typeof share === "number" &&
+    Number.isFinite(share) &&
+    share > 0 &&
+    typeof contextWindowTokens === "number" &&
+    Number.isFinite(contextWindowTokens) &&
+    contextWindowTokens > 0
+  ) {
+    const computed = Math.floor(contextWindowTokens * share);
+    if (computed > 0) {
+      return computed;
+    }
+  }
+  if (typeof absolute === "number" && Number.isFinite(absolute) && absolute >= 0) {
+    return Math.floor(absolute);
+  }
+  return fallback;
+}
+
+export function resolveCompactionReserveTokensFloor(
+  cfg?: OpenClawConfig,
+  contextWindowTokens?: number,
+): number {
+  const compaction = cfg?.agents?.defaults?.compaction;
+  const share = compaction?.reserveTokensFloorShare;
+  const raw = compaction?.reserveTokensFloor;
+  if (
+    typeof share === "number" &&
+    Number.isFinite(share) &&
+    share > 0 &&
+    typeof contextWindowTokens === "number" &&
+    Number.isFinite(contextWindowTokens) &&
+    contextWindowTokens > 0
+  ) {
+    const computed = Math.floor(contextWindowTokens * share);
+    if (computed >= 0) {
+      return computed;
+    }
+  }
   if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
     return Math.floor(raw);
   }
@@ -58,6 +123,13 @@ function toPositiveInt(value: unknown): number | undefined {
 export function applyPiCompactionSettingsFromConfig(params: {
   settingsManager: PiSettingsManagerLike;
   cfg?: OpenClawConfig;
+  /**
+   * Model context window in tokens (e.g. 200_000 for Claude/GLM, 1_000_000 for Kimi K2).
+   * When provided, `*Share` sibling fields are resolved against this window and win
+   * over their absolute counterparts. When omitted, only absolute fields apply and
+   * behavior matches pre-share configs exactly.
+   */
+  contextWindowTokens?: number;
 }): {
   didOverride: boolean;
   compaction: { reserveTokens: number; keepRecentTokens: number };
@@ -66,9 +138,38 @@ export function applyPiCompactionSettingsFromConfig(params: {
   const currentKeepRecentTokens = params.settingsManager.getCompactionKeepRecentTokens();
   const compactionCfg = params.cfg?.agents?.defaults?.compaction;
 
-  const configuredReserveTokens = toNonNegativeInt(compactionCfg?.reserveTokens);
-  const configuredKeepRecentTokens = toPositiveInt(compactionCfg?.keepRecentTokens);
-  const reserveTokensFloor = resolveCompactionReserveTokensFloor(params.cfg);
+  const configuredReserveTokensAbsolute = toNonNegativeInt(compactionCfg?.reserveTokens);
+  const configuredReserveTokens =
+    typeof compactionCfg?.reserveTokensShare === "number" &&
+    compactionCfg.reserveTokensShare > 0 &&
+    typeof params.contextWindowTokens === "number" &&
+    params.contextWindowTokens > 0
+      ? resolveShareBasedTokenBudget({
+          share: compactionCfg.reserveTokensShare,
+          absolute: configuredReserveTokensAbsolute,
+          contextWindowTokens: params.contextWindowTokens,
+          fallback: configuredReserveTokensAbsolute ?? currentReserveTokens,
+        })
+      : configuredReserveTokensAbsolute;
+
+  const configuredKeepRecentTokensAbsolute = toPositiveInt(compactionCfg?.keepRecentTokens);
+  const configuredKeepRecentTokens =
+    typeof compactionCfg?.keepRecentTokensShare === "number" &&
+    compactionCfg.keepRecentTokensShare > 0 &&
+    typeof params.contextWindowTokens === "number" &&
+    params.contextWindowTokens > 0
+      ? resolveShareBasedTokenBudget({
+          share: compactionCfg.keepRecentTokensShare,
+          absolute: configuredKeepRecentTokensAbsolute,
+          contextWindowTokens: params.contextWindowTokens,
+          fallback: configuredKeepRecentTokensAbsolute ?? currentKeepRecentTokens,
+        })
+      : configuredKeepRecentTokensAbsolute;
+
+  const reserveTokensFloor = resolveCompactionReserveTokensFloor(
+    params.cfg,
+    params.contextWindowTokens,
+  );
 
   const targetReserveTokens = Math.max(
     configuredReserveTokens ?? currentReserveTokens,

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -34,6 +34,7 @@ import {
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
 import {
+  applyMemoryFlushSharesToPlan,
   hasAlreadyFlushedForCurrentCompaction,
   resolveMemoryFlushContextWindowTokens,
   shouldRunMemoryFlush,
@@ -378,7 +379,14 @@ export async function runPreflightCompactionIfNeeded(params: {
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
   });
-  const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
+  const rawMemoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
+  const memoryFlushPlan = rawMemoryFlushPlan
+    ? applyMemoryFlushSharesToPlan({
+        plan: rawMemoryFlushPlan,
+        cfg: params.cfg,
+        contextWindowTokens,
+      })
+    : null;
   const reserveTokensFloor =
     memoryFlushPlan?.reserveTokensFloor ??
     params.cfg.agents?.defaults?.compaction?.reserveTokensFloor ??
@@ -518,8 +526,8 @@ export async function runMemoryFlushIfNeeded(params: {
   isHeartbeat: boolean;
   replyOperation: ReplyOperation;
 }): Promise<SessionEntry | undefined> {
-  const memoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
-  if (!memoryFlushPlan) {
+  const rawMemoryFlushPlan = resolveMemoryFlushPlan({ cfg: params.cfg });
+  if (!rawMemoryFlushPlan) {
     return params.sessionEntry;
   }
 
@@ -548,6 +556,11 @@ export async function runMemoryFlushIfNeeded(params: {
     provider: params.followupRun.run.provider,
     modelId: params.followupRun.run.model ?? params.defaultModel,
     agentCfgContextTokens: params.agentCfgContextTokens,
+  });
+  const memoryFlushPlan = applyMemoryFlushSharesToPlan({
+    plan: rawMemoryFlushPlan,
+    cfg: params.cfg,
+    contextWindowTokens,
   });
 
   const promptTokenEstimate = estimatePromptTokensForMemoryFlush(

--- a/src/auto-reply/reply/memory-flush.ts
+++ b/src/auto-reply/reply/memory-flush.ts
@@ -1,6 +1,10 @@
 import crypto from "node:crypto";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
+import {
+  resolveCompactionReserveTokensFloor,
+  resolveShareBasedTokenBudget,
+} from "../../agents/pi-settings.js";
 import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
@@ -19,6 +23,42 @@ export function resolveMemoryFlushContextWindowTokens(params: {
       allowAsyncLoad: false,
     }) ?? DEFAULT_CONTEXT_TOKENS
   );
+}
+
+/**
+ * Apply ratio-based sibling fields (`softThresholdTokensShare`,
+ * `reserveTokensFloorShare`) from config over a memory-flush plan that was
+ * built without knowledge of the model's context window. When the share is set
+ * it replaces the absolute value; otherwise the plan's absolute values are
+ * preserved (full backward compatibility).
+ */
+export function applyMemoryFlushSharesToPlan<
+  TPlan extends { softThresholdTokens: number; reserveTokensFloor: number },
+>(params: { plan: TPlan; cfg?: OpenClawConfig; contextWindowTokens: number }): TPlan {
+  const compactionCfg = params.cfg?.agents?.defaults?.compaction;
+  const memoryFlushCfg = compactionCfg?.memoryFlush;
+  const softThresholdTokens = resolveShareBasedTokenBudget({
+    share: memoryFlushCfg?.softThresholdTokensShare,
+    absolute: params.plan.softThresholdTokens,
+    contextWindowTokens: params.contextWindowTokens,
+    fallback: params.plan.softThresholdTokens,
+  });
+  const reserveTokensFloor = resolveCompactionReserveTokensFloor(
+    params.cfg,
+    params.contextWindowTokens,
+  );
+  // Preserve absolute floor from the plan when no share is configured and the
+  // caller's resolver returns the default (config-absent) value.
+  const resolvedReserveTokensFloor =
+    typeof compactionCfg?.reserveTokensFloorShare === "number" ||
+    typeof compactionCfg?.reserveTokensFloor === "number"
+      ? reserveTokensFloor
+      : params.plan.reserveTokensFloor;
+  return {
+    ...params.plan,
+    softThresholdTokens,
+    reserveTokensFloor: resolvedReserveTokensFloor,
+  };
 }
 
 function resolvePositiveTokenCount(value: number | undefined): number | undefined {

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -516,6 +516,73 @@ describe("applyMemoryFlushSharesToPlan", () => {
     expect(small.reserveTokensFloor).toBe(800);
     expect(small.softThresholdTokens).toBe(160);
   });
+
+  // Regression: a single agent runs sessions with different models. The share
+  // must be evaluated against the SESSION-active model's context window, not
+  // a value statically derived from the agent's default model. Two sessions
+  // of the same agent with different active models must yield different
+  // resolved budgets.
+  it("share resolves against the SESSION-active model, not the agent default model", () => {
+    // Same agent config: both share fields set, no absolute overrides.
+    const cfg = {
+      models: {
+        providers: {
+          glm: { models: [{ id: "glm-4.7", contextWindow: 200_000 }] },
+          moonshot: { models: [{ id: "kimi-k2", contextWindow: 1_000_000 }] },
+        },
+      },
+      agents: {
+        defaults: {
+          // Agent-level default model (would be used as a fallback when the
+          // session does not override).
+          model: { primary: "glm/glm-4.7" },
+          compaction: {
+            reserveTokensFloorShare: 0.1,
+            memoryFlush: { softThresholdTokensShare: 0.02 },
+          },
+        },
+      },
+    } as never;
+
+    // Session S1 inherits the agent default (glm-4.7, 200k window).
+    const sessionS1Window = resolveMemoryFlushContextWindowTokens({
+      cfg,
+      provider: "glm",
+      modelId: "glm-4.7",
+    });
+    expect(sessionS1Window).toBe(200_000);
+
+    const planS1 = applyMemoryFlushSharesToPlan({
+      plan: basePlan,
+      cfg,
+      contextWindowTokens: sessionS1Window,
+    });
+    expect(planS1.reserveTokensFloor).toBe(20_000); // 200k × 0.1
+    expect(planS1.softThresholdTokens).toBe(4_000); // 200k × 0.02
+
+    // Session S2 of the SAME agent overrides to kimi-k2 (1M window). The
+    // share must scale to the active session model, NOT stay locked at the
+    // agent default's 200k.
+    const sessionS2Window = resolveMemoryFlushContextWindowTokens({
+      cfg,
+      provider: "moonshot",
+      modelId: "kimi-k2",
+    });
+    expect(sessionS2Window).toBe(1_000_000);
+
+    const planS2 = applyMemoryFlushSharesToPlan({
+      plan: basePlan,
+      cfg,
+      contextWindowTokens: sessionS2Window,
+    });
+    expect(planS2.reserveTokensFloor).toBe(100_000); // 1M × 0.1
+    expect(planS2.softThresholdTokens).toBe(20_000); // 1M × 0.02
+
+    // Sanity: budgets really did differ between the two sessions even though
+    // the agent config is identical — proving the ratio is session-scoped.
+    expect(planS2.reserveTokensFloor).not.toBe(planS1.reserveTokensFloor);
+    expect(planS2.softThresholdTokens).not.toBe(planS1.softThresholdTokens);
+  });
 });
 
 describe("incrementCompactionCount", () => {

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -14,6 +14,7 @@ import {
   recordPendingHistoryEntryIfEnabled,
 } from "./history.js";
 import {
+  applyMemoryFlushSharesToPlan,
   hasAlreadyFlushedForCurrentCompaction,
   resolveMemoryFlushContextWindowTokens,
   shouldRunMemoryFlush,
@@ -411,6 +412,109 @@ describe("resolveMemoryFlushContextWindowTokens", () => {
         agentCfgContextTokens: 100_000,
       }),
     ).toBe(100_000);
+  });
+});
+
+describe("applyMemoryFlushSharesToPlan", () => {
+  const basePlan = {
+    softThresholdTokens: 4_000,
+    forceFlushTranscriptBytes: 2 * 1024 * 1024,
+    reserveTokensFloor: 20_000,
+    prompt: "p",
+    systemPrompt: "sp",
+    relativePath: "memory/today.md",
+  };
+
+  it("returns the plan unchanged when no shares are configured (backward compat)", () => {
+    const result = applyMemoryFlushSharesToPlan({
+      plan: basePlan,
+      contextWindowTokens: 200_000,
+    });
+    expect(result.softThresholdTokens).toBe(4_000);
+    expect(result.reserveTokensFloor).toBe(20_000);
+    expect(result.forceFlushTranscriptBytes).toBe(basePlan.forceFlushTranscriptBytes);
+    expect(result.relativePath).toBe("memory/today.md");
+  });
+
+  it("computes softThresholdTokens from share against the context window", () => {
+    const result = applyMemoryFlushSharesToPlan({
+      plan: basePlan,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: { softThresholdTokensShare: 0.02 },
+            },
+          },
+        },
+      } as never,
+      contextWindowTokens: 1_000_000,
+    });
+    expect(result.softThresholdTokens).toBe(20_000); // 1M × 0.02
+  });
+
+  it("share wins over absolute softThresholdTokens", () => {
+    const result = applyMemoryFlushSharesToPlan({
+      plan: { ...basePlan, softThresholdTokens: 999_999 },
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              memoryFlush: {
+                softThresholdTokens: 999_999,
+                softThresholdTokensShare: 0.02,
+              },
+            },
+          },
+        },
+      } as never,
+      contextWindowTokens: 200_000,
+    });
+    expect(result.softThresholdTokens).toBe(4_000); // 200k × 0.02
+  });
+
+  it("applies reserveTokensFloorShare from config", () => {
+    const result = applyMemoryFlushSharesToPlan({
+      plan: basePlan,
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: { reserveTokensFloorShare: 0.1 },
+          },
+        },
+      } as never,
+      contextWindowTokens: 200_000,
+    });
+    expect(result.reserveTokensFloor).toBe(20_000);
+  });
+
+  it("scales reasonably across heterogeneous context windows", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: {
+            reserveTokensFloorShare: 0.1,
+            memoryFlush: { softThresholdTokensShare: 0.02 },
+          },
+        },
+      },
+    } as never;
+
+    const big = applyMemoryFlushSharesToPlan({
+      plan: basePlan,
+      cfg,
+      contextWindowTokens: 1_000_000,
+    });
+    expect(big.reserveTokensFloor).toBe(100_000);
+    expect(big.softThresholdTokens).toBe(20_000);
+
+    const small = applyMemoryFlushSharesToPlan({
+      plan: basePlan,
+      cfg,
+      contextWindowTokens: 8_000,
+    });
+    expect(small.reserveTokensFloor).toBe(800);
+    expect(small.softThresholdTokens).toBe(160);
   });
 });
 

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4357,6 +4357,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     description:
                       "Token headroom reserved for reply generation and tool output after compaction runs. Use higher reserves for verbose/tool-heavy sessions, and lower reserves when maximizing retained history matters more.",
                   },
+                  reserveTokensShare: {
+                    type: "number",
+                    minimum: 0.01,
+                    maximum: 0.9,
+                    title: "Compaction Reserve Tokens Share",
+                    description:
+                      "Fraction of the model's contextWindowTokens used as reserveTokens (0.01-0.9). When set, it wins over reserveTokens so the reserve scales with the actual model window — a single config behaves sensibly across heterogeneous models (e.g. GLM/Claude 200k vs Kimi K2 1M vs small-window models).",
+                  },
                   keepRecentTokens: {
                     type: "integer",
                     exclusiveMinimum: 0,
@@ -4365,6 +4373,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     description:
                       "Minimum token budget preserved from the most recent conversation window during compaction. Use higher values to protect immediate context continuity and lower values to keep more long-tail history.",
                   },
+                  keepRecentTokensShare: {
+                    type: "number",
+                    minimum: 0.01,
+                    maximum: 0.9,
+                    title: "Compaction Keep Recent Tokens Share",
+                    description:
+                      "Fraction of the model's contextWindowTokens used as keepRecentTokens (0.01-0.9). When set, it wins over keepRecentTokens so recent-turn preservation scales with the model's actual context window rather than a fixed absolute count.",
+                  },
                   reserveTokensFloor: {
                     type: "integer",
                     minimum: 0,
@@ -4372,6 +4388,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     title: "Compaction Reserve Token Floor",
                     description:
                       "Minimum floor enforced for reserveTokens in Pi compaction paths (0 disables the floor guard). Use a non-zero floor to avoid over-aggressive compression under fluctuating token estimates.",
+                  },
+                  reserveTokensFloorShare: {
+                    type: "number",
+                    minimum: 0.01,
+                    maximum: 0.9,
+                    title: "Compaction Reserve Token Floor Share",
+                    description:
+                      "Fraction of the model's contextWindowTokens used as the reserveTokens floor (0.01-0.9). When set, it wins over reserveTokensFloor; the resolved floor is still applied as an absolute minimum on the final reserve tokens after share-based computation.",
                   },
                   maxHistoryShare: {
                     type: "number",
@@ -4486,6 +4510,14 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         title: "Compaction Memory Flush Soft Threshold",
                         description:
                           "Threshold distance to compaction (in tokens) that triggers pre-compaction memory flush execution. Use earlier thresholds for safer persistence, or tighter thresholds for lower flush frequency.",
+                      },
+                      softThresholdTokensShare: {
+                        type: "number",
+                        minimum: 0.01,
+                        maximum: 0.9,
+                        title: "Compaction Memory Flush Soft Threshold Share",
+                        description:
+                          "Fraction of the model's contextWindowTokens used as the memory-flush soft threshold (0.01-0.9). When set, it wins over softThresholdTokens so the trigger point scales with the actual context window rather than being fixed in absolute tokens.",
                       },
                       forceFlushTranscriptBytes: {
                         anyOf: [
@@ -25450,14 +25482,29 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: "Token headroom reserved for reply generation and tool output after compaction runs. Use higher reserves for verbose/tool-heavy sessions, and lower reserves when maximizing retained history matters more.",
       tags: ["security", "auth"],
     },
+    "agents.defaults.compaction.reserveTokensShare": {
+      label: "Compaction Reserve Tokens Share",
+      help: "Fraction of the model's contextWindowTokens used as reserveTokens (0.01-0.9). When set, it wins over reserveTokens so the reserve scales with the actual model window — a single config behaves sensibly across heterogeneous models (e.g. GLM/Claude 200k vs Kimi K2 1M vs small-window models).",
+      tags: ["security", "auth"],
+    },
     "agents.defaults.compaction.keepRecentTokens": {
       label: "Compaction Keep Recent Tokens",
       help: "Minimum token budget preserved from the most recent conversation window during compaction. Use higher values to protect immediate context continuity and lower values to keep more long-tail history.",
       tags: ["security", "auth"],
     },
+    "agents.defaults.compaction.keepRecentTokensShare": {
+      label: "Compaction Keep Recent Tokens Share",
+      help: "Fraction of the model's contextWindowTokens used as keepRecentTokens (0.01-0.9). When set, it wins over keepRecentTokens so recent-turn preservation scales with the model's actual context window rather than a fixed absolute count.",
+      tags: ["security", "auth"],
+    },
     "agents.defaults.compaction.reserveTokensFloor": {
       label: "Compaction Reserve Token Floor",
       help: "Minimum floor enforced for reserveTokens in Pi compaction paths (0 disables the floor guard). Use a non-zero floor to avoid over-aggressive compression under fluctuating token estimates.",
+      tags: ["security", "auth"],
+    },
+    "agents.defaults.compaction.reserveTokensFloorShare": {
+      label: "Compaction Reserve Token Floor Share",
+      help: "Fraction of the model's contextWindowTokens used as the reserveTokens floor (0.01-0.9). When set, it wins over reserveTokensFloor; the resolved floor is still applied as an absolute minimum on the final reserve tokens after share-based computation.",
       tags: ["security", "auth"],
     },
     "agents.defaults.compaction.maxHistoryShare": {
@@ -25538,6 +25585,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     "agents.defaults.compaction.memoryFlush.softThresholdTokens": {
       label: "Compaction Memory Flush Soft Threshold",
       help: "Threshold distance to compaction (in tokens) that triggers pre-compaction memory flush execution. Use earlier thresholds for safer persistence, or tighter thresholds for lower flush frequency.",
+      tags: ["security", "auth"],
+    },
+    "agents.defaults.compaction.memoryFlush.softThresholdTokensShare": {
+      label: "Compaction Memory Flush Soft Threshold Share",
+      help: "Fraction of the model's contextWindowTokens used as the memory-flush soft threshold (0.01-0.9). When set, it wins over softThresholdTokens so the trigger point scales with the actual context window rather than being fixed in absolute tokens.",
       tags: ["security", "auth"],
     },
     "agents.defaults.compaction.memoryFlush.forceFlushTranscriptBytes": {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1159,10 +1159,16 @@ export const FIELD_HELP: Record<string, string> = {
     "Id of a registered compaction provider plugin used for summarization. When set and the provider is registered, its summarize() method is called instead of the built-in summarizeInStages pipeline. Falls back to built-in on provider failure. Leave unset to use the default built-in summarization.",
   "agents.defaults.compaction.reserveTokens":
     "Token headroom reserved for reply generation and tool output after compaction runs. Use higher reserves for verbose/tool-heavy sessions, and lower reserves when maximizing retained history matters more.",
+  "agents.defaults.compaction.reserveTokensShare":
+    "Fraction of the model's contextWindowTokens used as reserveTokens (0.01-0.9). When set, it wins over reserveTokens so the reserve scales with the actual model window — a single config behaves sensibly across heterogeneous models (e.g. GLM/Claude 200k vs Kimi K2 1M vs small-window models).",
   "agents.defaults.compaction.keepRecentTokens":
     "Minimum token budget preserved from the most recent conversation window during compaction. Use higher values to protect immediate context continuity and lower values to keep more long-tail history.",
+  "agents.defaults.compaction.keepRecentTokensShare":
+    "Fraction of the model's contextWindowTokens used as keepRecentTokens (0.01-0.9). When set, it wins over keepRecentTokens so recent-turn preservation scales with the model's actual context window rather than a fixed absolute count.",
   "agents.defaults.compaction.reserveTokensFloor":
     "Minimum floor enforced for reserveTokens in Pi compaction paths (0 disables the floor guard). Use a non-zero floor to avoid over-aggressive compression under fluctuating token estimates.",
+  "agents.defaults.compaction.reserveTokensFloorShare":
+    "Fraction of the model's contextWindowTokens used as the reserveTokens floor (0.01-0.9). When set, it wins over reserveTokensFloor; the resolved floor is still applied as an absolute minimum on the final reserve tokens after share-based computation.",
   "agents.defaults.compaction.maxHistoryShare":
     "Maximum fraction of total context budget allowed for retained history after compaction (range 0.1-0.9). Use lower shares for more generation headroom or higher shares for deeper historical continuity.",
   "agents.defaults.compaction.identifierPolicy":
@@ -1195,6 +1201,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Enables pre-compaction memory flush before the runtime performs stronger history reduction near token limits. Keep enabled unless you intentionally disable memory side effects in constrained environments.",
   "agents.defaults.compaction.memoryFlush.softThresholdTokens":
     "Threshold distance to compaction (in tokens) that triggers pre-compaction memory flush execution. Use earlier thresholds for safer persistence, or tighter thresholds for lower flush frequency.",
+  "agents.defaults.compaction.memoryFlush.softThresholdTokensShare":
+    "Fraction of the model's contextWindowTokens used as the memory-flush soft threshold (0.01-0.9). When set, it wins over softThresholdTokens so the trigger point scales with the actual context window rather than being fixed in absolute tokens.",
   "agents.defaults.compaction.memoryFlush.forceFlushTranscriptBytes":
     'Forces pre-compaction memory flush when transcript file size reaches this threshold (bytes or strings like "2mb"). Use this to prevent long-session hangs even when token counters are stale; set to 0 to disable.',
   "agents.defaults.compaction.memoryFlush.prompt":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -534,8 +534,11 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.mode": "Compaction Mode",
   "agents.defaults.compaction.provider": "Compaction Provider",
   "agents.defaults.compaction.reserveTokens": "Compaction Reserve Tokens",
+  "agents.defaults.compaction.reserveTokensShare": "Compaction Reserve Tokens Share",
   "agents.defaults.compaction.keepRecentTokens": "Compaction Keep Recent Tokens",
+  "agents.defaults.compaction.keepRecentTokensShare": "Compaction Keep Recent Tokens Share",
   "agents.defaults.compaction.reserveTokensFloor": "Compaction Reserve Token Floor",
+  "agents.defaults.compaction.reserveTokensFloorShare": "Compaction Reserve Token Floor Share",
   "agents.defaults.compaction.maxHistoryShare": "Compaction Max History Share",
   "agents.defaults.compaction.identifierPolicy": "Compaction Identifier Policy",
   "agents.defaults.compaction.identifierInstructions": "Compaction Identifier Instructions",
@@ -553,6 +556,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.memoryFlush.enabled": "Compaction Memory Flush Enabled",
   "agents.defaults.compaction.memoryFlush.softThresholdTokens":
     "Compaction Memory Flush Soft Threshold",
+  "agents.defaults.compaction.memoryFlush.softThresholdTokensShare":
+    "Compaction Memory Flush Soft Threshold Share",
   "agents.defaults.compaction.memoryFlush.forceFlushTranscriptBytes":
     "Compaction Memory Flush Transcript Size Threshold",
   "agents.defaults.compaction.memoryFlush.prompt": "Compaction Memory Flush Prompt",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -388,6 +388,12 @@ export type AgentCompactionConfig = {
    * Fraction of the model's contextWindowTokens used as the reserve-tokens target
    * (0.01-0.9). Wins over `reserveTokens` when both are set, which lets a single
    * config scale correctly across heterogeneous context windows (e.g. 200k vs 1M).
+   *
+   * The base window is the context window of the model active for the CURRENT
+   * SESSION (resolved per-run from session model overrides), falling back to the
+   * agent's configured default model, then to DEFAULT_CONTEXT_TOKENS. This means
+   * a single agent can host sessions on differently-sized models and the share
+   * scales per session, not per agent config.
    */
   reserveTokensShare?: number;
   /** Pi keepRecentTokens budget used for cut-point selection. */
@@ -396,6 +402,10 @@ export type AgentCompactionConfig = {
    * Fraction of the model's contextWindowTokens used as the keepRecentTokens budget
    * (0.01-0.9). Wins over `keepRecentTokens` when both are set so recent-turn
    * preservation scales with the window instead of being fixed in absolute tokens.
+   *
+   * The base window is the context window of the model active for the CURRENT
+   * SESSION (per-run), falling back to the agent's default model, then to
+   * DEFAULT_CONTEXT_TOKENS.
    */
   keepRecentTokensShare?: number;
   /** Minimum reserve tokens enforced for Pi compaction (0 disables the floor). */
@@ -404,6 +414,10 @@ export type AgentCompactionConfig = {
    * Fraction of the model's contextWindowTokens used as the reserve-tokens floor
    * (0.01-0.9). Wins over `reserveTokensFloor` when both are set; the resolved
    * floor is still applied as an absolute minimum on the final reserve tokens.
+   *
+   * The base window is the context window of the model active for the CURRENT
+   * SESSION (per-run), falling back to the agent's default model, then to
+   * DEFAULT_CONTEXT_TOKENS.
    */
   reserveTokensFloorShare?: number;
   /** Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5). */
@@ -462,6 +476,10 @@ export type AgentCompactionMemoryFlushConfig = {
    * Fraction of the model's contextWindowTokens used as the memory-flush soft threshold
    * (0.01-0.9). Wins over `softThresholdTokens` when both are set, so the trigger point
    * scales with the actual context window rather than being fixed in absolute tokens.
+   *
+   * The base window is the context window of the model active for the CURRENT
+   * SESSION (resolved per-run from session model overrides), falling back to the
+   * agent's default model, then to DEFAULT_CONTEXT_TOKENS.
    */
   softThresholdTokensShare?: number;
   /**

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -384,10 +384,28 @@ export type AgentCompactionConfig = {
   mode?: AgentCompactionMode;
   /** Pi reserve tokens target before floor enforcement. */
   reserveTokens?: number;
+  /**
+   * Fraction of the model's contextWindowTokens used as the reserve-tokens target
+   * (0.01-0.9). Wins over `reserveTokens` when both are set, which lets a single
+   * config scale correctly across heterogeneous context windows (e.g. 200k vs 1M).
+   */
+  reserveTokensShare?: number;
   /** Pi keepRecentTokens budget used for cut-point selection. */
   keepRecentTokens?: number;
+  /**
+   * Fraction of the model's contextWindowTokens used as the keepRecentTokens budget
+   * (0.01-0.9). Wins over `keepRecentTokens` when both are set so recent-turn
+   * preservation scales with the window instead of being fixed in absolute tokens.
+   */
+  keepRecentTokensShare?: number;
   /** Minimum reserve tokens enforced for Pi compaction (0 disables the floor). */
   reserveTokensFloor?: number;
+  /**
+   * Fraction of the model's contextWindowTokens used as the reserve-tokens floor
+   * (0.01-0.9). Wins over `reserveTokensFloor` when both are set; the resolved
+   * floor is still applied as an absolute minimum on the final reserve tokens.
+   */
+  reserveTokensFloorShare?: number;
   /** Max share of context window for history during safeguard pruning (0.1–0.9, default 0.5). */
   maxHistoryShare?: number;
   /** Additional compaction-summary instructions that can preserve language or persona continuity. */
@@ -440,6 +458,12 @@ export type AgentCompactionMemoryFlushConfig = {
   enabled?: boolean;
   /** Run the memory flush when context is within this many tokens of the compaction threshold. */
   softThresholdTokens?: number;
+  /**
+   * Fraction of the model's contextWindowTokens used as the memory-flush soft threshold
+   * (0.01-0.9). Wins over `softThresholdTokens` when both are set, so the trigger point
+   * scales with the actual context window rather than being fixed in absolute tokens.
+   */
+  softThresholdTokensShare?: number;
   /**
    * Force a memory flush when transcript size reaches this threshold
    * (bytes, or byte-size string like "2mb"). Set to 0 to disable.

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -130,8 +130,11 @@ export const AgentDefaultsSchema = z
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
         provider: z.string().optional(),
         reserveTokens: z.number().int().nonnegative().optional(),
+        reserveTokensShare: z.number().min(0.01).max(0.9).optional(),
         keepRecentTokens: z.number().int().positive().optional(),
+        keepRecentTokensShare: z.number().min(0.01).max(0.9).optional(),
         reserveTokensFloor: z.number().int().nonnegative().optional(),
+        reserveTokensFloorShare: z.number().min(0.01).max(0.9).optional(),
         maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
         customInstructions: z.string().optional(),
         identifierPolicy: z
@@ -154,6 +157,7 @@ export const AgentDefaultsSchema = z
           .object({
             enabled: z.boolean().optional(),
             softThresholdTokens: z.number().int().nonnegative().optional(),
+            softThresholdTokensShare: z.number().min(0.01).max(0.9).optional(),
             forceFlushTranscriptBytes: z
               .union([
                 z.number().int().nonnegative(),


### PR DESCRIPTION
## Motivation

OpenClaw users increasingly run multiple agents side-by-side against models
with wildly different context windows — e.g. GLM 200k, Claude 200k, Kimi K2
1M, and smaller local models. The compaction config today mixes ratios
(`softTrimRatio`, `hardClearRatio`, `maxHistoryShare`) with absolute-token
budgets (`reserveTokens`, `keepRecentTokens`, `reserveTokensFloor`, and
`memoryFlush.softThresholdTokens`). An absolute like `reserveTokens: 50000`
reserves 25% of a 200k window but only 5% of a 1M window, and over-reserves
aggressively against an 8k window. The same config behaves completely
differently depending on the model, so per-model configs end up fragmented.

This PR introduces **additive** `*Share` sibling fields so a single config
can scale correctly across heterogeneous models.

## Fields that got a ratio sibling

- `agents.defaults.compaction.reserveTokensShare`
- `agents.defaults.compaction.keepRecentTokensShare`
- `agents.defaults.compaction.reserveTokensFloorShare`
- `agents.defaults.compaction.memoryFlush.softThresholdTokensShare`

All four are validated as `number` in `[0.01, 0.9]` in
`zod-schema.agent-defaults.ts`, mirroring the existing `maxHistoryShare`
range convention.

## Precedence rules

1. If `*Share` is set **and** the model's `contextWindowTokens` is known
   at runtime → `Math.floor(contextWindowTokens * share)`.
2. Otherwise, if the absolute field (`reserveTokens`, `keepRecentTokens`,
   `reserveTokensFloor`, `softThresholdTokens`) is set → use it as before.
3. Otherwise → the existing default (`DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR`,
   memory-core defaults, etc.).

`reserveTokensFloor` (resolved from share or absolute) is still applied as
an **absolute minimum** on the final `reserveTokens` value, so a small
share against a large window never drops below the safety floor.

## Backward compatibility

- No existing absolute field is removed. Users who prefer hard numbers
  for predictability keep that option.
- When only absolute fields are configured, behavior is byte-for-byte
  identical to pre-PR behavior.
- When `contextWindowTokens` is unknown (e.g. older code paths that don't
  plumb it yet), the share is silently ignored and the absolute/default
  path applies. No runtime error, no config error.
- Plugin SDK surface is unchanged; the `MemoryFlushPlan` still ships with
  absolute `softThresholdTokens` / `reserveTokensFloor` so external plugins
  keep working. Share-based overrides are applied at the consumption site
  (`applyMemoryFlushSharesToPlan`) where the context window is resolved.

## Implementation notes

- New helper `resolveShareBasedTokenBudget(...)` centralizes the share →
  absolute → fallback precedence.
- `applyPiCompactionSettingsFromConfig` takes an optional
  `contextWindowTokens` and resolves shares against it. Call sites in
  `pi-embedded-runner/run/attempt.ts` and `pi-embedded-runner/compact.ts`
  now pass `model.contextWindow`.
- `resolveCompactionReserveTokensFloor` gained an optional
  `contextWindowTokens` arg; when present, it resolves
  `reserveTokensFloorShare` first.
- `applyMemoryFlushSharesToPlan` overrides the plugin-provided flush plan's
  `softThresholdTokens` and `reserveTokensFloor` with share-based values
  when configured and a context window is known, leaving the rest of the
  plan untouched.
- Each new field has a one-sentence JSDoc explaining the relationship to
  `contextWindowTokens`, and matching entries in `schema.help.ts` /
  `schema.labels.ts`. `schema.base.generated.ts` was regenerated via
  `pnpm config:schema:gen`.

## Test coverage summary

Extended `src/agents/pi-settings.test.ts` and
`src/auto-reply/reply/reply-state.test.ts` with the following coverage:

- Only absolute set → uses absolute (regression)
- Only share set → computes from context window
- Both set → share wins (documented precedence)
- Share + floor → floor lifts the value when share yields less
- Share without `contextWindowTokens` → falls back to absolute (backward compat)
- 1M window + share → scales up reasonably
- 8k window + share → avoids over-reserving
- `keepRecentTokensShare` resolves against the window
- `applyMemoryFlushSharesToPlan` preserves a plan unchanged when no share is set,
  applies `softThresholdTokensShare` / `reserveTokensFloorShare`, and scales
  correctly across 8k ↔ 1M windows
- `resolveShareBasedTokenBudget` handles the full share/absolute/fallback lattice

### Test plan

- [x] `pnpm run config:schema:gen` — schema.base.generated.ts regenerated cleanly
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents.config.ts src/agents/` — 1343 pass
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/` — 1061 pass
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.config.ts src/config/` — 2080 pass
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/` — 36 pass
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-memory.config.ts` — 564 pass, 3 skipped
- [x] `pnpm tsgo` — no new type errors in touched files (pre-existing unrelated errors in whatsapp/ui remain)
- [x] `pnpm lint` — no new oxlint errors in touched files