### PR TITLE
fix(security): guard instruction file writes from agent sessions

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -484,3 +484,58 @@ describe("applyPatch", () => {
     });
   });
 });
+
+describe("applyPatch instruction file guard", () => {
+  it("blocks patch adding SOUL.md", async () => {
+    await withTempDir(async (dir) => {
+      const patch = `*** Begin Patch
+*** Add File: SOUL.md
++hacked identity
+*** End Patch`;
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /Patch targets protected instruction file "SOUL.md"/,
+      );
+    });
+  });
+
+  it("blocks patch updating CLAUDE.md", async () => {
+    await withTempDir(async (dir) => {
+      await fs.writeFile(path.join(dir, "CLAUDE.md"), "original\n");
+      const patch = `*** Begin Patch
+*** Update File: CLAUDE.md
+@@
+-original
++compromised
+*** End Patch`;
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /Patch targets protected instruction file "CLAUDE.md"/,
+      );
+    });
+  });
+
+  it("blocks patch moving to IDENTITY.md", async () => {
+    await withTempDir(async (dir) => {
+      await fs.writeFile(path.join(dir, "temp.md"), "data\n");
+      const patch = `*** Begin Patch
+*** Update File: temp.md
+*** Move to: IDENTITY.md
+@@
+ data
+*** End Patch`;
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /Patch moves to protected instruction file "IDENTITY.md"/,
+      );
+    });
+  });
+
+  it("allows patch to non-protected files", async () => {
+    await withTempDir(async (dir) => {
+      const patch = `*** Begin Patch
+*** Add File: notes.md
++safe content
+*** End Patch`;
+      const result = await applyPatch(patch, { cwd: dir });
+      expect(result.summary.added).toEqual(["notes.md"]);
+    });
+  });
+});

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -528,6 +528,18 @@ describe("applyPatch instruction file guard", () => {
     });
   });
 
