### PR TITLE
fix(openai-codex): normalize stale /backend-api/v1 baseUrl to canonical

### DIFF
--- a/extensions/openai/base-url.test.ts
+++ b/extensions/openai/base-url.test.ts
@@ -19,9 +19,21 @@ describe("openai base URL helpers", () => {
     expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/")).toBe(true);
   });
 
+  it("recognizes the legacy /backend-api/v1 form persisted by older releases (#67131)", () => {
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/v1")).toBe(true);
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/v1/")).toBe(true);
+    expect(isOpenAICodexBaseUrl("http://chatgpt.com/backend-api/v1")).toBe(true);
+  });
+
   it("rejects non-Codex backend routes", () => {
     expect(isOpenAICodexBaseUrl("https://api.openai.com/v1")).toBe(false);
     expect(isOpenAICodexBaseUrl("https://chatgpt.com")).toBe(false);
     expect(isOpenAICodexBaseUrl(undefined)).toBe(false);
+  });
+
+  it("rejects chatgpt.com paths that are not /backend-api or /backend-api/v1", () => {
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/v2")).toBe(false);
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/codex")).toBe(false);
+    expect(isOpenAICodexBaseUrl("https://chatgpt.com/api")).toBe(false);
   });
 });

--- a/extensions/openai/base-url.ts
+++ b/extensions/openai/base-url.ts
@@ -13,5 +13,11 @@ export function isOpenAICodexBaseUrl(baseUrl?: string): boolean {
   if (!trimmed) {
     return false;
   }
-  return /^https?:\/\/chatgpt\.com\/backend-api\/?$/i.test(trimmed);
+  // Match both the canonical `https://chatgpt.com/backend-api` and the legacy
+  // `https://chatgpt.com/backend-api/v1` form that older releases persisted in
+  // agent-scoped models.json. The Codex responses endpoint lives at
+  // `/backend-api/codex/responses`; the `/v1` variant triggers a Cloudflare 403.
+  // Treating both as "codex base URL" lets normalizeCodexTransport rewrite the
+  // stale value back to the canonical root on the next resolve.
+  return /^https?:\/\/chatgpt\.com\/backend-api(?:\/v1)?\/?$/i.test(trimmed);
 }

--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -375,4 +375,56 @@ describe("openai codex provider", () => {
       name: "gpt-5.4",
     });
   });
+
+  it("rewrites stale /backend-api/v1 baseUrl to the canonical codex root (#67131)", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+
+    const model = provider.normalizeResolvedModel?.({
+      provider: "openai-codex",
+      model: {
+        id: "gpt-5.4",
+        name: "gpt-5.4",
+        provider: "openai-codex",
+        api: "openai-codex-responses",
+        // Older releases persisted this stale path into agent-scoped
+        // models.json; the responses endpoint is /backend-api/codex/responses,
+        // and /backend-api/v1/codex/responses triggers a Cloudflare 403.
+        baseUrl: "https://chatgpt.com/backend-api/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+      },
+    } as never);
+
+    expect(model).toMatchObject({
+      baseUrl: "https://chatgpt.com/backend-api",
+      api: "openai-codex-responses",
+    });
+  });
+
+  it("leaves the canonical /backend-api baseUrl unchanged (no-op rewrite)", () => {
+    const provider = buildOpenAICodexProviderPlugin();
+    const original = {
+      id: "gpt-5.4",
+      name: "gpt-5.4",
+      provider: "openai-codex",
+      api: "openai-codex-responses",
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1_050_000,
+      contextTokens: 272_000,
+      maxTokens: 128_000,
+    };
+    const model = provider.normalizeResolvedModel?.({
+      provider: "openai-codex",
+      model: original,
+    } as never);
+
+    expect(model).toBe(original);
+  });
 });

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -106,8 +106,14 @@ function normalizeCodexTransport(model: ProviderRuntimeModel): ProviderRuntimeMo
     !model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl) || isOpenAICodexBaseUrl(model.baseUrl);
   const api =
     useCodexTransport && model.api === "openai-responses" ? "openai-codex-responses" : model.api;
+  // Rewrite empty, openai.com, and any chatgpt.com/backend-api* URL — including
+  // the stale `/backend-api/v1` form that older releases persisted to
+  // agent-scoped models.json — to the canonical codex base. Without this, a
+  // stale `/v1` suffix survives and requests hit `/backend-api/v1/codex/responses`,
+  // which Cloudflare blocks with a 403 challenge (see #67131).
   const baseUrl =
