### PR TITLE
fix: prevent trim error when skipping optional input during channel selection

### DIFF
--- a/src/channels/plugins/setup-wizard-helpers.test.ts
+++ b/src/channels/plugins/setup-wizard-helpers.test.ts
@@ -505,6 +505,25 @@ describe("promptSingleChannelToken", () => {
     expect(result).toEqual(expected);
     expect(prompter.text).toHaveBeenCalledTimes(expectTextCalls);
   });
+
+  it("does not throw when the text prompter returns undefined", async () => {
+    const prompter = {
+      confirm: vi.fn(async () => false),
+      text: vi.fn(async () => undefined),
+    };
+
+    await expect(
+      promptSingleChannelToken({
+        prompter: prompter as any,
+        accountConfigured: false,
+        canUseEnv: false,
+        hasConfigToken: false,
+        envPrompt: "use env",
+        keepPrompt: "keep",
+        inputPrompt: "token",
+      }),
+    ).resolves.toEqual({ useEnv: false, token: "" });
+  });
 });
 
 describe("promptSingleChannelSecretInput", () => {

--- a/src/channels/plugins/setup-wizard-helpers.ts
+++ b/src/channels/plugins/setup-wizard-helpers.ts
@@ -986,12 +986,12 @@ export async function promptSingleChannelToken(params: {
   inputPrompt: string;
 }): Promise<{ useEnv: boolean; token: string | null }> {
   const promptToken = async (): Promise<string> =>
-    (
+    normalizeOptionalString(
       await params.prompter.text({
         message: params.inputPrompt,
         validate: (value) => (value?.trim() ? undefined : "Required"),
-      })
-    ).trim();
+      }),
+    ) ?? "";
 
   if (params.canUseEnv) {
     const keepEnv = await params.prompter.confirm({

--- a/src/channels/plugins/setup-wizard.ts
+++ b/src/channels/plugins/setup-wizard.ts
@@ -455,7 +455,7 @@ export function buildChannelSetupWizardAdapterFromSetupWizard(params: {
               });
             },
           });
-          const trimmedValue = rawValue.trim();
+          const trimmedValue = normalizeOptionalString(rawValue) ?? "";
           if (!trimmedValue && textInput.required === false) {
             if (textInput.applyEmptyValue) {
               next = await applyWizardTextInputValue({

--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from "vitest";
-import { tokenizedOptionFilter } from "./clack-prompter.js";
+import { describe, expect, it, vi } from "vitest";
+
+const clackPromptsMocks = vi.hoisted(() => ({
+  autocompleteMultiselect: vi.fn(),
+  cancel: vi.fn(),
+  confirm: vi.fn(),
+  intro: vi.fn(),
+  isCancel: vi.fn(() => false),
+  multiselect: vi.fn(),
+  outro: vi.fn(),
+  select: vi.fn(),
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    message: vi.fn(),
+    stop: vi.fn(),
+  })),
+  text: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => clackPromptsMocks);
+
+import { createClackPrompter, tokenizedOptionFilter } from "./clack-prompter.js";
 
 describe("tokenizedOptionFilter", () => {
   it("matches tokens regardless of order", () => {
@@ -31,5 +51,16 @@ describe("tokenizedOptionFilter", () => {
 
     expect(tokenizedOptionFilter("provider openai", option)).toBe(true);
     expect(tokenizedOptionFilter("openai gpt-5.4", option)).toBe(true);
+  });
+});
+
+describe("createClackPrompter", () => {
+  it("normalizes undefined text responses to an empty string", async () => {
+    clackPromptsMocks.text.mockResolvedValueOnce(undefined);
+
+    const prompter = createClackPrompter();
+    const result = await prompter.text({ message: "Token" });
+
+    expect(result).toBe("");
   });
 });

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -100,7 +100,7 @@ export function createClackPrompter(): WizardPrompter {
     },
     text: async (params) => {
       const validate = params.validate;
-      return guardCancel(
+      const value = guardCancel(
         await text({
           message: stylePromptMessage(params.message),
           initialValue: params.initialValue,
@@ -108,6 +108,7 @@ export function createClackPrompter(): WizardPrompter {
           validate: validate ? (value) => validate(value ?? "") : undefined,
         }),
       );
+      return typeof value === "string" ? value : "";
     },
     confirm: async (params) =>
       guardCancel(


### PR DESCRIPTION
## Summary

- Problem: the onboarding/channel setup flow could crash with `TypeError: Cannot read properties of undefined (reading 'trim')` when a setup text prompt yielded `undefined` and downstream code assumed it was always a string.
- Why it matters: this breaks real onboarding paths and can stop users from finishing setup.
- What changed: normalize text prompt results before trimming at the prompt/setup boundary, and add regression tests covering the `undefined` prompt-result path.
- What did NOT change (scope boundary): this PR does not change required-field validation, channel semantics, or unrelated wizard behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #66945
- Related #66657, #66677, #66693, #66718, #66942
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: parts of the setup flow assumed `prompter.text(...)` always returned a string and called `.trim()` directly on the result.
- Missing detection / guardrail: there was no normalization guard for `undefined` text prompt results, and no regression test covering that path.
- Contributing context (if known): setup flows include skip/secret-input paths where the prompt layer can surface an empty or undefined-like result, but downstream code still treated the value as a guaranteed string.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/channels/plugins/setup-wizard-helpers.test.ts`
  - `src/wizard/clack-prompter.test.ts`
- Scenario the test should lock in: when the text prompter yields `undefined`, setup flow helpers normalize it safely instead of crashing on `.trim()`.
- Why this is the smallest reliable guardrail: the failure comes from a local string-assumption at the prompt/setup boundary, so unit coverage there is the narrowest test that directly protects the bug.
- Existing test that already covers this (if any): none that covered the `undefined` prompt-result path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Onboarding/channel setup no longer crashes with `TypeError: Cannot read properties of undefined (reading 'trim')` when a setup text prompt yields `undefined`.
- Required-field validation behavior remains unchanged.

## Diagram (if applicable)

```text
Before:
[setup text prompt yields undefined]
  -> [.trim() is called on undefined]
  -> [wizard crashes]

After:
[setup text prompt yields undefined]
  -> [value is normalized first]
  -> [wizard continues safely]
