### PR TITLE
fix(gateway): skip heartbeat diagnostics in session preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/sessions: ignore diagnostic transcript entries when deriving Control UI/WebChat session selector previews, so background health or context records do not replace the latest user/assistant title text. (#66656) Thanks @Tianworld.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -235,21 +235,27 @@ describe("readLastMessagePreviewFromTranscript", () => {
     expect(result).toBe("Real last");
   });
 
-  test("skips diagnostic heartbeat entries when deriving last message preview", () => {
-    const sessionId = "test-last-skip-heartbeat";
-    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
-    const lines = [
-      JSON.stringify({ message: { role: "user", content: "Real last" } }),
-      JSON.stringify({
-        type: "diagnostic.heartbeat",
-        message: { role: "assistant", content: "heartbeat: ok" },
-      }),
-    ];
-    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
+  test.each([
+    ["diagnostic.heartbeat", "heartbeat: ok"],
+    ["diagnostic.agentContext", "context refresh complete"],
+  ] as const)(
+    "skips %s entries when deriving last message preview",
+    (diagnosticType, diagnosticText) => {
+      const sessionId = `test-last-skip-${diagnosticType.replace(".", "-")}`;
+      const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+      const lines = [
+        JSON.stringify({ message: { role: "user", content: "Real last" } }),
+        JSON.stringify({
+          type: diagnosticType,
+          message: { role: "assistant", content: diagnosticText },
+        }),
+      ];
+      fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
 
-    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
-    expect(result).toBe("Real last");
-  });
+      const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
+      expect(result).toBe("Real last");
+    },
+  );
 
   test("returns null when no user/assistant messages exist", () => {
     const sessionId = "test-last-no-match";

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -235,6 +235,22 @@ describe("readLastMessagePreviewFromTranscript", () => {
     expect(result).toBe("Real last");
   });
 
+  test("skips diagnostic heartbeat entries when deriving last message preview", () => {
+    const sessionId = "test-last-skip-heartbeat";
+    const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      JSON.stringify({ message: { role: "user", content: "Real last" } }),
+      JSON.stringify({
+        type: "diagnostic.heartbeat",
+        message: { role: "assistant", content: "heartbeat: ok" },
+      }),
+    ];
+    fs.writeFileSync(transcriptPath, lines.join("\n"), "utf-8");
+
+    const result = readLastMessagePreviewFromTranscript(sessionId, storePath);
+    expect(result).toBe("Real last");
+  });
+
   test("returns null when no user/assistant messages exist", () => {
     const sessionId = "test-last-no-match";
     const transcriptPath = path.join(tmpDir, `${sessionId}.jsonl`);

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -415,6 +415,14 @@ export function readFirstUserMessageFromTranscript(
 const LAST_MSG_MAX_BYTES = 16384;
 const LAST_MSG_MAX_LINES = 20;
 
+function isDiagnosticTranscriptEntry(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return false;
+  }
+  const type = (entry as { type?: unknown }).type;
+  return typeof type === "string" && type.startsWith("diagnostic.");
+}
+
 function readLastMessagePreviewFromOpenTranscript(params: {
   fd: number;
   size: number;
@@ -434,7 +442,7 @@ function readLastMessagePreviewFromOpenTranscript(params: {
       const parsed = JSON.parse(line);
       // Keep session selectors usable: heartbeat/diagnostic lines are not
       // meaningful "last message" previews and can overwrite session titles.
-      if (typeof parsed?.type === "string" && parsed.type === "diagnostic.heartbeat") {
+      if (isDiagnosticTranscriptEntry(parsed)) {
         continue;
       }
       const msg = parsed?.message as TranscriptMessage | undefined;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -432,6 +432,11 @@ function readLastMessagePreviewFromOpenTranscript(params: {
     const line = tailLines[i];
     try {
       const parsed = JSON.parse(line);
+      // Keep session selectors usable: heartbeat/diagnostic lines are not
+      // meaningful "last message" previews and can overwrite session titles.
+      if (typeof parsed?.type === "string" && parsed.type === "diagnostic.heartbeat") {
+        continue;
+      }
       const msg = parsed?.message as TranscriptMessage | undefined;
       if (msg?.role !== "user" && msg?.role !== "assistant") {
         continue;


### PR DESCRIPTION
﻿## Summary

Session selectors (notably Control UI / WebChat) can become misleading over time because the backend derives `lastMessagePreview` from transcript tail lines, and heartbeat diagnostic entries may become the most recent content.

This change skips `type: "diagnostic.heartbeat"` entries when scanning for the last user/assistant preview.

Fixes #66533.

## Test plan

- `pnpm exec vitest run src/gateway/session-utils.fs.test.ts`
