### PR TITLE
memory: strip inbound metadata envelopes from user messages in session corpus

### DIFF
--- a/src/memory-host-sdk/host/session-files.test.ts
+++ b/src/memory-host-sdk/host/session-files.test.ts
@@ -151,6 +151,71 @@ describe("buildSessionEntry", () => {
     ]);
   });
 
+  it("strips inbound metadata envelope from user messages before normalization", async () => {
+    // Real Telegram inbound envelope: Conversation info + Sender blocks prepended
+    // to the actual user text. Without stripping, the JSON envelope dominates
+    // the corpus entry and the user's real words get truncated by the
+    // SESSION_INGESTION_MAX_SNIPPET_CHARS cap downstream.
+    // See: https://github.com/openclaw/openclaw/issues/63921
+    const envelopedUserText = [
+      "Conversation info (untrusted metadata):",
+      "```json",
+      '{"message_id":"msg-100","chat_id":"-100123","sender":"Chris"}',
+      "```",
+      "",
+      "Sender (untrusted metadata):",
+      "```json",
+      '{"label":"Chris","name":"Chris","id":"42"}',
+      "```",
+      "",
+      "帮我看看今天的 Oura 数据",
+    ].join("\n");
+
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: envelopedUserText },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "好的,我来查一下" },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "enveloped-session.jsonl");
+    await fs.writeFile(filePath, jsonlLines.join("\n"));
+
+    const entry = await buildSessionEntry(filePath);
+    expect(entry).not.toBeNull();
+
+    const contentLines = entry!.content.split("\n");
+    expect(contentLines).toHaveLength(2);
+    // User line should contain ONLY the real user text, not the JSON envelope.
+    expect(contentLines[0]).toBe("User: 帮我看看今天的 Oura 数据");
+    expect(contentLines[0]).not.toContain("untrusted metadata");
+    expect(contentLines[0]).not.toContain("message_id");
+    expect(contentLines[0]).not.toContain("```json");
+    expect(contentLines[1]).toBe("Assistant: 好的,我来查一下");
+  });
+
+  it("preserves assistant messages that happen to contain sentinel-like text", async () => {
+    // Assistant role must NOT be stripped — only user messages carry inbound
+    // envelopes, and assistants may legitimately discuss metadata formats.
+    const assistantText =
+      "The envelope format uses 'Conversation info (untrusted metadata):' as a sentinel";
+    const jsonlLines = [
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: assistantText },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "assistant-sentinel.jsonl");
+    await fs.writeFile(filePath, jsonlLines.join("\n"));
+
+    const entry = await buildSessionEntry(filePath);
+    expect(entry).not.toBeNull();
+    expect(entry!.content).toBe(`Assistant: ${assistantText}`);
+  });
+
   it("flags dreaming narrative transcripts from bootstrap metadata", async () => {
     const jsonlLines = [
       JSON.stringify({

--- a/src/memory-host-sdk/host/session-files.ts
+++ b/src/memory-host-sdk/host/session-files.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import { isUsageCountedSessionTranscriptFileName } from "../../config/sessions/artifacts.js";
 import { resolveSessionTranscriptsDirForAgent } from "../../config/sessions/paths.js";
 import { redactSensitiveText } from "../../logging/redact.js";
@@ -70,9 +71,33 @@ function normalizeSessionText(value: string): string {
     .trim();
 }
 
-export function extractSessionText(content: unknown): string | null {
+/**
+ * Strip OpenClaw-injected inbound metadata envelopes from a raw text block.
+ *
+ * User-role messages arriving from external channels (Telegram, Discord,
+ * Slack, …) are stored with a multi-line prefix containing Conversation info,
+ * Sender info, and other AI-facing metadata blocks. These envelopes must be
+ * removed BEFORE normalization, because `stripInboundMetadata` relies on
+ * newline structure and fenced `json` code fences to locate sentinels; once
+ * `normalizeSessionText` collapses newlines into spaces, stripping is
+ * impossible.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/63921
+ */
+function stripInboundMetadataForUserRole(text: string, role: "user" | "assistant"): string {
+  if (role !== "user") {
+    return text;
+  }
+  return stripInboundMetadata(text);
+}
+
+export function extractSessionText(
+  content: unknown,
+  role: "user" | "assistant" = "assistant",
+): string | null {
   if (typeof content === "string") {
-    const normalized = normalizeSessionText(content);
+    const stripped = stripInboundMetadataForUserRole(content, role);
+    const normalized = normalizeSessionText(stripped);
     return normalized ? normalized : null;
   }
   if (!Array.isArray(content)) {
@@ -87,7 +112,8 @@ export function extractSessionText(content: unknown): string | null {
     if (record.type !== "text" || typeof record.text !== "string") {
       continue;
     }
-    const normalized = normalizeSessionText(record.text);
+    const stripped = stripInboundMetadataForUserRole(record.text, role);
+    const normalized = normalizeSessionText(stripped);
     if (normalized) {
       parts.push(normalized);
     }
@@ -159,7 +185,7 @@ export async function buildSessionEntry(absPath: string): Promise<SessionFileEnt
       if (message.role !== "user" && message.role !== "assistant") {
         continue;
       }
-      const text = extractSessionText(message.content);
+      const text = extractSessionText(message.content, message.role);
       if (!text) {
         continue;
       }


### PR DESCRIPTION
## Summary

Session corpus ingestion was feeding raw Telegram/Discord/Slack inbound envelopes into the dreaming corpus unchanged. Each user message in the transcript carries a ~338-char \`Conversation info\` + \`Sender\` JSON prefix built by \`buildInboundUserContextPrefix\`, which exceeds the \`SESSION_INGESTION_MAX_SNIPPET_CHARS\` (280) cap used downstream in \`dreaming-phases.ts\`. Result: user's actual words never made it into the corpus, and REM topic extraction latched onto envelope words like \`assistant\` / \`untrusted metadata\` as the top \"topics\".

Root cause is ordering in \`buildSessionEntry\` → \`extractSessionText\`: \`normalizeSessionText\` collapses newlines to spaces per text block, and once newlines are gone, \`stripInboundMetadata\` can no longer locate sentinel lines or fenced-json blocks. So stripping must happen **before** normalization, and only for \`user\` role (assistant messages may legitimately discuss envelope formats).

Fixes #63921

## Changes

- \`src/memory-host-sdk/host/session-files.ts\`: add role parameter to \`extractSessionText\`; strip inbound metadata on user-role text blocks before \`normalizeSessionText\` runs.
- \`src/memory-host-sdk/host/session-files.test.ts\`: new test using a real multi-line Telegram envelope asserts the corpus entry contains only the actual user text; separate test confirms assistant messages containing sentinel-like text are preserved untouched.

## Test plan

- [x] \`pnpm test src/memory-host-sdk/host/session-files.test.ts\` — 8/8 passing (6 existing + 2 new)
- [x] \`pnpm check\` — clean (lint, format, type, import cycles, madge, webhook/auth guards)
- [ ] Manual verification on next dreaming cycle: REM topics should reflect real user words instead of envelope noise