+  it("blocks patch targeting @SOUL.md (at-prefix bypass)", async () => {
+    await withTempDir(async (dir) => {
+      const patch = `*** Begin Patch
+*** Add File: @SOUL.md
++injected identity
+*** End Patch`;
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /Patch targets protected instruction file/,
+      );
+    });
+  });
+
   it("allows patch to non-protected files", async () => {
     await withTempDir(async (dir) => {
       const patch = `*** Begin Patch

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -149,6 +149,8 @@ export async function applyPatch(
   const fileOps = resolvePatchFileOps(options);
 
   // Guard: block patches targeting protected instruction files.
+  // Check hunk paths BEFORE resolution (isProtectedInstructionFile normalizes
+  // @-prefix, unicode spaces, and trailing dots to match the resolution pipeline).
   for (const hunk of parsed.hunks) {
     const targetPath = hunk.path;
     if (targetPath && isProtectedInstructionFile(targetPath)) {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -13,6 +13,7 @@ import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-g
 import { applyUpdateHunk } from "./apply-patch-update.js";
 import { toRelativeSandboxPath, resolvePathFromInput } from "./path-policy.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
+import { isProtectedInstructionFile } from "./pi-tools.instruction-file-guard.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 
 const BEGIN_PATCH_MARKER = "*** Begin Patch";
@@ -146,6 +147,27 @@ export async function applyPatch(
     deleted: new Set<string>(),
   };
   const fileOps = resolvePatchFileOps(options);
+
+  // Guard: block patches targeting protected instruction files.
+  for (const hunk of parsed.hunks) {
+    const targetPath = hunk.path;
+    if (targetPath && isProtectedInstructionFile(targetPath)) {
+      const basename = path.basename(targetPath);
+      throw new Error(
+        `Patch targets protected instruction file "${basename}". ` +
+          `Agent sessions cannot modify protected instruction files. ` +
+          `Ask the operator to make this change directly.`,
+      );
+    }
+    if (hunk.movePath && isProtectedInstructionFile(hunk.movePath)) {
+      const basename = path.basename(hunk.movePath);
+      throw new Error(
+        `Patch moves to protected instruction file "${basename}". ` +
+          `Agent sessions cannot modify protected instruction files. ` +
+          `Ask the operator to make this change directly.`,
+      );
+    }
+  }
 
   for (const hunk of parsed.hunks) {
     if (options.signal?.aborted) {

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -152,16 +152,15 @@ export async function applyPatch(
   // Check hunk paths BEFORE resolution (isProtectedInstructionFile normalizes
   // @-prefix, unicode spaces, and trailing dots to match the resolution pipeline).
   for (const hunk of parsed.hunks) {
-    const targetPath = hunk.path;
-    if (targetPath && isProtectedInstructionFile(targetPath)) {
-      const basename = path.basename(targetPath);
+    if (isProtectedInstructionFile(hunk.path)) {
+      const basename = path.basename(hunk.path);
       throw new Error(
         `Patch targets protected instruction file "${basename}". ` +
           `Agent sessions cannot modify protected instruction files. ` +
           `Ask the operator to make this change directly.`,
       );
     }
-    if (hunk.movePath && isProtectedInstructionFile(hunk.movePath)) {
+    if (hunk.kind === "update" && hunk.movePath && isProtectedInstructionFile(hunk.movePath)) {
       const basename = path.basename(hunk.movePath);
       throw new Error(
         `Patch moves to protected instruction file "${basename}". ` +

--- a/src/agents/pi-tools.instruction-file-guard.test.ts
+++ b/src/agents/pi-tools.instruction-file-guard.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isProtectedInstructionFile,
+  wrapToolInstructionFileGuard,
+} from "./pi-tools.instruction-file-guard.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+function createMockTool(name = "write"): AnyAgentTool {
+  return {
+    name,
+    description: "test tool",
+    inputSchema: { type: "object", properties: {} },
+    execute: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+  } as unknown as AnyAgentTool;
+}
+
+describe("isProtectedInstructionFile", () => {
+  it("matches SOUL.md", () => {
+    expect(isProtectedInstructionFile("SOUL.md")).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(isProtectedInstructionFile("soul.md")).toBe(true);
+    expect(isProtectedInstructionFile("Soul.MD")).toBe(true);
+    expect(isProtectedInstructionFile("CLAUDE.MD")).toBe(true);
+  });
+
+  it("matches nested paths", () => {
+    expect(isProtectedInstructionFile("/workspace/agents/pj/SOUL.md")).toBe(true);
+    expect(isProtectedInstructionFile("/home/ka/.openclaw/agents/coach/IDENTITY.md")).toBe(true);
+  });
+
+  it("does not match non-protected files", () => {
+    expect(isProtectedInstructionFile("memory/2026-04-14.md")).toBe(false);
+    expect(isProtectedInstructionFile("README.md")).toBe(false);
+    expect(isProtectedInstructionFile("notes.md")).toBe(false);
+    expect(isProtectedInstructionFile("/workspace/src/soul.ts")).toBe(false);
+  });
+
+  it("matches all protected basenames", () => {
+    for (const name of [
+      "SOUL.md",
+      "MEMORY.md",
+      "IDENTITY.md",
+      "CLAUDE.md",
+      "TOOLS.md",
+      "BOOT.md",
+      "TASKS.md",
+    ]) {
+      expect(isProtectedInstructionFile(name)).toBe(true);
+    }
+  });
+});
+
+describe("wrapToolInstructionFileGuard", () => {
+  it("blocks write to SOUL.md", async () => {
+    const tool = createMockTool("write");
+    const guarded = wrapToolInstructionFileGuard(tool);
+    await expect(
+      guarded.execute("tc1", { path: "/workspace/SOUL.md", content: "hacked" }),
+    ).rejects.toThrow(/Write to instruction file "SOUL.md" is blocked/);
+    expect(tool.execute).not.toHaveBeenCalled();
+  });
+
+  it("blocks edit to CLAUDE.md", async () => {
+    const tool = createMockTool("edit");
+    const guarded = wrapToolInstructionFileGuard(tool);
+    await expect(
+      guarded.execute("tc2", { path: "CLAUDE.md", edits: [{ old: "a", new: "b" }] }),
+    ).rejects.toThrow(/Write to instruction file "CLAUDE.md" is blocked/);
+    expect(tool.execute).not.toHaveBeenCalled();
+  });
+
+  it("allows write to non-protected file", async () => {
+    const tool = createMockTool("write");
+    const guarded = wrapToolInstructionFileGuard(tool);
+    await guarded.execute("tc3", { path: "memory/2026-04-14.md", content: "notes" });
+    expect(tool.execute).toHaveBeenCalledOnce();
+  });
+
+  it("allows write when path is missing", async () => {
+    const tool = createMockTool("write");
+    const guarded = wrapToolInstructionFileGuard(tool);
+    await guarded.execute("tc4", { content: "no path" });
+    expect(tool.execute).toHaveBeenCalledOnce();
+  });
+
+  it("case-insensitive matching blocks soul.md", async () => {
+    const tool = createMockTool("write");
+    const guarded = wrapToolInstructionFileGuard(tool);
+    await expect(guarded.execute("tc5", { path: "/tmp/soul.md", content: "x" })).rejects.toThrow(
+      /Write to instruction file "soul.md" is blocked/,
+    );
+  });
+
+  it("passes through tool without execute", () => {
+    const tool = {
+      name: "noop",
+      description: "no exec",
+      inputSchema: {},
+    } as unknown as AnyAgentTool;
+    const guarded = wrapToolInstructionFileGuard(tool);
+    expect(guarded.execute).toBeUndefined();
+  });
+});

--- a/src/agents/pi-tools.instruction-file-guard.test.ts
+++ b/src/agents/pi-tools.instruction-file-guard.test.ts
@@ -61,6 +61,18 @@ describe("isProtectedInstructionFile", () => {
     expect(isProtectedInstructionFile("README.md.")).toBe(false);
     expect(isProtectedInstructionFile("notes.md.")).toBe(false);
   });
+
+  it("normalizes @-prefix bypass (resolvePathFromInput strips @)", () => {
+    expect(isProtectedInstructionFile("@SOUL.md")).toBe(true);
+    expect(isProtectedInstructionFile("@CLAUDE.md")).toBe(true);
+    expect(isProtectedInstructionFile("@IDENTITY.md")).toBe(true);
+    expect(isProtectedInstructionFile("@README.md")).toBe(false);
+  });
+
+  it("normalizes unicode space variants", () => {
+    expect(isProtectedInstructionFile("SOUL\u00A0.md")).toBe(true);
+    expect(isProtectedInstructionFile("CLAUDE\u200B.md")).toBe(true);
+  });
 });
 
 describe("wrapToolInstructionFileGuard", () => {

--- a/src/agents/pi-tools.instruction-file-guard.test.ts
+++ b/src/agents/pi-tools.instruction-file-guard.test.ts
@@ -50,6 +50,17 @@ describe("isProtectedInstructionFile", () => {
       expect(isProtectedInstructionFile(name)).toBe(true);
     }
   });
+
+  it("normalizes win32 trailing-dot aliases", () => {
+    expect(isProtectedInstructionFile("SOUL.md.")).toBe(true);
+    expect(isProtectedInstructionFile("CLAUDE.md..")).toBe(true);
+    expect(isProtectedInstructionFile("MEMORY.md. ")).toBe(true);
+  });
+
+  it("does not false-positive on similar names with trailing dots", () => {
+    expect(isProtectedInstructionFile("README.md.")).toBe(false);
+    expect(isProtectedInstructionFile("notes.md.")).toBe(false);
+  });
 });
 
 describe("wrapToolInstructionFileGuard", () => {

--- a/src/agents/pi-tools.instruction-file-guard.ts
+++ b/src/agents/pi-tools.instruction-file-guard.ts
@@ -24,9 +24,15 @@ const PROTECTED_BASENAMES = new Set([
 ]);
 
 export function isProtectedInstructionFile(filePath: string): boolean {
-  // Normalize: strip trailing dots/spaces (Windows aliases that resolve to the same file)
-  const basename = path.basename(filePath).toLowerCase().replace(/[\s.]+$/, "");
-  return PROTECTED_BASENAMES.has(basename);
+  // Normalize to match what the write/patch path resolution pipeline does:
+  // 1. Strip leading @ (normalizeAtPrefix in sandbox-paths.ts)
+  // 2. Strip unicode space variants (normalizeUnicodeSpaces)
+  // 3. Strip trailing dots/spaces (Windows aliases: SOUL.md. → SOUL.md)
+  let normalized = filePath.replace(/^@/, "");
+  normalized = path.basename(normalized).toLowerCase().replace(/[\s.]+$/, "");
+  // Also strip common unicode space chars that normalizeUnicodeSpaces handles
+  normalized = normalized.replace(/[\u00A0\u2000-\u200B\u202F\u205F\u3000\uFEFF]/g, "");
+  return PROTECTED_BASENAMES.has(normalized);
 }
 
 export function wrapToolInstructionFileGuard(tool: AnyAgentTool): AnyAgentTool {

--- a/src/agents/pi-tools.instruction-file-guard.ts
+++ b/src/agents/pi-tools.instruction-file-guard.ts
@@ -24,7 +24,8 @@ const PROTECTED_BASENAMES = new Set([
 ]);
 
 export function isProtectedInstructionFile(filePath: string): boolean {
-  const basename = path.basename(filePath).toLowerCase();
+  // Normalize: strip trailing dots/spaces (Windows aliases that resolve to the same file)
+  const basename = path.basename(filePath).toLowerCase().replace(/[\s.]+$/, "");
   return PROTECTED_BASENAMES.has(basename);
 }
 

--- a/src/agents/pi-tools.instruction-file-guard.ts
+++ b/src/agents/pi-tools.instruction-file-guard.ts
@@ -1,0 +1,56 @@
+/**
+ * Instruction File Write Guard
+ *
+ * Prevents agent sessions from overwriting their own instruction files
+ * (SOUL.md, MEMORY.md, IDENTITY.md, CLAUDE.md, TOOLS.md, BOOT.md, TASKS.md)
+ * without explicit operator approval. This mitigates prompt injection attacks
+ * where a compromised session removes safety constraints from its own files.
+ */
+import path from "node:path";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getToolParamsRecord } from "./pi-tools.params.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+const log = createSubsystemLogger("agents/instruction-file-guard");
+
+const PROTECTED_BASENAMES = new Set([
+  "soul.md",
+  "memory.md",
+  "identity.md",
+  "claude.md",
+  "tools.md",
+  "boot.md",
+  "tasks.md",
+]);
+
+export function isProtectedInstructionFile(filePath: string): boolean {
+  const basename = path.basename(filePath).toLowerCase();
+  return PROTECTED_BASENAMES.has(basename);
+}
+
+export function wrapToolInstructionFileGuard(tool: AnyAgentTool): AnyAgentTool {
+  const execute = tool.execute;
+  if (!execute) {
+    return tool;
+  }
+  return {
+    ...tool,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const record = getToolParamsRecord(args);
+      const filePath = typeof record?.path === "string" ? record.path.trim() : "";
+      if (filePath && isProtectedInstructionFile(filePath)) {
+        const basename = path.basename(filePath);
+        log.warn(
+          `Blocked ${tool.name} targeting protected instruction file: ${basename} (${filePath})`,
+        );
+        throw new Error(
+          `Write to instruction file "${basename}" is blocked. ` +
+            `Agent sessions cannot modify protected instruction files ` +
+            `(${[...PROTECTED_BASENAMES].join(", ")}). ` +
+            `Ask the operator to make this change directly.`,
+        );
+      }
+      return execute(toolCallId, args, signal, onUpdate);
+    },
+  };
+}

--- a/src/agents/pi-tools.instruction-file-guard.ts
+++ b/src/agents/pi-tools.instruction-file-guard.ts
@@ -6,6 +6,7 @@
  * without explicit operator approval. This mitigates prompt injection attacks
  * where a compromised session removes safety constraints from its own files.
  */
+import fs from "node:fs";
 import path from "node:path";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getToolParamsRecord } from "./pi-tools.params.js";
@@ -45,7 +46,12 @@ export function wrapToolInstructionFileGuard(tool: AnyAgentTool): AnyAgentTool {
     execute: async (toolCallId, args, signal, onUpdate) => {
       const record = getToolParamsRecord(args);
       const filePath = typeof record?.path === "string" ? record.path.trim() : "";
-      if (filePath && isProtectedInstructionFile(filePath)) {
+      // Check both the literal path and the resolved target (symlink defense).
+      const resolvedPath = filePath ? safeRealpath(filePath) : "";
+      if (
+        filePath &&
+        (isProtectedInstructionFile(filePath) || (resolvedPath && isProtectedInstructionFile(resolvedPath)))
+      ) {
         const basename = path.basename(filePath);
         log.warn(
           `Blocked ${tool.name} targeting protected instruction file: ${basename} (${filePath})`,
@@ -60,4 +66,13 @@ export function wrapToolInstructionFileGuard(tool: AnyAgentTool): AnyAgentTool {
       return execute(toolCallId, args, signal, onUpdate);
     },
   };
+}
+
+/** Resolve symlinks without throwing on non-existent paths. */
+function safeRealpath(filePath: string): string {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return "";
+  }
 }

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -25,6 +25,7 @@ import { createOpenClawTools } from "./openclaw-tools.js";
 import { wrapToolWithAbortSignal } from "./pi-tools.abort.js";
 import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
 import { applyDeferredFollowupToolDescriptions } from "./pi-tools.deferred-followup.js";
+import { wrapToolInstructionFileGuard } from "./pi-tools.instruction-file-guard.js";
 import { filterToolsByMessageProvider } from "./pi-tools.message-provider-policy.js";
 import {
   isToolAllowedByPolicies,
@@ -452,14 +453,18 @@ export function createOpenClawCodingTools(options?: {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
+      const wrapped = wrapToolInstructionFileGuard(
+        createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly }),
+      );
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
+      const wrapped = wrapToolInstructionFileGuard(
+        createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly }),
+      );
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
     }
     return [tool];
@@ -526,22 +531,30 @@ export function createOpenClawCodingTools(options?: {
         ? [
             workspaceOnly
               ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                  wrapToolInstructionFileGuard(
+                    createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                  ),
                   sandboxRoot,
                   {
                     containerWorkdir: sandbox.containerWorkdir,
                   },
                 )
-              : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+              : wrapToolInstructionFileGuard(
+                  createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                ),
             workspaceOnly
               ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                  wrapToolInstructionFileGuard(
+                    createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                  ),
                   sandboxRoot,
                   {
                     containerWorkdir: sandbox.containerWorkdir,
                   },
                 )
-              : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+              : wrapToolInstructionFileGuard(
+                  createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                ),
           ]
         : []
       : []),


### PR DESCRIPTION
## Summary
- Adds a write/edit guard that blocks agent sessions from overwriting instruction files without explicit approval
- Targets a known CVE class: prompt injection via memory/identity poisoning, where a compromised session overwrites SOUL.md, CLAUDE.md, MEMORY.md etc. to remove safety constraints
- A keyword-clean memory poisoning attack (no suspicious tokens, just behavioral nudges) can bypass all existing content-level checks — this guard catches it at the file level regardless of content

## Protected files
`SOUL.md`, `MEMORY.md`, `IDENTITY.md`, `CLAUDE.md`, `TOOLS.md`, `BOOT.md`, `TASKS.md` (case-insensitive, basename match)

## Changes
- **New**: `pi-tools.instruction-file-guard.ts` (~50 lines) — `isProtectedInstructionFile()` and `wrapToolInstructionFileGuard()` 
- **Modified**: `pi-tools.ts` — wraps all 4 write/edit tool creation points (host write, host edit, sandboxed write, sandboxed edit)
- **Tests**: 11 cases covering blocked writes, allowed non-protected files, case-insensitive matching, nested paths, edge cases

## Design decisions
- Innermost wrapper (before workspace root guards), following existing `wrapTool*` pattern
- Blocks with error + warning log, rather than silent drop — agent sees the rejection
- Basename-only matching — protects the file regardless of path prefix
- Minimal scope: ~50 lines of logic, zero architectural risk

## Test plan
- [ ] Write to SOUL.md is blocked
- [ ] Write to memory/2026-04-14.md is allowed
- [ ] Edit to CLAUDE.md is blocked
- [ ] Case-insensitive matching works
- [ ] All pi-tools instruction-file-guard tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)