### PR TITLE
fix(discord): unblock gateway CI checks

### DIFF
--- a/extensions/discord/src/monitor/gateway-plugin.test.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.test.ts
@@ -75,6 +75,9 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 
 describe("SafeGatewayPlugin.connect()", () => {
   let createDiscordGatewayPlugin: typeof import("./gateway-plugin.js").createDiscordGatewayPlugin;
+  type GatewayWithFirstHeartbeatTimeout = ReturnType<typeof createDiscordGatewayPlugin> & {
+    firstHeartbeatTimeout?: ReturnType<typeof setTimeout>;
+  };
 
   beforeAll(async () => {
     ({ createDiscordGatewayPlugin } = await import("./gateway-plugin.js"));
@@ -118,7 +121,7 @@ describe("SafeGatewayPlugin.connect()", () => {
   });
 
   it("clears stale firstHeartbeatTimeout before delegating to super when isConnecting=true", () => {
-    const plugin = createPlugin();
+    const plugin = createPlugin() as GatewayWithFirstHeartbeatTimeout;
 
     const staleTimeout = setTimeout(() => {}, 99_999);
     try {

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -37,6 +37,7 @@ type DiscordGatewayWebSocketCtor = new (url: string, options?: { agent?: unknown
 const registrationPromises = new WeakMap<carbonGateway.GatewayPlugin, Promise<void>>();
 type CarbonGatewayRegistrationState = {
   client?: Parameters<carbonGateway.GatewayPlugin["registerClient"]>[0];
+  firstHeartbeatTimeout?: ReturnType<typeof setTimeout>;
   ws?: unknown;
   isConnecting?: boolean;
 };
@@ -303,9 +304,10 @@ function createGatewayPlugin(params: {
         clearInterval(this.heartbeatInterval);
         this.heartbeatInterval = undefined;
       }
-      if (this.firstHeartbeatTimeout !== undefined) {
-        clearTimeout(this.firstHeartbeatTimeout);
-        this.firstHeartbeatTimeout = undefined;
+      const heartbeatState = this as CarbonGatewayRegistrationState;
+      if (heartbeatState.firstHeartbeatTimeout !== undefined) {
+        clearTimeout(heartbeatState.firstHeartbeatTimeout);
+        heartbeatState.firstHeartbeatTimeout = undefined;
       }
       super.connect(resume);
     }

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -304,7 +304,7 @@ function createGatewayPlugin(params: {
         clearInterval(this.heartbeatInterval);
         this.heartbeatInterval = undefined;
       }
-      const heartbeatState = this as CarbonGatewayRegistrationState;
+      const heartbeatState = this as unknown as CarbonGatewayRegistrationState;
       if (heartbeatState.firstHeartbeatTimeout !== undefined) {
         clearTimeout(heartbeatState.firstHeartbeatTimeout);
         heartbeatState.firstHeartbeatTimeout = undefined;


### PR DESCRIPTION
## Summary

- keep the Discord gateway `firstHeartbeatTimeout` cleanup behavior while using a local structural type for the upstream private timer field
- align the focused regression test with the same narrow structural type so `tsgo` no longer depends on undeclared `@buape/carbon` internals
- route non-proxy Discord gateway metadata lookups through `fetchWithSsrFGuard()` instead of raw `fetch()` while preserving fatal/transient metadata failure behavior

## Validation

- `pnpm.cmd tsgo`
- `pnpm.cmd exec vitest run extensions/discord/src/monitor/gateway-plugin.test.ts extensions/discord/src/monitor/provider.proxy.test.ts`
- `pnpm.cmd lint:tmp:no-raw-channel-fetch`
- `node_modules\.bin\oxlint.cmd extensions/discord/src/monitor/gateway-plugin.ts extensions/discord/src/monitor/gateway-plugin.test.ts extensions/discord/src/monitor/provider.proxy.test.ts`
- GitHub Actions: all visible checks passed on #67033