### PR TITLE
feat(feishu): add old version document read support

### DIFF
--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -20,6 +20,7 @@ import {
   mergeTableCells,
 } from "./docx-table-ops.js";
 import type { FeishuDocxBlock, FeishuDocxBlockChild } from "./docx-types.js";
+import { fetchOldDocMeta, readOldDoc } from "./old-doc.js";
 import { getFeishuRuntime } from "./runtime.js";
 import {
   createFeishuToolClient,
@@ -865,6 +866,19 @@ async function uploadFileBlock(
 const STRUCTURED_BLOCK_TYPES = new Set([14, 18, 21, 23, 27, 30, 31, 32]);
 
 async function readDoc(client: Lark.Client, docToken: string) {
+  // Version detection: check if this is an old-version document
+  try {
+    const meta = await fetchOldDocMeta(client, docToken);
+    if (!meta.is_upgraded) {
+      return await readOldDoc(client, docToken);
+    }
+    if (meta.upgraded_token) {
+      return await readDoc(client, meta.upgraded_token);
+    }
+  } catch {
+    // Meta API unavailable — proceed with docx API
+  }
+
   const [contentRes, infoRes, blocksRes] = await Promise.all([
     client.docx.document.rawContent({ path: { document_id: docToken } }),
     client.docx.document.get({ path: { document_id: docToken } }),

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -866,23 +866,31 @@ async function uploadFileBlock(
 const STRUCTURED_BLOCK_TYPES = new Set([14, 18, 21, 23, 27, 30, 31, 32]);
 
 async function readDoc(client: Lark.Client, docToken: string) {
-  // Version detection: check if this is an old-version document
+  // Version detection: check if this is an old-version document.
+  // Only the meta call is wrapped in try/catch; downstream read errors propagate.
+  let oldDocMeta: Awaited<ReturnType<typeof fetchOldDocMeta>> | undefined;
   try {
     const meta = await fetchOldDocMeta(client, docToken);
     if (!meta.is_upgraded) {
-      return await readOldDoc(client, docToken);
+      // Old version — read via legacy doc v2 API (meta passed to avoid redundant call)
+      return await readOldDoc(client, docToken, meta);
     }
+    // Document has been upgraded — use the upgraded token with the docx API path below.
+    // No recursion: we read the upgraded docx token directly in the parallel fetch below.
     if (meta.upgraded_token) {
-      return await readDoc(client, meta.upgraded_token);
+      oldDocMeta = meta;
     }
   } catch {
-    // Meta API unavailable — proceed with docx API
+    // Meta API unavailable (permissions, not an old doc, etc.) — proceed with docx API
   }
 
+  // Use upgraded token if available, otherwise use the original token
+  const resolvedToken = oldDocMeta?.upgraded_token ?? docToken;
+
   const [contentRes, infoRes, blocksRes] = await Promise.all([
-    client.docx.document.rawContent({ path: { document_id: docToken } }),
-    client.docx.document.get({ path: { document_id: docToken } }),
-    client.docx.documentBlock.list({ path: { document_id: docToken } }),
+    client.docx.document.rawContent({ path: { document_id: resolvedToken } }),
+    client.docx.document.get({ path: { document_id: resolvedToken } }),
+    client.docx.documentBlock.list({ path: { document_id: resolvedToken } }),
   ]);
 
   if (contentRes.code !== 0) {

--- a/extensions/feishu/src/old-doc-types.ts
+++ b/extensions/feishu/src/old-doc-types.ts
@@ -1,0 +1,137 @@
+/**
+ * Type definitions for Feishu old version (doc v2) document structures.
+ *
+ * Old version documents use URL format `/docs/:docs_token` and type field `doc`.
+ * They are distinct from upgraded documents (`/docx/:docx_token`, type `docx`).
+ *
+ * Reference: https://open.feishu.cn/document/server-docs/docs/docs/docs-doc-overview
+ */
+
+// ============ Element types ============
+
+export type OldDocTextRun = {
+  content?: string;
+  link?: string;
+  text_element_style?: {
+    bold?: boolean;
+    italic?: boolean;
+    strikethrough?: boolean;
+    underline?: boolean;
+    inline_code?: boolean;
+    link?: { url?: string };
+  };
+};
+
+export type OldDocElement = {
+  type?: string;
+  text_run?: OldDocTextRun;
+  mention?: { tenant_key?: string; user_id?: string; open_id?: string };
+  equation?: { content?: string };
+};
+
+// ============ Block types ============
+
+export type OldDocParagraph = {
+  elements?: OldDocElement[];
+  style?: {
+    align?: string;
+    heading_level?: number;
+    list?: { type?: string };
+  };
+};
+
+export type OldDocTableCell = {
+  content?: { blocks?: OldDocBlock[] };
+  cell_style?: Record<string, unknown>;
+};
+
+export type OldDocTableRow = {
+  cells?: OldDocTableCell[];
+};
+
+export type OldDocTable = {
+  row_size?: number;
+  column_size?: number;
+  rows?: OldDocTableRow[];
+  style?: Record<string, unknown>;
+};
+
+export type OldDocCode = {
+  language?: string;
+  elements?: OldDocElement[];
+  style?: Record<string, unknown>;
+};
+
+export type OldDocGallery = {
+  images?: Array<{
+    file_token?: string;
+    width?: number;
+    height?: number;
+  }>;
+};
+
+export type OldDocFile = {
+  file_token?: string;
+  name?: string;
+  type?: string;
+  size?: number;
+};
+
+export type OldDocBlock = {
+  type: string;
+  paragraph?: OldDocParagraph;
+  table?: OldDocTable;
+  code?: OldDocCode;
+  gallery?: OldDocGallery;
+  file?: OldDocFile;
+  callout?: OldDocParagraph;
+  horizontalLine?: Record<string, unknown>;
+  embeddedPage?: { url?: string };
+  sheet?: Record<string, unknown>;
+  bitable?: Record<string, unknown>;
+};
+
+// ============ Document content ============
+
+export type OldDocContent = {
+  title?: OldDocParagraph;
+  body?: {
+    blocks?: OldDocBlock[];
+  };
+};
+
+// ============ API response types ============
+
+export type OldDocMetaResponse = {
+  code: number;
+  msg?: string;
+  data?: {
+    title?: string;
+    create_time?: number;
+    edit_time?: number;
+    creator?: string;
+    owner?: string;
+    delete_flag?: number;
+    is_upgraded?: boolean;
+    upgraded_token?: string;
+    obj_type?: string;
+    url?: string;
+  };
+};
+
+export type OldDocContentResponse = {
+  code: number;
+  msg?: string;
+  data?: {
+    content?: string; // JSON-encoded OldDocContent
+    revision?: number;
+  };
+};
+
+export type OldDocRawContentResponse = {
+  code: number;
+  msg?: string;
+  data?: {
+    content?: string;
+  };
+};

--- a/extensions/feishu/src/old-doc.test.ts
+++ b/extensions/feishu/src/old-doc.test.ts
@@ -214,35 +214,27 @@ describe("feishu_doc old version document read", () => {
     expect(result.details.hint).toContain("table");
   });
 
-  it("redirects to upgraded token when meta says is_upgraded=true", async () => {
-    // First meta call returns upgraded=true with upgraded_token
-    // Second meta call (for upgraded token) should fall through to docx API
-    let metaCallCount = 0;
-    requestMock.mockImplementation((opts: { url: string }) => {
-      if (opts.url.includes("/open-apis/doc/v2/meta/")) {
-        metaCallCount++;
-        if (metaCallCount === 1) {
-          // Old doc token → upgraded
-          return Promise.resolve({
-            code: 0,
-            data: { is_upgraded: true, upgraded_token: "new_docx_token" },
-          });
-        }
-        // New docx token meta → not an old doc, throw to fall through
-        return Promise.resolve({ code: 99999, msg: "not found" });
-      }
-      return Promise.resolve({ code: -1, msg: "Not mocked" });
+  it("reads upgraded document via docx API with upgraded token", async () => {
+    // Meta returns is_upgraded=true with upgraded_token
+    // No second meta call — the upgraded token goes directly to docx API
+    setupRequestMock({
+      "/open-apis/doc/v2/meta/": {
+        code: 0,
+        data: { is_upgraded: true, upgraded_token: "new_docx_token" },
+      },
     });
 
     const tool = resolveFeishuDocTool();
     const result = await executeRead(tool, "old_token");
 
-    // Should have redirected to the new docx token and used docx API
+    // Should use upgraded token directly with docx API (no recursion)
     expect(result.details.title).toBe("New Doc");
     expect(result.details.content).toBe("new doc text");
     expect(rawContentMock).toHaveBeenCalledWith(
       expect.objectContaining({ path: { document_id: "new_docx_token" } }),
     );
+    // Only one meta call (no recursive readDoc → fetchOldDocMeta)
+    expect(requestMock).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to docx API when meta API fails", async () => {

--- a/extensions/feishu/src/old-doc.test.ts
+++ b/extensions/feishu/src/old-doc.test.ts
@@ -1,0 +1,313 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createToolFactoryHarness, type ToolLike } from "./tool-factory-test-harness.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+const resolveFeishuToolAccountMock = vi.hoisted(() => vi.fn());
+const requestMock = vi.hoisted(() => vi.fn());
+const rawContentMock = vi.hoisted(() => vi.fn());
+const documentGetMock = vi.hoisted(() => vi.fn());
+const blockListMock = vi.hoisted(() => vi.fn());
+const convertMock = vi.hoisted(() => vi.fn());
+const documentCreateMock = vi.hoisted(() => vi.fn());
+const blockChildrenCreateMock = vi.hoisted(() => vi.fn());
+const blockChildrenGetMock = vi.hoisted(() => vi.fn());
+const blockChildrenBatchDeleteMock = vi.hoisted(() => vi.fn());
+const blockDescendantCreateMock = vi.hoisted(() => vi.fn());
+const driveUploadAllMock = vi.hoisted(() => vi.fn());
+const permissionMemberCreateMock = vi.hoisted(() => vi.fn());
+const blockPatchMock = vi.hoisted(() => vi.fn());
+const scopeListMock = vi.hoisted(() => vi.fn());
+
+const toolAccountModule = await import("./tool-account.js");
+const runtimeModule = await import("./runtime.js");
+
+vi.spyOn(toolAccountModule, "createFeishuToolClient").mockImplementation(() =>
+  createFeishuClientMock(),
+);
+vi.spyOn(toolAccountModule, "resolveAnyEnabledFeishuToolsConfig").mockReturnValue({
+  doc: true,
+  chat: false,
+  wiki: false,
+  drive: false,
+  perm: false,
+  scopes: false,
+});
+vi.spyOn(toolAccountModule, "resolveFeishuToolAccount").mockImplementation((...args) =>
+  resolveFeishuToolAccountMock(...args),
+);
+vi.spyOn(runtimeModule, "getFeishuRuntime").mockImplementation(
+  () =>
+    ({
+      channel: {
+        media: {
+          fetchRemoteMedia: vi.fn(),
+          saveMediaBuffer: vi.fn(),
+        },
+      },
+      media: {
+        loadWebMedia: vi.fn(),
+        detectMime: vi.fn(async () => "application/octet-stream"),
+        mediaKindFromMime: vi.fn(() => "image"),
+        isVoiceCompatibleAudio: vi.fn(() => false),
+        getImageMetadata: vi.fn(async () => null),
+        resizeToJpeg: vi.fn(async () => Buffer.alloc(0)),
+      },
+    }) as unknown as ReturnType<typeof runtimeModule.getFeishuRuntime>,
+);
+
+const { registerFeishuDocTools } = await import("./docx.js");
+
+type ToolResultWithDetails = {
+  details: Record<string, unknown>;
+};
+
+function mockDocxClient() {
+  return {
+    docx: {
+      document: {
+        convert: convertMock,
+        create: documentCreateMock,
+        rawContent: rawContentMock,
+        get: documentGetMock,
+      },
+      documentBlock: {
+        list: blockListMock,
+        patch: blockPatchMock,
+      },
+      documentBlockChildren: {
+        create: blockChildrenCreateMock,
+        get: blockChildrenGetMock,
+        batchDelete: blockChildrenBatchDeleteMock,
+      },
+      documentBlockDescendant: {
+        create: blockDescendantCreateMock,
+      },
+    },
+    drive: {
+      media: {
+        uploadAll: driveUploadAllMock,
+      },
+      permissionMember: {
+        create: permissionMemberCreateMock,
+      },
+    },
+    application: {
+      scope: {
+        list: scopeListMock,
+      },
+    },
+    // client.request() used by old-doc.ts
+    request: requestMock,
+  };
+}
+
+const OLD_DOC_CONTENT = JSON.stringify({
+  title: { elements: [{ text_run: { content: "Test Old Doc" } }] },
+  body: {
+    blocks: [
+      { type: "paragraph", paragraph: { elements: [{ text_run: { content: "Hello world" } }] } },
+      { type: "table", table: { row_size: 2, column_size: 3 } },
+      {
+        type: "code",
+        code: { language: "python", elements: [{ text_run: { content: "print(1)" } }] },
+      },
+    ],
+  },
+});
+
+function setupRequestMock(responses: Record<string, unknown>) {
+  requestMock.mockImplementation((opts: { url: string }) => {
+    for (const [urlPattern, response] of Object.entries(responses)) {
+      if (opts.url.includes(urlPattern)) {
+        return Promise.resolve(response);
+      }
+    }
+    return Promise.resolve({ code: -1, msg: "Not mocked" });
+  });
+}
+
+describe("feishu_doc old version document read", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    createFeishuClientMock.mockReturnValue(mockDocxClient());
+    resolveFeishuToolAccountMock.mockReturnValue({
+      config: { mediaMaxMb: 30 },
+    });
+
+    // Default docx mocks
+    rawContentMock.mockResolvedValue({ code: 0, data: { content: "new doc text" } });
+    documentGetMock.mockResolvedValue({
+      code: 0,
+      data: { document: { title: "New Doc", revision_id: "rev1" } },
+    });
+    blockListMock.mockResolvedValue({ code: 0, data: { items: [] } });
+    convertMock.mockResolvedValue({
+      code: 0,
+      data: { blocks: [], first_level_block_ids: [] },
+    });
+    documentCreateMock.mockResolvedValue({
+      code: 0,
+      data: { document: { document_id: "doc_created", title: "Created Doc" } },
+    });
+    blockChildrenCreateMock.mockResolvedValue({ code: 0, data: { children: [] } });
+    blockChildrenGetMock.mockResolvedValue({ code: 0, data: { items: [] } });
+    blockChildrenBatchDeleteMock.mockResolvedValue({ code: 0 });
+    blockDescendantCreateMock.mockResolvedValue({ code: 0, data: { children: [] } });
+    driveUploadAllMock.mockResolvedValue({ file_token: "token_1" });
+    permissionMemberCreateMock.mockResolvedValue({ code: 0 });
+    blockPatchMock.mockResolvedValue({ code: 0 });
+    scopeListMock.mockResolvedValue({ code: 0, data: { scopes: [] } });
+  });
+
+  function resolveFeishuDocTool(context: Record<string, unknown> = {}) {
+    const harness = createToolFactoryHarness({
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "app_id",
+          appSecret: "app_secret",
+        },
+      },
+    });
+    registerFeishuDocTools(harness.api);
+    const tool = harness.resolveTool("feishu_doc", context);
+    expect(tool).toBeDefined();
+    return tool;
+  }
+
+  async function executeRead(tool: ToolLike, docToken: string) {
+    return (await tool.execute("tool-call", {
+      action: "read",
+      doc_token: docToken,
+    })) as ToolResultWithDetails;
+  }
+
+  it("reads old version document when meta says is_upgraded=false", async () => {
+    setupRequestMock({
+      "/open-apis/doc/v2/meta/": {
+        code: 0,
+        data: { title: "Old Doc Title", is_upgraded: false },
+      },
+      "/open-apis/doc/v2/old_token/raw_content": {
+        code: 0,
+        data: { content: "plain text from old doc" },
+      },
+      "/open-apis/doc/v2/old_token/content": {
+        code: 0,
+        data: { content: OLD_DOC_CONTENT },
+      },
+    });
+
+    const tool = resolveFeishuDocTool();
+    const result = await executeRead(tool, "old_token");
+
+    expect(result.details.document_version).toBe("old");
+    expect(result.details.content).toBe("plain text from old doc");
+    expect(result.details.title).toBe("Old Doc Title");
+    expect(result.details.block_count).toBe(3);
+    expect(result.details.block_types).toEqual({
+      paragraph: 1,
+      table: 1,
+      code: 1,
+    });
+    expect(result.details.hint).toContain("table");
+  });
+
+  it("redirects to upgraded token when meta says is_upgraded=true", async () => {
+    // First meta call returns upgraded=true with upgraded_token
+    // Second meta call (for upgraded token) should fall through to docx API
+    let metaCallCount = 0;
+    requestMock.mockImplementation((opts: { url: string }) => {
+      if (opts.url.includes("/open-apis/doc/v2/meta/")) {
+        metaCallCount++;
+        if (metaCallCount === 1) {
+          // Old doc token → upgraded
+          return Promise.resolve({
+            code: 0,
+            data: { is_upgraded: true, upgraded_token: "new_docx_token" },
+          });
+        }
+        // New docx token meta → not an old doc, throw to fall through
+        return Promise.resolve({ code: 99999, msg: "not found" });
+      }
+      return Promise.resolve({ code: -1, msg: "Not mocked" });
+    });
+
+    const tool = resolveFeishuDocTool();
+    const result = await executeRead(tool, "old_token");
+
+    // Should have redirected to the new docx token and used docx API
+    expect(result.details.title).toBe("New Doc");
+    expect(result.details.content).toBe("new doc text");
+    expect(rawContentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ path: { document_id: "new_docx_token" } }),
+    );
+  });
+
+  it("falls back to docx API when meta API fails", async () => {
+    setupRequestMock({
+      "/open-apis/doc/v2/meta/": {
+        code: 91403,
+        msg: "FORBIDDEN",
+      },
+    });
+
+    const tool = resolveFeishuDocTool();
+    const result = await executeRead(tool, "some_token");
+
+    // Should fall through to docx API
+    expect(result.details.title).toBe("New Doc");
+    expect(result.details.content).toBe("new doc text");
+    expect(result.details).not.toHaveProperty("document_version");
+  });
+
+  it("extracts title from content when meta has no title", async () => {
+    setupRequestMock({
+      "/open-apis/doc/v2/meta/": {
+        code: 0,
+        data: { is_upgraded: false }, // no title
+      },
+      "/open-apis/doc/v2/notitle/raw_content": {
+        code: 0,
+        data: { content: "content text" },
+      },
+      "/open-apis/doc/v2/notitle/content": {
+        code: 0,
+        data: { content: OLD_DOC_CONTENT }, // title is "Test Old Doc"
+      },
+    });
+
+    const tool = resolveFeishuDocTool();
+    const result = await executeRead(tool, "notitle");
+
+    expect(result.details.title).toBe("Test Old Doc");
+    expect(result.details.document_version).toBe("old");
+  });
+
+  it("handles empty old doc content gracefully", async () => {
+    setupRequestMock({
+      "/open-apis/doc/v2/meta/": {
+        code: 0,
+        data: { is_upgraded: false, title: "Empty Doc" },
+      },
+      "/open-apis/doc/v2/empty/raw_content": {
+        code: 0,
+        data: { content: "" },
+      },
+      "/open-apis/doc/v2/empty/content": {
+        code: 0,
+        data: { content: "" },
+      },
+    });
+
+    const tool = resolveFeishuDocTool();
+    const result = await executeRead(tool, "empty");
+
+    expect(result.details.document_version).toBe("old");
+    expect(result.details.content).toBe("");
+    expect(result.details.block_count).toBe(0);
+    expect(result.details.block_types).toEqual({});
+    expect(result.details).not.toHaveProperty("hint");
+  });
+});

--- a/extensions/feishu/src/old-doc.ts
+++ b/extensions/feishu/src/old-doc.ts
@@ -143,12 +143,18 @@ function countOldBlockTypes(blocks: OldDocBlock[]): {
 
 // ============ Main read function ============
 
+/** Pre-fetched meta result passed from readDoc to avoid redundant API calls. */
+export type OldDocMetaResult = {
+  is_upgraded: boolean;
+  upgraded_token?: string;
+  title?: string;
+};
+
 /** Read an old version Feishu document, returning a unified result shape. */
-export async function readOldDoc(client: Lark.Client, docToken: string) {
-  const [rawContentRes, contentRes, metaRes] = await Promise.all([
+export async function readOldDoc(client: Lark.Client, docToken: string, meta: OldDocMetaResult) {
+  const [rawContentRes, contentRes] = await Promise.all([
     fetchOldDocRawContent(client, docToken),
     fetchOldDocContent(client, docToken),
-    fetchOldDocMeta(client, docToken),
   ]);
 
   // Parse the rich content JSON string
@@ -166,8 +172,7 @@ export async function readOldDoc(client: Lark.Client, docToken: string) {
   const { blockCounts, structuredTypes } = countOldBlockTypes(blocks);
 
   // Extract title from content if meta didn't provide one
-  const title =
-    metaRes.title || (parsedContent ? extractTextFromParagraph(parsedContent.title) : "");
+  const title = meta.title || (parsedContent ? extractTextFromParagraph(parsedContent.title) : "");
 
   let hint: string | undefined;
   if (structuredTypes.length > 0) {
@@ -178,8 +183,8 @@ export async function readOldDoc(client: Lark.Client, docToken: string) {
     title,
     content: rawContentRes.data?.content ?? "",
     document_version: "old" as const,
-    is_upgraded: metaRes.is_upgraded,
-    upgraded_token: metaRes.upgraded_token,
+    is_upgraded: meta.is_upgraded,
+    upgraded_token: meta.upgraded_token,
     block_count: blocks.length,
     block_types: blockCounts,
     ...(hint && { hint }),

--- a/extensions/feishu/src/old-doc.ts
+++ b/extensions/feishu/src/old-doc.ts
@@ -1,0 +1,187 @@
+/**
+ * Old version (doc v2) Feishu document support.
+ *
+ * Provides read access to legacy Feishu documents (type `doc`, URL `/docs/:token`)
+ * that are not supported by the `@larksuiteoapi/node-sdk` docx API surface.
+ *
+ * Uses `client.request()` to call old version REST endpoints directly,
+ * reusing the SDK's authentication layer (tenant_access_token management).
+ */
+
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type {
+  OldDocBlock,
+  OldDocContent,
+  OldDocContentResponse,
+  OldDocMetaResponse,
+  OldDocRawContentResponse,
+} from "./old-doc-types.js";
+
+// ============ Internal client type ============
+
+type OldDocInternalClient = Lark.Client & {
+  request(params: {
+    method: "GET" | "POST";
+    url: string;
+    params?: Record<string, string | undefined>;
+    data?: unknown;
+    timeout?: number;
+  }): Promise<unknown>;
+};
+
+const OLD_DOC_REQUEST_TIMEOUT_MS = 30_000;
+
+function getOldDocInternalClient(client: Lark.Client): OldDocInternalClient {
+  return client as OldDocInternalClient;
+}
+
+// ============ API request helpers ============
+
+async function requestOldDocApi<T>(params: {
+  client: Lark.Client;
+  method: "GET" | "POST";
+  url: string;
+  query?: Record<string, string | undefined>;
+  data?: unknown;
+}): Promise<T> {
+  const internal = getOldDocInternalClient(params.client);
+  return (await internal.request({
+    method: params.method,
+    url: params.url,
+    params: params.query ?? {},
+    data: params.data ?? {},
+    timeout: OLD_DOC_REQUEST_TIMEOUT_MS,
+  })) as T;
+}
+
+// ============ API calls ============
+
+/** Fetch document metadata including version info (is_upgraded, upgraded_token). */
+export async function fetchOldDocMeta(client: Lark.Client, docToken: string) {
+  const res = await requestOldDocApi<OldDocMetaResponse>({
+    client,
+    method: "GET",
+    url: `/open-apis/doc/v2/meta/${encodeURIComponent(docToken)}`,
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg ?? `Old doc meta API failed (code: ${res.code})`);
+  }
+  return {
+    is_upgraded: res.data?.is_upgraded ?? false,
+    upgraded_token: res.data?.upgraded_token,
+    title: res.data?.title,
+  };
+}
+
+/** Fetch document rich content (JSON body structure). */
+async function fetchOldDocContent(client: Lark.Client, docToken: string) {
+  const res = await requestOldDocApi<OldDocContentResponse>({
+    client,
+    method: "GET",
+    url: `/open-apis/doc/v2/${encodeURIComponent(docToken)}/content`,
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg ?? `Old doc content API failed (code: ${res.code})`);
+  }
+  return res;
+}
+
+/** Fetch document plain text content. */
+async function fetchOldDocRawContent(client: Lark.Client, docToken: string) {
+  const res = await requestOldDocApi<OldDocRawContentResponse>({
+    client,
+    method: "GET",
+    url: `/open-apis/doc/v2/${encodeURIComponent(docToken)}/raw_content`,
+  });
+  if (res.code !== 0) {
+    throw new Error(res.msg ?? `Old doc raw content API failed (code: ${res.code})`);
+  }
+  return res;
+}
+
+// ============ Content parsing ============
+
+/** Extract text from an old doc paragraph's elements. */
+function extractTextFromParagraph(
+  paragraph: { elements?: Array<{ text_run?: { content?: string } }> } | undefined,
+): string {
+  if (!paragraph?.elements) {
+    return "";
+  }
+  return paragraph.elements.map((el) => el.text_run?.content ?? "").join("");
+}
+
+/** Block types that are structured and may not be fully visible in plain text. */
+const STRUCTURED_OLD_BLOCK_TYPES = new Set([
+  "table",
+  "gallery",
+  "file",
+  "code",
+  "sheet",
+  "bitable",
+  "embeddedPage",
+]);
+
+/** Parse old doc blocks into block type counts. */
+function countOldBlockTypes(blocks: OldDocBlock[]): {
+  blockCounts: Record<string, number>;
+  structuredTypes: string[];
+} {
+  const blockCounts: Record<string, number> = {};
+  const structuredTypes: string[] = [];
+
+  for (const block of blocks) {
+    const type = block.type || "unknown";
+    blockCounts[type] = (blockCounts[type] || 0) + 1;
+    if (STRUCTURED_OLD_BLOCK_TYPES.has(type) && !structuredTypes.includes(type)) {
+      structuredTypes.push(type);
+    }
+  }
+
+  return { blockCounts, structuredTypes };
+}
+
+// ============ Main read function ============
+
+/** Read an old version Feishu document, returning a unified result shape. */
+export async function readOldDoc(client: Lark.Client, docToken: string) {
+  const [rawContentRes, contentRes, metaRes] = await Promise.all([
+    fetchOldDocRawContent(client, docToken),
+    fetchOldDocContent(client, docToken),
+    fetchOldDocMeta(client, docToken),
+  ]);
+
+  // Parse the rich content JSON string
+  let parsedContent: OldDocContent | undefined;
+  try {
+    const contentStr = contentRes.data?.content;
+    if (contentStr) {
+      parsedContent = JSON.parse(contentStr) as OldDocContent;
+    }
+  } catch {
+    // If parsing fails, we still have raw content
+  }
+
+  const blocks = parsedContent?.body?.blocks ?? [];
+  const { blockCounts, structuredTypes } = countOldBlockTypes(blocks);
+
+  // Extract title from content if meta didn't provide one
+  const title =
+    metaRes.title || (parsedContent ? extractTextFromParagraph(parsedContent.title) : "");
+
+  let hint: string | undefined;
+  if (structuredTypes.length > 0) {
+    hint = `This is an old-version Feishu document containing ${structuredTypes.join(", ")} which may not be fully visible in plain text. Consider upgrading the document for full block-level access.`;
+  }
+
+  return {
+    title,
+    content: rawContentRes.data?.content ?? "",
+    document_version: "old" as const,
+    is_upgraded: metaRes.is_upgraded,
+    upgraded_token: metaRes.upgraded_token,
+    block_count: blocks.length,
+    block_types: blockCounts,
+    ...(hint && { hint }),
+  };
+}


### PR DESCRIPTION
## Summary

- Add transparent read support for legacy Feishu documents (type `doc`, URL format `/docs/:token`) that are not covered by the `@larksuiteoapi/node-sdk` docx API surface
- The `readDoc` function now auto-detects document version via the old doc meta API (`GET /open-apis/doc/v2/meta/:token`) and routes accordingly:
  - **Old version** (`is_upgraded=false`): fetches content via doc v2 REST endpoints using `client.request()`
  - **Upgraded** (`is_upgraded=true` + `upgraded_token`): transparently redirects to the new docx token
  - **Meta API failure**: falls back to existing docx API unchanged
- No schema changes — version detection is fully transparent to callers

### New files
- `extensions/feishu/src/old-doc-types.ts` — TypeScript types for old version document structures (Paragraph, Block, Table, etc.)
- `extensions/feishu/src/old-doc.ts` — API call helpers, content parsing, and `readOldDoc` orchestration
- `extensions/feishu/src/old-doc.test.ts` — unit tests covering version detection, upgraded redirect, fallback, and content parsing

### Modified files
- `extensions/feishu/src/docx.ts` — adds version detection to `readDoc()` (+14 lines, zero changes to existing logic)

## Test plan

- [x] `oxlint` passes on all new/modified files (0 errors, 0 warnings)
- [x] TypeScript parse check passes
- [ ] `pnpm check` passes (blocked by missing `madge` dep in local env — pre-existing issue)
- [ ] `pnpm test` for feishu extension (blocked by `non-isolated-runner` TestRunner resolution — pre-existing issue)
- [ ] Manual test: pass an old-version doc token to `feishu_doc` action `read`, verify output includes `document_version: "old"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)