### PR TITLE
fix(docker): verify matrix-sdk-crypto native addon without hardcoded pnpm path (#65608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - CLI/configure: re-read the persisted config hash after writes so config updates stop failing with stale-hash races. (#64188, #66528)
 - CLI/update: prune stale packaged `dist` chunks after npm upgrades and keep downgrade/verify inventory checks compat-safe so global upgrades stop failing on stale chunk imports. (#66959) Thanks @obviyus.
 - Onboarding/CLI: fix channel-selection crashes on globally installed CLI setups during onboarding. (#66736)
+- Video generation/live tests: bound provider polling for live video smoke, default to the fast non-FAL text-to-video path, and use a one-second lobster prompt so release validation no longer waits indefinitely on slow provider queues.
 - Memory-core/QMD `memory_get`: reject reads of arbitrary workspace markdown paths and only allow canonical memory files (`MEMORY.md`, `memory.md`, `DREAMS.md`, `dreams.md`, `memory/**`) plus exact paths of active indexed QMD workspace documents, so the QMD memory backend can no longer be used as a generic workspace-file read shim that bypasses `read` tool-policy denials. (#66026) Thanks @eleqtrizit.
 - Cron/agents: forward embedded-run tool policy and internal event params into the attempt layer so `--tools` allowlists, cron-owned message-tool suppression, explicit message targeting, and command-path internal events all take effect at runtime again. (#62675) Thanks @hexsprite.
 - Setup/providers: guard preferred-provider lookup during setup so malformed plugin metadata with a missing provider id no longer crashes the wizard with `Cannot read properties of undefined (reading 'trim')`. (#66649) Thanks @Tianworld.
@@ -64,6 +65,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/chat: keep optimistic user message cards visible during active sends by deferring same-session history reloads until the active run ends, including aborted and errored runs. (#66997) Thanks @scotthuang and @vincentkoc.
 - Media/Slack: allow host-local CSV and Markdown uploads only when the fallback buffer actually decodes as text, so real plain-text files work without letting opaque non-text blobs renamed to `.csv` or `.md` slip past the host-read guard. (#67047) Thanks @Unayung.
 - Ollama/onboarding: split setup into `Cloud + Local`, `Cloud only`, and `Local only`, support direct `OLLAMA_API_KEY` cloud setup without a local daemon, and keep Ollama web search on the local-host path. (#67005) Thanks @obviyus.
+- Docker/build: verify `@matrix-org/matrix-sdk-crypto-nodejs` native bindings with `find` under `node_modules` instead of a hardcoded `.pnpm/...` path so pnpm v10+ virtual-store layouts no longer fail the image build. (#67143) thanks @ly85206559.
 
 ## 2026.4.14
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,12 @@ COPY --from=ext-deps /out/ ./${OPENCLAW_BUNDLED_PLUGIN_DIR}/
 RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
     NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile
 
+# pnpm v10+ may append peer-resolution hashes to virtual-store folder names; do not hardcode `.pnpm/...`
+# paths. Fail fast here if the Matrix native binding did not materialize after install.
+RUN echo "==> Verifying critical native addons..." && \
+    find /app/node_modules -name "matrix-sdk-crypto*.node" 2>/dev/null | grep -q . || \
+    (echo "ERROR: matrix-sdk-crypto native addon missing (pnpm install may have silently failed on this arch)" >&2 && exit 1)
+
 COPY . .
 
 # Normalize extension paths now so runtime COPY preserves safe modes

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -42,6 +42,15 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain("apt-get install -y --no-install-recommends xvfb");
   });
 
+  it("verifies matrix-sdk-crypto native addons without hardcoded pnpm virtual-store paths", async () => {
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    expect(dockerfile).toContain("Verifying critical native addons");
+    expect(dockerfile).toContain('find /app/node_modules -name "matrix-sdk-crypto*.node"');
+    expect(dockerfile).not.toMatch(
+      /ADDON_DIR=.*node_modules\/\.pnpm\/@matrix-org\+matrix-sdk-crypto-nodejs@/,
+    );
+  });
+
   it("prunes runtime dependencies after the build stage", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     expect(dockerfile).toContain("FROM build AS runtime-assets");


### PR DESCRIPTION
## Summary

- Problem: Docker builds verify `@matrix-org/matrix-sdk-crypto-nodejs` through a hardcoded `.pnpm/.../@matrix-org+matrix-sdk-crypto-nodejs@...` path that stops matching on pnpm v10+ when the virtual-store entry includes peer-resolution hashes.
- Why it matters: the native addon can download successfully and still fail the Docker build with a false `matrix-sdk-crypto native addon missing` error, blocking Docker installs and smoke coverage.
- What changed: replace the brittle path probe with `find /app/node_modules -name "matrix-sdk-crypto*.node" | grep -q .`, add a Dockerfile regression test, and add a changelog entry.
- What did NOT change (scope boundary): no dependency versions, plugin manifests, or matrix runtime behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #65608
- Related #65608
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Dockerfile assumed the Matrix native addon would always live under an exact `.pnpm/@matrix-org+matrix-sdk-crypto-nodejs@...` path, but pnpm v10+ can append peer-resolution hashes to that virtual-store directory name.
- Missing detection / guardrail: there was no regression test asserting that Docker addon verification avoids hardcoded `.pnpm` paths.
- Contributing context (if known): the addon itself still downloads successfully; the failure is a false negative in the verification step after install.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/dockerfile.test.ts`
- Scenario the test should lock in: Dockerfile verifies Matrix native addons with a portable `find /app/node_modules ...` check and no longer hardcodes a `.pnpm/@matrix-org+matrix-sdk-crypto-nodejs@...` path.
- Why this is the smallest reliable guardrail: the regression is caused by static Dockerfile contents, so a focused Dockerfile assertion catches future path hardcoding without requiring a full image build.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Docker builds stop failing on pnpm v10+ virtual-store layouts when the Matrix native addon is present.
- Official Docker image builds stay compatible with newer pnpm folder naming.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 / Linux Docker build environment
- Runtime/container: root `Dockerfile` build stage with pnpm v10+ (`v10.32.1` in the linked issue repro)
- Model/provider: N/A
- Integration/channel (if any): Matrix bundled plugin native addon
- Relevant config (redacted): default Docker build; no special runtime config required

### Steps

1. Build the repo `Dockerfile` in an environment using pnpm v10+.
2. Let `pnpm install` complete and materialize `@matrix-org/matrix-sdk-crypto-nodejs`.
3. Run the old hardcoded addon verification step.

### Expected

- The build should pass when the Matrix native addon exists anywhere under `/app/node_modules`.

### Actual

- The old hardcoded `.pnpm/...` path probe can fail even after a successful addon download, producing a false `matrix-sdk-crypto native addon missing` error.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reviewed the linked issue repro/logs, confirmed the diff removes the hardcoded `.pnpm` path, confirmed `src/dockerfile.test.ts` now locks in the portable probe, and confirmed this PR's `Install Smoke` job successfully built the root Dockerfile image plus the matrix extension smoke image before failing later in an unrelated installer-smoke phase.
- Edge cases checked: pnpm virtual-store folder names with peer-resolution hash suffixes; addon discovery anywhere under `/app/node_modules` instead of one exact virtual-store entry.
- What you did **not** verify: a fresh local Docker rebuild/rerun from this branch; multi-arch/manual runtime validation.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: `find` could match an unexpected stale file if multiple copies existed.
  - Mitigation: the probe runs immediately after a clean `pnpm install` inside the image build and is limited to `/app/node_modules`.
- Risk: this PR currently still shows a failing `install-smoke` check.
  - Mitigation: the failure happens later in `scripts/test-install-sh-docker.sh` during the direct npm global baseline install of `openclaw@2026.4.10`, after the updated root Dockerfile smoke image and matrix extension smoke both already passed; treat that timeout as a separate installer-smoke issue unless a rerun proves otherwise.
