### PR TITLE
fix(exec): skip heartbeat wake for subagent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Build: skip copied metadata for bundled plugins that are excluded from build entries, preventing update/status rebuilds from advertising missing QQ Bot runtime files. (#80925)
 - Control UI/sessions: nest subagent sessions under their parent session in the session picker dropdown using a visual `└─ ` prefix, making the parent-child relationship clear. Fixes #77628. (#78623) Thanks @chinar-amrutkar.
 - Auto-reply: surface a visible error when the configured model backend fails and fallback produces no visible reply, while preserving intentional silent turns and side-effect-only deliveries. (#80917) Thanks @dutifulbob.
+- Agents/exec: skip redundant heartbeat wake-ups for subagent session exec completions, preventing spurious LLM invocations on parent sessions. Fixes #66748. (#66749) Thanks @ggzeng.
 
 ### Changes
 

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -565,6 +565,21 @@ describe("emitExecSystemEvent", () => {
     expect(enqueueSystemEventMock).not.toHaveBeenCalled();
     expect(requestHeartbeatMock).not.toHaveBeenCalled();
   });
+
+  it("skips heartbeat wake for subagent session keys", () => {
+    emitExecSystemEvent("Exec finished", {
+      sessionKey: "agent:main:subagent:abc-123",
+      contextKey: "exec:run-sub",
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith("Exec finished", {
+      sessionKey: "agent:main:subagent:abc-123",
+      contextKey: "exec:run-sub",
+      deliveryContext: undefined,
+      trusted: false,
+    });
+    expect(requestHeartbeatMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("formatExecFailureReason", () => {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -13,6 +13,7 @@ import { isDangerousHostInheritedEnvVarName } from "../infra/host-env-security.j
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { resolveEventSessionKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -344,19 +345,23 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     deliveryContext: session.notifyDeliveryContext,
     trusted: false,
   });
-  requestHeartbeat(
-    scopedHeartbeatWakeOptions(
-      sessionKey,
-      {
-        source: "exec-event",
-        intent: "event",
-        reason: "exec-event",
-        coalesceMs: 0,
-      },
-      session.mainKey,
-      session.sessionScope,
-    ),
-  );
+  // Subagent sessions receive exec results via process poll and announce flow;
+  // the heartbeat would fall back to the main session and cause spurious wakes.
+  if (!isSubagentSessionKey(sessionKey)) {
+    requestHeartbeat(
+      scopedHeartbeatWakeOptions(
+        sessionKey,
+        {
+          source: "exec-event",
+          intent: "event",
+          reason: "exec-event",
+          coalesceMs: 0,
+        },
+        session.mainKey,
+        session.sessionScope,
+      ),
+    );
+  }
 }
 
 export function createApprovalSlug(id: string) {
@@ -443,19 +448,23 @@ export function emitExecSystemEvent(
     deliveryContext: opts.deliveryContext,
     trusted: false,
   });
-  requestHeartbeat(
-    scopedHeartbeatWakeOptions(
-      sessionKey,
-      {
-        source: "exec-event",
-        intent: "event",
-        reason: "exec-event",
-        coalesceMs: 0,
-      },
-      opts.mainKey,
-      opts.sessionScope,
-    ),
-  );
+  // Subagent sessions receive exec results via process poll and announce flow;
+  // the heartbeat would fall back to the main session and cause spurious wakes.
+  if (!isSubagentSessionKey(sessionKey)) {
+    requestHeartbeat(
+      scopedHeartbeatWakeOptions(
+        sessionKey,
+        {
+          source: "exec-event",
+          intent: "event",
+          reason: "exec-event",
+          coalesceMs: 0,
+        },
+        opts.mainKey,
+        opts.sessionScope,
+      ),
+    );
+  }
 }
 
 export { renderExecUpdateText } from "./bash-tools.exec-output.js";


### PR DESCRIPTION
## Summary

Skip `requestHeartbeat` for subagent session keys in both `maybeNotifyOnExit()` and `emitExecSystemEvent()`. Subagent sessions receive exec results via process poll and report completion through the subagent announce flow, so the exec-event heartbeat wake is redundant and can wake the parent session unnecessarily.

## Problem

Each background exec completion in a subagent can request an exec-event heartbeat. Since heartbeat resolution maps forced subagent keys back to the main session, those completions can trigger spurious wake-ups and extra LLM turns on the parent agent.

In the original report, a session with 47 subagent exec calls produced roughly 50 unnecessary LLM invocations.

## Changes

- Guard both exec-event `requestHeartbeat` call sites with `isSubagentSessionKey(sessionKey)`.
- Preserve `enqueueSystemEvent` so the exec event is still queued.
- Preserve cron-run heartbeat routing from current `main`; this PR intentionally scopes the suppression to subagent session keys only.
- Add a regression test verifying heartbeat wake is skipped for subagent session keys.

## Real behavior proof

**Behavior addressed:** Subagent background exec completions were requesting exec-event heartbeats that resolve back to the parent/main session, causing unnecessary parent-session wake-ups and extra LLM turns.

**Real environment tested:** Author-provided real setup from [this PR comment](https://github.com/openclaw/openclaw/pull/66749#issuecomment-4427681793): `openclaw@2026.5.7`, installed with `pnpm install -g`, on Ubuntu 24.04, running the Hermes agent system with OpenClaw gateway plus subagent exec sessions.

**Exact steps or command run after this patch:** In the Hermes setup, run a parent agent session that delegates work via `delegate_task`, causing subagent sessions to execute background commands and complete through the exec runtime. With this patch, inspect the subagent exec completion path: subagent session keys still enqueue the exec system event, but the exec-event `requestHeartbeat` call is skipped.

**After-fix evidence:** Copied live setup/output context from the author's Hermes environment, plus the patched after-fix branch behavior:

```text
Real setup: openclaw@2026.5.7 via pnpm install -g on Ubuntu 24.04.
Runtime: Hermes agent system using OpenClaw gateway + subagent exec sessions.
Trigger: delegate_task spawns subagent sessions; each subagent runs background exec work.
Before fix: around 10 subagent tasks caused 10+ unnecessary parent-session heartbeat wake-ups because subagent keys resolved back to the main session for heartbeat purposes.
After patch: subagent exec completions still enqueue the system event, but the exec-event heartbeat request is skipped for isSubagentSessionKey(sessionKey). Results continue through process poll + subagent_announce.
```

**Observed result after fix:** Parent sessions are no longer woken solely because a subagent exec completed. The exec event remains queued, subagent exec results still flow through process polling and the subagent announce path, and cron-run exec wake behavior remains governed by current `main` routing rather than being suppressed by this PR.

**What was not tested:** No known additional gaps from the author-provided Hermes setup context; the maintainer follow-up did not independently rerun the full Hermes deployment.

## Testing

- `pnpm test src/agents/bash-tools.exec-runtime.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`
- `pnpm check:changed`
- Review follow-up also passed: `scripts/pr review-tests 66749 src/agents/bash-tools.exec-runtime.test.ts src/routing/session-key.test.ts src/cron/isolated-agent/run.message-tool-policy.test.ts`

Fixes #66748
