### PR TITLE
Google Chat: respect replyToMode: "off" for DM threading

### DIFF
--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -693,3 +693,56 @@ describe("googlechatPlugin security", () => {
     );
   });
 });
+
+
+describe("googlechatPlugin threading replyToMode off", () => {
+  it("resolves replyToMode 'off' from channel config", () => {
+    const cfg = {
+      channels: {
+        googlechat: {
+          replyToMode: "off",
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = googlechatThreadingAdapter.scopedAccountReplyToMode.resolveAccount(
+      cfg,
+      "default",
+    );
+
+    expect(
+      googlechatThreadingAdapter.scopedAccountReplyToMode.resolveReplyToMode(account),
+    ).toBe("off");
+  });
+
+  it("resolves replyToMode 'off' per-account override", () => {
+    const cfg = {
+      channels: {
+        googlechat: {
+          replyToMode: "all",
+          accounts: {
+            dm: {
+              replyToMode: "off",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const dmAccount = googlechatThreadingAdapter.scopedAccountReplyToMode.resolveAccount(
+      cfg,
+      "dm",
+    );
+    const defaultAccount = googlechatThreadingAdapter.scopedAccountReplyToMode.resolveAccount(
+      cfg,
+      "default",
+    );
+
+    expect(
+      googlechatThreadingAdapter.scopedAccountReplyToMode.resolveReplyToMode(dmAccount),
+    ).toBe("off");
+    expect(
+      googlechatThreadingAdapter.scopedAccountReplyToMode.resolveReplyToMode(defaultAccount),
+    ).toBe("all");
+  });
+});

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -255,8 +255,8 @@ async function processMessageWithPipeline(params: {
     Surface: "googlechat",
     MessageSid: message.name,
     MessageSidFull: message.name,
-    ReplyToId: message.thread?.name,
-    ReplyToIdFull: message.thread?.name,
+    ReplyToId: account.config.replyToMode === "off" ? undefined : message.thread?.name,
+    ReplyToIdFull: account.config.replyToMode === "off" ? undefined : message.thread?.name,
     MediaPath: mediaPath,
     MediaType: mediaType,
     MediaUrl: mediaPath,
@@ -300,7 +300,7 @@ async function processMessageWithPipeline(params: {
         account,
         space: spaceId,
         text: `_${botName} is typing..._`,
-        thread: message.thread?.name,
+        thread: account.config.replyToMode === "off" ? undefined : message.thread?.name,
       });
       typingMessageName = result?.messageName;
     } catch (err) {
@@ -434,7 +434,7 @@ async function deliverGoogleChatReply(params: {
             account,
             space: spaceId,
             text: chunk,
-            thread: payload.replyToId,
+            thread: account.config.replyToMode === "off" ? undefined : payload.replyToId,
           });
         }
         firstTextChunk = false;
@@ -463,7 +463,7 @@ async function deliverGoogleChatReply(params: {
           account,
           space: spaceId,
           text: caption,
-          thread: payload.replyToId,
+          thread: account.config.replyToMode === "off" ? undefined : payload.replyToId,
           attachments: [
             { attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName },
           ],


### PR DESCRIPTION
## Summary

The Google Chat monitor unconditionally copies `message.thread.name` from inbound webhooks into `ReplyToId` and passes it through to all outbound sends (typing indicator, text replies, media replies). This causes all agent responses to land inside a thread, even when `replyToMode` is set to `"off"` in the channel config.

## Changes

This checks `account.config.replyToMode` at all five thread propagation points in `extensions/googlechat/src/monitor.ts` and suppresses threading when the value is `"off"`:

1. **Inbound context**: `ReplyToId` and `ReplyToIdFull` (lines 258-259)
2. **Typing indicator**: `sendGoogleChatMessage` thread param (line 303)
3. **Text reply**: `sendGoogleChatMessage` thread param (line 437)
4. **Media reply**: `sendGoogleChatMessage` thread param (line 466)

## Testing

Tested on a live OpenClaw 2026.4.14 instance with Google Chat DMs. Before the patch, all replies landed in threads despite `replyToMode: "off"`. After the patch, replies appear flat in the DM conversation as expected.

Fixes #52475
Related: #39554