### PR TITLE
Suppress expired exec approval followup warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/exec: suppress expired approval followup warning logs for already-resolved approvals, reducing benign `unknown or expired approval id` noise after exec approvals complete. Refs #66675. Thanks @pfrederiksen.
 - Discord: own the Carbon interaction listener and hand off Discord slash/component handling asynchronously, so compaction or long session locks no longer trip `InteractionEventListener` listener timeouts. Fixes #73204. Thanks @slideshow-dingo.
 - Gateway/startup: keep value-option foreground starts on the gateway fast path and skip proxy bootstrap unless proxy env is configured, reducing normal gateway startup RSS and avoiding full CLI graph loading. Thanks @vincentkoc.
 - Heartbeat/models: show heartbeat model bleed guidance on context-overflow resets when the last runtime model matches configured `heartbeat.model`, so smaller local heartbeat models point users to `isolatedSession` or `lightContext` instead of only compaction-buffer tuning. Fixes #67314. Thanks @Knightmare6890.

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -88,6 +88,21 @@ describe("sendExecApprovalFollowupResult", () => {
     );
   });
 
+  it("suppresses approval-not-found followup dispatch failures", async () => {
+    sendExecApprovalFollowup.mockRejectedValue(new Error("unknown or expired approval id"));
+
+    await sendExecApprovalFollowupResult(
+      {
+        approvalId: "approval-expired",
+        sessionKey: "agent:main:main",
+      },
+      "Exec finished",
+      { sendExecApprovalFollowup, logWarn },
+    );
+
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
   it("evicts oldest followup failure dedupe keys after reaching the cap", async () => {
     sendExecApprovalFollowup.mockRejectedValue(new Error("Channel is required"));
     const deps = { sendExecApprovalFollowup, logWarn };

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -167,8 +167,26 @@ describe("sendExecApprovalFollowupResult", () => {
     );
   });
 
-  it("suppresses approval-not-found followup dispatch failures", async () => {
-    sendExecApprovalFollowup.mockRejectedValue(new Error("unknown or expired approval id"));
+  it.each([
+    {
+      name: "direct gateway code",
+      error: Object.assign(new Error("approval not found"), {
+        gatewayCode: "APPROVAL_NOT_FOUND",
+      }),
+    },
+    {
+      name: "structured invalid-request details",
+      error: Object.assign(new Error("approval not found"), {
+        gatewayCode: "INVALID_REQUEST",
+        details: { reason: "APPROVAL_NOT_FOUND" },
+      }),
+    },
+    {
+      name: "legacy message-only error",
+      error: new Error("unknown or expired approval id"),
+    },
+  ])("suppresses approval-not-found followup dispatch failures ($name)", async ({ error }) => {
+    sendExecApprovalFollowup.mockRejectedValue(error);
 
     await sendExecApprovalFollowupResult(
       {

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -167,6 +167,21 @@ describe("sendExecApprovalFollowupResult", () => {
     );
   });
 
+  it("suppresses approval-not-found followup dispatch failures", async () => {
+    sendExecApprovalFollowup.mockRejectedValue(new Error("unknown or expired approval id"));
+
+    await sendExecApprovalFollowupResult(
+      {
+        approvalId: "approval-expired",
+        sessionKey: "agent:main:main",
+      },
+      "Exec finished",
+      { sendExecApprovalFollowup, logWarn },
+    );
+
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
   it("evicts oldest followup failure dedupe keys after reaching the cap", async () => {
     sendExecApprovalFollowup.mockRejectedValue(new Error("Channel is required"));
     const deps = { sendExecApprovalFollowup, logWarn };

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { isApprovalNotFoundError } from "../infra/approval-errors.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildExecApprovalUnavailableReplyPayload } from "../infra/exec-approval-reply.js";
 import {
@@ -415,6 +416,9 @@ export async function sendExecApprovalFollowupResult(
     turnSourceThreadId: target.turnSourceThreadId,
     resultText,
   }).catch((error) => {
+    if (isApprovalNotFoundError(error)) {
+      return;
+    }
     const message = formatErrorMessage(error);
     const key = `${target.approvalId}:${message}`;
     if (!rememberExecApprovalFollowupFailureKey(key)) {

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -5,6 +5,7 @@
  */
 import crypto from "node:crypto";
 import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
+import { isApprovalNotFoundError } from "../infra/approval-errors.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildExecApprovalUnavailableReplyPayload } from "../infra/exec-approval-reply.js";
 import {
@@ -481,6 +482,9 @@ export async function sendExecApprovalFollowupResult(
         }
       : {}),
   }).catch((error: unknown) => {
+    if (isApprovalNotFoundError(error)) {
+      return;
+    }
     const message = formatErrorMessage(error);
     const key = `${target.approvalId}:${message}`;
     if (!rememberExecApprovalFollowupFailureKey(key)) {


### PR DESCRIPTION
## Summary

Suppress exec approval followup warning logs when the approval id is already gone (`unknown or expired approval id`).

## Why

During investigation of #66675, restart/reporting flows could leave the gateway healthy while adding noisy log lines like:

- `exec approval followup dispatch failed`
- `unknown or expired approval id`

This patch does **not** claim to fully solve the false non-zero restart on its own, but it removes one clearly benign error path that can fire after approval lifecycle completion and muddy the operator signal.

OpenClaw already has `isApprovalNotFoundError(...)` for this exact class of benign approval lookup failure in other paths, so this makes followup dispatch handling consistent with the rest of the codebase.

## Change

- import and use `isApprovalNotFoundError(...)` in `sendExecApprovalFollowupResult(...)`
- silently ignore approval-not-found followup dispatch errors
- continue deduped warning logs for real failures like missing channel, transport errors, etc.


## Validation

```bash
pnpm check:test-types
node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/bash-tools.exec-host-shared.test.ts
pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/bash-tools.exec-host-shared.ts src/agents/bash-tools.exec-host-shared.test.ts
git diff --check
node --import tsx tmp/pr66685-proof.mjs
```

## Real behavior proof
- **Behavior or issue addressed:** Expired/already-resolved exec approval followup dispatches could log noisy warnings (`exec approval followup dispatch failed` / `unknown or expired approval id`) even though the approval lifecycle failure is benign. The fix suppresses only approval-not-found followup errors and keeps real transport failures warning.
- **Real environment tested:** Local OpenClaw checkout for PR #66685 rebased onto current `origin/main` on Linux/Node 22, using the patched production `sendExecApprovalFollowupResult(...)` helper from `src/agents/bash-tools.exec-host-shared.ts`. The proof used redacted approval/session/account/chat identifiers.
- **Exact steps or command run after this patch:** Ran `node --import tsx tmp/pr66685-proof.mjs` from the patched checkout. The script invoked the production followup-result helper for an expired approval-not-found followup response, then invoked the same helper with a non-approval transport failure to confirm real warnings are still preserved.
- **Evidence after fix:** Copied terminal output from the after-fix command:

  ```text
  $ node --import tsx tmp/pr66685-proof.mjs
  expired approval followup warning count: 0
  expired approval followup suppressed: true
  real followup failure warning preserved: true
  warning event redacted: exec approval followup dispatch failed (id=approval_redacted_expired): transport unavailable after redaction
  ```

- **Observed result after fix:** The expired approval followup produced zero warning logs, while the non-approval failure still emitted the expected `exec approval followup dispatch failed` warning, so the suppression is limited to the benign approval-not-found lifecycle case.
- **What was not tested:** I did not run a full live UI/chat approval lifecycle with a real expired approval id; this proof directly exercises the production followup-result helper with redacted runtime-shaped inputs, and the focused unit/type/format checks remain supplemental.

## AI assistance

AI-assisted PR. I understand what the change does. I attempted the recommended local `codex review --base origin/main`, but the local Codex CLI returned `Quota exceeded`; GitHub CI/review checks still ran on the PR.

## Issue

- Related to #66675
