### PR TITLE
feat(auth): add models auth clean command to prune stale auth profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Auth/CLI: add `openclaw models auth clean` to prune stale auth profile entries no longer referenced by `openclaw.json` (auth.profiles, auth.order, or tools.media model entries), with `--dry-run`, `--json`, and `--agent` flags, atomic file-locked writes, and sanitized profile-id display. (#66911) Thanks @amittell.
 - Gateway/startup: skip plugin-backed auth-profile overlays during startup secrets preflight, reducing gateway readiness latency while keeping reload and OAuth recovery paths overlay-capable. (#68327) Thanks @JIRBOY.
 - Plugins/ClawHub: make diagnostics, onboarding, doctor repair, and channel setup carry ClawPack metadata through install records while keeping explicit `clawhub:` installs on ClawHub and bare package installs on npm for the launch cutover. Thanks @vincentkoc.
 - Plugins/runtime: scope broad runtime preloads to the effective plugin ids derived from config, startup planning, configured channels, slots, and auto-enable rules instead of importing every discoverable plugin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2550,6 +2550,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Auth/CLI: add `openclaw models auth clean` to prune stale auth profile entries no longer referenced by `openclaw.json` (auth.profiles, auth.order, or tools.media model entries), with `--dry-run`, `--json`, and `--agent` flags, atomic file-locked writes, and sanitized profile-id display. (#66911) Thanks @amittell.
 - Gateway/startup: skip plugin-backed auth-profile overlays during startup secrets preflight, reducing gateway readiness latency while keeping reload and OAuth recovery paths overlay-capable. (#68327) Thanks @JIRBOY.
 - Plugins/ClawHub: make diagnostics, onboarding, doctor repair, and channel setup carry ClawPack metadata through install records while keeping explicit `clawhub:` installs on ClawHub and bare package installs on npm for the launch cutover. Thanks @vincentkoc.
 - Plugins/runtime: scope broad runtime preloads to the effective plugin ids derived from config, startup planning, configured channels, slots, and auto-enable rules instead of importing every discoverable plugin.

--- a/src/agents/auth-profiles/doctor.ts
+++ b/src/agents/auth-profiles/doctor.ts
@@ -1,6 +1,10 @@
+import { formatCliCommand } from "../../cli/command-format.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { buildProviderAuthDoctorHintWithPlugin } from "../../plugins/provider-runtime.runtime.js";
 import { normalizeProviderId } from "../provider-id.js";
+import { listProfilesForProvider } from "./profiles.js";
+import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
+import { sanitizeProfileIdForDisplay } from "./sanitize.js";
 import type { AuthProfileStore } from "./types.js";
 
 /**
@@ -11,6 +15,10 @@ const DEPRECATED_PROVIDER_MIGRATION_HINTS: Record<string, string> = {
   "qwen-portal":
     "Qwen OAuth via portal.qwen.ai has been deprecated. Please migrate to Qwen Cloud Coding Plan. Run: openclaw onboard --auth-choice qwen-api-key (or qwen-api-key-cn for the China endpoint). Legacy modelstudio auth-choice ids still work.",
 };
+
+function sanitizeDoctorDisplayValue(value: unknown): string | undefined {
+  return typeof value === "string" ? sanitizeProfileIdForDisplay(value) : undefined;
+}
 
 export async function formatAuthDoctorHint(params: {
   cfg?: OpenClawConfig;
@@ -38,5 +46,44 @@ export async function formatAuthDoctorHint(params: {
   if (typeof pluginHint === "string" && pluginHint.trim()) {
     return pluginHint;
   }
-  return "";
+
+  const legacyProfileId = params.profileId ?? "anthropic:default";
+  const suggested = suggestOAuthProfileIdForLegacyDefault({
+    cfg: params.cfg,
+    store: params.store,
+    provider: normalizedProvider,
+    legacyProfileId,
+  });
+  if (!suggested || suggested === legacyProfileId) {
+    return "";
+  }
+
+  const storeOauthProfiles = listProfilesForProvider(params.store, normalizedProvider)
+    .filter((id) => params.store.profiles[id]?.type === "oauth")
+    .map((id) => sanitizeDoctorDisplayValue(id) ?? "")
+    .join(", ");
+
+  const cfgMode = params.cfg?.auth?.profiles?.[legacyProfileId]?.mode;
+  const cfgProvider = params.cfg?.auth?.profiles?.[legacyProfileId]?.provider;
+
+  // Sanitize all user/config-derived display fields before embedding them in
+  // error/log output to prevent terminal injection via crafted values.
+  const safeProvider = sanitizeDoctorDisplayValue(normalizedProvider) ?? normalizedProvider;
+  const safeConfigProvider = sanitizeDoctorDisplayValue(cfgProvider);
+  const safeConfigMode = sanitizeDoctorDisplayValue(cfgMode);
+  const safeProfileId = sanitizeDoctorDisplayValue(legacyProfileId) ?? legacyProfileId;
+  const safeSuggested = sanitizeDoctorDisplayValue(suggested) ?? suggested;
+
+  return [
+    "Doctor hint (for GitHub issue):",
+    `- provider: ${safeProvider}`,
+    `- config: ${safeProfileId}${
+      safeConfigProvider || safeConfigMode
+        ? ` (provider=${safeConfigProvider ?? "?"}, mode=${safeConfigMode ?? "?"})`
+        : ""
+    }`,
+    `- auth store oauth profiles: ${storeOauthProfiles || "(none)"}`,
+    `- suggested profile: ${safeSuggested}`,
+    `Fix: run "${formatCliCommand("openclaw doctor --yes")}"`,
+  ].join("\n");
 }

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -109,7 +109,7 @@ export function resolveAuthProfileOrder(params: {
     }).eligible;
   let filtered = baseOrder.filter(isValidProfile);
 
-  // Repair config/store profile-id drift from older setup flows:
+  // Repair config/store profile-id drift from older onboarding flows:
   // if configured profile ids no longer exist in auth-profiles.json, scan the
   // provider's stored credentials and use any valid entries.
   const allBaseProfilesMissing = baseOrder.every((profileId) => !store.profiles[profileId]);

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -299,7 +299,7 @@ export function resolveAuthProfileOrder(params: {
     }).eligible;
   let filtered = baseOrder.filter(isValidProfile);
 
-  // Repair config/store profile-id drift from older setup flows:
+  // Repair config/store profile-id drift from older onboarding flows:
   // if configured profile ids no longer exist in auth-profiles.json, scan the
   // provider's stored credentials and use any valid entries.
   const allBaseProfilesMissing = baseOrder.every((profileId) => !store.profiles[profileId]);

--- a/src/agents/auth-profiles/sanitize.test.ts
+++ b/src/agents/auth-profiles/sanitize.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeProfileIdForDisplay, validateProfileId } from "./sanitize.js";
+
+describe("sanitizeProfileIdForDisplay", () => {
+  it("passes through clean profile IDs unchanged", () => {
+    expect(sanitizeProfileIdForDisplay("openai-codex:user")).toBe("openai-codex:user");
+  });
+
+  it("strips ANSI escape sequences", () => {
+    expect(sanitizeProfileIdForDisplay("pre\x1b[31mred\x1b[0mpost")).toBe("preredpost");
+  });
+
+  it("strips C0 and C1 control characters", () => {
+    expect(sanitizeProfileIdForDisplay("a\x00b\x1fc\x7fd\x9be")).toBe("abcde");
+  });
+});
+
+describe("validateProfileId", () => {
+  it("accepts simple alphanumeric IDs", () => {
+    expect(validateProfileId("myprofile123")).toBeNull();
+  });
+
+  it("accepts IDs with dots, underscores, colons, and hyphens", () => {
+    expect(validateProfileId("openai-codex:my_profile.v2")).toBeNull();
+  });
+
+  it("accepts IDs with @ and + (OAuth-generated profile IDs)", () => {
+    expect(validateProfileId("openai-codex:user+alias@example.com")).toBeNull();
+  });
+
+  it("rejects empty IDs", () => {
+    expect(validateProfileId("")).toBe("Profile ID must not be empty.");
+  });
+
+  it("rejects IDs longer than 128 characters", () => {
+    const long = "a".repeat(129);
+    expect(validateProfileId(long)).toBe(`Profile ID must be at most 128 characters (got 129).`);
+  });
+
+  it("rejects IDs with spaces", () => {
+    expect(validateProfileId("has space")).toMatch(/may only contain/);
+  });
+
+  it("rejects IDs with shell metacharacters", () => {
+    expect(validateProfileId("profile;rm -rf /")).toMatch(/may only contain/);
+  });
+
+  it("rejects reserved object-property profile IDs", () => {
+    expect(validateProfileId("__proto__")).toBe(
+      "Profile ID '__proto__' is reserved and may not be used.",
+    );
+  });
+
+  it("rejects IDs with ANSI escape sequences", () => {
+    expect(validateProfileId("pre\x1b[31mred")).toMatch(/may only contain/);
+  });
+});

--- a/src/agents/auth-profiles/sanitize.test.ts
+++ b/src/agents/auth-profiles/sanitize.test.ts
@@ -28,21 +28,26 @@ describe("validateProfileId", () => {
     expect(validateProfileId("openai-codex:user+alias@example.com")).toBeNull();
   });
 
+  it("preserves the arbitrary-key contract: accepts spaces and other characters", () => {
+    // Auth profile IDs are arbitrary string keys; pre-existing IDs with spaces
+    // or punctuation must remain targetable from the CLI.
+    expect(validateProfileId("has space")).toBeNull();
+    expect(validateProfileId("profile;weird&chars")).toBeNull();
+    expect(validateProfileId("legacy/id.with-slashes")).toBeNull();
+  });
+
   it("rejects empty IDs", () => {
     expect(validateProfileId("")).toBe("Profile ID must not be empty.");
   });
 
-  it("rejects IDs longer than 128 characters", () => {
-    const long = "a".repeat(129);
-    expect(validateProfileId(long)).toBe(`Profile ID must be at most 128 characters (got 129).`);
+  it("rejects pathologically long IDs (over 512 chars)", () => {
+    const long = "a".repeat(513);
+    expect(validateProfileId(long)).toBe(`Profile ID must be at most 512 characters (got 513).`);
   });
 
-  it("rejects IDs with spaces", () => {
-    expect(validateProfileId("has space")).toMatch(/may only contain/);
-  });
-
-  it("rejects IDs with shell metacharacters", () => {
-    expect(validateProfileId("profile;rm -rf /")).toMatch(/may only contain/);
+  it("accepts realistic long IDs (over the old 128 cap)", () => {
+    // Regression: the old 128-char grammar broke existing longer IDs.
+    expect(validateProfileId("openai-codex:" + "x".repeat(150))).toBeNull();
   });
 
   it("rejects reserved object-property profile IDs", () => {
@@ -51,7 +56,9 @@ describe("validateProfileId", () => {
     );
   });
 
-  it("rejects IDs with ANSI escape sequences", () => {
-    expect(validateProfileId("pre\x1b[31mred")).toMatch(/may only contain/);
+  it("rejects IDs with control characters (terminal/log injection)", () => {
+    expect(validateProfileId("pre\x1b[31mred")).toMatch(/control or escape characters/);
+    expect(validateProfileId("line\nbreak")).toMatch(/control or escape characters/);
+    expect(validateProfileId("nul\x00byte")).toMatch(/control or escape characters/);
   });
 });

--- a/src/agents/auth-profiles/sanitize.ts
+++ b/src/agents/auth-profiles/sanitize.ts
@@ -1,0 +1,62 @@
+/**
+ * Canonical sanitizer for auth profile IDs before embedding in terminal/log
+ * output. Strips ANSI escape sequences and control characters to prevent
+ * terminal injection (log forging) via maliciously crafted profile IDs.
+ *
+ * Handles:
+ *   - Standard CSI:  ESC [ ... final        e.g. \x1b[31m, \x1b[1;32m
+ *   - Private CSI:   ESC [ ? ... final       e.g. \x1b[?25l (cursor hide)
+ *   - OSC:           ESC ] ... BEL/ST        e.g. \x1b]0;title\x07
+ *   - DCS/SOS/PM/APC: ESC P/X/^/_ ... ST   e.g. \x1bPdata\x1b\\
+ *   - Other Fe:      ESC <single char>       e.g. \x1bc (RIS reset)
+ *   - Bare ESC:      ESC at end of string    e.g. "myprofile\x1b"
+ *   - C0 controls:   U+0000-U+001F          (includes CR, LF, TAB, etc.)
+ *   - DEL:           U+007F
+ *   - C1 controls:   U+0080-U+009F          (includes 8-bit CSI \x9b)
+ */
+export function sanitizeProfileIdForDisplay(id: string): string {
+  return (
+    id
+      // Strip 7-bit ESC-prefixed ANSI/VT control sequences (CSI, OSC, DCS, APC, PM, SOS,
+      // private-use, and bare ESC + any char) to prevent terminal injection via profile IDs.
+      .replace(
+        // eslint-disable-next-line no-control-regex -- intentional: regex must match control chars to strip them
+        /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*\x1b\\|[\s\S]?)/g,
+        "",
+      )
+      // Strip C0 controls (U+0000-U+001F), DEL (U+007F), and C1 controls (U+0080-U+009F).
+      // C1 includes \x9b which can construct CSI sequences on xterm-compatible terminals
+      // without a leading ESC byte, bypassing the 7-bit escape strip above.
+      // C0 includes CR/LF so no separate newline strip is needed.
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\u0000-\u001f\u007f\u0080-\u009f]/g, "")
+  );
+}
+
+/** Safe character set for profile IDs: letters, digits, `.`, `_`, `:`, `-`, `+`, `@`. */
+const MAX_PROFILE_ID_LENGTH = 128;
+const PROFILE_ID_PATTERN = /^[a-zA-Z0-9._:+\-@]{1,128}$/;
+const RESERVED_PROFILE_IDS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Validate a profile ID string against a safe character set at the CLI input
+ * boundary. Rejects control characters, ANSI sequences, and any character
+ * outside the allowed set before the value reaches deeper auth logic.
+ *
+ * @returns null when valid, or a human-readable error string when invalid.
+ */
+export function validateProfileId(id: string): string | null {
+  if (!id) {
+    return "Profile ID must not be empty.";
+  }
+  if (id.length > MAX_PROFILE_ID_LENGTH) {
+    return `Profile ID must be at most ${MAX_PROFILE_ID_LENGTH} characters (got ${id.length}).`;
+  }
+  if (RESERVED_PROFILE_IDS.has(id)) {
+    return `Profile ID '${id}' is reserved and may not be used.`;
+  }
+  if (!PROFILE_ID_PATTERN.test(id)) {
+    return "Profile ID may only contain letters, digits, '.', '_', ':', '-', '+', and '@'.";
+  }
+  return null;
+}

--- a/src/agents/auth-profiles/sanitize.ts
+++ b/src/agents/auth-profiles/sanitize.ts
@@ -33,15 +33,24 @@ export function sanitizeProfileIdForDisplay(id: string): string {
   );
 }
 
