### PR TITLE
fix: return 1M context for Anthropic Opus/Sonnet 4 without requiring context1m flag

### DIFF
--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -228,6 +228,36 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
+  it("respects context1m: false opt-out for opus/sonnet-4", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            anthropic: {
+              baseUrl: "https://api.anthropic.com",
+              models: [testModelContextWindow("claude-opus-4-6", 200_000)],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-opus-4-6": {
+                params: { context1m: false },
+            },
+          },
+        },
+      },
+    },
+    provider: "anthropic",
+    model: "claude-opus-4-6",
+    fallbackContextTokens: 200_000,
+    allowAsyncLoad: false,
+  });
+
+  expect(result).toBe(200_000);
+});
+
   it("does not force 1M context for non-opus/sonnet Anthropic models", () => {
     const result = resolveContextTokensForModel({
       cfg: {

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -168,7 +168,7 @@ describe("createSessionManagerRuntimeRegistry", () => {
 });
 
 describe("resolveContextTokensForModel", () => {
-  it("returns 1M context when anthropic context1m is enabled for opus/sonnet", () => {
+  it("returns 1M context for Anthropic opus/sonnet-4 models", () => {
     const result = resolveContextTokensForModel({
       cfg: {
         models: {
@@ -198,7 +198,7 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
-  it("does not force 1M context when context1m is not enabled", () => {
+  it("returns 1M context for opus/sonnet-4 even without context1m flag", () => {
     const result = resolveContextTokensForModel({
       cfg: {
         models: {
@@ -225,7 +225,7 @@ describe("resolveContextTokensForModel", () => {
       allowAsyncLoad: false,
     });
 
-    expect(result).toBe(200_000);
+    expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
   });
 
   it("does not force 1M context for non-opus/sonnet Anthropic models", () => {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -22,6 +22,7 @@ type ModelRegistryLike = {
 type ConfigModelEntry = { id?: string; contextWindow?: number; contextTokens?: number };
 type ProviderConfigEntry = { models?: ConfigModelEntry[] };
 type ModelsConfig = { providers?: Record<string, ProviderConfigEntry | undefined> };
+type AgentModelEntry = { params?: Record<string, unknown> };
 
 const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as const;
 export const ANTHROPIC_CONTEXT_1M_TOKENS = 1_048_576;
@@ -263,6 +264,25 @@ if (shouldEagerWarmContextWindowCache()) {
   void ensureContextWindowCacheLoaded();
 }
 
+function resolveConfiguredModelParams(
+  cfg: OpenClawConfig | undefined,
+  provider: string,
+  model: string,
+): Record<string, unknown> | undefined {
+  const models = cfg?.agents?.defaults?.models;
+  if (!models) {
+    return undefined;
+  }
+  const key = normalizeLowercaseStringOrEmpty(`${provider}/${model}`);
+  for (const [rawKey, entry] of Object.entries(models)) {
+    if (normalizeLowercaseStringOrEmpty(rawKey) === key) {
+      const params = (entry as AgentModelEntry | undefined)?.params;
+      return params && typeof params === "object" ? params : undefined;
+    }
+  }
+  return undefined;
+}
+
 function resolveProviderModelRef(params: {
   provider?: string;
   model?: string;
@@ -379,8 +399,17 @@ export function resolveContextTokensForModel(params: {
   });
   const explicitProvider = params.provider?.trim();
   if (ref) {
+    const modelParams = resolveConfiguredModelParams(params.cfg, ref.provider, ref.model);
     if (isAnthropic1MModel(ref.provider, ref.model)) {
-      return ANTHROPIC_CONTEXT_1M_TOKENS;
+      // Respect explicit context1m: false opt-out (e.g. for OAuth/legacy
+      // token auth where Anthropic strips the context-1m beta header).
+      // context1m: true is a no-op now since isAnthropic1MModel already
+      // returns true; absence of the flag no longer prevents 1M context.
+      if (modelParams?.context1m === false) {
+        // Fall through to configured/discovered window
+      } else {
+        return ANTHROPIC_CONTEXT_1M_TOKENS;
+      }
     }
     // Only do the config direct scan when the caller explicitly passed a
     // provider. When provider is inferred from a slash in the model string

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -22,7 +22,6 @@ type ModelRegistryLike = {
 type ConfigModelEntry = { id?: string; contextWindow?: number; contextTokens?: number };
 type ProviderConfigEntry = { models?: ConfigModelEntry[] };
 type ModelsConfig = { providers?: Record<string, ProviderConfigEntry | undefined> };
-type AgentModelEntry = { params?: Record<string, unknown> };
 
 const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as const;
 export const ANTHROPIC_CONTEXT_1M_TOKENS = 1_048_576;
@@ -264,25 +263,6 @@ if (shouldEagerWarmContextWindowCache()) {
   void ensureContextWindowCacheLoaded();
 }
 
-function resolveConfiguredModelParams(
-  cfg: OpenClawConfig | undefined,
-  provider: string,
-  model: string,
-): Record<string, unknown> | undefined {
-  const models = cfg?.agents?.defaults?.models;
-  if (!models) {
-    return undefined;
-  }
-  const key = normalizeLowercaseStringOrEmpty(`${provider}/${model}`);
-  for (const [rawKey, entry] of Object.entries(models)) {
-    if (normalizeLowercaseStringOrEmpty(rawKey) === key) {
-      const params = (entry as AgentModelEntry | undefined)?.params;
-      return params && typeof params === "object" ? params : undefined;
-    }
-  }
-  return undefined;
-}
-
 function resolveProviderModelRef(params: {
   provider?: string;
   model?: string;
@@ -399,8 +379,7 @@ export function resolveContextTokensForModel(params: {
   });
   const explicitProvider = params.provider?.trim();
   if (ref) {
-    const modelParams = resolveConfiguredModelParams(params.cfg, ref.provider, ref.model);
-    if (modelParams?.context1m === true && isAnthropic1MModel(ref.provider, ref.model)) {
+    if (isAnthropic1MModel(ref.provider, ref.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
     }
     // Only do the config direct scan when the caller explicitly passed a


### PR DESCRIPTION
## Summary

Fixes #66766
Supersedes #66790 (same core fix, also addresses Greptile blocking issues)

Previously, `resolveContextTokensForModel()` required both `isAnthropic1MModel()` AND `params.context1m === true` to return 1M context tokens. This meant users had to manually add `context1m: true` to their model config, even though the model identity alone (matching `claude-opus-4` or `claude-sonnet-4` prefixes) is sufficient to determine 1M support.

The `context1m` config flag was a redundant gate: it only triggered for models already identified as 1M-capable by the prefix check, so it served as an opt-out rather than an opt-in — the opposite of what users expected.

## Changes

- **`src/agents/context.ts`**: `isAnthropic1MModel()` alone triggers the 1M return, no config flag needed
- **`src/agents/context.ts`**: `context1m: false` explicitly opts out of 1M return (for OAuth/legacy token auth where Anthropic strips the `context-1m` beta header)
- **`src/agents/context.ts`**: Removed dead `resolveConfiguredModelParams()` helper and `AgentModelEntry` type (re-added for `context1m: false` opt-out support)
- **`src/agents/context.test.ts`**: Updated test title and expectation for opus-4-6 without `context1m` (fixes stale test flagged by Greptile)
- **`src/agents/context.test.ts`**: Added test for `context1m: false` opt-out

## Test plan

- [x] All 14 tests in `src/agents/context.test.ts` pass
- [x] `claude-opus-4-6` without `context1m` flag now returns 1M (was 200k)
- [x] `claude-haiku-3-5` with `context1m: true` still returns 200k (non-1M model not in prefix list)
- [x] `claude-opus-4-6` with `context1m: false` returns 200k (opt-out for OAuth auth)