### PR TITLE
fix(infra): skip SSH-no-display short-circuit on darwin/win32

### DIFF
--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -24,6 +24,8 @@ const mocks = vi.hoisted(() => ({
   })),
   pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
   probeGateway: vi.fn(),
+  detectBinary: vi.fn<(bin: string) => Promise<boolean>>(async () => true),
+  isWSL: vi.fn<() => Promise<boolean>>(async () => false),
 }));
 
 vi.mock("../process/exec.js", () => ({
@@ -36,6 +38,14 @@ vi.mock("../infra/tailnet.js", () => ({
 
 vi.mock("../gateway/probe.js", () => ({
   probeGateway: mocks.probeGateway,
+}));
+
+vi.mock("../infra/detect-binary.js", () => ({
+  detectBinary: mocks.detectBinary,
+}));
+
+vi.mock("../infra/wsl.js", () => ({
+  isWSL: mocks.isWSL,
 }));
 
 afterEach(() => {
@@ -73,6 +83,32 @@ describe("resolveBrowserOpenCommand", () => {
     const resolved = await resolveBrowserOpenCommand();
     expect(resolved.argv).toEqual(["explorer.exe"]);
     expect(resolved.command).toBe("explorer.exe");
+    platformSpy.mockRestore();
+  });
+
+  it("does not short-circuit to ssh-no-display on darwin when only SSH_* env vars are set (#67088)", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    vi.stubEnv("SSH_CLIENT", "10.0.0.1 53822 22");
+    vi.stubEnv("SSH_TTY", "/dev/ttys002");
+    vi.stubEnv("SSH_CONNECTION", "10.0.0.1 53822 10.0.0.2 22");
+    vi.stubEnv("DISPLAY", "");
+    vi.stubEnv("WAYLAND_DISPLAY", "");
+    const resolved = await resolveBrowserOpenCommand();
+    expect(resolved.argv).toEqual(["open"]);
+    expect(resolved.command).toBe("open");
+    expect(resolved.reason).toBeUndefined();
+    platformSpy.mockRestore();
+  });
+
+  it("still short-circuits on linux when SSH_* is set without DISPLAY", async () => {
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    mocks.isWSL.mockResolvedValueOnce(false);
+    vi.stubEnv("SSH_CLIENT", "10.0.0.1 53822 22");
+    vi.stubEnv("DISPLAY", "");
+    vi.stubEnv("WAYLAND_DISPLAY", "");
+    const resolved = await resolveBrowserOpenCommand();
+    expect(resolved.argv).toBeNull();
+    expect(resolved.reason).toBe("ssh-no-display");
     platformSpy.mockRestore();
   });
 });

--- a/src/infra/browser-open.ts
+++ b/src/infra/browser-open.ts
@@ -29,7 +29,12 @@ export async function resolveBrowserOpenCommand(): Promise<BrowserOpenCommand> {
     Boolean(process.env.SSH_TTY) ||
     Boolean(process.env.SSH_CONNECTION);
 
-  if (isSsh && !hasDisplay && platform !== "win32") {
+  // macOS and Windows both ship their own native GUI subsystem; SSH_* env
+  // vars (for example lingering from Tailscale SSH or a reused shell) do
+  // NOT imply the local display is unavailable. Only use the SSH-without-
+  // DISPLAY heuristic on Linux, where DISPLAY/WAYLAND_DISPLAY is the
+  // canonical GUI probe.
+  if (isSsh && !hasDisplay && platform === "linux") {
     return { argv: null, reason: "ssh-no-display" };
   }
 


### PR DESCRIPTION
## What

Restrict the `ssh-no-display` short-circuit in `resolveBrowserOpenCommand` (`src/infra/browser-open.ts`) to Linux only. macOS and Windows now fall through to their native GUI-open path even when `SSH_CLIENT` / `SSH_TTY` / `SSH_CONNECTION` are set.

## Why

Fixes #67088.

`resolveBrowserOpenCommand` treats any SSH_* env var + absent `DISPLAY`/`WAYLAND_DISPLAY` as a strong signal that no local GUI is reachable:

```ts
// before
if (isSsh && !hasDisplay && platform !== "win32") {
  return { argv: null, reason: "ssh-no-display" };
}
```

That heuristic is correct on Linux, where `DISPLAY` is the canonical probe for an X/Wayland session. On macOS it is wrong:

- `DISPLAY` is not set in a normal macOS shell, so `hasDisplay` is `false` unconditionally.
- `SSH_*` vars routinely linger in a local iTerm/Terminal tab after a Tailscale SSH session or a reused/copied shell environment. They do not imply the user is currently remote.

Symptom: `openclaw dashboard` on macOS (v2026.4.14) prints "No GUI detected. Open from your computer: ssh -N -L ..." and never opens the browser, even though the user is physically at the Mac. Reproducer from @odin in #67088:

```text
~ ❯ env | grep '^SSH_'   # stale vars from a prior Tailscale SSH session
SSH_CLIENT=...
SSH_TTY=/dev/ttys002
SSH_CONNECTION=...

~ ❯ openclaw dashboard
... No GUI detected. Open from your computer: ...
```

Opening a fresh iTerm window (no inherited SSH env) makes `openclaw dashboard` work as expected — confirming the SSH_* env check is the sole culprit.

## Fix

Narrow the short-circuit to `platform === "linux"`. macOS continues to the `open` binary check; Windows continues to `explorer.exe`.

```ts
// after
if (isSsh && !hasDisplay && platform === "linux") {
  return { argv: null, reason: "ssh-no-display" };
}
```

Linux behavior is unchanged: `SSH_*` + no `DISPLAY` still returns `ssh-no-display`. WSL still hits its dedicated branch further down. Windows was already guarded by `platform !== "win32"` — now macOS gets the same correct treatment, because both have native GUI subsystems independent of `DISPLAY`.

## Test

Added two cases in `src/commands/onboard-helpers.test.ts`:

| Case | Expectation |
|------|-------------|
| darwin + `SSH_CLIENT`+`SSH_TTY`+`SSH_CONNECTION` + no DISPLAY | resolves `{ argv: ["open"], command: "open" }` (regression) |
| linux + `SSH_CLIENT` + no DISPLAY | resolves `{ argv: null, reason: "ssh-no-display" }` (preserved) |

Mocks added for `../infra/detect-binary.js` and `../infra/wsl.js` so the darwin path resolves deterministically.

Note: `pnpm test -- src/commands/onboard-helpers.test.ts` currently fails on an unrelated pre-existing infra bug (`test/non-isolated-runner.ts` → `Class extends value undefined`) that also reproduces on `main` with no edits. The logic-level change is straightforward and also verified by hand against the four relevant (platform, SSH, DISPLAY) combinations.

## Risk

Minimal. Single file change, 4-line delta in `browser-open.ts`. The Linux behavior is preserved byte-for-byte; only macOS and Windows gain the ability to ignore stray SSH_* env vars, matching their actual GUI semantics.