### PR TITLE
fix: add redaction patterns for JWTs, Basic auth, and custom security headers in logs.tail

### DIFF
--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -208,4 +208,32 @@ describe("redactSensitiveLines", () => {
     expect(joined).toContain("…redacted…");
     expect(joined).not.toContain("ABCDEF1234567890");
   });
+
+  it("masks generic JWT tokens", () => {
+    const jwt =
+      "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const input = `Authorization: Bearer ${jwt}`;
+    const output = redactSensitiveText(input, { mode: "tools", patterns: defaults });
+    expect(output).not.toContain("eyJzdWIiOiIxMjM0NTY3ODkwIn0");
+  });
+
+  it("masks Basic auth headers", () => {
+    const input = "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=";
+    const output = redactSensitiveText(input, { mode: "tools", patterns: defaults });
+    expect(output).not.toContain("dXNlcm5hbWU6cGFzc3dvcmQ=");
+  });
+
+  it("masks X-OpenClaw-Token headers", () => {
+    const input = 'X-OpenClaw-Token: oc_abcdef1234567890ghijklmn';
+    const output = redactSensitiveText(input, { mode: "tools", patterns: defaults });
+    expect(output).not.toContain("oc_abcdef1234567890ghijklmn");
+  });
+
+  it("masks x-pomerium-jwt-assertion headers", () => {
+    const jwt =
+      "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIn0.abc123def456ghi789jkl";
+    const input = `x-pomerium-jwt-assertion: ${jwt}`;
+    const output = redactSensitiveText(input, { mode: "tools", patterns: defaults });
+    expect(output).not.toContain("eyJzdWIiOiJ1c2VyQGV4YW1wbGUuY29tIn0");
+  });
 });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -38,6 +38,12 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   // Telegram Bot API URLs embed the token as `/bot<token>/...` (no word-boundary before digits).
   String.raw`\bbot(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
   String.raw`\b(\d{6,}:[A-Za-z0-9_-]{20,})\b`,
+  // Generic JWTs (three base64url segments separated by dots).
+  String.raw`\b(eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,})\b`,
+  // Basic auth headers.
+  String.raw`Authorization\s*[:=]\s*Basic\s+([A-Za-z0-9+/=]{18,})\b`,
+  // Custom security headers (X-OpenClaw-Token, x-pomerium-jwt-assertion, etc.).
+  String.raw`(?:X-OpenClaw-Token|x-pomerium-jwt-assertion|X-Api-Key|X-Auth-Token)\s*[:=]\s*["']?([A-Za-z0-9._\-+=]{18,})["']?`,
 ];
 
 type RedactOptions = {


### PR DESCRIPTION
## Summary

\logs.tail\ redaction missed several credential formats that could leak secrets to \operator.read\ clients.

## Changes

Added redaction patterns for:
- **Generic JWTs** — \yJ...\ three-segment base64url tokens
- **Basic auth headers** — \Authorization: Basic <base64>\
- **Custom security headers** — \X-OpenClaw-Token\, \x-pomerium-jwt-assertion\, \X-Api-Key\, \X-Auth-Token\

## Tests

Added 4 test cases in \edact.test.ts\ covering all new patterns.

Fixes #66832