-    api === "openai-codex-responses" && (!model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl))
+    api === "openai-codex-responses" &&
+    (!model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl) || isOpenAICodexBaseUrl(model.baseUrl))
       ? OPENAI_CODEX_BASE_URL
       : model.baseUrl;
   if (


### PR DESCRIPTION
## What

Two-line logic change plus tests:

1. `extensions/openai/base-url.ts` — `isOpenAICodexBaseUrl` regex now matches both `https://chatgpt.com/backend-api` and the legacy `https://chatgpt.com/backend-api/v1`:

   ```diff
   -return /^https?:\/\/chatgpt\.com\/backend-api\/?$/i.test(trimmed);
   +return /^https?:\/\/chatgpt\.com\/backend-api(?:\/v1)?\/?$/i.test(trimmed);
   ```

2. `extensions/openai/openai-codex-provider.ts` — `normalizeCodexTransport` now includes `isOpenAICodexBaseUrl(model.baseUrl)` in the baseUrl-rewrite condition, so the widened matcher rewrites legacy values to the canonical root:

   ```diff
    const baseUrl =
      api === 'openai-codex-responses' &&
   -  (!model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl))
   +  (!model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl) || isOpenAICodexBaseUrl(model.baseUrl))
        ? OPENAI_CODEX_BASE_URL
        : model.baseUrl;
   ```

## Why

Fixes #67131.

Older OpenClaw releases persisted `https://chatgpt.com/backend-api/v1` as the Codex provider's baseUrl in agent-scoped `~/.openclaw/agents/main/agent/models.json`. The Codex responses endpoint is actually `/backend-api/codex/responses`; requests to `/backend-api/v1/codex/responses` get Cloudflare-blocked with `HTTP 403 + cf-mitigated: challenge`, which OpenClaw surfaces as misleading downstream errors (`DNS lookup failed`, raw HTML challenge, rate-limit style).

PR #66969 already landed a partial fix for the related `model.api === undefined` regression, but stale `/v1` baseUrls survive #66969 because `normalizeCodexTransport` only rewrites baseUrl when `!model.baseUrl || isOpenAIApiBaseUrl(model.baseUrl)` — and `/backend-api/v1` matches neither: it is NOT `api.openai.com/v1` (that matcher), and it was NOT previously recognised as a codex URL (this PR adds that).

The reporter (#67131) independently confirmed the fix by manually editing the persisted baseUrl to `/backend-api`, which restored working codex turns.

## Relationship to #66969

#66969 is OPEN and touches `normalizeCodexTransport` in the same file but fixes a different symptom (`api` undefined for users without explicit `api: 'openai-responses'` in user config). The two fixes compose cleanly:

- #66969 guarantees `api` is upgraded to `openai-codex-responses` on the codex transport path.
- This PR guarantees the accompanying `baseUrl` is canonicalized, including when it was previously persisted with the stale `/v1` suffix.

Neither fix makes the other obsolete; both reach the same `useCodexTransport && model.api === 'openai-responses'` code path only under mutually-exclusive conditions.

## Behavior

| baseUrl (input) | Before | After |
|-----------------|--------|-------|
| `""` / undefined | rewritten to `/backend-api` | unchanged |
| `https://api.openai.com` | rewritten to `/backend-api` | unchanged |
| `https://api.openai.com/v1` | rewritten to `/backend-api` | unchanged |
| `https://chatgpt.com/backend-api` | passed through (no-op) | passed through (no-op, reference-equal) |
| `https://chatgpt.com/backend-api/v1` | **kept (broken)** | **rewritten to `/backend-api`** |
| `https://chatgpt.com/backend-api/v2` | kept | kept |
| `https://chatgpt.com/backend-api/codex` | kept | kept |
| arbitrary proxy URL | kept | kept |

## Test

Added 4 new test cases:

`extensions/openai/base-url.test.ts`
- recognizes `/backend-api/v1` and `/backend-api/v1/` forms (http + https)
- rejects `/backend-api/v2`, `/backend-api/codex`, `/api` to guard against over-broadening

`extensions/openai/openai-codex-provider.test.ts`
- rewrites stale `/backend-api/v1` baseUrl to canonical `/backend-api`, keeps `api: 'openai-codex-responses'`
- leaves canonical `/backend-api` baseUrl unchanged (reference-equal short-circuit in `normalizeCodexTransport`)

`pnpm test -- extensions/openai/base-url.test.ts` currently fails on an unrelated pre-existing infra bug (`test/non-isolated-runner.ts` → `Class extends value undefined`) that reproduces on `main` with no edits. Regex logic independently verified against 10 URL variants via isolated `node -e`.

## Risk

Low. Single regex widening + one additional clause in an existing rewrite condition. Canonical and unrelated-path cases preserved. The only behavior change is that stale `/backend-api/v1` values — which today cause 403s and misleading errors — get healed on the next model resolve.