### PR TITLE
QA: fix mock-openai qa-channel regressions

### DIFF
--- a/extensions/qa-lab/src/mock-openai-server.test.ts
+++ b/extensions/qa-lab/src/mock-openai-server.test.ts
@@ -657,6 +657,48 @@ describe("qa mock openai server", () => {
       "Protocol note: I checked memory and the current Project Nebula codename is ORBIT-10.",
     );
 
+    const memoryFollowupPrefersSessionResult = await fetch(`${server.baseUrl}/v1/responses`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        stream: true,
+        input: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "input_text",
+                text: "Session memory ranking check: what is the current Project Nebula codename? Use memory tools first.",
+              },
+            ],
+          },
+          {
+            type: "function_call_output",
+            output: JSON.stringify({
+              results: [
+                {
+                  path: "MEMORY.md",
+                  startLine: 1,
+                  endLine: 4,
+                },
+                {
+                  path: "sessions/qa-session-memory-ranking.jsonl",
+                  startLine: 2,
+                  endLine: 3,
+                },
+              ],
+            }),
+          },
+        ],
+      }),
+    });
+    expect(memoryFollowupPrefersSessionResult.status).toBe(200);
+    expect(await memoryFollowupPrefersSessionResult.text()).toContain(
+      "Protocol note: I checked memory and the current Project Nebula codename is ORBIT-10.",
+    );
+
     const activeMemorySearch = await fetch(`${server.baseUrl}/v1/responses`, {
       method: "POST",
       headers: {

--- a/extensions/qa-lab/src/mock-openai-server.ts
+++ b/extensions/qa-lab/src/mock-openai-server.ts
@@ -924,13 +924,16 @@ async function buildResponsesPayload(
     const results = Array.isArray(toolJson?.results)
       ? (toolJson.results as Array<Record<string, unknown>>)
       : [];
-    const first = results[0];
-    const firstPath = typeof first?.path === "string" ? first.path : undefined;
-    if (first?.source === "sessions" || firstPath?.startsWith("sessions/")) {
+    const preferredSessionResult = results.find((result) => {
+      const resultPath = typeof result.path === "string" ? result.path : undefined;
+      return result.source === "sessions" || resultPath?.startsWith("sessions/");
+    });
+    if (preferredSessionResult) {
       return buildAssistantEvents(
         "Protocol note: I checked memory and the current Project Nebula codename is ORBIT-10.",
       );
     }
+    const first = results[0];
     if (
       typeof first?.path === "string" &&
       (typeof first.startLine === "number" || typeof first.endLine === "number")

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { getMediaDir } from "../media/store.js";
 import { buildInboundMediaNote } from "./media-note.js";
 import {
   createSuccessfulAudioMediaDecision,
@@ -13,6 +15,18 @@ describe("buildInboundMediaNote", () => {
       MediaUrl: "/tmp/a.png",
     });
     expect(note).toBe("[media attached: /tmp/a.png (image/png) | /tmp/a.png]");
+  });
+
+  it("renders managed inbound media-store paths as media URIs", () => {
+    const inboundPath = path.join(getMediaDir(), "inbound", "photo---abc123.png");
+    const note = buildInboundMediaNote({
+      MediaPath: inboundPath,
+      MediaType: "image/png",
+      MediaUrl: inboundPath,
+    });
+    expect(note).toBe(
+      "[media attached: media://inbound/photo---abc123.png (image/png) | media://inbound/photo---abc123.png]",
+    );
   });
 
   it("formats multiple MediaPaths as numbered media notes", () => {

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -1,12 +1,44 @@
+import path from "node:path";
+import { getMediaDir } from "../media/store.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import type { MsgContext } from "./templating.js";
+
+function stripDarwinPrivatePrefix(value: string): string {
+  return process.platform === "darwin" && value.startsWith("/private/") ? value.slice(8) : value;
+}
+
+function normalizeManagedInboundMediaRef(value: string): string {
+  if (!path.isAbsolute(value)) {
+    return value;
+  }
+  const mediaInboundRoot = path.join(getMediaDir(), "inbound");
+  const normalizedValue = path.resolve(value);
+  const normalizedRoot = path.resolve(mediaInboundRoot);
+  const normalizedValueSansPrivate = stripDarwinPrivatePrefix(normalizedValue);
+  const normalizedRootSansPrivate = stripDarwinPrivatePrefix(normalizedRoot);
+  const rootWithSep = normalizedRoot.endsWith(path.sep)
+    ? normalizedRoot
+    : `${normalizedRoot}${path.sep}`;
+  const rootSansPrivateWithSep = normalizedRootSansPrivate.endsWith(path.sep)
+    ? normalizedRootSansPrivate
+    : `${normalizedRootSansPrivate}${path.sep}`;
+  const isManagedInboundPath =
+    normalizedValue === normalizedRoot ||
+    normalizedValue.startsWith(rootWithSep) ||
+    normalizedValueSansPrivate === normalizedRootSansPrivate ||
+    normalizedValueSansPrivate.startsWith(rootSansPrivateWithSep);
+  if (!isManagedInboundPath) {
+    return value;
+  }
+  return `media://inbound/${path.basename(normalizedValue)}`;
+}
 
 function sanitizeInlineMediaNoteValue(value: string | undefined): string {
   const trimmed = value?.trim();
   if (!trimmed) {
     return "";
   }
-  return trimmed
+  return normalizeManagedInboundMediaRef(trimmed)
     .replace(/[\p{Cc}\]]+/gu, " ")
     .replace(/\s+/g, " ")
     .trim();

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -165,6 +165,15 @@ describe("fs-safe", () => {
       await fs.writeFile(originalPath, "inside");
       await fs.writeFile(outsidePath, "outside");
 
+      const originalRealpath = fs.realpath.bind(fs);
+      const realpathSpy = vi.spyOn(fs, "realpath");
+      realpathSpy.mockImplementation(async (target) => {
+        if (typeof target === "string" && target.startsWith("/dev/fd/")) {
+          return movedPath;
+        }
+        return await originalRealpath(target);
+      });
+
       const handle = await fs.open(originalPath, "r");
       try {
         await fs.rename(originalPath, movedPath);
@@ -174,6 +183,33 @@ describe("fs-safe", () => {
 
         await expect(fs.realpath(movedPath)).resolves.toBe(resolved);
         await expect(handle.readFile({ encoding: "utf8" })).resolves.toBe("inside");
+      } finally {
+        await handle.close().catch(() => {});
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "falls back to the io path when /dev/fd realpath does not resolve to the opened file",
+    async () => {
+      const root = await tempDirs.make("openclaw-fs-safe-root-");
+      const filePath = path.join(root, "inside.txt");
+      await fs.writeFile(filePath, "inside");
+
+      const originalRealpath = fs.realpath.bind(fs);
+      const realpathSpy = vi.spyOn(fs, "realpath");
+      realpathSpy.mockImplementation(async (target) => {
+        if (typeof target === "string" && target.startsWith("/dev/fd/")) {
+          return "/dev/fd/inside.txt";
+        }
+        return await originalRealpath(target);
+      });
+
+      const handle = await fs.open(filePath, "r");
+      try {
+        await expect(resolveOpenedFileRealPathForHandle(handle, filePath)).resolves.toBe(
+          await originalRealpath(filePath),
+        );
       } finally {
         await handle.close().catch(() => {});
       }

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -417,7 +417,21 @@ export async function resolveOpenedFileRealPathForHandle(
   handle: FileHandle,
   ioPath: string,
 ): Promise<string> {
-  const handleStat = await handle.stat();
+  const openedStat = await handle.stat();
+  const resolveCandidate = async (candidatePath: string): Promise<string | null> => {
+    try {
+      const candidateStat = await fs.stat(candidatePath);
+      if (sameFileIdentity(openedStat, candidateStat)) {
+        return candidatePath;
+      }
+      return null;
+    } catch (err) {
+      if (isNotFoundPathError(err)) {
+        return null;
+      }
+      throw err;
+    }
+  };
   const fdCandidates =
     process.platform === "linux"
       ? [`/proc/self/fd/${handle.fd}`, `/dev/fd/${handle.fd}`]
@@ -426,10 +440,10 @@ export async function resolveOpenedFileRealPathForHandle(
         : [`/dev/fd/${handle.fd}`];
   for (const fdPath of fdCandidates) {
     try {
-      const fdRealPath = await fs.realpath(fdPath);
-      const fdRealStat = await fs.stat(fdRealPath);
-      if (sameFileIdentity(handleStat, fdRealStat)) {
-        return fdRealPath;
+      const resolved = await fs.realpath(fdPath);
+      const accepted = await resolveCandidate(resolved);
+      if (accepted) {
+        return accepted;
       }
     } catch {
       // try next fd path
@@ -437,17 +451,17 @@ export async function resolveOpenedFileRealPathForHandle(
   }
 
   try {
-    const ioRealPath = await fs.realpath(ioPath);
-    const ioRealStat = await fs.stat(ioRealPath);
-    if (sameFileIdentity(handleStat, ioRealStat)) {
-      return ioRealPath;
+    const resolved = await fs.realpath(ioPath);
+    const accepted = await resolveCandidate(resolved);
+    if (accepted) {
+      return accepted;
     }
   } catch (err) {
     if (!isNotFoundPathError(err)) {
       throw err;
     }
   }
-  const parentResolved = await resolveOpenedFileRealPathFromParent(handleStat, ioPath);
+  const parentResolved = await resolveOpenedFileRealPathFromParent(openedStat, ioPath);
   if (parentResolved) {
     return parentResolved;
   }


### PR DESCRIPTION
## Summary
- fix the mock OpenAI QA memory ranking lane to prefer transcript-backed `sessions/...` hits over stale `MEMORY.md` results
- normalize managed inbound media note paths to stable `media://inbound/...` refs for qa-channel image roundtrips
- harden `resolveOpenedFileRealPathForHandle` against bogus macOS `/dev/fd/*` realpaths by validating candidates against the opened handle before accepting them

## Testing
- `pnpm openclaw qa suite --transport qa-channel --provider-mode mock-openai --output-dir .artifacts/qa-e2e/mock-openai-qa-channel-20260414-rerun` (`46/46` pass)
- `pnpm test src/infra/fs-safe.test.ts -t "falls back to the io path when /dev/fd realpath does not resolve to the opened file"`
- `pnpm test src/auto-reply/media-note.test.ts -t "renders managed inbound media-store paths as media URIs"`
- `pnpm test extensions/qa-lab/src/mock-openai-server.test.ts -t "supports advanced QA memory and subagent recovery prompts"`
