### PR TITLE
fix(slack): honor dmHistoryLimit for 1:1 DMs

### DIFF
--- a/extensions/slack/src/monitor/context.test.ts
+++ b/extensions/slack/src/monitor/context.test.ts
@@ -18,6 +18,7 @@ function createTestContext() {
     teamId: "T_EXPECTED",
     apiAppId: "A_EXPECTED",
     historyLimit: 0,
+    dmHistoryLimit: 0,
     sessionScope: "per-sender",
     mainKey: "main",
     dmEnabled: true,

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -35,6 +35,7 @@ export type SlackMonitorContext = {
   apiAppId: string;
 
   historyLimit: number;
+  dmHistoryLimit: number;
   channelHistories: Map<string, HistoryEntry[]>;
   sessionScope: SessionScope;
   mainKey: string;
@@ -102,6 +103,7 @@ export function createSlackMonitorContext(params: {
   apiAppId: string;
 
   historyLimit: number;
+  dmHistoryLimit: number;
   sessionScope: SessionScope;
   mainKey: string;
 
@@ -402,6 +404,7 @@ export function createSlackMonitorContext(params: {
     teamId: params.teamId,
     apiAppId: params.apiAppId,
     historyLimit: params.historyLimit,
+    dmHistoryLimit: params.dmHistoryLimit,
     channelHistories,
     sessionScope: params.sessionScope,
     mainKey: params.mainKey,

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -671,11 +671,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   if (!anyReplyDelivered) {
     await draftStream?.clear();
-    if (prepared.isRoomish) {
+    if (prepared.activeHistoryLimit > 0) {
       clearHistoryEntriesIfEnabled({
         historyMap: ctx.channelHistories,
         historyKey: prepared.historyKey,
-        limit: ctx.historyLimit,
+        limit: prepared.activeHistoryLimit,
       });
     }
     return;
@@ -714,11 +714,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     });
   }
 
-  if (prepared.isRoomish) {
+  if (prepared.activeHistoryLimit > 0) {
     clearHistoryEntriesIfEnabled({
       historyMap: ctx.channelHistories,
       historyKey: prepared.historyKey,
-      limit: ctx.historyLimit,
+      limit: prepared.activeHistoryLimit,
     });
   }
 }

--- a/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test-helpers.ts
@@ -23,6 +23,7 @@ export function createInboundSlackTestContext(params: {
     teamId: "T1",
     apiAppId: "A1",
     historyLimit: 0,
+    dmHistoryLimit: 0,
     sessionScope: "per-sender",
     mainKey: "main",
     dmEnabled: true,

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -629,6 +629,7 @@ describe("prepareSlackMessage sender prefix", () => {
       teamId: "T1",
       apiAppId: "A1",
       historyLimit: 0,
+      dmHistoryLimit: 0,
       channelHistories: new Map(),
       sessionScope: "per-sender",
       mainKey: "agent:main:main",

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -516,6 +516,10 @@ export async function prepareSlackMessage(params: {
     },
   });
   const effectiveWasMentioned = mentionDecision.effectiveWasMentioned;
+  // Pick the active history limit for the current chat shape: rooms/group DMs
+  // use `historyLimit`; true 1:1 DMs use `dmHistoryLimit` (0 disables).
+  const activeHistoryLimit = isRoomish ? ctx.historyLimit : ctx.dmHistoryLimit;
+  const historyEnabled = activeHistoryLimit > 0;
   if (isRoom && shouldRequireMention && mentionDecision.shouldSkip) {
     ctx.logger.info({ channel: message.channel, reason: "no-mention" }, "skipping channel message");
     const pendingText = (message.text ?? "").trim();
@@ -528,7 +532,7 @@ export async function prepareSlackMessage(params: {
     recordPendingHistoryEntryIfEnabled({
       historyMap: ctx.channelHistories,
       historyKey,
-      limit: ctx.historyLimit,
+      limit: activeHistoryLimit,
       entry: pendingBody
         ? {
             sender: await resolveSenderName(),
@@ -653,11 +657,11 @@ export async function prepareSlackMessage(params: {
   });
 
   let combinedBody = body;
-  if (isRoomish && ctx.historyLimit > 0) {
+  if (historyEnabled) {
     combinedBody = buildPendingHistoryContextFromMap({
       historyMap: ctx.channelHistories,
       historyKey,
-      limit: ctx.historyLimit,
+      limit: activeHistoryLimit,
       currentMessage: combinedBody,
       formatEntry: (entry) =>
         formatInboundEnvelope({
@@ -709,14 +713,13 @@ export async function prepareSlackMessage(params: {
   const effectiveMedia = effectiveDirectMedia ?? threadStarterMedia;
   const firstMedia = effectiveMedia?.[0];
 
-  const inboundHistory =
-    isRoomish && ctx.historyLimit > 0
-      ? (ctx.channelHistories.get(historyKey) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
-      : undefined;
+  const inboundHistory = historyEnabled
+    ? (ctx.channelHistories.get(historyKey) ?? []).map((entry) => ({
+        sender: entry.sender,
+        body: entry.body,
+        timestamp: entry.timestamp,
+      }))
+    : undefined;
   const commandBody = textForCommandDetection.trim();
 
   const ctxPayload = finalizeInboundContext({
@@ -837,6 +840,7 @@ export async function prepareSlackMessage(params: {
     replyToMode,
     isDirectMessage,
     isRoomish,
+    activeHistoryLimit,
     historyKey,
     preview,
     ackReactionMessageTs,

--- a/extensions/slack/src/monitor/message-handler/types.ts
+++ b/extensions/slack/src/monitor/message-handler/types.ts
@@ -16,6 +16,7 @@ export type PreparedSlackMessage = {
   replyToMode: "off" | "first" | "all" | "batched";
   isDirectMessage: boolean;
   isRoomish: boolean;
+  activeHistoryLimit: number;
   historyKey: string;
   preview: string;
   ackReactionMessageTs?: string;

--- a/extensions/slack/src/monitor/monitor.test.ts
+++ b/extensions/slack/src/monitor/monitor.test.ts
@@ -116,6 +116,7 @@ const baseParams = () => ({
   teamId: "T1",
   apiAppId: "A1",
   historyLimit: 0,
+  dmHistoryLimit: 0,
   sessionScope: "per-sender" as const,
   mainKey: "main",
   dmEnabled: true,

--- a/extensions/slack/src/monitor/provider.ts
+++ b/extensions/slack/src/monitor/provider.ts
@@ -257,6 +257,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
       cfg.messages?.groupChat?.historyLimit ??
       DEFAULT_GROUP_HISTORY_LIMIT,
   );
+  const dmHistoryLimit = Math.max(0, account.config.dmHistoryLimit ?? 0);
 
   const sessionCfg = cfg.session;
   const sessionScope: SessionScope = sessionCfg?.scope ?? "per-sender";
@@ -408,6 +409,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     teamId,
     apiAppId,
     historyLimit,
+    dmHistoryLimit,
     sessionScope,
     mainKey,
     dmEnabled,


### PR DESCRIPTION
## What

Wire `channels.slack.accounts.*.dmHistoryLimit` through the Slack monitor so 1:1 DM turns include prior bot messages in prompt context instead of always seeing an empty history.

Changes:

| File | Change |
|------|--------|
| `provider.ts` | Derive `dmHistoryLimit` from `account.config.dmHistoryLimit` (default 0) and pass it into `createSlackMonitorContext` alongside `historyLimit`. |
| `context.ts` | `SlackMonitorContext` / `CreateSlackMonitorContextParams` carry `dmHistoryLimit: number`. |
| `message-handler/prepare.ts` | Compute `activeHistoryLimit = isRoomish ? ctx.historyLimit : ctx.dmHistoryLimit` once; use it to gate (a) the pending-history record on the no-mention skip path, (b) the `combinedBody` history injection, and (c) the structured `InboundHistory` field. |
| `message-handler/types.ts` | `PreparedSlackMessage` carries `activeHistoryLimit: number`. |
| `message-handler/dispatch.ts` | Clear history entries using `prepared.activeHistoryLimit` instead of gating on `prepared.isRoomish`, so DM history buckets don't leak across turns once `dmHistoryLimit > 0`. |
| tests | Add `dmHistoryLimit: 0` to the four in-tree SlackMonitorContext fixtures so they keep typechecking. |

## Why

Fixes #67020.

Before: `dmHistoryLimit` is defined in the Slack zod schema (`src/config/zod-schema.providers-core.ts`) and documented in channel-config metadata, so `openclaw config set channels.slack.accounts.X.dmHistoryLimit 30` succeeds — but no consumer reads it. In `provider.ts` the only derived limit was `account.config.historyLimit`, and in `prepare.ts` every history site (`combinedBody`, `InboundHistory`, `recordPendingHistoryEntryIfEnabled` on the no-mention path) was gated on `isRoomish = isRoom || isGroupDm`. True 1:1 DMs (`im`) are not roomish, so any non-threaded DM reply lost all context from the bot's prior message in the same DM.

For comparison, the Mattermost monitor gates its history path on `historyKey && historyLimit > 0` — no `isRoomish` gate — which is why the same class of bug doesn't exist there. The Slack `isRoomish` gate was an oversight, not an intentional design choice.

## Behavior preservation

- Default config (`dmHistoryLimit` unset → 0) leaves DM behavior exactly as before: `activeHistoryLimit === 0` skips both the record and the consumption sites.
- Rooms and group DMs continue to use `historyLimit` unchanged — they hit `isRoomish`, so `activeHistoryLimit === ctx.historyLimit`.
- `channelHistories` is still per-turn and per-channel keyed (`historyKey` resolution is unchanged), so enabling `dmHistoryLimit` does not add cross-channel leakage.

## Test

```
pnpm test -- src/poll-params.test.ts   # smoke: unit-fast project still runs clean
```

Slack tests currently require the `runtime-config` vitest project, which has a pre-existing `Class extends value undefined` infra bug unrelated to this change (reproduces on `main` with no edits). `tsc --noEmit` reports no new errors under `extensions/slack`.

## Risk

Low. The only runtime-visible effect when `dmHistoryLimit` is unset is:

- dispatch.ts clears history entries using `prepared.activeHistoryLimit` (= 0 for DMs by default) instead of skipping on `!isRoomish`. `clearHistoryEntriesIfEnabled` is a no-op when `limit === 0`, so DMs with `dmHistoryLimit: 0` behave identically to before.

When `dmHistoryLimit > 0`, DMs now populate `channelHistories`, build `combinedBody` prefix context, and set the structured `InboundHistory` field, matching the room-DM code path.