### PR TITLE
fix(agents): reapply compaction settings after resource loader reload (#65602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/device pairing: restrict non-admin paired-device sessions (device-token auth) to their own pairing list, approve, and reject actions so a paired device cannot enumerate other devices or approve/reject pairing requests authored by another device. Admin and shared-secret operator sessions retain full visibility. (#69375) Thanks @eleqtrizit.
 - Agents/gateway tool: extend the agent-facing `gateway` tool's config mutation guard so model-driven `config.patch` and `config.apply` cannot rewrite operator-trusted paths (sandbox, plugin trust, gateway auth/TLS, hook routing and tokens, SSRF policy, MCP servers, workspace filesystem hardening) and cannot bypass the guard by editing per-agent sandbox, tools, or embedded-Pi overrides in place under `agents.list[]`. (#69377) Thanks @eleqtrizit.
 - Gateway/websocket broadcasts: require `operator.read` (or higher) for chat, agent, and tool-result event frames so pairing-scoped and node-role sessions no longer passively receive session chat content, and scope-gate unknown broadcast events by default. Plugin-defined `plugin.*` broadcasts are scoped to operator.write/admin, and status/transport events (`heartbeat`, `presence`, `tick`, etc.) remain unrestricted. Per-client sequence numbers preserve per-connection monotonicity. (#69373) Thanks @eleqtrizit.
-
+- Agents/compaction: always reload embedded Pi resources through an explicit loader and reapply reserve-token overrides so runs without extension factories no longer silently lose compaction settings before session start. (#67146) Thanks @ly85206559.
 ## 2026.4.20
 
 ### Changes

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -835,6 +835,8 @@ export async function compactEmbeddedPiSessionDirect(
           extensionFactories,
         });
         await resourceLoader.reload();
+        // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
+        // compaction overrides applied in createPreparedEmbeddedPiSettingsManager.
         applyPiCompactionSettingsFromConfig({
           settingsManager,
           cfg: params.config,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -824,25 +824,20 @@ export async function compactEmbeddedPiSessionDirect(
         modelId,
         model,
       });
-      // Only create an explicit resource loader when there are extension factories
-      // to register; otherwise let createAgentSession use its built-in default.
-      let resourceLoader: DefaultResourceLoader | undefined;
-      if (extensionFactories.length > 0) {
-        resourceLoader = new DefaultResourceLoader({
-          cwd: resolvedWorkspace,
-          agentDir,
-          settingsManager,
-          extensionFactories,
-        });
-        await resourceLoader.reload();
-        // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
-        // compaction overrides applied in createPreparedEmbeddedPiSettingsManager.
-        applyPiCompactionSettingsFromConfig({
-          settingsManager,
-          cfg: params.config,
-          contextTokenBudget: ctxInfo.tokens,
-        });
-      }
+      const resourceLoader = new DefaultResourceLoader({
+        cwd: resolvedWorkspace,
+        agentDir,
+        settingsManager,
+        extensionFactories,
+      });
+      await resourceLoader.reload();
+      // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
+      // compaction overrides applied in createPreparedEmbeddedPiSettingsManager.
+      applyPiCompactionSettingsFromConfig({
+        settingsManager,
+        cfg: params.config,
+        contextTokenBudget: ctxInfo.tokens,
+      });
 
       const { builtInTools, customTools } = splitSdkTools({
         tools: effectiveTools,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -70,6 +70,7 @@ import {
   consumeCompactionSafeguardCancelReason,
   setCompactionSafeguardCancelReason,
 } from "../pi-hooks/compaction-safeguard-runtime.js";
+import { applyPiCompactionSettingsFromConfig } from "../pi-settings.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../pi-project-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
 import { wrapStreamFnTextTransforms } from "../plugin-text-transforms.js";
@@ -834,6 +835,11 @@ export async function compactEmbeddedPiSessionDirect(
           extensionFactories,
         });
         await resourceLoader.reload();
+        applyPiCompactionSettingsFromConfig({
+          settingsManager,
+          cfg: params.config,
+          contextTokenBudget: ctxInfo.tokens,
+        });
       }
 
       const { builtInTools, customTools } = splitSdkTools({

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.resource-loader.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.resource-loader.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  cleanupTempPaths,
+  createContextEngineAttemptRunner,
+  getHoisted,
+  resetEmbeddedAttemptHarness,
+} from "./attempt.spawn-workspace.test-support.js";
+
+const hoisted = getHoisted();
+
+describe("runEmbeddedAttempt resource loader wiring", () => {
+  const tempPaths: string[] = [];
+
+  beforeEach(() => {
+    resetEmbeddedAttemptHarness();
+  });
+
+  afterEach(async () => {
+    await cleanupTempPaths(tempPaths);
+  });
+
+  it("passes an explicit resourceLoader to createAgentSession even without extension factories", async () => {
+    await createContextEngineAttemptRunner({
+      sessionKey: "agent:main:discord:dm:test-resource-loader",
+      tempPaths,
+      contextEngine: {
+        assemble: async ({ messages }) => ({
+          messages,
+          estimatedTokens: 1,
+        }),
+      },
+    });
+
+    expect(hoisted.createAgentSessionMock).toHaveBeenCalled();
+    expect(hoisted.createAgentSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resourceLoader: expect.objectContaining({
+          reload: expect.any(Function),
+        }),
+      }),
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -284,6 +284,13 @@ vi.mock("../../pi-project-settings.js", () => ({
 
 vi.mock("../../pi-settings.js", () => ({
   applyPiAutoCompactionGuard: () => {},
+  applyPiCompactionSettingsFromConfig: () => ({
+    didOverride: false,
+    compaction: {
+      reserveTokens: 0,
+      keepRecentTokens: 40_000,
+    },
+  }),
 }));
 
 vi.mock("../extensions.js", () => ({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -79,9 +79,11 @@ import {
   resolveBootstrapTotalMaxChars,
 } from "../../pi-embedded-helpers.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
-import { applyPiCompactionSettingsFromConfig } from "../../pi-settings.js";
+import {
+  applyPiAutoCompactionGuard,
+  applyPiCompactionSettingsFromConfig,
+} from "../../pi-settings.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
-import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
 import {
   createClientToolNameConflictError,
   findClientToolNameConflicts,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1022,25 +1022,20 @@ export async function runEmbeddedAttempt(
         modelId: params.modelId,
         model: params.model,
       });
-      // Only create an explicit resource loader when there are extension factories
-      // to register; otherwise let createAgentSession use its built-in default.
-      let resourceLoader: DefaultResourceLoader | undefined;
-      if (extensionFactories.length > 0) {
-        resourceLoader = new DefaultResourceLoader({
-          cwd: resolvedWorkspace,
-          agentDir,
-          settingsManager,
-          extensionFactories,
-        });
-        await resourceLoader.reload();
-        // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
-        // compaction overrides applied in createPreparedEmbeddedPiSettingsManager.
-        applyPiCompactionSettingsFromConfig({
-          settingsManager,
-          cfg: params.config,
-          contextTokenBudget: params.contextTokenBudget,
-        });
-      }
+      const resourceLoader = new DefaultResourceLoader({
+        cwd: resolvedWorkspace,
+        agentDir,
+        settingsManager,
+        extensionFactories,
+      });
+      await resourceLoader.reload();
+      // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
+      // compaction overrides applied in createPreparedEmbeddedPiSettingsManager.
+      applyPiCompactionSettingsFromConfig({
+        settingsManager,
+        cfg: params.config,
+        contextTokenBudget: params.contextTokenBudget,
+      });
 
       // Get hook runner early so it's available when creating tools
       const hookRunner = getGlobalHookRunner();

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -79,6 +79,7 @@ import {
   resolveBootstrapTotalMaxChars,
 } from "../../pi-embedded-helpers.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
+import { applyPiCompactionSettingsFromConfig } from "../../pi-settings.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import { applyPiAutoCompactionGuard } from "../../pi-settings.js";
 import {
@@ -1030,6 +1031,13 @@ export async function runEmbeddedAttempt(
           extensionFactories,
         });
         await resourceLoader.reload();
+        // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
+        // compaction overrides applied in createPreparedEmbeddedPiSettingsManager.
+        applyPiCompactionSettingsFromConfig({
+          settingsManager,
+          cfg: params.config,
+          contextTokenBudget: params.contextTokenBudget,
+        });
       }
 
       // Get hook runner early so it's available when creating tools

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -23,6 +23,39 @@ describe("applyPiCompactionSettingsFromConfig", () => {
     });
   });
 
+  it("can restore reserveTokens after a simulated resource loader reload drops them below floor", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { reserveTokensFloor: DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR } } },
+    } as const;
+    let reserve = 16_384;
+    const keep = 20_000;
+    const settingsManager = {
+      getCompactionReserveTokens: () => reserve,
+      getCompactionKeepRecentTokens: () => keep,
+      applyOverrides: vi.fn((overrides: { compaction: { reserveTokens?: number } }) => {
+        if (overrides.compaction.reserveTokens !== undefined) {
+          reserve = overrides.compaction.reserveTokens;
+        }
+      }),
+    };
+
+    const first = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg,
+      contextTokenBudget: 100_000,
+    });
+    expect(first.compaction.reserveTokens).toBe(DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR);
+
+    reserve = 16_384;
+    const second = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      cfg,
+      contextTokenBudget: 100_000,
+    });
+    expect(second.compaction.reserveTokens).toBe(DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR);
+    expect(reserve).toBe(DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR);
+  });
+
   it("does not override when already above floor and not in safeguard mode", () => {
     const settingsManager = {
       getCompactionReserveTokens: () => 32_000,


### PR DESCRIPTION
## Summary

- **Problem:** `createPreparedEmbeddedPiSettingsManager` applies `applyPiCompactionSettingsFromConfig` (in-memory compaction overrides). When extension factories register a `DefaultResourceLoader`, `await resourceLoader.reload()` rehydrates Pi settings from disk and can drop those overrides (e.g. `reserveTokens` / floor alignment).
- **Why it matters:** Users with configured compaction floors or OpenClaw-derived reserve settings could see them silently reverted after reload, diverging from config and risking wrong compaction behavior.
- **What changed:** After `await resourceLoader.reload()`, call `applyPiCompactionSettingsFromConfig` again with the same `cfg` and `contextTokenBudget` as the prepared settings manager, in both embedded run (`run/attempt.ts`) and direct compaction (`compact.ts`) paths. Merged duplicate-import lint fix for `pi-settings.js` and aligned the explanatory comment on both reload sites.
- **What did NOT change:** No new abstraction around `reload()` globally; no changes to Pi SDK disk format; no unrelated refactors.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #65602
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `DefaultResourceLoader.reload()` reloads settings from disk, overwriting in-memory overrides that OpenClaw had applied via `createPreparedEmbeddedPiSettingsManager` / `applyPiCompactionSettingsFromConfig`.
- **Missing detection / guardrail:** Call sites that construct an explicit `DefaultResourceLoader` must re-apply OpenClaw compaction settings after `reload()` if they rely on prepared-manager overrides.
- **Contributing context (if known):** Only two production `resourceLoader.reload()` sites exist under `src/agents/` for this embedded path (verified via search); both are updated here.

## Regression Test Plan (if applicable)

- **Coverage level that should have caught this:**
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/agents/pi-settings.test.ts`
- **Scenario the test should lock in:** After applying compaction settings from config, a simulated “reload drops reserve below floor” state is corrected by a second `applyPiCompactionSettingsFromConfig` call (mirrors post-`reload()` reapply).
- **Why this is the smallest reliable guardrail:** Exercises the pure settings/override logic without booting a full embedded session or resource loader.
- **Existing test that already covers this (if any):** New case in `pi-settings.test.ts` (see file for the simulated reload drop).
- **If no new test is added, why not:** N/A — test added.

## User-visible / Behavior Changes

- Compaction reserve token / floor overrides from OpenClaw config remain effective when a `DefaultResourceLoader` is used with extension factories (embedded attempt and compaction paths).

## Diagram (if applicable)

```text
Before:
createPreparedEmbeddedPiSettingsManager → overrides in memory
→ DefaultResourceLoader.reload() → disk settings win → overrides lost

After:
createPreparedEmbeddedPiSettingsManager → overrides in memory
→ DefaultResourceLoader.reload() → applyPiCompactionSettingsFromConfig again → overrides restored
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: (CI / local dev)
- Runtime/container: Node 22+
- Model/provider: N/A for this fix
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.compaction.*` with non-default `reserveTokens` / `reserveTokensFloor` where applicable

### Steps

1. Use embedded Pi paths that register extension factories so an explicit `DefaultResourceLoader` runs `reload()`.
2. Configure compaction overrides via OpenClaw config.
3. Observe compaction reserve settings remain aligned with config after reload (no silent drop to disk-only values).

### Expected

- Post-`reload()`, `applyPiCompactionSettingsFromConfig` restores OpenClaw compaction overrides.

### Actual

- Matches expected after this PR.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** `pnpm test src/agents/pi-settings.test.ts`; `pnpm check` on the rebased branch.
- **Edge cases checked:** Import merge with latest `main` (`pi-tool-definition-adapter` client tool conflict helpers preserved).
- **What you did not verify:** Full gateway e2e with every provider; behavior is localized to settings reapplication after reload.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Risks and Mitigations

- **Risk:** Future new `resourceLoader.reload()` call site forgets to reapply.
  - **Mitigation:** Documented in code comments at both sites; grep shows only these two production sites in `src/agents/`. A follow-up could centralize reload+reapply if desired.
