### PR TITLE
fix(tools): clamp sessions_history limit to chat.history max

### DIFF
--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -201,6 +201,7 @@ describe("sessions tools", () => {
     };
 
     expect(schemaProp("sessions_history", "limit").type).toBe("number");
+    expect(schemaProp("sessions_history", "limit")).toMatchObject({ maximum: 1000 });
     expect(schemaProp("sessions_list", "limit").type).toBe("number");
     expect(schemaProp("sessions_list", "activeMinutes").type).toBe("number");
     expect(schemaProp("sessions_list", "messageLimit").type).toBe("number");

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -25,7 +25,9 @@ import {
 
 const SessionsHistoryToolSchema = Type.Object({
   sessionKey: Type.String(),
-  limit: Type.Optional(Type.Number({ minimum: 1 })),
+  // chat.history enforces a server-side hard cap of 1000; clamp here so callers
+  // don't silently fail on larger values.
+  limit: Type.Optional(Type.Number({ minimum: 1, maximum: 1000 })),
   includeTools: Type.Optional(Type.Boolean()),
 });
 
@@ -245,7 +247,7 @@ export function createSessionsHistoryTool(opts?: {
 
       const limit =
         typeof params.limit === "number" && Number.isFinite(params.limit)
-          ? Math.max(1, Math.floor(params.limit))
+          ? Math.min(1000, Math.max(1, Math.floor(params.limit)))
           : undefined;
       const includeTools = Boolean(params.includeTools);
       const result = await gatewayCall<{ messages: Array<unknown> }>({


### PR DESCRIPTION
﻿## Summary

`chat.history` rejects `limit > 1000`. The `sessions_history` tool accepted larger values (e.g. 2000), leading to `INVALID_REQUEST` and silent history loss.

This change:
- Adds `maximum: 1000` to the tool schema.
- Clamps outgoing requests to 1000.
- Updates tests.

Fixes #66573.

## Test plan

- `pnpm exec vitest run src/agents/openclaw-tools.sessions.test.ts`
