### PR TITLE
fix(outbound): peer-aware Slack account routing in runMessageAction

### DIFF
--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -835,6 +835,39 @@ export async function runMessageAction(
 
   const channel = await resolveChannel(cfg, params, input.toolContext);
   let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
+  // Peer-aware binding lookup — strictly more specific than agent-keyed
+  // lookup, so it runs first. Bindings that pin (channel, peer.id, accountId)
+  // should deterministically route outbound sends to that account regardless
+  // of which agent's CLI subprocess is doing the sending.
+  if (!accountId) {
+    const peerTarget =
+      readStringParam(params, "to") ??
+      readStringParam(params, "channelId") ??
+      readStringParam(params, "target");
+    if (peerTarget) {
+      const channelLc = typeof channel === "string" ? channel.trim().toLowerCase() : "";
+      const rawBindings = Array.isArray((cfg as { bindings?: unknown })?.bindings)
+        ? ((cfg as { bindings?: unknown[] }).bindings as unknown[])
+        : [];
+      for (const b of rawBindings) {
+        const m = b && typeof b === "object" ? (b as { match?: unknown }).match : null;
+        if (!m || typeof m !== "object") continue;
+        const match = m as { channel?: unknown; peer?: unknown; accountId?: unknown };
+        const bCh = typeof match.channel === "string" ? match.channel.trim().toLowerCase() : "";
+        if (bCh !== channelLc) continue;
+        const peer = match.peer && typeof match.peer === "object"
+          ? (match.peer as { id?: unknown })
+          : null;
+        const bPeerId = peer && typeof peer.id === "string" ? peer.id.trim() : "";
+        if (!bPeerId || bPeerId !== peerTarget.trim()) continue;
+        const bAcc = typeof match.accountId === "string" ? match.accountId.trim() : "";
+        if (bAcc && bAcc !== "*") {
+          accountId = bAcc;
+          break;
+        }
+      }
+    }
+  }
   if (!accountId && resolvedAgentId) {
     const byAgent = buildChannelAccountBindings(cfg).get(channel);
     const boundAccountIds = byAgent?.get(normalizeAgentId(resolvedAgentId));


### PR DESCRIPTION
# fix: peer-aware Slack account routing in runMessageAction

## The bug

OpenClaw's outbound message action runner can't route a CLI-originated send to
the correct account when a config has multiple bindings that share a channel
provider but differ on peer id. In practice this breaks any multi-account
Slack setup where different agents own different channels under different
bot apps.

### Empirical reproduction

Config (abbreviated):

```json
{
  "channels": {
    "slack": {
      "accounts": {
        "default": { "name": "Ranveer", "botToken": "xoxb-…A" },
        "anisha": { "name": "Anisha", "botToken": "xoxb-…B" }
      }
    }
  },
  "agents": {
    "list": [
      { "id": "eng-hygiene", "name": "eng-hygiene" },
      { "id": "anisha", "name": "anisha" }
    ]
  },
  "bindings": [
    {
      "agentId": "eng-hygiene",
      "match": {
        "channel": "slack",
        "accountId": "default",
        "peer": { "kind": "channel", "id": "C_CODE" }
      }
    },
    {
      "agentId": "anisha",
      "match": {
        "channel": "slack",
        "accountId": "anisha",
        "peer": { "kind": "channel", "id": "C_CONTENT" }
      }
    }
  ]
}
```

- `xoxb-…A` (Ranveer) is invited to `C_CODE` only.
- `xoxb-…B` (Anisha) is invited to `C_CONTENT` only.

Steps:

```
openclaw agent --agent anisha --message \
  "Use the openclaw message send tool now to target C_CONTENT and post 'hi'."
```

The agent's tool call shells out:

```
openclaw message send --channel slack --target C_CONTENT --message "hi"
```

Expected: message posted via `xoxb-…B` (Anisha), landing in `#content`.
Actual: Slack returns `channel_not_found` because the send is attempted via
`xoxb-…A` (Ranveer), which is not in `#content`.

### Root cause

In `src/infra/outbound/message-action-runner.ts` (current hashed filename
`dist/message-action-runner-D2rCz6di.js`), the account selection block reads:

```js
let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
if (!accountId && resolvedAgentId) {
  const boundAccountIds = buildChannelAccountBindings(cfg)
    .get(channel)
    ?.get(normalizeAgentId(resolvedAgentId));
  if (boundAccountIds && boundAccountIds.length > 0)
    accountId = boundAccountIds[0];
}
```

Two collaborating problems:

1. `buildChannelAccountBindings` keys the map `(channelProvider, agentId)` —
   **NOT** `(channelProvider, peerId)`. The target peer id is completely
   ignored even though bindings carry `match.peer.id`.
2. In every CLI subprocess, `register.message` sets
   `agentId: resolveDefaultAgentId(cfg)` — the first agent in `agents.list`
   with no subprocess-inherited agent identity. So when Anisha's agent turn
   shells out, the subprocess resolves to `eng-hygiene`, looks up
   `(slack, eng-hygiene)`, gets Ranveer's bot, and sends to the wrong peer.

Combined, bindings that carry a `peer.id` behave identically to bindings that
don't — first-in-`agents.list` wins per provider, insertion order.

## The fix

Add a peer-aware binding lookup in `runMessageAction` that runs **before** the
existing agent-keyed lookup. When no explicit `--account` was passed, scan
`cfg.bindings` for an entry whose `match.channel` equals the current channel
provider AND whose `match.peer.id` equals the current target id
(`params.to || params.channelId || params.target`). First match wins.

Peer-specific bindings are strictly more specific than provider-only bindings,
so letting them override is the right precedence.

```js
let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;

// NEW: peer-aware binding lookup — runs before agent-keyed fallback.
if (!accountId) {
  const peerTarget =
    readStringParam(params, "to") ??
    readStringParam(params, "channelId") ??
    readStringParam(params, "target");
  if (peerTarget) {
    const channelLc =
      typeof channel === "string" ? channel.trim().toLowerCase() : "";
    const rawBindings = Array.isArray(cfg?.bindings) ? cfg.bindings : [];
    for (const b of rawBindings) {
      const m = b && typeof b === "object" ? b.match : null;
      if (!m || typeof m !== "object") continue;
      const bCh =
        typeof m.channel === "string" ? m.channel.trim().toLowerCase() : "";
      if (bCh !== channelLc) continue;
      const bPeerId =
        m.peer && typeof m.peer === "object" ? m.peer.id : undefined;
      if (typeof bPeerId !== "string" || bPeerId.trim() !== peerTarget.trim())
        continue;
      const bAcc = typeof m.accountId === "string" ? m.accountId.trim() : "";
      if (bAcc && bAcc !== "*") {
        accountId = bAcc;
        break;
      }
    }
  }
}

if (!accountId && resolvedAgentId) {
  /* unchanged agent-keyed fallback */
}
```

## Backward compatibility

- Existing bindings without a `peer.id` are skipped by the new loop — they
  fall through to the existing agent-keyed lookup unchanged. No config
  migration needed.
- Bindings with `peer.id` but no `accountId` are skipped by the new loop
  (`bAcc` empty) — behavior unchanged for those. (A follow-up could make
  `resolveNormalizedBindingMatch` also retain peer-scoped bindings that carry
  no `accountId`, for a wider fix; out of scope here.)
- Explicit `--account` still wins, same as today.

## Verification

- OpenClaw version: 2026.4.12
- Empirically reproduced the bug with the above config, observed
  `channel_not_found` from Anisha's tool-call path
- Applied the patch as a local string replacement (see
  `~/.openclaw/patches/0001-peer-aware-bindings.mjs`)
- Re-ran the same agent turn; the send resolved to Anisha's bot and Slack
  returned a valid message id
- eng-hygiene → `#code` routing continues to work unchanged (existing
  agent-keyed fallback still fires for that path as a backup)

## Notes

This change is roughly 18 lines of new code, no signature changes, no schema
changes, no behavioral change for single-account or non-peer-bound configs.