### PR TITLE
fix(daemon): hand off systemd self-restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Daemon/systemd: repair the contributor systemd self-restart handoff from #66735 by matching suffix-less custom units, capping marker-triggered SIGTERM drains to systemd's stop budget, and discarding malformed restart markers. Refs #47133 and #29827. Thanks @alexlomt.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
 import { pickBeaconHost, pickGatewayPort } from "./discover.js";
@@ -62,6 +65,7 @@ const gatewayLog = {
   warn: vi.fn(),
   error: vi.fn(),
 };
+const SUPERVISED_RESTART_DRAIN_TIMEOUT_MS = 20_000;
 
 vi.mock("../../infra/gateway-lock.js", () => ({
   acquireGatewayLock: (opts?: { port?: number }) => acquireGatewayLock(opts),
@@ -322,7 +326,224 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("restarts after SIGUSR1 even when drain times out, and resets runtime state for the new iteration", async () => {
+  it("routes SIGTERM through restart semantics when a pending systemd restart marker exists", async () => {
+    vi.clearAllMocks();
+
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-run-loop-restart-"));
+    const unitName = "openclaw-gateway.service";
+    const markerPath = path.join(
+      tmpRoot,
+      "openclaw-systemd-restart-expected-openclaw-gateway.service.txt",
+    );
+    const prevTmpDir = process.env.TMPDIR;
+    const prevUnit = process.env.OPENCLAW_SYSTEMD_UNIT;
+
+    try {
+      process.env.TMPDIR = tmpRoot;
+      process.env.OPENCLAW_SYSTEMD_UNIT = unitName;
+      await fs.writeFile(markerPath, `${unitName}\n${Math.floor(Date.now() / 1000)}\n`, "utf8");
+      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
+        mode: "spawned",
+        pid: 9999,
+      });
+
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { close, runtime, exited } = await createSignaledLoopHarness();
+        const sigterm = captureSignal("SIGTERM");
+
+        sigterm();
+
+        await expect(exited).resolves.toBe(0);
+        expect(close).toHaveBeenCalledWith({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+        });
+        expect(runtime.exit).toHaveBeenCalledWith(0);
+        expect(consumeGatewayRestartIntentSync).not.toHaveBeenCalled();
+        expect(gatewayLog.info).toHaveBeenCalledWith(
+          "SIGTERM matched pending systemd restart expectation",
+        );
+      });
+
+      await expect(fs.access(markerPath)).rejects.toThrow();
+    } finally {
+      if (prevTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = prevTmpDir;
+      }
+      if (prevUnit === undefined) {
+        delete process.env.OPENCLAW_SYSTEMD_UNIT;
+      } else {
+        process.env.OPENCLAW_SYSTEMD_UNIT = prevUnit;
+      }
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("normalizes custom unit names before matching a pending systemd restart marker", async () => {
+    vi.clearAllMocks();
+
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-run-loop-custom-unit-"));
+    const markerPath = path.join(
+      tmpRoot,
+      "openclaw-systemd-restart-expected-custom-unit.service.txt",
+    );
+    const prevTmpDir = process.env.TMPDIR;
+    const prevUnit = process.env.OPENCLAW_SYSTEMD_UNIT;
+
+    try {
+      process.env.TMPDIR = tmpRoot;
+      process.env.OPENCLAW_SYSTEMD_UNIT = "custom-unit";
+      await fs.writeFile(
+        markerPath,
+        `custom-unit.service\n${Math.floor(Date.now() / 1000)}\n`,
+        "utf8",
+      );
+      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
+        mode: "spawned",
+        pid: 9999,
+      });
+
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { close, exited } = await createSignaledLoopHarness();
+        const sigterm = captureSignal("SIGTERM");
+
+        sigterm();
+
+        await expect(exited).resolves.toBe(0);
+        expect(close).toHaveBeenCalledWith({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+        });
+        expect(gatewayLog.info).toHaveBeenCalledWith(
+          "SIGTERM matched pending systemd restart expectation",
+        );
+      });
+
+      await expect(fs.access(markerPath)).rejects.toThrow();
+    } finally {
+      if (prevTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = prevTmpDir;
+      }
+      if (prevUnit === undefined) {
+        delete process.env.OPENCLAW_SYSTEMD_UNIT;
+      } else {
+        process.env.OPENCLAW_SYSTEMD_UNIT = prevUnit;
+      }
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects malformed restart markers and falls back to stop semantics", async () => {
+    vi.clearAllMocks();
+
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-run-loop-bad-marker-"));
+    const unitName = "openclaw-gateway.service";
+    const markerPath = path.join(
+      tmpRoot,
+      "openclaw-systemd-restart-expected-openclaw-gateway.service.txt",
+    );
+    const prevTmpDir = process.env.TMPDIR;
+    const prevUnit = process.env.OPENCLAW_SYSTEMD_UNIT;
+
+    try {
+      process.env.TMPDIR = tmpRoot;
+      process.env.OPENCLAW_SYSTEMD_UNIT = unitName;
+      await fs.writeFile(markerPath, `${unitName}\nnot-a-timestamp\n`, "utf8");
+
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { close, runtime, exited } = await createSignaledLoopHarness();
+        const sigterm = captureSignal("SIGTERM");
+
+        sigterm();
+
+        await expect(exited).resolves.toBe(0);
+        expect(close).toHaveBeenCalledWith({
+          reason: "gateway stopping",
+          restartExpectedMs: null,
+        });
+        expect(runtime.exit).toHaveBeenCalledWith(0);
+        expect(consumeGatewayRestartIntentSync).toHaveBeenCalledOnce();
+        expect(gatewayLog.info).not.toHaveBeenCalledWith(
+          "SIGTERM matched pending systemd restart expectation",
+        );
+      });
+
+      await expect(fs.access(markerPath)).rejects.toThrow();
+    } finally {
+      if (prevTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = prevTmpDir;
+      }
+      if (prevUnit === undefined) {
+        delete process.env.OPENCLAW_SYSTEMD_UNIT;
+      } else {
+        process.env.OPENCLAW_SYSTEMD_UNIT = prevUnit;
+      }
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("caps marker-triggered SIGTERM restart draining to the supervisor stop budget", async () => {
+    vi.clearAllMocks();
+    loadConfig.mockReturnValue({
+      gateway: {
+        reload: {
+          deferralTimeoutMs: 123_456,
+        },
+      },
+    });
+
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-run-loop-systemd-budget-"));
+    const unitName = "openclaw-gateway.service";
+    const markerPath = path.join(
+      tmpRoot,
+      "openclaw-systemd-restart-expected-openclaw-gateway.service.txt",
+    );
+    const prevTmpDir = process.env.TMPDIR;
+    const prevUnit = process.env.OPENCLAW_SYSTEMD_UNIT;
+
+    try {
+      process.env.TMPDIR = tmpRoot;
+      process.env.OPENCLAW_SYSTEMD_UNIT = unitName;
+      await fs.writeFile(markerPath, `${unitName}\n${Math.floor(Date.now() / 1000)}\n`, "utf8");
+      restartGatewayProcessWithFreshPid.mockReturnValueOnce({ mode: "spawned", pid: 9999 });
+      getActiveTaskCount.mockReturnValueOnce(2);
+      waitForActiveTasks.mockResolvedValueOnce({ drained: true });
+
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { close, exited } = await createSignaledLoopHarness();
+        const sigterm = captureSignal("SIGTERM");
+
+        sigterm();
+
+        await expect(exited).resolves.toBe(0);
+        expect(waitForActiveTasks).toHaveBeenCalledWith(SUPERVISED_RESTART_DRAIN_TIMEOUT_MS);
+        expect(close).toHaveBeenCalledWith({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+        });
+      });
+    } finally {
+      if (prevTmpDir === undefined) {
+        delete process.env.TMPDIR;
+      } else {
+        process.env.TMPDIR = prevTmpDir;
+      }
+      if (prevUnit === undefined) {
+        delete process.env.OPENCLAW_SYSTEMD_UNIT;
+      } else {
+        process.env.OPENCLAW_SYSTEMD_UNIT = prevUnit;
+      }
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("restarts after SIGUSR1 even when drain times out, and resets lanes for the new iteration", async () => {
     vi.clearAllMocks();
     loadConfig.mockReturnValue({
       gateway: {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -12,11 +12,12 @@ const RESTART_DRAIN_STILL_PENDING_WARN_MS = 30_000;
 const UPDATE_RESPAWN_HEALTH_TIMEOUT_MS = 10_000;
 const UPDATE_RESPAWN_HEALTH_POLL_MS = 200;
 
-type GatewayRunSignalAction = "stop" | "restart";
+type GatewayRunSignalAction = "stop" | "restart" | "supervised-restart";
 type RestartDrainTimeoutMs = number | undefined;
 
 type EmbeddedRunsModule = typeof import("../../agents/pi-embedded-runner/runs.js");
 type RuntimeConfigModule = typeof import("../../config/config.js");
+type SystemdModule = typeof import("../../daemon/systemd.js");
 type ProcessRespawnModule = typeof import("../../infra/process-respawn.js");
 type RestartSentinelModule = typeof import("../../infra/restart-sentinel.js");
 type RestartModule = typeof import("../../infra/restart.js");
@@ -30,6 +31,7 @@ type RuntimeInternalModule = typeof import("../../tasks/runtime-internal.js");
 
 let embeddedRunsModule: Promise<EmbeddedRunsModule> | undefined;
 let runtimeConfigModule: Promise<RuntimeConfigModule> | undefined;
+let systemdModule: Promise<SystemdModule> | undefined;
 let processRespawnModule: Promise<ProcessRespawnModule> | undefined;
 let restartSentinelModule: Promise<RestartSentinelModule> | undefined;
 let restartModule: Promise<RestartModule> | undefined;
@@ -42,6 +44,7 @@ let runtimeInternalModule: Promise<RuntimeInternalModule> | undefined;
 const loadEmbeddedRunsModule = () =>
   (embeddedRunsModule ??= import("../../agents/pi-embedded-runner/runs.js"));
 const loadRuntimeConfigModule = () => (runtimeConfigModule ??= import("../../config/config.js"));
+const loadSystemdModule = () => (systemdModule ??= import("../../daemon/systemd.js"));
 const loadProcessRespawnModule = () =>
   (processRespawnModule ??= import("../../infra/process-respawn.js"));
 const loadRestartSentinelModule = () =>
@@ -277,6 +280,7 @@ export async function runGatewayLoop(params: {
 
   const SUPERVISOR_STOP_TIMEOUT_MS = 30_000;
   const SHUTDOWN_TIMEOUT_MS = SUPERVISOR_STOP_TIMEOUT_MS - 5_000;
+  const SUPERVISED_RESTART_DRAIN_TIMEOUT_MS = SHUTDOWN_TIMEOUT_MS - 5_000;
   const resolveRestartDrainTimeoutMs = async (): Promise<RestartDrainTimeoutMs> => {
     try {
       const { getRuntimeConfig } = await loadRuntimeConfigModule();
@@ -295,7 +299,7 @@ export async function runGatewayLoop(params: {
       return;
     }
     shuttingDown = true;
-    const isRestart = action === "restart";
+    const isRestart = action !== "stop";
     gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
 
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
@@ -328,12 +332,20 @@ export async function runGatewayLoop(params: {
     };
 
     void (async () => {
-      const restartDrainTimeoutMs = isRestart ? await resolveRestartDrainTimeoutMs() : 0;
+      const restartDrainTimeoutMs =
+        action === "restart"
+          ? await resolveRestartDrainTimeoutMs()
+          : action === "supervised-restart"
+            ? SUPERVISED_RESTART_DRAIN_TIMEOUT_MS
+            : 0;
       if (!isRestart) {
         armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
-      } else if (restartDrainTimeoutMs !== undefined) {
+      } else if (action === "restart" && restartDrainTimeoutMs !== undefined) {
         // Allow extra time for draining active turns on explicitly capped restarts.
         armForceExitTimer(restartDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS);
+      } else if (action === "supervised-restart") {
+        // Marker-triggered systemd restarts are already inside systemd's stop window.
+        armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
       }
 
       const formatRestartDrainBudget = () =>
@@ -428,7 +440,13 @@ export async function runGatewayLoop(params: {
   const onSigterm = () => {
     gatewayLog.info("signal SIGTERM received");
     void (async () => {
-      const { consumeGatewayRestartIntentSync } = await loadRestartModule();
+      const [{ consumeGatewayRestartIntentSync }, { consumeSystemdRestartExpectationMarker }] =
+        await Promise.all([loadRestartModule(), loadSystemdModule()]);
+      if (consumeSystemdRestartExpectationMarker(process.env)) {
+        gatewayLog.info("SIGTERM matched pending systemd restart expectation");
+        request("supervised-restart", "SIGTERM");
+        return;
+      }
       request(consumeGatewayRestartIntentSync() ? "restart" : "stop", "SIGTERM");
     })();
   };

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -17,6 +17,7 @@ vi.mock("node:child_process", async () => {
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import { parseSystemdExecStart } from "./systemd-unit.js";
 import {
+  consumeSystemdRestartExpectationMarker,
   installSystemdService,
   isNonFatalSystemdInstallProbeError,
   isSystemdServiceEnabled,
@@ -1477,5 +1478,55 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     await assertRestartSuccess({ USER: "debian" });
+  });
+});
+
+describe("systemd restart expectation markers", () => {
+  it("rejects marker files with a missing timestamp", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-marker-missing-"));
+    const markerPath = path.join(
+      tmpRoot,
+      "openclaw-systemd-restart-expected-openclaw-gateway.service.txt",
+    );
+
+    try {
+      await fs.writeFile(markerPath, `${GATEWAY_SERVICE}\n`, "utf8");
+
+      expect(
+        consumeSystemdRestartExpectationMarker({
+          TMPDIR: tmpRoot,
+          OPENCLAW_SYSTEMD_UNIT: GATEWAY_SERVICE,
+        }),
+      ).toBe(false);
+      await expect(fs.access(markerPath)).rejects.toThrow();
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects marker files with extra payload after the timestamp", async () => {
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-marker-extra-"));
+    const markerPath = path.join(
+      tmpRoot,
+      "openclaw-systemd-restart-expected-openclaw-gateway.service.txt",
+    );
+
+    try {
+      await fs.writeFile(
+        markerPath,
+        `${GATEWAY_SERVICE}\n${Math.floor(Date.now() / 1000)}\nextra\n`,
+        "utf8",
+      );
+
+      expect(
+        consumeSystemdRestartExpectationMarker({
+          TMPDIR: tmpRoot,
+          OPENCLAW_SYSTEMD_UNIT: GATEWAY_SERVICE,
+        }),
+      ).toBe(false);
+      await expect(fs.access(markerPath)).rejects.toThrow();
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const execFileMock = vi.hoisted(() => vi.fn());
 
@@ -40,6 +40,16 @@ const TEST_SERVICE_HOME = "/home/test";
 const TEST_MANAGED_HOME = "/tmp/openclaw-test-home";
 const GATEWAY_SERVICE = "openclaw-gateway.service";
 const NODE_SERVICE = "openclaw-node.service";
+const SYSTEMD_PROCESS_ENV_KEYS = [
+  "INVOCATION_ID",
+  "SYSTEMD_EXEC_PID",
+  "JOURNAL_STREAM",
+  "OPENCLAW_SYSTEMD_UNIT",
+  "OPENCLAW_SERVICE_KIND",
+] as const;
+const ORIGINAL_SYSTEMD_PROCESS_ENV = Object.fromEntries(
+  SYSTEMD_PROCESS_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof SYSTEMD_PROCESS_ENV_KEYS)[number], string | undefined>;
 
 const createExecFileError = (
   message: string,
@@ -86,6 +96,64 @@ function mockEffectiveUid(uid: number) {
   vi.spyOn(process, "geteuid").mockReturnValue(uid);
 }
 
+function clearSystemdProcessEnv() {
+  for (const key of SYSTEMD_PROCESS_ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+function restoreSystemdProcessEnv() {
+  for (const key of SYSTEMD_PROCESS_ENV_KEYS) {
+    const value = ORIGINAL_SYSTEMD_PROCESS_ENV[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function setCurrentProcessSystemdGatewayEnv(unitName = GATEWAY_SERVICE) {
+  process.env.INVOCATION_ID = "test-invocation";
+  process.env.OPENCLAW_SYSTEMD_UNIT = unitName;
+  process.env.OPENCLAW_SERVICE_KIND = "gateway";
+}
+
+function resolveExpectedRestartMarkerPath(unitName = GATEWAY_SERVICE) {
+  const normalizedUnitName = unitName.endsWith(".service") ? unitName : `${unitName}.service`;
+  return path.join(
+    os.tmpdir(),
+    `openclaw-systemd-restart-expected-${normalizedUnitName.replace(/[^a-zA-Z0-9._-]+/g, "-")}.txt`,
+  );
+}
+
+function assertSystemdRestartHandoffArgs(args: string[], unitName = GATEWAY_SERVICE) {
+  const normalizedUnitName = unitName.endsWith(".service") ? unitName : `${unitName}.service`;
+  expect(args).toHaveLength(13);
+  expect(args[0]).toBe("--user");
+  expect(args[1]).toBe("--quiet");
+  expect(args[2]).toBe("--collect");
+  expect(args[3]).toBe("--no-block");
+  expect(args[4]).toBe("--unit");
+  expect(args[5]).toMatch(/^openclaw-gateway-restart-handoff-\d+-\d+$/);
+  expect(args[6]).toBe("/bin/sh");
+  expect(args[7]).toBe("-c");
+  expect(args[8]).toContain("deadline=$(( $(date +%s) + 30 ))");
+  expect(args[8]).toContain(
+    "openclaw-systemd-restart-handoff: timed out waiting for pid $wait_pid to exit; continuing restart",
+  );
+  expect(args[8]).toContain('marker_path="$3"');
+  expect(args[8]).toContain(`printf '%s\n%s\n' "$target_unit" "$(date +%s)" > "$marker_path"`);
+  expect(args[8]).toContain('systemctl --user restart "$target_unit"');
+  expect(args[8]).toContain('status="$?"');
+  expect(args[8]).toContain('if [ "$status" -ne 0 ]; then');
+  expect(args[8]).toContain('rm -f "$marker_path" >/dev/null 2>&1 || true');
+  expect(args[9]).toBe("openclaw-systemd-restart-handoff");
+  expect(args[10]).toBe(String(process.pid));
+  expect(args[11]).toBe(normalizedUnitName);
+  expect(args[12]).toBe(resolveExpectedRestartMarkerPath(normalizedUnitName));
+}
+
 async function readManagedServiceEnabled(env: NodeJS.ProcessEnv = { HOME: TEST_MANAGED_HOME }) {
   vi.spyOn(fs, "access").mockResolvedValue(undefined);
   return isSystemdServiceEnabled({ env });
@@ -120,8 +188,15 @@ async function expectExecStartWithoutEnvironment(envFileLine: string) {
 }
 
 const assertRestartSuccess = async (env: NodeJS.ProcessEnv) => {
+  vi.spyOn(fs, "readFile").mockImplementation(async (pathname) => {
+    if (pathLikeToString(pathname) === "/proc/self/cgroup") {
+      return "0::/user.slice/user-1000.slice/user@1000.service/app.slice/other.service\n";
+    }
+    throw new Error(`unexpected readFile path: ${pathLikeToString(pathname)}`);
+  });
   const { write, stdout } = createWritableStreamMock();
-  await restartSystemdService({ stdout, env });
+  const result = await restartSystemdService({ stdout, env });
+  expect(result).toEqual({ outcome: "completed" });
   expect(write).toHaveBeenCalledTimes(1);
   expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
 };
@@ -1089,7 +1164,13 @@ describe("systemd service control", () => {
   };
 
   beforeEach(() => {
+    clearSystemdProcessEnv();
+    vi.restoreAllMocks();
     execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    restoreSystemdProcessEnv();
   });
 
   it("stops the resolved user unit", async () => {
@@ -1136,6 +1217,174 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     await assertRestartSuccess({ OPENCLAW_PROFILE: "work" });
+  });
+
+  it("normalizes custom unit names before scheduling a restart handoff", async () => {
+    vi.spyOn(fs, "readFile").mockImplementation(async (pathname) => {
+      if (pathLikeToString(pathname) === "/proc/self/cgroup") {
+        return "0::/user.slice/user-1000.slice/user@1000.service/app.slice/custom-unit.service\n";
+      }
+      throw new Error(`unexpected readFile path: ${pathLikeToString(pathname)}`);
+    });
+    execFileMock.mockImplementationOnce((cmd, args, _opts, cb) => {
+      expect(cmd).toBe("systemd-run");
+      assertSystemdRestartHandoffArgs(args, "custom-unit");
+      cb(null, "", "");
+    });
+
+    const { stdout } = createWritableStreamMock();
+    const result = await restartSystemdService({
+      stdout,
+      env: { OPENCLAW_SYSTEMD_UNIT: "custom-unit" },
+    });
+
+    expect(result).toEqual({ outcome: "scheduled" });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules restart handoff when invoked from the current systemd service cgroup", async () => {
+    vi.spyOn(fs, "readFile").mockImplementation(async (pathname) => {
+      if (pathLikeToString(pathname) === "/proc/self/cgroup") {
+        return "0::/user.slice/user-1000.slice/user@1000.service/app.slice/openclaw-gateway.service\n";
+      }
+      throw new Error(`unexpected readFile path: ${pathLikeToString(pathname)}`);
+    });
+    execFileMock.mockImplementationOnce((cmd, args, _opts, cb) => {
+      expect(cmd).toBe("systemd-run");
+      assertSystemdRestartHandoffArgs(args);
+      cb(null, "", "");
+    });
+
+    const { write, stdout } = createWritableStreamMock();
+    const result = await restartSystemdService({ stdout, env: {} });
+
+    expect(result).toEqual({ outcome: "scheduled" });
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(String(write.mock.calls[0]?.[0])).toContain("Scheduled systemd service restart");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps external restarts synchronous when current process is outside the target unit cgroup", async () => {
+    vi.spyOn(fs, "readFile").mockImplementation(async (pathname) => {
+      if (pathLikeToString(pathname) === "/proc/self/cgroup") {
+        return "0::/user.slice/user-1000.slice/user@1000.service/app.slice/other.service\n";
+      }
+      throw new Error(`unexpected readFile path: ${pathLikeToString(pathname)}`);
+    });
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "restart", GATEWAY_SERVICE);
+        cb(null, "", "");
+      });
+
+    const { write, stdout } = createWritableStreamMock();
+    const result = await restartSystemdService({ stdout, env: {} });
+
+    expect(result).toEqual({ outcome: "completed" });
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps external restarts synchronous when restart env includes merged gateway markers", async () => {
+    vi.spyOn(fs, "readFile").mockImplementation(async (pathname) => {
+      if (pathLikeToString(pathname) === "/proc/self/cgroup") {
+        return "0::/user.slice/user-1000.slice/user@1000.service/app.slice/other.service\n";
+      }
+      throw new Error(`unexpected readFile path: ${pathLikeToString(pathname)}`);
+    });
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "restart", GATEWAY_SERVICE);
+        cb(null, "", "");
+      });
+
+    const { write, stdout } = createWritableStreamMock();
+    const result = await restartSystemdService({
+      stdout,
+      env: {
+        OPENCLAW_SERVICE_KIND: "gateway",
+        OPENCLAW_SYSTEMD_UNIT: GATEWAY_SERVICE,
+      },
+    });
+
+    expect(result).toEqual({ outcome: "completed" });
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps external restarts synchronous when cgroup is readable but current-process runtime hints match", async () => {
+    setCurrentProcessSystemdGatewayEnv();
+    vi.spyOn(fs, "readFile").mockImplementation(async (pathname) => {
+      if (pathLikeToString(pathname) === "/proc/self/cgroup") {
+        return "0::/user.slice/user-1000.slice/user@1000.service/app.slice/other.service\n";
+      }
+      throw new Error(`unexpected readFile path: ${pathLikeToString(pathname)}`);
+    });
+    execFileMock
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "status");
+        cb(null, "", "");
+      })
+      .mockImplementationOnce((_cmd, args, _opts, cb) => {
+        assertUserSystemctlArgs(args, "restart", GATEWAY_SERVICE);
+        cb(null, "", "");
+      });
+
+    const { write, stdout } = createWritableStreamMock();
+    const result = await restartSystemdService({ stdout, env: {} });
+
+    expect(result).toEqual({ outcome: "completed" });
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(String(write.mock.calls[0]?.[0])).toContain("Restarted systemd service");
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("schedules restart handoff when cgroup lookup fails but the current process env proves the unit", async () => {
+    setCurrentProcessSystemdGatewayEnv();
+    vi.spyOn(fs, "readFile").mockRejectedValue(new Error("missing cgroup"));
+    execFileMock.mockImplementationOnce((cmd, args, _opts, cb) => {
+      expect(cmd).toBe("systemd-run");
+      assertSystemdRestartHandoffArgs(args);
+      cb(null, "", "");
+    });
+
+    const { write, stdout } = createWritableStreamMock();
+    const result = await restartSystemdService({ stdout, env: {} });
+
+    expect(result).toEqual({ outcome: "scheduled" });
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(String(write.mock.calls[0]?.[0])).toContain("Scheduled systemd service restart");
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces systemd-run handoff failures", async () => {
+    vi.spyOn(fs, "readFile").mockImplementation(async (pathname) => {
+      if (pathLikeToString(pathname) === "/proc/self/cgroup") {
+        return "0::/user.slice/user-1000.slice/user@1000.service/app.slice/openclaw-gateway.service\n";
+      }
+      throw new Error(`unexpected readFile path: ${pathLikeToString(pathname)}`);
+    });
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      const err = createExecFileError("systemd-run failed");
+      cb(err, "", "interactive authentication required");
+    });
+
+    await expect(
+      restartSystemdService({
+        stdout: { write: vi.fn() } as unknown as NodeJS.WritableStream,
+        env: {},
+      }),
+    ).rejects.toThrow("systemd restart handoff failed: interactive authentication required");
   });
 
   it("surfaces stop failures with systemctl detail", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -182,6 +182,25 @@ function buildSystemdRestartHandoffScript(): string {
  `;
 }
 
+function parseSystemdRestartExpectationMarker(raw: string): {
+  expectedUnit: string;
+  epochSeconds: number;
+} | null {
+  const lines = raw.split(/\r?\n/);
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+  if (lines.length !== 2) {
+    return null;
+  }
+  const expectedUnit = normalizeSystemdUnitName(lines[0]);
+  const epochSeconds = parseStrictPositiveInteger(lines[1]);
+  if (!expectedUnit || epochSeconds === undefined) {
+    return null;
+  }
+  return { expectedUnit, epochSeconds };
+}
+
 export function consumeSystemdRestartExpectationMarker(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
   maxAgeMs = 600_000,
@@ -198,19 +217,14 @@ export function consumeSystemdRestartExpectationMarker(
   } catch {
     // Best effort only. Restart semantics should still continue.
   }
-  const [unitLine = "", tsLine = ""] = raw.split(/\r?\n/);
-  const expectedUnit = normalizeSystemdUnitName(unitLine);
+  const marker = parseSystemdRestartExpectationMarker(raw);
   const currentUnit =
     normalizeSystemdUnitName(env.OPENCLAW_SYSTEMD_UNIT) ??
     `${resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)}.service`;
-  if (!expectedUnit || expectedUnit !== currentUnit) {
+  if (!marker || marker.expectedUnit !== currentUnit) {
     return false;
   }
-  const epochSeconds = parseStrictPositiveInteger(tsLine);
-  if (epochSeconds === undefined) {
-    return false;
-  }
-  const ageMs = Date.now() - epochSeconds * 1000;
+  const ageMs = Date.now() - marker.epochSeconds * 1000;
   if (ageMs < 0 || ageMs > maxAgeMs) {
     return false;
   }

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,3 +1,4 @@
+import * as fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -5,7 +6,11 @@ import { resolveStateDir } from "../config/paths.js";
 import { readStateDirDotEnvVarsFromStateDir } from "../config/state-dir-dotenv.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { parseStrictInteger, parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 import { splitArgsPreservingQuotes } from "./arg-split.js";
 import {
   LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
@@ -64,6 +69,201 @@ function resolveSystemdUnitPath(env: GatewayServiceEnv): string {
 
 export function resolveSystemdUserUnitPath(env: GatewayServiceEnv): string {
   return resolveSystemdUnitPath(env);
+}
+
+function sanitizeSystemdUnitForFilename(unitName: string): string {
+  return unitName.replace(/[^a-zA-Z0-9._-]+/g, "-");
+}
+
+export function resolveSystemdRestartExpectationMarkerPath(
+  env: GatewayServiceEnv,
+  unitName?: string,
+): string {
+  const targetUnit =
+    normalizeSystemdUnitName(unitName) ?? `${resolveSystemdServiceName(env)}.service`;
+  const tmpDir = normalizeOptionalString(env.TMPDIR) || os.tmpdir();
+  return path.join(
+    tmpDir,
+    `openclaw-systemd-restart-expected-${sanitizeSystemdUnitForFilename(targetUnit)}.txt`,
+  );
+}
+
+export function normalizeSystemdUnitName(value: string | undefined): string | null {
+  const trimmed = normalizeOptionalString(value);
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.endsWith(".service") ? trimmed : `${trimmed}.service`;
+}
+
+function matchesSystemdCgroupUnit(cgroupPath: string, unitName: string): boolean {
+  const normalizedPath = normalizeOptionalString(cgroupPath);
+  if (!normalizedPath) {
+    return false;
+  }
+  return (
+    normalizedPath === `/${unitName}` ||
+    normalizedPath.endsWith(`/${unitName}`) ||
+    normalizedPath.includes(`/${unitName}/`)
+  );
+}
+
+const SYSTEMD_RUNTIME_HINT_ENV_VARS = ["INVOCATION_ID", "SYSTEMD_EXEC_PID", "JOURNAL_STREAM"];
+
+function hasCurrentProcessSystemdRuntimeHint(env: NodeJS.ProcessEnv = process.env): boolean {
+  return SYSTEMD_RUNTIME_HINT_ENV_VARS.some((key) => {
+    const value = env[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
+async function readCurrentProcessCgroupPaths(): Promise<string[] | null> {
+  try {
+    const raw = await fs.readFile("/proc/self/cgroup", "utf8");
+    return raw
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => line.split(":").slice(2).join(":").trim())
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+async function isCurrentProcessSystemdServiceUnit(
+  unitName: string,
+  currentEnv: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  const normalizedUnitName = normalizeSystemdUnitName(unitName);
+  if (!normalizedUnitName) {
+    return false;
+  }
+  const cgroupPaths = await readCurrentProcessCgroupPaths();
+  if (cgroupPaths !== null) {
+    return cgroupPaths.some((cgroupPath) =>
+      matchesSystemdCgroupUnit(cgroupPath, normalizedUnitName),
+    );
+  }
+  const configuredUnitName = normalizeSystemdUnitName(currentEnv.OPENCLAW_SYSTEMD_UNIT);
+  return (
+    hasCurrentProcessSystemdRuntimeHint(currentEnv) &&
+    normalizeOptionalLowercaseString(currentEnv.OPENCLAW_SERVICE_KIND) === "gateway" &&
+    configuredUnitName === normalizedUnitName
+  );
+}
+
+function buildSystemdRestartHandoffScript(): string {
+  return `wait_pid="$1"
+ target_unit="$2"
+ marker_path="$3"
+ deadline=$(( $(date +%s) + 30 ))
+ if [ -n "$wait_pid" ] && [ "$wait_pid" -gt 1 ] 2>/dev/null; then
+   while kill -0 "$wait_pid" >/dev/null 2>&1; do
+     if [ "$(date +%s)" -ge "$deadline" ]; then
+       echo "openclaw-systemd-restart-handoff: timed out waiting for pid $wait_pid to exit; continuing restart" >&2
+       break
+     fi
+     sleep 0.1
+   done
+ fi
+ if [ -n "$marker_path" ]; then
+   mkdir -p "$(dirname "$marker_path")" >/dev/null 2>&1 || true
+   printf '%s\n%s\n' "$target_unit" "$(date +%s)" > "$marker_path" || true
+ fi
+ systemctl --user restart "$target_unit"
+ status="$?"
+ if [ "$status" -ne 0 ]; then
+   if [ -n "$marker_path" ]; then
+     rm -f "$marker_path" >/dev/null 2>&1 || true
+   fi
+   exit "$status"
+ fi
+ `;
+}
+
+export function consumeSystemdRestartExpectationMarker(
+  env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+  maxAgeMs = 600_000,
+): boolean {
+  const markerPath = resolveSystemdRestartExpectationMarkerPath(env);
+  let raw: string;
+  try {
+    raw = fsSync.readFileSync(markerPath, "utf8");
+  } catch {
+    return false;
+  }
+  try {
+    fsSync.unlinkSync(markerPath);
+  } catch {
+    // Best effort only. Restart semantics should still continue.
+  }
+  const [unitLine = "", tsLine = ""] = raw.split(/\r?\n/);
+  const expectedUnit = normalizeSystemdUnitName(unitLine);
+  const currentUnit =
+    normalizeSystemdUnitName(env.OPENCLAW_SYSTEMD_UNIT) ??
+    `${resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)}.service`;
+  if (!expectedUnit || expectedUnit !== currentUnit) {
+    return false;
+  }
+  const epochSeconds = parseStrictPositiveInteger(tsLine);
+  if (epochSeconds === undefined) {
+    return false;
+  }
+  const ageMs = Date.now() - epochSeconds * 1000;
+  if (ageMs < 0 || ageMs > maxAgeMs) {
+    return false;
+  }
+  return true;
+}
+
+async function scheduleDetachedSystemdRestartHandoff(params: {
+  env?: GatewayServiceEnv;
+  unitName?: string;
+  waitForPid?: number;
+}): Promise<
+  | { ok: true; targetUnit: string; handoffUnit: string }
+  | { ok: false; targetUnit: string; handoffUnit: string; detail: string }
+> {
+  const env = params.env ?? process.env;
+  const targetUnit =
+    normalizeSystemdUnitName(params.unitName) ?? `${resolveSystemdServiceName(env)}.service`;
+  const waitForPid =
+    typeof params.waitForPid === "number" && Number.isFinite(params.waitForPid)
+      ? Math.max(0, Math.floor(params.waitForPid))
+      : 0;
+  const markerPath = resolveSystemdRestartExpectationMarkerPath(env, targetUnit);
+  const handoffUnitBase = `openclaw-gateway-restart-handoff-${process.pid}-${Date.now()}`;
+  const result = await execFileUtf8("systemd-run", [
+    "--user",
+    "--quiet",
+    "--collect",
+    "--no-block",
+    "--unit",
+    handoffUnitBase,
+    "/bin/sh",
+    "-c",
+    buildSystemdRestartHandoffScript(),
+    "openclaw-systemd-restart-handoff",
+    String(waitForPid),
+    targetUnit,
+    markerPath,
+  ]);
+  const handoffUnit = `${handoffUnitBase}.service`;
+  if (result.code === 0) {
+    return {
+      ok: true,
+      targetUnit,
+      handoffUnit,
+    };
+  }
+  const detail = `${result.stderr || ""} ${result.stdout || ""}`.trim();
+  return {
+    ok: false,
+    targetUnit,
+    handoffUnit,
+    detail: detail || `systemd-run failed with exit code ${result.code ?? "unknown"}`,
+  };
 }
 
 export { enableSystemdUserLinger, readSystemdUserLingerStatus };
@@ -730,9 +930,25 @@ export async function restartSystemdService({
   stdout,
   env,
 }: GatewayServiceControlArgs): Promise<GatewayServiceRestartResult> {
+  const effectiveEnv = env ?? process.env;
+  const unitName = `${resolveSystemdServiceName(effectiveEnv)}.service`;
+  if (await isCurrentProcessSystemdServiceUnit(unitName)) {
+    const handoff = await scheduleDetachedSystemdRestartHandoff({
+      env: effectiveEnv,
+      unitName,
+      waitForPid: process.pid,
+    });
+    if (!handoff.ok) {
+      throw new Error(`systemd restart handoff failed: ${handoff.detail ?? "unknown error"}`);
+    }
+    stdout.write(
+      `${formatLine("Scheduled systemd service restart", `${handoff.targetUnit} via ${handoff.handoffUnit}`)}\n`,
+    );
+    return { outcome: "scheduled" };
+  }
   await runSystemdServiceAction({
     stdout,
-    env,
+    env: effectiveEnv,
     action: "restart",
     label: "Restarted systemd service",
   });


### PR DESCRIPTION
## Summary

On Linux/systemd, restarting the gateway from inside the running gateway service can kill the calling CLI process with `SIGTERM` even though the service restart succeeds.

This happens because the restart command runs inside the same `openclaw-gateway.service` cgroup, and the unit uses `KillMode=control-group`. A plain `systemctl --user restart openclaw-gateway.service` therefore kills the gateway and the caller together.

This change makes the Linux systemd adapter treat **self-restarts** differently from **external restarts**:

- if the caller is already inside the target systemd service unit, schedule a detached `systemd-run --user` handoff and return `scheduled`
- otherwise keep the existing synchronous restart path and return `completed`

## Why this is safe

- Linux only
- systemd only
- restart path only
- external restart behaviour is preserved
- no unit-file semantics changed
- no change to launchd or macOS behaviour

## Implementation

- detect whether the current process is running inside the target systemd service cgroup
- if yes, schedule a transient user unit outside that cgroup with `systemd-run --user`
- wait for the current process PID to exit, then run `systemctl --user restart <unit>` from the detached handoff
- surface handoff failures clearly
- treat a matching expected SIGTERM during handoff as restart semantics instead of a normal stop

## Validation performed locally

- `corepack pnpm exec oxfmt --check src/daemon/systemd.ts src/daemon/systemd.test.ts src/cli/gateway-cli/run-loop.ts src/cli/gateway-cli/run-loop.test.ts src/agents/subagent-registry.steer-restart.test.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- `corepack pnpm exec vitest run src/daemon/systemd.test.ts src/cli/gateway-cli/run-loop.test.ts --reporter=verbose`
- `corepack pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/subagent-registry.steer-restart.test.ts --reporter=verbose`
- `corepack pnpm exec vitest run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts --reporter=verbose`

## Notes

This follows the same scheduled-restart contract already used elsewhere in the daemon lifecycle, rather than changing systemd unit kill behaviour.

## Review Focus
- `src/daemon/systemd.ts`
- `src/cli/gateway-cli/run-loop.ts`
- `src/daemon/systemd.test.ts`
- `src/cli/gateway-cli/run-loop.test.ts`

## Scope Boundary
- Linux only
- systemd only
- restart path only
- external restart behavior remains synchronous and unchanged

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: self-restarts inside the managed unit now schedule a detached `systemd-run --user` handoff only for the in-unit restart path. External restarts are unchanged, marker parsing is validated strictly, and tests cover malformed markers, custom unit names, and bounded restart draining.

## Human Verification
- Verified scenarios: self-restart handoff scheduling, marker-based SIGTERM restart handling, malformed marker rejection, custom unit normalization, and bounded supervised restart draining
- Edge cases checked: detached restart failure cleanup, marker timestamp validation, current-main test harness after rebase
- What I did not verify: live smoke on a real systemd user service manager
