### PR TITLE
feat(feishu): pass thread_id as MessageThreadId in inbound context

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1008,6 +1008,8 @@ export async function handleFeishuMessage(params: {
         Provider: "feishu" as const,
         Surface: "feishu" as const,
         MessageSid: ctx.messageId,
+        MessageThreadId: ctx.rootId ?? undefined,
+        ReplyToId: ctx.parentId ?? undefined,
         ReplyToBody: quotedContent ?? undefined,
         ThreadStarterBody: threadContext.threadStarterBody,
         ThreadHistoryBody: threadContext.threadHistoryBody,


### PR DESCRIPTION
## Summary

Pass Feishu thread identifiers (`root_id` and `parent_id`) through to the inbound context, enabling agents to distinguish messages from different threads.

## Changes

In `extensions/feishu/src/bot.ts`, add two fields to the `finalizeInboundContext()` call:

```ts
MessageSid: ctx.messageId,
MessageThreadId: ctx.rootId ?? undefined,   // ← NEW
ReplyToId: ctx.parentId ?? undefined,       // ← NEW
ReplyToBody: quotedContent ?? undefined,
```

## What this enables

- `topic_id` appears in the agent's conversation info metadata, containing the Feishu thread root message ID
- `reply_to_id` correctly reflects the parent message ID
- Agents can programmatically isolate context by thread, preventing cross-thread confusion when multiple conversations are active

## Context

When multiple Feishu threads are active simultaneously, agents receive interleaved messages with no way to distinguish which thread each belongs to. The `FeishuMessageContext` already captures `rootId` and `parentId` from the event payload — they just weren't being forwarded to the core inbound context.

Other channel plugins (Slack, Discord) already pass `MessageThreadId`. This aligns Feishu with that pattern.

## Testing

- Tested locally: confirmed `topic_id` (thread identifier) appears correctly in conversation info after the change
- Non-breaking: only adds new optional fields to existing metadata

Closes #67068