### PR TITLE
fix(media): allow validated host-read HTML/XML/CSS documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,7 @@ Docs: https://docs.openclaw.ai
 - Configure/GitHub Copilot: reuse existing Copilot auth during configure and show the provider's manifest model catalog in the model picker. (#74276) Thanks @obviyus.
 - Configure/models: keep the model picker scoped to the selected manifest provider and enable its bundled plugin before catalog lookup, so choosing GitHub Copilot no longer falls back to Ollama or skips the catalog. (#74322) Thanks @obviyus.
 - Auto-reply/subagents: reject `/focus` from leaf subagents and scope fallback target resolution to the requesting subagent's children, so subagents cannot bind conversations outside their control boundary. (#73613) Thanks @drobison00.
+- Media/host-read: allow validated HTML, XML, and CSS documents from host-local attachment reads while keeping opaque binary payloads blocked. Thanks @yosit.
 
 ## 2026.4.27
 

--- a/src/infra/outbound/message-action-runner.media.test.ts
+++ b/src/infra/outbound/message-action-runner.media.test.ts
@@ -389,6 +389,39 @@ describe("runMessageAction media behavior", () => {
       }
     });
 
+    it("allows host-local HTML attachments when fs root expansion is enabled", async () => {
+      await restoreRealMediaLoader();
+
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "msg-attachment-html-"));
+      try {
+        const outsidePath = path.join(tempDir, "report.html");
+        await fs.writeFile(outsidePath, "<!doctype html><html><body>Report</body></html>\n", "utf8");
+
+        const result = await runMessageAction({
+          cfg: {
+            ...cfg,
+            tools: { fs: { workspaceOnly: false } },
+          },
+          action: "sendAttachment",
+          params: {
+            channel: "attachmentchat",
+            target: "+15551234567",
+            media: outsidePath,
+            message: "caption",
+          },
+        });
+
+        expect(result.kind).toBe("action");
+        expect(result.payload).toMatchObject({
+          ok: true,
+          filename: "report.html",
+          contentType: "text/html",
+        });
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it("rejects host-local text attachments even when fs root expansion is enabled", async () => {
       await restoreRealMediaLoader();
 

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -196,39 +196,55 @@ describe("loadWebMedia", () => {
     });
   });
 
-  it("allows host-read CSV files", async () => {
-    const csvFile = path.join(fixtureRoot, "data.csv");
-    await fs.writeFile(csvFile, "name,value\nfoo,1\nbar,2\n", "utf8");
-    const result = await loadWebMedia(csvFile, {
-      maxBytes: 1024 * 1024,
-      localRoots: "any",
-      readFile: async (filePath) => await fs.readFile(filePath),
-      hostReadCapability: true,
-    });
+  it.each([
+    {
+      label: "CSV",
+      fileName: "data.csv",
+      body: "name,value\nfoo,1\nbar,2\n",
+      contentType: "text/csv",
+    },
+    {
+      label: "Markdown",
+      fileName: "notes.md",
+      body: "# Title\n\nSome **bold** text.\n",
+      contentType: "text/markdown",
+    },
+    {
+      label: "HTML",
+      fileName: "page.html",
+      body: "<!doctype html><html><body>Hello</body></html>\n",
+      contentType: "text/html",
+    },
+    {
+      label: "XML",
+      fileName: "feed.xml",
+      body: "<?xml version=\"1.0\"?><root>Hello</root>\n",
+      contentType: "application/xml",
+    },
+    {
+      label: "CSS",
+      fileName: "site.css",
+      body: "body { color: red; }\n",
+      contentType: "text/css",
+    },
+  ])("allows host-read $label files", async ({ fileName, body, contentType }) => {
+    const result = await loadDocumentWithHostRead(fileName, body);
     expect(result.kind).toBe("document");
-    expect(result.contentType).toBe("text/csv");
+    expect(result.contentType).toBe(contentType);
   });
 
-  it("allows host-read Markdown files", async () => {
-    const mdFile = path.join(fixtureRoot, "notes.md");
-    await fs.writeFile(mdFile, "# Title\n\nSome **bold** text.\n", "utf8");
-    const result = await loadWebMedia(mdFile, {
-      maxBytes: 1024 * 1024,
-      localRoots: "any",
-      readFile: async (filePath) => await fs.readFile(filePath),
-      hostReadCapability: true,
-    });
-    expect(result.kind).toBe("document");
-    expect(result.contentType).toBe("text/markdown");
-  });
-
-  it("rejects binary data disguised as a CSV file", async () => {
-    const fakeCsv = path.join(fixtureRoot, "evil.csv");
-    // Write ZIP magic bytes — file-type detects application/zip (not image, not CSV),
-    // so it is rejected by the host-read policy rather than allowed as an image.
-    await fs.writeFile(fakeCsv, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
+  it.each([
+    { label: "CSV", fileName: "evil.csv" },
+    { label: "Markdown", fileName: "evil.md" },
+    { label: "HTML", fileName: "evil.html" },
+    { label: "XML", fileName: "evil.xml" },
+    { label: "CSS", fileName: "evil.css" },
+  ])("rejects ZIP data disguised as a host-read $label file", async ({ fileName }) => {
+    const fakeTextFile = path.join(fixtureRoot, fileName);
+    // Write ZIP magic bytes so file-type detects application/zip rather than a text document.
+    await fs.writeFile(fakeTextFile, Buffer.from([0x50, 0x4b, 0x03, 0x04]));
     await expect(
-      loadWebMedia(fakeCsv, {
+      loadWebMedia(fakeTextFile, {
         maxBytes: 1024 * 1024,
         localRoots: "any",
         readFile: async (filePath) => await fs.readFile(filePath),
@@ -242,6 +258,9 @@ describe("loadWebMedia", () => {
   it.each([
     { label: "CSV", fileName: "opaque.csv" },
     { label: "Markdown", fileName: "opaque.md" },
+    { label: "HTML", fileName: "opaque.html" },
+    { label: "XML", fileName: "opaque.xml" },
+    { label: "CSS", fileName: "opaque.css" },
   ])("rejects opaque non-NUL binary data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
     const opaqueBinary = Buffer.alloc(9000);
@@ -405,6 +424,9 @@ describe("loadWebMedia", () => {
   it.each([
     { label: "CSV", fileName: "high-bytes.csv" },
     { label: "Markdown", fileName: "high-bytes.md" },
+    { label: "HTML", fileName: "high-bytes.html" },
+    { label: "XML", fileName: "high-bytes.xml" },
+    { label: "CSS", fileName: "high-bytes.css" },
   ])("rejects high-byte opaque data disguised as %s", async ({ fileName }) => {
     const fakeTextFile = path.join(fixtureRoot, fileName);
     const opaqueBinary = Buffer.alloc(9000);

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -103,12 +103,23 @@ const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/vnd.openxmlformats-officedocument.presentationml.presentation",
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/xml",
+  "text/css",
   "text/csv",
+  "text/html",
   "text/markdown",
+  "text/xml",
 ]);
-// file-type returns undefined (no magic bytes) for plain-text formats like CSV and
-// Markdown, so host-read needs an explicit "this really decodes as text" fallback.
-const HOST_READ_TEXT_PLAIN_ALIASES = new Set(["text/csv", "text/markdown"]);
+// file-type returns undefined (no magic bytes) for plain-text formats like CSV,
+// Markdown, HTML, XML, and CSS, so host-read needs an explicit text fallback.
+const HOST_READ_TEXT_PLAIN_ALIASES = new Set([
+  "application/xml",
+  "text/css",
+  "text/csv",
+  "text/html",
+  "text/markdown",
+  "text/xml",
+]);
 const MB = 1024 * 1024;
 
 function getTextStats(text: string): { printableRatio: number } {
@@ -223,24 +234,28 @@ function assertHostReadMediaAllowed(params: {
 }): void {
   const declaredMime = normalizeMimeType(mimeTypeFromFilePath(params.filePath));
   const normalizedMime = normalizeMimeType(params.contentType);
-  // For extension-declared plain-text aliases such as .csv/.md, trust only the
+  const sniffedMime = normalizeMimeType(params.sniffedContentType);
+  // For extension-declared plain-text aliases such as .csv/.md/.html/.xml/.css, trust only the
   // text validator path. Some opaque blobs can still produce bogus binary MIME
   // hits (for example BOM-prefixed 0xFF data sniffing as audio/mpeg), and
   // host-read should reject those instead of returning early on the sniff.
   if (declaredMime && HOST_READ_TEXT_PLAIN_ALIASES.has(declaredMime)) {
-    if (!params.sniffedContentType && params.buffer && isValidatedHostReadText(params.buffer)) {
+    if (
+      (!sniffedMime || HOST_READ_TEXT_PLAIN_ALIASES.has(sniffedMime)) &&
+      params.buffer &&
+      isValidatedHostReadText(params.buffer)
+    ) {
       return;
     }
     throw new LocalMediaAccessError(
       "path-not-allowed",
-      "hostReadCapability permits only validated plain-text CSV/Markdown documents for local reads",
+      "hostReadCapability permits only validated plain-text CSV/Markdown/HTML/XML/CSS documents for local reads",
     );
   }
   const sniffedKind = kindFromMime(params.sniffedContentType);
   if (sniffedKind === "image" || sniffedKind === "audio" || sniffedKind === "video") {
     return;
   }
-  const sniffedMime = normalizeMimeType(params.sniffedContentType);
   if (
     sniffedKind === "document" &&
     sniffedMime &&
@@ -254,10 +269,10 @@ function assertHostReadMediaAllowed(params: {
   ) {
     return;
   }
-  // CSV / Markdown exception: file-type v22 returns undefined (not "text/plain") for
+  // Plain-text document exception: file-type v22 returns undefined (not "text/plain") for
   // plain-text buffers that have no binary magic bytes. Allow these formats when:
   // - sniffedMime is undefined (no binary signature detected by file-type)
-  // - The extension-derived MIME is text/csv or text/markdown (operator intent)
+  // - The extension-derived MIME is a known plain-text document type (operator intent)
   // - The buffer decodes as actual text instead of opaque binary bytes
   if (
     !sniffedMime &&
@@ -280,7 +295,7 @@ function assertHostReadMediaAllowed(params: {
   }
   throw new LocalMediaAccessError(
     "path-not-allowed",
-    `Host-local media sends only allow buffer-verified images, audio, video, PDF, and Office documents (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
+    `Host-local media sends only allow buffer-verified images, audio, video, PDF, Office documents, and validated text documents (got ${sniffedMime ?? normalizedMime ?? "unknown"}).`,
   );
 }
 


### PR DESCRIPTION
## Problem

Host-local `filePath` sends still reject legitimate HTML/XML/CSS documents in the host-read media guard.

For text-based documents such as `.html`:
- `detectMime({ buffer })` can return `undefined` because there are no magic bytes
- `detectMime({ buffer, filePath })` can fall back to the extension-derived MIME, such as `text/html`
- `kindFromMime("text/html")` resolves to `document`
- but `assertHostReadMediaAllowed()` did not include HTML/XML/CSS in the validated-text fallback policy, so outbound attachment sends were rejected before channel handling

This is separate from #51562, which fixed MIME mapping and unknown-media fallback behavior earlier in the pipeline.

## Fix

- Extend the existing validated-text host-read policy from CSV/Markdown to HTML/XML/CSS/XML.
- Require sniff compatibility plus `isValidatedHostReadText()` before allowing those fallback MIME types.
- Keep plain `.txt` host-read attachments blocked.
- Keep binary document formats such as PDF and Office files on the existing buffer-verified path.

## Regression coverage

Adds tests proving that:
- real local `.html`, `.xml`, and `.css` files are accepted through the host-read fallback path
- `sendAttachment` accepts a real host-local `.html` file when fs root expansion is enabled
- ZIP and opaque binary payloads renamed as `.html`, `.xml`, or `.css` are rejected
- `.txt` host-read attachments remain rejected

## Testing

- `pnpm check` via `scripts/committer "test(media): cover host-read HTML attachment path" src/infra/outbound/message-action-runner.media.test.ts`
- `pnpm test src/media/web-media.test.ts src/media/mime.test.ts src/infra/outbound/message-action-runner.media.test.ts`
