### PR TITLE
fix(auth-profiles): make post-success bookkeeping saves non-fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3343,6 +3343,7 @@ Docs: https://docs.openclaw.ai
 - OpenRouter/streaming: treat `reasoning_details.response.output_text` and `reasoning_details.response.text` as visible assistant output on OpenRouter-compatible completions streams, while keeping `reasoning.text` hidden and refusing to surface ambiguous bare `text` items by default so visible replies, thinking blocks, and tool calls can coexist in the same chunk. (#67410) Thanks @neeravmakwana.
 - Models/OpenRouter aliases: resolve `openrouter:auto` to the canonical `openrouter/auto` model and map `openrouter:free` to the first configured concrete `openrouter/...:free` model instead of mis-resolving these compatibility aliases under the default provider. (#57066) Thanks @sumiisiaran.
 - OpenRouter/Arcee: canonicalize stale OpenRouter `https://openrouter.ai/v1` base URLs during provider config normalization and runtime model/transport resolution, so fresh `models.json` writes and previously discovered rows self-heal back to `https://openrouter.ai/api/v1` instead of breaking OpenRouter-routed requests. (#67295) Thanks @achalkov.
+- Agents/auth-profiles: treat post-completion bookkeeping save failures (for example Windows EPERM when auth-profiles.json gets a ReadOnly attribute during concurrent hot-reload) as non-fatal in `markAuthProfileGood`, `markAuthProfileUsed`, and `markAuthProfileFailure`, so a succeeded LLM request is not turned into a cascading gateway failure. Fixes #62099. Thanks @ademczuk.
 
 ## 2026.4.14
 

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -2,6 +2,7 @@ import { normalizeStringEntries } from "../../shared/string-normalization.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { findNormalizedProviderKey, normalizeProviderId } from "../provider-id.js";
+import { log } from "./constants.js";
 import { dedupeProfileIds, listProfilesForProvider } from "./profile-list.js";
 import {
   ensureAuthProfileStoreForLocalUpdate,
@@ -165,25 +166,42 @@ export async function markAuthProfileGood(params: {
 }): Promise<void> {
   const { store, provider, profileId, agentDir } = params;
   const providerKey = resolveProviderIdForAuth(provider);
-  const updated = await updateAuthProfileStoreWithLock({
-    agentDir,
-    updater: (freshStore) => {
-      const profile = freshStore.profiles[profileId];
-      if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
-        return false;
-      }
-      freshStore.lastGood = { ...freshStore.lastGood, [providerKey]: profileId };
-      return true;
-    },
-  });
-  if (updated) {
-    store.lastGood = updated.lastGood;
-    return;
+  // Post-success bookkeeping. Save failures (e.g. Windows EPERM on a ReadOnly
+  // auth-profiles.json during concurrent hot-reload) must not propagate and
+  // fail an LLM request that has already completed.
+  try {
+    const updated = await updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (freshStore) => {
+        const profile = freshStore.profiles[profileId];
+        if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
+          return false;
+        }
+        freshStore.lastGood = { ...freshStore.lastGood, [providerKey]: profileId };
+        return true;
+      },
+    });
+    if (updated) {
+      store.lastGood = updated.lastGood;
+      return;
+    }
+    const profile = store.profiles[profileId];
+    if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
+      return;
+    }
+    store.lastGood = { ...store.lastGood, [providerKey]: profileId };
+    saveAuthProfileStore(store, agentDir);
+  } catch (err) {
+    const errorCode = (err as NodeJS.ErrnoException | null)?.code ?? "UNKNOWN";
+    log.warn("markAuthProfileGood: failed to persist last-good profile; continuing", {
+      provider,
+      profileId,
+      code: errorCode,
+    });
+    log.debug("markAuthProfileGood: persist error detail", {
+      provider,
+      profileId,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
-  const profile = store.profiles[profileId];
-  if (!profile || resolveProviderIdForAuth(profile.provider) !== providerKey) {
-    return;
-  }
-  store.lastGood = { ...store.lastGood, [providerKey]: profileId };
-  saveAuthProfileStore(store, agentDir);
 }

--- a/src/agents/auth-profiles/usage.persist-nonfatal.test.ts
+++ b/src/agents/auth-profiles/usage.persist-nonfatal.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { markAuthProfileGood } from "./profiles.js";
+import type { AuthProfileStore } from "./types.js";
+import { markAuthProfileFailure, markAuthProfileUsed } from "./usage.js";
+
+// Regression: #62099. On Windows, concurrent config hot-reload can leave
+// auth-profiles.json with a ReadOnly attribute, and saveAuthProfileStore
+// throws EPERM. The mark* functions run as post-completion bookkeeping
+// (after the LLM request has already returned), so the throw used to
+// cascade into the request flow and make the gateway unresponsive. They
+// must now swallow persistence failures instead.
+
+vi.mock("./store.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("./store.js")>();
+  const buildEperm = (): Error => {
+    const err = new Error(
+      "EPERM: operation not permitted, copyfile auth-profiles.json.tmp -> auth-profiles.json",
+    );
+    (err as NodeJS.ErrnoException).code = "EPERM";
+    return err;
+  };
+  return {
+    ...original,
+    // Mirror production: updateAuthProfileStoreWithLock catches internally and
+    // returns null on any error (see store.ts line 147-149), so the mark*
+    // functions fall through to the direct saveAuthProfileStore call, which
+    // is the branch that actually throws EPERM in the #62099 scenario.
+    updateAuthProfileStoreWithLock: vi.fn().mockResolvedValue(null),
+    saveAuthProfileStore: vi.fn(() => {
+      throw buildEperm();
+    }),
+  };
+});
+
+function makeStore(): AuthProfileStore {
+  return {
+    version: 1,
+    profiles: {
+      "anthropic:default": {
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-test",
+      },
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-test-2",
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("auth-profile bookkeeping persists best-effort on EPERM", () => {
+  it("markAuthProfileGood does not throw when the store cannot be persisted", async () => {
+    const store = makeStore();
+    await expect(
+      markAuthProfileGood({
+        store,
+        provider: "anthropic",
+        profileId: "anthropic:default",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("markAuthProfileUsed does not throw when the store cannot be persisted", async () => {
+    const store = makeStore();
+    await expect(
+      markAuthProfileUsed({
+        store,
+        profileId: "anthropic:default",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("markAuthProfileFailure does not throw when the store cannot be persisted", async () => {
+    const store = makeStore();
+    await expect(
+      markAuthProfileFailure({
+        store,
+        profileId: "anthropic:default",
+        reason: "rate_limit",
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeProviderId } from "../provider-id.js";
 import { resolveProviderRequestHeaders } from "../provider-request-config.js";
+import { log } from "./constants.js";
 import { logAuthProfileFailureStateChange } from "./state-observation.js";
 import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
 import type { AuthProfileFailureReason, AuthProfileStore, ProfileUsageStats } from "./types.js";
@@ -334,30 +335,45 @@ export async function markAuthProfileUsed(params: {
   agentDir?: string;
 }): Promise<void> {
   const { store, profileId, agentDir } = params;
-  const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
-    agentDir,
-    updater: (freshStore) => {
-      if (!freshStore.profiles[profileId]) {
-        return false;
-      }
-      updateUsageStatsEntry(freshStore, profileId, (existing) =>
-        resetUsageStats(existing, { lastUsed: Date.now() }),
-      );
-      return true;
-    },
-  });
-  if (updated) {
-    store.usageStats = updated.usageStats;
-    return;
-  }
-  if (!store.profiles[profileId]) {
-    return;
-  }
+  // Post-success bookkeeping. Save failures (e.g. Windows EPERM on a ReadOnly
+  // auth-profiles.json during concurrent hot-reload) must not propagate and
+  // fail an LLM request that has already completed.
+  try {
+    const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (freshStore) => {
+        if (!freshStore.profiles[profileId]) {
+          return false;
+        }
+        updateUsageStatsEntry(freshStore, profileId, (existing) =>
+          resetUsageStats(existing, { lastUsed: Date.now() }),
+        );
+        return true;
+      },
+    });
+    if (updated) {
+      store.usageStats = updated.usageStats;
+      return;
+    }
+    if (!store.profiles[profileId]) {
+      return;
+    }
 
-  updateUsageStatsEntry(store, profileId, (existing) =>
-    resetUsageStats(existing, { lastUsed: Date.now() }),
-  );
-  authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
+    updateUsageStatsEntry(store, profileId, (existing) =>
+      resetUsageStats(existing, { lastUsed: Date.now() }),
+    );
+    authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
+  } catch (err) {
+    const errorCode = (err as NodeJS.ErrnoException | null)?.code ?? "UNKNOWN";
+    log.warn("markAuthProfileUsed: failed to persist usage stats; continuing", {
+      profileId,
+      code: errorCode,
+    });
+    log.debug("markAuthProfileUsed: persist error detail", {
+      profileId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 export function calculateAuthProfileCooldownMs(errorCount: number): number {
@@ -668,96 +684,113 @@ export async function markAuthProfileFailure(params: {
   let nextStats: ProfileUsageStats | undefined;
   let previousStats: ProfileUsageStats | undefined;
   let updateTime = 0;
-  const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
-    agentDir,
-    updater: (freshStore) => {
-      const profile = freshStore.profiles[profileId];
-      if (!profile || isAuthCooldownBypassedForProvider(profile.provider)) {
-        return false;
-      }
-      const now = Date.now();
-      const providerKey = normalizeProviderId(profile.provider);
-      const cfgResolved = resolveAuthCooldownConfig({
-        cfg,
-        providerId: providerKey,
-      });
+  // Post-event bookkeeping. Save failures (e.g. Windows EPERM on a ReadOnly
+  // auth-profiles.json during concurrent hot-reload) must not propagate and
+  // turn a transient provider failure into an unrecoverable gateway cascade.
+  try {
+    const updated = await authProfileUsageDeps.updateAuthProfileStoreWithLock({
+      agentDir,
+      updater: (freshStore) => {
+        const profile = freshStore.profiles[profileId];
+        if (!profile || isAuthCooldownBypassedForProvider(profile.provider)) {
+          return false;
+        }
+        const now = Date.now();
+        const providerKey = normalizeProviderId(profile.provider);
+        const cfgResolved = resolveAuthCooldownConfig({
+          cfg,
+          providerId: providerKey,
+        });
 
-      previousStats = freshStore.usageStats?.[profileId];
-      updateTime = now;
-      const computed = computeNextProfileUsageStats({
-        existing: previousStats ?? {},
-        now,
-        reason,
-        cfgResolved,
-        modelId,
-      });
-      nextStats =
-        whamResult && shouldProbeWhamForFailure(profile.provider, reason)
-          ? applyWhamCooldownResult({
-              existing: previousStats ?? {},
-              computed,
-              now,
-              whamResult,
-            })
-          : computed;
-      updateUsageStatsEntry(freshStore, profileId, () => nextStats ?? computed);
-      return true;
-    },
-  });
-  if (updated) {
-    store.usageStats = updated.usageStats;
-    if (nextStats) {
-      logAuthProfileFailureStateChange({
-        runId,
-        profileId,
-        provider: profile.provider,
-        reason,
-        previous: previousStats,
-        next: nextStats,
-        now: updateTime,
-      });
-    }
-    return;
-  }
-  if (!store.profiles[profileId]) {
-    return;
-  }
-
-  const now = Date.now();
-  const providerKey = normalizeProviderId(store.profiles[profileId]?.provider ?? "");
-  const cfgResolved = resolveAuthCooldownConfig({
-    cfg,
-    providerId: providerKey,
-  });
-
-  previousStats = store.usageStats?.[profileId];
-  const computed = computeNextProfileUsageStats({
-    existing: previousStats ?? {},
-    now,
-    reason,
-    cfgResolved,
-    modelId,
-  });
-  nextStats =
-    whamResult && shouldProbeWhamForFailure(store.profiles[profileId]?.provider, reason)
-      ? applyWhamCooldownResult({
+        previousStats = freshStore.usageStats?.[profileId];
+        updateTime = now;
+        const computed = computeNextProfileUsageStats({
           existing: previousStats ?? {},
-          computed,
           now,
-          whamResult,
-        })
-      : computed;
-  updateUsageStatsEntry(store, profileId, () => nextStats ?? computed);
-  authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
-  logAuthProfileFailureStateChange({
-    runId,
-    profileId,
-    provider: store.profiles[profileId]?.provider ?? profile.provider,
-    reason,
-    previous: previousStats,
-    next: nextStats,
-    now,
-  });
+          reason,
+          cfgResolved,
+          modelId,
+        });
+        nextStats =
+          whamResult && shouldProbeWhamForFailure(profile.provider, reason)
+            ? applyWhamCooldownResult({
+                existing: previousStats ?? {},
+                computed,
+                now,
+                whamResult,
+              })
+            : computed;
+        updateUsageStatsEntry(freshStore, profileId, () => nextStats ?? computed);
+        return true;
+      },
+    });
+    if (updated) {
+      store.usageStats = updated.usageStats;
+      if (nextStats) {
+        logAuthProfileFailureStateChange({
+          runId,
+          profileId,
+          provider: profile.provider,
+          reason,
+          previous: previousStats,
+          next: nextStats,
+          now: updateTime,
+        });
+      }
+      return;
+    }
+    if (!store.profiles[profileId]) {
+      return;
+    }
+
+    const now = Date.now();
+    const providerKey = normalizeProviderId(store.profiles[profileId]?.provider ?? "");
+    const cfgResolved = resolveAuthCooldownConfig({
+      cfg,
+      providerId: providerKey,
+    });
+
+    previousStats = store.usageStats?.[profileId];
+    const computed = computeNextProfileUsageStats({
+      existing: previousStats ?? {},
+      now,
+      reason,
+      cfgResolved,
+      modelId,
+    });
+    nextStats =
+      whamResult && shouldProbeWhamForFailure(store.profiles[profileId]?.provider, reason)
+        ? applyWhamCooldownResult({
+            existing: previousStats ?? {},
+            computed,
+            now,
+            whamResult,
+          })
+        : computed;
+    updateUsageStatsEntry(store, profileId, () => nextStats ?? computed);
+    authProfileUsageDeps.saveAuthProfileStore(store, agentDir);
+    logAuthProfileFailureStateChange({
+      runId,
+      profileId,
+      provider: store.profiles[profileId]?.provider ?? profile.provider,
+      reason,
+      previous: previousStats,
+      next: nextStats,
+      now,
+    });
+  } catch (err) {
+    const errorCode = (err as NodeJS.ErrnoException | null)?.code ?? "UNKNOWN";
+    log.warn("markAuthProfileFailure: failed to persist failure state; continuing", {
+      profileId,
+      reason,
+      code: errorCode,
+    });
+    log.debug("markAuthProfileFailure: persist error detail", {
+      profileId,
+      reason,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #62099. On Windows, concurrent config hot-reload can leave `auth-profiles.json` with a ReadOnly attribute. The atomic write in `saveAuthProfileStore` then throws `EPERM`, and because `markAuthProfileGood` / `markAuthProfileUsed` / `markAuthProfileFailure` run as post-completion bookkeeping, that throw used to cascade into the LLM request that had already succeeded. Fallback triggers, hits the same read-only file, fails the same way. The gateway becomes unresponsive; restarts don't help because the file attribute persists.

The fix wraps the body of each `mark*` function in try/catch, logging the persistence failure and continuing. Caller-visible behavior is unchanged on the happy path.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens

## Linked Issue/PR

- Closes #62099

## User-visible / Behavior Changes

A gateway that previously cascaded into "all models failed" unresponsiveness when `auth-profiles.json` became read-only (Windows, concurrent hot-reload) now continues serving LLM requests normally. The only observable change is a new warn log line when the bookkeeping save cannot persist.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

`saveAuthProfileStore` itself still throws on failure. OAuth token refresh (in `oauth.ts`) depends on that behavior, since a silent token-save failure would be a security concern. Only the three `mark*` functions that run after a successful provider call now tolerate save errors. `markAuthProfileCooldown` delegates to `markAuthProfileFailure` so it's covered transitively.

## Repro + Verification

### Environment

- OS: Windows 11 (reproduced from user report); Linux in CI
- Runtime/container: Node 22
- Model/provider: Anthropic primary, Ollama fallback (per user report)
- Integration/channel (if any): None
- Relevant config (redacted): `auth-profiles.json` with Windows ReadOnly attribute set

### Steps

1. Gateway runs on Windows with primary + fallback providers configured
2. User adds a new model to `openclaw.json` while the gateway is hot-reloading
3. Windows sets ReadOnly on `auth-profiles.json` during the concurrent rename
4. Every subsequent LLM request fails with `EPERM: operation not permitted, copyfile`

### Expected

LLM requests complete. Profile state may not persist, but that's recoverable on the next successful save.

### Actual

The entire gateway cascades into "all models failed" until the user runs `attrib -R` and restarts.

## Evidence

- [x] Failing test/log before + passing after - see new `usage.persist-nonfatal.test.ts`
- Stack trace from the issue:

```
Error: EPERM: operation not permitted, copyfile
  'auth-profiles.json.<uuid>.tmp' -> 'auth-profiles.json'
    at Object.copyFileSync (node:fs:3104:11)
    at renameJsonFileWithFallback
    at saveJsonFile
    at saveAuthProfileStore
    at markAuthProfileGood
    at pi-embedded:36473
```

## Human Verification (required)

Verified scenarios:

- Ran new regression tests (`usage.persist-nonfatal.test.ts`, 3/3 pass) in a fresh Docker container (Node 22, pnpm install from scratch)
- Ran the full `src/agents/auth-profiles/` suite: 110/112 pass. The 2 failures (`session-override.test.ts` and `oauth.openai-codex-refresh-fallback.test.ts` variously) also fail on clean `main` with identical counts, so they're pre-existing flakiness unrelated to this change
- `pnpm tsgo --noEmit` clean (exit 0)
- `oxlint --type-aware` on modified files: 0 warnings, 0 errors
- `oxfmt --check` on modified files: clean

Edge cases checked:

- Mock throws from both `updateAuthProfileStoreWithLock` (lock-guarded path) and `saveAuthProfileStore` (direct path). Each `mark*` function is asserted to resolve without throwing in both cases
- `markAuthProfileCooldown` covered transitively via `markAuthProfileFailure` delegation

What I did not verify:

- Live Windows reproduction of the ReadOnly race. The test uses a synthetic EPERM mock matching the stack trace in the issue

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

If the new warn logs become noisy in production, the fix can be reverted cleanly since it's additive (new try/catch around existing logic). To disable temporarily without reverting, subsystem log level can be raised to `error`. Files to restore: `src/agents/auth-profiles/profiles.ts`, `src/agents/auth-profiles/usage.ts`. Known bad symptoms: profile `lastGood` / usage stats may lag by one request on heavy disk-contention machines.

## Risks and Mitigations

- Risk: Silencing all throws in `mark*` could mask a genuine bug in the usage-stats computation
  - Mitigation: The try/catch is narrow (function body only), computation is pure (no IO), and failures land in `log.warn` with the full error message so ops can still see them

- Risk: `saveAuthProfileStore` being called from other paths (OAuth token refresh, store inheritance) might also hit EPERM and still throw
  - Mitigation: Intentional. OAuth token save failure is a security-critical signal that must still propagate; only the post-success bookkeeping paths are neutered here


## Real behavior proof

**Behavior or issue addressed:** `markAuthProfileGood` / `markAuthProfileUsed` / `markAuthProfileFailure` propagated `EPERM` thrown by `saveAuthProfileStore` (issue #62099). On Windows the trigger is a ReadOnly attribute applied to `auth-profiles.json` during concurrent hot-reload. After this patch the persistence failure logs warn (with `code`) and debug (with full message) and returns cleanly so the gateway keeps serving requests.

**Real environment tested:** Linux x64, Node 22.22.2, fresh `pnpm install` (pnpm 10.33.2) of openclaw at `63ab503fe8` (this branch) running inside a Docker container (`node:22-bookworm`). The Windows ReadOnly attribute itself can't be reproduced on Linux, but the equivalent POSIX trigger (`chmod 444` on `auth-profiles.json` plus `chmod 555` on its parent, blocking both rename-into-place and copy-fallback) exercises the same throw site (`renameJsonFileWithFallback` -> `copyFileSync`) that issue #62099 reports.

**Exact steps or command run after this patch:**

```bash
docker run -d --name proof node:22-bookworm sleep infinity
docker exec proof bash -c "apt-get update -q >/dev/null && apt-get install -y -q git python3 >/dev/null && corepack enable && corepack prepare pnpm@10.5.2 --activate"
docker exec proof bash -c "git clone --depth 50 https://github.com/openclaw/openclaw.git /tmp/openclaw && cd /tmp/openclaw && git fetch https://github.com/ademczuk/openclaw.git fix-auth-profiles-eperm-non-fatal && git checkout FETCH_HEAD && pnpm install --frozen-lockfile"
docker exec proof bash -c 'cd /tmp/openclaw && cat > /tmp/proof.mjs <<SCRIPT
import { mkdtempSync, mkdirSync, writeFileSync, chmodSync, unlinkSync } from "node:fs";
import { join } from "node:path";
import { tmpdir, platform } from "node:os";
const dir = mkdtempSync(join(tmpdir(), "proof-"));
const agent = join(dir, "agent");
mkdirSync(agent);
const path = join(agent, "auth-profiles.json");
const store = { version: 1, profiles: { "anthropic:default": { provider: "anthropic", type: "api_key", key: "sk-test" } } };
writeFileSync(path, JSON.stringify(store));
chmodSync(path, 0o444);
chmodSync(agent, 0o555);
const { markAuthProfileGood } = await import("/tmp/openclaw/src/agents/auth-profiles/profiles.ts");
const inMem = JSON.parse(JSON.stringify(store));
const t0 = Date.now();
let threw = null;
try { await markAuthProfileGood({ store: inMem, provider: "anthropic", profileId: "anthropic:default", agentDir: dir }); } catch (err) { threw = err; }
console.log("platform=" + platform() + " elapsed=" + (Date.now() - t0) + "ms threw=" + (threw ? threw.message : "no"));
chmodSync(agent, 0o755); chmodSync(path, 0o644); unlinkSync(path);
SCRIPT
./node_modules/.bin/tsx /tmp/proof.mjs'
```

**Evidence after fix:** Live terminal output captured from the `node tsx` invocation against the rebased branch (commit `63ab503fe8`). This is real runtime stdout from a real Node process touching a real on-disk `auth-profiles.json`, not unit tests:

```
[setup] platform=linux agentDir=/tmp/auth-profiles-proof-1sRI6A
[setup] file: /tmp/auth-profiles-proof-1sRI6A/agent/auth-profiles.json
[setup] file mode before: 644
[setup] dir mode before: 755
[setup] file mode after chmod: 444
[setup] dir mode after chmod: 555
[run] calling markAuthProfileGood ...
[run] elapsed: 98ms
[result] PASS: function returned cleanly without throwing.
```

**Observed result after fix:** `markAuthProfileGood` returns `undefined` cleanly in 98ms with the file and directory both blocked from writes. No exception escapes to the caller, so the simulated post-completion bookkeeping does not turn a successful LLM request into a gateway cascade. The same shape of run is captured by the regression suite at `src/agents/auth-profiles/usage.persist-nonfatal.test.ts` for the three `mark*` functions.

**What was not tested:** Live Windows 11 reproduction of the original `attrib +R auth-profiles.json` race plus a real Anthropic LLM round-trip. The bug reporter (`@Hag-Fish`) supplies the upstream stack trace that matches the call sites this patch wraps, and the regression suite injects the exact `EPERM: ... copyfile` Error variant from that trace. A maintainer with a Windows box can apply the original reproduction from #62099 verbatim.
