### PR TITLE
style: apply oxfmt formatting to 16 files

### DIFF
--- a/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
+++ b/.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs
@@ -52,7 +52,11 @@ function ghGraphQL(query, options = {}) {
 
 function failOnGraphQLFailure(result, message) {
   if (result?.gh_failed) {
-    const details = (result.stderr || result.stdout || `gh exited with status ${result.status}`).trim();
+    const details = (
+      result.stderr ||
+      result.stdout ||
+      `gh exited with status ${result.status}`
+    ).trim();
     fail(`${message}: ${details}`);
   }
   if (Array.isArray(result?.errors) && result.errors.length > 0) {
@@ -73,9 +77,7 @@ function formatGraphQLAfterClause(cursor) {
 }
 
 function findDiscussionCommentNode(nodes, discussionCommentDbId) {
-  return (
-    nodes.find((node) => String(node.databaseId) === String(discussionCommentDbId)) || null
-  );
+  return nodes.find((node) => String(node.databaseId) === String(discussionCommentDbId)) || null;
 }
 
 function fetchDiscussionReplyPage(commentNodeId, cursor) {
@@ -169,9 +171,13 @@ function fetchDiscussionComment(discussionNumber, discussionCommentDbId) {
 
       while (!reply && hasMoreReplies) {
         const replyPage = fetchDiscussionReplyPage(topLevelComment.id, replyCursor);
-        failOnGraphQLFailure(replyPage, `Failed to fetch replies for discussion comment ${topLevelComment.id}`);
+        failOnGraphQLFailure(
+          replyPage,
+          `Failed to fetch replies for discussion comment ${topLevelComment.id}`,
+        );
         const replies = replyPage?.data?.node?.replies;
-        if (!replies) fail(`Failed to paginate replies for discussion comment ${topLevelComment.id}`);
+        if (!replies)
+          fail(`Failed to paginate replies for discussion comment ${topLevelComment.id}`);
 
         reply = findDiscussionCommentNode(replies.nodes, discussionCommentDbId);
         hasMoreReplies = replies.pageInfo.hasNextPage;
@@ -189,9 +195,7 @@ function fetchDiscussionComment(discussionNumber, discussionCommentDbId) {
 }
 
 function createDiscussionComment(discussionNodeId, body, replyToNodeId) {
-  const replyToClause = replyToNodeId
-    ? `, replyToId: "${escapeGraphQLString(replyToNodeId)}"`
-    : "";
+  const replyToClause = replyToNodeId ? `, replyToId: "${escapeGraphQLString(replyToNodeId)}"` : "";
   const result = ghGraphQL(
     `mutation { addDiscussionComment(input: { discussionId: "${escapeGraphQLString(discussionNodeId)}"${replyToClause}, body: "${escapeGraphQLString(body)}" }) { comment { id url } } }`,
   );
@@ -261,7 +265,10 @@ function cmdFetchContent(locationJson) {
     const discussionNumber = urlMatch[1];
     const discussionCommentDbId = urlMatch[2];
 
-    const { discussionId, comment } = fetchDiscussionComment(discussionNumber, discussionCommentDbId);
+    const { discussionId, comment } = fetchDiscussionComment(
+      discussionNumber,
+      discussionCommentDbId,
+    );
     if (!comment)
       fail(
         `Discussion comment #${discussionCommentDbId} not found in discussion #${discussionNumber}`,

--- a/docs/style.css
+++ b/docs/style.css
@@ -82,7 +82,10 @@ html.dark .nav-tabs-underline {
   border-radius: 8px;
   background: color-mix(in oklab, rgb(var(--primary)) 4%, transparent);
   text-decoration: none;
-  transition: transform 0.16s ease, border-color 0.16s ease, background 0.16s ease;
+  transition:
+    transform 0.16s ease,
+    border-color 0.16s ease,
+    background 0.16s ease;
 }
 
 .showcase-actions a:first-child {

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -1619,8 +1619,7 @@ describe("active-memory plugin", () => {
         messages: [
           {
             role: "user",
-            content:
-              "Active Memory: I really do want you to remember that I prefer aisle seats.",
+            content: "Active Memory: I really do want you to remember that I prefer aisle seats.",
           },
           {
             role: "user",

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -1527,7 +1527,9 @@ function extractRecentTurns(messages: unknown[]): ActiveRecallRecentTurn[] {
     }
     const rawText = extractTextContent(typed.content);
     const text =
-      role === "assistant" ? stripRecalledContextNoise(rawText) : stripInjectedActiveMemoryPrefixOnly(rawText);
+      role === "assistant"
+        ? stripRecalledContextNoise(rawText)
+        : stripInjectedActiveMemoryPrefixOnly(rawText);
     if (!text) {
       continue;
     }

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -467,7 +467,10 @@ export async function executePreparedCliRun(
           ...parsed,
           rawText,
           finalPromptText: prompt,
-          text: applyPluginTextReplacements(rawText, context.backendResolved.textTransforms?.output),
+          text: applyPluginTextReplacements(
+            rawText,
+            context.backendResolved.textTransforms?.output,
+          ),
         };
       } finally {
         restoreSkillEnv?.();

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -669,7 +669,9 @@ function isOpenRouterKeyLimitExceededError(raw: string, provider?: string): bool
 }
 
 function isExactUnknownNoDetailsError(raw: string): boolean {
-  return normalizeOptionalLowercaseString(raw)?.trim() === "unknown error (no error details in response)";
+  return (
+    normalizeOptionalLowercaseString(raw)?.trim() === "unknown error (no error details in response)"
+  );
 }
 
 function classifyFailoverClassificationFromMessage(

--- a/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.context-engine-helpers.ts
@@ -207,51 +207,50 @@ export async function finalizeAttemptContextEngineTurn(params: {
   let postTurnFinalizationSucceeded = true;
 
   if (typeof params.contextEngine.afterTurn === "function") {
-      try {
-        await params.contextEngine.afterTurn({
-          sessionId: params.sessionIdUsed,
-          sessionKey: params.sessionKey,
-          sessionFile: params.sessionFile,
-          messages: params.messagesSnapshot,
-          prePromptMessageCount: params.prePromptMessageCount,
-          tokenBudget: params.tokenBudget,
-          runtimeContext: params.runtimeContext,
-        });
-      } catch (afterTurnErr) {
-        postTurnFinalizationSucceeded = false;
-        params.warn(`context engine afterTurn failed: ${String(afterTurnErr)}`);
-      }
-    } else {
-      const newMessages = params.messagesSnapshot.slice(params.prePromptMessageCount);
-      if (newMessages.length > 0) {
-        if (typeof params.contextEngine.ingestBatch === "function") {
+    try {
+      await params.contextEngine.afterTurn({
+        sessionId: params.sessionIdUsed,
+        sessionKey: params.sessionKey,
+        sessionFile: params.sessionFile,
+        messages: params.messagesSnapshot,
+        prePromptMessageCount: params.prePromptMessageCount,
+        tokenBudget: params.tokenBudget,
+        runtimeContext: params.runtimeContext,
+      });
+    } catch (afterTurnErr) {
+      postTurnFinalizationSucceeded = false;
+      params.warn(`context engine afterTurn failed: ${String(afterTurnErr)}`);
+    }
+  } else {
+    const newMessages = params.messagesSnapshot.slice(params.prePromptMessageCount);
+    if (newMessages.length > 0) {
+      if (typeof params.contextEngine.ingestBatch === "function") {
+        try {
+          await params.contextEngine.ingestBatch({
+            sessionId: params.sessionIdUsed,
+            sessionKey: params.sessionKey,
+            messages: newMessages,
+          });
+        } catch (ingestErr) {
+          postTurnFinalizationSucceeded = false;
+          params.warn(`context engine ingest failed: ${String(ingestErr)}`);
+        }
+      } else {
+        for (const msg of newMessages) {
           try {
-            await params.contextEngine.ingestBatch({
+            await params.contextEngine.ingest?.({
               sessionId: params.sessionIdUsed,
               sessionKey: params.sessionKey,
-              messages: newMessages,
+              message: msg,
             });
           } catch (ingestErr) {
             postTurnFinalizationSucceeded = false;
             params.warn(`context engine ingest failed: ${String(ingestErr)}`);
           }
-        } else {
-          for (const msg of newMessages) {
-            try {
-              await params.contextEngine.ingest?.({
-                sessionId: params.sessionIdUsed,
-                sessionKey: params.sessionKey,
-                message: msg,
-              });
-            } catch (ingestErr) {
-              postTurnFinalizationSucceeded = false;
-              params.warn(`context engine ingest failed: ${String(ingestErr)}`);
-            }
-          }
         }
       }
     }
-
+  }
 
   if (
     !params.promptError &&

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -255,13 +255,13 @@ export function buildAfterTurnRuntimeContext(params: {
       ownerNumbers: params.attempt.ownerNumbers,
     }),
     ...(typeof params.tokenBudget === "number" &&
-      Number.isFinite(params.tokenBudget) &&
-      params.tokenBudget > 0
+    Number.isFinite(params.tokenBudget) &&
+    params.tokenBudget > 0
       ? { tokenBudget: Math.floor(params.tokenBudget) }
       : {}),
     ...(typeof params.currentTokenCount === "number" &&
-      Number.isFinite(params.currentTokenCount) &&
-      params.currentTokenCount > 0
+    Number.isFinite(params.currentTokenCount) &&
+    params.currentTokenCount > 0
       ? { currentTokenCount: Math.floor(params.currentTokenCount) }
       : {}),
     ...(params.promptCache ? { promptCache: params.promptCache } : {}),

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1725,9 +1725,11 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
     );
 
     const wrapped = wrapStreamFnSanitizeMalformedToolCalls(baseFn as never, new Set(["read"]));
-    const stream = wrapped({ api: "google-gemini" } as never, { messages } as never, {} as never) as
-      | FakeWrappedStream
-      | Promise<FakeWrappedStream>;
+    const stream = wrapped(
+      { api: "google-gemini" } as never,
+      { messages } as never,
+      {} as never,
+    ) as FakeWrappedStream | Promise<FakeWrappedStream>;
     await Promise.resolve(stream);
 
     expect(baseFn).toHaveBeenCalledTimes(1);

--- a/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
+++ b/src/agents/pi-embedded-runner/run/preemptive-compaction.ts
@@ -1,12 +1,12 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { estimateTokens } from "@mariozechner/pi-coding-agent";
 import { SAFETY_MARGIN, estimateMessagesTokens } from "../../compaction.js";
-import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
-import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 import {
   MIN_PROMPT_BUDGET_RATIO,
   MIN_PROMPT_BUDGET_TOKENS,
 } from "../../pi-compaction-constants.js";
+import { estimateToolResultReductionPotential } from "../tool-result-truncation.js";
+import type { PreemptiveCompactionRoute } from "./preemptive-compaction.types.js";
 
 export const PREEMPTIVE_OVERFLOW_ERROR_TEXT =
   "Context overflow: prompt too large for the model (precheck).";

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import {
-  MIN_PROMPT_BUDGET_RATIO,
-  MIN_PROMPT_BUDGET_TOKENS,
-} from "./pi-compaction-constants.js";
+import { MIN_PROMPT_BUDGET_RATIO, MIN_PROMPT_BUDGET_TOKENS } from "./pi-compaction-constants.js";
 import {
   applyPiCompactionSettingsFromConfig,
   DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR,

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -1,9 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ContextEngineInfo } from "../context-engine/types.js";
-import {
-  MIN_PROMPT_BUDGET_RATIO,
-  MIN_PROMPT_BUDGET_TOKENS,
-} from "./pi-compaction-constants.js";
+import { MIN_PROMPT_BUDGET_RATIO, MIN_PROMPT_BUDGET_TOKENS } from "./pi-compaction-constants.js";
 
 export const DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
 

--- a/src/agents/sandbox-paths.windows-drive-resolve.test.ts
+++ b/src/agents/sandbox-paths.windows-drive-resolve.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveSandboxInputPath } from "./sandbox-paths.js";
 import { resolveToolPathAgainstWorkspaceRoot } from "./pi-tools.read.js";
+import { resolveSandboxInputPath } from "./sandbox-paths.js";
 
 describe("resolveSandboxInputPath (Windows drive paths under POSIX rules)", () => {
   it("does not join workspace cwd when path looks like a Windows drive path", () => {

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -121,7 +121,9 @@ This is plain user text`;
 
   it("strips an active-memory prompt prefix block even when earlier text precedes it", () => {
     const input = `Queued earlier user turn\n\n${ACTIVE_MEMORY_PREFIX_BLOCK}\n\nWhat should I grab on the way?`;
-    expect(stripInboundMetadata(input)).toBe("Queued earlier user turn\n\nWhat should I grab on the way?");
+    expect(stripInboundMetadata(input)).toBe(
+      "Queued earlier user turn\n\nWhat should I grab on the way?",
+    );
   });
 
   it("does not strip active-memory lookalike user text without exact tag lines", () => {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -682,9 +682,9 @@ export function buildStatusMessage(args: StatusArgs): string {
   const queueDetails = formatQueueDetails(args.queue);
   const verboseLabel =
     verboseLevel === "full" ? "verbose:full" : verboseLevel === "on" ? "verbose" : null;
-  const traceLevel = entry?.traceLevel === "raw" ? "raw" : entry?.traceLevel === "on" ? "on" : "off";
-  const traceLabel =
-    traceLevel === "raw" ? "trace:raw" : traceLevel === "on" ? "trace" : null;
+  const traceLevel =
+    entry?.traceLevel === "raw" ? "raw" : entry?.traceLevel === "on" ? "on" : "off";
+  const traceLabel = traceLevel === "raw" ? "trace:raw" : traceLevel === "on" ? "trace" : null;
   const pluginStatusLines = verboseLevel !== "off" ? resolveSessionPluginStatusLines(entry) : [];
   const pluginTraceLines =
     traceLevel === "on" || traceLevel === "raw" ? resolveSessionPluginTraceLines(entry) : [];

--- a/ui/src/ui/markdown.ts
+++ b/ui/src/ui/markdown.ts
@@ -274,7 +274,6 @@ md.linkify.add("www", {
       break;
     }
     return len;
-
   },
   normalize(match) {
     match.url = "http://" + match.url;


### PR DESCRIPTION
Running `pnpm format:check` found 16 files with formatting drift. Applied `pnpm format` (`oxfmt --write`). No logic changes.

Files touched:
- `.agents/skills/openclaw-secret-scanning-maintainer/scripts/secret-scanning.mjs`
- `docs/style.css`
- `extensions/active-memory/index.{ts,test.ts}`
- `src/agents/cli-runner/execute.ts`
- `src/agents/pi-embedded-helpers/errors.ts`
- `src/agents/pi-embedded-runner/run/attempt.{context-engine-helpers,prompt-helpers,test}.ts`
- `src/agents/pi-embedded-runner/run/preemptive-compaction.ts`
- `src/agents/pi-settings.{ts,test.ts}`
- `src/agents/sandbox-paths.windows-drive-resolve.test.ts`
- `src/auto-reply/reply/strip-inbound-meta.test.ts`
- `src/auto-reply/status.ts`
- `ui/src/ui/markdown.ts`
