### PR TITLE
feat(chutes): add zai-org/GLM-5.1-TEE to static model catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ Docs: https://docs.openclaw.ai
 - Docs/showcase: add a scannable hero, complete section jump links, and a responsive video grid for community examples. (#48493) Thanks @jchopard69.
 - Agents/local models: add `agents.defaults.localModelMode: "lean"` to drop heavyweight default tools like `browser`, `cron`, and `message`, reducing prompt size for weaker local-model setups without changing the normal path. Thanks @ImLukeF.
 - QA/Matrix: split Matrix live QA into a source-linked `qa-matrix` runner and keep repo-private `qa-*` surfaces out of packaged and published builds. (#66723) Thanks @gumadeiras.
-- Providers/Chutes: add `zai-org/GLM-5.1-TEE` to the bundled static model catalog. (#67008) Thanks @tardigrde.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Docs/showcase: add a scannable hero, complete section jump links, and a responsive video grid for community examples. (#48493) Thanks @jchopard69.
 - Agents/local models: add `agents.defaults.localModelMode: "lean"` to drop heavyweight default tools like `browser`, `cron`, and `message`, reducing prompt size for weaker local-model setups without changing the normal path. Thanks @ImLukeF.
 - QA/Matrix: split Matrix live QA into a source-linked `qa-matrix` runner and keep repo-private `qa-*` surfaces out of packaged and published builds. (#66723) Thanks @gumadeiras.
+- Providers/Chutes: add `zai-org/GLM-5.1-TEE` to the bundled static model catalog. (#67008) Thanks @tardigrde.
 
 ### Fixes
 

--- a/docs/providers/chutes.md
+++ b/docs/providers/chutes.md
@@ -90,6 +90,7 @@ The bundled fallback catalog includes current Chutes refs:
 | ----------------------------------------------------- |
 | `chutes/zai-org/GLM-4.7-TEE`                          |
 | `chutes/zai-org/GLM-5-TEE`                            |
+| `chutes/zai-org/GLM-5.1-TEE`                          |
 | `chutes/deepseek-ai/DeepSeek-V3.2-TEE`                |
 | `chutes/deepseek-ai/DeepSeek-R1-0528-TEE`             |
 | `chutes/moonshotai/Kimi-K2.5-TEE`                     |

--- a/extensions/chutes/models.ts
+++ b/extensions/chutes/models.ts
@@ -8,7 +8,7 @@ import {
 const log = createSubsystemLogger("chutes-models");
 
 export const CHUTES_BASE_URL = "https://llm.chutes.ai/v1";
-export const CHUTES_DEFAULT_MODEL_ID = "zai-org/GLM-5.1-TEE";
+export const CHUTES_DEFAULT_MODEL_ID = "zai-org/GLM-4.7-TEE";
 export const CHUTES_DEFAULT_MODEL_REF = `chutes/${CHUTES_DEFAULT_MODEL_ID}`;
 
 const CHUTES_DEFAULT_CONTEXT_WINDOW = 128000;

--- a/extensions/chutes/models.ts
+++ b/extensions/chutes/models.ts
@@ -8,7 +8,7 @@ import {
 const log = createSubsystemLogger("chutes-models");
 
 export const CHUTES_BASE_URL = "https://llm.chutes.ai/v1";
-export const CHUTES_DEFAULT_MODEL_ID = "zai-org/GLM-4.7-TEE";
+export const CHUTES_DEFAULT_MODEL_ID = "zai-org/GLM-5.1-TEE";
 export const CHUTES_DEFAULT_MODEL_REF = `chutes/${CHUTES_DEFAULT_MODEL_ID}`;
 
 const CHUTES_DEFAULT_CONTEXT_WINDOW = 128000;
@@ -131,6 +131,15 @@ export const CHUTES_MODEL_CATALOG: ModelDefinitionConfig[] = [
     contextWindow: 163840,
     maxTokens: 65536,
     cost: { input: 0.45, output: 2.15, cacheRead: 0, cacheWrite: 0 },
+  },
+  {
+    id: "zai-org/GLM-5.1-TEE",
+    name: "zai-org/GLM-5.1-TEE",
+    reasoning: true,
+    input: ["text"],
+    contextWindow: 202752,
+    maxTokens: 65535,
+    cost: { input: 0.95, output: 3.15, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "zai-org/GLM-5-TEE",

--- a/extensions/chutes/models.ts
+++ b/extensions/chutes/models.ts
@@ -139,7 +139,7 @@ export const CHUTES_MODEL_CATALOG: ModelDefinitionConfig[] = [
     input: ["text"],
     contextWindow: 202752,
     maxTokens: 65535,
-    cost: { input: 0.95, output: 3.15, cacheRead: 0, cacheWrite: 0 },
+    cost: { input: 1.05, output: 3.5, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "zai-org/GLM-5-TEE",


### PR DESCRIPTION
## Summary

`zai-org/GLM-5.1-TEE` is available on the Chutes unified gateway but was missing from the bundled static catalog.

The Chutes discovery endpoint (`GET /v1/models`) always times out from self-hosted VPS environments, so the static catalog is the only reliable way to surface the model for those users.

## Model specs (verified from live Chutes API)

| Field | Value |
|---|---|
| id | `zai-org/GLM-5.1-TEE` |
| contextWindow | 202 752 |
| maxTokens | 65 535 |
| input | text |
| reasoning | true |
| cost (input) | .05 / M tokens |
| cost (output) | .50 / M tokens |
| chute_id | `b048fe26-0352-5c46-acf7-335e527e7f3d` |

No other behavior changes — default model is untouched.

## Test plan

- [x] Existing `extensions/chutes/models.test.ts` — 10/10 tests pass unchanged
- [x] `discoverChutesModels("")` returns static catalog including the new entry
- [x] No import cycles, no TS errors in the chutes extension

🤖 Generated with [Claude Code](https://claude.ai/claude-code)