-/** Safe character set for profile IDs: letters, digits, `.`, `_`, `:`, `-`, `+`, `@`. */
-const MAX_PROFILE_ID_LENGTH = 128;
-const PROFILE_ID_PATTERN = /^[a-zA-Z0-9._:+\-@]{1,128}$/;
+// Generous upper bound to stop pathological multi-KB keys without rejecting any
+// realistic provider:label profile ID.
+const MAX_PROFILE_ID_LENGTH = 512;
 const RESERVED_PROFILE_IDS = new Set(["__proto__", "constructor", "prototype"]);
+// Control chars (C0/C1), DEL, and 8-bit CSI enable terminal/log injection when a
+// profile ID is echoed. These are the only characters that are genuinely unsafe
+// in an ID; everything else is a legitimate arbitrary object key.
+// eslint-disable-next-line no-control-regex -- intentional: must match control chars to reject them
+const PROFILE_ID_CONTROL_CHAR_PATTERN = /[\u0000-\u001f\u007f\u0080-\u009f]/;
 
 /**
- * Validate a profile ID string against a safe character set at the CLI input
- * boundary. Rejects control characters, ANSI sequences, and any character
- * outside the allowed set before the value reaches deeper auth logic.
+ * Validate a profile ID at the CLI input boundary. Auth profile IDs are
+ * arbitrary string keys in config and the store, so this only rejects the
+ * genuinely unsafe cases — empty, prototype-pollution reserved names, control/
+ * escape characters (terminal/log injection), and pathologically long values —
+ * while preserving the existing free-form ID contract so any pre-existing
+ * profile can still be targeted. Display output is separately sanitized via
+ * {@link sanitizeProfileIdForDisplay}.
  *
  * @returns null when valid, or a human-readable error string when invalid.
  */
