### PR TITLE
fix: avoid false circular detection for shared references

### DIFF
--- a/src/agents/cache-trace.test.ts
+++ b/src/agents/cache-trace.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import { createCacheTrace } from "./cache-trace.js";
+import { sanitizeDiagnosticPayload } from "./payload-redaction.js";
 
 describe("createCacheTrace", () => {
   function createMemoryTraceForTest() {
@@ -261,6 +262,55 @@ describe("createCacheTrace", () => {
     expect(source.data).toBe("<redacted>");
     expect(source.bytes).toBe(6);
     expect(source.sha256).toBe(crypto.createHash("sha256").update("U0VDUkVU").digest("hex"));
+  });
+
+  it("does not treat sibling references to the same object as circular", () => {
+    const lines: string[] = [];
+    const trace = createCacheTrace({
+      cfg: {
+        diagnostics: {
+          cacheTrace: {
+            enabled: true,
+          },
+        },
+      },
+      env: {},
+      writer: {
+        filePath: "memory",
+        write: (line) => lines.push(line),
+        flush: async () => undefined,
+      },
+    });
+
+    const shared = { value: "shared" };
+    trace?.recordStage("stream:context", {
+      options: {
+        left: shared,
+        right: shared,
+      },
+    });
+
+    const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
+    expect(event.options).toEqual({
+      left: { value: "shared" },
+      right: { value: "shared" },
+    });
+  });
+
+  it("preserves shared sanitized subtree identity for repeated references", () => {
+    const payload = { value: "leaf" };
+    const shared = { child: payload };
+    const sanitized = sanitizeDiagnosticPayload({
+      left: shared,
+      right: shared,
+    }) as {
+      left?: { child?: unknown };
+      right?: { child?: unknown };
+    };
+
+    expect(sanitized.left).toEqual({ child: { value: "leaf" } });
+    expect(sanitized.right).toEqual({ child: { value: "leaf" } });
+    expect(sanitized.left).toBe(sanitized.right);
   });
 
   it("handles circular references in messages without stack overflow", () => {

--- a/src/agents/payload-redaction.ts
+++ b/src/agents/payload-redaction.ts
@@ -77,7 +77,8 @@ function visitDiagnosticPayload(
   value: unknown,
   opts?: { omitField?: (key: string) => boolean },
 ): unknown {
-  const seen = new WeakSet<object>();
+  const activePath = new WeakSet<object>();
+  const memo = new WeakMap<object, unknown>();
 
   const visit = (input: unknown): unknown => {
     if (Array.isArray(input)) {
@@ -89,10 +90,14 @@ function visitDiagnosticPayload(
     if (!input || typeof input !== "object") {
       return input;
     }
-    if (seen.has(input)) {
+    if (activePath.has(input)) {
       return "[Circular]";
     }
-    seen.add(input);
+    const cached = memo.get(input);
+    if (cached !== undefined) {
+      return cached;
+    }
+    activePath.add(input);
 
     const record = input as Record<string, unknown>;
     const out: Record<string, unknown> = {};
@@ -109,6 +114,8 @@ function visitDiagnosticPayload(
       out.bytes = estimateBase64DecodedBytes(record.data);
       out.sha256 = digestBase64Payload(record.data);
     }
+    activePath.delete(input);
+    memo.set(input, out);
     return out;
   };
 


### PR DESCRIPTION
# PR: fix false circular detection for shared references in diagnostic payload traversal

## Summary
This PR fixes a false-positive circular detection bug in diagnostic payload traversal.

Previously, the traversal used a global `seen` set. That caused sibling fields that reference the same object instance to be treated as `[Circular]`, even when the object graph was acyclic.

This PR switches the tracking semantics from "seen anywhere in traversal history" to "currently active on the recursion path".

## What changed
- In `src/agents/payload-redaction.ts`
  - replace the global `seen` set with `activePath`
  - remove objects from the active set after finishing traversal of that subtree
- In `src/agents/cache-trace.test.ts`
  - add a regression test proving that sibling references to the same object are not treated as circular

## Why this is correct
A true circular reference occurs when traversal reaches an object that is already on the current DFS recursion path.
A shared sibling reference is not a cycle; it is only a repeated reference from a different branch.

Using `activePath` preserves correct circular detection while avoiding false positives for shared references.

## Scope
This PR intentionally only fixes traversal/circular-detection correctness.
It does **not** change cache-trace credential redaction/sanitization behavior.

## Validation
Ran:

```bash
npm exec -- pnpm test -- src/agents/cache-trace.test.ts
```

Result:
- 1 file passed
- 8 tests passed
- 0 failed
