### PR TITLE
fix(signal): send early typing indicator before dispatch

### DIFF
--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -321,17 +321,13 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       },
     });
 
-    // Send early typing indicator before dispatch to reduce perceived latency.
-    // The default typing indicator only fires on the first AI token (onReplyStart),
-    // but group messages have significant pre-dispatch overhead (history building,
-    // blocking hooks, larger context assembly). This fire-and-forget call ensures
-    // users see "typing..." immediately rather than waiting through pre-processing.
-    if (ctxPayload.To) {
-      sendTypingSignal(ctxPayload.To, {
-        baseUrl: deps.baseUrl,
-        account: deps.account,
-        accountId: deps.accountId,
-      }).catch(() => {});
+    // Early typing for GROUP messages only — group dispatch carries heavy
+    // pre-AI overhead (history build, hook chain, context assembly) that
+    // DMs don't have. Routes through typingCallbacks.onReplyStart so we
+    // reuse keepalive (3s tick), 60s TTL safety, and onIdle/onCleanup
+    // teardown wired into createReplyDispatcherWithTyping.
+    if (entry.isGroup) {
+      typingCallbacks?.onReplyStart().catch(() => {});
     }
 
     const { queuedFinal } = await dispatchInboundMessage({

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -321,6 +321,19 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       },
     });
 
+    // Send early typing indicator before dispatch to reduce perceived latency.
+    // The default typing indicator only fires on the first AI token (onReplyStart),
+    // but group messages have significant pre-dispatch overhead (history building,
+    // blocking hooks, larger context assembly). This fire-and-forget call ensures
+    // users see "typing..." immediately rather than waiting through pre-processing.
+    if (ctxPayload.To) {
+      sendTypingSignal(ctxPayload.To, {
+        baseUrl: deps.baseUrl,
+        account: deps.account,
+        accountId: deps.accountId,
+      }).catch(() => {});
+    }
+
     const { queuedFinal } = await dispatchInboundMessage({
       ctx: ctxPayload,
       cfg: deps.cfg,


### PR DESCRIPTION
## Problem

Group messages feel noticeably slower than DMs because the typing indicator only fires when the first AI token arrives (`onReplyStart`). Before that, there's significant pre-dispatch overhead that's invisible to users:

1. **Pending history context building** — `buildPendingHistoryContextFromMap()` iterates the group history Map (DMs skip this)
2. **Inbound history assembly** — builds `inboundHistory` array from group's history Map (DMs skip entirely)
3. **Blocking hooks** — `before_dispatch` and `reply_dispatch` hooks run with extra work for groups
4. **Larger AI context** — group sessions have multi-sender history → longer time-to-first-token
5. **Tool summaries suppressed** — groups don't get intermediate status messages, making the silence feel even longer

The result: in group chats, users stare at nothing for several seconds before seeing any feedback. DMs feel much more responsive.

## Fix

Send a fire-and-forget typing indicator **immediately before** `dispatchInboundMessage` in the Signal monitor. This ensures users see "typing..." right away rather than waiting through all pre-processing and context assembly.

The fix is minimal — one `sendTypingSignal().catch(() => {})` call before dispatch. The existing typing callback in `createChannelReplyPipeline` still handles the normal typing flow; this just front-loads the first signal.

## Scope

This PR applies the fix to the **Signal channel** only. The same pattern could benefit other channel monitors (Discord, Slack, iMessage) that share the same late-bound typing indicator behavior.

## Testing

Tested manually on a live Signal group chat. The typing indicator now appears immediately when a message is sent, rather than after 3-5 seconds of silent pre-processing.