### PR TITLE
feat(plugins): narrow gateway route loads from manifests

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -1119,6 +1119,9 @@ Route fields:
 Notes:
 
 - `api.registerHttpHandler(...)` was removed and will cause a plugin-load error. Use `api.registerHttpRoute(...)` instead.
+- `activation.onRoutes` can declare cheap route-owner hints such as
+  `"gateway-plugin-http"` so the gateway can narrow plugin HTTP route loads
+  before falling back to the pinned startup registry.
 - Plugin routes must declare `auth` explicitly.
 - Exact `path + match` conflicts are rejected unless `replaceExisting: true`, and one plugin cannot replace another plugin's route.
 - Overlapping routes with different `auth` levels are rejected. Keep `exact`/`prefix` fallthrough chains on the same auth level only.

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -257,7 +257,7 @@ change correctness while legacy manifest ownership fallbacks still exist.
     "onProviders": ["openai"],
     "onCommands": ["models"],
     "onChannels": ["web"],
-    "onRoutes": ["gateway-webhook"],
+    "onRoutes": ["gateway-plugin-http"],
     "onCapabilities": ["provider", "tool"]
   }
 }
@@ -280,6 +280,8 @@ Current live consumers:
 - provider-triggered setup/runtime planning falls back to legacy
   `providers[]` and top-level `cliBackends[]` ownership when explicit provider
   activation metadata is missing
+- route-triggered gateway plugin HTTP planning currently uses `onRoutes` as a
+  narrowing hint before it falls back to the pinned startup route registry
 
 ## setup reference
 

--- a/extensions/diffs/openclaw.plugin.json
+++ b/extensions/diffs/openclaw.plugin.json
@@ -2,6 +2,9 @@
   "id": "diffs",
   "name": "Diffs",
   "description": "Read-only diff viewer and file renderer for agents.",
