### PR TITLE
fix(google): do not inherit template 1M context window for gemma models

### DIFF
--- a/extensions/google/provider-models.test.ts
+++ b/extensions/google/provider-models.test.ts
@@ -255,4 +255,22 @@ describe("resolveGoogleGeminiForwardCompatModel", () => {
       reasoning: false,
     });
   });
+
+  it("does not inherit the template's 1M context window for gemma models", () => {
+    const model = resolveGoogleGeminiForwardCompatModel({
+      providerId: "google",
+      ctx: createContext({
+        provider: "google",
+        modelId: "gemma-4-26b-a4b-it",
+        models: [
+          createTemplateModel("google", "gemini-3-flash-preview", {
+            contextWindow: 1_048_576,
+          }),
+        ],
+      }),
+    });
+
+    expect(model).toBeDefined();
+    expect(model!.contextWindow).toBe(131_072);
+  });
 });

--- a/extensions/google/provider-models.ts
+++ b/extensions/google/provider-models.ts
@@ -13,6 +13,9 @@ const GEMINI_3_1_PRO_PREFIX = "gemini-3.1-pro";
 const GEMINI_3_1_FLASH_LITE_PREFIX = "gemini-3.1-flash-lite";
 const GEMINI_3_1_FLASH_PREFIX = "gemini-3.1-flash";
 const GEMMA_PREFIX = "gemma-";
+// Gemma models have much smaller context windows than Gemini flash (1M).
+// Use 128k as a safe default to avoid inheriting the template's 1M window.
+const GEMMA_DEFAULT_CONTEXT_WINDOW = 131_072;
 const GEMINI_2_5_PRO_TEMPLATE_IDS = ["gemini-2.5-pro"] as const;
 const GEMINI_2_5_FLASH_LITE_TEMPLATE_IDS = ["gemini-2.5-flash-lite"] as const;
 const GEMINI_2_5_FLASH_TEMPLATE_IDS = ["gemini-2.5-flash"] as const;
@@ -151,8 +154,9 @@ export function resolveGoogleGeminiForwardCompatModel(params: {
       googleTemplateIds: GEMMA_TEMPLATE_IDS,
       cliTemplateIds: GEMMA_TEMPLATE_IDS,
     };
+    patch = { contextWindow: GEMMA_DEFAULT_CONTEXT_WINDOW };
     if (lower.startsWith("gemma-4")) {
-      patch = { reasoning: true };
+      patch = { ...patch, reasoning: true };
     }
   } else {
     return undefined;


### PR DESCRIPTION
## Summary
- Gemma models use the `gemini-3-flash-preview` template as a forward-compat approximation, but this causes them to incorrectly display a **1024k** context window instead of their actual ~128k
- Added `GEMMA_DEFAULT_CONTEXT_WINDOW = 131_072` constant and applied it as a patch for all gemma models in the forward-compat resolver
- Added test verifying gemma models don't inherit the template's 1M window

Fixes #66740

## Test plan
- [x] Added unit test: `does not inherit the template's 1M context window for gemma models`
- [ ] Verify `openclaw models list` shows correct context window for gemma models

🤖 Generated with [Claude Code](https://claude.com/claude-code)