### PR TITLE
fix(gateway): exclude heartbeat sender ID from session display name

### DIFF
--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1131,7 +1131,9 @@ export function buildGatewaySessionRow(params: {
   const space = entry?.space;
   const id = parsed?.id;
   const origin = entry?.origin;
-  const originLabel = origin?.label;
+  // Exclude internal system sender IDs (e.g. "heartbeat") from the display
+  // name fallback chain so the webchat session selector stays meaningful.
+  const originLabel = origin?.label && origin.label !== "heartbeat" ? origin.label : undefined;
   const displayName =
     entry?.displayName ??
     (channel

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1131,9 +1131,10 @@ export function buildGatewaySessionRow(params: {
   const space = entry?.space;
   const id = parsed?.id;
   const origin = entry?.origin;
-  // Exclude internal system sender IDs (e.g. "heartbeat") from the display
-  // name fallback chain so the webchat session selector stays meaningful.
-  const originLabel = origin?.label && origin.label !== "heartbeat" ? origin.label : undefined;
+  // Matches the fallback sender ID in resolveHeartbeatSenderId (targets.ts).
+  const HEARTBEAT_FALLBACK_SENDER = "heartbeat";
+  const originLabel =
+    origin?.label && origin.label !== HEARTBEAT_FALLBACK_SENDER ? origin.label : undefined;
   const displayName =
     entry?.displayName ??
     (channel


### PR DESCRIPTION
## Summary

- Filters out the internal "heartbeat" placeholder from the session display name fallback chain in `buildGatewaySessionRow`
- Without this filter, the heartbeat delivery path's fallback sender ID ("heartbeat") flows into `origin.label`, which then becomes the session dropdown label in webchat

## Root Cause

`resolveHeartbeatSenderId` (in `targets.ts`) returns "heartbeat" as a fallback when no real sender can be resolved. This ends up in the session entry's `origin.label`. When `buildGatewaySessionRow` computes `displayName`, it falls through `entry.displayName -> groupName -> entry.label -> originLabel`, and if all the earlier values are undefined, "heartbeat" becomes the visible session label in the webchat dropdown.

## Fix

2-line change: check if `origin.label` is "heartbeat" before using it as `originLabel` in the display name fallback chain.

Closes #66533