### PR TITLE
fix(qa): honor stale cursor fallback in long polls

### DIFF
--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -1,6 +1,8 @@
 import { Agent, createServer, request } from "node:http";
-import { describe, expect, it } from "vitest";
-import { closeQaHttpServer } from "./bus-server.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeQaHttpServer, startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import type { QaBusPollResult } from "./runtime-api.js";
 
 async function listenOnLoopback(server: ReturnType<typeof createServer>): Promise<number> {
   await new Promise<void>((resolve, reject) => {
@@ -33,6 +35,79 @@ async function requestOnce(params: { port: number; agent: Agent }): Promise<void
     req.end();
   });
 }
+
+async function pollQaBus(params: {
+  baseUrl: string;
+  accountId: string;
+  cursor: number;
+  timeoutMs: number;
+}): Promise<QaBusPollResult> {
+  const response = await fetch(`${params.baseUrl}/v1/poll`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      accountId: params.accountId,
+      cursor: params.cursor,
+      timeoutMs: params.timeoutMs,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`qa-bus request failed: ${response.status}`);
+  }
+  return (await response.json()) as QaBusPollResult;
+}
+
+describe("qa-bus server", () => {
+  const stops: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(stops.splice(0).map((stop) => stop()));
+  });
+
+  it("wakes stale-cursor long polls as soon as matching account traffic arrives", async () => {
+    const state = createQaBusState();
+
+    const bus = await startQaBusServer({ state });
+    stops.push(bus.stop);
+
+    const pending = pollQaBus({
+      baseUrl: bus.baseUrl,
+      accountId: "acct-a",
+      cursor: 999,
+      timeoutMs: 500,
+    });
+
+    setTimeout(() => {
+      state.addInboundMessage({
+        accountId: "acct-a",
+        conversation: { id: "target", kind: "direct" },
+        senderId: "acct-a-user",
+        text: "fresh event",
+      });
+    }, 20);
+
+    const result = await Promise.race([
+      pending,
+      new Promise<"timed-out">((resolve) => {
+        setTimeout(() => resolve("timed-out"), 150);
+      }),
+    ]);
+
+    expect(result).not.toBe("timed-out");
+    if (result === "timed-out") {
+      throw new Error("stale-cursor long poll did not wake before timeout window");
+    }
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      accountId: "acct-a",
+      cursor: 1,
+      kind: "inbound-message",
+    });
+  });
+});
 
 describe("closeQaHttpServer", () => {
   it("closes idle keep-alive sockets so suite processes can exit", async () => {

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -15,6 +15,11 @@ import type {
   QaBusWaitForInput,
 } from "./runtime-api.js";
 
+function resolveEffectivePollCursor(currentCursor: number, requestedCursor?: number): number {
+  const startCursor = requestedCursor ?? 0;
+  return currentCursor < startCursor ? 0 : startCursor;
+}
+
 async function readJson(req: IncomingMessage): Promise<unknown> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) {
@@ -137,14 +142,15 @@ export async function handleQaBusRequest(params: {
         const timeoutMs = Math.max(0, Math.min(input.timeoutMs ?? 0, 30_000));
         const accountId = normalizeAccountId(input.accountId);
         const initial = params.state.poll(input);
+        const effectiveCursor = resolveEffectivePollCursor(initial.cursor, input.cursor);
         if (initial.events.length > 0 || timeoutMs === 0) {
           writeJson(params.res, 200, initial);
           return true;
         }
         try {
-          await params.state.waitForCursorAdvance(input.cursor ?? 0, timeoutMs, (snapshot) => {
+          await params.state.waitForCursorAdvance(effectiveCursor, timeoutMs, (snapshot) => {
             return snapshot.events.some(
-              (event) => event.accountId === accountId && event.cursor > (input.cursor ?? 0),
+              (event) => event.accountId === accountId && event.cursor > effectiveCursor,
             );
           });
         } catch {


### PR DESCRIPTION
## Summary
- keep qa-bus long-poll wakeups aligned with the same stale-cursor fallback that immediate polling already uses
- avoid waiting against an out-of-date client cursor after qa-bus restarts or other cursor resets
- add a regression test that proves a stale-cursor poll wakes promptly when matching account traffic arrives

## Test plan
- [x] pnpm test extensions/qa-lab/src/bus-server.test.ts
- [x] pnpm test extensions/qa-lab/src/bus-state.test.ts extensions/qa-channel/src/channel.test.ts

Made with [Cursor](https://cursor.com)