@@ -55,8 +64,8 @@ export function validateProfileId(id: string): string | null {
   if (RESERVED_PROFILE_IDS.has(id)) {
     return `Profile ID '${id}' is reserved and may not be used.`;
   }
-  if (!PROFILE_ID_PATTERN.test(id)) {
-    return "Profile ID may only contain letters, digits, '.', '_', ':', '-', '+', and '@'.";
+  if (PROFILE_ID_CONTROL_CHAR_PATTERN.test(id)) {
+    return "Profile ID may not contain control or escape characters.";
   }
   return null;
 }

--- a/src/agents/auth-profiles/store.legacy-migration.test.ts
+++ b/src/agents/auth-profiles/store.legacy-migration.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for legacy auth.json → auth-profiles.json migration behaviour in
+ * loadAuthProfileStoreForAgent (via loadAgentLocalAuthProfileStore).
+ *
+ * These tests use a real temporary filesystem directory so the migration code
+ * path is exercised end-to-end without mocking file I/O.
+ *
+ * Focus: fix for #2914491523 — legacy migration (auth.json → auth-profiles.json)
+ * is suppressed when readOnly:true.  The probe call that precedes
+ * updateAuthProfileStoreWithLock uses readOnly:false so migration still runs
+ * before ensureAuthStoreFile can create an empty placeholder.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadAgentLocalAuthProfileStore } from "./store.js";
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function writeLegacyAuthJson(dir: string, data: Record<string, unknown>): void {
+  fs.writeFileSync(path.join(dir, "auth.json"), JSON.stringify(data));
+}
+
+function readAuthProfilesJson(dir: string): Record<string, unknown> | null {
+  const p = path.join(dir, "auth-profiles.json");
+  if (!fs.existsSync(p)) {
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(p, "utf-8")) as Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+describe("loadAgentLocalAuthProfileStore – legacy migration with readOnly:true (#2914491523)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "auth-store-migration-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("does not write auth-profiles.json or delete auth.json when readOnly:true", () => {
+    writeLegacyAuthJson(tmpDir, {
+      anthropic: { type: "api_key", provider: "anthropic", key: "sk-test" },
+    });
+
+    const store = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    // Profiles should be present in the returned in-memory store
+    expect(store.profiles["anthropic:default"]).toBeDefined();
+    expect(store.profiles["anthropic:default"]?.type).toBe("api_key");
+
+    // auth-profiles.json must NOT have been written (migration suppressed when readOnly:true)
+    const migrated = readAuthProfilesJson(tmpDir);
+    expect(migrated).toBeNull();
+
+    // legacy auth.json must NOT have been deleted (readOnly suppresses all file writes)
+    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(true);
+  });
+
+  it("returns in-memory profiles matching what was in auth.json (readOnly:true)", () => {
+    writeLegacyAuthJson(tmpDir, {
+      openai: { type: "api_key", provider: "openai", key: "sk-openai" },
+      anthropic: { type: "token", provider: "anthropic", token: "tk-anth", expires: 9999999999 },
+    });
+
+    const store = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    // Both legacy profiles should be migrated and visible
+    expect(store.profiles["openai:default"]?.type).toBe("api_key");
+    expect(store.profiles["anthropic:default"]?.type).toBe("token");
+  });
+
+  it("does not create auth-profiles.json when legacy auth.json is absent (readOnly:true)", () => {
+    // No files in tmpDir — nothing to migrate
+    loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    expect(readAuthProfilesJson(tmpDir)).toBeNull();
+    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(false);
+  });
+
+  it("does not overwrite existing auth-profiles.json body when readOnly:true and no legacy", () => {
+    // Write an existing auth-profiles.json (no auth.json)
+    const existing = {
+      version: 1,
+      profiles: { "anthropic:existing": { type: "api_key", provider: "anthropic", key: "sk-ex" } },
+    };
+    fs.writeFileSync(path.join(tmpDir, "auth-profiles.json"), JSON.stringify(existing));
+
+    // Load with readOnly:true — no legacy present, so no migration; existing file unchanged
+    const store = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    // In-memory store should have the existing profile
+    expect(store.profiles["anthropic:existing"]).toBeDefined();
+
+    // File content should be unchanged (readOnly suppresses external-CLI / OAuth sync)
+    const after = readAuthProfilesJson(tmpDir);
+    expect(after).toEqual(existing);
+  });
+
+  it("migration semantics are preserved when readOnly:false (existing behaviour)", () => {
+    writeLegacyAuthJson(tmpDir, {
+      anthropic: { type: "api_key", provider: "anthropic", key: "sk-test" },
+    });
+
+    const store = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: false });
+
+    expect(store.profiles["anthropic:default"]).toBeDefined();
+    expect(readAuthProfilesJson(tmpDir)).not.toBeNull();
+    // legacy auth.json should be deleted after migration
+    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(false);
+  });
+
+  it("ensures updateAuthProfileStoreWithLock sees migrated profiles, not empty store", () => {
+    // Regression test for #2914491523.
+    // The correct fix is to probe with readOnly:false so migration runs before
+    // updateAuthProfileStoreWithLock's ensureAuthStoreFile can create an empty placeholder.
+    //
+    // This test validates the readOnly:true probe behaviour (no writes) and confirms
+    // that a subsequent readOnly:false load still migrates correctly from the
+    // untouched auth.json.
+    writeLegacyAuthJson(tmpDir, {
+      anthropic: { type: "api_key", provider: "anthropic", key: "sk-legacy" },
+    });
+
+    // Simulate a readOnly:true probe — must NOT create auth-profiles.json
+    loadAgentLocalAuthProfileStore(tmpDir, { readOnly: true });
+
+    const authProfilesPath = path.join(tmpDir, "auth-profiles.json");
+    // readOnly probe leaves the filesystem untouched
+    expect(fs.existsSync(authProfilesPath)).toBe(false);
+    // auth.json still present — not deleted by readOnly probe
+    expect(fs.existsSync(path.join(tmpDir, "auth.json"))).toBe(true);
+
+    // Simulate the write-enabled load inside the lock (readOnly:false default)
+    // — it still sees auth.json and performs the migration
+    const freshStore = loadAgentLocalAuthProfileStore(tmpDir, { readOnly: false });
+
+    // The write-enabled load must see the migrated profiles, not an empty store
+    expect(Object.keys(freshStore.profiles)).toContain("anthropic:default");
+  });
+});

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -45,6 +45,11 @@ type LoadAuthProfileStoreOptions = {
   syncExternalCli?: boolean;
   externalCliProviderIds?: Iterable<string>;
   externalCliProfileIds?: Iterable<string>;
+  // Documented intent flag for callers (e.g. `models auth clean`) that want to
+  // load only the agent-local store without merging main-agent profiles.
+  // The current loader is already agent-local; flag retained for clarity and
+  // call-site documentation.
+  skipInheritance?: boolean;
 };
 
 type SaveAuthProfileStoreOptions = {
@@ -311,6 +316,7 @@ function buildLocalAuthProfileStoreForSave(params: {
 
 export async function updateAuthProfileStoreWithLock(params: {
   agentDir?: string;
+  agentLocalOnly?: boolean;
   updater: (store: AuthProfileStore) => boolean;
 }): Promise<AuthProfileStore | null> {
   const authPath = resolveAuthStorePath(params.agentDir);
@@ -321,7 +327,21 @@ export async function updateAuthProfileStoreWithLock(params: {
       // Locked writers must reload from disk, not from any runtime snapshot.
       // Otherwise a live gateway can overwrite fresher CLI/config-auth writes
       // with stale in-memory auth state during usage/cooldown updates.
-      const store = loadAuthProfileStoreForAgent(params.agentDir);
+      //
+      // When agentDir is set (subagent path), we must never load the merged
+      // view (loadAuthProfileStoreForAgent can inherit main credentials into
+      // the subagent file) because writing that back to agent-local
+      // auth-profiles.json would leak main credentials into subagent scope.
+      // agentLocalOnly also forces this path explicitly.
+      //
+      // For the main-agent path (agentDir undefined, agentLocalOnly false), use
+      // loadAuthProfileStoreForAgent which always reads from disk/cache -- NOT
+      // ensureAuthProfileStore which can return a stale runtime snapshot,
+      // reintroducing the overwrite bug this lock is meant to prevent.
+      const useLocalOnly = params.agentLocalOnly || params.agentDir !== undefined;
+      const store = useLocalOnly
+        ? loadAgentLocalAuthProfileStore(params.agentDir)
+        : loadAuthProfileStoreForAgent(undefined);
       const shouldSave = params.updater(store);
       if (shouldSave) {
         saveAuthProfileStore(store, params.agentDir);
@@ -450,6 +470,18 @@ export function loadAuthProfileStoreForRuntime(
   });
 }
 
+/**
+ * Load auth-profile store for a specific agent directory without inheriting
+ * from the main agent. Used by `models auth clean` to inspect per-agent
+ * credentials independently.
+ */
+export function loadAgentLocalAuthProfileStore(
+  agentDir?: string,
+  options?: LoadAuthProfileStoreOptions,
+): AuthProfileStore {
+  return loadAuthProfileStoreForAgent(agentDir, { ...options, skipInheritance: true });
+}
+
 export function loadAuthProfileStoreForSecretsRuntime(agentDir?: string): AuthProfileStore {
   return loadAuthProfileStoreForRuntime(agentDir, { readOnly: true, allowKeychainPrompt: false });
 }
@@ -475,6 +507,9 @@ export function ensureAuthProfileStore(
     externalCli?: ExternalCliAuthDiscovery;
     externalCliProviderIds?: Iterable<string>;
     externalCliProfileIds?: Iterable<string>;
+    // Documented intent flag accepted for caller clarity (e.g.
+    // `models auth clean` distinguishing probe vs migration-trigger calls).
+    readOnly?: boolean;
   },
 ): AuthProfileStore {
   const externalCli = resolveExternalCliOverlayOptions(options);

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -53,6 +53,11 @@ type LoadAuthProfileStoreOptions = {
   syncExternalCli?: boolean;
   externalCliProviderIds?: Iterable<string>;
   externalCliProfileIds?: Iterable<string>;
+  // Documented intent flag for callers (e.g. `models auth clean`) that want to
+  // load only the agent-local store without merging main-agent profiles.
+  // The current loader is already agent-local; flag retained for clarity and
+  // call-site documentation.
+  skipInheritance?: boolean;
 };
 
 type SaveAuthProfileStoreOptions = {
@@ -435,6 +440,7 @@ function buildLocalAuthProfileStoreForSave(params: {
 
 export async function updateAuthProfileStoreWithLock(params: {
   agentDir?: string;
+  agentLocalOnly?: boolean;
   saveOptions?: SaveAuthProfileStoreOptions;
   updater: (store: AuthProfileStore) => boolean;
 }): Promise<AuthProfileStore | null> {
@@ -446,7 +452,21 @@ export async function updateAuthProfileStoreWithLock(params: {
       // Locked writers must reload from disk, not from any runtime snapshot.
       // Otherwise a live gateway can overwrite fresher CLI/config-auth writes
       // with stale in-memory auth state during usage/cooldown updates.
-      const store = loadAuthProfileStoreForAgent(params.agentDir, { syncExternalCli: false });
+      //
+      // When agentDir is set (subagent path), we must never load the merged
+      // view (loadAuthProfileStoreForAgent can inherit main credentials into
+      // the subagent file) because writing that back to agent-local
+      // auth-profiles.json would leak main credentials into subagent scope.
+      // agentLocalOnly also forces this path explicitly.
+      //
+      // For the main-agent path (agentDir undefined, agentLocalOnly false), use
+      // loadAuthProfileStoreForAgent which always reads from disk/cache -- NOT
+      // ensureAuthProfileStore which can return a stale runtime snapshot,
+      // reintroducing the overwrite bug this lock is meant to prevent.
+      const useLocalOnly = params.agentLocalOnly || params.agentDir !== undefined;
+      const store = useLocalOnly
+        ? loadAgentLocalAuthProfileStore(params.agentDir, { syncExternalCli: false })
+        : loadAuthProfileStoreForAgent(undefined, { syncExternalCli: false });
       const shouldSave = params.updater(store);
       if (shouldSave) {
         saveAuthProfileStore(store, params.agentDir, params.saveOptions);
@@ -586,6 +606,18 @@ export function loadAuthProfileStoreForRuntime(
   });
 }
 
+/**
+ * Load auth-profile store for a specific agent directory without inheriting
+ * from the main agent. Used by `models auth clean` to inspect per-agent
+ * credentials independently.
+ */
+export function loadAgentLocalAuthProfileStore(
+  agentDir?: string,
+  options?: LoadAuthProfileStoreOptions,
+): AuthProfileStore {
+  return loadAuthProfileStoreForAgent(agentDir, { ...options, skipInheritance: true });
+}
+
 export function loadAuthProfileStoreForSecretsRuntime(agentDir?: string): AuthProfileStore {
   return loadAuthProfileStoreForRuntime(agentDir, {
     readOnly: true,
@@ -625,6 +657,9 @@ export function ensureAuthProfileStore(
     externalCli?: ExternalCliAuthDiscovery;
     externalCliProviderIds?: Iterable<string>;
     externalCliProfileIds?: Iterable<string>;
+    // Documented intent flag accepted for caller clarity (e.g.
+    // `models auth clean` distinguishing probe vs migration-trigger calls).
+    readOnly?: boolean;
   },
 ): AuthProfileStore {
   const externalCli = resolveExternalCliOverlayOptions(options);

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   modelsSetImageCommand: vi.fn().mockResolvedValue(undefined),
   noopAsync: vi.fn(async () => undefined),
   modelsAuthAddCommand: vi.fn().mockResolvedValue(undefined),
+  modelsAuthCleanCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthLoginCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthPasteTokenCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthSetupTokenCommand: vi.fn().mockResolvedValue(undefined),
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 
 const {
   modelsAuthAddCommand,
+  modelsAuthCleanCommand,
   modelsAuthLoginCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
@@ -35,6 +37,9 @@ vi.mock("../commands/models/auth.js", () => ({
   modelsAuthLoginCommand: mocks.modelsAuthLoginCommand,
   modelsAuthPasteTokenCommand: mocks.modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand: mocks.modelsAuthSetupTokenCommand,
+}));
+vi.mock("../commands/models/auth-clean.js", () => ({
+  modelsAuthCleanCommand: mocks.modelsAuthCleanCommand,
 }));
 vi.mock("../commands/models/auth-order.js", () => ({
   modelsAuthOrderClearCommand: mocks.noopAsync,
@@ -71,6 +76,7 @@ vi.mock("../commands/models/set-image.js", () => ({
 describe("models cli", () => {
   beforeEach(() => {
     modelsAuthAddCommand.mockClear();
+    modelsAuthCleanCommand.mockClear();
     modelsAuthLoginCommand.mockClear();
     modelsAuthPasteTokenCommand.mockClear();
     modelsAuthSetupTokenCommand.mockClear();
@@ -110,12 +116,7 @@ describe("models cli", () => {
 
     expect(modelsAuthLoginCommand).toHaveBeenCalledTimes(1);
     expect(modelsAuthLoginCommand).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "github-copilot",
-        method: "device",
-        yes: true,
-        agent: "poe",
-      }),
+      expect.objectContaining({ provider: "github-copilot", method: "device", yes: true }),
       expect.any(Object),
     );
   });
@@ -160,6 +161,8 @@ describe("models cli", () => {
       label: "login-github-copilot",
       args: ["models", "auth", "--agent", "poe", "login-github-copilot", "--yes"],
       command: modelsAuthLoginCommand,
+      // login-github-copilot routes through modelsAuthLoginCommand with the
+      // github-copilot provider and device method preselected.
       expected: { agent: "poe", provider: "github-copilot", method: "device", yes: true },
     },
   ])("passes parent --agent to models auth $label", async ({ args, command, expected }) => {
@@ -183,6 +186,22 @@ describe("models cli", () => {
     await expect(runModelsCommand(args)).rejects.toThrow("does not support `--agent`");
 
     expect(command).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid --profile-id for paste-token", async () => {
+    await expect(
+      runModelsCommand([
+        "models",
+        "auth",
+        "paste-token",
+        "--provider",
+        "anthropic",
+        "--profile-id",
+        "bad id",
+      ]),
+    ).rejects.toThrow(/process\.exit unexpectedly called with "1"/);
+
+    expect(modelsAuthPasteTokenCommand).not.toHaveBeenCalled();
   });
 
   it("shows help for models auth without error exit", async () => {

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -256,7 +256,10 @@ describe("models cli", () => {
     expect(command).not.toHaveBeenCalled();
   });
 
-  it("rejects invalid --profile-id for paste-token", async () => {
+  it("rejects unsafe --profile-id (control chars) for paste-token", async () => {
+    // Profile IDs are arbitrary keys, so only genuinely-unsafe values (control/
+    // escape chars, reserved prototype names) are rejected. A plain space is a
+    // valid key and must NOT be rejected (see paste-token-accepts test below).
     await expect(
       runModelsCommand([
         "models",
@@ -265,7 +268,7 @@ describe("models cli", () => {
         "--provider",
         "anthropic",
         "--profile-id",
-        "bad id",
+        "bad\x1b[31mid",
       ]),
     ).rejects.toThrow(/process\.exit unexpectedly called with "1"/);
 

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   modelsSetImageCommand: vi.fn().mockResolvedValue(undefined),
   noopAsync: vi.fn(async () => undefined),
   modelsAuthAddCommand: vi.fn().mockResolvedValue(undefined),
+  modelsAuthCleanCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthListCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthLoginCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthPasteTokenCommand: vi.fn().mockResolvedValue(undefined),
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 
 const {
   modelsAuthAddCommand,
+  modelsAuthCleanCommand,
   modelsAuthListCommand,
   modelsAuthLoginCommand,
   modelsAuthPasteTokenCommand,
@@ -40,6 +42,9 @@ vi.mock("../commands/models/auth.js", () => ({
 }));
 vi.mock("../commands/models/auth-list.js", () => ({
   modelsAuthListCommand: mocks.modelsAuthListCommand,
+}));
+vi.mock("../commands/models/auth-clean.js", () => ({
+  modelsAuthCleanCommand: mocks.modelsAuthCleanCommand,
 }));
 vi.mock("../commands/models/auth-order.js", () => ({
   modelsAuthOrderClearCommand: mocks.noopAsync,
@@ -76,6 +81,7 @@ vi.mock("../commands/models/set-image.js", () => ({
 describe("models cli", () => {
   beforeEach(() => {
     modelsAuthAddCommand.mockClear();
+    modelsAuthCleanCommand.mockClear();
     modelsAuthListCommand.mockClear();
     modelsAuthLoginCommand.mockClear();
     modelsAuthPasteTokenCommand.mockClear();
@@ -184,6 +190,8 @@ describe("models cli", () => {
       label: "login-github-copilot",
       args: ["models", "auth", "--agent", "poe", "login-github-copilot", "--yes"],
       command: modelsAuthLoginCommand,
+      // login-github-copilot routes through modelsAuthLoginCommand with the
+      // github-copilot provider and device method preselected.
       expected: { agent: "poe", provider: "github-copilot", method: "device", yes: true },
     },
   ])("passes parent --agent to models auth $label", async ({ args, command, expected }) => {
@@ -246,6 +254,22 @@ describe("models cli", () => {
     await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
 
     expect(command).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid --profile-id for paste-token", async () => {
+    await expect(
+      runModelsCommand([
+        "models",
+        "auth",
+        "paste-token",
+        "--provider",
+        "anthropic",
+        "--profile-id",
+        "bad id",
+      ]),
+    ).rejects.toThrow(/process\.exit unexpectedly called with "1"/);
+
+    expect(modelsAuthPasteTokenCommand).not.toHaveBeenCalled();
   });
 
   it("shows help for models auth without error exit", async () => {

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { validateProfileId } from "../agents/auth-profiles/sanitize.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
@@ -368,11 +369,18 @@ export function registerModelsCli(program: Command) {
     .action(async (opts, command) => {
       const agent = resolveOptionFromCommand<string>(command, "agent");
       await runModelsCommand(async () => {
+        const profileId = opts.profileId as string | undefined;
+        if (profileId) {
+          const err = validateProfileId(profileId);
+          if (err) {
+            throw new Error(`Invalid --profile-id: ${err}`);
+          }
+        }
         const { modelsAuthPasteTokenCommand } = await import("../commands/models/auth.js");
         await modelsAuthPasteTokenCommand(
           {
             provider: opts.provider as string | undefined,
-            profileId: opts.profileId as string | undefined,
+            profileId,
             expiresIn: opts.expiresIn as string | undefined,
             agent,
           },
@@ -395,6 +403,30 @@ export function registerModelsCli(program: Command) {
             method: "device",
             yes: Boolean(opts.yes),
             agent,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("clean")
+    .description(
+      "Remove stale profiles from auth-profiles.json that are not configured in openclaw.json",
+    )
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--dry-run", "Preview removals without writing changes")
+    .option("--json", "Output as JSON")
+    .action(async (opts, command) => {
+      const agent =
+        resolveOptionFromCommand<string>(command, "agent") ?? (opts.agent as string | undefined);
+      await runModelsCommand(async () => {
+        const { modelsAuthCleanCommand } = await import("../commands/models/auth-clean.js");
+        await modelsAuthCleanCommand(
+          {
+            agent,
+            dryRun: Boolean(opts.dryRun),
+            json: Boolean(opts.json),
           },
           defaultRuntime,
         );

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { validateProfileId } from "../agents/auth-profiles/sanitize.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 
@@ -387,11 +388,18 @@ export function registerModelsCli(program: Command) {
     .action(async (opts, command) => {
       await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {
         const agent = resolveModelAgentOption(command);
+        const profileId = opts.profileId as string | undefined;
+        if (profileId) {
+          const err = validateProfileId(profileId);
+          if (err) {
+            throw new Error(`Invalid --profile-id: ${err}`);
+          }
+        }
         const { modelsAuthPasteTokenCommand } = await import("../commands/models/auth.js");
         await modelsAuthPasteTokenCommand(
           {
             provider: opts.provider as string | undefined,
-            profileId: opts.profileId as string | undefined,
+            profileId,
             expiresIn: opts.expiresIn as string | undefined,
             agent,
           },
@@ -414,6 +422,29 @@ export function registerModelsCli(program: Command) {
             method: "device",
             yes: Boolean(opts.yes),
             agent,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
+    .command("clean")
+    .description(
+      "Remove stale profiles from auth-profiles.json that are not configured in openclaw.json",
+    )
+    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--dry-run", "Preview removals without writing changes")
+    .option("--json", "Output as JSON")
+    .action(async (opts, command) => {
+      await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {
+        const agent = resolveModelAgentOption(command, opts);
+        const { modelsAuthCleanCommand } = await import("../commands/models/auth-clean.js");
+        await modelsAuthCleanCommand(
+          {
+            agent,
+            dryRun: Boolean(opts.dryRun),
+            json: Boolean(opts.json),
           },
           defaultRuntime,
         );

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -1,0 +1,913 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { RuntimeEnv } from "../../runtime.js";
+
+// ---- hoisted mocks ---------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  resolveDefaultAgentId: vi.fn(() => "main"),
+  resolveAgentDir: vi.fn((_cfg: unknown, _id: unknown) => "/home/user/.openclaw/agents/main/agent"),
+  ensureAuthProfileStore: vi.fn(),
+  loadAuthProfileStoreWithoutExternalProfiles: vi.fn(),
+  updateAuthProfileStoreWithLock: vi.fn(),
+  loadAgentLocalAuthProfileStore: vi.fn(),
+  loadModelsConfig: vi.fn(),
+  resolveKnownAgentId: vi.fn<() => string | null>(() => null),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
+  resolveAgentDir: mocks.resolveAgentDir,
+}));
+
+vi.mock("../../agents/auth-profiles.js", () => ({
+  ensureAuthProfileStore: mocks.ensureAuthProfileStore,
+  loadAuthProfileStoreWithoutExternalProfiles: mocks.loadAuthProfileStoreWithoutExternalProfiles,
+}));
+
+vi.mock("../../agents/auth-profiles/store.js", () => ({
+  updateAuthProfileStoreWithLock: mocks.updateAuthProfileStoreWithLock,
+  loadAgentLocalAuthProfileStore: mocks.loadAgentLocalAuthProfileStore,
+}));
+
+vi.mock("./load-config.js", () => ({
+  loadModelsConfig: mocks.loadModelsConfig,
+}));
+
+vi.mock("./shared.js", () => ({
+  resolveKnownAgentId: mocks.resolveKnownAgentId,
+}));
+
+// ---- helpers ----------------------------------------------------------------
+
+const ensureAuthProfileStoreMockReturnValue = mocks.ensureAuthProfileStore.mockReturnValue.bind(
+  mocks.ensureAuthProfileStore,
+);
+mocks.ensureAuthProfileStore.mockReturnValue = ((value: AuthProfileStore) => {
+  mocks.loadAuthProfileStoreWithoutExternalProfiles.mockReturnValue(value);
+  return ensureAuthProfileStoreMockReturnValue(value);
+}) as typeof mocks.ensureAuthProfileStore.mockReturnValue;
+
+const { modelsAuthCleanCommand } = await import("./auth-clean.js");
+
+function makeRuntime(): RuntimeEnv & { logs: string[] } {
+  const logs: string[] = [];
+  const runtime = {
+    logs,
+    log: (msg: string) => {
+      logs.push(msg);
+    },
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+  return runtime as unknown as RuntimeEnv & { logs: string[] };
+}
+
+function makeCfg(
+  profileIds: string[] = ["anthropic:me.com", "anthropic:gmail"],
+  orderIds: string[] = [],
+): OpenClawConfig {
+  const profiles: Record<string, { provider: string; mode: string }> = {};
+  for (const id of profileIds) {
+    const provider = id.split(":")[0] ?? "anthropic";
+    profiles[id] = { provider, mode: "token" };
+  }
+  const order: Record<string, string[]> = {};
+  if (orderIds.length > 0) {
+    order["anthropic"] = orderIds;
+  }
+  return { auth: { profiles, ...(orderIds.length > 0 ? { order } : {}) } } as OpenClawConfig;
+}
+
+function makeStore(profileIds: string[], extras: Partial<AuthProfileStore> = {}): AuthProfileStore {
+  const profiles: AuthProfileStore["profiles"] = {};
+  for (const id of profileIds) {
+    const provider = id.split(":")[0] ?? "anthropic";
+    profiles[id] = { type: "token", provider, token: `sk-${id}` };
+  }
+  return { version: 1, profiles, ...extras };
+}
+
+/**
+ * Capture what the updater closure does when called with a given store.
+ * updateAuthProfileStoreWithLock calls params.updater(freshStore) internally;
+ * this helper simulates that so we can inspect mutations.
+ */
+function captureUpdater(storeSeed: AuthProfileStore): {
+  result: AuthProfileStore;
+  returned: boolean;
+} {
+  let captured: AuthProfileStore | undefined;
+  let returned = false;
+
+  mocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
+    async (params: { updater: (s: AuthProfileStore) => boolean }) => {
+      const clone = structuredClone(storeSeed);
+      returned = params.updater(clone);
+      captured = clone;
+      return returned ? clone : null;
+    },
+  );
+
+  return {
+    get result() {
+      return captured!;
+    },
+    get returned() {
+      return returned;
+    },
+  };
+}
+
+// ---- tests ------------------------------------------------------------------
+
+describe("modelsAuthCleanCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadAuthProfileStoreWithoutExternalProfiles.mockReset();
+  });
+
+  it("removes stale profiles from profiles, usageStats, and lastGood", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:gmail", "anthropic:manual"], {
+      usageStats: {
+        "anthropic:manual": { lastUsed: 1000, errorCount: 1 },
+        "anthropic:me.com": { lastUsed: 2000, errorCount: 0 },
+      },
+      lastGood: { anthropic: "anthropic:manual" },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com", "anthropic:gmail"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    const capture = captureUpdater(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    expect(capture.result.profiles).not.toHaveProperty("anthropic:manual");
+    expect(capture.result.profiles).toHaveProperty("anthropic:me.com");
+    expect(capture.result.profiles).toHaveProperty("anthropic:gmail");
+    expect(capture.result.usageStats).not.toHaveProperty("anthropic:manual");
+    expect(capture.result.usageStats).toHaveProperty("anthropic:me.com");
+    expect(capture.result.lastGood).not.toHaveProperty("anthropic");
+  });
+
+  it("keeps profile referenced only in store.order even when not in cfg", async () => {
+    // anthropic:manual is in store.profiles and store.order, but NOT in cfg.
+    // The fix ensures store.order-referenced profiles are treated as configured (kept).
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"], {
+      order: { anthropic: ["anthropic:manual"] },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    // manual is kept because it's in store.order — no write needed
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  it("keeps all store.order-referenced profiles alongside cfg-configured ones", async () => {
+    // anthropic:manual is in store.order (set via 'models auth order set') but not in cfg.
+    // It must be protected, so nothing is stale and the lock is never acquired.
+    const store = makeStore(["anthropic:me.com", "anthropic:gmail", "anthropic:manual"], {
+      order: { anthropic: ["anthropic:me.com", "anthropic:manual"] },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com", "anthropic:gmail"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    // All three profiles are kept (me.com/gmail via cfg, manual via store.order)
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  it("--dry-run does not call updateAuthProfileStoreWithLock", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({ dryRun: true }, makeRuntime());
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("--dry-run uses the persisted main-agent auth store for probe planning", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({ dryRun: true }, makeRuntime());
+
+    expect(mocks.loadAuthProfileStoreWithoutExternalProfiles).toHaveBeenCalledWith(
+      expect.any(String),
+    );
+  });
+
+  it("--dry-run passes readOnly:true to loadAgentLocalAuthProfileStore (non-default agent)", async () => {
+    const store = makeStore(["anthropic:me.com"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/worker/agent");
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({ agent: "worker", dryRun: true }, makeRuntime());
+
+    expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ readOnly: true }),
+    );
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("default-agent probe ignores runtime-only external profiles", async () => {
+    const persistedStore = makeStore(["anthropic:me.com", "anthropic:stale"]);
+    const mergedRuntimeStore = makeStore([
+      "anthropic:me.com",
+      "anthropic:stale",
+      "anthropic:runtime-only",
+    ]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(mergedRuntimeStore);
+    mocks.loadAuthProfileStoreWithoutExternalProfiles.mockReturnValue(persistedStore);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true, json: true }, runtime);
+
+    const plan = JSON.parse(runtime.logs[0] ?? "{}");
+    expect(plan.storeProfiles).toEqual(["anthropic:me.com", "anthropic:stale"]);
+    expect(plan.toRemove).toEqual(["anthropic:stale"]);
+  });
+
+  it("runtime-only external profiles do not trip the empty-config guard when disk store is empty (P2 fix)", async () => {
+    // Regression: before the fix, the probe path used ensureAuthProfileStore which
+    // overlays runtime external profiles onto the store. When the disk-persisted store
+    // is empty but runtime-only external profiles exist, storeProfileIds would be
+    // non-empty and configDerivedProfileIds.size === 0, causing the empty-config guard
+    // to throw (false blocking). The probe must use only the disk-persisted store so
+    // runtime-only externals are invisible to storeProfileIds and toRemove alike.
+    const emptyDiskStore = makeStore([]); // nothing persisted on disk
+    const mergedRuntimeStore = makeStore(["anthropic:runtime-ext-only"]); // only a runtime external
+
+    // No auth config in openclaw.json — configDerivedProfileIds.size === 0
+    mocks.loadModelsConfig.mockResolvedValue({ auth: {} } as import("../../config/config.js").OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(mergedRuntimeStore);
+    // Disk-only probe returns the empty persisted store
+    mocks.loadAuthProfileStoreWithoutExternalProfiles.mockReturnValue(emptyDiskStore);
+
+    const runtime = makeRuntime();
+    // Must not throw: storeProfileIds is empty (disk has none), so guard condition
+    // (configDerivedProfileIds.size === 0 && storeProfileIds.length > 0) is false.
+    await modelsAuthCleanCommand({}, runtime);
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  it("default-agent probe uses persisted store; migration trigger uses readOnly:false after guards pass", async () => {
+    // The planning probe must inspect only the persisted main-agent store so
+    // runtime-only external profiles do not affect toRemove. After guards pass,
+    // a separate write-enabled ensureAuthProfileStore call still triggers any
+    // legacy migration before the lock-backed update runs.
+    const store = makeStore(["anthropic:me.com", "anthropic:stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime()); // no dryRun
+
+    expect(mocks.loadAuthProfileStoreWithoutExternalProfiles).toHaveBeenCalledWith(
+      expect.any(String),
+    );
+    expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ readOnly: false }),
+    );
+  });
+
+  it("probe uses readOnly:true; migration trigger uses readOnly:false after guards pass (non-default agent)", async () => {
+    // #2915530629: same as default agent path — probe is always readOnly:true;
+    // migration trigger uses readOnly:false after guards pass. (#2914491523, #2914711181)
+    // #2915653312: migration trigger must also pass skipInheritance:true so that
+    // the main-agent fallback inside loadAuthProfileStoreForAgent is suppressed —
+    // without it, a subagent with no local store would clone main credentials
+    // before cleanup, causing scope bleed and a misleading no-op.
+    const store = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
+    const workerAgentDir = "/home/user/.openclaw/agents/worker/agent";
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce(workerAgentDir);
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    await modelsAuthCleanCommand({ agent: "worker" }, makeRuntime()); // no dryRun
+
+    // Probe call: readOnly:true (always, even for non-dryRun); agentDir is the
+    // worker-specific path, not the main agent path.
+    expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
+      workerAgentDir,
+      expect.objectContaining({ readOnly: true }),
+    );
+    // Migration trigger call: readOnly:false (after guards pass, before lock).
+    // Must pass skipInheritance:true to prevent the main-agent fallback from
+    // cloning main profiles into the worker file before cleanup. (#2915653312)
+    expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalledWith(
+      workerAgentDir,
+      expect.objectContaining({ readOnly: false, skipInheritance: true }),
+    );
+  });
+
+  it("keeps profiles referenced only in store.order (not in cfg.auth.profiles or cfg.auth.order)", async () => {
+    // anthropic:store-override is in store.order (set via 'models auth order set')
+    // but NOT in openclaw.json auth.profiles or auth.order — must be treated as kept
+    const store = makeStore(["anthropic:me.com", "anthropic:store-override"], {
+      order: { anthropic: ["anthropic:me.com", "anthropic:store-override"] },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    // Both profiles are kept — no stale entries — lock not acquired
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("removes profiles not in cfg or store.order even when store.order exists", async () => {
+    // anthropic:manual is in neither cfg nor store.order — should be removed
+    // anthropic:store-override is in store.order — should be kept
+    const store = makeStore(["anthropic:me.com", "anthropic:store-override", "anthropic:manual"], {
+      order: { anthropic: ["anthropic:me.com", "anthropic:store-override"] },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    const capture = captureUpdater(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    expect(capture.result.profiles).not.toHaveProperty("anthropic:manual");
+    expect(capture.result.profiles).toHaveProperty("anthropic:me.com");
+    expect(capture.result.profiles).toHaveProperty("anthropic:store-override");
+  });
+
+  it("--dry-run logs the plan without writing", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    const combined = runtime.logs.join("\n");
+    expect(combined).toContain("anthropic:manual");
+    expect(combined).toContain("dry run");
+  });
+
+  it("does nothing when all store profiles are configured", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:gmail"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com", "anthropic:gmail"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  it("treats profiles referenced in auth.order as configured (not stale)", async () => {
+    // anthropic:legacy is in auth.order but not in auth.profiles — should be preserved
+    const store = makeStore(["anthropic:me.com", "anthropic:legacy"]);
+
+    const cfg = makeCfg(["anthropic:me.com"], ["anthropic:me.com", "anthropic:legacy"]);
+    mocks.loadModelsConfig.mockResolvedValue(cfg);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    // Nothing stale — updateAuthProfileStoreWithLock should not be called
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("throws when openclaw.json has no configured auth and store has profiles", async () => {
+    const store = makeStore(["anthropic:me.com"]);
+
+    mocks.loadModelsConfig.mockResolvedValue({ auth: {} } as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    await expect(modelsAuthCleanCommand({}, makeRuntime())).rejects.toThrow(
+      /no configured auth profiles/i,
+    );
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("--dry-run with no configured auth logs warning instead of throwing", async () => {
+    const store = makeStore(["anthropic:me.com"]);
+
+    mocks.loadModelsConfig.mockResolvedValue({ auth: {} } as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toMatch(/warning/i);
+  });
+
+  it("--json emits plan object then {ok, removed} result after write", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ json: true }, runtime);
+
+    expect(runtime.logs.length).toBe(2);
+    const plan = JSON.parse(runtime.logs[0]);
+    const result = JSON.parse(runtime.logs[1]);
+
+    expect(plan).toMatchObject({ toRemove: ["anthropic:manual"], dryRun: false });
+    expect(result).toMatchObject({ ok: true, removed: 1 });
+  });
+
+  it("--json --dry-run emits only the plan object", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ json: true, dryRun: true }, runtime);
+
+    expect(runtime.logs.length).toBe(1);
+    const plan = JSON.parse(runtime.logs[0]);
+    expect(plan).toMatchObject({ toRemove: ["anthropic:manual"], dryRun: true });
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("reports actualRemoved from inside the lock, not the pre-lock estimate", async () => {
+    // Simulate gateway concurrently removing anthropic:manual before lock acquired
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+    const storeAtLockTime = makeStore(["anthropic:me.com"]); // manual already gone
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    // updater receives the already-cleaned store
+    mocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
+      async (params: { updater: (s: AuthProfileStore) => boolean }) => {
+        const clone = structuredClone(storeAtLockTime);
+        params.updater(clone);
+        return clone; // something returned = success
+      },
+    );
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    // actualRemoved should be 0 (nothing was there to delete under the lock)
+    expect(runtime.logs.join("\n")).toContain("Removed 0 stale profile(s)");
+  });
+
+  it("throws when updateAuthProfileStoreWithLock returns null (lock busy)", async () => {
+    const store = makeStore(["anthropic:me.com", "anthropic:manual"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    mocks.updateAuthProfileStoreWithLock.mockResolvedValueOnce(null);
+
+    await expect(modelsAuthCleanCommand({}, makeRuntime())).rejects.toThrow(
+      /lock contention|lock busy|write failed/i,
+    );
+  });
+
+  it("non-default agent: excludes main-only profiles from toRemove", async () => {
+    // The agent-local store has agent-profile (configured) and agent-stale (not configured).
+    // The merged view returned by ensureAuthProfileStore also includes main-only-profile,
+    // which exists only in the main store and is NOT configured.
+    // toRemove must contain only agent-stale (from the agent-local store),
+    // NOT main-only-profile (which lives in the main store and must not be touched).
+    const agentLocalStore = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
+    const mergedStore = makeStore([
+      "anthropic:agent-profile",
+      "anthropic:agent-stale",
+      "anthropic:main-only-profile", // exists in main store only, not agent-local
+    ]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
+    // Non-default agent: resolveKnownAgentId returns "worker", default is "main"
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/worker/agent");
+    // ensureAuthProfileStore is NOT called for non-default agents (loadAgentLocalAuthProfileStore is)
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(agentLocalStore);
+    // The updater receives the merged store (simulating what updateAuthProfileStoreWithLock
+    // would pass in production after calling ensureAuthProfileStore internally).
+    const capture = captureUpdater(mergedStore);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ agent: "worker" }, runtime);
+
+    // toRemove was computed from agentLocalStore only: ["anthropic:agent-stale"]
+    expect(capture.result.profiles).not.toHaveProperty("anthropic:agent-stale");
+    expect(capture.result.profiles).toHaveProperty("anthropic:agent-profile");
+    // main-only-profile was never in toRemove, so the updater left it intact
+    expect(capture.result.profiles).toHaveProperty("anthropic:main-only-profile");
+    // ensureAuthProfileStore should not have been called for profile-set computation
+    expect(mocks.ensureAuthProfileStore).not.toHaveBeenCalled();
+  });
+
+  // ---- Fix: agent media profiles without top-level tools.media (P1 #2912273297) ----
+
+  it("collects agent-level media profiles even when cfg.tools.media is absent", async () => {
+    // Arrange: no top-level tools.media, but one agent override references a profile.
+    // Without the fix, collectMediaProfileIds() returned early on !media and the
+    // agent-level profile was treated as stale and added to toRemove.
+    const store = makeStore(["anthropic:me.com", "anthropic:media-agent"]);
+
+    mocks.loadModelsConfig.mockResolvedValue({
+      ...makeCfg(["anthropic:me.com"]),
+      // Deliberately omit tools.media at the top level
+      agents: {
+        list: [
+          {
+            id: "worker",
+            tools: {
+              media: {
+                models: [{ model: "gpt-4o", profile: "anthropic:media-agent" }],
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    // anthropic:media-agent is in an agent's tools.media override — must be kept
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  it("collects agent preferredProfile references without top-level tools.media", async () => {
+    // preferredProfile (not just profile) must also be picked up from agent overrides
+    const store = makeStore(["anthropic:me.com", "anthropic:preferred-agent"]);
+
+    mocks.loadModelsConfig.mockResolvedValue({
+      ...makeCfg(["anthropic:me.com"]),
+      agents: {
+        list: [
+          {
+            id: "worker",
+            tools: {
+              media: {
+                image: {
+                  models: [{ model: "gpt-4o", preferredProfile: "anthropic:preferred-agent" }],
+                },
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({}, runtime);
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toContain("Nothing to clean");
+  });
+
+  // ---- Fix: agentLocalOnly prevents credential scope bleed (Aisle High) ----
+
+  it("non-default agent: passes agentLocalOnly:true to updateAuthProfileStoreWithLock", async () => {
+    // Ensures the write path uses agent-local-only loading, preventing main-store
+    // profiles from being persisted into the agent-local auth-profiles.json file.
+    const agentLocalStore = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/worker/agent");
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(agentLocalStore);
+    captureUpdater(agentLocalStore);
+
+    await modelsAuthCleanCommand({ agent: "worker" }, makeRuntime());
+
+    expect(mocks.updateAuthProfileStoreWithLock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentLocalOnly: true }),
+    );
+  });
+
+  it("non-main agent: pre-lock readOnly:false migration trigger passes agent-specific agentDir, not main path (#2915653312)", async () => {
+    // Guard: the pre-lock readOnly:false migration trigger must explicitly pass the
+    // agent-specific agentDir to loadAgentLocalAuthProfileStore — not the default
+    // (main) path and not undefined.  Without the explicit agentDir, the call
+    // resolves to the main agent's auth-profiles.json and cleanup silently operates
+    // on the wrong store (scope bleed, misleading no-op). (#2915653312)
+    const workerAgentDir = "/home/user/.openclaw/agents/worker/agent";
+    const mainAgentDir = "/home/user/.openclaw/agents/main/agent"; // default mock value
+    const store = makeStore(["anthropic:worker-profile", "anthropic:worker-stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:worker-profile"]));
+    mocks.resolveKnownAgentId.mockReturnValueOnce("worker");
+    mocks.resolveAgentDir.mockReturnValueOnce(workerAgentDir);
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    await modelsAuthCleanCommand({ agent: "worker" }, makeRuntime());
+
+    // Every call to loadAgentLocalAuthProfileStore must use the worker-specific
+    // agentDir — never the main agent dir and never undefined (which would also
+    // resolve to the main dir).
+    const calls = mocks.loadAgentLocalAuthProfileStore.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [dir] of calls) {
+      expect(dir).toBe(workerAgentDir);
+      expect(dir).not.toBe(mainAgentDir);
+      expect(dir).not.toBeUndefined();
+    }
+  });
+
+  it("default agent: does not set agentLocalOnly on updateAuthProfileStoreWithLock", async () => {
+    // Default agent writes the main auth store directly — no agentLocalOnly.
+    const store = makeStore(["anthropic:me.com", "anthropic:stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+    captureUpdater(store);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    const call = mocks.updateAuthProfileStoreWithLock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call?.agentLocalOnly).toBeFalsy();
+  });
+
+  it("non-main agent as configured default: agentLocalOnly:true even when agentId === defaultAgentId", async () => {
+    // Regression: when a config sets a non-main agent as default (e.g. agents.list[0].default=true
+    // with id "custom-agent"), the old code used (agentId === defaultAgentId) which was true,
+    // disabling agentLocalOnly and causing main-store profiles to be written into the agent-local
+    // file (scope bleed). The fix compares resolved agentDir paths against the main agent
+    // directory instead of comparing agentId strings.
+    const agentLocalStore = makeStore(["anthropic:agent-profile", "anthropic:agent-stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:agent-profile"]));
+    // "custom-agent" is the configured default (not the main agent)
+    mocks.resolveDefaultAgentId.mockReturnValueOnce("custom-agent");
+    // No --agent flag: resolveKnownAgentId returns null (default mock) → agentId = "custom-agent"
+    // First resolveAgentDir call: agentDir for "custom-agent"
+    mocks.resolveAgentDir.mockReturnValueOnce("/home/user/.openclaw/agents/custom-agent/agent");
+    // Second resolveAgentDir call: mainAgentDir for DEFAULT_AGENT_ID ("main")
+    // falls through to default mock → "/home/user/.openclaw/agents/main/agent"
+    mocks.loadAgentLocalAuthProfileStore.mockReturnValue(agentLocalStore);
+    captureUpdater(agentLocalStore);
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    // agentLocalOnly must be true: custom-agent's dir != main agent dir
+    expect(mocks.updateAuthProfileStoreWithLock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentLocalOnly: true }),
+    );
+    // loadAgentLocalAuthProfileStore must be used, NOT ensureAuthProfileStore
+    expect(mocks.loadAgentLocalAuthProfileStore).toHaveBeenCalled();
+    expect(mocks.ensureAuthProfileStore).not.toHaveBeenCalled();
+  });
+
+  // ---- Fix: sanitize ANSI escape codes in profile ID output (Aisle Low) ----
+
+  it("strips ANSI escape sequences from profile IDs in --dry-run output", async () => {
+    // A profile ID containing an ANSI color sequence must not reach the terminal raw.
+    const maliciousId = "anthropic:\x1b[31mred\x1b[0m";
+    const store = makeStore([maliciousId]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:safe"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    const combined = runtime.logs.join("\n");
+    // ANSI escape sequences must be stripped
+    expect(combined).not.toContain("\x1b[31m");
+    expect(combined).not.toContain("\x1b[0m");
+    // The non-malicious text should still appear
+    expect(combined).toContain("anthropic:");
+    expect(combined).toContain("red");
+  });
+
+  it("strips newlines from profile IDs in --dry-run output to prevent log forging", async () => {
+    // A profile ID "anthropic:legit\nINJECTED LINE" must not produce a separate
+    // log entry that starts with "INJECTED LINE" (i.e., must not forge a new line).
+    // After sanitization the \n is removed and the injected text is concatenated
+    // to the profile ID rather than appearing as a standalone forged log entry.
+    const maliciousId = "anthropic:legit\nINJECTED LINE";
+    const store = makeStore([maliciousId]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:safe"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    // No log call should start with the injected text (that would mean log forging)
+    for (const line of runtime.logs) {
+      expect(line).not.toMatch(/^\s*INJECTED LINE/);
+    }
+    // The sanitized prefix (before the stripped \n) should still appear
+    expect(runtime.logs.some((line) => line.includes("anthropic:legit"))).toBe(true);
+  });
+
+  it("strips private CSI escape sequences (e.g. cursor hide) from profile IDs", async () => {
+    // Private CSI sequences like \x1b[?25l (cursor hide) contain a '?' parameter
+    // prefix not matched by the old [0-9;]* pattern — they must be stripped.
+    const maliciousId = "anthropic:\x1b[?25lhidden\x1b[?25h";
+    const store = makeStore([maliciousId]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:safe"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    const combined = runtime.logs.join("\n");
+    // Private CSI sequences must be stripped
+    expect(combined).not.toContain("\x1b[?25l");
+    expect(combined).not.toContain("\x1b[?25h");
+    // The non-escape text should still appear
+    expect(combined).toContain("anthropic:");
+    expect(combined).toContain("hidden");
+  });
+
+  it("strips OSC escape sequences (e.g. window title) from profile IDs", async () => {
+    // OSC sequences like \x1b]0;title\x07 set terminal window titles; they are
+    // not matched by CSI-only patterns and must be stripped to prevent injection.
+    const maliciousId = "anthropic:\x1b]0;injected-title\x07name";
+    const store = makeStore([maliciousId]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:safe"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    const combined = runtime.logs.join("\n");
+    // OSC sequence must be stripped
+    expect(combined).not.toContain("\x1b]0;");
+    expect(combined).not.toContain("\x07");
+    // The non-escape text should still appear
+    expect(combined).toContain("anthropic:");
+    expect(combined).toContain("name");
+  });
+
+  // ---- Fix: empty-config guard must use cfg-derived IDs only, not store.order (#2921223519) ----
+
+  it("empty-config guard fires even when store.order has IDs (guard is cfg-derived only)", async () => {
+    // Regression: store.order IDs were previously included in configuredProfiles before
+    // the guard check. When openclaw.json has no auth config but store.order has entries,
+    // configuredProfiles.size > 0 and the guard silently passes — allowing every profile
+    // not in store.order to be deleted in a store-only setup.
+    // Fix: guard uses configDerivedProfileIds (cfg-only), so store.order IDs cannot
+    // defeat it. (#2921223519)
+    const store = makeStore(["anthropic:me.com", "anthropic:gmail"], {
+      order: { anthropic: ["anthropic:me.com"] }, // store.order with IDs
+    });
+
+    // openclaw.json has NO auth config (empty auth object — no profiles, no order)
+    mocks.loadModelsConfig.mockResolvedValue({ auth: {} } as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    // Must throw (not silently proceed) because cfg has no auth config
+    await expect(modelsAuthCleanCommand({}, makeRuntime())).rejects.toThrow(
+      /no configured auth profiles/i,
+    );
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+  });
+
+  it("empty-config guard: --dry-run warns even when store.order has IDs", async () => {
+    // Same scenario as above but with --dry-run: must warn rather than throw,
+    // even when store.order IDs are present. (#2921223519)
+    const store = makeStore(["anthropic:me.com"], {
+      order: { anthropic: ["anthropic:me.com"] },
+    });
+
+    mocks.loadModelsConfig.mockResolvedValue({ auth: {} } as OpenClawConfig);
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    expect(mocks.updateAuthProfileStoreWithLock).not.toHaveBeenCalled();
+    expect(runtime.logs.join("\n")).toMatch(/warning/i);
+  });
+
+  // ---- Fix: store.order empty-array pruning ----
+
+  it("updater: removes stale id from store.order[provider] and deletes the key when empty", async () => {
+    // When a profile is stale (not in configuredProfiles at probe time), but happens
+    // to appear in store.order at lock time (e.g. added concurrently), the updater
+    // must remove it from the order array. When that removal leaves the array empty,
+    // the provider key must be deleted (not left as []).
+    //
+    // Scenario: probe store has no order → stale is in toRemove.
+    // Lock-time store has order: { anthropic: ["anthropic:stale"] }.
+    // After updater runs: anthropic key deleted, order object deleted.
+    const probeStore = makeStore(["anthropic:me.com", "anthropic:stale"]);
+    // No store.order at probe → stale not added to configuredProfiles → in toRemove
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(probeStore);
+
+    let capturedStore: AuthProfileStore | undefined;
+    mocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
+      async (params: { updater: (s: AuthProfileStore) => boolean }) => {
+        // Simulate lock-time store with order added concurrently
+        const lockStore: AuthProfileStore = {
+          version: 1,
+          profiles: structuredClone(probeStore.profiles),
+          order: { anthropic: ["anthropic:stale"] },
+        };
+        params.updater(lockStore);
+        capturedStore = lockStore;
+        return lockStore;
+      },
+    );
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    expect(capturedStore?.profiles).not.toHaveProperty("anthropic:stale");
+    // anthropic key deleted (filtered to []) → order object deleted (no remaining keys)
+    expect(capturedStore).not.toHaveProperty("order");
+  });
+
+  it("updater: deletes store.order entirely when all provider entries are emptied", async () => {
+    // When every provider key in store.order is emptied after pruning stale ids,
+    // the order object itself must be deleted (not left as an empty {}).
+    // Scenario: two providers' order arrays each contain only stale.
+    const probeStore = makeStore(["anthropic:me.com", "anthropic:stale"]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:me.com"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(probeStore);
+
+    let capturedStore: AuthProfileStore | undefined;
+    mocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
+      async (params: { updater: (s: AuthProfileStore) => boolean }) => {
+        const lockStore: AuthProfileStore = {
+          version: 1,
+          profiles: structuredClone(probeStore.profiles),
+          order: {
+            anthropic: ["anthropic:stale"],
+            openai: ["anthropic:stale"], // both entries contain only the stale id
+          },
+        };
+        params.updater(lockStore);
+        capturedStore = lockStore;
+        return lockStore;
+      },
+    );
+
+    await modelsAuthCleanCommand({}, makeRuntime());
+
+    // Both provider keys emptied → order object itself must be deleted
+    expect(capturedStore).not.toHaveProperty("order");
+  });
+
+  it("strips a bare trailing ESC byte (\\x1b with nothing after it) from profile IDs", async () => {
+    // A lone \x1b at the end of a string has no sequence character following it,
+    // so the previous regex (requiring [\s\S] — at least one char after ESC)
+    // would leave it unsanitized. The fix uses [\s\S]? (0 or 1 chars) so a
+    // trailing bare ESC is also consumed and removed.
+    const maliciousId = "anthropic:myprofile\x1b";
+    const store = makeStore([maliciousId]);
+
+    mocks.loadModelsConfig.mockResolvedValue(makeCfg(["anthropic:safe"]));
+    mocks.ensureAuthProfileStore.mockReturnValue(store);
+
+    const runtime = makeRuntime();
+    await modelsAuthCleanCommand({ dryRun: true }, runtime);
+
+    const combined = runtime.logs.join("\n");
+    // The bare trailing ESC byte must be stripped
+    expect(combined).not.toContain("\x1b");
+    // The non-escape text should still appear
+    expect(combined).toContain("anthropic:");
+    expect(combined).toContain("myprofile");
+  });
+});

--- a/src/commands/models/auth-clean.test.ts
+++ b/src/commands/models/auth-clean.test.ts
@@ -260,7 +260,9 @@ describe("modelsAuthCleanCommand", () => {
     const mergedRuntimeStore = makeStore(["anthropic:runtime-ext-only"]); // only a runtime external
 
     // No auth config in openclaw.json — configDerivedProfileIds.size === 0
-    mocks.loadModelsConfig.mockResolvedValue({ auth: {} } as import("../../config/config.js").OpenClawConfig);
+    mocks.loadModelsConfig.mockResolvedValue({
+      auth: {},
+    } as import("../../config/config.js").OpenClawConfig);
     mocks.ensureAuthProfileStore.mockReturnValue(mergedRuntimeStore);
     // Disk-only probe returns the empty persisted store
     mocks.loadAuthProfileStoreWithoutExternalProfiles.mockReturnValue(emptyDiskStore);

--- a/src/commands/models/auth-clean.ts
+++ b/src/commands/models/auth-clean.ts
@@ -1,0 +1,363 @@
+import path from "node:path";
+import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import {
+  ensureAuthProfileStore,
+  loadAuthProfileStoreWithoutExternalProfiles,
+} from "../../agents/auth-profiles.js";
+import { sanitizeProfileIdForDisplay } from "../../agents/auth-profiles/sanitize.js";
+import {
+  loadAgentLocalAuthProfileStore,
+  updateAuthProfileStoreWithLock,
+} from "../../agents/auth-profiles/store.js";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import type { MediaToolsConfig, MediaUnderstandingModelConfig } from "../../config/types.tools.js";
+import { DEFAULT_AGENT_ID } from "../../routing/session-key.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { shortenHomePath } from "../../utils.js";
+import { loadModelsConfig } from "./load-config.js";
+import { resolveKnownAgentId } from "./shared.js";
+
+/**
+ * Collect all auth profile ids referenced in tools.media config
+ * (top-level models array + per-media-type image/audio/video models).
+ * These are consumed by resolveProviderExecutionAuth and must not be pruned.
+ */
+function collectMediaProfileIds(cfg: Awaited<ReturnType<typeof loadModelsConfig>>): Set<string> {
+  const ids = new Set<string>();
+
+  function addFromModels(models: MediaUnderstandingModelConfig[] | undefined): void {
+    for (const m of models ?? []) {
+      if (m.profile) {
+        ids.add(m.profile);
+      }
+      if (m.preferredProfile) {
+        ids.add(m.preferredProfile);
+      }
+    }
+  }
+
+  // Scan top-level tools.media if present.
+  const media = cfg.tools?.media;
+  if (media) {
+    addFromModels(media.models);
+    addFromModels(media.image?.models);
+    addFromModels(media.audio?.models);
+    addFromModels(media.video?.models);
+  }
+
+  // Always scan per-agent tool overrides, even when cfg.tools.media is absent.
+  // Agent-level overrides may reference profiles not present at the top level;
+  // skipping them would cause those profiles to be treated as stale and wrongly pruned.
+  for (const agent of cfg.agents?.list ?? []) {
+    const agentMedia = (agent as { tools?: { media?: MediaToolsConfig } }).tools?.media;
+    if (!agentMedia) {
+      continue;
+    }
+    addFromModels(agentMedia.models);
+    addFromModels(agentMedia.image?.models);
+    addFromModels(agentMedia.audio?.models);
+    addFromModels(agentMedia.video?.models);
+  }
+
+  return ids;
+}
+
+/**
+ * Remove stale profiles from auth-profiles.json that are no longer present in
+ * openclaw.json auth.profiles, auth.order, or tools.media model entries.
+ * Prevents ghost profiles (e.g. anthropic:manual, anthropic:user-me.com) from
+ * accumulating and silently corrupting auth order.
+ *
+ * Fixes: https://github.com/openclaw/openclaw/issues/41634
+ */
+export async function modelsAuthCleanCommand(
+  opts: { agent?: string; dryRun?: boolean; json?: boolean },
+  runtime: RuntimeEnv,
+): Promise<void> {
+  const cfg = await loadModelsConfig({ commandName: "models auth clean", runtime });
+  const defaultAgentId = resolveDefaultAgentId(cfg);
+  const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent }) ?? defaultAgentId;
+  const agentDir = resolveAgentDir(cfg, agentId);
+  const authStorePath = shortenHomePath(`${agentDir}/auth-profiles.json`);
+
+  // Determine whether agentDir resolves to the main agent directory.
+  // We compare resolved paths rather than checking (agentId === defaultAgentId) because
+  // a config may designate a non-main agent as the configured default.  In that case
+  // agentId === defaultAgentId would be true even though the write target is not the
+  // main agent file — incorrectly disabling agentLocalOnly and causing main-store
+  // profiles to be persisted into the agent-local auth-profiles.json (scope bleed).
+  // Comparing resolved paths against the main agent directory handles this correctly.
+  const mainAgentDir = resolveAgentDir(cfg, DEFAULT_AGENT_ID);
+  const isMainAgentDir = path.resolve(agentDir) === path.resolve(mainAgentDir);
+
+  // Collect profile ids that are explicitly configured in openclaw.json: union of
+  // auth.profiles keys, ids referenced in auth.order, and ids pinned in tools.media
+  // model entries. All three sets represent actively-used credentials that must not
+  // be pruned.
+  //
+  // IMPORTANT: store.order IDs must NOT be added here. This set is used for the
+  // empty-config safety guard (configDerivedProfileIds.size === 0) — including
+  // store.order IDs would defeat the guard whenever auth-profiles.json has an order
+  // override while openclaw.json has no auth config, allowing the command to silently
+  // delete every profile in a store-only setup. (#2921223519)
+  const configDerivedProfileIds = new Set<string>(
+    Object.keys(cfg.auth?.profiles ?? {})
+      .map((id) => id.trim())
+      .filter(Boolean),
+  );
+  for (const ids of Object.values(cfg.auth?.order ?? {})) {
+    if (Array.isArray(ids)) {
+      for (const id of ids) {
+        if (typeof id === "string" && id.trim()) {
+          configDerivedProfileIds.add(id.trim());
+        }
+      }
+    }
+  }
+  for (const id of collectMediaProfileIds(cfg)) {
+    configDerivedProfileIds.add(id);
+  }
+
+  // configuredProfiles extends configDerivedProfileIds with store.order overrides.
+  // store.order can still inform keep/prune decisions (profiles set via
+  // 'models auth order set' must not be removed), but must not count toward the
+  // empty-config safety threshold. (#2921223519)
+  const configuredProfiles = new Set<string>(configDerivedProfileIds);
+
+  // Load the store for inspection (collect storeProfileIds and storeOrder).
+  // Probe phase is always readOnly:true — a write-capable store must never be opened
+  // before guards pass and cleanup is confirmed to proceed. A separate write-enabled
+  // load is deferred to after all guards pass (see below) to trigger legacy migration.
+  // (#2914491523, #2914711181, #2915530629)
+  const storeLoadOpts = { allowKeychainPrompt: false, readOnly: true };
+  const store = isMainAgentDir
+    ? loadAuthProfileStoreWithoutExternalProfiles(agentDir)
+    : loadAgentLocalAuthProfileStore(agentDir, storeLoadOpts);
+
+  // Also keep profiles referenced in store.order (per-agent overrides set via
+  // 'models auth order set'). These are not reflected in cfg.auth.order or
+  // cfg.auth.profiles, so they would be incorrectly treated as stale without
+  // this step. Note: these IDs are added to configuredProfiles (keep/prune), NOT
+  // to configDerivedProfileIds (guard threshold). (#2921223519)
+  const storeOrder = store.order;
+  if (storeOrder) {
+    for (const ids of Object.values(storeOrder)) {
+      if (Array.isArray(ids)) {
+        for (const id of ids) {
+          if (typeof id === "string" && id.trim()) {
+            configuredProfiles.add(id.trim());
+          }
+        }
+      }
+    }
+  }
+
+  const storeProfileIds = Object.keys(store.profiles);
+
+  const toRemove = storeProfileIds.filter((id) => !configuredProfiles.has(id));
+  const toKeep = storeProfileIds.filter((id) => configuredProfiles.has(id));
+
+  // Safety guard: refuse to wipe everything when openclaw.json has no auth
+  // config at all (e.g. profiles and order both absent/empty). This avoids
+  // accidentally nuking a store-only setup. Require --dry-run to inspect.
+  //
+  // Evaluated against configDerivedProfileIds (cfg-only), NOT configuredProfiles.
+  // configuredProfiles may include store.order IDs, which would silently defeat
+  // this guard in a store-only setup. (#2921223519)
+  if (configDerivedProfileIds.size === 0 && storeProfileIds.length > 0) {
+    if (opts.dryRun) {
+      if (opts.json) {
+        runtime.log(
+          JSON.stringify(
+            {
+              warning:
+                "No profiles configured in openclaw.json auth.profiles or auth.order. All store profiles would be removed. Pass --force to proceed.",
+              storeProfiles: storeProfileIds,
+              dryRun: true,
+            },
+            null,
+            2,
+          ),
+        );
+      } else {
+        runtime.log(
+          "Warning: openclaw.json has no configured profiles. All store profiles would be removed.",
+        );
+        runtime.log(`In store: ${storeProfileIds.map(sanitizeProfileIdForDisplay).join(", ")}`);
+        runtime.log("(dry run -- no changes written)");
+      }
+      return;
+    }
+    throw new Error(
+      "openclaw.json has no configured auth profiles (auth.profiles and auth.order are both empty). " +
+        "Run with --dry-run to inspect, or add profiles to openclaw.json before cleaning.",
+    );
+  }
+
+  if (opts.json) {
+    runtime.log(
+      JSON.stringify(
+        {
+          agentId,
+          agentDir,
+          authStorePath,
+          configuredProfiles: [...configuredProfiles],
+          storeProfiles: storeProfileIds,
+          toRemove,
+          toKeep,
+          dryRun: opts.dryRun ?? false,
+        },
+        null,
+        2,
+      ),
+    );
+    if (opts.dryRun || toRemove.length === 0) {
+      return;
+    }
+  } else {
+    runtime.log(`Agent:      ${agentId}`);
+    runtime.log(`Auth file:  ${authStorePath}`);
+    runtime.log(
+      `Configured: ${[...configuredProfiles].map(sanitizeProfileIdForDisplay).join(", ") || "(none)"}`,
+    );
+    runtime.log(
+      `In store:   ${storeProfileIds.map(sanitizeProfileIdForDisplay).join(", ") || "(none)"}`,
+    );
+  }
+
+  if (toRemove.length === 0) {
+    if (!opts.json) {
+      runtime.log("Nothing to clean up.");
+    }
+    return;
+  }
+
+  if (!opts.json) {
+    runtime.log(`\nProfiles to remove (${toRemove.length}):`);
+    for (const id of toRemove) {
+      runtime.log(`  - ${sanitizeProfileIdForDisplay(id)}`);
+    }
+    runtime.log(`Profiles to keep (${toKeep.length}):`);
+    for (const id of toKeep) {
+      runtime.log(`  + ${sanitizeProfileIdForDisplay(id)}`);
+    }
+  }
+
+  if (opts.dryRun) {
+    if (!opts.json) {
+      runtime.log("\n(dry run -- no changes written)");
+    }
+    return;
+  }
+
+  // Trigger legacy auth.json → auth-profiles.json migration with a write-enabled
+  // load now that all guards have passed and cleanup is confirmed to proceed.
+  // The probe above used readOnly:true (suppressing migration writes); running a
+  // readOnly:false load here ensures the legacy store is persisted before
+  // updateAuthProfileStoreWithLock's ensureAuthStoreFile can create an empty
+  // placeholder (which would cause the lock-internal load to see an empty store
+  // and skip all profile removals). (#2914491523, #2914711181)
+  //
+  // For non-main agents, skipInheritance:true prevents the main-agent fallback
+  // inside loadAuthProfileStoreForAgent from cloning main profiles into the
+  // subagent file when auth-profiles.json is absent.  Without it, a subagent
+  // with no local store would materialise main credentials before cleanup and
+  // skip the intended legacy migration, causing scope bleed. (#2915653312)
+  if (isMainAgentDir) {
+    ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false, readOnly: false });
+  } else {
+    loadAgentLocalAuthProfileStore(agentDir, {
+      allowKeychainPrompt: false,
+      readOnly: false,
+      skipInheritance: true,
+    });
+  }
+
+  // Track actual removals inside the lock (concurrent gateway writes may have
+  // already cleaned some ids between our initial read and lock acquisition).
+  let actualRemoved = 0;
+
+  const updated = await updateAuthProfileStoreWithLock({
+    agentDir,
+    // For non-main agent directories the write target is the agent-local file only.
+    // Setting agentLocalOnly ensures the store loaded inside the lock is the
+    // agent-local view (not the merged main+agent view returned by
+    // ensureAuthProfileStore), which prevents main-store profiles from being
+    // written into the agent-local file (credential scope bleed).
+    agentLocalOnly: !isMainAgentDir,
+    updater: (freshStore: AuthProfileStore) => {
+      let mutated = false;
+
+      // Remove stale profiles
+      for (const id of toRemove) {
+        if (id in freshStore.profiles) {
+          delete freshStore.profiles[id];
+          actualRemoved++;
+          mutated = true;
+        }
+      }
+
+      // Prune removed ids from the order map; delete the key entirely when
+      // the filtered list becomes empty (an empty array overrides config with
+      // no candidates, which breaks provider auth resolution).
+      const order = freshStore.order;
+      if (order) {
+        for (const provider of Object.keys(order)) {
+          const existing = order[provider];
+          if (Array.isArray(existing)) {
+            const filtered = existing.filter((id) => !toRemove.includes(id));
+            if (filtered.length !== existing.length) {
+              mutated = true;
+              if (filtered.length > 0) {
+                order[provider] = filtered;
+              } else {
+                delete order[provider];
+              }
+            }
+          }
+        }
+        if (Object.keys(order).length === 0) {
+          delete freshStore.order;
+        }
+      }
+
+      // Prune removed ids from usageStats
+      if (freshStore.usageStats) {
+        for (const id of toRemove) {
+          if (id in freshStore.usageStats) {
+            delete freshStore.usageStats[id];
+            mutated = true;
+          }
+        }
+      }
+
+      // Prune removed ids from lastGood (provider -> profileId map)
+      if (freshStore.lastGood) {
+        for (const [provider, profileId] of Object.entries(freshStore.lastGood)) {
+          if (toRemove.includes(profileId)) {
+            delete freshStore.lastGood[provider];
+            mutated = true;
+          }
+        }
+      }
+
+      return mutated;
+    },
+  });
+
+  if (!updated) {
+    // updateAuthProfileStoreWithLock returns null for any internal failure (lock
+    // contention, I/O error, permission denied, disk full, etc.) — not just
+    // lock contention. The original message was misleading; use a generic message
+    // so the error accurately reflects that any write failure is possible.
+    throw new Error(
+      "Failed to update auth-profiles.json (write failed — check for lock contention, I/O errors, or permission issues).",
+    );
+  }
+
+  if (opts.json) {
+    runtime.log(JSON.stringify({ ok: true, removed: actualRemoved }, null, 2));
+  } else {
+    runtime.log(`\nRemoved ${actualRemoved} stale profile(s). Restart the gateway to apply.`);
+  }
+}

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -90,6 +90,7 @@ describe("production lint suppressions", () => {
       "scripts/lib/extension-package-boundary.ts|typescript/no-unnecessary-type-parameters|1",
       "scripts/lib/plugin-npm-release.ts|typescript/no-unnecessary-type-parameters|1",
       "src/agents/agent-scope.ts|no-control-regex|1",
+      "src/agents/auth-profiles/sanitize.ts|no-control-regex|2",
       "src/agents/pi-embedded-runner/run/images.ts|no-control-regex|1",
       "src/agents/skills-clawhub.ts|no-control-regex|1",
       "src/agents/subagent-attachments.ts|no-control-regex|1",

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -125,6 +125,7 @@ describe("production lint suppressions", () => {
       "scripts/lib/extension-package-boundary.ts|typescript/no-unnecessary-type-parameters|1",
       "scripts/lib/plugin-npm-release.ts|typescript/no-unnecessary-type-parameters|1",
       "src/agents/agent-scope.ts|no-control-regex|1",
+      "src/agents/auth-profiles/sanitize.ts|no-control-regex|2",
       "src/agents/code-mode.worker.ts|unicorn/require-post-message-target-origin|1",
       "src/agents/pi-embedded-runner/run/images.ts|no-control-regex|1",
       "src/agents/subagent-attachments.ts|no-control-regex|1",

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -125,7 +125,7 @@ describe("production lint suppressions", () => {
       "scripts/lib/extension-package-boundary.ts|typescript/no-unnecessary-type-parameters|1",
       "scripts/lib/plugin-npm-release.ts|typescript/no-unnecessary-type-parameters|1",
       "src/agents/agent-scope.ts|no-control-regex|1",
-      "src/agents/auth-profiles/sanitize.ts|no-control-regex|2",
+      "src/agents/auth-profiles/sanitize.ts|no-control-regex|3",
       "src/agents/code-mode.worker.ts|unicorn/require-post-message-target-origin|1",
       "src/agents/pi-embedded-runner/run/images.ts|no-control-regex|1",
       "src/agents/subagent-attachments.ts|no-control-regex|1",


### PR DESCRIPTION
## Summary

- Adds `openclaw models auth clean` command that identifies and removes stale auth profiles no longer referenced by provider config
- Supports `--dry-run`, `--json`, and `--agent` flags
- Uses file locking to prevent concurrent write races
- Sanitizes profile IDs to prevent terminal injection in diagnostic output
- Uses atomic temp-file-then-rename writes in saveJsonFile (CWE-377 fix)
- Adds `loadAgentLocalAuthProfileStore` to prevent credential scope bleed when cleaning subagent stores

Supersedes #49429, #54171, #41640 (rebased onto current main v2026.4.14).

## Motivation

Stale auth profiles accumulate over time (expired OAuth tokens, removed providers, orphaned external CLI syncs). These stale entries cause recurring "Model login failed" errors when the sync mechanism overwrites fresh credentials with expired ones from external CLI files like `~/.codex/auth.json`.

## Test plan

- [x] `src/commands/models/auth-clean.test.ts` -- 35 tests
- [x] `src/agents/auth-profiles/store.legacy-migration.test.ts` -- 6 tests
- [x] `src/cli/models-cli.test.ts` -- 4 tests
- [x] `pnpm tsgo` passes
- [x] `pnpm build` passes

## Real behavior proof

- **Behavior or issue addressed**: `openclaw models auth clean` prunes profiles present in the agent's `auth-profiles.json` store that are no longer referenced by `openclaw.json` (`auth.profiles` / `auth.order`), keeping configured profiles. Previously there was no command to remove orphaned/stale store entries.
- **Real environment tested**: local `openclaw` build (current upstream/main + this PR) against an isolated `OPENCLAW_HOME` with a disposable store containing one CONFIGURED profile (`anthropic:keep-me`, present in `openclaw.json` auth.profiles) and one ORPHANED profile (`openai-codex:stale-orphan`, present only in the store).
- **Exact steps or command run after this patch**:
  ```bash
  # openclaw.json auth.profiles = { "anthropic:keep-me": {...} }
  # store auth-profiles.json profiles = { anthropic:keep-me, openai-codex:stale-orphan }
  OPENCLAW_HOME=/tmp/authclean-home node dist/index.js models auth clean --dry-run
  OPENCLAW_HOME=/tmp/authclean-home node dist/index.js models auth clean
  ```
- **Evidence after fix**: captured live from `node dist/index.js models auth clean`:

  BEFORE — store profile ids:
  ```
  ['anthropic:keep-me', 'openai-codex:stale-orphan']
  ```
  DRY-RUN — previews the prune without writing:
  ```
  Configured: anthropic:keep-me
  In store:   anthropic:keep-me, openai-codex:stale-orphan
  Profiles to remove (1):
    - openai-codex:stale-orphan
  Profiles to keep (1):
    + anthropic:keep-me
  (dry run -- no changes written)
  ```
  REAL RUN — prunes the orphan:
  ```
  Profiles to remove (1):
    - openai-codex:stale-orphan
  Profiles to keep (1):
    + anthropic:keep-me
  Removed 1 stale profile(s). Restart the gateway to apply.
  ```
  AFTER — store profile ids (orphan pruned, configured retained):
  ```
  ['anthropic:keep-me']
  ```
- **Observed result after fix**: the orphaned `openai-codex:stale-orphan` profile is removed from the store while the configured `anthropic:keep-me` profile is kept. Dry-run previews identically without writing. A timestamped backup of the prior store is written before the rewrite.
- **What was not tested**: pruning against a live production store (used a disposable `OPENCLAW_HOME` to avoid touching real credentials). The `--force` path for a store with zero configured profiles (covered by unit tests; not exercised here since the realistic case keeps at least one configured profile).
