### PR TITLE
fix(post-compaction): support H1 headings in extractSections

### DIFF
--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -150,6 +150,88 @@ Read these files.
     expect(result).toContain("Read these files");
   });
 
+  it("matches H1 headings (top-level section)", async () => {
+    // Regression: extractSections previously used /^(#{2,3})/ and silently
+    // skipped H1 headings, causing post-compaction injection to fail when users
+    // wrote "# Session Startup" instead of "## Session Startup".
+    const content = `# Session Startup
+
+Read WORKFLOW_AUTO.md first.
+
+# Other Section
+
+Not relevant.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Session Startup");
+    expect(result).toContain("WORKFLOW_AUTO.md");
+    expect(result).not.toContain("Other Section");
+  });
+
+  it("matches H4 headings", async () => {
+    const content = `#### Session Startup
+
+H4 startup instructions.
+
+#### Other
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("H4 startup instructions");
+  });
+
+  it("H1 section is terminated by the next H1", async () => {
+    // A same-level H1 should terminate the current H1 section.
+    const content = `# Session Startup
+
+Critical startup content.
+
+# Red Lines
+
+Do not break rules.
+
+# Unrelated
+
+Ignore this.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Critical startup content");
+    expect(result).toContain("Do not break rules");
+    expect(result).not.toContain("Unrelated");
+  });
+
+  it("H1 section includes lower-level sub-headings (H2/H3)", async () => {
+    // Sub-headings inside an H1 section must be captured as part of the section.
+    const content = `# Session Startup
+
+## Step 1
+
+Do step one.
+
+### Step 1a
+
+Detail for step 1a.
+
+## Step 2
+
+Do step two.
+
+# Other
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Step 1");
+    expect(result).toContain("Step 1a");
+    expect(result).toContain("Step 2");
+    expect(result).not.toContain("Other");
+  });
+
   it("skips sections inside code blocks", async () => {
     const content = `# Rules
 

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -157,7 +157,7 @@ export async function readPostCompactionContext(
 
 /**
  * Extract named sections from markdown content.
- * Matches H2 (##) or H3 (###) headings case-insensitively.
+ * Matches H1 (#) through H4 (####) headings case-insensitively.
  * Skips content inside fenced code blocks.
  * Captures until the next heading of same or higher level, or end of string.
  */
@@ -193,11 +193,11 @@ export function extractSections(
         continue;
       }
 
-      // Check if this line is a heading
-      const headingMatch = line.match(/^(#{2,3})\s+(.+?)\s*$/);
+      // Check if this line is a heading (H1 through H4)
+      const headingMatch = line.match(/^(#{1,4})\s+(.+?)\s*$/);
 
       if (headingMatch) {
-        const level = headingMatch[1].length; // 2 or 3
+        const level = headingMatch[1].length; // 1 to 4
         const headingText = headingMatch[2];
 
         if (!inSection) {


### PR DESCRIPTION
## Summary

`extractSections` in `post-compaction-context.ts` used the regex
`/^(#{2,3})\s+(.+?)\s*$/` which only matched H2 (`##`) and H3 (`###`)
headings. When a user writes their AGENTS.md with top-level H1 sections —
a very natural choice, e.g. `# Session Startup` — the function silently
returns `[]` and `readPostCompactionContext` returns `null`.

The result: after every compaction, the agent loses all injected critical
instructions with zero warning to the user. The bug is particularly
insidious because the AGENTS.md template and docs do not enforce a
specific heading level.

## Fix

Change the regex quantifier from `{2,3}` to `{1,4}` to accept H1
through H4 headings. The boundary termination logic (`level <= sectionLevel`)
already handles nesting correctly for any level — no further changes needed.

## Testing

Added four new test cases:

- **H1 section matching** – verifies `# Session Startup` is now extracted
- **H4 section matching** – verifies `#### Session Startup` is extracted  
- **H1 boundary termination** – verifies a subsequent H1 ends the section
- **H1 with H2/H3 sub-headings** – verifies nested headings are included

All existing tests continue to pass.

## Impact

- Zero breaking changes; existing H2/H3 behavior is unchanged
- No config changes required
- Fixes a silent failure path that would cause any deployment using H1
  headings in AGENTS.md to lose post-compaction context injection