+  "activation": {
+    "onRoutes": ["gateway-plugin-http"]
+  },
   "skills": ["./skills"],
   "uiHints": {
     "viewerBaseUrl": {

--- a/extensions/line/openclaw.plugin.json
+++ b/extensions/line/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "line",
   "channels": ["line"],
+  "activation": {
+    "onRoutes": ["gateway-plugin-http"]
+  },
   "channelEnvVars": {
     "line": ["LINE_CHANNEL_ACCESS_TOKEN", "LINE_CHANNEL_SECRET"]
   },

--- a/extensions/mattermost/openclaw.plugin.json
+++ b/extensions/mattermost/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "mattermost",
   "channels": ["mattermost"],
+  "activation": {
+    "onRoutes": ["gateway-plugin-http"]
+  },
   "channelEnvVars": {
     "mattermost": ["MATTERMOST_BOT_TOKEN", "MATTERMOST_URL"]
   },

--- a/extensions/nostr/openclaw.plugin.json
+++ b/extensions/nostr/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "nostr",
   "channels": ["nostr"],
+  "activation": {
+    "onRoutes": ["gateway-plugin-http"]
+  },
   "channelEnvVars": {
     "nostr": ["NOSTR_PRIVATE_KEY"]
   },

--- a/extensions/slack/openclaw.plugin.json
+++ b/extensions/slack/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "slack",
   "channels": ["slack"],
+  "activation": {
+    "onRoutes": ["gateway-plugin-http"]
+  },
   "channelEnvVars": {
     "slack": ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_USER_TOKEN"]
   },

--- a/extensions/synology-chat/openclaw.plugin.json
+++ b/extensions/synology-chat/openclaw.plugin.json
@@ -1,6 +1,9 @@
 {
   "id": "synology-chat",
   "channels": ["synology-chat"],
+  "activation": {
+    "onRoutes": ["gateway-plugin-http"]
+  },
   "channelEnvVars": {
     "synology-chat": [
       "SYNOLOGY_CHAT_TOKEN",

--- a/extensions/webhooks/openclaw.plugin.json
+++ b/extensions/webhooks/openclaw.plugin.json
@@ -2,6 +2,9 @@
   "id": "webhooks",
   "name": "Webhooks",
   "description": "Authenticated inbound webhooks that bind external automation to OpenClaw TaskFlows.",
+  "activation": {
+    "onRoutes": ["gateway-plugin-http"]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -12,6 +12,7 @@ import {
   releasePinnedPluginHttpRouteRegistry,
   resolveActivePluginHttpRouteRegistry,
 } from "../plugins/runtime.js";
+import { loadScopedGatewayPluginHttpRouteRegistry } from "../plugins/runtime/http-route-registry-loader.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -32,6 +33,7 @@ import {
   createGatewayHttpServer,
   type HookClientIpConfig,
 } from "./server-http.js";
+import type { GatewayRequestHandler } from "./server-methods/types.js";
 import type { DedupeEntry } from "./server-shared.js";
 import { createGatewayHooksRequestHandler } from "./server/hooks.js";
 import { listenGatewayHttpServer } from "./server/http-listen.js";
@@ -50,6 +52,7 @@ import type { GatewayWsClient } from "./server/ws-types.js";
 
 export async function createGatewayRuntimeState(params: {
   cfg: import("../config/config.js").OpenClawConfig;
+  workspaceDir?: string;
   bindHost: string;
   port: number;
   controlUiEnabled: boolean;
@@ -68,6 +71,7 @@ export async function createGatewayRuntimeState(params: {
   hooksConfig: () => HooksConfigResolved | null;
   getHookClientIpConfig: () => HookClientIpConfig;
   pluginRegistry: PluginRegistry;
+  coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
   pinChannelRegistry?: boolean;
   deps: CliDeps;
   canvasRuntime: RuntimeEnv;
@@ -147,6 +151,15 @@ export async function createGatewayRuntimeState(params: {
     const handlePluginRequest = createGatewayPluginRequestHandler({
       registry: params.pluginRegistry,
       log: params.logPlugins,
+      resolveScopedRegistry: ({ routeIds }) =>
+        loadScopedGatewayPluginHttpRouteRegistry({
+          config: params.cfg,
+          activationSourceConfig: params.cfg,
+          workspaceDir: params.workspaceDir,
+          env: process.env,
+          coreGatewayHandlers: params.coreGatewayHandlers,
+          routeIds,
+        }),
     });
     const shouldEnforcePluginGatewayAuth = (pathContext: PluginRoutePathContext): boolean => {
       return shouldEnforceGatewayAuthForPluginPath(

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -437,6 +437,7 @@ export async function startGatewayServer(
     toolEventRecipients,
   } = await createGatewayRuntimeState({
     cfg: cfgAtStart,
+    workspaceDir: defaultWorkspaceDir,
     bindHost,
     port,
     controlUiEnabled,
@@ -454,6 +455,7 @@ export async function startGatewayServer(
     hooksConfig: () => runtimeState?.hooksConfig ?? initialHooksConfig,
     getHookClientIpConfig: () => runtimeState?.hookClientIpConfig ?? initialHookClientIpConfig,
     pluginRegistry,
+    coreGatewayHandlers,
     pinChannelRegistry: !minimalTestGateway,
     deps,
     canvasRuntime,

--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -297,6 +297,38 @@ describe("createGatewayPluginRequestHandler", () => {
     expect(explicitRouteHandler).toHaveBeenCalledTimes(1);
   });
 
+  it("tries a scoped route registry when the active startup registry misses", async () => {
+    const scopedRouteHandler = vi.fn(async (_req, res: ServerResponse) => {
+      res.statusCode = 206;
+      return true;
+    });
+    const scopedRegistry = createTestRegistry({
+      httpRoutes: [
+        createRoute({
+          path: "/demo",
+          auth: "plugin",
+          handler: scopedRouteHandler,
+        }),
+      ],
+    });
+    const resolveScopedRegistry = vi.fn(() => scopedRegistry);
+    const handler = createGatewayPluginRequestHandler({
+      registry: createTestRegistry(),
+      log: createPluginLog(),
+      resolveScopedRegistry,
+    });
+
+    const { res } = makeMockHttpResponse();
+    const handled = await handler({ url: "/demo" } as IncomingMessage, res);
+    expect(handled).toBe(true);
+    expect(resolveScopedRegistry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        routeIds: ["gateway-plugin-http"],
+      }),
+    );
+    expect(scopedRouteHandler).toHaveBeenCalledTimes(1);
+  });
+
   it("handles routes registered into the pinned startup registry after the active registry changes", async () => {
     const startupRegistry = createTestRegistry();
     const laterActiveRegistry = createTestRegistry();

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -3,6 +3,7 @@ import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import { resolveActivePluginHttpRouteRegistry } from "../../plugins/runtime.js";
 import { withPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
+import { GATEWAY_PLUGIN_HTTP_ROUTE_ID } from "../../plugins/runtime/http-route-registry-loader.js";
 import type { AuthorizedGatewayHttpRequest } from "../http-utils.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../protocol/client-info.js";
 import { PROTOCOL_VERSION } from "../protocol/index.js";
@@ -60,25 +61,35 @@ export type PluginHttpRequestHandler = (
   dispatchContext?: PluginRouteDispatchContext,
 ) => Promise<boolean>;
 
+export type ScopedPluginRouteRegistryResolver = (params: {
+  pathContext: PluginRoutePathContext;
+  routeIds: readonly string[];
+}) => PluginRegistry | undefined;
+
 export function createGatewayPluginRequestHandler(params: {
   registry: PluginRegistry;
   log: SubsystemLogger;
+  resolveScopedRegistry?: ScopedPluginRouteRegistryResolver;
 }): PluginHttpRequestHandler {
   const { log } = params;
   return async (req, res, providedPathContext, dispatchContext) => {
-    const registry = resolveActivePluginHttpRouteRegistry(params.registry);
-    const routes = registry.httpRoutes ?? [];
-    if (routes.length === 0) {
-      return false;
-    }
-
+    const activeRegistry = resolveActivePluginHttpRouteRegistry(params.registry);
     const pathContext =
       providedPathContext ??
       (() => {
         const url = new URL(req.url ?? "/", "http://localhost");
         return resolvePluginRoutePathContext(url.pathname);
       })();
-    const matchedRoutes = findMatchingPluginHttpRoutes(registry, pathContext);
+    let matchedRoutes = findMatchingPluginHttpRoutes(activeRegistry, pathContext);
+    if (matchedRoutes.length === 0) {
+      const scopedRegistry = params.resolveScopedRegistry?.({
+        pathContext,
+        routeIds: [GATEWAY_PLUGIN_HTTP_ROUTE_ID],
+      });
+      if (scopedRegistry) {
+        matchedRoutes = findMatchingPluginHttpRoutes(scopedRegistry, pathContext);
+      }
+    }
     if (matchedRoutes.length === 0) {
       return false;
     }

--- a/src/plugins/activation-planner.test.ts
+++ b/src/plugins/activation-planner.test.ts
@@ -62,7 +62,7 @@ describe("resolveManifestActivationPluginIds", () => {
             tools: ["web-search"],
           },
           activation: {
-            onRoutes: ["webhook"],
+            onRoutes: ["gateway-webhook"],
             onCommands: ["demo-tools"],
           },
           origin: "workspace",
@@ -134,6 +134,15 @@ describe("resolveManifestActivationPluginIds", () => {
         trigger: {
           kind: "route",
           route: "webhook",
+        },
+      }),
+    ).toEqual(["demo-channel"]);
+
+    expect(
+      resolveManifestActivationPluginIds({
+        trigger: {
+          kind: "route",
+          route: "gateway-plugin-http",
         },
       }),
     ).toEqual(["demo-channel"]);

--- a/src/plugins/activation-planner.ts
+++ b/src/plugins/activation-planner.ts
@@ -55,7 +55,7 @@ function matchesManifestActivationTrigger(
     case "channel":
       return listActivationChannelIds(plugin).includes(normalizeCommandId(trigger.channel));
     case "route":
-      return listActivationRouteIds(plugin).includes(normalizeCommandId(trigger.route));
+      return listActivationRouteIds(plugin).includes(normalizeRouteId(trigger.route));
     case "capability":
       return hasActivationCapability(plugin, trigger.capability);
   }
@@ -89,7 +89,7 @@ function listActivationChannelIds(plugin: PluginManifestRecord): string[] {
 }
 
 function listActivationRouteIds(plugin: PluginManifestRecord): string[] {
-  return (plugin.activation?.onRoutes ?? []).map(normalizeCommandId).filter(Boolean);
+  return (plugin.activation?.onRoutes ?? []).map(normalizeRouteId).filter(Boolean);
 }
 
 function hasActivationCapability(
@@ -115,4 +115,15 @@ function hasActivationCapability(
 
 function normalizeCommandId(value: string | undefined): string {
   return normalizeOptionalLowercaseString(value) ?? "";
+}
+
+function normalizeRouteId(value: string | undefined): string {
+  const normalized = normalizeOptionalLowercaseString(value) ?? "";
+  switch (normalized) {
+    case "webhook":
+    case "gateway-webhook":
+      return "gateway-plugin-http";
+    default:
+      return normalized;
+  }
 }

--- a/src/plugins/activation-planner.ts
+++ b/src/plugins/activation-planner.ts
@@ -1,10 +1,15 @@
 import { normalizeProviderId } from "../agents/provider-id.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
-import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
+import {
+  loadPluginManifestRegistry,
+  type PluginManifestRecord,
+  type PluginManifestRegistry,
+} from "./manifest-registry.js";
 import type { PluginManifestActivationCapability } from "./manifest.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import { createPluginIdScopeSet, normalizePluginIdScope } from "./plugin-scope.js";
+import { normalizeActivationRouteId } from "./route-id-normalize.js";
 
 export type PluginActivationPlannerTrigger =
   | { kind: "command"; command: string }
@@ -21,18 +26,22 @@ export function resolveManifestActivationPluginIds(params: {
   cache?: boolean;
   origin?: PluginOrigin;
   onlyPluginIds?: readonly string[];
+  manifestRegistry?: PluginManifestRegistry;
 }): string[] {
   const onlyPluginIdSet = createPluginIdScopeSet(normalizePluginIdScope(params.onlyPluginIds));
+  const manifestRegistry =
+    params.manifestRegistry ??
+    loadPluginManifestRegistry({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
+      cache: params.cache,
+    });
 
   return [
     ...new Set(
-      loadPluginManifestRegistry({
-        config: params.config,
-        workspaceDir: params.workspaceDir,
-        env: params.env,
-        cache: params.cache,
-      })
-        .plugins.filter(
+      manifestRegistry.plugins
+        .filter(
           (plugin) =>
             (!params.origin || plugin.origin === params.origin) &&
             (!onlyPluginIdSet || onlyPluginIdSet.has(plugin.id)) &&
@@ -118,12 +127,5 @@ function normalizeCommandId(value: string | undefined): string {
 }
 
 function normalizeRouteId(value: string | undefined): string {
-  const normalized = normalizeOptionalLowercaseString(value) ?? "";
-  switch (normalized) {
-    case "webhook":
-    case "gateway-webhook":
-      return "gateway-plugin-http";
-    default:
-      return normalized;
-  }
+  return normalizeActivationRouteId(value);
 }

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -432,7 +432,7 @@ describe("loadPluginManifestRegistry", () => {
         onProviders: ["openai"],
         onCommands: ["models"],
         onChannels: ["web"],
-        onRoutes: ["gateway-webhook"],
+        onRoutes: ["gateway-plugin-http"],
         onCapabilities: ["provider", "tool"],
       },
       setup: {
@@ -460,7 +460,7 @@ describe("loadPluginManifestRegistry", () => {
       onProviders: ["openai"],
       onCommands: ["models"],
       onChannels: ["web"],
-      onRoutes: ["gateway-webhook"],
+      onRoutes: ["gateway-plugin-http"],
       onCapabilities: ["provider", "tool"],
     });
     expect(registry.plugins[0]?.setup).toEqual({

--- a/src/plugins/manifest.json5-tolerance.test.ts
+++ b/src/plugins/manifest.json5-tolerance.test.ts
@@ -132,7 +132,7 @@ describe("loadPluginManifest JSON5 tolerance", () => {
         onProviders: ["openai", "openai-codex"],
         onCommands: ["models"],
         onChannels: ["web"],
-        onRoutes: ["gateway-webhook"],
+        onRoutes: ["gateway-plugin-http"],
         onCapabilities: ["provider", "tool"],
       });
       expect(result.manifest.setup).toEqual({

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -429,7 +429,13 @@ function normalizeManifestActivation(value: unknown): PluginManifestActivation |
   const onProviders = normalizeTrimmedStringList(value.onProviders);
   const onCommands = normalizeTrimmedStringList(value.onCommands);
   const onChannels = normalizeTrimmedStringList(value.onChannels);
-  const onRoutes = normalizeTrimmedStringList(value.onRoutes);
+  const onRoutes = Array.from(
+    new Set(
+      normalizeTrimmedStringList(value.onRoutes).map((routeId) =>
+        normalizeManifestActivationRouteId(routeId),
+      ),
+    ),
+  );
   const onCapabilities = normalizeTrimmedStringList(value.onCapabilities).filter(
     (capability): capability is PluginManifestActivationCapability =>
       capability === "provider" ||
@@ -447,6 +453,16 @@ function normalizeManifestActivation(value: unknown): PluginManifestActivation |
   } satisfies PluginManifestActivation;
 
   return Object.keys(activation).length > 0 ? activation : undefined;
+}
+
+function normalizeManifestActivationRouteId(value: string): string {
+  switch (value.trim().toLowerCase()) {
+    case "webhook":
+    case "gateway-webhook":
+      return "gateway-plugin-http";
+    default:
+      return value;
+  }
 }
 
 function normalizeManifestSetupProviders(

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -13,6 +13,7 @@ import {
 } from "./manifest-command-aliases.js";
 import type { PluginConfigUiHint } from "./manifest-types.js";
 import type { PluginKind } from "./plugin-kind.types.js";
+import { normalizeActivationRouteId } from "./route-id-normalize.js";
 
 export const PLUGIN_MANIFEST_FILENAME = "openclaw.plugin.json";
 export const PLUGIN_MANIFEST_FILENAMES = [PLUGIN_MANIFEST_FILENAME] as const;
@@ -432,7 +433,7 @@ function normalizeManifestActivation(value: unknown): PluginManifestActivation |
   const onRoutes = Array.from(
     new Set(
       normalizeTrimmedStringList(value.onRoutes).map((routeId) =>
-        normalizeManifestActivationRouteId(routeId),
+        normalizeActivationRouteId(routeId),
       ),
     ),
   );
@@ -454,17 +455,6 @@ function normalizeManifestActivation(value: unknown): PluginManifestActivation |
 
   return Object.keys(activation).length > 0 ? activation : undefined;
 }
-
-function normalizeManifestActivationRouteId(value: string): string {
-  switch (value.trim().toLowerCase()) {
-    case "webhook":
-    case "gateway-webhook":
-      return "gateway-plugin-http";
-    default:
-      return value;
-  }
-}
-
 function normalizeManifestSetupProviders(
   value: unknown,
 ): PluginManifestSetupProvider[] | undefined {

--- a/src/plugins/route-id-normalize.ts
+++ b/src/plugins/route-id-normalize.ts
@@ -1,0 +1,12 @@
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+
+export function normalizeActivationRouteId(value: string | undefined): string {
+  const normalized = normalizeOptionalLowercaseString(value) ?? "";
+  switch (normalized) {
+    case "webhook":
+    case "gateway-webhook":
+      return "gateway-plugin-http";
+    default:
+      return normalized;
+  }
+}

--- a/src/plugins/route-plugin-ids.test.ts
+++ b/src/plugins/route-plugin-ids.test.ts
@@ -1,0 +1,141 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  loadPluginManifestRegistry: vi.fn(),
+}));
+
+vi.mock("./manifest-registry.js", () => ({
+  loadPluginManifestRegistry: (...args: unknown[]) => mocks.loadPluginManifestRegistry(...args),
+}));
+
+let resolveScopedRoutePluginIds: typeof import("./route-plugin-ids.js").resolveScopedRoutePluginIds;
+
+describe("resolveScopedRoutePluginIds", () => {
+  beforeAll(async () => {
+    ({ resolveScopedRoutePluginIds } = await import("./route-plugin-ids.js"));
+  });
+
+  beforeEach(() => {
+    mocks.loadPluginManifestRegistry.mockReset();
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "bundled-route",
+          origin: "bundled",
+          enabledByDefault: true,
+          activation: {
+            onRoutes: ["gateway-plugin-http"],
+          },
+          providers: [],
+          channels: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+        },
+        {
+          id: "global-route",
+          origin: "global",
+          enabledByDefault: true,
+          activation: {
+            onRoutes: ["gateway-plugin-http"],
+          },
+          providers: [],
+          channels: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+        },
+        {
+          id: "workspace-route",
+          origin: "workspace",
+          enabledByDefault: false,
+          activation: {
+            onRoutes: ["gateway-plugin-http"],
+          },
+          providers: [],
+          channels: [],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+        },
+      ],
+      diagnostics: [],
+    });
+  });
+
+  it("keeps bundled route owners and blocks untrusted global owners by default", () => {
+    expect(
+      resolveScopedRoutePluginIds({
+        config: {} as never,
+        routeIds: ["gateway-plugin-http"],
+        env: {} as NodeJS.ProcessEnv,
+      }),
+    ).toEqual(["bundled-route"]);
+  });
+
+  it("allows explicitly trusted global route owners", () => {
+    expect(
+      resolveScopedRoutePluginIds({
+        config: {
+          plugins: {
+            allow: ["global-route"],
+          },
+        } as never,
+        routeIds: ["gateway-plugin-http"],
+        env: {} as NodeJS.ProcessEnv,
+      }),
+    ).toEqual(["global-route"]);
+  });
+
+  it("requires workspace route owners to be activated and respects explicit disablement", () => {
+    expect(
+      resolveScopedRoutePluginIds({
+        config: {
+          plugins: {
+            entries: {
+              "workspace-route": {
+                enabled: true,
+              },
+            },
+          },
+        } as never,
+        activationSourceConfig: {
+          plugins: {
+            entries: {
+              "workspace-route": {
+                enabled: true,
+              },
+            },
+          },
+        } as never,
+        routeIds: ["gateway-plugin-http"],
+        env: {} as NodeJS.ProcessEnv,
+      }),
+    ).toEqual(["bundled-route", "workspace-route"]);
+
+    expect(
+      resolveScopedRoutePluginIds({
+        config: {
+          plugins: {
+            entries: {
+              "workspace-route": {
+                enabled: true,
+              },
+            },
+          },
+        } as never,
+        activationSourceConfig: {
+          plugins: {
+            entries: {
+              "workspace-route": {
+                enabled: false,
+              },
+            },
+          },
+        } as never,
+        routeIds: ["gateway-plugin-http"],
+        env: {} as NodeJS.ProcessEnv,
+      }),
+    ).toEqual(["bundled-route"]);
+  });
+});

--- a/src/plugins/route-plugin-ids.ts
+++ b/src/plugins/route-plugin-ids.ts
@@ -1,0 +1,104 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { resolveManifestActivationPluginIds } from "./activation-planner.js";
+import { normalizePluginsConfig } from "./config-state.js";
+import {
+  hasExplicitManifestOwnerTrust,
+  isActivatedManifestOwner,
+  isBundledManifestOwner,
+  passesManifestOwnerBasePolicy,
+} from "./manifest-owner-policy.js";
+import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
+
+function dedupeSortedPluginIds(values: Iterable<string>): string[] {
+  return [...new Set(values)].toSorted((left, right) => left.localeCompare(right));
+}
+
+function normalizeRouteIds(routeIds: Iterable<string>): string[] {
+  return dedupeSortedPluginIds(
+    [...routeIds]
+      .map((routeId) => normalizeOptionalLowercaseString(routeId))
+      .filter((routeId): routeId is string => Boolean(routeId)),
+  );
+}
+
+function isRoutePluginEligibleForRuntimeOwnerActivation(params: {
+  plugin: PluginManifestRecord;
+  normalizedConfig: ReturnType<typeof normalizePluginsConfig>;
+  rootConfig: OpenClawConfig;
+}): boolean {
+  if (
+    !passesManifestOwnerBasePolicy({
+      plugin: params.plugin,
+      normalizedConfig: params.normalizedConfig,
+    })
+  ) {
+    return false;
+  }
+  if (isBundledManifestOwner(params.plugin)) {
+    return true;
+  }
+  if (params.plugin.origin === "global" || params.plugin.origin === "config") {
+    return hasExplicitManifestOwnerTrust({
+      plugin: params.plugin,
+      normalizedConfig: params.normalizedConfig,
+    });
+  }
+  return isActivatedManifestOwner({
+    plugin: params.plugin,
+    normalizedConfig: params.normalizedConfig,
+    rootConfig: params.rootConfig,
+  });
+}
+
+export function resolveScopedRoutePluginIds(params: {
+  config: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
+  routeIds: readonly string[];
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+  cache?: boolean;
+}): string[] {
+  const routeIds = normalizeRouteIds(params.routeIds);
+  if (routeIds.length === 0) {
+    return [];
+  }
+  const registry = loadPluginManifestRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+    cache: params.cache,
+  });
+  const trustConfig = params.activationSourceConfig ?? params.config;
+  const normalizedConfig = normalizePluginsConfig(trustConfig.plugins);
+  const candidateIds = dedupeSortedPluginIds(
+    routeIds.flatMap((routeId) =>
+      resolveManifestActivationPluginIds({
+        trigger: {
+          kind: "route",
+          route: routeId,
+        },
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+        cache: params.cache,
+      }),
+    ),
+  );
+  if (candidateIds.length === 0) {
+    return [];
+  }
+  const candidateIdSet = new Set(candidateIds);
+  return registry.plugins
+    .filter(
+      (plugin) =>
+        candidateIdSet.has(plugin.id) &&
+        isRoutePluginEligibleForRuntimeOwnerActivation({
+          plugin,
+          normalizedConfig,
+          rootConfig: trustConfig,
+        }),
+    )
+    .map((plugin) => plugin.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}

--- a/src/plugins/route-plugin-ids.ts
+++ b/src/plugins/route-plugin-ids.ts
@@ -9,6 +9,7 @@ import {
   passesManifestOwnerBasePolicy,
 } from "./manifest-owner-policy.js";
 import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
+import { normalizeActivationRouteId } from "./route-id-normalize.js";
 
 function dedupeSortedPluginIds(values: Iterable<string>): string[] {
   return [...new Set(values)].toSorted((left, right) => left.localeCompare(right));
@@ -17,7 +18,7 @@ function dedupeSortedPluginIds(values: Iterable<string>): string[] {
 function normalizeRouteIds(routeIds: Iterable<string>): string[] {
   return dedupeSortedPluginIds(
     [...routeIds]
-      .map((routeId) => normalizeOptionalLowercaseString(routeId))
+      .map((routeId) => normalizeActivationRouteId(normalizeOptionalLowercaseString(routeId) ?? ""))
       .filter((routeId): routeId is string => Boolean(routeId)),
   );
 }
@@ -78,6 +79,7 @@ export function resolveScopedRoutePluginIds(params: {
           kind: "route",
           route: routeId,
         },
+        manifestRegistry: registry,
         config: params.config,
         workspaceDir: params.workspaceDir,
         env: params.env,

--- a/src/plugins/runtime/http-route-registry-loader.test.ts
+++ b/src/plugins/runtime/http-route-registry-loader.test.ts
@@ -1,0 +1,122 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createEmptyPluginRegistry } from "../registry.js";
+
+const mocks = vi.hoisted(() => ({
+  loadOpenClawPlugins: vi.fn<typeof import("../loader.js").loadOpenClawPlugins>(),
+  resolveScopedRoutePluginIds:
+    vi.fn<typeof import("../route-plugin-ids.js").resolveScopedRoutePluginIds>(),
+  applyPluginAutoEnable:
+    vi.fn<typeof import("../../config/plugin-auto-enable.js").applyPluginAutoEnable>(),
+  resolveAgentWorkspaceDir: vi.fn<
+    typeof import("../../agents/agent-scope.js").resolveAgentWorkspaceDir
+  >(() => "/resolved-workspace"),
+  resolveDefaultAgentId: vi.fn<typeof import("../../agents/agent-scope.js").resolveDefaultAgentId>(
+    () => "default",
+  ),
+}));
+
+vi.mock("../loader.js", () => ({
+  loadOpenClawPlugins: (...args: Parameters<typeof mocks.loadOpenClawPlugins>) =>
+    mocks.loadOpenClawPlugins(...args),
+}));
+
+vi.mock("../route-plugin-ids.js", () => ({
+  resolveScopedRoutePluginIds: (...args: Parameters<typeof mocks.resolveScopedRoutePluginIds>) =>
+    mocks.resolveScopedRoutePluginIds(...args),
+}));
+
+vi.mock("../../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable: (...args: Parameters<typeof mocks.applyPluginAutoEnable>) =>
+    mocks.applyPluginAutoEnable(...args),
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentWorkspaceDir: (...args: Parameters<typeof mocks.resolveAgentWorkspaceDir>) =>
+    mocks.resolveAgentWorkspaceDir(...args),
+  resolveDefaultAgentId: (...args: Parameters<typeof mocks.resolveDefaultAgentId>) =>
+    mocks.resolveDefaultAgentId(...args),
+}));
+
+let loadScopedGatewayPluginHttpRouteRegistry: typeof import("./http-route-registry-loader.js").loadScopedGatewayPluginHttpRouteRegistry;
+
+describe("loadScopedGatewayPluginHttpRouteRegistry", () => {
+  beforeAll(async () => {
+    ({ loadScopedGatewayPluginHttpRouteRegistry } =
+      await import("./http-route-registry-loader.js"));
+  });
+
+  beforeEach(() => {
+    mocks.loadOpenClawPlugins.mockReset();
+    mocks.resolveScopedRoutePluginIds.mockReset();
+    mocks.applyPluginAutoEnable.mockReset();
+    mocks.resolveAgentWorkspaceDir.mockClear();
+    mocks.resolveDefaultAgentId.mockClear();
+
+    mocks.applyPluginAutoEnable.mockImplementation((params) => ({
+      config:
+        params.config && typeof params.config === "object"
+          ? {
+              ...params.config,
+              plugins: {
+                entries: {
+                  auto: { enabled: true },
+                },
+              },
+            }
+          : {},
+      changes: [],
+      autoEnabledReasons: {
+        auto: ["auto enabled"],
+      },
+    }));
+    mocks.loadOpenClawPlugins.mockReturnValue(createEmptyPluginRegistry());
+  });
+
+  it("loads a scoped route registry when planned owners exist", () => {
+    const coreGatewayHandlers = {
+      "sessions.get": () => undefined,
+    };
+    mocks.resolveScopedRoutePluginIds.mockReturnValue(["diffs", "webhooks"]);
+
+    const registry = loadScopedGatewayPluginHttpRouteRegistry({
+      config: {} as never,
+      activationSourceConfig: { plugins: { allow: ["diffs"] } } as never,
+      env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+      coreGatewayHandlers,
+    });
+
+    expect(registry).toBeDefined();
+    expect(mocks.resolveScopedRoutePluginIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: {
+          plugins: {
+            entries: {
+              auto: { enabled: true },
+            },
+          },
+        },
+        activationSourceConfig: { plugins: { allow: ["diffs"] } },
+        routeIds: ["gateway-plugin-http"],
+        workspaceDir: "/resolved-workspace",
+      }),
+    );
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["diffs", "webhooks"],
+        coreGatewayHandlers,
+        runtimeOptions: {
+          allowGatewaySubagentBinding: true,
+        },
+        throwOnLoadError: true,
+        workspaceDir: "/resolved-workspace",
+      }),
+    );
+  });
+
+  it("does not load when route planning finds no owners", () => {
+    mocks.resolveScopedRoutePluginIds.mockReturnValue([]);
+
+    expect(loadScopedGatewayPluginHttpRouteRegistry({ config: {} as never })).toBeUndefined();
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/runtime/http-route-registry-loader.ts
+++ b/src/plugins/runtime/http-route-registry-loader.ts
@@ -1,0 +1,39 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { GatewayRequestHandler } from "../../gateway/server-methods/types.js";
+import { loadOpenClawPlugins } from "../loader.js";
+import type { PluginRegistry } from "../registry.js";
+import { resolveScopedRoutePluginIds } from "../route-plugin-ids.js";
+import { buildPluginRuntimeLoadOptions, resolvePluginRuntimeLoadContext } from "./load-context.js";
+
+export const GATEWAY_PLUGIN_HTTP_ROUTE_ID = "gateway-plugin-http";
+
+export function loadScopedGatewayPluginHttpRouteRegistry(options?: {
+  config?: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
+  coreGatewayHandlers?: Record<string, GatewayRequestHandler>;
+  routeIds?: readonly string[];
+}): PluginRegistry | undefined {
+  const context = resolvePluginRuntimeLoadContext(options);
+  const routePluginIds = resolveScopedRoutePluginIds({
+    config: context.config,
+    activationSourceConfig: context.activationSourceConfig,
+    routeIds: options?.routeIds ?? [GATEWAY_PLUGIN_HTTP_ROUTE_ID],
+    workspaceDir: context.workspaceDir,
+    env: context.env,
+  });
+  if (routePluginIds.length === 0) {
+    return undefined;
+  }
+  return loadOpenClawPlugins(
+    buildPluginRuntimeLoadOptions(context, {
+      throwOnLoadError: true,
+      onlyPluginIds: routePluginIds,
+      coreGatewayHandlers: options?.coreGatewayHandlers,
+      runtimeOptions: {
+        allowGatewaySubagentBinding: true,
+      },
+    }),
+  );
+}

--- a/src/plugins/runtime/http-route-registry-loader.ts
+++ b/src/plugins/runtime/http-route-registry-loader.ts
@@ -22,6 +22,7 @@ export function loadScopedGatewayPluginHttpRouteRegistry(options?: {
     routeIds: options?.routeIds ?? [GATEWAY_PLUGIN_HTTP_ROUTE_ID],
     workspaceDir: context.workspaceDir,
     env: context.env,
+    cache: true,
   });
   if (routePluginIds.length === 0) {
     return undefined;


### PR DESCRIPTION
## Summary

- Problem: route activation metadata existed, but gateway plugin HTTP routing still only read the pinned startup route registry.
- Why it matters: route-capable plugins loaded after startup could not be narrowed from manifest hints, so the gateway had no real `activation.onRoutes` consumer.
- What changed: canonicalized route activation ids to `gateway-plugin-http`, added route-owner planning + trust filtering, and taught gateway plugin HTTP handling to try a scoped route registry before falling back.
- What did NOT change (scope boundary): no global runtime-registry rewrite, no route-path metadata model, and no removal of the pinned startup registry fallback.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `activation.onRoutes` only existed as metadata. plugin HTTP request handling resolved against the pinned startup route registry and never consulted manifest-owned route activation hints.
- Missing detection / guardrail: there was no route-scoped registry seam and no coverage for “startup registry misses, scoped route load matches”.
- Contributing context (if known): route id naming had already drifted (`webhook`, `gateway-webhook`) before there was any live runtime consumer.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server/plugins-http.test.ts`
- Scenario the test should lock in: when the pinned startup route registry misses, the gateway should try a scoped manifest-planned route registry and handle the matching plugin route.
- Why this is the smallest reliable guardrail: the bug lives at the gateway/plugin-registry seam, not inside route matching or manifest parsing alone.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Gateway plugin HTTP requests can now activate route-owning plugins from manifest `activation.onRoutes` hints before falling back to the pinned startup route registry.
- Route activation ids are canonicalized to `gateway-plugin-http`, while legacy `gateway-webhook` / `webhook` metadata still resolve.

## Diagram (if applicable)

```text
Before:
[gateway request] -> [pinned startup route registry] -> [miss] -> [false]

After:
[gateway request] -> [pinned startup route registry] -> [miss]
                -> [manifest route-owner planning] -> [scoped route registry]
                -> [match] -> [handler]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: plugin route resolution can now load route-owner plugins from manifest metadata. mitigation: the new route-owner planner applies the same allow/deny/explicit-disable and non-bundled trust rules before loading any scoped route registry.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm worktree
- Model/provider: N/A
- Integration/channel (if any): gateway plugin HTTP routes
- Relevant config (redacted): default local config plus synthetic test configs

### Steps

1. Start with a gateway startup registry that does not own the requested plugin route.
2. Plan route owners from manifest `activation.onRoutes` metadata.
3. Load the scoped route registry and re-run route matching.

### Expected

- Matching route-owner plugins are loaded through the scoped registry.
- Untrusted or disabled route owners stay excluded.
- Legacy route aliases still normalize to the canonical route id.

### Actual

- Verified locally with seam and parser/planner tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - route activation alias normalization (`webhook` / `gateway-webhook` -> `gateway-plugin-http`)
  - route-owner trust filtering for bundled/global/workspace plugins
  - gateway plugin HTTP fallback to scoped registry on startup-registry miss
- Edge cases checked:
  - non-empty allowlists still constrain route owners
  - explicit workspace disablement blocks route-owner loading
  - no planned owners means no scoped load
- What you did **not** verify:
  - full end-to-end gateway runtime with live channel/plugin traffic

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: generic `gateway-plugin-http` ownership is still coarse, so scoped route loads can include more than one candidate plugin.
  - Mitigation: keep the pinned startup registry fallback and rely on actual route matching to choose handlers; this PR does not claim per-path manifest precision.
- Risk: non-bundled route owners could become an unsafe auto-load path.
  - Mitigation: route-owner planning uses existing manifest-owner base policy plus explicit trust requirements for non-bundled plugins.
